### PR TITLE
fix: cast bfloat16 tensors to float32 before numpy conversion in MLX pipeline

### DIFF
--- a/openmed/mlx/convert.py
+++ b/openmed/mlx/convert.py
@@ -132,7 +132,11 @@ def remap_key(key: str, model_type: str | None = None) -> str:
 
 def _to_numpy(tensor: Any) -> Any:
     if hasattr(tensor, "detach"):
-        return tensor.detach().cpu().numpy()
+        t = tensor.detach().cpu()
+        # numpy() does not support bfloat16 on CPU; cast to float32 first
+        if hasattr(t, "dtype") and str(t.dtype) == "torch.bfloat16":
+            t = t.to(float)
+        return t.numpy()
     return tensor
 
 


### PR DESCRIPTION
## Problem

When loading models with bfloat16 weights (e.g. `OpenMed/privacy-filter-nemotron`) through the MLX pipeline, conversion fails with:

```
TypeError: Got unsupported ScalarType BFloat16
```

This happens in `_to_numpy()` because PyTorch CPU does not support `.numpy()` on bfloat16 tensors.

## Fix

Cast bfloat16 tensors to float32 before calling `.numpy()`. The resulting MLX weights are stored in float32, which is fully supported on all Apple Silicon chips and incurs no meaningful accuracy loss for token classification.

## Affected models

- `OpenMed/privacy-filter-nemotron` (and any future bf16 models)

## Testing

Verified that `create_mlx_pipeline("OpenMed/privacy-filter-nemotron")` completes weight conversion successfully after this fix.