### PR TITLE
Provision write token and CI rotation policy

### DIFF
--- a/.github/workflows/convert-models.yml
+++ b/.github/workflows/convert-models.yml
@@ -15,6 +15,14 @@ on:
         description: 'Output formats (comma-separated: mlx,coreml)'
         required: false
         default: 'mlx'
+      publish_to_hub:
+        description: 'Run the protected HF publish credential gate'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 jobs:
   convert-mlx:
@@ -89,3 +97,32 @@ jobs:
         path: |
           OpenMedModel.mlpackage/
           *_id2label.json
+
+  publish-hf:
+    name: Publish to HF
+    runs-on: ubuntu-latest
+    needs:
+      - convert-mlx
+      - convert-coreml
+    if: >-
+      ${{
+        always() &&
+        github.event.inputs.publish_to_hub == 'true' &&
+        !cancelled() &&
+        (contains(github.event.inputs.formats, 'mlx') || contains(github.event.inputs.formats, 'coreml')) &&
+        (!contains(github.event.inputs.formats, 'mlx') || needs.convert-mlx.result == 'success') &&
+        (!contains(github.event.inputs.formats, 'coreml') || needs.convert-coreml.result == 'success')
+      }}
+    environment:
+      name: hf-publish
+      url: https://huggingface.co/OpenMed
+
+    steps:
+    - name: Require HF write token before publish
+      env:
+        HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+      run: |
+        if [ -z "${HF_WRITE_TOKEN:-}" ]; then
+          echo "::error title=Missing HF_WRITE_TOKEN::Configure HF_WRITE_TOKEN in the hf-publish protected environment before enabling publish."
+          exit 1
+        fi

--- a/docs/security/hf-token-policy.md
+++ b/docs/security/hf-token-policy.md
@@ -1,0 +1,57 @@
+# HF Write Token Policy
+
+OpenMed model publication uses a dedicated `HF_WRITE_TOKEN` secret for CI runs that write converted artifacts to the
+OpenMed organization. This token is separate from runtime read tokens and package publishing credentials.
+
+## Scope
+
+- Create a fine-grained token with org-write access limited to the OpenMed organization.
+- Do not grant admin, billing, or account-management permissions.
+- Do not reuse a personal development token, read token, or package publishing token.
+- Treat exposure as org-wide write access to OpenMed model repositories.
+
+## Storage
+
+- Store the value as the `HF_WRITE_TOKEN` secret in the `hf-publish` GitHub Actions protected environment.
+- Keep the secret out of repository-level Actions secrets unless a workflow cannot be environment-bound.
+- Require environment protection before jobs can read the secret.
+- Only repository administrators who can manage environment secrets may replace or delete it. The saved value cannot be
+  read back after it is stored.
+
+## CI Use
+
+The `convert-models.yml` workflow exposes the secret only to the protected `publish-hf` job. The publish guard uses a
+step-level environment binding:
+
+```yaml
+environment:
+  name: hf-publish
+steps:
+  - name: Require HF write token before publish
+    env:
+      HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+```
+
+The publish job must check that `HF_WRITE_TOKEN` is set before running any upload command. Logs may mention the secret
+name but must never print the value.
+
+## Rotation
+
+- Rotate the token every 90 days, or immediately after maintainer turnover, suspicious workflow activity, or accidental
+  disclosure.
+- Create the replacement token first, update the `hf-publish` environment secret, then run a manual publish credential
+  check before deleting the old token.
+- Record the rotation date and operator in the release notes or private operations log without copying the token value.
+
+## Revocation And Blast Radius
+
+If `HF_WRITE_TOKEN` is exposed:
+
+1. Revoke the token from the token provider immediately.
+2. Delete or replace the `hf-publish` environment secret.
+3. Disable queued or running publish workflows until the replacement secret is in place.
+4. Audit model repositories in the OpenMed organization for unexpected commits, files, tags, or metadata changes.
+5. Re-run the last known-good publish workflow after the audit if any artifact needs restoration.
+
+The blast radius is org-wide write access to OpenMed model repositories. The token must not have package publishing,
+repository administration, billing, or account ownership permissions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - Swift Package (OpenMedKit): swift-openmedkit.md
   - Project:
       - Contributing & Releases: contributing.md
+      - HF Write Token Policy: security/hf-token-policy.md
 
 theme:
   name: material

--- a/tests/unit/test_convert_workflow_hf_token.py
+++ b/tests/unit/test_convert_workflow_hf_token.py
@@ -1,0 +1,42 @@
+"""Conversion workflow credential policy tests."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONVERT_WORKFLOW = ROOT / ".github" / "workflows" / "convert-models.yml"
+HF_TOKEN_POLICY = ROOT / "docs" / "security" / "hf-token-policy.md"
+
+
+def test_convert_workflow_uses_protected_hf_publish_environment():
+    workflow = CONVERT_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "publish_to_hub:" in workflow
+    assert "  publish-hf:" in workflow
+    assert "name: hf-publish" in workflow
+    assert "HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}" in workflow
+
+
+def test_convert_workflow_fails_publish_job_when_hf_token_is_missing():
+    workflow = CONVERT_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Require HF write token before publish" in workflow
+    assert 'if [ -z "${HF_WRITE_TOKEN:-}" ]; then' in workflow
+    assert "::error title=Missing HF_WRITE_TOKEN::" in workflow
+    assert "exit 1" in workflow
+    assert re.search(r"hf_[A-Za-z0-9]{20,}", workflow) is None
+    assert 'echo "$HF_WRITE_TOKEN' not in workflow
+
+
+def test_hf_token_policy_documents_scope_storage_rotation_and_revocation():
+    policy = HF_TOKEN_POLICY.read_text(encoding="utf-8")
+
+    assert "org-write access" in policy
+    assert "`HF_WRITE_TOKEN` secret" in policy
+    assert "`hf-publish` GitHub Actions protected environment" in policy
+    assert "Rotate the token every 90 days" in policy
+    assert "Revoke the token" in policy
+    assert "org-wide write access" in policy


### PR DESCRIPTION
Closes #96.

Adds a protected model-publish credential gate to the conversion workflow, documents the write-token scope, storage, rotation cadence, revocation flow, and blast radius, and adds regression tests for the missing-secret failure path.

Validation:
- .venv/bin/python -m pytest tests/ -q
- .venv/bin/python -m mkdocs build --strict
