### PR TITLE
Release OpenMed 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-05-21
+
+### Changed
+
+- README, docs, website, and Apple demo version surfaces now point at `1.5.1`.
+- Prepared the patch release metadata for the tag-driven build and publish workflow.
+
 ## [1.5.0] - 2026-05-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Apple Silicon acceleration in Python:
 uv pip install -e ".[mlx]"
 ```
 
-Swift apps on macOS and iOS use `OpenMedKit`. As of `1.5.0`, that means:
+Swift apps on macOS and iOS use `OpenMedKit`. As of `1.5.1`, that means:
 
 - **MLX** on Apple Silicon macOS and real iPhone/iPad hardware for supported OpenMed PII, OpenAI Privacy Filter, OpenAI Nemotron Privacy Filter, OpenMed Multilingual Privacy Filter, and experimental GLiNER-family artifacts
 - **CoreML** when you already have a bundled Apple model package or want the fallback Apple path
@@ -65,7 +65,7 @@ Add the Swift package like this:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/maziyarpanahi/openmed.git", from: "1.5.0"),
+    .package(url: "https://github.com/maziyarpanahi/openmed.git", from: "1.5.1"),
 ]
 ```
 
@@ -140,7 +140,7 @@ result = processor.process_texts([
 - **Advanced NER Processing**: Confidence filtering, entity grouping, and span alignment
 - **Multiple Output Formats**: Dict, JSON, HTML, CSV for any downstream system
 
-### Production Tools (v1.5.0)
+### Production Tools (v1.5.1)
 
 - **Batch Processing**: Multi-text and multi-file workflows with progress tracking
 - **Configuration Profiles**: `dev`/`prod`/`test`/`fast` presets with flexible overrides
@@ -195,8 +195,8 @@ uvicorn openmed.service.app:app --host 0.0.0.0 --port 8080
 ### Run with Docker
 
 ```bash
-docker build -t openmed:1.5.0 .
-docker run --rm -p 8080:8080 -e OPENMED_PROFILE=prod openmed:1.5.0
+docker build -t openmed:1.5.1 .
+docker run --rm -p 8080:8080 -e OPENMED_PROFILE=prod openmed:1.5.1
 ```
 
 ### Example request

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -24,7 +24,7 @@ Run them with VS Code, Jupyter, or Google Colab—each relies on the same `uv pi
 
 ## Apple Silicon & Swift recipes
 
-OpenMed `1.5.0` includes release-critical Apple entry points:
+OpenMed `1.5.1` includes release-critical Apple entry points:
 
 - [MLX Backend](./mlx-backend.md) for Python on Apple Silicon Macs, including Privacy Filter, OpenMed Multilingual Privacy Filter, and experimental GLiNER-family artifacts
 - [OpenMedKit (Swift Package)](./swift-openmedkit.md) for macOS, iOS, and iPadOS apps

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ OpenMed bundles curated biomedical models, advanced extraction utilities, and on
 clinical NLP workflows without wrangling infrastructure. This documentation keeps the most copied snippets and workflows
 close at hand—each section is Markdown-first, searchable, and optimized for quick scanning or copy/paste into notebooks.
 
-OpenMed `1.5.0` expands multilingual PII and the Apple story:
+OpenMed `1.5.1` expands multilingual PII and the Apple story:
 
 - **Python MLX** on Apple Silicon Macs through `openmed[mlx]`
 - **OpenMedKit** for native macOS, iOS, and iPadOS apps
@@ -50,7 +50,7 @@ uv run python examples/pii_model_comparison.py
 The rest of the docs expand on this snippet—head to **Quick Start** for the end-to-end setup, then explore the guides for
 configuration, zero-shot GLiNER workflows, and advanced processing helpers.
 
-## 1.5.0 release highlights
+## 1.5.1 release highlights
 
 - [MLX Backend](./mlx-backend.md) – Python MLX on Apple Silicon, Privacy Filter family support, 28 new Arabic/Japanese/Turkish PII MLX artifacts, shared artifact packaging, and backend auto-detection.
 - [OpenMedKit (Swift Package)](./swift-openmedkit.md) – native macOS/iOS/iPadOS integration with MLX, CoreML, Privacy Filter, OpenMed Multilingual Privacy Filter, and experimental GLiNER-family APIs.

--- a/docs/mlx-backend.md
+++ b/docs/mlx-backend.md
@@ -1,6 +1,6 @@
 # MLX Backend (Apple Silicon)
 
-OpenMed v1.5.0 expands native Apple Silicon acceleration via [Apple MLX](https://github.com/ml-explore/mlx), including preconverted Arabic, Japanese, and Turkish PII token-classification artifacts.
+OpenMed v1.5.1 expands native Apple Silicon acceleration via [Apple MLX](https://github.com/ml-explore/mlx), including preconverted Arabic, Japanese, and Turkish PII token-classification artifacts.
 
 That MLX story now has two surfaces:
 

--- a/docs/swift-openmedkit.md
+++ b/docs/swift-openmedkit.md
@@ -2,7 +2,7 @@
 
 OpenMedKit is the Swift package for running OpenMed models in **macOS**, **iOS**, and **iPadOS** apps.
 
-As of `1.5.0`, OpenMedKit supports two Apple backends:
+As of `1.5.1`, OpenMedKit supports two Apple backends:
 
 - **MLX** for Apple Silicon Macs and real iPhone/iPad devices
 - **CoreML** for bundled Apple model packages
@@ -55,7 +55,7 @@ iOS Simulator is **not** a Swift MLX validation target.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/maziyarpanahi/openmed.git", from: "1.5.0"),
+    .package(url: "https://github.com/maziyarpanahi/openmed.git", from: "1.5.1"),
 ]
 ```
 

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OpenMed — Clinical AI that never leaves the device</title>
     <meta name="description"
-        content="OpenMed 1.5.0 brings the OpenMed Multilingual Privacy Filter, Arabic/Japanese/Turkish PII MLX artifacts, unified PyTorch/MLX privacy routing, Faker-backed anonymization, 1,000+ open-source healthcare LLM models, and Swift-native OpenMedKit, Apache-2.0 end to end." />
+        content="OpenMed 1.5.1 brings the OpenMed Multilingual Privacy Filter, Arabic/Japanese/Turkish PII MLX artifacts, unified PyTorch/MLX privacy routing, Faker-backed anonymization, 1,000+ open-source healthcare LLM models, and Swift-native OpenMedKit, Apache-2.0 end to end." />
     <meta name="keywords"
         content="OpenMed, state-of-the-art LLMs for healthcare, healthcare AI, clinical AI models, biomedical NER, zero-shot medical AI, clinical LLMs, medical language models, healthcare machine learning, clinical LLM workflows, medical AI, biomedical AI, SOTA healthcare models, Maziyar Panahi, Hugging Face, Apache-2.0, SageMaker, clinical decision support, medical text analysis" />
     <meta name="author" content="Maziyar Panahi" />
@@ -16,7 +16,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="OpenMed — Clinical AI that never leaves the device" />
     <meta property="og:description"
-        content="OpenMed 1.5.0 — OpenMed Multilingual Privacy Filter, Nemotron Privacy Filter MLX, Arabic/Japanese/Turkish PII, unified PyTorch/MLX routing, 1,000+ healthcare LLM models, and one local-first runtime across Python and Swift." />
+        content="OpenMed 1.5.1 — OpenMed Multilingual Privacy Filter, Nemotron Privacy Filter MLX, Arabic/Japanese/Turkish PII, unified PyTorch/MLX routing, 1,000+ healthcare LLM models, and one local-first runtime across Python and Swift." />
     <meta property="og:url" content="https://openmed.life/" />
     <meta property="og:site_name" content="OpenMed" />
     <meta property="og:image" content="https://openmed.life/og.png?v=20260425" />
@@ -30,7 +30,7 @@
     <meta name="twitter:creator" content="@MaziyarPanahi" />
     <meta name="twitter:title" content="OpenMed — Clinical AI that never leaves the device" />
     <meta name="twitter:description"
-        content="OpenMed 1.5.0 · OpenMed Multilingual Privacy Filter · Arabic/Japanese/Turkish PII · Nemotron Privacy Filter MLX · unified privacy routing · Swift-native OpenMedKit." />
+        content="OpenMed 1.5.1 · OpenMed Multilingual Privacy Filter · Arabic/Japanese/Turkish PII · Nemotron Privacy Filter MLX · unified privacy routing · Swift-native OpenMedKit." />
     <meta name="twitter:image" content="https://openmed.life/og.png?v=20260425" />
     <meta name="twitter:image:alt" content="OpenMed social preview showing local-first healthcare LLMs and an interactive clinical NER terminal." />
 
@@ -57,7 +57,7 @@
         "operatingSystem": "macOS, iOS, iPadOS, Cloud, On-Premises",
         "applicationCategory": "AIApplication",
         "description": "OpenMed Clinical LLM Suite provides open-source healthcare language models, biomedical named-entity recognition, Python MLX acceleration, and Swift-native deployment toolkits for compliant medical workflows.",
-        "softwareVersion": "1.5.0",
+        "softwareVersion": "1.5.1",
         "url": "https://openmed.life/",
         "provider": { "@type": "Organization", "name": "OpenMed", "url": "https://openmed.life/" },
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD", "availability": "https://schema.org/InStock" },
@@ -104,7 +104,7 @@
                     <circle cx="20" cy="20" r="2" fill="var(--accent)" />
                 </svg>
                 <span class="wordmark">open<span class="med">med</span></span>
-                <span class="version-tag">v1.5.0</span>
+                <span class="version-tag">v1.5.1</span>
             </a>
 
             <nav aria-label="Primary">
@@ -146,7 +146,7 @@
     <section id="home" class="hero bg-grid" data-screen>
         <div class="container hero-grid">
             <div>
-                <div class="eyebrow">OpenMed 1.5.0 · OpenMed Multilingual Privacy Filter · 8-bit MLX</div>
+                <div class="eyebrow">OpenMed 1.5.1 · OpenMed Multilingual Privacy Filter · 8-bit MLX</div>
                 <h1 class="display-xl hero-title">
                     Clinical AI that never leaves the <span class="serif-italic">device</span>.
                 </h1>
@@ -667,7 +667,7 @@
                             <span class="code-dot yellow"></span>
                             <span class="code-dot green"></span>
                         </div>
-                        <span class="code-title">openmed 1.5.0 · quickstart</span>
+                        <span class="code-title">openmed 1.5.1 · quickstart</span>
                         <button class="code-copy" type="button">copy</button>
                     </div>
                     <div class="code-tabs"></div>

--- a/openmed/__about__.py
+++ b/openmed/__about__.py
@@ -1,3 +1,3 @@
 """Version information for OpenMed."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/swift/OpenMedDemo/OpenMedDemo.xcodeproj/project.pbxproj
+++ b/swift/OpenMedDemo/OpenMedDemo.xcodeproj/project.pbxproj
@@ -161,7 +161,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = life.openmed.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -194,7 +194,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = life.openmed.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";

--- a/swift/OpenMedDemo/OpenMedDemo/Info.plist
+++ b/swift/OpenMedDemo/OpenMedDemo/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.0</string>
+    <string>1.5.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>

--- a/swift/OpenMedScanDemo/OpenMedScanDemo.xcodeproj/project.pbxproj
+++ b/swift/OpenMedScanDemo/OpenMedScanDemo.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 				"@executable_path/Frameworks",
 			);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 			PRODUCT_BUNDLE_IDENTIFIER = life.openmed.scandemo;
 			PRODUCT_NAME = "$(TARGET_NAME)";
 			SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -472,7 +472,7 @@
 				"@executable_path/Frameworks",
 			);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 			PRODUCT_BUNDLE_IDENTIFIER = life.openmed.scandemo;
 			PRODUCT_NAME = "$(TARGET_NAME)";
 			SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/swift/OpenMedScanDemo/OpenMedScanDemo/Info.plist
+++ b/swift/OpenMedScanDemo/OpenMedScanDemo/Info.plist
@@ -13,7 +13,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.0</string>
+    <string>1.5.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

- Bump the Python package version to 1.5.1.
- Refresh README, docs, website, and Apple demo version surfaces.
- Add the 1.5.1 changelog entry for the tag-driven release.

## Validation

- `python3 scripts/release/check_release_version.py --version 1.5.1`
- `python3 scripts/release/check_repo_policy.py`
- `uv run pytest tests/unit/test_publish_workflow_version.py`