### PR TITLE
Website: responsive mobile nav, 6M+ downloads stat, contribute CTA

### DIFF
--- a/docs/website/assets/script.js
+++ b/docs/website/assets/script.js
@@ -13,7 +13,39 @@ document.addEventListener("DOMContentLoaded", () => {
     initCopyInstall();
     initScrollSpy();
     initGitHubStars();
+    initMobileMenu();
 });
+
+/* ---------- Mobile menu --------------------------------------------------- */
+function initMobileMenu() {
+    const header = document.querySelector(".nav");
+    const toggle = document.getElementById("navToggle");
+    if (!header || !toggle) return;
+
+    function setOpen(open) {
+        header.classList.toggle("menu-open", open);
+        toggle.setAttribute("aria-expanded", String(open));
+        toggle.setAttribute("aria-label", open ? "Close menu" : "Open menu");
+    }
+
+    toggle.addEventListener("click", () => {
+        setOpen(!header.classList.contains("menu-open"));
+    });
+
+    header.querySelectorAll(".nav-links a").forEach(a => {
+        a.addEventListener("click", () => setOpen(false));
+    });
+
+    document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") setOpen(false);
+    });
+
+    // Reset state when leaving the mobile breakpoint
+    const mq = window.matchMedia("(min-width: 721px)");
+    const onChange = (e) => { if (e.matches) setOpen(false); };
+    if (mq.addEventListener) mq.addEventListener("change", onChange);
+    else mq.addListener(onChange);
+}
 
 /* ---------- GitHub stars (live, with cache + graceful fallback) --------- */
 function initGitHubStars() {

--- a/docs/website/assets/style.css
+++ b/docs/website/assets/style.css
@@ -355,6 +355,37 @@ section[data-screen] { padding: 96px 0; }
     background: var(--bg-panel);
     border-color: var(--fg);
 }
+.nav-toggle {
+    display: none;
+    width: 36px;
+    height: 36px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    background: transparent;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background var(--dur-micro) var(--ease-out), border-color var(--dur-micro) var(--ease-out);
+}
+.nav-toggle:hover {
+    background: var(--bg-panel);
+    border-color: var(--fg);
+}
+.nav-toggle-bar {
+    display: block;
+    width: 14px;
+    height: 1.5px;
+    background: var(--fg);
+    border-radius: 1px;
+    transition: transform var(--dur-base) var(--ease-out), opacity var(--dur-base) var(--ease-out);
+}
+.nav.menu-open .nav-toggle-bar:nth-child(1) { transform: translateY(5.5px) rotate(45deg); }
+.nav.menu-open .nav-toggle-bar:nth-child(2) { opacity: 0; }
+.nav.menu-open .nav-toggle-bar:nth-child(3) { transform: translateY(-5.5px) rotate(-45deg); }
+.nav-links-mobile-only { display: none; }
 
 /* ---------- Buttons ------------------------------------------------------- */
 .btn {
@@ -1223,8 +1254,36 @@ section[data-screen] { padding: 96px 0; }
 }
 @media (max-width: 720px) {
     :root { --fs-display-xl: 44px; --fs-display-lg: 34px; --fs-display-md: 28px; --gutter: 16px; }
-    .nav-links { display: none; }
+    .nav-inner { gap: 10px; }
+    .nav-toggle { display: inline-flex; }
+    .nav-actions { gap: 6px; }
     .nav-actions .btn.docs-btn { display: none; }
+    .nav-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        display: none;
+        background: var(--bg);
+        border-bottom: 1px solid var(--border);
+        box-shadow: var(--shadow-2);
+    }
+    .nav.menu-open .nav-menu { display: block; }
+    .nav-links {
+        flex-direction: column;
+        gap: 0;
+        padding: 6px var(--gutter) 10px;
+    }
+    .nav-links li { border-bottom: 1px solid var(--border); }
+    .nav-links li:last-child { border-bottom: none; }
+    .nav-links a {
+        display: block;
+        padding: 13px 0;
+        font-size: 15px;
+        border-bottom: none;
+    }
+    .nav-links a.active { color: var(--accent); }
+    .nav-links-mobile-only { display: block; }
     .hero { padding: 56px 0 40px; }
     section[data-screen] { padding: 64px 0; }
     .runtime-grid,
@@ -1238,4 +1297,10 @@ section[data-screen] { padding: 96px 0; }
     .statband-cell:nth-child(n+3) { border-top: 1px solid var(--border); }
     .statband-cell:last-child { grid-column: 1 / -1; }
     .footer-grid { grid-template-columns: 1fr; gap: 32px; }
+}
+@media (max-width: 480px) {
+    .version-tag { display: none; }
+    .nav-actions .btn-primary .btn-label { display: none; }
+    .nav-actions .btn-primary { padding: 9px 10px; }
+    .wordmark { font-size: 20px; }
 }

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -86,8 +86,8 @@
     }
     </script>
 
-    <link rel="stylesheet" href="assets/style.css?v=6">
-    <script src="assets/script.js?v=6" defer></script>
+    <link rel="stylesheet" href="assets/style.css?v=7">
+    <script src="assets/script.js?v=7" defer></script>
 </head>
 
 <body>
@@ -107,7 +107,7 @@
                 <span class="version-tag">v1.5.5</span>
             </a>
 
-            <nav aria-label="Primary">
+            <nav class="nav-menu" id="primaryNav" aria-label="Primary">
                 <ul class="nav-links">
                     <li><a href="#apple-runtime">Runtime</a></li>
                     <li><a href="#deidentification">Privacy</a></li>
@@ -115,6 +115,7 @@
                     <li><a href="#research">Research</a></li>
                     <li><a href="#sagemaker">SageMaker</a></li>
                     <li><a href="#faq">FAQ</a></li>
+                    <li class="nav-links-mobile-only"><a href="docs/">Docs</a></li>
                 </ul>
             </nav>
 
@@ -127,13 +128,18 @@
                     <svg class="icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <path d="M12 2a10 10 0 0 0-3.16 19.49c.5.1.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.26-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.9-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.39.1 2.65.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 12 2z" />
                     </svg>
-                    GitHub
-                    <svg class="icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <span class="btn-label">GitHub</span>
+                    <svg class="icon btn-label" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <line x1="7" y1="17" x2="17" y2="7" />
                         <polyline points="7 7 17 7 17 17" />
                     </svg>
                 </a>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle color theme" title="Toggle theme"></button>
+                <button id="navToggle" class="nav-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="primaryNav">
+                    <span class="nav-toggle-bar" aria-hidden="true"></span>
+                    <span class="nav-toggle-bar" aria-hidden="true"></span>
+                    <span class="nav-toggle-bar" aria-hidden="true"></span>
+                </button>
             </div>
         </div>
     </header>


### PR DESCRIPTION
## Responsive mobile nav

The website header didn't respect responsive design on phones. Below 720px the primary nav links and the Docs button were simply `display: none`, so there was no way to navigate to any section on mobile, and the remaining items (logo, version tag, star pill, GitHub button, theme toggle) crammed into a single overflowing row.

- Added a hamburger toggle in the header (mobile only) that opens the primary nav as a dropdown panel below the sticky header, with comfortable tap targets and a Docs link included
- The menu closes on link tap, on Escape, and automatically when resizing back to desktop; the toggle keeps `aria-expanded`/`aria-controls` in sync
- Below 480px the GitHub button collapses to icon-only and the version tag is hidden so the header fits on small phones
- Bumped the CSS/JS cache-buster query strings to `v=7`

## 6M+ PyPI downloads + contribute CTA

OpenMed crossed six million downloads on PyPI, so the milestone now leads the stat band (six columns, responsive border rules adjusted) and appears as a pip in the hero meta row. A new contribute section before the footer invites visitors to star the repo, open issues, and send pull requests, linking to GitHub and the contributing guide.

## Verification

Rendered with headless Chromium at 375px (menu closed/open, stat band, contribute section) and 1280/1440px — desktop layout is otherwise unchanged.