### PR TITLE
Add privacy filter stream demo

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -20,6 +20,7 @@ Run them with VS Code, Jupyter, or Google Colab—each relies on the same `uv pi
 | `examples/pii_model_comparison.py` | Compares multiple PII models across shared sample text and summarizes extraction quality. |
 | `examples/pii_batch_processing.py` | Runs batch PII extraction and de-identification with `BatchProcessor(operation=...)`. |
 | `examples/pii_multilingual_new_languages.py` | Exercises Dutch, Hindi, Telugu, Portuguese, Arabic, Japanese, and Turkish registry entries, locale-specific regex matches, and optional live extraction with the new public checkpoints. |
+| `examples/privacy_filter_stream/` | Web demo that streams raw agent traces beside a delayed, redacted or Faker-obfuscated shareable stream. |
 | `scripts/smoke_gliner.py` | Runs a bounded set of GLiNER models/texts to confirm zero-shot dependencies are installed before releasing. |
 | `tests/run-tests.sh` | Convenience runner that stitches together unit, integration, and smoke tests; extend it to include docs builds and API smoke checks. |
 

--- a/examples/privacy_filter_stream/README.md
+++ b/examples/privacy_filter_stream/README.md
@@ -1,0 +1,29 @@
+# OpenMed Privacy Filter Stream
+
+Streaming web demo for agent traces. The left pane receives raw trace chunks
+immediately; the right pane receives a delayed share-safe copy where sensitive
+values are masked or replaced with deterministic Faker surrogates.
+
+The demo is intentionally cache-free and model-free so it opens immediately. It
+uses a streaming detector for common trace secrets, user identifiers, clinical
+IDs, contact details, and scenario-specific names/addresses, then reuses
+OpenMed's `Anonymizer` to generate realistic fake values.
+
+## Run
+
+From the repository root:
+
+```bash
+pip install -e ".[service]"
+python -m uvicorn examples.privacy_filter_stream.app:app --reload --port 8771
+```
+
+Open <http://127.0.0.1:8771>.
+
+## What to look for
+
+- Raw agent/tool trace chunks arrive on the left as soon as they are produced.
+- The shareable trace on the right lags by the configured delay.
+- Repeated sensitive values map to the same surrogate during a stream.
+- Toggle **Mask** for bracketed labels or **Fake** for format-preserving
+  replacement values.

--- a/examples/privacy_filter_stream/__init__.py
+++ b/examples/privacy_filter_stream/__init__.py
@@ -1,0 +1,1 @@
+"""Streaming privacy-filter web demo."""

--- a/examples/privacy_filter_stream/app.py
+++ b/examples/privacy_filter_stream/app.py
@@ -1,0 +1,474 @@
+"""OpenMed Privacy Filter Stream — delayed redaction demo.
+
+A browser example for agent-trace sharing: the raw trace streams immediately
+to the left pane, while a share-safe version follows on the right after a
+configurable delay. The right pane masks or fakes secrets, contact details,
+people, addresses, clinical IDs, and operational identifiers before the trace
+would be stored or shared.
+
+Run from the repository root:
+
+    uvicorn examples.privacy_filter_stream.app:app --reload --port 8771
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import FastAPI, Query
+from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+
+from openmed.core.anonymizer import Anonymizer
+
+
+ROOT = Path(__file__).resolve().parent
+STATIC_DIR = ROOT / "static"
+
+Mode = Literal["mask", "replace"]
+
+
+@dataclass(frozen=True)
+class SensitiveHint:
+    label: str
+    literal: str
+
+
+@dataclass(frozen=True)
+class TraceScenario:
+    id: str
+    title: str
+    blurb: str
+    hints: tuple[SensitiveHint, ...]
+    lines: tuple[str, ...]
+
+    @property
+    def text(self) -> str:
+        return "".join(self.lines)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "blurb": self.blurb,
+            "lineCount": len(self.lines),
+            "charCount": len(self.text),
+        }
+
+
+def _support_handoff_lines() -> tuple[str, ...]:
+    return (
+        "[00:00.000] agent.start trace_id=trc_prod_01HV9M8Y5RN7VZ user='Sarah Johnson' account=acct_9f73a1\n",
+        "[00:00.044] input.message channel=web text='My bill still shows the pneumonia follow-up copay.'\n",
+        "[00:00.091] memory.fetch profile email=sarah.johnson@example.com phone=(415) 555-7012 plan=enterprise\n",
+        "[00:00.137] tool.crm.lookup customer_id=CUS-448102 mrn=MRN-4872910 dob=03/15/1985\n",
+        "[00:00.188] crm.result attending='Dr. Michael Chen' facility='Cedars Medical Center' next_visit=05/06/2026\n",
+        "[00:00.241] address.verify mailing='1742 Ocean View Ave, Apt 14, San Diego CA 92107' confidence=0.98\n",
+        "[00:00.294] policy.classify labels=payment,clinical,contact action=redact_before_trace_export\n",
+        "[00:00.352] retriever.query q='refund workflow pneumonia copay exception' index=support-playbooks\n",
+        "[00:00.416] retriever.hit id=kb_4421 title='Clinical billing handoff' snippet='Do not expose MRN or DOB in shared traces.'\n",
+        "[00:00.481] tool.http.request GET https://api.billing.example/v1/invoices/inv_2026_04_22_008712\n",
+        "[00:00.538] tool.http.header Authorization: Bearer sk-live-8ahWJD2lQ3pX9pTk1mZ-demo\n",
+        "[00:00.602] tool.http.response 200 card=4111-1111-1111-7392 bank_routing=021000089 balance_due=$42.10\n",
+        "[00:00.676] tool.billing.adjustment candidate=writeoff account=ACCT-0091-7782 reason='duplicate follow-up copay'\n",
+        "[00:00.743] agent.observe risk='invoice id and card appear in tool output' needs_redaction=true\n",
+        "[00:00.811] tool.calendar.lookup owner=michael.chen@hospital.example patient='Sarah Johnson' slot='May 6, 2026 09:30'\n",
+        "[00:00.884] policy.gate allow_response=true allow_trace_share=false until=sanitized\n",
+        "[00:00.947] assistant.draft sentence='Hi Sarah, I checked invoice inv_2026_04_22_008712 and found the duplicate copay.'\n",
+        "[00:01.016] evaluator.check criterion='no raw MRN, DOB, card, account, email, phone, address, or key in exported trace'\n",
+        "[00:01.088] tool.ticket.update id=TCK-55721 requester='Casey Rivera' note='Billing will reverse the duplicate line.'\n",
+        "[00:01.159] notification.preview to=sarah.johnson@example.com cc=casey.rivera@hospital.example\n",
+        "[00:01.226] store.trace.prepare destination=s3://support-traces-prod/acct_9f73a1/trc_prod_01HV9M8Y5RN7VZ.jsonl mode=shareable\n",
+        "[00:01.299] audit.emit reviewer=michael.chen@hospital.example ip=10.42.118.27 session=sess_live_44128\n",
+        "[00:01.367] agent.end status=complete tokens_in=3584 tokens_out=612\n",
+    )
+
+
+def _security_triage_lines() -> tuple[str, ...]:
+    return (
+        "[00:00.000] agent.start trace_id=trc_sec_7HF2KQ workspace=prod-secops user='Linda Park'\n",
+        "[00:00.041] ingest.alert source=siem host=billing-svc ip=10.42.118.27 mac=4c:bb:58:9a:11:7e severity=high\n",
+        "[00:00.099] identity.resolve employee_id=EMP-447128 email=linda.park@hospital.example phone=312-555-0144\n",
+        "[00:00.152] vault.read path=secret/data/prod/billing token=ghp_7N3kV0x9kT2bQ4mP1sR8demo\n",
+        "[00:00.211] tool.kube.describe pod=billing-svc-849ff namespace=prod env.OPENAI_API_KEY=sk-proj-zYw8fakel0ngSecret4711\n",
+        "[00:00.276] tool.netflow.summary src=10.42.118.27 dst=172.18.4.21 bytes=88420 window=15m\n",
+        "[00:00.337] log.sample service=auth-gateway principal=linda.park@hospital.example failures=9\n",
+        "[00:00.398] log.sample service=claims-worker principal=service-account/billing failures=2 token=sk-live-incident-01-R8zQpFake\n",
+        "[00:00.462] file.peek path=/runbooks/finance.md line='fallback account ACCT-0091-7782 belongs to Finance rotation queue'\n",
+        "[00:00.529] tool.slack.lookup channel=#incident-finance requester='Marcus Reilly'\n",
+        "[00:00.590] identity.resolve manager='Nina Torres' email=nina.torres@hospital.example escalation=SRE\n",
+        "[00:00.658] policy.classify labels=credential,employee,network action=redact_before_postmortem\n",
+        "[00:00.726] tool.kms.rotate key_alias=prod/billing-api actor=EMP-447128 approval=required\n",
+        "[00:00.798] agent.observe exposed_api_key=true exposed_employee_contact=true exposed_network_ioc=true\n",
+        "[00:00.871] detector.ioc ip=10.42.118.27 mac=4c:bb:58:9a:11:7e status=internal_workstation\n",
+        "[00:00.936] ticket.create incident=SEC-2026-044 owner=Marcus Reilly notify=linda.park@hospital.example\n",
+        "[00:01.004] assistant.draft summary='Credential material was present in billing pod environment and vault output.'\n",
+        "[00:01.078] containment.step revoke token ghp_7N3kV0x9kT2bQ4mP1sR8demo and expire session sess_live_44128\n",
+        "[00:01.151] containment.step rotate sk-proj-zYw8fakel0ngSecret4711 and sk-live-incident-01-R8zQpFake\n",
+        "[00:01.218] evidence.bundle path=s3://security-reviews/prod-secops/trc_sec_7HF2KQ.jsonl mode=redacted\n",
+        "[00:01.287] assistant.final rotate keys, expire session sess_live_44128, notify Linda Park and CISO office\n",
+        "[00:01.354] agent.end status=escalated severity=high\n",
+    )
+
+
+SCENARIOS: tuple[TraceScenario, ...] = (
+    TraceScenario(
+        id="support-handoff",
+        title="Support Handoff",
+        blurb="Agent trace with customer, billing, and clinical identifiers.",
+        lines=_support_handoff_lines(),
+        hints=(
+            SensitiveHint("person", "Sarah Johnson"),
+            SensitiveHint("person", "Sarah"),
+            SensitiveHint("person", "Michael Chen"),
+            SensitiveHint("person", "Dr. Michael Chen"),
+            SensitiveHint("person", "Casey Rivera"),
+            SensitiveHint("email", "sarah.johnson@example.com"),
+            SensitiveHint("email", "michael.chen@hospital.example"),
+            SensitiveHint("email", "casey.rivera@hospital.example"),
+            SensitiveHint("phone", "(415) 555-7012"),
+            SensitiveHint("street_address", "1742 Ocean View Ave, Apt 14, San Diego CA 92107"),
+            SensitiveHint("id_num", "CUS-448102"),
+            SensitiveHint("id_num", "MRN-4872910"),
+            SensitiveHint("date_of_birth", "03/15/1985"),
+            SensitiveHint("account_number", "ACCT-0091-7782"),
+            SensitiveHint("account_number", "acct_9f73a1"),
+            SensitiveHint("id_num", "trc_prod_01HV9M8Y5RN7VZ"),
+            SensitiveHint("id_num", "sess_live_44128"),
+            SensitiveHint("api_key", "sk-live-8ahWJD2lQ3pX9pTk1mZ-demo"),
+            SensitiveHint("credit_card", "4111-1111-1111-7392"),
+        ),
+    ),
+    TraceScenario(
+        id="security-triage",
+        title="Security Triage",
+        blurb="Incident trace with keys, employee data, hosts, and account IDs.",
+        lines=_security_triage_lines(),
+        hints=(
+            SensitiveHint("person", "Linda Park"),
+            SensitiveHint("person", "Marcus Reilly"),
+            SensitiveHint("person", "Nina Torres"),
+            SensitiveHint("email", "linda.park@hospital.example"),
+            SensitiveHint("email", "nina.torres@hospital.example"),
+            SensitiveHint("phone", "312-555-0144"),
+            SensitiveHint("id_num", "EMP-447128"),
+            SensitiveHint("account_number", "ACCT-0091-7782"),
+            SensitiveHint("id_num", "trc_sec_7HF2KQ"),
+            SensitiveHint("id_num", "sess_live_44128"),
+            SensitiveHint("api_key", "ghp_7N3kV0x9kT2bQ4mP1sR8demo"),
+            SensitiveHint("api_key", "sk-proj-zYw8fakel0ngSecret4711"),
+        ),
+    ),
+)
+
+
+REGEX_HINTS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("email", re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")),
+    ("phone", re.compile(r"\b(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b")),
+    ("ssn", re.compile(r"\b\d{3}-\d{2}-\d{4}\b")),
+    ("credit_card", re.compile(r"\b(?:\d[ -]*?){13,19}\b")),
+    ("ip_address", re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")),
+    ("mac_address", re.compile(r"\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b")),
+    ("api_key", re.compile(r"\b(?:sk|ghp|xox[baprs]|AKIA)[A-Za-z0-9_-]{12,}\b")),
+    ("api_key", re.compile(r"\bBearer\s+[A-Za-z0-9._-]{16,}\b")),
+    ("account_number", re.compile(r"\b(?:acct|account|ACCT|inv|sess|trc)[A-Za-z0-9_-]{6,}\b")),
+    ("id_num", re.compile(r"\b(?:MRN|CUS|EMP)-[A-Z0-9-]{4,}\b")),
+)
+
+LABEL_TITLES = {
+    "api_key": "API key",
+    "account_number": "Account",
+    "credit_card": "Card",
+    "date_of_birth": "DOB",
+    "email": "Email",
+    "id_num": "Identifier",
+    "ip_address": "IP address",
+    "mac_address": "MAC address",
+    "person": "Person",
+    "phone": "Phone",
+    "ssn": "SSN",
+    "street_address": "Address",
+}
+
+LABEL_GROUPS = {
+    "person": "identity",
+    "email": "contact",
+    "phone": "contact",
+    "street_address": "address",
+    "date_of_birth": "dates",
+    "ssn": "govid",
+    "id_num": "identifier",
+    "account_number": "financial",
+    "credit_card": "financial",
+    "api_key": "secret",
+    "ip_address": "network",
+    "mac_address": "network",
+}
+
+
+def _find_scenario(scenario_id: str) -> TraceScenario:
+    for scenario in SCENARIOS:
+        if scenario.id == scenario_id:
+            return scenario
+    return SCENARIOS[0]
+
+
+def _dedupe_entities(entities: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for entity in sorted(
+        entities,
+        key=lambda item: (item["start"], -(item["end"] - item["start"]), item["label"]),
+    ):
+        overlaps = any(
+            not (entity["end"] <= existing["start"] or entity["start"] >= existing["end"])
+            for existing in selected
+        )
+        if not overlaps:
+            selected.append(entity)
+    return sorted(selected, key=lambda item: (item["start"], item["end"], item["label"]))
+
+
+def _detect_entities(text: str, scenario: TraceScenario) -> list[dict[str, Any]]:
+    entities: list[dict[str, Any]] = []
+    for hint in scenario.hints:
+        start = 0
+        while True:
+            found = text.find(hint.literal, start)
+            if found == -1:
+                break
+            entities.append(
+                {
+                    "label": hint.label,
+                    "start": found,
+                    "end": found + len(hint.literal),
+                    "text": hint.literal,
+                    "score": 1.0,
+                }
+            )
+            start = found + len(hint.literal)
+
+    for label, pattern in REGEX_HINTS:
+        for match in pattern.finditer(text):
+            value = match.group(0).rstrip(".,;")
+            if not value:
+                continue
+            entities.append(
+                {
+                    "label": label,
+                    "start": match.start(),
+                    "end": match.start() + len(value),
+                    "text": value,
+                    "score": 0.92,
+                }
+            )
+
+    return _dedupe_entities(entities)
+
+
+class RedactorSession:
+    def __init__(self, *, mode: Mode, seed: int = 8771) -> None:
+        self.mode = mode
+        self.anonymizer = Anonymizer(lang="en", consistent=True, seed=seed)
+        self.surrogate_map: dict[str, str] = {}
+
+    def _replacement(self, label: str, original: str) -> str:
+        if self.mode == "mask":
+            return f"[{LABEL_TITLES.get(label, label).upper()}]"
+        key = f"{label}|{original}"
+        if key not in self.surrogate_map:
+            self.surrogate_map[key] = self.anonymizer.surrogate(original, label)
+        return self.surrogate_map[key]
+
+    def redact(self, text: str, scenario: TraceScenario) -> dict[str, Any]:
+        entities = _detect_entities(text, scenario)
+        cursor = 0
+        segments: list[dict[str, Any]] = []
+        for entity in entities:
+            if entity["start"] < cursor:
+                continue
+            if entity["start"] > cursor:
+                segments.append({"kind": "plain", "text": text[cursor:entity["start"]]})
+            replacement = self._replacement(entity["label"], entity["text"])
+            segments.append(
+                {
+                    "kind": "entity",
+                    "text": replacement,
+                    "label": entity["label"],
+                    "labelTitle": LABEL_TITLES.get(entity["label"], entity["label"]),
+                    "group": LABEL_GROUPS.get(entity["label"], "other"),
+                    "original": entity["text"],
+                }
+            )
+            cursor = entity["end"]
+        if cursor < len(text):
+            segments.append({"kind": "plain", "text": text[cursor:]})
+        redacted = "".join(segment["text"] for segment in segments)
+        return {
+            "redacted": redacted,
+            "segments": segments,
+            "entities": [
+                {
+                    "label": entity["label"],
+                    "labelTitle": LABEL_TITLES.get(entity["label"], entity["label"]),
+                    "group": LABEL_GROUPS.get(entity["label"], "other"),
+                    "text": entity["text"],
+                }
+                for entity in entities
+            ],
+        }
+
+
+def _sse(event: str, data: dict[str, Any]) -> str:
+    return f"event: {event}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
+
+
+async def _trace_event_stream(
+    scenario: TraceScenario,
+    *,
+    mode: Mode,
+    delay_ms: int,
+    speed_ms: int,
+) -> Any:
+    redactor = RedactorSession(mode=mode)
+    delay_s = delay_ms / 1000
+    speed_s = speed_ms / 1000
+    started = time.monotonic()
+    pending: list[tuple[float, int, str]] = []
+    raw_chars = 0
+    shared_chars = 0
+    total_entities = 0
+
+    yield _sse(
+        "meta",
+        {
+            "scenario": scenario.to_public_dict(),
+            "mode": mode,
+            "delayMs": delay_ms,
+            "speedMs": speed_ms,
+            "startedAt": started,
+        },
+    )
+
+    for index, line in enumerate(scenario.lines):
+        now = time.monotonic()
+        due, pending = (
+            [item for item in pending if item[0] <= now],
+            [item for item in pending if item[0] > now],
+        )
+        for _, redacted_index, queued_line in due:
+            result = redactor.redact(queued_line, scenario)
+            shared_chars += len(result["redacted"])
+            total_entities += len(result["entities"])
+            yield _sse(
+                "redacted",
+                {
+                    "index": redacted_index,
+                    "chunk": queued_line,
+                    "redacted": result["redacted"],
+                    "segments": result["segments"],
+                    "entities": result["entities"],
+                    "sharedChars": shared_chars,
+                    "entityCount": total_entities,
+                    "lagMs": delay_ms,
+                },
+            )
+
+        raw_chars += len(line)
+        yield _sse(
+            "source",
+            {
+                "index": index,
+                "chunk": line,
+                "rawChars": raw_chars,
+                "elapsedMs": round((time.monotonic() - started) * 1000),
+            },
+        )
+        pending.append((time.monotonic() + delay_s, index, line))
+        await asyncio.sleep(speed_s)
+
+    while pending:
+        pending.sort(key=lambda item: item[0])
+        due_at, redacted_index, queued_line = pending.pop(0)
+        wait_s = max(0.0, due_at - time.monotonic())
+        if wait_s:
+            await asyncio.sleep(wait_s)
+        result = redactor.redact(queued_line, scenario)
+        shared_chars += len(result["redacted"])
+        total_entities += len(result["entities"])
+        yield _sse(
+            "redacted",
+            {
+                "index": redacted_index,
+                "chunk": queued_line,
+                "redacted": result["redacted"],
+                "segments": result["segments"],
+                "entities": result["entities"],
+                "sharedChars": shared_chars,
+                "entityCount": total_entities,
+                "lagMs": delay_ms,
+            },
+        )
+
+    yield _sse(
+        "done",
+        {
+            "rawChars": raw_chars,
+            "sharedChars": shared_chars,
+            "entityCount": total_entities,
+            "elapsedMs": round((time.monotonic() - started) * 1000),
+        },
+    )
+
+
+app = FastAPI(
+    title="OpenMed Privacy Filter Stream",
+    description="Streaming agent-trace redaction demo with delayed share-safe output.",
+)
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+@app.get("/")
+def index() -> FileResponse:
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+@app.get("/favicon.ico")
+def favicon() -> FileResponse:
+    return FileResponse(STATIC_DIR / "assets" / "logo.svg", media_type="image/svg+xml")
+
+
+@app.get("/api/scenarios")
+def api_scenarios() -> dict[str, Any]:
+    return {
+        "scenarios": [scenario.to_public_dict() for scenario in SCENARIOS],
+        "defaults": {
+            "scenario": SCENARIOS[0].id,
+            "mode": "replace",
+            "delayMs": 1000,
+            "speedMs": 80,
+        },
+    }
+
+
+@app.get("/api/stream")
+async def api_stream(
+    scenario: str = Query(default=SCENARIOS[0].id),
+    mode: Mode = Query(default="replace"),
+    delay_ms: int = Query(default=1000, ge=250, le=4000),
+    speed_ms: int = Query(default=80, ge=20, le=400),
+) -> StreamingResponse:
+    trace = _find_scenario(scenario)
+    return StreamingResponse(
+        _trace_event_stream(trace, mode=mode, delay_ms=delay_ms, speed_ms=speed_ms),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/examples/privacy_filter_stream/static/app.js
+++ b/examples/privacy_filter_stream/static/app.js
@@ -1,0 +1,265 @@
+// OpenMed Privacy Filter Stream — frontend.
+
+const STATE = {
+  scenarios: [],
+  activeScenarioId: null,
+  source: null,
+  running: false,
+  mode: "replace",
+  rawChars: 0,
+  sharedChars: 0,
+  entityCount: 0,
+};
+
+const els = {
+  scenarioStrip: document.querySelector("#scenarioStrip"),
+  delayRange: document.querySelector("#delayRange"),
+  delayValue: document.querySelector("#delayValue"),
+  speedRange: document.querySelector("#speedRange"),
+  speedValue: document.querySelector("#speedValue"),
+  rawChars: document.querySelector("#rawChars"),
+  sharedChars: document.querySelector("#sharedChars"),
+  entityCount: document.querySelector("#entityCount"),
+  lagLabel: document.querySelector("#lagLabel"),
+  statusPill: document.querySelector("#statusPill"),
+  rawStream: document.querySelector("#rawStream"),
+  safeStream: document.querySelector("#safeStream"),
+  rawLiveDot: document.querySelector("#rawLiveDot"),
+  safeLiveDot: document.querySelector("#safeLiveDot"),
+  startButton: document.querySelector("#startButton"),
+  resetButton: document.querySelector("#resetButton"),
+  modeButtons: document.querySelectorAll(".mode-button"),
+};
+
+const MAX_OUTPUT_CHARS = 42000;
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function setStatus(kind, label) {
+  els.statusPill.className = "status-pill";
+  if (kind) els.statusPill.classList.add(kind);
+  els.statusPill.textContent = label;
+}
+
+function setLive(rawLive, safeLive) {
+  els.rawLiveDot.classList.toggle("is-live", rawLive);
+  els.safeLiveDot.classList.toggle("is-live", safeLive);
+}
+
+function formatDelay(ms) {
+  return `${(Number(ms) / 1000).toFixed(1)}s`;
+}
+
+function updateRangeLabels() {
+  els.delayValue.textContent = formatDelay(els.delayRange.value);
+  els.lagLabel.textContent = formatDelay(els.delayRange.value);
+  els.speedValue.textContent = `${els.speedRange.value}ms`;
+}
+
+function renderScenarios() {
+  els.scenarioStrip.innerHTML = STATE.scenarios.map((scenario) => {
+    const active = scenario.id === STATE.activeScenarioId ? " is-active" : "";
+    return `<button type="button" class="scenario-chip${active}" data-id="${escapeHtml(scenario.id)}">
+      <i data-lucide="scroll-text"></i>
+      <span>${escapeHtml(scenario.title)}</span>
+      <small>${escapeHtml(String(scenario.lineCount))} lines</small>
+    </button>`;
+  }).join("");
+
+  els.scenarioStrip.querySelectorAll(".scenario-chip").forEach((button) => {
+    button.addEventListener("click", () => {
+      STATE.activeScenarioId = button.dataset.id;
+      renderScenarios();
+      startStream();
+    });
+  });
+
+  if (window.lucide) window.lucide.createIcons();
+}
+
+function resetOutput() {
+  stopStream();
+  STATE.rawChars = 0;
+  STATE.sharedChars = 0;
+  STATE.entityCount = 0;
+  els.rawChars.textContent = "0";
+  els.sharedChars.textContent = "0";
+  els.entityCount.textContent = "0";
+  els.rawStream.innerHTML = "";
+  els.safeStream.innerHTML = "";
+  setLive(false, false);
+  setStatus("ready", "Ready");
+  els.startButton.querySelector("span").textContent = "Start Stream";
+}
+
+function appendRaw(chunk) {
+  els.rawStream.textContent += chunk;
+  trimOutput(els.rawStream);
+  scrollToBottom(els.rawStream);
+}
+
+function renderSegments(segments) {
+  return segments.map((segment) => {
+    if (segment.kind !== "entity") {
+      return escapeHtml(segment.text);
+    }
+    const label = escapeHtml(segment.labelTitle || segment.label || "PII");
+    const group = escapeHtml(segment.group || "other");
+    const original = escapeHtml(segment.original || "");
+    return `<span class="redacted-entity" data-group="${group}" data-tooltip="${label}: ${original}">${escapeHtml(segment.text)}<span>${label}</span></span>`;
+  }).join("");
+}
+
+function appendSafe(payload) {
+  els.safeStream.innerHTML += renderSegments(payload.segments || [{ kind: "plain", text: payload.redacted || "" }]);
+  trimOutput(els.safeStream);
+  scrollToBottom(els.safeStream);
+}
+
+function scrollToBottom(node) {
+  window.requestAnimationFrame(() => {
+    node.scrollTop = node.scrollHeight;
+  });
+}
+
+function trimOutput(node) {
+  const text = node.textContent || "";
+  if (text.length <= MAX_OUTPUT_CHARS) return;
+  const trimBy = text.length - MAX_OUTPUT_CHARS;
+  if (node === els.rawStream) {
+    node.textContent = text.slice(trimBy);
+  } else {
+    while ((node.textContent || "").length > MAX_OUTPUT_CHARS && node.firstChild) {
+      node.removeChild(node.firstChild);
+    }
+  }
+}
+
+function setMode(mode) {
+  STATE.mode = mode;
+  els.modeButtons.forEach((button) => {
+    button.classList.toggle("is-active", button.dataset.mode === mode);
+  });
+  startStream();
+}
+
+function stopStream() {
+  if (STATE.source) {
+    STATE.source.close();
+    STATE.source = null;
+  }
+  STATE.running = false;
+  setLive(false, false);
+}
+
+function startStream() {
+  stopStream();
+  STATE.rawChars = 0;
+  STATE.sharedChars = 0;
+  STATE.entityCount = 0;
+  els.rawStream.innerHTML = "";
+  els.safeStream.innerHTML = "";
+  els.rawChars.textContent = "0";
+  els.sharedChars.textContent = "0";
+  els.entityCount.textContent = "0";
+
+  const params = new URLSearchParams({
+    scenario: STATE.activeScenarioId || "",
+    mode: STATE.mode,
+    delay_ms: els.delayRange.value,
+    speed_ms: els.speedRange.value,
+  });
+  const source = new EventSource(`/api/stream?${params.toString()}`);
+  STATE.source = source;
+  STATE.running = true;
+  els.startButton.querySelector("span").textContent = "Restart";
+  setStatus("running", "Streaming");
+  setLive(true, false);
+
+  source.addEventListener("meta", () => {
+    setStatus("running", "Streaming");
+  });
+
+  source.addEventListener("source", (event) => {
+    const payload = JSON.parse(event.data);
+    appendRaw(payload.chunk || "");
+    STATE.rawChars = payload.rawChars || STATE.rawChars;
+    els.rawChars.textContent = String(STATE.rawChars);
+    setLive(true, false);
+  });
+
+  source.addEventListener("redacted", (event) => {
+    const payload = JSON.parse(event.data);
+    appendSafe(payload);
+    STATE.sharedChars = payload.sharedChars || STATE.sharedChars;
+    STATE.entityCount = payload.entityCount || STATE.entityCount;
+    els.sharedChars.textContent = String(STATE.sharedChars);
+    els.entityCount.textContent = String(STATE.entityCount);
+    setLive(true, true);
+  });
+
+  source.addEventListener("done", (event) => {
+    const payload = JSON.parse(event.data);
+    els.rawChars.textContent = String(payload.rawChars || STATE.rawChars);
+    els.sharedChars.textContent = String(payload.sharedChars || STATE.sharedChars);
+    els.entityCount.textContent = String(payload.entityCount || STATE.entityCount);
+    setStatus("done", "Complete");
+    setLive(false, false);
+    stopStream();
+  });
+
+  source.onerror = () => {
+    if (!STATE.running) return;
+    setStatus("error", "Disconnected");
+    setLive(false, false);
+    stopStream();
+  };
+}
+
+async function boot() {
+  updateRangeLabels();
+
+  els.startButton.addEventListener("click", startStream);
+  els.resetButton.addEventListener("click", resetOutput);
+  els.modeButtons.forEach((button) => {
+    button.addEventListener("click", () => setMode(button.dataset.mode));
+  });
+  els.delayRange.addEventListener("input", updateRangeLabels);
+  els.speedRange.addEventListener("input", updateRangeLabels);
+  els.delayRange.addEventListener("change", startStream);
+  els.speedRange.addEventListener("change", startStream);
+
+  try {
+    const response = await fetch("/api/scenarios");
+    const payload = await response.json();
+    STATE.scenarios = payload.scenarios || [];
+    STATE.activeScenarioId = payload.defaults?.scenario || STATE.scenarios[0]?.id;
+    STATE.mode = payload.defaults?.mode || STATE.mode;
+    els.delayRange.value = String(payload.defaults?.delayMs || els.delayRange.value);
+    els.speedRange.value = String(payload.defaults?.speedMs || els.speedRange.value);
+  } catch (error) {
+    console.warn("Failed to load scenarios", error);
+    setStatus("error", "Load error");
+  }
+
+  updateRangeLabels();
+  renderScenarios();
+  els.modeButtons.forEach((button) => {
+    button.classList.toggle("is-active", button.dataset.mode === STATE.mode);
+  });
+  if (window.lucide) window.lucide.createIcons();
+  if (STATE.scenarios.length > 0) {
+    window.setTimeout(startStream, 300);
+  }
+}
+
+window.addEventListener("beforeunload", stopStream);
+
+boot();

--- a/examples/privacy_filter_stream/static/app.js
+++ b/examples/privacy_filter_stream/static/app.js
@@ -112,8 +112,7 @@ function renderSegments(segments) {
     }
     const label = escapeHtml(segment.labelTitle || segment.label || "PII");
     const group = escapeHtml(segment.group || "other");
-    const original = escapeHtml(segment.original || "");
-    return `<span class="redacted-entity" data-group="${group}" data-tooltip="${label}: ${original}">${escapeHtml(segment.text)}<span>${label}</span></span>`;
+    return `<span class="redacted-entity" data-group="${group}" data-tooltip="${label}">${escapeHtml(segment.text)}<span>${label}</span></span>`;
   }).join("");
 }
 

--- a/examples/privacy_filter_stream/static/assets/logo.svg
+++ b/examples/privacy_filter_stream/static/assets/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40">
+  <rect x="2" y="2" width="36" height="36" rx="8" fill="#0E1116"></rect>
+  <rect x="11" y="17.5" width="18" height="5" rx="1" fill="#F7F4EC"></rect>
+  <rect x="17.5" y="11" width="5" height="18" rx="1" fill="#F7F4EC"></rect>
+  <circle cx="20" cy="20" r="2" fill="#0D6E6E"></circle>
+</svg>

--- a/examples/privacy_filter_stream/static/index.html
+++ b/examples/privacy_filter_stream/static/index.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenMed Privacy Filter Stream</title>
+    <link rel="icon" href="/static/assets/logo.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="topbar" aria-label="Application controls">
+        <a class="brand" href="/" aria-label="OpenMed Privacy Filter Stream">
+          <img src="/static/assets/logo.svg" alt="" class="brand-mark" />
+          <span class="brand-word">open<span>med</span></span>
+          <span class="brand-rule" aria-hidden="true"></span>
+          <span class="brand-title">Privacy Filter Stream</span>
+        </a>
+
+        <div class="toolbar">
+          <div class="mode-switch" role="group" aria-label="Redaction mode">
+            <button type="button" class="mode-button" data-mode="mask">
+              <i data-lucide="square-asterisk"></i>
+              <span>Mask</span>
+            </button>
+            <button type="button" class="mode-button is-active" data-mode="replace">
+              <i data-lucide="dices"></i>
+              <span>Fake</span>
+            </button>
+          </div>
+
+          <button class="ghost-button" id="resetButton" type="button">
+            <i data-lucide="rotate-ccw"></i>
+            <span>Reset</span>
+          </button>
+
+          <button class="run-button" id="startButton" type="button">
+            <i data-lucide="radio"></i>
+            <span>Start Stream</span>
+          </button>
+        </div>
+      </header>
+
+      <main class="stream-stage">
+        <section class="control-band" aria-label="Stream settings">
+          <div class="scenario-strip" id="scenarioStrip"></div>
+          <div class="range-controls">
+            <label class="range-control">
+              <span>Delay</span>
+              <input id="delayRange" type="range" min="250" max="4000" step="250" value="1000" />
+              <strong id="delayValue">1.0s</strong>
+            </label>
+            <label class="range-control">
+              <span>Speed</span>
+              <input id="speedRange" type="range" min="20" max="220" step="10" value="80" />
+              <strong id="speedValue">80ms</strong>
+            </label>
+          </div>
+        </section>
+
+        <section class="metrics-row" aria-label="Stream metrics">
+          <div class="metric">
+            <span>raw chars</span>
+            <strong id="rawChars">0</strong>
+          </div>
+          <div class="metric">
+            <span>shared chars</span>
+            <strong id="sharedChars">0</strong>
+          </div>
+          <div class="metric">
+            <span>redactions</span>
+            <strong id="entityCount">0</strong>
+          </div>
+          <div class="metric">
+            <span>lag</span>
+            <strong id="lagLabel">1.0s</strong>
+          </div>
+          <div class="status-pill" id="statusPill">Ready</div>
+        </section>
+
+        <section class="stream-grid" aria-label="Raw and redacted trace streams">
+          <article class="stream-pane" aria-labelledby="rawTitle">
+            <header class="pane-head">
+              <div class="pane-title">
+                <p>Input Stream</p>
+                <h1 id="rawTitle">Raw agent trace</h1>
+              </div>
+              <span class="live-dot" id="rawLiveDot" aria-hidden="true"></span>
+            </header>
+            <div class="paper-frame">
+              <pre id="rawStream" class="trace-output" aria-live="polite"></pre>
+            </div>
+          </article>
+
+          <article class="stream-pane" aria-labelledby="safeTitle">
+            <header class="pane-head">
+              <div class="pane-title">
+                <p>Share Stream</p>
+                <h1 id="safeTitle">Redacted trace</h1>
+              </div>
+              <span class="live-dot safe" id="safeLiveDot" aria-hidden="true"></span>
+            </header>
+            <div class="paper-frame">
+              <pre id="safeStream" class="trace-output trace-output--safe" aria-live="polite"></pre>
+            </div>
+          </article>
+        </section>
+      </main>
+    </div>
+
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="/static/app.js" type="module"></script>
+  </body>
+</html>

--- a/examples/privacy_filter_stream/static/styles.css
+++ b/examples/privacy_filter_stream/static/styles.css
@@ -1,0 +1,708 @@
+@import url("https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,500&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
+
+:root {
+  --paper: #f7f4ec;
+  --paper-2: #efe9d8;
+  --ink: #0e1116;
+  --ink-2: #1c2128;
+  --stone-50: #f2eee3;
+  --stone-100: #e4dece;
+  --stone-200: #cbc3ae;
+  --stone-300: #a9a088;
+  --stone-400: #7c7461;
+  --stone-500: #545042;
+  --stone-600: #3a3628;
+  --stone-800: #14130d;
+  --teal-600: #0d6e6e;
+  --teal-100: #d6ebeb;
+  --coral-600: #c5453a;
+  --coral-100: #f7dcd8;
+  --highlight: #f5e27a;
+  --bg: var(--paper);
+  --bg-panel: var(--paper-2);
+  --bg-elevated: #ffffff;
+  --fg: var(--ink);
+  --fg-muted: var(--stone-500);
+  --border: var(--stone-100);
+  --border-strong: var(--stone-200);
+  --accent: var(--teal-600);
+  --signal: var(--coral-600);
+  --signal-soft: var(--coral-100);
+  --font-display: "Newsreader", Georgia, serif;
+  --font-sans: "Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 14px;
+  --shadow-2: 0 12px 32px -12px rgba(14, 17, 22, 0.12), 0 2px 4px rgba(14, 17, 22, 0.04);
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+
+  --desk-bg: var(--paper);
+  --desk-grid: rgba(14, 17, 22, 0.045);
+  --chrome-bg: rgba(247, 244, 236, 0.88);
+  --chrome-fg: var(--ink);
+  --chrome-muted: rgba(14, 17, 22, 0.66);
+  --chrome-border: rgba(14, 17, 22, 0.14);
+  --chrome-control-bg: rgba(14, 17, 22, 0.04);
+  --chrome-control-hover-bg: rgba(14, 17, 22, 0.08);
+  --chrome-control-border: rgba(14, 17, 22, 0.16);
+  --chrome-control-hover-border: rgba(14, 17, 22, 0.28);
+  --chrome-control-active-bg: rgba(14, 17, 22, 0.12);
+  --caption-fg: rgba(14, 17, 22, 0.62);
+  --caption-accent: var(--accent);
+  --brand-mark-bg: #ffffff;
+  --pane-shell-bg: var(--paper-2);
+  --pane-shell-fg: var(--ink);
+  --pane-shell-muted: var(--fg-muted);
+  --pane-shell-border: var(--stone-200);
+  --paper-edge: #d7ceb8;
+  --paper-shadow: 0 18px 32px -18px rgba(14, 17, 22, 0.36);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  color: var(--fg);
+  background: var(--desk-bg);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+.app-shell {
+  min-height: 100vh;
+  background:
+    linear-gradient(to right, var(--desk-grid) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--desk-grid) 1px, transparent 1px),
+    var(--desk-bg);
+  background-size: 44px 44px;
+}
+
+.topbar {
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: 10px 24px;
+  border-bottom: 1px solid var(--chrome-border);
+  color: var(--chrome-fg);
+  background: var(--chrome-bg);
+  backdrop-filter: blur(14px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-mark {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  background: var(--brand-mark-bg);
+  border-radius: var(--radius-md);
+}
+
+.brand-word {
+  color: var(--chrome-fg);
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-style: italic;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.brand-word span {
+  color: var(--caption-accent);
+}
+
+.brand-rule {
+  width: 1px;
+  height: 24px;
+  background: var(--chrome-border);
+}
+
+.brand-title {
+  color: var(--chrome-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  white-space: nowrap;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.run-button,
+.mode-switch,
+.mode-button,
+.ghost-button {
+  min-height: 38px;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+}
+
+.run-button,
+.ghost-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  border: 1px solid var(--chrome-control-border);
+  background: var(--chrome-control-bg);
+  color: var(--chrome-fg);
+  transition: background 160ms var(--ease-out), border-color 160ms var(--ease-out), transform 160ms var(--ease-out);
+}
+
+.run-button {
+  padding: 0 16px;
+  color: #ffffff;
+  background: var(--accent);
+  border-color: var(--accent);
+  font-weight: 700;
+}
+
+.ghost-button {
+  padding: 0 12px;
+}
+
+.ghost-button:hover {
+  background: var(--chrome-control-hover-bg);
+  border-color: var(--chrome-control-hover-border);
+}
+
+.run-button:hover {
+  background: #0a5656;
+  border-color: #0a5656;
+}
+
+.ghost-button:active,
+.run-button:active {
+  transform: translateY(1px);
+}
+
+.run-button svg,
+.mode-button svg,
+.ghost-button svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.6;
+}
+
+.mode-switch {
+  display: inline-flex;
+  padding: 3px;
+  border: 1px solid var(--chrome-control-border);
+  background: var(--chrome-control-bg);
+  gap: 2px;
+}
+
+.mode-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  height: 32px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--chrome-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: background 160ms var(--ease-out), color 160ms var(--ease-out);
+}
+
+.mode-button.is-active {
+  background: var(--chrome-control-active-bg);
+  color: var(--chrome-fg);
+  font-weight: 700;
+}
+
+.mode-button:hover:not(.is-active) {
+  color: var(--chrome-fg);
+}
+
+.stream-stage {
+  width: min(1640px, 100%);
+  margin: 0 auto;
+  padding: 24px 24px 48px;
+}
+
+.control-band {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin: 0 auto var(--space-4);
+}
+
+.scenario-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.scenario-chip {
+  position: relative;
+  min-height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--chrome-control-border);
+  border-radius: 999px;
+  background: var(--chrome-control-bg);
+  color: var(--chrome-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 160ms var(--ease-out), color 160ms var(--ease-out), border-color 160ms var(--ease-out);
+}
+
+.scenario-chip:hover {
+  background: var(--chrome-control-hover-bg);
+  border-color: var(--chrome-control-hover-border);
+  color: var(--chrome-fg);
+}
+
+.scenario-chip.is-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.scenario-chip small {
+  color: currentColor;
+  font-size: 10px;
+  opacity: 0.72;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.range-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.range-control {
+  min-height: 38px;
+  display: grid;
+  grid-template-columns: auto 112px 48px;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 12px;
+  border: 1px solid var(--chrome-control-border);
+  border-radius: var(--radius-md);
+  background: var(--chrome-control-bg);
+  color: var(--chrome-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.range-control input {
+  width: 112px;
+  accent-color: var(--accent);
+}
+
+.range-control strong {
+  color: var(--chrome-fg);
+  font-weight: 700;
+  text-align: right;
+}
+
+.metrics-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr)) auto;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.metric,
+.status-pill {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 10px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.46);
+  box-shadow: var(--shadow-2);
+}
+
+.metric span {
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.metric strong {
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.status-pill {
+  min-width: 130px;
+  justify-content: center;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.status-pill.running {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.status-pill.done {
+  border-color: #2d7a50;
+  color: #2d7a50;
+}
+
+.status-pill.error {
+  border-color: var(--signal);
+  color: var(--signal);
+}
+
+.stream-grid {
+  height: clamp(560px, calc(100vh - 260px), 900px);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--space-4);
+}
+
+.stream-pane {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  border: 1px solid var(--pane-shell-border);
+  border-radius: var(--radius-lg);
+  background: var(--pane-shell-bg);
+  color: var(--pane-shell-fg);
+  box-shadow: var(--shadow-2);
+  overflow: hidden;
+}
+
+.pane-head {
+  min-height: 74px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--pane-shell-border);
+}
+
+.pane-title {
+  min-width: 0;
+}
+
+.pane-title p {
+  margin: 0 0 2px;
+  color: var(--pane-shell-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.pane-title h1 {
+  margin: 0;
+  color: var(--pane-shell-fg);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.12;
+  letter-spacing: 0;
+}
+
+.live-dot {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--stone-300);
+}
+
+.live-dot.is-live {
+  background: var(--signal);
+  box-shadow: 0 0 0 7px var(--signal-soft);
+}
+
+.live-dot.safe.is-live {
+  background: var(--accent);
+  box-shadow: 0 0 0 7px var(--teal-100);
+}
+
+.paper-frame {
+  min-height: 0;
+  margin: 14px;
+  border: 1px solid var(--paper-edge);
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(90deg, rgba(14, 17, 22, 0.035) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(14, 17, 22, 0.035) 1px, transparent 1px),
+    var(--paper);
+  background-size: 28px 28px;
+  box-shadow: var(--paper-shadow);
+  overflow: hidden;
+}
+
+.trace-output {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  margin: 0;
+  padding: 18px;
+  overflow: auto;
+  color: var(--ink-2);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.74;
+  white-space: pre-wrap;
+  word-break: break-word;
+  tab-size: 2;
+  scrollbar-gutter: stable;
+}
+
+.trace-output::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.trace-output::-webkit-scrollbar-track {
+  background: rgba(14, 17, 22, 0.06);
+}
+
+.trace-output::-webkit-scrollbar-thumb {
+  background: var(--stone-300);
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+
+.trace-output::-webkit-scrollbar-thumb:hover {
+  background: var(--stone-400);
+  background-clip: padding-box;
+}
+
+.redacted-entity {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  margin: 0 1px;
+  padding: 1px 5px 2px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--ink);
+  background: rgba(14, 17, 22, 0.05);
+  position: relative;
+}
+
+.redacted-entity span {
+  color: var(--fg-muted);
+  font-size: 9px;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.redacted-entity[data-group="identity"] {
+  border-color: #e7aaa4;
+  background: var(--coral-100);
+}
+
+.redacted-entity[data-group="contact"] {
+  border-color: #a9bddb;
+  background: #dfe8f6;
+}
+
+.redacted-entity[data-group="address"] {
+  border-color: #a9ccb5;
+  background: #deecdf;
+}
+
+.redacted-entity[data-group="secret"] {
+  border-color: #c4b4df;
+  background: #e7e0f3;
+}
+
+.redacted-entity[data-group="financial"],
+.redacted-entity[data-group="identifier"],
+.redacted-entity[data-group="govid"] {
+  border-color: #d8bd70;
+  background: #f5e8bd;
+}
+
+.redacted-entity[data-group="network"],
+.redacted-entity[data-group="dates"] {
+  border-color: #9ecaca;
+  background: var(--teal-100);
+}
+
+.redacted-entity::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 8px);
+  max-width: min(360px, 80vw);
+  padding: 7px 9px;
+  border: 1px solid var(--chrome-border);
+  border-radius: var(--radius-sm);
+  background: var(--ink-2);
+  color: var(--paper);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+  white-space: normal;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(4px);
+  transition: opacity 120ms var(--ease-out), transform 120ms var(--ease-out);
+  z-index: 20;
+}
+
+.redacted-entity:hover::after,
+.redacted-entity:focus-visible::after {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 1100px) {
+  .topbar,
+  .control-band {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .toolbar,
+  .range-controls {
+    justify-content: flex-start;
+  }
+
+  .metrics-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .status-pill {
+    grid-column: 1 / -1;
+  }
+
+  .stream-grid {
+    height: auto;
+    grid-template-columns: 1fr;
+  }
+
+  .stream-pane {
+    height: 560px;
+  }
+}
+
+@media (max-width: 680px) {
+  .stream-stage {
+    padding: 16px 10px 28px;
+  }
+
+  .brand-rule,
+  .brand-title {
+    display: none;
+  }
+
+  .toolbar,
+  .scenario-strip,
+  .range-controls,
+  .scenario-chip,
+  .range-control {
+    width: 100%;
+  }
+
+  .range-control {
+    grid-template-columns: auto minmax(96px, 1fr) 48px;
+  }
+
+  .range-control input {
+    width: 100%;
+  }
+
+  .metrics-row {
+    grid-template-columns: 1fr;
+  }
+
+  .stream-pane {
+    height: 520px;
+  }
+
+  .paper-frame {
+    margin: 10px;
+  }
+
+  .trace-output {
+    padding: 14px;
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
## Summary

- Add a FastAPI example that streams raw agent traces immediately while emitting a delayed share-safe stream.
- Include deterministic masking or Faker-backed replacement for sensitive trace values such as names, contact details, IDs, account numbers, network indicators, and secrets.
- Add the static frontend, logo, run instructions, and docs index entry for the new examples/privacy_filter_stream/ demo.

## Why

This gives developers a concrete, browser-based example of how OpenMed privacy filtering can sit between an internal agent trace and a shareable trace export. The side-by-side stream makes the delay, redaction mode, and repeated-value consistency easy to inspect without downloading a model.

## Impact

The new example is model-free and cache-free, so it starts quickly for docs and demos. It does not change library behavior outside the example directory and docs listing.

## Validation

- Passed: Python AST parse for app.py and __init__.py with python3.
- Passed: node --check examples/privacy_filter_stream/static/app.js.