### PR TITLE
Build the staged privacy detection pipeline runtime

### DIFF
--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -872,38 +872,30 @@ def deidentify(
         >>> result = deidentify(text, method="replace", lang="pt",
         ...                    locale="pt_BR", consistent=True, seed=42)
     """
-    text = text.strip()
-    effective_method = _resolve_deidentification_method(
-        method,
-        shift_dates,
-        date_shift_days,
-    )
-    pii_result = extract_pii(
-        text,
-        model_name,
-        confidence_threshold,
-        config,
-        use_smart_merging,
+    from .pipeline import Pipeline
+
+    pipeline = Pipeline(
+        model_name=model_name,
+        confidence_threshold=confidence_threshold,
+        config=config,
+        use_smart_merging=use_smart_merging,
         lang=lang,
         normalize_accents=normalize_accents,
+        use_safety_sweep=use_safety_sweep,
         loader=loader,
     )
-
-    if use_safety_sweep:
-        _apply_safety_sweep_to_result(text, pii_result, lang=lang)
-
-    return _build_deidentification_result(
+    result = pipeline.run(
         text,
-        pii_result,
-        effective_method=effective_method,
+        method=method,
         keep_year=keep_year,
+        shift_dates=shift_dates,
         date_shift_days=date_shift_days,
         keep_mapping=keep_mapping,
-        lang=lang,
         consistent=consistent,
         seed=seed,
         locale=locale,
     )
+    return result.deidentification_result
 
 
 def _redact_entity(

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -1,0 +1,800 @@
+"""Staged privacy de-identification pipeline runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Optional, Sequence
+import unicodedata
+
+from .labels import hipaa_class_for, normalize_label, policy_label_for
+from .pii_entity_merger import PIIPattern, PII_PATTERNS
+from .schemas.span import OpenMedSpan, hmac_text_hash
+
+
+STAGE_NAMES: tuple[str, ...] = (
+    "normalize",
+    "language_script",
+    "doc_type_section",
+    "deterministic_detectors",
+    "fast_pii_model",
+    "clinical_phi_model",
+    "span_arbitration",
+    "policy_actions",
+    "safety_sweep",
+    "emit",
+)
+
+DEFAULT_HASH_SECRET = b"openmed-pipeline-v1"
+
+
+@dataclass(frozen=True)
+class OffsetMap:
+    """Bidirectional character offset map from source to normalized text."""
+
+    original_to_normalized: tuple[int | None, ...]
+    normalized_to_original: tuple[int, ...]
+    normalized_to_original_span: tuple[tuple[int, int], ...]
+
+    def original_index_to_normalized(self, index: int) -> int | None:
+        return self.original_to_normalized[index]
+
+    def normalized_index_to_original(self, index: int) -> int:
+        return self.normalized_to_original[index]
+
+    def original_span_to_normalized(self, start: int, end: int) -> tuple[int, int]:
+        mapped = [
+            value
+            for value in self.original_to_normalized[start:end]
+            if value is not None
+        ]
+        if not mapped:
+            cursor = min(max(start, 0), len(self.original_to_normalized))
+            while cursor < len(self.original_to_normalized):
+                value = self.original_to_normalized[cursor]
+                if value is not None:
+                    return value, value
+                cursor += 1
+            return len(self.normalized_to_original), len(self.normalized_to_original)
+        return min(mapped), max(mapped) + 1
+
+    def normalized_span_to_original_offsets(self, start: int, end: int) -> tuple[int, int]:
+        if start == end:
+            if start >= len(self.normalized_to_original_span):
+                terminal = (
+                    self.normalized_to_original_span[-1][1]
+                    if self.normalized_to_original_span
+                    else 0
+                )
+                return terminal, terminal
+            original = self.normalized_to_original_span[start][0]
+            return original, original
+
+        spans = self.normalized_to_original_span[start:end]
+        if not spans:
+            return 0, 0
+        return min(span[0] for span in spans), max(span[1] for span in spans)
+
+
+@dataclass(frozen=True)
+class NormalizedDocument:
+    original_text: str
+    normalized_text: str
+    offset_map: OffsetMap
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LanguageRoute:
+    lang: str
+    script: str
+    model_name: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PipelineStageResult:
+    stage: int
+    name: str
+    spans: tuple[OpenMedSpan, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PipelineContext:
+    doc_id: str
+    original_text: str
+    normalized_text: str
+    offset_map: OffsetMap
+    route: LanguageRoute
+    section_metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    original_text: str
+    normalized_text: str
+    offset_map: OffsetMap
+    route: LanguageRoute
+    spans: tuple[OpenMedSpan, ...]
+    stage_results: tuple[PipelineStageResult, ...]
+    redacted_text: str
+    audit_record: Mapping[str, Any]
+    deidentification_result: Any = None
+
+    def stage(self, name: str) -> PipelineStageResult:
+        for result in self.stage_results:
+            if result.name == name:
+                return result
+        raise KeyError(name)
+
+
+SpanHook = Callable[[Sequence[OpenMedSpan], PipelineContext], Sequence[OpenMedSpan]]
+ModelDetector = Callable[..., Any]
+
+
+class Pipeline:
+    """Orchestrate the ten-stage privacy detection pipeline."""
+
+    stage_names = STAGE_NAMES
+
+    def __init__(
+        self,
+        *,
+        model_name: Optional[str] = None,
+        confidence_threshold: float = 0.7,
+        config: Any = None,
+        use_smart_merging: bool = True,
+        lang: str = "en",
+        normalize_accents: Optional[bool] = None,
+        use_safety_sweep: bool = True,
+        loader: Any = None,
+        privacy_filter_pipeline: Any = None,
+        model_detector: ModelDetector | None = None,
+        clinical_model_detector: ModelDetector | None = None,
+        arbitration: SpanHook | None = None,
+        policy_actions: SpanHook | None = None,
+        section_detector: Callable[..., Mapping[str, Any]] | None = None,
+        hmac_secret: str | bytes = DEFAULT_HASH_SECRET,
+    ) -> None:
+        from . import pii
+
+        self.model_name = model_name or pii._DEFAULT_EN_MODEL
+        self.confidence_threshold = confidence_threshold
+        self.config = config
+        self.use_smart_merging = use_smart_merging
+        self.lang = lang
+        self.normalize_accents = normalize_accents
+        self.use_safety_sweep = use_safety_sweep
+        self.loader = loader
+        self.privacy_filter_pipeline = privacy_filter_pipeline
+        self.model_detector = model_detector
+        self.clinical_model_detector = clinical_model_detector
+        self.arbitration = arbitration
+        self.policy_actions = policy_actions
+        self.section_detector = section_detector
+        self.hmac_secret = hmac_secret
+
+    def run(
+        self,
+        text: str,
+        *,
+        method: str = "mask",
+        keep_year: bool = True,
+        shift_dates: Optional[bool] = None,
+        date_shift_days: Optional[int] = None,
+        keep_mapping: bool = False,
+        consistent: bool = False,
+        seed: Optional[int] = None,
+        locale: Optional[str] = None,
+        doc_id: str | None = None,
+    ) -> PipelineResult:
+        from . import pii
+
+        effective_method = pii._resolve_deidentification_method(
+            method,
+            shift_dates,
+            date_shift_days,
+        )
+        original_text = text.strip()
+        normalized = self.stage1_normalize(original_text)
+        route = self.stage2_language_script(normalized.normalized_text)
+        resolved_doc_id = doc_id or hmac_text_hash(
+            normalized.normalized_text,
+            self.hmac_secret,
+        )
+        section_metadata = self.stage3_doc_type_section(normalized.normalized_text)
+        context = PipelineContext(
+            doc_id=resolved_doc_id,
+            original_text=normalized.original_text,
+            normalized_text=normalized.normalized_text,
+            offset_map=normalized.offset_map,
+            route=route,
+            section_metadata=section_metadata,
+        )
+
+        stage_results: list[PipelineStageResult] = [
+            PipelineStageResult(
+                1,
+                STAGE_NAMES[0],
+                metadata=normalized.metadata,
+            ),
+            PipelineStageResult(
+                2,
+                STAGE_NAMES[1],
+                metadata={
+                    "lang": route.lang,
+                    "script": route.script,
+                    "model_name": route.model_name,
+                    **dict(route.metadata),
+                },
+            ),
+            PipelineStageResult(
+                3,
+                STAGE_NAMES[2],
+                metadata=section_metadata,
+            ),
+        ]
+
+        deterministic_spans = self.stage4_deterministic_detectors(
+            normalized.normalized_text,
+            context,
+        )
+        stage_results.append(
+            PipelineStageResult(4, STAGE_NAMES[3], spans=deterministic_spans)
+        )
+
+        pii_result = self.stage5_fast_pii_model(normalized.normalized_text, route)
+        model_spans = self._entities_to_spans(
+            getattr(pii_result, "entities", ()),
+            normalized.normalized_text,
+            context,
+            default_detector=f"model:{getattr(pii_result, 'model_name', route.model_name)}",
+            stage=STAGE_NAMES[4],
+        )
+        stage_results.append(PipelineStageResult(5, STAGE_NAMES[4], spans=model_spans))
+
+        clinical_spans = self.stage6_clinical_phi_model(
+            normalized.normalized_text,
+            context,
+        )
+        stage_results.append(PipelineStageResult(6, STAGE_NAMES[5], spans=clinical_spans))
+
+        merged_spans = self.stage7_arbitration(
+            (*deterministic_spans, *model_spans, *clinical_spans),
+            context,
+        )
+        stage_results.append(PipelineStageResult(7, STAGE_NAMES[6], spans=merged_spans))
+
+        policy_spans = self.stage8_policy_actions(merged_spans, context)
+        stage_results.append(PipelineStageResult(8, STAGE_NAMES[7], spans=policy_spans))
+
+        sweep_spans, sweep_metadata = self.stage9_safety_sweep(
+            normalized.normalized_text,
+            pii_result,
+            context,
+        )
+        stage_results.append(
+            PipelineStageResult(
+                9,
+                STAGE_NAMES[8],
+                spans=sweep_spans,
+                metadata=sweep_metadata,
+            )
+        )
+
+        deidentified = self.stage10_emit(
+            normalized.normalized_text,
+            pii_result,
+            effective_method=effective_method,
+            keep_year=keep_year,
+            date_shift_days=date_shift_days,
+            keep_mapping=keep_mapping,
+            lang=route.lang,
+            consistent=consistent,
+            seed=seed,
+            locale=locale,
+        )
+        final_spans = sweep_spans or policy_spans
+        stage_results.append(
+            PipelineStageResult(
+                10,
+                STAGE_NAMES[9],
+                spans=final_spans,
+                metadata={
+                    "redacted_text_hash": hmac_text_hash(
+                        deidentified.deidentified_text,
+                        self.hmac_secret,
+                    ),
+                    "audit_stage_count": 10,
+                },
+            )
+        )
+        audit_record = self._audit_record(
+            context,
+            stage_results,
+            final_spans,
+            redacted_text=deidentified.deidentified_text,
+        )
+
+        return PipelineResult(
+            original_text=normalized.original_text,
+            normalized_text=normalized.normalized_text,
+            offset_map=normalized.offset_map,
+            route=route,
+            spans=final_spans,
+            stage_results=tuple(stage_results),
+            redacted_text=deidentified.deidentified_text,
+            audit_record=audit_record,
+            deidentification_result=deidentified,
+        )
+
+    def stage1_normalize(self, text: str) -> NormalizedDocument:
+        normalized_parts: list[str] = []
+        original_to_normalized: list[int | None] = [None] * len(text)
+        normalized_to_original: list[int] = []
+        normalized_to_original_span: list[tuple[int, int]] = []
+        normalized_length = 0
+
+        for start, end, segment, is_whitespace in _iter_normalization_segments(text):
+            normalized_start = normalized_length
+            if is_whitespace:
+                normalized_segment = " "
+            else:
+                normalized_segment = unicodedata.normalize(
+                    "NFC",
+                    _repair_encoding_segment(segment),
+                )
+
+            if not normalized_segment:
+                continue
+
+            for index in range(start, end):
+                original_to_normalized[index] = normalized_start
+
+            normalized_parts.append(normalized_segment)
+            normalized_length += len(normalized_segment)
+            for _ in normalized_segment:
+                normalized_to_original.append(start)
+                normalized_to_original_span.append((start, end))
+
+        normalized_text = "".join(normalized_parts)
+        offset_map = OffsetMap(
+            original_to_normalized=tuple(original_to_normalized),
+            normalized_to_original=tuple(normalized_to_original),
+            normalized_to_original_span=tuple(normalized_to_original_span),
+        )
+        return NormalizedDocument(
+            original_text=text,
+            normalized_text=normalized_text,
+            offset_map=offset_map,
+            metadata={
+                "unicode_normalization": "NFC",
+                "whitespace_collapsed": normalized_text != text,
+                "original_length": len(text),
+                "normalized_length": len(normalized_text),
+            },
+        )
+
+    def stage2_language_script(self, text: str) -> LanguageRoute:
+        from . import pii
+        from .pii_i18n import DEFAULT_PII_MODELS, SUPPORTED_LANGUAGES
+
+        script = _detect_script(text)
+        lang = _lang_from_script(script) if self.lang == "auto" else self.lang
+        if lang not in SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"Unsupported language '{lang}'. "
+                f"Supported: {sorted(SUPPORTED_LANGUAGES)}"
+            )
+        model_name = pii._resolve_effective_pii_model(self.model_name, lang)
+        return LanguageRoute(
+            lang=lang,
+            script=script,
+            model_name=model_name,
+            metadata={"available_default_model": DEFAULT_PII_MODELS.get(lang)},
+        )
+
+    def stage3_doc_type_section(self, text: str) -> Mapping[str, Any]:
+        if self.section_detector is not None:
+            return dict(self.section_detector(text))
+
+        try:
+            from openmed.clinical import sections
+        except ImportError:
+            return {"section_hook": "unavailable", "sections": ()}
+
+        if hasattr(sections, "detect_sections"):
+            return {
+                "section_hook": "detect_sections",
+                "sections": sections.detect_sections(text),
+            }
+        return {"section_hook": "unavailable", "sections": ()}
+
+    def stage4_deterministic_detectors(
+        self,
+        text: str,
+        context: PipelineContext,
+    ) -> tuple[OpenMedSpan, ...]:
+        from .safety_sweep import safety_sweep
+
+        entities = safety_sweep(
+            text,
+            [],
+            lang=context.route.lang,
+            patterns=_deterministic_patterns(context.route.lang),
+        )
+        return self._entities_to_spans(
+            entities,
+            text,
+            context,
+            default_detector="rules:regex",
+            stage=STAGE_NAMES[3],
+        )
+
+    def stage5_fast_pii_model(self, text: str, route: LanguageRoute) -> Any:
+        if self.model_detector is not None:
+            return self.model_detector(
+                text,
+                model_name=route.model_name,
+                confidence_threshold=self.confidence_threshold,
+                config=self.config,
+                use_smart_merging=self.use_smart_merging,
+                lang=route.lang,
+                normalize_accents=self.normalize_accents,
+                loader=self.loader,
+            )
+
+        from . import pii
+
+        return pii.extract_pii(
+            text,
+            self.model_name,
+            self.confidence_threshold,
+            self.config,
+            self.use_smart_merging,
+            lang=route.lang,
+            normalize_accents=self.normalize_accents,
+            loader=self.loader,
+        )
+
+    def stage6_clinical_phi_model(
+        self,
+        text: str,
+        context: PipelineContext,
+    ) -> tuple[OpenMedSpan, ...]:
+        if self.clinical_model_detector is None:
+            return ()
+
+        result = self.clinical_model_detector(text, context=context)
+        return self._entities_to_spans(
+            getattr(result, "entities", ()),
+            text,
+            context,
+            default_detector=f"model:{getattr(result, 'model_name', 'clinical_phi')}",
+            stage=STAGE_NAMES[5],
+        )
+
+    def stage7_arbitration(
+        self,
+        spans: Sequence[OpenMedSpan],
+        context: PipelineContext,
+    ) -> tuple[OpenMedSpan, ...]:
+        if self.arbitration is not None:
+            return tuple(self.arbitration(spans, context))
+        return tuple(sorted(spans, key=lambda span: (span.start, span.end, span.detector or "")))
+
+    def stage8_policy_actions(
+        self,
+        spans: Sequence[OpenMedSpan],
+        context: PipelineContext,
+    ) -> tuple[OpenMedSpan, ...]:
+        if self.policy_actions is not None:
+            return tuple(self.policy_actions(spans, context))
+        return tuple(spans)
+
+    def stage9_safety_sweep(
+        self,
+        text: str,
+        pii_result: Any,
+        context: PipelineContext,
+    ) -> tuple[tuple[OpenMedSpan, ...], Mapping[str, Any]]:
+        before = _redacted_char_count(getattr(pii_result, "entities", ()))
+        spans_added = 0
+        if self.use_safety_sweep:
+            from . import pii
+
+            spans_added = pii._apply_safety_sweep_to_result(
+                text,
+                pii_result,
+                lang=context.route.lang,
+            )
+        after = _redacted_char_count(getattr(pii_result, "entities", ()))
+        if after < before:
+            raise RuntimeError("safety sweep must not reduce redacted character count")
+
+        spans = self._entities_to_spans(
+            getattr(pii_result, "entities", ()),
+            text,
+            context,
+            default_detector=f"model:{getattr(pii_result, 'model_name', context.route.model_name)}",
+            stage=STAGE_NAMES[8],
+        )
+        return spans, {
+            "enabled": self.use_safety_sweep,
+            "spans_added": spans_added,
+            "redacted_chars_before": before,
+            "redacted_chars_after": after,
+        }
+
+    def stage10_emit(
+        self,
+        text: str,
+        pii_result: Any,
+        *,
+        effective_method: str,
+        keep_year: bool,
+        date_shift_days: Optional[int],
+        keep_mapping: bool,
+        lang: str,
+        consistent: bool,
+        seed: Optional[int],
+        locale: Optional[str],
+    ) -> Any:
+        from . import pii
+
+        return pii._build_deidentification_result(
+            text,
+            pii_result,
+            effective_method=effective_method,
+            keep_year=keep_year,
+            date_shift_days=date_shift_days,
+            keep_mapping=keep_mapping,
+            lang=lang,
+            consistent=consistent,
+            seed=seed,
+            locale=locale,
+        )
+
+    def _entities_to_spans(
+        self,
+        entities: Sequence[Any],
+        text: str,
+        context: PipelineContext,
+        *,
+        default_detector: str,
+        stage: str,
+    ) -> tuple[OpenMedSpan, ...]:
+        spans: list[OpenMedSpan] = []
+        for entity in entities:
+            bounds = _entity_bounds(entity, text)
+            if bounds is None:
+                continue
+            start, end = bounds
+            surface = text[start:end]
+            label = str(getattr(entity, "label", "") or "")
+            canonical = normalize_label(label, lang=context.route.lang)
+            detector = _detector_for_entity(entity, default_detector)
+            metadata = dict(getattr(entity, "metadata", None) or {})
+            metadata.setdefault("pipeline_stage", stage)
+            spans.append(
+                OpenMedSpan(
+                    doc_id=context.doc_id,
+                    start=start,
+                    end=end,
+                    text_hash=hmac_text_hash(surface, self.hmac_secret),
+                    entity_type=label or canonical,
+                    canonical_label=canonical,
+                    policy_label=policy_label_for(canonical, lang=context.route.lang),
+                    regulatory_tags=(hipaa_class_for(canonical, lang=context.route.lang),),
+                    score=float(getattr(entity, "confidence", 0.0) or 0.0),
+                    detector=detector,
+                    evidence=_evidence_for_entity(entity),
+                    section=_section_for_span(start, end, context.section_metadata),
+                    metadata=metadata,
+                )
+            )
+        return tuple(spans)
+
+    def _audit_record(
+        self,
+        context: PipelineContext,
+        stage_results: Sequence[PipelineStageResult],
+        final_spans: Sequence[OpenMedSpan],
+        *,
+        redacted_text: str,
+    ) -> Mapping[str, Any]:
+        return {
+            "doc_id": context.doc_id,
+            "language": context.route.lang,
+            "script": context.route.script,
+            "model_name": context.route.model_name,
+            "input_text_hash": hmac_text_hash(context.normalized_text, self.hmac_secret),
+            "redacted_text_hash": hmac_text_hash(redacted_text, self.hmac_secret),
+            "normalized_length": len(context.normalized_text),
+            "redacted_length": len(redacted_text),
+            "span_count": len(final_spans),
+            "stages": [
+                {
+                    "stage": result.stage,
+                    "name": result.name,
+                    "span_count": len(result.spans),
+                    "metadata": dict(result.metadata),
+                }
+                for result in stage_results
+            ],
+        }
+
+
+def _iter_normalization_segments(text: str):
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char.isspace():
+            start = index
+            index += 1
+            while index < len(text) and text[index].isspace():
+                index += 1
+            yield start, index, text[start:index], True
+            continue
+
+        start = index
+        index += 1
+        while index < len(text) and unicodedata.combining(text[index]):
+            index += 1
+        yield start, index, text[start:index], False
+
+
+def _repair_encoding_segment(segment: str) -> str:
+    try:
+        from ftfy import fix_text
+    except ImportError:
+        return segment
+    return fix_text(segment)
+
+
+def _detect_script(text: str) -> str:
+    for char in text:
+        codepoint = ord(char)
+        if 0x0600 <= codepoint <= 0x06FF:
+            return "arabic"
+        if 0x3040 <= codepoint <= 0x30FF or 0x4E00 <= codepoint <= 0x9FFF:
+            return "japanese"
+        if 0x0900 <= codepoint <= 0x097F:
+            return "devanagari"
+        if 0x0C00 <= codepoint <= 0x0C7F:
+            return "telugu"
+    return "latin"
+
+
+def _lang_from_script(script: str) -> str:
+    return {
+        "arabic": "ar",
+        "japanese": "ja",
+        "devanagari": "hi",
+        "telugu": "te",
+    }.get(script, "en")
+
+
+def _deterministic_patterns(lang: str) -> list[PIIPattern]:
+    from .anonymizer.providers import clinical_ids
+
+    luhn_mrn = PIIPattern(
+        r"\b(?:MRN|mrn)[:\s#-]*(?:\d[\s-]?){13,19}\b",
+        "medical_record_number",
+        priority=20,
+        base_score=0.95,
+        context_words=["mrn", "medical record", "patient id", "record number"],
+        context_boost=0.05,
+        validator=clinical_ids.validate_luhn,
+    )
+    if lang == "en":
+        return [luhn_mrn, *PII_PATTERNS]
+
+    from .pii_i18n import get_patterns_for_language
+
+    return [luhn_mrn, *get_patterns_for_language(lang)]
+
+
+def _entity_bounds(entity: Any, text: str) -> tuple[int, int] | None:
+    start = getattr(entity, "start", None)
+    end = getattr(entity, "end", None)
+    if isinstance(start, int) and isinstance(end, int) and 0 <= start <= end <= len(text):
+        return start, end
+
+    surface = str(getattr(entity, "text", "") or "")
+    if not surface:
+        return None
+    found = text.find(surface)
+    if found < 0:
+        return None
+    return found, found + len(surface)
+
+
+def _detector_for_entity(entity: Any, default_detector: str) -> str:
+    metadata = dict(getattr(entity, "metadata", None) or {})
+    detector = metadata.get("detector") or metadata.get("source")
+    if detector and str(detector).startswith(("rules:", "model:")):
+        return str(detector)
+
+    sweep = metadata.get("safety_sweep") if isinstance(metadata, Mapping) else None
+    pattern = str((sweep or {}).get("pattern", ""))
+    label = str(getattr(entity, "label", "") or "")
+    if label == "medical_record_number" and "13,19" in pattern:
+        return "rules:mrn_luhn"
+    if label == "medical_record_number":
+        return "rules:mrn_regex"
+    if label in {"credit_debit_card", "credit_card"}:
+        return "rules:luhn"
+    if label == "npi":
+        return "rules:npi_luhn"
+    if label == "iban":
+        return "rules:iban_mod97"
+    if label == "ssn":
+        return "rules:ssn"
+    if detector == "safety_sweep":
+        return "rules:regex"
+    return default_detector
+
+
+def _evidence_for_entity(entity: Any) -> Mapping[str, Any]:
+    metadata = dict(getattr(entity, "metadata", None) or {})
+    evidence: dict[str, Any] = {}
+    if "safety_sweep" in metadata:
+        evidence["rule"] = metadata["safety_sweep"]
+    if "patterns_version" in metadata:
+        evidence["patterns_version"] = metadata["patterns_version"]
+    return evidence
+
+
+def _section_for_span(
+    start: int,
+    end: int,
+    section_metadata: Mapping[str, Any],
+) -> str | None:
+    sections = section_metadata.get("sections")
+    if not sections:
+        return None
+    for section in sections:
+        if not isinstance(section, Mapping):
+            continue
+        section_start = section.get("start")
+        section_end = section.get("end")
+        if isinstance(section_start, int) and isinstance(section_end, int):
+            if start >= section_start and end <= section_end:
+                return str(section.get("label") or section.get("name") or "")
+    return None
+
+
+def _redacted_char_count(entities: Sequence[Any]) -> int:
+    intervals: list[tuple[int, int]] = []
+    for entity in entities:
+        start = getattr(entity, "start", None)
+        end = getattr(entity, "end", None)
+        if isinstance(start, int) and isinstance(end, int) and start < end:
+            intervals.append((start, end))
+    if not intervals:
+        return 0
+
+    intervals.sort()
+    total = 0
+    current_start, current_end = intervals[0]
+    for start, end in intervals[1:]:
+        if start <= current_end:
+            current_end = max(current_end, end)
+            continue
+        total += current_end - current_start
+        current_start, current_end = start, end
+    total += current_end - current_start
+    return total
+
+
+__all__ = [
+    "LanguageRoute",
+    "NormalizedDocument",
+    "OffsetMap",
+    "Pipeline",
+    "PipelineContext",
+    "PipelineResult",
+    "PipelineStageResult",
+    "STAGE_NAMES",
+]

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -1,0 +1,89 @@
+from datetime import datetime
+
+from openmed.core.pipeline import Pipeline
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+
+def _empty_prediction(text: str, model_name: str = "stub") -> PredictionResult:
+    return PredictionResult(
+        text=text,
+        entities=[],
+        model_name=model_name,
+        timestamp=datetime.now().isoformat(),
+    )
+
+
+def test_normalized_offsets_remap_combining_characters_to_original_positions():
+    text = "Cafe\u0301  MRN"
+    document = Pipeline().stage1_normalize(text)
+
+    assert document.normalized_text == "Café MRN"
+
+    original_e = text.index("e")
+    original_combining = original_e + 1
+    normalized_e = document.normalized_text.index("é")
+
+    assert document.offset_map.original_index_to_normalized(original_e) == normalized_e
+    assert (
+        document.offset_map.original_index_to_normalized(original_combining)
+        == normalized_e
+    )
+    assert document.offset_map.normalized_index_to_original(normalized_e) == original_e
+    assert document.offset_map.normalized_span_to_original_offsets(
+        normalized_e,
+        normalized_e + 1,
+    ) == (original_e, original_combining + 1)
+
+
+def test_luhn_valid_mrn_is_detected_before_model_stage_runs():
+    model_calls = []
+
+    def model_detector(text, **kwargs):
+        model_calls.append(("model", text, kwargs))
+        return _empty_prediction(text, model_name=kwargs["model_name"])
+
+    text = "MRN: 4111111111111111"
+    result = Pipeline(
+        model_detector=model_detector,
+        use_safety_sweep=False,
+    ).run(text)
+
+    deterministic_stage = result.stage("deterministic_detectors")
+    model_stage = result.stage("fast_pii_model")
+
+    assert len(model_calls) == 1
+    assert model_calls[0][1] == text
+    assert model_stage.spans == ()
+    assert deterministic_stage.spans
+    assert deterministic_stage.stage < model_stage.stage
+    assert deterministic_stage.spans[0].detector.startswith("rules:")
+    assert deterministic_stage.spans[0].detector == "rules:mrn_luhn"
+
+
+def test_stage9_safety_sweep_only_increases_redacted_character_count():
+    text = "Patient John Doe email jane.patient@example.com"
+
+    def model_detector(text, **kwargs):
+        return PredictionResult(
+            text=text,
+            entities=[
+                EntityPrediction(
+                    text="John Doe",
+                    label="NAME",
+                    start=8,
+                    end=16,
+                    confidence=0.95,
+                )
+            ],
+            model_name=kwargs["model_name"],
+            timestamp=datetime.now().isoformat(),
+        )
+
+    result = Pipeline(model_detector=model_detector).run(text, method="mask")
+    stage9 = result.stage("safety_sweep")
+
+    assert stage9.metadata["redacted_chars_after"] >= stage9.metadata[
+        "redacted_chars_before"
+    ]
+    assert stage9.metadata["spans_added"] == 1
+    assert result.redacted_text == "Patient [NAME] email [email]"


### PR DESCRIPTION
Closes #117.

Adds the staged privacy pipeline runtime with normalization offset maps, language routing, section hooks, deterministic rule provenance, model span conversion, a safety-sweep add-only guard, and audit emission while keeping deidentify output compatible with existing callers.