### PR TITLE
fix: add MLX weight remapping for openai_privacy_filter / nemotron architecture

### DIFF
--- a/openmed/mlx/convert.py
+++ b/openmed/mlx/convert.py
@@ -93,6 +93,16 @@ _ELECTRA_KEY_REPLACEMENTS: list[Tuple[str, str]] = [
     ("classifier.", "classifier."),
 ]
 
+_OPF_MODEL_TYPES = {
+    "openai-privacy-filter",
+    "privacy-filter",
+    "privacy-filter-nemotron",
+    "nemotron-privacy-filter",
+    "privacy-filter-multilingual",
+    "multilingual-privacy-filter",
+}
+
+
 def _convert_opf_weights(state_dict: dict) -> dict:
     """Remap and reshape HuggingFace OPF weights to the MLX namespace.
 
@@ -179,6 +189,86 @@ def _convert_opf_weights(state_dict: dict) -> dict:
     return out
 
 
+def _expected_opf_weight_shapes(config: dict[str, Any]) -> dict[str, tuple[int, ...]]:
+    """Return the MLX weight shapes expected by the OPF runtime."""
+    hidden_size = int(config["hidden_size"])
+    num_layers = int(config["num_hidden_layers"])
+    num_labels = int(config["num_labels"])
+    vocab_size = int(config["vocab_size"])
+    intermediate_size = int(config["intermediate_size"])
+    num_experts = int(config["num_experts"])
+    head_dim = int(config["head_dim"])
+    num_attention_heads = int(config["num_attention_heads"])
+    num_key_value_heads = int(config["num_key_value_heads"])
+    qkv_dim = head_dim * (num_attention_heads + 2 * num_key_value_heads)
+    attn_out_dim = head_dim * num_attention_heads
+
+    shapes: dict[str, tuple[int, ...]] = {
+        "embedding.weight": (vocab_size, hidden_size),
+        "norm.scale": (hidden_size,),
+        "unembedding.weight": (num_labels, hidden_size),
+    }
+    if bool(config.get("classifier_bias", config.get("unembedding_bias", False))):
+        shapes["unembedding.bias"] = (num_labels,)
+
+    for layer_idx in range(num_layers):
+        prefix = f"block.{layer_idx}"
+        shapes.update(
+            {
+                f"{prefix}.attn.norm.scale": (hidden_size,),
+                f"{prefix}.attn.qkv.weight": (qkv_dim, hidden_size),
+                f"{prefix}.attn.qkv.bias": (qkv_dim,),
+                f"{prefix}.attn.out.weight": (hidden_size, attn_out_dim),
+                f"{prefix}.attn.out.bias": (hidden_size,),
+                f"{prefix}.attn.sinks": (num_attention_heads,),
+                f"{prefix}.mlp.norm.scale": (hidden_size,),
+                f"{prefix}.mlp.gate.weight": (num_experts, hidden_size),
+                f"{prefix}.mlp.gate.bias": (num_experts,),
+                f"{prefix}.mlp.swiglu.weight": (
+                    num_experts,
+                    hidden_size,
+                    intermediate_size * 2,
+                ),
+                f"{prefix}.mlp.swiglu.bias": (num_experts, intermediate_size * 2),
+                f"{prefix}.mlp.out.weight": (
+                    num_experts,
+                    intermediate_size,
+                    hidden_size,
+                ),
+                f"{prefix}.mlp.out.bias": (num_experts, hidden_size),
+            }
+        )
+    return shapes
+
+
+def _validate_opf_weights(weights: dict[str, Any], config: dict[str, Any]) -> None:
+    """Fail early when OPF conversion misses keys or produces wrong shapes."""
+    expected_shapes = _expected_opf_weight_shapes(config)
+    expected_keys = set(expected_shapes)
+    actual_keys = set(weights)
+
+    missing = sorted(expected_keys - actual_keys)
+    unexpected = sorted(actual_keys - expected_keys)
+    if missing or unexpected:
+        details = []
+        if missing:
+            details.append(f"missing keys: {missing[:8]}")
+        if unexpected:
+            details.append(f"unexpected keys: {unexpected[:8]}")
+        raise ValueError("Invalid OPF MLX weight mapping (" + "; ".join(details) + ")")
+
+    bad_shapes: list[str] = []
+    for key, expected_shape in expected_shapes.items():
+        actual_shape = getattr(weights[key], "shape", None)
+        if actual_shape is not None and tuple(actual_shape) != expected_shape:
+            bad_shapes.append(f"{key}: expected {expected_shape}, got {tuple(actual_shape)}")
+
+    if bad_shapes:
+        raise ValueError(
+            "Invalid OPF MLX weight shapes: " + "; ".join(bad_shapes[:8])
+        )
+
+
 def _infer_source_model_type(key: str, model_type: str | None) -> str:
     normalized = normalize_model_type(model_type)
     if normalized is not None:
@@ -218,7 +308,12 @@ def remap_key(key: str, model_type: str | None = None) -> str:
 
 def _to_numpy(tensor: Any) -> Any:
     if hasattr(tensor, "detach"):
-        return tensor.detach().cpu().numpy()
+        t = tensor.detach().cpu()
+        # PyTorch CPU cannot expose bfloat16 tensors through numpy().
+        # Cast to float32 explicitly; ``to(float)`` would promote to float64.
+        if hasattr(t, "dtype") and str(t.dtype) == "torch.bfloat16":
+            t = t.float()
+        return t.numpy()
     return tensor
 
 
@@ -244,14 +339,20 @@ def convert_weights(
 
     source_model_type = normalize_model_type(config.model_type)
     state_dict = model.state_dict()
+    config_dict = normalize_model_config(config.to_dict())
+    config_dict["_mlx_model_type"] = resolve_model_type(config_dict)
+    config_dict["_mlx_task"] = "token-classification"
+    if config_dict.get("num_labels") is None:
+        config_dict["num_labels"] = config.num_labels
 
-    if source_model_type in {"openai-privacy-filter", "privacy-filter-nemotron", "nemotron-privacy-filter"}:
+    if source_model_type in _OPF_MODEL_TYPES:
         # OPF requires QKV fusion and weight remapping — use dedicated converter
+        if "score.bias" in state_dict:
+            config_dict["classifier_bias"] = True
         numpy_state = {k: _to_numpy(v) for k, v in state_dict.items()}
         mlx_weights = _convert_opf_weights(numpy_state)
-        _has_classifier_bias = "score.bias" in state_dict
+        _validate_opf_weights(mlx_weights, config_dict)
     else:
-        _has_classifier_bias = False
         mlx_weights = {}
         skipped = []
         for hf_key, tensor in state_dict.items():
@@ -263,12 +364,6 @@ def convert_weights(
         if skipped:
             logger.info("Skipped %d keys (pooler, etc.): %s", len(skipped), skipped[:5])
 
-    config_dict = normalize_model_config(config.to_dict())
-    config_dict["_mlx_model_type"] = resolve_model_type(config_dict)
-    config_dict["_mlx_task"] = "token-classification"
-    config_dict.setdefault("num_labels", config.num_labels)
-    if _has_classifier_bias:
-        config_dict["classifier_bias"] = True
     return mlx_weights, config_dict
 
 

--- a/openmed/mlx/convert.py
+++ b/openmed/mlx/convert.py
@@ -93,6 +93,92 @@ _ELECTRA_KEY_REPLACEMENTS: list[Tuple[str, str]] = [
     ("classifier.", "classifier."),
 ]
 
+def _convert_opf_weights(state_dict: dict) -> dict:
+    """Remap and reshape HuggingFace OPF weights to the MLX namespace.
+
+    The HF ``openai_privacy_filter`` model differs from the MLX layout in:
+
+    1. Top-level prefix: ``score.*`` → ``unembedding.*``
+    2. Layer container: ``model.layers.N.*`` → ``block.N.*``
+    3. QKV fusion: separate q/k/v_proj → single fused ``attn.qkv`` linear
+    4. Sub-key names: ``input_layernorm`` → ``attn.norm``, ``router`` → ``gate``
+    5. RMSNorm param: ``weight`` → ``scale``
+    6. Expert weight layout: HF stores as ``[E, in, out]``, same as MLX (no transpose needed)
+    """
+    import re
+    import numpy as np
+
+    out: dict[str, np.ndarray] = {}
+    # layer_idx → proj ("q"|"k"|"v") → param ("weight"|"bias") → array
+    qkv: dict[str, dict[str, dict[str, np.ndarray]]] = {}
+
+    for hf_key, arr in state_dict.items():
+        # classifier head
+        if hf_key == "score.weight":
+            out["unembedding.weight"] = arr; continue
+        if hf_key == "score.bias":
+            out["unembedding.bias"] = arr; continue
+
+        # top-level
+        if hf_key == "model.embed_tokens.weight":
+            out["embedding.weight"] = arr; continue
+        if hf_key == "model.norm.weight":
+            out["norm.scale"] = arr; continue
+
+        m = re.match(r"^model\.layers\.(\d+)\.(.*)", hf_key)
+        if m is None:
+            continue
+        n, rest = m.group(1), m.group(2)
+
+        # RMSNorms
+        if rest == "input_layernorm.weight":
+            out[f"block.{n}.attn.norm.scale"] = arr; continue
+        if rest == "post_attention_layernorm.weight":
+            out[f"block.{n}.mlp.norm.scale"] = arr; continue
+
+        # attention sinks
+        if rest == "self_attn.sinks":
+            out[f"block.{n}.attn.sinks"] = arr; continue
+
+        # output projection
+        if rest == "self_attn.o_proj.weight":
+            out[f"block.{n}.attn.out.weight"] = arr; continue
+        if rest == "self_attn.o_proj.bias":
+            out[f"block.{n}.attn.out.bias"] = arr; continue
+
+        # Q / K / V — collect for fusion
+        m2 = re.match(r"self_attn\.(q|k|v)_proj\.(weight|bias)", rest)
+        if m2:
+            proj, param = m2.group(1), m2.group(2)
+            qkv.setdefault(n, {}).setdefault(proj, {})[param] = arr
+            continue
+
+        # MLP router → gate
+        if rest == "mlp.router.weight":
+            out[f"block.{n}.mlp.gate.weight"] = arr; continue
+        if rest == "mlp.router.bias":
+            out[f"block.{n}.mlp.gate.bias"] = arr; continue
+
+        # expert weights: HF stores as [E, in_features, out_features] — same as MLX, no transpose needed
+        if rest == "mlp.experts.gate_up_proj":
+            out[f"block.{n}.mlp.swiglu.weight"] = arr; continue
+        if rest == "mlp.experts.gate_up_proj_bias":
+            out[f"block.{n}.mlp.swiglu.bias"] = arr; continue
+        if rest == "mlp.experts.down_proj":
+            out[f"block.{n}.mlp.out.weight"] = arr; continue
+        if rest == "mlp.experts.down_proj_bias":
+            out[f"block.{n}.mlp.out.bias"] = arr; continue
+
+    # fuse Q / K / V into a single QKV linear per layer
+    for n, projs in qkv.items():
+        for param in ("weight", "bias"):
+            parts = [projs[p][param] for p in ("q", "k", "v") if param in projs.get(p, {})]
+            if parts:
+                out[f"block.{n}.attn.qkv.{param}"] = np.concatenate(parts, axis=0)
+
+    return out
+
+
 def _infer_source_model_type(key: str, model_type: str | None) -> str:
     normalized = normalize_model_type(model_type)
     if normalized is not None:
@@ -158,23 +244,31 @@ def convert_weights(
 
     source_model_type = normalize_model_type(config.model_type)
     state_dict = model.state_dict()
-    mlx_weights = {}
-    skipped = []
 
-    for hf_key, tensor in state_dict.items():
-        mlx_key = remap_key(hf_key, source_model_type)
-        if mlx_key.startswith("_"):
-            skipped.append(hf_key)
-            continue
-        mlx_weights[mlx_key] = _to_numpy(tensor)
-
-    if skipped:
-        logger.info("Skipped %d keys (pooler, etc.): %s", len(skipped), skipped[:5])
+    if source_model_type in {"openai-privacy-filter", "privacy-filter-nemotron", "nemotron-privacy-filter"}:
+        # OPF requires QKV fusion and weight remapping — use dedicated converter
+        numpy_state = {k: _to_numpy(v) for k, v in state_dict.items()}
+        mlx_weights = _convert_opf_weights(numpy_state)
+        _has_classifier_bias = "score.bias" in state_dict
+    else:
+        _has_classifier_bias = False
+        mlx_weights = {}
+        skipped = []
+        for hf_key, tensor in state_dict.items():
+            mlx_key = remap_key(hf_key, source_model_type)
+            if mlx_key.startswith("_"):
+                skipped.append(hf_key)
+                continue
+            mlx_weights[mlx_key] = _to_numpy(tensor)
+        if skipped:
+            logger.info("Skipped %d keys (pooler, etc.): %s", len(skipped), skipped[:5])
 
     config_dict = normalize_model_config(config.to_dict())
     config_dict["_mlx_model_type"] = resolve_model_type(config_dict)
     config_dict["_mlx_task"] = "token-classification"
     config_dict.setdefault("num_labels", config.num_labels)
+    if _has_classifier_bias:
+        config_dict["classifier_bias"] = True
     return mlx_weights, config_dict
 
 

--- a/tests/unit/mlx/test_mlx_convert.py
+++ b/tests/unit/mlx/test_mlx_convert.py
@@ -26,6 +26,7 @@ def _module_importable(module_name: str) -> bool:
 
 _NUMPY_AVAILABLE = _module_importable("numpy")
 _SAFETENSORS_NUMPY_AVAILABLE = _module_importable("safetensors.numpy")
+_TORCH_AVAILABLE = _module_importable("torch")
 
 
 class TestWeightKeyRemapping:
@@ -153,6 +154,168 @@ class TestWeightKeyRemapping:
             assert not mlx_key.startswith("bert."), (
                 f"Key {key!r} was not remapped: {mlx_key!r}"
             )
+
+
+@pytest.mark.skipif(
+    not (_NUMPY_AVAILABLE and _TORCH_AVAILABLE),
+    reason="numpy and torch are required for BF16 conversion tests",
+)
+def test_to_numpy_casts_bfloat16_to_float32():
+    """BF16 tensors need an explicit float32 cast before numpy conversion."""
+    import numpy as np
+    import torch
+
+    from openmed.mlx.convert import _to_numpy
+
+    converted = _to_numpy(torch.tensor([1.0], dtype=torch.bfloat16))
+
+    assert converted.dtype == np.float32
+    np.testing.assert_allclose(converted, np.array([1.0], dtype=np.float32))
+
+
+def _tiny_opf_config() -> dict:
+    return {
+        "model_type": "openai_privacy_filter",
+        "num_hidden_layers": 1,
+        "num_experts": 3,
+        "experts_per_token": 2,
+        "vocab_size": 16,
+        "num_labels": 5,
+        "hidden_size": 8,
+        "intermediate_size": 4,
+        "head_dim": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "classifier_bias": True,
+    }
+
+
+def _tiny_opf_state_dict(config: dict):
+    import numpy as np
+
+    hidden = config["hidden_size"]
+    intermediate = config["intermediate_size"]
+    num_experts = config["num_experts"]
+    num_q = config["num_attention_heads"]
+    num_kv = config["num_key_value_heads"]
+    head_dim = config["head_dim"]
+    q_dim = num_q * head_dim
+    kv_dim = num_kv * head_dim
+
+    state = {
+        "model.embed_tokens.weight": np.zeros(
+            (config["vocab_size"], hidden),
+            dtype=np.float32,
+        ),
+        "model.norm.weight": np.ones((hidden,), dtype=np.float32),
+        "score.weight": np.zeros((config["num_labels"], hidden), dtype=np.float32),
+        "score.bias": np.zeros((config["num_labels"],), dtype=np.float32),
+    }
+
+    prefix = "model.layers.0"
+    state.update(
+        {
+            f"{prefix}.input_layernorm.weight": np.ones((hidden,), dtype=np.float32),
+            f"{prefix}.post_attention_layernorm.weight": np.ones(
+                (hidden,),
+                dtype=np.float32,
+            ),
+            f"{prefix}.self_attn.q_proj.weight": np.full(
+                (q_dim, hidden),
+                1.0,
+                dtype=np.float32,
+            ),
+            f"{prefix}.self_attn.k_proj.weight": np.full(
+                (kv_dim, hidden),
+                2.0,
+                dtype=np.float32,
+            ),
+            f"{prefix}.self_attn.v_proj.weight": np.full(
+                (kv_dim, hidden),
+                3.0,
+                dtype=np.float32,
+            ),
+            f"{prefix}.self_attn.q_proj.bias": np.full(
+                (q_dim,),
+                1.0,
+                dtype=np.float32,
+            ),
+            f"{prefix}.self_attn.k_proj.bias": np.full(
+                (kv_dim,),
+                2.0,
+                dtype=np.float32,
+            ),
+            f"{prefix}.self_attn.v_proj.bias": np.full(
+                (kv_dim,),
+                3.0,
+                dtype=np.float32,
+            ),
+            f"{prefix}.self_attn.o_proj.weight": np.zeros(
+                (hidden, q_dim),
+                dtype=np.float32,
+            ),
+            f"{prefix}.self_attn.o_proj.bias": np.zeros((hidden,), dtype=np.float32),
+            f"{prefix}.self_attn.sinks": np.zeros((num_q,), dtype=np.float32),
+            f"{prefix}.mlp.router.weight": np.zeros(
+                (num_experts, hidden),
+                dtype=np.float32,
+            ),
+            f"{prefix}.mlp.router.bias": np.zeros((num_experts,), dtype=np.float32),
+            f"{prefix}.mlp.experts.gate_up_proj": np.zeros(
+                (num_experts, hidden, intermediate * 2),
+                dtype=np.float32,
+            ),
+            f"{prefix}.mlp.experts.gate_up_proj_bias": np.zeros(
+                (num_experts, intermediate * 2),
+                dtype=np.float32,
+            ),
+            f"{prefix}.mlp.experts.down_proj": np.zeros(
+                (num_experts, intermediate, hidden),
+                dtype=np.float32,
+            ),
+            f"{prefix}.mlp.experts.down_proj_bias": np.zeros(
+                (num_experts, hidden),
+                dtype=np.float32,
+            ),
+        }
+    )
+    return state
+
+
+@pytest.mark.skipif(not _NUMPY_AVAILABLE, reason="numpy is required for OPF tests")
+def test_opf_converter_remaps_and_validates_hf_layout():
+    import numpy as np
+
+    from openmed.mlx.convert import _convert_opf_weights, _validate_opf_weights
+
+    config = _tiny_opf_config()
+    converted = _convert_opf_weights(_tiny_opf_state_dict(config))
+    _validate_opf_weights(converted, config)
+
+    q_dim = config["num_attention_heads"] * config["head_dim"]
+    kv_dim = config["num_key_value_heads"] * config["head_dim"]
+    qkv_weight = converted["block.0.attn.qkv.weight"]
+
+    assert "unembedding.bias" in converted
+    assert "model.layers.0.self_attn.q_proj.weight" not in converted
+    assert qkv_weight.shape == (q_dim + 2 * kv_dim, config["hidden_size"])
+    np.testing.assert_array_equal(qkv_weight[:q_dim], 1.0)
+    np.testing.assert_array_equal(qkv_weight[q_dim : q_dim + kv_dim], 2.0)
+    np.testing.assert_array_equal(qkv_weight[q_dim + kv_dim :], 3.0)
+
+
+@pytest.mark.skipif(not _NUMPY_AVAILABLE, reason="numpy is required for OPF tests")
+def test_opf_validation_rejects_partial_qkv_fusion():
+    from openmed.mlx.convert import _convert_opf_weights, _validate_opf_weights
+
+    config = _tiny_opf_config()
+    state = _tiny_opf_state_dict(config)
+    del state["model.layers.0.self_attn.v_proj.bias"]
+
+    converted = _convert_opf_weights(state)
+
+    with pytest.raises(ValueError, match="Invalid OPF MLX weight shapes"):
+        _validate_opf_weights(converted, config)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Problem

The `openai_privacy_filter` model family (e.g. `OpenMed/privacy-filter-nemotron`) cannot be loaded via `create_mlx_pipeline` because its HuggingFace weight namespace does not match the MLX model's namespace. All 140 parameters are rejected with `ValueError: Received 140 parameters not in model`.

## Root cause

The existing `remap_key()` function handles BERT/RoBERTa/DeBERTa/DistilBERT/ELECTRA architectures but has no case for `openai_privacy_filter`. The OPF architecture differs from all others:
- Different top-level prefix (`score.*` → `unembedding.*`)
- Different layer container (`model.layers.N.*` → `block.N.*`)
- QKV fusion: HF has separate `q/k/v_proj`, MLX has single `attn.qkv`
- Different sub-key names (`input_layernorm` → `attn.norm`, `router` → `gate`)
- RMSNorm uses `scale` not `weight`
- Expert weights already in `[E, in, out]` format (no transpose needed)

## Fix

Add `_convert_opf_weights()` and wire into `convert_weights()` for model types `openai-privacy-filter`, `privacy-filter-nemotron`, `nemotron-privacy-filter`. Also set `classifier_bias: True` in the MLX config when `score.bias` is present.

## Testing

Verified on `OpenMed/privacy-filter-nemotron` — model now loads and runs inference correctly:
```python
pipe = create_mlx_pipeline("OpenMed/privacy-filter-nemotron")
result = pipe("Patient John Smith DOB 01/01/1980")
# Returns: first_name=John, last_name=Smith, date=01/01/1980
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)