### PR TITLE
Implement detector arbitration with the cascade router and score calibration

### DIFF
--- a/openmed/core/arbitration.py
+++ b/openmed/core/arbitration.py
@@ -1,0 +1,440 @@
+"""Detector arbitration and score calibration for privacy spans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Mapping, Sequence
+
+from .labels import (
+    ACCOUNT_NUMBER,
+    API_KEY,
+    CREDIT_CARD,
+    CVV,
+    DATE,
+    DATE_OF_BIRTH,
+    EMAIL,
+    FIRST_NAME,
+    ID_NUM,
+    IBAN,
+    IP_ADDRESS,
+    LAST_NAME,
+    LOCATION,
+    MIDDLE_NAME,
+    OTHER,
+    PASSWORD,
+    PERSON,
+    PHONE,
+    PIN,
+    SSN,
+    STREET_ADDRESS,
+    URL,
+    USERNAME,
+    normalize_label,
+)
+from .pii_entity_merger import is_more_specific
+from .schemas.span import OpenMedSpan
+
+
+CALIBRATION_VERSION = 1
+MODE_BALANCED = "balanced"
+MODE_HIGH_RECALL_UNION = "high_recall_union"
+DEFAULT_BALANCED_FLOOR = 0.5
+DEFAULT_HIGH_RECALL_FLOOR = 0.05
+
+_SPECIFICITY_RANKS: Mapping[str, int] = {
+    OTHER: 0,
+    PERSON: 1,
+    LOCATION: 1,
+    DATE: 1,
+    ID_NUM: 1,
+    FIRST_NAME: 2,
+    LAST_NAME: 2,
+    MIDDLE_NAME: 2,
+    USERNAME: 2,
+    STREET_ADDRESS: 2,
+    DATE_OF_BIRTH: 2,
+    EMAIL: 2,
+    PHONE: 2,
+    URL: 2,
+    SSN: 2,
+    ACCOUNT_NUMBER: 2,
+    PASSWORD: 2,
+    PIN: 2,
+    API_KEY: 2,
+    CREDIT_CARD: 2,
+    CVV: 2,
+    IBAN: 2,
+    IP_ADDRESS: 2,
+}
+
+
+@dataclass(frozen=True)
+class DetectorCalibration:
+    """Monotonic score calibration curve for one detector."""
+
+    detector: str
+    breakpoints: tuple[tuple[float, float], ...]
+    method: str = "isotonic"
+
+    def apply(self, score: float | None) -> float | None:
+        if score is None:
+            return None
+        bounded_score = _clamp(float(score))
+        if not self.breakpoints:
+            return bounded_score
+        if bounded_score <= self.breakpoints[0][0]:
+            return self.breakpoints[0][1]
+        if bounded_score >= self.breakpoints[-1][0]:
+            return self.breakpoints[-1][1]
+
+        previous_raw, previous_value = self.breakpoints[0]
+        for raw, value in self.breakpoints[1:]:
+            if bounded_score <= raw:
+                width = raw - previous_raw
+                if width <= 0:
+                    return value
+                fraction = (bounded_score - previous_raw) / width
+                return _clamp(previous_value + fraction * (value - previous_value))
+            previous_raw, previous_value = raw, value
+        return self.breakpoints[-1][1]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "detector": self.detector,
+            "method": self.method,
+            "breakpoints": [
+                {"raw_score": raw, "calibrated_score": calibrated}
+                for raw, calibrated in self.breakpoints
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "DetectorCalibration":
+        return cls(
+            detector=str(payload["detector"]),
+            method=str(payload.get("method") or "isotonic"),
+            breakpoints=tuple(
+                (
+                    float(point["raw_score"]),
+                    float(point["calibrated_score"]),
+                )
+                for point in payload.get("breakpoints", ())
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ScoreCalibrator:
+    """Versioned per-detector score calibration table."""
+
+    detectors: Mapping[str, DetectorCalibration]
+    version: int = CALIBRATION_VERSION
+
+    @classmethod
+    def fit(cls, samples: Sequence[Any]) -> "ScoreCalibrator":
+        grouped: dict[str, list[tuple[float, float]]] = {}
+        for sample in samples:
+            detector = _sample_value(sample, "detector")
+            score = _sample_value(sample, "score", "raw_score")
+            target = _sample_value(sample, "target", "label", "outcome", "is_true")
+            if detector is None or score is None or target is None:
+                raise ValueError("calibration samples require detector, score, and target")
+            grouped.setdefault(str(detector), []).append(
+                (_clamp(float(score)), 1.0 if bool(target) else 0.0)
+            )
+
+        return cls(
+            detectors={
+                detector: DetectorCalibration(
+                    detector=detector,
+                    breakpoints=_fit_isotonic(points),
+                )
+                for detector, points in grouped.items()
+            }
+        )
+
+    def apply_score(self, detector: str | None, score: float | None) -> float | None:
+        if score is None:
+            return None
+        if detector is None:
+            return _clamp(float(score))
+        calibration = self.detectors.get(detector)
+        if calibration is None:
+            return _clamp(float(score))
+        return calibration.apply(score)
+
+    def apply_span(self, span: OpenMedSpan) -> OpenMedSpan:
+        calibrated = self.apply_score(span.detector, span.score)
+        if calibrated == span.score:
+            return span
+        metadata = dict(span.metadata)
+        metadata["score_calibration"] = {
+            "version": self.version,
+            "detector": span.detector,
+            "raw_score": span.score,
+            "calibrated_score": calibrated,
+        }
+        return replace(span, score=calibrated, metadata=metadata)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "detectors": {
+                detector: calibration.to_dict()
+                for detector, calibration in sorted(self.detectors.items())
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ScoreCalibrator":
+        return cls(
+            version=int(payload.get("version", CALIBRATION_VERSION)),
+            detectors={
+                detector: DetectorCalibration.from_dict(calibration)
+                for detector, calibration in (payload.get("detectors") or {}).items()
+            },
+        )
+
+
+def fit(samples: Sequence[Any]) -> ScoreCalibrator:
+    """Fit a versioned monotonic score calibrator from fixture/eval samples."""
+
+    return ScoreCalibrator.fit(samples)
+
+
+def apply_calibration(
+    spans: Sequence[OpenMedSpan],
+    calibrator: ScoreCalibrator | None,
+) -> tuple[OpenMedSpan, ...]:
+    if calibrator is None:
+        return tuple(spans)
+    return tuple(calibrator.apply_span(span) for span in spans)
+
+
+def arbitration_mode(*, strict_no_leak: bool = False, mode: str | None = None) -> str:
+    if mode is not None:
+        _validate_mode(mode)
+        return mode
+    return MODE_HIGH_RECALL_UNION if strict_no_leak else MODE_BALANCED
+
+
+def arbitrate(
+    spans: Sequence[OpenMedSpan],
+    *,
+    mode: str | None = None,
+    strict_no_leak: bool = False,
+    label_floors: Mapping[str, float] | None = None,
+    high_recall_label_floors: Mapping[str, float] | None = None,
+    calibrator: ScoreCalibrator | None = None,
+) -> tuple[OpenMedSpan, ...]:
+    """Resolve duplicate and overlapping detector spans."""
+
+    selected_mode = arbitration_mode(strict_no_leak=strict_no_leak, mode=mode)
+    calibrated = apply_calibration(spans, calibrator)
+    if selected_mode == MODE_HIGH_RECALL_UNION:
+        union_candidates = [
+            span
+            for span in calibrated
+            if _meets_floor(
+                span,
+                high_recall_label_floors,
+                default_floor=DEFAULT_HIGH_RECALL_FLOOR,
+            )
+        ]
+        return _sort_spans(_collapse_exact_duplicates(union_candidates))
+
+    candidates = [
+        span
+        for span in calibrated
+        if _meets_floor(span, label_floors, default_floor=DEFAULT_BALANCED_FLOOR)
+    ]
+    deduped = _collapse_exact_duplicates(candidates)
+    winners = [_choose_winner(cluster) for cluster in _overlap_clusters(deduped)]
+    return _sort_spans(winners)
+
+
+def specificity_rank(label: str) -> int:
+    canonical = normalize_label(label)
+    return _SPECIFICITY_RANKS.get(canonical, 1)
+
+
+def is_more_specific_label(left: str, right: str) -> bool:
+    left_canonical = normalize_label(left)
+    right_canonical = normalize_label(right)
+    left_rank = specificity_rank(left_canonical)
+    right_rank = specificity_rank(right_canonical)
+    if left_rank != right_rank:
+        return left_rank > right_rank
+    return is_more_specific(left_canonical.lower(), right_canonical.lower())
+
+
+def _validate_mode(mode: str) -> None:
+    if mode not in {MODE_BALANCED, MODE_HIGH_RECALL_UNION}:
+        raise ValueError(
+            f"mode must be {MODE_BALANCED!r} or {MODE_HIGH_RECALL_UNION!r}"
+        )
+
+
+def _sample_value(sample: Any, *names: str) -> Any:
+    if isinstance(sample, Mapping):
+        for name in names:
+            if name in sample:
+                return sample[name]
+        return None
+    for name in names:
+        if hasattr(sample, name):
+            return getattr(sample, name)
+    if isinstance(sample, Sequence) and not isinstance(sample, (str, bytes)):
+        index_by_name = {
+            "detector": 0,
+            "score": 1,
+            "raw_score": 1,
+            "target": 2,
+            "label": 2,
+            "outcome": 2,
+            "is_true": 2,
+        }
+        for name in names:
+            index = index_by_name.get(name)
+            if index is not None and len(sample) > index:
+                return sample[index]
+    return None
+
+
+def _fit_isotonic(points: Sequence[tuple[float, float]]) -> tuple[tuple[float, float], ...]:
+    if not points:
+        return ()
+
+    blocks: list[dict[str, float]] = []
+    for score, target in sorted(points):
+        blocks.append({"min": score, "max": score, "sum": target, "count": 1.0})
+        while len(blocks) >= 2:
+            left = blocks[-2]
+            right = blocks[-1]
+            if left["sum"] / left["count"] <= right["sum"] / right["count"]:
+                break
+            merged = {
+                "min": left["min"],
+                "max": right["max"],
+                "sum": left["sum"] + right["sum"],
+                "count": left["count"] + right["count"],
+            }
+            blocks[-2:] = [merged]
+
+    return tuple(
+        (block["max"], _clamp(block["sum"] / block["count"]))
+        for block in blocks
+    )
+
+
+def _collapse_exact_duplicates(
+    spans: Sequence[OpenMedSpan],
+) -> tuple[OpenMedSpan, ...]:
+    grouped: dict[tuple[str, int, int, str], list[OpenMedSpan]] = {}
+    for span in spans:
+        grouped.setdefault(
+            (span.doc_id, span.start, span.end, span.canonical_label),
+            [],
+        ).append(span)
+    return tuple(_choose_winner(group) for group in grouped.values())
+
+
+def _overlap_clusters(spans: Sequence[OpenMedSpan]) -> list[tuple[OpenMedSpan, ...]]:
+    sorted_spans = _sort_spans(spans)
+    clusters: list[list[OpenMedSpan]] = []
+    current: list[OpenMedSpan] = []
+    current_end: int | None = None
+
+    for span in sorted_spans:
+        if not current or current_end is None or span.start >= current_end:
+            if current:
+                clusters.append(current)
+            current = [span]
+            current_end = span.end
+            continue
+        current.append(span)
+        current_end = max(current_end, span.end)
+
+    if current:
+        clusters.append(current)
+    return [tuple(cluster) for cluster in clusters]
+
+
+def _choose_winner(spans: Sequence[OpenMedSpan]) -> OpenMedSpan:
+    if not spans:
+        raise ValueError("cannot choose a winner from no spans")
+    return max(spans, key=_winner_key)
+
+
+def _winner_key(span: OpenMedSpan) -> tuple[int, int, int, float, int, str]:
+    score = float(span.score or 0.0)
+    return (
+        1 if _is_rules_span(span) else 0,
+        specificity_rank(span.canonical_label),
+        span.end - span.start,
+        score,
+        -span.start,
+        span.detector or "",
+    )
+
+
+def _is_rules_span(span: OpenMedSpan) -> bool:
+    return bool(span.detector and span.detector.startswith("rules:"))
+
+
+def _meets_floor(
+    span: OpenMedSpan,
+    label_floors: Mapping[str, float] | None,
+    *,
+    default_floor: float,
+) -> bool:
+    score = float(span.score or 0.0)
+    floor = default_floor
+    if label_floors:
+        floor = float(
+            label_floors.get(
+                span.canonical_label,
+                label_floors.get(span.entity_type, default_floor),
+            )
+        )
+    return score >= floor
+
+
+def _sort_spans(spans: Sequence[OpenMedSpan]) -> tuple[OpenMedSpan, ...]:
+    return tuple(
+        sorted(
+            spans,
+            key=lambda span: (
+                span.doc_id,
+                span.start,
+                span.end,
+                span.canonical_label,
+                span.detector or "",
+            ),
+        )
+    )
+
+
+def _clamp(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value
+
+
+__all__ = [
+    "CALIBRATION_VERSION",
+    "DEFAULT_BALANCED_FLOOR",
+    "DEFAULT_HIGH_RECALL_FLOOR",
+    "DetectorCalibration",
+    "MODE_BALANCED",
+    "MODE_HIGH_RECALL_UNION",
+    "ScoreCalibrator",
+    "apply_calibration",
+    "arbitrate",
+    "arbitration_mode",
+    "fit",
+    "is_more_specific_label",
+    "specificity_rank",
+]

--- a/openmed/core/cascade.py
+++ b/openmed/core/cascade.py
@@ -1,0 +1,317 @@
+"""Cheapest-first local detector cascade for privacy spans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+
+from .arbitration import (
+    MODE_BALANCED,
+    MODE_HIGH_RECALL_UNION,
+    ScoreCalibrator,
+    arbitrate,
+    arbitration_mode,
+)
+from .schemas.span import OpenMedSpan
+
+
+Detector = Callable[..., Sequence[OpenMedSpan]]
+OfflineHook = Callable[[str, Any], bool | None]
+
+R0_RULES = "R0"
+R1_TINY = "R1"
+R2_BASE = "R2"
+R3_ACCURATE = "R3"
+R4_LOCAL_SLM = "R4"
+
+
+@dataclass(frozen=True)
+class CascadeStageResult:
+    route: str
+    name: str
+    spans: tuple[OpenMedSpan, ...]
+    reason: str
+
+
+@dataclass(frozen=True)
+class CascadeResult:
+    spans: tuple[OpenMedSpan, ...]
+    stage_results: tuple[CascadeStageResult, ...]
+    mode: str
+
+    def reached(self, route: str) -> bool:
+        return any(stage.route == route for stage in self.stage_results)
+
+    def stage(self, route: str) -> CascadeStageResult:
+        for stage in self.stage_results:
+            if stage.route == route:
+                return stage
+        raise KeyError(route)
+
+
+class CascadeRouter:
+    """Run local detectors R0..R4 and arbitrate the resulting span union."""
+
+    def __init__(
+        self,
+        *,
+        rules_detector: Detector | None = None,
+        tiny_detector: Detector | None = None,
+        base_detector: Detector | None = None,
+        accurate_detector: Detector | None = None,
+        local_slm_detector: Detector | None = None,
+        strict_no_leak: bool = False,
+        high_recall: bool = False,
+        allow_local_slm: bool = False,
+        low_confidence_threshold: float = 0.5,
+        clinical_doc_types: Sequence[str] = ("clinical", "note", "ehr", "medical"),
+        offline_hook: OfflineHook | None = None,
+        calibrator: ScoreCalibrator | None = None,
+        label_floors: Mapping[str, float] | None = None,
+        high_recall_label_floors: Mapping[str, float] | None = None,
+        arbitration_mode_override: str | None = None,
+    ) -> None:
+        self.rules_detector = rules_detector
+        self.tiny_detector = tiny_detector
+        self.base_detector = base_detector
+        self.accurate_detector = accurate_detector
+        self.local_slm_detector = local_slm_detector
+        self.strict_no_leak = strict_no_leak
+        self.high_recall = high_recall
+        self.allow_local_slm = allow_local_slm
+        self.low_confidence_threshold = low_confidence_threshold
+        self.clinical_doc_types = tuple(item.lower() for item in clinical_doc_types)
+        self.offline_hook = offline_hook
+        self.calibrator = calibrator
+        self.label_floors = label_floors
+        self.high_recall_label_floors = high_recall_label_floors
+        self.arbitration_mode_override = arbitration_mode_override
+
+    def run(
+        self,
+        text: str,
+        *,
+        context: Any = None,
+        doc_type: str | None = None,
+        strict_no_leak: bool | None = None,
+        high_recall: bool | None = None,
+        audit_flag: bool = False,
+    ) -> CascadeResult:
+        strict = self.strict_no_leak if strict_no_leak is None else strict_no_leak
+        recall = self.high_recall if high_recall is None else high_recall
+        selected_mode = (
+            self.arbitration_mode_override
+            or arbitration_mode(strict_no_leak=strict or recall)
+        )
+
+        stage_results: list[CascadeStageResult] = []
+        all_spans: list[OpenMedSpan] = []
+
+        r0_spans = self._run_detector(
+            R0_RULES,
+            "rules",
+            self.rules_detector,
+            text,
+            context=context,
+            reason="always",
+        )
+        stage_results.append(
+            CascadeStageResult(R0_RULES, "rules", r0_spans, "always")
+        )
+        all_spans.extend(r0_spans)
+
+        r1_spans = self._run_detector(
+            R1_TINY,
+            "tiny",
+            self.tiny_detector,
+            text,
+            context=context,
+            reason="always",
+        )
+        stage_results.append(CascadeStageResult(R1_TINY, "tiny", r1_spans, "always"))
+        all_spans.extend(r1_spans)
+
+        doc_type_value = self._doc_type(context, doc_type)
+        r2_reason = self._r2_reason(all_spans, doc_type_value)
+        r2_spans: tuple[OpenMedSpan, ...] = ()
+        if r2_reason is not None:
+            r2_spans = self._run_detector(
+                R2_BASE,
+                "base",
+                self.base_detector,
+                text,
+                context=context,
+                reason=r2_reason,
+            )
+            stage_results.append(CascadeStageResult(R2_BASE, "base", r2_spans, r2_reason))
+            all_spans.extend(r2_spans)
+
+        r3_reason = self._r3_reason(
+            strict=strict,
+            high_recall=recall,
+            before_r2=(*r0_spans, *r1_spans),
+            r2_spans=r2_spans,
+        )
+        if r3_reason is not None:
+            r3_spans = self._run_detector(
+                R3_ACCURATE,
+                "accurate",
+                self.accurate_detector,
+                text,
+                context=context,
+                reason=r3_reason,
+            )
+            stage_results.append(
+                CascadeStageResult(R3_ACCURATE, "accurate", r3_spans, r3_reason)
+            )
+            all_spans.extend(r3_spans)
+
+        r4_reason = self._r4_reason(all_spans, audit_flag=audit_flag)
+        if r4_reason is not None:
+            r4_spans = self._run_detector(
+                R4_LOCAL_SLM,
+                "local_slm",
+                self.local_slm_detector,
+                text,
+                context=context,
+                reason=r4_reason,
+            )
+            stage_results.append(
+                CascadeStageResult(R4_LOCAL_SLM, "local_slm", r4_spans, r4_reason)
+            )
+            all_spans.extend(r4_spans)
+
+        final_spans = arbitrate(
+            all_spans,
+            mode=selected_mode,
+            strict_no_leak=strict,
+            calibrator=self.calibrator,
+            label_floors=self.label_floors,
+            high_recall_label_floors=self.high_recall_label_floors,
+        )
+        return CascadeResult(
+            spans=final_spans,
+            stage_results=tuple(stage_results),
+            mode=selected_mode,
+        )
+
+    def _run_detector(
+        self,
+        route: str,
+        name: str,
+        detector: Detector | None,
+        text: str,
+        *,
+        context: Any,
+        reason: str,
+    ) -> tuple[OpenMedSpan, ...]:
+        if detector is None:
+            return ()
+        self._assert_local(route, detector)
+        try:
+            result = detector(text, context=context, route=route, reason=reason)
+        except TypeError:
+            try:
+                result = detector(text, context=context)
+            except TypeError:
+                result = detector(text)
+        return tuple(result or ())
+
+    def _assert_local(self, route: str, detector: Any) -> None:
+        if bool(getattr(detector, "network_egress", False)):
+            raise RuntimeError(f"{route} detector is not local-only")
+        if bool(getattr(detector, "allows_network", False)):
+            raise RuntimeError(f"{route} detector is not local-only")
+        if self.offline_hook is not None and self.offline_hook(route, detector) is False:
+            raise RuntimeError(f"{route} detector failed offline assertion")
+
+    def _doc_type(self, context: Any, doc_type: str | None) -> str | None:
+        if doc_type:
+            return doc_type.lower()
+        section_metadata = getattr(context, "section_metadata", None)
+        if isinstance(section_metadata, Mapping):
+            value = section_metadata.get("doc_type")
+            if value:
+                return str(value).lower()
+        return None
+
+    def _r2_reason(
+        self,
+        spans: Sequence[OpenMedSpan],
+        doc_type: str | None,
+    ) -> str | None:
+        if doc_type and doc_type.lower() in self.clinical_doc_types:
+            return "clinical_doc_type"
+        if _has_low_confidence(spans, self.low_confidence_threshold):
+            return "low_confidence"
+        return None
+
+    def _r3_reason(
+        self,
+        *,
+        strict: bool,
+        high_recall: bool,
+        before_r2: Sequence[OpenMedSpan],
+        r2_spans: Sequence[OpenMedSpan],
+    ) -> str | None:
+        if strict:
+            return "strict_no_leak"
+        if high_recall:
+            return "high_recall"
+        if r2_spans and _has_disagreement(before_r2, r2_spans):
+            return "r2_disagreement"
+        return None
+
+    def _r4_reason(
+        self,
+        spans: Sequence[OpenMedSpan],
+        *,
+        audit_flag: bool,
+    ) -> str | None:
+        if not self.allow_local_slm:
+            return None
+        if audit_flag:
+            return "audit_flag"
+        if _has_low_confidence(spans, self.low_confidence_threshold):
+            return "low_confidence"
+        return None
+
+
+def _has_low_confidence(
+    spans: Sequence[OpenMedSpan],
+    threshold: float,
+) -> bool:
+    if not spans:
+        return True
+    return any(span.score is None or float(span.score) < threshold for span in spans)
+
+
+def _has_disagreement(
+    left: Sequence[OpenMedSpan],
+    right: Sequence[OpenMedSpan],
+) -> bool:
+    for left_span in left:
+        for right_span in right:
+            if left_span.start >= right_span.end or left_span.end <= right_span.start:
+                continue
+            if (
+                left_span.start != right_span.start
+                or left_span.end != right_span.end
+                or left_span.canonical_label != right_span.canonical_label
+            ):
+                return True
+    return False
+
+
+__all__ = [
+    "CascadeResult",
+    "CascadeRouter",
+    "CascadeStageResult",
+    "MODE_BALANCED",
+    "MODE_HIGH_RECALL_UNION",
+    "R0_RULES",
+    "R1_TINY",
+    "R2_BASE",
+    "R3_ACCURATE",
+    "R4_LOCAL_SLM",
+]

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -151,7 +151,13 @@ class Pipeline:
         privacy_filter_pipeline: Any = None,
         model_detector: ModelDetector | None = None,
         clinical_model_detector: ModelDetector | None = None,
+        cascade_router: Any = None,
         arbitration: SpanHook | None = None,
+        arbitration_mode: str | None = None,
+        strict_no_leak: bool = False,
+        score_calibrator: Any = None,
+        arbitration_label_floors: Mapping[str, float] | None = None,
+        high_recall_label_floors: Mapping[str, float] | None = None,
         policy_actions: SpanHook | None = None,
         section_detector: Callable[..., Mapping[str, Any]] | None = None,
         hmac_secret: str | bytes = DEFAULT_HASH_SECRET,
@@ -169,7 +175,13 @@ class Pipeline:
         self.privacy_filter_pipeline = privacy_filter_pipeline
         self.model_detector = model_detector
         self.clinical_model_detector = clinical_model_detector
+        self.cascade_router = cascade_router
         self.arbitration = arbitration
+        self.arbitration_mode = arbitration_mode
+        self.strict_no_leak = strict_no_leak
+        self.score_calibrator = score_calibrator
+        self.arbitration_label_floors = arbitration_label_floors
+        self.high_recall_label_floors = high_recall_label_floors
         self.policy_actions = policy_actions
         self.section_detector = section_detector
         self.hmac_secret = hmac_secret
@@ -235,34 +247,86 @@ class Pipeline:
             ),
         ]
 
-        deterministic_spans = self.stage4_deterministic_detectors(
-            normalized.normalized_text,
-            context,
-        )
-        stage_results.append(
-            PipelineStageResult(4, STAGE_NAMES[3], spans=deterministic_spans)
-        )
+        cascade_driven = self.cascade_router is not None
+        if cascade_driven:
+            cascade_result = self.cascade_router.run(
+                normalized.normalized_text,
+                context=context,
+                strict_no_leak=self.strict_no_leak,
+            )
+            deterministic_spans = _cascade_stage_spans(cascade_result, {"R0"})
+            model_spans = _cascade_stage_spans(cascade_result, {"R1", "R2"})
+            clinical_spans = _cascade_stage_spans(cascade_result, {"R3", "R4"})
+            pii_result = _prediction_result_from_spans(
+                normalized.normalized_text,
+                cascade_result.spans,
+                model_name="cascade",
+            )
+            cascade_metadata = {
+                "cascade_mode": cascade_result.mode,
+                "routes": [
+                    {
+                        "route": stage.route,
+                        "name": stage.name,
+                        "reason": stage.reason,
+                        "span_count": len(stage.spans),
+                    }
+                    for stage in cascade_result.stage_results
+                ],
+            }
+            stage_results.append(
+                PipelineStageResult(
+                    4,
+                    STAGE_NAMES[3],
+                    spans=deterministic_spans,
+                    metadata=cascade_metadata,
+                )
+            )
+            stage_results.append(
+                PipelineStageResult(5, STAGE_NAMES[4], spans=model_spans)
+            )
+            stage_results.append(
+                PipelineStageResult(6, STAGE_NAMES[5], spans=clinical_spans)
+            )
+        else:
+            deterministic_spans = self.stage4_deterministic_detectors(
+                normalized.normalized_text,
+                context,
+            )
+            stage_results.append(
+                PipelineStageResult(4, STAGE_NAMES[3], spans=deterministic_spans)
+            )
 
-        pii_result = self.stage5_fast_pii_model(normalized.normalized_text, route)
-        model_spans = self._entities_to_spans(
-            getattr(pii_result, "entities", ()),
-            normalized.normalized_text,
-            context,
-            default_detector=f"model:{getattr(pii_result, 'model_name', route.model_name)}",
-            stage=STAGE_NAMES[4],
-        )
-        stage_results.append(PipelineStageResult(5, STAGE_NAMES[4], spans=model_spans))
+            pii_result = self.stage5_fast_pii_model(normalized.normalized_text, route)
+            model_spans = self._entities_to_spans(
+                getattr(pii_result, "entities", ()),
+                normalized.normalized_text,
+                context,
+                default_detector=f"model:{getattr(pii_result, 'model_name', route.model_name)}",
+                stage=STAGE_NAMES[4],
+            )
+            stage_results.append(
+                PipelineStageResult(5, STAGE_NAMES[4], spans=model_spans)
+            )
 
-        clinical_spans = self.stage6_clinical_phi_model(
-            normalized.normalized_text,
-            context,
-        )
-        stage_results.append(PipelineStageResult(6, STAGE_NAMES[5], spans=clinical_spans))
+            clinical_spans = self.stage6_clinical_phi_model(
+                normalized.normalized_text,
+                context,
+            )
+            stage_results.append(
+                PipelineStageResult(6, STAGE_NAMES[5], spans=clinical_spans)
+            )
 
         merged_spans = self.stage7_arbitration(
             (*deterministic_spans, *model_spans, *clinical_spans),
             context,
         )
+        if cascade_driven:
+            pii_result = _prediction_result_from_spans(
+                normalized.normalized_text,
+                merged_spans,
+                model_name="cascade",
+            )
         stage_results.append(PipelineStageResult(7, STAGE_NAMES[6], spans=merged_spans))
 
         policy_spans = self.stage8_policy_actions(merged_spans, context)
@@ -481,7 +545,16 @@ class Pipeline:
     ) -> tuple[OpenMedSpan, ...]:
         if self.arbitration is not None:
             return tuple(self.arbitration(spans, context))
-        return tuple(sorted(spans, key=lambda span: (span.start, span.end, span.detector or "")))
+        from .arbitration import arbitrate
+
+        return arbitrate(
+            spans,
+            mode=self.arbitration_mode,
+            strict_no_leak=self.strict_no_leak,
+            calibrator=self.score_calibrator,
+            label_floors=self.arbitration_label_floors,
+            high_recall_label_floors=self.high_recall_label_floors,
+        )
 
     def stage8_policy_actions(
         self,
@@ -786,6 +859,46 @@ def _redacted_char_count(entities: Sequence[Any]) -> int:
         current_start, current_end = start, end
     total += current_end - current_start
     return total
+
+
+def _cascade_stage_spans(cascade_result: Any, routes: set[str]) -> tuple[OpenMedSpan, ...]:
+    spans: list[OpenMedSpan] = []
+    for stage in getattr(cascade_result, "stage_results", ()):
+        if getattr(stage, "route", None) in routes:
+            spans.extend(getattr(stage, "spans", ()) or ())
+    return tuple(spans)
+
+
+def _prediction_result_from_spans(
+    text: str,
+    spans: Sequence[OpenMedSpan],
+    *,
+    model_name: str,
+) -> Any:
+    from datetime import datetime
+
+    from ..processing.outputs import EntityPrediction, PredictionResult
+
+    return PredictionResult(
+        text=text,
+        entities=[
+            EntityPrediction(
+                text=text[span.start:span.end],
+                label=span.entity_type or span.canonical_label,
+                start=span.start,
+                end=span.end,
+                confidence=float(span.score or 0.0),
+                metadata={
+                    **dict(span.metadata),
+                    "detector": span.detector,
+                    "canonical_label": span.canonical_label,
+                },
+            )
+            for span in spans
+        ],
+        model_name=model_name,
+        timestamp=datetime.now().isoformat(),
+    )
 
 
 __all__ = [

--- a/tests/unit/core/test_arbitration.py
+++ b/tests/unit/core/test_arbitration.py
@@ -1,0 +1,89 @@
+import pytest
+
+from openmed.core.arbitration import (
+    MODE_BALANCED,
+    MODE_HIGH_RECALL_UNION,
+    apply_calibration,
+    arbitrate,
+    arbitration_mode,
+    fit,
+    is_more_specific_label,
+)
+from openmed.core.schemas.span import OpenMedSpan, hmac_text_hash
+
+
+def _span(
+    *,
+    start: int = 0,
+    end: int = 8,
+    label: str = "PERSON",
+    detector: str = "model:tiny",
+    score: float = 0.9,
+) -> OpenMedSpan:
+    surface = f"{start}:{end}:{label}"
+    return OpenMedSpan(
+        doc_id="doc-1",
+        start=start,
+        end=end,
+        text_hash=hmac_text_hash(surface, "test-secret"),
+        entity_type=label,
+        canonical_label=label,
+        score=score,
+        detector=detector,
+    )
+
+
+def test_overlapping_rules_span_wins_against_model_span():
+    rules = _span(start=0, end=8, detector="rules:mrn_luhn", score=0.55)
+    model = _span(start=0, end=12, detector="model:base", score=0.99)
+
+    assert arbitrate([model, rules], mode=MODE_BALANCED) == (rules,)
+
+
+def test_high_recall_union_keeps_span_balanced_mode_drops():
+    weak_span = _span(label="EMAIL", detector="model:tiny", score=0.2)
+
+    assert arbitrate([weak_span], mode=MODE_BALANCED) == ()
+    assert arbitrate([weak_span], mode=MODE_HIGH_RECALL_UNION) == (weak_span,)
+    assert arbitrate([weak_span], strict_no_leak=True) == (weak_span,)
+    assert arbitration_mode(strict_no_leak=True) == MODE_HIGH_RECALL_UNION
+
+
+def test_more_specific_label_wins_overlap_before_score():
+    date = _span(start=4, end=14, label="DATE", detector="model:base", score=0.99)
+    dob = _span(
+        start=4,
+        end=12,
+        label="DATE_OF_BIRTH",
+        detector="model:tiny",
+        score=0.6,
+    )
+
+    assert is_more_specific_label("DATE_OF_BIRTH", "DATE")
+    assert arbitrate([date, dob], mode=MODE_BALANCED) == (dob,)
+
+
+def test_exact_duplicate_spans_collapse_to_best_scored_span():
+    lower = _span(detector="model:tiny", score=0.6)
+    higher = _span(detector="model:base", score=0.8)
+
+    assert arbitrate([lower, higher], mode=MODE_BALANCED) == (higher,)
+
+
+def test_score_calibration_makes_detector_scores_comparable():
+    calibrator = fit(
+        [
+            {"detector": "model:a", "score": 0.2, "target": 0},
+            {"detector": "model:a", "score": 0.8, "target": 1},
+            {"detector": "model:b", "score": 0.7, "target": 0},
+            {"detector": "model:b", "score": 0.9, "target": 1},
+        ]
+    )
+    a_span = _span(detector="model:a", score=0.8)
+    b_span = _span(start=12, end=20, detector="model:b", score=0.9)
+
+    calibrated_a, calibrated_b = apply_calibration([a_span, b_span], calibrator)
+
+    assert calibrated_a.score == pytest.approx(calibrated_b.score)
+    assert calibrated_a.score == pytest.approx(1.0)
+    assert calibrated_b.metadata["score_calibration"]["version"] == calibrator.version

--- a/tests/unit/core/test_cascade_router.py
+++ b/tests/unit/core/test_cascade_router.py
@@ -1,0 +1,112 @@
+import pytest
+
+from openmed.core.cascade import (
+    R0_RULES,
+    R1_TINY,
+    R2_BASE,
+    R3_ACCURATE,
+    CascadeRouter,
+)
+from openmed.core.pipeline import Pipeline
+from openmed.core.schemas.span import OpenMedSpan, hmac_text_hash
+
+
+def _span(
+    *,
+    start: int = 0,
+    end: int = 8,
+    label: str = "PERSON",
+    detector: str = "model:tiny",
+    score: float = 0.9,
+) -> OpenMedSpan:
+    surface = f"{start}:{end}:{label}"
+    return OpenMedSpan(
+        doc_id="doc-1",
+        start=start,
+        end=end,
+        text_hash=hmac_text_hash(surface, "test-secret"),
+        entity_type=label,
+        canonical_label=label,
+        score=score,
+        detector=detector,
+    )
+
+
+def _detector(route_calls, route, spans):
+    def detect(text, **kwargs):
+        route_calls.append((route, text, kwargs.get("reason")))
+        return spans
+
+    return detect
+
+
+def test_router_reaches_accurate_route_under_strict_no_leak():
+    calls = []
+    router = CascadeRouter(
+        tiny_detector=_detector(calls, R1_TINY, [_span(score=0.95)]),
+        accurate_detector=_detector(
+            calls,
+            R3_ACCURATE,
+            [_span(start=16, end=22, detector="model:accurate", score=0.9)],
+        ),
+        strict_no_leak=True,
+    )
+
+    result = router.run("Patient John Doe")
+
+    assert result.reached(R0_RULES)
+    assert result.reached(R1_TINY)
+    assert result.reached(R3_ACCURATE)
+    assert result.mode == "high_recall_union"
+    assert [call[0] for call in calls] == [R1_TINY, R3_ACCURATE]
+
+
+def test_router_stays_at_base_route_without_strict_policy():
+    calls = []
+    r1_span = _span(detector="model:tiny", score=0.2)
+    r2_span = _span(detector="model:base", score=0.8)
+    router = CascadeRouter(
+        tiny_detector=_detector(calls, R1_TINY, [r1_span]),
+        base_detector=_detector(calls, R2_BASE, [r2_span]),
+        accurate_detector=_detector(
+            calls,
+            R3_ACCURATE,
+            [_span(detector="model:accurate", score=0.9)],
+        ),
+    )
+
+    result = router.run("Patient John Doe")
+
+    assert result.reached(R1_TINY)
+    assert result.reached(R2_BASE)
+    assert not result.reached(R3_ACCURATE)
+    assert result.mode == "balanced"
+    assert [call[0] for call in calls] == [R1_TINY, R2_BASE]
+
+
+def test_router_rejects_detector_when_offline_hook_fails():
+    router = CascadeRouter(
+        tiny_detector=lambda text, **kwargs: [],
+        offline_hook=lambda route, detector: False,
+    )
+
+    with pytest.raises(RuntimeError, match="offline assertion"):
+        router.run("Patient John Doe")
+
+
+def test_pipeline_can_use_cascade_router_for_detection_stages():
+    rules_span = _span(start=0, end=4, detector="rules:regex", score=0.95)
+    tiny_span = _span(start=8, end=12, detector="model:tiny", score=0.95)
+    router = CascadeRouter(
+        rules_detector=lambda text, **kwargs: [rules_span],
+        tiny_detector=lambda text, **kwargs: [tiny_span],
+    )
+
+    result = Pipeline(
+        cascade_router=router,
+        use_safety_sweep=False,
+    ).run("John met Jane")
+
+    assert result.stage("deterministic_detectors").spans == (rules_span,)
+    assert result.stage("fast_pii_model").spans == (tiny_span,)
+    assert result.stage("span_arbitration").spans == (rules_span, tiny_span)


### PR DESCRIPTION
Closes #119.

Adds detector arbitration with calibrated score handling, balanced and high-recall modes, and a local cascade router that escalates detectors cheapest-first. The pipeline now uses arbitration at stage 7 and can accept a router to drive stages 4 through 6 while preserving existing deidentify behavior.