### PR TITLE
Generate model cards from the manifest at publish time

### DIFF
--- a/openmed/core/hf_publish.py
+++ b/openmed/core/hf_publish.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from openmed.core.baseline import update_baseline_entry
+from openmed.core.model_card import DEFAULT_ARXIV, write_model_card
 from openmed.core.repro_hash import compute_reproducibility_hash, resolve_git_sha
 
 
@@ -118,7 +119,7 @@ def build_manifest_row(
         "formats": [manifest_format],
         "canonical_labels": labels,
         "benchmark": {"dataset": None, "micro_f1": None, "recall": None},
-        "arxiv": None,
+        "arxiv": DEFAULT_ARXIV,
         "license": "apache-2.0",
         "reproducibility_hash": reproducibility_hash,
         "released": released,
@@ -190,6 +191,17 @@ def publish_artifact(
     )
     api = api or _load_hf_api()
     resolved_git_sha = git_sha or resolve_git_sha()
+    row = build_manifest_row(
+        repo_id=repo_id,
+        source_model_id=source_model_id,
+        artifact_dir=artifact_dir,
+        format_name=format_name,
+        released=released,
+        recipe=recipe,
+        data_manifest=data_manifest,
+        git_sha=resolved_git_sha,
+    )
+    write_model_card(artifact_dir / "README.md", row)
 
     skipped = False
     if skip_existing and _repo_exists(api, repo_id=repo_id, token=token):
@@ -210,16 +222,6 @@ def publish_artifact(
             commit_message=f"Publish {format_name} artifact",
         )
 
-    row = build_manifest_row(
-        repo_id=repo_id,
-        source_model_id=source_model_id,
-        artifact_dir=artifact_dir,
-        format_name=format_name,
-        released=released,
-        recipe=recipe,
-        data_manifest=data_manifest,
-        git_sha=resolved_git_sha,
-    )
     if manifest_path is not None:
         append_manifest_row(manifest_path, row)
     if baseline_path is not None:
@@ -262,6 +264,8 @@ def artifact_sha256(path: str | Path) -> str:
 
     for file_path in paths:
         relative = file_path.relative_to(root).as_posix()
+        if relative == "README.md":
+            continue
         digest.update(relative.encode("utf-8"))
         digest.update(b"\0")
         with file_path.open("rb") as handle:

--- a/openmed/core/model_card.py
+++ b/openmed/core/model_card.py
@@ -1,0 +1,125 @@
+"""Render OpenMed model cards from manifest rows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_ARXIV = "2508.01630"
+
+
+def render_model_card(row: dict[str, Any]) -> str:
+    """Return a README.md model card for one manifest row."""
+
+    repo_id = _string(row.get("repo_id"), "OpenMed/model")
+    title = repo_id.rsplit("/", 1)[-1]
+    benchmark = row.get("benchmark") if isinstance(row.get("benchmark"), dict) else {}
+    formats = _list(row.get("formats"))
+    languages = _list(row.get("languages"))
+    labels = _list(row.get("canonical_labels"))
+    arxiv = _string(row.get("arxiv"), DEFAULT_ARXIV)
+    license_name = _string(row.get("license"), "Not specified")
+    task = _string(row.get("task"), "unknown")
+
+    lines = [
+        "---",
+        f"license: {license_name}",
+        f"pipeline_tag: {task}",
+        "library_name: openmed",
+        "tags:",
+        "- openmed",
+        "- medical-nlp",
+        "---",
+        "",
+        f"# {title}",
+        "",
+        "This model card is rendered from the OpenMed model manifest. Update `models.jsonl` and rerun the publish step instead of editing this file directly.",
+        "",
+        "## Manifest Summary",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Repository | `{repo_id}` |",
+        f"| Family | {_string(row.get('family'), 'Not specified')} |",
+        f"| Task | {task} |",
+        f"| Languages | {_comma_or_unspecified(languages)} |",
+        f"| Tier | {_string(row.get('tier'), 'Not specified')} |",
+        f"| Parameters | {_format_param_count(row.get('param_count'))} |",
+        f"| Architecture | {_string(row.get('architecture'), 'Not specified')} |",
+        f"| Base model | {_string(row.get('base_model'), 'Not specified')} |",
+        f"| Formats | {_comma_or_unspecified(formats)} |",
+        f"| License | {license_name} |",
+        f"| arXiv | {_arxiv_link(arxiv)} |",
+        f"| Reproducibility hash | `{_string(row.get('reproducibility_hash'), 'Not specified')}` |",
+        f"| Released | {_string(row.get('released'), 'Not specified')} |",
+        "",
+        "## Benchmark",
+        "",
+        "| Dataset | Micro F1 | Recall |",
+        "|---|---:|---:|",
+        f"| {_string(benchmark.get('dataset'), 'Not reported')} | {_metric(benchmark.get('micro_f1'))} | {_metric(benchmark.get('recall'))} |",
+        "",
+        "## Canonical Labels",
+        "",
+        _labels_block(labels),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def write_model_card(path: str | Path, row: dict[str, Any]) -> Path:
+    """Write a rendered model card to *path* and return the path."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_model_card(row), encoding="utf-8")
+    return path
+
+
+def _string(value: Any, default: str) -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _comma_or_unspecified(values: list[str]) -> str:
+    return ", ".join(values) if values else "Not specified"
+
+
+def _format_param_count(value: Any) -> str:
+    if not isinstance(value, int) or value <= 0:
+        return "Not specified"
+    if value >= 1_000_000_000:
+        compact = f"{value / 1_000_000_000:g}B"
+    elif value >= 1_000_000:
+        compact = f"{value / 1_000_000:g}M"
+    elif value >= 1_000:
+        compact = f"{value / 1_000:g}K"
+    else:
+        compact = str(value)
+    return f"{compact} ({value:,})"
+
+
+def _metric(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value):.4f}"
+    return "Not reported"
+
+
+def _arxiv_link(value: str) -> str:
+    if value == "Not specified":
+        return value
+    return f"[arXiv:{value}](https://arxiv.org/abs/{value})"
+
+
+def _labels_block(labels: list[str]) -> str:
+    if not labels:
+        return "Not specified."
+    return ", ".join(f"`{label}`" for label in labels)

--- a/tests/fixtures/model_card_expected.md
+++ b/tests/fixtures/model_card_expected.md
@@ -1,0 +1,40 @@
+---
+license: apache-2.0
+pipeline_tag: token-classification
+library_name: openmed
+tags:
+- openmed
+- medical-nlp
+---
+
+# OpenMed-PII-Turkish-SuperClinical-Small-44M-v1-mlx
+
+This model card is rendered from the OpenMed model manifest. Update `models.jsonl` and rerun the publish step instead of editing this file directly.
+
+## Manifest Summary
+
+| Field | Value |
+|---|---|
+| Repository | `OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1-mlx` |
+| Family | PII |
+| Task | token-classification |
+| Languages | tr |
+| Tier | Small |
+| Parameters | 44M (44,000,000) |
+| Architecture | deberta-v2 |
+| Base model | OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1 |
+| Formats | mlx-fp, mlx-8bit |
+| License | apache-2.0 |
+| arXiv | [arXiv:2508.01630](https://arxiv.org/abs/2508.01630) |
+| Reproducibility hash | `sha256:1111111111111111111111111111111111111111111111111111111111111111` |
+| Released | 2026-06-14 |
+
+## Benchmark
+
+| Dataset | Micro F1 | Recall |
+|---|---:|---:|
+| openmed-golden-pii | 0.9823 | 0.9910 |
+
+## Canonical Labels
+
+`PERSON`, `DATE`, `ID_NUM`

--- a/tests/unit/core/test_model_card.py
+++ b/tests/unit/core/test_model_card.py
@@ -1,0 +1,62 @@
+"""Tests for manifest-rendered model cards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openmed.core.model_card import render_model_card, write_model_card
+
+
+ROOT = Path(__file__).resolve().parents[3]
+GOLDEN = ROOT / "tests" / "fixtures" / "model_card_expected.md"
+
+
+def _fixture_row():
+    return {
+        "repo_id": "OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1-mlx",
+        "family": "PII",
+        "task": "token-classification",
+        "languages": ["tr"],
+        "tier": "Small",
+        "param_count": 44_000_000,
+        "architecture": "deberta-v2",
+        "base_model": "OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1",
+        "formats": ["mlx-fp", "mlx-8bit"],
+        "canonical_labels": ["PERSON", "DATE", "ID_NUM"],
+        "benchmark": {
+            "dataset": "openmed-golden-pii",
+            "micro_f1": 0.9823,
+            "recall": 0.991,
+        },
+        "arxiv": "2508.01630",
+        "license": "apache-2.0",
+        "reproducibility_hash": (
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        ),
+        "released": "2026-06-14",
+    }
+
+
+def test_render_model_card_matches_golden_fixture():
+    assert render_model_card(_fixture_row()) == GOLDEN.read_text(encoding="utf-8")
+
+
+def test_render_model_card_contains_manifest_release_fields():
+    card = render_model_card(_fixture_row())
+
+    assert "| Tier | Small |" in card
+    assert "| Parameters | 44M (44,000,000) |" in card
+    assert "| Formats | mlx-fp, mlx-8bit |" in card
+    assert "| openmed-golden-pii | 0.9823 | 0.9910 |" in card
+    assert "[arXiv:2508.01630]" in card
+    assert "| License | apache-2.0 |" in card
+    assert _fixture_row()["reproducibility_hash"] in card
+
+
+def test_write_model_card_writes_readme_from_row(tmp_path):
+    target = tmp_path / "README.md"
+
+    path = write_model_card(target, _fixture_row())
+
+    assert path == target
+    assert target.read_text(encoding="utf-8") == GOLDEN.read_text(encoding="utf-8")

--- a/tests/unit/mlx/test_hf_publish.py
+++ b/tests/unit/mlx/test_hf_publish.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 import json
 import re
+from pathlib import Path
 
 import pytest
 
@@ -25,6 +26,7 @@ class FakeApi:
         self.exists = exists
         self.created = []
         self.uploaded = []
+        self.uploaded_cards = []
         self.info_calls = []
 
     def repo_info(self, **kwargs):
@@ -39,6 +41,9 @@ class FakeApi:
 
     def upload_folder(self, **kwargs):
         self.uploaded.append(kwargs)
+        self.uploaded_cards.append(
+            (Path(kwargs["folder_path"]) / "README.md").read_text(encoding="utf-8")
+        )
 
 
 def _write_mlx_artifact(tmp_path):
@@ -96,11 +101,15 @@ def test_publish_artifact_creates_repo_uploads_folder_and_writes_manifest(tmp_pa
     assert fake_api.created[0]["token"] == "secret-token"
     assert fake_api.uploaded[0]["folder_path"] == str(artifact)
     assert fake_api.uploaded[0]["token"] == "secret-token"
+    assert (artifact / "README.md").exists()
+    assert "OpenMed/test-model-v1-mlx" in fake_api.uploaded_cards[0]
+    assert "sha256:" in fake_api.uploaded_cards[0]
 
     rows = [json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines()]
     assert rows == [result.manifest_row]
     assert rows[0]["repo_id"] == "OpenMed/test-model-v1-mlx"
     assert rows[0]["formats"] == ["mlx-fp"]
+    assert rows[0]["arxiv"] == "2508.01630"
     assert rows[0]["canonical_labels"] == ["PERSON", "DATE"]
     assert re.fullmatch(r"sha256:[0-9a-f]{64}", rows[0]["reproducibility_hash"])
     assert "secret-token" not in json.dumps(rows[0])
@@ -121,6 +130,7 @@ def test_publish_artifact_skips_existing_repo_without_upload(tmp_path, monkeypat
     assert result.skipped is True
     assert fake_api.created == []
     assert fake_api.uploaded == []
+    assert (artifact / "README.md").exists()
     assert result.repo_id == "OpenMed/test-model-v1-coreml"
 
 


### PR DESCRIPTION
Closes #93.

Adds a manifest-driven model card renderer and wires the publish step to write README.md before uploading model artifacts. The card includes tier, parameter count, formats, benchmark metrics, arXiv reference, license, and reproducibility hash from the manifest row, with a golden fixture covering the rendered output.

Validation:
- .venv/bin/python -m pytest tests/ -q