### PR TITLE
Add Spanish PII support and cut v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6] - 2026-02-18
+
+### Added
+
+- **Spanish PII Detection & De-identification**: Full Spanish language support for PII extraction
+  - `extract_pii()` and `deidentify()` now accept `lang="es"` for Spanish clinical text
+  - Automatic model selection for Spanish — correct language-specific model chosen when `lang="es"`
+  - 7 new Spanish-specific regex patterns for dates, phone numbers, addresses, postal codes, and national IDs
+  - Spanish date format support with unique "de" connector (e.g., "15 de enero de 2020")
+
+- **Spanish National ID Validators**: DNI and NIE document validation with checksum verification
+  - `validate_spanish_dni()` — Spanish DNI 8-digit + check letter (mod-23 lookup table)
+  - `validate_spanish_nie()` — Spanish NIE with X/Y/Z prefix conversion and DNI algorithm
+
+- **2 New English Base Model Architectures**: Expanded PII model coverage
+  - `pii_biomed_bert_full` — BiomedBERTFull-Base-110M for comprehensive biomedical PII detection
+  - `pii_lite_clinical_u` — LiteClinicalU-Small-66M for universal lightweight PII detection
+  - Both architectures auto-generate variants for all 5 supported languages
+
+- **Expanded Model Registry**: 35 Spanish PII models + 8 new models across existing languages
+  - Total PII models expanded from 133 to 176+ (36 English + 35 x 4 languages)
+  - `get_pii_models_by_language("es")` returns all 35 Spanish models
+  - `get_default_pii_model("es")` returns the recommended Spanish default model
+
+- **Accent Normalization**: Transparent accent stripping for models trained on accent-free text
+  - `normalize_accents` parameter on `extract_pii()` and `deidentify()` (auto-enabled for Spanish)
+  - Strips diacritical marks before model inference, maps entity positions back to original accented text
+  - `_strip_accents()` helper preserves character count via NFC/NFD normalization
+  - Can be explicitly enabled (`normalize_accents=True`) or disabled (`normalize_accents=False`) for any language
+
+- **Spanish Locale Data**: Culturally appropriate synthetic data for the `replace` method
+  - Spanish fake names, emails, phone numbers (+34), addresses, and IDs (DNI/NIE)
+  - Spanish month names for date parsing and formatting
+  - European DD/MM/YYYY date handling for Spanish
+
+- **Testing**: Comprehensive Spanish PII test coverage
+  - Spanish DNI validator tests (6 tests) and NIE validator tests (6 tests)
+  - Spanish pattern matching tests for dates, phones, DNI, NIE
+  - Spanish model registry tests: count, naming, mirror structure
+  - Updated existing tests: fixed `"es"` to `"ja"` in unsupported language assertions
+
+### Changed
+
+- `_LANGUAGE_CONFIG` in model registry now includes `"es": {"name": "Spanish", "prefix": "Spanish-"}`
+- French, German, and Italian model counts updated from 33 to 35 per language (2 new base architectures)
+- `SUPPORTED_LANGUAGES` expanded to include `"es"`
+- Date handling functions (`_shift_date`, `_shift_date_basic`, `_format_date_like_original`) now support Spanish
+
 ## [0.5.5] - 2026-02-11
 
 ### Added
@@ -294,7 +342,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML/ENV configuration via `OpenMedConfig`
 - Zero-shot toolkit with GLiNER support
 
-[Unreleased]: https://github.com/OpenMed/openmed/compare/v0.5.5...HEAD
+[Unreleased]: https://github.com/OpenMed/openmed/compare/v0.5.6...HEAD
+[0.5.6]: https://github.com/OpenMed/openmed/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/OpenMed/openmed/compare/v0.5.1...v0.5.5
 [0.5.1]: https://github.com/OpenMed/openmed/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/OpenMed/openmed/compare/v0.4.0...v0.5.0

--- a/openmed/__about__.py
+++ b/openmed/__about__.py
@@ -1,3 +1,3 @@
 """Version information for OpenMed."""
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"

--- a/openmed/core/model_registry.py
+++ b/openmed/core/model_registry.py
@@ -620,6 +620,30 @@ OPENMED_MODELS = {
         size_category="Large",
         recommended_confidence=0.50
     ),
+
+    # BiomedBERTFull
+    "pii_biomed_bert_full": ModelInfo(
+        model_id="OpenMed/OpenMed-PII-BiomedBERTFull-Base-110M-v1",
+        display_name="PII Detection - BiomedBERTFull",
+        category="Privacy",
+        specialization="Full BiomedBERT PII detection",
+        description="Full BiomedBERT model for comprehensive biomedical PII detection",
+        entity_types=["first_name", "last_name", "email", "phone_number", "ssn", "medical_record_number", "date_of_birth", "street_address"],
+        size_category="Medium",
+        recommended_confidence=0.50
+    ),
+
+    # LiteClinicalU
+    "pii_lite_clinical_u": ModelInfo(
+        model_id="OpenMed/OpenMed-PII-LiteClinicalU-Small-66M-v1",
+        display_name="PII Detection - LiteClinicalU",
+        category="Privacy",
+        specialization="Universal lightweight PII detection",
+        description="Universal lightweight clinical model for fast PII detection",
+        entity_types=["first_name", "last_name", "email", "phone_number", "ssn", "date_of_birth", "street_address"],
+        size_category="Small",
+        recommended_confidence=0.50
+    ),
 }
 
 
@@ -631,6 +655,7 @@ _LANGUAGE_CONFIG = {
     "fr": {"name": "French", "prefix": "French-"},
     "de": {"name": "German", "prefix": "German-"},
     "it": {"name": "Italian", "prefix": "Italian-"},
+    "es": {"name": "Spanish", "prefix": "Spanish-"},
 }
 
 # Keys to skip when generating multilingual variants
@@ -639,11 +664,11 @@ _PII_SKIP_KEYS = {"pii_detection"}
 
 
 def _generate_multilingual_pii_models() -> Dict[str, ModelInfo]:
-    """Generate registry entries for French, German, and Italian PII models.
+    """Generate registry entries for French, German, Italian, and Spanish PII models.
 
-    For each of the 33 English PII model templates and each target language,
-    creates a new ModelInfo with the language prefix inserted into the
-    HuggingFace model ID.
+    For each English PII model template and each target language, creates a
+    new ModelInfo with the language prefix inserted into the HuggingFace
+    model ID.
 
     Returns:
         Dictionary mapping new registry keys to ModelInfo instances.
@@ -823,7 +848,7 @@ def get_pii_models_by_language(lang: str) -> Dict[str, ModelInfo]:
     """Return all PII models for a given language.
 
     Args:
-        lang: ISO 639-1 language code (en, fr, de, it)
+        lang: ISO 639-1 language code (en, fr, de, it, es)
 
     Returns:
         Dict mapping registry keys to ModelInfo for that language.
@@ -844,7 +869,7 @@ def get_default_pii_model(lang: str) -> Optional[str]:
     """Return the default (recommended) PII model_id for a language.
 
     Args:
-        lang: ISO 639-1 language code (en, fr, de, it)
+        lang: ISO 639-1 language code (en, fr, de, it, es)
 
     Returns:
         HuggingFace model ID string, or None if language unsupported.

--- a/tests/unit/test_model_registry_multilingual.py
+++ b/tests/unit/test_model_registry_multilingual.py
@@ -18,33 +18,38 @@ from openmed.core.pii_i18n import DEFAULT_PII_MODELS, SUPPORTED_LANGUAGES
 
 
 class TestRegistryCompleteness:
-    """Verify all 132+ PII models are registered."""
+    """Verify all 176+ PII models are registered."""
 
     def test_total_pii_model_count(self):
-        """All PII models including legacy alias should be >= 132."""
+        """All PII models including legacy alias should be >= 176."""
         pii_keys = [k for k in OPENMED_MODELS if k.startswith("pii_")]
-        # 34 English (33 + pii_detection alias) + 33 fr + 33 de + 33 it = 133
-        assert len(pii_keys) >= 132
+        # 36 English (35 + pii_detection alias) + 35x4 langs = 176
+        assert len(pii_keys) >= 176
 
     def test_english_pii_model_count(self):
-        """English has 33 PII models + 1 legacy alias = 34."""
+        """English has 35 PII models + 1 legacy alias = 36."""
         en_models = get_pii_models_by_language("en")
-        assert len(en_models) >= 33
+        assert len(en_models) >= 35
 
     def test_french_pii_model_count(self):
-        """French has 33 PII models."""
+        """French has 35 PII models."""
         fr_models = get_pii_models_by_language("fr")
-        assert len(fr_models) == 33
+        assert len(fr_models) == 35
 
     def test_german_pii_model_count(self):
-        """German has 33 PII models."""
+        """German has 35 PII models."""
         de_models = get_pii_models_by_language("de")
-        assert len(de_models) == 33
+        assert len(de_models) == 35
 
     def test_italian_pii_model_count(self):
-        """Italian has 33 PII models."""
+        """Italian has 35 PII models."""
         it_models = get_pii_models_by_language("it")
-        assert len(it_models) == 33
+        assert len(it_models) == 35
+
+    def test_spanish_pii_model_count(self):
+        """Spanish has 35 PII models."""
+        es_models = get_pii_models_by_language("es")
+        assert len(es_models) == 35
 
     def test_privacy_category_includes_all(self):
         """Privacy category should list all PII model keys."""
@@ -82,10 +87,17 @@ class TestModelNaming:
                 f"Italian model {key} missing 'Italian-' in model_id: {info.model_id}"
             )
 
+    def test_spanish_model_ids_contain_spanish(self):
+        es_models = get_pii_models_by_language("es")
+        for key, info in es_models.items():
+            assert "Spanish-" in info.model_id, (
+                f"Spanish model {key} missing 'Spanish-' in model_id: {info.model_id}"
+            )
+
     def test_english_model_ids_no_language_prefix(self):
         en_models = get_pii_models_by_language("en")
         for key, info in en_models.items():
-            for prefix in ("French-", "German-", "Italian-"):
+            for prefix in ("French-", "German-", "Italian-", "Spanish-"):
                 assert prefix not in info.model_id, (
                     f"English model {key} has unexpected prefix in: {info.model_id}"
                 )
@@ -106,7 +118,7 @@ class TestModelNaming:
 
     def test_generated_keys_follow_pattern(self):
         """Generated keys should be pii_{lang}_{architecture}."""
-        for lang in ("fr", "de", "it"):
+        for lang in ("fr", "de", "it", "es"):
             lang_models = get_pii_models_by_language(lang)
             for key in lang_models:
                 assert key.startswith(f"pii_{lang}_"), (
@@ -128,7 +140,7 @@ class TestMirrorStructure:
         # Filter out the legacy pii_detection alias
         en_archs = sorted(k[4:] for k in en_models if k != "pii_detection")
 
-        for lang in ("fr", "de", "it"):
+        for lang in ("fr", "de", "it", "es"):
             lang_models = get_pii_models_by_language(lang)
             lang_archs = sorted(k[len(f"pii_{lang}_"):] for k in lang_models)
             assert lang_archs == en_archs, (
@@ -144,7 +156,7 @@ class TestMirrorStructure:
             if en_key == "pii_detection":
                 continue
             arch = en_key[4:]  # strip "pii_"
-            for lang in ("fr", "de", "it"):
+            for lang in ("fr", "de", "it", "es"):
                 lang_key = f"pii_{lang}_{arch}"
                 assert lang_key in OPENMED_MODELS, f"Missing: {lang_key}"
                 assert OPENMED_MODELS[lang_key].size_category == en_info.size_category
@@ -178,8 +190,13 @@ class TestHelperFunctions:
         assert model_id == DEFAULT_PII_MODELS["it"]
         assert "Italian-" in model_id
 
+    def test_get_default_pii_model_es(self):
+        model_id = get_default_pii_model("es")
+        assert model_id == DEFAULT_PII_MODELS["es"]
+        assert "Spanish-" in model_id
+
     def test_get_default_pii_model_unsupported(self):
-        result = get_default_pii_model("es")
+        result = get_default_pii_model("ja")
         assert result is None
 
     def test_get_pii_models_returns_model_info(self):


### PR DESCRIPTION
CHANGELOG.md: Add 0.5.6 release notes for Spanish PII support, new model architectures, accent normalization, and updated compare links.

openmed/__about__.py: Bump package version from 0.5.5 to 0.5.6.

openmed/core/model_registry.py: Add two new English PII model architectures and include Spanish in multilingual model generation and API docs.

openmed/core/pii.py: Add optional accent normalization with Spanish auto-enable and extend date formatting/shift logic to Spanish conventions.

openmed/core/pii_i18n.py: Add Spanish language constants, DNI/NIE validators, Spanish regex patterns, month names, and locale fake data.

tests/unit/test_model_registry_multilingual.py: Update multilingual count expectations and add Spanish model/default coverage.

tests/unit/test_pii.py: Add accent-normalization unit tests, Spanish date-shift coverage, and fix unsupported-language assertions to use ja.

tests/unit/test_pii_i18n.py: Add Spanish validator/pattern/fake-data tests and update unsupported-language assertions to use ja.

