### PR TITLE
Fix case-sensitive trust_remote_code allowlist matching

### DIFF
--- a/openmed/torch/privacy_filter.py
+++ b/openmed/torch/privacy_filter.py
@@ -25,10 +25,14 @@ logger = logging.getLogger(__name__)
 # First-party privacy-filter repos that legitimately require
 # trust_remote_code=True (they ship modeling_openai_privacy_filter.py and
 # friends in the repo and rely on Transformers' auto_map import).
+# Stored in lower-case because HuggingFace namespaces are case-insensitive
+# (OpenMed and openmed resolve to the same org).  Normalising both sides
+# prevents a user-supplied "openmed/privacy-filter-multilingual" from failing
+# to match the hard-coded "OpenMed/..." entry.
 TRUSTED_REMOTE_CODE_MODELS = frozenset({
     "openai/privacy-filter",
-    "OpenMed/privacy-filter-multilingual",
-    "OpenMed/privacy-filter-nemotron",
+    "openmed/privacy-filter-multilingual",
+    "openmed/privacy-filter-nemotron",
 })
 
 # Operators with custom fine-tunes can extend the allowlist with a
@@ -38,7 +42,9 @@ _ALLOWLIST_ENV_VAR = "OPENMED_TRUSTED_REMOTE_CODE_MODELS"
 
 def _env_allowlist() -> frozenset[str]:
     raw = os.getenv(_ALLOWLIST_ENV_VAR, "")
-    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+    return frozenset(
+        part.strip().lower() for part in raw.split(",") if part.strip()
+    )
 
 
 def is_trusted_for_remote_code(model_name: str) -> bool:
@@ -56,9 +62,10 @@ def is_trusted_for_remote_code(model_name: str) -> bool:
     """
     if not model_name:
         return False
-    if model_name in TRUSTED_REMOTE_CODE_MODELS:
+    normalized = model_name.lower()
+    if normalized in TRUSTED_REMOTE_CODE_MODELS:
         return True
-    if model_name in _env_allowlist():
+    if normalized in _env_allowlist():
         return True
     # Local path check is deferred (it touches the filesystem) and imported
     # lazily to avoid a circular import with openmed.core.pii.

--- a/tests/unit/test_privacy_filter_security.py
+++ b/tests/unit/test_privacy_filter_security.py
@@ -122,6 +122,18 @@ class TestPrivacyFilterTorchPipelineGate:
         assert captured["tokenizer_kwargs"]["trust_remote_code"] is True
         assert captured["model_kwargs"]["trust_remote_code"] is True
 
+    def test_case_variant_of_trusted_model_loads(self):
+        """Issue #205 — lowercase variant of an allowlisted model must
+        also pass the trust_remote_code gate."""
+        captured = {}
+        with _patched_transformers(captured):
+            from openmed.torch.privacy_filter import PrivacyFilterTorchPipeline
+            PrivacyFilterTorchPipeline(
+                "openmed/privacy-filter-multilingual",
+                trust_remote_code=True,
+            )
+        assert captured["tokenizer_kwargs"]["trust_remote_code"] is True
+
 
 class TestIsTrustedForRemoteCode:
     """The allowlist function backs the gate."""
@@ -132,6 +144,10 @@ class TestIsTrustedForRemoteCode:
             "openai/privacy-filter",
             "OpenMed/privacy-filter-multilingual",
             "OpenMed/privacy-filter-nemotron",
+            # Case-insensitive matches (issue #205)
+            "openmed/privacy-filter-multilingual",
+            "OPENMED/PRIVACY-FILTER-NEMOTRON",
+            "OpenAI/Privacy-Filter",
         ],
     )
     def test_hardcoded_first_party_models_are_trusted(self, trusted):
@@ -163,6 +179,17 @@ class TestIsTrustedForRemoteCode:
         assert is_trusted_for_remote_code("other-org/another-fork") is True
         # Unrelated names are still rejected.
         assert is_trusted_for_remote_code("attacker/foo-privacy-filter") is False
+
+    def test_env_var_matches_case_insensitive(self, monkeypatch):
+        """Issue #205 — env-var allowlist entries should match regardless
+        of the case the caller supplies."""
+        from openmed.torch.privacy_filter import is_trusted_for_remote_code
+        monkeypatch.setenv(
+            "OPENMED_TRUSTED_REMOTE_CODE_MODELS",
+            "My-Org/My-Fork",
+        )
+        assert is_trusted_for_remote_code("my-org/my-fork") is True
+        assert is_trusted_for_remote_code("MY-ORG/MY-FORK") is True
 
     def test_env_var_unset_does_not_trust_extras(self, monkeypatch):
         monkeypatch.delenv("OPENMED_TRUSTED_REMOTE_CODE_MODELS", raising=False)


### PR DESCRIPTION
## Summary

Fixes #205

`is_trusted_for_remote_code()` compared model names against the hardcoded allowlist with exact case-sensitive membership. Since HuggingFace namespaces are case-insensitive (`OpenMed` and `openmed` resolve to the same org), a user passing `openmed/privacy-filter-multilingual` would not match the hardcoded `OpenMed/privacy-filter-multilingual`, so `trust_remote_code` stayed `False` and the first-party model failed to load its custom code.

## Changes

- Store `TRUSTED_REMOTE_CODE_MODELS` entries in lowercase
- Normalize `model_name` to lowercase in `is_trusted_for_remote_code()` before comparison
- Normalize env-var entries to lowercase in `_env_allowlist()`
- Add tests for case-variant matches across all three layers:
  - Hardcoded allowlist (e.g. `openmed/privacy-filter-multilingual`, `OPENMED/PRIVACY-FILTER-NEMOTRON`, `OpenAI/Privacy-Filter`)
  - Env-var allowlist (`My-Org/My-Fork` matches `my-org/my-fork`)
  - Pipeline gate (lowercase variant passes `trust_remote_code=True`)

## Security

This is safe because HuggingFace namespaces are case-insensitive — `OpenMed` and `openmed` resolve to the same org on the Hub. Normalizing both sides to lowercase does not expand the trust boundary to include lookalike repos from different orgs.

## Testing

All 44 tests in `test_privacy_filter_security.py` pass, including the 3 new case-insensitivity tests.