### PR TITLE
Add NOTICE, governance docs, and license policy gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
       run: |
         python scripts/release/check_repo_policy.py
 
+    - name: Enforce dependency license policy
+      run: |
+        python scripts/release/check_license_policy.py
+
   test:
     needs: repo-policy
     runs-on: ${{ matrix.os }}

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,59 @@
+OpenMed NOTICE
+==============
+
+OpenMed is licensed under Apache-2.0. This notice records third-party
+assets that are wrapped, ported, adapted, or planned as integration surfaces
+for the project. Direct package dependencies are also checked by
+scripts/release/check_license_policy.py.
+
+Permissive bundled or in-process assets
+---------------------------------------
+
+Name: Presidio
+Source: https://github.com/microsoft/presidio
+License: MIT
+Usage: Optional recognizers and image/DICOM redaction patterns may be wrapped
+behind OpenMed interfaces. OpenMed remains the orchestrator and routes
+detection decisions through its own policy and span layers.
+
+Name: DataProfiler
+Source: https://github.com/capitalone/DataProfiler
+License: Apache-2.0
+Usage: Planned structured-data profiling and quasi-identifier discovery for
+tabular anonymization workflows.
+
+Name: medspaCy ConText
+Source: https://github.com/medspacy/medspacy
+License: Apache-2.0
+Usage: Assertion, negation, temporality, and experiencer rule patterns may be
+ported into OpenMed clinical-context modules. Ported rule-set files must carry
+an upstream attribution header naming the source project, source URL, license,
+retrieval or port date, and a short summary of local modifications.
+
+Name: SHIELD clinical PHI corpus
+Source: https://github.com/susom/shield_dataset
+Paper: https://arxiv.org/abs/2605.03301
+License: Access and redistribution terms require review before use; current
+access instructions point to Stanford Redivis with a signed Data Use Agreement.
+Usage: Comparison and evaluation corpus for de-identification benchmarking.
+No dataset copy is bundled in the package unless its exact redistribution terms
+have been reviewed and approved.
+
+Name: ARX Data Anonymization Tool
+Source: https://github.com/arx-deidentifier/arx
+License: Apache-2.0
+Usage: Optional structured-data anonymization engine for k-anonymity,
+l-diversity, t-closeness, and differential-privacy workflows. ARX may run as
+an optional engine or out-of-process bridge and must not become a required core
+dependency.
+
+GPL bridge-only tools
+---------------------
+
+Name: sdcMicro
+Source: https://github.com/sdcTools/sdcMicro
+License: GPL-2.0-or-later
+Usage: Statistical disclosure-control reference tool. It is not bundled,
+vendored, imported, or required by the OpenMed package. Any future integration
+must be out-of-process only, isolated behind an optional bridge, and documented
+as a user-installed component.

--- a/PLANS/V2/DATASET_ACCESS_PLAN.md
+++ b/PLANS/V2/DATASET_ACCESS_PLAN.md
@@ -1,0 +1,59 @@
+# OpenMed V2 Dataset Access Plan
+
+OpenMed follows a public-by-default, DUA-eval-only, synthetic-augmentation data
+strategy. The package must remain redistributable, local-first, and free of
+gated clinical corpora.
+
+## Data Tiers
+
+| Tier | Use | Examples | Rule |
+|---|---|---|---|
+| Public-by-default | Ship, train, and evaluate when licenses permit | DrugProt, MedMentions, RxNorm, LOINC, ICD-10-CM, HPO, OMOP via Athena, FHIR, ARX, DataProfiler, ported ConText rules | Review license terms before bundling; record wrapped or ported assets in `NOTICE` |
+| DUA-gated | Evaluation only | i2b2 2006/2014, n2c2 2014/2018, CEGS N-GRID, SHAC, MIMIC-derived notes, MedNLI, MADE 1.0, SHIELD if Redivis access requires a signed DUA | Credential once, keep held out, never redistribute, never commit, never bake into weights |
+| Synthetic | Augment gaps | Locale PHI, social-history sections, structured IDs, OCR overlays, DICOM burned-in text | Augmentation only; never sole training source; validate against public or gated held-out sets |
+
+## Credentialing
+
+At least one maintainer role owns credentialing for DUA-gated evaluation pools.
+Credentialing includes required training, data-use agreements, local storage
+controls, and periodic access review. Access is limited to evaluation runs and
+aggregate reporting.
+
+Gated dataset paths are provided by local configuration or secret store entries.
+They are never checked into source control and are never downloaded by default
+CI jobs.
+
+## Bundling Rules
+
+- No DUA-gated dataset, note, annotation file, or derived row may be committed.
+- No UMLS, SNOMED CT, CPT, MIMIC-lineage, i2b2, n2c2, or PhysioNet restricted
+  content may be bundled into wheels, source distributions, fixtures, or model
+  artifacts.
+- Public datasets may be referenced by URL and loader instructions. Dataset
+  files are bundled only after their exact redistribution terms are reviewed.
+- Model cards and manifest rows track model-weight licenses separately from
+  training-data licenses.
+- `bigbio/*` loader stubs do not bypass the underlying dataset's access terms.
+- SHIELD is review-required: if public redistribution terms become available,
+  it can move to the public-by-default tier; if Redivis access requires a signed
+  Data Use Agreement, it stays DUA-gated and eval-only.
+
+## Evaluation Flow
+
+Daily blocking gates run on committed synthetic golden fixtures and public
+comparison data. DUA-gated leakage evaluation is a periodic promotion gate run
+by a credentialed maintainer role. If DUA access is unavailable, daily public
+and synthetic gates continue, but stable-promotion evidence must disclose the
+missing gated evaluation.
+
+## Audit Trail
+
+Every dataset used for training or evaluation needs a manifest row or run record
+with:
+
+- name and source URL;
+- license or DUA tier;
+- allowed use: train, eval, benchmark, or augmentation;
+- whether redistribution is allowed;
+- retrieval date or local credentialing date;
+- owner role responsible for review.

--- a/PLANS/V2/RISK_REGISTER_AND_NON_GOALS.md
+++ b/PLANS/V2/RISK_REGISTER_AND_NON_GOALS.md
@@ -1,0 +1,57 @@
+# OpenMed V2 Risk Register and Non-Goals
+
+This register turns roadmap sections 8.5 through 8.8 into operational checks for
+planning, release review, and pull request scope.
+
+## Hard Invariants
+
+These are never traded for cadence:
+
+- Critical leakage is zero on the curated golden fixtures and critical-identifier
+  suite.
+- The direct-identifier recall floor is enforced as a release gate.
+- No quantized model is published if its recall delta exceeds the gate.
+- No raw PHI is logged, cached, or telemetered.
+- The default runtime remains local-first after model weights are present.
+- The core package and required dependencies remain MIT, Apache-2.0, or BSD
+  compatible.
+
+## Risk Register
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Release machinery is incomplete | Critical | Track build-vs-existing gaps explicitly; do not claim daily release capability until scheduler, publish, manifest, and gate automation exist |
+| Daily-release regression | High | Run tests, benchmark non-regression, manifest diff checks, and stable-channel promotion gates |
+| PHI leakage | Critical | Enforce zero critical leakage, deterministic safety sweep, no-raw-PHI logging guard, audit provenance, and residual-risk reporting |
+| Quantization recall loss | High | Gate INT8 and INT4 artifacts against their full-precision parent before publication |
+| DUA evaluation availability | Medium | Keep daily gates public/synthetic; use credentialed DUA evaluation as periodic stable-promotion evidence |
+| Dataset redistribution mistake | High | Public/DUA/synthetic tiering, `NOTICE` review, manifest license rows, and no bundled restricted corpora |
+| Over-redaction | Medium | Track precision and over-redaction ceilings; use policy profiles to tune utility versus recall |
+| Scope creep | High | Prioritize product-core, gate, and manifest work before new model count growth |
+| Stale external facts | Medium | Date-stamp and cite external claims before using them in release or benchmark material |
+| Naming drift | Medium | Use the committed manifest as the source of truth for family, tier, parameter count, and generated surfaces |
+
+## Non-Goals
+
+OpenMed will not:
+
+1. Send raw PHI to remote generative services for redaction or extraction.
+2. Ship generative-only de-identification.
+3. Run a closed benchmark or private-only leaderboard.
+4. Add mandatory network calls, default telemetry, or a license server to the
+   core runtime.
+5. Bundle DUA-gated data, restricted vocabularies, or non-permissive components.
+6. Become dependent on wrapped libraries in the default path; adapters remain
+   optional interop.
+
+## Review Checklist
+
+Before a task that touches data, releases, adapters, or model policy is merged,
+reviewers should confirm:
+
+- data sources are assigned to the correct tier;
+- new dependencies pass the license policy gate;
+- ported rule files include upstream attribution headers;
+- any benchmark or model-card claim has a source and date;
+- raw PHI is absent from logs, fixtures, generated reports, and docs examples;
+- the change does not weaken a hard invariant.

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Full guides at **[openmed.life/docs](https://openmed.life/docs/)**.
 | [Getting Started](https://openmed.life/docs/) | [Analyze Text](https://openmed.life/docs/analyze-text) | [Model Registry](https://openmed.life/docs/model-registry) |
 | [PII Detection Guide](examples/notebooks/PII_Detection_Complete_Guide.ipynb) | [Anonymization](docs/anonymization.md) | [Batch Processing](https://openmed.life/docs/batch-processing) |
 | [Configuration Profiles](https://openmed.life/docs/profiles) | [REST Service](docs/rest-service.md) | [MLX Backend](docs/mlx-backend.md) |
+| [Release Streams](docs/release/semver-and-channels.md) | [Dataset Access Plan](PLANS/V2/DATASET_ACCESS_PLAN.md) | [Risk Register](PLANS/V2/RISK_REGISTER_AND_NON_GOALS.md) |
 
 ---
 
@@ -408,7 +409,7 @@ OpenMed builds on excellent open-source work — particular thanks to **OpenAI**
 
 ## License
 
-Released under the [Apache-2.0 License](LICENSE).
+Released under the [Apache-2.0 License](LICENSE). Third-party asset notices are recorded in [NOTICE](NOTICE).
 
 ## Citation
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,3 +38,13 @@ to publish outside CI, run `make docs-deploy`; it mirrors the workflow by buildi
 - Keep user-facing docs inside `docs/`; new guides only require Markdown and optional front matter.
 - Reference exact file + section when filing doc bugs so we can reproduce quickly.
 - Prefer small pull requests that focus on a single guide or feature; CI + Pages runs on every PR.
+
+## Governance references
+
+- [Release Streams & Channels](release/semver-and-channels.md) defines model artifact and library release cadence.
+- [Generative Model Policy](generative-model-policy.md) defines approved and prohibited model-assisted workflows.
+- [Dataset Access Plan](https://github.com/maziyarpanahi/openmed/blob/master/PLANS/V2/DATASET_ACCESS_PLAN.md) records public, DUA-gated, and synthetic data handling.
+- [Risk Register & Non-Goals](https://github.com/maziyarpanahi/openmed/blob/master/PLANS/V2/RISK_REGISTER_AND_NON_GOALS.md) records hard invariants, risks, and explicit non-goals.
+
+Ported rule-set files must start with an upstream attribution header naming the
+source project, source URL, license, port date, and local modifications.

--- a/docs/generative-model-policy.md
+++ b/docs/generative-model-policy.md
@@ -1,0 +1,45 @@
+# Generative Model Policy
+
+OpenMed is small-extractor-first and generative-second. Deterministic detectors,
+trained span models, checksum validators, and release gates do the privacy-
+critical work. A generative model may assist only around those controls.
+
+## Encouraged Uses
+
+- Synthetic data augmentation for locale examples, social-history sections, and
+  OCR/DICOM text overlays.
+- Teacher or weak labeling when labels are accepted through inter-model
+  agreement or human adjudication.
+- Active-learning triage from gate failures, low-agreement spans, and hard
+  negatives.
+- Error analysis that clusters missed spans and explains recurring leakage
+  patterns.
+- Post-de-identification summarization after the de-identification and leakage
+  checks have already passed.
+- Policy drafting support for profile text, gate reports, and review checklists.
+
+## Prohibited Uses
+
+- Sending raw PHI to a remote generative service for redaction, extraction, or
+  review.
+- Using a generative model as the sole de-identification detector.
+- Accepting schema-less extraction output without canonical labels, offsets, and
+  provenance.
+- Training only on synthetic examples without a real held-out evaluation gate.
+- Running a summarizer before de-identification.
+- Letting a model approve a release. Gates decide whether a candidate is
+  `RELEASABLE`.
+
+## Release Authority
+
+The release gate is the authority for shipping. Owners are roles, not named
+people:
+
+- Model Lead: recipe, candidate checkpoints, distillation, and hard negatives.
+- Privacy Eval Lead: leakage fixtures, benchmark reports, and signed gate
+  evidence.
+- Release Engineer: CI wiring, manifest state, channel promotion, and rollback.
+- Device/Export Lead: tier benchmarks, quantization deltas, and packaged formats.
+
+No model artifact or library increment moves to stable unless the applicable
+gate report passes and the responsible role has reviewed the evidence.

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,12 @@ configuration, zero-shot GLiNER workflows, and advanced processing helpers.
    - [Zero-shot Toolkit](./zero-shot-ner.md) when you need GLiNER workflows.
    - [Performance Profiling](./profiling.md) for timing and optimization.
    - [Examples](./examples.md) and [Testing & QA](./testing.md) for day-to-day operations.
-4. [Contributing & Releases](./contributing.md) – how we cut releases, publish docs, and keep CI green.
+4. Project operations:
+   - [Contributing & Releases](./contributing.md) – how we cut releases, publish docs, and keep CI green.
+   - [Release Streams & Channels](./release/semver-and-channels.md) – model artifact and library release policy.
+   - [Generative Model Policy](./generative-model-policy.md) – approved and prohibited model-assisted workflows.
+   - [Dataset Access Plan](https://github.com/maziyarpanahi/openmed/blob/master/PLANS/V2/DATASET_ACCESS_PLAN.md) – public, DUA-gated, and synthetic data handling.
+   - [Risk Register & Non-Goals](https://github.com/maziyarpanahi/openmed/blob/master/PLANS/V2/RISK_REGISTER_AND_NON_GOALS.md) – release risks, hard invariants, and scope boundaries.
 
 Need something that is not here yet? Drop an issue on GitHub and mention the missing recipe. Every addition is just a
 Markdown file away.

--- a/docs/release/semver-and-channels.md
+++ b/docs/release/semver-and-channels.md
@@ -1,0 +1,55 @@
+# Release Streams, SemVer, and Channels
+
+OpenMed uses two release streams with different blast radii.
+
+## Stream A: Model Artifacts
+
+Model artifacts are data. A bad checkpoint affects one model entry and can be
+rolled back by repointing the manifest to the last green artifact.
+
+- Versioning: repository suffix or artifact revision plus a reproducibility hash.
+- Cadence: daily-capable once the release gates and manifest automation are in place.
+- Gate owner: release engineering plus the evaluation gate.
+- Rollback: manifest pointer flip, regenerated cards, and a tracking issue.
+
+## Stream B: Library and SDK
+
+The `openmed` wheel and source distribution are code. A bad library release can
+break every downstream install, so it follows SemVer and moves more slowly.
+
+- Versioning: `MAJOR.MINOR.PATCH`.
+- Cadence: patch daily-to-weekly, minor monthly, major by milestone.
+- Gate owner: release engineering with maintainer sign-off for minor and major changes.
+- Rollback: forward-fix with the next patch; yanking remains a manual registry action.
+
+## Channels
+
+| Channel | Selector | Contents | Cadence | Audience |
+|---|---|---|---|---|
+| Nightly / edge | `pip install openmed --pre` | Latest green code and gated model pins | every green merge or daily | early adopters and internal evaluation |
+| Stable | `pip install openmed` | Full golden-suite pass and canary-ready pins | patch daily-to-weekly, minor monthly | default users |
+| LTS | `pip install "openmed==1.6.*"` | Security and recall-backstop fixes only | as needed for 12 months | regulated deployments |
+
+Nightly builds use PEP 440 development releases such as `1.6.0.devN`.
+Release candidates such as `1.6.0rc1` are reserved for pre-stable cuts.
+
+## SemVer Rules
+
+- PATCH: registry or manifest refresh, new gated model surfaced, bug fix, or
+  documentation sync without API change.
+- MINOR: additive public API, new optional argument, new optional extra, or new
+  capability package.
+- MAJOR: breaking API change, label-schema break, or migration that requires a
+  downstream code change.
+
+Public APIs are deprecated for two minor releases before removal. Deprecations
+must emit `DeprecationWarning`, name the replacement, and appear in
+`CHANGELOG.md` under `Deprecated`.
+
+## Release Gates
+
+The release gates, not aggregate F1 alone, decide whether a model artifact is
+releasable. A candidate must satisfy critical-leakage, recall, quantization
+delta, device-tier, span-integrity, and regression checks before it can move to
+stable. Library releases must also pass the repository policy, dependency
+license policy, and test suite.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ nav:
   - Project:
       - Contributing & Releases: contributing.md
       - HF Write Token Policy: security/hf-token-policy.md
+      - Release Streams & Channels: release/semver-and-channels.md
+      - Generative Model Policy: generative-model-policy.md
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
   "jsonschema>=4.0",
   "fastapi>=0.110",
   "httpx>=0.27",
+  "tomli>=2.0; python_version < '3.11'",
 ]
 
 cli = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,8 @@ include = [
   "openmed/core/schemas/json/*.json",
   "gates/baseline.json",
   "models.jsonl",
+  "LICENSE",
+  "NOTICE",
   "README.md",
   "pyproject.toml"
 ]

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Fail closed when installable direct dependencies are not permissive."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import re
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PYPROJECT = ROOT / "pyproject.toml"
+
+EXCLUDED_OPTIONAL_GROUPS = frozenset({"dev"})
+
+ALLOWED_LICENSE_MARKERS = (
+    "MIT",
+    "APACHE-2.0",
+    "APACHE SOFTWARE LICENSE",
+    "BSD",
+    "BSD-2-CLAUSE",
+    "BSD-3-CLAUSE",
+)
+
+DISALLOWED_LICENSE_MARKERS = (
+    "AGPL",
+    "AFFRO GENERAL PUBLIC LICENSE",
+    "COMMONS CLAUSE",
+    "ELASTIC",
+    "GENERAL PUBLIC LICENSE",
+    "GPL",
+    "LGPL",
+    "LESSER GENERAL PUBLIC LICENSE",
+    "POLYFORM",
+    "SERVER SIDE PUBLIC LICENSE",
+    "SSPL",
+)
+
+GPL_BRIDGE_EXCEPTIONS = {
+    "sdcmicro": "GPL-2.0-only; optional out-of-process disclosure-control bridge",
+}
+
+REVIEWED_LICENSES = {
+    "accelerate": "Apache-2.0",
+    "coremltools": "BSD-3-Clause",
+    "faker": "MIT",
+    "fastapi": "MIT",
+    "gliner": "Apache-2.0",
+    "huggingface-hub": "Apache-2.0",
+    "httpx": "BSD-3-Clause",
+    "mcp": "MIT",
+    "mkdocs": "BSD-2-Clause",
+    "mkdocs-git-revision-date-localized-plugin": "MIT",
+    "mkdocs-material": "MIT",
+    "mkdocs-minify-plugin": "MIT",
+    "mlx": "MIT",
+    "pymdown-extensions": "MIT",
+    "pysbd": "MIT",
+    "rich": "MIT",
+    "safetensors": "Apache-2.0",
+    "tiktoken": "MIT",
+    "tokenizers": "Apache-2.0",
+    "torch": "BSD-3-Clause",
+    "transformers": "Apache-2.0",
+    "typer": "MIT",
+    "uvicorn": "BSD-3-Clause",
+}
+
+NAME_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+)")
+
+
+@dataclass(frozen=True)
+class RequirementEntry:
+    """A direct requirement declared in project metadata."""
+
+    group: str
+    requirement: str
+    name: str
+
+
+@dataclass(frozen=True)
+class LicenseAuditResult:
+    """License policy decision for one direct requirement."""
+
+    entry: RequirementEntry
+    license_text: str
+    allowed: bool
+    reason: str
+
+
+def normalize_name(name: str) -> str:
+    """Normalize package names according to PEP 503."""
+
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def dependency_name(requirement: str) -> str:
+    """Extract the distribution name from a PEP 508 requirement string."""
+
+    match = NAME_RE.match(requirement)
+    if not match:
+        raise ValueError(f"Cannot parse dependency name from requirement: {requirement!r}")
+    return normalize_name(match.group(1))
+
+
+def iter_installable_requirements(pyproject: Mapping[str, object]) -> list[RequirementEntry]:
+    """Return direct non-dev dependencies from project metadata."""
+
+    project = pyproject.get("project", {})
+    if not isinstance(project, dict):
+        raise ValueError("pyproject.toml is missing a [project] table")
+
+    entries: list[RequirementEntry] = []
+
+    dependencies = project.get("dependencies", [])
+    if dependencies:
+        if not isinstance(dependencies, list):
+            raise ValueError("[project].dependencies must be a list")
+        entries.extend(
+            RequirementEntry("default", str(requirement), dependency_name(str(requirement)))
+            for requirement in dependencies
+        )
+
+    optional_dependencies = project.get("optional-dependencies", {})
+    if optional_dependencies:
+        if not isinstance(optional_dependencies, dict):
+            raise ValueError("[project.optional-dependencies] must be a table")
+        for group, requirements in sorted(optional_dependencies.items()):
+            if normalize_name(str(group)) in EXCLUDED_OPTIONAL_GROUPS:
+                continue
+            if not isinstance(requirements, list):
+                raise ValueError(f"[project.optional-dependencies].{group} must be a list")
+            entries.extend(
+                RequirementEntry(str(group), str(requirement), dependency_name(str(requirement)))
+                for requirement in requirements
+            )
+
+    return entries
+
+
+def read_pyproject(path: Path) -> dict[str, object]:
+    """Load a pyproject file as TOML."""
+
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def installed_license_text(name: str) -> str | None:
+    """Resolve license text from installed distribution metadata, when available."""
+
+    try:
+        distribution = importlib.metadata.distribution(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+    package_metadata = distribution.metadata
+    candidates: list[str] = []
+
+    for field in ("License-Expression", "License"):
+        value = package_metadata.get(field)
+        if value:
+            candidates.append(value)
+
+    for classifier in package_metadata.get_all("Classifier") or []:
+        if classifier.startswith("License ::"):
+            candidates.append(classifier)
+
+    return " ; ".join(candidates) if candidates else None
+
+
+def resolve_license(
+    name: str,
+    reviewed_licenses: Mapping[str, str] = REVIEWED_LICENSES,
+) -> str:
+    """Resolve a direct dependency license from review data or package metadata."""
+
+    normalized = normalize_name(name)
+    if normalized in reviewed_licenses:
+        return reviewed_licenses[normalized]
+    return installed_license_text(normalized) or ""
+
+
+def contains_marker(license_text: str, markers: Sequence[str]) -> bool:
+    """Return true when license text includes one of the normalized markers."""
+
+    normalized = license_text.upper().replace("_", "-")
+    return any(marker in normalized for marker in markers)
+
+
+def is_allowed_license(name: str, license_text: str) -> tuple[bool, str]:
+    """Classify license text against the permissive-only policy."""
+
+    normalized_name = normalize_name(name)
+    if not license_text:
+        return False, "license could not be resolved; add a reviewed license entry"
+
+    has_disallowed = contains_marker(license_text, DISALLOWED_LICENSE_MARKERS)
+    has_allowed = contains_marker(license_text, ALLOWED_LICENSE_MARKERS)
+    is_bridge_exception = normalized_name in GPL_BRIDGE_EXCEPTIONS
+
+    if is_bridge_exception and has_disallowed and "ELASTIC" not in license_text.upper():
+        return True, f"allowed only as bridge exception: {GPL_BRIDGE_EXCEPTIONS[normalized_name]}"
+
+    if has_disallowed:
+        return False, "license is not allowed for bundled or in-process dependencies"
+
+    if has_allowed:
+        return True, "permissive license"
+
+    return False, "license is outside the MIT/Apache-2.0/BSD allowlist"
+
+
+def audit_pyproject(
+    pyproject_path: Path = DEFAULT_PYPROJECT,
+    reviewed_licenses: Mapping[str, str] = REVIEWED_LICENSES,
+) -> list[LicenseAuditResult]:
+    """Audit direct installable dependencies declared by a pyproject file."""
+
+    pyproject = read_pyproject(pyproject_path)
+    results: list[LicenseAuditResult] = []
+
+    for entry in iter_installable_requirements(pyproject):
+        license_text = resolve_license(entry.name, reviewed_licenses)
+        allowed, reason = is_allowed_license(entry.name, license_text)
+        results.append(LicenseAuditResult(entry, license_text, allowed, reason))
+
+    return results
+
+
+def print_results(results: Sequence[LicenseAuditResult]) -> None:
+    """Print a compact human-readable audit summary."""
+
+    failures = [result for result in results if not result.allowed]
+
+    if failures:
+        print("License policy failed:", file=sys.stderr)
+        for result in failures:
+            print(
+                f"- {result.entry.group}:{result.entry.name} "
+                f"({result.license_text or 'unknown'}): {result.reason}",
+                file=sys.stderr,
+            )
+        return
+
+    print("License policy passed")
+    for result in results:
+        print(f"- {result.entry.group}:{result.entry.name}: {result.license_text}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Check direct non-dev dependency licenses against OpenMed policy."
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=DEFAULT_PYPROJECT,
+        help="Path to pyproject.toml to audit.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the dependency license audit."""
+
+    args = parse_args(argv)
+    results = audit_pyproject(args.pyproject)
+    print_results(results)
+    return 1 if any(not result.allowed for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -7,10 +7,14 @@ import argparse
 import importlib.metadata
 import re
 import sys
-import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Sequence
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised by Python 3.10 CI
+    import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_PYPROJECT = ROOT / "pyproject.toml"

--- a/tests/unit/release/test_license_policy.py
+++ b/tests/unit/release/test_license_policy.py
@@ -1,0 +1,117 @@
+"""Dependency license policy tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "release" / "check_license_policy.py"
+
+spec = importlib.util.spec_from_file_location("check_license_policy", SCRIPT)
+assert spec is not None
+policy = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = policy
+spec.loader.exec_module(policy)
+
+
+def write_pyproject(path: Path, body: str) -> Path:
+    target = path / "pyproject.toml"
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def test_current_non_dev_dependencies_are_permissive():
+    results = policy.audit_pyproject(ROOT / "pyproject.toml")
+
+    assert results
+    assert not [result for result in results if not result.allowed]
+    assert {result.entry.name for result in results if result.entry.group == "dev"} == set()
+
+
+def test_gpl_dependency_fails_policy(tmp_path):
+    pyproject = write_pyproject(
+        tmp_path,
+        """
+[project]
+name = "sample"
+version = "0.0.1"
+dependencies = ["example-gpl>=1"]
+""",
+    )
+
+    results = policy.audit_pyproject(
+        pyproject,
+        reviewed_licenses={"example-gpl": "GPL-3.0-only"},
+    )
+
+    assert len(results) == 1
+    assert results[0].allowed is False
+    assert "not allowed" in results[0].reason
+
+
+def test_elastic_dependency_fails_policy(tmp_path):
+    pyproject = write_pyproject(
+        tmp_path,
+        """
+[project]
+name = "sample"
+version = "0.0.1"
+dependencies = ["source-available-package>=1"]
+""",
+    )
+
+    results = policy.audit_pyproject(
+        pyproject,
+        reviewed_licenses={"source-available-package": "Elastic-2.0"},
+    )
+
+    assert len(results) == 1
+    assert results[0].allowed is False
+    assert "not allowed" in results[0].reason
+
+
+def test_dev_optional_dependencies_are_not_audited(tmp_path):
+    pyproject = write_pyproject(
+        tmp_path,
+        """
+[project]
+name = "sample"
+version = "0.0.1"
+dependencies = ["runtime-package>=1"]
+
+[project.optional-dependencies]
+dev = ["dev-only-gpl>=1"]
+cli = ["cli-package>=1"]
+""",
+    )
+
+    results = policy.audit_pyproject(
+        pyproject,
+        reviewed_licenses={
+            "cli-package": "BSD-3-Clause",
+            "dev-only-gpl": "GPL-3.0-only",
+            "runtime-package": "MIT",
+        },
+    )
+
+    assert {result.entry.name for result in results} == {"runtime-package", "cli-package"}
+    assert all(result.allowed for result in results)
+
+
+def test_main_returns_nonzero_for_disallowed_dependency(tmp_path, monkeypatch):
+    pyproject = write_pyproject(
+        tmp_path,
+        """
+[project]
+name = "sample"
+version = "0.0.1"
+dependencies = ["example-gpl>=1"]
+""",
+    )
+    monkeypatch.setattr(policy, "REVIEWED_LICENSES", {"example-gpl": "GPL-3.0-only"})
+
+    assert policy.main(["--pyproject", str(pyproject)]) == 1


### PR DESCRIPTION
Closes #135.

Adds a NOTICE file for wrapped and bridge-only assets, governance docs for release channels, data access, model-use policy, and risk/non-goals, plus a CI license policy check that audits non-dev direct dependencies against the permissive allowlist. Links the new material from README, the docs index, and contributing docs, with unit coverage for GPL and Elastic-2.0 rejection.