### PR TITLE
Extend label policy metadata and HIPAA cross-map

### DIFF
--- a/openmed/core/labels.py
+++ b/openmed/core/labels.py
@@ -6,7 +6,7 @@ Different OpenMed PII model families use different label-naming conventions:
   (``first_name``, ``date_of_birth``).
 - Portuguese models expose 52 ``UPPERCASE`` labels (``FIRSTNAME``,
   ``DATEOFBIRTH``).
-- The OpenAI privacy-filter family emits BIOES-tagged labels (``B-NAME``,
+- The privacy-filter family emits BIOES-tagged labels (``B-NAME``,
   ``I-EMAIL``, ``E-ADDRESS``, ``S-PHONE``).
 
 This module provides a single ``CANONICAL_LABELS`` taxonomy in
@@ -18,7 +18,7 @@ mapping tables, configuration) should key off canonical labels only.
 from __future__ import annotations
 
 import re
-from typing import Final, FrozenSet, Mapping
+from typing import Final, FrozenSet, Mapping, cast
 
 
 # ---------------------------------------------------------------------------
@@ -110,6 +110,273 @@ CANONICAL_LABELS: Final[FrozenSet[str]] = frozenset({
     IP_ADDRESS, MAC_ADDRESS, USER_AGENT, VIN, VEHICLE_REGISTRATION, IMEI,
     OTHER,
 })
+
+
+# ---------------------------------------------------------------------------
+# Policy metadata
+# ---------------------------------------------------------------------------
+
+DIRECT_IDENTIFIER: Final = "DIRECT_IDENTIFIER"
+QUASI_IDENTIFIER: Final = "QUASI_IDENTIFIER"
+CLINICAL_CONCEPT: Final = "CLINICAL_CONCEPT"
+POLICY_LABELS: Final[FrozenSet[str]] = frozenset({
+    DIRECT_IDENTIFIER,
+    QUASI_IDENTIFIER,
+    CLINICAL_CONCEPT,
+})
+
+RISK_LOW: Final = "low"
+RISK_MEDIUM: Final = "medium"
+RISK_HIGH: Final = "high"
+RISK_LEVELS: Final[tuple[str, ...]] = (RISK_LOW, RISK_MEDIUM, RISK_HIGH)
+
+RXNORM: Final = "RxNorm"
+LOINC: Final = "LOINC"
+ICD_10_CM: Final = "ICD-10-CM"
+HPO: Final = "HPO"
+SNOMED: Final = "SNOMED"
+CLINICAL_SYSTEM_HINTS: Final[tuple[str, ...]] = (
+    SNOMED,
+    ICD_10_CM,
+    HPO,
+    RXNORM,
+    LOINC,
+)
+
+HIPAA_NAME: Final = "NAME"
+HIPAA_GEOGRAPHIC_SUBDIVISION: Final = "GEOGRAPHIC_SUBDIVISION"
+HIPAA_DATE_ELEMENT: Final = "DATE_ELEMENT"
+HIPAA_TELEPHONE_NUMBER: Final = "TELEPHONE_NUMBER"
+HIPAA_FAX_NUMBER: Final = "FAX_NUMBER"
+HIPAA_EMAIL_ADDRESS: Final = "EMAIL_ADDRESS"
+HIPAA_SOCIAL_SECURITY_NUMBER: Final = "SOCIAL_SECURITY_NUMBER"
+HIPAA_MEDICAL_RECORD_NUMBER: Final = "MEDICAL_RECORD_NUMBER"
+HIPAA_HEALTH_PLAN_BENEFICIARY_NUMBER: Final = "HEALTH_PLAN_BENEFICIARY_NUMBER"
+HIPAA_ACCOUNT_NUMBER: Final = "ACCOUNT_NUMBER"
+HIPAA_CERTIFICATE_LICENSE_NUMBER: Final = "CERTIFICATE_LICENSE_NUMBER"
+HIPAA_VEHICLE_IDENTIFIER: Final = "VEHICLE_IDENTIFIER"
+HIPAA_DEVICE_IDENTIFIER: Final = "DEVICE_IDENTIFIER"
+HIPAA_URL: Final = "URL"
+HIPAA_IP_ADDRESS: Final = "IP_ADDRESS"
+HIPAA_BIOMETRIC_IDENTIFIER: Final = "BIOMETRIC_IDENTIFIER"
+HIPAA_FULL_FACE_PHOTO: Final = "FULL_FACE_PHOTO"
+HIPAA_UNIQUE_IDENTIFIER: Final = "UNIQUE_IDENTIFIER"
+
+HIPAA_SAFE_HARBOR_CLASSES: Final[FrozenSet[str]] = frozenset({
+    HIPAA_NAME,
+    HIPAA_GEOGRAPHIC_SUBDIVISION,
+    HIPAA_DATE_ELEMENT,
+    HIPAA_TELEPHONE_NUMBER,
+    HIPAA_FAX_NUMBER,
+    HIPAA_EMAIL_ADDRESS,
+    HIPAA_SOCIAL_SECURITY_NUMBER,
+    HIPAA_MEDICAL_RECORD_NUMBER,
+    HIPAA_HEALTH_PLAN_BENEFICIARY_NUMBER,
+    HIPAA_ACCOUNT_NUMBER,
+    HIPAA_CERTIFICATE_LICENSE_NUMBER,
+    HIPAA_VEHICLE_IDENTIFIER,
+    HIPAA_DEVICE_IDENTIFIER,
+    HIPAA_URL,
+    HIPAA_IP_ADDRESS,
+    HIPAA_BIOMETRIC_IDENTIFIER,
+    HIPAA_FULL_FACE_PHOTO,
+    HIPAA_UNIQUE_IDENTIFIER,
+})
+
+_NO_SYSTEM_HINTS: Final[tuple[str, ...]] = ()
+
+
+def _label_metadata(
+    policy_label: str,
+    risk_level: str,
+    system_hints: tuple[str, ...] = _NO_SYSTEM_HINTS,
+) -> Mapping[str, object]:
+    return {
+        "policy_label": policy_label,
+        "risk_level": risk_level,
+        "system_hints": system_hints,
+    }
+
+
+LABEL_METADATA: Final[Mapping[str, Mapping[str, object]]] = {
+    # People
+    PERSON: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    FIRST_NAME: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    LAST_NAME: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    MIDDLE_NAME: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    PREFIX: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    USERNAME: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+
+    # Contact
+    EMAIL: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    PHONE: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    URL: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+
+    # Location
+    LOCATION: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    STREET_ADDRESS: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    BUILDING_NUMBER: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    ZIPCODE: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    GPS_COORDINATES: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    ORDINAL_DIRECTION: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+
+    # Time
+    DATE: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    DATE_OF_BIRTH: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    TIME: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    AGE: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+
+    # Identifiers
+    ID_NUM: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    SSN: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    ACCOUNT_NUMBER: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    PASSWORD: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    PIN: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    API_KEY: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+
+    # Financial
+    CREDIT_CARD: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    CREDIT_CARD_ISSUER: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    CVV: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    IBAN: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    BIC: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    AMOUNT: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    CURRENCY: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    BITCOIN_ADDRESS: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    ETHEREUM_ADDRESS: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    LITECOIN_ADDRESS: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    MASKED_NUMBER: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+
+    # Demographics
+    GENDER: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    EYE_COLOR: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    HEIGHT: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+
+    # Work
+    ORGANIZATION: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    JOB_TITLE: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    JOB_DEPARTMENT: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+    OCCUPATION: _label_metadata(QUASI_IDENTIFIER, RISK_MEDIUM),
+
+    # Tech
+    IP_ADDRESS: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    MAC_ADDRESS: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    USER_AGENT: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    VIN: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    VEHICLE_REGISTRATION: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+    IMEI: _label_metadata(DIRECT_IDENTIFIER, RISK_HIGH),
+
+    # Catch-all
+    OTHER: _label_metadata(CLINICAL_CONCEPT, RISK_LOW, CLINICAL_SYSTEM_HINTS),
+}
+
+LABEL_TO_HIPAA: Final[Mapping[str, str]] = {
+    # People
+    PERSON: HIPAA_NAME,
+    FIRST_NAME: HIPAA_NAME,
+    LAST_NAME: HIPAA_NAME,
+    MIDDLE_NAME: HIPAA_NAME,
+    PREFIX: HIPAA_NAME,
+    USERNAME: HIPAA_UNIQUE_IDENTIFIER,
+
+    # Contact
+    EMAIL: HIPAA_EMAIL_ADDRESS,
+    PHONE: HIPAA_TELEPHONE_NUMBER,
+    URL: HIPAA_URL,
+
+    # Location
+    LOCATION: HIPAA_GEOGRAPHIC_SUBDIVISION,
+    STREET_ADDRESS: HIPAA_GEOGRAPHIC_SUBDIVISION,
+    BUILDING_NUMBER: HIPAA_GEOGRAPHIC_SUBDIVISION,
+    ZIPCODE: HIPAA_GEOGRAPHIC_SUBDIVISION,
+    GPS_COORDINATES: HIPAA_GEOGRAPHIC_SUBDIVISION,
+    ORDINAL_DIRECTION: HIPAA_GEOGRAPHIC_SUBDIVISION,
+
+    # Time
+    DATE: HIPAA_DATE_ELEMENT,
+    DATE_OF_BIRTH: HIPAA_DATE_ELEMENT,
+    TIME: HIPAA_DATE_ELEMENT,
+    AGE: HIPAA_DATE_ELEMENT,
+
+    # Identifiers
+    ID_NUM: HIPAA_UNIQUE_IDENTIFIER,
+    SSN: HIPAA_SOCIAL_SECURITY_NUMBER,
+    ACCOUNT_NUMBER: HIPAA_ACCOUNT_NUMBER,
+    PASSWORD: HIPAA_UNIQUE_IDENTIFIER,
+    PIN: HIPAA_UNIQUE_IDENTIFIER,
+    API_KEY: HIPAA_UNIQUE_IDENTIFIER,
+
+    # Financial
+    CREDIT_CARD: HIPAA_ACCOUNT_NUMBER,
+    CREDIT_CARD_ISSUER: HIPAA_UNIQUE_IDENTIFIER,
+    CVV: HIPAA_ACCOUNT_NUMBER,
+    IBAN: HIPAA_ACCOUNT_NUMBER,
+    BIC: HIPAA_ACCOUNT_NUMBER,
+    AMOUNT: HIPAA_UNIQUE_IDENTIFIER,
+    CURRENCY: HIPAA_UNIQUE_IDENTIFIER,
+    BITCOIN_ADDRESS: HIPAA_ACCOUNT_NUMBER,
+    ETHEREUM_ADDRESS: HIPAA_ACCOUNT_NUMBER,
+    LITECOIN_ADDRESS: HIPAA_ACCOUNT_NUMBER,
+    MASKED_NUMBER: HIPAA_ACCOUNT_NUMBER,
+
+    # Demographics
+    GENDER: HIPAA_UNIQUE_IDENTIFIER,
+    EYE_COLOR: HIPAA_UNIQUE_IDENTIFIER,
+    HEIGHT: HIPAA_UNIQUE_IDENTIFIER,
+
+    # Work
+    ORGANIZATION: HIPAA_UNIQUE_IDENTIFIER,
+    JOB_TITLE: HIPAA_UNIQUE_IDENTIFIER,
+    JOB_DEPARTMENT: HIPAA_UNIQUE_IDENTIFIER,
+    OCCUPATION: HIPAA_UNIQUE_IDENTIFIER,
+
+    # Tech
+    IP_ADDRESS: HIPAA_IP_ADDRESS,
+    MAC_ADDRESS: HIPAA_DEVICE_IDENTIFIER,
+    USER_AGENT: HIPAA_UNIQUE_IDENTIFIER,
+    VIN: HIPAA_VEHICLE_IDENTIFIER,
+    VEHICLE_REGISTRATION: HIPAA_VEHICLE_IDENTIFIER,
+    IMEI: HIPAA_DEVICE_IDENTIFIER,
+
+    # Catch-all
+    OTHER: HIPAA_UNIQUE_IDENTIFIER,
+}
+
+
+def _validate_label_metadata() -> None:
+    metadata_labels = set(LABEL_METADATA)
+    hipaa_labels = set(LABEL_TO_HIPAA)
+    if metadata_labels != CANONICAL_LABELS:
+        missing = sorted(CANONICAL_LABELS - metadata_labels)
+        extra = sorted(metadata_labels - CANONICAL_LABELS)
+        raise RuntimeError(
+            "LABEL_METADATA must cover CANONICAL_LABELS exactly; "
+            f"missing={missing}, extra={extra}"
+        )
+    if hipaa_labels != CANONICAL_LABELS:
+        missing = sorted(CANONICAL_LABELS - hipaa_labels)
+        extra = sorted(hipaa_labels - CANONICAL_LABELS)
+        raise RuntimeError(
+            "LABEL_TO_HIPAA must cover CANONICAL_LABELS exactly; "
+            f"missing={missing}, extra={extra}"
+        )
+    for label, metadata in LABEL_METADATA.items():
+        policy_label = metadata["policy_label"]
+        risk_level = metadata["risk_level"]
+        system_hints = metadata["system_hints"]
+        if policy_label not in POLICY_LABELS:
+            raise RuntimeError(f"{label} has invalid policy_label {policy_label!r}")
+        if risk_level not in RISK_LEVELS:
+            raise RuntimeError(f"{label} has invalid risk_level {risk_level!r}")
+        if not isinstance(system_hints, tuple):
+            raise RuntimeError(f"{label} system_hints must be a tuple")
+        if policy_label == CLINICAL_CONCEPT and not system_hints:
+            raise RuntimeError(f"{label} clinical concepts require system_hints")
+        if policy_label != CLINICAL_CONCEPT and system_hints:
+            raise RuntimeError(f"{label} identifier labels must not have system_hints")
+    for label, hipaa_class in LABEL_TO_HIPAA.items():
+        if hipaa_class not in HIPAA_SAFE_HARBOR_CLASSES:
+            raise RuntimeError(f"{label} has invalid HIPAA class {hipaa_class!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -309,9 +576,52 @@ def normalize_label(label: str, lang: str = "en") -> str:
     return OTHER
 
 
+def _metadata_for(label: str, lang: str = "en") -> Mapping[str, object]:
+    return LABEL_METADATA[normalize_label(label, lang=lang)]
+
+
+def policy_label_for(label: str, lang: str = "en") -> str:
+    """Return the policy class for a label after canonical normalization."""
+    return cast(str, _metadata_for(label, lang=lang)["policy_label"])
+
+
+def risk_level_for(label: str, lang: str = "en") -> str:
+    """Return the residual-risk level for a label after canonical normalization."""
+    return cast(str, _metadata_for(label, lang=lang)["risk_level"])
+
+
+def system_hints_for(label: str, lang: str = "en") -> tuple[str, ...]:
+    """Return candidate clinical coding systems for a normalized label."""
+    return cast(tuple[str, ...], _metadata_for(label, lang=lang)["system_hints"])
+
+
+def hipaa_class_for(label: str, lang: str = "en") -> str:
+    """Return the outbound HIPAA Safe Harbor class for a normalized label."""
+    return LABEL_TO_HIPAA[normalize_label(label, lang=lang)]
+
+
+_validate_label_metadata()
+
+
 __all__ = [
     "CANONICAL_LABELS",
     "normalize_label",
+    "LABEL_METADATA",
+    "LABEL_TO_HIPAA",
+    "POLICY_LABELS",
+    "DIRECT_IDENTIFIER",
+    "QUASI_IDENTIFIER",
+    "CLINICAL_CONCEPT",
+    "RISK_LEVELS",
+    "RISK_LOW",
+    "RISK_MEDIUM",
+    "RISK_HIGH",
+    "CLINICAL_SYSTEM_HINTS",
+    "HIPAA_SAFE_HARBOR_CLASSES",
+    "policy_label_for",
+    "risk_level_for",
+    "system_hints_for",
+    "hipaa_class_for",
     # canonical label constants
     "PERSON", "FIRST_NAME", "LAST_NAME", "MIDDLE_NAME", "PREFIX", "USERNAME",
     "EMAIL", "PHONE", "URL",

--- a/tests/unit/core/test_labels.py
+++ b/tests/unit/core/test_labels.py
@@ -25,7 +25,11 @@ from openmed.core.labels import (
     URL,
     USERNAME,
     ZIPCODE,
+    hipaa_class_for,
     normalize_label,
+    policy_label_for,
+    risk_level_for,
+    system_hints_for,
 )
 
 
@@ -190,6 +194,19 @@ class TestEdgeCases:
         """The lang hint is accepted but currently doesn't change output."""
         for lang in ("en", "fr", "de", "it", "es", "nl", "hi", "te", "pt"):
             assert normalize_label("first_name", lang=lang) == FIRST_NAME
+
+    def test_top_level_label_import_stability(self):
+        from openmed import CANONICAL_LABELS as top_level_labels
+        from openmed import normalize_label as top_level_normalize
+
+        assert top_level_labels is CANONICAL_LABELS
+        assert top_level_normalize("id_num") == ID_NUM
+
+    def test_policy_accessors_import(self):
+        assert policy_label_for("ID_NUM") == "DIRECT_IDENTIFIER"
+        assert risk_level_for("ID_NUM") == "high"
+        assert system_hints_for("ID_NUM") == ()
+        assert hipaa_class_for("ID_NUM") == "UNIQUE_IDENTIFIER"
 
 
 class TestRegistryCoverage:

--- a/tests/unit/core/test_labels_policy_spine.py
+++ b/tests/unit/core/test_labels_policy_spine.py
@@ -1,0 +1,78 @@
+"""Tests for policy metadata attached to canonical labels."""
+
+from collections import Counter
+
+from openmed.core.labels import (
+    AGE,
+    CANONICAL_LABELS,
+    CLINICAL_CONCEPT,
+    DIRECT_IDENTIFIER,
+    HIPAA_SAFE_HARBOR_CLASSES,
+    LABEL_METADATA,
+    LABEL_TO_HIPAA,
+    POLICY_LABELS,
+    QUASI_IDENTIFIER,
+    RISK_LEVELS,
+    RISK_MEDIUM,
+    ZIPCODE,
+    hipaa_class_for,
+    normalize_label,
+    policy_label_for,
+    risk_level_for,
+    system_hints_for,
+)
+
+
+ALLOWED_SYSTEM_HINTS = {"RxNorm", "LOINC", "ICD-10-CM", "HPO", "SNOMED"}
+
+
+def test_metadata_tables_cover_canonical_labels_exactly():
+    assert len(CANONICAL_LABELS) == 50
+    assert set(LABEL_METADATA) == CANONICAL_LABELS
+    assert set(LABEL_TO_HIPAA) == CANONICAL_LABELS
+
+
+def test_every_label_resolves_policy_risk_hipaa_and_hints():
+    for label in CANONICAL_LABELS:
+        policy_label = policy_label_for(label)
+        risk_level = risk_level_for(label)
+        system_hints = system_hints_for(label)
+        hipaa_class = hipaa_class_for(label)
+
+        assert policy_label in POLICY_LABELS
+        assert risk_level in RISK_LEVELS
+        assert hipaa_class in HIPAA_SAFE_HARBOR_CLASSES
+        assert isinstance(system_hints, tuple)
+
+        if policy_label == CLINICAL_CONCEPT:
+            assert system_hints
+            assert set(system_hints) <= ALLOWED_SYSTEM_HINTS
+        else:
+            assert system_hints == ()
+
+
+def test_accessors_normalize_before_lookup():
+    assert policy_label_for("medical_record_number") == DIRECT_IDENTIFIER
+    assert policy_label_for("FIRSTNAME", lang="pt") == DIRECT_IDENTIFIER
+    assert hipaa_class_for("B-EMAIL") == "EMAIL_ADDRESS"
+
+    assert normalize_label("not_a_real_label") == "OTHER"
+    assert policy_label_for("not_a_real_label") == CLINICAL_CONCEPT
+    assert set(system_hints_for("not_a_real_label")) <= ALLOWED_SYSTEM_HINTS
+
+
+def test_acceptance_specific_direct_and_quasi_labels():
+    assert policy_label_for("ID_NUM") == DIRECT_IDENTIFIER
+    for label in (AGE, "DATE", ZIPCODE):
+        assert label in CANONICAL_LABELS
+        assert policy_label_for(label) == QUASI_IDENTIFIER
+        assert risk_level_for(label) == RISK_MEDIUM
+
+
+def test_label_to_hipaa_is_many_to_one():
+    class_counts = Counter(LABEL_TO_HIPAA.values())
+
+    assert len(HIPAA_SAFE_HARBOR_CLASSES) == 18
+    assert set(LABEL_TO_HIPAA.values()) <= HIPAA_SAFE_HARBOR_CLASSES
+    assert len(class_counts) < len(LABEL_TO_HIPAA)
+    assert any(count > 1 for count in class_counts.values())


### PR DESCRIPTION
Closes #83.

Adds canonical label policy metadata, risk levels, clinical system hints, and the HIPAA Safe Harbor cross-map so downstream de-identification, policy profiles, and grounding code can resolve metadata from normalized labels.
