### PR TITLE
Promote quality_gates span overlap detection to deterministic resolution

### DIFF
--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -972,6 +972,12 @@ def _build_deidentification_result(
 ) -> DeidentificationResult:
     """Build a de-identification result from an existing PII result."""
     from .labels import normalize_label
+    from .quality_gates import resolve_overlapping_entities
+
+    resolved_entities = resolve_overlapping_entities(list(pii_result.entities))
+    pii_result.entities = resolved_entities
+    if hasattr(pii_result, "num_entities"):
+        pii_result.num_entities = len(resolved_entities)
 
     pii_entities = [
         PIIEntity(

--- a/openmed/core/quality_gates.py
+++ b/openmed/core/quality_gates.py
@@ -3,24 +3,147 @@
 Runtime validation functions that catch stale spans, off-by-one errors,
 and overlapping entities *after* tokenizer repair and smart merging.
 
-All guards are **warn-only** — they log diagnostics and set metadata flags
-but never silently drop entities.
+Validation guards are **warn-only** — they log diagnostics and set metadata
+flags but never silently drop entities. Callers that need release-gate style
+output can opt into deterministic overlap resolution explicitly.
 """
 
 from __future__ import annotations
 
 import logging
 import warnings
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, Any, List, Mapping, Sequence, Tuple, TypeVar
+
+from .labels import normalize_label
 
 if TYPE_CHECKING:
     from openmed.processing.outputs import EntityPrediction
 
 logger = logging.getLogger(__name__)
 
+EntityT = TypeVar("EntityT")
+
+_RISK_LEVEL_RANKS = {
+    "none": 0,
+    "minimal": 0,
+    "low": 1,
+    "medium": 2,
+    "moderate": 2,
+    "high": 3,
+    "critical": 4,
+    "severe": 4,
+}
+
+_HIGH_RISK_LABEL_RANKS = {
+    "PERSON": 2,
+    "FIRST_NAME": 2,
+    "LAST_NAME": 2,
+    "MIDDLE_NAME": 2,
+    "USERNAME": 2,
+    "EMAIL": 2,
+    "PHONE": 2,
+    "STREET_ADDRESS": 2,
+    "GPS_COORDINATES": 2,
+    "DATE_OF_BIRTH": 3,
+    "ID_NUM": 3,
+    "SSN": 4,
+    "ACCOUNT_NUMBER": 3,
+    "PASSWORD": 4,
+    "PIN": 4,
+    "API_KEY": 4,
+    "CREDIT_CARD": 4,
+    "CVV": 4,
+    "IBAN": 3,
+    "BIC": 3,
+    "BITCOIN_ADDRESS": 3,
+    "ETHEREUM_ADDRESS": 3,
+    "LITECOIN_ADDRESS": 3,
+    "IP_ADDRESS": 3,
+    "MAC_ADDRESS": 3,
+    "VIN": 3,
+    "VEHICLE_REGISTRATION": 3,
+    "IMEI": 3,
+}
+
 
 class SpanValidationWarning(UserWarning):
     """Raised when an entity span fails a boundary check."""
+
+
+def _span_value(entity: Any, key: str) -> Any:
+    if isinstance(entity, Mapping):
+        return entity.get(key)
+    return getattr(entity, key, None)
+
+
+def _span_bounds(entity: Any) -> tuple[int | None, int | None]:
+    start = _span_value(entity, "start")
+    end = _span_value(entity, "end")
+    return start, end
+
+
+def _entity_label(entity: Any) -> str:
+    label = (
+        _span_value(entity, "label")
+        or _span_value(entity, "entity_type")
+        or _span_value(entity, "entity_group")
+        or _span_value(entity, "entity")
+        or ""
+    )
+    return str(label)
+
+
+def _entity_metadata(entity: Any) -> Mapping[str, Any]:
+    metadata = _span_value(entity, "metadata")
+    if isinstance(metadata, Mapping):
+        return metadata
+    return {}
+
+
+def _entity_confidence(entity: Any) -> float:
+    value = _span_value(entity, "confidence")
+    if value is None:
+        value = _span_value(entity, "score")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _risk_rank_from_value(value: Any) -> int:
+    if isinstance(value, (int, float)):
+        return max(0, min(4, int(value)))
+    if value is None:
+        return 0
+    normalized = str(value).strip().lower().replace("-", "_").replace(" ", "_")
+    return _RISK_LEVEL_RANKS.get(normalized, 0)
+
+
+def _entity_risk_rank(entity: Any) -> int:
+    metadata = _entity_metadata(entity)
+    metadata_rank = max(
+        _risk_rank_from_value(metadata.get("risk_level")),
+        _risk_rank_from_value(metadata.get("risk")),
+        _risk_rank_from_value(metadata.get("severity")),
+    )
+    label_rank = _HIGH_RISK_LABEL_RANKS.get(
+        normalize_label(_entity_label(entity)),
+        0,
+    )
+    return max(metadata_rank, label_rank)
+
+
+def _spans_overlap(
+    a_start: int,
+    a_end: int,
+    b_start: int,
+    b_end: int,
+) -> bool:
+    return a_start < b_end and a_end > b_start
+
+
+def _valid_offsets(start: Any, end: Any) -> bool:
+    return isinstance(start, int) and isinstance(end, int) and start < end
 
 
 def validate_entity_spans(
@@ -98,6 +221,71 @@ def validate_entity_spans(
         entity.metadata = meta
 
     return entities
+
+
+def resolve_overlapping_entities(
+    entities: Sequence[EntityT],
+) -> list[EntityT]:
+    """Return a deterministic, non-overlapping span set.
+
+    The resolver is opt-in and leaves the warn-only validation functions
+    unchanged. Offset-less or invalid spans are preserved but do not participate
+    in overlap resolution.
+
+    Conflict policy, in order:
+    - critical/high-risk labels or explicit metadata risk levels win;
+    - within the same risk tier, the longest span wins;
+    - within the same span length, the highest confidence/score wins;
+    - remaining ties use earliest span position and original input order.
+    """
+    ranked: list[tuple[int, EntityT, int, int]] = []
+    unresolved: list[tuple[int, EntityT]] = []
+
+    for index, entity in enumerate(entities):
+        start, end = _span_bounds(entity)
+        if not _valid_offsets(start, end):
+            unresolved.append((index, entity))
+            continue
+        ranked.append((index, entity, start, end))
+
+    ranked.sort(
+        key=lambda item: (
+            -_entity_risk_rank(item[1]),
+            -(item[3] - item[2]),
+            -_entity_confidence(item[1]),
+            item[2],
+            item[3],
+            item[0],
+        )
+    )
+
+    selected: list[tuple[int, EntityT, int, int]] = []
+    selected_bounds: list[tuple[int, int]] = []
+
+    for index, entity, start, end in ranked:
+        if any(
+            _spans_overlap(start, end, kept_start, kept_end)
+            for kept_start, kept_end in selected_bounds
+        ):
+            continue
+        selected.append((index, entity, start, end))
+        selected_bounds.append((start, end))
+
+    resolved: list[tuple[int, EntityT, int | None, int | None]] = [
+        (index, entity, start, end)
+        for index, entity, start, end in selected
+    ]
+    resolved.extend((index, entity, None, None) for index, entity in unresolved)
+
+    resolved.sort(
+        key=lambda item: (
+            item[2] is None,
+            item[2] if item[2] is not None else 0,
+            item[3] if item[3] is not None else 0,
+            item[0],
+        )
+    )
+    return [entity for _, entity, _, _ in resolved]
 
 
 def detect_overlapping_entities(

--- a/openmed/core/safety_sweep.py
+++ b/openmed/core/safety_sweep.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping, Sequence
 import re
 
 from .pii_entity_merger import PIIPattern, PII_PATTERNS, find_context_words
+from .quality_gates import resolve_overlapping_entities
 from ..processing.outputs import EntityPrediction
 
 
@@ -134,7 +135,8 @@ def safety_sweep(
     """Add deterministic structured identifier spans not covered by ML spans.
 
     Existing spans always win. Sweep candidates that overlap any supplied span,
-    or any higher-ranked sweep candidate, are discarded so callers receive a
+    or any higher-ranked sweep candidate, are discarded. Existing overlapping
+    spans are resolved by the quality-gate policy so callers receive a
     non-overlapping span set.
     """
     existing = list(spans)
@@ -158,10 +160,7 @@ def safety_sweep(
         active_spans.append(entity)
         existing.append(entity)
 
-    if not selected:
-        return existing
-
-    return sorted(
+    ordered = sorted(
         existing,
         key=lambda span: (
             _span_value(span, "start") is None,
@@ -169,6 +168,7 @@ def safety_sweep(
             _span_value(span, "end") or 0,
         ),
     )
+    return resolve_overlapping_entities(ordered)
 
 
 __all__ = [

--- a/tests/unit/core/test_safety_sweep.py
+++ b/tests/unit/core/test_safety_sweep.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from openmed.core.anonymizer.providers import clinical_ids
 from openmed.core.pii import deidentify
+from openmed.core.quality_gates import detect_overlapping_entities
 from openmed.core.safety_sweep import (
     SAFETY_SWEEP_PATTERNS_VERSION,
     SAFETY_SWEEP_SOURCE,
@@ -105,6 +106,29 @@ def test_safety_sweep_never_adds_spans_overlapping_model_spans():
         assert entity.start >= model_card.end or entity.end <= model_card.start
 
 
+def test_safety_sweep_resolves_overlapping_existing_spans():
+    text = "Patient SSN 123-45-6789 was verified."
+    broad = EntityPrediction(
+        text="Patient SSN 123-45-6789",
+        label="OTHER",
+        start=0,
+        end=24,
+        confidence=0.99,
+    )
+    sensitive = EntityPrediction(
+        text="123-45-6789",
+        label="SSN",
+        start=12,
+        end=23,
+        confidence=0.50,
+    )
+
+    entities = safety_sweep(text, [broad, sensitive])
+
+    assert detect_overlapping_entities(entities) == []
+    assert [entity.label for entity in entities] == ["SSN"]
+
+
 @patch("openmed.core.pii.extract_pii")
 def test_deidentify_runs_safety_sweep_by_default_for_ml_misses(mock_extract):
     text = "Email: jane.patient@example.com"
@@ -139,3 +163,35 @@ def test_deidentify_can_disable_safety_sweep(mock_extract):
 
     assert result.deidentified_text == text
     assert result.pii_entities == []
+
+
+@patch("openmed.core.pii.extract_pii")
+def test_deidentify_resolves_overlaps_before_redaction(mock_extract):
+    text = "Patient SSN 123-45-6789 was verified."
+    mock_extract.return_value = PredictionResult(
+        text=text,
+        entities=[
+            EntityPrediction(
+                text="Patient SSN 123-45-6789",
+                label="OTHER",
+                start=0,
+                end=24,
+                confidence=0.99,
+            ),
+            EntityPrediction(
+                text="123-45-6789",
+                label="SSN",
+                start=12,
+                end=23,
+                confidence=0.50,
+            ),
+        ],
+        model_name="stub",
+        timestamp=datetime.now().isoformat(),
+    )
+
+    result = deidentify(text, method="mask", use_safety_sweep=False)
+
+    assert detect_overlapping_entities(result.pii_entities) == []
+    assert [entity.label for entity in result.pii_entities] == ["SSN"]
+    assert result.deidentified_text == "Patient SSN [SSN] was verified."

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -9,6 +9,7 @@ import pytest
 from openmed.core.quality_gates import (
     SpanValidationWarning,
     detect_overlapping_entities,
+    resolve_overlapping_entities,
     validate_entity_spans,
 )
 from openmed.processing.outputs import EntityPrediction
@@ -18,12 +19,21 @@ from openmed.processing.outputs import EntityPrediction
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _ent(text, label="NAME", start=0, end=None, confidence=0.9):
+def _ent(text, label="NAME", start=0, end=None, confidence=0.9, metadata=None):
     if end is None:
         end = start + len(text)
     return EntityPrediction(
-        text=text, label=label, start=start, end=end, confidence=confidence,
+        text=text,
+        label=label,
+        start=start,
+        end=end,
+        confidence=confidence,
+        metadata=metadata,
     )
+
+
+def _assert_no_overlaps(entities):
+    assert detect_overlapping_entities(entities) == []
 
 
 # ---------------------------------------------------------------------------
@@ -201,6 +211,102 @@ class TestDetectOverlappingEntities:
 
     def test_single_entity(self):
         assert detect_overlapping_entities([_ent("John", start=0, end=4)]) == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_overlapping_entities
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOverlappingEntities:
+    """Tests for deterministic overlap resolution."""
+
+    def test_prefers_critical_label_over_longer_nested_span(self):
+        entities = [
+            _ent(
+                "Patient SSN 123-45-6789",
+                label="OTHER",
+                start=0,
+                end=24,
+                confidence=0.99,
+            ),
+            _ent("123-45-6789", label="SSN", start=12, end=23, confidence=0.50),
+        ]
+
+        resolved = resolve_overlapping_entities(entities)
+
+        _assert_no_overlaps(resolved)
+        assert [entity.label for entity in resolved] == ["SSN"]
+
+    def test_partial_overlap_prefers_longest_span_within_same_risk_tier(self):
+        entities = [
+            _ent("Alpha", label="OTHER", start=0, end=5, confidence=0.95),
+            _ent("ha Bravo", label="OTHER", start=3, end=11, confidence=0.40),
+            _ent("Charlie", label="OTHER", start=12, end=19, confidence=0.70),
+        ]
+
+        resolved = resolve_overlapping_entities(entities)
+
+        _assert_no_overlaps(resolved)
+        assert [(entity.start, entity.end) for entity in resolved] == [
+            (3, 11),
+            (12, 19),
+        ]
+
+    def test_identical_span_prefers_highest_confidence(self):
+        entities = [
+            _ent("John Doe", label="OTHER", start=8, end=16, confidence=0.60),
+            _ent("John Doe", label="OTHER", start=8, end=16, confidence=0.95),
+        ]
+
+        resolved = resolve_overlapping_entities(entities)
+
+        _assert_no_overlaps(resolved)
+        assert len(resolved) == 1
+        assert resolved[0].confidence == 0.95
+
+    def test_metadata_risk_level_wins_and_resolution_is_idempotent(self):
+        entities = [
+            _ent(
+                "Patient identifier",
+                label="OTHER",
+                start=0,
+                end=18,
+                confidence=0.99,
+            ),
+            _ent(
+                "identifier",
+                label="OTHER",
+                start=8,
+                end=18,
+                confidence=0.10,
+                metadata={"risk_level": "high"},
+            ),
+        ]
+
+        resolved = resolve_overlapping_entities(entities)
+        resolved_again = resolve_overlapping_entities(resolved)
+
+        _assert_no_overlaps(resolved)
+        assert resolved == resolved_again
+        assert len(resolved) == 1
+        assert resolved[0].metadata["risk_level"] == "high"
+
+    def test_validate_entity_spans_stays_warn_only_for_overlaps(self):
+        text = "Patient John Doe visited"
+        entities = [
+            _ent("John Doe", label="PERSON", start=8, end=16),
+            _ent("Doe", label="LAST_NAME", start=13, end=16),
+        ]
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = validate_entity_spans(entities, text)
+
+        assert len(w) == 0
+        assert result is entities
+        assert len(entities) == 2
+        assert len(detect_overlapping_entities(entities)) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #87.

Adds deterministic span overlap resolution to quality gates, then applies it where safety sweep and de-identification need non-overlapping spans. The resolver keeps validation warn-only while enforcing the documented precedence for sensitive labels, risk metadata, span length, and confidence.

Validation: .venv/bin/python -m pytest tests/ -q