### PR TITLE
Document export format support matrix

### DIFF
--- a/docs/coreml-export.md
+++ b/docs/coreml-export.md
@@ -4,6 +4,9 @@ Use CoreML when you need a bundled Apple model package for **Swift/iOS/macOS app
 
 OpenMedKit is the public Swift runtime and supports both MLX and CoreML backends. The universal OpenMed-to-CoreML packaging workflow is still being generalized across the model collection, so conversion should be treated as **active platform work**, not a stable public release surface yet.
 
+For the current architecture-by-format limits across MLX, CoreML, ONNX,
+Transformers.js, and GGUF, see the [export format support matrix](export-matrix.md).
+
 ## Current Status
 
 As of April 4, 2026:

--- a/docs/export-matrix.md
+++ b/docs/export-matrix.md
@@ -1,0 +1,64 @@
+# Export Format Support Matrix
+
+This matrix is the quick reference for OpenMed model-export support across
+architecture families and deployment tiers. It keeps the current backend limits
+in one place so contributors can decide whether a model belongs on the MLX,
+CoreML, browser, or embedding-only path before opening an export issue.
+
+Status key:
+
+- **Supported**: the repository has a current runtime or converter path for this
+  combination.
+- **Partial**: a path exists with the limitation named in the cell.
+- **Unsupported**: no stable public path exists yet.
+
+## Current Limitations
+
+- GGUF is embedding-only in the current export story; it is not a
+  token-classification or span-classification runtime.
+- CoreML is token-classification-only today; zero-shot span, classification, and
+  relation-extraction tasks should stay on the MLX or PyTorch path.
+- The MLX rows track the current `_SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES`
+  allowlist plus the experimental GLiNER-family artifacts.
+- INT4 only-if-recall-holds: 4-bit MLX artifacts should be published only when
+  recall remains acceptable for the target clinical or PII task.
+
+## Architecture by Format
+
+| Architecture family | MLX-fp | MLX-8bit | MLX-4bit | CoreML-fp16 | CoreML-int8 | ONNX | Transformers.js | GGUF |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `bert` | Supported - BERT token-classification runtime | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - use standard token-classification export | Partial - browser runtime depends on tokenizer/assets | Unsupported - GGUF is embedding-only |
+| `distilbert` | Supported - dispatches through the BERT MLX runtime | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - use standard token-classification export | Partial - browser runtime depends on tokenizer/assets | Unsupported - GGUF is embedding-only |
+| `electra` | Supported - dispatches through the BERT MLX runtime | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - use standard token-classification export | Partial - browser runtime depends on tokenizer/assets | Unsupported - GGUF is embedding-only |
+| `roberta` | Supported - dispatches through the BERT MLX runtime | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - use standard token-classification export | Partial - browser runtime depends on tokenizer/assets | Unsupported - GGUF is embedding-only |
+| `xlm-roberta` | Supported - multilingual BERT-family MLX path | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - use standard token-classification export | Partial - browser runtime depends on tokenizer/assets | Unsupported - GGUF is embedding-only |
+| `xlm_roberta` | Supported - alias for `xlm-roberta` | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - use standard token-classification export | Partial - browser runtime depends on tokenizer/assets | Unsupported - GGUF is embedding-only |
+| `deberta` | Supported - resolves to the DeBERTa-v2 MLX runtime | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only; current arm64 packaging is still rollout work | Partial - token-classification-only and calibration-dependent | Partial - use standard token-classification export | Partial - browser runtime depends on tokenizer/assets | Unsupported - GGUF is embedding-only |
+| `deberta-v2` | Supported - native DeBERTa-v2 MLX runtime | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only; current arm64 packaging is still rollout work | Partial - token-classification-only and calibration-dependent | Partial - use standard token-classification export | Partial - browser runtime depends on tokenizer/assets | Unsupported - GGUF is embedding-only |
+| `modernbert` | Unsupported - converter support is still in active rollout | Unsupported - no supported MLX runtime yet | Unsupported - no supported MLX runtime yet | Partial - target architecture is planned, not stable | Unsupported - no stable quantized CoreML path yet | Partial - backend-specific export work required | Partial - backend-specific export work required | Unsupported - GGUF is embedding-only |
+| `longformer` | Unsupported - converter support is still in active rollout | Unsupported - no supported MLX runtime yet | Unsupported - no supported MLX runtime yet | Partial - target architecture is planned, not stable | Unsupported - no stable quantized CoreML path yet | Partial - backend-specific export work required | Partial - long-sequence browser limits apply | Unsupported - GGUF is embedding-only |
+| `openai-privacy-filter` | Supported - OpenAI Privacy Filter MLX runtime | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - preserve BIOES label schema | Partial - tokenizer and label assets must travel with the model | Unsupported - GGUF is embedding-only |
+| `privacy-filter` | Supported - alias for `openai-privacy-filter` | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - preserve BIOES label schema | Partial - tokenizer and label assets must travel with the model | Unsupported - GGUF is embedding-only |
+| `privacy-filter-nemotron` | Supported - Nemotron weights on the Privacy Filter runtime | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - preserve BIOES label schema | Partial - tokenizer and label assets must travel with the model | Unsupported - GGUF is embedding-only |
+| `nemotron-privacy-filter` | Supported - alias for `privacy-filter-nemotron` | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - preserve BIOES label schema | Partial - tokenizer and label assets must travel with the model | Unsupported - GGUF is embedding-only |
+| `privacy-filter-multilingual` | Supported - multilingual Privacy Filter runtime | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - preserve multilingual BIOES label schema | Partial - tokenizer and label assets must travel with the model | Unsupported - GGUF is embedding-only |
+| `multilingual-privacy-filter` | Supported - alias for `privacy-filter-multilingual` | Supported - quantized MLX weights | Partial - INT4 only-if-recall-holds | Partial - token-classification-only | Partial - token-classification-only and calibration-dependent | Partial - preserve multilingual BIOES label schema | Partial - tokenizer and label assets must travel with the model | Unsupported - GGUF is embedding-only |
+| `gliner-uni-encoder-span` | Partial - experimental GLiNER span MLX runtime | Partial - experimental; validate per artifact | Partial - INT4 only-if-recall-holds and span recall must be checked | Unsupported - CoreML is token-classification-only | Unsupported - CoreML is token-classification-only | Partial - task-specific export work required | Partial - task-specific export work required | Unsupported - GGUF is embedding-only |
+| `gliclass-uni-encoder` | Partial - experimental GLiClass MLX runtime | Partial - experimental; validate per artifact | Partial - INT4 only-if-recall-holds and classification recall must be checked | Unsupported - CoreML is token-classification-only | Unsupported - CoreML is token-classification-only | Partial - task-specific export work required | Partial - task-specific export work required | Unsupported - GGUF is embedding-only |
+| `gliner-uni-encoder-token-relex` | Partial - experimental GLiNER relation-extraction MLX runtime | Partial - experimental; validate per artifact | Partial - INT4 only-if-recall-holds and relation recall must be checked | Unsupported - CoreML is token-classification-only | Unsupported - CoreML is token-classification-only | Partial - task-specific export work required | Partial - task-specific export work required | Unsupported - GGUF is embedding-only |
+
+## Reading the Table
+
+For Python inference on Apple Silicon, prefer the MLX-fp row first and consider
+MLX-8bit when memory or cold-start size matters. Use MLX-4bit only after a
+task-specific recall check, especially for privacy or clinical extraction.
+
+For Swift and Apple app packaging, use CoreML when you already have a compatible
+token-classification package or need simulator/older-platform coverage. Use
+Swift MLX for current Apple Silicon and real-device paths that consume OpenMed
+MLX artifacts directly.
+
+For browser and interchange formats, treat ONNX and Transformers.js as
+backend-specific packaging work. Treat GGUF as an embedding export target only,
+not as a replacement for token-classification, span, classification, or
+relation-extraction runtimes.

--- a/docs/mlx-backend.md
+++ b/docs/mlx-backend.md
@@ -55,6 +55,9 @@ The public runtime focuses on automatic preparation at first use. OpenMed's broa
 
 ## Architecture Coverage
 
+For a format-by-format view of MLX, CoreML, ONNX, Transformers.js, and GGUF
+support, see the [export format support matrix](export-matrix.md).
+
 As of May 4, 2026, the current public MLX path covers these families:
 
 - `bert`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
   - Apple Silicon & Mobile:
       - MLX Backend: mlx-backend.md
       - CoreML Packaging: coreml-export.md
+      - Export Format Matrix: export-matrix.md
       - Swift Package (OpenMedKit): swift-openmedkit.md
   - Project:
       - Contributing & Releases: contributing.md

--- a/tests/unit/test_export_matrix.py
+++ b/tests/unit/test_export_matrix.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from openmed.mlx.models import _SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES
+
+
+DOC_PATH = Path(__file__).resolve().parents[2] / "docs" / "export-matrix.md"
+
+
+def _matrix_family_rows() -> set[str]:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    rows: set[str] = set()
+    for line in text.splitlines():
+        match = re.match(r"^\|\s*`([^`]+)`\s*\|", line)
+        if match:
+            rows.add(match.group(1))
+    return rows
+
+
+def test_export_matrix_covers_every_mlx_token_classification_family() -> None:
+    rows = _matrix_family_rows()
+
+    assert set(_SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES).issubset(rows)
+
+
+def test_export_matrix_documents_current_platform_limitations() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+
+    assert "GGUF is embedding-only" in text
+    assert "CoreML is token-classification-only" in text
+    assert "INT4 only-if-recall-holds" in text


### PR DESCRIPTION
## Summary
- Add `docs/export-matrix.md` with architecture-by-format support status for MLX, CoreML, ONNX, Transformers.js, and GGUF
- Document current platform limits including GGUF embedding-only, CoreML token-classification-only, MLX allowlist coverage, and INT4 recall gating
- Add the page to MkDocs navigation and link it from MLX/CoreML export docs
- Add a coherence test that checks every MLX token-classification family has a matrix row

## Verification
- `uvx --with '.[dev]' pytest tests/unit/test_export_matrix.py -q`
- `uvx --with '.[docs]' mkdocs build --strict`
- `uvx --with '.[dev]' pytest tests/ -q`
- `git diff --check`

Closes #311