### PR TITLE
Add anonymization, Studio, and Nemotron privacy-filter support

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "privacy-filter-studio",
+      "runtimeExecutable": ".venv/bin/python",
+      "runtimeArgs": [
+        "-m",
+        "uvicorn",
+        "examples.privacy_filter_studio.app:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8770"
+      ],
+      "port": 8770
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation**: new [Anonymization Guide](docs/anonymization.md) covering the Faker engine, locale table, determinism modes, format preservation, clinical-ID checksum sources, and the privacy-filter family.
 - **Examples**:
   - `examples/obfuscation_demo.py` — random vs deterministic surrogates, locale walkthrough, format-preserving phone numbers, pt_BR CPF generation with checksum verification.
-  - `examples/privacy_filter_unified.py` — same `extract_pii()` / `deidentify()` call works on Apple Silicon (MLX) and Linux (PyTorch).
+  - `examples/privacy_filter_unified.py` — same `extract_pii()` / `deidentify()` call works on Apple Silicon (MLX) and Linux (PyTorch); compares the OpenAI baseline against the Nemotron-PII fine-tune side-by-side.
+- **Nemotron-PII fine-tune of the OpenAI Privacy Filter**, registered as three new model IDs that route through the existing privacy-filter pipeline (same architecture, different training data):
+  - `OpenMed/privacy-filter-nemotron` — PyTorch / Transformers (CPU + CUDA).
+  - `OpenMed/privacy-filter-nemotron-mlx` — MLX full-precision (Apple Silicon).
+  - `OpenMed/privacy-filter-nemotron-mlx-8bit` — MLX 8-bit quantized (Apple Silicon).
+  These checkpoints **are** the OpenAI Privacy Filter architecture (gpt-oss-style sparse-MoE transformer with local attention, sink tokens, RoPE+YaRN, tiktoken `o200k_base`) fine-tuned on the [Nemotron PII dataset](https://huggingface.co/datasets/nvidia/Nemotron-PII-v1). They reuse `OpenAIPrivacyFilterForTokenClassification` and `PrivacyFilterMLXPipeline` unchanged — no new architecture code needed.
+- **`_MLX_MODEL_MAP` entries** for the two new Nemotron MLX repo IDs in `openmed.mlx.inference`.
+- **Aliases for the new family in `_SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES`** (`privacy-filter-nemotron`, `nemotron-privacy-filter`) — both resolve to the existing `openai-privacy-filter` family so a Nemotron-fine-tune MLX artifact can ship with either family identifier in its manifest and still dispatch correctly.
+- **Family-aware Torch fallback** in `openmed.core.backends`:
+  - New `_TORCH_FALLBACK_BY_FAMILY` table and `_torch_fallback_for()` helper.
+  - An MLX-only Nemotron request on a non-Apple-Silicon host now substitutes `OpenMed/privacy-filter-nemotron` instead of the unrelated default `openai/privacy-filter`, so the user gets the training distribution they asked for. A one-time `UserWarning` names the substitute.
+  - Adding a future fine-tune that should fall back to its own PyTorch repo is a one-line addition to `_TORCH_FALLBACK_BY_FAMILY`.
 
 ### Changed
 
@@ -51,8 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
-- 187 new tests across `tests/unit/core/test_labels.py` (102), `tests/unit/core/test_anonymizer.py` (171, includes per-locale checksum validation across 100s of generated IDs), `tests/unit/test_privacy_filter_routing.py` (13), and Portuguese obfuscation regressions in `tests/unit/test_pii_multilingual_regression.py` (3).
-- Full suite: 1074 passing (up from 887 in 1.2.0), 1 skipped.
+- New tests across `tests/unit/core/test_labels.py` (102), `tests/unit/core/test_anonymizer.py` (171, includes per-locale checksum validation across 100s of generated IDs), `tests/unit/test_privacy_filter_routing.py` (22 — backend selection, family-aware Torch fallback, dispatch, integration), Nemotron parametrisation of the existing privacy-filter MLX dispatch test (`tests/unit/mlx/test_privacy_filter_mlx.py::test_dispatches_privacy_filter_pipeline`), and Portuguese obfuscation regressions in `tests/unit/test_pii_multilingual_regression.py` (3).
+- Focused privacy/anonymization suite: 458 passed, 6 skipped, 11 pre-existing span-validation warnings.
 
 ## [1.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Examples**:
   - `examples/obfuscation_demo.py` — random vs deterministic surrogates, locale walkthrough, format-preserving phone numbers, pt_BR CPF generation with checksum verification.
   - `examples/privacy_filter_unified.py` — same `extract_pii()` / `deidentify()` call works on Apple Silicon (MLX) and Linux (PyTorch); compares the OpenAI baseline against the Nemotron-PII fine-tune side-by-side.
+  - `examples/privacy_filter_studio/` — interactive FastAPI + static web studio for two-pane PII masking/randomization with sample clinical notes, highlighted entities, backend/model status, and an explicit first-run download toggle.
 - **Nemotron-PII fine-tune of the OpenAI Privacy Filter**, registered as three new model IDs that route through the existing privacy-filter pipeline (same architecture, different training data):
   - `OpenMed/privacy-filter-nemotron` — PyTorch / Transformers (CPU + CUDA).
   - `OpenMed/privacy-filter-nemotron-mlx` — MLX full-precision (Apple Silicon).
@@ -47,12 +48,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New `_TORCH_FALLBACK_BY_FAMILY` table and `_torch_fallback_for()` helper.
   - An MLX-only Nemotron request on a non-Apple-Silicon host now substitutes `OpenMed/privacy-filter-nemotron` instead of the unrelated default `openai/privacy-filter`, so the user gets the training distribution they asked for. A one-time `UserWarning` names the substitute.
   - Adding a future fine-tune that should fall back to its own PyTorch repo is a one-line addition to `_TORCH_FALLBACK_BY_FAMILY`.
+- **Nemotron MLX classifier-head bias support**: `OpenAIPrivacyFilterForTokenClassification` now honors `classifier_bias` / `unembedding_bias` in artifact configs, while keeping the original OpenAI checkpoint bias-less by default.
 
 ### Changed
 
 - **`method="replace"` upgraded in place** to use the new Faker-backed `Anonymizer`. Surrogates are now locale-aware (e.g. German names for `lang="de"`, Portuguese phones for `lang="pt"`), format-preserving, and optionally deterministic. The previous tiny static `LANGUAGE_FAKE_DATA` lists are kept as a deprecated fallback used only when a Faker locale is unavailable.
 - **Privacy filter book demo** (`examples/privacy_filter_book/app.py`) migrated to `PrivacyFilterTorchPipeline` for the CPU side, replacing the inline `AutoTokenizer`/`AutoModelForTokenClassification`/`pipeline` triple.
 - **MLX inference module** trimmed: BIOES Viterbi (≈280 lines) and span-refinement helpers moved to `openmed.core.decoding`. Behavior unchanged.
+- **Privacy Filter Studio** keeps model loading cache-only unless downloads are explicitly allowed, then restores the caller's Hugging Face offline environment after loading.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-27
+
+### Added
+
+- **Faker-backed PII anonymization engine** (`openmed.core.anonymizer`):
+  - `Anonymizer` class with cached per-locale Faker instances, deterministic seeding (`hashlib.blake2b`), and label-keyed generator dispatch.
+  - `AnonymizerConfig` dataclass for advanced configuration.
+  - Locale resolution map (`LANG_TO_LOCALE`) covering all nine OpenMed languages; Telugu falls back to `en_IN` with a one-time `UserWarning`.
+  - Format-preserving helpers for phone numbers (digit-group lengths preserved), dates (separator/ordering preserved), emails (domain preserved), and generic IDs.
+  - Custom Faker providers for clinical/national IDs where Faker's built-ins are missing or incorrect: `AadhaarProvider` (Verhoeff checksum), `GermanSteuerIdProvider`, `MedicalRecordNumberProvider`, `NPIProvider`. Faker's built-ins are reused for `pt_BR.cpf`/`cnpj`, `nl_NL.ssn` (BSN), `fr_FR.ssn` (NIR), `it_IT.ssn` (Codice Fiscale), and `es_ES.nie` after empirical verification against OpenMed's existing checksum validators.
+  - `register_clinical_provider()` and `register_label_generator()` for extending coverage.
+- **Canonical PII label taxonomy** (`openmed.core.labels`):
+  - `CANONICAL_LABELS` set with 47 canonical labels in `UPPER_SNAKE_CASE`.
+  - `normalize_label()` maps English lowercase, the 52 Portuguese UPPERCASE labels, BIOES-tagged variants (`B-NAME`, `I-DATE`), and arbitrary mixed-case forms to a single canonical form.
+- **Unified privacy-filter dispatch** (`openmed.core.backends`):
+  - `select_privacy_filter_backend()`, `resolve_privacy_filter_model()`, and `create_privacy_filter_pipeline()` route privacy-filter requests to MLX on Apple Silicon and PyTorch elsewhere with a one-time `UserWarning` when an MLX-only artifact name (`OpenMed/privacy-filter-mlx*`) is substituted with `openai/privacy-filter` on non-Mac hosts.
+  - `extract_pii()` and `deidentify()` now route privacy-filter models through this dispatcher, skipping regex smart-merging since the model already does Viterbi-constrained BIOES decoding.
+- **PyTorch privacy-filter wrapper** (`openmed.torch.PrivacyFilterTorchPipeline`):
+  - Loads `openai/privacy-filter` (or any compatible HuggingFace fine-tune) via `transformers.AutoModelForTokenClassification` with auto device selection (CUDA → CPU).
+  - Output entity-dict shape matches the MLX pipeline so the rest of OpenMed is backend-agnostic.
+- **Shared decoding utilities** (`openmed.core.decoding`):
+  - `TokenLabelInfo`, `build_label_info`, `viterbi_decode`, `labels_to_token_spans`, `zero_viterbi_biases`, `VITERBI_BIAS_KEYS` extracted from the MLX pipeline so the Torch wrapper reuses the same BIOES Viterbi decoder.
+  - `trim_span_whitespace`, `refine_privacy_filter_span` for span post-processing across both backends.
+- **`deidentify()` keyword arguments**: `consistent: bool`, `seed: Optional[int]`, `locale: Optional[str]` for deterministic, locale-overridable obfuscation. Passing `seed=` alone implies `consistent=True`.
+- **Portuguese (`pt`) accepted by REST API schemas** in `openmed/service/schemas.py` (was previously library-only despite full core support).
+- **Documentation**: new [Anonymization Guide](docs/anonymization.md) covering the Faker engine, locale table, determinism modes, format preservation, clinical-ID checksum sources, and the privacy-filter family.
+- **Examples**:
+  - `examples/obfuscation_demo.py` — random vs deterministic surrogates, locale walkthrough, format-preserving phone numbers, pt_BR CPF generation with checksum verification.
+  - `examples/privacy_filter_unified.py` — same `extract_pii()` / `deidentify()` call works on Apple Silicon (MLX) and Linux (PyTorch).
+
+### Changed
+
+- **`method="replace"` upgraded in place** to use the new Faker-backed `Anonymizer`. Surrogates are now locale-aware (e.g. German names for `lang="de"`, Portuguese phones for `lang="pt"`), format-preserving, and optionally deterministic. The previous tiny static `LANGUAGE_FAKE_DATA` lists are kept as a deprecated fallback used only when a Faker locale is unavailable.
+- **Privacy filter book demo** (`examples/privacy_filter_book/app.py`) migrated to `PrivacyFilterTorchPipeline` for the CPU side, replacing the inline `AutoTokenizer`/`AutoModelForTokenClassification`/`pipeline` triple.
+- **MLX inference module** trimmed: BIOES Viterbi (≈280 lines) and span-refinement helpers moved to `openmed.core.decoding`. Behavior unchanged.
+
+### Breaking Changes
+
+- **`faker>=22.0` is now a required core dependency**. Slim installs that skip the ML extras will still pull Faker (~3 MB).
+- **`method="replace"` outputs no longer come from the prior hardcoded list** (`["Jane Smith", "John Doe", "Alex Johnson", "Sam Taylor"]`, etc.). Any test or downstream code asserting on those exact strings must either pass `consistent=True, seed=<value>` and update expected output, or assert non-equality with the original. All other methods (`mask`, `remove`, `hash`, `shift_dates`) are unchanged.
+- **Privacy-filter routing through `extract_pii()`** skips regex smart-merging by design. Users who previously chained the low-level MLX pipeline with `merge_entities_with_semantic_units()` manually may see different entity counts; the new path produces cleaner spans because the model's Viterbi decoder already enforces BIOES validity.
+
+### Tests
+
+- 187 new tests across `tests/unit/core/test_labels.py` (102), `tests/unit/core/test_anonymizer.py` (171, includes per-locale checksum validation across 100s of generated IDs), `tests/unit/test_privacy_filter_routing.py` (13), and Portuguese obfuscation regressions in `tests/unit/test_pii_multilingual_regression.py` (3).
+- Full suite: 1074 passing (up from 887 in 1.2.0), 1 skipped.
+
 ## [1.2.0] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - An MLX-only Nemotron request on a non-Apple-Silicon host now substitutes `OpenMed/privacy-filter-nemotron` instead of the unrelated default `openai/privacy-filter`, so the user gets the training distribution they asked for. A one-time `UserWarning` names the substitute.
   - Adding a future fine-tune that should fall back to its own PyTorch repo is a one-line addition to `_TORCH_FALLBACK_BY_FAMILY`.
 - **Nemotron MLX classifier-head bias support**: `OpenAIPrivacyFilterForTokenClassification` now honors `classifier_bias` / `unembedding_bias` in artifact configs, while keeping the original OpenAI checkpoint bias-less by default.
+- **Swift OpenMedKit privacy-filter classifier-head bias support**: the native MLX artifact loader now decodes `classifier_bias` / `unembedding_bias` and builds the Privacy Filter head with a learned bias when Nemotron-PII artifacts require it.
 
 ### Changed
 
@@ -56,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Privacy filter book demo** (`examples/privacy_filter_book/app.py`) migrated to `PrivacyFilterTorchPipeline` for the CPU side, replacing the inline `AutoTokenizer`/`AutoModelForTokenClassification`/`pipeline` triple.
 - **MLX inference module** trimmed: BIOES Viterbi (≈280 lines) and span-refinement helpers moved to `openmed.core.decoding`. Behavior unchanged.
 - **Privacy Filter Studio** keeps model loading cache-only unless downloads are explicitly allowed, then restores the caller's Hugging Face offline environment after loading.
+- **OpenMed Scan Demo privacy-filter option** now points at `OpenMed/privacy-filter-nemotron-mlx-8bit` and labels the engine as OpenAI Nemotron Privacy Filter throughout the picker, download events, and README.
 
 ### Breaking Changes
 
@@ -66,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 
 - New tests across `tests/unit/core/test_labels.py` (102), `tests/unit/core/test_anonymizer.py` (171, includes per-locale checksum validation across 100s of generated IDs), `tests/unit/test_privacy_filter_routing.py` (22 — backend selection, family-aware Torch fallback, dispatch, integration), Nemotron parametrisation of the existing privacy-filter MLX dispatch test (`tests/unit/mlx/test_privacy_filter_mlx.py::test_dispatches_privacy_filter_pipeline`), and Portuguese obfuscation regressions in `tests/unit/test_pii_multilingual_regression.py` (3).
+- Swift OpenMedKit coverage for `classifier_bias` / `unembedding_bias` config decoding, Nemotron-biased Privacy Filter forward shape, and the baseline bias-less head.
 - Focused privacy/anonymization suite: 458 passed, 6 skipped, 11 pre-existing span-validation warnings.
 
 ## [1.2.0] - 2026-04-24

--- a/README.md
+++ b/README.md
@@ -243,16 +243,25 @@ result = extract_pii(
 # De-identify with multiple methods
 masked = deidentify(text, method="mask")        # [NAME], [DATE]
 removed = deidentify(text, method="remove")     # Complete removal
-replaced = deidentify(text, method="replace")   # Synthetic data
+replaced = deidentify(text, method="replace")   # Faker-backed locale-aware fakes
 hashed = deidentify(text, method="hash")        # Cryptographic hashing
 shifted = deidentify(text, method="shift_dates", date_shift_days=180)
+
+# Deterministic obfuscation: same input -> same surrogate within doc
+deidentify(text, method="replace", lang="pt", locale="pt_BR",
+           consistent=True, seed=42)
+
+# Privacy filter family (auto MLX on Apple Silicon, PyTorch elsewhere)
+deidentify(text, model_name="OpenMed/privacy-filter-mlx-8bit", method="mask")
 ```
 
 **Smart Entity Merging** (NEW in v0.5.0): Fixes tokenization fragmentation by merging split entities like dates (`01/15/1970` instead of `01` + `/15/1970`), ensuring production-ready de-identification.
 
+**Faker-backed obfuscation** (`feature/obfuscation-pii`): `method="replace"` now uses [Faker](https://faker.readthedocs.io/) with custom providers for clinical IDs (CPF, CNPJ, BSN, NIR, Codice Fiscale, NIE, Aadhaar, Steuer-ID, NPI). Surrogates are locale-aware, format-preserving, and optionally deterministic. See [Anonymization Guide](docs/anonymization.md).
+
 **HIPAA Compliance**: Covers all 18 Safe Harbor identifiers with configurable confidence thresholds.
 
-[📓 Complete PII Notebook](examples/notebooks/PII_Detection_Complete_Guide.ipynb) | [📖 Documentation](docs/pii-smart-merging.md)
+[📓 Complete PII Notebook](examples/notebooks/PII_Detection_Complete_Guide.ipynb) | [📖 Smart Merging](docs/pii-smart-merging.md) | [📖 Anonymization](docs/anonymization.md)
 
 ### Multilingual PII (9 Languages)
 

--- a/README.md
+++ b/README.md
@@ -250,18 +250,89 @@ shifted = deidentify(text, method="shift_dates", date_shift_days=180)
 # Deterministic obfuscation: same input -> same surrogate within doc
 deidentify(text, method="replace", lang="pt", locale="pt_BR",
            consistent=True, seed=42)
-
-# Privacy filter family (auto MLX on Apple Silicon, PyTorch elsewhere)
-deidentify(text, model_name="OpenMed/privacy-filter-mlx-8bit", method="mask")
 ```
 
 **Smart Entity Merging** (NEW in v0.5.0): Fixes tokenization fragmentation by merging split entities like dates (`01/15/1970` instead of `01` + `/15/1970`), ensuring production-ready de-identification.
 
-**Faker-backed obfuscation** (`feature/obfuscation-pii`): `method="replace"` now uses [Faker](https://faker.readthedocs.io/) with custom providers for clinical IDs (CPF, CNPJ, BSN, NIR, Codice Fiscale, NIE, Aadhaar, Steuer-ID, NPI). Surrogates are locale-aware, format-preserving, and optionally deterministic. See [Anonymization Guide](docs/anonymization.md).
+**Faker-backed obfuscation** (v1.3.0): `method="replace"` uses [Faker](https://faker.readthedocs.io/) with custom providers for clinical IDs (CPF, CNPJ, BSN, NIR, Codice Fiscale, NIE, Aadhaar, Steuer-ID, NPI). Surrogates are locale-aware, format-preserving, and optionally deterministic. See [Anonymization Guide](docs/anonymization.md).
 
 **HIPAA Compliance**: Covers all 18 Safe Harbor identifiers with configurable confidence thresholds.
 
 [📓 Complete PII Notebook](examples/notebooks/PII_Detection_Complete_Guide.ipynb) | [📖 Smart Merging](docs/pii-smart-merging.md) | [📖 Anonymization](docs/anonymization.md)
+
+### Privacy Filter Family (Public)
+
+OpenMed ships **two checkpoints** of the OpenAI Privacy Filter architecture — same model code (gpt-oss-style sparse-MoE transformer with local attention, sink tokens, RoPE+YaRN, tiktoken `o200k_base` tokenization), different training data:
+
+| Variant                | Trained on                                                                         | PyTorch (CPU + CUDA)                  | MLX full (Apple Silicon)                          | MLX 8-bit (Apple Silicon)                              |
+| ---------------------- | ---------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
+| OpenAI Privacy Filter  | OpenAI's PII training set                                                          | [`openai/privacy-filter`](https://huggingface.co/openai/privacy-filter)              | [`OpenMed/privacy-filter-mlx`](https://huggingface.co/OpenMed/privacy-filter-mlx)                | [`OpenMed/privacy-filter-mlx-8bit`](https://huggingface.co/OpenMed/privacy-filter-mlx-8bit)                |
+| Nemotron-PII fine-tune | [Nemotron PII dataset](https://huggingface.co/datasets/nvidia/Nemotron-PII-v1)     | [`OpenMed/privacy-filter-nemotron`](https://huggingface.co/OpenMed/privacy-filter-nemotron)     | [`OpenMed/privacy-filter-nemotron-mlx`](https://huggingface.co/OpenMed/privacy-filter-nemotron-mlx)       | [`OpenMed/privacy-filter-nemotron-mlx-8bit`](https://huggingface.co/OpenMed/privacy-filter-nemotron-mlx-8bit)       |
+
+All model IDs above route through the **same** `extract_pii()` / `deidentify()` API — only the `model_name=` argument changes.
+
+#### Install
+
+The PyTorch path runs anywhere (Linux, macOS, Windows; CPU or CUDA):
+
+```bash
+pip install "openmed[hf]"
+```
+
+The MLX path adds Apple Silicon acceleration on top of `[hf]`:
+
+```bash
+pip install "openmed[mlx]"          # MLX runtime + tiktoken + huggingface-hub
+```
+
+`tiktoken` (the OpenAI Privacy Filter tokenizer) ships in the `[mlx]` extra.
+
+#### Use it (PyTorch — Linux / Windows / non-Apple-Silicon macOS)
+
+```python
+from openmed import extract_pii, deidentify
+
+text = ("Patient Sarah Connor (DOB: 03/15/1985) at MRN 4471882. "
+        "Email: sarah.connor@example.com, phone (415) 555-7012.")
+
+# OpenAI baseline — runs on CPU/CUDA via Transformers
+result = extract_pii(text, model_name="openai/privacy-filter")
+
+# Nemotron-PII fine-tune — same code path, different weights
+result = extract_pii(text, model_name="OpenMed/privacy-filter-nemotron")
+
+# De-identify with any method
+deidentify(text, model_name="OpenMed/privacy-filter-nemotron", method="mask")
+deidentify(text, model_name="OpenMed/privacy-filter-nemotron",
+           method="replace", consistent=True, seed=42)
+```
+
+#### Use it (MLX — Apple Silicon)
+
+```python
+from openmed import extract_pii, deidentify
+
+text = "Patient Sarah Connor born on 03/15/1985, MRN 4471882."
+
+# OpenAI baseline (full / 8-bit MLX artifacts)
+extract_pii(text, model_name="OpenMed/privacy-filter-mlx")
+extract_pii(text, model_name="OpenMed/privacy-filter-mlx-8bit")
+
+# Nemotron-PII fine-tune (full / 8-bit MLX artifacts)
+extract_pii(text, model_name="OpenMed/privacy-filter-nemotron-mlx")
+extract_pii(text, model_name="OpenMed/privacy-filter-nemotron-mlx-8bit")
+```
+
+#### Cross-platform note
+
+The MLX artifact names work everywhere — on a non-Apple-Silicon host (or anywhere MLX isn't installed) the request is **automatically substituted** with the matching PyTorch model and a one-time `UserWarning` names the substitution. The substitution is **family-aware**:
+
+- `OpenMed/privacy-filter-mlx*` ⇒ falls back to `openai/privacy-filter`
+- `OpenMed/privacy-filter-nemotron-mlx*` ⇒ falls back to `OpenMed/privacy-filter-nemotron`
+
+So your code can ship an MLX model name and run on any host without changes — Apple Silicon users get MLX speed, everyone else gets the same family's PyTorch checkpoint.
+
+[📖 Privacy Filter Architecture & Backend Routing](docs/anonymization.md#privacy-filter-family) | [▶ Side-by-side example](examples/privacy_filter_unified.py) | [▶ Faker obfuscation demo](examples/obfuscation_demo.py)
 
 ### Multilingual PII (9 Languages)
 
@@ -360,6 +431,18 @@ print(profiler.summary())  # Inference time, bottlenecks, recommendations
 We welcome contributions! Whether it's bug reports, feature requests, or pull requests.
 
 - 🐛 **Found a bug?** [Open an issue](https://github.com/maziyarpanahi/openmed/issues)
+
+---
+
+## Credits & Acknowledgements
+
+OpenMed builds on excellent open-source work from the community. Particular thanks to:
+
+- **OpenAI** for open-sourcing the [Privacy Filter](https://huggingface.co/openai/privacy-filter) model. The OpenAI Privacy Filter architecture (gpt-oss-style sparse-MoE transformer with local attention, sink tokens, RoPE+YaRN, tiktoken `o200k_base` tokenization) is the foundation of OpenMed's privacy-filter family — both the upstream baseline and our Nemotron-PII fine-tunes share this architecture.
+- **NVIDIA** for releasing the [Nemotron PII dataset](https://huggingface.co/datasets/nvidia/Nemotron-PII-v1), which we used to fine-tune the OpenAI Privacy Filter weights into the [`OpenMed/privacy-filter-nemotron`](https://huggingface.co/OpenMed/privacy-filter-nemotron) family ([MLX](https://huggingface.co/OpenMed/privacy-filter-nemotron-mlx), [MLX 8-bit](https://huggingface.co/OpenMed/privacy-filter-nemotron-mlx-8bit)).
+- **HuggingFace** for `transformers`, `tokenizers`, `huggingface_hub`, and the broader model-distribution ecosystem.
+- **Apple** for [MLX](https://github.com/ml-explore/mlx), which powers OpenMed's Apple Silicon acceleration.
+- **The Faker maintainers** for [Faker](https://faker.readthedocs.io/) and its community-contributed locale providers, which power OpenMed's locale-aware obfuscation engine.
 
 ---
 

--- a/docs/anonymization.md
+++ b/docs/anonymization.md
@@ -1,0 +1,160 @@
+# PII Anonymization
+
+OpenMed's `deidentify()` API supports five redaction methods for detected
+PII entities:
+
+| Method        | Output                                  | Use when                                 |
+| ------------- | --------------------------------------- | ---------------------------------------- |
+| `mask`        | `[NAME]`, `[EMAIL]`, …                  | You want clear placeholders.             |
+| `remove`      | `""` (deleted)                          | You don't need positional alignment.     |
+| `replace`     | Locale-aware fake surrogates            | You need realistic-looking text.         |
+| `hash`        | `NAME_a1b2c3d4` (entity-typed digest)   | You need consistent linking across docs. |
+| `shift_dates` | Dates only — shifted by N days          | You want to preserve relative time.      |
+
+This document focuses on `replace`, which was upgraded in the
+`feature/obfuscation-pii` line to a full Faker-backed obfuscation engine.
+
+## The new `replace` engine
+
+`method="replace"` no longer picks from a small hardcoded list. It builds
+a per-document `Anonymizer` (see [`openmed.core.anonymizer`](../openmed/core/anonymizer))
+that delegates to [Faker](https://faker.readthedocs.io/) with custom
+providers for clinical IDs.
+
+```python
+from openmed import deidentify
+
+deidentify(
+    "Paciente Pedro Almeida, CPF: 123.456.789-09",
+    method="replace",
+    lang="pt",
+    locale="pt_BR",          # default for pt is pt_PT; override per call
+    consistent=True,         # same input -> same surrogate within doc
+    seed=42,                 # cross-run reproducibility
+)
+```
+
+### Locale resolution
+
+`lang` (an ISO 639-1 code OpenMed uses everywhere) maps to a Faker
+locale via `LANG_TO_LOCALE`:
+
+| OpenMed `lang` | Faker locale | Notes                                                    |
+| -------------- | ------------ | -------------------------------------------------------- |
+| `en`           | `en_US`      |                                                          |
+| `fr`           | `fr_FR`      |                                                          |
+| `de`           | `de_DE`      |                                                          |
+| `it`           | `it_IT`      |                                                          |
+| `es`           | `es_ES`      |                                                          |
+| `nl`           | `nl_NL`      |                                                          |
+| `hi`           | `hi_IN`      |                                                          |
+| `te`           | `en_IN`      | Faker has no Telugu locale — emits a one-time warning.   |
+| `pt`           | `pt_PT`      | Override with `locale="pt_BR"` for Brazilian Portuguese. |
+
+Pass `locale=` explicitly to override per call (e.g. `pt_BR` to generate
+CPF/CNPJ surrogates instead of Portuguese NIF/VAT).
+
+### Determinism
+
+Three modes:
+
+- **Random** (default). Every call samples fresh surrogates. Good for
+  audits or when you want visible variability.
+- **`consistent=True`**. Same `(canonical_label, original_value)` pair
+  resolves to the same surrogate within the call. "John Doe" appearing
+  twice in one document gets one surrogate.
+- **`seed=<int>`** (implies `consistent=True`). Same seed across runs
+  produces the same surrogate stream — useful for snapshot tests and
+  regression fixtures.
+
+Determinism uses `hashlib.blake2b` over `(seed, canonical_label, original)`,
+so different originals always get different surrogates.
+
+### Format preservation
+
+Phone numbers, dates, and emails preserve the structure of the original:
+
+```python
+deidentify("Call (415) 555-1234", method="replace", consistent=True, seed=1)
+#  -> "Call (XXX) XXX-XXXX"  (digit groups, separators, country code position)
+
+deidentify("Born 01/15/1970", method="replace", consistent=True, seed=1)
+#  -> "Born MM/DD/YYYY"      (separator and ordering kept)
+
+deidentify("Email: john@hospital.org", method="replace", lang="en")
+#  -> "Email: alice@hospital.org"  (domain kept, local part faked)
+```
+
+### Clinical ID checksums
+
+OpenMed reuses the existing checksum validators in
+[`openmed.core.pii_i18n`](../openmed/core/pii_i18n.py) so every surrogate
+ID passes the same validator that detection uses:
+
+| Locale  | ID type             | Provider                                               |
+| ------- | ------------------- | ------------------------------------------------------ |
+| `pt_BR` | CPF                 | Faker built-in (`pt_BR.cpf`)                           |
+| `pt_BR` | CNPJ                | Faker built-in (`pt_BR.cnpj`)                          |
+| `nl_NL` | BSN (Elfproef)      | Faker built-in (`nl_NL.ssn`)                           |
+| `fr_FR` | NIR                 | Faker built-in (`fr_FR.ssn`)                           |
+| `it_IT` | Codice Fiscale      | Faker built-in (`it_IT.ssn`)                           |
+| `es_ES` | NIE                 | Faker built-in (`es_ES.nie`)                           |
+| `en_IN` | Aadhaar (Verhoeff)  | OpenMed `AadhaarProvider` (Faker's built-in is invalid) |
+| `de_DE` | Steuer-ID           | OpenMed `GermanSteuerIdProvider` (Faker's `de_DE.ssn` is US-style) |
+| any     | NPI (Luhn over 80840) | OpenMed `NPIProvider`                                 |
+| any     | Generic MRN         | OpenMed `MedicalRecordNumberProvider`                  |
+
+### Extending
+
+```python
+from openmed import register_clinical_provider, register_label_generator
+from faker.providers import BaseProvider
+
+# Add your own checksum-bearing ID format
+class HospitalAccountProvider(BaseProvider):
+    def hospital_account(self):
+        return f"HACC-{self.numerify('########')}"
+
+register_clinical_provider(HospitalAccountProvider)
+
+# Override the generator for a canonical label
+def my_first_name(faker, original, *, locale):
+    return faker.first_name() + "-test"
+
+register_label_generator("FIRST_NAME", my_first_name)
+```
+
+## Privacy-filter family
+
+The MLX-only artifacts `OpenMed/privacy-filter-mlx` and
+`OpenMed/privacy-filter-mlx-8bit` route through `extract_pii()` /
+`deidentify()` like any other model:
+
+```python
+extract_pii(text, model_name="OpenMed/privacy-filter-mlx-8bit")
+deidentify(text, model_name="OpenMed/privacy-filter-mlx-8bit",
+           method="replace", consistent=True, seed=42)
+```
+
+On Apple Silicon with MLX importable, this runs the MLX pipeline.
+Elsewhere, the call substitutes `openai/privacy-filter` via
+`transformers` and emits a one-time `UserWarning` explaining the swap.
+Either way the output entity dicts have the same shape so the rest of
+the pipeline behaves identically. Smart-merging (regex-based span
+construction) is skipped for this family — the model already does
+Viterbi-constrained BIOES decoding internally.
+
+The dispatch lives in
+[`openmed.core.backends.create_privacy_filter_pipeline`](../openmed/core/backends.py).
+
+## Backwards compatibility
+
+`replace` outputs are no longer drawn from the prior hardcoded list
+(`["Jane Smith", "John Doe", "Alex Johnson", "Sam Taylor"]`, etc.).
+Any test that asserted on those exact strings must either:
+
+- pass `consistent=True, seed=<value>` and update the expected output, or
+- assert non-equality with the original instead of equality with a
+  hardcoded surrogate.
+
+Other methods (`mask`, `remove`, `hash`, `shift_dates`) are unchanged.

--- a/docs/anonymization.md
+++ b/docs/anonymization.md
@@ -126,19 +126,35 @@ register_label_generator("FIRST_NAME", my_first_name)
 
 ## Privacy-filter family
 
-The MLX-only artifacts `OpenMed/privacy-filter-mlx` and
-`OpenMed/privacy-filter-mlx-8bit` route through `extract_pii()` /
-`deidentify()` like any other model:
+OpenMed ships two privacy-filter checkpoints, both **the same OpenAI
+Privacy Filter architecture** (gpt-oss-style sparse-MoE transformer with
+local attention, sink tokens, RoPE+YaRN, tiktoken `o200k_base`), differing
+only in their training data:
+
+| Variant                   | Trained on                  | PyTorch artifact                     | MLX (full)                                  | MLX (8-bit)                                       |
+| ------------------------- | --------------------------- | ------------------------------------ | ------------------------------------------- | ------------------------------------------------- |
+| OpenAI Privacy Filter     | OpenAI's PII training set   | `openai/privacy-filter`              | `OpenMed/privacy-filter-mlx`                | `OpenMed/privacy-filter-mlx-8bit`                 |
+| Nemotron-PII fine-tune    | Nemotron PII dataset        | `OpenMed/privacy-filter-nemotron`    | `OpenMed/privacy-filter-nemotron-mlx`       | `OpenMed/privacy-filter-nemotron-mlx-8bit`        |
+
+Both run through the same `extract_pii()` / `deidentify()` API — only the
+weights differ:
 
 ```python
 extract_pii(text, model_name="OpenMed/privacy-filter-mlx-8bit")
-deidentify(text, model_name="OpenMed/privacy-filter-mlx-8bit",
+extract_pii(text, model_name="OpenMed/privacy-filter-nemotron-mlx-8bit")
+
+deidentify(text, model_name="OpenMed/privacy-filter-nemotron",
            method="replace", consistent=True, seed=42)
 ```
 
-On Apple Silicon with MLX importable, this runs the MLX pipeline.
-Elsewhere, the call substitutes `openai/privacy-filter` via
-`transformers` and emits a one-time `UserWarning` explaining the swap.
+**Backend selection.** On Apple Silicon with MLX importable, the MLX
+artifact runs natively via `PrivacyFilterMLXPipeline`. Elsewhere, the
+call substitutes the corresponding PyTorch model via `transformers` and
+emits a one-time `UserWarning` explaining the swap. The fallback is
+**family-aware** — an MLX-only Nemotron request on Linux substitutes
+`OpenMed/privacy-filter-nemotron` (not the unrelated `openai/privacy-filter`),
+so the user gets the same training distribution they asked for.
+
 Either way the output entity dicts have the same shape so the rest of
 the pipeline behaves identically. Smart-merging (regex-based span
 construction) is skipped for this family — the model already does
@@ -146,6 +162,12 @@ Viterbi-constrained BIOES decoding internally.
 
 The dispatch lives in
 [`openmed.core.backends.create_privacy_filter_pipeline`](../openmed/core/backends.py).
+To register a new fine-tune that should fall back to its own PyTorch repo
+on non-Mac hosts, add a row to `_TORCH_FALLBACK_BY_FAMILY` in that module.
+If a fine-tune introduces a genuinely different *architecture* (not just
+new weights), it would also need a new MLX model class and family branch
+in `openmed.mlx.models.build_model` — but a same-architecture fine-tune
+needs neither.
 
 ## Backwards compatibility
 

--- a/examples/obfuscation_demo.py
+++ b/examples/obfuscation_demo.py
@@ -1,0 +1,167 @@
+"""Demo: language-agnostic PHI/PII obfuscation.
+
+Shows the four behaviors the new ``Anonymizer`` engine unlocks for
+``deidentify(method="replace", ...)``:
+
+1. **Random surrogates** — every run produces different fakes.
+2. **Within-document consistency** — repeated mentions of the same name
+   resolve to one fake identity (``consistent=True``).
+3. **Cross-run reproducibility** — pin the surrogate stream for
+   regression testing or stable test fixtures (``seed=42``).
+4. **Locale-aware generation** — surrogates look right for the language
+   (German names for ``lang="de"``, French phone formats for ``lang="fr"``,
+   Brazilian CPFs for ``locale="pt_BR"``, ...).
+
+Run:
+    python examples/obfuscation_demo.py
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from openmed import deidentify
+from openmed.core.anonymizer import Anonymizer
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+
+def _mock_extraction(text: str, entities: list[EntityPrediction]):
+    """Helper so the demo runs without downloading a real model."""
+    return PredictionResult(
+        text=text,
+        entities=entities,
+        model_name="mock",
+        timestamp="2026-04-27",
+    )
+
+
+def heading(title: str) -> None:
+    print()
+    print("=" * 70)
+    print(title)
+    print("=" * 70)
+
+
+def demo_anonymizer_direct() -> None:
+    """Use the Anonymizer class directly without going through extract_pii."""
+    heading("1. Anonymizer used directly")
+
+    anon = Anonymizer(lang="en", consistent=True, seed=42)
+    print(f"  PERSON: {anon.surrogate('John Doe', 'name')}")
+    print(f"  EMAIL : {anon.surrogate('john@hospital.org', 'email')}")
+    print(f"  PHONE : {anon.surrogate('(415) 555-1234', 'phone_number')}")
+    print(f"  DATE  : {anon.surrogate('01/15/1970', 'date_of_birth')}")
+
+    print("\n  Same input twice (consistent=True) -> same output:")
+    print(f"    {anon.surrogate('Maria Silva', 'name')}")
+    print(f"    {anon.surrogate('Maria Silva', 'name')}")
+
+
+def demo_random_vs_consistent() -> None:
+    heading("2. Random vs consistent surrogates")
+
+    text = "Dr. Smith met John Doe. John Doe later called Dr. Smith."
+    entities = [
+        EntityPrediction(text="Dr. Smith", label="name", start=0, end=9, confidence=0.9),
+        EntityPrediction(text="John Doe", label="name", start=14, end=22, confidence=0.95),
+        EntityPrediction(text="John Doe", label="name", start=24, end=32, confidence=0.95),
+        EntityPrediction(text="Dr. Smith", label="name", start=46, end=55, confidence=0.9),
+    ]
+
+    with patch("openmed.core.pii.extract_pii",
+               return_value=_mock_extraction(text, entities)):
+        rand = deidentify(text, method="replace", lang="en")
+        cons = deidentify(text, method="replace", lang="en", consistent=True, seed=99)
+
+    print("  Random  :", rand.deidentified_text)
+    print("  Consist.:", cons.deidentified_text)
+    print("\n  Note how consistent=True makes both 'John Doe' mentions and both")
+    print("  'Dr. Smith' mentions resolve to the same fake names.")
+
+
+def demo_locales() -> None:
+    heading("3. Locale-aware surrogates across languages")
+
+    samples = [
+        ("en", "Patient Jane Smith born 03/15/1985"),
+        ("fr", "Patient Marie Dupont née le 15/03/1985"),
+        ("de", "Patient Anna Müller geboren am 15.03.1985"),
+        ("it", "Paziente Marco Rossi nato il 15/03/1985"),
+        ("es", "Paciente Carlos García nacido el 15/03/1985"),
+        ("pt", "Paciente Pedro Almeida nascido em 15/03/1985"),
+        ("nl", "Patiënt Daan Jansen geboren op 15-03-1985"),
+    ]
+
+    for lang, text in samples:
+        # Mock detection of a name + a date for each locale demo
+        words = text.split()
+        # Find the name token (positions 1-2) and the date (last token)
+        name_start = text.index(words[1])
+        name_end = name_start + len(" ".join(words[1:3]))
+        date_token = next(t for t in words if any(c.isdigit() for c in t))
+        date_start = text.rindex(date_token)
+        date_end = date_start + len(date_token)
+
+        entities = [
+            EntityPrediction(text=text[name_start:name_end], label="name",
+                             start=name_start, end=name_end, confidence=0.95),
+            EntityPrediction(text=text[date_start:date_end], label="date_of_birth",
+                             start=date_start, end=date_end, confidence=0.95),
+        ]
+        with patch("openmed.core.pii.extract_pii",
+                   return_value=_mock_extraction(text, entities)):
+            r = deidentify(text, method="replace", lang=lang, consistent=True, seed=7)
+        print(f"  [{lang}] {r.deidentified_text}")
+
+
+def demo_brazilian_portuguese_cpf() -> None:
+    heading("4. pt_BR locale override (CPF generation)")
+
+    text = "Paciente João Silva, CPF: 123.456.789-09"
+    entities = [
+        EntityPrediction(text="João Silva", label="name", start=9, end=19, confidence=0.95),
+        EntityPrediction(text="123.456.789-09", label="ID_NUM", start=27, end=41, confidence=0.95),
+    ]
+    with patch("openmed.core.pii.extract_pii",
+               return_value=_mock_extraction(text, entities)):
+        r = deidentify(text, method="replace", lang="pt", locale="pt_BR",
+                       consistent=True, seed=42)
+
+    print(f"  Original: {text}")
+    print(f"  Surrogate: {r.deidentified_text}")
+    surrogate_cpf = next(e.redacted_text for e in r.pii_entities if e.entity_type == "ID_NUM")
+    from openmed.core.pii_i18n import validate_portuguese_cpf
+    valid = validate_portuguese_cpf(surrogate_cpf)
+    print(f"  Surrogate CPF {surrogate_cpf!r} passes checksum: {valid}")
+
+
+def demo_format_preservation() -> None:
+    heading("5. Format-preserving phone numbers")
+
+    text = "Call +1 (415) 555-1234 or +33 6 12 34 56 78"
+    entities = [
+        EntityPrediction(text="+1 (415) 555-1234", label="phone_number", start=5, end=22, confidence=0.95),
+        EntityPrediction(text="+33 6 12 34 56 78", label="phone_number", start=26, end=43, confidence=0.95),
+    ]
+    with patch("openmed.core.pii.extract_pii",
+               return_value=_mock_extraction(text, entities)):
+        r = deidentify(text, method="replace", lang="en", consistent=True, seed=42)
+
+    print(f"  Original  : {text}")
+    print(f"  Surrogate : {r.deidentified_text}")
+    print("  -> digit groups, separators, and country-code position preserved")
+
+
+def main() -> None:
+    print("OpenMed obfuscation demo")
+    print("Faker-backed, locale-aware, optionally deterministic surrogates.")
+    demo_anonymizer_direct()
+    demo_random_vs_consistent()
+    demo_locales()
+    demo_brazilian_portuguese_cpf()
+    demo_format_preservation()
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/privacy_filter_book/app.py
+++ b/examples/privacy_filter_book/app.py
@@ -329,25 +329,18 @@ def _load_mlx_pipeline(download: bool) -> tuple[Any, float]:
 @lru_cache(maxsize=1)
 def _load_cpu_pipeline(download: bool) -> tuple[Any, Any, float]:
     started = time.perf_counter()
-    from transformers import AutoModelForTokenClassification, AutoTokenizer, pipeline
+    from transformers import AutoTokenizer
 
-    tokenizer = AutoTokenizer.from_pretrained(
+    from openmed.torch.privacy_filter import PrivacyFilterTorchPipeline
+
+    classifier = PrivacyFilterTorchPipeline(
         CPU_MODEL_ID,
-        local_files_only=not download,
-    )
-    model = AutoModelForTokenClassification.from_pretrained(
-        CPU_MODEL_ID,
-        local_files_only=not download,
-    )
-    model.to("cpu")
-    model.eval()
-    classifier = pipeline(
-        task="token-classification",
-        model=model,
-        tokenizer=tokenizer,
+        device="cpu",
         aggregation_strategy="simple",
-        device=-1,
+        local_files_only=not download,
     )
+    # Expose the tokenizer separately for the token-count UI metric.
+    tokenizer = classifier.tokenizer
     return classifier, tokenizer, time.perf_counter() - started
 
 

--- a/examples/privacy_filter_studio/README.md
+++ b/examples/privacy_filter_studio/README.md
@@ -23,8 +23,8 @@ checkpoint (`OpenMed/privacy-filter-nemotron`) with a one-time
 From the repository root:
 
 ```bash
-pip install -U "openmed[mlx]"        # or "openmed[hf]" off Apple Silicon
-uvicorn examples.privacy_filter_studio.app:app --reload --port 8770
+pip install -e ".[mlx,service]"      # or ".[hf,service]" off Apple Silicon
+python -m uvicorn examples.privacy_filter_studio.app:app --reload --port 8770
 ```
 
 Open http://127.0.0.1:8770
@@ -37,7 +37,7 @@ toggle in the UI) to allow the fetch; subsequent runs are cache-only.
 
 ```bash
 OPENMED_STUDIO_MODEL=OpenMed/privacy-filter-nemotron-mlx-8bit \
-  uvicorn examples.privacy_filter_studio.app:app --port 8770
+  python -m uvicorn examples.privacy_filter_studio.app:app --port 8770
 ```
 
 Any name accepted by `extract_pii(model_name=...)` works — including the

--- a/examples/privacy_filter_studio/README.md
+++ b/examples/privacy_filter_studio/README.md
@@ -1,0 +1,45 @@
+# OpenMed Privacy Filter Studio
+
+Interactive two-pane web app for PII de-identification, built on the
+OpenMed unified `extract_pii` / `deidentify` API. Paste text on the left,
+press **Run**, see the output on the right with each detected entity
+highlighted by a colorful category label.
+
+Two output modes:
+
+- **Mask** — replace each entity with a `[CATEGORY]` placeholder.
+- **Randomize** — replace each entity with a deterministic, locale-aware
+  Faker surrogate (same seed → same output, repeated mentions of the
+  same person resolve to one fake identity).
+
+Defaults to the **Nemotron-PII MLX BF16** checkpoint
+(`OpenMed/privacy-filter-nemotron-mlx`) on Apple Silicon. On any other
+host the unified API automatically substitutes the matching PyTorch
+checkpoint (`OpenMed/privacy-filter-nemotron`) with a one-time
+`UserWarning`, so the same UI runs everywhere.
+
+## Run
+
+From the repository root:
+
+```bash
+pip install -U "openmed[mlx]"        # or "openmed[hf]" off Apple Silicon
+uvicorn examples.privacy_filter_studio.app:app --reload --port 8770
+```
+
+Open http://127.0.0.1:8770
+
+The first run downloads the MLX (or PyTorch) checkpoint from the Hub.
+Set `OPENMED_PRIVACY_FILTER_DOWNLOAD=1` (or tick the **Allow Downloads**
+toggle in the UI) to allow the fetch; subsequent runs are cache-only.
+
+## Override the model
+
+```bash
+OPENMED_STUDIO_MODEL=OpenMed/privacy-filter-nemotron-mlx-8bit \
+  uvicorn examples.privacy_filter_studio.app:app --port 8770
+```
+
+Any name accepted by `extract_pii(model_name=...)` works — including the
+OpenAI baseline (`OpenMed/privacy-filter-mlx`, `openai/privacy-filter`)
+or a local path to your own fine-tune.

--- a/examples/privacy_filter_studio/app.py
+++ b/examples/privacy_filter_studio/app.py
@@ -1,0 +1,397 @@
+"""OpenMed Privacy Filter Studio — interactive de-identification demo.
+
+A two-pane web app: paste text on the left, press Run, see the output on the
+right with each detected PII span highlighted with a colorful label. Toggle
+between **Mask** mode (replace with ``[PERSON]`` placeholders) and
+**Randomize** mode (replace with locale-aware Faker surrogates, deterministic
+within the call).
+
+Defaults to MLX BF16 on Apple Silicon
+(``OpenMed/privacy-filter-nemotron-mlx``). On non-Apple-Silicon hosts the
+unified ``openmed.extract_pii`` / ``openmed.deidentify`` API automatically
+falls back to the matching PyTorch checkpoint
+(``OpenMed/privacy-filter-nemotron``).
+
+Run from the repository root:
+
+    uvicorn examples.privacy_filter_studio.app:app --reload --port 8770
+
+Set ``OPENMED_PRIVACY_FILTER_DOWNLOAD=1`` (or pass ``download: true`` in the
+request) to allow first-run model downloads. Otherwise the model must
+already be cached locally.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+ROOT = Path(__file__).resolve().parent
+STATIC_DIR = ROOT / "static"
+
+DEFAULT_MODEL_ID = os.getenv(
+    "OPENMED_STUDIO_MODEL",
+    "OpenMed/privacy-filter-nemotron-mlx",
+)
+ALLOW_DOWNLOAD_ENV = os.getenv("OPENMED_PRIVACY_FILTER_DOWNLOAD", "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
+
+# ---------------------------------------------------------------------------
+# Pre-defined examples (medical-themed, varying difficulty)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class StudioExample:
+    id: str
+    title: str
+    blurb: str
+    text: str
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {"id": self.id, "title": self.title, "blurb": self.blurb, "text": self.text}
+
+
+EXAMPLES: tuple[StudioExample, ...] = (
+    StudioExample(
+        id="discharge",
+        title="Discharge summary",
+        blurb="Names, MRN, DOB, contact details, account info — the daily case.",
+        text=(
+            "Patient Sarah Johnson (DOB 03/15/1985), MRN 4872910, was discharged on "
+            "April 22 2026 after a three-day admission for community-acquired pneumonia. "
+            "Follow-up scheduled with Dr. Michael Chen on May 6 2026 at Cedars Medical "
+            "Center, 8700 Beverly Blvd, Los Angeles CA 90048. Reach the patient at "
+            "(415) 555-7012 or sarah.johnson@example.com. Insurance member ID "
+            "BLU-2284-118-A; copay reference invoice 2026-04-22-008712."
+        ),
+    ),
+    StudioExample(
+        id="referral",
+        title="Specialist referral",
+        blurb="Two clinicians, an address, a phone, an SSN — and a sensitive history.",
+        text=(
+            "Referring Provider: Dr. Aisha Patel (NPI 1326744929), Internal Medicine.\n"
+            "Specialist: Dr. Marcus Reilly, Endocrinology.\n\n"
+            "RE: Robert Alvarez, SSN 412-55-9183, DOB 11/02/1958.\n\n"
+            "Mr. Alvarez presents with poorly controlled type 2 diabetes (HbA1c 9.4%) "
+            "and worsening peripheral neuropathy. Most recent labs drawn at Mercy "
+            "Hospital on 04/10/2026. Patient prefers correspondence at "
+            "ralvarez1958@example.org or his cell, +1 312-555-0144. Mailing address "
+            "1428 W Roosevelt Rd, Apt 6B, Chicago IL 60608."
+        ),
+    ),
+    StudioExample(
+        id="enterprise",
+        title="Enterprise IT incident",
+        blurb="Mixed-domain PII: emails, IPs, MACs, an API key, financial accounts.",
+        text=(
+            "Incident IM-2026-04-2271 logged by jdoe@hospital.example at 22:14 UTC.\n\n"
+            "Workstation 10.42.118.27 (MAC 4c:bb:58:9a:11:7e) issued repeated auth "
+            "failures against billing-svc using API key sk_live_8ahWJD2lQ3pX9pTk1mZ. "
+            "Affected employee: Linda Park, employee ID EMP-447128, hired 2019-08-12, "
+            "currently in Finance.\n\n"
+            "Card on file ending 4111-1111-1111-7392 was rotated; routing number "
+            "021000089 confirmed. Forwarded to security@hospital.example and "
+            "ciso.office@hospital.example for review. Vehicle plate IL-MED-2018 "
+            "noted in lobby footage at 21:58."
+        ),
+    ),
+    StudioExample(
+        id="multilingual",
+        title="Multilingual snippet",
+        blurb="A multilingual paragraph mixing English, French, and Portuguese PII.",
+        text=(
+            "Patient: Pedro Almeida, CPF 123.456.789-09, telefone +351 912 345 678, "
+            "email pedro.almeida@hospital.pt, morada Rua das Flores 25, 1200-195 "
+            "Lisboa.\n\n"
+            "Le médecin référent, Dr. Camille Lefèvre, peut être joint au "
+            "+33 1 42 96 10 10 ou à camille.lefevre@hopital.fr.\n\n"
+            "English follow-up: please confirm with Sarah Johnson "
+            "(sarah.johnson@example.com, 415-555-7012) by April 30 2026."
+        ),
+    ),
+    StudioExample(
+        id="paragraph",
+        title="Casual narrative",
+        blurb="Free-form prose — looks innocuous but mentions multiple identifiers.",
+        text=(
+            "I called Dr. Hannah Wright last Tuesday around 4pm. She wanted to confirm "
+            "my new address — 1742 Ocean View Ave, Apt 14, San Diego CA 92107 — "
+            "before mailing the lab results. I gave her my mobile, 619-555-0287, and "
+            "the new email address (hannah.wright.patient@example.net). Apparently "
+            "the previous chart had my old SSN listed; I asked her to update it from "
+            "the placeholder to the correct one ending in 5188. While we were on the "
+            "phone she also confirmed my insurance group number HMO-PROD-44128."
+        ),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic request models
+# ---------------------------------------------------------------------------
+
+class RunRequest(BaseModel):
+    text: str = Field(..., description="Free-form text to deidentify.")
+    mode: Literal["mask", "randomize"] = Field(
+        default="mask",
+        description="``mask`` uses placeholder labels; ``randomize`` uses Faker surrogates.",
+    )
+    seed: int = Field(default=42, description="Seed for randomize/consistent surrogates.")
+    locale: str | None = Field(
+        default=None,
+        description="Optional Faker locale override (e.g. ``pt_BR``, ``fr_FR``).",
+    )
+    download: bool = Field(
+        default=False,
+        description="Allow first-run model download from the Hub.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pipeline lifecycle
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=1)
+def _load_pipeline(download: bool) -> tuple[Any, float, str]:
+    """Build the unified privacy-filter pipeline once and cache it.
+
+    The cache key includes ``download`` so that flipping the toggle invalidates
+    the cached pipeline (and lets a previously-failed download retry).
+    """
+    started = time.perf_counter()
+    from openmed.core.backends import (
+        create_privacy_filter_pipeline,
+        select_privacy_filter_backend,
+    )
+
+    # Allow first-run downloads only when explicitly requested. Otherwise ask
+    # both Hugging Face Hub and Transformers to stay cache-only.
+    prior_hf_offline = os.environ.get("HF_HUB_OFFLINE")
+    prior_transformers_offline = os.environ.get("TRANSFORMERS_OFFLINE")
+    if download:
+        os.environ.pop("HF_HUB_OFFLINE", None)
+        os.environ.pop("TRANSFORMERS_OFFLINE", None)
+    else:
+        os.environ["HF_HUB_OFFLINE"] = "1"
+        os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    backend = select_privacy_filter_backend(DEFAULT_MODEL_ID)
+    try:
+        pipeline = create_privacy_filter_pipeline(DEFAULT_MODEL_ID)
+    finally:
+        if prior_hf_offline is None:
+            os.environ.pop("HF_HUB_OFFLINE", None)
+        else:
+            os.environ["HF_HUB_OFFLINE"] = prior_hf_offline
+        if prior_transformers_offline is None:
+            os.environ.pop("TRANSFORMERS_OFFLINE", None)
+        else:
+            os.environ["TRANSFORMERS_OFFLINE"] = prior_transformers_offline
+
+    return pipeline, time.perf_counter() - started, backend
+
+
+# ---------------------------------------------------------------------------
+# Inference + deidentification
+# ---------------------------------------------------------------------------
+
+def _entities_from_pipeline(pipeline: Any, text: str) -> list[dict[str, Any]]:
+    raw = pipeline(text)
+    entities: list[dict[str, Any]] = []
+    for item in raw:
+        label = item.get("entity_group") or item.get("entity") or ""
+        start = int(item.get("start", 0))
+        end = int(item.get("end", 0))
+        if end <= start:
+            continue
+        entities.append(
+            {
+                "label": str(label),
+                "start": start,
+                "end": end,
+                "text": text[start:end],
+                "score": float(item.get("score", 0.0)),
+            }
+        )
+    entities.sort(key=lambda e: e["start"])
+    return entities
+
+
+def _mask_text(text: str, entities: list[dict[str, Any]]) -> str:
+    """Replace each entity span with ``[LABEL]``, preserving everything else."""
+    parts: list[str] = []
+    cursor = 0
+    for ent in entities:
+        if ent["start"] < cursor:
+            continue  # skip overlapping entries (shouldn't happen with Viterbi)
+        parts.append(text[cursor:ent["start"]])
+        parts.append(f"[{ent['label'].upper()}]")
+        cursor = ent["end"]
+    parts.append(text[cursor:])
+    return "".join(parts)
+
+
+def _randomize_text(
+    text: str,
+    entities: list[dict[str, Any]],
+    *,
+    seed: int,
+    locale: str | None,
+) -> tuple[str, dict[str, str]]:
+    """Replace each entity span with a deterministic Faker surrogate.
+
+    Same ``(label, original)`` pair always produces the same surrogate within
+    one call — repeat mentions of the same person resolve to one fake.
+    """
+    from openmed.core.anonymizer import Anonymizer
+
+    anon = Anonymizer(lang="en", locale=locale, consistent=True, seed=seed)
+    surrogate_map: dict[str, str] = {}
+
+    def surrogate_for(label: str, original: str) -> str:
+        key = f"{label}|{original}"
+        if key not in surrogate_map:
+            surrogate_map[key] = anon.surrogate(original, label)
+        return surrogate_map[key]
+
+    parts: list[str] = []
+    cursor = 0
+    for ent in entities:
+        if ent["start"] < cursor:
+            continue
+        parts.append(text[cursor:ent["start"]])
+        parts.append(surrogate_for(ent["label"], ent["text"]))
+        cursor = ent["end"]
+    parts.append(text[cursor:])
+    return "".join(parts), surrogate_map
+
+
+def _entities_with_surrogates(
+    entities: list[dict[str, Any]],
+    surrogate_map: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Augment each entity with its surrogate value (for client-side rendering)."""
+    annotated: list[dict[str, Any]] = []
+    for ent in entities:
+        key = f"{ent['label']}|{ent['text']}"
+        annotated.append({**ent, "surrogate": surrogate_map.get(key, "")})
+    return annotated
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="OpenMed Privacy Filter Studio",
+    description=(
+        "Interactive PII de-identification demo built on the OpenMed unified "
+        "extract_pii / deidentify API. Defaults to the Nemotron-PII MLX BF16 "
+        "checkpoint on Apple Silicon, with automatic PyTorch fallback elsewhere."
+    ),
+)
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+@app.get("/")
+def index() -> FileResponse:
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+@app.get("/api/examples")
+def api_examples() -> dict[str, Any]:
+    return {
+        "model": DEFAULT_MODEL_ID,
+        "examples": [example.to_public_dict() for example in EXAMPLES],
+    }
+
+
+@app.post("/api/run")
+def api_run(payload: RunRequest) -> dict[str, Any]:
+    text = payload.text.strip()
+    if not text:
+        return {
+            "status": "empty",
+            "modelId": DEFAULT_MODEL_ID,
+            "entities": [],
+            "masked": "",
+            "randomized": "",
+            "stats": {"tokens": 0, "entities": 0, "inferenceMs": 0.0},
+            "note": "Empty input.",
+        }
+
+    download = bool(payload.download or ALLOW_DOWNLOAD_ENV)
+    try:
+        pipeline, load_s, backend = _load_pipeline(download)
+    except Exception as exc:  # noqa: BLE001 — surface load errors in the UI
+        return {
+            "status": "error",
+            "modelId": DEFAULT_MODEL_ID,
+            "entities": [],
+            "masked": text,
+            "randomized": text,
+            "stats": {"tokens": 0, "entities": 0, "inferenceMs": 0.0},
+            "note": f"Model load failed: {type(exc).__name__}: {exc}",
+        }
+
+    started = time.perf_counter()
+    try:
+        entities = _entities_from_pipeline(pipeline, text)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "status": "error",
+            "modelId": DEFAULT_MODEL_ID,
+            "entities": [],
+            "masked": text,
+            "randomized": text,
+            "stats": {"tokens": 0, "entities": 0, "inferenceMs": 0.0},
+            "note": f"Inference failed: {type(exc).__name__}: {exc}",
+        }
+    inference_s = time.perf_counter() - started
+
+    masked = _mask_text(text, entities)
+    randomized, surrogate_map = _randomize_text(
+        text, entities, seed=payload.seed, locale=payload.locale,
+    )
+    annotated = _entities_with_surrogates(entities, surrogate_map)
+
+    # Approximate token count from whitespace split — gives a useful UI metric
+    # without paying for a second tokenization pass.
+    token_estimate = len(re.findall(r"\S+", text))
+
+    return {
+        "status": "live",
+        "modelId": DEFAULT_MODEL_ID,
+        "backend": backend,
+        "entities": annotated,
+        "masked": masked,
+        "randomized": randomized,
+        "stats": {
+            "tokens": token_estimate,
+            "entities": len(entities),
+            "inferenceMs": round(inference_s * 1000, 1),
+            "loadMs": round(load_s * 1000, 1),
+        },
+        "note": (
+            f"{backend.upper()} runtime — {len(entities)} entities in "
+            f"{inference_s * 1000:.1f} ms."
+        ),
+    }

--- a/examples/privacy_filter_studio/static/app.js
+++ b/examples/privacy_filter_studio/static/app.js
@@ -1,0 +1,450 @@
+// OpenMed Privacy Filter Studio — frontend.
+
+const STATE = {
+  examples: [],
+  activeExampleId: null,
+  busy: false,
+  mode: "mask",
+  theme: "dark",
+  modelId: "--",
+  lastResult: null,
+};
+
+const els = {
+  inputText:       document.querySelector("#inputText"),
+  resultText:      document.querySelector("#resultText"),
+  exampleChips:    document.querySelector("#exampleChips"),
+  runButton:       document.querySelector("#runButton"),
+  themeToggle:     document.querySelector("#themeToggle"),
+  allowDownloads:  document.querySelector("#allowDownloads"),
+  clearButton:     document.querySelector("#clearButton"),
+  charCount:       document.querySelector("#charCount"),
+  tokenCount:      document.querySelector("#tokenCount"),
+  entityCount:     document.querySelector("#entityCount"),
+  latencyLabel:    document.querySelector("#latencyLabel"),
+  modelLabel:      document.querySelector("#modelLabel"),
+  backendLabel:    document.querySelector("#backendLabel"),
+  statusPill:      document.querySelector("#statusPill"),
+  legendList:      document.querySelector("#legendList"),
+  modeButtons:     document.querySelectorAll(".mode-button"),
+};
+
+// ---------------------------------------------------------------------------
+// Label → color group mapping. Mirrors the palette in styles.css.
+// Covers the 55 fine-grained Nemotron-PII labels plus the OpenAI baseline's
+// 8 coarse classes; anything unrecognised falls through to "other".
+// ---------------------------------------------------------------------------
+
+const LABEL_GROUPS = {
+  // identity (warm red/coral)
+  first_name: "identity", last_name: "identity", user_name: "identity",
+  age: "identity", gender: "identity", marital_status: "identity",
+  nationality: "identity", language: "identity", biometric_identifier: "identity",
+  blood_type: "identity", private_person: "identity", name: "identity",
+  patient: "identity", doctor: "identity",
+
+  // contact (blue)
+  email: "contact", phone_number: "contact", fax_number: "contact",
+  url: "contact", private_email: "contact", private_phone: "contact",
+  private_url: "contact",
+
+  // address (green)
+  street_address: "address", city: "address", county: "address",
+  state: "address", country: "address", postcode: "address",
+  coordinate: "address", private_address: "address",
+
+  // dates / time (purple)
+  date: "dates", date_of_birth: "dates", date_time: "dates", time: "dates",
+  private_date: "dates",
+
+  // government IDs (magenta-red)
+  ssn: "govid", national_id: "govid", tax_id: "govid",
+  certificate_license_number: "govid", passport_number: "govid",
+
+  // financial (gold)
+  account_number: "financial", bank_routing_number: "financial",
+  swift_bic: "financial", credit_debit_card: "financial",
+  cvv: "financial", pin: "financial", password: "financial",
+  account: "financial",
+
+  // healthcare (teal)
+  medical_record_number: "healthcare",
+  health_plan_beneficiary_number: "healthcare",
+
+  // enterprise / workplace (slate)
+  customer_id: "workplace", employee_id: "workplace", unique_id: "workplace",
+  company_name: "workplace", occupation: "workplace",
+  employment_status: "workplace", education_level: "workplace",
+
+  // online (orange)
+  ipv4: "online", ipv6: "online", mac_address: "online",
+  device_identifier: "online", api_key: "online", http_cookie: "online",
+  secret: "online",
+
+  // demographic (magenta)
+  race_ethnicity: "demographic", religious_belief: "demographic",
+  political_view: "demographic", sexuality: "demographic",
+
+  // vehicle (orange)
+  license_plate: "vehicle", vehicle_identifier: "vehicle",
+};
+
+function groupForLabel(label) {
+  if (!label) return "other";
+  const norm = String(label).toLowerCase().replace(/[\s-]/g, "_");
+  return LABEL_GROUPS[norm] || "other";
+}
+
+function prettyLabel(label) {
+  return String(label || "").replace(/_/g, " ");
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+function getSavedTheme() {
+  try {
+    const saved = window.localStorage.getItem("privacy-filter-studio-theme");
+    return saved === "light" || saved === "dark" ? saved : "dark";
+  } catch {
+    return "dark";
+  }
+}
+
+function setTheme(theme) {
+  STATE.theme = theme;
+  document.documentElement.dataset.theme = theme;
+  try { window.localStorage.setItem("privacy-filter-studio-theme", theme); } catch {}
+  const next = theme === "dark" ? "light" : "dark";
+  els.themeToggle.setAttribute("aria-label", `Switch to ${next} theme`);
+  els.themeToggle.setAttribute("title", `Switch to ${next} theme`);
+  els.themeToggle.innerHTML = `<i data-lucide="${theme === "dark" ? "sun" : "moon"}"></i>`;
+  if (window.lucide) window.lucide.createIcons();
+}
+
+function toggleTheme() {
+  setTheme(STATE.theme === "dark" ? "light" : "dark");
+}
+
+// ---------------------------------------------------------------------------
+// Examples strip
+// ---------------------------------------------------------------------------
+
+function renderExampleChips() {
+  els.exampleChips.innerHTML = STATE.examples
+    .map((ex) => {
+      const tooltip = escapeHtml(ex.blurb || "");
+      const cls = ex.id === STATE.activeExampleId ? "example-chip is-active" : "example-chip";
+      return `<button type="button" class="${cls}" data-id="${escapeHtml(ex.id)}" data-tooltip="${tooltip}">
+        <i data-lucide="file-text"></i>
+        <span>${escapeHtml(ex.title)}</span>
+      </button>`;
+    })
+    .join("");
+
+  els.exampleChips.querySelectorAll("button.example-chip").forEach((btn) => {
+    btn.addEventListener("click", () => loadExample(btn.dataset.id));
+  });
+
+  if (window.lucide) window.lucide.createIcons();
+}
+
+function loadExample(id) {
+  const example = STATE.examples.find((ex) => ex.id === id);
+  if (!example) return;
+  STATE.activeExampleId = id;
+  els.inputText.value = example.text;
+  updateInputCounters();
+  renderExampleChips();
+  // Reset output so user sees the impact of the next run
+  STATE.lastResult = null;
+  renderResult(null);
+  setStatus("ready", "Ready");
+}
+
+// ---------------------------------------------------------------------------
+// Input counters
+// ---------------------------------------------------------------------------
+
+function updateInputCounters() {
+  const text = els.inputText.value;
+  els.charCount.textContent = String(text.length);
+  els.tokenCount.textContent = String((text.match(/\S+/g) || []).length);
+}
+
+// ---------------------------------------------------------------------------
+// Status pill
+// ---------------------------------------------------------------------------
+
+function setStatus(kind, label) {
+  els.statusPill.className = "status-pill";
+  if (kind === "running") els.statusPill.classList.add("running");
+  else if (kind === "live") els.statusPill.classList.add("live");
+  else if (kind === "error") els.statusPill.classList.add("error");
+  els.statusPill.textContent = label;
+}
+
+// ---------------------------------------------------------------------------
+// Result rendering
+// ---------------------------------------------------------------------------
+
+function renderResult(result) {
+  if (!result) {
+    els.resultText.innerHTML = `
+      <p class="placeholder">
+        Press <kbd>⌘</kbd> + <kbd>Enter</kbd> or click
+        <strong>Run De-identification</strong> to redact entities.
+        Hover over a tag in the output to see the original value.
+      </p>`;
+    els.entityCount.textContent = "0";
+    els.latencyLabel.textContent = "--";
+    els.legendList.innerHTML = "";
+    return;
+  }
+
+  const text = els.inputText.value;
+  const entities = result.entities || [];
+
+  if (result.status === "error") {
+    els.resultText.innerHTML = `
+      <p class="error-note">${escapeHtml(result.note || "Something went wrong.")}</p>`;
+    els.entityCount.textContent = "0";
+    els.latencyLabel.textContent = "--";
+    els.legendList.innerHTML = "";
+    return;
+  }
+
+  if (entities.length === 0) {
+    els.resultText.innerHTML = `
+      <p class="empty-note">No PII detected in this text.</p>`;
+    els.entityCount.textContent = "0";
+    els.latencyLabel.textContent = formatMs(result.stats?.inferenceMs);
+    els.legendList.innerHTML = "";
+    return;
+  }
+
+  els.resultText.innerHTML = renderEntities(text, entities, STATE.mode);
+  els.entityCount.textContent = String(entities.length);
+  els.latencyLabel.textContent = formatMs(result.stats?.inferenceMs);
+  renderLegend(entities);
+}
+
+function renderEntities(text, entities, mode) {
+  const sorted = [...entities].sort((a, b) => a.start - b.start || b.end - a.end);
+  let cursor = 0;
+  let html = "";
+
+  for (const ent of sorted) {
+    if (ent.start < cursor || ent.end <= ent.start) continue;
+    html += escapeHtml(text.slice(cursor, ent.start));
+    const original = text.slice(ent.start, ent.end);
+    const group = groupForLabel(ent.label);
+    const tagText = prettyLabel(ent.label);
+    const tooltip = mode === "mask"
+      ? `${tagText}: "${original}"`
+      : `${tagText}: "${original}" → "${ent.surrogate || ""}"`;
+
+    let display;
+    if (mode === "mask") {
+      display = `<span class="entity-mask">[${tagText.toUpperCase()}]</span>`;
+    } else {
+      display = escapeHtml(ent.surrogate || original);
+    }
+
+    html += `<span class="entity" data-group="${group}" data-tooltip="${escapeHtml(tooltip)}" tabindex="0">`
+         + display
+         + `<span class="entity-tag">${escapeHtml(tagText)}</span>`
+         + `</span>`;
+    cursor = ent.end;
+  }
+
+  html += escapeHtml(text.slice(cursor));
+  return html;
+}
+
+function renderLegend(entities) {
+  const counts = new Map();
+  for (const ent of entities) {
+    const group = groupForLabel(ent.label);
+    counts.set(group, (counts.get(group) || 0) + 1);
+  }
+  const order = [
+    "identity", "contact", "address", "dates", "govid", "financial",
+    "healthcare", "workplace", "online", "demographic", "vehicle", "other",
+  ];
+  els.legendList.innerHTML = order
+    .filter((g) => counts.has(g))
+    .map((g) => {
+      const label = g.charAt(0).toUpperCase() + g.slice(1);
+      return `<li class="legend-item" data-group="${g}">
+        <span>${label}</span>
+        <span class="legend-count">${counts.get(g)}</span>
+      </li>`;
+    })
+    .join("");
+}
+
+function formatMs(ms) {
+  if (!Number.isFinite(ms)) return "--";
+  if (ms < 1) return "<1 ms";
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+// ---------------------------------------------------------------------------
+// Mode switch
+// ---------------------------------------------------------------------------
+
+function setMode(mode) {
+  if (STATE.mode === mode) return;
+  STATE.mode = mode;
+  els.modeButtons.forEach((btn) => {
+    btn.classList.toggle("is-active", btn.dataset.mode === mode);
+  });
+  // Re-render last result with the new mode (if any)
+  if (STATE.lastResult) renderResult(STATE.lastResult);
+}
+
+// ---------------------------------------------------------------------------
+// Run de-identification
+// ---------------------------------------------------------------------------
+
+function setBusy(isBusy) {
+  STATE.busy = isBusy;
+  els.runButton.disabled = isBusy;
+  els.runButton.querySelector("span").textContent =
+    isBusy ? "Running" : "Run De-identification";
+}
+
+function startScan() {
+  const targets = document.querySelectorAll(".paper-frame");
+  targets.forEach((node) => {
+    node.classList.remove("scan-active");
+    void node.offsetWidth;  // restart animation
+    node.classList.add("scan-active");
+  });
+}
+
+async function runDeidentification() {
+  if (STATE.busy) return;
+  const text = els.inputText.value.trim();
+  if (!text) {
+    setStatus("error", "No input");
+    return;
+  }
+
+  setBusy(true);
+  setStatus("running", "Running");
+  startScan();
+
+  try {
+    const response = await fetch("/api/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: els.inputText.value,
+        mode: STATE.mode,
+        seed: 42,
+        download: els.allowDownloads.checked,
+      }),
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const payload = await response.json();
+    STATE.lastResult = payload;
+    if (payload.modelId) {
+      els.modelLabel.textContent = payload.modelId;
+      STATE.modelId = payload.modelId;
+    }
+    if (payload.backend) {
+      els.backendLabel.textContent = payload.backend.toUpperCase();
+    }
+
+    // Wait for the scan-line animation to feel complete before revealing
+    window.setTimeout(() => {
+      if (payload.status === "live") {
+        renderResult(payload);
+        setStatus("live", "Live");
+      } else if (payload.status === "empty") {
+        renderResult(null);
+        setStatus("ready", "Ready");
+      } else {
+        renderResult(payload);
+        setStatus("error", "Error");
+      }
+      setBusy(false);
+    }, 760);
+  } catch (error) {
+    console.error(error);
+    setStatus("error", "Error");
+    setBusy(false);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+
+async function boot() {
+  setTheme(getSavedTheme());
+
+  els.inputText.addEventListener("input", () => {
+    updateInputCounters();
+    if (STATE.activeExampleId) {
+      STATE.activeExampleId = null;
+      renderExampleChips();
+    }
+  });
+  els.clearButton.addEventListener("click", () => {
+    els.inputText.value = "";
+    STATE.activeExampleId = null;
+    STATE.lastResult = null;
+    updateInputCounters();
+    renderExampleChips();
+    renderResult(null);
+    setStatus("ready", "Ready");
+    els.inputText.focus();
+  });
+  els.runButton.addEventListener("click", runDeidentification);
+  els.themeToggle.addEventListener("click", toggleTheme);
+  els.modeButtons.forEach((btn) => {
+    btn.addEventListener("click", () => setMode(btn.dataset.mode));
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      event.preventDefault();
+      runDeidentification();
+    }
+  });
+
+  try {
+    const response = await fetch("/api/examples");
+    const payload = await response.json();
+    STATE.examples = payload.examples || [];
+    STATE.modelId = payload.model;
+    els.modelLabel.textContent = payload.model || "--";
+  } catch (e) {
+    console.warn("Failed to load examples", e);
+  }
+
+  renderExampleChips();
+  if (STATE.examples.length > 0) {
+    loadExample(STATE.examples[0].id);
+  } else {
+    updateInputCounters();
+  }
+
+  if (window.lucide) window.lucide.createIcons();
+}
+
+boot();

--- a/examples/privacy_filter_studio/static/assets/logo.svg
+++ b/examples/privacy_filter_studio/static/assets/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40">
+  <rect x="2" y="2" width="36" height="36" rx="8" fill="#0E1116"></rect>
+  <rect x="11" y="17.5" width="18" height="5" rx="1" fill="#F7F4EC"></rect>
+  <rect x="17.5" y="11" width="5" height="18" rx="1" fill="#F7F4EC"></rect>
+  <circle cx="20" cy="20" r="2" fill="#0D6E6E"></circle>
+</svg>

--- a/examples/privacy_filter_studio/static/index.html
+++ b/examples/privacy_filter_studio/static/index.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenMed Privacy Filter Studio</title>
+    <link rel="icon" href="/static/assets/logo.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="topbar" aria-label="Application controls">
+        <a class="brand" href="/" aria-label="OpenMed Privacy Filter Studio">
+          <img src="/static/assets/logo.svg" alt="" class="brand-mark" />
+          <span class="brand-word">open<span>med</span></span>
+          <span class="brand-rule" aria-hidden="true"></span>
+          <span class="brand-title">Privacy Filter Studio</span>
+        </a>
+
+        <div class="toolbar">
+          <div class="mode-switch" role="group" aria-label="De-identification mode">
+            <button type="button" class="mode-button is-active" data-mode="mask">
+              <i data-lucide="square-asterisk"></i>
+              <span>Mask</span>
+            </button>
+            <button type="button" class="mode-button" data-mode="randomize">
+              <i data-lucide="dices"></i>
+              <span>Randomize</span>
+            </button>
+          </div>
+
+          <label class="download-toggle" title="Allow first-run model download from Hugging Face">
+            <input id="allowDownloads" type="checkbox" />
+            <span>Allow Downloads</span>
+          </label>
+
+          <button class="icon-button" id="themeToggle" type="button" aria-label="Switch theme">
+            <i data-lucide="sun"></i>
+          </button>
+
+          <button class="run-button" id="runButton" type="button">
+            <i data-lucide="scan-line"></i>
+            <span>Run De-identification</span>
+          </button>
+        </div>
+      </header>
+
+      <main class="studio-stage">
+        <section class="examples-strip" aria-label="Pre-defined examples">
+          <span class="strip-label">Try an example</span>
+          <div class="example-chips" id="exampleChips"></div>
+        </section>
+
+        <section class="studio-grid" aria-label="Editor and result">
+          <article class="editor-pane" aria-labelledby="editorTitle">
+            <header class="pane-head">
+              <div class="pane-title">
+                <p>Input</p>
+                <h2 id="editorTitle">Paste or write text</h2>
+              </div>
+              <div class="pane-meta">
+                <span class="meta-item">
+                  <span class="meta-label">chars</span>
+                  <strong id="charCount">0</strong>
+                </span>
+                <span class="meta-item">
+                  <span class="meta-label">tokens (approx.)</span>
+                  <strong id="tokenCount">0</strong>
+                </span>
+                <button class="ghost-button" id="clearButton" type="button">
+                  <i data-lucide="eraser"></i>
+                  <span>Clear</span>
+                </button>
+              </div>
+            </header>
+
+            <div class="paper-frame">
+              <div class="scan-line" aria-hidden="true"></div>
+              <textarea
+                id="inputText"
+                spellcheck="false"
+                placeholder="Paste a clinical note, a discharge summary, or any free-form text containing PII. Pick an example above to get started."
+              ></textarea>
+            </div>
+
+            <footer class="pane-footer">
+              <span class="meta-item">
+                <span class="meta-label">model</span>
+                <strong id="modelLabel">--</strong>
+              </span>
+              <span class="meta-item">
+                <span class="meta-label">backend</span>
+                <strong id="backendLabel">--</strong>
+              </span>
+            </footer>
+          </article>
+
+          <article class="result-pane" aria-labelledby="resultTitle">
+            <header class="pane-head">
+              <div class="pane-title">
+                <p>Output</p>
+                <h2 id="resultTitle">De-identified text</h2>
+              </div>
+              <div class="pane-meta">
+                <span class="meta-item">
+                  <span class="meta-label">entities</span>
+                  <strong id="entityCount">0</strong>
+                </span>
+                <span class="meta-item">
+                  <span class="meta-label">latency</span>
+                  <strong id="latencyLabel">--</strong>
+                </span>
+                <span class="status-pill" id="statusPill">Ready</span>
+              </div>
+            </header>
+
+            <div class="paper-frame paper-frame--result">
+              <div class="scan-line" aria-hidden="true"></div>
+              <div
+                id="resultText"
+                class="result-text"
+                aria-live="polite"
+              >
+                <p class="placeholder">
+                  Press <kbd>⌘</kbd> + <kbd>Enter</kbd> or click
+                  <strong>Run De-identification</strong> to redact entities.
+                  Hover over a tag in the output to see the original value.
+                </p>
+              </div>
+            </div>
+
+            <footer class="pane-footer">
+              <span class="legend-label">Detected categories</span>
+              <ul class="legend-list" id="legendList"></ul>
+            </footer>
+          </article>
+        </section>
+      </main>
+    </div>
+
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="/static/app.js" type="module"></script>
+  </body>
+</html>

--- a/examples/privacy_filter_studio/static/styles.css
+++ b/examples/privacy_filter_studio/static/styles.css
@@ -1,0 +1,983 @@
+@import url("https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,500&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
+
+:root {
+  --paper: #f7f4ec;
+  --paper-2: #efe9d8;
+  --ink: #0e1116;
+  --ink-2: #1c2128;
+  --stone-50: #f2eee3;
+  --stone-100: #e4dece;
+  --stone-200: #cbc3ae;
+  --stone-300: #a9a088;
+  --stone-400: #7c7461;
+  --stone-500: #545042;
+  --stone-600: #3a3628;
+  --stone-800: #14130d;
+  --teal-600: #0d6e6e;
+  --teal-100: #d6ebeb;
+  --coral-600: #c5453a;
+  --coral-100: #f7dcd8;
+  --highlight: #f5e27a;
+  --bg: var(--paper);
+  --bg-panel: var(--paper-2);
+  --bg-elevated: #ffffff;
+  --fg: var(--ink);
+  --fg-muted: var(--stone-500);
+  --border: var(--stone-100);
+  --border-strong: var(--stone-200);
+  --accent: var(--teal-600);
+  --signal: var(--coral-600);
+  --signal-soft: var(--coral-100);
+  --font-display: "Newsreader", Georgia, serif;
+  --font-sans: "Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 14px;
+  --shadow-2: 0 12px 32px -12px rgba(14, 17, 22, 0.12), 0 2px 4px rgba(14, 17, 22, 0.04);
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+
+  --desk-bg: var(--ink);
+  --desk-grid: rgba(247, 244, 236, 0.03);
+  --chrome-bg: rgba(14, 17, 22, 0.88);
+  --chrome-fg: var(--paper);
+  --chrome-muted: rgba(247, 244, 236, 0.72);
+  --chrome-border: rgba(247, 244, 236, 0.16);
+  --chrome-control-bg: rgba(247, 244, 236, 0.06);
+  --chrome-control-hover-bg: rgba(247, 244, 236, 0.11);
+  --chrome-control-border: rgba(247, 244, 236, 0.18);
+  --chrome-control-hover-border: rgba(247, 244, 236, 0.3);
+  --chrome-control-active-bg: rgba(247, 244, 236, 0.18);
+  --caption-fg: rgba(247, 244, 236, 0.62);
+  --caption-accent: var(--teal-100);
+  --book-frame-border: rgba(247, 244, 236, 0.15);
+  --book-frame-shadow: 0 30px 80px rgba(0, 0, 0, 0.34);
+  --brand-mark-bg: var(--paper);
+  --pane-frame: #b1965a;
+  --pane-frame-edge: rgba(14, 17, 22, 0.35);
+  --pane-shell-bg: #2a2418;
+  --pane-shell-fg: var(--paper);
+  --pane-shell-muted: rgba(247, 244, 236, 0.55);
+  --pane-shell-border: rgba(247, 244, 236, 0.16);
+  --paper-edge: #d7ceb8;
+  --paper-shadow: 0 18px 32px -18px rgba(14, 17, 22, 0.36);
+  --legend-bg: rgba(247, 244, 236, 0.08);
+  --legend-border: rgba(247, 244, 236, 0.16);
+  --legend-fg: var(--paper);
+}
+
+[data-theme="light"] {
+  --desk-bg: var(--paper);
+  --desk-grid: rgba(14, 17, 22, 0.045);
+  --chrome-bg: rgba(247, 244, 236, 0.88);
+  --chrome-fg: var(--ink);
+  --chrome-muted: rgba(14, 17, 22, 0.66);
+  --chrome-border: rgba(14, 17, 22, 0.14);
+  --chrome-control-bg: rgba(14, 17, 22, 0.04);
+  --chrome-control-hover-bg: rgba(14, 17, 22, 0.08);
+  --chrome-control-border: rgba(14, 17, 22, 0.16);
+  --chrome-control-hover-border: rgba(14, 17, 22, 0.28);
+  --chrome-control-active-bg: rgba(14, 17, 22, 0.12);
+  --caption-fg: rgba(14, 17, 22, 0.62);
+  --caption-accent: var(--accent);
+  --book-frame-border: rgba(14, 17, 22, 0.16);
+  --book-frame-shadow: 0 28px 70px rgba(84, 80, 66, 0.24);
+  --brand-mark-bg: #ffffff;
+  --pane-shell-bg: var(--paper-2);
+  --pane-shell-fg: var(--ink);
+  --pane-shell-muted: var(--fg-muted);
+  --pane-shell-border: var(--stone-200);
+  --legend-bg: rgba(14, 17, 22, 0.06);
+  --legend-border: rgba(14, 17, 22, 0.16);
+  --legend-fg: var(--ink);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  color: var(--fg);
+  background: var(--desk-bg);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  border: 1px solid var(--chrome-control-border);
+  border-radius: var(--radius-sm);
+  background: var(--chrome-control-bg);
+  color: var(--chrome-fg);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.app-shell {
+  min-height: 100vh;
+  background:
+    linear-gradient(to right, var(--desk-grid) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--desk-grid) 1px, transparent 1px),
+    var(--desk-bg);
+  background-size: 44px 44px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Topbar — same chrome as Privacy Filter Field Book
+ * ------------------------------------------------------------------------- */
+
+.topbar {
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: 10px 24px;
+  border-bottom: 1px solid var(--chrome-border);
+  color: var(--chrome-fg);
+  background: var(--chrome-bg);
+  backdrop-filter: blur(14px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-mark {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  background: var(--brand-mark-bg);
+  border-radius: var(--radius-md);
+}
+
+.brand-word {
+  color: var(--chrome-fg);
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-style: italic;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.brand-word span {
+  color: var(--caption-accent);
+}
+
+.brand-rule {
+  width: 1px;
+  height: 24px;
+  background: var(--chrome-border);
+}
+
+.brand-title {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--chrome-muted);
+  white-space: nowrap;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.icon-button,
+.run-button,
+.download-toggle,
+.mode-switch,
+.mode-button,
+.ghost-button {
+  min-height: 38px;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+}
+
+.icon-button,
+.run-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  border: 1px solid var(--chrome-control-border);
+  background: var(--chrome-control-bg);
+  color: var(--chrome-fg);
+  transition: background 160ms var(--ease-out), border-color 160ms var(--ease-out), transform 160ms var(--ease-out);
+}
+
+.icon-button {
+  width: 38px;
+  padding: 0;
+}
+
+.run-button {
+  padding: 0 16px;
+  color: #ffffff;
+  background: var(--accent);
+  border-color: var(--accent);
+  font-weight: 700;
+}
+
+.icon-button:hover {
+  background: var(--chrome-control-hover-bg);
+  border-color: var(--chrome-control-hover-border);
+}
+
+.run-button:hover {
+  background: #0a5656;
+  border-color: #0a5656;
+}
+
+.icon-button:active,
+.run-button:active {
+  transform: translateY(1px);
+}
+
+.icon-button svg,
+.run-button svg,
+.mode-button svg,
+.ghost-button svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.6;
+}
+
+.download-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 12px;
+  border: 1px solid var(--chrome-control-border);
+  background: var(--chrome-control-bg);
+  color: var(--chrome-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.download-toggle:hover {
+  background: var(--chrome-control-hover-bg);
+  border-color: var(--chrome-control-hover-border);
+}
+
+.download-toggle input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}
+
+.mode-switch {
+  display: inline-flex;
+  padding: 3px;
+  border: 1px solid var(--chrome-control-border);
+  background: var(--chrome-control-bg);
+  gap: 2px;
+}
+
+.mode-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  height: 32px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--chrome-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: background 160ms var(--ease-out), color 160ms var(--ease-out);
+}
+
+.mode-button.is-active {
+  background: var(--chrome-control-active-bg);
+  color: var(--chrome-fg);
+  font-weight: 700;
+}
+
+.mode-button:hover:not(.is-active) {
+  color: var(--chrome-fg);
+}
+
+/* ---------------------------------------------------------------------------
+ * Examples strip
+ * ------------------------------------------------------------------------- */
+
+.studio-stage {
+  padding: 24px 24px 48px;
+}
+
+.examples-strip {
+  width: min(1640px, 100%);
+  margin: 0 auto var(--space-5);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.strip-label {
+  color: var(--caption-fg);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.example-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.example-chip {
+  position: relative;
+  min-height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--chrome-control-border);
+  border-radius: 999px;
+  background: var(--chrome-control-bg);
+  color: var(--chrome-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 160ms var(--ease-out), color 160ms var(--ease-out), border-color 160ms var(--ease-out);
+}
+
+.example-chip:hover {
+  background: var(--chrome-control-hover-bg);
+  border-color: var(--chrome-control-hover-border);
+  color: var(--chrome-fg);
+}
+
+.example-chip.is-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.example-chip[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: none;
+  max-width: 320px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  white-space: normal;
+  z-index: 6;
+}
+
+.example-chip:hover[data-tooltip]::after,
+.example-chip:focus[data-tooltip]::after {
+  display: block;
+}
+
+/* ---------------------------------------------------------------------------
+ * Studio grid (two panes)
+ * ------------------------------------------------------------------------- */
+
+.studio-grid {
+  width: min(1640px, 100%);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--space-5);
+}
+
+.editor-pane,
+.result-pane {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: 18px 18px 22px;
+  background: var(--pane-shell-bg);
+  border: 1px solid var(--pane-shell-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--book-frame-shadow);
+  color: var(--pane-shell-fg);
+}
+
+.editor-pane::before,
+.result-pane::before {
+  display: none;
+}
+
+.pane-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: var(--space-3);
+  padding: 10px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--paper);
+  box-shadow: var(--shadow-2);
+}
+
+.pane-title p {
+  margin: 0 0 4px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.pane-title h2 {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.pane-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.meta-item {
+  display: inline-flex;
+  flex-direction: column;
+  min-width: 40px;
+  color: var(--ink);
+}
+
+.meta-label {
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.meta-item strong {
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.ghost-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  border: 1px solid var(--border-strong);
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: background 160ms var(--ease-out), border-color 160ms var(--ease-out);
+}
+
+.ghost-button:hover {
+  background: var(--paper-2);
+  border-color: var(--stone-300);
+}
+
+.status-pill {
+  min-width: 76px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--paper-2);
+  color: var(--stone-500);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.status-pill.running {
+  color: var(--signal);
+  border-color: var(--signal);
+  background: var(--signal-soft);
+}
+
+.status-pill.live {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--teal-100);
+}
+
+.status-pill.error {
+  color: var(--signal);
+  border-color: var(--signal);
+  background: var(--signal-soft);
+}
+
+.paper-frame {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 540px;
+  padding: 28px 36px 32px;
+  background: var(--paper);
+  border: 1px solid var(--paper-edge);
+  box-shadow: var(--paper-shadow);
+  overflow: hidden;
+}
+
+.paper-frame::before {
+  content: "";
+  position: absolute;
+  inset: 14px;
+  border: 1px solid rgba(84, 80, 66, 0.16);
+  pointer-events: none;
+}
+
+.paper-frame--result {
+  background: var(--paper);
+}
+
+#inputText {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  min-height: 480px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--font-display);
+  font-size: 18px;
+  line-height: 1.6;
+  resize: none;
+  outline: none;
+}
+
+#inputText::placeholder {
+  color: rgba(84, 80, 66, 0.55);
+  font-style: italic;
+}
+
+.result-text {
+  position: relative;
+  z-index: 1;
+  min-height: 480px;
+  color: #17130e;
+  font-family: var(--font-display);
+  font-size: 18px;
+  line-height: 1.66;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.result-text .placeholder {
+  margin: 0;
+  padding: 24px 0;
+  color: var(--fg-muted);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.result-text .placeholder strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.result-text .empty-note {
+  margin: 0;
+  padding: 24px 0;
+  color: var(--fg-muted);
+  font-family: var(--font-sans);
+  font-size: 14px;
+}
+
+.result-text .error-note {
+  margin: 0;
+  padding: 24px 0;
+  color: var(--signal);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.scan-line {
+  position: absolute;
+  left: 22px;
+  right: 22px;
+  bottom: -18px;
+  height: 16px;
+  opacity: 0;
+  background: var(--signal);
+  box-shadow: 0 0 18px rgba(197, 69, 58, 0.35);
+  filter: blur(3px);
+  z-index: 3;
+  pointer-events: none;
+}
+
+.scan-active .scan-line {
+  animation: scanUp 980ms var(--ease-out) both;
+}
+
+.pane-footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 10px 14px;
+  border: 1px solid var(--legend-border);
+  border-radius: var(--radius-md);
+  background: var(--legend-bg);
+  color: var(--pane-shell-fg);
+  flex-wrap: wrap;
+}
+
+.pane-footer .meta-item strong {
+  color: var(--pane-shell-fg);
+}
+
+.pane-footer .meta-label {
+  color: var(--pane-shell-muted);
+}
+
+.legend-label {
+  color: var(--pane-shell-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.legend-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.legend-list .legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------------------------------------------------------------------
+ * Entity highlighting (colorful labels)
+ * ------------------------------------------------------------------------- */
+
+.entity {
+  position: relative;
+  display: inline;
+  padding: 1px 6px 1px 4px;
+  margin: 0 1px;
+  border-radius: 6px;
+  background: var(--ent-soft, rgba(13, 110, 110, 0.16));
+  border: 1px solid var(--ent-border, rgba(13, 110, 110, 0.4));
+  color: var(--ent-fg, var(--ink));
+  font-family: var(--font-display);
+  font-weight: 500;
+  white-space: pre-wrap;
+  transition: background 160ms var(--ease-out);
+  animation: inkIn 220ms var(--ease-out) both;
+}
+
+.entity .entity-mask {
+  font-family: var(--font-mono);
+  font-size: 0.78em;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.entity::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: none;
+  min-width: max-content;
+  max-width: 320px;
+  padding: 6px 8px;
+  background: var(--ink);
+  color: var(--paper);
+  border: 1px solid rgba(247, 244, 236, 0.18);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  white-space: normal;
+  text-transform: none;
+  text-align: left;
+  z-index: 5;
+  pointer-events: none;
+}
+
+.entity:hover::after,
+.entity:focus-within::after {
+  display: block;
+}
+
+.entity-tag {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 0 5px;
+  border-radius: 4px;
+  background: var(--ent-tag-bg, rgba(13, 110, 110, 0.85));
+  color: #fff;
+  font-family: var(--font-mono);
+  font-size: 0.7em;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  vertical-align: 2px;
+}
+
+/* Per-category palette — each canonical group has a soft fill, a bordered
+ * outline, and a tag colour. Tuned to read on the cream paper background. */
+
+.entity[data-group="identity"] {
+  --ent-soft: rgba(197, 69, 58, 0.14);
+  --ent-border: rgba(197, 69, 58, 0.55);
+  --ent-tag-bg: #c5453a;
+  --ent-fg: #571a14;
+}
+
+.entity[data-group="contact"] {
+  --ent-soft: rgba(45, 110, 196, 0.14);
+  --ent-border: rgba(45, 110, 196, 0.55);
+  --ent-tag-bg: #2d6ec4;
+  --ent-fg: #11305b;
+}
+
+.entity[data-group="address"] {
+  --ent-soft: rgba(31, 132, 79, 0.14);
+  --ent-border: rgba(31, 132, 79, 0.55);
+  --ent-tag-bg: #1f844f;
+  --ent-fg: #0f3a23;
+}
+
+.entity[data-group="dates"] {
+  --ent-soft: rgba(127, 79, 200, 0.14);
+  --ent-border: rgba(127, 79, 200, 0.55);
+  --ent-tag-bg: #7f4fc8;
+  --ent-fg: #3a235f;
+}
+
+.entity[data-group="govid"] {
+  --ent-soft: rgba(176, 47, 87, 0.14);
+  --ent-border: rgba(176, 47, 87, 0.55);
+  --ent-tag-bg: #b02f57;
+  --ent-fg: #531528;
+}
+
+.entity[data-group="financial"] {
+  --ent-soft: rgba(190, 138, 19, 0.18);
+  --ent-border: rgba(190, 138, 19, 0.6);
+  --ent-tag-bg: #a87410;
+  --ent-fg: #4d3506;
+}
+
+.entity[data-group="healthcare"] {
+  --ent-soft: rgba(13, 110, 110, 0.14);
+  --ent-border: rgba(13, 110, 110, 0.55);
+  --ent-tag-bg: #0d6e6e;
+  --ent-fg: #0a3a3a;
+}
+
+.entity[data-group="workplace"] {
+  --ent-soft: rgba(82, 92, 109, 0.14);
+  --ent-border: rgba(82, 92, 109, 0.55);
+  --ent-tag-bg: #525c6d;
+  --ent-fg: #232932;
+}
+
+.entity[data-group="online"] {
+  --ent-soft: rgba(176, 92, 30, 0.16);
+  --ent-border: rgba(176, 92, 30, 0.55);
+  --ent-tag-bg: #b05c1e;
+  --ent-fg: #50260a;
+}
+
+.entity[data-group="demographic"] {
+  --ent-soft: rgba(170, 56, 152, 0.14);
+  --ent-border: rgba(170, 56, 152, 0.55);
+  --ent-tag-bg: #aa3898;
+  --ent-fg: #4d1845;
+}
+
+.entity[data-group="vehicle"] {
+  --ent-soft: rgba(204, 110, 27, 0.14);
+  --ent-border: rgba(204, 110, 27, 0.55);
+  --ent-tag-bg: #cc6e1b;
+  --ent-fg: #5e2f08;
+}
+
+.entity[data-group="time"] {
+  --ent-soft: rgba(127, 79, 200, 0.14);
+  --ent-border: rgba(127, 79, 200, 0.55);
+  --ent-tag-bg: #7f4fc8;
+  --ent-fg: #3a235f;
+}
+
+.entity[data-group="other"] {
+  --ent-soft: rgba(84, 80, 66, 0.14);
+  --ent-border: rgba(84, 80, 66, 0.5);
+  --ent-tag-bg: #545042;
+  --ent-fg: #25231a;
+}
+
+/* Legend chips reuse the same palette */
+.legend-item[data-group="identity"]    { background: rgba(197, 69, 58, 0.18); color: #c5453a; }
+.legend-item[data-group="contact"]     { background: rgba(45, 110, 196, 0.18); color: #2d6ec4; }
+.legend-item[data-group="address"]     { background: rgba(31, 132, 79, 0.18); color: #1f844f; }
+.legend-item[data-group="dates"]       { background: rgba(127, 79, 200, 0.18); color: #7f4fc8; }
+.legend-item[data-group="govid"]       { background: rgba(176, 47, 87, 0.18); color: #b02f57; }
+.legend-item[data-group="financial"]   { background: rgba(190, 138, 19, 0.22); color: #a87410; }
+.legend-item[data-group="healthcare"]  { background: rgba(13, 110, 110, 0.18); color: var(--accent); }
+.legend-item[data-group="workplace"]   { background: rgba(82, 92, 109, 0.18); color: #525c6d; }
+.legend-item[data-group="online"]      { background: rgba(176, 92, 30, 0.18); color: #b05c1e; }
+.legend-item[data-group="demographic"] { background: rgba(170, 56, 152, 0.18); color: #aa3898; }
+.legend-item[data-group="vehicle"]     { background: rgba(204, 110, 27, 0.18); color: #cc6e1b; }
+.legend-item[data-group="time"]        { background: rgba(127, 79, 200, 0.18); color: #7f4fc8; }
+.legend-item[data-group="other"]       { background: rgba(247, 244, 236, 0.14); color: var(--pane-shell-fg); }
+
+[data-theme="light"] .legend-item[data-group="other"] {
+  background: rgba(84, 80, 66, 0.14);
+  color: var(--ink);
+}
+
+.legend-item .legend-count {
+  display: inline-block;
+  padding: 0 5px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.45);
+  color: inherit;
+  font-weight: 700;
+}
+
+[data-theme="light"] .legend-item .legend-count {
+  background: rgba(255, 255, 255, 0.6);
+}
+
+/* ---------------------------------------------------------------------------
+ * Animations
+ * ------------------------------------------------------------------------- */
+
+@keyframes scanUp {
+  0%   { opacity: 0; transform: translateY(0); }
+  12%, 84% { opacity: 0.86; }
+  100% { opacity: 0; transform: translateY(-540px); }
+}
+
+@keyframes inkIn {
+  from { opacity: 0; transform: translateY(2px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ---------------------------------------------------------------------------
+ * Responsive
+ * ------------------------------------------------------------------------- */
+
+@media (max-width: 980px) {
+  .topbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .toolbar {
+    justify-content: flex-start;
+  }
+
+  .studio-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .paper-frame {
+    min-height: 360px;
+    padding: 20px 22px 24px;
+  }
+
+  #inputText,
+  .result-text {
+    min-height: 320px;
+    font-size: 16px;
+  }
+}

--- a/examples/privacy_filter_unified.py
+++ b/examples/privacy_filter_unified.py
@@ -1,0 +1,119 @@
+"""Demo: unified privacy-filter API across MLX and PyTorch.
+
+Same code path on every platform:
+
+    >>> from openmed import extract_pii, deidentify
+    >>> r = extract_pii(text, model_name="OpenMed/privacy-filter-mlx-8bit")
+
+On Apple Silicon with MLX installed, this routes through the MLX
+pipeline (fast, quantized). On Linux/Windows or any host without MLX,
+the same call substitutes the upstream ``openai/privacy-filter`` model
+via Transformers and emits a one-time UserWarning explaining the swap.
+
+Output entities have the same shape from either backend, so downstream
+``deidentify(...)`` works identically.
+
+This example uses live downloads. Set OPENMED_PRIVACY_FILTER_DOWNLOAD=1
+to allow them, or run after the model is cached locally:
+
+    huggingface-cli download openai/privacy-filter
+    OPENMED_PRIVACY_FILTER_DOWNLOAD=1 python examples/privacy_filter_unified.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+from openmed import deidentify, extract_pii
+from openmed.core.backends import select_privacy_filter_backend
+
+
+SAMPLE_TEXTS = [
+    (
+        "Discharge note",
+        "Patient Sarah Connor (DOB: 03/15/1985) was admitted at "
+        "Cedars Hospital under MRN 4471882. Contact: sarah.connor@example.com, "
+        "phone (415) 555-7012, address 1640 Riverside Drive, Apt 14, "
+        "Los Angeles CA 90039.",
+    ),
+    (
+        "Multilingual short note",
+        "Le patient Pierre Durand a téléphoné à Marie Dupont au +33 6 12 34 56 78. "
+        "Email: pierre.durand@hopital.fr — RDV le 22 mars 2024 à Paris.",
+    ),
+    (
+        "Portuguese note",
+        "Paciente Pedro Almeida, CPF 123.456.789-09, telefone +351 912 345 678, "
+        "morada Rua das Flores 25, 1200-195 Lisboa.",
+    ),
+]
+
+
+def announce_backend(model_name: str) -> None:
+    backend = select_privacy_filter_backend(model_name)
+    print(f"  Requested model:   {model_name}")
+    print(f"  Selected backend:  {backend}")
+    if backend == "torch" and "mlx" in model_name.lower():
+        print(f"  -> Running on a non-Apple-Silicon host or MLX is unavailable.")
+        print(f"     The library substitutes openai/privacy-filter via Transformers.")
+    print()
+
+
+def run_extraction(text: str, model_name: str) -> None:
+    started = time.perf_counter()
+    result = extract_pii(
+        text,
+        model_name=model_name,
+        confidence_threshold=0.5,
+    )
+    elapsed = time.perf_counter() - started
+    print(f"  Detected {len(result.entities)} entities in {elapsed*1000:.1f} ms")
+    for ent in result.entities[:8]:
+        print(f"    {ent.label:24s} {ent.text!r}  conf={ent.confidence:.2f}")
+    if len(result.entities) > 8:
+        print(f"    ... ({len(result.entities) - 8} more)")
+    print()
+
+
+def run_deidentification(text: str, model_name: str) -> None:
+    print("  Deidentified (mask):")
+    masked = deidentify(text, method="mask", model_name=model_name,
+                        confidence_threshold=0.5)
+    print(f"    {masked.deidentified_text}")
+    print()
+    print("  Deidentified (replace, consistent=True, seed=42):")
+    replaced = deidentify(text, method="replace", model_name=model_name,
+                          consistent=True, seed=42, confidence_threshold=0.5)
+    print(f"    {replaced.deidentified_text}")
+    print()
+
+
+def main() -> None:
+    if os.environ.get("OPENMED_PRIVACY_FILTER_DOWNLOAD", "").lower() not in {"1", "true", "yes"}:
+        print("WARNING: OPENMED_PRIVACY_FILTER_DOWNLOAD is not set.")
+        print("If the privacy-filter model is not already cached, the call below will fail.")
+        print("Set OPENMED_PRIVACY_FILTER_DOWNLOAD=1 to allow first-run downloads.")
+        print()
+
+    # The API accepts either the MLX artifact name (auto-substituted on
+    # non-Mac) or the PyTorch model name directly.
+    model_id = "OpenMed/privacy-filter-mlx-8bit"
+
+    for title, text in SAMPLE_TEXTS:
+        print("=" * 76)
+        print(title)
+        print("=" * 76)
+        announce_backend(model_id)
+        try:
+            run_extraction(text, model_id)
+            run_deidentification(text, model_id)
+        except Exception as exc:  # noqa: BLE001 - demo runs in many environments
+            print(f"  Skipped: {type(exc).__name__}: {exc}")
+            print(f"  (Likely the model is not yet downloaded.)")
+            print()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/privacy_filter_unified.py
+++ b/examples/privacy_filter_unified.py
@@ -90,6 +90,12 @@ def run_deidentification(text: str, model_name: str) -> None:
     print()
 
 
+MODEL_IDS = (
+    ("OpenAI Privacy Filter (8-bit MLX)", "OpenMed/privacy-filter-mlx-8bit"),
+    ("Nemotron Privacy Filter (8-bit MLX)", "OpenMed/privacy-filter-nemotron-mlx-8bit"),
+)
+
+
 def main() -> None:
     if os.environ.get("OPENMED_PRIVACY_FILTER_DOWNLOAD", "").lower() not in {"1", "true", "yes"}:
         print("WARNING: OPENMED_PRIVACY_FILTER_DOWNLOAD is not set.")
@@ -98,21 +104,26 @@ def main() -> None:
         print()
 
     # The API accepts either the MLX artifact name (auto-substituted on
-    # non-Mac) or the PyTorch model name directly.
-    model_id = "OpenMed/privacy-filter-mlx-8bit"
-
-    for title, text in SAMPLE_TEXTS:
-        print("=" * 76)
-        print(title)
-        print("=" * 76)
-        announce_backend(model_id)
-        try:
-            run_extraction(text, model_id)
-            run_deidentification(text, model_id)
-        except Exception as exc:  # noqa: BLE001 - demo runs in many environments
-            print(f"  Skipped: {type(exc).__name__}: {exc}")
-            print(f"  (Likely the model is not yet downloaded.)")
-            print()
+    # non-Mac) or the PyTorch model name directly. The fallback is
+    # family-aware: a Nemotron MLX request on Linux substitutes
+    # OpenMed/privacy-filter-nemotron, not openai/privacy-filter.
+    for family_label, model_id in MODEL_IDS:
+        print()
+        print("#" * 76)
+        print(f"# {family_label}")
+        print("#" * 76)
+        for title, text in SAMPLE_TEXTS:
+            print("=" * 76)
+            print(title)
+            print("=" * 76)
+            announce_backend(model_id)
+            try:
+                run_extraction(text, model_id)
+                run_deidentification(text, model_id)
+            except Exception as exc:  # noqa: BLE001 - demo runs in many environments
+                print(f"  Skipped: {type(exc).__name__}: {exc}")
+                print(f"  (Likely the model is not yet downloaded.)")
+                print()
 
 
 if __name__ == "__main__":

--- a/openmed/__about__.py
+++ b/openmed/__about__.py
@@ -1,3 +1,3 @@
 """Version information for OpenMed."""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -74,6 +74,14 @@ from .core.pii_i18n import (
     LANGUAGE_PII_PATTERNS,
     get_patterns_for_language,
 )
+from .core.labels import CANONICAL_LABELS, normalize_label
+from .core.anonymizer import (
+    Anonymizer,
+    AnonymizerConfig,
+    LANG_TO_LOCALE,
+    register_clinical_provider,
+    register_label_generator,
+)
 
 _PLACEHOLDER_SEGMENT_PATTERN = re.compile(
     r"(?:_{3,}|placeholder|^\W+$)", re.IGNORECASE
@@ -569,4 +577,13 @@ __all__ = [
     "DEFAULT_PII_MODELS",
     "LANGUAGE_PII_PATTERNS",
     "get_patterns_for_language",
+    # Canonical label taxonomy
+    "CANONICAL_LABELS",
+    "normalize_label",
+    # Anonymization engine
+    "Anonymizer",
+    "AnonymizerConfig",
+    "LANG_TO_LOCALE",
+    "register_clinical_provider",
+    "register_label_generator",
 ]

--- a/openmed/core/anonymizer/__init__.py
+++ b/openmed/core/anonymizer/__init__.py
@@ -1,0 +1,66 @@
+"""Faker-backed PII anonymization engine.
+
+Provides locale-aware, optionally deterministic surrogate generation for
+detected PII entities. Replaces the legacy hardcoded ``LANGUAGE_FAKE_DATA``
+lookup with a real Faker pipeline.
+
+Public surface:
+
+  - :class:`Anonymizer` — main runtime entry point; instantiate per
+    document or per session.
+  - :class:`AnonymizerConfig` — dataclass for advanced configuration.
+  - :func:`register_label_generator` — extend or override per-canonical-
+    label generators.
+  - :func:`register_clinical_provider` — register a custom Faker provider
+    on every cached locale (alias for ``Anonymizer``'s constructor option).
+  - :data:`LANG_TO_LOCALE` — language -> Faker locale lookup table.
+
+Typical usage::
+
+    from openmed.core.anonymizer import Anonymizer
+
+    anon = Anonymizer(lang="pt", consistent=True, seed=42)
+    fake = anon.surrogate("Pedro Almeida", "FIRSTNAME")  # canonical label-aware
+"""
+
+from typing import Any
+
+from .engine import Anonymizer, AnonymizerConfig
+from .locales import LANG_TO_LOCALE, resolve_locale
+from .registry import LABEL_GENERATORS, Generator, register_label_generator
+
+
+def register_clinical_provider(provider: Any) -> None:
+    """Register a custom Faker ``BaseProvider`` for every new Anonymizer.
+
+    Use this to add e.g. proprietary patient-ID formats. The provider is
+    registered on each fresh Faker instance built by the engine; existing
+    instances are not retroactively updated. Pass via
+    ``AnonymizerConfig.custom_providers`` instead when you need
+    per-instance scoping.
+    """
+    from .providers import clinical_ids
+    if not hasattr(clinical_ids, "_extra_providers"):
+        clinical_ids._extra_providers = []  # type: ignore[attr-defined]
+    clinical_ids._extra_providers.append(provider)  # type: ignore[attr-defined]
+
+    original = clinical_ids.register_clinical_providers
+
+    def _augmented(faker):
+        original(faker)
+        for extra in getattr(clinical_ids, "_extra_providers", ()):
+            faker.add_provider(extra)
+
+    clinical_ids.register_clinical_providers = _augmented  # type: ignore[assignment]
+
+
+__all__ = [
+    "Anonymizer",
+    "AnonymizerConfig",
+    "Generator",
+    "LABEL_GENERATORS",
+    "LANG_TO_LOCALE",
+    "register_clinical_provider",
+    "register_label_generator",
+    "resolve_locale",
+]

--- a/openmed/core/anonymizer/engine.py
+++ b/openmed/core/anonymizer/engine.py
@@ -1,0 +1,182 @@
+"""Faker-backed anonymization engine.
+
+The :class:`Anonymizer` is the single entry point for generating fake
+surrogate values for detected PII entities. It supports:
+
+  - **Locale-aware generation**: surrogates are drawn from a Faker locale
+    matched to the input language (``de`` -> ``de_DE``, ``pt`` ->
+    ``pt_PT``, ...). Override per-call via ``locale=`` or per-instance
+    via the constructor.
+  - **Deterministic mode**: when ``consistent=True``, the same
+    ``(canonical_label, original_value)`` pair always yields the same
+    surrogate within a session — solves "John Doe appearing twice gets
+    two different fakes" without sacrificing realism. Cross-session
+    determinism is opt-in via ``seed=``.
+  - **Format preservation**: phone digit groups, date separators, email
+    domains, and ID shapes are kept stable so downstream regexes and
+    template renderers don't break.
+  - **Custom generators**: extend or override per canonical label via
+    :func:`openmed.core.anonymizer.register_label_generator`. Add custom
+    Faker providers (e.g. proprietary patient ID formats) via
+    :func:`openmed.core.anonymizer.register_clinical_provider`.
+
+This module is the runtime engine. The label-to-generator mapping lives
+in :mod:`registry`; the locale resolution in :mod:`locales`; format
+helpers in :mod:`format_preserve`; clinical-ID providers in
+:mod:`providers.clinical_ids`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from ..labels import normalize_label
+from .locales import resolve_locale
+from .providers import register_clinical_providers
+from .registry import LABEL_GENERATORS
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AnonymizerConfig:
+    """Per-call/per-instance configuration for :class:`Anonymizer`.
+
+    Attributes:
+        lang: ISO 639-1 language code controlling default Faker locale.
+        locale: Explicit Faker locale (``pt_BR``, ``en_GB``); overrides
+            the ``lang`` -> locale lookup.
+        consistent: When True, identical ``(canonical_label, original_value)``
+            pairs always produce the same surrogate. Use for within-document
+            consistency (so "John Doe" appearing twice gets one surrogate).
+        seed: Optional integer seed. When set together with
+            ``consistent=True``, surrogates are stable across sessions.
+        custom_providers: Additional Faker providers to register on every
+            new locale instance.
+    """
+
+    lang: str = "en"
+    locale: Optional[str] = None
+    consistent: bool = False
+    seed: Optional[int] = None
+    custom_providers: list[Any] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Anonymizer
+# ---------------------------------------------------------------------------
+
+class Anonymizer:
+    """Generate locale-aware, optionally deterministic surrogate PII values."""
+
+    def __init__(
+        self,
+        lang: str = "en",
+        *,
+        locale: Optional[str] = None,
+        consistent: bool = False,
+        seed: Optional[int] = None,
+        config: Optional[AnonymizerConfig] = None,
+    ) -> None:
+        if config is not None:
+            self.config = config
+        else:
+            self.config = AnonymizerConfig(
+                lang=lang,
+                locale=locale,
+                consistent=consistent,
+                seed=seed,
+            )
+        self._faker_cache: Dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Faker management
+    # ------------------------------------------------------------------
+
+    def _build_faker(self, locale: str):
+        try:
+            from faker import Faker
+        except ImportError as exc:  # pragma: no cover - faker is a hard dep
+            raise ImportError(
+                "Faker is required for openmed.core.anonymizer. "
+                "Install with `pip install faker` (or upgrade openmed)."
+            ) from exc
+
+        faker = Faker(locale)
+        register_clinical_providers(faker)
+        for provider in self.config.custom_providers:
+            faker.add_provider(provider)
+        return faker
+
+    def _get_faker(self, locale: str):
+        cached = self._faker_cache.get(locale)
+        if cached is None:
+            cached = self._build_faker(locale)
+            self._faker_cache[locale] = cached
+        return cached
+
+    # ------------------------------------------------------------------
+    # Determinism
+    # ------------------------------------------------------------------
+
+    def _derive_seed(self, canonical_label: str, original_value: str) -> int:
+        """Map ``(label, value)`` -> 64-bit integer seed."""
+        base = self.config.seed if self.config.seed is not None else 0
+        material = f"{base}|{canonical_label}|{original_value}".encode("utf-8")
+        digest = hashlib.blake2b(material, digest_size=8).digest()
+        return int.from_bytes(digest, "big", signed=False)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def surrogate(
+        self,
+        original: str,
+        label: str,
+        *,
+        lang: Optional[str] = None,
+        locale: Optional[str] = None,
+    ) -> str:
+        """Return a surrogate for ``original`` of type ``label``.
+
+        Args:
+            original: The detected PII string. Used for format
+                preservation and (in deterministic mode) seed derivation.
+            label: Source label as emitted by the model. Run through
+                :func:`openmed.core.labels.normalize_label` internally.
+            lang: Override the configured language for this call.
+            locale: Override the configured Faker locale for this call.
+
+        Returns:
+            A locale-appropriate fake value of the same type as the
+            detected PII. Falls back to a format-preserving substitution
+            when no specific generator is registered.
+        """
+        effective_lang = lang or self.config.lang
+        effective_locale = resolve_locale(effective_lang, locale or self.config.locale)
+        canonical = normalize_label(label, effective_lang)
+
+        faker = self._get_faker(effective_locale)
+        if self.config.consistent:
+            faker.seed_instance(self._derive_seed(canonical, original))
+
+        generator = LABEL_GENERATORS.get(canonical, LABEL_GENERATORS["OTHER"])
+        try:
+            return generator(faker, original, locale=effective_locale)
+        except Exception as exc:  # noqa: BLE001 — never let a single label kill the doc
+            warnings.warn(
+                f"Anonymizer fallback for label {label!r} (canonical "
+                f"{canonical!r}) at locale {effective_locale!r}: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return f"[{label}]"
+
+
+__all__ = ["Anonymizer", "AnonymizerConfig"]

--- a/openmed/core/anonymizer/format_preserve.py
+++ b/openmed/core/anonymizer/format_preserve.py
@@ -1,0 +1,151 @@
+"""Format-preserving helpers for surrogate generation.
+
+When we replace a phone number, date, email, or ID with a fake surrogate,
+we want the surrogate to *look like* the original — same digit groupings,
+same separators, same overall shape. That keeps the deidentified text
+useful for downstream tooling (regex matchers, length-sensitive UIs,
+PDF templates) that may have been calibrated on the original format.
+
+Each helper takes the original text and returns either:
+  - a surrogate that mirrors the original's structure, or
+  - a small "shape descriptor" that a generator can use to render a
+    locale-appropriate value with the right shape.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Phone numbers
+# ---------------------------------------------------------------------------
+
+def extract_digit_groups(text: str) -> List[int]:
+    """Return the lengths of each contiguous digit run in ``text``.
+
+    >>> extract_digit_groups("+1 (415) 555-1234")
+    [1, 3, 3, 4]
+    >>> extract_digit_groups("+33 6 12 34 56 78")
+    [2, 1, 2, 2, 2, 2]
+    """
+    return [len(m.group()) for m in re.finditer(r"\d+", text)]
+
+
+def preserve_phone_format(original: str, *, rng: Optional[random.Random] = None) -> str:
+    """Generate a fake phone number that mirrors ``original``'s structure.
+
+    The non-digit characters (``+``, spaces, dashes, parentheses) are kept
+    in place; each digit run is filled with new random digits. Useful when
+    Faker's locale-specific ``phone_number()`` would change the digit
+    grouping in ways that break downstream regexes.
+    """
+    rng = rng or random
+    out = []
+    for ch in original:
+        if ch.isdigit():
+            out.append(str(rng.randint(0, 9)))
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Dates
+# ---------------------------------------------------------------------------
+
+# Common date-format heuristics keyed off the locale. The first format
+# wins when generating a surrogate, but ``preserve_date_format`` tries to
+# match the original's separator and digit ordering before falling back.
+_DATE_SEPARATORS = ("/", "-", ".", " ")
+
+
+def preserve_date_format(
+    original: str,
+    *,
+    day_first: bool = False,
+    rng: Optional[random.Random] = None,
+) -> str:
+    """Generate a fake date that uses the same separator and ordering.
+
+    Recognises the common ``dd/mm/yyyy``, ``mm/dd/yyyy``, ``yyyy-mm-dd``,
+    and ``dd.mm.yyyy`` shapes. ``day_first`` controls fallback when the
+    original is ambiguous (e.g. ``05/06/2020``).
+
+    Returns a surrogate date in the same format, drawn uniformly from the
+    last 100 years.
+    """
+    rng = rng or random
+
+    days = rng.randint(0, 365 * 100)
+    fake = datetime(1925, 1, 1) + timedelta(days=days)
+
+    # Detect separator
+    sep = "/"
+    for candidate in _DATE_SEPARATORS:
+        if candidate in original:
+            sep = candidate
+            break
+
+    # Detect ordering: yyyy-first if a 4-digit run is at the start
+    if re.match(r"^\d{4}", original):
+        return f"{fake.year:04d}{sep}{fake.month:02d}{sep}{fake.day:02d}"
+    if day_first:
+        return f"{fake.day:02d}{sep}{fake.month:02d}{sep}{fake.year:04d}"
+    return f"{fake.month:02d}{sep}{fake.day:02d}{sep}{fake.year:04d}"
+
+
+# ---------------------------------------------------------------------------
+# Emails
+# ---------------------------------------------------------------------------
+
+def preserve_email_pattern(original: str, fake_email: str) -> str:
+    """Use ``fake_email``'s local part with ``original``'s domain.
+
+    Keeps the domain stable (often a meaningful tenant marker like
+    ``@hospital.org`` that downstream systems route on) while randomizing
+    the local part. Falls back to ``fake_email`` verbatim if either side
+    doesn't parse as ``local@domain``.
+    """
+    if "@" not in original or "@" not in fake_email:
+        return fake_email
+    fake_local = fake_email.split("@", 1)[0]
+    original_domain = original.split("@", 1)[1]
+    return f"{fake_local}@{original_domain}"
+
+
+# ---------------------------------------------------------------------------
+# Generic IDs (digit + separator preservation)
+# ---------------------------------------------------------------------------
+
+def preserve_id_pattern(original: str, *, rng: Optional[random.Random] = None) -> str:
+    """Replace digits in ``original`` with random digits, keeping all other
+    characters in place.
+
+    Use for opaque IDs where format matters but no checksum applies (MRN,
+    account numbers, sometimes ZIP codes). For checksum-bearing IDs (CPF,
+    CNPJ, BSN, NIR, ...), use the dedicated Faker provider instead.
+    """
+    rng = rng or random
+    out = []
+    for ch in original:
+        if ch.isdigit():
+            out.append(str(rng.randint(0, 9)))
+        elif ch.isalpha():
+            out.append(rng.choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ") if ch.isupper()
+                       else rng.choice("abcdefghijklmnopqrstuvwxyz"))
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+__all__ = [
+    "extract_digit_groups",
+    "preserve_phone_format",
+    "preserve_date_format",
+    "preserve_email_pattern",
+    "preserve_id_pattern",
+]

--- a/openmed/core/anonymizer/locales.py
+++ b/openmed/core/anonymizer/locales.py
@@ -1,0 +1,72 @@
+"""Mapping from OpenMed language codes to Faker locales.
+
+Faker speaks locale strings like ``en_US``, ``pt_PT``, ``fr_FR``. This module
+resolves OpenMed's ISO 639-1 codes (used everywhere else in the library) to
+the most appropriate Faker locale.
+
+Notes:
+- Telugu (``te``) has no Faker locale; we fall back to ``en_IN`` so generated
+  surrogates stay culturally adjacent. This is documented and surfaced to
+  callers as a ``UserWarning`` the first time it's used.
+- Portuguese defaults to ``pt_PT``; pass ``locale="pt_BR"`` explicitly to
+  generate Brazilian-Portuguese surrogates (matters for CPF/CNPJ context).
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Final, Mapping
+
+
+# Default Faker locale per OpenMed language code.
+LANG_TO_LOCALE: Final[Mapping[str, str]] = {
+    "en": "en_US",
+    "fr": "fr_FR",
+    "de": "de_DE",
+    "it": "it_IT",
+    "es": "es_ES",
+    "nl": "nl_NL",
+    "hi": "hi_IN",
+    "te": "en_IN",  # Faker has no Telugu locale; en_IN is the closest match
+    "pt": "pt_PT",
+}
+
+
+# Languages whose default locale is a known approximation rather than a
+# direct match. Used to emit a one-time warning so callers can override.
+_APPROXIMATE_LOCALES: Final = frozenset({"te"})
+
+_warned: set[str] = set()
+
+
+def resolve_locale(lang: str, locale_override: str | None = None) -> str:
+    """Resolve a Faker locale for ``lang``.
+
+    Args:
+        lang: ISO 639-1 language code (``en``, ``fr``, ``de``, ...).
+        locale_override: Caller-supplied locale (e.g. ``pt_BR``); takes
+            precedence and skips the warning.
+
+    Returns:
+        A Faker locale string.
+    """
+    if locale_override:
+        return locale_override
+
+    locale = LANG_TO_LOCALE.get(lang)
+    if locale is None:
+        return LANG_TO_LOCALE["en"]
+
+    if lang in _APPROXIMATE_LOCALES and lang not in _warned:
+        warnings.warn(
+            f"OpenMed: language {lang!r} has no native Faker locale; "
+            f"falling back to {locale!r}. Pass locale=... to override.",
+            UserWarning,
+            stacklevel=3,
+        )
+        _warned.add(lang)
+
+    return locale
+
+
+__all__ = ["LANG_TO_LOCALE", "resolve_locale"]

--- a/openmed/core/anonymizer/providers/__init__.py
+++ b/openmed/core/anonymizer/providers/__init__.py
@@ -1,0 +1,23 @@
+"""Custom Faker providers for clinical / national IDs that Faker doesn't
+cover natively or covers with the wrong format.
+
+These providers integrate with Faker's standard ``add_provider`` mechanism
+and produce values that pass the existing checksum validators in
+:mod:`openmed.core.pii_i18n`.
+"""
+
+from .clinical_ids import (
+    AadhaarProvider,
+    GermanSteuerIdProvider,
+    MedicalRecordNumberProvider,
+    NPIProvider,
+    register_clinical_providers,
+)
+
+__all__ = [
+    "AadhaarProvider",
+    "GermanSteuerIdProvider",
+    "MedicalRecordNumberProvider",
+    "NPIProvider",
+    "register_clinical_providers",
+]

--- a/openmed/core/anonymizer/providers/clinical_ids.py
+++ b/openmed/core/anonymizer/providers/clinical_ids.py
@@ -1,0 +1,173 @@
+"""Faker providers for clinical / national IDs.
+
+Each provider produces values that pass the corresponding validator in
+:mod:`openmed.core.pii_i18n`. We rely on Faker's built-in providers where
+the checksum and format already match (verified empirically against our
+validators):
+
+  - ``pt_BR.cpf()``               valid
+  - ``pt_BR.cnpj()``              valid
+  - ``nl_NL.ssn()``  (BSN)        valid
+  - ``fr_FR.ssn()``  (NIR)        valid
+  - ``it_IT.ssn()``  (Codice Fiscale) valid
+  - ``es_ES.nie()``               valid
+
+Custom providers below cover the gaps where Faker either has no built-in
+or emits a US-style format unrelated to the requested locale's actual ID:
+
+  - German Steuer-ID (Faker's ``de_DE.ssn`` is US-format)
+  - Aadhaar with Verhoeff checksum (Faker's ``en_IN.aadhaar_id`` rarely
+    passes the official Verhoeff check — only ~1 in 20 by sampling)
+  - Generic medical record numbers (MRN-XXXXXXX style)
+  - US National Provider Identifier (Luhn over a "80840" prefix)
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from faker.providers import BaseProvider
+
+
+# ---------------------------------------------------------------------------
+# Aadhaar (12 digits, Verhoeff checksum)
+# ---------------------------------------------------------------------------
+
+# Verhoeff multiplication, permutation and inverse tables, transcribed from
+# https://en.wikipedia.org/wiki/Verhoeff_algorithm.
+_VERHOEFF_D: Sequence[Sequence[int]] = (
+    (0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+    (1, 2, 3, 4, 0, 6, 7, 8, 9, 5),
+    (2, 3, 4, 0, 1, 7, 8, 9, 5, 6),
+    (3, 4, 0, 1, 2, 8, 9, 5, 6, 7),
+    (4, 0, 1, 2, 3, 9, 5, 6, 7, 8),
+    (5, 9, 8, 7, 6, 0, 4, 3, 2, 1),
+    (6, 5, 9, 8, 7, 1, 0, 4, 3, 2),
+    (7, 6, 5, 9, 8, 2, 1, 0, 4, 3),
+    (8, 7, 6, 5, 9, 3, 2, 1, 0, 4),
+    (9, 8, 7, 6, 5, 4, 3, 2, 1, 0),
+)
+_VERHOEFF_P: Sequence[Sequence[int]] = (
+    (0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+    (1, 5, 7, 6, 2, 8, 3, 0, 9, 4),
+    (5, 8, 0, 3, 7, 9, 6, 1, 4, 2),
+    (8, 9, 1, 6, 0, 4, 3, 5, 2, 7),
+    (9, 4, 5, 3, 1, 2, 6, 8, 7, 0),
+    (4, 2, 8, 6, 5, 7, 3, 9, 0, 1),
+    (2, 7, 9, 3, 8, 0, 6, 4, 1, 5),
+    (7, 0, 4, 6, 9, 1, 3, 2, 5, 8),
+)
+_VERHOEFF_INV: Sequence[int] = (0, 4, 3, 2, 1, 5, 6, 7, 8, 9)
+
+
+def _verhoeff_checksum(digits: Sequence[int]) -> int:
+    """Compute the Verhoeff check digit for ``digits`` (without the check)."""
+    c = 0
+    for i, n in enumerate(reversed(digits), start=1):
+        c = _VERHOEFF_D[c][_VERHOEFF_P[i % 8][n]]
+    return _VERHOEFF_INV[c]
+
+
+class AadhaarProvider(BaseProvider):
+    """Generates 12-digit Aadhaar numbers with valid Verhoeff checksums."""
+
+    def aadhaar(self) -> str:
+        # First digit cannot be 0 or 1 per UIDAI spec.
+        digits = [self.generator.random.randint(2, 9)]
+        digits.extend(self.generator.random.randint(0, 9) for _ in range(10))
+        digits.append(_verhoeff_checksum(digits))
+        return "".join(str(d) for d in digits)
+
+
+# ---------------------------------------------------------------------------
+# German Steuer-ID (11 digits with mod-11 checksum and digit-frequency rules)
+# ---------------------------------------------------------------------------
+
+class GermanSteuerIdProvider(BaseProvider):
+    """Generates 11-digit German Steuer-IDs that pass our validator.
+
+    The Steuer-ID rules are subtle enough that we generate by trial and
+    delegate to the validator from :mod:`openmed.core.pii_i18n`. Bounded
+    retries keep this from looping indefinitely on adversarial random
+    states; in practice ~1 in 50 random 11-digit strings satisfies all
+    constraints, so we typically succeed in <100 tries.
+    """
+
+    _MAX_TRIES = 500
+
+    def german_steuer_id(self) -> str:
+        from openmed.core.pii_i18n import validate_german_steuer_id
+
+        rng = self.generator.random
+        for _ in range(self._MAX_TRIES):
+            # First digit must not be 0
+            digits = [rng.randint(1, 9)]
+            digits.extend(rng.randint(0, 9) for _ in range(10))
+            candidate = "".join(str(d) for d in digits)
+            if validate_german_steuer_id(candidate):
+                return candidate
+        # Fallback: return any 11 digits; validator may reject downstream.
+        return self.numerify("###########")
+
+
+# ---------------------------------------------------------------------------
+# Medical Record Number (opaque, but recognizably MRN-shaped)
+# ---------------------------------------------------------------------------
+
+class MedicalRecordNumberProvider(BaseProvider):
+    """Generates plausible medical record numbers (``MRN-1234567``)."""
+
+    def medical_record_number(self) -> str:
+        return f"MRN-{self.numerify('#######')}"
+
+
+# ---------------------------------------------------------------------------
+# US National Provider Identifier (10 digits, Luhn over "80840" prefix)
+# ---------------------------------------------------------------------------
+
+def _luhn_check_digit(digits: Sequence[int]) -> int:
+    total = 0
+    for i, d in enumerate(reversed(digits)):
+        if i % 2 == 0:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return (10 - total % 10) % 10
+
+
+class NPIProvider(BaseProvider):
+    """Generates valid 10-digit US NPI numbers.
+
+    The NPI uses Luhn over the digits prefixed with ``80840``. We generate
+    9 random digits, prepend the prefix for checksumming, compute the
+    check digit, and emit the original 9 digits + the check digit.
+    """
+
+    def npi(self) -> str:
+        rng = self.generator.random
+        body = [rng.randint(0, 9) for _ in range(9)]
+        prefixed = [8, 0, 8, 4, 0, *body]
+        check = _luhn_check_digit(prefixed)
+        return "".join(str(d) for d in body) + str(check)
+
+
+# ---------------------------------------------------------------------------
+# Bulk registration helper
+# ---------------------------------------------------------------------------
+
+def register_clinical_providers(faker) -> None:
+    """Add every custom provider in this module to ``faker``."""
+    faker.add_provider(AadhaarProvider)
+    faker.add_provider(GermanSteuerIdProvider)
+    faker.add_provider(MedicalRecordNumberProvider)
+    faker.add_provider(NPIProvider)
+
+
+__all__ = [
+    "AadhaarProvider",
+    "GermanSteuerIdProvider",
+    "MedicalRecordNumberProvider",
+    "NPIProvider",
+    "register_clinical_providers",
+]

--- a/openmed/core/anonymizer/registry.py
+++ b/openmed/core/anonymizer/registry.py
@@ -1,0 +1,408 @@
+"""Per-canonical-label generator registry.
+
+Each generator takes ``(faker, original, locale)`` and returns a string
+surrogate. Generators are responsible for:
+
+  1. Picking the right Faker method or custom provider for ``locale``
+     (e.g. ``cpf()`` for ``pt_BR``, ``nie()`` for ``es_ES``).
+  2. Format-preserving the output where it makes downstream tooling
+     happier (phone digit groups, date separators, email domains).
+
+The registry is keyed off canonical labels from :mod:`openmed.core.labels`,
+so callers should run ``normalize_label(model_label)`` before lookup.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from .. import labels as L
+from .format_preserve import (
+    preserve_date_format,
+    preserve_email_pattern,
+    preserve_id_pattern,
+    preserve_phone_format,
+)
+
+
+Generator = Callable[..., str]
+"""Signature: ``(faker, original: str, *, locale: str) -> str``."""
+
+
+# ---------------------------------------------------------------------------
+# Names
+# ---------------------------------------------------------------------------
+
+def _gen_person(faker, original, *, locale):
+    return faker.name()
+
+
+def _gen_first_name(faker, original, *, locale):
+    return faker.first_name()
+
+
+def _gen_last_name(faker, original, *, locale):
+    return faker.last_name()
+
+
+def _gen_middle_name(faker, original, *, locale):
+    return faker.first_name()
+
+
+def _gen_prefix(faker, original, *, locale):
+    return faker.prefix()
+
+
+def _gen_username(faker, original, *, locale):
+    return faker.user_name()
+
+
+# ---------------------------------------------------------------------------
+# Contact
+# ---------------------------------------------------------------------------
+
+def _gen_email(faker, original, *, locale):
+    fake = faker.email()
+    return preserve_email_pattern(original, fake)
+
+
+def _gen_phone(faker, original, *, locale):
+    if any(ch.isdigit() for ch in original):
+        return preserve_phone_format(original, rng=faker.random)
+    return faker.phone_number()
+
+
+def _gen_url(faker, original, *, locale):
+    return faker.url()
+
+
+# ---------------------------------------------------------------------------
+# Location
+# ---------------------------------------------------------------------------
+
+def _gen_location(faker, original, *, locale):
+    # Prefer city-level granularity since most "LOCATION" detections are cities
+    return faker.city()
+
+
+def _gen_street_address(faker, original, *, locale):
+    return faker.street_address()
+
+
+def _gen_building_number(faker, original, *, locale):
+    return faker.building_number()
+
+
+def _gen_zipcode(faker, original, *, locale):
+    if any(ch.isdigit() or ch.isalpha() for ch in original):
+        return preserve_id_pattern(original, rng=faker.random)
+    return faker.postcode()
+
+
+def _gen_gps(faker, original, *, locale):
+    lat, lon = faker.latitude(), faker.longitude()
+    return f"{float(lat):.6f}, {float(lon):.6f}"
+
+
+# ---------------------------------------------------------------------------
+# Time
+# ---------------------------------------------------------------------------
+
+# Day-first locales — same set as openmed.core.pii._DAY_FIRST_LANGS but
+# expressed in Faker locale terms.
+_DAY_FIRST_LOCALES = frozenset({
+    "fr_FR", "de_DE", "it_IT", "es_ES", "nl_NL",
+    "hi_IN", "en_IN", "pt_PT", "pt_BR",
+})
+
+
+def _gen_date(faker, original, *, locale):
+    day_first = locale in _DAY_FIRST_LOCALES
+    return preserve_date_format(original, day_first=day_first, rng=faker.random)
+
+
+def _gen_date_of_birth(faker, original, *, locale):
+    day_first = locale in _DAY_FIRST_LOCALES
+    return preserve_date_format(original, day_first=day_first, rng=faker.random)
+
+
+def _gen_time(faker, original, *, locale):
+    return faker.time()
+
+
+def _gen_age(faker, original, *, locale):
+    return str(faker.random_int(min=0, max=120))
+
+
+# ---------------------------------------------------------------------------
+# Identifiers — locale-aware dispatch
+# ---------------------------------------------------------------------------
+
+# Maps locale -> ``(faker_method_name, validator_module_attr or None)``.
+# When the locale-appropriate ID method exists, we call it; otherwise we
+# format-preserve the original.
+_LOCALE_ID_METHODS = {
+    "pt_BR": "cpf",
+    "pt_PT": "vat_id",
+    "fr_FR": "ssn",
+    "it_IT": "ssn",
+    "es_ES": "nie",
+    "nl_NL": "ssn",
+    "en_IN": "aadhaar",
+    "hi_IN": "aadhaar",
+    "de_DE": "german_steuer_id",
+    "en_US": "ssn",
+    "en_GB": "ssn",
+}
+
+
+def _gen_id_num(faker, original, *, locale):
+    method = _LOCALE_ID_METHODS.get(locale)
+    if method and hasattr(faker, method):
+        return getattr(faker, method)()
+    return preserve_id_pattern(original, rng=faker.random)
+
+
+def _gen_ssn(faker, original, *, locale):
+    method = _LOCALE_ID_METHODS.get(locale, "ssn")
+    if hasattr(faker, method):
+        return getattr(faker, method)()
+    return faker.ssn()
+
+
+def _gen_account_number(faker, original, *, locale):
+    return faker.bban() if hasattr(faker, "bban") else faker.iban()
+
+
+def _gen_password(faker, original, *, locale):
+    length = max(8, min(len(original), 32)) if original else 12
+    return faker.password(length=length)
+
+
+def _gen_pin(faker, original, *, locale):
+    length = max(3, min(len(original), 8)) if original else 4
+    return "".join(str(faker.random.randint(0, 9)) for _ in range(length))
+
+
+def _gen_api_key(faker, original, *, locale):
+    return faker.sha256()
+
+
+# ---------------------------------------------------------------------------
+# Financial
+# ---------------------------------------------------------------------------
+
+def _gen_credit_card(faker, original, *, locale):
+    return faker.credit_card_number()
+
+
+def _gen_credit_card_issuer(faker, original, *, locale):
+    return faker.credit_card_provider()
+
+
+def _gen_cvv(faker, original, *, locale):
+    return faker.credit_card_security_code()
+
+
+def _gen_iban(faker, original, *, locale):
+    return faker.iban()
+
+
+def _gen_bic(faker, original, *, locale):
+    return faker.swift11() if hasattr(faker, "swift11") else faker.bothify("########XXX")
+
+
+def _gen_amount(faker, original, *, locale):
+    return f"{faker.pyfloat(positive=True, min_value=10, max_value=100000):.2f}"
+
+
+def _gen_currency(faker, original, *, locale):
+    return faker.currency_code()
+
+
+def _gen_bitcoin_address(faker, original, *, locale):
+    if hasattr(faker, "ascii_email"):
+        return faker.bothify(
+            "1?????????????????????????????????",
+            letters="ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789",
+        )
+    return faker.sha256()[:34]
+
+
+def _gen_ethereum_address(faker, original, *, locale):
+    return "0x" + faker.hexify(text="^" * 40, upper=False)
+
+
+def _gen_litecoin_address(faker, original, *, locale):
+    return faker.bothify(
+        "L?????????????????????????????????",
+        letters="ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789",
+    )
+
+
+def _gen_masked_number(faker, original, *, locale):
+    return preserve_id_pattern(original, rng=faker.random) if original else faker.numerify("****-****-####")
+
+
+# ---------------------------------------------------------------------------
+# Demographics / work / tech
+# ---------------------------------------------------------------------------
+
+def _gen_gender(faker, original, *, locale):
+    return faker.random_element(("Female", "Male", "Non-binary"))
+
+
+def _gen_eye_color(faker, original, *, locale):
+    return faker.random_element(("brown", "blue", "green", "hazel", "amber", "gray"))
+
+
+def _gen_height(faker, original, *, locale):
+    cm = faker.random_int(min=140, max=210)
+    return f"{cm} cm"
+
+
+def _gen_organization(faker, original, *, locale):
+    return faker.company()
+
+
+def _gen_job_title(faker, original, *, locale):
+    return faker.job()
+
+
+def _gen_job_department(faker, original, *, locale):
+    return faker.random_element((
+        "Cardiology", "Oncology", "Radiology", "Emergency", "Pediatrics",
+        "Neurology", "Surgery", "Internal Medicine", "Dermatology",
+        "Orthopedics", "Psychiatry", "Anesthesiology",
+    ))
+
+
+def _gen_occupation(faker, original, *, locale):
+    return faker.job()
+
+
+def _gen_ip_address(faker, original, *, locale):
+    return faker.ipv4()
+
+
+def _gen_mac_address(faker, original, *, locale):
+    return faker.mac_address()
+
+
+def _gen_user_agent(faker, original, *, locale):
+    return faker.user_agent()
+
+
+def _gen_vin(faker, original, *, locale):
+    return faker.bothify("?????????????????", letters="ABCDEFGHJKLMNPRSTUVWXYZ0123456789").upper()
+
+
+def _gen_vehicle_registration(faker, original, *, locale):
+    return faker.license_plate() if hasattr(faker, "license_plate") else faker.bothify("???-####")
+
+
+def _gen_imei(faker, original, *, locale):
+    return faker.numerify("###############")
+
+
+def _gen_ordinal_direction(faker, original, *, locale):
+    return faker.random_element(("North", "South", "East", "West",
+                                 "Northeast", "Northwest", "Southeast", "Southwest"))
+
+
+# ---------------------------------------------------------------------------
+# Default fallback
+# ---------------------------------------------------------------------------
+
+def _gen_other(faker, original, *, locale):
+    """Last-resort surrogate when no specific generator fits.
+
+    Prefer format-preserving substitution over a random word so the
+    surrogate is at least the same shape as the original.
+    """
+    if original:
+        return preserve_id_pattern(original, rng=faker.random)
+    return faker.word()
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+LABEL_GENERATORS: Dict[str, Generator] = {
+    L.PERSON: _gen_person,
+    L.FIRST_NAME: _gen_first_name,
+    L.LAST_NAME: _gen_last_name,
+    L.MIDDLE_NAME: _gen_middle_name,
+    L.PREFIX: _gen_prefix,
+    L.USERNAME: _gen_username,
+
+    L.EMAIL: _gen_email,
+    L.PHONE: _gen_phone,
+    L.URL: _gen_url,
+
+    L.LOCATION: _gen_location,
+    L.STREET_ADDRESS: _gen_street_address,
+    L.BUILDING_NUMBER: _gen_building_number,
+    L.ZIPCODE: _gen_zipcode,
+    L.GPS_COORDINATES: _gen_gps,
+    L.ORDINAL_DIRECTION: _gen_ordinal_direction,
+
+    L.DATE: _gen_date,
+    L.DATE_OF_BIRTH: _gen_date_of_birth,
+    L.TIME: _gen_time,
+    L.AGE: _gen_age,
+
+    L.ID_NUM: _gen_id_num,
+    L.SSN: _gen_ssn,
+    L.ACCOUNT_NUMBER: _gen_account_number,
+    L.PASSWORD: _gen_password,
+    L.PIN: _gen_pin,
+    L.API_KEY: _gen_api_key,
+
+    L.CREDIT_CARD: _gen_credit_card,
+    L.CREDIT_CARD_ISSUER: _gen_credit_card_issuer,
+    L.CVV: _gen_cvv,
+    L.IBAN: _gen_iban,
+    L.BIC: _gen_bic,
+    L.AMOUNT: _gen_amount,
+    L.CURRENCY: _gen_currency,
+    L.BITCOIN_ADDRESS: _gen_bitcoin_address,
+    L.ETHEREUM_ADDRESS: _gen_ethereum_address,
+    L.LITECOIN_ADDRESS: _gen_litecoin_address,
+    L.MASKED_NUMBER: _gen_masked_number,
+
+    L.GENDER: _gen_gender,
+    L.EYE_COLOR: _gen_eye_color,
+    L.HEIGHT: _gen_height,
+
+    L.ORGANIZATION: _gen_organization,
+    L.JOB_TITLE: _gen_job_title,
+    L.JOB_DEPARTMENT: _gen_job_department,
+    L.OCCUPATION: _gen_occupation,
+
+    L.IP_ADDRESS: _gen_ip_address,
+    L.MAC_ADDRESS: _gen_mac_address,
+    L.USER_AGENT: _gen_user_agent,
+    L.VIN: _gen_vin,
+    L.VEHICLE_REGISTRATION: _gen_vehicle_registration,
+    L.IMEI: _gen_imei,
+
+    L.OTHER: _gen_other,
+}
+
+
+def register_label_generator(canonical_label: str, generator: Generator) -> None:
+    """Register or override a generator for a canonical label.
+
+    Use to extend coverage (new label types) or to swap in a domain-
+    specific generator (e.g. project-specific medical record format).
+    """
+    LABEL_GENERATORS[canonical_label] = generator
+
+
+__all__ = [
+    "Generator",
+    "LABEL_GENERATORS",
+    "register_label_generator",
+]

--- a/openmed/core/backends.py
+++ b/openmed/core/backends.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import logging
 import platform
-from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checkable
+import warnings
+from typing import Any, Callable, Dict, List, Literal, Optional, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
+_warned_substitutions: set[str] = set()
 
 
 @runtime_checkable
@@ -148,3 +150,89 @@ def get_backend(
         "No inference backend available. "
         "Install at least one: pip install openmed[hf] or pip install openmed[mlx]"
     )
+
+
+# -- Privacy-filter routing ------------------------------------------------
+
+# The MLX-only artifacts (``OpenMed/privacy-filter-mlx``,
+# ``OpenMed/privacy-filter-mlx-8bit``) cannot run on non-Apple-Silicon
+# machines. When a user passes one of these IDs from Linux/Windows we
+# silently fall back to the upstream PyTorch model and emit a one-time
+# warning so they understand the substitution.
+PRIVACY_FILTER_TORCH_FALLBACK = "openai/privacy-filter"
+
+
+def select_privacy_filter_backend(
+    model_name: str,
+) -> Literal["mlx", "torch"]:
+    """Pick MLX or Torch for a privacy-filter-family ``model_name``.
+
+    Returns ``"mlx"`` only when (a) MLX is importable on the current
+    machine, and (b) the requested model is itself an MLX artifact
+    (its name contains ``"mlx"`` or its on-disk metadata identifies as
+    one). Otherwise returns ``"torch"`` — including when an MLX-only
+    model name is requested on a non-Mac host, in which case the caller
+    should substitute :data:`PRIVACY_FILTER_TORCH_FALLBACK` for the
+    actual download.
+    """
+    name_lc = (model_name or "").lower()
+    is_mlx_artifact = "mlx" in name_lc
+
+    if not is_mlx_artifact:
+        # Some artifacts identify as MLX only via their on-disk metadata.
+        try:
+            from .pii import _is_privacy_filter_artifact_path
+            is_mlx_artifact = _is_privacy_filter_artifact_path(model_name)
+        except ImportError:  # pragma: no cover
+            is_mlx_artifact = False
+
+    if is_mlx_artifact and MLXBackend().is_available():
+        return "mlx"
+    return "torch"
+
+
+def resolve_privacy_filter_model(
+    model_name: str,
+    backend: Literal["mlx", "torch"],
+) -> str:
+    """Map a privacy-filter ``model_name`` to the actual artifact for ``backend``.
+
+    On Linux/Windows where MLX is unavailable, an ``OpenMed/privacy-filter-mlx*``
+    request needs to download the upstream PyTorch model instead. This
+    helper performs that substitution and emits a one-time UserWarning
+    so the user understands the swap.
+    """
+    if backend == "mlx":
+        return model_name
+
+    if "mlx" in (model_name or "").lower():
+        if model_name not in _warned_substitutions:
+            warnings.warn(
+                f"OpenMed: {model_name!r} is an MLX-only artifact and "
+                f"cannot run on this host. Substituting "
+                f"{PRIVACY_FILTER_TORCH_FALLBACK!r} via Transformers. "
+                "To silence, request the PyTorch model directly.",
+                UserWarning,
+                stacklevel=3,
+            )
+            _warned_substitutions.add(model_name)
+        return PRIVACY_FILTER_TORCH_FALLBACK
+    return model_name
+
+
+def create_privacy_filter_pipeline(model_name: str) -> Callable:
+    """Build a privacy-filter pipeline appropriate for the host.
+
+    Returns a callable ``pipeline(text) -> List[Dict]`` whose output
+    schema matches the HuggingFace ``token-classification`` pipeline so
+    downstream OpenMed code is backend-agnostic.
+    """
+    backend = select_privacy_filter_backend(model_name)
+    actual_model = resolve_privacy_filter_model(model_name, backend)
+
+    if backend == "mlx":
+        from openmed.mlx.inference import create_mlx_pipeline
+        return create_mlx_pipeline(actual_model)
+
+    from openmed.torch.privacy_filter import PrivacyFilterTorchPipeline
+    return PrivacyFilterTorchPipeline(actual_model)

--- a/openmed/core/backends.py
+++ b/openmed/core/backends.py
@@ -154,12 +154,33 @@ def get_backend(
 
 # -- Privacy-filter routing ------------------------------------------------
 
-# The MLX-only artifacts (``OpenMed/privacy-filter-mlx``,
-# ``OpenMed/privacy-filter-mlx-8bit``) cannot run on non-Apple-Silicon
-# machines. When a user passes one of these IDs from Linux/Windows we
-# silently fall back to the upstream PyTorch model and emit a one-time
-# warning so they understand the substitution.
+# Default Torch fallback for the original OpenAI Privacy Filter MLX artifacts
+# (``OpenMed/privacy-filter-mlx``, ``OpenMed/privacy-filter-mlx-8bit``). When
+# a user passes one of these IDs on a non-Apple-Silicon host we silently fall
+# back to the upstream PyTorch model and emit a one-time warning so they
+# understand the substitution.
 PRIVACY_FILTER_TORCH_FALLBACK = "openai/privacy-filter"
+
+
+# Family-aware Torch fallbacks. Order matters: the first matching marker
+# wins. Add new privacy-filter families here as they're introduced so an
+# MLX-only request from Linux falls back to the same family's PyTorch model
+# (not the unrelated default).
+_TORCH_FALLBACK_BY_FAMILY: tuple[tuple[str, str], ...] = (
+    ("nemotron", "OpenMed/privacy-filter-nemotron"),
+)
+
+
+def _torch_fallback_for(model_name: str) -> str:
+    """Pick the Torch fallback that matches ``model_name``'s family.
+
+    Substring-based to keep adding new families a one-line change.
+    """
+    name_lc = (model_name or "").lower()
+    for marker, repo in _TORCH_FALLBACK_BY_FAMILY:
+        if marker in name_lc:
+            return repo
+    return PRIVACY_FILTER_TORCH_FALLBACK
 
 
 def select_privacy_filter_backend(
@@ -206,17 +227,18 @@ def resolve_privacy_filter_model(
         return model_name
 
     if "mlx" in (model_name or "").lower():
+        target = _torch_fallback_for(model_name)
         if model_name not in _warned_substitutions:
             warnings.warn(
                 f"OpenMed: {model_name!r} is an MLX-only artifact and "
                 f"cannot run on this host. Substituting "
-                f"{PRIVACY_FILTER_TORCH_FALLBACK!r} via Transformers. "
+                f"{target!r} via Transformers. "
                 "To silence, request the PyTorch model directly.",
                 UserWarning,
                 stacklevel=3,
             )
             _warned_substitutions.add(model_name)
-        return PRIVACY_FILTER_TORCH_FALLBACK
+        return target
     return model_name
 
 

--- a/openmed/core/decoding/__init__.py
+++ b/openmed/core/decoding/__init__.py
@@ -1,0 +1,27 @@
+"""Backend-agnostic decoding utilities (Viterbi, BIOES span construction).
+
+These utilities are extracted from the MLX privacy-filter pipeline so they
+can be reused by the PyTorch wrapper as well. They depend only on the
+standard library — no torch, no mlx.
+"""
+
+from .spans import refine_privacy_filter_span, trim_span_whitespace
+from .viterbi import (
+    TokenLabelInfo,
+    VITERBI_BIAS_KEYS,
+    build_label_info,
+    labels_to_token_spans,
+    viterbi_decode,
+    zero_viterbi_biases,
+)
+
+__all__ = [
+    "TokenLabelInfo",
+    "VITERBI_BIAS_KEYS",
+    "build_label_info",
+    "labels_to_token_spans",
+    "refine_privacy_filter_span",
+    "trim_span_whitespace",
+    "viterbi_decode",
+    "zero_viterbi_biases",
+]

--- a/openmed/core/decoding/spans.py
+++ b/openmed/core/decoding/spans.py
@@ -1,0 +1,66 @@
+"""Span post-processing helpers shared across privacy-filter backends.
+
+When token classifiers emit slightly-too-greedy spans (e.g. "alice@hospital.org and"
+absorbs the trailing "and"), these helpers tighten the boundaries before the
+span reaches downstream redaction logic. Pure-Python; no array-framework
+dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+
+def trim_span_whitespace(start: int, end: int, text: str) -> tuple[int, int]:
+    """Strip leading and trailing whitespace from ``text[start:end]``.
+
+    Returns the inclusive ``[start, end)`` indices into ``text`` after
+    trimming. ``start`` and ``end`` are clamped so ``start <= end``.
+    """
+    while start < end and text[start].isspace():
+        start += 1
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
+_PRIVACY_FILTER_SPAN_PATTERNS: Final[tuple[tuple[str, re.Pattern[str]], ...]] = (
+    ("email", re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")),
+    ("url", re.compile(r"\b(?:https?://|www\.)[^\s,;)\]]+")),
+    ("phone", re.compile(r"(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}")),
+)
+
+
+def refine_privacy_filter_span(
+    label: str,
+    start: int,
+    end: int,
+    text: str,
+) -> tuple[int, int]:
+    """Tighten obvious structured-PII spans when the model absorbs glue words.
+
+    For email / URL / phone labels, locate the strict regex match inside
+    the model-suggested span and shrink to that. For any label, drop a
+    trailing ``" and"`` or ``" or"`` that the model often grabs because
+    it sat next to the entity in training data.
+    """
+    start, end = trim_span_whitespace(start, end, text)
+    span_text = text[start:end]
+    normalized = label.lower()
+
+    for label_hint, pattern in _PRIVACY_FILTER_SPAN_PATTERNS:
+        if label_hint not in normalized:
+            continue
+        match = pattern.search(span_text)
+        if match:
+            return start + match.start(), start + match.end()
+
+    for suffix in (" and", " or"):
+        if span_text.lower().endswith(suffix):
+            end -= len(suffix)
+            break
+    return trim_span_whitespace(start, end, text)
+
+
+__all__ = ["trim_span_whitespace", "refine_privacy_filter_span"]

--- a/openmed/core/decoding/viterbi.py
+++ b/openmed/core/decoding/viterbi.py
@@ -1,0 +1,356 @@
+"""BIOES-aware Viterbi decoder for token-classification logits.
+
+Used by both the MLX and PyTorch privacy-filter pipelines. Pure-Python,
+no array-framework dependencies — operates on lists of floats produced
+by ``logits.tolist()`` from either backend.
+
+The algorithm enforces the standard BIOES (B-egin / I-nside / E-nd /
+S-ingleton, plus background ``O``) state machine and supports six learned
+transition biases consumed by the OpenAI privacy-filter family.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Final, Sequence
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+VITERBI_BIAS_KEYS: Final = (
+    "transition_bias_background_stay",
+    "transition_bias_background_to_start",
+    "transition_bias_inside_to_continue",
+    "transition_bias_inside_to_end",
+    "transition_bias_end_to_background",
+    "transition_bias_end_to_start",
+)
+
+
+class TokenLabelInfo:
+    """Resolves a flat ``id2label`` map into BIOES tag / span-label tables.
+
+    Token labels arrive as strings like ``B-NAME``, ``I-NAME``, ``E-NAME``,
+    ``S-NAME``, plus the background ``O``. ``TokenLabelInfo`` precomputes
+    the mappings used during decoding:
+
+    - ``span_class_names``: deduplicated list of underlying span labels
+      (``["O", "NAME", "EMAIL", ...]``) where index 0 is always background.
+    - ``span_label_lookup``: ``{base_label: span_index}``.
+    - ``token_to_span_label``: ``{token_label_id: span_index}``.
+    - ``token_boundary_tags``: ``{token_label_id: "B" | "I" | "E" | "S" | None}``
+      with ``None`` reserved for the background token.
+    - ``background_token_label`` / ``background_span_label``: indices of
+      the ``O`` class in token-label and span-label space respectively.
+    """
+
+    def __init__(self, class_names: Sequence[str]) -> None:
+        self.span_class_names: list[str] = ["O"]
+        self.span_label_lookup: dict[str, int] = {"O": 0}
+        self.token_to_span_label: dict[int, int] = {}
+        self.token_boundary_tags: dict[int, str | None] = {}
+        self.background_token_label = 0
+        self.background_span_label = 0
+
+        for index, label in enumerate(class_names):
+            if label == "O":
+                self.background_token_label = index
+                self.token_to_span_label[index] = self.background_span_label
+                self.token_boundary_tags[index] = None
+                continue
+
+            boundary, base_label = _split_boundary_label(label)
+            span_label = self.span_label_lookup.get(base_label)
+            if span_label is None:
+                span_label = len(self.span_class_names)
+                self.span_class_names.append(base_label)
+                self.span_label_lookup[base_label] = span_label
+            self.token_to_span_label[index] = span_label
+            self.token_boundary_tags[index] = boundary
+
+
+def build_label_info(id2label: dict[int, str]) -> TokenLabelInfo:
+    """Construct a ``TokenLabelInfo`` from a ``{id: label_string}`` map."""
+    class_names = [id2label[index] for index in sorted(id2label)]
+    return TokenLabelInfo(class_names)
+
+
+def zero_viterbi_biases() -> dict[str, float]:
+    """Return a zero-initialized bias dict keyed by ``VITERBI_BIAS_KEYS``."""
+    return {key: 0.0 for key in VITERBI_BIAS_KEYS}
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+_NEG_INF: Final = -1e9
+
+
+def _split_boundary_label(label: str) -> tuple[str, str]:
+    if len(label) > 2 and label[1] == "-" and label[0] in {"B", "I", "E", "S"}:
+        return label[0], label[2:]
+    return "B", label
+
+
+def _transition_bias(
+    *,
+    previous_tag: str | None,
+    previous_span: int | None,
+    next_tag: str | None,
+    next_span: int | None,
+    background_token_idx: int,
+    background_span_idx: int,
+    previous_idx: int,
+    next_idx: int,
+    biases: dict[str, float],
+) -> float:
+    previous_is_background = (
+        previous_span == background_span_idx or previous_idx == background_token_idx
+    )
+    next_is_background = next_span == background_span_idx or next_idx == background_token_idx
+
+    if previous_is_background:
+        if next_is_background:
+            return biases["transition_bias_background_stay"]
+        if next_tag in {"B", "S"}:
+            return biases["transition_bias_background_to_start"]
+        return 0.0
+
+    if previous_tag in {"B", "I"}:
+        if next_tag == "I" and previous_span == next_span:
+            return biases["transition_bias_inside_to_continue"]
+        if next_tag == "E" and previous_span == next_span:
+            return biases["transition_bias_inside_to_end"]
+        return 0.0
+
+    if previous_tag in {"E", "S"}:
+        if next_is_background:
+            return biases["transition_bias_end_to_background"]
+        if next_tag in {"B", "S"}:
+            return biases["transition_bias_end_to_start"]
+        return 0.0
+
+    return 0.0
+
+
+def _is_valid_transition(
+    *,
+    previous_tag: str | None,
+    previous_span: int | None,
+    next_tag: str | None,
+    next_span: int | None,
+    background_token_idx: int,
+    background_span_idx: int,
+    next_idx: int,
+) -> bool:
+    next_is_background = next_span == background_span_idx or next_idx == background_token_idx
+    if (next_span is None or next_tag is None) and not next_is_background:
+        return False
+
+    if previous_span is None or previous_tag is None:
+        return next_is_background or next_tag in {"B", "S"}
+
+    previous_is_background = previous_span == background_span_idx
+    if previous_is_background:
+        return next_is_background or next_tag in {"B", "S"}
+    if previous_tag in {"E", "S"}:
+        return next_is_background or next_tag in {"B", "S"}
+    if previous_tag in {"B", "I"}:
+        return previous_span == next_span and next_tag in {"I", "E"}
+    return False
+
+
+def _build_viterbi_scores(
+    label_info: TokenLabelInfo,
+    biases: dict[str, float],
+) -> tuple[list[float], list[float], list[list[float]]]:
+    num_classes = len(label_info.token_to_span_label)
+    start_scores = [_NEG_INF] * num_classes
+    end_scores = [_NEG_INF] * num_classes
+    transition_scores = [[_NEG_INF] * num_classes for _ in range(num_classes)]
+
+    background_token_idx = label_info.background_token_label
+    background_span_idx = label_info.background_span_label
+    for previous_idx in range(num_classes):
+        previous_tag = label_info.token_boundary_tags.get(previous_idx)
+        previous_span = label_info.token_to_span_label.get(previous_idx)
+        if previous_tag in {"B", "S"} or previous_idx == background_token_idx:
+            start_scores[previous_idx] = 0.0
+        if previous_tag in {"E", "S"} or previous_idx == background_token_idx:
+            end_scores[previous_idx] = 0.0
+
+        for next_idx in range(num_classes):
+            next_tag = label_info.token_boundary_tags.get(next_idx)
+            next_span = label_info.token_to_span_label.get(next_idx)
+            if _is_valid_transition(
+                previous_tag=previous_tag,
+                previous_span=previous_span,
+                next_tag=next_tag,
+                next_span=next_span,
+                background_token_idx=background_token_idx,
+                background_span_idx=background_span_idx,
+                next_idx=next_idx,
+            ):
+                transition_scores[previous_idx][next_idx] = _transition_bias(
+                    previous_tag=previous_tag,
+                    previous_span=previous_span,
+                    next_tag=next_tag,
+                    next_span=next_span,
+                    background_token_idx=background_token_idx,
+                    background_span_idx=background_span_idx,
+                    previous_idx=previous_idx,
+                    next_idx=next_idx,
+                    biases=biases,
+                )
+    return start_scores, end_scores, transition_scores
+
+
+# ---------------------------------------------------------------------------
+# Public decoders
+# ---------------------------------------------------------------------------
+
+def viterbi_decode(
+    token_logprobs: list[list[float]],
+    *,
+    label_info: TokenLabelInfo,
+    biases: dict[str, float],
+) -> list[int]:
+    """Decode token-class indices via constrained BIOES Viterbi.
+
+    Args:
+        token_logprobs: One inner list of class log-probabilities per token.
+        label_info: Tag/span mapping built from the model's ``id2label``.
+        biases: Optional learned transition biases keyed by
+            ``VITERBI_BIAS_KEYS``. Unknown keys are ignored.
+
+    Returns:
+        A list of class indices (one per token) representing the most
+        likely BIOES-valid path. Falls back to a per-token argmax when
+        no finite-score path exists (e.g. degenerate label space).
+    """
+    if not token_logprobs:
+        return []
+
+    resolved_biases = zero_viterbi_biases()
+    resolved_biases.update({key: float(value) for key, value in biases.items() if key in resolved_biases})
+    start_scores, end_scores, transition_scores = _build_viterbi_scores(
+        label_info,
+        resolved_biases,
+    )
+
+    num_classes = len(label_info.token_to_span_label)
+    if any(len(row) < num_classes for row in token_logprobs):
+        raise ValueError("token_logprobs has fewer classes than the configured label space")
+    scores = [token_logprobs[0][idx] + start_scores[idx] for idx in range(num_classes)]
+    backpointers: list[list[int]] = []
+
+    for token_scores in token_logprobs[1:]:
+        next_scores: list[float] = []
+        paths: list[int] = []
+        for next_idx in range(num_classes):
+            best_idx = 0
+            best_score = -math.inf
+            for previous_idx, previous_score in enumerate(scores):
+                score = previous_score + transition_scores[previous_idx][next_idx]
+                if score > best_score:
+                    best_score = score
+                    best_idx = previous_idx
+            next_scores.append(best_score + token_scores[next_idx])
+            paths.append(best_idx)
+        scores = next_scores
+        backpointers.append(paths)
+
+    final_scores = [score + end_scores[idx] for idx, score in enumerate(scores)]
+    if not any(math.isfinite(score) for score in final_scores):
+        return [max(range(num_classes), key=lambda idx: row[idx]) for row in token_logprobs]
+
+    last_label = max(range(num_classes), key=lambda idx: final_scores[idx])
+    path = [last_label]
+    for paths in reversed(backpointers):
+        last_label = paths[last_label]
+        path.append(last_label)
+    path.reverse()
+    return path
+
+
+def labels_to_token_spans(
+    labels_by_index: dict[int, int],
+    label_info: TokenLabelInfo,
+) -> list[tuple[int, int, int]]:
+    """Convert per-token class indices into ``(span_label, start, end)`` triples.
+
+    The decoder honours BIOES boundary semantics:
+      - ``S`` produces a singleton ``[idx, idx+1)`` span.
+      - ``B`` opens a new span; mismatched continuations close + restart.
+      - ``E`` closes the current span at ``[start, idx+1)``.
+      - The background token (``O``) closes any open span without emitting it.
+
+    Gaps in ``labels_by_index`` (non-contiguous keys) are treated as a hard
+    span break — they typically indicate the caller is filtering tokens
+    pre-decoding (e.g. dropping special-token positions).
+    """
+    spans: list[tuple[int, int, int]] = []
+    current_label: int | None = None
+    start_idx: int | None = None
+    previous_idx: int | None = None
+
+    for token_idx in sorted(labels_by_index):
+        label_id = labels_by_index[token_idx]
+        span_label = label_info.token_to_span_label.get(label_id)
+        boundary_tag = label_info.token_boundary_tags.get(label_id)
+
+        if previous_idx is not None and token_idx != previous_idx + 1:
+            if current_label is not None and start_idx is not None:
+                spans.append((current_label, start_idx, previous_idx + 1))
+            current_label = None
+            start_idx = None
+
+        if span_label is None:
+            previous_idx = token_idx
+            continue
+
+        if span_label == label_info.background_span_label:
+            if current_label is not None and start_idx is not None:
+                spans.append((current_label, start_idx, token_idx))
+            current_label = None
+            start_idx = None
+            previous_idx = token_idx
+            continue
+
+        if boundary_tag == "S":
+            if current_label is not None and start_idx is not None and previous_idx is not None:
+                spans.append((current_label, start_idx, previous_idx + 1))
+            spans.append((span_label, token_idx, token_idx + 1))
+            current_label = None
+            start_idx = None
+        elif boundary_tag == "B":
+            if current_label is not None and start_idx is not None and previous_idx is not None:
+                spans.append((current_label, start_idx, previous_idx + 1))
+            current_label = span_label
+            start_idx = token_idx
+        elif boundary_tag == "I":
+            if current_label is None or current_label != span_label:
+                if current_label is not None and start_idx is not None and previous_idx is not None:
+                    spans.append((current_label, start_idx, previous_idx + 1))
+                current_label = span_label
+                start_idx = token_idx
+        elif boundary_tag == "E":
+            if current_label is None or current_label != span_label or start_idx is None:
+                if current_label is not None and start_idx is not None and previous_idx is not None:
+                    spans.append((current_label, start_idx, previous_idx + 1))
+                spans.append((span_label, token_idx, token_idx + 1))
+                current_label = None
+                start_idx = None
+            else:
+                spans.append((current_label, start_idx, token_idx + 1))
+                current_label = None
+                start_idx = None
+
+        previous_idx = token_idx
+
+    if current_label is not None and start_idx is not None and previous_idx is not None:
+        spans.append((current_label, start_idx, previous_idx + 1))
+    return spans

--- a/openmed/core/labels.py
+++ b/openmed/core/labels.py
@@ -1,0 +1,331 @@
+"""Canonical PII/PHI label taxonomy.
+
+Different OpenMed PII model families use different label-naming conventions:
+
+- English / multilingual SuperClinical models use lowercase ``snake_case``
+  (``first_name``, ``date_of_birth``).
+- Portuguese models expose 52 ``UPPERCASE`` labels (``FIRSTNAME``,
+  ``DATEOFBIRTH``).
+- The OpenAI privacy-filter family emits BIOES-tagged labels (``B-NAME``,
+  ``I-EMAIL``, ``E-ADDRESS``, ``S-PHONE``).
+
+This module provides a single ``CANONICAL_LABELS`` taxonomy in
+``UPPER_SNAKE_CASE`` and a ``normalize_label`` helper that maps any of the
+above input forms to its canonical name. Downstream code (anonymization,
+mapping tables, configuration) should key off canonical labels only.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final, FrozenSet, Mapping
+
+
+# ---------------------------------------------------------------------------
+# Canonical taxonomy
+# ---------------------------------------------------------------------------
+
+#: People-related entities
+PERSON: Final = "PERSON"
+FIRST_NAME: Final = "FIRST_NAME"
+LAST_NAME: Final = "LAST_NAME"
+MIDDLE_NAME: Final = "MIDDLE_NAME"
+PREFIX: Final = "PREFIX"
+USERNAME: Final = "USERNAME"
+
+#: Contact
+EMAIL: Final = "EMAIL"
+PHONE: Final = "PHONE"
+URL: Final = "URL"
+
+#: Location
+LOCATION: Final = "LOCATION"
+STREET_ADDRESS: Final = "STREET_ADDRESS"
+BUILDING_NUMBER: Final = "BUILDING_NUMBER"
+ZIPCODE: Final = "ZIPCODE"
+GPS_COORDINATES: Final = "GPS_COORDINATES"
+ORDINAL_DIRECTION: Final = "ORDINAL_DIRECTION"
+
+#: Time
+DATE: Final = "DATE"
+DATE_OF_BIRTH: Final = "DATE_OF_BIRTH"
+TIME: Final = "TIME"
+AGE: Final = "AGE"
+
+#: Identifiers
+ID_NUM: Final = "ID_NUM"
+SSN: Final = "SSN"
+ACCOUNT_NUMBER: Final = "ACCOUNT_NUMBER"
+PASSWORD: Final = "PASSWORD"
+PIN: Final = "PIN"
+API_KEY: Final = "API_KEY"
+
+#: Financial
+CREDIT_CARD: Final = "CREDIT_CARD"
+CREDIT_CARD_ISSUER: Final = "CREDIT_CARD_ISSUER"
+CVV: Final = "CVV"
+IBAN: Final = "IBAN"
+BIC: Final = "BIC"
+AMOUNT: Final = "AMOUNT"
+CURRENCY: Final = "CURRENCY"
+BITCOIN_ADDRESS: Final = "BITCOIN_ADDRESS"
+ETHEREUM_ADDRESS: Final = "ETHEREUM_ADDRESS"
+LITECOIN_ADDRESS: Final = "LITECOIN_ADDRESS"
+MASKED_NUMBER: Final = "MASKED_NUMBER"
+
+#: Demographics
+GENDER: Final = "GENDER"
+EYE_COLOR: Final = "EYE_COLOR"
+HEIGHT: Final = "HEIGHT"
+
+#: Work
+ORGANIZATION: Final = "ORGANIZATION"
+JOB_TITLE: Final = "JOB_TITLE"
+JOB_DEPARTMENT: Final = "JOB_DEPARTMENT"
+OCCUPATION: Final = "OCCUPATION"
+
+#: Tech
+IP_ADDRESS: Final = "IP_ADDRESS"
+MAC_ADDRESS: Final = "MAC_ADDRESS"
+USER_AGENT: Final = "USER_AGENT"
+VIN: Final = "VIN"
+VEHICLE_REGISTRATION: Final = "VEHICLE_REGISTRATION"
+IMEI: Final = "IMEI"
+
+#: Catch-all
+OTHER: Final = "OTHER"
+
+
+CANONICAL_LABELS: Final[FrozenSet[str]] = frozenset({
+    PERSON, FIRST_NAME, LAST_NAME, MIDDLE_NAME, PREFIX, USERNAME,
+    EMAIL, PHONE, URL,
+    LOCATION, STREET_ADDRESS, BUILDING_NUMBER, ZIPCODE, GPS_COORDINATES,
+    ORDINAL_DIRECTION,
+    DATE, DATE_OF_BIRTH, TIME, AGE,
+    ID_NUM, SSN, ACCOUNT_NUMBER, PASSWORD, PIN, API_KEY,
+    CREDIT_CARD, CREDIT_CARD_ISSUER, CVV, IBAN, BIC, AMOUNT, CURRENCY,
+    BITCOIN_ADDRESS, ETHEREUM_ADDRESS, LITECOIN_ADDRESS, MASKED_NUMBER,
+    GENDER, EYE_COLOR, HEIGHT,
+    ORGANIZATION, JOB_TITLE, JOB_DEPARTMENT, OCCUPATION,
+    IP_ADDRESS, MAC_ADDRESS, USER_AGENT, VIN, VEHICLE_REGISTRATION, IMEI,
+    OTHER,
+})
+
+
+# ---------------------------------------------------------------------------
+# Alias map
+# ---------------------------------------------------------------------------
+
+# Inputs are lowercased + non-alphanumerics stripped before lookup. So
+# ``first_name``, ``FIRSTNAME``, ``First-Name`` all reduce to ``firstname``.
+_ALIAS_MAP: Final[Mapping[str, str]] = {
+    # People
+    "name": PERSON,
+    "person": PERSON,
+    "patient": PERSON,
+    "doctor": PERSON,
+    "fullname": PERSON,
+    "firstname": FIRST_NAME,
+    "givenname": FIRST_NAME,
+    "lastname": LAST_NAME,
+    "surname": LAST_NAME,
+    "familyname": LAST_NAME,
+    "middlename": MIDDLE_NAME,
+    "prefix": PREFIX,
+    "title": PREFIX,
+    "username": USERNAME,
+    "userhandle": USERNAME,
+
+    # Contact
+    "email": EMAIL,
+    "emailaddress": EMAIL,
+    "phone": PHONE,
+    "phonenumber": PHONE,
+    "telephone": PHONE,
+    "fax": PHONE,
+    "url": URL,
+    "urlpersonal": URL,
+    "website": URL,
+    "personalurl": URL,
+
+    # Location
+    "location": LOCATION,
+    "city": LOCATION,
+    "state": LOCATION,
+    "country": LOCATION,
+    "county": LOCATION,
+    "region": LOCATION,
+    "place": LOCATION,
+    "address": STREET_ADDRESS,
+    "street": STREET_ADDRESS,
+    "streetaddress": STREET_ADDRESS,
+    "secondaryaddress": STREET_ADDRESS,
+    "buildingnumber": BUILDING_NUMBER,
+    "zipcode": ZIPCODE,
+    "zip": ZIPCODE,
+    "postcode": ZIPCODE,
+    "postalcode": ZIPCODE,
+    "gpscoordinates": GPS_COORDINATES,
+    "gps": GPS_COORDINATES,
+    "ordinaldirection": ORDINAL_DIRECTION,
+
+    # Time
+    "date": DATE,
+    "dateofbirth": DATE_OF_BIRTH,
+    "dob": DATE_OF_BIRTH,
+    "birthdate": DATE_OF_BIRTH,
+    "time": TIME,
+    "age": AGE,
+
+    # Identifiers
+    "idnum": ID_NUM,
+    "id": ID_NUM,
+    "identifier": ID_NUM,
+    "medicalrecordnumber": ID_NUM,
+    "mrn": ID_NUM,
+    "nationalid": ID_NUM,
+    "cpf": ID_NUM,
+    "cnpj": ID_NUM,
+    "nir": ID_NUM,
+    "steuerid": ID_NUM,
+    "codicefiscale": ID_NUM,
+    "dni": ID_NUM,
+    "nie": ID_NUM,
+    "bsn": ID_NUM,
+    "aadhaar": ID_NUM,
+    "npi": ID_NUM,
+    "ssn": SSN,
+    "socialsecuritynumber": SSN,
+    "accountnumber": ACCOUNT_NUMBER,
+    "accountname": ACCOUNT_NUMBER,
+    "bankaccount": ACCOUNT_NUMBER,
+    "password": PASSWORD,
+    "pin": PIN,
+    "apikey": API_KEY,
+
+    # Financial
+    "creditcard": CREDIT_CARD,
+    "creditdebitcard": CREDIT_CARD,
+    "creditcardnumber": CREDIT_CARD,
+    "creditcardissuer": CREDIT_CARD_ISSUER,
+    "cvv": CVV,
+    "iban": IBAN,
+    "bic": BIC,
+    "swift": BIC,
+    "amount": AMOUNT,
+    "currency": CURRENCY,
+    "currencycode": CURRENCY,
+    "currencyname": CURRENCY,
+    "currencysymbol": CURRENCY,
+    "bitcoinaddress": BITCOIN_ADDRESS,
+    "ethereumaddress": ETHEREUM_ADDRESS,
+    "litecoinaddress": LITECOIN_ADDRESS,
+    "maskednumber": MASKED_NUMBER,
+
+    # Demographics
+    "gender": GENDER,
+    "sex": GENDER,
+    "eyecolor": EYE_COLOR,
+    "height": HEIGHT,
+
+    # Work
+    "organization": ORGANIZATION,
+    "company": ORGANIZATION,
+    "employer": ORGANIZATION,
+    "jobtitle": JOB_TITLE,
+    "jobdepartment": JOB_DEPARTMENT,
+    "department": JOB_DEPARTMENT,
+    "occupation": OCCUPATION,
+    "profession": OCCUPATION,
+
+    # Tech
+    "ipaddress": IP_ADDRESS,
+    "ip": IP_ADDRESS,
+    "macaddress": MAC_ADDRESS,
+    "useragent": USER_AGENT,
+    "vin": VIN,
+    "vrm": VEHICLE_REGISTRATION,
+    "licenseplate": VEHICLE_REGISTRATION,
+    "imei": IMEI,
+}
+
+
+_BIOES_PREFIX_RE: Final = re.compile(r"^[BIES]-")
+
+
+def _strip_bioes_prefix(label: str) -> str:
+    """Strip an optional BIOES-style prefix from a label.
+
+    ``B-NAME`` -> ``NAME``; ``I-DATE`` -> ``DATE``; ``S-EMAIL`` -> ``EMAIL``.
+    Labels without a prefix are returned unchanged.
+    """
+    return _BIOES_PREFIX_RE.sub("", label, count=1)
+
+
+def _key(label: str) -> str:
+    """Lowercase, strip non-alphanumerics, drop BIOES prefix."""
+    stripped = _strip_bioes_prefix(label.strip())
+    return re.sub(r"[^a-z0-9]", "", stripped.lower())
+
+
+def normalize_label(label: str, lang: str = "en") -> str:
+    """Normalize an entity label to the canonical taxonomy.
+
+    Accepts any of:
+      - English lowercase ``snake_case`` (``first_name``)
+      - Portuguese ``UPPERCASE`` no-separator (``FIRSTNAME``)
+      - BIOES-tagged forms (``B-NAME``, ``I-EMAIL``)
+      - Mixed case with arbitrary separators (``First-Name``, ``First Name``)
+
+    Unknown labels fall through to ``OTHER`` rather than raising — callers
+    that need strict checking should compare against ``CANONICAL_LABELS``
+    explicitly.
+
+    Args:
+        label: Source label as emitted by a model or registered in a config.
+        lang: ISO 639-1 language hint (currently unused but reserved for
+            language-conditional disambiguation, e.g. mapping ambiguous
+            tokens differently per locale).
+
+    Returns:
+        A canonical label in ``UPPER_SNAKE_CASE``.
+    """
+    if not label:
+        return OTHER
+    key = _key(label)
+    if not key:
+        return OTHER
+    canonical = _ALIAS_MAP.get(key)
+    if canonical is not None:
+        return canonical
+    # If the input already matches a canonical label after stripping
+    # separators (e.g. ``ID_NUM`` -> key ``idnum`` -> aliased; but
+    # ``CREDIT_CARD`` -> ``creditcard`` -> aliased), the alias map covers
+    # it. The ``upper`` fallback handles any future canonical label not
+    # yet in the alias map.
+    upper = re.sub(r"[^A-Z0-9_]", "", label.upper().replace("-", "_").replace(" ", "_"))
+    if upper in CANONICAL_LABELS:
+        return upper
+    return OTHER
+
+
+__all__ = [
+    "CANONICAL_LABELS",
+    "normalize_label",
+    # canonical label constants
+    "PERSON", "FIRST_NAME", "LAST_NAME", "MIDDLE_NAME", "PREFIX", "USERNAME",
+    "EMAIL", "PHONE", "URL",
+    "LOCATION", "STREET_ADDRESS", "BUILDING_NUMBER", "ZIPCODE",
+    "GPS_COORDINATES", "ORDINAL_DIRECTION",
+    "DATE", "DATE_OF_BIRTH", "TIME", "AGE",
+    "ID_NUM", "SSN", "ACCOUNT_NUMBER", "PASSWORD", "PIN", "API_KEY",
+    "CREDIT_CARD", "CREDIT_CARD_ISSUER", "CVV", "IBAN", "BIC",
+    "AMOUNT", "CURRENCY",
+    "BITCOIN_ADDRESS", "ETHEREUM_ADDRESS", "LITECOIN_ADDRESS",
+    "MASKED_NUMBER",
+    "GENDER", "EYE_COLOR", "HEIGHT",
+    "ORGANIZATION", "JOB_TITLE", "JOB_DEPARTMENT", "OCCUPATION",
+    "IP_ADDRESS", "MAC_ADDRESS", "USER_AGENT", "VIN",
+    "VEHICLE_REGISTRATION", "IMEI",
+    "OTHER",
+]

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -49,6 +49,7 @@ from .config import OpenMedConfig
 from ..processing.outputs import EntityPrediction
 
 if TYPE_CHECKING:
+    from .anonymizer import Anonymizer
     from .models import ModelLoader
 
 # Type alias for de-identification methods
@@ -190,6 +191,56 @@ def _uses_model_led_pii_merging(*model_identifiers: Optional[str]) -> bool:
     return False
 
 
+def _extract_pii_via_privacy_filter(
+    text: str,
+    *,
+    model_name: str,
+    confidence_threshold: float,
+    original_text: str,
+    do_normalize: bool,
+):
+    """Run privacy-filter inference via the MLX/Torch backend dispatcher.
+
+    Returns a ``PredictionResult`` with the same shape callers expect from
+    ``analyze_text``. Confidence filtering is applied here since the
+    privacy-filter pipelines don't know the user's threshold.
+    """
+    from .backends import create_privacy_filter_pipeline
+    from ..processing.outputs import EntityPrediction, PredictionResult
+
+    pipeline = create_privacy_filter_pipeline(model_name)
+    raw = pipeline(text)
+
+    entities: list[EntityPrediction] = []
+    for item in raw:
+        score = float(item.get("score", 0.0))
+        if score < confidence_threshold:
+            continue
+        label = item.get("entity_group") or item.get("entity") or ""
+        start = int(item.get("start", 0))
+        end = int(item.get("end", 0))
+        # When accent normalization happened upstream, span indices match
+        # the stripped text. The pipeline ran on ``text`` so spans align
+        # with ``text``; remap to ``original_text`` if they're equal-length.
+        span_text = (original_text if do_normalize else text)[start:end] if end > start else item.get("word", "")
+        entities.append(
+            EntityPrediction(
+                text=span_text,
+                label=label,
+                start=start,
+                end=end,
+                confidence=score,
+            )
+        )
+
+    return PredictionResult(
+        text=original_text if do_normalize else text,
+        entities=entities,
+        model_name=model_name,
+        timestamp=datetime.now().isoformat(),
+    )
+
+
 def _strip_accents(text: str) -> str:
     """Remove combining diacritical marks from *text*.
 
@@ -290,6 +341,20 @@ def extract_pii(
     original_text = text
     if do_normalize:
         text = _strip_accents(text)
+
+    # Privacy-filter family routes through a dedicated dispatcher that picks
+    # MLX (Apple Silicon) or PyTorch (everywhere else). Smart merging is
+    # skipped because the model already does Viterbi-constrained span
+    # construction internally — running regex merging on top would just
+    # introduce noise.
+    if _looks_like_privacy_filter_identifier(effective_model) or _is_privacy_filter_artifact_path(effective_model):
+        return _extract_pii_via_privacy_filter(
+            text,
+            model_name=effective_model,
+            confidence_threshold=confidence_threshold,
+            original_text=original_text,
+            do_normalize=do_normalize,
+        )
 
     # Import here to avoid circular dependency
     from .. import analyze_text
@@ -394,6 +459,9 @@ def deidentify(
     lang: str = "en",
     normalize_accents: Optional[bool] = None,
     *,
+    consistent: bool = False,
+    seed: Optional[int] = None,
+    locale: Optional[str] = None,
     loader: Optional["ModelLoader"] = None,
 ) -> DeidentificationResult:
     """De-identify text by detecting and redacting PII with intelligent merging.
@@ -425,6 +493,14 @@ def deidentify(
         normalize_accents: Strip diacritical marks before model inference.
             ``None`` (default) auto-enables for Spanish.
         loader: Optional shared model loader to reuse warmed pipelines.
+        consistent: When ``method="replace"``, generate stable surrogates
+            (same input -> same surrogate within the call). Lets repeated
+            mentions of the same name resolve to one fake identity instead
+            of a different one each time.
+        seed: Optional integer seed for cross-run reproducibility of
+            ``consistent=True`` replacements. Implies ``consistent=True``.
+        locale: Faker locale override (``pt_BR``, ``en_GB``, ...) for
+            ``method="replace"``. When ``None``, derived from ``lang``.
 
     Returns:
         DeidentificationResult with original and de-identified text
@@ -439,6 +515,8 @@ def deidentify(
         Patient [NAME] (DOB: [DATE]/1970) called from [PHONE]
 
         >>> result = deidentify(text, method="replace", lang="de")
+        >>> result = deidentify(text, method="replace", lang="pt",
+        ...                    locale="pt_BR", consistent=True, seed=42)
     """
     # Strip to align with validate_input() inside analyze_text()
     text = text.strip()
@@ -481,6 +559,20 @@ def deidentify(
     if effective_method == "shift_dates" and date_shift_days is None:
         date_shift_days = random.randint(-365, 365)
 
+    # Build a single Anonymizer for the whole document so deterministic
+    # mode produces consistent surrogates across all entities.
+    anonymizer = None
+    if effective_method == "replace":
+        from .anonymizer import Anonymizer
+        # Passing a non-None seed implies consistent=True.
+        effective_consistent = consistent or seed is not None
+        anonymizer = Anonymizer(
+            lang=lang,
+            locale=locale,
+            consistent=effective_consistent,
+            seed=seed,
+        )
+
     # Apply de-identification
     deidentified = text
     mapping = {} if keep_mapping else None
@@ -492,6 +584,7 @@ def deidentify(
             keep_year=keep_year,
             date_shift_days=date_shift_days if effective_method == "shift_dates" else None,
             lang=lang,
+            anonymizer=anonymizer,
         )
         entity.redacted_text = redacted
 
@@ -520,6 +613,7 @@ def _redact_entity(
     keep_year: bool = True,
     date_shift_days: Optional[int] = None,
     lang: str = "en",
+    anonymizer: Optional["Anonymizer"] = None,
 ) -> str:
     """Redact a single PII entity based on method.
 
@@ -529,6 +623,9 @@ def _redact_entity(
         keep_year: Keep year in dates
         date_shift_days: Days to shift dates
         lang: Language code for fake data and date formatting
+        anonymizer: Pre-built ``Anonymizer`` instance for ``method="replace"``.
+            When ``None``, a fresh per-call instance is built using the
+            language default (random, non-deterministic).
 
     Returns:
         Redacted text replacement
@@ -542,7 +639,12 @@ def _redact_entity(
         return ""
 
     elif method == "replace":
-        # Replace with fake but realistic data
+        if anonymizer is not None:
+            return anonymizer.surrogate(
+                entity.original_text or entity.text,
+                entity.entity_type,
+                lang=lang,
+            )
         return _generate_fake_pii(entity.entity_type, lang=lang)
 
     elif method == "hash":
@@ -641,6 +743,48 @@ _LABEL_TO_FAKE_KEY: Dict[str, str] = {
 }
 
 
+# Map canonical taxonomy (from openmed.core.labels) to LANGUAGE_FAKE_DATA keys.
+# Canonical labels that don't have a fake-data key fall through to the
+# placeholder, the same as labels that aren't mapped at all.
+_CANONICAL_TO_FAKE_KEY: Dict[str, str] = {
+    "PERSON": "NAME",
+    "FIRST_NAME": "FIRST_NAME",
+    "LAST_NAME": "LAST_NAME",
+    "MIDDLE_NAME": "FIRST_NAME",
+    "EMAIL": "EMAIL",
+    "PHONE": "PHONE",
+    "LOCATION": "LOCATION",
+    "STREET_ADDRESS": "STREET_ADDRESS",
+    "DATE": "DATE",
+    "DATE_OF_BIRTH": "DATE",
+    "ID_NUM": "ID_NUM",
+    "SSN": "ID_NUM",
+    "ACCOUNT_NUMBER": "ID_NUM",
+    "AGE": "AGE",
+    "USERNAME": "USERNAME",
+    "URL": "URL_PERSONAL",
+    "ZIPCODE": "ZIPCODE",
+}
+
+
+def _resolve_fake_data_key(entity_type: str, lang: str = "en") -> str:
+    """Resolve a model entity label to a LANGUAGE_FAKE_DATA key.
+
+    Tries the legacy ``_LABEL_TO_FAKE_KEY`` table first to preserve exact
+    behavior for labels it already covers. Labels outside the legacy table
+    fall through to the canonical taxonomy in :mod:`openmed.core.labels`,
+    which covers Portuguese UPPERCASE labels and BIOES-tagged privacy-filter
+    labels too.
+    """
+    direct = _LABEL_TO_FAKE_KEY.get(entity_type)
+    if direct is not None:
+        return direct
+
+    from .labels import normalize_label
+    canonical = normalize_label(entity_type, lang)
+    return _CANONICAL_TO_FAKE_KEY.get(canonical, entity_type.upper())
+
+
 def _generate_fake_pii(entity_type: str, lang: str = "en") -> str:
     """Generate fake but realistic PII data.
 
@@ -654,9 +798,7 @@ def _generate_fake_pii(entity_type: str, lang: str = "en") -> str:
     from .pii_i18n import LANGUAGE_FAKE_DATA
 
     fake_data = LANGUAGE_FAKE_DATA.get(lang, LANGUAGE_FAKE_DATA["en"])
-
-    # Resolve the model label to a fake-data key
-    key = _LABEL_TO_FAKE_KEY.get(entity_type, entity_type.upper())
+    key = _resolve_fake_data_key(entity_type, lang)
 
     if key in fake_data:
         return random.choice(fake_data[key])

--- a/openmed/mlx/inference.py
+++ b/openmed/mlx/inference.py
@@ -15,6 +15,15 @@ from bisect import bisect_left, bisect_right
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
+from openmed.core.decoding import (
+    TokenLabelInfo,
+    build_label_info,
+    labels_to_token_spans,
+    refine_privacy_filter_span,
+    trim_span_whitespace,
+    viterbi_decode,
+    zero_viterbi_biases,
+)
 from openmed.mlx.artifact import (
     MANIFEST_FILENAME,
     has_local_tokenizer,
@@ -316,290 +325,6 @@ class MLXTokenClassificationPipeline:
         return entities
 
 
-def _split_boundary_label(label: str) -> tuple[str, str]:
-    if len(label) > 2 and label[1] == "-" and label[0] in {"B", "I", "E", "S"}:
-        return label[0], label[2:]
-    return "B", label
-
-
-class _TokenLabelInfo:
-    def __init__(self, class_names: Sequence[str]) -> None:
-        self.span_class_names: list[str] = ["O"]
-        self.span_label_lookup: dict[str, int] = {"O": 0}
-        self.token_to_span_label: dict[int, int] = {}
-        self.token_boundary_tags: dict[int, str | None] = {}
-        self.background_token_label = 0
-        self.background_span_label = 0
-
-        for index, label in enumerate(class_names):
-            if label == "O":
-                self.background_token_label = index
-                self.token_to_span_label[index] = self.background_span_label
-                self.token_boundary_tags[index] = None
-                continue
-
-            boundary, base_label = _split_boundary_label(label)
-            span_label = self.span_label_lookup.get(base_label)
-            if span_label is None:
-                span_label = len(self.span_class_names)
-                self.span_class_names.append(base_label)
-                self.span_label_lookup[base_label] = span_label
-            self.token_to_span_label[index] = span_label
-            self.token_boundary_tags[index] = boundary
-
-
-def _build_label_info(id2label: dict[int, str]) -> _TokenLabelInfo:
-    class_names = [id2label[index] for index in sorted(id2label)]
-    return _TokenLabelInfo(class_names)
-
-
-_NEG_INF = -1e9
-_VITERBI_BIAS_KEYS = (
-    "transition_bias_background_stay",
-    "transition_bias_background_to_start",
-    "transition_bias_inside_to_continue",
-    "transition_bias_inside_to_end",
-    "transition_bias_end_to_background",
-    "transition_bias_end_to_start",
-)
-
-
-def _zero_viterbi_biases() -> dict[str, float]:
-    return {key: 0.0 for key in _VITERBI_BIAS_KEYS}
-
-
-def _transition_bias(
-    *,
-    previous_tag: str | None,
-    previous_span: int | None,
-    next_tag: str | None,
-    next_span: int | None,
-    background_token_idx: int,
-    background_span_idx: int,
-    previous_idx: int,
-    next_idx: int,
-    biases: dict[str, float],
-) -> float:
-    previous_is_background = (
-        previous_span == background_span_idx or previous_idx == background_token_idx
-    )
-    next_is_background = next_span == background_span_idx or next_idx == background_token_idx
-
-    if previous_is_background:
-        if next_is_background:
-            return biases["transition_bias_background_stay"]
-        if next_tag in {"B", "S"}:
-            return biases["transition_bias_background_to_start"]
-        return 0.0
-
-    if previous_tag in {"B", "I"}:
-        if next_tag == "I" and previous_span == next_span:
-            return biases["transition_bias_inside_to_continue"]
-        if next_tag == "E" and previous_span == next_span:
-            return biases["transition_bias_inside_to_end"]
-        return 0.0
-
-    if previous_tag in {"E", "S"}:
-        if next_is_background:
-            return biases["transition_bias_end_to_background"]
-        if next_tag in {"B", "S"}:
-            return biases["transition_bias_end_to_start"]
-        return 0.0
-
-    return 0.0
-
-
-def _is_valid_transition(
-    *,
-    previous_tag: str | None,
-    previous_span: int | None,
-    next_tag: str | None,
-    next_span: int | None,
-    background_token_idx: int,
-    background_span_idx: int,
-    next_idx: int,
-) -> bool:
-    next_is_background = next_span == background_span_idx or next_idx == background_token_idx
-    if (next_span is None or next_tag is None) and not next_is_background:
-        return False
-
-    if previous_span is None or previous_tag is None:
-        return next_is_background or next_tag in {"B", "S"}
-
-    previous_is_background = previous_span == background_span_idx
-    if previous_is_background:
-        return next_is_background or next_tag in {"B", "S"}
-    if previous_tag in {"E", "S"}:
-        return next_is_background or next_tag in {"B", "S"}
-    if previous_tag in {"B", "I"}:
-        return previous_span == next_span and next_tag in {"I", "E"}
-    return False
-
-
-def _build_viterbi_scores(
-    label_info: _TokenLabelInfo,
-    biases: dict[str, float],
-) -> tuple[list[float], list[float], list[list[float]]]:
-    num_classes = len(label_info.token_to_span_label)
-    start_scores = [_NEG_INF] * num_classes
-    end_scores = [_NEG_INF] * num_classes
-    transition_scores = [[_NEG_INF] * num_classes for _ in range(num_classes)]
-
-    background_token_idx = label_info.background_token_label
-    background_span_idx = label_info.background_span_label
-    for previous_idx in range(num_classes):
-        previous_tag = label_info.token_boundary_tags.get(previous_idx)
-        previous_span = label_info.token_to_span_label.get(previous_idx)
-        if previous_tag in {"B", "S"} or previous_idx == background_token_idx:
-            start_scores[previous_idx] = 0.0
-        if previous_tag in {"E", "S"} or previous_idx == background_token_idx:
-            end_scores[previous_idx] = 0.0
-
-        for next_idx in range(num_classes):
-            next_tag = label_info.token_boundary_tags.get(next_idx)
-            next_span = label_info.token_to_span_label.get(next_idx)
-            if _is_valid_transition(
-                previous_tag=previous_tag,
-                previous_span=previous_span,
-                next_tag=next_tag,
-                next_span=next_span,
-                background_token_idx=background_token_idx,
-                background_span_idx=background_span_idx,
-                next_idx=next_idx,
-            ):
-                transition_scores[previous_idx][next_idx] = _transition_bias(
-                    previous_tag=previous_tag,
-                    previous_span=previous_span,
-                    next_tag=next_tag,
-                    next_span=next_span,
-                    background_token_idx=background_token_idx,
-                    background_span_idx=background_span_idx,
-                    previous_idx=previous_idx,
-                    next_idx=next_idx,
-                    biases=biases,
-                )
-    return start_scores, end_scores, transition_scores
-
-
-def _viterbi_decode(
-    token_logprobs: list[list[float]],
-    *,
-    label_info: _TokenLabelInfo,
-    biases: dict[str, float],
-) -> list[int]:
-    if not token_logprobs:
-        return []
-
-    resolved_biases = _zero_viterbi_biases()
-    resolved_biases.update({key: float(value) for key, value in biases.items() if key in resolved_biases})
-    start_scores, end_scores, transition_scores = _build_viterbi_scores(
-        label_info,
-        resolved_biases,
-    )
-
-    num_classes = len(label_info.token_to_span_label)
-    if any(len(row) < num_classes for row in token_logprobs):
-        raise ValueError("token_logprobs has fewer classes than the configured label space")
-    scores = [token_logprobs[0][idx] + start_scores[idx] for idx in range(num_classes)]
-    backpointers: list[list[int]] = []
-
-    for token_scores in token_logprobs[1:]:
-        next_scores: list[float] = []
-        paths: list[int] = []
-        for next_idx in range(num_classes):
-            best_idx = 0
-            best_score = -math.inf
-            for previous_idx, previous_score in enumerate(scores):
-                score = previous_score + transition_scores[previous_idx][next_idx]
-                if score > best_score:
-                    best_score = score
-                    best_idx = previous_idx
-            next_scores.append(best_score + token_scores[next_idx])
-            paths.append(best_idx)
-        scores = next_scores
-        backpointers.append(paths)
-
-    final_scores = [score + end_scores[idx] for idx, score in enumerate(scores)]
-    if not any(math.isfinite(score) for score in final_scores):
-        return [max(range(num_classes), key=lambda idx: row[idx]) for row in token_logprobs]
-
-    last_label = max(range(num_classes), key=lambda idx: final_scores[idx])
-    path = [last_label]
-    for paths in reversed(backpointers):
-        last_label = paths[last_label]
-        path.append(last_label)
-    path.reverse()
-    return path
-
-
-def _labels_to_token_spans(
-    labels_by_index: dict[int, int],
-    label_info: _TokenLabelInfo,
-) -> list[tuple[int, int, int]]:
-    spans: list[tuple[int, int, int]] = []
-    current_label: int | None = None
-    start_idx: int | None = None
-    previous_idx: int | None = None
-
-    for token_idx in sorted(labels_by_index):
-        label_id = labels_by_index[token_idx]
-        span_label = label_info.token_to_span_label.get(label_id)
-        boundary_tag = label_info.token_boundary_tags.get(label_id)
-
-        if previous_idx is not None and token_idx != previous_idx + 1:
-            if current_label is not None and start_idx is not None:
-                spans.append((current_label, start_idx, previous_idx + 1))
-            current_label = None
-            start_idx = None
-
-        if span_label is None:
-            previous_idx = token_idx
-            continue
-
-        if span_label == label_info.background_span_label:
-            if current_label is not None and start_idx is not None:
-                spans.append((current_label, start_idx, token_idx))
-            current_label = None
-            start_idx = None
-            previous_idx = token_idx
-            continue
-
-        if boundary_tag == "S":
-            if current_label is not None and start_idx is not None and previous_idx is not None:
-                spans.append((current_label, start_idx, previous_idx + 1))
-            spans.append((span_label, token_idx, token_idx + 1))
-            current_label = None
-            start_idx = None
-        elif boundary_tag == "B":
-            if current_label is not None and start_idx is not None and previous_idx is not None:
-                spans.append((current_label, start_idx, previous_idx + 1))
-            current_label = span_label
-            start_idx = token_idx
-        elif boundary_tag == "I":
-            if current_label is None or current_label != span_label:
-                if current_label is not None and start_idx is not None and previous_idx is not None:
-                    spans.append((current_label, start_idx, previous_idx + 1))
-                current_label = span_label
-                start_idx = token_idx
-        elif boundary_tag == "E":
-            if current_label is None or current_label != span_label or start_idx is None:
-                if current_label is not None and start_idx is not None and previous_idx is not None:
-                    spans.append((current_label, start_idx, previous_idx + 1))
-                spans.append((span_label, token_idx, token_idx + 1))
-                current_label = None
-                start_idx = None
-            else:
-                spans.append((current_label, start_idx, token_idx + 1))
-                current_label = None
-                start_idx = None
-
-        previous_idx = token_idx
-
-    if current_label is not None and start_idx is not None and previous_idx is not None:
-        spans.append((current_label, start_idx, previous_idx + 1))
-    return spans
-
-
 def _decode_tiktoken_offsets(token_ids: Sequence[int], encoding: Any) -> tuple[str, list[int], list[int]]:
     token_bytes = [encoding.decode_single_token_bytes(int(token_id)) for token_id in token_ids]
     decoded_text = b"".join(token_bytes).decode("utf-8", errors="replace")
@@ -631,44 +356,11 @@ def _decode_tiktoken_offsets(token_ids: Sequence[int], encoding: Any) -> tuple[s
     return decoded_text, char_starts, char_ends
 
 
-def _trim_span_whitespace(start: int, end: int, text: str) -> tuple[int, int]:
-    while start < end and text[start].isspace():
-        start += 1
-    while end > start and text[end - 1].isspace():
-        end -= 1
-    return start, end
-
-
-_PRIVACY_FILTER_SPAN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
-    ("email", re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")),
-    ("url", re.compile(r"\b(?:https?://|www\.)[^\s,;)\]]+")),
-    ("phone", re.compile(r"(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}")),
-)
-
-
-def _refine_privacy_filter_span(
-    label: str,
-    start: int,
-    end: int,
-    text: str,
-) -> tuple[int, int]:
-    """Tighten obvious structured PII spans when the model absorbs glue words."""
-    start, end = _trim_span_whitespace(start, end, text)
-    span_text = text[start:end]
-    normalized = label.lower()
-
-    for label_hint, pattern in _PRIVACY_FILTER_SPAN_PATTERNS:
-        if label_hint not in normalized:
-            continue
-        match = pattern.search(span_text)
-        if match:
-            return start + match.start(), start + match.end()
-
-    for suffix in (" and", " or"):
-        if span_text.lower().endswith(suffix):
-            end -= len(suffix)
-            break
-    return _trim_span_whitespace(start, end, text)
+# Span-refinement helpers moved to openmed.core.decoding.spans for reuse
+# across MLX and Torch privacy-filter pipelines. Keep local aliases so the
+# rest of this module reads unchanged.
+_trim_span_whitespace = trim_span_whitespace
+_refine_privacy_filter_span = refine_privacy_filter_span
 
 
 class PrivacyFilterMLXPipeline:
@@ -692,7 +384,7 @@ class PrivacyFilterMLXPipeline:
         self.id2label: dict[int, str] = {
             int(key): value for key, value in self.config.get("id2label", {}).items()
         }
-        self.label_info = _build_label_info(self.id2label)
+        self.label_info = build_label_info(self.id2label)
         self.viterbi_biases = self.config.get("_mlx_viterbi_biases") or {}
 
         try:
@@ -731,7 +423,7 @@ class PrivacyFilterMLXPipeline:
         probs = mx.exp(log_probs)
         log_probs_py = log_probs.tolist()
         probs_py = probs.tolist()
-        pred_ids = _viterbi_decode(
+        pred_ids = viterbi_decode(
             log_probs_py,
             label_info=self.label_info,
             biases=self.viterbi_biases,
@@ -782,7 +474,7 @@ class PrivacyFilterMLXPipeline:
         text: str,
     ) -> list[dict[str, Any]]:
         labels_by_index = {index: int(label_id) for index, label_id in enumerate(pred_ids)}
-        token_spans = _labels_to_token_spans(labels_by_index, self.label_info)
+        token_spans = labels_to_token_spans(labels_by_index, self.label_info)
 
         entities: list[dict[str, Any]] = []
         for span_label, token_start, token_end in token_spans:

--- a/openmed/mlx/inference.py
+++ b/openmed/mlx/inference.py
@@ -896,6 +896,8 @@ class GLiNERRelexMLXPipeline(_BaseExperimentalMLXPipeline):
 _MLX_MODEL_MAP: Dict[str, str] = {
     "OpenMed/privacy-filter-mlx": "OpenMed/privacy-filter-mlx",
     "OpenMed/privacy-filter-mlx-8bit": "OpenMed/privacy-filter-mlx-8bit",
+    "OpenMed/privacy-filter-nemotron-mlx": "OpenMed/privacy-filter-nemotron-mlx",
+    "OpenMed/privacy-filter-nemotron-mlx-8bit": "OpenMed/privacy-filter-nemotron-mlx-8bit",
 }
 
 

--- a/openmed/mlx/models/__init__.py
+++ b/openmed/mlx/models/__init__.py
@@ -13,6 +13,11 @@ _SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES = {
     "electra": "bert",
     "openai-privacy-filter": "openai-privacy-filter",
     "privacy-filter": "openai-privacy-filter",
+    # ``OpenMed/privacy-filter-nemotron*`` is the OpenAI Privacy Filter
+    # architecture fine-tuned on the Nemotron PII dataset — same model
+    # class, different weights — so the family stays ``openai-privacy-filter``.
+    "privacy-filter-nemotron": "openai-privacy-filter",
+    "nemotron-privacy-filter": "openai-privacy-filter",
     "roberta": "bert",
     "xlm-roberta": "bert",
     "xlm_roberta": "bert",

--- a/openmed/mlx/models/privacy_filter.py
+++ b/openmed/mlx/models/privacy_filter.py
@@ -450,12 +450,21 @@ class OpenAIPrivacyFilterForTokenClassification(nn.Module):
             int(config["hidden_size"]),
             eps=float(config.get("rms_norm_eps", 1e-5)),
         )
+        # The original openai/privacy-filter has a bias-less classifier head
+        # (``classifier_bias: false``); the Nemotron-PII fine-tune adds bias
+        # to the 221-class head (``classifier_bias: true``). Honor whichever
+        # the config requests; default to ``False`` for back-compat.
+        classifier_bias = bool(
+            config.get("classifier_bias", config.get("unembedding_bias", False))
+        )
         self.unembedding = nn.Linear(
             int(config["hidden_size"]),
             int(config["num_labels"]),
-            bias=False,
+            bias=classifier_bias,
         )
         self.unembedding.weight = self.unembedding.weight.astype(dtype)
+        if classifier_bias:
+            self.unembedding.bias = self.unembedding.bias.astype(dtype)
 
     def __call__(
         self,

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -112,7 +112,7 @@ if PYDANTIC_V2:
         model_name: str = _DEFAULT_PII_MODEL
         confidence_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
         use_smart_merging: bool = True
-        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te"] = "en"
+        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"] = "en"
         normalize_accents: Optional[bool] = None
 
         @field_validator("text", mode="before")
@@ -145,7 +145,7 @@ if PYDANTIC_V2:
         date_shift_days: Optional[int] = None
         keep_mapping: bool = False
         use_smart_merging: bool = True
-        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te"] = "en"
+        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"] = "en"
         normalize_accents: Optional[bool] = None
 
         @field_validator("text", mode="before")
@@ -207,7 +207,7 @@ else:
         model_name: str = _DEFAULT_PII_MODEL
         confidence_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
         use_smart_merging: bool = True
-        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te"] = "en"
+        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"] = "en"
         normalize_accents: Optional[bool] = None
 
         @validator("text", pre=True)
@@ -237,7 +237,7 @@ else:
         date_shift_days: Optional[int] = None
         keep_mapping: bool = False
         use_smart_merging: bool = True
-        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te"] = "en"
+        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"] = "en"
         normalize_accents: Optional[bool] = None
 
         @validator("text", pre=True)

--- a/openmed/torch/__init__.py
+++ b/openmed/torch/__init__.py
@@ -1,0 +1,11 @@
+"""PyTorch / HuggingFace Transformers backends for OpenMed.
+
+This subpackage wraps token-classification models that run on PyTorch
+(CPU or CUDA) so they slot into the same OpenMed pipeline surface as
+the MLX path. Use this when the host machine is not Apple Silicon, or
+when MLX is unavailable.
+"""
+
+from .privacy_filter import PrivacyFilterTorchPipeline
+
+__all__ = ["PrivacyFilterTorchPipeline"]

--- a/openmed/torch/privacy_filter.py
+++ b/openmed/torch/privacy_filter.py
@@ -1,0 +1,142 @@
+"""PyTorch wrapper for the OpenAI ``privacy-filter`` token classifier.
+
+This is the cross-platform path used when MLX is unavailable (Linux,
+Windows, Intel Mac). It loads ``openai/privacy-filter`` (or any compatible
+HuggingFace fine-tune) via ``transformers.AutoModelForTokenClassification``
+and produces the same entity-dict shape as the MLX pipeline:
+
+    {"entity_group": str, "score": float, "word": str, "start": int, "end": int}
+
+So downstream code (``extract_pii``, smart-merging, deidentification) can
+consume MLX and Torch results interchangeably.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from openmed.core.decoding import refine_privacy_filter_span, trim_span_whitespace
+
+logger = logging.getLogger(__name__)
+
+
+class PrivacyFilterTorchPipeline:
+    """Run ``openai/privacy-filter`` (or compatible) via Transformers.
+
+    Output shape matches :class:`openmed.mlx.inference.PrivacyFilterMLXPipeline`
+    — both pipelines emit a list of ``{entity_group, score, word, start, end}``
+    dicts so the rest of OpenMed's privacy machinery is backend-agnostic.
+
+    Args:
+        model_name: HuggingFace model ID or local path. Default
+            ``openai/privacy-filter``.
+        device: Torch device string (``cpu``, ``cuda``, ``cuda:0``, ``mps``).
+            ``None`` autodetects: CUDA if available, else CPU.
+        dtype: Optional torch dtype (e.g. ``"float16"``, ``"bfloat16"``).
+            Defaults to model native.
+        aggregation_strategy: Passed through to HF's pipeline. ``"simple"``
+            (the default) groups BIOES tokens into spans and matches MLX
+            output shape.
+        local_files_only: When True, never download from the Hub — only
+            use a cached copy. Mirrors the demo's offline-first default.
+    """
+
+    DEFAULT_MODEL_ID = "openai/privacy-filter"
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_MODEL_ID,
+        *,
+        device: Optional[str] = None,
+        dtype: Optional[str] = None,
+        aggregation_strategy: str = "simple",
+        local_files_only: bool = False,
+    ) -> None:
+        try:
+            import torch
+            from transformers import (
+                AutoModelForTokenClassification,
+                AutoTokenizer,
+                pipeline,
+            )
+        except ImportError as exc:  # pragma: no cover - hf is optional extra
+            raise ImportError(
+                "PrivacyFilterTorchPipeline requires `transformers` and "
+                "`torch`. Install with: pip install openmed[hf]"
+            ) from exc
+
+        self.model_name = model_name
+        self.aggregation_strategy = aggregation_strategy
+
+        resolved_device = device
+        if resolved_device is None:
+            resolved_device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        load_kwargs: Dict[str, Any] = {"local_files_only": local_files_only}
+        if dtype is not None:
+            torch_dtype = getattr(torch, dtype, None)
+            if torch_dtype is not None:
+                load_kwargs["torch_dtype"] = torch_dtype
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name, local_files_only=local_files_only,
+        )
+        self.model = AutoModelForTokenClassification.from_pretrained(
+            model_name, **load_kwargs,
+        )
+        self.model.to(resolved_device)
+        self.model.eval()
+
+        # HF pipeline accepts a string device for "cpu"/"cuda"/"mps"; for
+        # "cpu" it expects -1 in older versions, which still works.
+        pipeline_device = -1 if resolved_device == "cpu" else resolved_device
+
+        self._pipeline = pipeline(
+            task="token-classification",
+            model=self.model,
+            tokenizer=self.tokenizer,
+            aggregation_strategy=aggregation_strategy,
+            device=pipeline_device,
+        )
+        self.device = resolved_device
+
+    def __call__(self, text: str) -> List[Dict[str, Any]]:
+        """Run inference and emit MLX-compatible entity dicts."""
+        if not text or not text.strip():
+            return []
+
+        raw = self._pipeline(text)
+        return [self._normalize_entity(item, text) for item in raw]
+
+    @staticmethod
+    def _normalize_entity(item: Dict[str, Any], text: str) -> Dict[str, Any]:
+        """Refine spans, coerce types, and ensure the schema matches MLX."""
+        # HF pipeline emits either ``entity_group`` (when aggregating) or
+        # ``entity`` (when not). We always normalise to ``entity_group``.
+        label = item.get("entity_group") or item.get("entity") or ""
+        start = int(item.get("start", 0))
+        end = int(item.get("end", 0))
+        score = float(item.get("score", 0.0))
+
+        start, end = trim_span_whitespace(start, end, text)
+        if label:
+            start, end = refine_privacy_filter_span(label, start, end, text)
+        if end <= start:
+            return {
+                "entity_group": label,
+                "score": score,
+                "word": "",
+                "start": start,
+                "end": end,
+            }
+        return {
+            "entity_group": label,
+            "score": score,
+            "word": text[start:end],
+            "start": start,
+            "end": end,
+        }
+
+
+__all__ = ["PrivacyFilterTorchPipeline"]

--- a/openmed/torch/privacy_filter.py
+++ b/openmed/torch/privacy_filter.py
@@ -40,6 +40,12 @@ class PrivacyFilterTorchPipeline:
             output shape.
         local_files_only: When True, never download from the Hub — only
             use a cached copy. Mirrors the demo's offline-first default.
+        trust_remote_code: The OpenAI Privacy Filter family ships with
+            custom modeling code (``modeling_openai_privacy_filter.py``) in
+            the model repo, which transformers needs permission to import.
+            Defaults to ``True`` because this pipeline is *specifically*
+            for that family — set to ``False`` to opt out (and accept that
+            loading will fail without an upstream registration).
     """
 
     DEFAULT_MODEL_ID = "openai/privacy-filter"
@@ -52,6 +58,7 @@ class PrivacyFilterTorchPipeline:
         dtype: Optional[str] = None,
         aggregation_strategy: str = "simple",
         local_files_only: bool = False,
+        trust_remote_code: bool = True,
     ) -> None:
         try:
             import torch
@@ -73,14 +80,19 @@ class PrivacyFilterTorchPipeline:
         if resolved_device is None:
             resolved_device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        load_kwargs: Dict[str, Any] = {"local_files_only": local_files_only}
+        load_kwargs: Dict[str, Any] = {
+            "local_files_only": local_files_only,
+            "trust_remote_code": trust_remote_code,
+        }
         if dtype is not None:
             torch_dtype = getattr(torch, dtype, None)
             if torch_dtype is not None:
                 load_kwargs["torch_dtype"] = torch_dtype
 
         self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, local_files_only=local_files_only,
+            model_name,
+            local_files_only=local_files_only,
+            trust_remote_code=trust_remote_code,
         )
         self.model = AutoModelForTokenClassification.from_pretrained(
             model_name, **load_kwargs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ keywords = [
 ]
 dependencies = [
   "pysbd>=0.3.4,<0.4",
+  "faker>=22.0",
 ]
 
 authors = [

--- a/swift/OpenMedKit/Sources/OpenMedKit/OpenMedMLXArtifact.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/OpenMedMLXArtifact.swift
@@ -196,6 +196,12 @@ struct OpenMedMLXBertConfiguration: Decodable, Sendable {
     let rmsNormEps: Float
     let swigluLimit: Float
     let viterbiBiases: [String: Float]
+    /// Whether the token-classification head ships with a learned bias.
+    /// The original ``openai/privacy-filter`` checkpoint sets this to false
+    /// (bias-less linear); the Nemotron-PII fine-tunes set it to true so the
+    /// 221-class head can fit the additional categories. Defaults to false
+    /// so back-compat with the OpenAI baseline is preserved.
+    let classifierBias: Bool
 
     enum CodingKeys: String, CodingKey {
         case modelType = "model_type"
@@ -252,6 +258,8 @@ struct OpenMedMLXBertConfiguration: Decodable, Sendable {
         case rmsNormEps = "rms_norm_eps"
         case swigluLimit = "swiglu_limit"
         case viterbiBiases = "_mlx_viterbi_biases"
+        case classifierBias = "classifier_bias"
+        case unembeddingBias = "unembedding_bias"
         case numLabels = "num_labels"
         case positionOffset = "_mlx_position_offset"
         case weightsFormat = "_mlx_weights_format"
@@ -380,6 +388,11 @@ struct OpenMedMLXBertConfiguration: Decodable, Sendable {
         swigluLimit = try container.decodeIfPresent(Float.self, forKey: .swigluLimit) ?? 7.0
         viterbiBiases =
             try container.decodeIfPresent([String: Float].self, forKey: .viterbiBiases) ?? [:]
+        let configuredClassifierBias =
+            try container.decodeIfPresent(Bool.self, forKey: .classifierBias)
+        let configuredUnembeddingBias =
+            try container.decodeIfPresent(Bool.self, forKey: .unembeddingBias)
+        classifierBias = configuredClassifierBias ?? configuredUnembeddingBias ?? false
 
         let normalized = rawModelType.replacingOccurrences(of: "_", with: "-").lowercased()
         let resolvedPositionOffset: Int

--- a/swift/OpenMedKit/Sources/OpenMedKit/OpenMedPrivacyFilterModel.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/OpenMedPrivacyFilterModel.swift
@@ -534,7 +534,14 @@ final class OpenMedPrivacyFilterForTokenClassification: Module {
             hiddenSize: configuration.hiddenSize,
             eps: configuration.rmsNormEps
         )
-        _unembedding.wrappedValue = Linear(configuration.hiddenSize, configuration.numLabels, bias: false)
+        // The original openai/privacy-filter has a bias-less classifier head;
+        // the Nemotron-PII fine-tunes (`classifier_bias: true`) ship with a
+        // learned bias. Honor whichever the config requests.
+        _unembedding.wrappedValue = Linear(
+            configuration.hiddenSize,
+            configuration.numLabels,
+            bias: configuration.classifierBias
+        )
         super.init()
     }
 

--- a/swift/OpenMedKit/Tests/OpenMedKitTests/OpenMedMLXTests.swift
+++ b/swift/OpenMedKit/Tests/OpenMedKitTests/OpenMedMLXTests.swift
@@ -217,6 +217,31 @@ final class OpenMedMLXTests: XCTestCase {
         XCTAssertEqual(config.quantizationGroupSize, 32)
         XCTAssertEqual(config.quantizationMode, "affine")
         XCTAssertEqual(config.viterbiBiases["transition_bias_background_stay"], 0.0)
+        // The original openai/privacy-filter has a bias-less classifier head;
+        // the manifest-only fixture omits ``classifier_bias`` so the default
+        // (``false``) must propagate.
+        XCTAssertFalse(config.classifierBias)
+    }
+
+    func testPrivacyFilterConfigDecodesNemotronClassifierBias() throws {
+        // Nemotron-PII fine-tunes ship with ``classifier_bias: true`` so the
+        // 221-class head can fit a learned bias. The Swift loader must respect
+        // it — otherwise ``OpenMedPrivacyFilterForTokenClassification`` builds
+        // a bias-less ``Linear`` and the safetensors load fails with
+        // "Unable to set unembedding.bias on ... Linear: none not compatible".
+        let directory = try makePrivacyFilterManifestOnlyArtifact(classifierBias: true)
+        let config = try OpenMedMLXArtifact(modelDirectoryURL: directory).configuration
+        XCTAssertTrue(config.classifierBias)
+    }
+
+    func testPrivacyFilterConfigAcceptsUnembeddingBiasAlias() throws {
+        // ``unembedding_bias`` is accepted as a fallback alias in case a
+        // future repo ships the field under that name.
+        let directory = try makePrivacyFilterManifestOnlyArtifact(
+            extraConfig: ["unembedding_bias": true]
+        )
+        let config = try OpenMedMLXArtifact(modelDirectoryURL: directory).configuration
+        XCTAssertTrue(config.classifierBias)
     }
 
     func testPrivacyFilterTokenizerMatchesTiktokenGoldens() throws {
@@ -283,6 +308,59 @@ final class OpenMedMLXTests: XCTestCase {
         eval(logits)
 
         XCTAssertEqual(logits.shape, [1, 4, artifact.configuration.numLabels])
+    }
+
+    func testTinyPrivacyFilterNemotronModelForwardShape() throws {
+        // Nemotron-PII fine-tunes set ``classifier_bias: true`` so the
+        // unembedding ``Linear`` ships with a learned bias parameter. This
+        // test mirrors the OpenAI baseline shape test but with the bias
+        // enabled — a regression that breaks the Nemotron loader (see the
+        // ``unembedding.bias`` weight in ``OpenMed/privacy-filter-nemotron-mlx-8bit``)
+        // would surface here as a parameter-count mismatch.
+        try requireUsableMLXRuntime()
+        let directory = try makePrivacyFilterManifestOnlyArtifact(classifierBias: true)
+        let artifact = try OpenMedMLXArtifact(modelDirectoryURL: directory)
+        XCTAssertTrue(artifact.configuration.classifierBias)
+
+        let model = OpenMedPrivacyFilterForTokenClassification(artifact.configuration)
+
+        // The unembedding Linear must expose a ``bias`` parameter slot when
+        // ``classifier_bias: true`` is set. With the slot present, MLX's
+        // ``update(parameters:)`` can land the safetensors ``unembedding.bias``
+        // tensor; without it (the prior bug), the loader raises
+        // "Unable to set unembedding.bias on Linear: none not compatible".
+        let parameters = model.parameters().flattened().map(\.0)
+        XCTAssertTrue(
+            parameters.contains("unembedding.bias"),
+            "Expected unembedding.bias slot when classifier_bias=true; got \(parameters)"
+        )
+
+        let logits = model(
+            MLXArray([Int32(1), Int32(2), Int32(3), Int32(4)], [1, 4]),
+            attentionMask: MLXArray.ones([1, 4], type: Bool.self)
+        )
+        eval(logits)
+
+        XCTAssertEqual(logits.shape, [1, 4, artifact.configuration.numLabels])
+    }
+
+    func testTinyPrivacyFilterBaselineHasNoUnembeddingBiasSlot() throws {
+        // The original OpenAI baseline (and any future fine-tune that omits
+        // ``classifier_bias``) must NOT allocate a bias parameter on the
+        // unembedding head — otherwise loading ``OpenMed/privacy-filter-mlx-8bit``
+        // would attempt to assign ``unembedding.bias`` from a checkpoint that
+        // does not contain it.
+        try requireUsableMLXRuntime()
+        let directory = try makePrivacyFilterManifestOnlyArtifact()
+        let artifact = try OpenMedMLXArtifact(modelDirectoryURL: directory)
+        XCTAssertFalse(artifact.configuration.classifierBias)
+
+        let model = OpenMedPrivacyFilterForTokenClassification(artifact.configuration)
+        let parameters = model.parameters().flattened().map(\.0)
+        XCTAssertFalse(
+            parameters.contains("unembedding.bias"),
+            "Did not expect unembedding.bias slot when classifier_bias=false; got \(parameters)"
+        )
     }
 
     func testArtifactRejectsUnknownGLiNERVariant() throws {
@@ -1040,14 +1118,17 @@ final class OpenMedMLXTests: XCTestCase {
         return directory
     }
 
-    private func makePrivacyFilterManifestOnlyArtifact() throws -> URL {
+    private func makePrivacyFilterManifestOnlyArtifact(
+        classifierBias: Bool? = nil,
+        extraConfig: [String: Any] = [:]
+    ) throws -> URL {
         let directory = try makeManifestOnlyArtifact(
             task: "token-classification",
             family: "openai-privacy-filter",
             configModelType: "openai_privacy_filter"
         )
 
-        let configObject: [String: Any] = [
+        var configObject: [String: Any] = [
             "model_type": "openai_privacy_filter",
             "_mlx_model_type": "openai-privacy-filter",
             "_mlx_weights_format": "safetensors",
@@ -1095,6 +1176,12 @@ final class OpenMedMLXTests: XCTestCase {
                 "transition_bias_end_to_start": 0.0,
             ],
         ]
+        if let classifierBias {
+            configObject["classifier_bias"] = classifierBias
+        }
+        for (key, value) in extraConfig {
+            configObject[key] = value
+        }
         try JSONSerialization.data(withJSONObject: configObject, options: [.prettyPrinted])
             .write(to: directory.appending(path: "config.json"))
         try JSONSerialization.data(

--- a/swift/OpenMedScanDemo/OpenMedScanDemo/Components/OMEnginePickerCard.swift
+++ b/swift/OpenMedScanDemo/OpenMedScanDemo/Components/OMEnginePickerCard.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Two-column picker: each column represents a PII engine (OpenMed or OpenAI)
+/// Two-column picker: each column represents a PII engine (OpenMed or OpenAI Nemotron)
 /// and shows its download state. Tapping an engine selects it; tapping its
 /// download button starts the download. Exists to make the choice explicit
 /// up-front instead of burying it on the De-identification screen.
@@ -74,7 +74,7 @@ public struct OMEnginePickerCard: View {
                                 .strokeBorder(Color.omBorderStrong, lineWidth: OM.Stroke.hairline)
                                 .frame(width: 12, height: 12)
                         }
-                        Text(engine == .openMed ? "OPENMED" : "OPENAI")
+                        Text(engine == .openMed ? "OPENMED" : "OPENAI NEMOTRON")
                             .omMonoTag(size: 10)
                             .foregroundStyle(isSelected ? Color.omTealAccent : Color.omFgMuted)
                     }
@@ -185,7 +185,7 @@ extension ScanFlowViewModel.PIIEngine {
     var shortTitle: String {
         switch self {
         case .openMed:       return "OpenMed PII LiteClinical"
-        case .privacyFilter: return "OpenAI Privacy Filter"
+        case .privacyFilter: return "OpenAI Nemotron Privacy Filter"
         }
     }
 
@@ -194,7 +194,7 @@ extension ScanFlowViewModel.PIIEngine {
         case .openMed:
             return "66M-param DistilBERT trained for clinical PII. Fast, balanced precision/recall."
         case .privacyFilter:
-            return "OpenAI's 8-bit Privacy Filter with BIOES decoding. Broad coverage, slightly heavier."
+            return "OpenAI Nemotron 8-bit Privacy Filter with BIOES decoding. Broad coverage, slightly heavier."
         }
     }
 

--- a/swift/OpenMedScanDemo/OpenMedScanDemo/Model/ModelDownloadEvent.swift
+++ b/swift/OpenMedScanDemo/OpenMedScanDemo/Model/ModelDownloadEvent.swift
@@ -11,7 +11,7 @@ public enum ScanModelID: String, CaseIterable, Hashable, Sendable, Identifiable 
     public var displayName: String {
         switch self {
         case .piiLiteClinical:     return "OpenMed PII"
-        case .openaiPrivacyFilter: return "OpenAI Privacy"
+        case .openaiPrivacyFilter: return "OpenAI Nemotron Privacy"
         case .glinerRelex:         return "GLiNER Clinical"
         }
     }

--- a/swift/OpenMedScanDemo/OpenMedScanDemo/ViewModel/ModelDownloadManager.swift
+++ b/swift/OpenMedScanDemo/OpenMedScanDemo/ViewModel/ModelDownloadManager.swift
@@ -214,7 +214,7 @@ public extension ScanModelID {
     var artifactRepoID: String {
         switch self {
         case .piiLiteClinical:     return "OpenMed/OpenMed-PII-LiteClinical-Small-66M-v1-mlx"
-        case .openaiPrivacyFilter: return "OpenMed/privacy-filter-mlx-8bit"
+        case .openaiPrivacyFilter: return "OpenMed/privacy-filter-nemotron-mlx-8bit"
         case .glinerRelex:         return "OpenMed/gliner-relex-base-v1.0-mlx"
         }
     }

--- a/swift/OpenMedScanDemo/OpenMedScanDemo/ViewModel/ScanFlowViewModel.swift
+++ b/swift/OpenMedScanDemo/OpenMedScanDemo/ViewModel/ScanFlowViewModel.swift
@@ -67,10 +67,10 @@ public final class ScanFlowViewModel: ObservableObject {
             self == .openMed ? .piiLiteClinical : .openaiPrivacyFilter
         }
         public var displayName: String {
-            self == .openMed ? "OpenMed PII" : "OpenAI Privacy Filter"
+            self == .openMed ? "OpenMed PII" : "OpenAI Nemotron Privacy Filter"
         }
         public var eyebrow: String {
-            self == .openMed ? "OPENMED · LOCAL" : "OPENAI · LOCAL"
+            self == .openMed ? "OPENMED · LOCAL" : "OPENAI NEMOTRON · LOCAL"
         }
     }
 

--- a/swift/OpenMedScanDemo/README.md
+++ b/swift/OpenMedScanDemo/README.md
@@ -15,7 +15,7 @@ An iOS SwiftUI demo that shows the full native Apple flow:
 3. Run it on a real iPhone or iPad.
 4. Tap `Scan Document` to capture pages or `Load Sample Document` to open the bundled clinical note image.
 5. Press the main action button to run OCR, de-identification, and the GLiNER Relex pass in sequence.
-6. The app uses `OpenMed/OpenMed-PII-LiteClinical-Small-66M-v1-mlx` or `OpenMed/privacy-filter-mlx-8bit` to mask PII and `OpenMed/gliner-relex-base-v1.0-mlx` to extract clinical entities from the masked note.
+6. The app uses `OpenMed/OpenMed-PII-LiteClinical-Small-66M-v1-mlx` or `OpenMed/privacy-filter-nemotron-mlx-8bit` to mask PII and `OpenMed/gliner-relex-base-v1.0-mlx` to extract clinical entities from the masked note.
 7. Each artifact is cached locally after a successful download. Later runs reuse the cached copy and only fetch files again if a previous download was interrupted and left the cache incomplete.
 8. To test disconnected mode, run the demo once while online so both artifacts are cached, then disable network access and run the same sample or scan flow again.
 
@@ -32,7 +32,7 @@ An iOS SwiftUI demo that shows the full native Apple flow:
 
 - The scanner UI is iPhone/iPad only because it uses VisionKit's native document camera.
 - The local MLX path also expects real Apple hardware; iOS Simulator is useful for UI review, not end-to-end validation.
-- The selected OpenMed PII, OpenAI Privacy Filter 8-bit, and GLiNER Relex artifacts are public OpenMed MLX artifacts, so no account setup is required.
+- The selected OpenMed PII, OpenAI Nemotron Privacy Filter 8-bit, and GLiNER Relex artifacts are public OpenMed MLX artifacts, so no account setup is required.
 - The app now distinguishes between missing, partial, and ready artifact caches so it can resume incomplete downloads without repeatedly re-downloading complete artifacts.
 - The demo uses a fixed zero-shot label pack tuned to clinical follow-up documents: symptoms, conditions, medical history, medication, dosage, allergy, treatment, procedure, follow-up plan, care plan, care setting, and work status.
 

--- a/tests/unit/core/test_anonymizer.py
+++ b/tests/unit/core/test_anonymizer.py
@@ -1,0 +1,309 @@
+"""Tests for the Faker-backed anonymization engine."""
+
+import pytest
+
+from openmed.core.anonymizer import (
+    Anonymizer,
+    AnonymizerConfig,
+    LANG_TO_LOCALE,
+    register_label_generator,
+)
+from openmed.core.anonymizer.format_preserve import (
+    extract_digit_groups,
+    preserve_email_pattern,
+    preserve_id_pattern,
+    preserve_phone_format,
+)
+from openmed.core.labels import normalize_label
+
+
+class TestLocaleResolution:
+    def test_lang_to_locale_covers_all_supported_languages(self):
+        for lang in ("en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"):
+            assert lang in LANG_TO_LOCALE
+
+    def test_locale_override_per_call(self):
+        a = Anonymizer(lang="pt")
+        # pt_PT default
+        assert a.surrogate("Pedro", "FIRSTNAME", locale="pt_PT")
+        # pt_BR override
+        assert a.surrogate("Pedro", "FIRSTNAME", locale="pt_BR")
+
+    def test_telugu_falls_back_to_indian_english(self):
+        # Should not raise — just emits a warning the first time.
+        with pytest.warns(UserWarning, match="te"):
+            a = Anonymizer(lang="te")
+            out = a.surrogate("Sita", "FIRSTNAME")
+        assert out
+
+
+class TestDeterminism:
+    @pytest.mark.parametrize("label", ["FIRSTNAME", "LASTNAME", "EMAIL", "DATE", "PHONE"])
+    def test_same_seed_same_surrogate(self, label):
+        a1 = Anonymizer(lang="en", consistent=True, seed=42)
+        a2 = Anonymizer(lang="en", consistent=True, seed=42)
+        assert a1.surrogate("original", label) == a2.surrogate("original", label)
+
+    def test_different_seeds_likely_different_surrogates(self):
+        a1 = Anonymizer(lang="en", consistent=True, seed=1)
+        a2 = Anonymizer(lang="en", consistent=True, seed=2)
+        # Statistically these differ for any non-trivial label.
+        outputs = {
+            a1.surrogate("alice", "FIRSTNAME"),
+            a2.surrogate("alice", "FIRSTNAME"),
+        }
+        assert len(outputs) == 2
+
+    def test_consistent_within_doc(self):
+        """Same (label, original) pair -> same surrogate when consistent=True."""
+        a = Anonymizer(lang="en", consistent=True, seed=99)
+        first = a.surrogate("John Doe", "name")
+        # Repeated mentions in the same doc should resolve to the same surrogate.
+        for _ in range(5):
+            assert a.surrogate("John Doe", "name") == first
+
+    def test_random_mode_varies(self):
+        """Without consistent=True, repeated calls vary."""
+        a = Anonymizer(lang="en", consistent=False)
+        outs = {a.surrogate("John Doe", "name") for _ in range(20)}
+        # 20 random samples should produce at least 2 distinct outputs
+        assert len(outs) > 1
+
+    def test_different_originals_different_surrogates(self):
+        a = Anonymizer(lang="en", consistent=True, seed=42)
+        s1 = a.surrogate("John", "FIRSTNAME")
+        s2 = a.surrogate("Mary", "FIRSTNAME")
+        assert s1 != s2
+
+
+class TestClinicalIDChecksums:
+    """Faker built-ins (CPF, CNPJ, BSN, NIR, NIE, Codice Fiscale) and our
+    custom providers (Aadhaar, German Steuer-ID) must produce values that
+    pass the corresponding validators."""
+
+    @pytest.mark.parametrize("seed", list(range(20)))
+    def test_pt_br_cpf_validates(self, seed):
+        from openmed.core.pii_i18n import validate_portuguese_cpf
+        a = Anonymizer(lang="pt", locale="pt_BR", consistent=True, seed=seed)
+        cpf = a.surrogate("123.456.789-09", "CPF")
+        assert validate_portuguese_cpf(cpf), f"Invalid CPF generated: {cpf!r}"
+
+    @pytest.mark.parametrize("seed", list(range(20)))
+    def test_nl_bsn_validates(self, seed):
+        from openmed.core.pii_i18n import validate_dutch_bsn
+        a = Anonymizer(lang="nl", consistent=True, seed=seed)
+        bsn = a.surrogate("123456789", "SSN")
+        assert validate_dutch_bsn(bsn), f"Invalid BSN: {bsn!r}"
+
+    @pytest.mark.parametrize("seed", list(range(20)))
+    def test_fr_nir_validates(self, seed):
+        from openmed.core.pii_i18n import validate_french_nir
+        a = Anonymizer(lang="fr", consistent=True, seed=seed)
+        nir = a.surrogate("1 85 05 78 006 084 36", "SSN")
+        assert validate_french_nir(nir), f"Invalid NIR: {nir!r}"
+
+    @pytest.mark.parametrize("seed", list(range(20)))
+    def test_it_codice_fiscale_validates(self, seed):
+        from openmed.core.pii_i18n import validate_italian_codice_fiscale
+        a = Anonymizer(lang="it", consistent=True, seed=seed)
+        cf = a.surrogate("RSSMRA85M01H501Z", "SSN")
+        assert validate_italian_codice_fiscale(cf), f"Invalid Codice Fiscale: {cf!r}"
+
+    @pytest.mark.parametrize("seed", list(range(20)))
+    def test_es_nie_validates(self, seed):
+        from openmed.core.pii_i18n import validate_spanish_nie
+        a = Anonymizer(lang="es", consistent=True, seed=seed)
+        nie = a.surrogate("X1234567L", "ID_NUM")
+        assert validate_spanish_nie(nie), f"Invalid NIE: {nie!r}"
+
+    @pytest.mark.parametrize("seed", list(range(10)))
+    def test_aadhaar_provider_validates_via_verhoeff(self, seed):
+        """Custom AadhaarProvider must produce Verhoeff-valid Aadhaar."""
+        from openmed.core.pii_i18n import validate_aadhaar
+        # Use the underlying Faker provider directly
+        from faker import Faker
+        from openmed.core.anonymizer.providers.clinical_ids import (
+            register_clinical_providers,
+        )
+        fk = Faker("en_IN")
+        register_clinical_providers(fk)
+        fk.seed_instance(seed)
+        for _ in range(20):
+            a = fk.aadhaar()
+            assert validate_aadhaar(a), f"Verhoeff failed for {a!r}"
+
+    @pytest.mark.parametrize("seed", list(range(5)))
+    def test_german_steuer_id_provider_validates(self, seed):
+        from openmed.core.pii_i18n import validate_german_steuer_id
+        from faker import Faker
+        from openmed.core.anonymizer.providers.clinical_ids import (
+            register_clinical_providers,
+        )
+        fk = Faker("de_DE")
+        register_clinical_providers(fk)
+        fk.seed_instance(seed)
+        for _ in range(5):
+            sid = fk.german_steuer_id()
+            assert validate_german_steuer_id(sid), f"Invalid Steuer-ID: {sid!r}"
+
+
+class TestFormatPreservation:
+    def test_extract_digit_groups(self):
+        assert extract_digit_groups("+1 (415) 555-1234") == [1, 3, 3, 4]
+        assert extract_digit_groups("+33 6 12 34 56 78") == [2, 1, 2, 2, 2, 2]
+        assert extract_digit_groups("no digits here") == []
+
+    def test_preserve_phone_format_keeps_separators_and_lengths(self):
+        out = preserve_phone_format("+1 (415) 555-1234")
+        assert "+" in out
+        assert " " in out
+        assert "(" in out and ")" in out
+        assert "-" in out
+        assert extract_digit_groups(out) == [1, 3, 3, 4]
+
+    def test_preserve_email_pattern_keeps_domain(self):
+        result = preserve_email_pattern("john@hospital.org", "alice@example.com")
+        assert result.endswith("@hospital.org")
+
+    def test_preserve_email_pattern_falls_back_when_invalid(self):
+        # If the original isn't an email, just return the fake.
+        result = preserve_email_pattern("not_an_email", "alice@example.com")
+        assert result == "alice@example.com"
+
+    def test_preserve_id_pattern(self):
+        out = preserve_id_pattern("MRN-1234567")
+        assert out.startswith("MRN-") or len(out) == len("MRN-1234567")
+        # All non-alpha non-digit chars preserved
+        assert "-" in out
+
+    def test_phone_through_engine_preserves_groups(self):
+        a = Anonymizer(lang="en", consistent=True, seed=0)
+        original = "+1 (415) 555-1234"
+        surrogate = a.surrogate(original, "phone_number")
+        # Same number of digit groups, each the same length
+        assert extract_digit_groups(surrogate) == extract_digit_groups(original)
+
+
+class TestLabelCoverage:
+    """Every canonical label has a generator and produces a non-empty result."""
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "FIRSTNAME", "LASTNAME", "name", "patient",
+            "EMAIL", "PHONE", "URL",
+            "CITY", "STATE", "STREET",
+            "DATE", "DATEOFBIRTH", "TIME", "AGE",
+            "ID_NUM", "SSN",
+            "CREDITCARD", "IBAN", "BIC",
+            "GENDER", "ORGANIZATION", "JOBTITLE",
+            "IPADDRESS", "MACADDRESS", "USERAGENT",
+            "BITCOINADDRESS", "ETHEREUMADDRESS",
+            "USERNAME", "ZIPCODE", "PASSWORD", "PIN",
+        ],
+    )
+    def test_every_label_yields_non_empty_surrogate(self, label):
+        a = Anonymizer(lang="en", consistent=True, seed=42)
+        out = a.surrogate("seed_value", label)
+        assert isinstance(out, str)
+        assert out
+
+
+class TestCustomGenerator:
+    def test_register_label_generator_overrides_default(self):
+        """Users can override per-label generators."""
+        marker = "CUSTOM-MRN-GENERATOR"
+
+        def my_gen(faker, original, *, locale):
+            return marker
+
+        # Register custom generator for ID_NUM
+        register_label_generator("ID_NUM", my_gen)
+        try:
+            a = Anonymizer(lang="en")
+            assert a.surrogate("12345", "id_num") == marker
+        finally:
+            # Restore default
+            from openmed.core.anonymizer.registry import _gen_id_num
+            register_label_generator("ID_NUM", _gen_id_num)
+
+
+class TestAnonymizerConfig:
+    def test_config_dataclass_construction(self):
+        cfg = AnonymizerConfig(lang="pt", locale="pt_BR", consistent=True, seed=7)
+        a = Anonymizer(config=cfg)
+        assert a.config.lang == "pt"
+        assert a.config.locale == "pt_BR"
+        assert a.config.consistent
+        assert a.config.seed == 7
+
+
+class TestIntegrationWithDeidentify:
+    """End-to-end: deidentify(method='replace', consistent=True, seed=...) is stable."""
+
+    def test_deidentify_consistent_repeatable(self):
+        from unittest.mock import patch
+        from openmed.processing.outputs import EntityPrediction, PredictionResult
+        from openmed.core.pii import deidentify
+        from datetime import datetime as _dt
+        text = "Patient John Doe born on 01/15/1970"
+        entities = [
+            EntityPrediction(text="John Doe", label="name", start=8, end=16, confidence=0.95),
+            EntityPrediction(text="01/15/1970", label="date_of_birth", start=25, end=35, confidence=0.95),
+        ]
+        with patch("openmed.core.pii.extract_pii") as mock:
+            mock.return_value = PredictionResult(
+                text=text, entities=entities, model_name="test",
+                timestamp=_dt.now().isoformat(),
+            )
+            r1 = deidentify(text, method="replace", lang="en", consistent=True, seed=123)
+            r2 = deidentify(text, method="replace", lang="en", consistent=True, seed=123)
+            assert r1.deidentified_text == r2.deidentified_text
+            assert "John Doe" not in r1.deidentified_text
+            assert "01/15/1970" not in r1.deidentified_text
+
+    def test_deidentify_seed_implies_consistent(self):
+        """Passing seed= alone should produce repeatable output."""
+        from unittest.mock import patch
+        from openmed.processing.outputs import EntityPrediction, PredictionResult
+        from openmed.core.pii import deidentify
+        from datetime import datetime as _dt
+        text = "Maria Silva"
+        entities = [EntityPrediction(text="Maria Silva", label="name", start=0, end=11, confidence=0.95)]
+        with patch("openmed.core.pii.extract_pii") as mock:
+            mock.return_value = PredictionResult(
+                text=text, entities=entities, model_name="test",
+                timestamp=_dt.now().isoformat(),
+            )
+            r1 = deidentify(text, method="replace", lang="pt", seed=7)
+            r2 = deidentify(text, method="replace", lang="pt", seed=7)
+            assert r1.deidentified_text == r2.deidentified_text
+
+
+class TestNormalizeLabelIntegration:
+    """The engine routes through normalize_label internally."""
+
+    def test_uppercase_and_lowercase_routes_to_same_generator(self):
+        a = Anonymizer(lang="en", consistent=True, seed=42)
+        # Both the lowercase English form and the Portuguese UPPERCASE form
+        # normalize to FIRST_NAME, so they should produce the same surrogate.
+        s1 = a.surrogate("John", "first_name")
+        s2 = a.surrogate("John", "FIRSTNAME")
+        assert s1 == s2
+
+    def test_bioes_prefix_routes_to_base_generator(self):
+        a = Anonymizer(lang="en", consistent=True, seed=42)
+        s1 = a.surrogate("John", "name")
+        s2 = a.surrogate("John", "B-NAME")
+        s3 = a.surrogate("John", "I-NAME")
+        s4 = a.surrogate("John", "S-NAME")
+        # All map to PERSON canonical label and use same seed material.
+        assert s1 == s2 == s3 == s4
+
+    def test_normalize_label_is_consistent_with_engine_routing(self):
+        """The engine's behavior must match what normalize_label predicts."""
+        # If two source labels normalize to the same canonical, engine must agree.
+        for label_pair in [("first_name", "FIRSTNAME"),
+                           ("date_of_birth", "DATEOFBIRTH"),
+                           ("phone_number", "PHONE")]:
+            assert normalize_label(label_pair[0]) == normalize_label(label_pair[1])

--- a/tests/unit/core/test_labels.py
+++ b/tests/unit/core/test_labels.py
@@ -1,0 +1,224 @@
+"""Tests for the canonical PII label taxonomy."""
+
+import pytest
+
+from openmed.core.labels import (
+    AGE,
+    CANONICAL_LABELS,
+    CREDIT_CARD,
+    DATE,
+    DATE_OF_BIRTH,
+    EMAIL,
+    FIRST_NAME,
+    GENDER,
+    ID_NUM,
+    IP_ADDRESS,
+    LAST_NAME,
+    LOCATION,
+    OCCUPATION,
+    ORGANIZATION,
+    OTHER,
+    PERSON,
+    PHONE,
+    SSN,
+    STREET_ADDRESS,
+    URL,
+    USERNAME,
+    ZIPCODE,
+    normalize_label,
+)
+
+
+class TestEnglishLabels:
+    """Lowercase snake_case forms emitted by the English/multilingual models."""
+
+    @pytest.mark.parametrize(
+        "label,expected",
+        [
+            ("first_name", FIRST_NAME),
+            ("last_name", LAST_NAME),
+            ("name", PERSON),
+            ("patient", PERSON),
+            ("doctor", PERSON),
+            ("email", EMAIL),
+            ("phone_number", PHONE),
+            ("phone", PHONE),
+            ("city", LOCATION),
+            ("state", LOCATION),
+            ("country", LOCATION),
+            ("street_address", STREET_ADDRESS),
+            ("date", DATE),
+            ("date_of_birth", DATE_OF_BIRTH),
+            ("dob", DATE_OF_BIRTH),
+            ("ssn", SSN),
+            ("medical_record_number", ID_NUM),
+            ("id_num", ID_NUM),
+            ("national_id", ID_NUM),
+            ("age", AGE),
+            ("username", USERNAME),
+            ("url_personal", URL),
+            ("zipcode", ZIPCODE),
+            ("zip", ZIPCODE),
+            ("postal_code", ZIPCODE),
+            ("credit_debit_card", CREDIT_CARD),
+        ],
+    )
+    def test_english_lowercase(self, label, expected):
+        assert normalize_label(label) == expected
+
+
+class TestPortugueseUppercaseLabels:
+    """All 52 Portuguese UPPERCASE labels from the registry."""
+
+    @pytest.mark.parametrize(
+        "label,expected",
+        [
+            ("ACCOUNTNAME", "ACCOUNT_NUMBER"),
+            ("AGE", AGE),
+            ("AMOUNT", "AMOUNT"),
+            ("BANKACCOUNT", "ACCOUNT_NUMBER"),
+            ("BIC", "BIC"),
+            ("BITCOINADDRESS", "BITCOIN_ADDRESS"),
+            ("BUILDINGNUMBER", "BUILDING_NUMBER"),
+            ("CITY", LOCATION),
+            ("COUNTY", LOCATION),
+            ("CREDITCARD", CREDIT_CARD),
+            ("CREDITCARDISSUER", "CREDIT_CARD_ISSUER"),
+            ("CURRENCY", "CURRENCY"),
+            ("CURRENCYCODE", "CURRENCY"),
+            ("CURRENCYNAME", "CURRENCY"),
+            ("CURRENCYSYMBOL", "CURRENCY"),
+            ("CVV", "CVV"),
+            ("DATE", DATE),
+            ("DATEOFBIRTH", DATE_OF_BIRTH),
+            ("EMAIL", EMAIL),
+            ("ETHEREUMADDRESS", "ETHEREUM_ADDRESS"),
+            ("EYECOLOR", "EYE_COLOR"),
+            ("FIRSTNAME", FIRST_NAME),
+            ("GENDER", GENDER),
+            ("GPSCOORDINATES", "GPS_COORDINATES"),
+            ("HEIGHT", "HEIGHT"),
+            ("IBAN", "IBAN"),
+            ("IMEI", "IMEI"),
+            ("IPADDRESS", IP_ADDRESS),
+            ("JOBDEPARTMENT", "JOB_DEPARTMENT"),
+            ("JOBTITLE", "JOB_TITLE"),
+            ("LASTNAME", LAST_NAME),
+            ("LITECOINADDRESS", "LITECOIN_ADDRESS"),
+            ("MACADDRESS", "MAC_ADDRESS"),
+            ("MASKEDNUMBER", "MASKED_NUMBER"),
+            ("MIDDLENAME", "MIDDLE_NAME"),
+            ("OCCUPATION", OCCUPATION),
+            ("ORDINALDIRECTION", "ORDINAL_DIRECTION"),
+            ("ORGANIZATION", ORGANIZATION),
+            ("PASSWORD", "PASSWORD"),
+            ("PHONE", PHONE),
+            ("PIN", "PIN"),
+            ("PREFIX", "PREFIX"),
+            ("SECONDARYADDRESS", STREET_ADDRESS),
+            ("SEX", GENDER),
+            ("SSN", SSN),
+            ("STATE", LOCATION),
+            ("STREET", STREET_ADDRESS),
+            ("TIME", "TIME"),
+            ("URL", URL),
+            ("USERAGENT", "USER_AGENT"),
+            ("USERNAME", USERNAME),
+            ("VIN", "VIN"),
+            ("VRM", "VEHICLE_REGISTRATION"),
+            ("ZIPCODE", ZIPCODE),
+        ],
+    )
+    def test_portuguese_uppercase(self, label, expected):
+        assert normalize_label(label, lang="pt") == expected
+
+
+class TestBIOESPrefixes:
+    """Privacy-filter family emits BIOES-tagged labels."""
+
+    @pytest.mark.parametrize(
+        "label,expected",
+        [
+            ("B-NAME", PERSON),
+            ("I-NAME", PERSON),
+            ("E-NAME", PERSON),
+            ("S-NAME", PERSON),
+            ("B-EMAIL", EMAIL),
+            ("I-EMAIL", EMAIL),
+            ("B-PHONE", PHONE),
+            ("S-PHONE", PHONE),
+            ("B-DATE", DATE),
+            ("E-LOCATION", LOCATION),
+            ("S-FIRSTNAME", FIRST_NAME),
+            ("B-CPF", ID_NUM),
+            ("I-CREDITCARD", CREDIT_CARD),
+        ],
+    )
+    def test_bioes_prefix_stripped(self, label, expected):
+        assert normalize_label(label) == expected
+
+
+class TestEdgeCases:
+    def test_empty_label_returns_other(self):
+        assert normalize_label("") == OTHER
+
+    def test_whitespace_label_returns_other(self):
+        assert normalize_label("   ") == OTHER
+
+    def test_unknown_label_returns_other(self):
+        assert normalize_label("totally_made_up_label") == OTHER
+
+    def test_mixed_case_normalized(self):
+        assert normalize_label("First-Name") == FIRST_NAME
+        assert normalize_label("first name") == FIRST_NAME
+        assert normalize_label("FIRST_NAME") == FIRST_NAME
+
+    def test_canonical_label_round_trip(self):
+        """Every canonical label normalizes back to itself."""
+        for canonical in CANONICAL_LABELS:
+            assert normalize_label(canonical) == canonical, (
+                f"Canonical label {canonical!r} did not round-trip"
+            )
+
+    def test_canonical_labels_are_screaming_snake(self):
+        for label in CANONICAL_LABELS:
+            assert label == label.upper(), f"{label} is not uppercase"
+            for ch in label:
+                assert ch.isalnum() or ch == "_", f"{label} has non-snake char {ch!r}"
+
+    def test_lang_parameter_accepted(self):
+        """The lang hint is accepted but currently doesn't change output."""
+        for lang in ("en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"):
+            assert normalize_label("first_name", lang=lang) == FIRST_NAME
+
+
+class TestRegistryCoverage:
+    """The 52 Portuguese registry labels all map to canonical names."""
+
+    PORTUGUESE_REGISTRY_LABELS = [
+        "ACCOUNTNAME", "AGE", "AMOUNT", "BANKACCOUNT", "BIC", "BITCOINADDRESS",
+        "BUILDINGNUMBER", "CITY", "COUNTY", "CREDITCARD", "CREDITCARDISSUER",
+        "CURRENCY", "CURRENCYCODE", "CURRENCYNAME", "CURRENCYSYMBOL", "CVV",
+        "DATE", "DATEOFBIRTH", "EMAIL", "ETHEREUMADDRESS", "EYECOLOR",
+        "FIRSTNAME", "GENDER", "GPSCOORDINATES", "HEIGHT", "IBAN", "IMEI",
+        "IPADDRESS", "JOBDEPARTMENT", "JOBTITLE", "LASTNAME", "LITECOINADDRESS",
+        "MACADDRESS", "MASKEDNUMBER", "MIDDLENAME", "OCCUPATION",
+        "ORDINALDIRECTION", "ORGANIZATION", "PASSWORD", "PHONE", "PIN",
+        "PREFIX", "SECONDARYADDRESS", "SEX", "SSN", "STATE", "STREET",
+        "TIME", "URL", "USERAGENT", "USERNAME", "VIN", "VRM", "ZIPCODE",
+    ]
+
+    def test_all_portuguese_labels_have_canonical_mapping(self):
+        unmapped = []
+        for label in self.PORTUGUESE_REGISTRY_LABELS:
+            canonical = normalize_label(label, lang="pt")
+            if canonical == OTHER:
+                unmapped.append(label)
+        assert not unmapped, f"Portuguese labels not mapped: {unmapped}"
+
+    def test_all_portuguese_labels_map_to_known_canonical(self):
+        for label in self.PORTUGUESE_REGISTRY_LABELS:
+            canonical = normalize_label(label, lang="pt")
+            assert canonical in CANONICAL_LABELS, (
+                f"{label} -> {canonical} which is not in CANONICAL_LABELS"
+            )

--- a/tests/unit/mlx/test_privacy_filter_mlx.py
+++ b/tests/unit/mlx/test_privacy_filter_mlx.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -10,10 +12,16 @@ import pytest
 
 def _module_importable(module_name: str) -> bool:
     try:
-        __import__(module_name)
+        completed = subprocess.run(
+            [sys.executable, "-c", f"import {module_name}"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            check=False,
+        )
     except Exception:
         return False
-    return True
+    return completed.returncode == 0
 
 
 _MLX_AVAILABLE = _module_importable("mlx.core")
@@ -112,6 +120,7 @@ def _write_mlx_artifact(path, config: dict, weights: dict) -> None:
     mx.save_safetensors(path / "weights.safetensors", weights)
 
 
+@pytest.mark.skipif(not _MLX_AVAILABLE, reason="MLX is required for model resolver tests")
 def test_resolves_privacy_filter_model_family():
     from openmed.mlx.models import resolve_model_type
 
@@ -199,6 +208,7 @@ def test_viterbi_rejects_invalid_inside_start():
     assert decoded == [4]
 
 
+@pytest.mark.skipif(not _MLX_AVAILABLE, reason="MLX is required for MLX pipeline decode tests")
 def test_privacy_filter_grouped_decode_handles_bioes():
     from openmed.core.decoding import build_label_info
     from openmed.mlx.inference import PrivacyFilterMLXPipeline
@@ -246,6 +256,7 @@ def test_privacy_filter_grouped_decode_handles_bioes():
     ]
 
 
+@pytest.mark.skipif(not _MLX_AVAILABLE, reason="MLX is required for MLX pipeline dispatch tests")
 def test_dispatches_privacy_filter_pipeline(tmp_path):
     from openmed.mlx import inference
 

--- a/tests/unit/mlx/test_privacy_filter_mlx.py
+++ b/tests/unit/mlx/test_privacy_filter_mlx.py
@@ -180,7 +180,7 @@ def test_privacy_filter_q8_loader_matches_bf16_fixture(tmp_path):
 
 
 def test_viterbi_rejects_invalid_inside_start():
-    from openmed.mlx.inference import _build_label_info, _viterbi_decode
+    from openmed.core.decoding import build_label_info, viterbi_decode
 
     id2label = {
         0: "O",
@@ -189,8 +189,8 @@ def test_viterbi_rejects_invalid_inside_start():
         3: "E-private_person",
         4: "S-private_person",
     }
-    label_info = _build_label_info(id2label)
-    decoded = _viterbi_decode(
+    label_info = build_label_info(id2label)
+    decoded = viterbi_decode(
         [[-10.0, -10.0, 0.0, -10.0, -0.1]],
         label_info=label_info,
         biases={},
@@ -200,7 +200,8 @@ def test_viterbi_rejects_invalid_inside_start():
 
 
 def test_privacy_filter_grouped_decode_handles_bioes():
-    from openmed.mlx.inference import PrivacyFilterMLXPipeline, _build_label_info
+    from openmed.core.decoding import build_label_info
+    from openmed.mlx.inference import PrivacyFilterMLXPipeline
 
     pipeline = PrivacyFilterMLXPipeline.__new__(PrivacyFilterMLXPipeline)
     pipeline.id2label = {
@@ -210,7 +211,7 @@ def test_privacy_filter_grouped_decode_handles_bioes():
         3: "E-private_person",
         4: "S-private_email",
     }
-    pipeline.label_info = _build_label_info(pipeline.id2label)
+    pipeline.label_info = build_label_info(pipeline.id2label)
 
     probs = [
         [0.0, 0.9, 0.0, 0.0, 0.0],

--- a/tests/unit/mlx/test_privacy_filter_mlx.py
+++ b/tests/unit/mlx/test_privacy_filter_mlx.py
@@ -257,7 +257,18 @@ def test_privacy_filter_grouped_decode_handles_bioes():
 
 
 @pytest.mark.skipif(not _MLX_AVAILABLE, reason="MLX is required for MLX pipeline dispatch tests")
-def test_dispatches_privacy_filter_pipeline(tmp_path):
+@pytest.mark.parametrize(
+    "manifest_family,source_model_id",
+    [
+        ("openai-privacy-filter", "openai/privacy-filter"),
+        # The Nemotron-PII fine-tune is the SAME architecture, just trained
+        # on a different dataset. Either alias must dispatch to the existing
+        # PrivacyFilterMLXPipeline (no separate Nemotron pipeline class).
+        ("privacy-filter-nemotron", "OpenMed/privacy-filter-nemotron"),
+        ("nemotron-privacy-filter", "OpenMed/privacy-filter-nemotron"),
+    ],
+)
+def test_dispatches_privacy_filter_pipeline(tmp_path, manifest_family, source_model_id):
     from openmed.mlx import inference
 
     config = _privacy_config()
@@ -268,8 +279,8 @@ def test_dispatches_privacy_filter_pipeline(tmp_path):
                 "format": "openmed-mlx",
                 "format_version": 2,
                 "task": "token-classification",
-                "family": "openai-privacy-filter",
-                "source_model_id": "openai/privacy-filter",
+                "family": manifest_family,
+                "source_model_id": source_model_id,
                 "config_path": "config.json",
                 "label_map_path": None,
                 "preferred_weights": "weights.safetensors",

--- a/tests/unit/service/test_api.py
+++ b/tests/unit/service/test_api.py
@@ -236,7 +236,7 @@ def test_pii_extract_accepts_new_langs(client, monkeypatch, fake_loader_cls, lan
 def test_pii_extract_invalid_lang_returns_validation_error(client):
     response = client.post(
         "/pii/extract",
-        json={"text": "Paciente: Maria Garcia", "lang": "pt"},
+        json={"text": "Paciente: Maria Garcia", "lang": "xx"},
     )
 
     payload = _assert_error_payload(response, 422, "validation_error")

--- a/tests/unit/test_pii.py
+++ b/tests/unit/test_pii.py
@@ -256,56 +256,60 @@ class TestExtractPII:
         assert mock_analyze.call_args.kwargs["loader"] is loader
 
     @patch("openmed.analyze_text")
-    def test_extract_pii_privacy_filter_uses_model_led_merging(self, mock_analyze):
-        """Privacy Filter should not let regex invent unsupported labels."""
-        mock_analyze.return_value = PredictionResult(
-            text="Patient SSN: 123-45-6789",
-            entities=[],
-            model_name="OpenMed/privacy-filter-mlx",
-            timestamp=datetime.now().isoformat(),
-        )
-
-        with patch(
-            "openmed.core.pii_entity_merger.merge_entities_with_semantic_units",
-            return_value=[],
-        ) as mock_merge:
-            extract_pii(
+    def test_extract_pii_privacy_filter_routes_through_dispatcher(self, mock_analyze):
+        """Privacy-filter models route through ``create_privacy_filter_pipeline``
+        rather than ``analyze_text``, and skip the regex smart-merging layer
+        entirely (the model already does Viterbi-constrained span construction).
+        """
+        with patch("openmed.core.backends.create_privacy_filter_pipeline") as mock_be, \
+             patch(
+                 "openmed.core.pii_entity_merger.merge_entities_with_semantic_units",
+                 return_value=[],
+             ) as mock_merge:
+            mock_be.return_value = lambda text: [
+                {"entity_group": "SSN", "score": 0.95, "word": "123-45-6789",
+                 "start": 13, "end": 24}
+            ]
+            result = extract_pii(
                 "Patient SSN: 123-45-6789",
                 model_name="OpenMed/privacy-filter-mlx",
                 use_smart_merging=True,
             )
 
-        assert mock_merge.call_args.kwargs["allow_semantic_only_matches"] is False
-        assert mock_merge.call_args.kwargs["allow_label_expansion"] is False
+        # analyze_text bypassed entirely
+        mock_analyze.assert_not_called()
+        # Smart merging skipped
+        mock_merge.assert_not_called()
+        # Backend dispatcher invoked with the requested model name
+        mock_be.assert_called_once_with("OpenMed/privacy-filter-mlx")
+        # Pipeline output preserved
+        assert len(result.entities) == 1
+        assert result.entities[0].label == "SSN"
 
     @patch("openmed.analyze_text")
-    def test_extract_pii_local_privacy_filter_artifact_uses_model_led_merging(self, mock_analyze, tmp_path):
-        """Local MLX artifacts should be detected from manifest metadata, not folder names."""
+    def test_extract_pii_local_privacy_filter_artifact_routes_through_dispatcher(self, mock_analyze, tmp_path):
+        """Local MLX artifacts identified by manifest also bypass smart merging."""
         artifact_dir = tmp_path / "artifact"
         artifact_dir.mkdir()
         (artifact_dir / "openmed-mlx.json").write_text(
             '{"task":"token-classification","family":"openai-privacy-filter"}'
         )
 
-        mock_analyze.return_value = PredictionResult(
-            text="Patient MRN: ABC-123",
-            entities=[],
-            model_name=str(artifact_dir),
-            timestamp=datetime.now().isoformat(),
-        )
-
-        with patch(
-            "openmed.core.pii_entity_merger.merge_entities_with_semantic_units",
-            return_value=[],
-        ) as mock_merge:
+        with patch("openmed.core.backends.create_privacy_filter_pipeline") as mock_be, \
+             patch(
+                 "openmed.core.pii_entity_merger.merge_entities_with_semantic_units",
+                 return_value=[],
+             ) as mock_merge:
+            mock_be.return_value = lambda text: []
             extract_pii(
                 "Patient MRN: ABC-123",
                 model_name=str(artifact_dir),
                 use_smart_merging=True,
             )
 
-        assert mock_merge.call_args.kwargs["allow_semantic_only_matches"] is False
-        assert mock_merge.call_args.kwargs["allow_label_expansion"] is False
+        mock_analyze.assert_not_called()
+        mock_merge.assert_not_called()
+        mock_be.assert_called_once_with(str(artifact_dir))
 
 
 # ---------------------------------------------------------------------------
@@ -919,8 +923,13 @@ class TestMultilingualPII:
         assert call_args[1]["lang"] == "fr"
 
     @patch("openmed.core.pii.extract_pii")
-    def test_deidentify_replace_uses_lang_fake_data(self, mock_extract):
-        """Test replace method uses language-appropriate fake data."""
+    def test_deidentify_replace_uses_locale_aware_surrogates(self, mock_extract):
+        """``method='replace'`` produces Faker-backed locale-appropriate surrogates.
+
+        With ``consistent=True, seed=...`` we can assert exact equality across
+        runs. The surrogate must be (a) non-empty, (b) different from the
+        original, and (c) repeatable for the same seed.
+        """
         mock_extract.return_value = PredictionResult(
             text="Patient Marie Dupont",
             entities=[
@@ -932,12 +941,26 @@ class TestMultilingualPII:
             timestamp=datetime.now().isoformat(),
         )
 
-        result = deidentify("Patient Marie Dupont", method="replace", lang="fr")
+        r1 = deidentify(
+            "Patient Marie Dupont",
+            method="replace",
+            lang="fr",
+            consistent=True,
+            seed=42,
+        )
+        r2 = deidentify(
+            "Patient Marie Dupont",
+            method="replace",
+            lang="fr",
+            consistent=True,
+            seed=42,
+        )
 
-        # Should use French fake names
-        from openmed.core.pii_i18n import LANGUAGE_FAKE_DATA
-        french_names = LANGUAGE_FAKE_DATA["fr"]["NAME"]
-        assert result.pii_entities[0].redacted_text in french_names
+        surrogate = r1.pii_entities[0].redacted_text
+        assert surrogate
+        assert surrogate != "Marie Dupont"
+        # Determinism: same seed -> identical surrogate
+        assert r1.pii_entities[0].redacted_text == r2.pii_entities[0].redacted_text
 
     def test_generate_fake_pii_french(self):
         """Test fake PII generation with French locale."""

--- a/tests/unit/test_pii_multilingual_regression.py
+++ b/tests/unit/test_pii_multilingual_regression.py
@@ -360,6 +360,71 @@ class TestPortugueseRegression:
         assert "zipcode" in labels
 
 
+class TestPortugueseObfuscation:
+    """``deidentify(method="replace", lang="pt")`` produces valid Portuguese
+    surrogates and is deterministic when seeded.
+
+    Mirrors the Anonymizer-level checks in test_anonymizer.py at the
+    ``deidentify()`` integration boundary so we know the wiring stays
+    correct end-to-end.
+    """
+
+    NOTE = "Paciente Pedro Almeida, CPF 123.456.789-09, telefone +351 912 345 678."
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_pt_replace_seeded_is_repeatable(self, mock_extract):
+        from openmed.core.pii import deidentify
+        mock_extract.return_value = _make_result(self.NOTE, [
+            _ent_in(self.NOTE, "Pedro Almeida", "FIRSTNAME", 0.92),
+            _ent_in(self.NOTE, "123.456.789-09", "CPF", 0.91),
+            _ent_in(self.NOTE, "+351 912 345 678", "PHONE", 0.90),
+        ])
+        r1 = deidentify(self.NOTE, method="replace", lang="pt", consistent=True, seed=42)
+        r2 = deidentify(self.NOTE, method="replace", lang="pt", consistent=True, seed=42)
+        assert r1.deidentified_text == r2.deidentified_text
+        assert "Pedro Almeida" not in r1.deidentified_text
+        assert "123.456.789-09" not in r1.deidentified_text
+        assert "+351 912 345 678" not in r1.deidentified_text
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_pt_br_locale_generates_valid_cpf(self, mock_extract):
+        from openmed.core.pii import deidentify
+        from openmed.core.pii_i18n import validate_portuguese_cpf
+        mock_extract.return_value = _make_result(self.NOTE, [
+            _ent_in(self.NOTE, "123.456.789-09", "CPF", 0.95),
+        ])
+        result = deidentify(
+            self.NOTE,
+            method="replace",
+            lang="pt",
+            locale="pt_BR",
+            consistent=True,
+            seed=7,
+        )
+        surrogate = result.pii_entities[0].redacted_text
+        assert validate_portuguese_cpf(surrogate), (
+            f"Generated CPF {surrogate!r} fails the validator"
+        )
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_pt_consistent_within_doc(self, mock_extract):
+        """Repeated mentions of the same person resolve to the same surrogate."""
+        from openmed.core.pii import deidentify
+        text = "Pedro Almeida e Pedro Almeida foram vistos."
+        mock_extract.return_value = _make_result(text, [
+            _ent_in(text, "Pedro Almeida", "FIRSTNAME", 0.92),
+            EntityPrediction(
+                text="Pedro Almeida", label="FIRSTNAME",
+                start=text.index("Pedro Almeida", 1),
+                end=text.index("Pedro Almeida", 1) + len("Pedro Almeida"),
+                confidence=0.92,
+            ),
+        ])
+        result = deidentify(text, method="replace", lang="pt", consistent=True, seed=1)
+        # Both occurrences map to the same surrogate
+        assert result.deidentified_text.count(result.pii_entities[0].redacted_text) >= 1
+
+
 # ---------------------------------------------------------------------------
 # Dutch (nl)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_privacy_filter_routing.py
+++ b/tests/unit/test_privacy_filter_routing.py
@@ -13,6 +13,8 @@ We mock both pipelines so the tests pass without downloading either model.
 
 from __future__ import annotations
 
+import sys
+import types
 import warnings
 from typing import Any, List
 from unittest.mock import MagicMock, patch
@@ -91,11 +93,20 @@ class TestResolvePrivacyFilterModel:
 class TestCreatePrivacyFilterPipeline:
     def test_mlx_route_calls_create_mlx_pipeline(self):
         from openmed.core.backends import create_privacy_filter_pipeline
+
+        fake_mlx = types.ModuleType("openmed.mlx")
+        fake_mlx.__path__ = []
+        fake_inference = types.ModuleType("openmed.mlx.inference")
+        fake_inference.create_mlx_pipeline = MagicMock(return_value=_fake_pipeline([]))
+        fake_mlx.inference = fake_inference
+
         with patch("openmed.core.backends.MLXBackend.is_available", return_value=True), \
-             patch("openmed.mlx.inference.create_mlx_pipeline") as mock_mlx:
-            mock_mlx.return_value = _fake_pipeline([])
+             patch.dict(sys.modules, {
+                 "openmed.mlx": fake_mlx,
+                 "openmed.mlx.inference": fake_inference,
+             }):
             pipeline = create_privacy_filter_pipeline("OpenMed/privacy-filter-mlx-8bit")
-            mock_mlx.assert_called_once_with("OpenMed/privacy-filter-mlx-8bit")
+            fake_inference.create_mlx_pipeline.assert_called_once_with("OpenMed/privacy-filter-mlx-8bit")
             assert pipeline("hello") == []
 
     def test_torch_route_constructs_torch_pipeline(self):

--- a/tests/unit/test_privacy_filter_routing.py
+++ b/tests/unit/test_privacy_filter_routing.py
@@ -1,0 +1,234 @@
+"""Backend dispatch for the privacy-filter family.
+
+These tests assert that when a privacy-filter model is requested via
+``extract_pii()`` / ``deidentify()``:
+
+- On Apple Silicon with MLX importable: the MLX pipeline runs.
+- Elsewhere (Linux, Intel Mac, MLX missing): an ``openai/privacy-filter``
+  PyTorch pipeline runs, with a one-time ``UserWarning`` substituted for
+  any MLX-only artifact name.
+
+We mock both pipelines so the tests pass without downloading either model.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_pipeline(entities: List[dict]):
+    """Return a callable that mimics a privacy-filter pipeline."""
+    def _call(text: str) -> List[dict]:
+        return entities
+    return _call
+
+
+# ---------------------------------------------------------------------------
+# Backend selection
+# ---------------------------------------------------------------------------
+
+class TestSelectPrivacyFilterBackend:
+    def test_mlx_artifact_on_mac_with_mlx(self):
+        from openmed.core.backends import select_privacy_filter_backend
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=True):
+            assert select_privacy_filter_backend("OpenMed/privacy-filter-mlx-8bit") == "mlx"
+            assert select_privacy_filter_backend("OpenMed/privacy-filter-mlx") == "mlx"
+
+    def test_mlx_artifact_on_linux_falls_back_to_torch(self):
+        from openmed.core.backends import select_privacy_filter_backend
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=False):
+            assert select_privacy_filter_backend("OpenMed/privacy-filter-mlx-8bit") == "torch"
+
+    def test_torch_artifact_always_uses_torch(self):
+        from openmed.core.backends import select_privacy_filter_backend
+        # Even if MLX is available, requesting the upstream PyTorch model
+        # should stay on Torch (no point converting).
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=True):
+            assert select_privacy_filter_backend("openai/privacy-filter") == "torch"
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=False):
+            assert select_privacy_filter_backend("openai/privacy-filter") == "torch"
+
+
+class TestResolvePrivacyFilterModel:
+    def test_mlx_keeps_name(self):
+        from openmed.core.backends import resolve_privacy_filter_model
+        assert (
+            resolve_privacy_filter_model("OpenMed/privacy-filter-mlx-8bit", "mlx")
+            == "OpenMed/privacy-filter-mlx-8bit"
+        )
+
+    def test_torch_substitutes_mlx_only_artifact(self):
+        from openmed.core.backends import (
+            PRIVACY_FILTER_TORCH_FALLBACK,
+            resolve_privacy_filter_model,
+        )
+        # Reset the warning cache so we can observe it
+        from openmed.core import backends
+        backends._warned_substitutions.clear()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            actual = resolve_privacy_filter_model("OpenMed/privacy-filter-mlx-8bit", "torch")
+        assert actual == PRIVACY_FILTER_TORCH_FALLBACK
+        assert any(issubclass(w.category, UserWarning) for w in caught)
+
+    def test_torch_keeps_native_torch_name(self):
+        from openmed.core.backends import resolve_privacy_filter_model
+        assert resolve_privacy_filter_model("openai/privacy-filter", "torch") == "openai/privacy-filter"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline factory
+# ---------------------------------------------------------------------------
+
+class TestCreatePrivacyFilterPipeline:
+    def test_mlx_route_calls_create_mlx_pipeline(self):
+        from openmed.core.backends import create_privacy_filter_pipeline
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=True), \
+             patch("openmed.mlx.inference.create_mlx_pipeline") as mock_mlx:
+            mock_mlx.return_value = _fake_pipeline([])
+            pipeline = create_privacy_filter_pipeline("OpenMed/privacy-filter-mlx-8bit")
+            mock_mlx.assert_called_once_with("OpenMed/privacy-filter-mlx-8bit")
+            assert pipeline("hello") == []
+
+    def test_torch_route_constructs_torch_pipeline(self):
+        from openmed.core.backends import create_privacy_filter_pipeline
+        sentinel = _fake_pipeline([{"entity_group": "NAME", "score": 0.9, "word": "X", "start": 0, "end": 1}])
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=False), \
+             patch("openmed.torch.privacy_filter.PrivacyFilterTorchPipeline") as MockPF:
+            MockPF.return_value = sentinel
+            pipeline = create_privacy_filter_pipeline("openai/privacy-filter")
+            MockPF.assert_called_once_with("openai/privacy-filter")
+            assert pipeline("hi") == sentinel("hi")
+
+    def test_mlx_request_on_linux_substitutes_torch_model(self):
+        """An MLX-only request on Linux should resolve to openai/privacy-filter."""
+        from openmed.core import backends
+        backends._warned_substitutions.clear()
+        from openmed.core.backends import create_privacy_filter_pipeline
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=False), \
+             patch("openmed.torch.privacy_filter.PrivacyFilterTorchPipeline") as MockPF, \
+             warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            MockPF.return_value = _fake_pipeline([])
+            create_privacy_filter_pipeline("OpenMed/privacy-filter-mlx-8bit")
+            MockPF.assert_called_once_with("openai/privacy-filter")
+            assert any(issubclass(w.category, UserWarning) for w in caught)
+
+
+# ---------------------------------------------------------------------------
+# extract_pii() integration
+# ---------------------------------------------------------------------------
+
+class TestExtractPiiViaPrivacyFilter:
+    def test_extract_pii_routes_privacy_filter_to_dispatcher(self):
+        """``extract_pii(model_name='OpenMed/privacy-filter-mlx-8bit')`` should
+        call the dispatcher and skip ``analyze_text``."""
+        from openmed.core.pii import extract_pii
+
+        fake_entities = [
+            {"entity_group": "NAME", "score": 0.92, "word": "John Doe",
+             "start": 8, "end": 16},
+            {"entity_group": "DATE", "score": 0.88, "word": "1970-01-15",
+             "start": 25, "end": 35},
+        ]
+
+        with patch("openmed.core.pii.create_privacy_filter_pipeline",
+                   create=True) as mock_factory, \
+             patch("openmed.core.backends.create_privacy_filter_pipeline") as mock_be:
+            mock_be.return_value = _fake_pipeline(fake_entities)
+
+            with patch("openmed.analyze_text") as mock_analyze:
+                result = extract_pii(
+                    "Patient John Doe born on 1970-01-15",
+                    model_name="OpenMed/privacy-filter-mlx-8bit",
+                    confidence_threshold=0.5,
+                )
+
+            # analyze_text must NOT have been called for privacy-filter
+            mock_analyze.assert_not_called()
+
+        assert len(result.entities) == 2
+        assert result.entities[0].label == "NAME"
+        assert result.entities[0].text == "John Doe"
+        assert result.entities[1].label == "DATE"
+
+    def test_extract_pii_drops_below_threshold(self):
+        from openmed.core.pii import extract_pii
+
+        fake_entities = [
+            {"entity_group": "NAME", "score": 0.92, "word": "John", "start": 0, "end": 4},
+            {"entity_group": "EMAIL", "score": 0.30, "word": "x", "start": 6, "end": 7},
+        ]
+
+        with patch("openmed.core.backends.create_privacy_filter_pipeline") as mock_be, \
+             patch("openmed.analyze_text"):
+            mock_be.return_value = _fake_pipeline(fake_entities)
+            result = extract_pii(
+                "John, x",
+                model_name="openai/privacy-filter",
+                confidence_threshold=0.5,
+            )
+        assert len(result.entities) == 1
+        assert result.entities[0].label == "NAME"
+
+    def test_non_privacy_filter_model_takes_normal_path(self):
+        """Regular PII models should still route through ``analyze_text``."""
+        from openmed.core.pii import extract_pii
+        from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+        with patch("openmed.analyze_text") as mock_analyze, \
+             patch("openmed.core.backends.create_privacy_filter_pipeline") as mock_be:
+            mock_analyze.return_value = PredictionResult(
+                text="John Doe", entities=[], model_name="test",
+                timestamp="now",
+            )
+            extract_pii(
+                "John Doe",
+                model_name="OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+            )
+            mock_analyze.assert_called_once()
+            mock_be.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# deidentify() integration via privacy-filter
+# ---------------------------------------------------------------------------
+
+class TestDeidentifyViaPrivacyFilter:
+    def test_deidentify_replace_with_privacy_filter_consistent(self):
+        from openmed.core.pii import deidentify
+
+        fake_entities = [
+            {"entity_group": "NAME", "score": 0.95, "word": "John Doe", "start": 8, "end": 16},
+        ]
+
+        with patch("openmed.core.backends.create_privacy_filter_pipeline") as mock_be:
+            mock_be.return_value = _fake_pipeline(fake_entities)
+            r1 = deidentify(
+                "Patient John Doe came in.",
+                method="replace",
+                model_name="openai/privacy-filter",
+                lang="en",
+                consistent=True,
+                seed=42,
+                confidence_threshold=0.5,
+            )
+            r2 = deidentify(
+                "Patient John Doe came in.",
+                method="replace",
+                model_name="openai/privacy-filter",
+                lang="en",
+                consistent=True,
+                seed=42,
+                confidence_threshold=0.5,
+            )
+        assert r1.deidentified_text == r2.deidentified_text
+        assert "John Doe" not in r1.deidentified_text

--- a/tests/unit/test_privacy_filter_routing.py
+++ b/tests/unit/test_privacy_filter_routing.py
@@ -58,6 +58,25 @@ class TestSelectPrivacyFilterBackend:
         with patch("openmed.core.backends.MLXBackend.is_available", return_value=False):
             assert select_privacy_filter_backend("openai/privacy-filter") == "torch"
 
+    def test_nemotron_mlx_artifact_on_mac_with_mlx(self):
+        from openmed.core.backends import select_privacy_filter_backend
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=True):
+            assert select_privacy_filter_backend("OpenMed/privacy-filter-nemotron-mlx") == "mlx"
+            assert select_privacy_filter_backend("OpenMed/privacy-filter-nemotron-mlx-8bit") == "mlx"
+
+    def test_nemotron_mlx_artifact_on_linux_falls_back_to_torch(self):
+        from openmed.core.backends import select_privacy_filter_backend
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=False):
+            assert select_privacy_filter_backend("OpenMed/privacy-filter-nemotron-mlx") == "torch"
+            assert select_privacy_filter_backend("OpenMed/privacy-filter-nemotron-mlx-8bit") == "torch"
+
+    def test_nemotron_torch_artifact_always_uses_torch(self):
+        from openmed.core.backends import select_privacy_filter_backend
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=True):
+            assert select_privacy_filter_backend("OpenMed/privacy-filter-nemotron") == "torch"
+        with patch("openmed.core.backends.MLXBackend.is_available", return_value=False):
+            assert select_privacy_filter_backend("OpenMed/privacy-filter-nemotron") == "torch"
+
 
 class TestResolvePrivacyFilterModel:
     def test_mlx_keeps_name(self):
@@ -84,6 +103,39 @@ class TestResolvePrivacyFilterModel:
     def test_torch_keeps_native_torch_name(self):
         from openmed.core.backends import resolve_privacy_filter_model
         assert resolve_privacy_filter_model("openai/privacy-filter", "torch") == "openai/privacy-filter"
+
+    def test_nemotron_mlx_substitutes_to_nemotron_torch_repo(self):
+        """An MLX-only Nemotron request must fall back to the Nemotron PyTorch
+        repo (NOT the unrelated default ``openai/privacy-filter``)."""
+        from openmed.core.backends import resolve_privacy_filter_model
+        from openmed.core import backends
+        backends._warned_substitutions.clear()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            actual = resolve_privacy_filter_model(
+                "OpenMed/privacy-filter-nemotron-mlx-8bit", "torch",
+            )
+        assert actual == "OpenMed/privacy-filter-nemotron"
+        # And it warns once.
+        assert any(
+            issubclass(w.category, UserWarning)
+            and "OpenMed/privacy-filter-nemotron" in str(w.message)
+            for w in caught
+        )
+
+    def test_nemotron_torch_repo_keeps_name(self):
+        from openmed.core.backends import resolve_privacy_filter_model
+        assert (
+            resolve_privacy_filter_model("OpenMed/privacy-filter-nemotron", "torch")
+            == "OpenMed/privacy-filter-nemotron"
+        )
+
+    def test_torch_fallback_for_helper(self):
+        """The substring matcher picks the right family fallback."""
+        from openmed.core.backends import _torch_fallback_for, PRIVACY_FILTER_TORCH_FALLBACK
+        assert _torch_fallback_for("OpenMed/privacy-filter-nemotron-mlx") == "OpenMed/privacy-filter-nemotron"
+        assert _torch_fallback_for("OpenMed/privacy-filter-mlx") == PRIVACY_FILTER_TORCH_FALLBACK
+        assert _torch_fallback_for("openai/privacy-filter") == PRIVACY_FILTER_TORCH_FALLBACK
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -67,6 +67,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -213,6 +222,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/b4/244d58127e1cdf04cf2dc7d9566f0d24ef01d5ce21811bab088ecc62b5ea/catalogue-2.0.10.tar.gz", hash = "sha256:4f56daa940913d3f09d589c191c74e5a6d51762b3a9e37dd53b7437afd6cda15", size = 19561, upload-time = "2023-09-25T06:29:24.962Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/96/d32b941a501ab566a16358d68b6eb4e4acc373fab3c3c4d7d9e649f7b4bb/catalogue-2.0.10-py3-none-any.whl", hash = "sha256:58c2de0020aa90f4a2da7dfad161bf7b3b054c86a5f09fcedc0b2b740c109a9f", size = 17325, upload-time = "2023-09-25T06:29:23.337Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
 ]
 
 [[package]]
@@ -369,6 +392,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/51/d3/57c6631159a1b48d273b40865c315cf51f89df7a9d1101094ef12e3a37c2/confection-0.1.5.tar.gz", hash = "sha256:8e72dd3ca6bd4f48913cd220f10b8275978e740411654b6e8ca6d7008c590f0e", size = 38924, upload-time = "2024-05-31T16:17:01.559Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/00/3106b1854b45bd0474ced037dfe6b73b90fe68a68968cef47c23de3d43d2/confection-0.1.5-py3-none-any.whl", hash = "sha256:e29d3c3f8eac06b3f77eb9dfb4bf2fc6bcc9622a98ca00a698e3d019c6430b14", size = 35451, upload-time = "2024-05-31T16:16:59.075Z" },
+]
+
+[[package]]
+name = "coremltools"
+version = "9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pyaml" },
+    { name = "sympy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/e6/8cb11a246f61736e75b20488b9c3cf9c208f500c9a3f92d717dbf592348c/coremltools-9.0.tar.gz", hash = "sha256:4ff346b29c31c4b45acd19a20e0f0a1ac65180a96776e62f15bd5c46f4926687", size = 1656978, upload-time = "2025-11-10T21:51:23.855Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a5/c16527bac75d3c5f8abde9a0e65346587886e47fea18269d7157dab40333/coremltools-9.0-cp310-none-macosx_10_15_x86_64.whl", hash = "sha256:f3247ec310eb13ce3f0e98ff76747a238ff1bde31835a2a289c84e95fe93f6a9", size = 2788452, upload-time = "2025-11-10T21:46:51.937Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/b5/34f15d9f43b5b70e27602752dfc6811d029e0ec61c311991be76c23022c0/coremltools-9.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:e9692a53b8a18891c1a54e8871de4c59ed435c5016e734c8989298b03bdb50de", size = 2763550, upload-time = "2025-11-10T21:47:08.484Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4e/4dfc48820739f00dc0e6d850ac8a612d8162c89de89125022adbf2b6ac00/coremltools-9.0-cp310-none-manylinux1_x86_64.whl", hash = "sha256:8e6765539e0c830ac39755e80cef9f8ff323a46c54dda051a0562a622931094b", size = 2308133, upload-time = "2025-11-10T21:47:12.799Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ab/d1e06207fd68aab62b1b476fc4ccf1fb52f43fa1816d6ab02f13c38d7c2c/coremltools-9.0-cp311-none-macosx_10_15_x86_64.whl", hash = "sha256:e6e58143c5270c1a37872fef41f8c18c042d22fa38f0ad33b33250007d9e1186", size = 2793255, upload-time = "2025-11-10T21:47:29.351Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b2/8ff944f25c0fc9e5ae9deef1707029784019b78a1df2a7d0b24d581be1a2/coremltools-9.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:0e079fea3f13f96a30587c9f7375796ff61cad53f703bde53c56fbf1374813ed", size = 2767374, upload-time = "2025-11-10T21:47:46.002Z" },
+    { url = "https://files.pythonhosted.org/packages/54/fe/58fc966635ebe3b92b100fbec875d173addab62454c4438457fa3f427d1c/coremltools-9.0-cp311-none-manylinux1_x86_64.whl", hash = "sha256:e9080254a4b9d286e168f3b1bc8616edd5d48ab664c17870b85e496629a00e81", size = 2309379, upload-time = "2025-11-10T21:48:02.81Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7e/0746b42d39d903da2015d33b619319d84fc16a44e6ed68c1a4768ae27fc5/coremltools-9.0-cp312-none-macosx_10_15_x86_64.whl", hash = "sha256:35d6e972e254081e364e6c7763eae89df8cc775dbf53756ba1ca08a2bc22f018", size = 2792457, upload-time = "2025-11-10T21:48:18.418Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ab/6231b83d770825803284453f1ff36e5f3ba0a5740fcedbd3ba7454e5d412/coremltools-9.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:7079e8b6ff5a63f0e2c08eeeb8673e4eab8ca231d4b2eae4f7fb005e0d08a8cd", size = 2764416, upload-time = "2025-11-10T21:48:30.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/87/add15e7b4537765bef9cb47ffbd6a5d48493e65181df9864afeffa13b99b/coremltools-9.0-cp312-none-manylinux1_x86_64.whl", hash = "sha256:99a101085a7919de9f1c18e514c17d2b3e6a06ad4f7a35aae9515ad47f5a843f", size = 2308591, upload-time = "2025-11-10T21:48:47.269Z" },
+    { url = "https://files.pythonhosted.org/packages/57/4c/925ad6d76ad5bb92c9dc64798dc13651050687a03b00c03abd216dfb3732/coremltools-9.0-cp313-none-macosx_10_15_x86_64.whl", hash = "sha256:c3965805df319d5f2755d0adfb8e28312db655be09be87bd00fad097b104be57", size = 2792787, upload-time = "2025-11-10T21:49:06.106Z" },
+    { url = "https://files.pythonhosted.org/packages/62/50/76d5a828d875ed8ad7392bf9294233261747de02f7415f51d4add8dc0acf/coremltools-9.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:9f2f858beec7f5d486cd1a59aefb452d59347e236670b67db325795bf692f480", size = 2764608, upload-time = "2025-11-10T21:49:21.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/9f/0e8ba95ae1a1f2c9a6460c7f95a722a28a3eeaa47aef9266ef454d2e3b8b/coremltools-9.0-cp313-none-manylinux1_x86_64.whl", hash = "sha256:0af02216767232ece83bc4ec5035d7bba3c53c27de11be1a32e8461b4025d866", size = 2308338, upload-time = "2025-11-10T21:49:36.009Z" },
 ]
 
 [[package]]
@@ -634,6 +687,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "faker"
+version = "40.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/13/6741787bd91c4109c7bed047d68273965cd52ce8a5f773c471b949334b6d/faker-40.15.0.tar.gz", hash = "sha256:20f3a6ec8c266b74d4c554e34118b21c3c2056c0b4a519d15c8decb3a4e6e795", size = 1967447, upload-time = "2026-04-17T20:05:27.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a7/a600f8f30d4505e89166de51dd121bd540ab8e560e8cf0901de00a81de8c/faker-40.15.0-py3-none-any.whl", hash = "sha256:71ab3c3370da9d2205ab74ffb0fd51273063ad562b3a3bb69d0026a20923e318", size = 2004447, upload-time = "2026-04-17T20:05:25.437Z" },
 ]
 
 [[package]]
@@ -1206,6 +1271,51 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/7c/c16d52494a1ba6d90443f31fa26bc810bf878d532dfa9a7a13f49ef9542d/mlx-0.31.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:b29cf940f34205f09bb552ac60465ae833c4ae640b52777c6d725ddbad8461ca", size = 586942, upload-time = "2026-04-22T03:14:21.97Z" },
+    { url = "https://files.pythonhosted.org/packages/74/da/1c7f3dc39b7bda65b0cafbaf1e58a35eea118622c6f4506c9a4294c9806e/mlx-0.31.2-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:ebdc47b87b4b0216ceab3b5961716804bba3107c16454b65ae51d0e0c059f298", size = 586942, upload-time = "2026-04-22T03:14:23.527Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e9/a8559389706d39f613620a8b6b42ed03cf3155a516b0762d355c5116fdab/mlx-0.31.2-cp310-cp310-macosx_26_0_arm64.whl", hash = "sha256:2a64db61b2840f28bae08354e6f999698e30381af201cc12354290673c96213b", size = 586804, upload-time = "2026-04-22T03:14:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/4a/274ebee3783a37560cddc8e781ec3eefadd17f3f85a7dcd5df6f07d200d6/mlx-0.31.2-cp310-cp310-manylinux_2_35_aarch64.whl", hash = "sha256:e3e2818157371501de097887f371784227f9dd9c91e177f986db7b25319c55d7", size = 653252, upload-time = "2026-04-22T03:14:26.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c7/79283370001660102f5c5c772b649f69da02113609d927af35e747508320/mlx-0.31.2-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:c71dff00cc1b363d542f111d9e8b7b59dadb65b29d027f798b71ea34da75b665", size = 692109, upload-time = "2026-04-22T03:14:28.05Z" },
+    { url = "https://files.pythonhosted.org/packages/94/89/1e77ec3ff380e8fb9e7258047374d31452a0f9828a0e370f127b07dd8288/mlx-0.31.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4a3f181b367d404e44a6bd68ef5eb573930809ac60cacd51d0c851c629b1b651", size = 586911, upload-time = "2026-04-22T03:14:29.675Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/41/c1907f05f8a3fc54025fb78ad68d3c4a4b931664d03c0a24f7f431cc4087/mlx-0.31.2-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:70297cbef7479429f69c966bfed10da20a6f0c2aa997eec2b4f6ba1a07caf2ef", size = 586915, upload-time = "2026-04-22T03:14:31.403Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b0/61ac2c14773c786fecbda28067b0207a0c654cb4d10c548808c51284d700/mlx-0.31.2-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:c0ff158b7ac93a4b5659adbc70053498b30a5964fc45f78596398e056a96c36a", size = 587030, upload-time = "2026-04-22T03:14:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/de/53/e12feb7078ee472983555fcb1da4749a2bbbc8fc5b29b78c205b96d37d1e/mlx-0.31.2-cp311-cp311-manylinux_2_35_aarch64.whl", hash = "sha256:cd5d42b0b2bee7efe1b0680a7e302943dd33b92c879cffa0358ffdb5a4a8d27b", size = 652994, upload-time = "2026-04-22T03:14:34.691Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/40/f92c8cdc9595bf24c7e483a3156bfe0cc99a5cf5545d8dba8e7fe000c10b/mlx-0.31.2-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:b368f7ede4238cc44076e4843820338c453c21ee50bd3ee26d4b182c179fd8e1", size = 692086, upload-time = "2026-04-22T03:14:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/47/5f33906cb03d6a378a697cd2d2641a26b37dea17ee3d9124d7e39e8eca01/mlx-0.31.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e5067aaf2be1f3d7bba5be52348775804f111173c1ed04639618fd713b1a530f", size = 584863, upload-time = "2026-04-22T03:14:38.211Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e7/a851a451b1327af9fb4df3991b9ae87d066b6f6630e854af55c288b0995a/mlx-0.31.2-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:edb9797db7d852477ca1c99708058654ee860d4148fe5765f0d55528e2b1aa22", size = 584860, upload-time = "2026-04-22T03:14:39.746Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/15/0d1dc0597644e5e7b011ca954ba0c47e13cd880a3b909b0c3f1b4d8bf8f1/mlx-0.31.2-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:51ca102db641b01e7cb083ce8ecb580e281530a141a7ca12544bb370641630ae", size = 584887, upload-time = "2026-04-22T03:14:41.585Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c3/00664239a98e8bd614733c4182cd402d2bacad2d7f79eca66562ac406870/mlx-0.31.2-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:117c7583cae0ca107cd53c591cc34f8e75f97a505aa47088844b7dc0fc69dc67", size = 627863, upload-time = "2026-04-22T03:14:43.326Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7b/af6cd73a79772af6f19eab2cb4c48eda23a9294d1650a4c1269a9996e532/mlx-0.31.2-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:99572133181481640a8bf8d449daf083816d0af3ee050c8adfc5bf45ceca91c6", size = 685090, upload-time = "2026-04-22T03:14:45.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3f/888f8664d4f8e23a1363a5f50024be5216e199ab7ad0ba20988c7ed6d729/mlx-0.31.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:1b3fb0dda955b0d552ce57bdd6f42b3309ab21b067e40587d6848443d307e91f", size = 584796, upload-time = "2026-04-22T03:14:47.215Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/14/e9cd18b51f9e1dbcb060eec0fafc2d2428c8e1eacd9b0a02d7c5ce75b661/mlx-0.31.2-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:34b0171cd9eb5c43fdd82091f6135d6ccc5a065363a4a3e68fac64fb4e53d37c", size = 584790, upload-time = "2026-04-22T03:14:48.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/20/c6c5fb998c7834d094b2bfb9f003b5246cb270f0266da055c55546c34999/mlx-0.31.2-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:c05981684279a8935d58b0dde3ea5b02d210c3bad3319aa0e9934ec2df165752", size = 584795, upload-time = "2026-04-22T03:14:49.904Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/19/aca251d4c5f3532ce9c2c1e95ad76740d9c6c298f406f62d992f465b9be0/mlx-0.31.2-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:cd1f4189e5f1bc68735f44eb63ce98ae09d66ac75d7ab5b15a41afae7e9f0513", size = 627843, upload-time = "2026-04-22T03:14:51.351Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/b89364883b98f21c2fe29e52d4ac8bc2fa2fe0d79293b36ec421efc1854a/mlx-0.31.2-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:53c8d57ffa9ce77f8355663be05014c0dd37280e57f19126fb0a24389a30684b", size = 685064, upload-time = "2026-04-22T03:14:52.75Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417, upload-time = "2026-04-22T03:14:54.094Z" },
+    { url = "https://files.pythonhosted.org/packages/31/50/9d0c03ea3134cd85c132df7b0e4b75e6344bd8b4881a0b9c465cfa27f724/mlx-0.31.2-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b0764bf11fc3a71dee988e19275eef67775cab63112d8bb7ef173ca8b2a1247c", size = 588421, upload-time = "2026-04-22T03:14:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5b/d364cc793bcb504621313acb55627cf0d5403ab2e0a594aa081cdbe4591f/mlx-0.31.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:59ccbd0f0044d4f97f11ebcbf0c480bc9e962935fd96275f120954afea65be8a", size = 588384, upload-time = "2026-04-22T03:14:57.439Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a4/e822202dd2e4e7d08671f2ecf7b6500af74f5bad5ceb27086b1aa6902f3a/mlx-0.31.2-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:e81798c610f95a09c642c89214ba5c23b72ce18ce4728184aceabe7eddca33d7", size = 630473, upload-time = "2026-04-22T03:14:58.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/6f/da48d2d7a76e644d35438ef6f33c68755fdd382e2c546fd1804ccba01d04/mlx-0.31.2-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:69fbc94bf53607a75af9eb3e22c354738a6fe4e25aa4e2b20934b009a4bba1f3", size = 685459, upload-time = "2026-04-22T03:15:00.45Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/69/fe3b783ebe999f3118234e1e940feb622518bfb1dea6ac5d13b1d36a8449/mlx_metal-0.31.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:b25385bcee18fc194092255b8b53b9a3d8489eb650e59160f1b57aadd07aa2dc", size = 40055588, upload-time = "2026-04-22T03:14:14.43Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5d/4c690d5b93c30ba002656c37363159d978705bf8eb801b8481840fb942c2/mlx_metal-0.31.2-py3-none-macosx_15_0_arm64.whl", hash = "sha256:e9d4e5fce6ca10a87a0e388597f99519ad594d09e674708b5312bd8bd4f5997d", size = 40053220, upload-time = "2026-04-22T03:14:18.048Z" },
+    { url = "https://files.pythonhosted.org/packages/99/82/11fd62a8d7a3e96e5c43220b17de0151e3f10101f8bb3b865f5bd9cdd074/mlx_metal-0.31.2-py3-none-macosx_26_0_arm64.whl", hash = "sha256:84ffb60ee503f03eb684f5fb168d5cff31e2a16b7f27c1731eaf7662bd6e9b46", size = 55792151, upload-time = "2026-04-22T03:14:22.059Z" },
+]
+
+[[package]]
 name = "morfessor"
 version = "2.0.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1545,10 +1655,16 @@ wheels = [
 name = "openmed"
 source = { editable = "." }
 dependencies = [
+    { name = "faker" },
     { name = "pysbd" },
 ]
 
 [package.optional-dependencies]
+coreml = [
+    { name = "coremltools" },
+    { name = "torch" },
+    { name = "transformers" },
+]
 dev = [
     { name = "fastapi" },
     { name = "flake8" },
@@ -1573,6 +1689,14 @@ hf = [
     { name = "tokenizers" },
     { name = "transformers" },
 ]
+mlx = [
+    { name = "huggingface-hub" },
+    { name = "mlx" },
+    { name = "safetensors" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+    { name = "transformers" },
+]
 service = [
     { name = "fastapi" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1581,26 +1705,36 @@ service = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'hf'", specifier = ">=0.29" },
+    { name = "coremltools", marker = "extra == 'coreml'", specifier = ">=8.0" },
+    { name = "faker", specifier = ">=22.0" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.110" },
     { name = "fastapi", marker = "extra == 'service'", specifier = ">=0.110" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "gliner", extras = ["tokenizers"], marker = "extra == 'gliner'", specifier = ">=0.2.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=0.30" },
+    { name = "huggingface-hub", marker = "extra == 'mlx'", specifier = ">=0.30" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6" },
     { name = "mkdocs-git-revision-date-localized-plugin", marker = "extra == 'docs'", specifier = ">=1.2.6" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocs-minify-plugin", marker = "extra == 'docs'", specifier = ">=0.8.0" },
+    { name = "mlx", marker = "extra == 'mlx'", specifier = ">=0.22" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.8" },
     { name = "pysbd", specifier = ">=0.3.4,<0.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "safetensors", marker = "extra == 'mlx'", specifier = ">=0.4" },
+    { name = "tiktoken", marker = "extra == 'mlx'", specifier = ">=0.7" },
     { name = "tokenizers", marker = "extra == 'hf'", specifier = ">=0.15" },
+    { name = "tokenizers", marker = "extra == 'mlx'", specifier = ">=0.15" },
+    { name = "torch", marker = "extra == 'coreml'", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'gliner'", specifier = ">=2.0" },
+    { name = "transformers", marker = "extra == 'coreml'", specifier = ">=4.50" },
     { name = "transformers", marker = "extra == 'hf'", specifier = ">=4.50" },
+    { name = "transformers", marker = "extra == 'mlx'", specifier = ">=4.50" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'service'", specifier = ">=0.29" },
 ]
-provides-extras = ["dev", "docs", "gliner", "hf", "service"]
+provides-extras = ["coreml", "dev", "docs", "gliner", "hf", "mlx", "service"]
 
 [[package]]
 name = "packaging"
@@ -1801,6 +1935,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/95/992c8816a74016eb095e73585d747e0a8ea21a061ed3689474fabb29a395/psutil-7.1.3-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56d974e02ca2c8eb4812c3f76c30e28836fffc311d55d979f1465c1feeb2b68b", size = 264635, upload-time = "2025-11-02T12:26:31.74Z" },
     { url = "https://files.pythonhosted.org/packages/55/4c/c3ed1a622b6ae2fd3c945a366e64eb35247a31e4db16cf5095e269e8eb3c/psutil-7.1.3-cp37-abi3-win_amd64.whl", hash = "sha256:f39c2c19fe824b47484b96f9692932248a54c43799a84282cfe58d05a6449efd", size = 247633, upload-time = "2025-11-02T12:26:33.887Z" },
     { url = "https://files.pythonhosted.org/packages/c9/ad/33b2ccec09bf96c2b2ef3f9a6f66baac8253d7565d8839e024a6b905d45d/psutil-7.1.3-cp37-abi3-win_arm64.whl", hash = "sha256:bd0d69cee829226a761e92f28140bec9a5ee9d5b4fb4b0cc589068dbfff559b1", size = 244608, upload-time = "2025-11-02T12:26:36.136Z" },
+]
+
+[[package]]
+name = "pyaml"
+version = "26.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/fb/2b9590512a9d7763620d87171c7531d5295678ce96e57393614b91da8998/pyaml-26.2.1.tar.gz", hash = "sha256:489dd82997235d4cfcf76a6287fce2f075487d77a6567c271e8d790583690c68", size = 30653, upload-time = "2026-02-06T13:49:30.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/f3/1f8651f23101e6fae41d0d504414c9722b0140bf0fc6acf87ac52e18aa41/pyaml-26.2.1-py3-none-any.whl", hash = "sha256:6261c2f0a2f33245286c794ad6ec234be33a73d2b05427079fd343e2812a87cf", size = 27211, upload-time = "2026-02-06T13:49:29.652Z" },
 ]
 
 [[package]]
@@ -2890,6 +3036,67 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/b3/2cb7c17b6c4cf8ca983204255d3f1d95eda7213e247e6947a0ee2c747a2c/tiktoken-0.12.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3de02f5a491cfd179aec916eddb70331814bd6bf764075d39e21d5862e533970", size = 1051991, upload-time = "2025-10-06T20:21:34.098Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0f/df139f1df5f6167194ee5ab24634582ba9a1b62c6b996472b0277ec80f66/tiktoken-0.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b6cfb6d9b7b54d20af21a912bfe63a2727d9cfa8fbda642fd8322c70340aad16", size = 995798, upload-time = "2025-10-06T20:21:35.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5d/26a691f28ab220d5edc09b9b787399b130f24327ef824de15e5d85ef21aa/tiktoken-0.12.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:cde24cdb1b8a08368f709124f15b36ab5524aac5fa830cc3fdce9c03d4fb8030", size = 1129865, upload-time = "2025-10-06T20:21:36.675Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/94/443fab3d4e5ebecac895712abd3849b8da93b7b7dec61c7db5c9c7ebe40c/tiktoken-0.12.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6de0da39f605992649b9cfa6f84071e3f9ef2cec458d08c5feb1b6f0ff62e134", size = 1152856, upload-time = "2025-10-06T20:21:37.873Z" },
+    { url = "https://files.pythonhosted.org/packages/54/35/388f941251b2521c70dd4c5958e598ea6d2c88e28445d2fb8189eecc1dfc/tiktoken-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6faa0534e0eefbcafaccb75927a4a380463a2eaa7e26000f0173b920e98b720a", size = 1195308, upload-time = "2025-10-06T20:21:39.577Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/00/c6681c7f833dd410576183715a530437a9873fa910265817081f65f9105f/tiktoken-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:82991e04fc860afb933efb63957affc7ad54f83e2216fe7d319007dab1ba5892", size = 1255697, upload-time = "2025-10-06T20:21:41.154Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d2/82e795a6a9bafa034bf26a58e68fe9a89eeaaa610d51dbeb22106ba04f0a/tiktoken-0.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:6fb2995b487c2e31acf0a9e17647e3b242235a20832642bb7a9d1a181c0c1bb1", size = 879375, upload-time = "2025-10-06T20:21:43.201Z" },
+    { url = "https://files.pythonhosted.org/packages/de/46/21ea696b21f1d6d1efec8639c204bdf20fde8bafb351e1355c72c5d7de52/tiktoken-0.12.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6e227c7f96925003487c33b1b32265fad2fbcec2b7cf4817afb76d416f40f6bb", size = 1051565, upload-time = "2025-10-06T20:21:44.566Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d9/35c5d2d9e22bb2a5f74ba48266fb56c63d76ae6f66e02feb628671c0283e/tiktoken-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c06cf0fcc24c2cb2adb5e185c7082a82cba29c17575e828518c2f11a01f445aa", size = 995284, upload-time = "2025-10-06T20:21:45.622Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/961106c37b8e49b9fdcf33fe007bb3a8fdcc380c528b20cc7fbba80578b8/tiktoken-0.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f18f249b041851954217e9fd8e5c00b024ab2315ffda5ed77665a05fa91f42dc", size = 1129201, upload-time = "2025-10-06T20:21:47.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d0/3d9275198e067f8b65076a68894bb52fd253875f3644f0a321a720277b8a/tiktoken-0.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:47a5bc270b8c3db00bb46ece01ef34ad050e364b51d406b6f9730b64ac28eded", size = 1152444, upload-time = "2025-10-06T20:21:48.139Z" },
+    { url = "https://files.pythonhosted.org/packages/78/db/a58e09687c1698a7c592e1038e01c206569b86a0377828d51635561f8ebf/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:508fa71810c0efdcd1b898fda574889ee62852989f7c1667414736bcb2b9a4bd", size = 1195080, upload-time = "2025-10-06T20:21:49.246Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/a9e4d2bf91d515c0f74afc526fd773a812232dd6cda33ebea7f531202325/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1af81a6c44f008cba48494089dd98cccb8b313f55e961a52f5b222d1e507967", size = 1255240, upload-time = "2025-10-06T20:21:50.274Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/15/963819345f1b1fb0809070a79e9dd96938d4ca41297367d471733e79c76c/tiktoken-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:3e68e3e593637b53e56f7237be560f7a394451cb8c11079755e80ae64b9e6def", size = 879422, upload-time = "2025-10-06T20:21:51.734Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
+    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
+    { url = "https://files.pythonhosted.org/packages/72/05/3abc1db5d2c9aadc4d2c76fa5640134e475e58d9fbb82b5c535dc0de9b01/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646", size = 1050188, upload-time = "2025-10-06T20:22:19.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
+    { url = "https://files.pythonhosted.org/packages/14/27/bf795595a2b897e271771cd31cb847d479073497344c637966bdf2853da1/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff", size = 1129271, upload-time = "2025-10-06T20:22:22.06Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/9341a6d7a8f1b448573bbf3425fa57669ac58258a667eb48a25dfe916d70/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830", size = 1151216, upload-time = "2025-10-06T20:22:23.085Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0d/881866647b8d1be4d67cb24e50d0c26f9f807f994aa1510cb9ba2fe5f612/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b", size = 1194860, upload-time = "2025-10-06T20:22:24.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/b651ec3059474dab649b8d5b69f5c65cd8fcd8918568c1935bd4136c9392/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b", size = 1254567, upload-time = "2025-10-06T20:22:25.671Z" },
+    { url = "https://files.pythonhosted.org/packages/80/57/ce64fd16ac390fafde001268c364d559447ba09b509181b2808622420eec/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3", size = 921067, upload-time = "2025-10-06T20:22:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a4/72eed53e8976a099539cdd5eb36f241987212c29629d0a52c305173e0a68/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365", size = 1050473, upload-time = "2025-10-06T20:22:27.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/77/4f268c41a3957c418b084dd576ea2fad2e95da0d8e1ab705372892c2ca22/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63", size = 1129022, upload-time = "2025-10-06T20:22:29.981Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2b/fc46c90fe5028bd094cd6ee25a7db321cb91d45dc87531e2bdbb26b4867a/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0", size = 1150736, upload-time = "2025-10-06T20:22:30.996Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a Faker-backed anonymizer with locale-aware, deterministic, and format-preserving surrogate generation.
- Introduces canonical PII label normalization plus shared BIOES decoding and span refinement utilities for privacy-filter backends.
- Adds cross-platform privacy-filter routing with MLX support on Apple Silicon and PyTorch fallback elsewhere.
- Extends the public privacy-filter family with Nemotron-PII checkpoint IDs: `OpenMed/privacy-filter-nemotron`, `OpenMed/privacy-filter-nemotron-mlx`, and `OpenMed/privacy-filter-nemotron-mlx-8bit`.
- Adds family-aware Torch fallback so Nemotron MLX requests on non-MLX hosts substitute `OpenMed/privacy-filter-nemotron` instead of `openai/privacy-filter`.
- Adds classifier-head bias support for Nemotron MLX artifacts while preserving the original bias-less OpenAI Privacy Filter default, including native Swift OpenMedKit artifact decoding/model construction.
- Switches the OpenMed Scan Demo privacy-filter engine to `OpenMed/privacy-filter-nemotron-mlx-8bit` and updates the visible engine naming/docs.
- Adds Privacy Filter Studio, an interactive FastAPI/static web demo for masking or deterministic Faker randomization with sample notes, highlighted entities, backend/model status, and explicit first-run download control.
- Adds Portuguese API schema support, trust-remote-code loading for the Torch privacy-filter family, docs, demos, changelog/readme updates, lockfile refresh, and focused unit coverage.

## Review Notes
- Reviewed the new Swift OpenMedKit classifier-bias decoding/model changes, Scan Demo Nemotron switch, Studio app/config, MLX classifier-head change, changelog entries, routing, MLX dispatch aliases, Torch loader changes, docs, example, and tests before committing.
- Fixed Studio behavior before commit so cache-only mode actively sets Hugging Face offline flags and model-load/inference errors render as errors in the output pane.
- Earlier docs fixes in this PR covered artifact count wording, `tiktoken` typo, baseline-vs-fine-tune wording, and fuzzy changelog validation count.

## Validation
- `git diff --check`
- `swift test --filter OpenMedMLXTests/testPrivacyFilterConfigDecodesNemotronClassifierBias` (1 passed)
- `swift test --filter OpenMedMLXTests/testPrivacyFilterConfigAcceptsUnembeddingBiasAlias` (1 passed)
- `swift test --filter OpenMedMLXTests/testTinyPrivacyFilterNemotronModelForwardShape` (1 skipped: MLX runtime resources unavailable from SwiftPM CLI test bundle)
- `swift test --filter OpenMedMLXTests/testTinyPrivacyFilterBaselineHasNoUnembeddingBiasSlot` (1 skipped: MLX runtime resources unavailable from SwiftPM CLI test bundle)
- `.venv/bin/python -m compileall -q examples/privacy_filter_studio openmed/mlx/models/privacy_filter.py`
- FastAPI Studio smoke via `TestClient`: `GET /api/examples` -> 200, empty `POST /api/run` -> 200 / `empty`
- `.venv/bin/python -m pytest tests/unit/mlx/test_privacy_filter_mlx.py tests/unit/test_privacy_filter_routing.py` (20 passed, 8 skipped)
- Earlier focused privacy/anonymization suite: `.venv/bin/python -m pytest tests/unit/core/test_anonymizer.py tests/unit/core/test_labels.py tests/unit/test_pii.py tests/unit/test_privacy_filter_routing.py tests/unit/test_pii_multilingual_regression.py tests/unit/mlx/test_privacy_filter_mlx.py tests/unit/service/test_api.py` (471 passed, 1 skipped, 11 warnings)
