### PR TITLE
fix: respect batch_size in BatchProcessor.iter_process

### DIFF
--- a/openmed/processing/batch.py
+++ b/openmed/processing/batch.py
@@ -640,8 +640,9 @@ class BatchProcessor:
         """
         items = self._create_batch_items(texts, ids)
 
-        for item in items:
-            yield self._process_batch_chunk([item])[0]
+        for chunk in self._iter_chunks(items):
+            for result in self._process_batch_chunk(chunk):
+                yield result
 
 
 def process_batch(

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -444,6 +444,31 @@ class TestBatchProcessor:
         assert calls[0][1]["normalize_accents"] is True
         assert result.items[0].id == "a"
 
+    def test_iter_process_batches_by_batch_size(self, monkeypatch):
+        """iter_process must stream in chunks of batch_size, not one at a time."""
+        calls = []
+
+        def fake_extract_batch(texts, **kwargs):
+            calls.append(list(texts))
+            return [_prediction_result(text=text) for text in texts]
+
+        monkeypatch.setattr(
+            "openmed.core.pii._extract_pii_batch",
+            fake_extract_batch,
+        )
+        monkeypatch.setattr(BatchProcessor, "_get_shared_loader", lambda self: "loader")
+
+        processor = BatchProcessor(
+            model_name="pii-model",
+            operation="extract_pii",
+            batch_size=2,
+        )
+
+        results = list(processor.iter_process(["A", "B", "C"], ids=["a", "b", "c"]))
+
+        assert [r.id for r in results] == ["a", "b", "c"]
+        assert calls == [["A", "B"], ["C"]]
+
     def test_deidentify_operation_forwards_privacy_kwargs(self, monkeypatch):
         """Test deidentify operation forwards method and anonymizer kwargs."""
         calls = []


### PR DESCRIPTION
What

iter_process called _process_batch_chunk([item]) once per text, so it always
ran with an effective batch size of 1 regardless of batch_size. For
privacy-filter PII this runs the pipeline N times instead of ceil(N/batch_size);
for other models it rebuilds per item.

Stream through the existing _iter_chunks helper (the same one process_texts
uses) so results come out in order, batched by batch_size.

Verified

Added a test asserting the chunking and ordering. Full suite: 1215 passed,
22 skipped.
