### PR TITLE
Add the deterministic post-ML safety sweep recall backstop

### DIFF
--- a/openmed/core/anonymizer/providers/clinical_ids.py
+++ b/openmed/core/anonymizer/providers/clinical_ids.py
@@ -24,9 +24,133 @@ or emits a US-style format unrelated to the requested locale's actual ID:
 
 from __future__ import annotations
 
+import re
 from typing import Sequence
 
 from faker.providers import BaseProvider
+
+
+# ---------------------------------------------------------------------------
+# Shared deterministic validators
+# ---------------------------------------------------------------------------
+
+def _digits_only(text: str) -> str:
+    return re.sub(r"[^0-9]", "", text)
+
+
+def validate_ssn(ssn_text: str) -> bool:
+    """Validate a US SSN's format and basic impossible-number rules."""
+    digits = _digits_only(ssn_text)
+
+    if len(digits) != 9:
+        return False
+
+    area = digits[0:3]
+    group = digits[3:5]
+    serial = digits[5:9]
+
+    if area == "000" or area == "666" or area[0] == "9":
+        return False
+    if group == "00":
+        return False
+    if serial == "0000":
+        return False
+
+    return True
+
+
+def validate_phone_us(phone_text: str) -> bool:
+    """Validate US phone numbers accepted by the PII detector."""
+    digits = _digits_only(phone_text)
+
+    if len(digits) == 11 and digits[0] == "1":
+        digits = digits[1:]
+
+    if len(digits) != 10:
+        return False
+
+    area_code = digits[0:3]
+    exchange = digits[3:6]
+    if area_code[0] in "01":
+        return False
+    if exchange[0] == "0":
+        return False
+    return True
+
+
+def validate_luhn(number_text: str) -> bool:
+    """Validate a numeric identifier with the Luhn checksum."""
+    digits = _digits_only(number_text)
+
+    if len(digits) < 13:
+        return False
+
+    body = [int(digit) for digit in digits[:-1]]
+    return _luhn_check_digit(body) == int(digits[-1])
+
+
+def validate_npi(npi_text: str) -> bool:
+    """Validate a 10-digit US National Provider Identifier."""
+    digits = _digits_only(npi_text)
+
+    if len(digits) != 10:
+        return False
+
+    body = [int(digit) for digit in digits[:-1]]
+    prefixed = [8, 0, 8, 4, 0, *body]
+    return _luhn_check_digit(prefixed) == int(digits[-1])
+
+
+_IBAN_LENGTHS = {
+    "AD": 24, "AE": 23, "AL": 28, "AT": 20, "AZ": 28,
+    "BA": 20, "BE": 16, "BG": 22, "BH": 22, "BR": 29, "BY": 28,
+    "CH": 21, "CR": 22, "CY": 28, "CZ": 24,
+    "DE": 22, "DK": 18, "DO": 28,
+    "EE": 20, "EG": 29, "ES": 24,
+    "FI": 18, "FO": 18, "FR": 27,
+    "GB": 22, "GE": 22, "GI": 23, "GL": 18, "GR": 27, "GT": 28,
+    "HR": 21, "HU": 28,
+    "IE": 22, "IL": 23, "IS": 26, "IT": 27,
+    "JO": 30,
+    "KW": 30, "KZ": 20,
+    "LB": 28, "LC": 32, "LI": 21, "LT": 20, "LU": 20, "LV": 21,
+    "MC": 27, "MD": 24, "ME": 22, "MK": 19, "MR": 27, "MT": 31, "MU": 30,
+    "NL": 18, "NO": 15,
+    "PK": 24, "PL": 28, "PS": 29, "PT": 25,
+    "QA": 29,
+    "RO": 24, "RS": 22,
+    "SA": 24, "SC": 31, "SE": 24, "SI": 19, "SK": 24, "SM": 27,
+    "TN": 24, "TR": 26,
+    "UA": 29,
+    "VA": 22, "VG": 24,
+    "XK": 20,
+}
+
+
+def validate_iban(iban_text: str) -> bool:
+    """Validate an IBAN with the ISO 13616 mod-97 checksum."""
+    cleaned = re.sub(r"[\s-]", "", iban_text).upper()
+
+    if not re.fullmatch(r"[A-Z]{2}\d{2}[A-Z0-9]{11,30}", cleaned):
+        return False
+
+    expected_length = _IBAN_LENGTHS.get(cleaned[:2])
+    if expected_length is not None and len(cleaned) != expected_length:
+        return False
+    if expected_length is None and not 15 <= len(cleaned) <= 34:
+        return False
+
+    rearranged = cleaned[4:] + cleaned[:4]
+    remainder = 0
+    for char in rearranged:
+        if char.isdigit():
+            values = char
+        else:
+            values = str(ord(char) - 55)
+        for digit in values:
+            remainder = (remainder * 10 + int(digit)) % 97
+
+    return remainder == 1
 
 
 # ---------------------------------------------------------------------------
@@ -170,4 +294,9 @@ __all__ = [
     "MedicalRecordNumberProvider",
     "NPIProvider",
     "register_clinical_providers",
+    "validate_iban",
+    "validate_luhn",
+    "validate_npi",
+    "validate_phone_us",
+    "validate_ssn",
 ]

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -102,6 +102,7 @@ class DeidentificationResult:
     method: str
     timestamp: datetime
     mapping: Optional[dict[str, str]] = None
+    metadata: Optional[dict[str, Any]] = None
 
     def to_dict(self) -> dict:
         """Convert result to dictionary format.
@@ -121,12 +122,14 @@ class DeidentificationResult:
                     "end": e.end,
                     "confidence": e.confidence,
                     "redacted_text": e.redacted_text,
+                    "metadata": e.metadata or {},
                 }
                 for e in self.pii_entities
             ],
             "method": self.method,
             "timestamp": self.timestamp.isoformat(),
             "num_entities_redacted": len(self.pii_entities),
+            "metadata": self.metadata or {},
         }
 
 
@@ -614,6 +617,42 @@ def _resolve_deidentification_method(
     return effective_method
 
 
+def _copy_metadata(metadata: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    if metadata is None:
+        return None
+    return dict(metadata)
+
+
+def _apply_safety_sweep_to_result(
+    text: str,
+    pii_result: Any,
+    *,
+    lang: str,
+) -> int:
+    """Run the deterministic sweep and record its net span contribution."""
+    from .safety_sweep import (
+        SAFETY_SWEEP_PATTERNS_VERSION,
+        SAFETY_SWEEP_SOURCE,
+        safety_sweep,
+    )
+    from .quality_gates import validate_entity_spans
+
+    before_count = len(pii_result.entities)
+    pii_result.entities = safety_sweep(text, pii_result.entities, lang=lang)
+    added_count = len(pii_result.entities) - before_count
+
+    metadata = dict(getattr(pii_result, "metadata", None) or {})
+    metadata["safety_sweep"] = {
+        "source": SAFETY_SWEEP_SOURCE,
+        "patterns_version": SAFETY_SWEEP_PATTERNS_VERSION,
+        "spans_added": added_count,
+    }
+    pii_result.metadata = metadata
+    pii_result.num_entities = len(pii_result.entities)
+    validate_entity_spans(pii_result.entities, text)
+    return added_count
+
+
 def _build_deidentification_result(
     text: str,
     pii_result: Any,
@@ -635,13 +674,14 @@ def _build_deidentification_result(
             start=e.start,
             end=e.end,
             confidence=e.confidence,
+            metadata=_copy_metadata(getattr(e, "metadata", None)),
             entity_type=e.label,
             original_text=e.text,
         )
         for e in pii_result.entities
     ]
 
-    pii_entities.sort(key=lambda e: e.start, reverse=True)
+    redaction_entities = sorted(pii_entities, key=lambda e: e.start, reverse=True)
 
     if effective_method == "shift_dates" and date_shift_days is None:
         date_shift_days = random.randint(-365, 365)
@@ -661,7 +701,7 @@ def _build_deidentification_result(
     deidentified = text
     mapping = {} if keep_mapping else None
 
-    for entity in pii_entities:
+    for entity in redaction_entities:
         redacted = _redact_entity(
             entity,
             effective_method,
@@ -688,6 +728,7 @@ def _build_deidentification_result(
         method=effective_method,
         timestamp=datetime.now(),
         mapping=mapping,
+        metadata=_copy_metadata(getattr(pii_result, "metadata", None)),
     )
 
 
@@ -704,6 +745,7 @@ def _deidentify_batch(
     use_smart_merging: bool = True,
     lang: str = "en",
     normalize_accents: Optional[bool] = None,
+    use_safety_sweep: bool = True,
     *,
     consistent: bool = False,
     seed: Optional[int] = None,
@@ -731,6 +773,10 @@ def _deidentify_batch(
         privacy_filter_pipeline=privacy_filter_pipeline,
         **pipeline_kwargs,
     )
+
+    if use_safety_sweep:
+        for stripped_text, pii_result in zip(stripped_texts, pii_results):
+            _apply_safety_sweep_to_result(stripped_text, pii_result, lang=lang)
 
     return [
         _build_deidentification_result(
@@ -762,6 +808,7 @@ def deidentify(
     use_smart_merging: bool = True,
     lang: str = "en",
     normalize_accents: Optional[bool] = None,
+    use_safety_sweep: bool = True,
     *,
     consistent: bool = False,
     seed: Optional[int] = None,
@@ -792,6 +839,8 @@ def deidentify(
         keep_mapping: Keep mapping for re-identification
         config: Optional configuration override
         use_smart_merging: Enable regex-based semantic unit merging (recommended)
+        use_safety_sweep: Run a deterministic structured-identifier sweep
+            after model detection and before redaction.
         lang: ISO 639-1 language code (en, fr, de, it, es, nl, hi, te, pt,
             ar, ja, tr). Controls model
             selection, regex patterns, and fake data for replacement.
@@ -839,6 +888,9 @@ def deidentify(
         normalize_accents=normalize_accents,
         loader=loader,
     )
+
+    if use_safety_sweep:
+        _apply_safety_sweep_to_result(text, pii_result, lang=lang)
 
     return _build_deidentification_result(
         text,

--- a/openmed/core/pii_entity_merger.py
+++ b/openmed/core/pii_entity_merger.py
@@ -72,25 +72,9 @@ def validate_ssn(ssn_text: str) -> bool:
     Returns:
         True if valid SSN format
     """
-    # Extract digits only
-    digits = re.sub(r'[^0-9]', '', ssn_text)
+    from .anonymizer.providers import clinical_ids
 
-    if len(digits) != 9:
-        return False
-
-    area = digits[0:3]
-    group = digits[3:5]
-    serial = digits[5:9]
-
-    # Check for invalid patterns
-    if area == '000' or area == '666' or area[0] == '9':
-        return False
-    if group == '00':
-        return False
-    if serial == '0000':
-        return False
-
-    return True
+    return clinical_ids.validate_ssn(ssn_text)
 
 
 def validate_luhn(number_text: str) -> bool:
@@ -105,26 +89,9 @@ def validate_luhn(number_text: str) -> bool:
     Returns:
         True if passes Luhn checksum
     """
-    # Extract digits only
-    digits = re.sub(r'[^0-9]', '', number_text)
+    from .anonymizer.providers import clinical_ids
 
-    if len(digits) < 13:  # Minimum for credit cards
-        return False
-
-    # Luhn algorithm
-    def luhn_checksum(card_number):
-        def digits_of(n):
-            return [int(d) for d in str(n)]
-
-        digits = digits_of(card_number)
-        odd_digits = digits[-1::-2]
-        even_digits = digits[-2::-2]
-        checksum = sum(odd_digits)
-        for d in even_digits:
-            checksum += sum(digits_of(d * 2))
-        return checksum % 10
-
-    return luhn_checksum(digits) == 0
+    return clinical_ids.validate_luhn(number_text)
 
 
 def validate_npi(npi_text: str) -> bool:
@@ -138,31 +105,16 @@ def validate_npi(npi_text: str) -> bool:
     Returns:
         True if valid NPI
     """
-    # Extract digits only
-    digits = re.sub(r'[^0-9]', '', npi_text)
+    from .anonymizer.providers import clinical_ids
 
-    if len(digits) != 10:
-        return False
+    return clinical_ids.validate_npi(npi_text)
 
-    # NPI uses Luhn algorithm with prefix "80840"
-    # The constant 24 is added to the checksum
-    prefix = "80840"
-    checksum_input = prefix + digits
 
-    def luhn_checksum(number):
-        def digits_of(n):
-            return [int(d) for d in str(n)]
+def validate_iban(iban_text: str) -> bool:
+    """Validate an IBAN using the shared clinical identifier validator."""
+    from .anonymizer.providers import clinical_ids
 
-        digits = digits_of(number)
-        odd_digits = digits[-1::-2]
-        even_digits = digits[-2::-2]
-        checksum = sum(odd_digits)
-        for d in even_digits:
-            checksum += sum(digits_of(d * 2))
-        return checksum % 10
-
-    total = luhn_checksum(checksum_input)
-    return total == 0
+    return clinical_ids.validate_iban(iban_text)
 
 
 def validate_phone_us(phone_text: str) -> bool:
@@ -180,27 +132,9 @@ def validate_phone_us(phone_text: str) -> bool:
     Returns:
         True if valid US phone format
     """
-    # Extract digits only
-    digits = re.sub(r'[^0-9]', '', phone_text)
+    from .anonymizer.providers import clinical_ids
 
-    if len(digits) == 10:
-        area_code = digits[0:3]
-        exchange = digits[3:6]
-
-        # Area code can't start with 0 or 1
-        if area_code[0] in '01':
-            return False
-
-        # Exchange can't start with 0 (allow 1 for test numbers)
-        if exchange[0] == '0':
-            return False
-
-        return True
-    elif len(digits) == 11 and digits[0] == '1':
-        # 1-XXX-XXX-XXXX format
-        return validate_phone_us(digits[1:])
-
-    return False
+    return clinical_ids.validate_phone_us(phone_text)
 
 
 # Comprehensive PII regex patterns with context-aware scoring
@@ -338,6 +272,28 @@ PII_PATTERNS = [
         context_words=['card', 'credit', 'debit', 'visa', 'mastercard', 'amex', 'discover', 'payment'],
         context_boost=0.4,
         validator=validate_luhn
+    ),
+
+    # IBANs with ISO 13616 checksum validation
+    PIIPattern(
+        r'\b[A-Z]{2}\d{2}(?:[\s-]?[A-Z0-9]){11,30}\b',
+        'iban',
+        priority=9,
+        base_score=0.85,
+        context_words=['iban', 'bank account', 'account', 'routing', 'wire'],
+        context_boost=0.1,
+        validator=validate_iban
+    ),
+
+    # Account numbers when explicitly labeled in context
+    PIIPattern(
+        r'\b(?:account number|account #|acct\.|acct|account)[:\s#-]*[A-Z0-9][A-Z0-9-]{5,23}\b',
+        'account_number',
+        priority=8,
+        base_score=0.75,
+        context_words=['account', 'acct', 'account number', 'bank', 'billing'],
+        context_boost=0.15,
+        flags=re.IGNORECASE
     ),
 
     # Medical record numbers (common formats)

--- a/openmed/core/safety_sweep.py
+++ b/openmed/core/safety_sweep.py
@@ -1,0 +1,178 @@
+"""Deterministic post-detector safety sweep for structured PII."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+import re
+
+from .pii_entity_merger import PIIPattern, PII_PATTERNS, find_context_words
+from ..processing.outputs import EntityPrediction
+
+
+SAFETY_SWEEP_SOURCE = "safety_sweep"
+SAFETY_SWEEP_PATTERNS_VERSION = "safety-sweep-v1"
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    start: int
+    end: int
+    label: str
+    text: str
+    confidence: float
+    priority: int
+    pattern: PIIPattern
+
+
+def _span_value(span: Any, key: str) -> Any:
+    if isinstance(span, Mapping):
+        return span.get(key)
+    return getattr(span, key, None)
+
+
+def _span_bounds(span: Any) -> tuple[int | None, int | None]:
+    start = _span_value(span, "start")
+    end = _span_value(span, "end")
+    return start, end
+
+
+def _overlaps(start: int, end: int, spans: Sequence[Any]) -> bool:
+    for span in spans:
+        span_start, span_end = _span_bounds(span)
+        if span_start is None or span_end is None:
+            continue
+        if start < span_end and end > span_start:
+            return True
+    return False
+
+
+def _patterns_for_language(lang: str) -> list[PIIPattern]:
+    if lang == "en":
+        return list(PII_PATTERNS)
+
+    from .pii_i18n import get_patterns_for_language
+
+    return list(get_patterns_for_language(lang))
+
+
+def _validated(pattern: PIIPattern, text: str) -> bool:
+    if pattern.validator is None:
+        return True
+    try:
+        return bool(pattern.validator(text))
+    except Exception:
+        return False
+
+
+def _confidence(text: str, start: int, end: int, pattern: PIIPattern) -> float:
+    score = pattern.base_score
+    if pattern.context_words and find_context_words(
+        text,
+        start,
+        end,
+        pattern.context_words,
+    ):
+        score = min(1.0, score + pattern.context_boost)
+    return score
+
+
+def _candidate_metadata(candidate: _Candidate) -> dict[str, Any]:
+    return {
+        "source": SAFETY_SWEEP_SOURCE,
+        "patterns_version": SAFETY_SWEEP_PATTERNS_VERSION,
+        "safety_sweep": {
+            "entity_type": candidate.label,
+            "confidence": candidate.confidence,
+            "pattern": candidate.pattern.pattern,
+        },
+    }
+
+
+def _collect_candidates(text: str, patterns: Sequence[PIIPattern]) -> list[_Candidate]:
+    candidates: list[_Candidate] = []
+    for pattern in patterns:
+        for match in re.finditer(pattern.pattern, text, pattern.flags):
+            start, end = match.span()
+            if start >= end:
+                continue
+
+            matched_text = text[start:end]
+            if not _validated(pattern, matched_text):
+                continue
+
+            candidates.append(
+                _Candidate(
+                    start=start,
+                    end=end,
+                    label=pattern.entity_type,
+                    text=matched_text,
+                    confidence=_confidence(text, start, end, pattern),
+                    priority=pattern.priority,
+                    pattern=pattern,
+                )
+            )
+
+    candidates.sort(
+        key=lambda candidate: (
+            -candidate.confidence,
+            -candidate.priority,
+            candidate.start,
+            -(candidate.end - candidate.start),
+        )
+    )
+    return candidates
+
+
+def safety_sweep(
+    text: str,
+    spans: Sequence[Any],
+    *,
+    lang: str = "en",
+    patterns: Sequence[PIIPattern] | None = None,
+) -> list[Any]:
+    """Add deterministic structured identifier spans not covered by ML spans.
+
+    Existing spans always win. Sweep candidates that overlap any supplied span,
+    or any higher-ranked sweep candidate, are discarded so callers receive a
+    non-overlapping span set.
+    """
+    existing = list(spans)
+    selected: list[_Candidate] = []
+    active_spans: list[Any] = list(existing)
+    sweep_patterns = list(patterns) if patterns is not None else _patterns_for_language(lang)
+
+    for candidate in _collect_candidates(text, sweep_patterns):
+        if _overlaps(candidate.start, candidate.end, active_spans):
+            continue
+
+        entity = EntityPrediction(
+            text=candidate.text,
+            label=candidate.label,
+            start=candidate.start,
+            end=candidate.end,
+            confidence=candidate.confidence,
+            metadata=_candidate_metadata(candidate),
+        )
+        selected.append(candidate)
+        active_spans.append(entity)
+        existing.append(entity)
+
+    if not selected:
+        return existing
+
+    return sorted(
+        existing,
+        key=lambda span: (
+            _span_value(span, "start") is None,
+            _span_value(span, "start") or 0,
+            _span_value(span, "end") or 0,
+        ),
+    )
+
+
+__all__ = [
+    "SAFETY_SWEEP_PATTERNS_VERSION",
+    "SAFETY_SWEEP_SOURCE",
+    "safety_sweep",
+]

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -319,6 +319,7 @@ def _pii_deidentify_payload(
         keep_mapping=payload.keep_mapping,
         config=runtime.config,
         use_smart_merging=payload.use_smart_merging,
+        use_safety_sweep=payload.use_safety_sweep,
         lang=payload.lang,
         normalize_accents=payload.normalize_accents,
         loader=runtime.get_loader(),

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -165,6 +165,7 @@ if PYDANTIC_V2:
         date_shift_days: Optional[int] = None
         keep_mapping: bool = False
         use_smart_merging: bool = True
+        use_safety_sweep: bool = True
         lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"] = "en"
         normalize_accents: Optional[bool] = None
         keep_alive: Optional[KeepAliveValue] = None
@@ -293,6 +294,7 @@ else:
         date_shift_days: Optional[int] = None
         keep_mapping: bool = False
         use_smart_merging: bool = True
+        use_safety_sweep: bool = True
         lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"] = "en"
         normalize_accents: Optional[bool] = None
         keep_alive: Optional[KeepAliveValue] = None

--- a/tests/unit/core/test_safety_sweep.py
+++ b/tests/unit/core/test_safety_sweep.py
@@ -1,0 +1,141 @@
+"""Tests for the deterministic post-ML PII safety sweep."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+from openmed.core.anonymizer.providers import clinical_ids
+from openmed.core.pii import deidentify
+from openmed.core.safety_sweep import (
+    SAFETY_SWEEP_PATTERNS_VERSION,
+    SAFETY_SWEEP_SOURCE,
+    safety_sweep,
+)
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+
+def _entity_for(text: str, value: str, label: str = "MODEL") -> EntityPrediction:
+    start = text.index(value)
+    return EntityPrediction(
+        text=value,
+        label=label,
+        start=start,
+        end=start + len(value),
+        confidence=0.99,
+        metadata={"source": "model"},
+    )
+
+
+def _swept_by_label(entities):
+    return {
+        entity.label: entity
+        for entity in entities
+        if (entity.metadata or {}).get("source") == SAFETY_SWEEP_SOURCE
+    }
+
+
+def test_safety_sweep_recovers_ml_missed_deterministic_identifiers():
+    text = (
+        "Card 4111 1111 1111 1111. "
+        "IBAN GB82 WEST 1234 5698 7654 32. "
+        "SSN 123-45-6789. "
+        "Email jane.patient@example.com. "
+        "Phone 415-555-2671."
+    )
+
+    entities = safety_sweep(text, [])
+    swept = _swept_by_label(entities)
+
+    assert "credit_debit_card" in swept
+    assert "iban" in swept
+    assert "ssn" in swept
+    assert "email" in swept
+    assert "phone_number" in swept
+    assert swept["iban"].metadata["patterns_version"] == SAFETY_SWEEP_PATTERNS_VERSION
+    assert swept["email"].metadata["source"] == SAFETY_SWEEP_SOURCE
+
+
+def test_safety_sweep_rejects_invalid_checksum_identifiers():
+    text = (
+        "Card 4111 1111 1111 1112. "
+        "IBAN GB83 WEST 1234 5698 7654 32."
+    )
+
+    swept = _swept_by_label(safety_sweep(text, []))
+
+    assert "credit_debit_card" not in swept
+    assert "iban" not in swept
+
+
+def test_safety_sweep_delegates_checksum_validation_to_clinical_ids(monkeypatch):
+    luhn_calls = []
+    iban_calls = []
+
+    def fake_luhn(value: str) -> bool:
+        luhn_calls.append(value)
+        return True
+
+    def fake_iban(value: str) -> bool:
+        iban_calls.append(value)
+        return False
+
+    monkeypatch.setattr(clinical_ids, "validate_luhn", fake_luhn)
+    monkeypatch.setattr(clinical_ids, "validate_iban", fake_iban)
+
+    text = "Card 1234 5678 9012 3456. IBAN GB82 WEST 1234 5698 7654 32."
+    swept = _swept_by_label(safety_sweep(text, []))
+
+    assert luhn_calls == ["1234 5678 9012 3456"]
+    assert iban_calls == ["GB82 WEST 1234 5698 7654 32"]
+    assert "credit_debit_card" in swept
+    assert "iban" not in swept
+
+
+def test_safety_sweep_never_adds_spans_overlapping_model_spans():
+    text = "Card 4111 1111 1111 1111. Email jane.patient@example.com."
+    model_card = _entity_for(text, "4111 1111 1111 1111", label="ID_NUM")
+
+    entities = safety_sweep(text, [model_card])
+    swept = _swept_by_label(entities)
+
+    assert "credit_debit_card" not in swept
+    assert "email" in swept
+    for entity in swept.values():
+        assert entity.start >= model_card.end or entity.end <= model_card.start
+
+
+@patch("openmed.core.pii.extract_pii")
+def test_deidentify_runs_safety_sweep_by_default_for_ml_misses(mock_extract):
+    text = "Email: jane.patient@example.com"
+    mock_extract.return_value = PredictionResult(
+        text=text,
+        entities=[],
+        model_name="stub",
+        timestamp=datetime.now().isoformat(),
+    )
+
+    result = deidentify(text, method="mask")
+
+    assert result.deidentified_text == "Email: [email]"
+    assert result.metadata["safety_sweep"]["spans_added"] == 1
+    assert result.pii_entities[0].metadata["source"] == SAFETY_SWEEP_SOURCE
+    assert result.to_dict()["pii_entities"][0]["metadata"]["patterns_version"] == (
+        SAFETY_SWEEP_PATTERNS_VERSION
+    )
+
+
+@patch("openmed.core.pii.extract_pii")
+def test_deidentify_can_disable_safety_sweep(mock_extract):
+    text = "Email: jane.patient@example.com"
+    mock_extract.return_value = PredictionResult(
+        text=text,
+        entities=[],
+        model_name="stub",
+        timestamp=datetime.now().isoformat(),
+    )
+
+    result = deidentify(text, method="mask", use_safety_sweep=False)
+
+    assert result.deidentified_text == text
+    assert result.pii_entities == []


### PR DESCRIPTION
Closes #79.

Adds a deterministic post-detection safety sweep that recovers structured identifiers before redaction, delegates checksum validation through shared clinical ID validators, records sweep provenance and span contribution metadata, and covers overlap and opt-out behavior with unit tests.