### PR TITLE
Add HF push_to_hub publishing to the model conversion pipeline

### DIFF
--- a/.github/workflows/convert-models.yml
+++ b/.github/workflows/convert-models.yml
@@ -16,7 +16,7 @@ on:
         required: false
         default: 'mlx'
       publish_to_hub:
-        description: 'Run the protected HF publish credential gate'
+        description: 'Publish converted artifacts to HF after successful conversion'
         required: false
         default: 'false'
         type: choice
@@ -118,6 +118,18 @@ jobs:
       url: https://huggingface.co/OpenMed
 
     steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install publish dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[hf]"
+
     - name: Require HF write token before publish
       env:
         HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
@@ -126,3 +138,52 @@ jobs:
           echo "::error title=Missing HF_WRITE_TOKEN::Configure HF_WRITE_TOKEN in the hf-publish protected environment before enabling publish."
           exit 1
         fi
+
+    - name: Download MLX model
+      if: contains(github.event.inputs.formats, 'mlx')
+      uses: actions/download-artifact@v4
+      with:
+        name: mlx-model
+        path: publish-artifacts/mlx-output
+
+    - name: Publish MLX model
+      if: contains(github.event.inputs.formats, 'mlx')
+      env:
+        HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+      run: |
+        FORMAT="mlx-fp"
+        if [ "${{ github.event.inputs.quantize }}" = "8" ]; then
+          FORMAT="mlx-8bit"
+        fi
+        if [ "${{ github.event.inputs.quantize }}" = "4" ]; then
+          FORMAT="mlx-4bit"
+        fi
+        python -m openmed.core.hf_publish \
+          --model "${{ github.event.inputs.model_id }}" \
+          --artifact-dir publish-artifacts/mlx-output \
+          --format "$FORMAT" \
+          --manifest models.jsonl
+
+    - name: Download CoreML model
+      if: contains(github.event.inputs.formats, 'coreml')
+      uses: actions/download-artifact@v4
+      with:
+        name: coreml-model
+        path: publish-artifacts/coreml-output
+
+    - name: Publish CoreML model
+      if: contains(github.event.inputs.formats, 'coreml')
+      env:
+        HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+      run: |
+        python -m openmed.core.hf_publish \
+          --model "${{ github.event.inputs.model_id }}" \
+          --artifact-dir publish-artifacts/coreml-output \
+          --format coreml \
+          --manifest models.jsonl
+
+    - name: Upload publish manifest snapshot
+      uses: actions/upload-artifact@v4
+      with:
+        name: published-model-manifest
+        path: models.jsonl

--- a/openmed/core/hf_publish.py
+++ b/openmed/core/hf_publish.py
@@ -1,0 +1,478 @@
+"""Publish converted OpenMed model artifacts to the Hugging Face Hub."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_ORG = "OpenMed"
+DEFAULT_TOKEN_ENV = "HF_WRITE_TOKEN"
+DEFAULT_MANIFEST_PATH = Path("models.jsonl")
+
+_VERSION_SUFFIX_RE = re.compile(r"-v\d+(?=$|-)")
+_SAFE_REPO_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class HfPublishError(RuntimeError):
+    """Raised when a model artifact cannot be published safely."""
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """Result for one artifact publish attempt."""
+
+    repo_id: str
+    artifact_dir: Path
+    manifest_row: dict[str, Any]
+    skipped: bool = False
+
+
+def read_hf_token(env_var: str = DEFAULT_TOKEN_ENV) -> str:
+    """Read the write token from *env_var* without logging or exposing it."""
+
+    token = os.environ.get(env_var)
+    if not token:
+        raise HfPublishError(
+            f"{env_var} is required to publish model artifacts. "
+            "Configure it as a protected CI secret before enabling publish."
+        )
+    return token
+
+
+def target_repo_id(
+    source_model_id: str,
+    format_name: str,
+    *,
+    org: str = DEFAULT_ORG,
+    version: int = 1,
+) -> str:
+    """Return the OpenMed target repo id for a source model and artifact format."""
+
+    repo_name = _source_repo_name(source_model_id)
+    if not _VERSION_SUFFIX_RE.search(repo_name):
+        repo_name = f"{repo_name}-v{version}"
+
+    suffix = _format_repo_suffix(format_name)
+    if suffix and not repo_name.endswith(f"-{suffix}"):
+        repo_name = f"{repo_name}-{suffix}"
+
+    return f"{org}/{repo_name}"
+
+
+def build_manifest_row(
+    *,
+    repo_id: str,
+    source_model_id: str,
+    artifact_dir: str | Path,
+    format_name: str,
+    released: str | None = None,
+) -> dict[str, Any]:
+    """Build a models.jsonl-compatible row for a published artifact."""
+
+    artifact_dir = Path(artifact_dir)
+    config = _read_optional_json(artifact_dir / "config.json")
+    labels = _canonical_labels(repo_id, config)
+    released = released or datetime.now(timezone.utc).date().isoformat()
+    artifact_hash = artifact_sha256(artifact_dir)
+    reproducibility_hash = _reproducibility_hash(
+        repo_id=repo_id,
+        source_model_id=source_model_id,
+        format_name=format_name,
+        artifact_hash=artifact_hash,
+    )
+
+    if not _SHA256_RE.fullmatch(reproducibility_hash):
+        raise HfPublishError("invalid reproducibility hash generated for publish row")
+
+    return {
+        "repo_id": repo_id,
+        "family": _family(repo_id),
+        "task": str(config.get("_mlx_task") or "token-classification"),
+        "languages": _languages(repo_id),
+        "tier": _tier(repo_id),
+        "param_count": _param_count(repo_id),
+        "architecture": _architecture(repo_id, config),
+        "base_model": source_model_id,
+        "formats": [_manifest_format_name(format_name)],
+        "canonical_labels": labels,
+        "benchmark": {"dataset": None, "micro_f1": None, "recall": None},
+        "arxiv": None,
+        "license": "apache-2.0",
+        "reproducibility_hash": reproducibility_hash,
+        "released": released,
+    }
+
+
+def append_manifest_row(path: str | Path, row: dict[str, Any]) -> None:
+    """Append or replace *row* in a JSONL manifest keyed by repo_id."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    replaced = False
+
+    if path.exists():
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                existing = json.loads(line)
+                if existing.get("repo_id") == row["repo_id"]:
+                    rows.append(row)
+                    replaced = True
+                else:
+                    rows.append(existing)
+
+    if not replaced:
+        rows.append(row)
+
+    with path.open("w", encoding="utf-8") as handle:
+        for manifest_row in rows:
+            handle.write(json.dumps(manifest_row, sort_keys=False, separators=(",", ":")))
+            handle.write("\n")
+
+
+def publish_artifact(
+    *,
+    artifact_dir: str | Path,
+    source_model_id: str,
+    format_name: str,
+    repo_id: str | None = None,
+    org: str = DEFAULT_ORG,
+    version: int = 1,
+    token: str | None = None,
+    token_env: str = DEFAULT_TOKEN_ENV,
+    manifest_path: str | Path | None = None,
+    api: Any | None = None,
+    private: bool = False,
+    skip_existing: bool = True,
+    released: str | None = None,
+) -> PublishResult:
+    """Create a target repo, upload *artifact_dir*, and emit a manifest row."""
+
+    artifact_dir = Path(artifact_dir)
+    if not artifact_dir.exists():
+        raise HfPublishError(f"artifact directory does not exist: {artifact_dir}")
+
+    token = token or read_hf_token(token_env)
+    repo_id = repo_id or target_repo_id(
+        source_model_id,
+        format_name,
+        org=org,
+        version=version,
+    )
+    api = api or _load_hf_api()
+
+    skipped = False
+    if skip_existing and _repo_exists(api, repo_id=repo_id, token=token):
+        skipped = True
+    else:
+        api.create_repo(
+            repo_id=repo_id,
+            repo_type="model",
+            private=private,
+            exist_ok=True,
+            token=token,
+        )
+        api.upload_folder(
+            repo_id=repo_id,
+            repo_type="model",
+            folder_path=str(artifact_dir),
+            token=token,
+            commit_message=f"Publish {format_name} artifact",
+        )
+
+    row = build_manifest_row(
+        repo_id=repo_id,
+        source_model_id=source_model_id,
+        artifact_dir=artifact_dir,
+        format_name=format_name,
+        released=released,
+    )
+    if manifest_path is not None:
+        append_manifest_row(manifest_path, row)
+
+    return PublishResult(
+        repo_id=repo_id,
+        artifact_dir=artifact_dir,
+        manifest_row=row,
+        skipped=skipped,
+    )
+
+
+def artifact_sha256(path: str | Path) -> str:
+    """Return a deterministic sha256 digest for a file or directory tree."""
+
+    path = Path(path)
+    if not path.exists():
+        raise HfPublishError(f"artifact path does not exist: {path}")
+
+    digest = hashlib.sha256()
+    root = path if path.is_dir() else path.parent
+    paths = [path] if path.is_file() else sorted(p for p in path.rglob("*") if p.is_file())
+
+    for file_path in paths:
+        relative = file_path.relative_to(root).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        with file_path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        digest.update(b"\0")
+
+    return f"sha256:{digest.hexdigest()}"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Publish one converted OpenMed model artifact to the Hub.",
+    )
+    parser.add_argument("--model", required=True, help="Source model id")
+    parser.add_argument("--artifact-dir", required=True, help="Converted artifact directory")
+    parser.add_argument(
+        "--format",
+        required=True,
+        dest="format_name",
+        help="Published artifact format, such as mlx-fp, mlx-8bit, or coreml",
+    )
+    parser.add_argument("--repo-id", default=None, help="Explicit target repo id")
+    parser.add_argument("--org", default=DEFAULT_ORG, help="Target organization")
+    parser.add_argument("--version", type=int, default=1, help="Version suffix for new repos")
+    parser.add_argument(
+        "--manifest",
+        default=str(DEFAULT_MANIFEST_PATH),
+        help="JSONL manifest path to append or update",
+    )
+    parser.add_argument(
+        "--token-env",
+        default=DEFAULT_TOKEN_ENV,
+        help="Environment variable containing the write token",
+    )
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help="Create the target repo as private if it does not already exist",
+    )
+    parser.add_argument(
+        "--overwrite-existing",
+        action="store_true",
+        help="Upload into an existing target repo instead of skipping it",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    result = publish_artifact(
+        artifact_dir=args.artifact_dir,
+        source_model_id=args.model,
+        format_name=args.format_name,
+        repo_id=args.repo_id,
+        org=args.org,
+        version=args.version,
+        token_env=args.token_env,
+        manifest_path=args.manifest,
+        private=args.private,
+        skip_existing=not args.overwrite_existing,
+    )
+    action = "Skipped existing" if result.skipped else "Published"
+    print(f"{action} model artifact: {result.repo_id}")
+
+
+def _load_hf_api() -> Any:
+    try:
+        from huggingface_hub import HfApi
+    except ImportError as exc:
+        raise HfPublishError(
+            "huggingface-hub is required to publish model artifacts. "
+            "Install the hf extra before enabling publish."
+        ) from exc
+    return HfApi()
+
+
+def _repo_exists(api: Any, *, repo_id: str, token: str) -> bool:
+    try:
+        api.repo_info(repo_id=repo_id, repo_type="model", token=token)
+        return True
+    except Exception as exc:
+        if _is_not_found(exc):
+            return False
+        raise
+
+
+def _is_not_found(exc: Exception) -> bool:
+    if exc.__class__.__name__ == "RepositoryNotFoundError":
+        return True
+    if getattr(exc, "response", None) is not None:
+        status_code = getattr(exc.response, "status_code", None)
+        if status_code == 404:
+            return True
+    return getattr(exc, "status_code", None) == 404
+
+
+def _source_repo_name(source_model_id: str) -> str:
+    name = source_model_id.rstrip("/").rsplit("/", 1)[-1]
+    name = _SAFE_REPO_RE.sub("-", name).strip(".-_")
+    if not name:
+        raise HfPublishError(f"could not derive target repo name from {source_model_id!r}")
+    return name
+
+
+def _format_repo_suffix(format_name: str) -> str:
+    normalized = format_name.lower().replace("_", "-")
+    if normalized in {"mlx", "mlx-fp", "mlx-float", "mlx-float16"}:
+        return "mlx"
+    if normalized in {"mlx-8bit", "mlx-int8"}:
+        return "mlx-8bit"
+    if normalized in {"mlx-4bit", "mlx-int4"}:
+        return "mlx-4bit"
+    if normalized == "coreml":
+        return "coreml"
+    return normalized
+
+
+def _manifest_format_name(format_name: str) -> str:
+    normalized = format_name.lower().replace("_", "-")
+    if normalized in {"mlx", "mlx-fp", "mlx-float", "mlx-float16"}:
+        return "mlx-fp"
+    if normalized in {"mlx-8bit", "mlx-int8"}:
+        return "mlx-8bit"
+    if normalized in {"mlx-4bit", "mlx-int4"}:
+        return "mlx-4bit"
+    return normalized
+
+
+def _read_optional_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    return value if isinstance(value, dict) else {}
+
+
+def _family(repo_id: str) -> str:
+    lowered = repo_id.lower()
+    if "pii" in lowered or "privacy-filter" in lowered:
+        return "PII"
+    if "zero-shot" in lowered or "zeroshot" in lowered:
+        return "ZeroShot"
+    if "ner" in lowered:
+        return "NER"
+    return "General"
+
+
+def _languages(repo_id: str) -> list[str]:
+    lowered = repo_id.lower()
+    language_names = {
+        "arabic": "ar",
+        "dutch": "nl",
+        "french": "fr",
+        "german": "de",
+        "hindi": "hi",
+        "italian": "it",
+        "japanese": "ja",
+        "portuguese": "pt",
+        "spanish": "es",
+        "telugu": "te",
+        "turkish": "tr",
+    }
+    for name, code in language_names.items():
+        if name in lowered:
+            return [code]
+    if "pii" in lowered or "ner" in lowered or "privacy-filter" in lowered:
+        return ["en"]
+    return []
+
+
+def _tier(repo_id: str) -> str | None:
+    match = re.search(r"(?<![A-Za-z])(TinyMed|Tiny|Small|Base|Medium|Large|XLarge)(?![A-Za-z])", repo_id)
+    if not match:
+        return None
+    value = match.group(1)
+    return "Tiny" if value == "TinyMed" else value
+
+
+def _param_count(repo_id: str) -> int | None:
+    matches = list(re.finditer(r"(?P<value>\d+(?:\.\d+)?)(?P<unit>[mMbB])", repo_id))
+    if not matches:
+        return None
+    match = matches[-1]
+    multiplier = 1_000_000_000 if match.group("unit").lower() == "b" else 1_000_000
+    return int(float(match.group("value")) * multiplier)
+
+
+def _architecture(repo_id: str, config: dict[str, Any]) -> str | None:
+    model_type = config.get("_mlx_model_type") or config.get("model_type")
+    if isinstance(model_type, str) and model_type:
+        return model_type
+
+    lowered = repo_id.lower()
+    for name in (
+        "deberta-v2",
+        "xlm-roberta",
+        "modernbert",
+        "distilbert",
+        "eurobert",
+        "roberta",
+        "bert",
+        "gliner",
+        "t5",
+        "qwen",
+        "bge",
+        "e5",
+    ):
+        if name.replace("-", "") in lowered.replace("-", ""):
+            return name
+    return None
+
+
+def _canonical_labels(repo_id: str, config: dict[str, Any]) -> list[str]:
+    id2label = config.get("id2label")
+    if not isinstance(id2label, dict):
+        return []
+
+    labels: list[str] = []
+    for value in id2label.values():
+        if not isinstance(value, str):
+            continue
+        label = value
+        if label.startswith(("B-", "I-")):
+            label = label[2:]
+        if label == "O" or not label:
+            continue
+        if label not in labels:
+            labels.append(label)
+    return labels
+
+
+def _reproducibility_hash(
+    *,
+    repo_id: str,
+    source_model_id: str,
+    format_name: str,
+    artifact_hash: str,
+) -> str:
+    payload = json.dumps(
+        {
+            "repo_id": repo_id,
+            "source_model_id": source_model_id,
+            "format": _manifest_format_name(format_name),
+            "artifact_hash": artifact_hash,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"sha256:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
+
+
+if __name__ == "__main__":
+    main()

--- a/openmed/coreml/convert.py
+++ b/openmed/coreml/convert.py
@@ -17,6 +17,8 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from openmed.core.hf_publish import publish_artifact
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,6 +28,14 @@ def convert(
     max_seq_length: int = 512,
     compute_precision: str = "float16",
     cache_dir: Optional[str] = None,
+    publish_to_hub: bool = False,
+    publish_repo_id: str | None = None,
+    publish_org: str = "OpenMed",
+    publish_version: int = 1,
+    publish_manifest_path: str | Path | None = None,
+    publish_token_env: str = "HF_WRITE_TOKEN",
+    publish_private: bool = False,
+    publish_overwrite_existing: bool = False,
 ) -> Path:
     """Convert a HuggingFace token-classification model to CoreML.
 
@@ -153,6 +163,23 @@ def convert(
         json.dump({str(k): v for k, v in id2label.items()}, f, indent=2)
 
     logger.info("CoreML model saved to %s", output_path)
+    if publish_to_hub:
+        result = publish_artifact(
+            artifact_dir=output_path,
+            source_model_id=model_id,
+            format_name="coreml",
+            repo_id=publish_repo_id,
+            org=publish_org,
+            version=publish_version,
+            token_env=publish_token_env,
+            manifest_path=publish_manifest_path,
+            private=publish_private,
+            skip_existing=not publish_overwrite_existing,
+        )
+        if result.skipped:
+            logger.info("Skipped existing Hub repo %s", result.repo_id)
+        else:
+            logger.info("Published CoreML artifact to %s", result.repo_id)
     return output_path
 
 
@@ -180,6 +207,47 @@ def main():
         "--cache-dir", default=None,
         help="HuggingFace model cache directory",
     )
+    parser.add_argument(
+        "--publish-to-hub",
+        action="store_true",
+        help="Publish the converted artifact after a successful conversion",
+    )
+    parser.add_argument(
+        "--publish-repo-id",
+        default=None,
+        help="Explicit target repo id for publishing",
+    )
+    parser.add_argument(
+        "--publish-org",
+        default="OpenMed",
+        help="Target organization for derived publish repo ids",
+    )
+    parser.add_argument(
+        "--publish-version",
+        type=int,
+        default=1,
+        help="Version suffix used when the source repo is not already versioned",
+    )
+    parser.add_argument(
+        "--publish-manifest",
+        default=None,
+        help="JSONL manifest path to append or update after publishing",
+    )
+    parser.add_argument(
+        "--publish-token-env",
+        default="HF_WRITE_TOKEN",
+        help="Environment variable containing the Hub write token",
+    )
+    parser.add_argument(
+        "--publish-private",
+        action="store_true",
+        help="Create the target repo as private when it does not exist",
+    )
+    parser.add_argument(
+        "--publish-overwrite-existing",
+        action="store_true",
+        help="Upload into an existing target repo instead of skipping it",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
@@ -189,6 +257,14 @@ def main():
         max_seq_length=args.max_seq_length,
         compute_precision=args.precision,
         cache_dir=args.cache_dir,
+        publish_to_hub=args.publish_to_hub,
+        publish_repo_id=args.publish_repo_id,
+        publish_org=args.publish_org,
+        publish_version=args.publish_version,
+        publish_manifest_path=args.publish_manifest,
+        publish_token_env=args.publish_token_env,
+        publish_private=args.publish_private,
+        publish_overwrite_existing=args.publish_overwrite_existing,
     )
 
 

--- a/openmed/mlx/convert.py
+++ b/openmed/mlx/convert.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
+from openmed.core.hf_publish import publish_artifact
 from openmed.mlx.artifact import find_tokenizer_files, write_manifest
 from openmed.mlx.models import (
     build_model,
@@ -550,13 +551,21 @@ def convert(
     output_dir: str | Path,
     quantize_bits: int | None = None,
     cache_dir: str | None = None,
+    publish_to_hub: bool = False,
+    publish_repo_id: str | None = None,
+    publish_org: str = "OpenMed",
+    publish_version: int = 1,
+    publish_manifest_path: str | Path | None = None,
+    publish_token_env: str = "HF_WRITE_TOKEN",
+    publish_private: bool = False,
+    publish_overwrite_existing: bool = False,
 ) -> Path:
     """End-to-end: download a model, remap it, and save an OpenMed MLX artifact."""
     weights, config = convert_weights(model_id, cache_dir=cache_dir)
 
     try:
         import mlx.core  # noqa: F401
-        return save_mlx_model(
+        output_path = save_mlx_model(
             weights,
             config,
             output_dir,
@@ -570,13 +579,39 @@ def convert(
                 "MLX not available — skipping quantization. "
                 "Install mlx for quantization support."
             )
-        return save_numpy_model(
+        output_path = save_numpy_model(
             weights,
             config,
             output_dir,
             source_model_id=model_id,
             cache_dir=cache_dir,
         )
+
+    if publish_to_hub:
+        result = publish_artifact(
+            artifact_dir=output_path,
+            source_model_id=model_id,
+            format_name=_publish_format(quantize_bits),
+            repo_id=publish_repo_id,
+            org=publish_org,
+            version=publish_version,
+            token_env=publish_token_env,
+            manifest_path=publish_manifest_path,
+            private=publish_private,
+            skip_existing=not publish_overwrite_existing,
+        )
+        if result.skipped:
+            logger.info("Skipped existing Hub repo %s", result.repo_id)
+        else:
+            logger.info("Published MLX artifact to %s", result.repo_id)
+
+    return output_path
+
+
+def _publish_format(quantize_bits: int | None) -> str:
+    if quantize_bits is None:
+        return "mlx-fp"
+    return f"mlx-{quantize_bits}bit"
 
 
 def main() -> None:
@@ -605,10 +640,64 @@ def main() -> None:
         default=None,
         help="Hugging Face cache directory",
     )
+    parser.add_argument(
+        "--publish-to-hub",
+        action="store_true",
+        help="Publish the converted artifact after a successful conversion",
+    )
+    parser.add_argument(
+        "--publish-repo-id",
+        default=None,
+        help="Explicit target repo id for publishing",
+    )
+    parser.add_argument(
+        "--publish-org",
+        default="OpenMed",
+        help="Target organization for derived publish repo ids",
+    )
+    parser.add_argument(
+        "--publish-version",
+        type=int,
+        default=1,
+        help="Version suffix used when the source repo is not already versioned",
+    )
+    parser.add_argument(
+        "--publish-manifest",
+        default=None,
+        help="JSONL manifest path to append or update after publishing",
+    )
+    parser.add_argument(
+        "--publish-token-env",
+        default="HF_WRITE_TOKEN",
+        help="Environment variable containing the Hub write token",
+    )
+    parser.add_argument(
+        "--publish-private",
+        action="store_true",
+        help="Create the target repo as private when it does not exist",
+    )
+    parser.add_argument(
+        "--publish-overwrite-existing",
+        action="store_true",
+        help="Upload into an existing target repo instead of skipping it",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
-    convert(args.model, args.output, args.quantize, args.cache_dir)
+    convert(
+        args.model,
+        args.output,
+        args.quantize,
+        args.cache_dir,
+        publish_to_hub=args.publish_to_hub,
+        publish_repo_id=args.publish_repo_id,
+        publish_org=args.publish_org,
+        publish_version=args.publish_version,
+        publish_manifest_path=args.publish_manifest,
+        publish_token_env=args.publish_token_env,
+        publish_private=args.publish_private,
+        publish_overwrite_existing=args.publish_overwrite_existing,
+    )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ mlx = [
 
 coreml = [
   "coremltools>=8.0",
+  "huggingface-hub>=0.30",
   "torch>=2.0",
   "transformers>=4.50",
 ]

--- a/tests/unit/core/test_manifest_schema.py
+++ b/tests/unit/core/test_manifest_schema.py
@@ -109,7 +109,6 @@ def test_only_manifest_generator_lists_org_models():
     forbidden_patterns = (
         "from huggingface_hub import list_models",
         "model_info as",
-        "HfApi",
         ".list_models(",
     )
     offenders = []

--- a/tests/unit/mlx/test_hf_publish.py
+++ b/tests/unit/mlx/test_hf_publish.py
@@ -1,0 +1,157 @@
+"""Tests for publishing converted model artifacts."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+
+import pytest
+
+from openmed.core.hf_publish import (
+    HfPublishError,
+    append_manifest_row,
+    publish_artifact,
+    target_repo_id,
+)
+
+
+class RepositoryNotFoundError(Exception):
+    pass
+
+
+class FakeApi:
+    def __init__(self, *, exists: bool = False):
+        self.exists = exists
+        self.created = []
+        self.uploaded = []
+        self.info_calls = []
+
+    def repo_info(self, **kwargs):
+        self.info_calls.append(kwargs)
+        if not self.exists:
+            raise RepositoryNotFoundError("not found")
+        return object()
+
+    def create_repo(self, **kwargs):
+        self.created.append(kwargs)
+        self.exists = True
+
+    def upload_folder(self, **kwargs):
+        self.uploaded.append(kwargs)
+
+
+def _write_mlx_artifact(tmp_path):
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "config.json").write_text(
+        json.dumps(
+            {
+                "_mlx_task": "token-classification",
+                "_mlx_model_type": "deberta-v2",
+                "id2label": {"0": "O", "1": "B-PERSON", "2": "I-DATE"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact / "weights.safetensors").write_bytes(b"weights")
+    return artifact
+
+
+def test_target_repo_id_keeps_existing_version_and_adds_variant():
+    assert (
+        target_repo_id(
+            "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+            "mlx-fp",
+        )
+        == "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1-mlx"
+    )
+
+
+def test_target_repo_id_adds_version_before_8bit_variant():
+    assert (
+        target_repo_id("OpenMed/test-model", "mlx-8bit", version=2)
+        == "OpenMed/test-model-v2-mlx-8bit"
+    )
+
+
+def test_publish_artifact_creates_repo_uploads_folder_and_writes_manifest(tmp_path, monkeypatch):
+    artifact = _write_mlx_artifact(tmp_path)
+    manifest = tmp_path / "models.jsonl"
+    fake_api = FakeApi()
+    monkeypatch.setenv("HF_WRITE_TOKEN", "secret-token")
+
+    result = publish_artifact(
+        artifact_dir=artifact,
+        source_model_id="OpenMed/test-model",
+        format_name="mlx-fp",
+        manifest_path=manifest,
+        api=fake_api,
+        released="2026-06-14",
+    )
+
+    assert result.repo_id == "OpenMed/test-model-v1-mlx"
+    assert result.skipped is False
+    assert fake_api.created[0]["repo_id"] == result.repo_id
+    assert fake_api.created[0]["token"] == "secret-token"
+    assert fake_api.uploaded[0]["folder_path"] == str(artifact)
+    assert fake_api.uploaded[0]["token"] == "secret-token"
+
+    rows = [json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines()]
+    assert rows == [result.manifest_row]
+    assert rows[0]["repo_id"] == "OpenMed/test-model-v1-mlx"
+    assert rows[0]["formats"] == ["mlx-fp"]
+    assert rows[0]["canonical_labels"] == ["PERSON", "DATE"]
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", rows[0]["reproducibility_hash"])
+    assert "secret-token" not in json.dumps(rows[0])
+
+
+def test_publish_artifact_skips_existing_repo_without_upload(tmp_path, monkeypatch):
+    artifact = _write_mlx_artifact(tmp_path)
+    fake_api = FakeApi(exists=True)
+    monkeypatch.setenv("HF_WRITE_TOKEN", "secret-token")
+
+    result = publish_artifact(
+        artifact_dir=artifact,
+        source_model_id="OpenMed/test-model",
+        format_name="coreml",
+        api=fake_api,
+    )
+
+    assert result.skipped is True
+    assert fake_api.created == []
+    assert fake_api.uploaded == []
+    assert result.repo_id == "OpenMed/test-model-v1-coreml"
+
+
+def test_publish_artifact_errors_when_token_is_missing(tmp_path, monkeypatch):
+    artifact = _write_mlx_artifact(tmp_path)
+    monkeypatch.delenv("HF_WRITE_TOKEN", raising=False)
+
+    with pytest.raises(HfPublishError, match="HF_WRITE_TOKEN is required"):
+        publish_artifact(
+            artifact_dir=artifact,
+            source_model_id="OpenMed/test-model",
+            format_name="mlx-fp",
+            api=FakeApi(),
+        )
+
+
+def test_manifest_append_replaces_existing_repo_row(tmp_path):
+    manifest = tmp_path / "models.jsonl"
+    first = {"repo_id": "OpenMed/model", "formats": ["mlx-fp"]}
+    second = {"repo_id": "OpenMed/model", "formats": ["coreml"]}
+
+    append_manifest_row(manifest, first)
+    append_manifest_row(manifest, second)
+
+    rows = [json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines()]
+    assert rows == [second]
+
+
+def test_conversion_modules_expose_publish_options():
+    from openmed.coreml.convert import convert as convert_coreml
+    from openmed.mlx.convert import convert as convert_mlx
+
+    assert "publish_to_hub" in inspect.signature(convert_mlx).parameters
+    assert "publish_to_hub" in inspect.signature(convert_coreml).parameters

--- a/tests/unit/test_convert_workflow_hf_token.py
+++ b/tests/unit/test_convert_workflow_hf_token.py
@@ -31,6 +31,20 @@ def test_convert_workflow_fails_publish_job_when_hf_token_is_missing():
     assert 'echo "$HF_WRITE_TOKEN' not in workflow
 
 
+def test_convert_workflow_publishes_downloaded_conversion_artifacts():
+    workflow = CONVERT_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "actions/download-artifact@v4" in workflow
+    assert "name: mlx-model" in workflow
+    assert "name: coreml-model" in workflow
+    assert "python -m openmed.core.hf_publish" in workflow
+    assert "--artifact-dir publish-artifacts/mlx-output" in workflow
+    assert "--artifact-dir publish-artifacts/coreml-output" in workflow
+    assert "--format \"$FORMAT\"" in workflow
+    assert "--format coreml" in workflow
+    assert "published-model-manifest" in workflow
+
+
 def test_hf_token_policy_documents_scope_storage_rotation_and_revocation():
     policy = HF_TOKEN_POLICY.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Closes #89.

Adds a shared HF publish helper for converted MLX and CoreML artifacts, wires the conversion CLIs and workflow to publish successful artifacts behind the protected token gate, and emits a models.jsonl manifest row with formats and reproducibility hashes. The publish path creates target repos safely, skips existing repos by default, and keeps tokens out of logs.

Validation:
- .venv/bin/python -m pytest tests/ -q