### PR TITLE
fix: clamp Feb 29 when keep_year date shifting hits a leap day

### DIFF
--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1120,6 +1120,21 @@ def _format_localized_month_date(
     return f"{new_date.day} {month_name} {new_date.year}"
 
 
+def _replace_year_safe(date_value: datetime, year: int) -> datetime:
+    """Return ``date_value`` with its year set to ``year``.
+
+    ``datetime.replace(year=...)`` raises ``ValueError`` for Feb 29 when the
+    target year is not a leap year. Clamp to Feb 28 in that case so keep_year
+    date shifting degrades gracefully instead of falling through to the
+    ``[DATE_SHIFTED]`` placeholder.
+    """
+    try:
+        return date_value.replace(year=year)
+    except ValueError:
+        # The only date that can fail here is Feb 29 -> a non-leap year.
+        return date_value.replace(year=year, month=2, day=28)
+
+
 def _shift_date(
     date_str: str, shift_days: int, keep_year: bool = True, lang: str = "en",
 ) -> str:
@@ -1149,7 +1164,7 @@ def _shift_date(
             shifted_date = parsed_date + timedelta(days=shift_days)
 
             if keep_year:
-                shifted_date = shifted_date.replace(year=original_year)
+                shifted_date = _replace_year_safe(shifted_date, original_year)
 
             return _format_localized_month_date(shifted_date, lang, localized_style)
         except (ValueError, OverflowError):
@@ -1173,7 +1188,7 @@ def _shift_date(
 
         # If keep_year is True, restore the original year
         if keep_year:
-            shifted_date = shifted_date.replace(year=original_year)
+            shifted_date = _replace_year_safe(shifted_date, original_year)
 
         # Try to preserve the original format
         return _format_date_like_original(date_str, shifted_date, lang=lang)
@@ -1253,7 +1268,7 @@ def _shift_date_basic(
 
                 # Keep year if requested
                 if keep_year:
-                    shifted = shifted.replace(year=original_year)
+                    shifted = _replace_year_safe(shifted, original_year)
 
                 # Format back preserving separator
                 if "." in date_str:

--- a/tests/unit/test_pii.py
+++ b/tests/unit/test_pii.py
@@ -696,6 +696,17 @@ class TestShiftDate:
         result = _shift_date("not-a-date", 30)
         assert result == "[DATE_SHIFTED]"
 
+    def test_shift_date_keep_year_handles_leap_day(self):
+        """keep_year shifting onto Feb 29 must not fall through to a placeholder.
+
+        02/28/2019 + 366 days lands on 2020-02-29 (a leap day). Restoring the
+        original year 2019 (not a leap year) used to raise ValueError and
+        degrade the whole result to ``[DATE_SHIFTED]``; it should clamp to
+        Feb 28 instead.
+        """
+        result = _shift_date("02/28/2019", 366, keep_year=True)
+        assert result == "02/28/2019"
+
 
 # ---------------------------------------------------------------------------
 # reidentify Tests


### PR DESCRIPTION
What

When shift_dates lands on Feb 29 in a leap year and keep_year restores a
non-leap original year, datetime.replace(year=...) raised ValueError. The
except clause swallowed it and the date degraded to the [DATE_SHIFTED]
placeholder instead of a real shifted date.

Add a _replace_year_safe helper that clamps Feb 29 to Feb 28 for non-leap
target years, and route all three keep_year replace(year=...) sites through it.

Verified

Added a regression test (02/28/2019 + 366 days). Full suite: 1215 passed,
22 skipped.
