### PR TITLE
Add public and gated dataset adapters with weak labeling

### DIFF
--- a/openmed/eval/datasets/__init__.py
+++ b/openmed/eval/datasets/__init__.py
@@ -1,0 +1,47 @@
+"""Dataset adapters for public and data-use-gated eval corpora."""
+
+from .dua_stubs import (
+    DUA_GATED_CORPORA,
+    DUACorpusStub,
+    DUACredentialRequired,
+    all_dua_stubs,
+    dua_stub_for,
+    load_dua_corpus,
+)
+from .licenses import DatasetLicense, PUBLIC_DATASET_LICENSES, license_for
+from .public import (
+    DatasetLoadResult,
+    DatasetUnavailable,
+    PUBLIC_DATASETS,
+    PUBLIC_LABEL_MAPS,
+    PublicDatasetAdapter,
+    PublicDatasetRecord,
+    PublicDatasetSpan,
+    adapter_for,
+    assert_no_gated_content_committed,
+    load_public_dataset,
+    map_public_label,
+)
+
+__all__ = [
+    "DUA_GATED_CORPORA",
+    "DUACorpusStub",
+    "DUACredentialRequired",
+    "DatasetLicense",
+    "DatasetLoadResult",
+    "DatasetUnavailable",
+    "PUBLIC_DATASETS",
+    "PUBLIC_DATASET_LICENSES",
+    "PUBLIC_LABEL_MAPS",
+    "PublicDatasetAdapter",
+    "PublicDatasetRecord",
+    "PublicDatasetSpan",
+    "adapter_for",
+    "all_dua_stubs",
+    "assert_no_gated_content_committed",
+    "dua_stub_for",
+    "license_for",
+    "load_dua_corpus",
+    "load_public_dataset",
+    "map_public_label",
+]

--- a/openmed/eval/datasets/dua_stubs.py
+++ b/openmed/eval/datasets/dua_stubs.py
@@ -1,0 +1,72 @@
+"""Eval-only stubs for corpora that require a local data-use agreement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from .public import DatasetLoadResult
+
+
+DUA_GATED_CORPORA: tuple[str, ...] = (
+    "i2b2",
+    "n2c2",
+    "shac",
+    "thyme",
+    "mednli",
+    "made",
+    "mimic",
+)
+
+
+class DUACredentialRequired(PermissionError):
+    """Raised when a gated corpus is requested without a credentialed path."""
+
+
+@dataclass(frozen=True)
+class DUACorpusStub:
+    name: str
+    eval_only: bool = True
+
+    def load(self, credentialed_path: str | Path | None = None) -> DatasetLoadResult:
+        if credentialed_path is None:
+            raise DUACredentialRequired(
+                f"{self.name} requires a credentialed local path and cannot be bundled"
+            )
+        path = Path(credentialed_path)
+        if not path.exists():
+            raise DUACredentialRequired(
+                f"{self.name} credentialed path does not exist: {path}"
+            )
+        return DatasetLoadResult(
+            dataset=self.name,
+            records=(),
+            skipped=True,
+            reason="eval-only gated corpus stub; local loader is intentionally not bundled",
+        )
+
+
+def dua_stub_for(name: str) -> DUACorpusStub:
+    key = name.lower()
+    if key not in DUA_GATED_CORPORA:
+        raise ValueError(f"unknown gated corpus: {name}")
+    return DUACorpusStub(key)
+
+
+def load_dua_corpus(name: str, credentialed_path: str | Path | None = None) -> DatasetLoadResult:
+    return dua_stub_for(name).load(credentialed_path)
+
+
+def all_dua_stubs() -> Mapping[str, DUACorpusStub]:
+    return {name: DUACorpusStub(name) for name in DUA_GATED_CORPORA}
+
+
+__all__ = [
+    "DUA_GATED_CORPORA",
+    "DUACorpusStub",
+    "DUACredentialRequired",
+    "all_dua_stubs",
+    "dua_stub_for",
+    "load_dua_corpus",
+]

--- a/openmed/eval/datasets/licenses.py
+++ b/openmed/eval/datasets/licenses.py
@@ -1,0 +1,73 @@
+"""License metadata for dataset adapter declarations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class DatasetLicense:
+    dataset: str
+    license_id: str
+    source_url: str
+    redistribution: str
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "dataset": self.dataset,
+            "license_id": self.license_id,
+            "source_url": self.source_url,
+            "redistribution": self.redistribution,
+            "notes": self.notes,
+        }
+
+
+PUBLIC_DATASET_LICENSES: Mapping[str, DatasetLicense] = {
+    "shield": DatasetLicense(
+        dataset="shield",
+        license_id="access-controlled-full; public-sample",
+        source_url="https://huggingface.co/datasets/tds-research-tech/shield-sample",
+        redistribution="reference-only",
+        notes="Public sample can be loaded by reference; full dataset requires access approval.",
+    ),
+    "drugprot": DatasetLicense(
+        dataset="drugprot",
+        license_id="CC-BY-4.0",
+        source_url="https://zenodo.org/records/4955411",
+        redistribution="reference-only",
+        notes="Adapter stores no corpus rows and expects a local user-provided path.",
+    ),
+    "medmentions": DatasetLicense(
+        dataset="medmentions",
+        license_id="CC0-1.0",
+        source_url="https://github.com/chanzuckerberg/MedMentions",
+        redistribution="reference-only",
+        notes="Adapter strips controlled-vocabulary identifiers from loaded metadata.",
+    ),
+    "ncbi_disease": DatasetLicense(
+        dataset="ncbi_disease",
+        license_id="public-research-corpus",
+        source_url="https://www.ncbi.nlm.nih.gov/research/bionlp/Data/disease/",
+        redistribution="reference-only",
+        notes="Adapter stores no corpus rows and expects a local user-provided path.",
+    ),
+    "bc5cdr": DatasetLicense(
+        dataset="bc5cdr",
+        license_id="public-domain-us-government-work",
+        source_url="https://pubmed.ncbi.nlm.nih.gov/27161011/",
+        redistribution="reference-only",
+        notes="Adapter stores no corpus rows and expects a local user-provided path.",
+    ),
+}
+
+
+def license_for(dataset: str) -> DatasetLicense:
+    try:
+        return PUBLIC_DATASET_LICENSES[dataset]
+    except KeyError as exc:
+        raise ValueError(f"unknown public dataset: {dataset}") from exc
+
+
+__all__ = ["DatasetLicense", "PUBLIC_DATASET_LICENSES", "license_for"]

--- a/openmed/eval/datasets/public.py
+++ b/openmed/eval/datasets/public.py
@@ -1,0 +1,391 @@
+"""Public biomedical dataset adapters for evaluation and training prep."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from openmed.core.labels import CANONICAL_LABELS, normalize_label
+from openmed.eval.harness import BenchmarkFixture
+from openmed.eval.metrics import EvalSpan
+
+from .licenses import DatasetLicense, PUBLIC_DATASET_LICENSES, license_for
+
+
+PUBLIC_DATASETS: tuple[str, ...] = (
+    "shield",
+    "drugprot",
+    "medmentions",
+    "ncbi_disease",
+    "bc5cdr",
+)
+
+PUBLIC_LABEL_MAPS: Mapping[str, Mapping[str, str]] = {
+    "shield": {
+        "age": "AGE",
+        "date": "DATE",
+        "doctor": "PERSON",
+        "hospital": "ORGANIZATION",
+        "id": "ID_NUM",
+        "location": "LOCATION",
+        "patient": "PERSON",
+        "phone": "PHONE",
+        "web": "URL",
+    },
+    "drugprot": {
+        "chemical": "OTHER",
+        "gene": "OTHER",
+        "protein": "OTHER",
+        "relation": "OTHER",
+    },
+    "medmentions": {
+        "concept": "OTHER",
+        "mention": "OTHER",
+        "disease": "OTHER",
+        "drug": "OTHER",
+    },
+    "ncbi_disease": {
+        "disease": "OTHER",
+        "specific_disease": "OTHER",
+        "modifier": "OTHER",
+        "composite_mention": "OTHER",
+    },
+    "bc5cdr": {
+        "chemical": "OTHER",
+        "disease": "OTHER",
+        "relation": "OTHER",
+    },
+}
+
+_CONTROLLED_METADATA_KEYS = {
+    "cui",
+    "concept_id",
+    "concept_ids",
+    "mesh",
+    "mesh_id",
+    "ontology",
+    "semantic_type_id",
+    "semantic_type_ids",
+    "snomed",
+    "umls",
+    "umls_id",
+}
+
+_GATED_CONTENT_MARKERS = (
+    "UMLS",
+    "SNOMED",
+    "CPT",
+    "i2b2",
+    "n2c2",
+    "SHAC",
+    "THYME",
+    "MedNLI",
+    "MADE",
+    "MIMIC",
+)
+_DATA_EXTENSIONS = {".csv", ".json", ".jsonl", ".ndjson", ".tsv", ".txt"}
+
+
+class DatasetUnavailable(FileNotFoundError):
+    """Raised when a dataset source was requested but is absent."""
+
+
+@dataclass(frozen=True)
+class PublicDatasetSpan:
+    start: int
+    end: int
+    label: str
+    text: str = ""
+    source_label: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_eval_span(self, *, language: str = "en") -> EvalSpan:
+        return EvalSpan(
+            start=self.start,
+            end=self.end,
+            label=self.label,
+            text=self.text,
+            language=language,
+            metadata={
+                **dict(self.metadata),
+                "source_label": self.source_label or self.label,
+            },
+        )
+
+
+@dataclass(frozen=True)
+class PublicDatasetRecord:
+    record_id: str
+    dataset: str
+    text: str
+    spans: tuple[PublicDatasetSpan, ...]
+    split: str = "unspecified"
+    language: str = "en"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    license: DatasetLicense | None = None
+
+    def to_benchmark_fixture(self) -> BenchmarkFixture:
+        return BenchmarkFixture(
+            fixture_id=self.record_id,
+            text=self.text,
+            gold_spans=tuple(span.to_eval_span(language=self.language) for span in self.spans),
+            language=self.language,
+            metadata={
+                **dict(self.metadata),
+                "dataset": self.dataset,
+                "license": self.license.to_dict() if self.license else None,
+                "split": self.split,
+            },
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dataset": self.dataset,
+            "id": self.record_id,
+            "language": self.language,
+            "license": self.license.to_dict() if self.license else None,
+            "metadata": dict(self.metadata),
+            "spans": [
+                {
+                    "end": span.end,
+                    "label": span.label,
+                    "metadata": dict(span.metadata),
+                    "source_label": span.source_label,
+                    "start": span.start,
+                    "text": span.text,
+                }
+                for span in self.spans
+            ],
+            "split": self.split,
+            "text": self.text,
+        }
+
+
+@dataclass(frozen=True)
+class DatasetLoadResult:
+    dataset: str
+    records: tuple[PublicDatasetRecord, ...]
+    skipped: bool = False
+    reason: str = ""
+    license: DatasetLicense | None = None
+
+    def to_benchmark_fixtures(self) -> list[BenchmarkFixture]:
+        return [record.to_benchmark_fixture() for record in self.records]
+
+
+@dataclass(frozen=True)
+class PublicDatasetAdapter:
+    dataset: str
+    label_map: Mapping[str, str]
+    license: DatasetLicense
+
+    def load(self, path: str | Path | None = None) -> DatasetLoadResult:
+        if path is None:
+            return DatasetLoadResult(
+                dataset=self.dataset,
+                records=(),
+                skipped=True,
+                reason="dataset path not provided",
+                license=self.license,
+            )
+
+        source_path = Path(path)
+        if not source_path.exists():
+            return DatasetLoadResult(
+                dataset=self.dataset,
+                records=(),
+                skipped=True,
+                reason=f"dataset path not found: {source_path}",
+                license=self.license,
+            )
+
+        rows = _load_rows(source_path)
+        records = tuple(self._record_from_mapping(row) for row in rows)
+        return DatasetLoadResult(
+            dataset=self.dataset,
+            records=records,
+            skipped=False,
+            license=self.license,
+        )
+
+    def _record_from_mapping(self, row: Mapping[str, Any]) -> PublicDatasetRecord:
+        text = _record_text(row)
+        language = str(row.get("language") or row.get("lang") or "en")
+        spans = tuple(
+            self._span_from_mapping(span, text=text, language=language)
+            for span in row.get("spans") or row.get("entities") or row.get("annotations") or []
+        )
+        return PublicDatasetRecord(
+            record_id=str(row.get("id") or row.get("record_id") or row.get("pmid") or "record"),
+            dataset=self.dataset,
+            text=text,
+            spans=spans,
+            split=str(row.get("split") or "unspecified"),
+            language=language,
+            metadata=_clean_metadata(row.get("metadata") or {}),
+            license=self.license,
+        )
+
+    def _span_from_mapping(
+        self,
+        span: Mapping[str, Any],
+        *,
+        text: str,
+        language: str,
+    ) -> PublicDatasetSpan:
+        start = _int_field(span, "start", "span_start", "begin")
+        end = _int_field(span, "end", "span_end", "offset_end")
+        source_label = str(
+            span.get("label")
+            or span.get("source_label")
+            or span.get("entity_type")
+            or span.get("type")
+            or "OTHER"
+        )
+        canonical = map_public_label(self.dataset, source_label, language=language)
+        span_text = str(span.get("text") or text[start:end])
+        return PublicDatasetSpan(
+            start=start,
+            end=end,
+            label=canonical,
+            text=span_text,
+            source_label=source_label,
+            metadata=_clean_metadata(span.get("metadata") or {}),
+        )
+
+
+def adapter_for(dataset: str) -> PublicDatasetAdapter:
+    if dataset not in PUBLIC_DATASETS:
+        raise ValueError(f"unknown public dataset: {dataset}")
+    return PublicDatasetAdapter(
+        dataset=dataset,
+        label_map=PUBLIC_LABEL_MAPS[dataset],
+        license=license_for(dataset),
+    )
+
+
+def load_public_dataset(dataset: str, path: str | Path | None = None) -> DatasetLoadResult:
+    return adapter_for(dataset).load(path)
+
+
+def map_public_label(dataset: str, label: str, *, language: str = "en") -> str:
+    label_map = PUBLIC_LABEL_MAPS.get(dataset)
+    if label_map is None:
+        raise ValueError(f"unknown public dataset: {dataset}")
+    mapped = label_map.get(label.lower(), label_map.get(label.upper(), label))
+    canonical = normalize_label(mapped, language)
+    if canonical not in CANONICAL_LABELS:
+        return "OTHER"
+    return canonical
+
+
+def assert_no_gated_content_committed(root: str | Path) -> None:
+    """Fail if committed dataset payload files contain gated-code markers."""
+
+    root_path = Path(root)
+    offenders: list[str] = []
+    for path in _iter_payload_files(root_path):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for marker in _GATED_CONTENT_MARKERS:
+            if marker in text:
+                offenders.append(f"{path}: {marker}")
+    if offenders:
+        raise AssertionError(
+            "gated dataset content must not be committed: " + ", ".join(offenders)
+        )
+
+
+def _load_rows(path: Path) -> list[Mapping[str, Any]]:
+    if path.is_dir():
+        rows: list[Mapping[str, Any]] = []
+        for child in sorted(path.iterdir()):
+            if child.suffix.lower() in {".json", ".jsonl", ".ndjson"}:
+                rows.extend(_load_rows(child))
+        return rows
+
+    if path.suffix.lower() in {".jsonl", ".ndjson"}:
+        return [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(raw, Mapping):
+        rows = (
+            raw.get("records")
+            or raw.get("documents")
+            or raw.get("fixtures")
+            or raw.get("examples")
+            or []
+        )
+    else:
+        rows = raw
+    if not isinstance(rows, list):
+        raise ValueError("public dataset payload must contain a list of records")
+    return [row for row in rows if isinstance(row, Mapping)]
+
+
+def _record_text(row: Mapping[str, Any]) -> str:
+    if isinstance(row.get("text"), str):
+        return str(row["text"])
+    parts = [
+        str(row[key])
+        for key in ("title", "abstract", "note_text")
+        if isinstance(row.get(key), str)
+    ]
+    return " ".join(part for part in parts if part).strip()
+
+
+def _int_field(data: Mapping[str, Any], *keys: str) -> int:
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+    raise ValueError(f"span missing integer field from {keys!r}")
+
+
+def _clean_metadata(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        str(key): _plain_metadata(item)
+        for key, item in value.items()
+        if str(key).lower() not in _CONTROLLED_METADATA_KEYS
+    }
+
+
+def _plain_metadata(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _clean_metadata(value)
+    if isinstance(value, (list, tuple)):
+        return [_plain_metadata(item) for item in value]
+    return value
+
+
+def _iter_payload_files(root: Path) -> Iterable[Path]:
+    if root.is_file():
+        if root.suffix.lower() in _DATA_EXTENSIONS:
+            yield root
+        return
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.suffix.lower() in _DATA_EXTENSIONS:
+            yield path
+
+
+__all__ = [
+    "DatasetLoadResult",
+    "DatasetUnavailable",
+    "PUBLIC_DATASETS",
+    "PUBLIC_DATASET_LICENSES",
+    "PUBLIC_LABEL_MAPS",
+    "PublicDatasetAdapter",
+    "PublicDatasetRecord",
+    "PublicDatasetSpan",
+    "adapter_for",
+    "assert_no_gated_content_committed",
+    "load_public_dataset",
+    "map_public_label",
+]

--- a/openmed/training/__init__.py
+++ b/openmed/training/__init__.py
@@ -7,19 +7,55 @@ __all__ = [
     "CONFIG_SCHEMA_VERSION",
     "MAX_LORA_TRAINABLE_RATIO",
     "PRESET_BY_MODE",
+    "AdjudicationCandidate",
+    "AdjudicationItem",
+    "AdjudicationQueue",
     "DryRunResult",
     "RecipeConfigError",
     "TrainingRecipeConfig",
+    "WeakLabelDecision",
+    "WeakLabelSpan",
     "config_hash",
     "dry_run_recipe",
     "load_preset",
+    "make_adjudication_item",
+    "normalize_weak_span",
     "run_recipe",
     "runtime_dependencies",
+    "weak_label_document",
 ]
 
 
 def __getattr__(name: str) -> Any:
-    if name in __all__:
+    if name in {
+        "CONFIG_SCHEMA_VERSION",
+        "MAX_LORA_TRAINABLE_RATIO",
+        "PRESET_BY_MODE",
+        "DryRunResult",
+        "RecipeConfigError",
+        "TrainingRecipeConfig",
+        "config_hash",
+        "dry_run_recipe",
+        "load_preset",
+        "run_recipe",
+        "runtime_dependencies",
+    }:
         recipe = import_module(".recipe", __name__)
         return getattr(recipe, name)
+    if name in {
+        "AdjudicationCandidate",
+        "AdjudicationItem",
+        "AdjudicationQueue",
+        "make_adjudication_item",
+    }:
+        adjudication = import_module(".adjudication", __name__)
+        return getattr(adjudication, name)
+    if name in {
+        "WeakLabelDecision",
+        "WeakLabelSpan",
+        "normalize_weak_span",
+        "weak_label_document",
+    }:
+        weak_labeling = import_module(".weak_labeling", __name__)
+        return getattr(weak_labeling, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/openmed/training/adjudication.py
+++ b/openmed/training/adjudication.py
@@ -1,0 +1,101 @@
+"""Adjudication queue primitives for weak-labeling disagreements."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class AdjudicationCandidate:
+    start: int
+    end: int
+    label: str
+    text: str = ""
+    score: float = 0.0
+    sources: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "end": self.end,
+            "label": self.label,
+            "metadata": dict(self.metadata),
+            "score": self.score,
+            "sources": list(self.sources),
+            "start": self.start,
+            "text": self.text,
+        }
+
+
+@dataclass(frozen=True)
+class AdjudicationItem:
+    text: str
+    candidates: tuple[AdjudicationCandidate, ...]
+    reason: str
+    record_id: str = ""
+    active_learning_priority: float = 1.0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "active_learning_priority": self.active_learning_priority,
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+            "metadata": dict(self.metadata),
+            "reason": self.reason,
+            "record_id": self.record_id,
+            "text": self.text,
+        }
+
+    def to_hard_negative_seed(self) -> dict[str, Any]:
+        return {
+            "reason": self.reason,
+            "source": "weak_labeling_adjudication",
+            "spans": [candidate.to_dict() for candidate in self.candidates],
+            "text": self.text,
+        }
+
+
+@dataclass
+class AdjudicationQueue:
+    items: list[AdjudicationItem] = field(default_factory=list)
+
+    def add(self, item: AdjudicationItem) -> AdjudicationItem:
+        self.items.append(item)
+        return item
+
+    def extend(self, items: Iterable[AdjudicationItem]) -> None:
+        self.items.extend(items)
+
+    def drain(self) -> tuple[AdjudicationItem, ...]:
+        drained = tuple(self.items)
+        self.items.clear()
+        return drained
+
+
+def make_adjudication_item(
+    *,
+    text: str,
+    candidates: Iterable[AdjudicationCandidate],
+    reason: str,
+    record_id: str = "",
+    metadata: Mapping[str, Any] | None = None,
+) -> AdjudicationItem:
+    candidates_tuple = tuple(candidates)
+    priority = 1.0 + max((candidate.score for candidate in candidates_tuple), default=0.0)
+    return AdjudicationItem(
+        text=text,
+        candidates=candidates_tuple,
+        reason=reason,
+        record_id=record_id,
+        active_learning_priority=priority,
+        metadata=dict(metadata or {}),
+    )
+
+
+__all__ = [
+    "AdjudicationCandidate",
+    "AdjudicationItem",
+    "AdjudicationQueue",
+    "make_adjudication_item",
+]

--- a/openmed/training/weak_labeling.py
+++ b/openmed/training/weak_labeling.py
@@ -1,0 +1,256 @@
+"""Teacher weak-labeling with agreement and adjudication routing."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from openmed.core.labels import normalize_label
+
+from .adjudication import (
+    AdjudicationCandidate,
+    AdjudicationItem,
+    make_adjudication_item,
+)
+
+
+SpanValidator = Callable[["WeakLabelSpan"], bool]
+ActiveLearningHook = Callable[[AdjudicationItem], None]
+
+
+@dataclass(frozen=True)
+class WeakLabelSpan:
+    start: int
+    end: int
+    label: str
+    text: str = ""
+    score: float = 0.0
+    source: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def key(self) -> tuple[int, int, str]:
+        return self.start, self.end, self.label
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "end": self.end,
+            "label": self.label,
+            "metadata": dict(self.metadata),
+            "score": self.score,
+            "source": self.source,
+            "start": self.start,
+            "text": self.text,
+        }
+
+    def to_candidate(self, sources: Iterable[str] | None = None) -> AdjudicationCandidate:
+        return AdjudicationCandidate(
+            start=self.start,
+            end=self.end,
+            label=self.label,
+            text=self.text,
+            score=self.score,
+            sources=tuple(sorted(set(sources or ([self.source] if self.source else [])))),
+            metadata=dict(self.metadata),
+        )
+
+
+@dataclass(frozen=True)
+class WeakLabelDecision:
+    accepted_spans: tuple[WeakLabelSpan, ...]
+    rejected_spans: tuple[WeakLabelSpan, ...]
+    adjudication_items: tuple[AdjudicationItem, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted_spans": [span.to_dict() for span in self.accepted_spans],
+            "adjudication_items": [item.to_dict() for item in self.adjudication_items],
+            "rejected_spans": [span.to_dict() for span in self.rejected_spans],
+        }
+
+
+def weak_label_document(
+    text: str,
+    detector_outputs: Mapping[str, Iterable[Any]],
+    *,
+    record_id: str = "",
+    min_agreeing_models: int = 2,
+    validators: Sequence[SpanValidator] = (),
+    human_reviewed_spans: Iterable[Any] = (),
+    active_learning_hook: ActiveLearningHook | None = None,
+) -> WeakLabelDecision:
+    """Accept only agreed or reviewed spans; route conflicts to adjudication."""
+
+    if min_agreeing_models < 2:
+        raise ValueError("min_agreeing_models must be at least 2")
+
+    spans = _normalize_detector_outputs(detector_outputs, text=text)
+    reviewed_keys = {
+        span.key
+        for span in (
+            normalize_weak_span(raw, source="human_review", text=text)
+            for raw in human_reviewed_spans
+        )
+    }
+
+    by_key: dict[tuple[int, int, str], list[WeakLabelSpan]] = defaultdict(list)
+    for span in spans:
+        by_key[span.key].append(span)
+
+    accepted: list[WeakLabelSpan] = []
+    rejected: list[WeakLabelSpan] = []
+    routed_keys: set[tuple[int, int, str]] = set()
+
+    for key, grouped in sorted(by_key.items()):
+        sources = {span.source for span in grouped if span.source}
+        representative = _combine_group(grouped)
+        if key in reviewed_keys or bool(representative.metadata.get("human_reviewed")):
+            accepted.append(_with_metadata(representative, accepted_by="human_review"))
+            continue
+        if len(sources) >= min_agreeing_models and _validators_accept(representative, validators):
+            accepted.append(_with_metadata(representative, accepted_by="inter_model_agreement"))
+            continue
+        if len(sources) < min_agreeing_models:
+            rejected.append(_with_metadata(representative, rejection_reason="single_model"))
+        else:
+            rejected.append(_with_metadata(representative, rejection_reason="validator_rejected"))
+
+    adjudication_items: list[AdjudicationItem] = []
+    for group in _disagreement_groups(spans):
+        group_keys = {span.key for span in group}
+        if group_keys & {span.key for span in accepted}:
+            continue
+        if group_keys <= routed_keys:
+            continue
+        item = make_adjudication_item(
+            text=text,
+            candidates=[
+                span.to_candidate(_sources_for_key(by_key, span.key))
+                for span in group
+            ],
+            reason="inter_model_disagreement",
+            record_id=record_id,
+            metadata={"hard_negative_seed": True},
+        )
+        adjudication_items.append(item)
+        routed_keys.update(group_keys)
+        if active_learning_hook is not None:
+            active_learning_hook(item)
+
+    return WeakLabelDecision(
+        accepted_spans=tuple(accepted),
+        rejected_spans=tuple(rejected),
+        adjudication_items=tuple(adjudication_items),
+    )
+
+
+def normalize_weak_span(raw: Any, *, source: str = "", text: str = "") -> WeakLabelSpan:
+    if isinstance(raw, WeakLabelSpan):
+        return raw
+    data = raw if isinstance(raw, Mapping) else vars(raw)
+    metadata = data.get("metadata") or {}
+    if not isinstance(metadata, Mapping):
+        metadata = {"value": metadata}
+
+    start = int(data["start"])
+    end = int(data["end"])
+    label = normalize_label(
+        str(
+            data.get("canonical_label")
+            or data.get("label")
+            or data.get("entity_type")
+            or data.get("entity_group")
+            or "OTHER"
+        )
+    )
+    span_text = str(data.get("text") or text[start:end])
+    score = data.get("score", data.get("confidence", 0.0))
+    return WeakLabelSpan(
+        start=start,
+        end=end,
+        label=label,
+        text=span_text,
+        score=float(score),
+        source=str(data.get("source") or source),
+        metadata=dict(metadata),
+    )
+
+
+def _normalize_detector_outputs(
+    detector_outputs: Mapping[str, Iterable[Any]],
+    *,
+    text: str,
+) -> list[WeakLabelSpan]:
+    spans: list[WeakLabelSpan] = []
+    for source, raw_spans in detector_outputs.items():
+        spans.extend(
+            normalize_weak_span(raw_span, source=source, text=text)
+            for raw_span in raw_spans
+        )
+    return spans
+
+
+def _combine_group(grouped: Sequence[WeakLabelSpan]) -> WeakLabelSpan:
+    best = max(grouped, key=lambda span: span.score)
+    sources = tuple(sorted({span.source for span in grouped if span.source}))
+    score = sum(span.score for span in grouped) / len(grouped)
+    return WeakLabelSpan(
+        start=best.start,
+        end=best.end,
+        label=best.label,
+        text=best.text,
+        score=score,
+        source="+".join(sources),
+        metadata={**dict(best.metadata), "sources": sources},
+    )
+
+
+def _with_metadata(span: WeakLabelSpan, **updates: Any) -> WeakLabelSpan:
+    return WeakLabelSpan(
+        start=span.start,
+        end=span.end,
+        label=span.label,
+        text=span.text,
+        score=span.score,
+        source=span.source,
+        metadata={**dict(span.metadata), **updates},
+    )
+
+
+def _validators_accept(span: WeakLabelSpan, validators: Sequence[SpanValidator]) -> bool:
+    return all(validator(span) for validator in validators)
+
+
+def _disagreement_groups(spans: Sequence[WeakLabelSpan]) -> list[tuple[WeakLabelSpan, ...]]:
+    groups: list[tuple[WeakLabelSpan, ...]] = []
+    for index, span in enumerate(spans):
+        conflicts = [
+            other
+            for other in spans[index + 1 :]
+            if _overlap(span, other) and span.key != other.key
+        ]
+        if conflicts:
+            groups.append(tuple([span, *conflicts]))
+    return groups
+
+
+def _overlap(left: WeakLabelSpan, right: WeakLabelSpan) -> bool:
+    return left.start < right.end and right.start < left.end
+
+
+def _sources_for_key(
+    by_key: Mapping[tuple[int, int, str], Sequence[WeakLabelSpan]],
+    key: tuple[int, int, str],
+) -> tuple[str, ...]:
+    return tuple(sorted({span.source for span in by_key.get(key, ()) if span.source}))
+
+
+__all__ = [
+    "ActiveLearningHook",
+    "SpanValidator",
+    "WeakLabelDecision",
+    "WeakLabelSpan",
+    "normalize_weak_span",
+    "weak_label_document",
+]

--- a/tests/unit/eval/test_dataset_adapters.py
+++ b/tests/unit/eval/test_dataset_adapters.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.eval.datasets import (
+    DUA_GATED_CORPORA,
+    DUACredentialRequired,
+    PUBLIC_DATASETS,
+    assert_no_gated_content_committed,
+    license_for,
+    load_dua_corpus,
+    load_public_dataset,
+    map_public_label,
+)
+
+
+def test_public_adapter_loads_common_schema_and_maps_labels(tmp_path):
+    text = "Patient Jordan Smith called 555-111-2222."
+    payload = {
+        "records": [
+            {
+                "id": "shield-1",
+                "text": text,
+                "split": "sample",
+                "spans": [
+                    {"start": 8, "end": 20, "label": "patient", "text": "Jordan Smith"},
+                    {"start": 28, "end": 40, "label": "phone", "text": "555-111-2222"},
+                ],
+                "metadata": {"source": "unit-test"},
+            }
+        ]
+    }
+    path = tmp_path / "shield.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = load_public_dataset("shield", path)
+
+    assert result.skipped is False
+    assert len(result.records) == 1
+    record = result.records[0]
+    assert record.license == license_for("shield")
+    assert [span.label for span in record.spans] == ["PERSON", "PHONE"]
+    fixture = record.to_benchmark_fixture()
+    assert fixture.fixture_id == "shield-1"
+    assert fixture.gold_spans[0].label == "PERSON"
+    assert fixture.metadata["license"]["redistribution"] == "reference-only"
+
+
+def test_public_adapters_skip_cleanly_when_source_absent(tmp_path):
+    for dataset in PUBLIC_DATASETS:
+        result = load_public_dataset(dataset, tmp_path / f"{dataset}.json")
+        assert result.skipped is True
+        assert result.records == ()
+        assert result.license is not None
+
+
+def test_public_label_maps_are_canonical():
+    assert map_public_label("shield", "id") == "ID_NUM"
+    assert map_public_label("drugprot", "CHEMICAL") == "OTHER"
+    assert map_public_label("ncbi_disease", "Disease") == "OTHER"
+    assert map_public_label("bc5cdr", "chemical") == "OTHER"
+
+
+def test_dua_stubs_refuse_without_credentialed_path():
+    for corpus in DUA_GATED_CORPORA:
+        with pytest.raises(DUACredentialRequired):
+            load_dua_corpus(corpus)
+
+
+def test_dua_stub_accepts_existing_credentialed_path_as_eval_only(tmp_path):
+    result = load_dua_corpus("i2b2", tmp_path)
+
+    assert result.skipped is True
+    assert result.reason.startswith("eval-only gated corpus stub")
+
+
+def test_guard_rejects_gated_payload_markers(tmp_path):
+    data_file = tmp_path / "payload.jsonl"
+    data_file.write_text('{"label": "UMLS"}\n', encoding="utf-8")
+
+    with pytest.raises(AssertionError, match="gated dataset content"):
+        assert_no_gated_content_committed(tmp_path)
+
+
+def test_guard_ignores_python_source_and_clean_payloads(tmp_path):
+    (tmp_path / "adapter.py").write_text('MARKER = "UMLS"\n', encoding="utf-8")
+    (tmp_path / "payload.jsonl").write_text('{"label": "PERSON"}\n', encoding="utf-8")
+
+    assert_no_gated_content_committed(tmp_path)

--- a/tests/unit/training/test_weak_labeling.py
+++ b/tests/unit/training/test_weak_labeling.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from openmed.training.adjudication import AdjudicationQueue
+from openmed.training.weak_labeling import WeakLabelSpan, weak_label_document
+
+
+def test_accepts_spans_on_inter_model_agreement():
+    text = "Patient Jordan Smith was discharged."
+    outputs = {
+        "teacher_a": [{"start": 8, "end": 20, "label": "PERSON", "score": 0.91}],
+        "teacher_b": [{"start": 8, "end": 20, "label": "PERSON", "score": 0.87}],
+    }
+
+    decision = weak_label_document(text, outputs)
+
+    assert len(decision.accepted_spans) == 1
+    accepted = decision.accepted_spans[0]
+    assert accepted.label == "PERSON"
+    assert accepted.metadata["accepted_by"] == "inter_model_agreement"
+    assert decision.adjudication_items == ()
+
+
+def test_never_auto_accepts_single_model_span():
+    text = "Patient Jordan Smith was discharged."
+    outputs = {
+        "teacher_a": [{"start": 8, "end": 20, "label": "PERSON", "score": 0.91}],
+    }
+
+    decision = weak_label_document(text, outputs)
+
+    assert decision.accepted_spans == ()
+    assert len(decision.rejected_spans) == 1
+    assert decision.rejected_spans[0].metadata["rejection_reason"] == "single_model"
+
+
+def test_human_review_can_accept_single_model_span():
+    text = "Patient Jordan Smith was discharged."
+    span = {"start": 8, "end": 20, "label": "PERSON", "score": 0.91}
+
+    decision = weak_label_document(text, {"teacher_a": [span]}, human_reviewed_spans=[span])
+
+    assert len(decision.accepted_spans) == 1
+    assert decision.accepted_spans[0].metadata["accepted_by"] == "human_review"
+
+
+def test_routes_overlapping_disagreements_to_adjudication_and_hook():
+    text = "Patient Jordan Smith was discharged."
+    queued = []
+    outputs = {
+        "teacher_a": [{"start": 8, "end": 20, "label": "PERSON", "score": 0.91}],
+        "teacher_b": [{"start": 16, "end": 20, "label": "LAST_NAME", "score": 0.88}],
+    }
+
+    decision = weak_label_document(
+        text,
+        outputs,
+        record_id="note-1",
+        active_learning_hook=queued.append,
+    )
+
+    assert decision.accepted_spans == ()
+    assert len(decision.adjudication_items) == 1
+    item = decision.adjudication_items[0]
+    assert item.record_id == "note-1"
+    assert item.reason == "inter_model_disagreement"
+    assert item.metadata["hard_negative_seed"] is True
+    assert item.to_hard_negative_seed()["source"] == "weak_labeling_adjudication"
+    assert queued == [item]
+
+
+def test_validators_can_reject_agreed_span():
+    text = "Patient Jordan Smith was discharged."
+    outputs = {
+        "teacher_a": [{"start": 8, "end": 20, "label": "PERSON", "score": 0.91}],
+        "teacher_b": [{"start": 8, "end": 20, "label": "PERSON", "score": 0.87}],
+    }
+
+    decision = weak_label_document(text, outputs, validators=[lambda span: False])
+
+    assert decision.accepted_spans == ()
+    assert len(decision.rejected_spans) == 1
+    assert decision.rejected_spans[0].metadata["rejection_reason"] == "validator_rejected"
+
+
+def test_adjudication_queue_drains_items():
+    queue = AdjudicationQueue()
+    decision = weak_label_document(
+        "Call 555-111-2222 tomorrow.",
+        {
+            "teacher_a": [{"start": 5, "end": 17, "label": "PHONE", "score": 0.9}],
+            "teacher_b": [{"start": 5, "end": 14, "label": "PHONE", "score": 0.8}],
+        },
+    )
+    queue.extend(decision.adjudication_items)
+
+    drained = queue.drain()
+
+    assert len(drained) == 1
+    assert queue.items == []
+
+
+def test_weak_label_span_to_dict_is_json_ready():
+    span = WeakLabelSpan(start=0, end=4, label="PERSON", text="John", score=0.5)
+
+    assert span.to_dict()["label"] == "PERSON"


### PR DESCRIPTION
Closes #143.

Adds public dataset adapters with label mapping and license metadata, eval-only stubs for credentialed corpora, a committed-payload guard for restricted dataset markers, and teacher weak-labeling with agreement-only acceptance plus adjudication and active-learning routing for disagreements.

Validation:
- `.venv/bin/python -m pytest tests/ -q`