### PR TITLE
Add the SHIELD public comparison corpus loader and first clinical-PHI baseline

### DIFF
--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -114,6 +114,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_analyze_command(subparsers)
     _add_batch_command(subparsers)
     _add_pii_command(subparsers)
+    _add_benchmark_command(subparsers)
     _add_tui_command(subparsers)
     _add_models_command(subparsers)
     _add_config_command(subparsers)
@@ -384,6 +385,44 @@ def _add_pii_command(subparsers: argparse._SubParsersAction) -> None:
         help="Minimum confidence for redaction.",
     )
     batch_parser.set_defaults(handler=_handle_pii_batch)
+
+
+def _add_benchmark_command(subparsers: argparse._SubParsersAction) -> None:
+    benchmark_parser = subparsers.add_parser(
+        "benchmark", help="Run OpenMed benchmark suites."
+    )
+    benchmark_sub = benchmark_parser.add_subparsers(dest="benchmark_command")
+
+    pii_parser = benchmark_sub.add_parser(
+        "pii", help="Run PII/PHI de-identification benchmark suites."
+    )
+    pii_parser.add_argument(
+        "--suite",
+        default="shield",
+        help="Benchmark suite name.",
+    )
+    pii_parser.add_argument(
+        "--models",
+        nargs="+",
+        required=True,
+        help="One or more model identifiers. Comma-separated values are accepted.",
+    )
+    pii_parser.add_argument(
+        "--device",
+        default="cpu",
+        help="Device tier label recorded in the benchmark report.",
+    )
+    pii_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write BenchmarkReport JSON to this path instead of stdout.",
+    )
+    pii_parser.add_argument(
+        "--full-shield",
+        action="store_true",
+        help="Use the approved-access full SHIELD corpus instead of the public sample.",
+    )
+    pii_parser.set_defaults(handler=_handle_benchmark_pii)
 
 
 def _add_tui_command(subparsers: argparse._SubParsersAction) -> None:
@@ -696,6 +735,66 @@ def _handle_batch(args: argparse.Namespace) -> int:
         sys.stdout.write(f"{output}\n")
 
     return 0 if result.failed_items == 0 else 1
+
+
+def _handle_benchmark_pii(args: argparse.Namespace) -> int:
+    from openmed.eval.harness import run_benchmark
+    from openmed.eval.suites import SHIELD, load_suite_fixtures, suite_metadata
+
+    models = _parse_model_args(args.models)
+    if not models:
+        sys.stderr.write("At least one model identifier is required.\n")
+        return 1
+
+    suite = str(args.suite)
+    try:
+        if suite == SHIELD:
+            use_sample = not bool(args.full_shield)
+            fixtures = load_suite_fixtures(suite, use_sample=use_sample)
+            metadata = suite_metadata(suite, use_sample=use_sample)
+        else:
+            fixtures = load_suite_fixtures(suite)
+            metadata = suite_metadata(suite)
+    except (RuntimeError, ValueError) as exc:
+        sys.stderr.write(f"Failed to load benchmark suite: {exc}\n")
+        return 1
+
+    reports = [
+        run_benchmark(
+            fixtures,
+            suite=suite,
+            model_name=model,
+            device=args.device,
+            metadata=metadata,
+        )
+        for model in models
+    ]
+    if len(reports) == 1:
+        payload: Any = reports[0].to_dict()
+    else:
+        payload = {
+            "metadata": metadata,
+            "reports": [report.to_dict() for report in reports],
+            "suite": suite,
+        }
+
+    output = json.dumps(payload, indent=2, sort_keys=True)
+    if args.output:
+        try:
+            args.output.write_text(output + "\n", encoding="utf-8")
+        except OSError as exc:
+            sys.stderr.write(f"Failed to write benchmark output: {exc}\n")
+            return 1
+    else:
+        sys.stdout.write(output + "\n")
+    return 0
+
+
+def _parse_model_args(values: Sequence[str]) -> list[str]:
+    models: list[str] = []
+    for value in values:
+        models.extend(item.strip() for item in value.split(",") if item.strip())
+    return models
 
 
 def _handle_tui(args: argparse.Namespace) -> int:

--- a/openmed/eval/suites/__init__.py
+++ b/openmed/eval/suites/__init__.py
@@ -1,17 +1,22 @@
-"""Benchmark suite registry for the OpenMed eval harness.
-
-The first concrete fixture loaders land in follow-up tasks. OM-018 defines the
-suite names and keeps this package importable for local and CI runners.
-"""
+"""Benchmark suite registry for the OpenMed eval harness."""
 
 from __future__ import annotations
+
+from typing import Any
+
+from openmed.eval.harness import BenchmarkFixture
+from openmed.eval.suites.shield import (
+    SHIELD,
+    load_shield_fixtures,
+    shield_suite_metadata,
+)
 
 
 GOLDEN = "golden"
 I2B2 = "i2b2"
 N2C2 = "n2c2"
 
-DEFAULT_SUITES: tuple[str, ...] = (GOLDEN, I2B2, N2C2)
+DEFAULT_SUITES: tuple[str, ...] = (GOLDEN, I2B2, N2C2, SHIELD)
 
 
 def validate_suite_name(name: str) -> str:
@@ -22,10 +27,31 @@ def validate_suite_name(name: str) -> str:
     return name
 
 
+def load_suite_fixtures(name: str, **kwargs: Any) -> list[BenchmarkFixture]:
+    """Load benchmark fixtures for a named suite."""
+    suite = validate_suite_name(name)
+    if suite == SHIELD:
+        return load_shield_fixtures(**kwargs)
+    raise ValueError(f"benchmark suite {suite!r} does not have a concrete loader yet")
+
+
+def suite_metadata(name: str, **kwargs: Any) -> dict[str, Any]:
+    """Return suite-specific report metadata."""
+    suite = validate_suite_name(name)
+    if suite == SHIELD:
+        return shield_suite_metadata(**kwargs)
+    return {"suite": suite}
+
+
 __all__ = [
     "GOLDEN",
     "I2B2",
     "N2C2",
+    "SHIELD",
     "DEFAULT_SUITES",
     "validate_suite_name",
+    "load_suite_fixtures",
+    "suite_metadata",
+    "load_shield_fixtures",
+    "shield_suite_metadata",
 ]

--- a/openmed/eval/suites/shield.py
+++ b/openmed/eval/suites/shield.py
@@ -1,0 +1,305 @@
+"""SHIELD clinical PHI comparison corpus loader.
+
+The suite is intentionally loaded by reference from the public dataset mirror.
+No corpus rows are stored in this repository.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Mapping
+from urllib.parse import quote
+from urllib.request import urlopen
+
+from openmed.core.labels import (
+    AGE,
+    CANONICAL_LABELS,
+    DATE,
+    ID_NUM,
+    LOCATION,
+    ORGANIZATION,
+    PERSON,
+    PHONE,
+    URL,
+)
+from openmed.eval.harness import BenchmarkFixture
+from openmed.eval.metrics import EvalSpan
+
+
+SHIELD = "shield"
+CORPUS_ROLE = "comparison"
+SUITE_ANNOTATION = "comparison corpus, not a high-recall gate target"
+IS_HIGH_RECALL_GATE_TARGET = False
+
+PUBLIC_SAMPLE_REPOSITORY = "tds-research-tech/shield-sample"
+FULL_REPOSITORY = "tds-research-tech/shield"
+PUBLIC_SAMPLE_NOTES_CONFIG = "sample_notes"
+PUBLIC_SAMPLE_SPANS_CONFIG = "sample_spans"
+FULL_NOTES_CONFIG = "full_notes"
+FULL_SPANS_CONFIG = "full_spans"
+DEFAULT_SPLIT = "train"
+VERIFIED_LICENSE = "data-use-agreement"
+VERIFIED_LICENSE_DATE = "2026-06-12"
+
+SHIELD_LABEL_TO_CANONICAL: dict[str, str] = {
+    "age": AGE,
+    "date": DATE,
+    "doctor": PERSON,
+    "hospital": ORGANIZATION,
+    "id": ID_NUM,
+    "location": LOCATION,
+    "patient": PERSON,
+    "phone": PHONE,
+    "web": URL,
+}
+
+RowsLoader = Callable[[str, str, str], list[Mapping[str, Any]]]
+
+
+@dataclass(frozen=True)
+class ShieldSource:
+    """Dataset mirror coordinates for one SHIELD variant."""
+
+    repository: str
+    notes_config: str
+    spans_config: str
+    split: str
+    variant: str
+    requires_approval: bool
+
+
+PUBLIC_SAMPLE_SOURCE = ShieldSource(
+    repository=PUBLIC_SAMPLE_REPOSITORY,
+    notes_config=PUBLIC_SAMPLE_NOTES_CONFIG,
+    spans_config=PUBLIC_SAMPLE_SPANS_CONFIG,
+    split=DEFAULT_SPLIT,
+    variant="public_sample",
+    requires_approval=False,
+)
+
+FULL_SOURCE = ShieldSource(
+    repository=FULL_REPOSITORY,
+    notes_config=FULL_NOTES_CONFIG,
+    spans_config=FULL_SPANS_CONFIG,
+    split=DEFAULT_SPLIT,
+    variant="full_access_controlled",
+    requires_approval=True,
+)
+
+
+def map_shield_label(label: str) -> str:
+    """Map a SHIELD PHI category onto OpenMed's canonical label taxonomy."""
+    canonical = SHIELD_LABEL_TO_CANONICAL.get(label.strip().lower())
+    if canonical is None:
+        allowed = ", ".join(sorted(SHIELD_LABEL_TO_CANONICAL))
+        raise ValueError(f"unknown SHIELD label {label!r}; expected one of: {allowed}")
+    return canonical
+
+
+def shield_suite_metadata(*, use_sample: bool = True) -> dict[str, Any]:
+    """Return source, license, and role metadata for SHIELD benchmark reports."""
+    source = _source_for(use_sample=use_sample)
+    return {
+        "access": (
+            "public sample is available without approval; full corpus requires "
+            "approved access and a signed data-use agreement"
+        ),
+        "annotation": SUITE_ANNOTATION,
+        "corpus_role": CORPUS_ROLE,
+        "full_repository": FULL_REPOSITORY,
+        "gate_target": IS_HIGH_RECALL_GATE_TARGET,
+        "label_mapping": dict(sorted(SHIELD_LABEL_TO_CANONICAL.items())),
+        "license": VERIFIED_LICENSE,
+        "license_verified_at": VERIFIED_LICENSE_DATE,
+        "notes_config": source.notes_config,
+        "redistribution": "not vendored; loaded by reference",
+        "repository": source.repository,
+        "requires_approval": source.requires_approval,
+        "source_url": f"https://huggingface.co/datasets/{source.repository}",
+        "span_count_paper": 10505,
+        "spans_config": source.spans_config,
+        "split": source.split,
+        "suite": SHIELD,
+        "variant": source.variant,
+    }
+
+
+def load_shield_fixtures(
+    *,
+    use_sample: bool = True,
+    rows_loader: RowsLoader | None = None,
+) -> list[BenchmarkFixture]:
+    """Load SHIELD notes and spans as benchmark fixtures.
+
+    The default uses the public sample mirror. Set ``use_sample=False`` only
+    on an approved machine with access to the full corpus.
+    """
+    source = _source_for(use_sample=use_sample)
+    loader = rows_loader or _load_dataset_rows
+    notes = loader(source.repository, source.notes_config, source.split)
+    spans = loader(source.repository, source.spans_config, source.split)
+    return fixtures_from_rows(notes, spans, source=source)
+
+
+def fixtures_from_rows(
+    notes: Iterable[Mapping[str, Any]],
+    spans: Iterable[Mapping[str, Any]],
+    *,
+    source: ShieldSource = PUBLIC_SAMPLE_SOURCE,
+) -> list[BenchmarkFixture]:
+    """Build benchmark fixtures from SHIELD note and span table rows."""
+    spans_by_note: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for span in spans:
+        note_id = str(span.get("note_id", ""))
+        if note_id:
+            spans_by_note[note_id].append(span)
+
+    metadata = shield_suite_metadata(use_sample=source.variant == "public_sample")
+    fixtures: list[BenchmarkFixture] = []
+    for note in notes:
+        note_id = str(note.get("note_id", ""))
+        text = str(note.get("note_text", ""))
+        note_type = str(note.get("note_type") or "")
+        gold_spans = tuple(
+            _span_from_row(span, text=text)
+            for span in sorted(
+                spans_by_note.get(note_id, []),
+                key=lambda row: (int(row.get("span_start", 0)), str(row.get("span_id", ""))),
+            )
+        )
+        fixture_metadata = dict(metadata)
+        fixture_metadata.update(
+            {
+                "note_type": note_type,
+                "source_note_id": note_id,
+            }
+        )
+        fixtures.append(
+            BenchmarkFixture(
+                fixture_id=note_id,
+                text=text,
+                gold_spans=gold_spans,
+                language="en",
+                metadata=fixture_metadata,
+            )
+        )
+    return fixtures
+
+
+def _span_from_row(row: Mapping[str, Any], *, text: str) -> EvalSpan:
+    raw_label = str(row.get("span_label", ""))
+    canonical_label = map_shield_label(raw_label)
+    start = _read_required_int(row, "span_start")
+    end = _read_required_int(row, "span_end")
+    if start < 0 or end < start or end > len(text):
+        raise ValueError(
+            f"invalid SHIELD span offsets {start}:{end} for text length {len(text)}"
+        )
+    return EvalSpan(
+        start=start,
+        end=end,
+        label=canonical_label,
+        text=text[start:end],
+        language="en",
+        metadata={
+            "canonical_label": canonical_label,
+            "shield_label": raw_label.strip().lower(),
+            "span_id": str(row.get("span_id") or ""),
+        },
+    )
+
+
+def _load_dataset_rows(repository: str, config: str, split: str) -> list[Mapping[str, Any]]:
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        return _load_dataset_rows_via_server(repository, config, split)
+
+    try:
+        dataset = load_dataset(repository, config, split=split)
+    except Exception as exc:
+        if repository == PUBLIC_SAMPLE_REPOSITORY:
+            return _load_dataset_rows_via_server(repository, config, split)
+        raise RuntimeError(
+            f"failed to load approved SHIELD rows for {repository}/{config}/{split}: {exc}"
+        ) from exc
+    return [dict(row) for row in dataset]
+
+
+def _load_dataset_rows_via_server(
+    repository: str,
+    config: str,
+    split: str,
+    *,
+    page_size: int = 100,
+) -> list[Mapping[str, Any]]:
+    encoded_repository = quote(repository, safe="")
+    encoded_config = quote(config, safe="")
+    encoded_split = quote(split, safe="")
+    rows: list[Mapping[str, Any]] = []
+    offset = 0
+
+    while True:
+        url = (
+            "https://datasets-server.huggingface.co/rows"
+            f"?dataset={encoded_repository}"
+            f"&config={encoded_config}"
+            f"&split={encoded_split}"
+            f"&offset={offset}"
+            f"&length={page_size}"
+        )
+        try:
+            with urlopen(url, timeout=30) as response:  # nosec: trusted fixed host
+                payload = json.loads(response.read().decode("utf-8"))
+        except OSError as exc:
+            raise RuntimeError(
+                f"failed to load SHIELD rows for {repository}/{config}/{split}: {exc}"
+            ) from exc
+
+        page_rows = [item["row"] for item in payload.get("rows", [])]
+        rows.extend(page_rows)
+        total = int(payload.get("num_rows_total") or len(rows))
+        if not page_rows or len(rows) >= total:
+            return rows
+        offset += len(page_rows)
+
+
+def _read_required_int(row: Mapping[str, Any], key: str) -> int:
+    try:
+        return int(row[key])
+    except (KeyError, TypeError, ValueError):
+        raise ValueError(f"SHIELD span row missing integer {key!r}: {row!r}") from None
+
+
+def _source_for(*, use_sample: bool) -> ShieldSource:
+    return PUBLIC_SAMPLE_SOURCE if use_sample else FULL_SOURCE
+
+
+_invalid_mapping = {
+    label: canonical
+    for label, canonical in SHIELD_LABEL_TO_CANONICAL.items()
+    if canonical not in CANONICAL_LABELS
+}
+if _invalid_mapping:
+    raise RuntimeError(f"SHIELD mapping contains non-canonical labels: {_invalid_mapping}")
+
+
+__all__ = [
+    "SHIELD",
+    "CORPUS_ROLE",
+    "SUITE_ANNOTATION",
+    "IS_HIGH_RECALL_GATE_TARGET",
+    "PUBLIC_SAMPLE_REPOSITORY",
+    "FULL_REPOSITORY",
+    "VERIFIED_LICENSE",
+    "SHIELD_LABEL_TO_CANONICAL",
+    "ShieldSource",
+    "PUBLIC_SAMPLE_SOURCE",
+    "FULL_SOURCE",
+    "map_shield_label",
+    "shield_suite_metadata",
+    "load_shield_fixtures",
+    "fixtures_from_rows",
+]

--- a/tests/unit/eval/test_metrics.py
+++ b/tests/unit/eval/test_metrics.py
@@ -27,7 +27,7 @@ def test_eval_modules_import_cleanly():
     assert openmed.eval.harness.run_benchmark
     assert openmed.eval.metrics.compute_leakage_rate
     assert openmed.eval.report.BenchmarkReport
-    assert openmed.eval.suites.DEFAULT_SUITES == ("golden", "i2b2", "n2c2")
+    assert openmed.eval.suites.DEFAULT_SUITES == ("golden", "i2b2", "n2c2", "shield")
 
 
 def test_leakage_rate_is_char_weighted_and_sliced():

--- a/tests/unit/eval/test_shield_suite.py
+++ b/tests/unit/eval/test_shield_suite.py
@@ -1,0 +1,218 @@
+"""Unit tests for the SHIELD comparison corpus suite."""
+
+from __future__ import annotations
+
+import json
+from typing import Mapping
+
+import pytest
+
+from openmed.core.labels import (
+    AGE,
+    CANONICAL_LABELS,
+    DATE,
+    ID_NUM,
+    LOCATION,
+    ORGANIZATION,
+    PERSON,
+    PHONE,
+    URL,
+)
+from openmed.eval.harness import run_benchmark
+from openmed.eval.suites import SHIELD, load_suite_fixtures, suite_metadata
+from openmed.eval.suites.shield import (
+    IS_HIGH_RECALL_GATE_TARGET,
+    PUBLIC_SAMPLE_NOTES_CONFIG,
+    PUBLIC_SAMPLE_REPOSITORY,
+    PUBLIC_SAMPLE_SPANS_CONFIG,
+    SHIELD_LABEL_TO_CANONICAL,
+    SUITE_ANNOTATION,
+    VERIFIED_LICENSE,
+    fixtures_from_rows,
+    load_shield_fixtures,
+    map_shield_label,
+)
+
+
+def test_shield_label_mapping_is_total_and_canonical() -> None:
+    assert SHIELD_LABEL_TO_CANONICAL == {
+        "age": AGE,
+        "date": DATE,
+        "doctor": PERSON,
+        "hospital": ORGANIZATION,
+        "id": ID_NUM,
+        "location": LOCATION,
+        "patient": PERSON,
+        "phone": PHONE,
+        "web": URL,
+    }
+    assert len(SHIELD_LABEL_TO_CANONICAL) == 9
+    assert set(SHIELD_LABEL_TO_CANONICAL.values()) <= CANONICAL_LABELS
+    assert map_shield_label(" Doctor ") == PERSON
+
+    with pytest.raises(ValueError, match="unknown SHIELD label"):
+        map_shield_label("room")
+
+
+def test_fixtures_from_rows_joins_notes_and_spans_without_vendored_corpus() -> None:
+    note, spans = _synthetic_shield_rows()
+
+    fixtures = fixtures_from_rows([note], spans)
+
+    assert len(fixtures) == 1
+    fixture = fixtures[0]
+    assert fixture.fixture_id == "note-x"
+    assert fixture.metadata["annotation"] == SUITE_ANNOTATION
+    assert fixture.metadata["corpus_role"] == "comparison"
+    assert fixture.metadata["gate_target"] is IS_HIGH_RECALL_GATE_TARGET
+    assert fixture.metadata["license"] == VERIFIED_LICENSE
+    assert fixture.metadata["redistribution"] == "not vendored; loaded by reference"
+    assert fixture.metadata["repository"] == PUBLIC_SAMPLE_REPOSITORY
+    assert {span.label for span in fixture.gold_spans} == set(
+        SHIELD_LABEL_TO_CANONICAL.values()
+    )
+    assert {span.metadata["shield_label"] for span in fixture.gold_spans} == set(
+        SHIELD_LABEL_TO_CANONICAL
+    )
+
+
+def test_load_shield_fixtures_uses_public_sample_reference_by_default() -> None:
+    note, spans = _synthetic_shield_rows()
+    calls: list[tuple[str, str, str]] = []
+
+    def rows_loader(repository: str, config: str, split: str) -> list[Mapping[str, object]]:
+        calls.append((repository, config, split))
+        if config == PUBLIC_SAMPLE_NOTES_CONFIG:
+            return [note]
+        if config == PUBLIC_SAMPLE_SPANS_CONFIG:
+            return spans
+        raise AssertionError(f"unexpected config: {config}")
+
+    fixtures = load_shield_fixtures(rows_loader=rows_loader)
+
+    assert len(fixtures) == 1
+    assert calls == [
+        (PUBLIC_SAMPLE_REPOSITORY, PUBLIC_SAMPLE_NOTES_CONFIG, "train"),
+        (PUBLIC_SAMPLE_REPOSITORY, PUBLIC_SAMPLE_SPANS_CONFIG, "train"),
+    ]
+
+
+def test_suite_registry_loads_shield_and_metadata() -> None:
+    note, spans = _synthetic_shield_rows()
+
+    def rows_loader(repository: str, config: str, split: str) -> list[Mapping[str, object]]:
+        return [note] if config == PUBLIC_SAMPLE_NOTES_CONFIG else spans
+
+    fixtures = load_suite_fixtures(SHIELD, rows_loader=rows_loader)
+    metadata = suite_metadata(SHIELD)
+
+    assert len(fixtures) == 1
+    assert metadata["annotation"] == SUITE_ANNOTATION
+    assert metadata["label_mapping"]["web"] == URL
+
+
+def test_shield_report_contains_per_label_leakage_and_recall() -> None:
+    note, spans = _synthetic_shield_rows()
+    fixture = fixtures_from_rows([note], spans)[0]
+
+    def runner(fixture, model_name, device):
+        assert model_name == "fixture-model"
+        assert device == "cpu"
+        return [
+            {"start": span.start, "end": span.end, "label": span.label}
+            for span in fixture.gold_spans
+            if span.label in {PERSON, AGE}
+        ]
+
+    report = run_benchmark(
+        [fixture],
+        suite=SHIELD,
+        model_name="fixture-model",
+        runner=runner,
+        metadata=suite_metadata(SHIELD),
+    )
+
+    data = report.to_dict()
+    assert data["suite"] == SHIELD
+    assert data["metadata"]["annotation"] == SUITE_ANNOTATION
+    assert data["metrics"]["leakage"]["by_label"][PERSON] == 0.0
+    assert data["metrics"]["leakage"]["by_label"][PHONE] == 1.0
+    assert data["metrics"]["recall_slices"]["by_label"][PERSON] == 1.0
+    assert data["metrics"]["recall_slices"]["by_label"][PHONE] == 0.0
+
+
+def test_cli_benchmark_pii_emits_shield_benchmark_report(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from openmed.cli import main_module
+    from openmed.eval import harness, suites
+
+    note, spans = _synthetic_shield_rows()
+    fixtures = fixtures_from_rows([note], spans)
+
+    monkeypatch.setattr(
+        suites,
+        "load_shield_fixtures",
+        lambda **kwargs: fixtures,
+    )
+
+    def runner(fixture, model_name, device):
+        return [
+            {"start": span.start, "end": span.end, "label": span.label}
+            for span in fixture.gold_spans
+        ]
+
+    monkeypatch.setattr(harness, "default_model_runner", runner)
+
+    result = main_module.main(
+        ["benchmark", "pii", "--suite", "shield", "--models", "fixture-model"]
+    )
+
+    assert result == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["suite"] == SHIELD
+    assert output["model_name"] == "fixture-model"
+    assert output["metadata"]["license"] == VERIFIED_LICENSE
+    assert output["metrics"]["leakage"]["by_label"][PERSON] == 0.0
+    assert output["metrics"]["recall_slices"]["by_label"][PERSON] == 1.0
+
+
+def _synthetic_shield_rows() -> tuple[dict[str, object], list[dict[str, object]]]:
+    pieces = [
+        ("patient", "John Doe"),
+        ("age", "45"),
+        ("date", "2025-01-15"),
+        ("doctor", "Jane Doe"),
+        ("hospital", "General Hospital"),
+        ("id", "MRN-98765"),
+        ("location", "123 Main St"),
+        ("phone", "555-0123"),
+        ("web", "clinic.example"),
+    ]
+    text = ""
+    spans: list[dict[str, object]] = []
+    for index, (label, value) in enumerate(pieces, start=1):
+        if text:
+            text += " "
+        start = len(text)
+        text += value
+        end = len(text)
+        spans.append(
+            {
+                "span_id": f"span-{index}",
+                "note_id": "note-x",
+                "span_start": start,
+                "span_end": end,
+                "span_label": label,
+            }
+        )
+
+    return (
+        {
+            "note_id": "note-x",
+            "note_text": text,
+            "note_type": "synthetic_unit",
+        },
+        spans,
+    )


### PR DESCRIPTION
Closes #102.

Adds a SHIELD comparison suite that loads the public sample and approved-access full corpus by reference, maps the nine PHI categories into canonical labels, and wires `openmed benchmark pii --suite shield --models ...` to emit BenchmarkReport JSON with leakage and recall slices. Records the verified data-use-agreement license and comparison-corpus annotation in report metadata, with offline tests for mapping, loading, and CLI output.

Validation:
- `.venv/bin/python -m pytest tests/ -q`