### PR TITLE
Commit synthetic golden de-identification fixtures for the eval suites

### DIFF
--- a/openmed/eval/golden/README.md
+++ b/openmed/eval/golden/README.md
@@ -1,0 +1,45 @@
+# Golden De-Identification Fixtures
+
+This directory contains synthetic-only golden fixtures for the eval suites. The
+fixtures contain no DUA data, no production data, and no real PHI.
+
+Each JSON file has a top-level `fixtures` list. Each fixture uses this shape:
+
+```json
+{
+  "id": "golden-multilingual-en-ssn",
+  "language": "en",
+  "text": "Synthetic chart lists SSN 123-45-6789 for test patient.",
+  "gold_spans": [
+    {
+      "start": 26,
+      "end": 37,
+      "label": "SSN",
+      "text": "123-45-6789"
+    }
+  ],
+  "metadata": {
+    "category": "multilingual",
+    "synthetic": true,
+    "expected_output": {
+      "method": "mask",
+      "text": "Synthetic chart lists SSN [SSN] for test patient."
+    }
+  }
+}
+```
+
+Required fields:
+
+- `text`: source fixture text.
+- `gold_spans`: canonical-label spans with character offsets into `text`.
+- `metadata.category`: one of `nested_overlapping`, `chunk_boundary`,
+  `multilingual`, `checksum_ids`, or `date_arithmetic`.
+- `metadata.expected_output`: expected post-action output, including `method`
+  and resulting `text`.
+- `metadata.synthetic`: must be `true`.
+
+The package loader validates offsets, canonical labels, synthetic markers,
+expected output, and language coverage. The JSON files are also compatible with
+`openmed.eval.harness.load_fixtures`; golden-specific expected output remains
+available through each fixture's metadata.

--- a/openmed/eval/golden/__init__.py
+++ b/openmed/eval/golden/__init__.py
@@ -1,0 +1,21 @@
+"""Synthetic-only golden de-identification fixtures for eval suites."""
+
+from .loader import (
+    GOLDEN_CATEGORIES,
+    GoldenFixture,
+    fixture_languages,
+    fixtures_by_category,
+    list_fixture_paths,
+    load_benchmark_fixtures,
+    load_golden_fixtures,
+)
+
+__all__ = [
+    "GOLDEN_CATEGORIES",
+    "GoldenFixture",
+    "fixture_languages",
+    "fixtures_by_category",
+    "list_fixture_paths",
+    "load_benchmark_fixtures",
+    "load_golden_fixtures",
+]

--- a/openmed/eval/golden/fixtures/checksum_ids.json
+++ b/openmed/eval/golden/fixtures/checksum_ids.json
@@ -1,0 +1,70 @@
+{
+  "fixtures": [
+    {
+      "gold_spans": [
+        {
+          "end": 47,
+          "label": "CREDIT_CARD",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "credit_card"
+          },
+          "start": 28,
+          "text": "4111 1111 1111 1111"
+        },
+        {
+          "end": 107,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "cpf"
+          },
+          "start": 93,
+          "text": "456.378.921-64"
+        },
+        {
+          "end": 163,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "aadhaar"
+          },
+          "start": 151,
+          "text": "681937567577"
+        }
+      ],
+      "id": "golden-checksum-valid-invalid-identifiers",
+      "language": "en",
+      "metadata": {
+        "category": "checksum_ids",
+        "expected_output": {
+          "method": "mask",
+          "text": "Checksum fixture valid card [CREDIT_CARD], invalid card 4111 1111 1111 1112, valid CPF [ID_NUM], invalid CPF 456.378.921-65, valid Aadhaar [ID_NUM], invalid Aadhaar 681937567570."
+        },
+        "hard_negatives": [
+          {
+            "identifier_type": "credit_card",
+            "reason": "fails_luhn",
+            "text": "4111 1111 1111 1112"
+          },
+          {
+            "identifier_type": "cpf",
+            "reason": "fails_checksum",
+            "text": "456.378.921-65"
+          },
+          {
+            "identifier_type": "aadhaar",
+            "reason": "fails_verhoeff",
+            "text": "681937567570"
+          }
+        ],
+        "synthetic": true
+      },
+      "text": "Checksum fixture valid card 4111 1111 1111 1111, invalid card 4111 1111 1111 1112, valid CPF 456.378.921-64, invalid CPF 456.378.921-65, valid Aadhaar 681937567577, invalid Aadhaar 681937567570."
+    }
+  ],
+  "notice": "Synthetic-only golden fixtures for evals; no DUA data and no real PHI.",
+  "suite": "golden",
+  "synthetic": true,
+  "version": 1
+}

--- a/openmed/eval/golden/fixtures/chunk_boundary.json
+++ b/openmed/eval/golden/fixtures/chunk_boundary.json
@@ -1,0 +1,39 @@
+{
+  "fixtures": [
+    {
+      "gold_spans": [
+        {
+          "end": 71,
+          "label": "ID_NUM",
+          "metadata": {
+            "identifier_type": "mrn"
+          },
+          "start": 60,
+          "text": "MRN-2468135"
+        }
+      ],
+      "id": "golden-chunk-boundary-mrn",
+      "language": "en",
+      "metadata": {
+        "category": "chunk_boundary",
+        "chunk_window": {
+          "crosses_boundary": true,
+          "expected_global_end": 71,
+          "expected_global_start": 60,
+          "max_length": 64,
+          "span_id": "MRN-2468135"
+        },
+        "expected_output": {
+          "method": "mask",
+          "text": "Chunk remap synthetic note pads to boundary marker: xxxxxxxx[ID_NUM] after."
+        },
+        "synthetic": true
+      },
+      "text": "Chunk remap synthetic note pads to boundary marker: xxxxxxxxMRN-2468135 after."
+    }
+  ],
+  "notice": "Synthetic-only golden fixtures for evals; no DUA data and no real PHI.",
+  "suite": "golden",
+  "synthetic": true,
+  "version": 1
+}

--- a/openmed/eval/golden/fixtures/date_arithmetic.json
+++ b/openmed/eval/golden/fixtures/date_arithmetic.json
@@ -1,0 +1,68 @@
+{
+  "fixtures": [
+    {
+      "gold_spans": [
+        {
+          "end": 38,
+          "label": "DATE",
+          "metadata": {
+            "shift_group": "date_chain"
+          },
+          "start": 28,
+          "text": "2026-01-10"
+        },
+        {
+          "end": 60,
+          "label": "DATE",
+          "metadata": {
+            "shift_group": "date_chain"
+          },
+          "start": 50,
+          "text": "2026-01-17"
+        },
+        {
+          "end": 80,
+          "label": "DATE",
+          "metadata": {
+            "shift_group": "date_chain"
+          },
+          "start": 70,
+          "text": "2026-02-14"
+        }
+      ],
+      "id": "golden-date-arithmetic-shift-chain",
+      "language": "en",
+      "metadata": {
+        "category": "date_arithmetic",
+        "date_chain": {
+          "expected_interval_days": [
+            7,
+            28
+          ],
+          "original_dates": [
+            "2026-01-10",
+            "2026-01-17",
+            "2026-02-14"
+          ],
+          "shifted_dates": [
+            "2026-02-09",
+            "2026-02-16",
+            "2026-03-16"
+          ]
+        },
+        "expected_output": {
+          "date_shift_days": 30,
+          "keep_year": false,
+          "method": "shift_dates",
+          "text": "Date chain synthetic: visit 2026-02-09, follow-up 2026-02-16, imaging 2026-03-16."
+        },
+        "synthetic": true
+      },
+      "text": "Date chain synthetic: visit 2026-01-10, follow-up 2026-01-17, imaging 2026-02-14."
+    }
+  ],
+  "notice": "Synthetic-only golden fixtures for evals; no DUA data and no real PHI.",
+  "suite": "golden",
+  "synthetic": true,
+  "version": 1
+}

--- a/openmed/eval/golden/fixtures/multilingual.json
+++ b/openmed/eval/golden/fixtures/multilingual.json
@@ -1,0 +1,332 @@
+{
+  "fixtures": [
+    {
+      "gold_spans": [
+        {
+          "end": 37,
+          "label": "SSN",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "ssn"
+          },
+          "start": 26,
+          "text": "123-45-6789"
+        }
+      ],
+      "id": "golden-multilingual-en-ssn",
+      "language": "en",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "Synthetic chart lists SSN [SSN] for test patient."
+        },
+        "identifier_type": "ssn",
+        "locale": "en_US",
+        "synthetic": true
+      },
+      "text": "Synthetic chart lists SSN 123-45-6789 for test patient."
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 40,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "nir"
+          },
+          "start": 25,
+          "text": "242108708540372"
+        }
+      ],
+      "id": "golden-multilingual-fr-nir",
+      "language": "fr",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "Dossier synthétique: NIR [ID_NUM] pour patient fictif."
+        },
+        "identifier_type": "nir",
+        "locale": "fr_FR",
+        "synthetic": true
+      },
+      "text": "Dossier synthétique: NIR 242108708540372 pour patient fictif."
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 40,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "steuer_id"
+          },
+          "start": 29,
+          "text": "38449725069"
+        }
+      ],
+      "id": "golden-multilingual-de-steuer-id",
+      "language": "de",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "Synthetische Akte: Steuer-ID [ID_NUM] für Testperson."
+        },
+        "identifier_type": "steuer_id",
+        "locale": "de_DE",
+        "synthetic": true
+      },
+      "text": "Synthetische Akte: Steuer-ID 38449725069 für Testperson."
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 51,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "codice_fiscale"
+          },
+          "start": 35,
+          "text": "MNCPNL59L71E221W"
+        }
+      ],
+      "id": "golden-multilingual-it-codice-fiscale",
+      "language": "it",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "Cartella sintetica: codice fiscale [ID_NUM] per paziente fittizio."
+        },
+        "identifier_type": "codice_fiscale",
+        "locale": "it_IT",
+        "synthetic": true
+      },
+      "text": "Cartella sintetica: codice fiscale MNCPNL59L71E221W per paziente fittizio."
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 29,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "dni"
+          },
+          "start": 20,
+          "text": "12345678Z"
+        }
+      ],
+      "id": "golden-multilingual-es-dni",
+      "language": "es",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "Nota sintética: DNI [ID_NUM] para paciente ficticio."
+        },
+        "identifier_type": "dni",
+        "locale": "es_ES",
+        "synthetic": true
+      },
+      "text": "Nota sintética: DNI 12345678Z para paciente ficticio."
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 34,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "bsn"
+          },
+          "start": 25,
+          "text": "456378923"
+        }
+      ],
+      "id": "golden-multilingual-nl-bsn",
+      "language": "nl",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "Synthetisch dossier: BSN [ID_NUM] voor testpatiënt."
+        },
+        "identifier_type": "bsn",
+        "locale": "nl_NL",
+        "synthetic": true
+      },
+      "text": "Synthetisch dossier: BSN 456378923 voor testpatiënt."
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 31,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "aadhaar"
+          },
+          "start": 19,
+          "text": "659676687472"
+        }
+      ],
+      "id": "golden-multilingual-hi-aadhaar",
+      "language": "hi",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "सिंथेटिक नोट: आधार [ID_NUM] परीक्षण रोगी के लिए है।"
+        },
+        "identifier_type": "aadhaar",
+        "locale": "hi_IN",
+        "synthetic": true
+      },
+      "text": "सिंथेटिक नोट: आधार 659676687472 परीक्षण रोगी के लिए है।"
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 33,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "aadhaar"
+          },
+          "start": 21,
+          "text": "691256223921"
+        }
+      ],
+      "id": "golden-multilingual-te-aadhaar",
+      "language": "te",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "కృత్రిమ గమనిక: ఆధార్ [ID_NUM] పరీక్ష రోగి కోసం ఉంది."
+        },
+        "identifier_type": "aadhaar",
+        "locale": "en_IN",
+        "synthetic": true
+      },
+      "text": "కృత్రిమ గమనిక: ఆధార్ 691256223921 పరీక్ష రోగి కోసం ఉంది."
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 34,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "cpf"
+          },
+          "start": 20,
+          "text": "456.378.921-64"
+        }
+      ],
+      "id": "golden-multilingual-pt-cpf",
+      "language": "pt",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "Nota sintética: CPF [ID_NUM] para paciente fictício."
+        },
+        "identifier_type": "cpf",
+        "locale": "pt_BR",
+        "synthetic": true
+      },
+      "text": "Nota sintética: CPF 456.378.921-64 para paciente fictício."
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 44,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "not_validated",
+            "identifier_type": "egyptian_national_id"
+          },
+          "start": 30,
+          "text": "29801011234567"
+        }
+      ],
+      "id": "golden-multilingual-ar-egyptian-national-id",
+      "language": "ar",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "ملاحظة اصطناعية: الرقم القومي [ID_NUM] لمريض اختبار."
+        },
+        "identifier_type": "egyptian_national_id",
+        "locale": "ar_EG",
+        "synthetic": true
+      },
+      "text": "ملاحظة اصطناعية: الرقم القومي 29801011234567 لمريض اختبار."
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 27,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "not_validated",
+            "identifier_type": "my_number"
+          },
+          "start": 13,
+          "text": "1234 5678 9012"
+        }
+      ],
+      "id": "golden-multilingual-ja-my-number",
+      "language": "ja",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "合成メモ: マイナンバー [ID_NUM] はテスト患者用です。"
+        },
+        "identifier_type": "my_number",
+        "locale": "ja_JP",
+        "synthetic": true
+      },
+      "text": "合成メモ: マイナンバー 1234 5678 9012 はテスト患者用です。"
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 30,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "tckn"
+          },
+          "start": 19,
+          "text": "13198785260"
+        }
+      ],
+      "id": "golden-multilingual-tr-tckn",
+      "language": "tr",
+      "metadata": {
+        "category": "multilingual",
+        "expected_output": {
+          "method": "mask",
+          "text": "Sentetik not: TCKN [ID_NUM] test hastası içindir."
+        },
+        "identifier_type": "tckn",
+        "locale": "tr_TR",
+        "synthetic": true
+      },
+      "text": "Sentetik not: TCKN 13198785260 test hastası içindir."
+    }
+  ],
+  "notice": "Synthetic-only golden fixtures for evals; no DUA data and no real PHI.",
+  "suite": "golden",
+  "synthetic": true,
+  "version": 1
+}

--- a/openmed/eval/golden/fixtures/overlap.json
+++ b/openmed/eval/golden/fixtures/overlap.json
@@ -1,0 +1,64 @@
+{
+  "fixtures": [
+    {
+      "gold_spans": [
+        {
+          "end": 28,
+          "label": "PERSON",
+          "metadata": {
+            "role": "parent_span"
+          },
+          "start": 18,
+          "text": "Alex River"
+        },
+        {
+          "end": 22,
+          "label": "FIRST_NAME",
+          "metadata": {
+            "role": "nested_child"
+          },
+          "start": 18,
+          "text": "Alex"
+        },
+        {
+          "end": 57,
+          "label": "EMAIL",
+          "start": 34,
+          "text": "alex.river@example.test"
+        }
+      ],
+      "id": "golden-overlap-full-name-email",
+      "language": "en",
+      "metadata": {
+        "category": "nested_overlapping",
+        "expected_output": {
+          "method": "mask",
+          "text": "Synthetic patient [PERSON] uses [EMAIL] in Clinic Alpha."
+        },
+        "resolution": {
+          "expected_spans": [
+            {
+              "end": 28,
+              "label": "PERSON",
+              "start": 18,
+              "text": "Alex River"
+            },
+            {
+              "end": 57,
+              "label": "EMAIL",
+              "start": 34,
+              "text": "alex.river@example.test"
+            }
+          ],
+          "policy": "full_redaction_span_wins_over_nested_child"
+        },
+        "synthetic": true
+      },
+      "text": "Synthetic patient Alex River uses alex.river@example.test in Clinic Alpha."
+    }
+  ],
+  "notice": "Synthetic-only golden fixtures for evals; no DUA data and no real PHI.",
+  "suite": "golden",
+  "synthetic": true,
+  "version": 1
+}

--- a/openmed/eval/golden/loader.py
+++ b/openmed/eval/golden/loader.py
@@ -1,0 +1,232 @@
+"""Loader for synthetic golden de-identification fixtures."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from openmed.core.labels import CANONICAL_LABELS, normalize_label
+from openmed.core.pii_i18n import SUPPORTED_LANGUAGES
+from openmed.eval.harness import BenchmarkFixture
+from openmed.eval.metrics import EvalSpan, normalize_eval_spans
+
+
+GOLDEN_CATEGORIES: tuple[str, ...] = (
+    "nested_overlapping",
+    "chunk_boundary",
+    "multilingual",
+    "checksum_ids",
+    "date_arithmetic",
+)
+
+_FIXTURE_VERSION = 1
+_FIXTURE_DIR = Path(__file__).with_name("fixtures")
+
+
+@dataclass(frozen=True)
+class GoldenFixture:
+    """One validated golden fixture with expected post-action output."""
+
+    fixture_id: str
+    category: str
+    language: str
+    text: str
+    gold_spans: tuple[EvalSpan, ...]
+    expected_output: Mapping[str, Any]
+    metadata: Mapping[str, Any]
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "GoldenFixture":
+        """Build and validate a golden fixture from a JSON-ready mapping."""
+        if not isinstance(data, Mapping):
+            raise ValueError("golden fixture must be a mapping")
+
+        metadata = data.get("metadata") or {}
+        if not isinstance(metadata, Mapping):
+            raise ValueError("golden fixture metadata must be a mapping")
+        metadata = dict(metadata)
+
+        if metadata.get("synthetic") is not True:
+            raise ValueError("golden fixture metadata.synthetic must be true")
+
+        category = str(metadata.get("category", ""))
+        if category not in GOLDEN_CATEGORIES:
+            raise ValueError(f"unknown golden fixture category: {category!r}")
+
+        expected_output = metadata.get("expected_output")
+        if not isinstance(expected_output, Mapping):
+            raise ValueError("golden fixture metadata.expected_output must be a mapping")
+        if not str(expected_output.get("method", "")):
+            raise ValueError("golden fixture expected_output.method is required")
+        if not isinstance(expected_output.get("text"), str):
+            raise ValueError("golden fixture expected_output.text is required")
+
+        language = str(data.get("language") or data.get("lang") or "en")
+        if language not in SUPPORTED_LANGUAGES:
+            raise ValueError(f"unsupported golden fixture language: {language!r}")
+
+        text = str(data.get("text", ""))
+        if not text:
+            raise ValueError("golden fixture text is required")
+
+        raw_spans = data.get("gold_spans") or []
+        if not isinstance(raw_spans, list) or not raw_spans:
+            raise ValueError("golden fixture must include at least one gold span")
+        _validate_raw_span_labels(raw_spans, language)
+
+        gold_spans = tuple(
+            normalize_eval_spans(raw_spans, default_language=language, source_text=text)
+        )
+        _validate_offsets(text, gold_spans)
+
+        fixture_id = str(data.get("id") or data.get("fixture_id") or "")
+        if not fixture_id:
+            raise ValueError("golden fixture id is required")
+
+        return cls(
+            fixture_id=fixture_id,
+            category=category,
+            language=language,
+            text=text,
+            gold_spans=gold_spans,
+            expected_output=dict(expected_output),
+            metadata=metadata,
+        )
+
+    def to_benchmark_fixture(self) -> BenchmarkFixture:
+        """Return the harness-compatible fixture view."""
+        return BenchmarkFixture(
+            fixture_id=self.fixture_id,
+            text=self.text,
+            gold_spans=self.gold_spans,
+            language=self.language,
+            metadata=dict(self.metadata),
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        """Return a stable JSON-ready mapping."""
+        return {
+            "id": self.fixture_id,
+            "language": self.language,
+            "text": self.text,
+            "gold_spans": [_span_to_mapping(span) for span in self.gold_spans],
+            "metadata": _plain_mapping(self.metadata),
+        }
+
+
+def list_fixture_paths(path: str | Path | None = None) -> tuple[Path, ...]:
+    """Return fixture JSON paths in deterministic order."""
+    fixture_path = Path(path) if path is not None else _FIXTURE_DIR
+    if fixture_path.is_file():
+        return (fixture_path,)
+    return tuple(sorted(fixture_path.glob("*.json")))
+
+
+def load_golden_fixtures(path: str | Path | None = None) -> list[GoldenFixture]:
+    """Load and validate all golden fixtures under *path*."""
+    fixtures: list[GoldenFixture] = []
+    for fixture_path in list_fixture_paths(path):
+        raw = json.loads(fixture_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"{fixture_path} must contain a mapping")
+        if raw.get("version") != _FIXTURE_VERSION:
+            raise ValueError(f"{fixture_path} has unsupported fixture version")
+        if raw.get("synthetic") is not True:
+            raise ValueError(f"{fixture_path} must be marked synthetic")
+        rows = raw.get("fixtures")
+        if not isinstance(rows, list):
+            raise ValueError(f"{fixture_path} must contain a fixtures list")
+        fixtures.extend(GoldenFixture.from_mapping(row) for row in rows)
+    return fixtures
+
+
+def load_benchmark_fixtures(path: str | Path | None = None) -> list[BenchmarkFixture]:
+    """Load golden fixtures as eval harness benchmark fixtures."""
+    return [fixture.to_benchmark_fixture() for fixture in load_golden_fixtures(path)]
+
+
+def fixtures_by_category(
+    fixtures: list[GoldenFixture] | None = None,
+) -> dict[str, list[GoldenFixture]]:
+    """Group fixtures by golden category."""
+    source = fixtures if fixtures is not None else load_golden_fixtures()
+    grouped: defaultdict[str, list[GoldenFixture]] = defaultdict(list)
+    for fixture in source:
+        grouped[fixture.category].append(fixture)
+    return dict(grouped)
+
+
+def fixture_languages(
+    fixtures: list[GoldenFixture] | None = None,
+    *,
+    category: str | None = None,
+) -> set[str]:
+    """Return languages covered by loaded fixtures."""
+    source = fixtures if fixtures is not None else load_golden_fixtures()
+    return {
+        fixture.language
+        for fixture in source
+        if category is None or fixture.category == category
+    }
+
+
+def _validate_raw_span_labels(raw_spans: list[Any], language: str) -> None:
+    for raw_span in raw_spans:
+        if not isinstance(raw_span, Mapping):
+            raise ValueError("gold span must be a mapping")
+        raw_label = raw_span.get("label") or raw_span.get("canonical_label")
+        if not isinstance(raw_label, str):
+            raise ValueError("gold span label is required")
+        canonical = normalize_label(raw_label, language)
+        if canonical != raw_label or canonical not in CANONICAL_LABELS:
+            raise ValueError(f"gold span label must be canonical: {raw_label!r}")
+
+
+def _validate_offsets(text: str, spans: tuple[EvalSpan, ...]) -> None:
+    for span in spans:
+        if span.start < 0 or span.end <= span.start or span.end > len(text):
+            raise ValueError(f"gold span has invalid offsets: {span!r}")
+        actual_text = text[span.start : span.end]
+        if span.text and actual_text != span.text:
+            raise ValueError(
+                f"gold span text mismatch for {span.label}: "
+                f"{span.text!r} != {actual_text!r}"
+            )
+
+
+def _span_to_mapping(span: EvalSpan) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "start": span.start,
+        "end": span.end,
+        "label": span.label,
+        "text": span.text,
+    }
+    if span.metadata:
+        row["metadata"] = _plain_mapping(span.metadata)
+    return row
+
+
+def _plain_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): _plain(value[key]) for key in sorted(value, key=str)}
+
+
+def _plain(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _plain_mapping(value)
+    if isinstance(value, (list, tuple)):
+        return [_plain(item) for item in value]
+    return value
+
+
+__all__ = [
+    "GOLDEN_CATEGORIES",
+    "GoldenFixture",
+    "fixture_languages",
+    "fixtures_by_category",
+    "list_fixture_paths",
+    "load_benchmark_fixtures",
+    "load_golden_fixtures",
+]

--- a/tests/unit/eval/test_golden_fixtures.py
+++ b/tests/unit/eval/test_golden_fixtures.py
@@ -1,0 +1,167 @@
+"""Tests for synthetic golden de-identification fixtures."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from openmed.core.labels import CANONICAL_LABELS
+from openmed.core.pii_entity_merger import validate_luhn
+from openmed.core.pii_i18n import (
+    SUPPORTED_LANGUAGES,
+    validate_aadhaar,
+    validate_portuguese_cpf,
+)
+from openmed.eval import harness
+from openmed.eval.golden import (
+    GOLDEN_CATEGORIES,
+    GoldenFixture,
+    fixture_languages,
+    fixtures_by_category,
+    list_fixture_paths,
+    load_benchmark_fixtures,
+    load_golden_fixtures,
+)
+from openmed.eval.metrics import compute_date_shift_consistency
+
+
+def test_golden_directory_documents_synthetic_only_no_dua():
+    readme = Path("openmed/eval/golden/README.md").read_text(encoding="utf-8").lower()
+
+    assert "synthetic-only" in readme
+    assert "no dua" in readme
+    assert "no real phi" in readme
+
+
+def test_golden_fixtures_cover_required_categories_and_languages():
+    fixtures = load_golden_fixtures()
+    grouped = fixtures_by_category(fixtures)
+
+    assert set(grouped) == set(GOLDEN_CATEGORIES)
+    assert fixture_languages(fixtures, category="multilingual") == SUPPORTED_LANGUAGES
+
+    multilingual = grouped["multilingual"]
+    assert len(multilingual) == len(SUPPORTED_LANGUAGES)
+    assert all(fixture.metadata["synthetic"] is True for fixture in fixtures)
+
+
+def test_golden_fixtures_parse_offsets_expected_output_and_round_trip():
+    seen_ids: set[str] = set()
+
+    for fixture in load_golden_fixtures():
+        assert fixture.fixture_id not in seen_ids
+        seen_ids.add(fixture.fixture_id)
+        assert fixture.expected_output["text"]
+        assert fixture.expected_output["method"]
+        assert fixture.gold_spans
+
+        for span in fixture.gold_spans:
+            assert span.label in CANONICAL_LABELS
+            assert fixture.text[span.start : span.end] == span.text
+
+        mapping = fixture.to_mapping()
+        assert GoldenFixture.from_mapping(mapping).to_mapping() == mapping
+
+
+def test_golden_json_files_are_harness_loadable():
+    for fixture_path in list_fixture_paths():
+        loaded = harness.load_fixtures(fixture_path)
+        assert loaded
+        assert all(item.gold_spans for item in loaded)
+        assert all(item.metadata["expected_output"]["text"] for item in loaded)
+
+    benchmark_fixtures = load_benchmark_fixtures()
+    assert len(benchmark_fixtures) == len(load_golden_fixtures())
+    assert all(item.metadata["category"] for item in benchmark_fixtures)
+
+
+def test_nested_overlap_fixture_asserts_resolution_not_just_detection():
+    fixture = _one("nested_overlapping")
+
+    assert _has_overlap(fixture.gold_spans)
+
+    expected_spans = fixture.metadata["resolution"]["expected_spans"]
+    assert not _has_overlap(expected_spans)
+    assert [span["label"] for span in expected_spans] == ["PERSON", "EMAIL"]
+    assert fixture.expected_output["text"] == (
+        "Synthetic patient [PERSON] uses [EMAIL] in Clinic Alpha."
+    )
+
+
+def test_chunk_boundary_fixture_crosses_max_length_window_and_keeps_global_offsets():
+    fixture = _one("chunk_boundary")
+    span = fixture.gold_spans[0]
+    chunk_window = fixture.metadata["chunk_window"]
+    max_length = chunk_window["max_length"]
+
+    assert span.start < max_length < span.end
+    assert chunk_window["crosses_boundary"] is True
+    assert chunk_window["expected_global_start"] == span.start
+    assert chunk_window["expected_global_end"] == span.end
+
+
+def test_checksum_fixture_has_valid_gold_ids_and_invalid_hard_negatives():
+    fixture = _one("checksum_ids")
+    gold_by_type = {
+        span.metadata["identifier_type"]: span.text
+        for span in fixture.gold_spans
+    }
+    hard_negatives = {
+        item["identifier_type"]: item["text"]
+        for item in fixture.metadata["hard_negatives"]
+    }
+
+    assert validate_luhn(gold_by_type["credit_card"])
+    assert not validate_luhn(hard_negatives["credit_card"])
+    assert validate_portuguese_cpf(gold_by_type["cpf"])
+    assert not validate_portuguese_cpf(hard_negatives["cpf"])
+    assert validate_aadhaar(gold_by_type["aadhaar"])
+    assert not validate_aadhaar(hard_negatives["aadhaar"])
+
+    for invalid_text in hard_negatives.values():
+        assert invalid_text in fixture.text
+        assert invalid_text in fixture.expected_output["text"]
+        assert all(span.text != invalid_text for span in fixture.gold_spans)
+
+
+def test_date_arithmetic_fixture_preserves_intervals_after_shift_dates():
+    fixture = _one("date_arithmetic")
+    date_chain = fixture.metadata["date_chain"]
+    original_dates = date_chain["original_dates"]
+    shifted_dates = date_chain["shifted_dates"]
+
+    assert compute_date_shift_consistency(original_dates, shifted_dates).score == 1.0
+    assert _interval_days(original_dates) == date_chain["expected_interval_days"]
+    assert _interval_days(shifted_dates) == date_chain["expected_interval_days"]
+    for original, shifted in zip(original_dates, shifted_dates):
+        assert original in fixture.text
+        assert shifted in fixture.expected_output["text"]
+
+
+def _one(category: str) -> GoldenFixture:
+    matches = [fixture for fixture in load_golden_fixtures() if fixture.category == category]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _has_overlap(spans) -> bool:
+    rows = [
+        (
+            span["start"] if isinstance(span, dict) else span.start,
+            span["end"] if isinstance(span, dict) else span.end,
+        )
+        for span in spans
+    ]
+    return any(
+        first_start < second_end and second_start < first_end
+        for index, (first_start, first_end) in enumerate(rows)
+        for second_start, second_end in rows[index + 1 :]
+    )
+
+
+def _interval_days(values: list[str]) -> list[int]:
+    parsed = [date.fromisoformat(value) for value in values]
+    return [
+        (parsed[index + 1] - parsed[index]).days
+        for index in range(len(parsed) - 1)
+    ]


### PR DESCRIPTION
Closes #100.

Adds synthetic no-DUA golden de-identification fixtures covering nested overlap resolution, chunk-boundary offset remap, multilingual IDs across the 12 wired languages, valid and invalid checksum identifiers, and date-shift interval preservation. Includes a loader that validates offsets, canonical labels, expected post-action output, and harness-compatible fixture conversion; validated with `.venv/bin/python -m pytest tests/ -q`.