### PR TITLE
Wire the openmed benchmark CLI command into the eval harness

### DIFF
--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -1013,6 +1013,12 @@ def _add_benchmark_command(subparsers: argparse._SubParsersAction) -> None:
         help="Optional path for the BenchmarkReport JSON.",
     )
     pii_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Optional directory for per-model JSON and Markdown reports.",
+    )
+    pii_parser.add_argument(
         "--leaderboard-output",
         type=Path,
         default=None,
@@ -1042,7 +1048,7 @@ def _add_benchmark_command(subparsers: argparse._SubParsersAction) -> None:
     )
     clinical_parser.add_argument(
         "--task",
-        choices=["ner", "relation"],
+        choices=["ner", "linking", "assertion", "relation"],
         default="ner",
         help="Clinical benchmark task view to load.",
     )
@@ -1084,6 +1090,37 @@ def _add_benchmark_command(subparsers: argparse._SubParsersAction) -> None:
         help="Optional path for a JSON suite-resolution summary.",
     )
     clinical_parser.set_defaults(handler=_handle_benchmark_clinical)
+
+    mobile_parser = benchmark_sub.add_parser(
+        "mobile",
+        help="Parse mobile benchmark options.",
+    )
+    mobile_parser.add_argument(
+        "--models",
+        nargs="+",
+        required=True,
+        metavar="MODEL",
+        help="Model id(s), comma-separated ids, or @manifest.",
+    )
+    mobile_parser.add_argument(
+        "--device",
+        choices=["mlx", "coreml"],
+        required=True,
+        help="Mobile runtime device.",
+    )
+    mobile_parser.add_argument(
+        "--tier",
+        choices=["phone", "laptop", "workstation", "server"],
+        required=True,
+        help="Device tier to benchmark.",
+    )
+    mobile_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory where benchmark reports will be written.",
+    )
+    mobile_parser.set_defaults(handler=_handle_benchmark_mobile)
 
 
 def _add_eval_command(subparsers: argparse._SubParsersAction) -> None:
@@ -1614,7 +1651,11 @@ def _handle_benchmark_pii(args: argparse.Namespace) -> int:
     from openmed.eval.harness import run_benchmark
     from openmed.eval.suites import SHIELD, load_suite_fixtures, suite_metadata
 
-    models = _parse_model_args(args.models or [])
+    try:
+        models = _parse_model_args(args.models or [])
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
     if not models:
         sys.stderr.write("At least one model identifier is required.\n")
         return 1
@@ -1631,6 +1672,10 @@ def _handle_benchmark_pii(args: argparse.Namespace) -> int:
     except (PermissionError, RuntimeError, ValueError) as exc:
         sys.stderr.write(f"Failed to load benchmark suite: {exc}\n")
         return 1
+
+    metadata = dict(metadata)
+    metadata.setdefault("benchmark_domain", "pii")
+    metadata.setdefault("source_suite", suite)
 
     reports = [
         run_benchmark(
@@ -1650,6 +1695,25 @@ def _handle_benchmark_pii(args: argparse.Namespace) -> int:
             "reports": [report.to_dict() for report in reports],
             "suite": suite,
         }
+
+    if args.output_dir:
+        try:
+            paths = _write_benchmark_report_files(
+                reports,
+                output_dir=args.output_dir,
+                domain="pii",
+                suite=suite,
+                device=str(args.device),
+            )
+        except OSError as exc:
+            sys.stderr.write(f"Failed to write benchmark output: {exc}\n")
+            return 1
+        if args.output is None:
+            sys.stdout.write("Benchmark reports written:\n")
+            for json_path, markdown_path in paths:
+                sys.stdout.write(f"  JSON: {json_path}\n")
+                sys.stdout.write(f"  Markdown: {markdown_path}\n")
+            return 0
 
     output = json.dumps(payload, indent=2, sort_keys=True)
     if args.output:
@@ -1674,6 +1738,11 @@ def _handle_benchmark_clinical(args: argparse.Namespace) -> int:
     try:
         suite = str(args.suite)
         task = str(args.task)
+        if task in {"linking", "assertion"}:
+            sys.stderr.write(
+                f"Clinical benchmark task '{task}' is not implemented yet.\n"
+            )
+            return 1
         load_kwargs: dict[str, Any] = {
             "task": task,
             "path": args.input,
@@ -1694,7 +1763,11 @@ def _handle_benchmark_clinical(args: argparse.Namespace) -> int:
 
     if suite == BIOMEDICAL_NER and task == "ner":
         split = str(args.split) if args.split is not None else "test"
-        models = _parse_model_args(args.models or [])
+        try:
+            models = _parse_model_args(args.models or [])
+        except ValueError as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 1
         if not models:
             models = ["disease_detection_superclinical"]
         reports = [
@@ -1735,6 +1808,19 @@ def _handle_benchmark_clinical(args: argparse.Namespace) -> int:
     return _write_json_payload(payload, args.output)
 
 
+def _handle_benchmark_mobile(args: argparse.Namespace) -> int:
+    try:
+        models = _parse_model_args(args.models or [])
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+    sys.stderr.write(
+        "Mobile benchmark execution is not implemented yet for "
+        f"models={', '.join(models)}, device={args.device}, tier={args.tier}.\n"
+    )
+    return 1
+
+
 def _write_json_payload(payload: Any, output_path: Path | None) -> int:
     output = json.dumps(payload, indent=2, sort_keys=True)
     if output_path:
@@ -1748,10 +1834,66 @@ def _write_json_payload(payload: Any, output_path: Path | None) -> int:
     return 0
 
 
+def _write_benchmark_report_files(
+    reports: Sequence[Any],
+    *,
+    output_dir: Path,
+    domain: str,
+    suite: str,
+    device: str,
+) -> list[tuple[Path, Path]]:
+    paths: list[tuple[Path, Path]] = []
+    for report in reports:
+        json_path, markdown_path = _benchmark_report_paths(
+            output_dir=output_dir,
+            domain=domain,
+            suite=suite,
+            model_name=str(report.model_name),
+            device=device,
+        )
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        report.write_json(json_path)
+        report.write_markdown(markdown_path)
+        paths.append((json_path, markdown_path))
+    return paths
+
+
+def _benchmark_report_paths(
+    *,
+    output_dir: Path,
+    domain: str,
+    suite: str,
+    model_name: str,
+    device: str,
+) -> tuple[Path, Path]:
+    stem = f"{_path_token(model_name)}-{_path_token(device)}"
+    directory = output_dir / _path_token(domain) / _path_token(suite)
+    return directory / f"{stem}.json", directory / f"{stem}.md"
+
+
+def _path_token(value: str) -> str:
+    token = "".join(
+        character if character.isalnum() or character in "._-" else "-"
+        for character in value
+    ).strip("-")
+    return token or "value"
+
+
 def _parse_model_args(values: Sequence[str]) -> list[str]:
     models: list[str] = []
     for value in values:
         models.extend(item.strip() for item in value.split(",") if item.strip())
+    if models == ["@manifest"]:
+        manifest_models = [
+            str(row["repo_id"])
+            for row in load_manifest_rows(MANIFEST_PATH)
+            if isinstance(row.get("repo_id"), str) and row["repo_id"]
+        ]
+        if not manifest_models:
+            raise ValueError(f"model manifest is empty: {MANIFEST_PATH}")
+        return manifest_models
+    if "@manifest" in models:
+        raise ValueError("--models @manifest cannot be combined with explicit ids")
     return models
 
 

--- a/openmed/eval/suites/__init__.py
+++ b/openmed/eval/suites/__init__.py
@@ -22,6 +22,7 @@ from openmed.eval.datasets.i2b2 import (
     i2b2_suite_metadata,
     load_i2b2_deid,
 )
+from openmed.eval.golden import load_benchmark_fixtures
 from openmed.eval.harness import BenchmarkFixture
 from openmed.eval.suites.policy_compliance import (
     POLICY_COMPLIANCE,
@@ -61,6 +62,8 @@ def validate_suite_name(name: str) -> str:
 def load_suite_fixtures(name: str, **kwargs: Any) -> list[Any]:
     """Load benchmark fixtures for a named suite."""
     suite = validate_suite_name(name)
+    if suite == GOLDEN:
+        return load_benchmark_fixtures(kwargs.get("path"))
     if suite == I2B2:
         return load_i2b2_deid(
             path=kwargs.get("path"),
@@ -106,6 +109,7 @@ __all__ = [
     "BIOMEDICAL_NER",
     "DEFAULT_SUITES",
     "validate_suite_name",
+    "load_benchmark_fixtures",
     "load_suite_fixtures",
     "suite_metadata",
     "load_i2b2_deid",

--- a/tests/unit/cli/test_benchmark_cli.py
+++ b/tests/unit/cli/test_benchmark_cli.py
@@ -1,0 +1,170 @@
+"""Tests for the benchmark CLI command group."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.cli import main_module
+from openmed.eval import harness
+from openmed.eval.report import BenchmarkReport
+
+
+def test_benchmark_pii_golden_writes_report_from_committed_fixtures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run_benchmark(fixtures, **kwargs):
+        seen["fixture_count"] = len(fixtures)
+        seen["suite"] = kwargs["suite"]
+        seen["model_name"] = kwargs["model_name"]
+        seen["device"] = kwargs["device"]
+        seen["metadata"] = kwargs["metadata"]
+        return BenchmarkReport(
+            suite=kwargs["suite"],
+            model_name=kwargs["model_name"],
+            device=kwargs["device"],
+            fixture_count=len(fixtures),
+            generated_at=kwargs.get("generated_at"),
+            metrics={
+                "leakage": {"overall": 0.0},
+                "exact_span_f1": {"f1": 1.0},
+            },
+            metadata=kwargs["metadata"],
+        )
+
+    monkeypatch.setattr(harness, "run_benchmark", fake_run_benchmark)
+
+    result = main_module.main(
+        [
+            "benchmark",
+            "pii",
+            "--suite",
+            "golden",
+            "--models",
+            "test-model",
+            "--device",
+            "cpu",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert result == 0
+    assert seen["fixture_count"]
+    assert seen["suite"] == "golden"
+    assert seen["model_name"] == "test-model"
+    assert seen["device"] == "cpu"
+
+    json_path = tmp_path / "pii" / "golden" / "test-model-cpu.json"
+    markdown_path = tmp_path / "pii" / "golden" / "test-model-cpu.md"
+    assert json_path.is_file()
+    assert markdown_path.is_file()
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["suite"] == "golden"
+    assert payload["model_name"] == "test-model"
+    assert payload["metadata"]["benchmark_domain"] == "pii"
+    assert str(json_path) in capsys.readouterr().out
+
+
+def test_models_manifest_shortcut_resolves_canonical_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    seen_models: list[str] = []
+
+    def fake_load_manifest_rows(path=main_module.MANIFEST_PATH):
+        assert path == main_module.MANIFEST_PATH
+        return [
+            {"repo_id": "OpenMed/model-a"},
+            {"repo_id": "OpenMed/model-b"},
+        ]
+
+    def fake_run_benchmark(fixtures, **kwargs):
+        seen_models.append(kwargs["model_name"])
+        return BenchmarkReport(
+            suite=kwargs["suite"],
+            model_name=kwargs["model_name"],
+            device=kwargs["device"],
+            fixture_count=len(fixtures),
+            generated_at=kwargs.get("generated_at"),
+            metrics={"leakage": {"overall": 0.0}},
+            metadata=kwargs["metadata"],
+        )
+
+    monkeypatch.setattr(main_module, "load_manifest_rows", fake_load_manifest_rows)
+    monkeypatch.setattr(harness, "run_benchmark", fake_run_benchmark)
+
+    result = main_module.main(
+        [
+            "benchmark",
+            "pii",
+            "--suite",
+            "golden",
+            "--models",
+            "@manifest",
+            "--device",
+            "cpu",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert result == 0
+    assert seen_models == ["OpenMed/model-a", "OpenMed/model-b"]
+
+
+def test_explicit_model_ids_accept_space_and_comma_separated_values() -> None:
+    assert main_module._parse_model_args(["a", "b,c"]) == ["a", "b", "c"]
+
+
+def test_manifest_shortcut_cannot_be_combined_with_explicit_ids() -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        main_module._parse_model_args(["@manifest", "explicit-model"])
+
+
+def test_clinical_command_parses_documented_flags(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = main_module.main(
+        [
+            "benchmark",
+            "clinical",
+            "--suite",
+            "drugprot",
+            "--task",
+            "linking",
+        ]
+    )
+
+    assert result == 1
+    assert "not implemented yet" in capsys.readouterr().err
+
+
+def test_mobile_command_parses_documented_flags(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = main_module.main(
+        [
+            "benchmark",
+            "mobile",
+            "--models",
+            "OpenMed/mobile-model",
+            "--device",
+            "mlx",
+            "--tier",
+            "phone",
+        ]
+    )
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "not implemented yet" in captured.err
+    assert "phone" in captured.err
+    assert "OpenMed/mobile-model" in captured.err


### PR DESCRIPTION
Closes #112.

Adds the `openmed benchmark` command group to the existing console entry point. The PII golden suite resolves explicit model ids or `@manifest`, runs the committed golden fixtures through the eval harness, and writes JSON plus Markdown BenchmarkReport outputs to `benchmark-reports/pii/<suite>/`; clinical and mobile benchmark flags now parse and return clear implementation-boundary messages.

Validation:
- `.venv/bin/python -m pytest tests/ -q`