### PR TITLE
fix: accept ar/ja/tr in REST/MCP PII lang schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- REST/MCP request schemas now accept `ar`, `ja`, and `tr` for the `lang` field. These languages have published PII models and are listed in `SUPPORTED_LANGUAGES`, but the `lang` `Literal` in `openmed/service/schemas.py` was never updated, so the service rejected them with a 422 even though the Python API and the models worked. The four `lang` annotations now share a single `PIILanguage` alias kept in sync with `SUPPORTED_LANGUAGES` (guarded by a regression test).
+
 ## [1.5.5] - 2026-06-08
 
 ### Added

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -27,6 +27,16 @@ except ImportError:  # pragma: no cover
 _DEFAULT_PII_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
 KeepAliveValue = Union[int, float, str]
 
+# Languages accepted by the PII endpoints. This MUST mirror
+# ``openmed.core.pii_i18n.SUPPORTED_LANGUAGES`` so the REST/MCP layer does not
+# reject a language the core library actually supports (e.g. ar/ja/tr, which
+# shipped with published models but were missing from these schemas). The
+# parity is guarded by
+# ``tests/unit/service/test_api.py::test_pii_lang_literal_matches_supported_languages``.
+PIILanguage = Literal[
+    "en", "fr", "de", "it", "es", "nl", "hi", "te", "pt", "ar", "ja", "tr"
+]
+
 
 def _normalize_text(value: Any) -> str:
     if value is None:
@@ -126,7 +136,7 @@ if PYDANTIC_V2:
         model_name: str = _DEFAULT_PII_MODEL
         confidence_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
         use_smart_merging: bool = True
-        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"] = "en"
+        lang: PIILanguage = "en"
         normalize_accents: Optional[bool] = None
         keep_alive: Optional[KeepAliveValue] = None
 
@@ -166,7 +176,7 @@ if PYDANTIC_V2:
         keep_mapping: bool = False
         use_smart_merging: bool = True
         use_safety_sweep: bool = True
-        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"] = "en"
+        lang: PIILanguage = "en"
         normalize_accents: Optional[bool] = None
         keep_alive: Optional[KeepAliveValue] = None
 
@@ -259,7 +269,7 @@ else:
         model_name: str = _DEFAULT_PII_MODEL
         confidence_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
         use_smart_merging: bool = True
-        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"] = "en"
+        lang: PIILanguage = "en"
         normalize_accents: Optional[bool] = None
         keep_alive: Optional[KeepAliveValue] = None
 
@@ -295,7 +305,7 @@ else:
         keep_mapping: bool = False
         use_smart_merging: bool = True
         use_safety_sweep: bool = True
-        lang: Literal["en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"] = "en"
+        lang: PIILanguage = "en"
         normalize_accents: Optional[bool] = None
         keep_alive: Optional[KeepAliveValue] = None
 

--- a/tests/unit/service/test_api.py
+++ b/tests/unit/service/test_api.py
@@ -246,7 +246,7 @@ def test_pii_extract_success_with_lang_es(client, monkeypatch, fake_loader_cls):
     assert payload["entities"][0]["label"] == "NAME"
 
 
-@pytest.mark.parametrize("lang", ["nl", "hi", "te"])
+@pytest.mark.parametrize("lang", ["nl", "hi", "te", "ar", "ja", "tr"])
 def test_pii_extract_accepts_new_langs(client, monkeypatch, fake_loader_cls, lang):
     result = _sample_prediction_result()
 
@@ -275,6 +275,21 @@ def test_pii_extract_invalid_lang_returns_validation_error(client):
     assert payload["error"]["details"][0]["field"] == "body.lang"
 
 
+def test_pii_lang_literal_matches_supported_languages():
+    """The REST schema must accept exactly the languages the core supports.
+
+    Regression guard: ar/ja/tr shipped with published PII models and were in
+    ``SUPPORTED_LANGUAGES`` but were missing from the schema ``Literal``, so the
+    REST/MCP layer rejected them. Keep the two in lockstep.
+    """
+    from typing import get_args
+
+    from openmed.core.pii_i18n import SUPPORTED_LANGUAGES
+    from openmed.service.schemas import PIILanguage
+
+    assert set(get_args(PIILanguage)) == set(SUPPORTED_LANGUAGES)
+
+
 def test_pii_deidentify_mask_success(client, monkeypatch, fake_loader_cls):
     result = _sample_deid_result()
 
@@ -296,7 +311,7 @@ def test_pii_deidentify_mask_success(client, monkeypatch, fake_loader_cls):
     assert payload["method"] == "mask"
 
 
-@pytest.mark.parametrize("lang", ["nl", "hi", "te"])
+@pytest.mark.parametrize("lang", ["nl", "hi", "te", "ar", "ja", "tr"])
 def test_pii_deidentify_accepts_new_langs(client, monkeypatch, fake_loader_cls, lang):
     result = _sample_deid_result()
 


### PR DESCRIPTION
## Description

The PII endpoints' `lang` field was annotated `Literal["en","fr","de","it","es","nl","hi","te","pt"]` in four places (`PIIExtractRequest`/`PIIDeidentifyRequest`, Pydantic v1 + v2 variants). Arabic (`ar`), Japanese (`ja`), and Turkish (`tr`) ship with published PII models (added in the 1.5.0 release, #55) and are listed in `openmed.core.pii_i18n.SUPPORTED_LANGUAGES`, but the schema `Literal` was never updated to include them.

As a result the **REST service rejects `lang=ar|ja|tr` with a `422` validation error** (and the MCP layer built on these schemas inherits the same gap), even though the Python API and the models themselves work fine:

```bash
curl -X POST http://127.0.0.1:8080/pii/extract \
  -H "Content-Type: application/json" \
  -d '{"text":"患者 佐藤 花子","lang":"ja"}'
# -> 422 {"error":{"code":"validation_error", ... "field":"body.lang"}}
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Replace the four duplicated `lang` literals with a single module-level `PIILanguage` alias in `openmed/service/schemas.py` that mirrors `SUPPORTED_LANGUAGES` (now includes `ar`, `ja`, `tr`).
- Add `test_pii_lang_literal_matches_supported_languages` asserting the schema's accepted languages stay in lockstep with `SUPPORTED_LANGUAGES`, so this can't silently drift again.
- Extend the existing `test_pii_extract_accepts_new_langs` / `test_pii_deidentify_accepts_new_langs` parametrizations to cover `ar`, `ja`, `tr`.

## Testing
- [x] New and existing unit tests pass locally (`pytest tests/unit/service/test_api.py` -> 47 passed).
- [x] Added tests that prove the fix (new langs accepted, parity guard, invalid `lang` still rejected with 422).

## Documentation
- [x] Updated `CHANGELOG.md` (Unreleased -> Fixed).

## Dependencies
- [x] I have not added any new dependencies.

## Code Quality
- [x] Self-reviewed; no new warnings. Single-purpose change scoped to the schema bug.

## Related Issues
Closes #211
Related to #55 (1.5.0 added ar/ja/tr PII models).

## Notes
This is intentionally scoped to the request-schema bug only. Separately, `AnalyzeRequest.sentence_language` is a free `str` and pySBD does not support every value - out of scope here, happy to file a follow-up if useful.
