### PR TITLE
Add the versioned per-label/language/policy thresholds matrix

### DIFF
--- a/openmed/core/arbitration.py
+++ b/openmed/core/arbitration.py
@@ -223,30 +223,50 @@ def arbitrate(
     *,
     mode: str | None = None,
     strict_no_leak: bool = False,
+    language: str = "en",
+    policy_profile: str | None = None,
     label_floors: Mapping[str, float] | None = None,
     high_recall_label_floors: Mapping[str, float] | None = None,
+    threshold_matrix: Mapping[str, Any] | None = None,
     calibrator: ScoreCalibrator | None = None,
 ) -> tuple[OpenMedSpan, ...]:
     """Resolve duplicate and overlapping detector spans."""
 
     selected_mode = arbitration_mode(strict_no_leak=strict_no_leak, mode=mode)
     calibrated = apply_calibration(spans, calibrator)
+    resolved_profile = _profile_for_mode(
+        selected_mode,
+        strict_no_leak=strict_no_leak,
+        policy_profile=policy_profile,
+    )
     if selected_mode == MODE_HIGH_RECALL_UNION:
+        floors = high_recall_label_floors or _matrix_keep_floors(
+            calibrated,
+            language=language,
+            policy_profile=resolved_profile,
+            matrix=threshold_matrix,
+        )
         union_candidates = [
             span
             for span in calibrated
             if _meets_floor(
                 span,
-                high_recall_label_floors,
+                floors,
                 default_floor=DEFAULT_HIGH_RECALL_FLOOR,
             )
         ]
         return _sort_spans(_collapse_exact_duplicates(union_candidates))
 
+    floors = label_floors or _matrix_keep_floors(
+        calibrated,
+        language=language,
+        policy_profile=resolved_profile,
+        matrix=threshold_matrix,
+    )
     candidates = [
         span
         for span in calibrated
-        if _meets_floor(span, label_floors, default_floor=DEFAULT_BALANCED_FLOOR)
+        if _meets_floor(span, floors, default_floor=DEFAULT_BALANCED_FLOOR)
     ]
     deduped = _collapse_exact_duplicates(candidates)
     winners = [_choose_winner(cluster) for cluster in _overlap_clusters(deduped)]
@@ -273,6 +293,49 @@ def _validate_mode(mode: str) -> None:
         raise ValueError(
             f"mode must be {MODE_BALANCED!r} or {MODE_HIGH_RECALL_UNION!r}"
         )
+
+
+def _profile_for_mode(
+    mode: str,
+    *,
+    strict_no_leak: bool,
+    policy_profile: str | None,
+) -> str:
+    if policy_profile is not None:
+        return policy_profile
+    if strict_no_leak or mode == MODE_HIGH_RECALL_UNION:
+        return "strict_no_leak"
+    return "balanced"
+
+
+def _matrix_keep_floors(
+    spans: Sequence[OpenMedSpan],
+    *,
+    language: str,
+    policy_profile: str,
+    matrix: Mapping[str, Any] | None,
+) -> dict[str, float]:
+    if not spans:
+        return {}
+
+    from .thresholds import lookup_threshold
+
+    floors: dict[str, float] = {}
+    for span in spans:
+        if span.canonical_label in floors:
+            continue
+        try:
+            floors[span.canonical_label] = float(
+                lookup_threshold(
+                    span.canonical_label,
+                    language,
+                    policy_profile,
+                    matrix=matrix,
+                )["keep_floor"]
+            )
+        except Exception:
+            continue
+    return floors
 
 
 def _sample_value(sample: Any, *names: str) -> Any:

--- a/openmed/core/cascade.py
+++ b/openmed/core/cascade.py
@@ -67,6 +67,9 @@ class CascadeRouter:
         clinical_doc_types: Sequence[str] = ("clinical", "note", "ehr", "medical"),
         offline_hook: OfflineHook | None = None,
         calibrator: ScoreCalibrator | None = None,
+        policy_profile: str | None = None,
+        language: str = "en",
+        threshold_matrix: Mapping[str, Any] | None = None,
         label_floors: Mapping[str, float] | None = None,
         high_recall_label_floors: Mapping[str, float] | None = None,
         arbitration_mode_override: str | None = None,
@@ -83,6 +86,9 @@ class CascadeRouter:
         self.clinical_doc_types = tuple(item.lower() for item in clinical_doc_types)
         self.offline_hook = offline_hook
         self.calibrator = calibrator
+        self.policy_profile = policy_profile
+        self.language = language
+        self.threshold_matrix = threshold_matrix
         self.label_floors = label_floors
         self.high_recall_label_floors = high_recall_label_floors
         self.arbitration_mode_override = arbitration_mode_override
@@ -96,9 +102,17 @@ class CascadeRouter:
         strict_no_leak: bool | None = None,
         high_recall: bool | None = None,
         audit_flag: bool = False,
+        language: str | None = None,
+        policy_profile: str | None = None,
     ) -> CascadeResult:
         strict = self.strict_no_leak if strict_no_leak is None else strict_no_leak
         recall = self.high_recall if high_recall is None else high_recall
+        route_language = language or self._language(context)
+        route_profile = (
+            policy_profile
+            or self.policy_profile
+            or ("strict_no_leak" if strict or recall else "balanced")
+        )
         selected_mode = (
             self.arbitration_mode_override
             or arbitration_mode(strict_no_leak=strict or recall)
@@ -132,7 +146,12 @@ class CascadeRouter:
         all_spans.extend(r1_spans)
 
         doc_type_value = self._doc_type(context, doc_type)
-        r2_reason = self._r2_reason(all_spans, doc_type_value)
+        r2_reason = self._r2_reason(
+            all_spans,
+            doc_type_value,
+            language=route_language,
+            policy_profile=route_profile,
+        )
         r2_spans: tuple[OpenMedSpan, ...] = ()
         if r2_reason is not None:
             r2_spans = self._run_detector(
@@ -166,7 +185,12 @@ class CascadeRouter:
             )
             all_spans.extend(r3_spans)
 
-        r4_reason = self._r4_reason(all_spans, audit_flag=audit_flag)
+        r4_reason = self._r4_reason(
+            all_spans,
+            audit_flag=audit_flag,
+            language=route_language,
+            policy_profile=route_profile,
+        )
         if r4_reason is not None:
             r4_spans = self._run_detector(
                 R4_LOCAL_SLM,
@@ -185,9 +209,12 @@ class CascadeRouter:
             all_spans,
             mode=selected_mode,
             strict_no_leak=strict,
+            language=route_language,
+            policy_profile=route_profile,
             calibrator=self.calibrator,
             label_floors=self.label_floors,
             high_recall_label_floors=self.high_recall_label_floors,
+            threshold_matrix=self.threshold_matrix,
         )
         return CascadeResult(
             spans=final_spans,
@@ -235,14 +262,27 @@ class CascadeRouter:
                 return str(value).lower()
         return None
 
+    def _language(self, context: Any) -> str:
+        route = getattr(context, "route", None)
+        if route is not None and getattr(route, "lang", None):
+            return str(route.lang)
+        return self.language
+
     def _r2_reason(
         self,
         spans: Sequence[OpenMedSpan],
         doc_type: str | None,
+        *,
+        language: str,
+        policy_profile: str,
     ) -> str | None:
         if doc_type and doc_type.lower() in self.clinical_doc_types:
             return "clinical_doc_type"
-        if _has_low_confidence(spans, self.low_confidence_threshold):
+        if self._has_low_confidence(
+            spans,
+            language=language,
+            policy_profile=policy_profile,
+        ):
             return "low_confidence"
         return None
 
@@ -267,23 +307,48 @@ class CascadeRouter:
         spans: Sequence[OpenMedSpan],
         *,
         audit_flag: bool,
+        language: str,
+        policy_profile: str,
     ) -> str | None:
         if not self.allow_local_slm:
             return None
         if audit_flag:
             return "audit_flag"
-        if _has_low_confidence(spans, self.low_confidence_threshold):
+        if self._has_low_confidence(
+            spans,
+            language=language,
+            policy_profile=policy_profile,
+        ):
             return "low_confidence"
         return None
 
+    def _has_low_confidence(
+        self,
+        spans: Sequence[OpenMedSpan],
+        *,
+        language: str,
+        policy_profile: str,
+    ) -> bool:
+        if not spans:
+            return True
 
-def _has_low_confidence(
-    spans: Sequence[OpenMedSpan],
-    threshold: float,
-) -> bool:
-    if not spans:
-        return True
-    return any(span.score is None or float(span.score) < threshold for span in spans)
+        from .thresholds import lookup_threshold
+
+        for span in spans:
+            try:
+                threshold = float(
+                    lookup_threshold(
+                        span.canonical_label,
+                        language,
+                        policy_profile,
+                        matrix=self.threshold_matrix,
+                    )["escalate_below"]
+                )
+            except Exception:
+                threshold = self.low_confidence_threshold
+            if span.score is None or float(span.score) < threshold:
+                return True
+        return False
 
 
 def _has_disagreement(

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Mapping, Optional, Sequence
 import unicodedata
 
@@ -155,6 +155,8 @@ class Pipeline:
         arbitration: SpanHook | None = None,
         arbitration_mode: str | None = None,
         strict_no_leak: bool = False,
+        policy_profile: str | None = None,
+        threshold_matrix: Mapping[str, Any] | None = None,
         score_calibrator: Any = None,
         arbitration_label_floors: Mapping[str, float] | None = None,
         high_recall_label_floors: Mapping[str, float] | None = None,
@@ -179,6 +181,8 @@ class Pipeline:
         self.arbitration = arbitration
         self.arbitration_mode = arbitration_mode
         self.strict_no_leak = strict_no_leak
+        self.policy_profile = policy_profile
+        self.threshold_matrix = threshold_matrix
         self.score_calibrator = score_calibrator
         self.arbitration_label_floors = arbitration_label_floors
         self.high_recall_label_floors = high_recall_label_floors
@@ -253,6 +257,8 @@ class Pipeline:
                 normalized.normalized_text,
                 context=context,
                 strict_no_leak=self.strict_no_leak,
+                language=route.lang,
+                policy_profile=self.policy_profile,
             )
             deterministic_spans = _cascade_stage_spans(cascade_result, {"R0"})
             model_spans = _cascade_stage_spans(cascade_result, {"R1", "R2"})
@@ -551,9 +557,12 @@ class Pipeline:
             spans,
             mode=self.arbitration_mode,
             strict_no_leak=self.strict_no_leak,
+            language=context.route.lang,
+            policy_profile=self.policy_profile,
             calibrator=self.score_calibrator,
             label_floors=self.arbitration_label_floors,
             high_recall_label_floors=self.high_recall_label_floors,
+            threshold_matrix=self.threshold_matrix,
         )
 
     def stage8_policy_actions(
@@ -563,7 +572,16 @@ class Pipeline:
     ) -> tuple[OpenMedSpan, ...]:
         if self.policy_actions is not None:
             return tuple(self.policy_actions(spans, context))
-        return tuple(spans)
+        return tuple(
+            _apply_threshold_action(
+                span,
+                language=context.route.lang,
+                policy_profile=self.policy_profile,
+                strict_no_leak=self.strict_no_leak,
+                matrix=self.threshold_matrix,
+            )
+            for span in spans
+        )
 
     def stage9_safety_sweep(
         self,
@@ -899,6 +917,36 @@ def _prediction_result_from_spans(
         model_name=model_name,
         timestamp=datetime.now().isoformat(),
     )
+
+
+def _apply_threshold_action(
+    span: OpenMedSpan,
+    *,
+    language: str,
+    policy_profile: str | None,
+    strict_no_leak: bool,
+    matrix: Mapping[str, Any] | None,
+) -> OpenMedSpan:
+    from .thresholds import lookup_threshold
+
+    profile = policy_profile or ("strict_no_leak" if strict_no_leak else "balanced")
+    threshold = lookup_threshold(
+        span.canonical_label,
+        language,
+        profile,
+        matrix=matrix,
+    )
+    action = str(threshold["action"])
+    if span.action == action:
+        return span
+
+    metadata = dict(span.metadata)
+    metadata["threshold_action"] = {
+        "policy_profile": threshold["policy_profile"],
+        "source": threshold["source"],
+        "schema_version": threshold["schema_version"],
+    }
+    return replace(span, action=action, metadata=metadata)
 
 
 __all__ = [

--- a/openmed/core/thresholds.json
+++ b/openmed/core/thresholds.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": 1,
+  "default_policy_profile": "balanced",
+  "profiles": {
+    "balanced": {
+      "recall_floor": 0.97,
+      "default": {
+        "keep_floor": 0.5,
+        "escalate_below": 0.5,
+        "action": "mask"
+      },
+      "labels": {
+        "DATE": {
+          "*": {
+            "keep_floor": 0.55,
+            "escalate_below": 0.5,
+            "action": "mask"
+          }
+        },
+        "EMAIL": {
+          "*": {
+            "keep_floor": 0.5,
+            "escalate_below": 0.45,
+            "action": "mask"
+          }
+        },
+        "ID_NUM": {
+          "*": {
+            "keep_floor": 0.55,
+            "escalate_below": 0.55,
+            "action": "mask"
+          },
+          "en": {
+            "keep_floor": 0.6,
+            "escalate_below": 0.58,
+            "action": "mask"
+          }
+        },
+        "PERSON": {
+          "*": {
+            "keep_floor": 0.5,
+            "escalate_below": 0.45,
+            "action": "mask"
+          }
+        }
+      }
+    },
+    "strict_no_leak": {
+      "recall_floor": 0.995,
+      "default": {
+        "keep_floor": 0.1,
+        "escalate_below": 0.98,
+        "action": "mask"
+      },
+      "labels": {
+        "DATE": {
+          "*": {
+            "keep_floor": 0.08,
+            "escalate_below": 0.97,
+            "action": "mask"
+          }
+        },
+        "EMAIL": {
+          "*": {
+            "keep_floor": 0.05,
+            "escalate_below": 0.98,
+            "action": "mask"
+          }
+        },
+        "ID_NUM": {
+          "*": {
+            "keep_floor": 0.05,
+            "escalate_below": 0.99,
+            "action": "mask"
+          },
+          "en": {
+            "keep_floor": 0.04,
+            "escalate_below": 0.99,
+            "action": "mask"
+          }
+        },
+        "PERSON": {
+          "*": {
+            "keep_floor": 0.08,
+            "escalate_below": 0.98,
+            "action": "mask"
+          }
+        }
+      }
+    }
+  }
+}

--- a/openmed/core/thresholds.py
+++ b/openmed/core/thresholds.py
@@ -1,0 +1,337 @@
+"""Versioned per-label/language/policy threshold matrix."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+import copy
+import json
+
+from .labels import normalize_label
+from .schemas.span import ACTION_VALUES
+
+
+CURRENT_SCHEMA_VERSION = 1
+DEFAULT_RESOURCE = "thresholds.json"
+DEFAULT_POLICY_PROFILE = "balanced"
+STRICT_NO_LEAK_PROFILE = "strict_no_leak"
+WILDCARD_LANGUAGE = "*"
+
+
+@dataclass(frozen=True)
+class Threshold:
+    keep_floor: float
+    escalate_below: float
+    action: str
+    canonical_label: str
+    language: str
+    policy_profile: str
+    source: str
+    schema_version: int
+
+    def to_dict(self) -> dict[str, float | str | int]:
+        return {
+            "keep_floor": self.keep_floor,
+            "escalate_below": self.escalate_below,
+            "action": self.action,
+            "canonical_label": self.canonical_label,
+            "language": self.language,
+            "policy_profile": self.policy_profile,
+            "source": self.source,
+            "schema_version": self.schema_version,
+        }
+
+
+@dataclass(frozen=True)
+class RecallGuardResult:
+    block: bool
+    policy_profile: str
+    recall_floor: float
+    violations: tuple[dict[str, float | str], ...]
+
+    @property
+    def reason(self) -> str:
+        if not self.block:
+            return "ok"
+        labels = ", ".join(str(item["canonical_label"]) for item in self.violations)
+        return f"protected recall below floor for {labels}"
+
+
+def load_thresholds(path: str | Path | None = None) -> dict[str, Any]:
+    """Load and validate the versioned thresholds matrix."""
+
+    if path is None:
+        resource = resources.files("openmed.core").joinpath(DEFAULT_RESOURCE)
+        with resource.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    else:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    validate_threshold_matrix(payload)
+    return payload
+
+
+def validate_threshold_matrix(matrix: Mapping[str, Any]) -> None:
+    schema_version = matrix.get("schema_version")
+    if not isinstance(schema_version, int) or schema_version < 1:
+        raise ValueError("thresholds matrix requires positive integer schema_version")
+
+    profiles = matrix.get("profiles")
+    if not isinstance(profiles, Mapping) or not profiles:
+        raise ValueError("thresholds matrix requires profiles")
+
+    for profile_name, profile in profiles.items():
+        if not isinstance(profile, Mapping):
+            raise ValueError(f"profile {profile_name!r} must be an object")
+        _validate_recall_floor(profile.get("recall_floor"), profile_name)
+        _validate_entry(profile.get("default"), f"{profile_name}.default")
+        labels = profile.get("labels") or {}
+        if not isinstance(labels, Mapping):
+            raise ValueError(f"profile {profile_name!r} labels must be an object")
+        for label, languages in labels.items():
+            canonical_label = normalize_label(str(label))
+            if not isinstance(languages, Mapping):
+                raise ValueError(f"{profile_name}.{canonical_label} must be an object")
+            for language, entry in languages.items():
+                _validate_entry(entry, f"{profile_name}.{canonical_label}.{language}")
+
+
+def lookup_threshold(
+    canonical_label: str,
+    language: str,
+    policy_profile: str = DEFAULT_POLICY_PROFILE,
+    *,
+    matrix: Mapping[str, Any] | None = None,
+) -> dict[str, float | str | int]:
+    """Lookup a threshold entry.
+
+    Fallback order is deterministic:
+    exact (label, language, profile) -> wildcard language for the label ->
+    profile default.
+    """
+
+    payload = matrix if matrix is not None else load_thresholds()
+    validate_threshold_matrix(payload)
+    profile_name = _resolve_profile_name(payload, policy_profile)
+    profile = payload["profiles"][profile_name]
+    label = normalize_label(canonical_label)
+    lang = (language or WILDCARD_LANGUAGE).lower()
+    labels = profile.get("labels") or {}
+    language_entries = labels.get(label) or {}
+
+    if lang in language_entries:
+        entry = language_entries[lang]
+        source = "exact"
+        source_language = lang
+    elif WILDCARD_LANGUAGE in language_entries:
+        entry = language_entries[WILDCARD_LANGUAGE]
+        source = "wildcard_language"
+        source_language = WILDCARD_LANGUAGE
+    else:
+        entry = profile["default"]
+        source = "profile_default"
+        source_language = WILDCARD_LANGUAGE
+
+    threshold = Threshold(
+        keep_floor=float(entry["keep_floor"]),
+        escalate_below=float(entry["escalate_below"]),
+        action=str(entry["action"]),
+        canonical_label=label,
+        language=source_language,
+        policy_profile=profile_name,
+        source=source,
+        schema_version=int(payload["schema_version"]),
+    )
+    return threshold.to_dict()
+
+
+def profile_recall_floor(
+    policy_profile: str = DEFAULT_POLICY_PROFILE,
+    *,
+    matrix: Mapping[str, Any] | None = None,
+) -> float:
+    payload = matrix if matrix is not None else load_thresholds()
+    validate_threshold_matrix(payload)
+    profile_name = _resolve_profile_name(payload, policy_profile)
+    return float(payload["profiles"][profile_name]["recall_floor"])
+
+
+def label_keep_floors(
+    labels: Sequence[str],
+    language: str,
+    policy_profile: str,
+    *,
+    matrix: Mapping[str, Any] | None = None,
+) -> dict[str, float]:
+    return {
+        normalize_label(label): float(
+            lookup_threshold(
+                label,
+                language,
+                policy_profile,
+                matrix=matrix,
+            )["keep_floor"]
+        )
+        for label in labels
+    }
+
+
+def fit_thresholds(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    policy_profile: str = DEFAULT_POLICY_PROFILE,
+    base_matrix: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a matrix copy with threshold entries fit from eval-style samples."""
+
+    matrix = copy.deepcopy(dict(base_matrix or load_thresholds()))
+    validate_threshold_matrix(matrix)
+    profile_name = _resolve_profile_name(matrix, policy_profile)
+    profile = matrix["profiles"][profile_name]
+    labels = profile.setdefault("labels", {})
+
+    grouped: dict[tuple[str, str], list[float]] = {}
+    for sample in samples:
+        if bool(sample.get("target", sample.get("is_true", True))) is False:
+            continue
+        label = normalize_label(str(sample["canonical_label"]))
+        language = str(sample.get("language") or WILDCARD_LANGUAGE).lower()
+        grouped.setdefault((label, language), []).append(float(sample["score"]))
+
+    for (label, language), scores in grouped.items():
+        if not scores:
+            continue
+        keep_floor = max(0.0, min(scores))
+        entry = {
+            "keep_floor": keep_floor,
+            "escalate_below": min(1.0, keep_floor + 0.05),
+            "action": lookup_threshold(
+                label,
+                language,
+                profile_name,
+                matrix=matrix,
+            )["action"],
+        }
+        labels.setdefault(label, {})[language] = entry
+
+    validate_threshold_matrix(matrix)
+    return matrix
+
+
+def update_thresholds(
+    base_matrix: Mapping[str, Any],
+    updates: Mapping[tuple[str, str, str], Mapping[str, Any]],
+    *,
+    bump_schema_version: bool = False,
+) -> dict[str, Any]:
+    """Apply explicit threshold updates and optionally bump schema_version."""
+
+    matrix = copy.deepcopy(dict(base_matrix))
+    validate_threshold_matrix(matrix)
+    if bump_schema_version:
+        matrix["schema_version"] = int(matrix["schema_version"]) + 1
+
+    profiles = matrix["profiles"]
+    for (label, language, profile_name), entry in updates.items():
+        resolved_profile = _resolve_profile_name(matrix, profile_name)
+        canonical_label = normalize_label(label)
+        language_key = (language or WILDCARD_LANGUAGE).lower()
+        profiles[resolved_profile].setdefault("labels", {}).setdefault(
+            canonical_label,
+            {},
+        )[language_key] = {
+            "keep_floor": float(entry["keep_floor"]),
+            "escalate_below": float(entry["escalate_below"]),
+            "action": str(entry["action"]),
+        }
+
+    validate_threshold_matrix(matrix)
+    return matrix
+
+
+def recall_floor_guard(
+    old_recall: Mapping[str, float],
+    new_recall: Mapping[str, float],
+    *,
+    policy_profile: str = STRICT_NO_LEAK_PROFILE,
+    protected_labels: Sequence[str] | None = None,
+    matrix: Mapping[str, Any] | None = None,
+) -> RecallGuardResult:
+    """Signal whether a threshold change would violate a profile recall floor."""
+
+    floor = profile_recall_floor(policy_profile, matrix=matrix)
+    labels = tuple(protected_labels or sorted(set(old_recall) | set(new_recall)))
+    violations: list[dict[str, float | str]] = []
+
+    for label in labels:
+        canonical_label = normalize_label(label)
+        before = float(old_recall.get(label, old_recall.get(canonical_label, 0.0)))
+        after = float(new_recall.get(label, new_recall.get(canonical_label, 0.0)))
+        if before >= floor and after < floor:
+            violations.append(
+                {
+                    "canonical_label": canonical_label,
+                    "old_recall": before,
+                    "new_recall": after,
+                    "recall_floor": floor,
+                }
+            )
+
+    return RecallGuardResult(
+        block=bool(violations),
+        policy_profile=policy_profile,
+        recall_floor=floor,
+        violations=tuple(violations),
+    )
+
+
+def _resolve_profile_name(matrix: Mapping[str, Any], policy_profile: str) -> str:
+    profiles = matrix["profiles"]
+    if policy_profile in profiles:
+        return policy_profile
+    default_profile = str(matrix.get("default_policy_profile") or DEFAULT_POLICY_PROFILE)
+    if default_profile in profiles:
+        return default_profile
+    raise KeyError(f"unknown policy profile {policy_profile!r}")
+
+
+def _validate_recall_floor(value: Any, profile_name: str) -> None:
+    if not isinstance(value, (int, float)) or not 0.0 <= float(value) <= 1.0:
+        raise ValueError(f"profile {profile_name!r} recall_floor must be 0..1")
+
+
+def _validate_entry(entry: Any, path: str) -> None:
+    if not isinstance(entry, Mapping):
+        raise ValueError(f"{path} must be an object")
+    for key in ("keep_floor", "escalate_below", "action"):
+        if key not in entry:
+            raise ValueError(f"{path} missing {key}")
+    keep_floor = entry["keep_floor"]
+    escalate_below = entry["escalate_below"]
+    if not isinstance(keep_floor, (int, float)) or not 0.0 <= float(keep_floor) <= 1.0:
+        raise ValueError(f"{path}.keep_floor must be 0..1")
+    if (
+        not isinstance(escalate_below, (int, float))
+        or not 0.0 <= float(escalate_below) <= 1.0
+    ):
+        raise ValueError(f"{path}.escalate_below must be 0..1")
+    if entry["action"] not in ACTION_VALUES:
+        raise ValueError(f"{path}.action must be one of {ACTION_VALUES!r}")
+
+
+__all__ = [
+    "CURRENT_SCHEMA_VERSION",
+    "DEFAULT_POLICY_PROFILE",
+    "RecallGuardResult",
+    "STRICT_NO_LEAK_PROFILE",
+    "Threshold",
+    "fit_thresholds",
+    "label_keep_floors",
+    "load_thresholds",
+    "lookup_threshold",
+    "profile_recall_floor",
+    "recall_floor_guard",
+    "update_thresholds",
+    "validate_threshold_matrix",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ openmed = "openmed.cli:main"
 [tool.hatch.build]
 include = [
   "openmed/**",
+  "openmed/core/thresholds.json",
   "openmed/core/schemas/json/*.json",
   "gates/baseline.json",
   "models.jsonl",

--- a/tests/unit/core/test_thresholds_matrix.py
+++ b/tests/unit/core/test_thresholds_matrix.py
@@ -1,0 +1,155 @@
+from importlib import resources
+import json
+
+from openmed.core.arbitration import MODE_BALANCED, MODE_HIGH_RECALL_UNION, arbitrate
+from openmed.core.cascade import R2_BASE, CascadeRouter
+from openmed.core.pipeline import Pipeline
+from openmed.core.schemas.span import ACTION_VALUES, OpenMedSpan, hmac_text_hash
+from openmed.core.thresholds import (
+    fit_thresholds,
+    load_thresholds,
+    lookup_threshold,
+    recall_floor_guard,
+    update_thresholds,
+    validate_threshold_matrix,
+)
+
+
+def _span(
+    *,
+    start: int = 0,
+    end: int = 8,
+    label: str = "ID_NUM",
+    score: float = 0.5,
+    detector: str = "model:tiny",
+) -> OpenMedSpan:
+    return OpenMedSpan(
+        doc_id="doc-1",
+        start=start,
+        end=end,
+        text_hash=hmac_text_hash(f"{start}:{end}:{label}", "test-secret"),
+        entity_type=label,
+        canonical_label=label,
+        score=score,
+        detector=detector,
+    )
+
+
+def test_lookup_threshold_exact_and_fallback_order():
+    exact = lookup_threshold("ID_NUM", "en", "strict_no_leak")
+    wildcard = lookup_threshold("ID_NUM", "de", "strict_no_leak")
+    profile_default = lookup_threshold("ORGANIZATION", "en", "strict_no_leak")
+
+    assert {
+        "keep_floor",
+        "escalate_below",
+        "action",
+    }.issubset(exact)
+    assert exact["source"] == "exact"
+    assert exact["language"] == "en"
+    assert wildcard["source"] == "wildcard_language"
+    assert wildcard["language"] == "*"
+    assert profile_default["source"] == "profile_default"
+    assert profile_default["canonical_label"] == "ORGANIZATION"
+
+
+def test_thresholds_json_has_schema_version_and_valid_actions():
+    payload = json.loads(
+        resources.files("openmed.core")
+        .joinpath("thresholds.json")
+        .read_text(encoding="utf-8")
+    )
+
+    assert isinstance(payload["schema_version"], int)
+    validate_threshold_matrix(payload)
+    for profile in payload["profiles"].values():
+        assert profile["default"]["action"] in ACTION_VALUES
+        for label_entries in profile["labels"].values():
+            for entry in label_entries.values():
+                assert entry["action"] in ACTION_VALUES
+
+
+def test_recall_floor_guard_blocks_drop_below_profile_floor():
+    result = recall_floor_guard(
+        {"ID_NUM": 0.996},
+        {"ID_NUM": 0.992},
+        policy_profile="strict_no_leak",
+        protected_labels=("ID_NUM",),
+    )
+
+    assert result.block is True
+    assert result.violations[0]["canonical_label"] == "ID_NUM"
+    assert result.recall_floor == 0.995
+
+
+def test_fit_and_update_thresholds_return_valid_versioned_matrix():
+    matrix = load_thresholds()
+    fitted = fit_thresholds(
+        [
+            {
+                "canonical_label": "EMAIL",
+                "language": "en",
+                "score": 0.42,
+                "target": True,
+            }
+        ],
+        policy_profile="balanced",
+        base_matrix=matrix,
+    )
+    updated = update_thresholds(
+        fitted,
+        {
+            ("EMAIL", "en", "balanced"): {
+                "keep_floor": 0.4,
+                "escalate_below": 0.45,
+                "action": "mask",
+            }
+        },
+        bump_schema_version=True,
+    )
+
+    validate_threshold_matrix(updated)
+    assert updated["schema_version"] == matrix["schema_version"] + 1
+    assert (
+        lookup_threshold("EMAIL", "en", "balanced", matrix=updated)["keep_floor"]
+        == 0.4
+    )
+
+
+def test_arbitration_reads_matrix_keep_floor_by_mode():
+    weak_id = _span(score=0.2)
+
+    assert arbitrate([weak_id], mode=MODE_BALANCED) == ()
+    assert arbitrate([weak_id], mode=MODE_HIGH_RECALL_UNION) == (weak_id,)
+
+
+def test_cascade_reads_matrix_escalate_below():
+    base_calls = []
+    weak_id = _span(score=0.57)
+
+    def base_detector(text, **kwargs):
+        base_calls.append(kwargs["reason"])
+        return []
+
+    router = CascadeRouter(
+        tiny_detector=lambda text, **kwargs: [weak_id],
+        base_detector=base_detector,
+    )
+
+    result = router.run("MRN 123")
+
+    assert result.reached(R2_BASE)
+    assert base_calls == ["low_confidence"]
+
+
+def test_pipeline_default_policy_action_comes_from_threshold_matrix():
+    span = _span(label="EMAIL", score=0.9)
+    router = CascadeRouter(tiny_detector=lambda text, **kwargs: [span])
+
+    result = Pipeline(
+        cascade_router=router,
+        use_safety_sweep=False,
+    ).run("email a@b.co")
+
+    assert result.stage("policy_actions").spans[0].action == "mask"
+    assert "threshold_action" in result.stage("policy_actions").spans[0].metadata


### PR DESCRIPTION
Closes #121.

Adds the versioned thresholds matrix and lookup helpers for per-label, language, and policy-profile floors. Arbitration, cascade escalation, and pipeline policy-action defaults now read the matrix, with update helpers and a recall-floor guard for leakage-protected profiles.