### PR TITLE
Add the last-green baseline store and reproducibility hash

### DIFF
--- a/.github/workflows/convert-models.yml
+++ b/.github/workflows/convert-models.yml
@@ -162,7 +162,9 @@ jobs:
           --model "${{ github.event.inputs.model_id }}" \
           --artifact-dir publish-artifacts/mlx-output \
           --format "$FORMAT" \
-          --manifest models.jsonl
+          --manifest models.jsonl \
+          --baseline gates/baseline.json \
+          --git-sha "${{ github.sha }}"
 
     - name: Download CoreML model
       if: contains(github.event.inputs.formats, 'coreml')
@@ -180,10 +182,14 @@ jobs:
           --model "${{ github.event.inputs.model_id }}" \
           --artifact-dir publish-artifacts/coreml-output \
           --format coreml \
-          --manifest models.jsonl
+          --manifest models.jsonl \
+          --baseline gates/baseline.json \
+          --git-sha "${{ github.sha }}"
 
     - name: Upload publish manifest snapshot
       uses: actions/upload-artifact@v4
       with:
         name: published-model-manifest
-        path: models.jsonl
+        path: |
+          models.jsonl
+          gates/baseline.json

--- a/gates/baseline.json
+++ b/gates/baseline.json
@@ -1,0 +1,21 @@
+{
+  "entries": {
+    "pii::small::mlx-fp": {
+      "family": "PII",
+      "format": "mlx-fp",
+      "key": "pii::small::mlx-fp",
+      "metrics": {
+        "dataset": null,
+        "micro_f1": null,
+        "recall": null
+      },
+      "released": "2026-04-14",
+      "repo_id": "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1-mlx",
+      "reproducibility_hash": "sha256:4818bdef580eb406f5cc665cc0892aefab1fd90c8743822d843dd48f135bde34",
+      "source_model_id": "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+      "tier": "Small",
+      "updated_at": "2026-04-14T00:00:00+00:00"
+    }
+  },
+  "schema_version": 1
+}

--- a/openmed/core/baseline.py
+++ b/openmed/core/baseline.py
@@ -1,0 +1,247 @@
+"""Last-green baseline store for release gates.
+
+The baseline JSON schema is intentionally small and versioned:
+
+```
+{
+  "schema_version": 1,
+  "entries": {
+    "<family>::<tier>::<format>": {
+      "key": "<family>::<tier>::<format>",
+      "family": "PII",
+      "tier": "Small",
+      "format": "mlx-fp",
+      "metrics": {"micro_f1": 0.98},
+      "reproducibility_hash": "sha256:...",
+      "repo_id": "OpenMed/...",
+      "released": "2026-06-14"
+    }
+  }
+}
+```
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+
+BASELINE_SCHEMA_VERSION = 1
+BASELINE_PATH = Path(__file__).resolve().parents[2] / "gates" / "baseline.json"
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+class BaselineError(ValueError):
+    """Raised when the baseline store is malformed."""
+
+
+class BaselineMiss(LookupError):
+    """Raised when a requested baseline key is not present."""
+
+
+def baseline_key(family: str, tier: str | None, format_name: str) -> str:
+    """Return the stable store key for ``(family, tier, format)``."""
+
+    return "::".join(
+        (
+            _normalise_key_part(family),
+            _normalise_key_part(tier or "none"),
+            _normalise_key_part(format_name),
+        )
+    )
+
+
+def load_baseline_store(path: str | Path = BASELINE_PATH) -> dict[str, Any]:
+    """Load and validate a baseline store JSON document."""
+
+    baseline_path = Path(path)
+    with baseline_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    validate_baseline_store(payload)
+    return payload
+
+
+def write_baseline_store(
+    store: Mapping[str, Any],
+    path: str | Path = BASELINE_PATH,
+) -> Path:
+    """Validate and write a baseline store with deterministic formatting."""
+
+    payload = copy.deepcopy(dict(store))
+    validate_baseline_store(payload)
+    baseline_path = Path(path)
+    baseline_path.parent.mkdir(parents=True, exist_ok=True)
+    baseline_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return baseline_path
+
+
+def get_baseline(
+    family: str,
+    tier: str | None,
+    format_name: str,
+    *,
+    path: str | Path = BASELINE_PATH,
+    store: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Return a baseline entry for ``(family, tier, format)`` or ``None``."""
+
+    payload = copy.deepcopy(dict(store)) if store is not None else load_baseline_store(path)
+    validate_baseline_store(payload)
+    entry = payload["entries"].get(baseline_key(family, tier, format_name))
+    return copy.deepcopy(entry) if entry is not None else None
+
+
+def require_baseline(
+    family: str,
+    tier: str | None,
+    format_name: str,
+    *,
+    path: str | Path = BASELINE_PATH,
+    store: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a baseline entry or raise a clear miss for unknown keys."""
+
+    entry = get_baseline(
+        family,
+        tier,
+        format_name,
+        path=path,
+        store=store,
+    )
+    if entry is None:
+        key = baseline_key(family, tier, format_name)
+        raise BaselineMiss(f"No last-green baseline for key: {key}")
+    return entry
+
+
+def update_baseline_entry(
+    path: str | Path,
+    *,
+    family: str,
+    tier: str | None,
+    format_name: str,
+    metrics: Mapping[str, Any],
+    reproducibility_hash: str,
+    repo_id: str | None = None,
+    source_model_id: str | None = None,
+    released: str | None = None,
+    git_sha: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Update one last-green baseline entry without changing other keys."""
+
+    baseline_path = Path(path)
+    if baseline_path.exists():
+        store = load_baseline_store(baseline_path)
+    else:
+        store = {"schema_version": BASELINE_SCHEMA_VERSION, "entries": {}}
+
+    key = baseline_key(family, tier, format_name)
+    entry: dict[str, Any] = {
+        "key": key,
+        "family": family,
+        "tier": tier,
+        "format": format_name,
+        "metrics": _jsonable(metrics),
+        "reproducibility_hash": reproducibility_hash,
+        "updated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+    }
+    if repo_id is not None:
+        entry["repo_id"] = repo_id
+    if source_model_id is not None:
+        entry["source_model_id"] = source_model_id
+    if released is not None:
+        entry["released"] = released
+    if git_sha is not None:
+        entry["git_sha"] = git_sha
+    if metadata is not None:
+        entry["metadata"] = _jsonable(metadata)
+
+    store["entries"][key] = entry
+    write_baseline_store(store, baseline_path)
+    return copy.deepcopy(entry)
+
+
+def validate_baseline_store(store: Mapping[str, Any]) -> None:
+    """Validate the documented baseline store schema."""
+
+    if not isinstance(store, Mapping):
+        raise BaselineError("baseline store must be a JSON object")
+    if store.get("schema_version") != BASELINE_SCHEMA_VERSION:
+        raise BaselineError(
+            f"baseline schema_version must be {BASELINE_SCHEMA_VERSION}"
+        )
+    entries = store.get("entries")
+    if not isinstance(entries, Mapping):
+        raise BaselineError("baseline entries must be a JSON object")
+
+    for key, entry in entries.items():
+        _validate_entry(str(key), entry)
+
+
+def _validate_entry(key: str, entry: Any) -> None:
+    if not isinstance(entry, Mapping):
+        raise BaselineError(f"baseline entry {key!r} must be a JSON object")
+
+    required = {
+        "key",
+        "family",
+        "tier",
+        "format",
+        "metrics",
+        "reproducibility_hash",
+    }
+    missing = sorted(required - set(entry))
+    if missing:
+        raise BaselineError(f"baseline entry {key!r} missing fields: {missing}")
+
+    if entry["key"] != key:
+        raise BaselineError(f"baseline entry {key!r} has mismatched key")
+    expected_key = baseline_key(entry["family"], entry["tier"], entry["format"])
+    if expected_key != key:
+        raise BaselineError(f"baseline entry {key!r} does not match its dimensions")
+    if not isinstance(entry["family"], str) or not entry["family"]:
+        raise BaselineError(f"baseline entry {key!r} family must be non-empty")
+    if entry["tier"] is not None and not isinstance(entry["tier"], str):
+        raise BaselineError(f"baseline entry {key!r} tier must be string or null")
+    if not isinstance(entry["format"], str) or not entry["format"]:
+        raise BaselineError(f"baseline entry {key!r} format must be non-empty")
+    if not isinstance(entry["metrics"], Mapping):
+        raise BaselineError(f"baseline entry {key!r} metrics must be an object")
+    if not _SHA256_RE.fullmatch(str(entry["reproducibility_hash"])):
+        raise BaselineError(f"baseline entry {key!r} has invalid reproducibility_hash")
+    if "released" in entry and entry["released"] is not None:
+        if not isinstance(entry["released"], str) or not _DATE_RE.fullmatch(entry["released"]):
+            raise BaselineError(f"baseline entry {key!r} released must be YYYY-MM-DD")
+
+
+def _normalise_key_part(value: str) -> str:
+    return str(value).strip().lower().replace("_", "-") or "none"
+
+
+def _jsonable(value: Any) -> Any:
+    return json.loads(json.dumps(value, sort_keys=True))
+
+
+__all__ = [
+    "BASELINE_PATH",
+    "BASELINE_SCHEMA_VERSION",
+    "BaselineError",
+    "BaselineMiss",
+    "baseline_key",
+    "get_baseline",
+    "load_baseline_store",
+    "require_baseline",
+    "update_baseline_entry",
+    "validate_baseline_store",
+    "write_baseline_store",
+]

--- a/openmed/core/hf_publish.py
+++ b/openmed/core/hf_publish.py
@@ -12,6 +12,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from openmed.core.baseline import update_baseline_entry
+from openmed.core.repro_hash import compute_reproducibility_hash, resolve_git_sha
+
 
 DEFAULT_ORG = "OpenMed"
 DEFAULT_TOKEN_ENV = "HF_WRITE_TOKEN"
@@ -75,6 +78,9 @@ def build_manifest_row(
     artifact_dir: str | Path,
     format_name: str,
     released: str | None = None,
+    recipe: Any | None = None,
+    data_manifest: Any | None = None,
+    git_sha: str | None = None,
 ) -> dict[str, Any]:
     """Build a models.jsonl-compatible row for a published artifact."""
 
@@ -83,11 +89,18 @@ def build_manifest_row(
     labels = _canonical_labels(repo_id, config)
     released = released or datetime.now(timezone.utc).date().isoformat()
     artifact_hash = artifact_sha256(artifact_dir)
-    reproducibility_hash = _reproducibility_hash(
-        repo_id=repo_id,
-        source_model_id=source_model_id,
-        format_name=format_name,
-        artifact_hash=artifact_hash,
+    manifest_format = _manifest_format_name(format_name)
+    reproducibility_hash = compute_reproducibility_hash(
+        recipe=recipe or _default_repro_recipe(
+            repo_id=repo_id,
+            format_name=manifest_format,
+            artifact_hash=artifact_hash,
+        ),
+        data_manifest=data_manifest
+        if data_manifest is not None
+        else _default_data_manifest(artifact_dir, artifact_hash),
+        base_model=source_model_id,
+        git_sha=git_sha,
     )
 
     if not _SHA256_RE.fullmatch(reproducibility_hash):
@@ -102,7 +115,7 @@ def build_manifest_row(
         "param_count": _param_count(repo_id),
         "architecture": _architecture(repo_id, config),
         "base_model": source_model_id,
-        "formats": [_manifest_format_name(format_name)],
+        "formats": [manifest_format],
         "canonical_labels": labels,
         "benchmark": {"dataset": None, "micro_f1": None, "recall": None},
         "arxiv": None,
@@ -152,10 +165,15 @@ def publish_artifact(
     token: str | None = None,
     token_env: str = DEFAULT_TOKEN_ENV,
     manifest_path: str | Path | None = None,
+    baseline_path: str | Path | None = None,
+    baseline_metrics: dict[str, Any] | None = None,
     api: Any | None = None,
     private: bool = False,
     skip_existing: bool = True,
     released: str | None = None,
+    recipe: Any | None = None,
+    data_manifest: Any | None = None,
+    git_sha: str | None = None,
 ) -> PublishResult:
     """Create a target repo, upload *artifact_dir*, and emit a manifest row."""
 
@@ -171,6 +189,7 @@ def publish_artifact(
         version=version,
     )
     api = api or _load_hf_api()
+    resolved_git_sha = git_sha or resolve_git_sha()
 
     skipped = False
     if skip_existing and _repo_exists(api, repo_id=repo_id, token=token):
@@ -197,9 +216,30 @@ def publish_artifact(
         artifact_dir=artifact_dir,
         format_name=format_name,
         released=released,
+        recipe=recipe,
+        data_manifest=data_manifest,
+        git_sha=resolved_git_sha,
     )
     if manifest_path is not None:
         append_manifest_row(manifest_path, row)
+    if baseline_path is not None:
+        update_baseline_entry(
+            baseline_path,
+            family=str(row["family"]),
+            tier=row.get("tier"),
+            format_name=str(row["formats"][0]),
+            metrics=baseline_metrics if baseline_metrics is not None else row["benchmark"],
+            reproducibility_hash=str(row["reproducibility_hash"]),
+            repo_id=str(row["repo_id"]),
+            source_model_id=source_model_id,
+            released=str(row["released"]) if row.get("released") else None,
+            git_sha=resolved_git_sha,
+            metadata={
+                "architecture": row.get("architecture"),
+                "base_model": row.get("base_model"),
+                "task": row.get("task"),
+            },
+        )
 
     return PublishResult(
         repo_id=repo_id,
@@ -253,6 +293,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="JSONL manifest path to append or update",
     )
     parser.add_argument(
+        "--baseline",
+        default=None,
+        help="Optional last-green baseline JSON path to update after publish",
+    )
+    parser.add_argument(
+        "--baseline-metrics",
+        default=None,
+        help="Optional JSON object, or @file, with metrics for the baseline entry",
+    )
+    parser.add_argument(
+        "--git-sha",
+        default=None,
+        help="Git SHA to include in the reproducibility hash",
+    )
+    parser.add_argument(
         "--token-env",
         default=DEFAULT_TOKEN_ENV,
         help="Environment variable containing the write token",
@@ -281,8 +336,13 @@ def main(argv: list[str] | None = None) -> None:
         version=args.version,
         token_env=args.token_env,
         manifest_path=args.manifest,
+        baseline_path=args.baseline,
+        baseline_metrics=_parse_json_object_arg(args.baseline_metrics)
+        if args.baseline_metrics
+        else None,
         private=args.private,
         skip_existing=not args.overwrite_existing,
+        git_sha=args.git_sha,
     )
     action = "Skipped existing" if result.skipped else "Published"
     print(f"{action} model artifact: {result.repo_id}")
@@ -357,6 +417,37 @@ def _read_optional_json(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as handle:
         value = json.load(handle)
     return value if isinstance(value, dict) else {}
+
+
+def _parse_json_object_arg(value: str) -> dict[str, Any]:
+    source = value
+    if value.startswith("@"):
+        source = Path(value[1:]).read_text(encoding="utf-8")
+    payload = json.loads(source)
+    if not isinstance(payload, dict):
+        raise HfPublishError("--baseline-metrics must be a JSON object")
+    return payload
+
+
+def _default_repro_recipe(
+    *,
+    repo_id: str,
+    format_name: str,
+    artifact_hash: str,
+) -> dict[str, Any]:
+    return {
+        "artifact_hash": artifact_hash,
+        "format": format_name,
+        "repo_id": repo_id,
+    }
+
+
+def _default_data_manifest(artifact_dir: Path, artifact_hash: str) -> dict[str, Any]:
+    artifact_manifest = _read_optional_json(artifact_dir / "openmed-mlx.json")
+    return {
+        "artifact_hash": artifact_hash,
+        "artifact_manifest": artifact_manifest or None,
+    }
 
 
 def _family(repo_id: str) -> str:
@@ -452,26 +543,6 @@ def _canonical_labels(repo_id: str, config: dict[str, Any]) -> list[str]:
         if label not in labels:
             labels.append(label)
     return labels
-
-
-def _reproducibility_hash(
-    *,
-    repo_id: str,
-    source_model_id: str,
-    format_name: str,
-    artifact_hash: str,
-) -> str:
-    payload = json.dumps(
-        {
-            "repo_id": repo_id,
-            "source_model_id": source_model_id,
-            "format": _manifest_format_name(format_name),
-            "artifact_hash": artifact_hash,
-        },
-        sort_keys=True,
-        separators=(",", ":"),
-    )
-    return f"sha256:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
 
 
 if __name__ == "__main__":

--- a/openmed/core/repro_hash.py
+++ b/openmed/core/repro_hash.py
@@ -1,0 +1,104 @@
+"""Deterministic release reproducibility hashes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def compute_reproducibility_hash(
+    *,
+    recipe: Any,
+    data_manifest: Any,
+    base_model: Any,
+    git_sha: str | None = None,
+) -> str:
+    """Return ``sha256(recipe + data manifest + base model + git SHA)``."""
+
+    payload = {
+        "base_model": _normalise_component(base_model),
+        "data_manifest": _normalise_component(data_manifest),
+        "git_sha": git_sha or resolve_git_sha(),
+        "recipe": _normalise_component(recipe),
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def resolve_git_sha(*, cwd: str | Path | None = None) -> str:
+    """Resolve the current git SHA from CI environment or local checkout."""
+
+    env_sha = os.environ.get("GITHUB_SHA")
+    if env_sha:
+        return env_sha
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(cwd) if cwd is not None else None,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def _normalise_component(value: Any) -> Any:
+    if isinstance(value, Path):
+        return _path_component(value)
+    if isinstance(value, bytes):
+        return {"sha256": hashlib.sha256(value).hexdigest()}
+    if isinstance(value, Mapping):
+        return {
+            str(key): _normalise_component(value[key])
+            for key in sorted(value, key=str)
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalise_component(item) for item in value]
+    if isinstance(value, set):
+        return [_normalise_component(item) for item in sorted(value, key=repr)]
+    return value
+
+
+def _path_component(path: Path) -> dict[str, Any]:
+    if path.is_file():
+        return {
+            "path": path.as_posix(),
+            "sha256": _file_sha256(path),
+        }
+    if path.is_dir():
+        return {
+            "path": path.as_posix(),
+            "files": [
+                {
+                    "path": file_path.relative_to(path).as_posix(),
+                    "sha256": _file_sha256(file_path),
+                }
+                for file_path in sorted(path.rglob("*"))
+                if file_path.is_file()
+            ],
+        }
+    return {"path": path.as_posix(), "missing": True}
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+__all__ = ["compute_reproducibility_hash", "resolve_git_sha"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ openmed = "openmed.cli:main"
 [tool.hatch.build]
 include = [
   "openmed/**",
+  "gates/baseline.json",
   "models.jsonl",
   "README.md",
   "pyproject.toml"

--- a/tests/unit/core/test_baseline.py
+++ b/tests/unit/core/test_baseline.py
@@ -1,0 +1,197 @@
+"""Tests for last-green baseline storage and reproducibility hashes."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from openmed.core.baseline import (
+    BASELINE_PATH,
+    BASELINE_SCHEMA_VERSION,
+    BaselineMiss,
+    baseline_key,
+    get_baseline,
+    load_baseline_store,
+    require_baseline,
+    update_baseline_entry,
+    validate_baseline_store,
+    write_baseline_store,
+)
+from openmed.core.hf_publish import publish_artifact
+from openmed.core.repro_hash import compute_reproducibility_hash
+
+
+class RepositoryNotFoundError(Exception):
+    pass
+
+
+class FakeApi:
+    def __init__(self) -> None:
+        self.created: list[dict[str, object]] = []
+        self.uploaded: list[dict[str, object]] = []
+
+    def repo_info(self, **kwargs: object) -> object:
+        raise RepositoryNotFoundError("not found")
+
+    def create_repo(self, **kwargs: object) -> None:
+        self.created.append(dict(kwargs))
+
+    def upload_folder(self, **kwargs: object) -> None:
+        self.uploaded.append(dict(kwargs))
+
+
+def _store() -> dict[str, object]:
+    return {
+        "schema_version": BASELINE_SCHEMA_VERSION,
+        "entries": {
+            "pii::small::mlx-fp": {
+                "key": "pii::small::mlx-fp",
+                "family": "PII",
+                "tier": "Small",
+                "format": "mlx-fp",
+                "metrics": {"micro_f1": 0.98, "recall": 0.97},
+                "reproducibility_hash": "sha256:" + "a" * 64,
+                "repo_id": "OpenMed/pii-small-mlx",
+                "released": "2026-06-01",
+            },
+            "ner::large::pytorch": {
+                "key": "ner::large::pytorch",
+                "family": "NER",
+                "tier": "Large",
+                "format": "pytorch",
+                "metrics": {"micro_f1": 0.93},
+                "reproducibility_hash": "sha256:" + "b" * 64,
+                "repo_id": "OpenMed/ner-large",
+                "released": "2026-05-20",
+            },
+        },
+    }
+
+
+def _write_artifact(tmp_path: Path) -> Path:
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "config.json").write_text(
+        json.dumps(
+            {
+                "_mlx_task": "token-classification",
+                "_mlx_model_type": "deberta-v2",
+                "id2label": {"0": "O", "1": "B-PERSON", "2": "I-DATE"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact / "openmed-mlx.json").write_text(
+        json.dumps({"format": "openmed-mlx", "format_version": 2}),
+        encoding="utf-8",
+    )
+    (artifact / "weights.safetensors").write_bytes(b"weights")
+    return artifact
+
+
+def test_committed_baseline_store_validates_schema() -> None:
+    store = load_baseline_store(BASELINE_PATH)
+
+    validate_baseline_store(store)
+    assert store["schema_version"] == BASELINE_SCHEMA_VERSION
+    assert get_baseline("PII", "Small", "mlx-fp", store=store) is not None
+
+
+def test_update_baseline_entry_preserves_other_keys(tmp_path: Path) -> None:
+    path = tmp_path / "baseline.json"
+    write_baseline_store(_store(), path)
+    before = load_baseline_store(path)
+    untouched = before["entries"]["ner::large::pytorch"]
+
+    updated = update_baseline_entry(
+        path,
+        family="PII",
+        tier="Small",
+        format_name="mlx-fp",
+        metrics={"micro_f1": 0.991, "recall": 0.988},
+        reproducibility_hash="sha256:" + "c" * 64,
+        repo_id="OpenMed/pii-small-mlx-v2",
+        source_model_id="OpenMed/pii-small",
+        released="2026-06-14",
+        git_sha="abc123",
+    )
+    after = load_baseline_store(path)
+
+    assert updated["key"] == "pii::small::mlx-fp"
+    assert after["entries"]["pii::small::mlx-fp"]["metrics"]["micro_f1"] == 0.991
+    assert after["entries"]["ner::large::pytorch"] == untouched
+
+
+def test_reader_returns_entry_and_clear_miss() -> None:
+    store = _store()
+
+    entry = get_baseline("PII", "Small", "mlx-fp", store=store)
+    missing = get_baseline("PII", "Large", "mlx-fp", store=store)
+
+    assert entry is not None
+    assert entry["repo_id"] == "OpenMed/pii-small-mlx"
+    assert missing is None
+    with pytest.raises(BaselineMiss, match="No last-green baseline"):
+        require_baseline("PII", "Large", "mlx-fp", store=store)
+
+
+def test_reproducibility_hash_is_deterministic_for_fixed_inputs() -> None:
+    first = compute_reproducibility_hash(
+        recipe={"format": "mlx-fp", "steps": ["convert", "publish"]},
+        data_manifest={"dataset": "fixture", "revision": "2026-06-14"},
+        base_model="OpenMed/base-model",
+        git_sha="abc123",
+    )
+    second = compute_reproducibility_hash(
+        recipe={"steps": ["convert", "publish"], "format": "mlx-fp"},
+        data_manifest={"revision": "2026-06-14", "dataset": "fixture"},
+        base_model="OpenMed/base-model",
+        git_sha="abc123",
+    )
+    changed = compute_reproducibility_hash(
+        recipe={"format": "mlx-fp", "steps": ["convert", "publish"]},
+        data_manifest={"dataset": "fixture", "revision": "2026-06-14"},
+        base_model="OpenMed/base-model",
+        git_sha="def456",
+    )
+
+    assert first == second
+    assert first != changed
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", first)
+
+
+def test_baseline_key_uses_family_tier_format_dimensions() -> None:
+    assert baseline_key("PII", "Small", "MLX_FP") == "pii::small::mlx-fp"
+    assert baseline_key("General", None, "coreml") == "general::none::coreml"
+
+
+def test_publish_artifact_updates_manifest_and_baseline(tmp_path: Path, monkeypatch) -> None:
+    artifact = _write_artifact(tmp_path)
+    manifest = tmp_path / "models.jsonl"
+    baseline = tmp_path / "baseline.json"
+    monkeypatch.setenv("HF_WRITE_TOKEN", "secret-token")
+
+    result = publish_artifact(
+        artifact_dir=artifact,
+        source_model_id="OpenMed/test-model",
+        format_name="mlx-fp",
+        manifest_path=manifest,
+        baseline_path=baseline,
+        baseline_metrics={"micro_f1": 0.99, "recall": 0.98},
+        api=FakeApi(),
+        released="2026-06-14",
+        git_sha="abc123",
+    )
+
+    rows = [json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines()]
+    store = load_baseline_store(baseline)
+    entry = require_baseline("General", None, "mlx-fp", store=store)
+
+    assert rows == [result.manifest_row]
+    assert entry["repo_id"] == "OpenMed/test-model-v1-mlx"
+    assert entry["metrics"] == {"micro_f1": 0.99, "recall": 0.98}
+    assert entry["reproducibility_hash"] == rows[0]["reproducibility_hash"]
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", rows[0]["reproducibility_hash"])


### PR DESCRIPTION
Closes #108.

Adds a versioned last-green baseline store keyed by family, tier, and format, plus deterministic reproducibility hashes that combine release recipe, data manifest, base model, and git SHA. The publish path can update the baseline on green releases while preserving unrelated entries, and the conversion workflow now retains the generated baseline snapshot with the manifest.

Validation:
- .venv/bin/python -m pytest tests/ -q