### PR TITLE
Add catalog coherence gate

### DIFF
--- a/.github/workflows/coherence.yml
+++ b/.github/workflows/coherence.yml
@@ -1,0 +1,26 @@
+name: Catalog coherence
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  catalog-coherence:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Regenerate manifest-derived surfaces
+        run: python scripts/manifest/regenerate_surfaces.py
+
+      - name: Fail on generated surface drift
+        run: git diff --exit-code

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 <h3>Local-first healthcare AI that never leaves the device</h3>
 
 <p><b>Turn clinical text into structured insight with one line of code.</b><br/>
-Entity extraction, PII de-identification, and 1,000+ specialized medical models that run entirely on
+Entity extraction, PII de-identification, and 1,518 specialized medical models that run entirely on
 your own hardware — from a one-liner in Python to a native Swift app on iPhone, powered by Apple MLX.
 No cloud. No vendor lock-in. No patient data leaving your network.</p>
 
 <p>
   <a href="https://pypi.org/project/openmed/"><img alt="PyPI" src="https://img.shields.io/pypi/v/openmed?style=for-the-badge&label=PyPI&logo=pypi&logoColor=white&color=0D6E6E"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python" src="https://img.shields.io/badge/Python-3.10+-128787?style=for-the-badge&logo=python&logoColor=white"></a>
-  <a href="https://huggingface.co/OpenMed"><img alt="Models" src="https://img.shields.io/badge/%F0%9F%A4%97%20Models-1%2C000+-F5E27A?style=for-the-badge&labelColor=0E1116"></a>
+  <a href="https://huggingface.co/OpenMed"><img alt="Models" src="https://img.shields.io/badge/%F0%9F%A4%97%20Models-1%2C518-F5E27A?style=for-the-badge&labelColor=0E1116"></a>
   <a href="https://arxiv.org/abs/2508.01630"><img alt="arXiv" src="https://img.shields.io/badge/arXiv-2508.01630-C5453A?style=for-the-badge&logo=arxiv&logoColor=white"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-0A5656?style=for-the-badge"></a>
   <a href="https://github.com/maziyarpanahi/openmed/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/maziyarpanahi/openmed?style=for-the-badge&logo=github&logoColor=0E1116&color=F5E27A&labelColor=0E1116"></a>
@@ -26,7 +26,7 @@ No cloud. No vendor lock-in. No patient data leaving your network.</p>
 </p>
 
 <p>
-  <b>1,000+ models</b> &nbsp;·&nbsp; <b>12 languages</b> &nbsp;·&nbsp; <b>247 PII checkpoints</b> &nbsp;·&nbsp; <b>100% on-device</b> &nbsp;·&nbsp; <b>Apache-2.0</b>
+  <b>1,518 models</b> &nbsp;·&nbsp; <b>12 languages</b> &nbsp;·&nbsp; <b>978 PII checkpoints</b> &nbsp;·&nbsp; <b>100% on-device</b> &nbsp;·&nbsp; <b>Apache-2.0</b>
 </p>
 
 <p>
@@ -97,14 +97,14 @@ A state-of-the-art clinical NER model running locally — no API key, no network
 | Runs on your device / servers         |            ✅            |           ❌           |
 | Patient data leaves your network      |        **Never**         |   Sent to the vendor   |
 | Cost                                  |    Free & open-source    |    Per-call pricing    |
-| Specialized medical models            |          1,000+          |        Limited         |
-| Languages                             |           12+            |         Varies         |
+| Specialized medical models            |          1,518          |        Limited         |
+| Languages                             |           12            |         Varies         |
 | Offline / air-gapped                  |            ✅            |           ❌           |
 | Apple Silicon (MLX) acceleration      |            ✅            |          n/a           |
 | Native iOS / macOS apps               |   ✅ via OpenMedKit      |           ❌           |
 | Vendor lock-in                        |    None — Apache-2.0     |          Yes           |
 
-- **Specialized models** — 1,000+ curated biomedical & clinical models, many outperforming proprietary stacks.
+- **Specialized models** — 1,518 curated biomedical & clinical models, many outperforming proprietary stacks.
 - **HIPAA-aware de-identification** — all 18 Safe Harbor identifiers, smart entity merging, format-preserving fakes.
 - **Runs everywhere** — CPU, CUDA, Apple Silicon (MLX), and natively in iOS/macOS apps via OpenMedKit.
 - **One-line deployment** — Python API, Dockerized REST service, or batch pipelines.
@@ -309,7 +309,7 @@ On non-Apple-Silicon hosts, MLX model names are automatically substituted with t
 
 ## Multilingual PII (12 languages)
 
-Extraction and de-identification across `en`, `fr`, `de`, `it`, `es`, `nl`, `hi`, `te`, `pt`, `ar`, `ja`, and `tr` — **247 PII checkpoints** total.
+Extraction and de-identification across `en`, `fr`, `de`, `it`, `es`, `nl`, `hi`, `te`, `pt`, `ar`, `ja`, `tr` — **978 PII checkpoints** total.
 
 ```bash
 python -c "from openmed import extract_pii; print([(e.label, e.text) for e in extract_pii('Dr. Pedro Almeida, CPF: 123.456.789-09, email: pedro@hospital.pt', lang='pt').entities])"

--- a/docs/model-registry.md
+++ b/docs/model-registry.md
@@ -39,13 +39,1594 @@ for model_key, info, reason in suggestions:
 - `entity_types` feed dropdowns or filter chips in your frontend.
 - `recommended_confidence` can drive slider defaults or guardrails on API calls (pass it to `analyze_text`).
 
+## Manifest-backed catalog
+
+The committed manifest currently contains 1,518 models across 12 supported PII languages. Family counts: General=3, NER=385, PII=978, Vision=7, ZeroShot=145.
+
+<!-- BEGIN MANIFEST MODEL TABLE -->
+| Model | Family | Task | Languages | Tier | Formats |
+|---|---|---|---|---|---|
+| `OpenMed/Ministral-3B-Medical-v1` | General | unknown | - | - | pytorch |
+| `OpenMed/Qwen2.5-VL-3B-Medical-v1` | General | unknown | - | - | pytorch |
+| `OpenMed/Qwen3.5-2B-Medical-v1` | General | unknown | - | - | pytorch |
+| `OpenMed/OpenMed-ClinicalNER-SuperClinical-Large-434M-v1` | NER | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-EuroMed-212M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-EuroMed-212M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-EuroMed-212M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-EuroMed-212M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-EuroMed-212M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-EuroMed-212M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-EuroMed-212M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-EuroMed-212M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-EuroMed-212M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BigMed-278M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BigMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BioClinical-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BioMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BioMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BioPatient-108M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ElectraMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ElectraMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ElectraMed-33M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ElectraMed-560M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ModernClinical-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ModernClinical-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ModernMed-149M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ModernMed-395M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-MultiMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-MultiMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-PubMed-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-PubMed-335M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-PubMed-v2-109M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SnowMed-568M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SuperClinical-141M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SuperClinical-184M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SuperClinical-434M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SuperMedical-125M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SuperMedical-355M` | NER | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-TinyMed-135M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-TinyMed-65M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-TinyMed-66M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-TinyMed-82M` | NER | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-AnatomyDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-BloodCancerDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ChemicalDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DNADetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-DiseaseDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomeDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-GenomicDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OncologyDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-OrganismDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PathologyDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-PharmaDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-ProteinDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BigMed-278M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BigMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BioClinical-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BioMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BioMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-BioPatient-108M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ElectraMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ElectraMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ElectraMed-33M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-ElectraMed-560M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-MultiMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-MultiMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-PubMed-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-PubMed-335M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-PubMed-v2-109M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SnowMed-568M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SuperClinical-141M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SuperClinical-184M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SuperClinical-434M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SuperMedical-125M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-SuperMedical-355M-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-TinyMed-135M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-TinyMed-65M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-TinyMed-66M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-NER-SpeciesDetect-TinyMed-82M-mlx` | PII | token-classification | en | Tiny | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Arabic-BigMed-Large-560M-v1` | PII | token-classification | ar | Large | pytorch |
+| `OpenMed/OpenMed-PII-Arabic-BigMed-Large-560M-v1-mlx` | PII | token-classification | ar | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Arabic-SnowflakeMed-Large-568M-v1` | PII | token-classification | ar | Large | pytorch |
+| `OpenMed/OpenMed-PII-Arabic-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | ar | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Bengali-mSuperClinical-Large-279M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Bengali-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-BigMed-Large-278M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-BigMed-Large-278M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-BigMed-Large-560M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-BigMed-Large-560M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-BioClinicalBERT-Base-110M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-BioClinicalBERT-Base-110M-v1-mlx` | PII | token-classification | en | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-BioClinicalModern-Base-149M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-BioClinicalModern-Large-395M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-BiomedBERT-Base-110M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-BiomedBERT-Base-110M-v1-mlx` | PII | token-classification | en | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-BiomedBERT-Large-340M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-BiomedBERT-Large-340M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-BiomedELECTRA-Base-110M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-BiomedELECTRA-Base-110M-v1-mlx` | PII | token-classification | en | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-BiomedELECTRA-Large-335M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-BiomedELECTRA-Large-335M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Chinese-BigMed-Large-278M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Chinese-BigMed-Large-278M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Chinese-BigMed-Large-560M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Chinese-BigMed-Large-560M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Chinese-BioClinicalModern-Large-395M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Chinese-ModernMed-Large-395M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Chinese-NomicMed-Large-395M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Chinese-QwenMed-XLarge-600M-v1` | PII | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-Chinese-SnowflakeMed-Large-568M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Chinese-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-ClinicDischarge-Base-110M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-ClinicDischarge-Base-110M-v1-mlx` | PII | token-classification | en | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-ClinicalBGE-Large-335M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-ClinicalBGE-Large-568M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-ClinicalE5-Base-109M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalE5-Base-109M-v1-mlx` | PII | token-classification | en | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-ClinicalE5-Large-335M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalE5-Large-335M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-ClinicalE5-Small-33M-v1` | PII | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalE5-Small-33M-v1-mlx` | PII | token-classification | en | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-ClinicalLongformer-Base-149M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BigMed-Large-278M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BigMed-Large-278M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BigMed-Large-560M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BigMed-Large-560M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BioClinicalBERT-Base-110M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BioClinicalBERT-Base-110M-v1-mlx` | PII | token-classification | nl | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BioClinicalModern-Base-149M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BioClinicalModern-Large-395M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BiomedBERT-Base-110M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BiomedBERT-Base-110M-v1-mlx` | PII | token-classification | nl | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BiomedBERT-Large-340M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BiomedBERT-Large-340M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BiomedBERTFull-Base-110M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BiomedBERTFull-Base-110M-v1-mlx` | PII | token-classification | nl | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BiomedELECTRA-Base-110M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BiomedELECTRA-Base-110M-v1-mlx` | PII | token-classification | nl | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BiomedELECTRA-Large-335M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-BiomedELECTRA-Large-335M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicDischarge-Base-110M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicDischarge-Base-110M-v1-mlx` | PII | token-classification | nl | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalBGE-Large-335M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalBGE-Large-568M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalE5-Base-109M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalE5-Base-109M-v1-mlx` | PII | token-classification | nl | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalE5-Large-335M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalE5-Large-335M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalE5-Small-33M-v1` | PII | token-classification | nl | Small | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalE5-Small-33M-v1-mlx` | PII | token-classification | nl | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ClinicalLongformer-Base-149M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-EuroMed-Large-210M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-FastClinical-Small-82M-v1` | PII | token-classification | nl | Small | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-FastClinical-Small-82M-v1-mlx` | PII | token-classification | nl | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-GTEMed-Base-149M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-LiteClinical-Small-66M-v1` | PII | token-classification | nl | Small | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-LiteClinical-Small-66M-v1-mlx` | PII | token-classification | nl | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-LiteClinicalU-Small-66M-v1` | PII | token-classification | nl | Small | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-LiteClinicalU-Small-66M-v1-mlx` | PII | token-classification | nl | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ModernMed-Base-149M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-ModernMed-Large-395M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-NomicMed-Large-395M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-QwenMed-XLarge-600M-v1` | PII | token-classification | nl | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SnowflakeMed-Large-568M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SuperClinical-Base-184M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | nl | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SuperClinical-Large-434M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SuperClinical-Small-44M-v1` | PII | token-classification | nl | Small | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | nl | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SuperMedical-Base-125M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SuperMedical-Base-125M-v1-mlx` | PII | token-classification | nl | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SuperMedical-Large-355M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-mClinicalE5-Large-560M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-mClinicalE5-Large-560M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-mLiteClinical-Base-135M-v1` | PII | token-classification | nl | Base | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-mLiteClinical-Base-135M-v1-mlx` | PII | token-classification | nl | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Dutch-mSuperClinical-Large-279M-v1` | PII | token-classification | nl | Large | pytorch |
+| `OpenMed/OpenMed-PII-Dutch-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | nl | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-EuroMed-Large-210M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-FastClinical-Small-82M-v1` | PII | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-PII-FastClinical-Small-82M-v1-mlx` | PII | token-classification | en | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-BigMed-Large-278M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-BigMed-Large-278M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-BigMed-Large-560M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-BigMed-Large-560M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-BioClinicalBERT-Base-110M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-BioClinicalBERT-Base-110M-v1-mlx` | PII | token-classification | fr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-BioClinicalModern-Base-149M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-BioClinicalModern-Large-395M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-BiomedBERT-Base-110M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-BiomedBERT-Base-110M-v1-mlx` | PII | token-classification | fr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-BiomedBERT-Large-340M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-BiomedBERT-Large-340M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-BiomedBERTFull-Base-110M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-BiomedBERTFull-Base-110M-v1-mlx` | PII | token-classification | fr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-BiomedELECTRA-Base-110M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-BiomedELECTRA-Base-110M-v1-mlx` | PII | token-classification | fr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-BiomedELECTRA-Large-335M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-BiomedELECTRA-Large-335M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicDischarge-Base-110M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicDischarge-Base-110M-v1-mlx` | PII | token-classification | fr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalBGE-Large-335M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalBGE-Large-568M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalE5-Base-109M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalE5-Base-109M-v1-mlx` | PII | token-classification | fr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalE5-Large-335M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalE5-Large-335M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalE5-Small-33M-v1` | PII | token-classification | fr | Small | pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalE5-Small-33M-v1-mlx` | PII | token-classification | fr | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-ClinicalLongformer-Base-149M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-EuroMed-Large-210M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-FastClinical-Small-82M-v1` | PII | token-classification | fr | Small | pytorch |
+| `OpenMed/OpenMed-PII-French-FastClinical-Small-82M-v1-mlx` | PII | token-classification | fr | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-GTEMed-Base-149M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-LiteClinical-Small-66M-v1` | PII | token-classification | fr | Small | pytorch |
+| `OpenMed/OpenMed-PII-French-LiteClinical-Small-66M-v1-mlx` | PII | token-classification | fr | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-LiteClinicalU-Small-66M-v1` | PII | token-classification | fr | Small | pytorch |
+| `OpenMed/OpenMed-PII-French-LiteClinicalU-Small-66M-v1-mlx` | PII | token-classification | fr | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-ModernMed-Base-149M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-ModernMed-Large-395M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-NomicMed-Large-395M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-QwenMed-XLarge-600M-v1` | PII | token-classification | fr | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-French-SnowflakeMed-Large-568M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-SuperClinical-Base-184M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | fr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-SuperClinical-Large-434M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-SuperClinical-Small-44M-v1` | PII | token-classification | fr | Small | pytorch |
+| `OpenMed/OpenMed-PII-French-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | fr | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-SuperMedical-Base-125M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-SuperMedical-Base-125M-v1-mlx` | PII | token-classification | fr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-SuperMedical-Large-355M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-mClinicalE5-Large-560M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-mClinicalE5-Large-560M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-mLiteClinical-Base-135M-v1` | PII | token-classification | fr | Base | pytorch |
+| `OpenMed/OpenMed-PII-French-mLiteClinical-Base-135M-v1-mlx` | PII | token-classification | fr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-French-mSuperClinical-Large-279M-v1` | PII | token-classification | fr | Large | pytorch |
+| `OpenMed/OpenMed-PII-French-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | fr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-GTEMed-Base-149M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-BigMed-Large-278M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-BigMed-Large-278M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-BigMed-Large-560M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-BigMed-Large-560M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-BioClinicalBERT-Base-110M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-BioClinicalBERT-Base-110M-v1-mlx` | PII | token-classification | de | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-BioClinicalModern-Base-149M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-BioClinicalModern-Large-395M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-BiomedBERT-Base-110M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-BiomedBERT-Base-110M-v1-mlx` | PII | token-classification | de | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-BiomedBERT-Large-340M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-BiomedBERT-Large-340M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-BiomedBERTFull-Base-110M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-BiomedBERTFull-Base-110M-v1-mlx` | PII | token-classification | de | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-BiomedELECTRA-Base-110M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-BiomedELECTRA-Base-110M-v1-mlx` | PII | token-classification | de | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-BiomedELECTRA-Large-335M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-BiomedELECTRA-Large-335M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicDischarge-Base-110M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicDischarge-Base-110M-v1-mlx` | PII | token-classification | de | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalBGE-Large-335M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalBGE-Large-568M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalE5-Base-109M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalE5-Base-109M-v1-mlx` | PII | token-classification | de | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalE5-Large-335M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalE5-Large-335M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalE5-Small-33M-v1` | PII | token-classification | de | Small | pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalE5-Small-33M-v1-mlx` | PII | token-classification | de | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-ClinicalLongformer-Base-149M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-EuroMed-Large-210M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-FastClinical-Small-82M-v1` | PII | token-classification | de | Small | pytorch |
+| `OpenMed/OpenMed-PII-German-FastClinical-Small-82M-v1-mlx` | PII | token-classification | de | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-GTEMed-Base-149M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-LiteClinical-Small-66M-v1` | PII | token-classification | de | Small | pytorch |
+| `OpenMed/OpenMed-PII-German-LiteClinical-Small-66M-v1-mlx` | PII | token-classification | de | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-LiteClinicalU-Small-66M-v1` | PII | token-classification | de | Small | pytorch |
+| `OpenMed/OpenMed-PII-German-LiteClinicalU-Small-66M-v1-mlx` | PII | token-classification | de | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-ModernMed-Base-149M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-ModernMed-Large-395M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-NomicMed-Large-395M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-QwenMed-XLarge-600M-v1` | PII | token-classification | de | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-German-SnowflakeMed-Large-568M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-SuperClinical-Base-184M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | de | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-SuperClinical-Large-434M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-SuperClinical-Small-44M-v1` | PII | token-classification | de | Small | pytorch |
+| `OpenMed/OpenMed-PII-German-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | de | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-SuperMedical-Base-125M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-SuperMedical-Base-125M-v1-mlx` | PII | token-classification | de | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-SuperMedical-Large-355M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-mClinicalE5-Large-560M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-mClinicalE5-Large-560M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-mLiteClinical-Base-135M-v1` | PII | token-classification | de | Base | pytorch |
+| `OpenMed/OpenMed-PII-German-mLiteClinical-Base-135M-v1-mlx` | PII | token-classification | de | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-German-mSuperClinical-Large-279M-v1` | PII | token-classification | de | Large | pytorch |
+| `OpenMed/OpenMed-PII-German-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | de | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BigMed-Large-278M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BigMed-Large-278M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BigMed-Large-560M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BigMed-Large-560M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BioClinicalBERT-Base-110M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BioClinicalBERT-Base-110M-v1-mlx` | PII | token-classification | hi | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BioClinicalModern-Base-149M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BioClinicalModern-Large-395M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BiomedBERT-Base-110M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BiomedBERT-Base-110M-v1-mlx` | PII | token-classification | hi | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BiomedBERT-Large-340M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BiomedBERT-Large-340M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BiomedBERTFull-Base-110M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BiomedBERTFull-Base-110M-v1-mlx` | PII | token-classification | hi | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BiomedELECTRA-Base-110M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BiomedELECTRA-Base-110M-v1-mlx` | PII | token-classification | hi | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BiomedELECTRA-Large-335M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-BiomedELECTRA-Large-335M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicDischarge-Base-110M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicDischarge-Base-110M-v1-mlx` | PII | token-classification | hi | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalBGE-Large-335M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalBGE-Large-568M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalE5-Base-109M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalE5-Base-109M-v1-mlx` | PII | token-classification | hi | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalE5-Large-335M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalE5-Large-335M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalE5-Small-33M-v1` | PII | token-classification | hi | Small | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalE5-Small-33M-v1-mlx` | PII | token-classification | hi | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ClinicalLongformer-Base-149M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-EuroMed-Large-210M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-FastClinical-Small-82M-v1` | PII | token-classification | hi | Small | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-FastClinical-Small-82M-v1-mlx` | PII | token-classification | hi | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-GTEMed-Base-149M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-LiteClinical-Small-66M-v1` | PII | token-classification | hi | Small | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-LiteClinical-Small-66M-v1-mlx` | PII | token-classification | hi | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-LiteClinicalU-Small-66M-v1` | PII | token-classification | hi | Small | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-LiteClinicalU-Small-66M-v1-mlx` | PII | token-classification | hi | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ModernMed-Base-149M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-ModernMed-Large-395M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-NomicMed-Large-395M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-QwenMed-XLarge-600M-v1` | PII | token-classification | hi | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SnowflakeMed-Large-568M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SuperClinical-Base-184M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | hi | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SuperClinical-Large-434M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SuperClinical-Small-44M-v1` | PII | token-classification | hi | Small | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | hi | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SuperMedical-Base-125M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SuperMedical-Base-125M-v1-mlx` | PII | token-classification | hi | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SuperMedical-Large-355M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-mClinicalE5-Large-560M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-mClinicalE5-Large-560M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-mLiteClinical-Base-135M-v1` | PII | token-classification | hi | Base | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-mLiteClinical-Base-135M-v1-mlx` | PII | token-classification | hi | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Hindi-mSuperClinical-Large-279M-v1` | PII | token-classification | hi | Large | pytorch |
+| `OpenMed/OpenMed-PII-Hindi-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | hi | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-BigMed-Large-278M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-BigMed-Large-278M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-BigMed-Large-560M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-BigMed-Large-560M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-BioClinicalBERT-Base-110M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-BioClinicalBERT-Base-110M-v1-mlx` | PII | token-classification | it | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-BioClinicalModern-Base-149M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-BioClinicalModern-Large-395M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-BiomedBERT-Base-110M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-BiomedBERT-Base-110M-v1-mlx` | PII | token-classification | it | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-BiomedBERT-Large-340M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-BiomedBERT-Large-340M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-BiomedBERTFull-Base-110M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-BiomedBERTFull-Base-110M-v1-mlx` | PII | token-classification | it | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-BiomedELECTRA-Base-110M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-BiomedELECTRA-Base-110M-v1-mlx` | PII | token-classification | it | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-BiomedELECTRA-Large-335M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-BiomedELECTRA-Large-335M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicDischarge-Base-110M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicDischarge-Base-110M-v1-mlx` | PII | token-classification | it | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalBGE-Large-335M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalBGE-Large-568M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalE5-Base-109M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalE5-Base-109M-v1-mlx` | PII | token-classification | it | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalE5-Large-335M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalE5-Large-335M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalE5-Small-33M-v1` | PII | token-classification | it | Small | pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalE5-Small-33M-v1-mlx` | PII | token-classification | it | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-ClinicalLongformer-Base-149M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-EuroMed-Large-210M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-FastClinical-Small-82M-v1` | PII | token-classification | it | Small | pytorch |
+| `OpenMed/OpenMed-PII-Italian-FastClinical-Small-82M-v1-mlx` | PII | token-classification | it | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-GTEMed-Base-149M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-LiteClinical-Small-66M-v1` | PII | token-classification | it | Small | pytorch |
+| `OpenMed/OpenMed-PII-Italian-LiteClinical-Small-66M-v1-mlx` | PII | token-classification | it | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-LiteClinicalU-Small-66M-v1` | PII | token-classification | it | Small | pytorch |
+| `OpenMed/OpenMed-PII-Italian-LiteClinicalU-Small-66M-v1-mlx` | PII | token-classification | it | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-ModernMed-Base-149M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-ModernMed-Large-395M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-NomicMed-Large-395M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-QwenMed-XLarge-600M-v1` | PII | token-classification | it | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-Italian-SnowflakeMed-Large-568M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-SuperClinical-Base-184M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | it | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-SuperClinical-Large-434M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-SuperClinical-Small-44M-v1` | PII | token-classification | it | Small | pytorch |
+| `OpenMed/OpenMed-PII-Italian-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | it | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-SuperMedical-Base-125M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-SuperMedical-Base-125M-v1-mlx` | PII | token-classification | it | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-SuperMedical-Large-355M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-mClinicalE5-Large-560M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-mClinicalE5-Large-560M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-mLiteClinical-Base-135M-v1` | PII | token-classification | it | Base | pytorch |
+| `OpenMed/OpenMed-PII-Italian-mLiteClinical-Base-135M-v1-mlx` | PII | token-classification | it | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Italian-mSuperClinical-Large-279M-v1` | PII | token-classification | it | Large | pytorch |
+| `OpenMed/OpenMed-PII-Italian-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | it | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Japanese-BigMed-Large-560M-v1` | PII | token-classification | ja | Large | pytorch |
+| `OpenMed/OpenMed-PII-Japanese-BigMed-Large-560M-v1-mlx` | PII | token-classification | ja | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Japanese-NomicMed-Large-395M-v1` | PII | token-classification | ja | Large | pytorch |
+| `OpenMed/OpenMed-PII-Japanese-QwenMed-XLarge-600M-v1` | PII | token-classification | ja | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-Korean-NomicMed-Large-395M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Korean-QwenMed-XLarge-600M-v1` | PII | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-LiteClinical-Small-66M-v1` | PII | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-PII-LiteClinical-Small-66M-v1-mlx` | PII | token-classification | en | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-ModernMed-Base-149M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-ModernMed-Large-395M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-NomicMed-Large-395M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BigMed-Large-278M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BigMed-Large-278M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BigMed-Large-560M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BigMed-Large-560M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BioClinicalBERT-Base-110M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BioClinicalBERT-Base-110M-v1-mlx` | PII | token-classification | pt | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BioClinicalModern-Base-149M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BioClinicalModern-Large-395M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BiomedBERT-Base-110M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BiomedBERT-Base-110M-v1-mlx` | PII | token-classification | pt | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BiomedBERT-Large-340M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BiomedBERT-Large-340M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BiomedBERTFull-Base-110M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BiomedBERTFull-Base-110M-v1-mlx` | PII | token-classification | pt | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BiomedELECTRA-Base-110M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BiomedELECTRA-Base-110M-v1-mlx` | PII | token-classification | pt | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BiomedELECTRA-Large-335M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-BiomedELECTRA-Large-335M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicDischarge-Base-110M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicDischarge-Base-110M-v1-mlx` | PII | token-classification | pt | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalBGE-Large-335M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalBGE-Large-568M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalE5-Base-109M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalE5-Base-109M-v1-mlx` | PII | token-classification | pt | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalE5-Large-335M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalE5-Large-335M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalE5-Small-33M-v1` | PII | token-classification | pt | Small | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalE5-Small-33M-v1-mlx` | PII | token-classification | pt | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ClinicalLongformer-Base-149M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-FastClinical-Small-82M-v1` | PII | token-classification | pt | Small | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-FastClinical-Small-82M-v1-mlx` | PII | token-classification | pt | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-LiteClinical-Small-66M-v1` | PII | token-classification | pt | Small | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-LiteClinical-Small-66M-v1-mlx` | PII | token-classification | pt | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-LiteClinicalU-Small-66M-v1` | PII | token-classification | pt | Small | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-LiteClinicalU-Small-66M-v1-mlx` | PII | token-classification | pt | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ModernMed-Base-149M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-ModernMed-Large-395M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-NomicMed-Large-395M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-QwenMed-XLarge-600M-v1` | PII | token-classification | pt | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SnowflakeMed-Large-568M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SuperClinical-Base-184M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | pt | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SuperClinical-Large-434M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SuperClinical-Small-44M-v1` | PII | token-classification | pt | Small | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | pt | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SuperMedical-Base-125M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SuperMedical-Base-125M-v1-mlx` | PII | token-classification | pt | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SuperMedical-Large-355M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-mLiteClinical-Base-135M-v1` | PII | token-classification | pt | Base | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-mLiteClinical-Base-135M-v1-mlx` | PII | token-classification | pt | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-mSuperClinical-Large-279M-v1` | PII | token-classification | pt | Large | pytorch |
+| `OpenMed/OpenMed-PII-Portuguese-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | pt | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-QwenMed-XLarge-600M-v1` | PII | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-SnowflakeMed-Large-568M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BigMed-Large-278M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BigMed-Large-278M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BigMed-Large-560M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BigMed-Large-560M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BioClinicalBERT-Base-110M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BioClinicalBERT-Base-110M-v1-mlx` | PII | token-classification | es | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BioClinicalModern-Base-149M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BioClinicalModern-Large-395M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BiomedBERT-Base-110M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BiomedBERT-Base-110M-v1-mlx` | PII | token-classification | es | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BiomedBERT-Large-340M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BiomedBERT-Large-340M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BiomedBERTFull-Base-110M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BiomedBERTFull-Base-110M-v1-mlx` | PII | token-classification | es | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BiomedELECTRA-Base-110M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BiomedELECTRA-Base-110M-v1-mlx` | PII | token-classification | es | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BiomedELECTRA-Large-335M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-BiomedELECTRA-Large-335M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicDischarge-Base-110M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicDischarge-Base-110M-v1-mlx` | PII | token-classification | es | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalBGE-Large-335M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalBGE-Large-568M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalE5-Base-109M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalE5-Base-109M-v1-mlx` | PII | token-classification | es | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalE5-Large-335M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalE5-Large-335M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalE5-Small-33M-v1` | PII | token-classification | es | Small | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalE5-Small-33M-v1-mlx` | PII | token-classification | es | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ClinicalLongformer-Base-149M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-EuroMed-Large-210M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-FastClinical-Small-82M-v1` | PII | token-classification | es | Small | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-FastClinical-Small-82M-v1-mlx` | PII | token-classification | es | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-GTEMed-Base-149M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-LiteClinical-Small-66M-v1` | PII | token-classification | es | Small | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-LiteClinical-Small-66M-v1-mlx` | PII | token-classification | es | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-LiteClinicalU-Small-66M-v1` | PII | token-classification | es | Small | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-LiteClinicalU-Small-66M-v1-mlx` | PII | token-classification | es | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ModernMed-Base-149M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-ModernMed-Large-395M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-NomicMed-Large-395M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-QwenMed-XLarge-600M-v1` | PII | token-classification | es | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SnowflakeMed-Large-568M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SuperClinical-Base-184M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | es | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SuperClinical-Large-434M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SuperClinical-Small-44M-v1` | PII | token-classification | es | Small | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | es | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SuperMedical-Base-125M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SuperMedical-Base-125M-v1-mlx` | PII | token-classification | es | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SuperMedical-Large-355M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-mClinicalE5-Large-560M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-mClinicalE5-Large-560M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-mLiteClinical-Base-135M-v1` | PII | token-classification | es | Base | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-mLiteClinical-Base-135M-v1-mlx` | PII | token-classification | es | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Spanish-mSuperClinical-Large-279M-v1` | PII | token-classification | es | Large | pytorch |
+| `OpenMed/OpenMed-PII-Spanish-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | es | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-SuperClinical-Base-184M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | en | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-SuperClinical-Large-434M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1` | PII | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | en | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-SuperMedical-Base-125M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-SuperMedical-Base-125M-v1-mlx` | PII | token-classification | en | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-SuperMedical-Large-355M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BigMed-Large-278M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BigMed-Large-278M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BigMed-Large-560M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BigMed-Large-560M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BioClinicalBERT-Base-110M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BioClinicalBERT-Base-110M-v1-mlx` | PII | token-classification | te | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BioClinicalModern-Base-149M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BioClinicalModern-Large-395M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BiomedBERT-Base-110M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BiomedBERT-Base-110M-v1-mlx` | PII | token-classification | te | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BiomedBERT-Large-340M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BiomedBERT-Large-340M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BiomedBERTFull-Base-110M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BiomedBERTFull-Base-110M-v1-mlx` | PII | token-classification | te | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BiomedELECTRA-Base-110M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BiomedELECTRA-Base-110M-v1-mlx` | PII | token-classification | te | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BiomedELECTRA-Large-335M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-BiomedELECTRA-Large-335M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicDischarge-Base-110M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicDischarge-Base-110M-v1-mlx` | PII | token-classification | te | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalBGE-Large-335M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalBGE-Large-568M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalE5-Base-109M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalE5-Base-109M-v1-mlx` | PII | token-classification | te | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalE5-Large-335M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalE5-Large-335M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalE5-Small-33M-v1` | PII | token-classification | te | Small | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalE5-Small-33M-v1-mlx` | PII | token-classification | te | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ClinicalLongformer-Base-149M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-EuroMed-Large-210M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-FastClinical-Small-82M-v1` | PII | token-classification | te | Small | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-FastClinical-Small-82M-v1-mlx` | PII | token-classification | te | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-GTEMed-Base-149M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-LiteClinical-Small-66M-v1` | PII | token-classification | te | Small | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-LiteClinical-Small-66M-v1-mlx` | PII | token-classification | te | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-LiteClinicalU-Small-66M-v1` | PII | token-classification | te | Small | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-LiteClinicalU-Small-66M-v1-mlx` | PII | token-classification | te | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ModernMed-Base-149M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-ModernMed-Large-395M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-NomicMed-Large-395M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-QwenMed-XLarge-600M-v1` | PII | token-classification | te | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SnowflakeMed-Large-568M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SuperClinical-Base-184M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | te | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SuperClinical-Large-434M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SuperClinical-Small-44M-v1` | PII | token-classification | te | Small | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | te | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SuperMedical-Base-125M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SuperMedical-Base-125M-v1-mlx` | PII | token-classification | te | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SuperMedical-Large-355M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-mClinicalE5-Large-560M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-mClinicalE5-Large-560M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-mLiteClinical-Base-135M-v1` | PII | token-classification | te | Base | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-mLiteClinical-Base-135M-v1-mlx` | PII | token-classification | te | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Telugu-mSuperClinical-Large-279M-v1` | PII | token-classification | te | Large | pytorch |
+| `OpenMed/OpenMed-PII-Telugu-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | te | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BigMed-Large-278M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BigMed-Large-278M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BigMed-Large-560M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BigMed-Large-560M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BioClinicalBERT-Base-110M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BioClinicalBERT-Base-110M-v1-mlx` | PII | token-classification | tr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BioClinicalModern-Base-149M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BioClinicalModern-Large-395M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BiomedBERT-Base-110M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BiomedBERT-Base-110M-v1-mlx` | PII | token-classification | tr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BiomedBERT-Large-340M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BiomedBERT-Large-340M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BiomedBERTFull-Base-110M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BiomedBERTFull-Base-110M-v1-mlx` | PII | token-classification | tr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BiomedELECTRA-Base-110M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BiomedELECTRA-Base-110M-v1-mlx` | PII | token-classification | tr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BiomedELECTRA-Large-335M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-BiomedELECTRA-Large-335M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicDischarge-Base-110M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicDischarge-Base-110M-v1-mlx` | PII | token-classification | tr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalBGE-Large-335M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalBGE-Large-568M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalE5-Base-109M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalE5-Base-109M-v1-mlx` | PII | token-classification | tr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalE5-Large-335M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalE5-Large-335M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalE5-Small-33M-v1` | PII | token-classification | tr | Small | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalE5-Small-33M-v1-mlx` | PII | token-classification | tr | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ClinicalLongformer-Base-149M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-FastClinical-Small-82M-v1` | PII | token-classification | tr | Small | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-FastClinical-Small-82M-v1-mlx` | PII | token-classification | tr | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-LiteClinical-Small-66M-v1` | PII | token-classification | tr | Small | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-LiteClinical-Small-66M-v1-mlx` | PII | token-classification | tr | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-LiteClinicalU-Small-66M-v1` | PII | token-classification | tr | Small | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-LiteClinicalU-Small-66M-v1-mlx` | PII | token-classification | tr | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ModernMed-Base-149M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-ModernMed-Large-395M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-NomicMed-Large-395M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-QwenMed-XLarge-600M-v1` | PII | token-classification | tr | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SnowflakeMed-Large-568M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SuperClinical-Base-184M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | tr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SuperClinical-Large-434M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1` | PII | token-classification | tr | Small | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | tr | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SuperMedical-Base-125M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SuperMedical-Base-125M-v1-mlx` | PII | token-classification | tr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SuperMedical-Large-355M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-mLiteClinical-Base-135M-v1` | PII | token-classification | tr | Base | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-mLiteClinical-Base-135M-v1-mlx` | PII | token-classification | tr | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Turkish-mSuperClinical-Large-279M-v1` | PII | token-classification | tr | Large | pytorch |
+| `OpenMed/OpenMed-PII-Turkish-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | tr | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-BigMed-Large-278M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-BigMed-Large-278M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-ClinicalBGE-Large-335M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-ClinicalBGE-Large-335M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-ClinicalBGE-Large-568M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-ClinicalBGE-Large-568M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-SnowflakeMed-Large-568M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-SnowflakeMed-Large-568M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-SuperClinical-Base-184M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-SuperClinical-Base-184M-v1-mlx` | PII | token-classification | en | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-SuperClinical-Large-434M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-SuperClinical-Large-434M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-SuperClinical-Small-44M-v1` | PII | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-SuperClinical-Small-44M-v1-mlx` | PII | token-classification | en | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-SuperMedical-Large-355M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-SuperMedical-Large-355M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-mSuperClinical-Large-279M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-Vietnamese-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-mClinicalE5-Large-560M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-mClinicalE5-Large-560M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-mLiteClinical-Base-135M-v1` | PII | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-PII-mLiteClinical-Base-135M-v1-mlx` | PII | token-classification | en | Base | mlx-fp, pytorch |
+| `OpenMed/OpenMed-PII-mSuperClinical-Large-279M-v1` | PII | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-PII-mSuperClinical-Large-279M-v1-mlx` | PII | token-classification | en | Large | mlx-fp, pytorch |
+| `OpenMed/gliner-multi-pii-v1-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/privacy-filter-ai4privacy` | PII | token-classification | en | - | pytorch |
+| `OpenMed/privacy-filter-ai4privacy-multilingual` | PII | token-classification | de, en, es, fr, it, nl | - | pytorch |
+| `OpenMed/privacy-filter-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/privacy-filter-mlx-8bit` | PII | token-classification | en | - | mlx-8bit, pytorch |
+| `OpenMed/privacy-filter-multilingual` | PII | token-classification | ar, de, en, es, fr, hi, it, ja, nl, pt, te, tr | - | pytorch |
+| `OpenMed/privacy-filter-multilingual-mlx` | PII | token-classification | ar, de, en, es, fr, hi, it, ja, nl, pt, te, tr | - | mlx-fp, pytorch |
+| `OpenMed/privacy-filter-multilingual-mlx-8bit` | PII | token-classification | ar, de, en, es, fr, hi, it, ja, nl, pt, te, tr | - | mlx-8bit, pytorch |
+| `OpenMed/privacy-filter-multilingual-v2` | PII | token-classification | ar, de, en, es, fr, hi, it, ja, nl, pt, te, tr | - | pytorch |
+| `OpenMed/privacy-filter-nemotron` | PII | token-classification | en | - | pytorch |
+| `OpenMed/privacy-filter-nemotron-mlx` | PII | token-classification | en | - | mlx-fp, pytorch |
+| `OpenMed/privacy-filter-nemotron-mlx-8bit` | PII | token-classification | en | - | mlx-8bit, pytorch |
+| `OpenMed/privacy-filter-nemotron-piimb-v2` | PII | token-classification | de, en, es, fr, it, nl, pt | - | pytorch |
+| `OpenMed/privacy-filter-nemotron-v2` | PII | token-classification | de, en, es, fr, it, nl, pt | - | pytorch |
+| `OpenMed/privacy-filter-openmed-pii54-multilingual` | PII | token-classification | ar, de, en, es, fr, hi, it, ja, nl, pt, te, tr | - | pytorch |
+| `OpenMed/privacy-filter-piimb-fine-grained` | PII | token-classification | de, en, es, fr, it, nl, pt | - | pytorch |
+| `OpenMed/falcon-ocr-bf16-mlx` | Vision | image-text-to-text | en | - | mlx-fp, pytorch |
+| `OpenMed/falcon-ocr-q6-mlx` | Vision | image-text-to-text | en | - | mlx-fp, pytorch |
+| `OpenMed/falcon-ocr-q8-mlx` | Vision | image-text-to-text | en | - | mlx-fp, pytorch |
+| `OpenMed/ppocr-v5-mobile-coreml` | Vision | image-to-text | en | - | mlx-fp |
+| `OpenMed/Ministral-3B-MedVL` | Vision | visual-question-answering | - | - | pytorch |
+| `OpenMed/Qwen2.5-3B-MedVL` | Vision | visual-question-answering | - | - | pytorch |
+| `OpenMed/Qwen3.5-2B-MedVL` | Vision | visual-question-answering | - | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Anatomy-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-BloodCancer-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Chemical-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-DNA-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Disease-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genome-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Genomic-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Oncology-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Organism-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pathology-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Pharma-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Protein-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-Base-220M` | ZeroShot | token-classification | en | Base | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-Large-459M` | ZeroShot | token-classification | en | Large | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-Large-459M-mlx` | ZeroShot | token-classification | - | Large | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-Medium-209M` | ZeroShot | token-classification | en | Medium | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-Medium-209M-mlx` | ZeroShot | token-classification | - | Medium | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-Multi-209M` | ZeroShot | token-classification | en | - | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-Multi-209M-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-Small-166M` | ZeroShot | token-classification | en | Small | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-Small-166M-mlx` | ZeroShot | token-classification | - | Small | mlx-fp, pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-Tiny-60M` | ZeroShot | token-classification | en | Tiny | pytorch |
+| `OpenMed/OpenMed-ZeroShot-NER-Species-XLarge-770M` | ZeroShot | token-classification | en | XLarge | pytorch |
+| `OpenMed/gliner-relex-base-v1.0-mlx` | ZeroShot | token-classification | - | - | mlx-fp, pytorch |
+| `OpenMed/gliclass-instruct-base-v1.0-mlx` | ZeroShot | zero-shot-classification | - | - | mlx-fp, pytorch |
+<!-- END MANIFEST MODEL TABLE -->
+
+## Benchmark rows
+
+<!-- BEGIN MANIFEST BENCHMARK TABLE -->
+| Model | Family | Dataset | Micro F1 | Recall | Tier | Formats |
+|---|---|---|---:|---:|---|---|
+| `OpenMed/privacy-filter-multilingual` | PII | ai4privacy/pii-masking-200k | - | - | - | pytorch |
+| `OpenMed/privacy-filter-multilingual-mlx` | PII | ai4privacy/pii-masking-200k | - | - | - | mlx-fp, pytorch |
+| `OpenMed/privacy-filter-multilingual-mlx-8bit` | PII | ai4privacy/pii-masking-200k | - | - | - | mlx-8bit, pytorch |
+| `OpenMed/privacy-filter-multilingual-v2` | PII | ai4privacy/pii-masking-200k | - | - | - | pytorch |
+| `OpenMed/privacy-filter-openmed-pii54-multilingual` | PII | ai4privacy/pii-masking-200k | - | - | - | pytorch |
+| `OpenMed/privacy-filter-ai4privacy` | PII | ai4privacy/pii-masking-400k | - | - | - | pytorch |
+| `OpenMed/privacy-filter-ai4privacy-multilingual` | PII | ai4privacy/pii-masking-400k | - | - | - | pytorch |
+| `OpenMed/OpenMed-ClinicalNER-SuperClinical-Large-434M-v1` | NER | custom | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-BigMed-Large-278M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-BigMed-Large-560M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-BioClinicalBERT-Base-110M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-BioClinicalModern-Base-149M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-BioClinicalModern-Large-395M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-BiomedBERT-Base-110M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-BiomedBERT-Large-340M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-BiomedELECTRA-Base-110M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-BiomedELECTRA-Large-335M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-ClinicDischarge-Base-110M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalBGE-Large-335M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalBGE-Large-568M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalE5-Base-109M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalE5-Large-335M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalE5-Small-33M-v1` | PII | nvidia/Nemotron-PII | - | - | Small | pytorch |
+| `OpenMed/OpenMed-PII-ClinicalLongformer-Base-149M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-EuroMed-Large-210M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-FastClinical-Small-82M-v1` | PII | nvidia/Nemotron-PII | - | - | Small | pytorch |
+| `OpenMed/OpenMed-PII-GTEMed-Base-149M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-LiteClinical-Small-66M-v1` | PII | nvidia/Nemotron-PII | - | - | Small | pytorch |
+| `OpenMed/OpenMed-PII-ModernMed-Base-149M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-ModernMed-Large-395M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-NomicMed-Large-395M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-QwenMed-XLarge-600M-v1` | PII | nvidia/Nemotron-PII | - | - | XLarge | pytorch |
+| `OpenMed/OpenMed-PII-SnowflakeMed-Large-568M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-SuperClinical-Base-184M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-SuperClinical-Large-434M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1` | PII | nvidia/Nemotron-PII | - | - | Small | pytorch |
+| `OpenMed/OpenMed-PII-SuperMedical-Base-125M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-SuperMedical-Large-355M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-mClinicalE5-Large-560M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/OpenMed-PII-mLiteClinical-Base-135M-v1` | PII | nvidia/Nemotron-PII | - | - | Base | pytorch |
+| `OpenMed/OpenMed-PII-mSuperClinical-Large-279M-v1` | PII | nvidia/Nemotron-PII | - | - | Large | pytorch |
+| `OpenMed/privacy-filter-nemotron` | PII | nvidia/Nemotron-PII | - | - | - | pytorch |
+| `OpenMed/privacy-filter-nemotron-mlx` | PII | nvidia/Nemotron-PII | - | - | - | mlx-fp, pytorch |
+| `OpenMed/privacy-filter-nemotron-mlx-8bit` | PII | nvidia/Nemotron-PII | - | - | - | mlx-8bit, pytorch |
+| `OpenMed/privacy-filter-nemotron-piimb-v2` | PII | nvidia/Nemotron-PII | - | - | - | pytorch |
+| `OpenMed/privacy-filter-nemotron-v2` | PII | nvidia/Nemotron-PII | - | - | - | pytorch |
+| `OpenMed/privacy-filter-piimb-fine-grained` | PII | nvidia/Nemotron-PII | - | - | - | pytorch |
+<!-- END MANIFEST BENCHMARK TABLE -->
+
 ## Keeping the registry fresh
 
-If you add a new Hugging Face checkpoint, update `openmed/core/model_registry.py` with:
+The committed `models.jsonl` snapshot is the source of truth for registry entries, language defaults, README counts, and
+the generated tables on this page. Refresh the manifest through the dedicated manifest refresh workflow, then run:
 
-1. A unique key (e.g., `radiology_detection_superclinical`).
-2. The full HF model id (`OpenMed/...`), user-friendly name, category, specialization.
-3. Representative `entity_types` and a recommended confidence based on evaluation runs.
+```bash
+python scripts/manifest/regenerate_surfaces.py
+```
 
-CI will enforce type safety through the unit tests, and the docs automatically pick up the new entry via the examples
-above.
+CI reruns the same regenerator and fails if the generated surfaces disagree with the committed manifest.

--- a/openmed/core/labels.py
+++ b/openmed/core/labels.py
@@ -92,6 +92,27 @@ VIN: Final = "VIN"
 VEHICLE_REGISTRATION: Final = "VEHICLE_REGISTRATION"
 IMEI: Final = "IMEI"
 
+#: Biomedical entities
+DISEASE: Final = "DISEASE"
+CONDITION: Final = "CONDITION"
+PATHOLOGY: Final = "PATHOLOGY"
+CANCER: Final = "CANCER"
+CELL: Final = "CELL"
+GENE_OR_GENE_PRODUCT: Final = "GENE_OR_GENE_PRODUCT"
+GENE: Final = "GENE"
+PROTEIN: Final = "PROTEIN"
+DNA: Final = "DNA"
+RNA: Final = "RNA"
+MEDICATION: Final = "MEDICATION"
+DRUG: Final = "DRUG"
+CHEM: Final = "CHEM"
+SIMPLE_CHEMICAL: Final = "SIMPLE_CHEMICAL"
+ANATOMY: Final = "ANATOMY"
+ORGAN: Final = "ORGAN"
+TISSUE: Final = "TISSUE"
+ORGANISM: Final = "ORGANISM"
+SPECIES: Final = "SPECIES"
+
 #: Catch-all
 OTHER: Final = "OTHER"
 
@@ -108,6 +129,10 @@ CANONICAL_LABELS: Final[FrozenSet[str]] = frozenset({
     GENDER, EYE_COLOR, HEIGHT,
     ORGANIZATION, JOB_TITLE, JOB_DEPARTMENT, OCCUPATION,
     IP_ADDRESS, MAC_ADDRESS, USER_AGENT, VIN, VEHICLE_REGISTRATION, IMEI,
+    DISEASE, CONDITION, PATHOLOGY, CANCER, CELL,
+    GENE_OR_GENE_PRODUCT, GENE, PROTEIN, DNA, RNA,
+    MEDICATION, DRUG, CHEM, SIMPLE_CHEMICAL,
+    ANATOMY, ORGAN, TISSUE, ORGANISM, SPECIES,
     OTHER,
 })
 
@@ -247,6 +272,29 @@ _ALIAS_MAP: Final[Mapping[str, str]] = {
     "vrm": VEHICLE_REGISTRATION,
     "licenseplate": VEHICLE_REGISTRATION,
     "imei": IMEI,
+
+    # Biomedical entities
+    "disease": DISEASE,
+    "condition": CONDITION,
+    "pathology": PATHOLOGY,
+    "cancer": CANCER,
+    "cell": CELL,
+    "geneorgeneproduct": GENE_OR_GENE_PRODUCT,
+    "genegeneproduct": GENE_OR_GENE_PRODUCT,
+    "gene": GENE,
+    "protein": PROTEIN,
+    "dna": DNA,
+    "rna": RNA,
+    "medication": MEDICATION,
+    "drug": DRUG,
+    "chem": CHEM,
+    "chemical": CHEM,
+    "simplechemical": SIMPLE_CHEMICAL,
+    "anatomy": ANATOMY,
+    "organ": ORGAN,
+    "tissue": TISSUE,
+    "organism": ORGANISM,
+    "species": SPECIES,
 }
 
 
@@ -327,5 +375,9 @@ __all__ = [
     "ORGANIZATION", "JOB_TITLE", "JOB_DEPARTMENT", "OCCUPATION",
     "IP_ADDRESS", "MAC_ADDRESS", "USER_AGENT", "VIN",
     "VEHICLE_REGISTRATION", "IMEI",
+    "DISEASE", "CONDITION", "PATHOLOGY", "CANCER", "CELL",
+    "GENE_OR_GENE_PRODUCT", "GENE", "PROTEIN", "DNA", "RNA",
+    "MEDICATION", "DRUG", "CHEM", "SIMPLE_CHEMICAL",
+    "ANATOMY", "ORGAN", "TISSUE", "ORGANISM", "SPECIES",
     "OTHER",
 ]

--- a/openmed/core/pii_i18n.py
+++ b/openmed/core/pii_i18n.py
@@ -14,7 +14,8 @@ from typing import Dict, List, Optional, Set
 # ---------------------------------------------------------------------------
 
 SUPPORTED_LANGUAGES: Set[str] = {
-    "en", "fr", "de", "it", "es", "nl", "hi", "te", "pt", "ar", "ja", "tr",
+    "en", "fr", "de", "it", "es", "nl",
+    "hi", "te", "pt", "ar", "ja", "tr",
 }
 
 LANGUAGE_NAMES: Dict[str, str] = {

--- a/scripts/manifest/regenerate_surfaces.py
+++ b/scripts/manifest/regenerate_surfaces.py
@@ -1,0 +1,522 @@
+"""Regenerate manifest-derived repository surfaces from ``models.jsonl``."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterable, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = ROOT / "models.jsonl"
+LABELS_PATH = ROOT / "openmed" / "core" / "labels.py"
+MODEL_REGISTRY_PATH = ROOT / "openmed" / "core" / "model_registry.py"
+
+LANGUAGE_ORDER = (
+    "en",
+    "fr",
+    "de",
+    "it",
+    "es",
+    "nl",
+    "hi",
+    "te",
+    "pt",
+    "ar",
+    "ja",
+    "tr",
+)
+LANGUAGE_NAMES = {
+    "en": "English",
+    "fr": "French",
+    "de": "German",
+    "it": "Italian",
+    "es": "Spanish",
+    "nl": "Dutch",
+    "hi": "Hindi",
+    "te": "Telugu",
+    "pt": "Portuguese",
+    "ar": "Arabic",
+    "ja": "Japanese",
+    "tr": "Turkish",
+}
+DEFAULT_PII_MODEL_IDS = {
+    "en": "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+    "fr": "OpenMed/OpenMed-PII-French-SuperClinical-Small-44M-v1",
+    "de": "OpenMed/OpenMed-PII-German-SuperClinical-Small-44M-v1",
+    "it": "OpenMed/OpenMed-PII-Italian-SuperClinical-Small-44M-v1",
+    "es": "OpenMed/OpenMed-PII-Spanish-SuperClinical-Small-44M-v1",
+    "nl": "OpenMed/OpenMed-PII-Dutch-SuperClinical-Large-434M-v1",
+    "hi": "OpenMed/OpenMed-PII-Hindi-SuperClinical-Large-434M-v1",
+    "te": "OpenMed/OpenMed-PII-Telugu-SuperClinical-Large-434M-v1",
+    "pt": "OpenMed/OpenMed-PII-Portuguese-SnowflakeMed-Large-568M-v1",
+    "ar": "OpenMed/OpenMed-PII-Arabic-SnowflakeMed-Large-568M-v1",
+    "ja": "OpenMed/OpenMed-PII-Japanese-BigMed-Large-560M-v1",
+    "tr": "OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1",
+}
+TIER_ORDER = {"Tiny": 0, "Small": 1, "Base": 2, "Medium": 3, "Large": 4, "XLarge": 5}
+
+CATALOG_TABLE_BEGIN = "<!-- BEGIN MANIFEST MODEL TABLE -->"
+CATALOG_TABLE_END = "<!-- END MANIFEST MODEL TABLE -->"
+BENCHMARK_TABLE_BEGIN = "<!-- BEGIN MANIFEST BENCHMARK TABLE -->"
+BENCHMARK_TABLE_END = "<!-- END MANIFEST BENCHMARK TABLE -->"
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> list[dict[str, Any]]:
+    """Load the committed JSONL manifest without doing remote discovery."""
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                rows.append(json.loads(stripped))
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON in {path} line {line_number}: {exc}") from exc
+    return rows
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _format_count(value: int) -> str:
+    return f"{value:,}"
+
+
+def _language_sort_key(language: str) -> tuple[int, str]:
+    try:
+        return (LANGUAGE_ORDER.index(language), language)
+    except ValueError:
+        return (len(LANGUAGE_ORDER), language)
+
+
+def supported_pii_languages(rows: Iterable[dict[str, Any]]) -> list[str]:
+    languages = {
+        language
+        for row in rows
+        if row.get("family") == "PII"
+        for language in row.get("languages", [])
+    }
+    unknown = sorted(language for language in languages if language not in LANGUAGE_NAMES)
+    if unknown:
+        raise ValueError(
+            "PII manifest uses unsupported language code(s): " + ", ".join(unknown)
+        )
+    return sorted(languages, key=_language_sort_key)
+
+
+def _is_pii_row(row: dict[str, Any]) -> bool:
+    return row.get("family") == "PII" and isinstance(row.get("repo_id"), str)
+
+
+def _is_model_file_variant(repo_id: str) -> bool:
+    name = repo_id.rsplit("/", 1)[-1].lower()
+    return name.endswith("-mlx") or name.endswith("-mlx-8bit")
+
+
+def default_pii_model_id(rows: Sequence[dict[str, Any]], language: str) -> str:
+    preferred = DEFAULT_PII_MODEL_IDS.get(language)
+    manifest_ids = {row["repo_id"] for row in rows if isinstance(row.get("repo_id"), str)}
+    if preferred in manifest_ids:
+        return preferred
+
+    candidates = [
+        row
+        for row in rows
+        if _is_pii_row(row)
+        and row.get("languages") == [language]
+        and not _is_model_file_variant(row["repo_id"])
+    ]
+    if not candidates:
+        raise ValueError(f"No default PII model candidate found for {language!r}")
+
+    def score(row: dict[str, Any]) -> tuple[int, int, int, int, str]:
+        repo_id = row["repo_id"]
+        expected_language = LANGUAGE_NAMES[language]
+        if language == "en":
+            language_score = 0
+        else:
+            language_score = 0 if f"-{expected_language}-" in repo_id else 1
+        superclinical_score = 0 if "SuperClinical" in repo_id else 1
+        tier_score = TIER_ORDER.get(str(row.get("tier")), 99)
+        param_count = row.get("param_count")
+        param_score = param_count if isinstance(param_count, int) else 10**12
+        return (language_score, superclinical_score, tier_score, param_score, repo_id)
+
+    return sorted(candidates, key=score)[0]["repo_id"]
+
+
+def default_pii_models(rows: Sequence[dict[str, Any]]) -> dict[str, str]:
+    return {
+        language: default_pii_model_id(rows, language)
+        for language in supported_pii_languages(rows)
+    }
+
+
+def _inline_string_set(values: Sequence[str], indent: str = "    ") -> list[str]:
+    quoted = [f'"{value}"' for value in values]
+    lines: list[str] = []
+    for index in range(0, len(quoted), 6):
+        lines.append(indent + ", ".join(quoted[index:index + 6]) + ",")
+    return lines
+
+
+def render_pii_constants(rows: Sequence[dict[str, Any]]) -> dict[str, str]:
+    languages = supported_pii_languages(rows)
+    defaults = default_pii_models(rows)
+
+    supported = ["SUPPORTED_LANGUAGES: Set[str] = {"]
+    supported.extend(_inline_string_set(languages))
+    supported.append("}")
+
+    names = ["LANGUAGE_NAMES: Dict[str, str] = {"]
+    names.extend(f'    "{language}": "{LANGUAGE_NAMES[language]}",' for language in languages)
+    names.append("}")
+
+    prefixes = ["LANGUAGE_MODEL_PREFIX: Dict[str, str] = {"]
+    for language in languages:
+        prefix = "" if language == "en" else f"{LANGUAGE_NAMES[language]}-"
+        prefixes.append(f'    "{language}": "{prefix}",')
+    prefixes.append("}")
+
+    models = ["DEFAULT_PII_MODELS: Dict[str, str] = {"]
+    models.extend(f'    "{language}": "{defaults[language]}",' for language in languages)
+    models.append("}")
+
+    return {
+        "SUPPORTED_LANGUAGES": "\n".join(supported),
+        "LANGUAGE_NAMES": "\n".join(names),
+        "LANGUAGE_MODEL_PREFIX": "\n".join(prefixes),
+        "DEFAULT_PII_MODELS": "\n".join(models),
+    }
+
+
+def _assignment_name(node: ast.stmt) -> str | None:
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id
+    if isinstance(node, ast.Assign) and len(node.targets) == 1:
+        target = node.targets[0]
+        if isinstance(target, ast.Name):
+            return target.id
+    return None
+
+
+def replace_assignments(text: str, replacements: dict[str, str]) -> str:
+    tree = ast.parse(text)
+    ranges: dict[str, tuple[int, int]] = {}
+    for node in tree.body:
+        name = _assignment_name(node)
+        if name in replacements and hasattr(node, "end_lineno"):
+            ranges[name] = (node.lineno - 1, node.end_lineno or node.lineno)
+
+    missing = sorted(set(replacements) - set(ranges))
+    if missing:
+        raise ValueError("Could not find assignment(s): " + ", ".join(missing))
+
+    lines = text.splitlines()
+    for name, (start, end) in sorted(ranges.items(), key=lambda item: item[1][0], reverse=True):
+        lines[start:end] = replacements[name].splitlines()
+    return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+
+
+def regenerate_pii_i18n(text: str, rows: Sequence[dict[str, Any]]) -> str:
+    return replace_assignments(text, render_pii_constants(rows))
+
+
+def _must_replace(pattern: str, replacement: str, text: str, *, flags: int = 0) -> str:
+    updated, count = re.subn(pattern, replacement, text, flags=flags)
+    if count == 0:
+        raise ValueError(f"Pattern did not match: {pattern}")
+    return updated
+
+
+def regenerate_readme(text: str, rows: Sequence[dict[str, Any]]) -> str:
+    model_count = len(rows)
+    languages = supported_pii_languages(rows)
+    language_count = len(languages)
+    pii_count = sum(1 for row in rows if row.get("family") == "PII")
+    model_count_text = _format_count(model_count)
+    encoded_model_count = model_count_text.replace(",", "%2C")
+    language_codes = ", ".join(f"`{language}`" for language in languages)
+
+    text = _must_replace(
+        r"Entity extraction, PII de-identification, and [0-9,]+\+? specialized medical models",
+        f"Entity extraction, PII de-identification, and {model_count_text} specialized medical models",
+        text,
+    )
+    text = _must_replace(
+        r"(%F0%9F%A4%97%20Models-)[^-]+(-F5E27A)",
+        rf"\g<1>{encoded_model_count}\2",
+        text,
+    )
+    text = _must_replace(
+        r"<b>[0-9,]+\+? models</b> &nbsp;·&nbsp; <b>[0-9,]+\+? languages</b> &nbsp;·&nbsp; <b>[0-9,]+\+? PII checkpoints</b>",
+        (
+            f"<b>{model_count_text} models</b> &nbsp;·&nbsp; "
+            f"<b>{language_count} languages</b> &nbsp;·&nbsp; "
+            f"<b>{_format_count(pii_count)} PII checkpoints</b>"
+        ),
+        text,
+    )
+    text = _must_replace(
+        r"(\| Specialized medical models\s+\|\s+)[0-9,]+\+?(\s+\|\s+Limited\s+\|)",
+        rf"\g<1>{model_count_text}\2",
+        text,
+    )
+    text = _must_replace(
+        r"(\| Languages\s+\|\s+)[0-9,]+\+?(\s+\|\s+Varies\s+\|)",
+        rf"\g<1>{language_count}\2",
+        text,
+    )
+    text = _must_replace(
+        r"\*\*Specialized models\*\* — [0-9,]+\+? curated biomedical & clinical models",
+        f"**Specialized models** — {model_count_text} curated biomedical & clinical models",
+        text,
+    )
+    text = _must_replace(
+        r"## Multilingual PII \([0-9,]+ languages\)",
+        f"## Multilingual PII ({language_count} languages)",
+        text,
+    )
+    text = _must_replace(
+        r"Extraction and de-identification across .*? — \*\*[0-9,]+\+? PII checkpoints\*\* total\.",
+        (
+            f"Extraction and de-identification across {language_codes} — "
+            f"**{_format_count(pii_count)} PII checkpoints** total."
+        ),
+        text,
+    )
+    return text
+
+
+def _join_values(values: Iterable[Any]) -> str:
+    cleaned = [str(value) for value in values if value not in (None, "")]
+    return ", ".join(cleaned) if cleaned else "-"
+
+
+def _format_metric(value: Any) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def render_catalog_table(rows: Sequence[dict[str, Any]]) -> str:
+    lines = [
+        "| Model | Family | Task | Languages | Tier | Formats |",
+        "|---|---|---|---|---|---|",
+    ]
+    for row in sorted(
+        rows,
+        key=lambda item: (
+            str(item.get("family") or ""),
+            str(item.get("task") or ""),
+            str(item.get("repo_id") or ""),
+        ),
+    ):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    f"`{row['repo_id']}`",
+                    str(row.get("family") or "-"),
+                    str(row.get("task") or "-"),
+                    _join_values(row.get("languages") or []),
+                    str(row.get("tier") or "-"),
+                    _join_values(row.get("formats") or []),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def _has_benchmark(row: dict[str, Any]) -> bool:
+    benchmark = row.get("benchmark") or {}
+    return any(benchmark.get(key) is not None for key in ("dataset", "micro_f1", "recall"))
+
+
+def render_benchmark_table(rows: Sequence[dict[str, Any]]) -> str:
+    benchmark_rows = [row for row in rows if _has_benchmark(row)]
+    lines = [
+        "| Model | Family | Dataset | Micro F1 | Recall | Tier | Formats |",
+        "|---|---|---|---:|---:|---|---|",
+    ]
+    for row in sorted(
+        benchmark_rows,
+        key=lambda item: (
+            str((item.get("benchmark") or {}).get("dataset") or ""),
+            str(item.get("repo_id") or ""),
+        ),
+    ):
+        benchmark = row.get("benchmark") or {}
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    f"`{row['repo_id']}`",
+                    str(row.get("family") or "-"),
+                    str(benchmark.get("dataset") or "-"),
+                    _format_metric(benchmark.get("micro_f1")),
+                    _format_metric(benchmark.get("recall")),
+                    str(row.get("tier") or "-"),
+                    _join_values(row.get("formats") or []),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def _replace_marker_block(text: str, begin: str, end: str, body: str) -> str:
+    pattern = re.compile(
+        rf"{re.escape(begin)}\n.*?\n{re.escape(end)}",
+        flags=re.DOTALL,
+    )
+    replacement = f"{begin}\n{body}\n{end}"
+    updated, count = pattern.subn(replacement, text)
+    if count != 1:
+        raise ValueError(f"Expected exactly one generated block for {begin}")
+    return updated
+
+
+def regenerate_model_registry_doc(text: str, rows: Sequence[dict[str, Any]]) -> str:
+    model_count = len(rows)
+    language_count = len(supported_pii_languages(rows))
+    family_counts = Counter(str(row.get("family") or "Unknown") for row in rows)
+    summary = (
+        f"The committed manifest currently contains {_format_count(model_count)} "
+        f"models across {language_count} supported PII languages. Family counts: "
+        + ", ".join(
+            f"{family}={_format_count(count)}"
+            for family, count in sorted(family_counts.items())
+        )
+        + "."
+    )
+    text = _must_replace(
+        r"^The committed manifest currently contains .*$",
+        summary,
+        text,
+        flags=re.MULTILINE,
+    )
+    text = _replace_marker_block(
+        text,
+        CATALOG_TABLE_BEGIN,
+        CATALOG_TABLE_END,
+        render_catalog_table(rows),
+    )
+    text = _replace_marker_block(
+        text,
+        BENCHMARK_TABLE_BEGIN,
+        BENCHMARK_TABLE_END,
+        render_benchmark_table(rows),
+    )
+    return text
+
+
+def validate_canonical_labels(rows: Sequence[dict[str, Any]]) -> None:
+    labels_module = _load_module("_openmed_manifest_labels", LABELS_PATH)
+    canonical_labels = set(labels_module.CANONICAL_LABELS)
+    unknown: dict[str, list[str]] = defaultdict(list)
+    for row in rows:
+        repo_id = str(row.get("repo_id") or "<unknown>")
+        for label in row.get("canonical_labels") or []:
+            if label not in canonical_labels:
+                unknown[label].append(repo_id)
+    if unknown:
+        details = "; ".join(
+            f"{label}: {', '.join(repo_ids[:3])}"
+            for label, repo_ids in sorted(unknown.items())
+        )
+        raise ValueError(f"Manifest canonical_labels outside CANONICAL_LABELS: {details}")
+
+
+def validate_registry_derivation(rows: Sequence[dict[str, Any]]) -> None:
+    registry_module = _load_module("_openmed_manifest_registry", MODEL_REGISTRY_PATH)
+    registry = registry_module._build_registry(rows)
+    manifest_ids = {
+        row["repo_id"]
+        for row in rows
+        if isinstance(row.get("repo_id"), str) and row["repo_id"]
+    }
+    registry_ids = {info.model_id for info in registry.values()}
+    missing = sorted(manifest_ids - registry_ids)
+    if missing:
+        raise ValueError(
+            "Manifest rows missing from generated registry: " + ", ".join(missing[:20])
+        )
+
+
+def _write_or_report(path: Path, content: str, *, check: bool) -> bool:
+    current = path.read_text(encoding="utf-8")
+    if current == content:
+        return False
+    if not check:
+        path.write_text(content, encoding="utf-8")
+    return True
+
+
+def regenerate_surfaces(root: Path = ROOT, *, check: bool = False) -> list[Path]:
+    rows = load_manifest(root / "models.jsonl")
+    validate_canonical_labels(rows)
+    validate_registry_derivation(rows)
+
+    updates = {
+        root / "openmed" / "core" / "pii_i18n.py": regenerate_pii_i18n(
+            (root / "openmed" / "core" / "pii_i18n.py").read_text(encoding="utf-8"),
+            rows,
+        ),
+        root / "README.md": regenerate_readme(
+            (root / "README.md").read_text(encoding="utf-8"),
+            rows,
+        ),
+        root / "docs" / "model-registry.md": regenerate_model_registry_doc(
+            (root / "docs" / "model-registry.md").read_text(encoding="utf-8"),
+            rows,
+        ),
+    }
+
+    changed: list[Path] = []
+    for path, content in updates.items():
+        if _write_or_report(path, content, check=check):
+            changed.append(path)
+    return changed
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Regenerate manifest-derived surfaces from committed models.jsonl."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report drift without writing files.",
+    )
+    args = parser.parse_args(argv)
+
+    changed = regenerate_surfaces(check=args.check)
+    if args.check and changed:
+        for path in changed:
+            print(f"out of date: {path.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/core/test_catalog_coherence.py
+++ b/tests/unit/core/test_catalog_coherence.py
@@ -1,0 +1,65 @@
+"""Coherence checks for manifest-derived catalog surfaces."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.manifest import regenerate_surfaces
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "coherence.yml"
+
+
+def test_regenerated_surfaces_are_current():
+    assert regenerate_surfaces.regenerate_surfaces(check=True) == []
+
+
+def test_canonical_labels_must_exist_in_core_taxonomy():
+    rows = regenerate_surfaces.load_manifest()
+    invalid_row = dict(rows[0])
+    invalid_row["canonical_labels"] = ["NOT_A_CANONICAL_LABEL"]
+
+    with pytest.raises(ValueError, match="outside CANONICAL_LABELS"):
+        regenerate_surfaces.validate_canonical_labels([invalid_row])
+
+
+def test_workflow_uses_committed_manifest_only():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "scripts/manifest/regenerate_surfaces.py" in text
+    assert "git diff --exit-code" in text
+    assert "scripts/manifest/generate_manifest.py" not in text
+    assert "pip install" not in text
+    assert "schedule:" not in text
+    assert "cron:" not in text
+
+
+def test_manifest_labels_are_within_core_taxonomy():
+    rows = regenerate_surfaces.load_manifest()
+    regenerate_surfaces.validate_canonical_labels(rows)
+
+
+def test_registry_derivation_covers_manifest_rows():
+    rows = regenerate_surfaces.load_manifest()
+    regenerate_surfaces.validate_registry_derivation(rows)
+
+
+def test_pii_defaults_are_derived_from_manifest_rows():
+    rows = regenerate_surfaces.load_manifest()
+    manifest_ids = {row["repo_id"] for row in rows}
+    defaults = regenerate_surfaces.default_pii_models(rows)
+
+    assert set(defaults) == set(regenerate_surfaces.supported_pii_languages(rows))
+    assert set(defaults.values()) <= manifest_ids
+
+
+def test_manifest_loader_rejects_invalid_json(tmp_path):
+    bad_manifest = tmp_path / "models.jsonl"
+    bad_manifest.write_text(json.dumps({"repo_id": "OpenMed/example"}) + "\n{", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        regenerate_surfaces.load_manifest(bad_manifest)


### PR DESCRIPTION
Closes #77.

Adds a read-only catalog coherence workflow that regenerates manifest-derived constants, README counts, and MkDocs catalog tables from the committed models.jsonl before failing on drift. The regenerator validates model registry coverage and checks manifest canonical labels against the core taxonomy so stale surfaces and unknown labels fail in CI.

Validation: .venv/bin/python -m pytest tests/ -q