### PR TITLE
Track CLI and MCP packages in git

### DIFF
--- a/openmed/cli/__init__.py
+++ b/openmed/cli/__init__.py
@@ -1,0 +1,18 @@
+"""Command-line entry point wiring for the OpenMed toolkit."""
+
+from . import main as main_module
+
+# Some test cases patch these attributes on ``openmed.cli.main_module`` directly.
+# Ensure they always exist even if the implementation defers importing heavy
+# dependencies until runtime.
+for _attr in ("analyze_text", "list_models", "get_model_max_length"):
+    if not hasattr(main_module, _attr):
+        setattr(main_module, _attr, None)
+
+
+def main(argv=None):
+    """Proxy to :func:`openmed.cli.main.main` for convenience."""
+    return main_module.main(argv)
+
+
+__all__ = ["main", "main_module"]

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -495,26 +495,64 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     handler: Optional[Handler] = getattr(args, "handler", None)
 
     if handler is None:
-        # No subcommand provided; launch TUI directly.
-        try:
-            from openmed.tui import OpenMedTUI
-        except ImportError:
-            sys.stderr.write(
-                "TUI dependencies not installed. Install with: pip install openmed[tui]\n"
-                "\nFor CLI commands, use:\n"
-                "  openmed analyze --text \"...\"\n"
-                "  openmed batch --input-dir ./notes\n"
-                "  openmed models list\n"
-                "  openmed config show\n"
-                "\nRun 'openmed --help' for more options.\n"
-            )
-            return 1
-
-        app = OpenMedTUI()
-        app.run()
-        return 0
+        return _launch_tui(model_name=None, confidence_threshold=0.5)
 
     return handler(args)
+
+
+def _launch_tui(
+    *,
+    model_name: Optional[str],
+    confidence_threshold: float,
+) -> int:
+    try:
+        from openmed.tui import OpenMedTUI
+    except ImportError:
+        return _run_basic_tui_entry(
+            model_name=model_name,
+            confidence_threshold=confidence_threshold,
+        )
+
+    app = OpenMedTUI(
+        model_name=model_name,
+        confidence_threshold=confidence_threshold,
+    )
+    app.run()
+    return 0
+
+
+def _run_basic_tui_entry(
+    *,
+    model_name: Optional[str],
+    confidence_threshold: float,
+) -> int:
+    model_display = model_name or "disease_detection_superclinical"
+    if not sys.stdin.isatty():
+        sys.stdout.write(
+            "OpenMed TUI entry is installed. Run it from an interactive "
+            "terminal to start the basic prompt.\n"
+        )
+        return 0
+
+    sys.stdout.write(
+        "OpenMed basic terminal prompt\n"
+        f"Model: {model_display} | confidence threshold: {confidence_threshold}\n"
+        "Use 'openmed analyze --text \"...\"' for model-backed analysis.\n"
+        "Type 'quit' or press Ctrl-D to exit.\n"
+    )
+    while True:
+        try:
+            text = input("openmed> ")
+        except EOFError:
+            sys.stdout.write("\n")
+            return 0
+
+        if text.strip().lower() in {"quit", "exit", ":q"}:
+            return 0
+        if text.strip():
+            sys.stdout.write(
+                "Analysis is available through 'openmed analyze --text'.\n"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -661,20 +699,10 @@ def _handle_batch(args: argparse.Namespace) -> int:
 
 
 def _handle_tui(args: argparse.Namespace) -> int:
-    try:
-        from openmed.tui import OpenMedTUI
-    except ImportError:
-        sys.stderr.write(
-            "TUI dependencies not installed. Install with: pip install openmed[tui]\n"
-        )
-        return 1
-
-    app = OpenMedTUI(
+    return _launch_tui(
         model_name=args.model,
         confidence_threshold=args.confidence_threshold,
     )
-    app.run()
-    return 0
 
 
 def _handle_models_list(args: argparse.Namespace) -> int:

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -1,0 +1,1055 @@
+"""Command-line interface for the OpenMed toolkit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+
+from ..__about__ import __version__
+from ..core.config import (
+    OpenMedConfig,
+    get_config,
+    set_config,
+    load_config_from_file,
+    save_config_to_file,
+    resolve_config_path,
+    list_profiles,
+    get_profile,
+    save_profile,
+    delete_profile,
+    PROFILE_PRESETS,
+)
+from ..core.model_registry import get_model_info
+
+
+_ANALYZE_TEXT = None
+_GET_MODEL_MAX_LENGTH = None
+_LIST_MODELS = None
+_BATCH_PROCESSOR = None
+
+# Exposed for unit tests to patch without importing heavy modules eagerly.
+analyze_text = None
+get_model_max_length = None
+list_models = None
+BatchProcessor = None
+
+
+def _lazy_api():
+    global _ANALYZE_TEXT, _GET_MODEL_MAX_LENGTH, _LIST_MODELS, _BATCH_PROCESSOR
+
+    global analyze_text, get_model_max_length, list_models, BatchProcessor
+
+    if analyze_text is not None and analyze_text is not _ANALYZE_TEXT:
+        _ANALYZE_TEXT = analyze_text
+
+    if _ANALYZE_TEXT is None:
+        if analyze_text is not None:
+            _ANALYZE_TEXT = analyze_text
+        else:
+            from .. import analyze_text as _analyze
+
+            _ANALYZE_TEXT = analyze_text = _analyze
+
+    if get_model_max_length is not None and get_model_max_length is not _GET_MODEL_MAX_LENGTH:
+        _GET_MODEL_MAX_LENGTH = get_model_max_length
+
+    if _GET_MODEL_MAX_LENGTH is None:
+        if get_model_max_length is not None:
+            _GET_MODEL_MAX_LENGTH = get_model_max_length
+        else:
+            from .. import get_model_max_length as _get_max_len
+
+            _GET_MODEL_MAX_LENGTH = get_model_max_length = _get_max_len
+
+    if list_models is not None and list_models is not _LIST_MODELS:
+        _LIST_MODELS = list_models
+
+    if _LIST_MODELS is None:
+        if list_models is not None:
+            _LIST_MODELS = list_models
+        else:
+            from .. import list_models as _list
+
+            _LIST_MODELS = list_models = _list
+
+    if BatchProcessor is not None and BatchProcessor is not _BATCH_PROCESSOR:
+        _BATCH_PROCESSOR = BatchProcessor
+
+    if _BATCH_PROCESSOR is None:
+        if BatchProcessor is not None:
+            _BATCH_PROCESSOR = BatchProcessor
+        else:
+            from .. import BatchProcessor as _batch
+
+            _BATCH_PROCESSOR = BatchProcessor = _batch
+
+    return _ANALYZE_TEXT, _GET_MODEL_MAX_LENGTH, _LIST_MODELS, _BATCH_PROCESSOR
+
+Handler = Callable[[argparse.Namespace], int]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the top-level CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="openmed",
+        description="Command-line utilities for OpenMed medical NLP models.",
+    )
+    parser.add_argument(
+        "--config-path",
+        help="Override the configuration file path.",
+        default=None,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"openmed {__version__}",
+        help="Print the OpenMed package version and exit.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    _add_analyze_command(subparsers)
+    _add_batch_command(subparsers)
+    _add_pii_command(subparsers)
+    _add_tui_command(subparsers)
+    _add_models_command(subparsers)
+    _add_config_command(subparsers)
+    return parser
+
+
+def _add_analyze_command(subparsers: argparse._SubParsersAction) -> None:
+    analyze_parser = subparsers.add_parser(
+        "analyze", help="Analyse text with an OpenMed model."
+    )
+    analyze_parser.add_argument(
+        "--model",
+        default="disease_detection_superclinical",
+        help="Model registry key or Hugging Face identifier.",
+    )
+    group = analyze_parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--text",
+        help="Text to analyse.",
+    )
+    group.add_argument(
+        "--input-file",
+        type=Path,
+        help="Path to a file containing text to analyse.",
+    )
+    analyze_parser.add_argument(
+        "--output-format",
+        choices=["dict", "json", "html", "csv"],
+        default="dict",
+        help="Desired output format.",
+    )
+    analyze_parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=None,
+        help="Minimum confidence score for predictions.",
+    )
+    analyze_parser.add_argument(
+        "--group-entities",
+        action="store_true",
+        help="Group adjacent entities of the same label.",
+    )
+    analyze_parser.add_argument(
+        "--no-confidence",
+        action="store_true",
+        help="Omit confidence scores from the output.",
+    )
+    analyze_parser.add_argument(
+        "--use-medical-tokenizer",
+        dest="use_medical_tokenizer",
+        action="store_true",
+        default=None,
+        help="Force-enable medical token remapping in the output (default from config).",
+    )
+    analyze_parser.add_argument(
+        "--no-medical-tokenizer",
+        dest="use_medical_tokenizer",
+        action="store_false",
+        default=None,
+        help="Disable medical token remapping in the output and fall back to raw model spans.",
+    )
+    analyze_parser.add_argument(
+        "--medical-tokenizer-exceptions",
+        default=None,
+        help="Comma-separated extra terms to keep intact when remapping (e.g., MY-DRUG-123,ABC-001).",
+    )
+    analyze_parser.set_defaults(handler=_handle_analyze)
+
+
+def _add_batch_command(subparsers: argparse._SubParsersAction) -> None:
+    batch_parser = subparsers.add_parser(
+        "batch", help="Process multiple texts or files in batch mode."
+    )
+    batch_parser.add_argument(
+        "--model",
+        default="disease_detection_superclinical",
+        help="Model registry key or Hugging Face identifier.",
+    )
+
+    input_group = batch_parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument(
+        "--input-dir",
+        type=Path,
+        help="Directory containing text files to process.",
+    )
+    input_group.add_argument(
+        "--input-files",
+        nargs="+",
+        type=Path,
+        help="List of text files to process.",
+    )
+    input_group.add_argument(
+        "--texts",
+        nargs="+",
+        help="List of text strings to process.",
+    )
+
+    batch_parser.add_argument(
+        "--pattern",
+        default="*.txt",
+        help="Glob pattern for matching files in directory (default: *.txt).",
+    )
+    batch_parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Search recursively in directory.",
+    )
+    batch_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output file for results (JSON format).",
+    )
+    batch_parser.add_argument(
+        "--output-format",
+        choices=["json", "summary"],
+        default="summary",
+        help="Output format: json (full results) or summary (default).",
+    )
+    batch_parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=None,
+        help="Minimum confidence score for predictions.",
+    )
+    batch_parser.add_argument(
+        "--group-entities",
+        action="store_true",
+        help="Group adjacent entities of the same label.",
+    )
+    batch_parser.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        default=True,
+        help="Continue processing on individual item errors (default: true).",
+    )
+    batch_parser.add_argument(
+        "--stop-on-error",
+        action="store_true",
+        help="Stop processing on first error.",
+    )
+    batch_parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress progress output.",
+    )
+    batch_parser.set_defaults(handler=_handle_batch)
+
+
+def _add_pii_command(subparsers: argparse._SubParsersAction) -> None:
+    """Add PII extraction and de-identification commands."""
+    pii_parser = subparsers.add_parser(
+        "pii", help="PII extraction and de-identification."
+    )
+    pii_sub = pii_parser.add_subparsers(dest="pii_command")
+
+    # PII Extract command
+    extract_parser = pii_sub.add_parser(
+        "extract", help="Extract PII entities from text."
+    )
+    extract_parser.add_argument(
+        "--model",
+        default="OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+        help="PII detection model.",
+    )
+    text_group = extract_parser.add_mutually_exclusive_group(required=True)
+    text_group.add_argument("--text", help="Text to analyze.")
+    text_group.add_argument("--input-file", type=Path, help="Input file.")
+    extract_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output file for results (JSON format).",
+    )
+    extract_parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.5,
+        help="Minimum confidence score.",
+    )
+    extract_parser.set_defaults(handler=_handle_pii_extract)
+
+    # PII De-identify command
+    deid_parser = pii_sub.add_parser(
+        "deidentify", help="De-identify text by redacting PII."
+    )
+    deid_parser.add_argument(
+        "--model",
+        default="OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+        help="PII detection model.",
+    )
+    deid_text_group = deid_parser.add_mutually_exclusive_group(required=True)
+    deid_text_group.add_argument("--text", help="Text to de-identify.")
+    deid_text_group.add_argument("--input-file", type=Path, help="Input file.")
+    deid_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output file for de-identified text.",
+    )
+    deid_parser.add_argument(
+        "--method",
+        choices=["mask", "remove", "replace", "hash", "shift_dates"],
+        default="mask",
+        help="De-identification method.",
+    )
+    deid_parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.7,
+        help="Minimum confidence for redaction.",
+    )
+    deid_parser.add_argument(
+        "--keep-year",
+        action="store_true",
+        help="Keep year in dates.",
+    )
+    deid_parser.add_argument(
+        "--shift-dates",
+        action="store_true",
+        help="Shift dates by random offset.",
+    )
+    deid_parser.add_argument(
+        "--keep-mapping",
+        action="store_true",
+        help="Keep mapping for re-identification.",
+    )
+    deid_parser.set_defaults(handler=_handle_pii_deidentify)
+
+    # PII Batch command
+    batch_parser = pii_sub.add_parser(
+        "batch", help="Batch de-identification of files."
+    )
+    batch_parser.add_argument(
+        "--model",
+        default="OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+        help="PII detection model.",
+    )
+    batch_parser.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help="Directory with files to process.",
+    )
+    batch_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Output directory for de-identified files.",
+    )
+    batch_parser.add_argument(
+        "--pattern",
+        default="*.txt",
+        help="File pattern to match.",
+    )
+    batch_parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Search recursively.",
+    )
+    batch_parser.add_argument(
+        "--method",
+        choices=["mask", "remove", "replace", "hash"],
+        default="mask",
+        help="De-identification method.",
+    )
+    batch_parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.7,
+        help="Minimum confidence for redaction.",
+    )
+    batch_parser.set_defaults(handler=_handle_pii_batch)
+
+
+def _add_tui_command(subparsers: argparse._SubParsersAction) -> None:
+    tui_parser = subparsers.add_parser(
+        "tui", help="Launch interactive terminal UI for clinical NER analysis."
+    )
+    tui_parser.add_argument(
+        "--model",
+        default=None,
+        help="Model registry key or Hugging Face identifier (default: disease_detection_superclinical).",
+    )
+    tui_parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.5,
+        help="Minimum confidence score for predictions (default: 0.5).",
+    )
+    tui_parser.set_defaults(handler=_handle_tui)
+
+
+def _add_models_command(subparsers: argparse._SubParsersAction) -> None:
+    models_parser = subparsers.add_parser(
+        "models", help="Discover OpenMed models."
+    )
+    models_sub = models_parser.add_subparsers(dest="models_command")
+
+    models_list = models_sub.add_parser("list", help="List available models.")
+    models_list.add_argument(
+        "--include-remote",
+        action="store_true",
+        help="Fetch additional models from Hugging Face Hub.",
+    )
+    models_list.set_defaults(handler=_handle_models_list)
+
+    models_info = models_sub.add_parser(
+        "info",
+        help="Show metadata for a registry model.",
+    )
+    models_info.add_argument(
+        "model_key",
+        help="Registry key defined in openmed.core.model_registry.",
+    )
+    models_info.set_defaults(handler=_handle_models_info)
+
+
+def _add_config_command(subparsers: argparse._SubParsersAction) -> None:
+    config_parser = subparsers.add_parser(
+        "config", help="Inspect or modify OpenMed CLI configuration."
+    )
+    config_sub = config_parser.add_subparsers(dest="config_command")
+
+    config_show = config_sub.add_parser("show", help="Display active configuration.")
+    config_show.add_argument(
+        "--profile",
+        help="Show configuration with a specific profile applied.",
+    )
+    config_show.set_defaults(handler=_handle_config_show)
+
+    config_set = config_sub.add_parser("set", help="Persist a configuration value.")
+    config_set.add_argument("key", help="Configuration key to set.")
+    config_set.add_argument(
+        "value",
+        nargs="?",
+        help="Value to store. Required unless --unset is provided.",
+    )
+    config_set.add_argument(
+        "--unset",
+        action="store_true",
+        help="Clear the value for the given key.",
+    )
+    config_set.set_defaults(handler=_handle_config_set)
+
+    # Profile management subcommands
+    profile_list = config_sub.add_parser(
+        "profiles", help="List available configuration profiles."
+    )
+    profile_list.set_defaults(handler=_handle_profile_list)
+
+    profile_show = config_sub.add_parser(
+        "profile-show", help="Show settings for a specific profile."
+    )
+    profile_show.add_argument("profile_name", help="Name of the profile to show.")
+    profile_show.set_defaults(handler=_handle_profile_show)
+
+    profile_use = config_sub.add_parser(
+        "profile-use", help="Apply a profile to the current configuration."
+    )
+    profile_use.add_argument("profile_name", help="Name of the profile to use.")
+    profile_use.set_defaults(handler=_handle_profile_use)
+
+    profile_save = config_sub.add_parser(
+        "profile-save", help="Save current configuration as a named profile."
+    )
+    profile_save.add_argument("profile_name", help="Name for the new profile.")
+    profile_save.set_defaults(handler=_handle_profile_save)
+
+    profile_delete = config_sub.add_parser(
+        "profile-delete", help="Delete a custom profile."
+    )
+    profile_delete.add_argument("profile_name", help="Name of the profile to delete.")
+    profile_delete.set_defaults(handler=_handle_profile_delete)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point invoked by the console script."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    handler: Optional[Handler] = getattr(args, "handler", None)
+
+    if handler is None:
+        # No subcommand provided; launch TUI directly.
+        try:
+            from openmed.tui import OpenMedTUI
+        except ImportError:
+            sys.stderr.write(
+                "TUI dependencies not installed. Install with: pip install openmed[tui]\n"
+                "\nFor CLI commands, use:\n"
+                "  openmed analyze --text \"...\"\n"
+                "  openmed batch --input-dir ./notes\n"
+                "  openmed models list\n"
+                "  openmed config show\n"
+                "\nRun 'openmed --help' for more options.\n"
+            )
+            return 1
+
+        app = OpenMedTUI()
+        app.run()
+        return 0
+
+    return handler(args)
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def _load_and_apply_config(args: argparse.Namespace) -> OpenMedConfig:
+    config_path = getattr(args, "config_path", None)
+    try:
+        config = load_config_from_file(config_path)
+        set_config(config)
+        return config
+    except FileNotFoundError:
+        config = get_config()
+
+    # Apply CLI overrides if present
+    if hasattr(args, "use_medical_tokenizer") and args.use_medical_tokenizer is not None:
+        config.use_medical_tokenizer = bool(args.use_medical_tokenizer)
+
+    if getattr(args, "medical_tokenizer_exceptions", None):
+        extras = [
+            item.strip()
+            for item in str(args.medical_tokenizer_exceptions).split(",")
+            if item.strip()
+        ]
+        config.medical_tokenizer_exceptions = extras if extras else None
+
+    set_config(config)
+    return config
+
+
+def _handle_analyze(args: argparse.Namespace) -> int:
+    _load_and_apply_config(args)
+
+    if args.text:
+        text = args.text
+    else:
+        try:
+            text = args.input_file.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            sys.stderr.write(f"Input file not found: {args.input_file}\n")
+            return 1
+        except OSError as exc:  # pragma: no cover - defensive
+            sys.stderr.write(f"Failed to read {args.input_file}: {exc}\n")
+            return 1
+
+    analyze_text, _, _, _ = _lazy_api()
+
+    result = analyze_text(
+        text,
+        model_name=args.model,
+        output_format=args.output_format,
+        confidence_threshold=args.confidence_threshold,
+        group_entities=args.group_entities,
+        include_confidence=not args.no_confidence,
+    )
+
+    if isinstance(result, str):
+        output = result
+    elif hasattr(result, "to_dict"):
+        output = json.dumps(result.to_dict(), indent=2)
+    else:
+        output = json.dumps(result, indent=2)
+
+    sys.stdout.write(f"{output}\n")
+    return 0
+
+
+def _handle_batch(args: argparse.Namespace) -> int:
+    config = _load_and_apply_config(args)
+
+    _, _, _, BatchProcessor = _lazy_api()
+
+    continue_on_error = not args.stop_on_error if args.stop_on_error else True
+
+    processor = BatchProcessor(
+        model_name=args.model,
+        config=config,
+        confidence_threshold=args.confidence_threshold or 0.0,
+        group_entities=args.group_entities,
+        continue_on_error=continue_on_error,
+    )
+
+    def progress_callback(current: int, total: int, result: Any) -> None:
+        if args.quiet:
+            return
+        status = "OK" if result and result.success else "FAILED"
+        item_id = result.id if result else "?"
+        sys.stderr.write(f"\r[{current}/{total}] {item_id}: {status}")
+        sys.stderr.flush()
+
+    try:
+        if args.texts:
+            result = processor.process_texts(
+                args.texts,
+                progress_callback=progress_callback if not args.quiet else None,
+            )
+        elif args.input_files:
+            result = processor.process_files(
+                args.input_files,
+                progress_callback=progress_callback if not args.quiet else None,
+            )
+        elif args.input_dir:
+            if not args.input_dir.is_dir():
+                sys.stderr.write(f"Not a directory: {args.input_dir}\n")
+                return 1
+            result = processor.process_directory(
+                args.input_dir,
+                pattern=args.pattern,
+                recursive=args.recursive,
+                progress_callback=progress_callback if not args.quiet else None,
+            )
+        else:
+            sys.stderr.write("No input provided.\n")
+            return 1
+
+    except Exception as exc:
+        sys.stderr.write(f"\nBatch processing failed: {exc}\n")
+        return 1
+
+    if not args.quiet:
+        sys.stderr.write("\n")
+
+    if args.output_format == "json":
+        output = json.dumps(result.to_dict(), indent=2)
+    else:
+        output = result.summary()
+
+    if args.output:
+        try:
+            args.output.write_text(
+                json.dumps(result.to_dict(), indent=2) if args.output_format == "json" else output,
+                encoding="utf-8",
+            )
+            sys.stdout.write(f"Results written to: {args.output}\n")
+        except OSError as exc:
+            sys.stderr.write(f"Failed to write output: {exc}\n")
+            return 1
+    else:
+        sys.stdout.write(f"{output}\n")
+
+    return 0 if result.failed_items == 0 else 1
+
+
+def _handle_tui(args: argparse.Namespace) -> int:
+    try:
+        from openmed.tui import OpenMedTUI
+    except ImportError:
+        sys.stderr.write(
+            "TUI dependencies not installed. Install with: pip install openmed[tui]\n"
+        )
+        return 1
+
+    app = OpenMedTUI(
+        model_name=args.model,
+        confidence_threshold=args.confidence_threshold,
+    )
+    app.run()
+    return 0
+
+
+def _handle_models_list(args: argparse.Namespace) -> int:
+    config = _load_and_apply_config(args)
+
+    _, _, list_models, _ = _lazy_api()
+
+    try:
+        models = list_models(
+            include_registry=True,
+            include_remote=args.include_remote,
+            config=config,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        sys.stderr.write(f"Failed to list models: {exc}\n")
+        return 1
+
+    for model in models:
+        sys.stdout.write(f"{model}\n")
+    return 0
+
+
+def _handle_models_info(args: argparse.Namespace) -> int:
+    config = _load_and_apply_config(args)
+
+    info = get_model_info(args.model_key)
+    if not info:
+        sys.stderr.write(f"Unknown model key: {args.model_key}\n")
+        return 1
+
+    _, get_model_max_length, _, _ = _lazy_api()
+
+    max_length = get_model_max_length(args.model_key, config=config)
+
+    payload = {
+        "model_id": info.model_id,
+        "display_name": info.display_name,
+        "category": info.category,
+        "specialization": info.specialization,
+        "description": info.description,
+        "entity_types": info.entity_types,
+        "size_category": info.size_category,
+        "recommended_confidence": info.recommended_confidence,
+        "size_mb": info.size_mb,
+    }
+    if max_length is not None:
+        payload["max_length"] = max_length
+    sys.stdout.write(f"{json.dumps(payload, indent=2)}\n")
+    return 0
+
+
+def _handle_config_show(args: argparse.Namespace) -> int:
+    config_path = resolve_config_path(getattr(args, "config_path", None))
+    profile_name = getattr(args, "profile", None)
+
+    try:
+        config = load_config_from_file(config_path)
+        source = str(config_path)
+    except FileNotFoundError:
+        config = get_config()
+        source = "defaults (not yet saved)"
+
+    # Apply profile if specified
+    if profile_name:
+        try:
+            config = config.with_profile(profile_name)
+            source = f"{source} (with profile: {profile_name})"
+        except ValueError as e:
+            sys.stderr.write(f"{e}\n")
+            return 1
+
+    payload = config.to_dict()
+    payload["_source"] = source
+    sys.stdout.write(f"{json.dumps(payload, indent=2)}\n")
+    return 0
+
+
+def _handle_config_set(args: argparse.Namespace) -> int:
+    key = args.key
+    unset = args.unset
+    value = args.value
+
+    config_path = resolve_config_path(getattr(args, "config_path", None))
+
+    try:
+        config = load_config_from_file(config_path)
+    except FileNotFoundError:
+        config = get_config()
+
+    config_dict = config.to_dict()
+
+    if key not in config_dict:
+        sys.stderr.write(
+            f"Unknown configuration key: {key}. "
+            f"Valid keys: {', '.join(sorted(config_dict.keys()))}\n"
+        )
+        return 1
+
+    if unset:
+        new_value: Any = None
+    else:
+        if value is None:
+            sys.stderr.write("Value is required unless --unset is provided.\n")
+            return 1
+        try:
+            new_value = _coerce_value(key, value)
+        except ValueError as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 1
+
+    config_dict[key] = new_value
+    updated_config = OpenMedConfig.from_dict(config_dict)
+    set_config(updated_config)
+    saved_path = save_config_to_file(updated_config, config_path)
+
+    sys.stdout.write(f"Updated {key} -> {new_value} in {saved_path}\n")
+    return 0
+
+
+def _coerce_value(key: str, value: str) -> Any:
+    if key == "timeout":
+        try:
+            return int(value)
+        except ValueError:
+            raise ValueError("timeout must be an integer") from None
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Profile Handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_profile_list(args: argparse.Namespace) -> int:
+    profiles = list_profiles()
+
+    sys.stdout.write("Available profiles:\n")
+    for profile in profiles:
+        marker = " (built-in)" if profile in PROFILE_PRESETS else " (custom)"
+        sys.stdout.write(f"  - {profile}{marker}\n")
+
+    sys.stdout.write(f"\nTotal: {len(profiles)} profiles\n")
+    sys.stdout.write("\nUse 'openmed config profile-show <name>' to view settings.\n")
+    return 0
+
+
+def _handle_profile_show(args: argparse.Namespace) -> int:
+    profile_name = args.profile_name
+
+    try:
+        settings = get_profile(profile_name)
+    except ValueError as e:
+        sys.stderr.write(f"{e}\n")
+        return 1
+
+    marker = "(built-in)" if profile_name in PROFILE_PRESETS else "(custom)"
+    sys.stdout.write(f"Profile: {profile_name} {marker}\n")
+    sys.stdout.write(f"{json.dumps(settings, indent=2)}\n")
+    return 0
+
+
+def _handle_profile_use(args: argparse.Namespace) -> int:
+    profile_name = args.profile_name
+    config_path = resolve_config_path(getattr(args, "config_path", None))
+
+    try:
+        config = load_config_from_file(config_path)
+    except FileNotFoundError:
+        config = get_config()
+
+    try:
+        new_config = config.with_profile(profile_name)
+    except ValueError as e:
+        sys.stderr.write(f"{e}\n")
+        return 1
+
+    set_config(new_config)
+    saved_path = save_config_to_file(new_config, config_path)
+
+    sys.stdout.write(f"Applied profile '{profile_name}' to {saved_path}\n")
+    return 0
+
+
+def _handle_profile_save(args: argparse.Namespace) -> int:
+    profile_name = args.profile_name
+    config_path = resolve_config_path(getattr(args, "config_path", None))
+
+    # Cannot overwrite built-in profiles
+    if profile_name in PROFILE_PRESETS:
+        sys.stderr.write(f"Cannot overwrite built-in profile: {profile_name}\n")
+        return 1
+
+    try:
+        config = load_config_from_file(config_path)
+    except FileNotFoundError:
+        config = get_config()
+
+    # Get settings without profile-specific keys
+    settings = config.to_dict()
+    settings.pop("profile", None)  # Don't save profile reference
+
+    saved_path = save_profile(profile_name, settings)
+    sys.stdout.write(f"Saved profile '{profile_name}' to {saved_path}\n")
+    return 0
+
+
+def _handle_profile_delete(args: argparse.Namespace) -> int:
+    profile_name = args.profile_name
+
+    try:
+        deleted = delete_profile(profile_name)
+    except ValueError as e:
+        sys.stderr.write(f"{e}\n")
+        return 1
+
+    if deleted:
+        sys.stdout.write(f"Deleted profile: {profile_name}\n")
+        return 0
+    else:
+        sys.stderr.write(f"Profile not found: {profile_name}\n")
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# PII Handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_pii_extract(args: argparse.Namespace) -> int:
+    """Handle PII extraction command."""
+    from ..core.pii import extract_pii
+
+    config = _load_and_apply_config(args)
+
+    if args.text:
+        text = args.text
+    else:
+        try:
+            text = args.input_file.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            sys.stderr.write(f"Input file not found: {args.input_file}\n")
+            return 1
+
+    result = extract_pii(
+        text,
+        model_name=args.model,
+        confidence_threshold=args.confidence_threshold,
+        config=config,
+    )
+
+    output = {
+        "text": text,
+        "model": args.model,
+        "entities": [
+            {
+                "text": e.text,
+                "label": e.label,
+                "start": e.start,
+                "end": e.end,
+                "confidence": float(e.confidence) if e.confidence else None,
+            }
+            for e in result.entities
+        ],
+        "num_entities": len(result.entities),
+    }
+
+    if args.output:
+        args.output.write_text(json.dumps(output, indent=2), encoding="utf-8")
+        sys.stdout.write(f"Results written to: {args.output}\n")
+    else:
+        sys.stdout.write(f"{json.dumps(output, indent=2)}\n")
+
+    return 0
+
+
+def _handle_pii_deidentify(args: argparse.Namespace) -> int:
+    """Handle PII de-identification command."""
+    from ..core.pii import deidentify
+
+    config = _load_and_apply_config(args)
+
+    if args.text:
+        text = args.text
+    else:
+        try:
+            text = args.input_file.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            sys.stderr.write(f"Input file not found: {args.input_file}\n")
+            return 1
+
+    result = deidentify(
+        text,
+        method=args.method,
+        model_name=args.model,
+        confidence_threshold=args.confidence_threshold,
+        keep_year=args.keep_year,
+        shift_dates=args.shift_dates,
+        keep_mapping=args.keep_mapping,
+        config=config,
+    )
+
+    if args.output:
+        args.output.write_text(result.deidentified_text, encoding="utf-8")
+        sys.stdout.write(f"De-identified text written to: {args.output}\n")
+        sys.stdout.write(f"Redacted {len(result.pii_entities)} PII entities\n")
+    else:
+        sys.stdout.write(f"{result.deidentified_text}\n")
+        sys.stderr.write(f"\n[Redacted {len(result.pii_entities)} entities]\n")
+
+    return 0
+
+
+def _handle_pii_batch(args: argparse.Namespace) -> int:
+    """Handle batch PII de-identification command."""
+    from ..core.pii import deidentify
+
+    config = _load_and_apply_config(args)
+
+    if not args.input_dir.is_dir():
+        sys.stderr.write(f"Not a directory: {args.input_dir}\n")
+        return 1
+
+    # Create output directory
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Find files to process
+    if args.recursive:
+        files = list(args.input_dir.rglob(args.pattern))
+    else:
+        files = list(args.input_dir.glob(args.pattern))
+
+    if not files:
+        sys.stderr.write(f"No files found matching pattern: {args.pattern}\n")
+        return 1
+
+    # Process files
+    processed = 0
+    failed = 0
+
+    for input_file in files:
+        try:
+            text = input_file.read_text(encoding="utf-8")
+
+            result = deidentify(
+                text,
+                method=args.method,
+                model_name=args.model,
+                confidence_threshold=args.confidence_threshold,
+                config=config,
+            )
+
+            # Preserve directory structure
+            relative_path = input_file.relative_to(args.input_dir)
+            output_file = args.output_dir / relative_path
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+
+            output_file.write_text(result.deidentified_text, encoding="utf-8")
+
+            processed += 1
+            sys.stdout.write(
+                f"[{processed}/{len(files)}] {input_file.name}: "
+                f"{len(result.pii_entities)} entities redacted\n"
+            )
+
+        except Exception as exc:
+            failed += 1
+            sys.stderr.write(f"Failed to process {input_file}: {exc}\n")
+
+    sys.stdout.write(
+        f"\nProcessed {processed} files, {failed} failed\n"
+        f"Output directory: {args.output_dir}\n"
+    )
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/openmed/cli/typer_app.py
+++ b/openmed/cli/typer_app.py
@@ -1,0 +1,282 @@
+"""Draft Typer-powered CLI for OpenMed.
+
+This supplements the existing argparse CLI without breaking it. It is
+optional: install extras `pip install .[cli]` or add Typer/Rich to your
+environment, then run:
+
+    python -m openmed.cli.typer_app --help
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, List
+
+try:  # soft dependency to avoid import errors in base installs
+    import typer
+    from rich import print as rprint
+    from rich.console import Console
+    from rich.table import Table
+except ImportError:  # pragma: no cover - optional surface
+    typer = None
+    Console = None
+    Table = None
+    rprint = print
+
+from openmed import analyze_text, list_models, get_model_max_length
+from openmed.core.config import (
+    OpenMedConfig,
+    get_config,
+    set_config,
+    resolve_config_path,
+    load_config_from_file,
+    save_config_to_file,
+)
+from openmed.ner import (
+    build_index,
+    write_index,
+    infer as zs_infer,
+    NerRequest,
+    ensure_gliner_available,
+    ensure_gliner2_available,
+)
+
+
+def _ensure_typer():
+    if typer is None:
+        raise RuntimeError(
+            "Typer/Rich not installed. Install with `pip install .[cli]` or "
+            "`pip install typer rich`."
+        )
+
+
+def _load_config(config_path: Optional[Path]) -> OpenMedConfig:
+    if config_path:
+        try:
+            cfg = load_config_from_file(config_path)
+            set_config(cfg)
+            return cfg
+        except FileNotFoundError:
+            pass
+    return get_config()
+
+
+def _echo_json(payload: object) -> None:
+    rprint(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def _render_table(title: str, headers: List[str], rows: List[List[str]]) -> None:
+    if Console is None or Table is None:
+        for row in rows:
+            rprint(" | ".join(row))
+        return
+    table = Table(title=title)
+    for head in headers:
+        table.add_column(head)
+    for row in rows:
+        table.add_row(*[str(cell) for cell in row])
+    Console().print(table)
+
+
+def main() -> None:
+    _ensure_typer()
+
+    app = typer.Typer(help="OpenMed Typer CLI (draft).")
+    models_app = typer.Typer(help="Model discovery commands.")
+    cli_app = typer.Typer(help="Config utilities.")
+    zero_app = typer.Typer(help="Zero-shot (GLiNER/GLiNER2) utilities.")
+
+    # ------------------------------------------------------------------
+    # analyze
+    # ------------------------------------------------------------------
+    @app.command("analyze")
+    def analyze(
+        text: Optional[str] = typer.Option(
+            None, "--text", "-t", help="Inline text to analyse."
+        ),
+        input_file: Optional[Path] = typer.Option(
+            None, "--input-file", "-f", help="Path to a text file."
+        ),
+        model: str = typer.Option(
+            "disease_detection_superclinical",
+            "--model",
+            "-m",
+            help="Registry key or HF model id.",
+        ),
+        output_format: str = typer.Option(
+            "dict", "--format", "-o", help="dict|json|html|csv"
+        ),
+        confidence_threshold: Optional[float] = typer.Option(
+            None, "--threshold", "-c", help="Minimum confidence to keep entities."
+        ),
+        group_entities: bool = typer.Option(
+            False, "--group", help="Merge adjacent spans of the same label."
+        ),
+        no_confidence: bool = typer.Option(
+            False, "--no-confidence", help="Exclude confidence values."
+        ),
+        sentence_detection: bool = typer.Option(
+            True, "--sentence-detection/--no-sentence-detection", help="Toggle sentence splitting."
+        ),
+        config_path: Optional[Path] = typer.Option(
+            None, "--config-path", help="Override config path."
+        ),
+    ):
+        """Analyse text with an OpenMed model and pretty-print the result."""
+        cfg = _load_config(config_path)
+        if text is None and input_file is None:
+            raise typer.BadParameter("Provide --text or --input-file.")
+        payload = text
+        if input_file:
+            payload = input_file.read_text(encoding="utf-8")
+
+        result = analyze_text(
+            payload,
+            model_name=model,
+            output_format=output_format,
+            confidence_threshold=confidence_threshold,
+            group_entities=group_entities,
+            include_confidence=not no_confidence,
+            sentence_detection=sentence_detection,
+            config=cfg,
+        )
+
+        if hasattr(result, "to_dict"):
+            _echo_json(result.to_dict())
+        else:
+            rprint(result)
+
+    # ------------------------------------------------------------------
+    # models
+    # ------------------------------------------------------------------
+    @models_app.command("list")
+    def list_available_models(
+        include_remote: bool = typer.Option(
+            False, "--include-remote", help="Query Hugging Face Hub."
+        ),
+        config_path: Optional[Path] = typer.Option(
+            None, "--config-path", help="Override config path."
+        ),
+    ):
+        cfg = _load_config(config_path)
+        models = list_models(include_registry=True, include_remote=include_remote, config=cfg)
+        rows = [[m] for m in models]
+        _render_table("Models", ["model_id"], rows)
+
+    @models_app.command("info")
+    def model_info(
+        model_key: str = typer.Argument(..., help="Registry key or HF id."),
+        config_path: Optional[Path] = typer.Option(
+            None, "--config-path", help="Override config path."
+        ),
+    ):
+        cfg = _load_config(config_path)
+        max_len = get_model_max_length(model_key, config=cfg)
+        _echo_json({"model_key": model_key, "max_length": max_len})
+
+    app.add_typer(models_app, name="models")
+
+    # ------------------------------------------------------------------
+    # config
+    # ------------------------------------------------------------------
+    @cli_app.command("show")
+    def config_show(config_path: Optional[Path] = typer.Option(None, "--config-path")):
+        cfg_path = resolve_config_path(config_path)
+        try:
+            cfg = load_config_from_file(cfg_path)
+            source = str(cfg_path)
+        except FileNotFoundError:
+            cfg = get_config()
+            source = "defaults (not yet saved)"
+        payload = cfg.to_dict()
+        payload["_source"] = source
+        _echo_json(payload)
+
+    @cli_app.command("set")
+    def config_set(
+        key: str,
+        value: Optional[str] = typer.Argument(None),
+        unset: bool = typer.Option(False, "--unset", help="Clear the value."),
+        config_path: Optional[Path] = typer.Option(None, "--config-path"),
+    ):
+        cfg_path = resolve_config_path(config_path)
+        try:
+            cfg = load_config_from_file(cfg_path)
+        except FileNotFoundError:
+            cfg = get_config()
+        cfg_dict = cfg.to_dict()
+        if key not in cfg_dict:
+            raise typer.BadParameter(f"Unknown key '{key}'. Valid: {', '.join(cfg_dict.keys())}")
+        cfg_dict[key] = None if unset else value
+        new_cfg = OpenMedConfig.from_dict(cfg_dict)
+        set_config(new_cfg)
+        save_config_to_file(new_cfg, cfg_path)
+        rprint(f"[green]Updated {key} -> {cfg_dict[key]} in {cfg_path}[/green]")
+
+    app.add_typer(cli_app, name="config")
+
+    # ------------------------------------------------------------------
+    # zero-shot (GLiNER/GLiNER2)
+    # ------------------------------------------------------------------
+    @zero_app.command("deps")
+    def zero_deps():
+        messages = []
+        try:
+            ensure_gliner_available()
+            messages.append("GLiNER v1: ok")
+        except Exception as exc:  # pragma: no cover
+            messages.append(f"GLiNER v1: missing ({exc})")
+        try:
+            ensure_gliner2_available()
+            messages.append("GLiNER v2: ok")
+        except Exception as exc:  # pragma: no cover
+            messages.append(f"GLiNER v2: missing ({exc})")
+        for line in messages:
+            rprint(line)
+
+    @zero_app.command("index")
+    def zero_index(
+        models_dir: Path = typer.Argument(..., help="Root directory containing zero-shot models."),
+        output: Optional[Path] = typer.Option(None, "--output", "-o", help="Path to write index.json"),
+        pretty: bool = typer.Option(True, "--pretty/--compact", help="Pretty-print JSON."),
+    ):
+        index = build_index(models_dir)
+        out_path = output or (models_dir / "index.json")
+        write_index(index, out_path, pretty=pretty)
+        rprint(f"[green]Index written to {out_path}[/green]")
+
+    @zero_app.command("infer")
+    def zero_infer(
+        text: str = typer.Argument(..., help="Input text for zero-shot NER."),
+        model_id: str = typer.Option(..., "--model-id", "-m", help="Model id from index."),
+        labels: Optional[str] = typer.Option(
+            None, "--labels", "-l", help="Comma-separated label list (optional)."
+        ),
+        domain: Optional[str] = typer.Option(None, "--domain", "-d", help="Domain hint."),
+        threshold: float = typer.Option(0.5, "--threshold", "-c", help="Score threshold."),
+        index_path: Optional[Path] = typer.Option(
+            None, "--index-path", "-i", help="Path to index.json (defaults to models/index.json)."
+        ),
+    ):
+        label_list = [label.strip() for label in labels.split(",")] if labels else None
+        request = NerRequest(
+            model_id=model_id,
+            text=text,
+            labels=label_list,
+            domain=domain,
+            threshold=threshold,
+        )
+        response = zs_infer(request, index_path=index_path)
+        _echo_json(response.to_dict())
+
+    app.add_typer(zero_app, name="zero")
+
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    try:
+        main()
+    except RuntimeError as exc:
+        rprint(f"[red]{exc}[/red]")

--- a/openmed/core/pii_i18n.py
+++ b/openmed/core/pii_i18n.py
@@ -70,9 +70,11 @@ DEFAULT_PII_MODELS: Dict[str, str] = {
 def validate_french_nir(text: str) -> bool:
     """Validate French NIR/INSEE number.
 
-    The NIR (Numero d'Inscription au Repertoire) is 15 digits.
+    The NIR (Numero d'Inscription au Repertoire) is 15 characters.
     Format: S AA MM DDD CCC OOO KK
     Key (last 2 digits) = 97 - (first 13 digits mod 97)
+    Corsica department codes 2A and 2B are normalized to 19 and 18
+    respectively before computing the checksum.
 
     Args:
         text: NIR string (may contain spaces)
@@ -80,18 +82,26 @@ def validate_french_nir(text: str) -> bool:
     Returns:
         True if valid NIR format and checksum
     """
-    digits = re.sub(r"[^0-9]", "", text)
+    cleaned = re.sub(r"[\s.-]", "", text).upper()
 
-    if len(digits) != 15:
+    if len(cleaned) != 15:
         return False
 
     # First digit must be 1 or 2
-    if digits[0] not in ("1", "2"):
+    if cleaned[0] not in ("1", "2"):
         return False
 
     try:
-        number = int(digits[:13])
-        key = int(digits[13:15])
+        body = cleaned[:13]
+        key = int(cleaned[13:15])
+        if "A" in body or "B" in body:
+            if not re.match(r"^[12]\d{4}2[AB]\d{6}$", body):
+                return False
+            body = body.replace("2A", "19").replace("2B", "18")
+        elif not body.isdigit():
+            return False
+
+        number = int(body)
         return key == 97 - (number % 97)
     except (ValueError, IndexError):
         return False
@@ -531,9 +541,9 @@ _FRENCH_PII_PATTERNS: List[PIIPattern] = [
         ],
         context_boost=0.3,
     ),
-    # French NIR/INSEE (15 digits, possibly spaced)
+    # French NIR/INSEE (15 characters, possibly spaced; includes Corsica 2A/2B)
     PIIPattern(
-        r"\b[12]\s?\d{2}\s?\d{2}\s?\d{2}\s?\d{3}\s?\d{3}\s?\d{2}\b",
+        r"\b[12]\s?\d{2}\s?\d{2}\s?(?:\d{2}|2[ABab])\s?\d{3}\s?\d{3}\s?\d{2}\b",
         "national_id",
         priority=10,
         base_score=0.55,

--- a/openmed/mcp/__init__.py
+++ b/openmed/mcp/__init__.py
@@ -1,0 +1,16 @@
+"""Model Context Protocol integration for OpenMed."""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["create_mcp_server", "main"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        from .server import create_mcp_server, main
+
+        exports = {"create_mcp_server": create_mcp_server, "main": main}
+        return exports[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/openmed/mcp/server.py
+++ b/openmed/mcp/server.py
@@ -1,0 +1,588 @@
+"""MCP server for OpenMed agent integrations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import asdict
+from typing import Any, Callable, Dict, Optional
+
+import openmed
+from openmed.core.model_registry import ModelInfo
+from openmed.core.pii_i18n import (
+    DEFAULT_PII_MODELS,
+    LANGUAGE_NAMES,
+    SUPPORTED_LANGUAGES,
+)
+from openmed.service.runtime import ServiceRuntime
+from openmed.utils.validation import validate_model_name
+
+RuntimeProvider = Callable[[], ServiceRuntime]
+
+MCP_INSTRUCTIONS = (
+    "OpenMed exposes local clinical NLP, PII extraction, and de-identification "
+    "tools. Use synthetic examples for tests and docs. Only send real PHI to "
+    "OpenMed instances the user operates and trusts. Prefer local model paths "
+    "or approved OpenMed/Hugging Face model identifiers in regulated flows."
+)
+
+_DEFAULT_RUNTIME: Optional[ServiceRuntime] = None
+
+
+def _load_fastmcp() -> Any:
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:  # pragma: no cover - exercised by packaging users
+        raise RuntimeError(
+            "The MCP SDK is not installed. Install OpenMed with the MCP extra: "
+            'pip install "openmed[mcp]"'
+        ) from exc
+    return FastMCP
+
+
+def _get_default_runtime() -> ServiceRuntime:
+    global _DEFAULT_RUNTIME
+    if _DEFAULT_RUNTIME is None:
+        _DEFAULT_RUNTIME = ServiceRuntime.from_env()
+    return _DEFAULT_RUNTIME
+
+
+def _runtime(runtime_provider: Optional[RuntimeProvider] = None) -> ServiceRuntime:
+    if runtime_provider is not None:
+        return runtime_provider()
+    return _get_default_runtime()
+
+
+def _result_to_dict(result: Any) -> Dict[str, Any]:
+    if hasattr(result, "to_dict") and callable(result.to_dict):
+        payload = result.to_dict()
+        if isinstance(payload, dict):
+            return dict(payload)
+        raise TypeError("Result to_dict() must return a dictionary.")
+
+    if isinstance(result, dict):
+        return dict(result)
+
+    raise TypeError("Unsupported OpenMed result type.")
+
+
+def _run_model_request(
+    runtime: ServiceRuntime,
+    model_name: str,
+    keep_alive: Any,
+    operation: Callable[[], Dict[str, Any]],
+) -> Dict[str, Any]:
+    return runtime.run_model_request(model_name, keep_alive, operation)
+
+
+def _model_info_to_dict(key: str, model: ModelInfo) -> Dict[str, Any]:
+    payload = asdict(model)
+    payload["key"] = key
+    payload["size_mb"] = model.size_mb
+    return payload
+
+
+def _json_resource(payload: Any) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def openmed_analyze_text(
+    text: str,
+    model_name: str = "disease_detection_superclinical",
+    confidence_threshold: Optional[float] = 0.0,
+    group_entities: bool = False,
+    aggregation_strategy: Optional[str] = "simple",
+    sentence_detection: bool = True,
+    sentence_language: str = "en",
+    sentence_clean: bool = False,
+    use_fast_tokenizer: bool = True,
+    keep_alive: Optional[str] = None,
+    *,
+    runtime_provider: Optional[RuntimeProvider] = None,
+) -> Dict[str, Any]:
+    """Run OpenMed named-entity recognition and return a JSON-ready result."""
+    from openmed.service.schemas import AnalyzeRequest
+
+    payload = AnalyzeRequest(
+        text=text,
+        model_name=model_name,
+        confidence_threshold=confidence_threshold,
+        group_entities=group_entities,
+        aggregation_strategy=aggregation_strategy,
+        sentence_detection=sentence_detection,
+        sentence_language=sentence_language,
+        sentence_clean=sentence_clean,
+        use_fast_tokenizer=use_fast_tokenizer,
+        keep_alive=keep_alive,
+    )
+    runtime = _runtime(runtime_provider)
+
+    def operation() -> Dict[str, Any]:
+        result = openmed.analyze_text(
+            payload.text,
+            model_name=payload.model_name,
+            config=runtime.config,
+            loader=runtime.get_loader(),
+            aggregation_strategy=payload.aggregation_strategy,
+            output_format="dict",
+            confidence_threshold=payload.confidence_threshold,
+            group_entities=payload.group_entities,
+            sentence_detection=payload.sentence_detection,
+            sentence_language=payload.sentence_language,
+            sentence_clean=payload.sentence_clean,
+            use_fast_tokenizer=payload.use_fast_tokenizer,
+        )
+        return _result_to_dict(result)
+
+    return _run_model_request(
+        runtime,
+        payload.model_name,
+        payload.keep_alive,
+        operation,
+    )
+
+
+def openmed_extract_pii(
+    text: str,
+    model_name: str = DEFAULT_PII_MODELS["en"],
+    confidence_threshold: float = 0.5,
+    use_smart_merging: bool = True,
+    lang: str = "en",
+    normalize_accents: Optional[bool] = None,
+    keep_alive: Optional[str] = None,
+    *,
+    runtime_provider: Optional[RuntimeProvider] = None,
+) -> Dict[str, Any]:
+    """Extract PII/PHI entities and return a JSON-ready result."""
+    from openmed.service.schemas import PIIExtractRequest
+
+    payload = PIIExtractRequest(
+        text=text,
+        model_name=model_name,
+        confidence_threshold=confidence_threshold,
+        use_smart_merging=use_smart_merging,
+        lang=lang,
+        normalize_accents=normalize_accents,
+        keep_alive=keep_alive,
+    )
+    runtime = _runtime(runtime_provider)
+
+    def operation() -> Dict[str, Any]:
+        result = openmed.extract_pii(
+            payload.text,
+            model_name=payload.model_name,
+            confidence_threshold=payload.confidence_threshold,
+            config=runtime.config,
+            use_smart_merging=payload.use_smart_merging,
+            lang=payload.lang,
+            normalize_accents=payload.normalize_accents,
+            loader=runtime.get_loader(),
+        )
+        return _result_to_dict(result)
+
+    return _run_model_request(
+        runtime,
+        payload.model_name,
+        payload.keep_alive,
+        operation,
+    )
+
+
+def openmed_deidentify(
+    text: str,
+    method: str = "mask",
+    model_name: str = DEFAULT_PII_MODELS["en"],
+    confidence_threshold: float = 0.7,
+    keep_year: bool = True,
+    shift_dates: Optional[bool] = None,
+    date_shift_days: Optional[int] = None,
+    keep_mapping: bool = False,
+    use_smart_merging: bool = True,
+    lang: str = "en",
+    normalize_accents: Optional[bool] = None,
+    keep_alive: Optional[str] = None,
+    *,
+    runtime_provider: Optional[RuntimeProvider] = None,
+) -> Dict[str, Any]:
+    """De-identify text by masking, removing, replacing, hashing, or shifting PII."""
+    from openmed.service.schemas import PIIDeidentifyRequest
+
+    payload = PIIDeidentifyRequest(
+        text=text,
+        method=method,
+        model_name=model_name,
+        confidence_threshold=confidence_threshold,
+        keep_year=keep_year,
+        shift_dates=shift_dates,
+        date_shift_days=date_shift_days,
+        keep_mapping=keep_mapping,
+        use_smart_merging=use_smart_merging,
+        lang=lang,
+        normalize_accents=normalize_accents,
+        keep_alive=keep_alive,
+    )
+    runtime = _runtime(runtime_provider)
+
+    def operation() -> Dict[str, Any]:
+        result = openmed.deidentify(
+            payload.text,
+            method=payload.method,
+            model_name=payload.model_name,
+            confidence_threshold=payload.confidence_threshold,
+            keep_year=payload.keep_year,
+            shift_dates=payload.shift_dates,
+            date_shift_days=payload.date_shift_days,
+            keep_mapping=payload.keep_mapping,
+            config=runtime.config,
+            use_smart_merging=payload.use_smart_merging,
+            lang=payload.lang,
+            normalize_accents=payload.normalize_accents,
+            loader=runtime.get_loader(),
+        )
+        response = _result_to_dict(result)
+        if payload.keep_mapping and getattr(result, "mapping", None):
+            response["mapping"] = result.mapping
+        return response
+
+    return _run_model_request(
+        runtime,
+        payload.model_name,
+        payload.keep_alive,
+        operation,
+    )
+
+
+def openmed_list_models(
+    category: Optional[str] = None,
+    pii_language: Optional[str] = None,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """List OpenMed registry models with optional category or PII language filters."""
+    models = openmed.get_all_models()
+
+    if category:
+        category_lower = category.strip().lower()
+        models = {
+            key: model
+            for key, model in models.items()
+            if model.category.lower() == category_lower
+        }
+
+    if pii_language:
+        if pii_language not in SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"Unsupported language '{pii_language}'. "
+                f"Supported: {sorted(SUPPORTED_LANGUAGES)}"
+            )
+        allowed = openmed.get_pii_models_by_language(pii_language)
+        models = {key: model for key, model in models.items() if key in allowed}
+
+    limited_items = list(sorted(models.items()))[: max(limit, 0)]
+    return {
+        "count": len(models),
+        "returned": len(limited_items),
+        "models": [_model_info_to_dict(key, model) for key, model in limited_items],
+    }
+
+
+def openmed_list_pii_languages() -> Dict[str, Any]:
+    """List supported PII languages and their default model IDs."""
+    languages = []
+    for code in sorted(SUPPORTED_LANGUAGES):
+        languages.append(
+            {
+                "code": code,
+                "name": LANGUAGE_NAMES.get(code, code),
+                "default_pii_model": DEFAULT_PII_MODELS[code],
+                "model_count": len(openmed.get_pii_models_by_language(code)),
+            }
+        )
+    return {"count": len(languages), "languages": languages}
+
+
+def openmed_loaded_models(
+    *,
+    runtime_provider: Optional[RuntimeProvider] = None,
+) -> Dict[str, Any]:
+    """Return currently loaded model resources for the MCP runtime."""
+    return _runtime(runtime_provider).loaded_models()
+
+
+def openmed_unload_model(
+    model_name: Optional[str] = None,
+    all_models: bool = False,
+    *,
+    runtime_provider: Optional[RuntimeProvider] = None,
+) -> Dict[str, Any]:
+    """Unload one inactive model or all inactive models from memory."""
+    runtime = _runtime(runtime_provider)
+    if all_models:
+        return runtime.unload_all_models()
+    if model_name is None:
+        raise ValueError("model_name is required unless all_models=true")
+    return runtime.unload_model(validate_model_name(model_name))
+
+
+def _register_tools(
+    server: Any,
+    runtime_provider: Optional[RuntimeProvider],
+) -> None:
+    @server.tool(name="openmed_analyze_text")
+    def _analyze_text_tool(
+        text: str,
+        model_name: str = "disease_detection_superclinical",
+        confidence_threshold: Optional[float] = 0.0,
+        group_entities: bool = False,
+        aggregation_strategy: Optional[str] = "simple",
+        sentence_detection: bool = True,
+        sentence_language: str = "en",
+        sentence_clean: bool = False,
+        use_fast_tokenizer: bool = True,
+        keep_alive: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Run OpenMed named-entity recognition on clinical text."""
+        return openmed_analyze_text(
+            text=text,
+            model_name=model_name,
+            confidence_threshold=confidence_threshold,
+            group_entities=group_entities,
+            aggregation_strategy=aggregation_strategy,
+            sentence_detection=sentence_detection,
+            sentence_language=sentence_language,
+            sentence_clean=sentence_clean,
+            use_fast_tokenizer=use_fast_tokenizer,
+            keep_alive=keep_alive,
+            runtime_provider=runtime_provider,
+        )
+
+    @server.tool(name="openmed_extract_pii")
+    def _extract_pii_tool(
+        text: str,
+        model_name: str = DEFAULT_PII_MODELS["en"],
+        confidence_threshold: float = 0.5,
+        use_smart_merging: bool = True,
+        lang: str = "en",
+        normalize_accents: Optional[bool] = None,
+        keep_alive: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Extract PII/PHI entities from clinical text."""
+        return openmed_extract_pii(
+            text=text,
+            model_name=model_name,
+            confidence_threshold=confidence_threshold,
+            use_smart_merging=use_smart_merging,
+            lang=lang,
+            normalize_accents=normalize_accents,
+            keep_alive=keep_alive,
+            runtime_provider=runtime_provider,
+        )
+
+    @server.tool(name="openmed_deidentify")
+    def _deidentify_tool(
+        text: str,
+        method: str = "mask",
+        model_name: str = DEFAULT_PII_MODELS["en"],
+        confidence_threshold: float = 0.7,
+        keep_year: bool = True,
+        shift_dates: Optional[bool] = None,
+        date_shift_days: Optional[int] = None,
+        keep_mapping: bool = False,
+        use_smart_merging: bool = True,
+        lang: str = "en",
+        normalize_accents: Optional[bool] = None,
+        keep_alive: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """De-identify text by masking, removing, replacing, hashing, or shifting."""
+        return openmed_deidentify(
+            text=text,
+            method=method,
+            model_name=model_name,
+            confidence_threshold=confidence_threshold,
+            keep_year=keep_year,
+            shift_dates=shift_dates,
+            date_shift_days=date_shift_days,
+            keep_mapping=keep_mapping,
+            use_smart_merging=use_smart_merging,
+            lang=lang,
+            normalize_accents=normalize_accents,
+            keep_alive=keep_alive,
+            runtime_provider=runtime_provider,
+        )
+
+    @server.tool(name="openmed_list_models")
+    def _list_models_tool(
+        category: Optional[str] = None,
+        pii_language: Optional[str] = None,
+        limit: int = 50,
+    ) -> Dict[str, Any]:
+        """List OpenMed model registry entries."""
+        return openmed_list_models(
+            category=category,
+            pii_language=pii_language,
+            limit=limit,
+        )
+
+    @server.tool(name="openmed_list_pii_languages")
+    def _list_pii_languages_tool() -> Dict[str, Any]:
+        """List supported PII languages and default models."""
+        return openmed_list_pii_languages()
+
+    @server.tool(name="openmed_loaded_models")
+    def _loaded_models_tool() -> Dict[str, Any]:
+        """Return currently loaded model resources."""
+        return openmed_loaded_models(runtime_provider=runtime_provider)
+
+    @server.tool(name="openmed_unload_model")
+    def _unload_model_tool(
+        model_name: Optional[str] = None,
+        all_models: bool = False,
+    ) -> Dict[str, Any]:
+        """Unload one inactive model, or all inactive models."""
+        return openmed_unload_model(
+            model_name=model_name,
+            all_models=all_models,
+            runtime_provider=runtime_provider,
+        )
+
+
+def _register_resources(server: Any) -> None:
+    @server.resource(
+        "openmed://models",
+        name="OpenMed model registry",
+        mime_type="application/json",
+    )
+    def _models_resource() -> str:
+        return _json_resource(openmed_list_models(limit=1000))
+
+    @server.resource(
+        "openmed://pii-languages",
+        name="OpenMed PII languages",
+        mime_type="application/json",
+    )
+    def _pii_languages_resource() -> str:
+        return _json_resource(openmed_list_pii_languages())
+
+    @server.resource(
+        "openmed://examples",
+        name="OpenMed safe examples",
+        mime_type="application/json",
+    )
+    def _examples_resource() -> str:
+        return _json_resource(
+            {
+                "analyze": "Patient received 75mg clopidogrel for NSTEMI.",
+                "pii_extract": "Paciente: Maria Garcia, DNI: 12345678Z",
+                "pii_deidentify": (
+                    "Patient John Doe called 555-123-4567 on 01/15/2020."
+                ),
+            }
+        )
+
+
+def _register_prompts(server: Any) -> None:
+    @server.prompt(name="openmed-clinical-ner")
+    def _clinical_ner_prompt(
+        text: str = "Patient received 75mg clopidogrel for NSTEMI.",
+        model_name: str = "disease_detection_superclinical",
+    ) -> str:
+        """Prompt an agent to use OpenMed clinical NER."""
+        return (
+            "Use the openmed_analyze_text tool on the provided clinical text. "
+            f"Use model_name={model_name!r}. Text: {text!r}"
+        )
+
+    @server.prompt(name="openmed-pii-deidentify")
+    def _pii_deidentify_prompt(
+        text: str = "Patient John Doe called 555-123-4567 on 01/15/2020.",
+        method: str = "mask",
+        lang: str = "en",
+    ) -> str:
+        """Prompt an agent to de-identify synthetic or approved text."""
+        return (
+            "Use the openmed_deidentify tool. Confirm the user controls the "
+            "OpenMed runtime before processing real PHI. "
+            f"Use method={method!r}, lang={lang!r}. Text: {text!r}"
+        )
+
+
+def create_mcp_server(
+    *,
+    runtime_provider: Optional[RuntimeProvider] = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    streamable_http_path: str = "/mcp",
+) -> Any:
+    """Create a FastMCP server exposing OpenMed tools, resources, and prompts."""
+    FastMCP = _load_fastmcp()
+    server = FastMCP(
+        "OpenMed",
+        instructions=MCP_INSTRUCTIONS,
+        website_url="https://openmed.life/docs/",
+        host=host or os.getenv("OPENMED_MCP_HOST", "127.0.0.1"),
+        port=port or int(os.getenv("OPENMED_MCP_PORT", "8081")),
+        streamable_http_path=streamable_http_path,
+        stateless_http=True,
+        json_response=True,
+    )
+    _register_tools(server, runtime_provider)
+    _register_resources(server)
+    _register_prompts(server)
+    return server
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the OpenMed MCP server.")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "streamable-http", "http"),
+        default=os.getenv("OPENMED_MCP_TRANSPORT", "stdio"),
+        help="MCP transport. Defaults to stdio.",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("OPENMED_MCP_HOST", "127.0.0.1"),
+        help="Host for streamable HTTP transport.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("OPENMED_MCP_PORT", "8081")),
+        help="Port for streamable HTTP transport.",
+    )
+    parser.add_argument(
+        "--streamable-http-path",
+        default=os.getenv("OPENMED_MCP_PATH", "/mcp"),
+        help="Path for streamable HTTP transport.",
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the OpenMed package version and exit.",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if args.version:
+        print(openmed.__version__)
+        return 0
+
+    transport = args.transport
+    if transport == "http":
+        transport = "streamable-http"
+
+    server = create_mcp_server(
+        host=args.host,
+        port=args.port,
+        streamable_http_path=args.streamable_http_path,
+    )
+    server.run(transport=transport)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,15 @@ dev = [
   "httpx>=0.27",
 ]
 
+cli = [
+  "rich>=13.0",
+  "typer>=0.12",
+]
+
+mcp = [
+  "mcp>=1.9",
+]
+
 hf = [
   "transformers>=4.50",
   "huggingface-hub>=0.30",
@@ -82,6 +91,9 @@ docs = [
   "mkdocs-minify-plugin>=0.8.0",
   "pymdown-extensions>=10.8",
 ]
+
+[project.scripts]
+openmed = "openmed.cli:main"
 
 [tool.hatch.build]
 include = [

--- a/tests/unit/cli/__init__.py
+++ b/tests/unit/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI unit tests."""

--- a/tests/unit/cli/test_cli_smoke.py
+++ b/tests/unit/cli/test_cli_smoke.py
@@ -1,0 +1,101 @@
+"""Smoke tests for the tracked CLI and MCP packages."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import openmed
+from openmed.cli import main as cli_entry
+from openmed.cli import main_module
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _run_module(module: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", module, *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_argparse_cli_imports_and_prints_help() -> None:
+    assert callable(cli_entry)
+    assert callable(main_module.main)
+
+    result = _run_module("openmed.cli.main", "--help")
+
+    assert result.returncode == 0
+    assert "Command-line utilities for OpenMed" in result.stdout
+
+
+def test_argparse_cli_prints_version() -> None:
+    result = _run_module("openmed.cli.main", "--version")
+
+    assert result.returncode == 0
+    assert openmed.__version__ in result.stdout
+
+
+def test_tui_entry_invokes_openmed_tui(monkeypatch: pytest.MonkeyPatch) -> None:
+    launched: dict[str, object] = {}
+
+    class FakeTUI:
+        def __init__(self, **kwargs: object) -> None:
+            launched["kwargs"] = kwargs
+
+        def run(self) -> None:
+            launched["ran"] = True
+
+    fake_tui = types.ModuleType("openmed.tui")
+    fake_tui.OpenMedTUI = FakeTUI
+    monkeypatch.setitem(sys.modules, "openmed.tui", fake_tui)
+
+    result = main_module.main(
+        ["tui", "--model", "disease_detection_superclinical", "--confidence-threshold", "0.6"]
+    )
+
+    assert result == 0
+    assert launched == {
+        "kwargs": {
+            "model_name": "disease_detection_superclinical",
+            "confidence_threshold": 0.6,
+        },
+        "ran": True,
+    }
+
+
+def test_typer_surface_is_importable() -> None:
+    from openmed.cli import typer_app
+
+    assert callable(typer_app.main)
+
+
+def test_mcp_package_imports_and_prints_help() -> None:
+    from openmed.mcp import server
+
+    assert callable(server.create_mcp_server)
+
+    result = _run_module("openmed.mcp.server", "--help")
+
+    assert result.returncode == 0
+    assert "Run the OpenMed MCP server" in result.stdout
+
+
+def test_console_script_is_declared() -> None:
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:  # pragma: no cover - Python 3.10 compatibility
+        import tomli as tomllib
+
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert pyproject["project"]["scripts"]["openmed"] == "openmed.cli:main"

--- a/tests/unit/cli/test_cli_smoke.py
+++ b/tests/unit/cli/test_cli_smoke.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import subprocess
 import sys
 import types
@@ -71,6 +72,19 @@ def test_tui_entry_invokes_openmed_tui(monkeypatch: pytest.MonkeyPatch) -> None:
         },
         "ran": True,
     }
+
+
+def test_tui_entry_has_base_install_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delitem(sys.modules, "openmed.tui", raising=False)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+
+    result = main_module.main(["tui"])
+
+    assert result == 0
+    assert "OpenMed TUI entry is installed" in capsys.readouterr().out
 
 
 def test_typer_surface_is_importable() -> None:

--- a/tests/unit/test_pii_i18n.py
+++ b/tests/unit/test_pii_i18n.py
@@ -131,6 +131,13 @@ class TestValidateFrenchNIR:
         # number = 2000000000000, key = 97 - (2000000000000 % 97) = 94
         assert validate_french_nir("200000000000094") is True
 
+    def test_valid_nir_corsica_departments(self):
+        assert validate_french_nir("291032A03396109") is True
+        assert validate_french_nir("291032B03396136") is True
+
+    def test_invalid_nir_corsica_wrong_checksum(self):
+        assert validate_french_nir("291032B03396137") is False
+
 
 # ---------------------------------------------------------------------------
 # German Steuer-ID Validator Tests


### PR DESCRIPTION
Closes #71.

Restores the tracked CLI and MCP package sources, adds the openmed console script metadata, and covers the restored help, version, TUI, and MCP smoke paths so editable installs expose the expected command without loading models.

Validation: .venv/bin/python -m pytest tests/ -q
