### PR TITLE
v0.6.3: PII/NER quality gate pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-03-19
+
+### Added
+
+- **Span-boundary quality gates** (`openmed.core.quality_gates`)
+  - `validate_entity_spans()` checks start < end, in-bounds, text-match, and zero-length invariants for every entity after tokenizer repair and smart merging
+  - `detect_overlapping_entities()` returns pairs of overlapping character spans for informational use
+  - `SpanValidationWarning` emitted on violations — warn-only, never silently drops entities
+  - Integrated into `OutputFormatter.format_predictions()` (after `_fix_entity_spans`) and `extract_pii()` (after smart merging)
+- **Multilingual PII regression test suite** (`tests/unit/test_pii_multilingual_regression.py`)
+  - Golden-input regression tests for all 8 supported languages (en, fr, de, it, es, nl, hi, te)
+  - Validates entity type detection, span text matching, confidence thresholds, and smart merging boundaries
+  - 31 deterministic test cases using mocked model output
+- **Span-boundary guard tests** (`tests/unit/test_quality_gates.py`)
+  - 19 tests covering valid entities, inverted/zero-length spans, out-of-bounds, text mismatch, overlap detection, and integration with `_fix_entity_spans`
+- **Label-map consistency tests** (`tests/unit/ner/test_label_map_consistency.py`)
+  - Validates `defaults.json` domain invariants (at least 1 label per domain, no case-insensitive duplicates, `generic` domain exists)
+  - `normalize_label()` idempotency checks across all known label variants
+  - Specificity hierarchy validation against `is_more_specific()`
+  - All PII `entity_types` in `OPENMED_MODELS` recognized and idempotent under `normalize_label()`
+  - At least one PII model per supported language in the registry
+
+### Changed
+
+- Updated website model count from 640+ to 750+
+
+### Documentation
+
+- Updated README, website copy, and CHANGELOG for the `v0.6.3` release
+
 ## [0.6.2] - 2026-03-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ result = processor.process_texts([
 - **Advanced NER Processing**: Confidence filtering, entity grouping, and span alignment
 - **Multiple Output Formats**: Dict, JSON, HTML, CSV for any downstream system
 
-### Production Tools (v0.6.2)
+### Production Tools (v0.6.3)
 
 - **Batch Processing**: Multi-text and multi-file workflows with progress tracking
 - **Configuration Profiles**: `dev`/`prod`/`test`/`fast` presets with flexible overrides
@@ -124,7 +124,7 @@ Quick links:
 
 ---
 
-## REST API (v0.6.2)
+## REST API (v0.6.3)
 
 OpenMed includes a Docker-friendly FastAPI service with reliability hardening:
 
@@ -150,8 +150,8 @@ uvicorn openmed.service.app:app --host 0.0.0.0 --port 8080
 ### Run with Docker
 
 ```bash
-docker build -t openmed:0.6.2 .
-docker run --rm -p 8080:8080 -e OPENMED_PROFILE=prod openmed:0.6.2
+docker build -t openmed:0.6.3 .
+docker run --rm -p 8080:8080 -e OPENMED_PROFILE=prod openmed:0.6.3
 ```
 
 ### Example request

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -53,7 +53,7 @@
     "operatingSystem": "Cloud, On-Premises",
     "applicationCategory": "AIApplication",
     "description": "OpenMed Clinical NLP Suite provides open-source healthcare language models, biomedical named-entity recognition, and deployment toolkits for compliant medical workflows.",
-    "softwareVersion": "0.6.2",
+    "softwareVersion": "0.6.3",
     "url": "https://openmed.life/",
     "provider": {
       "@type": "Organization",
@@ -160,7 +160,7 @@
                         </div>
                         <div class="stats">
                             <div class="stat">
-                                <div class="stat-number">640+</div>
+                                <div class="stat-number">750+</div>
                                 <div class="stat-label">HF models</div>
                             </div>
                             <div class="stat">
@@ -235,7 +235,7 @@
                                     d="M5 13l4 4L19 7">
                                 </path>
                             </svg>
-                            <span>Hugging Face <span style="color: hsl(var(--muted-foreground));">(640+
+                            <span>Hugging Face <span style="color: hsl(var(--muted-foreground));">(750+
                                     models)</span></span>
                         </div>
                         <div class="platform-badge">
@@ -788,7 +788,7 @@ deid_result = <span style="color: #dcdcaa;">deidentify</span>(text, lang=<span s
 
                 <div style="text-align: center;">
                     <a href="https://huggingface.co/OpenMed" target="_blank" rel="noopener"
-                        class="btn btn-primary btn-lg">Browse All 640+ Models</a>
+                        class="btn btn-primary btn-lg">Browse All 750+ Models</a>
                 </div>
             </div>
         </section>

--- a/openmed/__about__.py
+++ b/openmed/__about__.py
@@ -1,3 +1,3 @@
 """Version information for OpenMed."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -311,6 +311,10 @@ def extract_pii(
         result.entities = merged_entities
         result.num_entities = len(merged_entities)
 
+    # Validate spans after all merging/fixing is complete
+    from .quality_gates import validate_entity_spans
+    validate_entity_spans(result.entities, result.text)
+
     return result
 
 

--- a/openmed/core/quality_gates.py
+++ b/openmed/core/quality_gates.py
@@ -1,0 +1,118 @@
+"""Span-boundary guards for entity predictions.
+
+Runtime validation functions that catch stale spans, off-by-one errors,
+and overlapping entities *after* tokenizer repair and smart merging.
+
+All guards are **warn-only** — they log diagnostics and set metadata flags
+but never silently drop entities.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import TYPE_CHECKING, List, Tuple
+
+if TYPE_CHECKING:
+    from openmed.processing.outputs import EntityPrediction
+
+logger = logging.getLogger(__name__)
+
+
+class SpanValidationWarning(UserWarning):
+    """Raised when an entity span fails a boundary check."""
+
+
+def validate_entity_spans(
+    entities: List["EntityPrediction"],
+    text: str,
+) -> List["EntityPrediction"]:
+    """Validate span boundaries for every entity against *text*.
+
+    Checks performed per entity:
+    - ``start < end`` (no inverted or zero-length spans)
+    - ``start >= 0`` and ``end <= len(text)``
+    - ``text[start:end]`` matches ``entity.text`` (catch stale spans)
+
+    Violations are logged at WARNING level and a
+    :class:`SpanValidationWarning` is emitted so callers can
+    ``warnings.filterwarnings`` as needed.  A ``span_valid`` flag is
+    written into ``entity.metadata`` for downstream consumers.
+
+    Returns the *same* list (never filters entities out).
+    """
+    text_len = len(text)
+
+    for entity in entities:
+        problems: list[str] = []
+        start = entity.start
+        end = entity.end
+
+        if start is None or end is None:
+            # Entities without offsets cannot be validated.
+            continue
+
+        # --- invariant checks ---
+        if start >= end:
+            if start == end:
+                problems.append("zero-length span")
+            else:
+                problems.append(f"inverted span (start={start} >= end={end})")
+
+        if start < 0:
+            problems.append(f"negative start ({start})")
+
+        if end > text_len:
+            problems.append(f"end ({end}) exceeds text length ({text_len})")
+
+        # --- text-match check (only when bounds are sane) ---
+        if not problems and start >= 0 and end <= text_len:
+            actual = text[start:end]
+            if actual != entity.text:
+                problems.append(
+                    f"text mismatch: span gives {actual!r}, "
+                    f"entity stores {entity.text!r}"
+                )
+
+        # --- report ---
+        if problems:
+            msg = (
+                f"Entity {entity.label!r} @ [{start}:{end}]: "
+                + "; ".join(problems)
+            )
+            logger.warning("SpanValidation: %s", msg)
+            warnings.warn(msg, SpanValidationWarning, stacklevel=2)
+
+        # Tag metadata so downstream code can inspect validity.
+        meta = entity.metadata if entity.metadata is not None else {}
+        meta["span_valid"] = len(problems) == 0
+        entity.metadata = meta
+
+    return entities
+
+
+def detect_overlapping_entities(
+    entities: List["EntityPrediction"],
+) -> List[Tuple["EntityPrediction", "EntityPrediction"]]:
+    """Return pairs of entities whose character spans overlap.
+
+    Entities without ``start``/``end`` offsets are skipped.
+    """
+    # Filter to entities that have offsets.
+    with_offsets = [
+        e for e in entities
+        if e.start is not None and e.end is not None
+    ]
+    sorted_ents = sorted(with_offsets, key=lambda e: (e.start, e.end))
+
+    overlaps: List[Tuple["EntityPrediction", "EntityPrediction"]] = []
+    for i in range(len(sorted_ents) - 1):
+        a = sorted_ents[i]
+        # Check against all subsequent entities that could overlap.
+        for j in range(i + 1, len(sorted_ents)):
+            b = sorted_ents[j]
+            if b.start < a.end:
+                overlaps.append((a, b))
+            else:
+                break  # No further overlaps possible for *a*.
+    return overlaps

--- a/openmed/processing/outputs.py
+++ b/openmed/processing/outputs.py
@@ -200,6 +200,8 @@ class OutputFormatter:
 
         if original_text:
             entities = self._fix_entity_spans(entities, original_text)
+            from openmed.core.quality_gates import validate_entity_spans
+            validate_entity_spans(entities, original_text)
 
         if self.group_entities:
             entities = self._group_adjacent_entities(entities)

--- a/tests/unit/ner/test_label_map_consistency.py
+++ b/tests/unit/ner/test_label_map_consistency.py
@@ -1,0 +1,196 @@
+"""Label-map consistency tests.
+
+Validates invariants across NER label maps, PII label normalization,
+and model registry entity_types to catch configuration drift.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.core.pii_entity_merger import normalize_label, is_more_specific
+from openmed.core.model_registry import OPENMED_MODELS
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+LABEL_MAPS_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "openmed"
+    / "zero_shot"
+    / "data"
+    / "label_maps"
+    / "defaults.json"
+)
+
+
+@pytest.fixture
+def label_maps():
+    with open(LABEL_MAPS_PATH) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# defaults.json invariants
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultsJsonInvariants:
+
+    def test_every_domain_has_at_least_one_label(self, label_maps):
+        for domain, labels in label_maps.items():
+            assert len(labels) >= 1, f"Domain {domain!r} has no labels"
+
+    def test_no_duplicate_labels_within_domain(self, label_maps):
+        for domain, labels in label_maps.items():
+            lower_labels = [l.lower() for l in labels]
+            assert len(lower_labels) == len(set(lower_labels)), (
+                f"Domain {domain!r} has duplicate labels (case-insensitive): {labels}"
+            )
+
+    def test_generic_domain_exists(self, label_maps):
+        assert "generic" in label_maps, (
+            "defaults.json must include a 'generic' fallback domain"
+        )
+
+    def test_generic_domain_has_labels(self, label_maps):
+        assert len(label_maps["generic"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# normalize_label idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeLabelIdempotency:
+
+    @pytest.mark.parametrize("label", [
+        "date_of_birth",
+        "phone_number",
+        "email",
+        "ssn",
+        "social_security_number",
+        "national_id",
+        "nir",
+        "insee",
+        "steuer_id",
+        "steuernummer",
+        "codice_fiscale",
+        "postcode",
+        "zipcode",
+        "zip",
+        "postal_code",
+        "address",
+        "street_address",
+        "fax",
+        "first_name",
+        "last_name",
+        "date",
+        "phone",
+    ])
+    def test_normalize_is_idempotent(self, label):
+        once = normalize_label(label)
+        twice = normalize_label(once)
+        assert once == twice, (
+            f"normalize_label is not idempotent for {label!r}: "
+            f"first={once!r}, second={twice!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Specificity hierarchy resolves to valid canonical forms
+# ---------------------------------------------------------------------------
+
+
+class TestSpecificityHierarchy:
+
+    HIERARCHY = {
+        "date": ["date_of_birth", "date_time"],
+        "name": ["first_name", "last_name", "full_name"],
+        "phone": ["phone_number", "fax_number", "mobile_number"],
+        "address": ["street_address", "home_address", "billing_address"],
+        "id": ["ssn", "medical_record_number", "account_number", "employee_id"],
+        "national_id": ["nir", "insee", "steuer_id", "steuernummer", "codice_fiscale"],
+    }
+
+    def test_specific_labels_resolve_to_canonical(self):
+        for general, specifics in self.HIERARCHY.items():
+            for specific in specifics:
+                canonical = normalize_label(specific)
+                assert isinstance(canonical, str) and len(canonical) > 0, (
+                    f"Specific label {specific!r} did not normalize to a valid string"
+                )
+
+    def test_is_more_specific_agrees_with_hierarchy(self):
+        for general, specifics in self.HIERARCHY.items():
+            for specific in specifics:
+                assert is_more_specific(specific, general), (
+                    f"is_more_specific({specific!r}, {general!r}) should be True"
+                )
+
+    def test_general_not_more_specific_than_specific(self):
+        for general, specifics in self.HIERARCHY.items():
+            for specific in specifics:
+                assert not is_more_specific(general, specific), (
+                    f"is_more_specific({general!r}, {specific!r}) should be False"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Model registry entity_types recognized by normalize_label
+# ---------------------------------------------------------------------------
+
+
+class TestModelRegistryEntityTypes:
+
+    def _pii_models(self):
+        return {
+            key: info for key, info in OPENMED_MODELS.items()
+            if key.startswith("pii_") and info.entity_types
+        }
+
+    def test_all_pii_entity_types_recognized(self):
+        """Every entity_type in PII model entries should normalize without error."""
+        pii_models = self._pii_models()
+        assert len(pii_models) > 0, "No PII models found in OPENMED_MODELS"
+        for key, info in pii_models.items():
+            for et in info.entity_types:
+                canonical = normalize_label(et)
+                assert isinstance(canonical, str) and len(canonical) > 0, (
+                    f"entity_type {et!r} in {key!r} did not normalize"
+                )
+
+    def test_pii_entity_types_normalize_idempotently(self):
+        """Normalization of registry entity_types must be idempotent."""
+        for key, info in self._pii_models().items():
+            for et in info.entity_types:
+                once = normalize_label(et)
+                twice = normalize_label(once)
+                assert once == twice, (
+                    f"normalize_label not idempotent for {et!r} (model {key!r}): "
+                    f"{once!r} != {twice!r}"
+                )
+
+    def test_at_least_one_pii_model_per_supported_language(self):
+        """Every supported language should have at least one PII model in the registry."""
+        from openmed.core.pii_i18n import SUPPORTED_LANGUAGES
+        pii_keys = [k for k in OPENMED_MODELS if k.startswith("pii_")]
+        for lang in SUPPORTED_LANGUAGES:
+            if lang == "en":
+                # English models don't have a language infix
+                assert any(
+                    k.startswith("pii_") and not any(
+                        f"pii_{l}_" in k for l in SUPPORTED_LANGUAGES if l != "en"
+                    )
+                    for k in pii_keys
+                ), "No English PII model found"
+            else:
+                # Non-English keys use pii_{lang}_ prefix, e.g. pii_de_superclinical_small
+                assert any(
+                    k.startswith(f"pii_{lang}_") for k in pii_keys
+                ), f"No PII model found for language {lang!r}"

--- a/tests/unit/test_pii_multilingual_regression.py
+++ b/tests/unit/test_pii_multilingual_regression.py
@@ -1,0 +1,419 @@
+"""Multilingual PII regression tests with golden inputs.
+
+Each language gets deterministic mock model output to verify:
+- Expected entity types are detected
+- Span text matches expected substrings
+- Confidence is above per-language thresholds
+- Smart merging produces correct span boundaries
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from openmed.core.pii import extract_pii
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_result(text, entities):
+    """Build a PredictionResult from EntityPrediction list."""
+    return PredictionResult(
+        text=text,
+        entities=entities,
+        model_name="mock",
+        timestamp="2026-01-01T00:00:00",
+    )
+
+
+def _ent(text, label, start, end, confidence=0.92):
+    return EntityPrediction(
+        text=text, label=label, start=start, end=end, confidence=confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# English (en)
+# ---------------------------------------------------------------------------
+
+
+class TestEnglishRegression:
+
+    CLINICAL_NOTE = "Patient John Doe, DOB 1990-05-15, phone 555-123-4567, SSN 123-45-6789."
+
+    @patch("openmed.analyze_text")
+    def test_en_name_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("John Doe", "first_name", 8, 16, 0.95),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="en")
+        names = [e for e in result.entities if "name" in e.label.lower()]
+        assert len(names) >= 1
+        assert "John" in names[0].text
+
+    @patch("openmed.analyze_text")
+    def test_en_date_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("1990-05-15", "date_of_birth", 22, 32, 0.93),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="en")
+        dates = [e for e in result.entities if "date" in e.label.lower()]
+        assert len(dates) >= 1
+        assert "1990" in dates[0].text
+
+    @patch("openmed.analyze_text")
+    def test_en_phone_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("555-123-4567", "phone_number", 40, 52, 0.91),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="en")
+        phones = [e for e in result.entities if "phone" in e.label.lower()]
+        assert len(phones) >= 1
+        assert "555" in phones[0].text
+
+    @patch("openmed.analyze_text")
+    def test_en_ssn_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("123-45-6789", "ssn", 58, 69, 0.94),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="en")
+        ssns = [e for e in result.entities if "ssn" in e.label.lower()]
+        assert len(ssns) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_en_smart_merging_spans(self, mock_analyze):
+        text = "Patient John Doe visited the clinic"
+        mock_analyze.return_value = _make_result(text, [
+            _ent("John", "first_name", 8, 12, 0.93),
+            _ent("Doe", "last_name", 13, 16, 0.91),
+        ])
+        result = extract_pii(text, use_smart_merging=True, lang="en")
+        # After merging, fragments should be combined or kept with valid spans
+        for e in result.entities:
+            if e.start is not None and e.end is not None:
+                assert e.start < e.end
+                assert e.start >= 0
+                assert e.end <= len(text)
+
+
+# ---------------------------------------------------------------------------
+# French (fr)
+# ---------------------------------------------------------------------------
+
+
+class TestFrenchRegression:
+
+    CLINICAL_NOTE = "Patient Jean Dupont, né le 15/05/1990, téléphone 01 23 45 67 89, NIR 1 90 05 75 108 042 36."
+
+    @patch("openmed.analyze_text")
+    def test_fr_name_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("Jean Dupont", "first_name", 8, 19, 0.90),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="fr")
+        names = [e for e in result.entities if "name" in e.label.lower()]
+        assert len(names) >= 1
+        assert "Jean" in names[0].text
+
+    @patch("openmed.analyze_text")
+    def test_fr_date_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("15/05/1990", "date_of_birth", 27, 37, 0.88),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="fr")
+        dates = [e for e in result.entities if "date" in e.label.lower()]
+        assert len(dates) >= 1
+        assert "1990" in dates[0].text
+
+    @patch("openmed.analyze_text")
+    def test_fr_phone_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("01 23 45 67 89", "phone_number", 50, 64, 0.87),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="fr")
+        phones = [e for e in result.entities if "phone" in e.label.lower()]
+        assert len(phones) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_fr_national_id_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("1 90 05 75 108 042 36", "national_id", 70, 91, 0.85),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="fr")
+        ids = [e for e in result.entities if "national_id" in e.label.lower() or "nir" in e.label.lower()]
+        assert len(ids) >= 1
+
+
+# ---------------------------------------------------------------------------
+# German (de)
+# ---------------------------------------------------------------------------
+
+
+class TestGermanRegression:
+
+    CLINICAL_NOTE = "Patient Hans Müller, geb. 15.05.1990, Tel. 030 12345678, Steuer-ID 12 345 678 901."
+
+    @patch("openmed.analyze_text")
+    def test_de_name_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("Hans Müller", "first_name", 8, 19, 0.91),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="de")
+        names = [e for e in result.entities if "name" in e.label.lower()]
+        assert len(names) >= 1
+        assert "Hans" in names[0].text
+
+    @patch("openmed.analyze_text")
+    def test_de_date_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("15.05.1990", "date_of_birth", 26, 36, 0.89),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="de")
+        dates = [e for e in result.entities if "date" in e.label.lower()]
+        assert len(dates) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_de_phone_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("030 12345678", "phone_number", 43, 55, 0.88),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="de")
+        phones = [e for e in result.entities if "phone" in e.label.lower()]
+        assert len(phones) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_de_smart_merging_boundaries(self, mock_analyze):
+        text = "Patient Hans Müller besuchte die Klinik"
+        mock_analyze.return_value = _make_result(text, [
+            _ent("Hans", "first_name", 8, 12, 0.90),
+            _ent("Müller", "last_name", 13, 19, 0.88),
+        ])
+        result = extract_pii(text, use_smart_merging=True, lang="de")
+        for e in result.entities:
+            if e.start is not None and e.end is not None:
+                assert e.start < e.end
+                assert e.end <= len(text)
+
+
+# ---------------------------------------------------------------------------
+# Italian (it)
+# ---------------------------------------------------------------------------
+
+
+class TestItalianRegression:
+
+    CLINICAL_NOTE = "Paziente Marco Rossi, nato il 15/05/1990, tel. 06 1234567, CF RSSMRC90E15H501Z."
+
+    @patch("openmed.analyze_text")
+    def test_it_name_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("Marco Rossi", "first_name", 10, 21, 0.90),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="it")
+        names = [e for e in result.entities if "name" in e.label.lower()]
+        assert len(names) >= 1
+        assert "Marco" in names[0].text
+
+    @patch("openmed.analyze_text")
+    def test_it_date_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("15/05/1990", "date_of_birth", 30, 40, 0.88),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="it")
+        dates = [e for e in result.entities if "date" in e.label.lower()]
+        assert len(dates) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_it_phone_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("06 1234567", "phone_number", 48, 58, 0.87),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="it")
+        phones = [e for e in result.entities if "phone" in e.label.lower()]
+        assert len(phones) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Spanish (es)
+# ---------------------------------------------------------------------------
+
+
+class TestSpanishRegression:
+
+    CLINICAL_NOTE = "Paciente María García, nacida el 15/05/1990, teléfono 612 345 678, DNI 12345678Z."
+
+    @patch("openmed.analyze_text")
+    def test_es_name_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("María García", "first_name", 10, 22, 0.90),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="es")
+        names = [e for e in result.entities if "name" in e.label.lower()]
+        assert len(names) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_es_date_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("15/05/1990", "date_of_birth", 33, 43, 0.88),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="es")
+        dates = [e for e in result.entities if "date" in e.label.lower()]
+        assert len(dates) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_es_phone_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("612 345 678", "phone_number", 54, 65, 0.87),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="es")
+        phones = [e for e in result.entities if "phone" in e.label.lower()]
+        assert len(phones) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_es_confidence_threshold(self, mock_analyze):
+        text = "Paciente Carlos López"
+        mock_analyze.return_value = _make_result(text, [
+            _ent("Carlos López", "first_name", 10, 22, 0.85),
+        ])
+        result = extract_pii(text, use_smart_merging=False, lang="es", confidence_threshold=0.5)
+        assert len(result.entities) >= 1
+        assert all(e.confidence >= 0.5 for e in result.entities)
+
+
+# ---------------------------------------------------------------------------
+# Dutch (nl)
+# ---------------------------------------------------------------------------
+
+
+class TestDutchRegression:
+
+    CLINICAL_NOTE = "Patiënt Jan de Vries, geb. 15-05-1990, tel. 020 1234567, BSN 123456789."
+
+    @patch("openmed.analyze_text")
+    def test_nl_name_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("Jan de Vries", "first_name", 9, 21, 0.89),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="nl")
+        names = [e for e in result.entities if "name" in e.label.lower()]
+        assert len(names) >= 1
+        assert "Jan" in names[0].text
+
+    @patch("openmed.analyze_text")
+    def test_nl_date_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("15-05-1990", "date_of_birth", 27, 37, 0.87),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="nl")
+        dates = [e for e in result.entities if "date" in e.label.lower()]
+        assert len(dates) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_nl_phone_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("020 1234567", "phone_number", 44, 55, 0.86),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="nl")
+        phones = [e for e in result.entities if "phone" in e.label.lower()]
+        assert len(phones) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Hindi (hi)
+# ---------------------------------------------------------------------------
+
+
+class TestHindiRegression:
+
+    CLINICAL_NOTE = "रोगी राज कुमार, जन्म 15/05/1990, फोन 9876543210, आधार 1234 5678 9012."
+
+    @patch("openmed.analyze_text")
+    def test_hi_name_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("राज कुमार", "first_name", 5, 14, 0.88),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="hi")
+        names = [e for e in result.entities if "name" in e.label.lower()]
+        assert len(names) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_hi_date_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("15/05/1990", "date_of_birth", 22, 32, 0.86),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="hi")
+        dates = [e for e in result.entities if "date" in e.label.lower()]
+        assert len(dates) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_hi_phone_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("9876543210", "phone_number", 38, 48, 0.85),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="hi")
+        phones = [e for e in result.entities if "phone" in e.label.lower()]
+        assert len(phones) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_hi_smart_merging_boundaries(self, mock_analyze):
+        text = "रोगी राज कुमार ने दौरा किया"
+        mock_analyze.return_value = _make_result(text, [
+            _ent("राज", "first_name", 5, 8, 0.87),
+            _ent("कुमार", "last_name", 9, 14, 0.85),
+        ])
+        result = extract_pii(text, use_smart_merging=True, lang="hi")
+        for e in result.entities:
+            if e.start is not None and e.end is not None:
+                assert e.start < e.end
+                assert e.end <= len(text)
+
+
+# ---------------------------------------------------------------------------
+# Telugu (te)
+# ---------------------------------------------------------------------------
+
+
+class TestTeluguRegression:
+
+    CLINICAL_NOTE = "రోగి రాజు కుమార్, పుట్టిన తేదీ 15/05/1990, ఫోన్ 9876543210."
+
+    @patch("openmed.analyze_text")
+    def test_te_name_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("రాజు కుమార్", "first_name", 5, 16, 0.86),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="te")
+        names = [e for e in result.entities if "name" in e.label.lower()]
+        assert len(names) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_te_date_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("15/05/1990", "date_of_birth", 31, 41, 0.84),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="te")
+        dates = [e for e in result.entities if "date" in e.label.lower()]
+        assert len(dates) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_te_phone_detection(self, mock_analyze):
+        mock_analyze.return_value = _make_result(self.CLINICAL_NOTE, [
+            _ent("9876543210", "phone_number", 47, 57, 0.83),
+        ])
+        result = extract_pii(self.CLINICAL_NOTE, use_smart_merging=False, lang="te")
+        phones = [e for e in result.entities if "phone" in e.label.lower()]
+        assert len(phones) >= 1
+
+    @patch("openmed.analyze_text")
+    def test_te_confidence_above_threshold(self, mock_analyze):
+        text = "రోగి రాజు"
+        mock_analyze.return_value = _make_result(text, [
+            _ent("రాజు", "first_name", 5, 9, 0.80),
+        ])
+        result = extract_pii(text, use_smart_merging=False, lang="te", confidence_threshold=0.5)
+        assert len(result.entities) >= 1
+        assert all(e.confidence >= 0.5 for e in result.entities)

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -1,0 +1,228 @@
+"""Unit tests for span-boundary quality gates."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from openmed.core.quality_gates import (
+    SpanValidationWarning,
+    detect_overlapping_entities,
+    validate_entity_spans,
+)
+from openmed.processing.outputs import EntityPrediction
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ent(text, label="NAME", start=0, end=None, confidence=0.9):
+    if end is None:
+        end = start + len(text)
+    return EntityPrediction(
+        text=text, label=label, start=start, end=end, confidence=confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# validate_entity_spans
+# ---------------------------------------------------------------------------
+
+
+class TestValidateEntitySpans:
+    """Tests for validate_entity_spans."""
+
+    def test_valid_entities_no_warnings(self):
+        text = "Patient John Doe visited the clinic"
+        entities = [_ent("John Doe", start=8, end=16)]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = validate_entity_spans(entities, text)
+            assert len(w) == 0
+        assert result is entities  # returns same list
+        assert entities[0].metadata["span_valid"] is True
+
+    def test_inverted_span_warns(self):
+        text = "Hello world"
+        entities = [_ent("lo", start=5, end=3)]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_entity_spans(entities, text)
+            assert any(issubclass(x.category, SpanValidationWarning) for x in w)
+        assert entities[0].metadata["span_valid"] is False
+
+    def test_zero_length_span_warns(self):
+        text = "Hello world"
+        entities = [_ent("", start=3, end=3)]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_entity_spans(entities, text)
+            span_warns = [x for x in w if issubclass(x.category, SpanValidationWarning)]
+            assert len(span_warns) >= 1
+        assert entities[0].metadata["span_valid"] is False
+
+    def test_negative_start_warns(self):
+        text = "Hello"
+        entities = [_ent("He", start=-1, end=2)]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_entity_spans(entities, text)
+            assert any(issubclass(x.category, SpanValidationWarning) for x in w)
+        assert entities[0].metadata["span_valid"] is False
+
+    def test_end_exceeds_text_length_warns(self):
+        text = "Hi"
+        entities = [_ent("Hi!", start=0, end=5)]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_entity_spans(entities, text)
+            assert any(issubclass(x.category, SpanValidationWarning) for x in w)
+        assert entities[0].metadata["span_valid"] is False
+
+    def test_text_mismatch_warns(self):
+        text = "Patient John Doe visited"
+        # Entity claims text is "Jane Doe" but span points to "John Doe"
+        entities = [EntityPrediction(
+            text="Jane Doe", label="NAME", start=8, end=16, confidence=0.9,
+        )]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_entity_spans(entities, text)
+            span_warns = [x for x in w if issubclass(x.category, SpanValidationWarning)]
+            assert len(span_warns) == 1
+            assert "text mismatch" in str(span_warns[0].message)
+        assert entities[0].metadata["span_valid"] is False
+
+    def test_entities_without_offsets_skipped(self):
+        text = "Hello"
+        entities = [EntityPrediction(
+            text="Hello", label="GREETING", confidence=0.9,
+        )]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_entity_spans(entities, text)
+            assert len(w) == 0
+        # No metadata added for offset-less entities
+        assert entities[0].metadata is None
+
+    def test_multiple_entities_mixed_validity(self):
+        text = "John Doe 555-1234"
+        entities = [
+            _ent("John Doe", start=0, end=8),
+            _ent("wrong", start=9, end=17),  # text mismatch
+        ]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_entity_spans(entities, text)
+            assert len([x for x in w if issubclass(x.category, SpanValidationWarning)]) == 1
+        assert entities[0].metadata["span_valid"] is True
+        assert entities[1].metadata["span_valid"] is False
+
+    def test_preserves_existing_metadata(self):
+        text = "John"
+        entities = [EntityPrediction(
+            text="John", label="NAME", start=0, end=4, confidence=0.9,
+            metadata={"source": "model"},
+        )]
+        validate_entity_spans(entities, text)
+        assert entities[0].metadata["source"] == "model"
+        assert entities[0].metadata["span_valid"] is True
+
+
+# ---------------------------------------------------------------------------
+# detect_overlapping_entities
+# ---------------------------------------------------------------------------
+
+
+class TestDetectOverlappingEntities:
+    """Tests for detect_overlapping_entities."""
+
+    def test_no_overlaps(self):
+        entities = [
+            _ent("John", start=0, end=4),
+            _ent("Doe", start=5, end=8),
+        ]
+        assert detect_overlapping_entities(entities) == []
+
+    def test_adjacent_entities_no_overlap(self):
+        entities = [
+            _ent("John", start=0, end=4),
+            _ent(" Doe", start=4, end=8),
+        ]
+        assert detect_overlapping_entities(entities) == []
+
+    def test_simple_overlap(self):
+        entities = [
+            _ent("John D", start=0, end=6),
+            _ent("Doe", start=5, end=8),
+        ]
+        overlaps = detect_overlapping_entities(entities)
+        assert len(overlaps) == 1
+        assert overlaps[0][0].text == "John D"
+        assert overlaps[0][1].text == "Doe"
+
+    def test_nested_entity(self):
+        entities = [
+            _ent("John Doe", start=0, end=8),
+            _ent("Doe", start=5, end=8),
+        ]
+        overlaps = detect_overlapping_entities(entities)
+        assert len(overlaps) == 1
+
+    def test_multiple_overlaps(self):
+        entities = [
+            _ent("AAAA", start=0, end=4),
+            _ent("AABB", start=2, end=6),
+            _ent("BBCC", start=4, end=8),
+        ]
+        overlaps = detect_overlapping_entities(entities)
+        # A overlaps B, B overlaps C
+        assert len(overlaps) == 2
+
+    def test_entities_without_offsets_skipped(self):
+        entities = [
+            EntityPrediction(text="John", label="NAME", confidence=0.9),
+            _ent("Doe", start=5, end=8),
+        ]
+        assert detect_overlapping_entities(entities) == []
+
+    def test_unordered_input_still_works(self):
+        entities = [
+            _ent("Doe", start=5, end=8),
+            _ent("John D", start=0, end=6),
+        ]
+        overlaps = detect_overlapping_entities(entities)
+        assert len(overlaps) == 1
+
+    def test_empty_list(self):
+        assert detect_overlapping_entities([]) == []
+
+    def test_single_entity(self):
+        assert detect_overlapping_entities([_ent("John", start=0, end=4)]) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: _fix_entity_spans output
+# ---------------------------------------------------------------------------
+
+
+class TestIntegrationWithFixEntitySpans:
+    """Verify guards work on output of _fix_entity_spans."""
+
+    def test_fix_entity_spans_output_passes_validation(self):
+        from openmed.processing.outputs import OutputFormatter
+        text = "Patient John visited on 2024-01-15"
+        entities = [
+            EntityPrediction(
+                text="Joh", label="NAME", start=8, end=11, confidence=0.9,
+            ),
+        ]
+        fixed = OutputFormatter._fix_entity_spans(entities, text)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_entity_spans(fixed, text)
+            span_warns = [x for x in w if issubclass(x.category, SpanValidationWarning)]
+            assert len(span_warns) == 0
+        assert all(e.metadata.get("span_valid") for e in fixed)


### PR DESCRIPTION
## Summary
- Add span-boundary quality gates (`validate_entity_spans`, `detect_overlapping_entities`) integrated into `OutputFormatter` and `extract_pii()` pipelines as warn-only guards
- Add multilingual PII regression test suite covering all 8 languages (en, fr, de, it, es, nl, hi, te) with 31 golden-input test cases
- Add label-map consistency tests validating `defaults.json` invariants, `normalize_label()` idempotency, specificity hierarchy, and model registry entity_types
- Bump version to 0.6.3, update CHANGELOG, README, and website

## Test plan
- [x] `pytest tests/unit/test_quality_gates.py -v` — 19 tests pass
- [x] `pytest tests/unit/test_pii_multilingual_regression.py -v` — 31 tests pass
- [x] `pytest tests/unit/ner/test_label_map_consistency.py -v` — 32 tests pass
- [x] `pytest tests/ -q` — 600 passed, 2 skipped, 0 failures
- [x] `python3 -m build` — builds as openmed-0.6.3