### PR TITLE
Enforce no-raw-PHI logging guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,10 @@ jobs:
       run: |
         uv run python -m scripts.manifest.validate_manifest
 
+    - name: Trust-CI no-raw-PHI logging guard
+      run: |
+        uv run pytest tests/unit/test_no_raw_text_logging.py -q
+
     - name: Test with pytest
       run: |
         uv run pytest --cov=openmed --cov-report=xml --cov-report=term-missing

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,6 +13,8 @@ publish the package to PyPI or GitHub Pages.
 - `make docs-serve` starts the MkDocs preview with hot reload at `http://127.0.0.1:8008`.
 - `make docs-build` runs `mkdocs build --strict` for CI parity.
 - `uv pip install ".[dev]"` pulls in pytest + coverage; `uv pip install ".[dev,hf]"` stacks extras.
+- Follow the [no-raw-PHI logging policy](security/no-raw-phi-logging.md) for every PII, de-identification,
+  text-processing, service, and batch change.
 
 ## Code style
 
@@ -68,6 +70,8 @@ to publish outside CI, run `make docs-deploy`; it mirrors the workflow by buildi
 - **Security issues are different:** a redaction bypass or PHI/PII leak must be
   reported privately, never as a public issue. Follow the
   [Security & Disclosure policy](security/disclosure-policy.md).
+- Run `pytest tests/unit/test_no_raw_text_logging.py -q` when touching logging, text processing, service request
+  handling, PII extraction, or de-identification code.
 
 ## Governance references
 

--- a/docs/security/no-raw-phi-logging.md
+++ b/docs/security/no-raw-phi-logging.md
@@ -1,0 +1,43 @@
+# No-Raw-PHI Logging Policy
+
+OpenMed code must not write raw protected health information (PHI), patient
+text, source documents, or extracted cleartext spans to logs at any level.
+Logs are operational telemetry only.
+
+## Allowed log content
+
+- Counts, durations, thresholds, model identifiers, backend names, and status
+  transitions.
+- Span metadata such as label, start offset, end offset, confidence bucket, and
+  validity flags.
+- A precomputed keyed `text_hash` when one already exists for the span or
+  document. Do not create ad hoc hashes in log statements.
+- Exception class names and high-level failure categories.
+
+## Disallowed log content
+
+- Input document text, cleaned text, truncated text snippets, prompts, sentences,
+  or source surfaces that may contain clinical content.
+- Entity text, original PII values, redacted-to-original mappings, or replacement
+  mapping payloads.
+- Exception messages that may include user input, source paths, request bodies,
+  or downstream library payloads.
+- File paths or item identifiers derived from patient, chart, or encounter data.
+
+## Engineering requirements
+
+- Prefer structured fields over formatted prose when adding logs.
+- Use lengths, counts, labels, offsets, and safe identifiers instead of text.
+- Keep request and response bodies out of service logs.
+- When adding or changing a PII, de-identification, text-processing, or batch
+  path, run the no-raw-PHI logging guard:
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_no_raw_text_logging.py -q
+```
+
+The full suite must also pass before release or pull request review:
+
+```bash
+.venv/bin/python -m pytest tests/ -q
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
       - De-identification API: api/deidentification.md
       - PII Anonymization: anonymization.md
       - Smart Entity Merging: pii-smart-merging.md
+      - No-Raw-PHI Logging: security/no-raw-phi-logging.md
       - LangChain Redaction Wrapper: integrations-langchain.md
       - spaCy Pipeline Component: spacy-component.md
       - HL7 v2 De-identification: hl7v2-deidentification.md

--- a/openmed/core/quality_gates.py
+++ b/openmed/core/quality_gates.py
@@ -270,17 +270,19 @@ def _span_problems(entity: Any, text: str) -> list[str] | None:
             if " ".join(actual.split()) == " ".join(entity_text.split()):
                 logger.info(
                     "SpanValidation: Entity %r @ [%d:%d]: "
-                    "whitespace-only text difference (span=%r, stored=%r)",
+                    "whitespace-only text difference "
+                    "(span_chars=%d, stored_chars=%d)",
                     _entity_label(entity),
                     start,
                     end,
-                    actual,
-                    entity_text,
+                    len(actual),
+                    len(entity_text),
                 )
             else:
                 problems.append(
-                    f"text mismatch: span gives {actual!r}, "
-                    f"entity stores {entity_text!r}"
+                    "text mismatch: "
+                    f"span_chars={len(actual)}, "
+                    f"entity_chars={len(entity_text)}"
                 )
 
     return problems

--- a/openmed/processing/batch.py
+++ b/openmed/processing/batch.py
@@ -385,8 +385,11 @@ class BatchProcessor:
                         source=str(path),
                     )
                 )
-            except OSError as e:
-                logger.warning("Failed to read file %s: %s", path, e)
+            except (OSError, IOError) as e:
+                logger.warning(
+                    "Failed to read batch input file: error_type=%s",
+                    type(e).__name__,
+                )
                 if not self.continue_on_error:
                     raise
                 items.append(
@@ -521,14 +524,20 @@ class BatchProcessor:
             )
             try:
                 on_progress(progress)
-            except Exception:
-                logger.warning("on_progress callback raised; continuing batch")
+            except Exception as e:
+                logger.warning(
+                    "on_progress callback raised; continuing batch: error_type=%s",
+                    type(e).__name__,
+                )
 
         if progress_callback:
             try:
                 progress_callback(completed, total, item_result)
-            except Exception:
-                logger.warning("progress_callback raised; continuing batch")
+            except Exception as e:
+                logger.warning(
+                    "progress_callback raised; continuing batch: error_type=%s",
+                    type(e).__name__,
+                )
 
     def _process_batch_chunk(self, items: List[BatchItem]) -> List[BatchItemResult]:
         """Process a contiguous item chunk for the selected operation."""
@@ -632,7 +641,10 @@ class BatchProcessor:
                 )
 
         except Exception as e:
-            logger.warning("Error processing batch chunk: %s", e)
+            logger.warning(
+                "Error processing batch chunk: error_type=%s",
+                type(e).__name__,
+            )
             if not self.continue_on_error:
                 raise
 
@@ -686,7 +698,10 @@ class BatchProcessor:
 
         except Exception as e:
             processing_time = time.time() - start_time
-            logger.warning("Error processing item %s: %s", item.id, e)
+            logger.warning(
+                "Error processing batch item: error_type=%s",
+                type(e).__name__,
+            )
 
             if not self.continue_on_error:
                 raise

--- a/openmed/processing/outputs.py
+++ b/openmed/processing/outputs.py
@@ -28,7 +28,10 @@ def _to_float(value: Any, default: Optional[float] = None) -> Optional[float]:
     try:
         return float(value)
     except (TypeError, ValueError):
-        logger.debug("Failed to convert %r to float", value)
+        logger.debug(
+            "Failed to convert value to float: value_type=%s",
+            type(value).__name__,
+        )
         return default
 
 
@@ -49,7 +52,10 @@ def _to_int(value: Any) -> Optional[int]:
     try:
         return int(value)
     except (TypeError, ValueError):
-        logger.debug("Failed to convert %r to int", value)
+        logger.debug(
+            "Failed to convert value to int: value_type=%s",
+            type(value).__name__,
+        )
         return None
 
 

--- a/openmed/processing/text.py
+++ b/openmed/processing/text.py
@@ -122,7 +122,12 @@ class TextProcessor:
         if self.normalize_whitespace:
             text = re.sub(r"\s+", " ", text.strip())
 
-        logger.debug("Text cleaning: '%s...' -> '%s...'", original_text[:50], text[:50])
+        logger.debug(
+            "Text cleaning completed: input_chars=%d output_chars=%d changed=%s",
+            len(original_text),
+            len(text),
+            original_text != text,
+        )
         return text
 
     def segment_sentences(self, text: str) -> List[str]:

--- a/tests/unit/test_no_raw_text_logging.py
+++ b/tests/unit/test_no_raw_text_logging.py
@@ -1,0 +1,173 @@
+"""Guard that PII and de-identification paths do not log raw PHI."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import openmed
+from openmed.core.pii import deidentify, extract_pii
+from openmed.processing.batch import BatchProcessor
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+from openmed.processing.text import TextProcessor
+from openmed.service import runtime as service_runtime
+from openmed.service.app import create_app
+
+LOOPBACK_BASE_URL = "http://127.0.0.1"
+
+PHI_TEXT = (
+    "Patient Evelyn Quantum, MRN ZQ-7391, DOB 04/17/1972, "
+    "SSN 042-66-9001, phone 919-555-0188, email "
+    "evelyn.quantum@example.test, address 9 Radiant Plaza."
+)
+
+PHI_SUBSTRINGS = (
+    "Evelyn Quantum",
+    "ZQ-7391",
+    "04/17/1972",
+    "042-66-9001",
+    "919-555-0188",
+    "evelyn.quantum@example.test",
+    "9 Radiant Plaza",
+)
+
+PHI_LABELS = {
+    "Evelyn Quantum": "NAME",
+    "ZQ-7391": "MEDICAL_RECORD_NUMBER",
+    "04/17/1972": "DATE",
+    "042-66-9001": "SSN",
+    "919-555-0188": "PHONE",
+    "evelyn.quantum@example.test": "EMAIL",
+    "9 Radiant Plaza": "STREET_ADDRESS",
+}
+
+
+class _NoopLoader:
+    """Loader double used by REST service tests to avoid model loading."""
+
+    def __init__(self, config: Any):
+        self.config = config
+
+    def resolve_model_name(self, model_name: str) -> str:
+        return model_name
+
+    def loaded_models(self) -> dict[str, Any]:
+        return {}
+
+    def unload_model(self, model_name: str) -> dict[str, Any]:
+        return {
+            "model_name": model_name,
+            "models": 0,
+            "tokenizers": 0,
+            "pipelines": 0,
+        }
+
+    def unload_all_models(self) -> dict[str, int]:
+        return {"models": 0, "tokenizers": 0, "pipelines": 0}
+
+
+def _entities_for(text: str) -> list[EntityPrediction]:
+    entities = []
+    for substring, label in PHI_LABELS.items():
+        start = text.index(substring)
+        entities.append(
+            EntityPrediction(
+                text=substring,
+                label=label,
+                start=start,
+                end=start + len(substring),
+                confidence=0.99,
+            )
+        )
+    return entities
+
+
+def _fake_analyze_text(text: str, *args: Any, **kwargs: Any) -> PredictionResult:
+    return PredictionResult(
+        text=text,
+        entities=_entities_for(text),
+        model_name=kwargs.get("model_name", "test-pii-model"),
+        timestamp=datetime.now().isoformat(),
+    )
+
+
+def _fake_extract_pii(text: str, *args: Any, **kwargs: Any) -> PredictionResult:
+    return extract_pii(text, *args, **kwargs)
+
+
+def _fake_deidentify(text: str, *args: Any, **kwargs: Any) -> Any:
+    return deidentify(text, *args, **kwargs)
+
+
+def _render_logs(records: list[logging.LogRecord]) -> str:
+    return "\n".join(
+        f"{record.name} {record.levelname} {record.getMessage()} {record.args!r}"
+        for record in records
+    )
+
+
+def _assert_no_phi_substrings(log_output: str) -> None:
+    leaked = [substring for substring in PHI_SUBSTRINGS if substring in log_output]
+    assert leaked == [], f"raw PHI leaked into logs: {leaked!r}"
+
+
+def test_guard_detects_intentional_raw_phi_log_payload():
+    log_output = f"openmed.test INFO processing source text {PHI_SUBSTRINGS[0]}"
+
+    with pytest.raises(AssertionError, match="raw PHI leaked into logs"):
+        _assert_no_phi_substrings(log_output)
+
+
+def test_pii_processing_and_service_paths_do_not_log_raw_phi(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(openmed, "analyze_text", _fake_analyze_text)
+    monkeypatch.setattr(openmed, "extract_pii", _fake_extract_pii)
+    monkeypatch.setattr(openmed, "deidentify", _fake_deidentify)
+    monkeypatch.setattr(service_runtime, "ModelLoader", _NoopLoader)
+    monkeypatch.setenv("OPENMED_PROFILE", "test")
+    monkeypatch.delenv("OPENMED_SERVICE_PRELOAD_MODELS", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_KEEP_ALIVE", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_MAX_TEXT_LENGTH", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_TRUSTED_HOSTS", raising=False)
+
+    caplog.set_level(logging.DEBUG)
+
+    with caplog.at_level(logging.DEBUG):
+        cleaned = TextProcessor().clean_text(PHI_TEXT)
+        pii_result = extract_pii(PHI_TEXT, model_name="test-pii-model")
+        deid_result = deidentify(PHI_TEXT, model_name="test-pii-model")
+        batch_result = BatchProcessor(
+            model_name="test-pii-model",
+            operation="deidentify",
+            batch_size=1,
+        ).process_texts([PHI_TEXT], ids=["case-001"])
+
+        app = create_app()
+        with TestClient(
+            app,
+            base_url=LOOPBACK_BASE_URL,
+            raise_server_exceptions=False,
+        ) as client:
+            extract_response = client.post(
+                "/pii/extract",
+                json={"text": PHI_TEXT, "model_name": "test-pii-model"},
+            )
+            deid_response = client.post(
+                "/pii/deidentify",
+                json={"text": PHI_TEXT, "model_name": "test-pii-model"},
+            )
+
+    assert cleaned
+    assert len(pii_result.entities) >= len(PHI_SUBSTRINGS)
+    assert deid_result.deidentified_text != PHI_TEXT
+    assert batch_result.successful_items == 1
+    assert extract_response.status_code == 200
+    assert deid_response.status_code == 200
+    _assert_no_phi_substrings(_render_logs(caplog.records))


### PR DESCRIPTION
Closes #73.

Adds a no-raw-PHI logging policy, sanitizes processing and span diagnostics so logs use counts, offsets, and error types instead of source text, and adds a CI guard that exercises PII extraction, de-identification, batch processing, and REST endpoints against distinctive PHI fixtures.

Validation:
- .venv/bin/python -m pytest tests/unit/test_no_raw_text_logging.py -q
- .venv/bin/python -m pytest tests/ -q
- .venv/bin/python -m mkdocs build --strict