### PR TITLE
Refresh website and fix strict docs build

### DIFF
--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OpenMed — Clinical AI that never leaves the device</title>
     <meta name="description"
-        content="OpenMed 1.2.0 brings native MLX Privacy Filter support, experimental GLiNER-family workflows, 1,000+ open-source healthcare LLM models, Portuguese PII, and Swift-native OpenMedKit, Apache-2.0 end to end." />
+        content="OpenMed 1.3.0 brings Faker-backed anonymization, Nemotron Privacy Filter MLX, unified PyTorch/MLX privacy routing, 1,000+ open-source healthcare LLM models, and Swift-native OpenMedKit, Apache-2.0 end to end." />
     <meta name="keywords"
         content="OpenMed, state-of-the-art LLMs for healthcare, healthcare AI, clinical AI models, biomedical NER, zero-shot medical AI, clinical LLMs, medical language models, healthcare machine learning, clinical LLM workflows, medical AI, biomedical AI, SOTA healthcare models, Maziyar Panahi, Hugging Face, Apache-2.0, SageMaker, clinical decision support, medical text analysis" />
     <meta name="author" content="Maziyar Panahi" />
@@ -16,7 +16,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="OpenMed — Clinical AI that never leaves the device" />
     <meta property="og:description"
-        content="OpenMed 1.2.0 — native Privacy Filter MLX, experimental GLiNER-family extraction, 1,000+ healthcare LLM models, Portuguese PII, and one local-first runtime across Python and Swift." />
+        content="OpenMed 1.3.0 — Faker anonymization, Nemotron Privacy Filter MLX, unified PyTorch/MLX routing, 1,000+ healthcare LLM models, and one local-first runtime across Python and Swift." />
     <meta property="og:url" content="https://openmed.life/" />
     <meta property="og:site_name" content="OpenMed" />
     <meta property="og:image" content="https://openmed.life/og.png?v=20260425" />
@@ -30,7 +30,7 @@
     <meta name="twitter:creator" content="@MaziyarPanahi" />
     <meta name="twitter:title" content="OpenMed — Clinical AI that never leaves the device" />
     <meta name="twitter:description"
-        content="OpenMed 1.2.0 · Privacy Filter MLX · GLiNER-family extraction · Portuguese PII · Swift-native OpenMedKit." />
+        content="OpenMed 1.3.0 · Nemotron Privacy Filter MLX · Faker anonymization · unified privacy routing · Swift-native OpenMedKit." />
     <meta name="twitter:image" content="https://openmed.life/og.png?v=20260425" />
     <meta name="twitter:image:alt" content="OpenMed social preview showing local-first healthcare LLMs and an interactive clinical NER terminal." />
 
@@ -57,7 +57,7 @@
         "operatingSystem": "macOS, iOS, iPadOS, Cloud, On-Premises",
         "applicationCategory": "AIApplication",
         "description": "OpenMed Clinical LLM Suite provides open-source healthcare language models, biomedical named-entity recognition, Python MLX acceleration, and Swift-native deployment toolkits for compliant medical workflows.",
-        "softwareVersion": "1.2.0",
+        "softwareVersion": "1.3.0",
         "url": "https://openmed.life/",
         "provider": { "@type": "Organization", "name": "OpenMed", "url": "https://openmed.life/" },
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD", "availability": "https://schema.org/InStock" },
@@ -104,7 +104,7 @@
                     <circle cx="20" cy="20" r="2" fill="var(--accent)" />
                 </svg>
                 <span class="wordmark">open<span class="med">med</span></span>
-                <span class="version-tag">v1.2</span>
+                <span class="version-tag">v1.3</span>
             </a>
 
             <nav aria-label="Primary">
@@ -146,12 +146,12 @@
     <section id="home" class="hero bg-grid" data-screen>
         <div class="container hero-grid">
             <div>
-                <div class="eyebrow">OpenMed 1.2.0 · Privacy Filter MLX · GLiNER-family extraction · Portuguese PII</div>
+                <div class="eyebrow">OpenMed 1.3.0 · Nemotron Privacy Filter MLX · Faker anonymization</div>
                 <h1 class="display-xl hero-title">
                     Clinical AI that never leaves the <span class="serif-italic">device</span>.
                 </h1>
                 <p class="body-lg hero-desc">
-                    1,000+ state-of-the-art healthcare LLM models, native Privacy Filter MLX, experimental GLiNER-family extraction, Portuguese PII, and 25+ curated datasets — one local-first runtime story across Python MLX on Apple Silicon and Swift-native OpenMedKit.
+                    1,000+ state-of-the-art healthcare LLM models, Nemotron Privacy Filter MLX, Faker-backed de-identification, Portuguese PII, and 25+ curated datasets — one local-first runtime story across Python MLX on Apple Silicon and Swift-native OpenMedKit.
                 </p>
 
                 <div class="hero-ctas">
@@ -287,7 +287,7 @@
                     <div class="eyebrow muted">Python MLX</div>
                     <h3 class="heading-md">Accelerated local workflows on Apple Silicon</h3>
                     <p class="body-sm">
-                        Install <span class="code-inline">openmed[mlx]</span> to run local inference, PII extraction, and benchmark workflows with Apple-native MLX acceleration on Mac.
+                        Install <span class="code-inline">openmed[mlx]</span> to run local inference, PII extraction, and Nemotron Privacy Filter workflows with Apple-native MLX acceleration on Mac.
                     </p>
                     <a class="link-arrow" href="docs/mlx-backend/">Read the MLX backend guide →</a>
                 </div>
@@ -318,7 +318,7 @@
                     <div class="eyebrow muted">Shared MLX artifacts</div>
                     <h3 class="heading-md">Move from notebooks to native apps with less friction</h3>
                     <p class="body-sm">
-                        The same MLX artifacts power the Python and Swift paths — prototype in a notebook, then ship the identical model into a native app without a second packaging track.
+                        The same MLX artifacts power the Python and Swift paths — including <span class="code-inline">OpenMed/privacy-filter-nemotron-mlx</span> and the 8-bit variant — so you can prototype in a notebook, then ship the identical model into a native app without a second packaging track.
                     </p>
                     <a class="link-arrow" href="docs/mlx-backend/#mlx-and-swift-apps">See the shared artifact story →</a>
                 </div>
@@ -409,7 +409,7 @@
                         </svg>
                     </div>
                     <h3 class="heading-sm">Flexible redaction methods</h3>
-                    <p class="body-sm">Mask with entity-type labels [NAME], redact completely, or replace with synthetic data. Configurable thresholds for precision control.</p>
+                    <p class="body-sm">Mask with entity-type labels [NAME], redact completely, hash, shift dates, or replace with deterministic Faker-backed surrogates. Configurable thresholds for precision control.</p>
                     <div class="tag-row">
                         <span class="tag">Mask</span>
                         <span class="tag">Redact</span>
@@ -667,7 +667,7 @@
                             <span class="code-dot yellow"></span>
                             <span class="code-dot green"></span>
                         </div>
-                        <span class="code-title">openmed 1.2.0 · quickstart</span>
+                        <span class="code-title">openmed 1.3.0 · quickstart</span>
                         <button class="code-copy" type="button">copy</button>
                     </div>
                     <div class="code-tabs"></div>


### PR DESCRIPTION
## Summary
- Updates `docs/website/index.html` from v1.2.0 messaging to v1.3.0 messaging.
- Mentions Nemotron Privacy Filter MLX in the hero, metadata, and MLX runtime section.
- Updates the privacy section to mention deterministic Faker-backed surrogates and the broader de-identification methods.
- Adds `docs/anonymization.md` to the MkDocs nav so strict mode no longer reports it as an unlisted page.
- Converts source-code links in `docs/anonymization.md` to GitHub source URLs so MkDocs strict mode no longer treats them as broken docs-relative links.

## Validation
- `git diff --check`
- `uv run --extra docs mkdocs build --strict`
