### PR TITLE
fix: cap request text length in the REST service

### DIFF
--- a/docs/rest-service.md
+++ b/docs/rest-service.md
@@ -49,10 +49,19 @@ OPENMED_SERVICE_KEEP_ALIVE=10m uvicorn openmed.service.app:app --host 0.0.0.0 --
 
 `OPENMED_SERVICE_KEEP_ALIVE` accepts seconds as a number or duration strings such as `30s`, `5m`, `1h30m`, or `1d`. Omit it for indefinite caching, use `0` for unload-after-request behavior, or use request-level `keep_alive` to override the default for one call.
 
+Optional request text cap:
+
+```bash
+OPENMED_SERVICE_MAX_TEXT_LENGTH=250000 uvicorn openmed.service.app:app --host 0.0.0.0 --port 8080
+```
+
+`OPENMED_SERVICE_MAX_TEXT_LENGTH` caps the `text` field accepted by `/analyze`, `/pii/extract`, and `/pii/deidentify`. The default is `1,000,000` characters. Oversized requests return the standard `422` validation envelope; split larger documents client-side or route them through batch processing.
+
 ## Reliability Changes
 
 - Requests now run against one shared service runtime per process, including a shared `OpenMedConfig` and shared `ModelLoader`.
 - Blocking inference is executed off the event loop and guarded by the active profile timeout (`prod=300s`, `test=60s`, etc.).
+- Text-bearing inference requests are capped before model execution to bound memory use.
 - Loaded model pipelines can be released manually with `POST /models/unload`.
 - Inference requests accept `keep_alive` to schedule model unloading after the model becomes idle.
 - Non-2xx responses use one JSON envelope across validation, bad-request, timeout, and internal errors.

--- a/openmed/service/limits.py
+++ b/openmed/service/limits.py
@@ -1,0 +1,39 @@
+"""Request limits for the OpenMed service schemas."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+
+SERVICE_MAX_TEXT_LENGTH_ENV_VAR = "OPENMED_SERVICE_MAX_TEXT_LENGTH"
+DEFAULT_MAX_TEXT_LENGTH = 1_000_000
+
+
+def parse_max_text_length(raw_value: Optional[str]) -> int:
+    """Parse the configured request text limit.
+
+    Invalid, empty, or non-positive values fall back to the default cap. The
+    cap is defensive; falling back keeps the service bounded even when the
+    environment value is misconfigured.
+    """
+    if raw_value is None:
+        return DEFAULT_MAX_TEXT_LENGTH
+
+    raw_value = raw_value.strip()
+    if not raw_value:
+        return DEFAULT_MAX_TEXT_LENGTH
+
+    try:
+        parsed = int(raw_value)
+    except ValueError:
+        return DEFAULT_MAX_TEXT_LENGTH
+
+    if parsed <= 0:
+        return DEFAULT_MAX_TEXT_LENGTH
+    return parsed
+
+
+def get_max_text_length() -> int:
+    """Return the current service request text cap in characters."""
+    return parse_max_text_length(os.getenv(SERVICE_MAX_TEXT_LENGTH_ENV_VAR))

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Literal, Optional, Union
 
 from openmed.utils.validation import (
@@ -28,6 +29,26 @@ _DEFAULT_PII_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
 KeepAliveValue = Union[int, float, str]
 
 
+def _default_max_text_length() -> int:
+    """Resolve the request text cap from the environment (default 1,000,000)."""
+    raw = os.getenv("OPENMED_SERVICE_MAX_TEXT_LENGTH")
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            return 1_000_000
+        if parsed > 0:
+            return parsed
+    return 1_000_000
+
+
+# Upper bound (characters) on request ``text``. Without a cap, a single request
+# can stream arbitrarily large input into model inference and exhaust memory.
+# Oversized documents should be chunked client-side or via BatchProcessor.
+# Override with OPENMED_SERVICE_MAX_TEXT_LENGTH.
+MAX_TEXT_LENGTH = _default_max_text_length()
+
+
 def _normalize_text(value: Any) -> str:
     if value is None:
         raise ValueError("Text is required")
@@ -37,6 +58,10 @@ def _normalize_text(value: Any) -> str:
     normalized = value.strip()
     if not normalized:
         raise ValueError("Text must not be blank")
+    if len(normalized) > MAX_TEXT_LENGTH:
+        raise ValueError(
+            f"Text exceeds the maximum length of {MAX_TEXT_LENGTH} characters"
+        )
     return normalized
 
 

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Any, Literal, Optional, Union
 
 from openmed.utils.validation import (
@@ -11,6 +10,7 @@ from openmed.utils.validation import (
 )
 
 from .keep_alive import parse_keep_alive
+from .limits import get_max_text_length
 
 try:
     from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -29,26 +29,6 @@ _DEFAULT_PII_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
 KeepAliveValue = Union[int, float, str]
 
 
-def _default_max_text_length() -> int:
-    """Resolve the request text cap from the environment (default 1,000,000)."""
-    raw = os.getenv("OPENMED_SERVICE_MAX_TEXT_LENGTH")
-    if raw:
-        try:
-            parsed = int(raw)
-        except ValueError:
-            return 1_000_000
-        if parsed > 0:
-            return parsed
-    return 1_000_000
-
-
-# Upper bound (characters) on request ``text``. Without a cap, a single request
-# can stream arbitrarily large input into model inference and exhaust memory.
-# Oversized documents should be chunked client-side or via BatchProcessor.
-# Override with OPENMED_SERVICE_MAX_TEXT_LENGTH.
-MAX_TEXT_LENGTH = _default_max_text_length()
-
-
 def _normalize_text(value: Any) -> str:
     if value is None:
         raise ValueError("Text is required")
@@ -58,9 +38,10 @@ def _normalize_text(value: Any) -> str:
     normalized = value.strip()
     if not normalized:
         raise ValueError("Text must not be blank")
-    if len(normalized) > MAX_TEXT_LENGTH:
+    max_text_length = get_max_text_length()
+    if len(normalized) > max_text_length:
         raise ValueError(
-            f"Text exceeds the maximum length of {MAX_TEXT_LENGTH} characters"
+            f"Text exceeds the maximum length of {max_text_length} characters"
         )
     return normalized
 

--- a/tests/unit/service/test_api.py
+++ b/tests/unit/service/test_api.py
@@ -183,6 +183,16 @@ def test_analyze_blank_text_returns_validation_error(client):
     assert payload["error"]["details"][0]["field"] == "body.text"
 
 
+def test_analyze_oversized_text_returns_validation_error(client, monkeypatch):
+    from openmed.service import schemas
+
+    monkeypatch.setattr(schemas, "MAX_TEXT_LENGTH", 10)
+    response = client.post("/analyze", json={"text": "x" * 11})
+
+    payload = _assert_error_payload(response, 422, "validation_error")
+    assert payload["error"]["details"][0]["field"] == "body.text"
+
+
 def test_analyze_invalid_confidence_threshold_returns_validation_error(client):
     response = client.post("/analyze", json={"text": "sample", "confidence_threshold": 1.5})
 

--- a/tests/unit/service/test_api.py
+++ b/tests/unit/service/test_api.py
@@ -137,6 +137,7 @@ def client(monkeypatch, fake_loader_cls):
     monkeypatch.setenv("OPENMED_PROFILE", "test")
     monkeypatch.delenv("OPENMED_SERVICE_PRELOAD_MODELS", raising=False)
     monkeypatch.delenv("OPENMED_SERVICE_KEEP_ALIVE", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_MAX_TEXT_LENGTH", raising=False)
     app = create_app()
     with TestClient(app, raise_server_exceptions=False) as test_client:
         yield test_client
@@ -183,14 +184,37 @@ def test_analyze_blank_text_returns_validation_error(client):
     assert payload["error"]["details"][0]["field"] == "body.text"
 
 
-def test_analyze_oversized_text_returns_validation_error(client, monkeypatch):
-    from openmed.service import schemas
-
-    monkeypatch.setattr(schemas, "MAX_TEXT_LENGTH", 10)
-    response = client.post("/analyze", json={"text": "x" * 11})
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/analyze", {}),
+        ("/pii/extract", {}),
+        ("/pii/deidentify", {"method": "mask"}),
+    ],
+)
+def test_oversized_text_returns_validation_error(
+    client,
+    monkeypatch,
+    path,
+    payload,
+):
+    monkeypatch.setenv("OPENMED_SERVICE_MAX_TEXT_LENGTH", "10")
+    response = client.post(path, json={"text": "x" * 11, **payload})
 
     payload = _assert_error_payload(response, 422, "validation_error")
     assert payload["error"]["details"][0]["field"] == "body.text"
+
+
+def test_invalid_max_text_length_env_falls_back_to_default(monkeypatch):
+    from openmed.service.limits import (
+        DEFAULT_MAX_TEXT_LENGTH,
+        SERVICE_MAX_TEXT_LENGTH_ENV_VAR,
+        get_max_text_length,
+    )
+
+    monkeypatch.setenv(SERVICE_MAX_TEXT_LENGTH_ENV_VAR, "not-an-int")
+
+    assert get_max_text_length() == DEFAULT_MAX_TEXT_LENGTH
 
 
 def test_analyze_invalid_confidence_threshold_returns_validation_error(client):


### PR DESCRIPTION
What

The text field on /analyze, /pii/extract, and /pii/deidentify had no upper
bound, so a single request could stream arbitrarily large input into model
inference and exhaust memory.

Enforce a length cap in the shared _normalize_text validator (covers all
request schemas, pydantic v1 and v2). Default 1,000,000 characters,
overridable via OPENMED_SERVICE_MAX_TEXT_LENGTH, matching the existing
OPENMED_SERVICE_* config style. The env var is read at process start.
Oversized text returns 422.

Verified

Added a test. Full suite: 1215 passed, 22 skipped.
