### PR TITLE
chore: run the Docker container as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,13 @@ RUN python -m pip install --upgrade pip \
     && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
     && pip install --no-cache-dir ".[hf,service]"
 
+# Run as an unprivileged user. Created after install (which needs root); the
+# --create-home flag gives appuser a writable HOME for the Hugging Face model
+# cache pulled at runtime.
+RUN useradd --create-home --uid 1000 appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     OPENMED_PROFILE=prod \
-    OPENMED_SERVICE_KEEP_ALIVE=10m
+    OPENMED_SERVICE_KEEP_ALIVE=10m \
+    HOME=/home/appuser \
+    XDG_CACHE_HOME=/home/appuser/.cache \
+    HF_HOME=/home/appuser/.cache/huggingface
 
 WORKDIR /app
 
@@ -17,7 +20,8 @@ RUN python -m pip install --upgrade pip \
 # --create-home flag gives appuser a writable HOME for the Hugging Face model
 # cache pulled at runtime.
 RUN useradd --create-home --uid 1000 appuser \
-    && chown -R appuser:appuser /app
+    && mkdir -p /home/appuser/.cache/openmed /home/appuser/.cache/huggingface \
+    && chown -R appuser:appuser /app /home/appuser
 USER appuser
 
 EXPOSE 8080


### PR DESCRIPTION
What

The image ran uvicorn as root. Add an unprivileged appuser (created after the
root-only install step), give it ownership of /app and a home for the runtime
Hugging Face cache, and switch to it before EXPOSE/CMD so the service no longer
runs as root.

Verified

Confirmed the Hugging Face cache and the openmed cache_dir both resolve under
the appuser HOME, so they remain writable at runtime.
