### PR TITLE
Build signed reproducible audit report with span provenance

### DIFF
--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -61,6 +61,7 @@ from .core.pii import (
     PIIEntity,
     DeidentificationResult,
 )
+from .core.audit import AuditReport, AuditSignature, AuditSpan, DetectorInfo
 from .core.pii_entity_merger import (
     merge_entities_with_semantic_units,
     find_semantic_units,

--- a/openmed/core/__init__.py
+++ b/openmed/core/__init__.py
@@ -10,11 +10,16 @@ from .config import (
     delete_profile,
     load_config_with_profile,
 )
+from .audit import AuditReport, AuditSignature, AuditSpan, DetectorInfo
 
 __all__ = [
     "ModelLoader",
     "load_model",
     "OpenMedConfig",
+    "AuditReport",
+    "AuditSignature",
+    "AuditSpan",
+    "DetectorInfo",
     "PROFILE_PRESETS",
     "list_profiles",
     "get_profile",

--- a/openmed/core/audit.py
+++ b/openmed/core/audit.py
@@ -1,0 +1,367 @@
+"""Deterministic audit reports for de-identification runs."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import hmac
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+_HASH_ALGORITHM = "sha256"
+_SIGNATURE_ALGORITHM = "HMAC-SHA256"
+
+
+def _canonical_json(data: Any) -> str:
+    return json.dumps(
+        data,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return f"{_HASH_ALGORITHM}:{hashlib.sha256(data).hexdigest()}"
+
+
+def hash_text(text: str) -> str:
+    """Return a stable SHA-256 hash for text content."""
+    return _sha256_bytes(text.encode("utf-8"))
+
+
+def stable_hash(data: Any) -> str:
+    """Return a stable SHA-256 hash for canonical JSON data."""
+    return _sha256_bytes(_canonical_json(data).encode("utf-8"))
+
+
+def manifest_hash(path: Path | None = None) -> str:
+    """Return the committed model manifest hash used by audit reports."""
+    manifest_path = path or Path(__file__).resolve().parents[2] / "models.jsonl"
+    try:
+        return _sha256_bytes(manifest_path.read_bytes())
+    except OSError:
+        return _sha256_bytes(b"")
+
+
+def _key_bytes(key: bytes | str) -> bytes:
+    if isinstance(key, bytes):
+        return key
+    if isinstance(key, str):
+        return key.encode("utf-8")
+    raise TypeError("Signing key must be str or bytes")
+
+
+@dataclass
+class DetectorInfo:
+    """Detector provenance recorded in an audit report."""
+
+    source: str
+    model_id: str
+    model_format: str
+    commit: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "model_id": self.model_id,
+            "model_format": self.model_format,
+            "commit": self.commit,
+            "metadata": copy.deepcopy(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "DetectorInfo":
+        return cls(
+            source=str(data.get("source", "")),
+            model_id=str(data.get("model_id", "")),
+            model_format=str(data.get("model_format", "")),
+            commit=(str(data["commit"]) if data.get("commit") is not None else None),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+@dataclass
+class AuditSpan:
+    """Per-span provenance and redaction action."""
+
+    start: int
+    end: int
+    label: str
+    canonical_label: str
+    sources: list[str]
+    confidence: float
+    threshold: float
+    action: str
+    surrogate: str | None
+    text_hash: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+    context: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "start": self.start,
+            "end": self.end,
+            "label": self.label,
+            "canonical_label": self.canonical_label,
+            "sources": list(self.sources),
+            "confidence": float(self.confidence),
+            "threshold": float(self.threshold),
+            "action": self.action,
+            "surrogate": self.surrogate,
+            "text_hash": self.text_hash,
+            "evidence": copy.deepcopy(self.evidence),
+            "context": dict(self.context),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AuditSpan":
+        return cls(
+            start=int(data.get("start", 0)),
+            end=int(data.get("end", 0)),
+            label=str(data.get("label", "")),
+            canonical_label=str(data.get("canonical_label", "")),
+            sources=[str(source) for source in data.get("sources", [])],
+            confidence=float(data.get("confidence", 0.0)),
+            threshold=float(data.get("threshold", 0.0)),
+            action=str(data.get("action", "")),
+            surrogate=(
+                str(data["surrogate"]) if data.get("surrogate") is not None else None
+            ),
+            text_hash=str(data.get("text_hash", "")),
+            evidence=dict(data.get("evidence") or {}),
+            context=dict(data.get("context") or {}),
+        )
+
+
+@dataclass
+class AuditSignature:
+    """Signature metadata for an audit report."""
+
+    key_id: str
+    algorithm: str
+    value: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "key_id": self.key_id,
+            "algorithm": self.algorithm,
+            "value": self.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AuditSignature":
+        return cls(
+            key_id=str(data.get("key_id", "")),
+            algorithm=str(data.get("algorithm", "")),
+            value=str(data.get("value", "")),
+        )
+
+
+@dataclass
+class AuditReport:
+    """Signed, reproducible de-identification audit report."""
+
+    policy: str
+    resolved_profile: dict[str, Any]
+    detectors: list[DetectorInfo]
+    safety_sweep: dict[str, Any]
+    spans: list[AuditSpan]
+    thresholds: dict[str, float]
+    residual_risk: dict[str, Any]
+    openmed_version: str
+    manifest_hash: str
+    document_length: int
+    input_hash: str
+    deidentified_text_hash: str
+    repro_hash: str = ""
+    signature: AuditSignature | None = None
+
+    def __post_init__(self) -> None:
+        if not self.repro_hash:
+            self.repro_hash = self.recompute_repro_hash()
+
+    def _payload(
+        self,
+        *,
+        include_repro_hash: bool,
+        include_signature: bool,
+    ) -> dict[str, Any]:
+        payload = {
+            "policy": self.policy,
+            "resolved_profile": copy.deepcopy(self.resolved_profile),
+            "detectors": [detector.to_dict() for detector in self.detectors],
+            "safety_sweep": copy.deepcopy(self.safety_sweep),
+            "spans": [span.to_dict() for span in self.spans],
+            "thresholds": {
+                str(label): float(value)
+                for label, value in sorted(self.thresholds.items())
+            },
+            "residual_risk": copy.deepcopy(self.residual_risk),
+            "openmed_version": self.openmed_version,
+            "manifest_hash": self.manifest_hash,
+            "document_length": int(self.document_length),
+            "input_hash": self.input_hash,
+            "deidentified_text_hash": self.deidentified_text_hash,
+        }
+        if include_repro_hash:
+            payload["repro_hash"] = self.repro_hash
+        if include_signature:
+            payload["signature"] = (
+                self.signature.to_dict() if self.signature is not None else None
+            )
+        return payload
+
+    def recompute_repro_hash(self) -> str:
+        """Recompute the report hash without trusting the stored value."""
+        return stable_hash(
+            self._payload(include_repro_hash=False, include_signature=False)
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._payload(include_repro_hash=True, include_signature=True)
+
+    def to_json(self) -> str:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AuditReport":
+        signature_data = data.get("signature")
+        return cls(
+            policy=str(data.get("policy", "")),
+            resolved_profile=dict(data.get("resolved_profile") or {}),
+            detectors=[
+                DetectorInfo.from_dict(item)
+                for item in data.get("detectors", [])
+                if isinstance(item, Mapping)
+            ],
+            safety_sweep=dict(data.get("safety_sweep") or {}),
+            spans=[
+                AuditSpan.from_dict(item)
+                for item in data.get("spans", [])
+                if isinstance(item, Mapping)
+            ],
+            thresholds={
+                str(label): float(value)
+                for label, value in (data.get("thresholds") or {}).items()
+            },
+            residual_risk=dict(data.get("residual_risk") or {}),
+            openmed_version=str(data.get("openmed_version", "")),
+            manifest_hash=str(data.get("manifest_hash", "")),
+            document_length=int(data.get("document_length", 0)),
+            input_hash=str(data.get("input_hash", "")),
+            deidentified_text_hash=str(data.get("deidentified_text_hash", "")),
+            repro_hash=str(data.get("repro_hash", "")),
+            signature=(
+                AuditSignature.from_dict(signature_data)
+                if isinstance(signature_data, Mapping)
+                else None
+            ),
+        )
+
+    @classmethod
+    def from_json(cls, data: str | bytes) -> "AuditReport":
+        return cls.from_dict(json.loads(data))
+
+    def sign(self, key: bytes | str, *, key_id: str = "release") -> "AuditReport":
+        """Sign the report with a release key and return ``self``."""
+        self.repro_hash = self.recompute_repro_hash()
+        message = _canonical_json(
+            self._payload(include_repro_hash=True, include_signature=False)
+        ).encode("utf-8")
+        signature = hmac.new(_key_bytes(key), message, hashlib.sha256).hexdigest()
+        self.signature = AuditSignature(
+            key_id=key_id,
+            algorithm=_SIGNATURE_ALGORITHM,
+            value=signature,
+        )
+        return self
+
+    def verify(
+        self,
+        key: bytes | str,
+        *,
+        original_text: str | None = None,
+        deidentified_text: str | None = None,
+    ) -> bool:
+        """Verify the signature and reproducibility hash."""
+        if original_text is not None and hash_text(original_text) != self.input_hash:
+            return False
+        if (
+            deidentified_text is not None
+            and hash_text(deidentified_text) != self.deidentified_text_hash
+        ):
+            return False
+        if self.recompute_repro_hash() != self.repro_hash:
+            return False
+        if self.signature is None or self.signature.algorithm != _SIGNATURE_ALGORITHM:
+            return False
+
+        message = _canonical_json(
+            self._payload(include_repro_hash=True, include_signature=False)
+        ).encode("utf-8")
+        expected = hmac.new(_key_bytes(key), message, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, self.signature.value)
+
+    def export_review_bundle(self) -> dict[str, Any]:
+        """Export reviewable spans and context windows without full text."""
+        return {
+            "policy": self.policy,
+            "document_length": self.document_length,
+            "input_hash": self.input_hash,
+            "deidentified_text_hash": self.deidentified_text_hash,
+            "repro_hash": self.repro_hash,
+            "spans": [
+                {
+                    "start": span.start,
+                    "end": span.end,
+                    "label": span.label,
+                    "canonical_label": span.canonical_label,
+                    "sources": list(span.sources),
+                    "confidence": float(span.confidence),
+                    "threshold": float(span.threshold),
+                    "action": span.action,
+                    "surrogate": span.surrogate,
+                    "text_hash": span.text_hash,
+                    "context": dict(span.context),
+                }
+                for span in self.spans
+            ],
+        }
+
+    def export_review_bundle_json(self) -> str:
+        return _canonical_json(self.export_review_bundle())
+
+
+def recompute_repro_hash(report: AuditReport | Mapping[str, Any]) -> str:
+    """Offline helper to recompute a report hash from an object or mapping."""
+    if isinstance(report, AuditReport):
+        return report.recompute_repro_hash()
+    return AuditReport.from_dict(report).recompute_repro_hash()
+
+
+def verify_repro_hash(report: AuditReport | Mapping[str, Any]) -> bool:
+    """Return whether a report's stored hash matches its canonical payload."""
+    if isinstance(report, AuditReport):
+        return report.recompute_repro_hash() == report.repro_hash
+    parsed = AuditReport.from_dict(report)
+    return parsed.recompute_repro_hash() == parsed.repro_hash
+
+
+__all__ = [
+    "AuditReport",
+    "AuditSignature",
+    "AuditSpan",
+    "DetectorInfo",
+    "hash_text",
+    "manifest_hash",
+    "recompute_repro_hash",
+    "stable_hash",
+    "verify_repro_hash",
+]

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -34,7 +34,8 @@ Example:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Literal, TYPE_CHECKING, Sequence
 from datetime import datetime, timedelta
 from functools import lru_cache
@@ -49,6 +50,7 @@ from .config import OpenMedConfig
 from ..processing.outputs import EntityPrediction
 
 if TYPE_CHECKING:
+    from .audit import AuditReport
     from .anonymizer import Anonymizer
     from .models import ModelLoader
 
@@ -78,6 +80,12 @@ class PIIEntity(EntityPrediction):
     original_text: Optional[str] = None
     hash_value: Optional[str] = None
     reversible_id: Optional[str] = None
+    canonical_label: Optional[str] = None
+    sources: list[str] = field(default_factory=list)
+    evidence: dict[str, Any] = field(default_factory=dict)
+    threshold: Optional[float] = None
+    action: Optional[str] = None
+    surrogate: Optional[str] = None
 
     def __post_init__(self):
         """Initialize entity_type from label if not set."""
@@ -105,6 +113,7 @@ class DeidentificationResult:
     timestamp: datetime
     mapping: Optional[dict[str, str]] = None
     metadata: Optional[dict[str, Any]] = None
+    audit_report: Optional["AuditReport"] = None
 
     def to_dict(self) -> dict:
         """Convert result to dictionary format.
@@ -124,6 +133,12 @@ class DeidentificationResult:
                     "end": e.end,
                     "confidence": e.confidence,
                     "redacted_text": e.redacted_text,
+                    "canonical_label": e.canonical_label,
+                    "sources": list(e.sources),
+                    "evidence": e.evidence,
+                    "threshold": e.threshold,
+                    "action": e.action,
+                    "surrogate": e.surrogate,
                     "metadata": e.metadata or {},
                     **(
                         {"reversible_id": e.reversible_id}
@@ -137,6 +152,9 @@ class DeidentificationResult:
             "timestamp": self.timestamp.isoformat(),
             "num_entities_redacted": len(self.pii_entities),
             "metadata": self.metadata or {},
+            "audit_report": (
+                self.audit_report.to_dict() if self.audit_report is not None else None
+            ),
         }
 
 
@@ -660,6 +678,276 @@ def _apply_safety_sweep_to_result(
     return added_count
 
 
+_AUDIT_TEXT_KEYS = {
+    "text",
+    "word",
+    "value",
+    "surface",
+    "replacement",
+    "original_text",
+    "deidentified_text",
+}
+
+
+def _sanitize_audit_evidence(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _sanitize_audit_evidence(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            if str(key).lower() not in _AUDIT_TEXT_KEYS
+        }
+    if isinstance(value, list):
+        return [_sanitize_audit_evidence(item) for item in value]
+    if isinstance(value, tuple):
+        return [_sanitize_audit_evidence(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _entity_sources(entity: Any) -> list[str]:
+    metadata = getattr(entity, "metadata", None) or {}
+    source = str(metadata.get("source", "")).strip()
+    if source == "safety_sweep":
+        return ["safety_sweep"]
+    if source == "locale_rule":
+        return ["locale_rule"]
+    return ["ml"]
+
+
+def _entity_evidence(
+    entity: Any,
+    *,
+    pii_result: Any,
+    model_name: str,
+    lang: str,
+) -> dict[str, Any]:
+    metadata = _sanitize_audit_evidence(getattr(entity, "metadata", None) or {})
+    evidence = {
+        "raw_label": getattr(entity, "label", ""),
+        "language": lang,
+        "metadata": metadata,
+    }
+    if "ml" in _entity_sources(entity):
+        evidence["model_id"] = getattr(pii_result, "model_name", None) or model_name
+    return evidence
+
+
+def _model_format(model_id: str) -> str:
+    if not model_id:
+        return "unknown"
+    lowered = model_id.lower()
+    if lowered.endswith(".mlmodel") or "coreml" in lowered:
+        return "coreml"
+    if "mlx" in lowered or _is_privacy_filter_artifact_path(model_id):
+        return "mlx"
+    if _looks_like_privacy_filter_identifier(model_id):
+        return "privacy_filter"
+    return "transformers"
+
+
+def _detector_infos(
+    pii_result: Any,
+    *,
+    model_name: str,
+    use_safety_sweep: bool,
+) -> list[Any]:
+    from .audit import DetectorInfo
+    from .safety_sweep import SAFETY_SWEEP_PATTERNS_VERSION
+
+    metadata = getattr(pii_result, "metadata", None) or {}
+    result_model = str(getattr(pii_result, "model_name", None) or model_name)
+    detectors = [
+        DetectorInfo(
+            source="ml",
+            model_id=result_model,
+            model_format=_model_format(result_model),
+            commit=metadata.get("model_commit"),
+        )
+    ]
+    if use_safety_sweep:
+        detectors.append(
+            DetectorInfo(
+                source="safety_sweep",
+                model_id="safety_sweep",
+                model_format="rules",
+                commit=None,
+                metadata={"patterns_version": SAFETY_SWEEP_PATTERNS_VERSION},
+            )
+        )
+    return detectors
+
+
+def _context_window(text: str, start: int, end: int, *, size: int = 32) -> dict[str, str]:
+    return {
+        "before": text[max(0, start - size):start],
+        "after": text[end:min(len(text), end + size)],
+    }
+
+
+def _audit_span_from_entity(text: str, entity: PIIEntity) -> Any:
+    from .audit import AuditSpan, hash_text
+
+    start = int(entity.start or 0)
+    end = int(entity.end or start)
+    return AuditSpan(
+        start=start,
+        end=end,
+        label=entity.label,
+        canonical_label=entity.canonical_label or entity.entity_type,
+        sources=list(entity.sources),
+        confidence=float(entity.confidence),
+        threshold=float(entity.threshold or 0.0),
+        action=entity.action or "",
+        surrogate=entity.surrogate,
+        text_hash=hash_text(text[start:end]),
+        evidence=dict(entity.evidence),
+        context=_context_window(text, start, end),
+    )
+
+
+def _span_record(entity: PIIEntity) -> dict[str, Any]:
+    return {
+        "label": entity.label,
+        "canonical_label": entity.canonical_label or entity.entity_type,
+        "start": entity.start,
+        "end": entity.end,
+        "metadata": {
+            "source": list(entity.sources),
+            **(entity.metadata or {}),
+        },
+    }
+
+
+def _projected_leakage(spans: Sequence[PIIEntity]) -> float:
+    if not spans:
+        return 0.0
+    residual = sum(max(0.0, 1.0 - float(span.confidence)) for span in spans)
+    return round(min(1.0, residual / len(spans)), 6)
+
+
+def _risk_summary(
+    *,
+    original_text: str,
+    deidentified_text: str,
+    spans: Sequence[PIIEntity],
+) -> dict[str, Any]:
+    from ..risk import risk_report
+
+    report = risk_report(
+        {"text": deidentified_text},
+        original={
+            "text": original_text,
+            "entities": [_span_record(entity) for entity in spans],
+        },
+    )
+    record_score = max(
+        float(report.get("leakage_rate", 0.0)),
+        float(report.get("reid_rate", 0.0)),
+    )
+    if report.get("k_min") == 1:
+        record_score = max(record_score, 1.0)
+    return {
+        "projected_leakage": _projected_leakage(spans),
+        "risk_report_record_score": round(record_score, 6),
+        "risk_report": report,
+    }
+
+
+def _resolved_audit_profile(
+    *,
+    method: DeidentificationMethod,
+    model_name: str,
+    confidence_threshold: float,
+    keep_year: bool,
+    keep_mapping: bool,
+    lang: str,
+    normalize_accents: Optional[bool],
+    use_smart_merging: bool,
+    use_safety_sweep: bool,
+) -> dict[str, Any]:
+    return {
+        "method": method,
+        "model_name": model_name,
+        "confidence_threshold": float(confidence_threshold),
+        "keep_year": bool(keep_year),
+        "keep_mapping": bool(keep_mapping),
+        "language": lang,
+        "normalize_accents": normalize_accents,
+        "use_smart_merging": bool(use_smart_merging),
+        "use_safety_sweep": bool(use_safety_sweep),
+    }
+
+
+def _build_audit_report(
+    *,
+    original_text: str,
+    deidentified_text: str,
+    pii_result: Any,
+    pii_entities: Sequence[PIIEntity],
+    effective_method: DeidentificationMethod,
+    model_name: str,
+    confidence_threshold: float,
+    keep_year: bool,
+    keep_mapping: bool,
+    lang: str,
+    normalize_accents: Optional[bool],
+    use_smart_merging: bool,
+    use_safety_sweep: bool,
+    policy: str,
+) -> Any:
+    from .audit import AuditReport, hash_text, manifest_hash
+    from .safety_sweep import SAFETY_SWEEP_PATTERNS_VERSION, SAFETY_SWEEP_SOURCE
+    from .labels import normalize_label
+    from ..__about__ import __version__
+
+    thresholds = {
+        normalize_label(entity.label, lang): float(confidence_threshold)
+        for entity in pii_entities
+    }
+    if not thresholds:
+        thresholds["DEFAULT"] = float(confidence_threshold)
+
+    metadata = getattr(pii_result, "metadata", None) or {}
+    sweep_metadata = dict(metadata.get("safety_sweep") or {})
+    sweep_metadata.setdefault("source", SAFETY_SWEEP_SOURCE)
+    sweep_metadata.setdefault("patterns_version", SAFETY_SWEEP_PATTERNS_VERSION)
+    sweep_metadata.setdefault("enabled", bool(use_safety_sweep))
+
+    return AuditReport(
+        policy=policy,
+        resolved_profile=_resolved_audit_profile(
+            method=effective_method,
+            model_name=model_name,
+            confidence_threshold=confidence_threshold,
+            keep_year=keep_year,
+            keep_mapping=keep_mapping,
+            lang=lang,
+            normalize_accents=normalize_accents,
+            use_smart_merging=use_smart_merging,
+            use_safety_sweep=use_safety_sweep,
+        ),
+        detectors=_detector_infos(
+            pii_result,
+            model_name=model_name,
+            use_safety_sweep=use_safety_sweep,
+        ),
+        safety_sweep=sweep_metadata,
+        spans=[_audit_span_from_entity(original_text, entity) for entity in pii_entities],
+        thresholds=thresholds,
+        residual_risk=_risk_summary(
+            original_text=original_text,
+            deidentified_text=deidentified_text,
+            spans=pii_entities,
+        ),
+        openmed_version=__version__,
+        manifest_hash=manifest_hash(),
+        document_length=len(original_text),
+        input_hash=hash_text(original_text),
+        deidentified_text_hash=hash_text(deidentified_text),
+    )
+
+
 def _build_deidentification_result(
     text: str,
     pii_result: Any,
@@ -672,10 +960,19 @@ def _build_deidentification_result(
     consistent: bool,
     seed: Optional[int],
     locale: Optional[str],
+    model_name: str = _DEFAULT_EN_MODEL,
+    confidence_threshold: float = 0.7,
+    normalize_accents: Optional[bool] = None,
+    use_smart_merging: bool = True,
+    use_safety_sweep: bool = True,
     reversible_ids: bool = False,
     policy_name: Optional[str] = None,
+    policy: str = "hipaa_safe_harbor",
+    audit: bool = False,
 ) -> DeidentificationResult:
     """Build a de-identification result from an existing PII result."""
+    from .labels import normalize_label
+
     pii_entities = [
         PIIEntity(
             text=e.text,
@@ -686,6 +983,15 @@ def _build_deidentification_result(
             metadata=_copy_metadata(getattr(e, "metadata", None)),
             entity_type=e.label,
             original_text=e.text,
+            canonical_label=normalize_label(e.label, lang),
+            sources=_entity_sources(e),
+            evidence=_entity_evidence(
+                e,
+                pii_result=pii_result,
+                model_name=model_name,
+                lang=lang,
+            ),
+            threshold=confidence_threshold,
         )
         for e in pii_result.entities
     ]
@@ -730,6 +1036,8 @@ def _build_deidentification_result(
                 entity,
                 policy_name=policy_name,
             )
+        entity.action = entity_method
+        entity.surrogate = redacted if redacted else None
 
         deidentified = (
             deidentified[: entity.start] + redacted + deidentified[entity.end :]
@@ -737,6 +1045,25 @@ def _build_deidentification_result(
 
         if keep_mapping and mapping is not None:
             mapping[redacted] = entity.original_text or entity.text
+
+    audit_report = None
+    if audit:
+        audit_report = _build_audit_report(
+            original_text=text,
+            deidentified_text=deidentified,
+            pii_result=pii_result,
+            pii_entities=pii_entities,
+            effective_method=effective_method,
+            model_name=model_name,
+            confidence_threshold=confidence_threshold,
+            keep_year=keep_year,
+            keep_mapping=keep_mapping,
+            lang=lang,
+            normalize_accents=normalize_accents,
+            use_smart_merging=use_smart_merging,
+            use_safety_sweep=use_safety_sweep,
+            policy=policy,
+        )
 
     return DeidentificationResult(
         original_text=text,
@@ -746,6 +1073,7 @@ def _build_deidentification_result(
         timestamp=datetime.now(),
         mapping=mapping,
         metadata=_copy_metadata(getattr(pii_result, "metadata", None)),
+        audit_report=audit_report,
     )
 
 
@@ -836,13 +1164,19 @@ def _deidentify_batch(
             text,
             pii_result,
             effective_method=effective_method,
+            model_name=model_name,
+            confidence_threshold=confidence_threshold,
             keep_year=keep_year,
             date_shift_days=date_shift_days,
             keep_mapping=keep_mapping,
             lang=lang,
+            normalize_accents=normalize_accents,
+            use_smart_merging=use_smart_merging,
+            use_safety_sweep=use_safety_sweep,
             consistent=consistent,
             seed=seed,
             locale=locale,
+            policy="hipaa_safe_harbor",
         )
         for text, pii_result in zip(stripped_texts, pii_results)
     ]
@@ -868,7 +1202,8 @@ def deidentify(
     locale: Optional[str] = None,
     loader: Optional["ModelLoader"] = None,
     policy: Optional[str] = None,
-) -> DeidentificationResult:
+    audit: bool = False,
+) -> DeidentificationResult | "AuditReport":
     """De-identify text by detecting and redacting PII with intelligent merging.
 
     Implements multiple de-identification strategies for HIPAA compliance:
@@ -895,8 +1230,6 @@ def deidentify(
         use_smart_merging: Enable regex-based semantic unit merging (recommended)
         use_safety_sweep: Run a deterministic structured-identifier sweep
             after model detection and before redaction.
-        policy: Optional policy profile name controlling arbitration, action
-            selection, mandatory safety sweep behavior, and reversible mapping.
         lang: ISO 639-1 language code (en, fr, de, it, es, nl, hi, te, pt,
             ar, ja, tr). Controls model
             selection, regex patterns, and fake data for replacement.
@@ -911,9 +1244,14 @@ def deidentify(
             ``consistent=True`` replacements. Implies ``consistent=True``.
         locale: Faker locale override (``pt_BR``, ``en_GB``, ...) for
             ``method="replace"``. When ``None``, derived from ``lang``.
+        policy: Optional policy profile name controlling arbitration, action
+            selection, mandatory safety sweep behavior, and reversible mapping.
+        audit: Return a deterministic AuditReport instead of the
+            DeidentificationResult.
 
     Returns:
-        DeidentificationResult with original and de-identified text
+        DeidentificationResult with original and de-identified text, or
+        AuditReport when ``audit=True``.
 
     Example:
         >>> result = deidentify(
@@ -951,7 +1289,10 @@ def deidentify(
         consistent=consistent,
         seed=seed,
         locale=locale,
+        audit=audit,
     )
+    if audit and result.deidentification_result.audit_report is not None:
+        return result.deidentification_result.audit_report
     return result.deidentification_result
 
 

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -215,6 +215,7 @@ class Pipeline:
         seed: Optional[int] = None,
         locale: Optional[str] = None,
         doc_id: str | None = None,
+        audit: bool = False,
     ) -> PipelineResult:
         from . import pii
 
@@ -386,8 +387,15 @@ class Pipeline:
             consistent=consistent,
             seed=seed,
             locale=locale,
+            model_name=route.model_name,
+            confidence_threshold=self.confidence_threshold,
+            normalize_accents=self.normalize_accents,
+            use_smart_merging=self.use_smart_merging,
+            use_safety_sweep=self.use_safety_sweep,
             reversible_ids=bool(self.policy is not None and self.policy.reversible_id),
             policy_name=self.policy.name if self.policy is not None else None,
+            policy=self.policy.name if self.policy is not None else "hipaa_safe_harbor",
+            audit=audit,
         )
         final_spans = (
             sweep_spans
@@ -664,8 +672,15 @@ class Pipeline:
         consistent: bool,
         seed: Optional[int],
         locale: Optional[str],
+        model_name: str,
+        confidence_threshold: float,
+        normalize_accents: Optional[bool],
+        use_smart_merging: bool,
+        use_safety_sweep: bool,
         reversible_ids: bool = False,
         policy_name: Optional[str] = None,
+        policy: str = "hipaa_safe_harbor",
+        audit: bool = False,
     ) -> Any:
         from . import pii
 
@@ -680,8 +695,15 @@ class Pipeline:
             consistent=consistent,
             seed=seed,
             locale=locale,
+            model_name=model_name,
+            confidence_threshold=confidence_threshold,
+            normalize_accents=normalize_accents,
+            use_smart_merging=use_smart_merging,
+            use_safety_sweep=use_safety_sweep,
             reversible_ids=reversible_ids,
             policy_name=policy_name,
+            policy=policy,
+            audit=audit,
         )
 
     def _entities_to_spans(

--- a/tests/unit/core/test_audit_report.py
+++ b/tests/unit/core/test_audit_report.py
@@ -1,0 +1,106 @@
+"""Tests for deterministic de-identification audit reports."""
+
+from __future__ import annotations
+
+import json
+
+from openmed.core.audit import (
+    AuditReport,
+    AuditSpan,
+    DetectorInfo,
+    recompute_repro_hash,
+    verify_repro_hash,
+    hash_text,
+)
+
+
+def _report() -> AuditReport:
+    text = "Patient John Doe called 555-1234."
+    return AuditReport(
+        policy="hipaa_safe_harbor",
+        resolved_profile={
+            "method": "mask",
+            "confidence_threshold": 0.7,
+            "language": "en",
+        },
+        detectors=[
+            DetectorInfo(
+                source="ml",
+                model_id="unit-test-model",
+                model_format="transformers",
+                commit="abc123",
+            )
+        ],
+        safety_sweep={
+            "source": "safety_sweep",
+            "patterns_version": "safety-sweep-v1",
+            "spans_added": 0,
+        },
+        spans=[
+            AuditSpan(
+                start=8,
+                end=16,
+                label="NAME",
+                canonical_label="PERSON",
+                sources=["ml"],
+                confidence=0.95,
+                threshold=0.7,
+                action="mask",
+                surrogate="[NAME]",
+                text_hash=hash_text("John Doe"),
+                evidence={"raw_label": "NAME", "model_id": "unit-test-model"},
+                context={"before": "Patient ", "after": " called 555-1234."},
+            )
+        ],
+        thresholds={"PERSON": 0.7},
+        residual_risk={
+            "projected_leakage": 0.05,
+            "risk_report_record_score": 0.0,
+            "risk_report": {
+                "leakage_rate": 0.0,
+                "reid_rate": 0.0,
+                "k_min": 0,
+                "singleton_records": [],
+                "quasi_identifiers": [],
+            },
+        },
+        openmed_version="1.5.5",
+        manifest_hash="sha256:manifest",
+        document_length=len(text),
+        input_hash=hash_text(text),
+        deidentified_text_hash=hash_text("Patient [NAME] called [PHONE]."),
+    )
+
+
+def test_report_json_round_trip_is_byte_stable_and_hash_recomputes():
+    report = _report()
+
+    payload = report.to_json()
+    restored = AuditReport.from_json(payload)
+
+    assert restored == report
+    assert restored.to_json() == payload
+    assert recompute_repro_hash(restored) == report.repro_hash
+    assert verify_repro_hash(json.loads(payload))
+
+
+def test_report_sign_verify_and_tamper_detection():
+    report = _report().sign("release-key", key_id="test-key")
+
+    assert report.verify("release-key")
+    assert not report.verify("wrong-key")
+
+    tampered = AuditReport.from_json(report.to_json())
+    tampered.spans[0].canonical_label = "EMAIL"
+
+    assert not tampered.verify("release-key")
+
+
+def test_review_bundle_excludes_full_document_and_span_text():
+    report = _report()
+    bundle_json = report.export_review_bundle_json()
+
+    assert "Patient John Doe called 555-1234." not in bundle_json
+    assert "John Doe" not in bundle_json
+    assert "Patient " in bundle_json
+    assert " called 555-1234." in bundle_json

--- a/tests/unit/core/test_deid_provenance.py
+++ b/tests/unit/core/test_deid_provenance.py
@@ -1,0 +1,84 @@
+"""Tests for de-identification span provenance and audit reports."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+from openmed.core.audit import AuditReport, verify_repro_hash
+from openmed.core.pii import deidentify
+from openmed.core.safety_sweep import SAFETY_SWEEP_SOURCE
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+
+def _prediction(text: str) -> PredictionResult:
+    return PredictionResult(
+        text=text,
+        entities=[
+            EntityPrediction(
+                text="John Doe",
+                label="NAME",
+                start=text.index("John Doe"),
+                end=text.index("John Doe") + len("John Doe"),
+                confidence=0.95,
+                metadata={"detector": "unit"},
+            )
+        ],
+        model_name="unit-test-model",
+        timestamp=datetime.now().isoformat(),
+    )
+
+
+@patch("openmed.core.pii.extract_pii")
+def test_deidentify_audit_report_records_ml_and_safety_sweep_provenance(mock_extract):
+    text = "Patient John Doe emailed jane.patient@example.com."
+    mock_extract.side_effect = lambda *args, **kwargs: _prediction(text)
+
+    report = deidentify(text, method="mask", audit=True)
+
+    assert isinstance(report, AuditReport)
+    assert report.policy == "hipaa_safe_harbor"
+    assert report.resolved_profile["method"] == "mask"
+    assert report.resolved_profile["confidence_threshold"] == 0.7
+    assert report.safety_sweep["enabled"] is True
+    assert report.safety_sweep["spans_added"] == 1
+    assert verify_repro_hash(report)
+
+    by_label = {span.label: span for span in report.spans}
+    assert by_label["NAME"].sources == ["ml"]
+    assert by_label["NAME"].canonical_label == "PERSON"
+    assert by_label["NAME"].threshold == 0.7
+    assert by_label["NAME"].surrogate == "[NAME]"
+
+    email_span = by_label["email"]
+    assert email_span.sources == [SAFETY_SWEEP_SOURCE]
+    assert email_span.canonical_label == "EMAIL"
+    assert email_span.evidence["metadata"]["patterns_version"] == "safety-sweep-v1"
+    assert "jane.patient@example.com" not in report.export_review_bundle_json()
+
+
+@patch("openmed.core.pii.extract_pii")
+def test_audit_repro_hash_is_stable_for_identical_inputs(mock_extract):
+    text = "Patient John Doe emailed jane.patient@example.com."
+    mock_extract.side_effect = lambda *args, **kwargs: _prediction(text)
+
+    first = deidentify(text, method="mask", audit=True)
+    second = deidentify(text, method="mask", audit=True)
+
+    assert first.repro_hash == second.repro_hash
+    assert first.to_json() == second.to_json()
+
+
+@patch("openmed.core.pii.extract_pii")
+def test_regular_deidentify_keeps_provenance_on_entities(mock_extract):
+    text = "Patient John Doe."
+    mock_extract.return_value = _prediction(text)
+
+    result = deidentify(text, method="mask", use_safety_sweep=False)
+
+    assert result.audit_report is None
+    assert result.pii_entities[0].canonical_label == "PERSON"
+    assert result.pii_entities[0].sources == ["ml"]
+    assert result.pii_entities[0].evidence["model_id"] == "unit-test-model"
+    assert result.pii_entities[0].action == "mask"
+    assert result.pii_entities[0].surrogate == "[NAME]"


### PR DESCRIPTION
Closes #85.

Adds a deterministic AuditReport for de-identification runs with per-span provenance, detector metadata, thresholds, residual-risk scoring, manifest/input/output hashes, signing and verification helpers, and review-bundle export without full-document text. Wires `deidentify(..., audit=True)` to return the report while preserving the default DeidentificationResult path, and adds focused audit/provenance tests.

Validation:
- `.venv/bin/python -m pytest tests/ -q`