### PR TITLE
Prepare v0.5.7 span-fix and Spanish notebook updates

### DIFF
--- a/examples/notebooks/Multilingual_PII_Detection_Guide.ipynb
+++ b/examples/notebooks/Multilingual_PII_Detection_Guide.ipynb
@@ -4,34 +4,7 @@
    "cell_type": "markdown",
    "id": "cell-0",
    "metadata": {},
-   "source": [
-    "# Multilingual PII Detection & De-identification Guide\n",
-    "\n",
-    "This notebook demonstrates **multilingual PII detection and de-identification** in OpenMed v0.5.5+, covering:\n",
-    "\n",
-    "1. **Overview** - Supported languages and model catalog\n",
-    "2. **Quick Start** - Using the `lang` parameter\n",
-    "3. **French Clinical Notes** - Extraction & de-identification\n",
-    "4. **German Clinical Notes** - Extraction & de-identification\n",
-    "5. **Italian Clinical Notes** - Extraction & de-identification\n",
-    "6. **Cross-Language Comparison** - Detecting PII across languages\n",
-    "7. **Language-Specific Patterns** - NIR, Steuer-ID, Codice Fiscale\n",
-    "8. **De-identification Methods** - Mask, replace, hash with multilingual data\n",
-    "9. **Date Handling** - Locale-aware date parsing and shifting\n",
-    "10. **Batch Processing** - Processing multilingual documents\n",
-    "11. **Custom Model Selection** - Choosing models by architecture\n",
-    "\n",
-    "---\n",
-    "\n",
-    "**Requirements:**\n",
-    "```bash\n",
-    "pip install openmed\n",
-    "```\n",
-    "\n",
-    "**Supported Languages:** English (en), French (fr), German (de), Italian (it)\n",
-    "\n",
-    "---"
-   ]
+   "source": "# Multilingual PII Detection & De-identification Guide\n\nThis notebook demonstrates **multilingual PII detection and de-identification** in OpenMed v0.5.6+, covering:\n\n1. **Overview** - Supported languages and model catalog\n2. **Quick Start** - Using the `lang` parameter\n3. **French Clinical Notes** - Extraction & de-identification\n4. **German Clinical Notes** - Extraction & de-identification\n5. **Italian Clinical Notes** - Extraction & de-identification\n6. **Spanish Clinical Notes** - Extraction & de-identification\n7. **Cross-Language Comparison** - Detecting PII across languages\n8. **Language-Specific Patterns** - NIR, Steuer-ID, Codice Fiscale, DNI/NIE\n9. **Accent Normalization** - Handling accented text in Spanish\n10. **De-identification Methods** - Mask, replace, hash with multilingual data\n11. **Date Handling** - Locale-aware date parsing and shifting\n12. **Batch Processing** - Processing multilingual documents\n13. **Custom Model Selection** - Choosing models by architecture\n\n---\n\n**Requirements:**\n```bash\npip install openmed\n```\n\n**Supported Languages:** English (en), French (fr), German (de), Italian (it), Spanish (es)\n\n---"
   },
   {
    "cell_type": "markdown",
@@ -80,12 +53,7 @@
    "cell_type": "markdown",
    "id": "cell-3",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## 1. Overview: Model Catalog\n",
-    "\n",
-    "OpenMed provides **132+ multilingual PII models** across 4 languages, each with 33 architecture variants ranging from 33M to 600M parameters."
-   ]
+   "source": "---\n## 1. Overview: Model Catalog\n\nOpenMed provides **176+ multilingual PII models** across 5 languages, each with 35 architecture variants ranging from 33M to 600M parameters."
   },
   {
    "cell_type": "code",
@@ -93,24 +61,7 @@
    "id": "cell-4",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "print(\"=\" * 80)\n",
-    "print(\"MULTILINGUAL PII MODEL CATALOG\")\n",
-    "print(\"=\" * 80)\n",
-    "\n",
-    "for lang in sorted(SUPPORTED_LANGUAGES):\n",
-    "    models = get_pii_models_by_language(lang)\n",
-    "    default = get_default_pii_model(lang)\n",
-    "    lang_names = {\"en\": \"English\", \"fr\": \"French\", \"de\": \"German\", \"it\": \"Italian\"}\n",
-    "    print(f\"\\n{lang_names[lang]} ({lang}):\")\n",
-    "    print(f\"  Models available: {len(models)}\")\n",
-    "    print(f\"  Default model:    {default}\")\n",
-    "\n",
-    "# Total count\n",
-    "from openmed.core.model_registry import OPENMED_MODELS\n",
-    "total = len([k for k in OPENMED_MODELS if k.startswith(\"pii_\")])\n",
-    "print(f\"\\nTotal PII models registered: {total}\")"
-   ]
+   "source": "print(\"=\" * 80)\nprint(\"MULTILINGUAL PII MODEL CATALOG\")\nprint(\"=\" * 80)\n\nlang_names = {\n    \"en\": \"English\", \"fr\": \"French\", \"de\": \"German\",\n    \"it\": \"Italian\", \"es\": \"Spanish\",\n}\n\nfor lang in sorted(SUPPORTED_LANGUAGES):\n    models = get_pii_models_by_language(lang)\n    default = get_default_pii_model(lang)\n    print(f\"\\n{lang_names[lang]} ({lang}):\")\n    print(f\"  Models available: {len(models)}\")\n    print(f\"  Default model:    {default}\")\n\n# Total count\nfrom openmed.core.model_registry import OPENMED_MODELS\ntotal = len([k for k in OPENMED_MODELS if k.startswith(\"pii_\")])\nprint(f\"\\nTotal PII models registered: {total}\")"
   },
   {
    "cell_type": "code",
@@ -410,14 +361,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dx4fecscavl",
+   "source": "---\n## 6. Spanish Clinical Notes\n\nSpanish PII detection handles DD/MM/YYYY dates, dates with the unique \"de\" connector (15 de marzo de 2025), +34 phone numbers, DNI/NIE national IDs, and Spanish-language context.\n\n**Accent normalization** is enabled by default for Spanish — models trained on accent-free text will correctly detect accented names like \"María García\".",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "h2ji74eptao",
+   "source": "spanish_note = \"\"\"\nINFORME CLÍNICO\n===============\nNombre del paciente: María García López\nFecha de nacimiento: 15 de marzo de 1985\nDNI: 12345678Z\nTeléfono: +34 612 345 678\nEmail: maria.garcia@email.es\nDirección: Calle Serrano 42, 28001 Madrid\n\nFecha de ingreso: 03/02/2026\n\nMOTIVO DE CONSULTA:\nLa paciente María García acude por dolor torácico de 2 horas\nde evolución. Antecedentes: hipertensión arterial.\n\nEXPLORACIÓN FÍSICA:\nTensión arterial: 145/90 mmHg\nFrecuencia cardíaca: 88 lpm\n\nDra. Ana Martínez\n\"\"\"\n\nprint(\"=\" * 80)\nprint(\"SPANISH CLINICAL NOTE - PII EXTRACTION\")\nprint(\"=\" * 80)\n\nes_result = extract_pii(\n    spanish_note,\n    lang=\"es\",\n    confidence_threshold=0.5,\n    use_smart_merging=True,\n)\n\nprint(f\"Found {len(es_result.entities)} PII entities:\\n\")\nfor e in es_result.entities:\n    print(f\"  [{e.label:20s}] '{e.text}' ({e.confidence:.3f})\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "cn1tjun0pk9",
+   "source": "# De-identify the Spanish note\nprint(\"=\" * 80)\nprint(\"SPANISH CLINICAL NOTE - DE-IDENTIFICATION\")\nprint(\"=\" * 80)\n\nes_deid = deidentify(\n    spanish_note,\n    lang=\"es\",\n    method=\"mask\",\n    confidence_threshold=0.5,\n    use_smart_merging=True,\n)\n\nprint(es_deid.deidentified_text)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-17",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## 6. Cross-Language Comparison\n",
-    "\n",
-    "Compare PII detection across all four languages with equivalent clinical text."
-   ]
+   "source": "---\n## 7. Cross-Language Comparison\n\nCompare PII detection across all five languages with equivalent clinical text."
   },
   {
    "cell_type": "code",
@@ -425,43 +393,13 @@
    "id": "cell-18",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Equivalent clinical texts in 4 languages\n",
-    "texts = {\n",
-    "    \"en\": \"Patient: John Smith, DOB: 03/15/1975, Email: john@email.com\",\n",
-    "    \"fr\": \"Patient : Jean Dupont, ne le 15/03/1975, Email : jean@email.fr\",\n",
-    "    \"de\": \"Patient: Hans Schmidt, Geburtsdatum: 15.03.1975, E-Mail: hans@email.de\",\n",
-    "    \"it\": \"Paziente: Marco Rossi, data di nascita: 15/03/1975, Email: marco@email.it\",\n",
-    "}\n",
-    "\n",
-    "lang_names = {\"en\": \"English\", \"fr\": \"French\", \"de\": \"German\", \"it\": \"Italian\"}\n",
-    "\n",
-    "print(\"=\" * 80)\n",
-    "print(\"CROSS-LANGUAGE PII DETECTION COMPARISON\")\n",
-    "print(\"=\" * 80)\n",
-    "\n",
-    "for lang, text in texts.items():\n",
-    "    result = extract_pii(\n",
-    "        text,\n",
-    "        lang=lang,\n",
-    "        confidence_threshold=0.5,\n",
-    "        use_smart_merging=True,\n",
-    "    )\n",
-    "    print(f\"\\n{lang_names[lang]} ({lang}): {len(result.entities)} entities\")\n",
-    "    for e in result.entities:\n",
-    "        print(f\"  [{e.label:20s}] '{e.text}'\")"
-   ]
+   "source": "# Equivalent clinical texts in 5 languages\ntexts = {\n    \"en\": \"Patient: John Smith, DOB: 03/15/1975, Email: john@email.com\",\n    \"fr\": \"Patient : Jean Dupont, né le 15/03/1975, Email : jean@email.fr\",\n    \"de\": \"Patient: Hans Schmidt, Geburtsdatum: 15.03.1975, E-Mail: hans@email.de\",\n    \"it\": \"Paziente: Marco Rossi, data di nascita: 15/03/1975, Email: marco@email.it\",\n    \"es\": \"Paciente: María García, fecha de nacimiento: 15/03/1975, Email: maria@email.es\",\n}\n\nlang_names = {\n    \"en\": \"English\", \"fr\": \"French\", \"de\": \"German\",\n    \"it\": \"Italian\", \"es\": \"Spanish\",\n}\n\nprint(\"=\" * 80)\nprint(\"CROSS-LANGUAGE PII DETECTION COMPARISON\")\nprint(\"=\" * 80)\n\nfor lang, text in texts.items():\n    result = extract_pii(\n        text,\n        lang=lang,\n        confidence_threshold=0.5,\n        use_smart_merging=True,\n    )\n    print(f\"\\n{lang_names[lang]} ({lang}): {len(result.entities)} entities\")\n    for e in result.entities:\n        print(f\"  [{e.label:20s}] '{e.text}'\")"
   },
   {
    "cell_type": "markdown",
    "id": "cell-19",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## 7. Language-Specific Patterns\n",
-    "\n",
-    "Each language has specialized regex patterns for national IDs, phone numbers, dates, and addresses."
-   ]
+   "source": "---\n## 8. Language-Specific Patterns\n\nEach language has specialized regex patterns for national IDs, phone numbers, dates, and addresses."
   },
   {
    "cell_type": "code",
@@ -469,27 +407,7 @@
    "id": "cell-20",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import re\n",
-    "\n",
-    "print(\"=\" * 80)\n",
-    "print(\"LANGUAGE-SPECIFIC PII PATTERNS\")\n",
-    "print(\"=\" * 80)\n",
-    "\n",
-    "for lang in [\"fr\", \"de\", \"it\"]:\n",
-    "    patterns = LANGUAGE_PII_PATTERNS[lang]\n",
-    "    print(f\"\\n{lang_names[lang]} ({lang}): {len(patterns)} language-specific patterns\")\n",
-    "\n",
-    "    # Group by entity type\n",
-    "    from collections import defaultdict\n",
-    "    by_type = defaultdict(list)\n",
-    "    for p in patterns:\n",
-    "        by_type[p.entity_type].append(p)\n",
-    "\n",
-    "    for etype in sorted(by_type.keys()):\n",
-    "        count = len(by_type[etype])\n",
-    "        print(f\"  {etype}: {count} pattern(s)\")"
-   ]
+   "source": "import re\n\nprint(\"=\" * 80)\nprint(\"LANGUAGE-SPECIFIC PII PATTERNS\")\nprint(\"=\" * 80)\n\nfor lang in [\"fr\", \"de\", \"it\", \"es\"]:\n    patterns = LANGUAGE_PII_PATTERNS[lang]\n    print(f\"\\n{lang_names[lang]} ({lang}): {len(patterns)} language-specific patterns\")\n\n    # Group by entity type\n    from collections import defaultdict\n    by_type = defaultdict(list)\n    for p in patterns:\n        by_type[p.entity_type].append(p)\n\n    for etype in sorted(by_type.keys()):\n        count = len(by_type[etype])\n        print(f\"  {etype}: {count} pattern(s)\")"
   },
   {
    "cell_type": "code",
@@ -497,48 +415,7 @@
    "id": "cell-21",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Demonstrate national ID pattern matching\n",
-    "print(\"=\" * 80)\n",
-    "print(\"NATIONAL ID PATTERNS\")\n",
-    "print(\"=\" * 80)\n",
-    "\n",
-    "# French NIR/INSEE\n",
-    "fr_nir_patterns = [p for p in LANGUAGE_PII_PATTERNS[\"fr\"] if p.entity_type == \"national_id\"]\n",
-    "nir_text = \"1 80 03 75 123 456 20\"\n",
-    "for p in fr_nir_patterns:\n",
-    "    match = re.search(p.pattern, nir_text, p.flags)\n",
-    "    if match:\n",
-    "        print(f\"French NIR: '{nir_text}' -> matched\")\n",
-    "\n",
-    "# German Steuer-ID\n",
-    "de_id_patterns = [p for p in LANGUAGE_PII_PATTERNS[\"de\"] if p.entity_type == \"national_id\"]\n",
-    "steuer_text = \"12345678912\"\n",
-    "for p in de_id_patterns:\n",
-    "    match = re.search(p.pattern, steuer_text, p.flags)\n",
-    "    if match:\n",
-    "        print(f\"German Steuer-ID: '{steuer_text}' -> matched\")\n",
-    "\n",
-    "# Italian Codice Fiscale\n",
-    "it_id_patterns = [p for p in LANGUAGE_PII_PATTERNS[\"it\"] if p.entity_type == \"national_id\"]\n",
-    "cf_text = \"RSSMRC72E10H501Z\"\n",
-    "for p in it_id_patterns:\n",
-    "    match = re.search(p.pattern, cf_text, p.flags)\n",
-    "    if match:\n",
-    "        print(f\"Italian Codice Fiscale: '{cf_text}' -> matched\")\n",
-    "\n",
-    "# Show context-aware scoring\n",
-    "print(\"\\nContext-aware scoring with semantic units:\")\n",
-    "print(\"-\" * 50)\n",
-    "\n",
-    "nir_with_context = \"Numero de securite sociale : 1 80 03 75 123 456 20\"\n",
-    "fr_patterns = get_patterns_for_language(\"fr\")\n",
-    "nir_only = [p for p in fr_patterns if p.entity_type == \"national_id\"]\n",
-    "\n",
-    "units = find_semantic_units(nir_with_context, nir_only)\n",
-    "for start, end, etype, score, pattern in units:\n",
-    "    print(f\"  [{etype}] '{nir_with_context[start:end]}' score={score:.3f}\")"
-   ]
+   "source": "# Demonstrate national ID pattern matching\nfrom openmed.core.pii_i18n import (\n    validate_french_nir,\n    validate_german_steuer_id,\n    validate_italian_codice_fiscale,\n    validate_spanish_dni,\n    validate_spanish_nie,\n)\n\nprint(\"=\" * 80)\nprint(\"NATIONAL ID PATTERNS & VALIDATORS\")\nprint(\"=\" * 80)\n\n# French NIR/INSEE\nfr_nir_patterns = [p for p in LANGUAGE_PII_PATTERNS[\"fr\"] if p.entity_type == \"national_id\"]\nnir_text = \"1 80 03 75 123 456 20\"\nfor p in fr_nir_patterns:\n    match = re.search(p.pattern, nir_text, p.flags)\n    if match:\n        print(f\"French NIR: '{nir_text}' -> matched\")\n\n# German Steuer-ID\nde_id_patterns = [p for p in LANGUAGE_PII_PATTERNS[\"de\"] if p.entity_type == \"national_id\"]\nsteuer_text = \"12345678912\"\nfor p in de_id_patterns:\n    match = re.search(p.pattern, steuer_text, p.flags)\n    if match:\n        print(f\"German Steuer-ID: '{steuer_text}' -> matched\")\n\n# Italian Codice Fiscale\nit_id_patterns = [p for p in LANGUAGE_PII_PATTERNS[\"it\"] if p.entity_type == \"national_id\"]\ncf_text = \"RSSMRC72E10H501Z\"\nfor p in it_id_patterns:\n    match = re.search(p.pattern, cf_text, p.flags)\n    if match:\n        print(f\"Italian Codice Fiscale: '{cf_text}' -> matched\")\n\n# Spanish DNI\nes_id_patterns = [p for p in LANGUAGE_PII_PATTERNS[\"es\"] if p.entity_type == \"national_id\"]\ndni_text = \"12345678Z\"\nfor p in es_id_patterns:\n    match = re.search(p.pattern, dni_text, p.flags)\n    if match:\n        print(f\"Spanish DNI: '{dni_text}' -> matched\")\n\n# Spanish NIE\nnie_text = \"X1234567L\"\nfor p in es_id_patterns:\n    match = re.search(p.pattern, nie_text, p.flags)\n    if match:\n        print(f\"Spanish NIE: '{nie_text}' -> matched\")\n\n# Checksum validators\nprint(\"\\nChecksum validation:\")\nprint(\"-\" * 50)\nprint(f\"  validate_spanish_dni('12345678Z') = {validate_spanish_dni('12345678Z')}\")   # True\nprint(f\"  validate_spanish_dni('12345678A') = {validate_spanish_dni('12345678A')}\")   # False\nprint(f\"  validate_spanish_nie('X1234567L') = {validate_spanish_nie('X1234567L')}\")   # True\nprint(f\"  validate_spanish_nie('A1234567L') = {validate_spanish_nie('A1234567L')}\")   # False\n\n# Show context-aware scoring with semantic units\nprint(\"\\nContext-aware scoring with semantic units:\")\nprint(\"-\" * 50)\n\nnir_with_context = \"Numero de securite sociale : 1 80 03 75 123 456 20\"\nfr_patterns = get_patterns_for_language(\"fr\")\nnir_only = [p for p in fr_patterns if p.entity_type == \"national_id\"]\n\nunits = find_semantic_units(nir_with_context, nir_only)\nfor start, end, etype, score, pattern in units:\n    print(f\"  [{etype}] '{nir_with_context[start:end]}' score={score:.3f}\")"
   },
   {
    "cell_type": "code",
@@ -546,37 +423,27 @@
    "id": "cell-22",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Demonstrate date patterns per language\n",
-    "print(\"=\" * 80)\n",
-    "print(\"DATE PATTERNS BY LANGUAGE\")\n",
-    "print(\"=\" * 80)\n",
-    "\n",
-    "date_examples = {\n",
-    "    \"fr\": [\"15/01/2025\", \"15 janvier 2025\", \"1/3/2025\"],\n",
-    "    \"de\": [\"15.01.2025\", \"15 Januar 2025\", \"1.3.2025\"],\n",
-    "    \"it\": [\"15/01/2025\", \"15 gennaio 2025\", \"1/3/2025\"],\n",
-    "}\n",
-    "\n",
-    "for lang, examples in date_examples.items():\n",
-    "    date_patterns = [p for p in LANGUAGE_PII_PATTERNS[lang] if p.entity_type == \"date\"]\n",
-    "    print(f\"\\n{lang_names[lang]} date patterns:\")\n",
-    "    for text in examples:\n",
-    "        matched = any(re.search(p.pattern, text, p.flags) for p in date_patterns)\n",
-    "        status = \"matched\" if matched else \"no match\"\n",
-    "        print(f\"  '{text}' -> {status}\")"
-   ]
+   "source": "# Demonstrate date patterns per language\nprint(\"=\" * 80)\nprint(\"DATE PATTERNS BY LANGUAGE\")\nprint(\"=\" * 80)\n\ndate_examples = {\n    \"fr\": [\"15/01/2025\", \"15 janvier 2025\", \"1/3/2025\"],\n    \"de\": [\"15.01.2025\", \"15 Januar 2025\", \"1.3.2025\"],\n    \"it\": [\"15/01/2025\", \"15 gennaio 2025\", \"1/3/2025\"],\n    \"es\": [\"15/01/2025\", \"15 de enero de 2025\", \"1/3/2025\"],\n}\n\nfor lang, examples in date_examples.items():\n    date_patterns = [p for p in LANGUAGE_PII_PATTERNS[lang] if p.entity_type == \"date\"]\n    print(f\"\\n{lang_names[lang]} date patterns:\")\n    for text in examples:\n        matched = any(re.search(p.pattern, text, p.flags) for p in date_patterns)\n        status = \"matched\" if matched else \"no match\"\n        print(f\"  '{text}' -> {status}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sli4n8m3rb",
+   "source": "---\n## 9. Accent Normalization\n\nSpanish PII models were trained on accent-free text, so \"María López\" would not be detected without normalization. OpenMed transparently handles this:\n\n- **Auto-enabled for Spanish** (`lang=\"es\"`) — accents are stripped before model inference\n- **Entity positions map back** to the original accented text\n- **Controllable** — disable with `normalize_accents=False` if using an accent-aware model\n- **Works for any language** — enable with `normalize_accents=True` on any `lang`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "n036qvowmq",
+   "source": "from openmed.core.pii import _strip_accents\n\n# Demonstrate the normalization function\nprint(\"=\" * 80)\nprint(\"ACCENT NORMALIZATION\")\nprint(\"=\" * 80)\n\nexamples = [\n    \"María García López\",\n    \"José Sánchez Fernández\",\n    \"niño, pingüino, teléfono\",\n    \"DNI: 12345678Z — no accents, unchanged\",\n]\n\nprint(\"\\n_strip_accents() examples:\")\nprint(\"-\" * 50)\nfor text in examples:\n    stripped = _strip_accents(text)\n    print(f\"  '{text}'\")\n    print(f\"  → '{stripped}'  (len: {len(text)} → {len(stripped)})\")\n    print()\n\n# Show that accent normalization is transparent to the user\nprint(\"=\" * 80)\nprint(\"SPANISH EXTRACTION — WITH vs WITHOUT ACCENT NORMALIZATION\")\nprint(\"=\" * 80)\n\naccented_text = \"Paciente: María García López, teléfono: +34 612 345 678\"\n\n# Default: normalize_accents=True for Spanish\nresult_normalized = extract_pii(\n    accented_text,\n    lang=\"es\",\n    confidence_threshold=0.5,\n)\n\nprint(f\"\\nWith normalization (default for es):\")\nfor e in result_normalized.entities:\n    print(f\"  [{e.label:20s}] '{e.text}' ({e.confidence:.3f})\")\n\n# Explicitly disable normalization\nresult_raw = extract_pii(\n    accented_text,\n    lang=\"es\",\n    normalize_accents=False,\n    confidence_threshold=0.5,\n)\n\nprint(f\"\\nWithout normalization (normalize_accents=False):\")\nif result_raw.entities:\n    for e in result_raw.entities:\n        print(f\"  [{e.label:20s}] '{e.text}' ({e.confidence:.3f})\")\nelse:\n    print(\"  (fewer entities detected — model can't match accented text)\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
    "id": "cell-23",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## 8. De-identification Methods with Multilingual Data\n",
-    "\n",
-    "All de-identification methods (mask, replace, hash, shift_dates) work with multilingual text. The `replace` method uses language-appropriate fake data."
-   ]
+   "source": "---\n## 10. De-identification Methods with Multilingual Data\n\nAll de-identification methods (mask, replace, hash, shift_dates) work with multilingual text. The `replace` method uses language-appropriate fake data."
   },
   {
    "cell_type": "code",
@@ -584,23 +451,7 @@
    "id": "cell-24",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Show language-specific fake data\n",
-    "from openmed.core.pii_i18n import LANGUAGE_FAKE_DATA\n",
-    "\n",
-    "print(\"=\" * 80)\n",
-    "print(\"LANGUAGE-SPECIFIC FAKE DATA FOR REPLACEMENT\")\n",
-    "print(\"=\" * 80)\n",
-    "\n",
-    "for lang in [\"en\", \"fr\", \"de\", \"it\"]:\n",
-    "    data = LANGUAGE_FAKE_DATA[lang]\n",
-    "    print(f\"\\n{lang_names[lang]} ({lang}):\")\n",
-    "    print(f\"  Names: {data['NAME'][:3]}\")\n",
-    "    print(f\"  Phones: {data['PHONE'][:2]}\")\n",
-    "    print(f\"  Emails: {data['EMAIL'][:2]}\")\n",
-    "    if 'LOCATION' in data:\n",
-    "        print(f\"  Locations: {data['LOCATION'][:2]}\")"
-   ]
+   "source": "# Show language-specific fake data\nfrom openmed.core.pii_i18n import LANGUAGE_FAKE_DATA\n\nprint(\"=\" * 80)\nprint(\"LANGUAGE-SPECIFIC FAKE DATA FOR REPLACEMENT\")\nprint(\"=\" * 80)\n\nfor lang in [\"en\", \"fr\", \"de\", \"it\", \"es\"]:\n    data = LANGUAGE_FAKE_DATA[lang]\n    print(f\"\\n{lang_names[lang]} ({lang}):\")\n    print(f\"  Names: {data['NAME'][:3]}\")\n    print(f\"  Phones: {data['PHONE'][:2]}\")\n    print(f\"  Emails: {data['EMAIL'][:2]}\")\n    if 'LOCATION' in data:\n        print(f\"  Locations: {data['LOCATION'][:2]}\")"
   },
   {
    "cell_type": "code",
@@ -632,15 +483,7 @@
    "cell_type": "markdown",
    "id": "cell-26",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## 9. Date Handling\n",
-    "\n",
-    "The `lang` parameter controls date parsing and formatting:\n",
-    "- **English**: MM/DD/YYYY (month-first)\n",
-    "- **French/Italian**: DD/MM/YYYY (day-first)\n",
-    "- **German**: DD.MM.YYYY (day-first, dot separator)"
-   ]
+   "source": "---\n## 11. Date Handling\n\nThe `lang` parameter controls date parsing and formatting:\n- **English**: MM/DD/YYYY (month-first)\n- **French/Italian/Spanish**: DD/MM/YYYY (day-first)\n- **German**: DD.MM.YYYY (day-first, dot separator)\n- **Spanish (unique)**: \"15 de marzo de 2025\" (with \"de\" connector)"
   },
   {
    "cell_type": "code",
@@ -648,41 +491,13 @@
    "id": "cell-27",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Date shifting with locale-aware formatting\n",
-    "date_texts = {\n",
-    "    \"en\": \"Admission: 03/15/2025\",\n",
-    "    \"fr\": \"Admission : 15/03/2025\",\n",
-    "    \"de\": \"Aufnahme: 15.03.2025\",\n",
-    "    \"it\": \"Ricovero: 15/03/2025\",\n",
-    "}\n",
-    "\n",
-    "print(\"=\" * 80)\n",
-    "print(\"DATE SHIFTING BY LANGUAGE\")\n",
-    "print(\"=\" * 80)\n",
-    "\n",
-    "for lang, text in date_texts.items():\n",
-    "    result = deidentify(\n",
-    "        text,\n",
-    "        lang=lang,\n",
-    "        method=\"shift_dates\",\n",
-    "        date_shift_days=30,\n",
-    "        confidence_threshold=0.3,\n",
-    "        use_smart_merging=True,\n",
-    "    )\n",
-    "    print(f\"  {lang_names[lang]:8s}: {text:30s} -> {result.deidentified_text}\")"
-   ]
+   "source": "# Date shifting with locale-aware formatting\ndate_texts = {\n    \"en\": \"Admission: 03/15/2025\",\n    \"fr\": \"Admission : 15/03/2025\",\n    \"de\": \"Aufnahme: 15.03.2025\",\n    \"it\": \"Ricovero: 15/03/2025\",\n    \"es\": \"Ingreso: 15/03/2025\",\n}\n\nprint(\"=\" * 80)\nprint(\"DATE SHIFTING BY LANGUAGE\")\nprint(\"=\" * 80)\n\nfor lang, text in date_texts.items():\n    result = deidentify(\n        text,\n        lang=lang,\n        method=\"shift_dates\",\n        date_shift_days=30,\n        confidence_threshold=0.3,\n        use_smart_merging=True,\n    )\n    print(f\"  {lang_names[lang]:8s}: {text:30s} -> {result.deidentified_text}\")"
   },
   {
    "cell_type": "markdown",
    "id": "cell-28",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## 10. Batch Processing Across Languages\n",
-    "\n",
-    "Process multilingual documents by grouping them by language."
-   ]
+   "source": "---\n## 12. Batch Processing Across Languages\n\nProcess multilingual documents by grouping them by language."
   },
   {
    "cell_type": "code",
@@ -690,41 +505,13 @@
    "id": "cell-29",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Multilingual batch processing\n",
-    "documents = [\n",
-    "    {\"lang\": \"en\", \"text\": \"Patient: John Smith, DOB: 03/15/1975, Email: john@email.com\"},\n",
-    "    {\"lang\": \"fr\", \"text\": \"Patient : Marie Dupont, ne le 15/03/1975, Email : marie@email.fr\"},\n",
-    "    {\"lang\": \"de\", \"text\": \"Patient: Hans Mueller, Geburtsdatum: 15.03.1975, E-Mail: hans@email.de\"},\n",
-    "    {\"lang\": \"it\", \"text\": \"Paziente: Marco Rossi, data di nascita: 15/03/1975, Email: marco@email.it\"},\n",
-    "]\n",
-    "\n",
-    "print(\"=\" * 80)\n",
-    "print(\"MULTILINGUAL BATCH PROCESSING\")\n",
-    "print(\"=\" * 80)\n",
-    "\n",
-    "for doc in documents:\n",
-    "    deid = deidentify(\n",
-    "        doc[\"text\"],\n",
-    "        lang=doc[\"lang\"],\n",
-    "        method=\"mask\",\n",
-    "        confidence_threshold=0.5,\n",
-    "        use_smart_merging=True,\n",
-    "    )\n",
-    "    print(f\"\\n[{doc['lang']}] Original:      {doc['text']}\")\n",
-    "    print(f\"[{doc['lang']}] De-identified: {deid.deidentified_text}\")"
-   ]
+   "source": "# Multilingual batch processing\ndocuments = [\n    {\"lang\": \"en\", \"text\": \"Patient: John Smith, DOB: 03/15/1975, Email: john@email.com\"},\n    {\"lang\": \"fr\", \"text\": \"Patient : Marie Dupont, née le 15/03/1975, Email : marie@email.fr\"},\n    {\"lang\": \"de\", \"text\": \"Patient: Hans Mueller, Geburtsdatum: 15.03.1975, E-Mail: hans@email.de\"},\n    {\"lang\": \"it\", \"text\": \"Paziente: Marco Rossi, data di nascita: 15/03/1975, Email: marco@email.it\"},\n    {\"lang\": \"es\", \"text\": \"Paciente: María García, fecha de nacimiento: 15/03/1975, Email: maria@email.es\"},\n]\n\nprint(\"=\" * 80)\nprint(\"MULTILINGUAL BATCH PROCESSING\")\nprint(\"=\" * 80)\n\nfor doc in documents:\n    deid = deidentify(\n        doc[\"text\"],\n        lang=doc[\"lang\"],\n        method=\"mask\",\n        confidence_threshold=0.5,\n        use_smart_merging=True,\n    )\n    print(f\"\\n[{doc['lang']}] Original:      {doc['text']}\")\n    print(f\"[{doc['lang']}] De-identified: {deid.deidentified_text}\")"
   },
   {
    "cell_type": "markdown",
    "id": "cell-30",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## 11. Custom Model Selection\n",
-    "\n",
-    "While `lang` auto-selects the recommended default model (SuperClinical-Small-44M), you can choose any of the 33 architectures per language."
-   ]
+   "source": "---\n## 13. Custom Model Selection\n\nWhile `lang` auto-selects the recommended default model (SuperClinical-Small-44M), you can choose any of the 35 architectures per language."
   },
   {
    "cell_type": "code",
@@ -732,24 +519,7 @@
    "id": "cell-31",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "print(\"=\" * 80)\n",
-    "print(\"AVAILABLE MODEL ARCHITECTURES PER LANGUAGE\")\n",
-    "print(\"=\" * 80)\n",
-    "\n",
-    "# Show all architectures for French as an example\n",
-    "fr_models = get_pii_models_by_language(\"fr\")\n",
-    "\n",
-    "print(f\"\\nFrench models ({len(fr_models)} total):\")\n",
-    "for key, info in sorted(fr_models.items()):\n",
-    "    is_default = info.model_id == get_default_pii_model(\"fr\")\n",
-    "    marker = \" <- DEFAULT\" if is_default else \"\"\n",
-    "    print(f\"  {info.size_category:8s} {info.model_id}{marker}\")\n",
-    "\n",
-    "print(\"\\nTo use a specific model:\")\n",
-    "print('  extract_pii(text, model_name=\"OpenMed/OpenMed-PII-French-SuperClinical-Large-434M-v1\")')\n",
-    "print(\"  # model_name overrides the lang default\")"
-   ]
+   "source": "print(\"=\" * 80)\nprint(\"AVAILABLE MODEL ARCHITECTURES PER LANGUAGE\")\nprint(\"=\" * 80)\n\n# Show all architectures for Spanish as an example\nes_models = get_pii_models_by_language(\"es\")\n\nprint(f\"\\nSpanish models ({len(es_models)} total):\")\nfor key, info in sorted(es_models.items(), key=lambda x: x[1].model_id):\n    is_default = info.model_id == get_default_pii_model(\"es\")\n    marker = \" <- DEFAULT\" if is_default else \"\"\n    print(f\"  {info.size_category:8s} {info.model_id}{marker}\")\n\nprint(\"\\nTo use a specific model:\")\nprint('  extract_pii(text, model_name=\"OpenMed/OpenMed-PII-Spanish-SuperClinical-Large-434M-v1\")')\nprint(\"  # model_name overrides the lang default\")"
   },
   {
    "cell_type": "code",
@@ -757,76 +527,13 @@
    "id": "cell-32",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Example: use a specific model while keeping lang for patterns\n",
-    "text = \"Patient : Jean Dupont, ne le 15/01/1975\"\n",
-    "\n",
-    "# Using lang default (SuperClinical-Small-44M)\n",
-    "result_default = extract_pii(\n",
-    "    text,\n",
-    "    lang=\"fr\",\n",
-    "    confidence_threshold=0.5,\n",
-    "    use_smart_merging=True,\n",
-    ")\n",
-    "\n",
-    "# Using a custom larger model\n",
-    "result_custom = extract_pii(\n",
-    "    text,\n",
-    "    lang=\"fr\",\n",
-    "    model_name=\"OpenMed/OpenMed-PII-French-SuperClinical-Large-434M-v1\",\n",
-    "    confidence_threshold=0.5,\n",
-    "    use_smart_merging=True,\n",
-    ")\n",
-    "\n",
-    "print(\"Default model:\")\n",
-    "for e in result_default.entities:\n",
-    "    print(f\"  [{e.label:20s}] '{e.text}' ({e.confidence:.3f})\")\n",
-    "\n",
-    "print(\"\\nLarger model:\")\n",
-    "for e in result_custom.entities:\n",
-    "    print(f\"  [{e.label:20s}] '{e.text}' ({e.confidence:.3f})\")"
-   ]
+   "source": "# Example: use a specific model while keeping lang for patterns\ntext = \"Paciente: María García, DNI: 12345678Z, nacida el 15/03/1975\"\n\n# Using lang default (SuperClinical-Small-44M)\nresult_default = extract_pii(\n    text,\n    lang=\"es\",\n    confidence_threshold=0.5,\n    use_smart_merging=True,\n)\n\n# Using a custom larger model\nresult_custom = extract_pii(\n    text,\n    lang=\"es\",\n    model_name=\"OpenMed/OpenMed-PII-Spanish-SuperClinical-Large-434M-v1\",\n    confidence_threshold=0.5,\n    use_smart_merging=True,\n)\n\nprint(\"Default model:\")\nfor e in result_default.entities:\n    print(f\"  [{e.label:20s}] '{e.text}' ({e.confidence:.3f})\")\n\nprint(\"\\nLarger model:\")\nfor e in result_custom.entities:\n    print(f\"  [{e.label:20s}] '{e.text}' ({e.confidence:.3f})\")"
   },
   {
    "cell_type": "markdown",
    "id": "cell-33",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## Summary\n",
-    "\n",
-    "### Key Points\n",
-    "\n",
-    "| Feature | How to Use |\n",
-    "|---------|------------|\n",
-    "| French PII | `extract_pii(text, lang=\"fr\")` |\n",
-    "| German PII | `extract_pii(text, lang=\"de\")` |\n",
-    "| Italian PII | `extract_pii(text, lang=\"it\")` |\n",
-    "| English PII | `extract_pii(text)` (default) |\n",
-    "| Custom model | `extract_pii(text, lang=\"fr\", model_name=\"...\")` |\n",
-    "| De-identify | `deidentify(text, lang=\"fr\", method=\"mask\")` |\n",
-    "| Browse models | `get_pii_models_by_language(\"fr\")` |\n",
-    "\n",
-    "### Architecture\n",
-    "\n",
-    "- **132+ models** across 4 languages (33 architectures each)\n",
-    "- **Language-specific patterns** for dates, phones, national IDs, addresses\n",
-    "- **Language-specific fake data** for the `replace` de-identification method\n",
-    "- **Locale-aware date handling** (day-first for European languages)\n",
-    "- **Backward compatible** - all existing English code works unchanged\n",
-    "\n",
-    "### Resources\n",
-    "\n",
-    "- [HuggingFace Collection](https://huggingface.co/collections/OpenMed/multilingual-pii-and-de-identification)\n",
-    "- [OpenMed GitHub](https://github.com/maziyarpanahi/openmed)\n",
-    "- [PII Detection Complete Guide](./PII_Detection_Complete_Guide.ipynb) (English-focused)\n",
-    "\n",
-    "---\n",
-    "\n",
-    "**Version:** OpenMed v0.5.5+\n",
-    "\n",
-    "**Last Updated:** 2026-02-11"
-   ]
+   "source": "---\n## Summary\n\n### Key Points\n\n| Feature | How to Use |\n|---------|------------|\n| English PII | `extract_pii(text)` (default) |\n| French PII | `extract_pii(text, lang=\"fr\")` |\n| German PII | `extract_pii(text, lang=\"de\")` |\n| Italian PII | `extract_pii(text, lang=\"it\")` |\n| Spanish PII | `extract_pii(text, lang=\"es\")` |\n| Custom model | `extract_pii(text, lang=\"es\", model_name=\"...\")` |\n| De-identify | `deidentify(text, lang=\"es\", method=\"mask\")` |\n| Browse models | `get_pii_models_by_language(\"es\")` |\n| Disable accent norm | `extract_pii(text, lang=\"es\", normalize_accents=False)` |\n\n### Architecture\n\n- **176+ models** across 5 languages (35 architectures each)\n- **Language-specific patterns** for dates, phones, national IDs, addresses\n- **National ID validators** with checksum verification (NIR, Steuer-ID, Codice Fiscale, DNI, NIE)\n- **Language-specific fake data** for the `replace` de-identification method\n- **Locale-aware date handling** (day-first for European languages, \"de\" connector for Spanish)\n- **Accent normalization** for models trained on accent-free text (auto-enabled for Spanish)\n- **Backward compatible** — all existing English code works unchanged\n\n### Resources\n\n- [HuggingFace Collection — Multilingual](https://huggingface.co/collections/OpenMed/multilingual-pii-and-de-identification)\n- [HuggingFace Collection — Spanish](https://huggingface.co/collections/OpenMed/spanish-pii-and-de-identification)\n- [OpenMed GitHub](https://github.com/maziyarpanahi/openmed)\n- [PII Detection Complete Guide](./PII_Detection_Complete_Guide.ipynb) (English-focused)\n\n---\n\n**Version:** OpenMed v0.5.6+\n\n**Last Updated:** 2026-02-18"
   },
   {
    "cell_type": "code",

--- a/openmed/__about__.py
+++ b/openmed/__about__.py
@@ -1,3 +1,3 @@
 """Version information for OpenMed."""
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"


### PR DESCRIPTION
openmed/__about__.py: Bump version from 0.5.6 to 0.5.7.

openmed/processing/outputs.py: Add _fix_entity_spans and apply it to correct tokenizer off-by-one end offsets before grouping.

tests/unit/test_processing.py: Add focused tests for span fixing behavior including truncation, whitespace trimming, and boundary cases.

examples/notebooks/Multilingual_PII_Detection_Guide.ipynb: Update the multilingual guide for v0.5.6+ Spanish coverage, accent normalization, and 5-language examples.