### PR TITLE
Define the canonical OpenMedSpan record and ship versioned JSON schemas

### DIFF
--- a/openmed/core/schemas/__init__.py
+++ b/openmed/core/schemas/__init__.py
@@ -1,0 +1,35 @@
+"""Versioned OpenMed schema records and JSON Schema loaders."""
+
+from .span import (
+    CURRENT_SCHEMA_VERSION,
+    SCHEMA_NAMES,
+    OpenMedSpan,
+    SchemaDriftResult,
+    build_schema_snapshot,
+    compare_all_schema_drift,
+    compare_schema_drift,
+    current_schema_version,
+    hmac_text_hash,
+    load_all_schemas,
+    load_schema,
+    load_schema_bundle,
+    load_schema_snapshot,
+    schema_fingerprint,
+)
+
+__all__ = [
+    "CURRENT_SCHEMA_VERSION",
+    "SCHEMA_NAMES",
+    "OpenMedSpan",
+    "SchemaDriftResult",
+    "build_schema_snapshot",
+    "compare_all_schema_drift",
+    "compare_schema_drift",
+    "current_schema_version",
+    "hmac_text_hash",
+    "load_all_schemas",
+    "load_schema",
+    "load_schema_bundle",
+    "load_schema_snapshot",
+    "schema_fingerprint",
+]

--- a/openmed/core/schemas/json/__init__.py
+++ b/openmed/core/schemas/json/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled OpenMed JSON Schema resources."""

--- a/openmed/core/schemas/json/action.schema.json
+++ b/openmed/core/schemas/json/action.schema.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://openmed.dev/schemas/v1/action.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "action": {
+      "enum": ["keep", "redact", "replace", "mask", "hash"],
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "policy_label": {
+      "enum": ["DIRECT_IDENTIFIER", "QUASI_IDENTIFIER", "CLINICAL_CONCEPT"],
+      "type": "string"
+    },
+    "replacement": {
+      "type": ["string", "null"]
+    },
+    "reversible_id": {
+      "type": ["string", "null"]
+    },
+    "schema_version": {
+      "const": 1,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "schema_version",
+    "action",
+    "policy_label",
+    "replacement",
+    "reversible_id",
+    "metadata"
+  ],
+  "schema_version": 1,
+  "title": "OpenMedAction",
+  "type": "object"
+}

--- a/openmed/core/schemas/json/audit.schema.json
+++ b/openmed/core/schemas/json/audit.schema.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://openmed.dev/schemas/v1/audit.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "actor": {
+      "type": ["string", "null"]
+    },
+    "doc_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "event_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "provenance_id": {
+      "type": ["string", "null"]
+    },
+    "schema_version": {
+      "const": 1,
+      "type": "integer"
+    },
+    "span_id": {
+      "type": ["string", "null"]
+    },
+    "timestamp": {
+      "format": "date-time",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "event_id",
+    "doc_id",
+    "timestamp",
+    "actor",
+    "span_id",
+    "provenance_id",
+    "metadata"
+  ],
+  "schema_version": 1,
+  "title": "OpenMedAuditEvent",
+  "type": "object"
+}

--- a/openmed/core/schemas/json/code.schema.json
+++ b/openmed/core/schemas/json/code.schema.json
@@ -1,0 +1,45 @@
+{
+  "$id": "https://openmed.dev/schemas/v1/code.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "code": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "confidence": {
+      "maximum": 1,
+      "minimum": 0,
+      "type": ["number", "null"]
+    },
+    "display": {
+      "type": ["string", "null"]
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "provenance_id": {
+      "type": ["string", "null"]
+    },
+    "schema_version": {
+      "const": 1,
+      "type": "integer"
+    },
+    "system": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "system",
+    "code",
+    "display",
+    "confidence",
+    "provenance_id",
+    "metadata"
+  ],
+  "schema_version": 1,
+  "title": "OpenMedCode",
+  "type": "object"
+}

--- a/openmed/core/schemas/json/entity.schema.json
+++ b/openmed/core/schemas/json/entity.schema.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://openmed.dev/schemas/v1/entity.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "canonical_label": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "entity_type": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "policy_label": {
+      "enum": ["DIRECT_IDENTIFIER", "QUASI_IDENTIFIER", "CLINICAL_CONCEPT"],
+      "type": "string"
+    },
+    "regulatory_tags": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "schema_version": {
+      "const": 1,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "schema_version",
+    "entity_type",
+    "canonical_label",
+    "policy_label",
+    "regulatory_tags"
+  ],
+  "schema_version": 1,
+  "title": "OpenMedEntity",
+  "type": "object"
+}

--- a/openmed/core/schemas/json/provenance.schema.json
+++ b/openmed/core/schemas/json/provenance.schema.json
@@ -1,0 +1,47 @@
+{
+  "$id": "https://openmed.dev/schemas/v1/provenance.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "artifact_hash": {
+      "type": ["string", "null"]
+    },
+    "detector": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "model": {
+      "type": ["string", "null"]
+    },
+    "parameters": {
+      "type": "object"
+    },
+    "provenance_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 1,
+      "type": "integer"
+    },
+    "version": {
+      "type": ["string", "null"]
+    }
+  },
+  "required": [
+    "schema_version",
+    "provenance_id",
+    "detector",
+    "version",
+    "model",
+    "artifact_hash",
+    "parameters",
+    "metadata"
+  ],
+  "schema_version": 1,
+  "title": "OpenMedProvenance",
+  "type": "object"
+}

--- a/openmed/core/schemas/json/relation.schema.json
+++ b/openmed/core/schemas/json/relation.schema.json
@@ -1,0 +1,46 @@
+{
+  "$id": "https://openmed.dev/schemas/v1/relation.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "evidence": {
+      "type": "object"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "relation_type": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 1,
+      "type": "integer"
+    },
+    "score": {
+      "maximum": 1,
+      "minimum": 0,
+      "type": ["number", "null"]
+    },
+    "source_span_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "target_span_id": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "source_span_id",
+    "target_span_id",
+    "relation_type",
+    "score",
+    "evidence",
+    "metadata"
+  ],
+  "schema_version": 1,
+  "title": "OpenMedRelation",
+  "type": "object"
+}

--- a/openmed/core/schemas/json/schema-fingerprints.json
+++ b/openmed/core/schemas/json/schema-fingerprints.json
@@ -1,0 +1,174 @@
+{
+  "action": {
+    "fingerprint": "sha256:c62cc995a07fbe13d199f55dc65009329de389aaf7d49c2478d14b2a9a064a43",
+    "properties": [
+      "action",
+      "metadata",
+      "policy_label",
+      "replacement",
+      "reversible_id",
+      "schema_version"
+    ],
+    "required": [
+      "action",
+      "metadata",
+      "policy_label",
+      "replacement",
+      "reversible_id",
+      "schema_version"
+    ],
+    "schema_version": 1
+  },
+  "audit": {
+    "fingerprint": "sha256:cc3ef86ebf54062843880c889524e49c7b0a506f714c1666a193596ab04aba6b",
+    "properties": [
+      "actor",
+      "doc_id",
+      "event_id",
+      "metadata",
+      "provenance_id",
+      "schema_version",
+      "span_id",
+      "timestamp"
+    ],
+    "required": [
+      "actor",
+      "doc_id",
+      "event_id",
+      "metadata",
+      "provenance_id",
+      "schema_version",
+      "span_id",
+      "timestamp"
+    ],
+    "schema_version": 1
+  },
+  "code": {
+    "fingerprint": "sha256:ad4e56848f6cbf9cf3d3935af4ab264c318479ad81a16fb5f3de4db6ee1af48f",
+    "properties": [
+      "code",
+      "confidence",
+      "display",
+      "metadata",
+      "provenance_id",
+      "schema_version",
+      "system"
+    ],
+    "required": [
+      "code",
+      "confidence",
+      "display",
+      "metadata",
+      "provenance_id",
+      "schema_version",
+      "system"
+    ],
+    "schema_version": 1
+  },
+  "entity": {
+    "fingerprint": "sha256:95d4b7026fd2dac95cf0a6d279eb31b46e51ee5d8d6edbf5733287313f0e441d",
+    "properties": [
+      "canonical_label",
+      "entity_type",
+      "policy_label",
+      "regulatory_tags",
+      "schema_version"
+    ],
+    "required": [
+      "canonical_label",
+      "entity_type",
+      "policy_label",
+      "regulatory_tags",
+      "schema_version"
+    ],
+    "schema_version": 1
+  },
+  "provenance": {
+    "fingerprint": "sha256:56bd3334a6f3d8263e1c7f4e20d81746c931bef11aba9d10a4c2add92062b4fe",
+    "properties": [
+      "artifact_hash",
+      "detector",
+      "metadata",
+      "model",
+      "parameters",
+      "provenance_id",
+      "schema_version",
+      "version"
+    ],
+    "required": [
+      "artifact_hash",
+      "detector",
+      "metadata",
+      "model",
+      "parameters",
+      "provenance_id",
+      "schema_version",
+      "version"
+    ],
+    "schema_version": 1
+  },
+  "relation": {
+    "fingerprint": "sha256:e60356134bd24aba6382b7d4267147e5bd0d6fc9873ca26f8b629d1cef91c3bb",
+    "properties": [
+      "evidence",
+      "metadata",
+      "relation_type",
+      "schema_version",
+      "score",
+      "source_span_id",
+      "target_span_id"
+    ],
+    "required": [
+      "evidence",
+      "metadata",
+      "relation_type",
+      "schema_version",
+      "score",
+      "source_span_id",
+      "target_span_id"
+    ],
+    "schema_version": 1
+  },
+  "span": {
+    "fingerprint": "sha256:29cb59267e46adfac0f277c94a41586357def44fcccb833d8324a0c5e21acc45",
+    "properties": [
+      "action",
+      "canonical_label",
+      "detector",
+      "doc_id",
+      "end",
+      "entity_type",
+      "evidence",
+      "metadata",
+      "policy_label",
+      "regulatory_tags",
+      "replacement",
+      "reversible_id",
+      "schema_version",
+      "score",
+      "section",
+      "start",
+      "text_hash"
+    ],
+    "required": [
+      "action",
+      "canonical_label",
+      "detector",
+      "doc_id",
+      "end",
+      "entity_type",
+      "evidence",
+      "metadata",
+      "policy_label",
+      "regulatory_tags",
+      "replacement",
+      "reversible_id",
+      "schema_version",
+      "score",
+      "section",
+      "start",
+      "text_hash"
+    ],
+    "schema_version": 1
+  }
+}

--- a/openmed/core/schemas/json/span.schema.json
+++ b/openmed/core/schemas/json/span.schema.json
@@ -1,0 +1,145 @@
+{
+  "$id": "https://openmed.dev/schemas/v1/span.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "action": {
+      "enum": ["keep", "redact", "replace", "mask", "hash"],
+      "type": "string"
+    },
+    "canonical_label": {
+      "enum": [
+        "ACCOUNT_NUMBER",
+        "AGE",
+        "AMOUNT",
+        "API_KEY",
+        "BIC",
+        "BITCOIN_ADDRESS",
+        "BUILDING_NUMBER",
+        "CREDIT_CARD",
+        "CREDIT_CARD_ISSUER",
+        "CURRENCY",
+        "CVV",
+        "DATE",
+        "DATE_OF_BIRTH",
+        "EMAIL",
+        "ETHEREUM_ADDRESS",
+        "EYE_COLOR",
+        "FIRST_NAME",
+        "GENDER",
+        "GPS_COORDINATES",
+        "HEIGHT",
+        "IBAN",
+        "ID_NUM",
+        "IMEI",
+        "IP_ADDRESS",
+        "JOB_DEPARTMENT",
+        "JOB_TITLE",
+        "LAST_NAME",
+        "LITECOIN_ADDRESS",
+        "LOCATION",
+        "MAC_ADDRESS",
+        "MASKED_NUMBER",
+        "MIDDLE_NAME",
+        "OCCUPATION",
+        "ORDINAL_DIRECTION",
+        "ORGANIZATION",
+        "OTHER",
+        "PASSWORD",
+        "PERSON",
+        "PHONE",
+        "PIN",
+        "PREFIX",
+        "SSN",
+        "STREET_ADDRESS",
+        "TIME",
+        "URL",
+        "USER_AGENT",
+        "USERNAME",
+        "VEHICLE_REGISTRATION",
+        "VIN",
+        "ZIPCODE"
+      ],
+      "type": "string"
+    },
+    "detector": {
+      "type": ["string", "null"]
+    },
+    "doc_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "end": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "entity_type": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "evidence": {
+      "type": "object"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "policy_label": {
+      "enum": ["DIRECT_IDENTIFIER", "QUASI_IDENTIFIER", "CLINICAL_CONCEPT"],
+      "type": "string"
+    },
+    "regulatory_tags": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "replacement": {
+      "type": ["string", "null"]
+    },
+    "reversible_id": {
+      "type": ["string", "null"]
+    },
+    "schema_version": {
+      "const": 1,
+      "type": "integer"
+    },
+    "score": {
+      "maximum": 1,
+      "minimum": 0,
+      "type": ["number", "null"]
+    },
+    "section": {
+      "type": ["string", "null"]
+    },
+    "start": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "text_hash": {
+      "pattern": "^hmac-sha256:[0-9a-f]{64}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "doc_id",
+    "start",
+    "end",
+    "text_hash",
+    "entity_type",
+    "canonical_label",
+    "policy_label",
+    "regulatory_tags",
+    "score",
+    "detector",
+    "evidence",
+    "action",
+    "replacement",
+    "reversible_id",
+    "section",
+    "metadata"
+  ],
+  "schema_version": 1,
+  "title": "OpenMedSpan",
+  "type": "object"
+}

--- a/openmed/core/schemas/span.py
+++ b/openmed/core/schemas/span.py
@@ -1,0 +1,328 @@
+"""Canonical span record and schema-version helpers."""
+
+from __future__ import annotations
+
+import copy
+import hmac
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from importlib import resources
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from openmed.core.labels import CANONICAL_LABELS, policy_label_for
+
+
+CURRENT_SCHEMA_VERSION = 1
+SCHEMA_PACKAGE = "openmed.core.schemas.json"
+SCHEMA_NAMES = (
+    "span",
+    "action",
+    "audit",
+    "entity",
+    "relation",
+    "code",
+    "provenance",
+)
+ACTION_KEEP = "keep"
+ACTION_VALUES = (ACTION_KEEP, "redact", "replace", "mask", "hash")
+_TEXT_HASH_RE = re.compile(r"^hmac-sha256:[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class OpenMedSpan:
+    """Immutable span contract shared across OpenMed privacy layers."""
+
+    doc_id: str
+    start: int
+    end: int
+    text_hash: str
+    entity_type: str
+    canonical_label: str
+    policy_label: str | None = None
+    regulatory_tags: Sequence[str] = field(default_factory=tuple)
+    score: float | None = None
+    detector: str | None = None
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+    action: str = ACTION_KEEP
+    replacement: str | None = None
+    reversible_id: str | None = None
+    section: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CURRENT_SCHEMA_VERSION:
+            raise ValueError(
+                f"schema_version must be {CURRENT_SCHEMA_VERSION}, "
+                f"got {self.schema_version!r}"
+            )
+        if not self.doc_id:
+            raise ValueError("doc_id must be non-empty")
+        if not isinstance(self.start, int) or not isinstance(self.end, int):
+            raise TypeError("start and end must be integers")
+        if self.start < 0 or self.end < self.start:
+            raise ValueError("start/end must be non-negative offsets with end >= start")
+        if not _TEXT_HASH_RE.fullmatch(self.text_hash):
+            raise ValueError("text_hash must be hmac-sha256:<64 lowercase hex chars>")
+        if self.canonical_label not in CANONICAL_LABELS:
+            raise ValueError(
+                f"canonical_label must be in CANONICAL_LABELS: {self.canonical_label!r}"
+            )
+        if not self.entity_type:
+            raise ValueError("entity_type must be non-empty")
+        if self.action not in ACTION_VALUES:
+            raise ValueError(f"action must be one of {ACTION_VALUES!r}")
+        if self.score is not None and not 0.0 <= float(self.score) <= 1.0:
+            raise ValueError("score must be between 0.0 and 1.0")
+
+        object.__setattr__(self, "regulatory_tags", tuple(map(str, self.regulatory_tags)))
+        object.__setattr__(self, "evidence", _plain_mapping(self.evidence))
+        object.__setattr__(self, "metadata", _plain_mapping(self.metadata))
+        if self.policy_label is None:
+            object.__setattr__(self, "policy_label", policy_label_for(self.canonical_label))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this span to a JSON-compatible dictionary."""
+
+        return {
+            "schema_version": self.schema_version,
+            "doc_id": self.doc_id,
+            "start": self.start,
+            "end": self.end,
+            "text_hash": self.text_hash,
+            "entity_type": self.entity_type,
+            "canonical_label": self.canonical_label,
+            "policy_label": self.policy_label,
+            "regulatory_tags": list(self.regulatory_tags),
+            "score": self.score,
+            "detector": self.detector,
+            "evidence": copy.deepcopy(dict(self.evidence)),
+            "action": self.action,
+            "replacement": self.replacement,
+            "reversible_id": self.reversible_id,
+            "section": self.section,
+            "metadata": copy.deepcopy(dict(self.metadata)),
+        }
+
+    def to_json(self, *, indent: int | None = None) -> str:
+        """Serialize this span to deterministic JSON."""
+
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "OpenMedSpan":
+        """Deserialize a span from a JSON-compatible dictionary."""
+
+        data = dict(payload)
+        return cls(
+            doc_id=str(data["doc_id"]),
+            start=int(data["start"]),
+            end=int(data["end"]),
+            text_hash=str(data["text_hash"]),
+            entity_type=str(data["entity_type"]),
+            canonical_label=str(data["canonical_label"]),
+            policy_label=data.get("policy_label"),
+            regulatory_tags=tuple(data.get("regulatory_tags") or ()),
+            score=data.get("score"),
+            detector=data.get("detector"),
+            evidence=data.get("evidence") or {},
+            action=str(data.get("action") or ACTION_KEEP),
+            replacement=data.get("replacement"),
+            reversible_id=data.get("reversible_id"),
+            section=data.get("section"),
+            metadata=data.get("metadata") or {},
+            schema_version=int(data.get("schema_version", CURRENT_SCHEMA_VERSION)),
+        )
+
+    @classmethod
+    def from_json(cls, text: str) -> "OpenMedSpan":
+        """Deserialize a span from JSON text."""
+
+        return cls.from_dict(json.loads(text))
+
+
+@dataclass(frozen=True)
+class SchemaDriftResult:
+    """Result of comparing one schema against a saved fingerprint snapshot."""
+
+    schema_name: str
+    schema_version: int
+    snapshot_version: int | None
+    fingerprint: str
+    snapshot_fingerprint: str | None
+    version_bumped: bool
+    breaking_change: bool
+    removed_required: tuple[str, ...] = ()
+    removed_properties: tuple[str, ...] = ()
+
+
+def hmac_text_hash(surface: str | bytes, secret: str | bytes) -> str:
+    """Return the safe loggable HMAC-SHA256 hash for source surface text."""
+
+    payload = surface.encode("utf-8") if isinstance(surface, str) else surface
+    key = secret.encode("utf-8") if isinstance(secret, str) else secret
+    digest = hmac.new(key, payload, hashlib.sha256).hexdigest()
+    return f"hmac-sha256:{digest}"
+
+
+def current_schema_version() -> int:
+    """Return the current schema version."""
+
+    return CURRENT_SCHEMA_VERSION
+
+
+def load_schema(name: str) -> dict[str, Any]:
+    """Load one bundled JSON Schema by logical name."""
+
+    schema_name = _normalise_schema_name(name)
+    resource = resources.files(SCHEMA_PACKAGE).joinpath(f"{schema_name}.schema.json")
+    with resource.open("r", encoding="utf-8") as handle:
+        schema = json.load(handle)
+    if "schema_version" not in schema:
+        raise ValueError(f"{schema_name} schema is missing schema_version")
+    return schema
+
+
+def load_all_schemas() -> dict[str, dict[str, Any]]:
+    """Load every bundled JSON Schema."""
+
+    return {name: load_schema(name) for name in SCHEMA_NAMES}
+
+
+def load_schema_bundle() -> dict[str, Any]:
+    """Return current schema_version plus parsed bundled schemas."""
+
+    return {
+        "schema_version": current_schema_version(),
+        "schemas": load_all_schemas(),
+    }
+
+
+def schema_fingerprint(schema: Mapping[str, Any]) -> str:
+    """Return a deterministic SHA256 fingerprint for a JSON Schema."""
+
+    payload = json.dumps(schema, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def build_schema_snapshot(
+    schemas: Mapping[str, Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Build the drift snapshot format from parsed schemas."""
+
+    return {
+        name: _schema_state(schema)
+        for name, schema in sorted(schemas.items(), key=lambda item: item[0])
+    }
+
+
+def load_schema_snapshot(path: str | Path | None = None) -> dict[str, dict[str, Any]]:
+    """Load the committed schema fingerprint snapshot."""
+
+    if path is None:
+        resource = resources.files(SCHEMA_PACKAGE).joinpath("schema-fingerprints.json")
+        with resource.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def compare_schema_drift(
+    schema_name: str,
+    current_schema: Mapping[str, Any] | None = None,
+    *,
+    snapshot: Mapping[str, Mapping[str, Any]] | None = None,
+) -> SchemaDriftResult:
+    """Compare one schema against a saved snapshot.
+
+    A field removal without a schema_version bump is reported as a breaking
+    change. Gate wiring that turns this result into CI failure is owned by a
+    later task.
+    """
+
+    name = _normalise_schema_name(schema_name)
+    schema = dict(current_schema or load_schema(name))
+    state = _schema_state(schema)
+    snapshot_state = dict((snapshot or load_schema_snapshot()).get(name) or {})
+    snapshot_version = snapshot_state.get("schema_version")
+    version_bumped = snapshot_version is not None and state["schema_version"] != snapshot_version
+    removed_required = tuple(
+        sorted(set(snapshot_state.get("required", ())) - set(state["required"]))
+    )
+    removed_properties = tuple(
+        sorted(set(snapshot_state.get("properties", ())) - set(state["properties"]))
+    )
+    breaking_change = bool(
+        not version_bumped
+        and (removed_required or removed_properties)
+        and snapshot_state
+    )
+    return SchemaDriftResult(
+        schema_name=name,
+        schema_version=int(state["schema_version"]),
+        snapshot_version=int(snapshot_version) if snapshot_version is not None else None,
+        fingerprint=str(state["fingerprint"]),
+        snapshot_fingerprint=snapshot_state.get("fingerprint"),
+        version_bumped=version_bumped,
+        breaking_change=breaking_change,
+        removed_required=removed_required,
+        removed_properties=removed_properties,
+    )
+
+
+def compare_all_schema_drift(
+    *,
+    schemas: Mapping[str, Mapping[str, Any]] | None = None,
+    snapshot: Mapping[str, Mapping[str, Any]] | None = None,
+) -> dict[str, SchemaDriftResult]:
+    """Compare all current schemas against the committed snapshot."""
+
+    current = schemas or load_all_schemas()
+    saved = snapshot or load_schema_snapshot()
+    return {
+        name: compare_schema_drift(name, schema, snapshot=saved)
+        for name, schema in current.items()
+    }
+
+
+def _plain_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(dict(value), sort_keys=True))
+
+
+def _normalise_schema_name(name: str) -> str:
+    schema_name = name.removesuffix(".schema.json").removesuffix(".schema")
+    if schema_name not in SCHEMA_NAMES:
+        raise KeyError(f"unknown schema: {name!r}")
+    return schema_name
+
+
+def _schema_state(schema: Mapping[str, Any]) -> dict[str, Any]:
+    properties = schema.get("properties") or {}
+    return {
+        "schema_version": schema.get("schema_version"),
+        "fingerprint": schema_fingerprint(schema),
+        "required": sorted(str(item) for item in schema.get("required", ())),
+        "properties": sorted(str(key) for key in properties),
+    }
+
+
+__all__ = [
+    "ACTION_KEEP",
+    "ACTION_VALUES",
+    "CURRENT_SCHEMA_VERSION",
+    "SCHEMA_NAMES",
+    "OpenMedSpan",
+    "SchemaDriftResult",
+    "build_schema_snapshot",
+    "compare_all_schema_drift",
+    "compare_schema_drift",
+    "current_schema_version",
+    "hmac_text_hash",
+    "load_all_schemas",
+    "load_schema",
+    "load_schema_bundle",
+    "load_schema_snapshot",
+    "schema_fingerprint",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
   "flake8>=7.0",
   "pytest>=7.0",
   "pytest-cov>=4.0",
+  "jsonschema>=4.0",
   "fastapi>=0.110",
   "httpx>=0.27",
 ]
@@ -99,6 +100,7 @@ openmed = "openmed.cli:main"
 [tool.hatch.build]
 include = [
   "openmed/**",
+  "openmed/core/schemas/json/*.json",
   "gates/baseline.json",
   "models.jsonl",
   "README.md",

--- a/tests/unit/core/test_openmed_span.py
+++ b/tests/unit/core/test_openmed_span.py
@@ -1,0 +1,107 @@
+"""Tests for the canonical OpenMedSpan record."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from jsonschema import validate
+
+from openmed.core.labels import ID_NUM
+from openmed.core.schemas import OpenMedSpan, hmac_text_hash, load_schema
+
+
+def _span() -> OpenMedSpan:
+    return OpenMedSpan(
+        doc_id="doc-1",
+        start=10,
+        end=18,
+        text_hash=hmac_text_hash("MRN-1234", "test-secret"),
+        entity_type="medical_record_number",
+        canonical_label=ID_NUM,
+        regulatory_tags=("HIPAA",),
+        score=0.91,
+        detector="safety_sweep",
+        evidence={"pattern": "MRN"},
+        action="keep",
+        replacement=None,
+        reversible_id=None,
+        section="Assessment",
+        metadata={"source": "fixture"},
+    )
+
+
+def test_openmed_span_importable_and_round_trips_through_schema() -> None:
+    span = _span()
+    payload = span.to_dict()
+
+    validate(payload, load_schema("span"))
+    restored = OpenMedSpan.from_json(span.to_json())
+
+    assert restored == span
+    assert restored.policy_label == "DIRECT_IDENTIFIER"
+    assert restored.regulatory_tags == ("HIPAA",)
+
+
+def test_invalid_canonical_label_raises_at_construction() -> None:
+    with pytest.raises(ValueError, match="canonical_label"):
+        OpenMedSpan(
+            doc_id="doc-1",
+            start=0,
+            end=1,
+            text_hash=hmac_text_hash("x", "secret"),
+            entity_type="made_up",
+            canonical_label="NOT_A_CANONICAL_LABEL",
+        )
+
+
+def test_span_is_frozen_and_does_not_store_surface_text() -> None:
+    span = _span()
+
+    with pytest.raises(FrozenInstanceError):
+        span.doc_id = "other"  # type: ignore[misc]
+
+    serialized = span.to_json()
+    assert "MRN-1234" not in serialized
+    assert span.text_hash.startswith("hmac-sha256:")
+
+
+def test_span_validates_offsets_score_action_and_hash() -> None:
+    with pytest.raises(ValueError, match="start/end"):
+        OpenMedSpan(
+            doc_id="doc-1",
+            start=3,
+            end=1,
+            text_hash=hmac_text_hash("x", "secret"),
+            entity_type="id_num",
+            canonical_label=ID_NUM,
+        )
+    with pytest.raises(ValueError, match="score"):
+        OpenMedSpan(
+            doc_id="doc-1",
+            start=0,
+            end=1,
+            text_hash=hmac_text_hash("x", "secret"),
+            entity_type="id_num",
+            canonical_label=ID_NUM,
+            score=2.0,
+        )
+    with pytest.raises(ValueError, match="action"):
+        OpenMedSpan(
+            doc_id="doc-1",
+            start=0,
+            end=1,
+            text_hash=hmac_text_hash("x", "secret"),
+            entity_type="id_num",
+            canonical_label=ID_NUM,
+            action="delete",
+        )
+    with pytest.raises(ValueError, match="text_hash"):
+        OpenMedSpan(
+            doc_id="doc-1",
+            start=0,
+            end=1,
+            text_hash="cleartext",
+            entity_type="id_num",
+            canonical_label=ID_NUM,
+        )

--- a/tests/unit/core/test_schemas_versioning.py
+++ b/tests/unit/core/test_schemas_versioning.py
@@ -1,0 +1,77 @@
+"""Tests for bundled OpenMed JSON Schemas and drift detection."""
+
+from __future__ import annotations
+
+import copy
+
+from jsonschema.validators import validator_for
+
+from openmed.core.schemas import (
+    CURRENT_SCHEMA_VERSION,
+    SCHEMA_NAMES,
+    build_schema_snapshot,
+    compare_all_schema_drift,
+    compare_schema_drift,
+    current_schema_version,
+    load_all_schemas,
+    load_schema,
+    load_schema_bundle,
+    load_schema_snapshot,
+)
+
+
+def test_each_shipped_json_schema_is_valid_and_versioned() -> None:
+    for name in SCHEMA_NAMES:
+        schema = load_schema(name)
+        validator = validator_for(schema)
+        validator.check_schema(schema)
+
+        assert schema["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert schema["properties"]["schema_version"]["const"] == CURRENT_SCHEMA_VERSION
+
+
+def test_schema_loader_returns_bundle_and_current_version() -> None:
+    bundle = load_schema_bundle()
+
+    assert current_schema_version() == CURRENT_SCHEMA_VERSION
+    assert bundle["schema_version"] == CURRENT_SCHEMA_VERSION
+    assert set(bundle["schemas"]) == set(SCHEMA_NAMES)
+
+
+def test_committed_snapshot_matches_current_schemas() -> None:
+    results = compare_all_schema_drift()
+
+    assert set(results) == set(SCHEMA_NAMES)
+    assert all(not result.breaking_change for result in results.values())
+    assert build_schema_snapshot(load_all_schemas()) == load_schema_snapshot()
+
+
+def test_drift_helper_flags_removed_field_without_version_bump() -> None:
+    schemas = load_all_schemas()
+    snapshot = build_schema_snapshot(schemas)
+    changed_span = copy.deepcopy(schemas["span"])
+    changed_span["required"].remove("detector")
+    del changed_span["properties"]["detector"]
+
+    result = compare_schema_drift("span", changed_span, snapshot=snapshot)
+
+    assert result.breaking_change is True
+    assert result.version_bumped is False
+    assert result.removed_required == ("detector",)
+    assert result.removed_properties == ("detector",)
+
+
+def test_drift_helper_accepts_breaking_change_with_version_bump() -> None:
+    schemas = load_all_schemas()
+    snapshot = build_schema_snapshot(schemas)
+    changed_span = copy.deepcopy(schemas["span"])
+    changed_span["schema_version"] = CURRENT_SCHEMA_VERSION + 1
+    changed_span["properties"]["schema_version"]["const"] = CURRENT_SCHEMA_VERSION + 1
+    changed_span["required"].remove("detector")
+    del changed_span["properties"]["detector"]
+
+    result = compare_schema_drift("span", changed_span, snapshot=snapshot)
+
+    assert result.version_bumped is True
+    assert result.breaking_change is False
+    assert result.removed_required == ("detector",)


### PR DESCRIPTION
Closes #115.

Adds the immutable OpenMedSpan record, bundled versioned JSON Schemas for span/action/audit/entity/relation/code/provenance contracts, schema resource loaders, serialization helpers, and drift fingerprint comparison so breaking schema changes can be detected before gate wiring lands.

Validation:
- `.venv/bin/python -c 'from openmed.core.schemas import OpenMedSpan'`
- `.venv/bin/python -m pytest tests/ -q`