### PR TITLE
Add the free-text dataset-redaction runner over CSV/JSONL/Parquet rows

### DIFF
--- a/docs/batch-processing.md
+++ b/docs/batch-processing.md
@@ -134,6 +134,40 @@ processor = BatchProcessor(
 )
 ```
 
+## Dataset Redaction
+
+Use `redact_dataset()` when the source is a tabular or line-delimited dataset
+and only specific free-text columns should be de-identified. Supported formats
+are `.csv`, `.jsonl`/`.ndjson`, and `.parquet`; CSV and JSONL rows are streamed,
+and Parquet input is processed in row batches when `pyarrow` is installed.
+Columns are never inferred automatically: pass the free-text columns explicitly.
+
+```python
+from openmed import redact_dataset
+
+result = redact_dataset(
+    "notes.csv",
+    text_columns=["note", "comment"],
+    output_path="notes.redacted.csv",
+    policy="strict_no_leak",
+)
+
+print(result.summary.to_dict())
+```
+
+The console entry point exposes the same path:
+
+```bash
+openmed redact-dataset notes.csv \
+  --text-columns note,comment \
+  --policy strict_no_leak \
+  --output notes.redacted.csv
+```
+
+The audit summary contains aggregate counts only, including total spans,
+per-label counts, and a residual-leakage estimate. It does not include raw
+cell values or detected entity text.
+
 ## Progress Tracking
 
 Track progress with `on_progress`. The callback receives a frozen

--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -76,6 +76,8 @@ from .processing import (
     BatchProcessor,
     BatchProgress,
     BatchResult,
+    DatasetRedactionResult,
+    DatasetRedactionSummary,
     OutputFormatter,
     TextProcessor,
     TokenizationHelper,
@@ -83,6 +85,7 @@ from .processing import (
     postprocess_text,
     preprocess_text,
     process_batch,
+    redact_dataset,
 )
 from .processing import sentences as sentence_utils
 from .processing.advanced_ner import AdvancedNERProcessor, create_advanced_processor
@@ -622,7 +625,10 @@ __all__ = [
     "BatchItemResult",
     "BatchProgress",
     "BatchResult",
+    "DatasetRedactionResult",
+    "DatasetRedactionSummary",
     "process_batch",
+    "redact_dataset",
     "AdvancedNERProcessor",
     "create_advanced_processor",
     "AnalyzeResult",

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -157,6 +157,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_analyze_command(subparsers)
     _add_batch_command(subparsers)
     _add_deid_command(subparsers)
+    _add_redact_dataset_command(subparsers)
     _add_pii_command(subparsers)
     _add_audit_command(subparsers)
     _add_risk_command(subparsers)
@@ -372,6 +373,87 @@ def _add_deid_command(subparsers: argparse._SubParsersAction) -> None:
         help="Keep year in dates.",
     )
     deid_parser.set_defaults(handler=_handle_deid)
+
+
+def _add_redact_dataset_command(subparsers: argparse._SubParsersAction) -> None:
+    redact_parser = subparsers.add_parser(
+        "redact-dataset",
+        help="Redact selected free-text columns in a CSV, JSONL, or Parquet dataset.",
+    )
+    redact_parser.add_argument(
+        "path",
+        type=Path,
+        help="Input .csv, .jsonl, .ndjson, or .parquet file.",
+    )
+    redact_parser.add_argument(
+        "--text-column",
+        dest="text_column",
+        action="append",
+        default=[],
+        help="Free-text column to redact. Repeat for multiple columns.",
+    )
+    redact_parser.add_argument(
+        "--text-columns",
+        dest="text_columns",
+        default=None,
+        help="Comma-separated free-text columns to redact.",
+    )
+    redact_parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        help="Output dataset path. Defaults to <stem>.redacted<suffix>.",
+    )
+    redact_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Policy profile name to pass to de-identification.",
+    )
+    redact_parser.add_argument(
+        "--method",
+        choices=["mask", "remove", "replace", "hash", "shift_dates"],
+        default="mask",
+        help="Fallback de-identification method.",
+    )
+    redact_parser.add_argument(
+        "--model",
+        default=_DEFAULT_PII_MODEL,
+        help="PII detection model.",
+    )
+    redact_parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.7,
+        help="Minimum confidence for redaction.",
+    )
+    redact_parser.add_argument(
+        "--lang",
+        default="en",
+        help="Language hint for PII detection and redaction.",
+    )
+    redact_parser.add_argument(
+        "--encoding",
+        default="utf-8",
+        help="Text encoding for CSV and JSONL inputs.",
+    )
+    redact_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=512,
+        help="Row batch size for Parquet processing.",
+    )
+    redact_parser.add_argument(
+        "--keep-year",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Keep year in dates where applicable. Use --no-keep-year to disable.",
+    )
+    redact_parser.add_argument(
+        "--no-safety-sweep",
+        action="store_true",
+        help="Disable deterministic structured-identifier sweep.",
+    )
+    redact_parser.set_defaults(handler=_handle_redact_dataset)
 
 
 def _add_pii_command(subparsers: argparse._SubParsersAction) -> None:
@@ -1187,6 +1269,13 @@ def _handle_batch(args: argparse.Namespace) -> int:
         sys.stdout.write(f"{output}\n")
 
     return 0 if result.failed_items == 0 else 1
+
+
+def _handle_redact_dataset(args: argparse.Namespace) -> int:
+    from .redact_dataset import run_from_args
+
+    config = _load_and_apply_config(args)
+    return run_from_args(args, config=config)
 
 
 def _handle_audit_verify(args: argparse.Namespace) -> int:

--- a/openmed/cli/redact_dataset.py
+++ b/openmed/cli/redact_dataset.py
@@ -1,0 +1,72 @@
+"""CLI handler for dataset redaction."""
+
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+from typing import Any, Sequence, TextIO
+
+from openmed.processing.batch import redact_dataset
+
+
+def parse_text_columns(
+    text_columns: str | None,
+    repeated_columns: Sequence[str] | None,
+) -> list[str]:
+    """Parse comma-separated and repeated text-column arguments."""
+    columns: list[str] = []
+    if text_columns:
+        columns.extend(_split_columns(text_columns))
+    for value in repeated_columns or ():
+        columns.extend(_split_columns(value))
+    return columns
+
+
+def run_from_args(
+    args: Namespace,
+    *,
+    config: Any | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    """Run dataset redaction from argparse arguments."""
+    stdout = stdout or sys.stdout
+    stderr = stderr or sys.stderr
+    columns = parse_text_columns(
+        getattr(args, "text_columns", None),
+        getattr(args, "text_column", None),
+    )
+    if not columns:
+        stderr.write(
+            "At least one --text-column or --text-columns value is required.\n"
+        )
+        return 1
+
+    try:
+        result = redact_dataset(
+            getattr(args, "path"),
+            columns,
+            output_path=getattr(args, "output", None),
+            policy=getattr(args, "policy", None),
+            method=getattr(args, "method", "mask"),
+            model_name=getattr(args, "model"),
+            confidence_threshold=getattr(args, "confidence_threshold", 0.7),
+            config=config,
+            lang=getattr(args, "lang", "en"),
+            keep_year=getattr(args, "keep_year", True),
+            use_safety_sweep=not getattr(args, "no_safety_sweep", False),
+            encoding=getattr(args, "encoding", "utf-8"),
+            batch_size=getattr(args, "batch_size", 512),
+        )
+    except Exception as exc:
+        stderr.write(f"Dataset redaction failed: {exc}\n")
+        return 1
+
+    stdout.write(json.dumps(result.summary.to_dict(), indent=2, sort_keys=True))
+    stdout.write("\n")
+    return 0
+
+
+def _split_columns(value: str) -> list[str]:
+    return [column.strip() for column in value.split(",") if column.strip()]

--- a/openmed/processing/__init__.py
+++ b/openmed/processing/__init__.py
@@ -7,7 +7,10 @@ from .batch import (
     BatchProcessor,
     BatchProgress,
     BatchResult,
+    DatasetRedactionResult,
+    DatasetRedactionSummary,
     process_batch,
+    redact_dataset,
 )
 from .kafka_connector import (
     ConsumerProtocol,
@@ -36,7 +39,10 @@ __all__ = [
     "BatchItemResult",
     "BatchProgress",
     "BatchResult",
+    "DatasetRedactionResult",
+    "DatasetRedactionSummary",
     "process_batch",
+    "redact_dataset",
     "ConsumerProtocol",
     "ProducerProtocol",
     "KafkaClientPair",

--- a/openmed/processing/batch.py
+++ b/openmed/processing/batch.py
@@ -2,12 +2,19 @@
 
 This module provides efficient batch processing capabilities for analyzing
 multiple texts or files with progress reporting and result aggregation.
+
+Dataset redaction supports local ``.csv``, ``.jsonl``/``.ndjson``, and
+``.parquet`` files. Callers choose one or more free-text columns explicitly;
+all other columns are copied through unchanged.
 """
 
 from __future__ import annotations
 
+import csv
+import json
 import logging
 import time
+from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import (
@@ -17,6 +24,7 @@ from typing import (
     Iterator,
     List,
     Literal,
+    Mapping,
     Optional,
     Sequence,
     Union,
@@ -27,7 +35,9 @@ from .outputs import PredictionResult
 logger = logging.getLogger(__name__)
 
 BatchOperation = Literal["analyze_text", "extract_pii", "deidentify"]
+DatasetFormat = Literal["csv", "jsonl", "parquet"]
 _VALID_OPERATIONS = {"analyze_text", "extract_pii", "deidentify"}
+_DEFAULT_PII_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
 
 
 @dataclass
@@ -153,6 +163,60 @@ class BatchResult:
             f"Average time per item: {self.average_processing_time:.3f}s",
         ]
         return "\n".join(lines)
+
+
+@dataclass
+class DatasetRedactionSummary:
+    """Aggregate audit summary for dataset redaction.
+
+    The summary intentionally contains counts and rates only. It does not
+    include raw input values, redacted cell values, or entity surfaces.
+    """
+
+    input_format: DatasetFormat
+    text_columns: List[str]
+    total_rows: int = 0
+    processed_cells: int = 0
+    redacted_cells: int = 0
+    total_spans: int = 0
+    per_label_counts: Dict[str, int] = field(default_factory=dict)
+    residual_span_count: int = 0
+
+    @property
+    def residual_leakage_estimate(self) -> float:
+        """Estimated residual span leakage rate after redaction."""
+        if self.total_spans == 0:
+            return 0.0
+        return self.residual_span_count / self.total_spans
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a PHI-free dictionary representation."""
+        return {
+            "input_format": self.input_format,
+            "text_columns": list(self.text_columns),
+            "total_rows": self.total_rows,
+            "processed_cells": self.processed_cells,
+            "redacted_cells": self.redacted_cells,
+            "total_spans": self.total_spans,
+            "per_label_counts": dict(sorted(self.per_label_counts.items())),
+            "residual_span_count": self.residual_span_count,
+            "residual_leakage_estimate": self.residual_leakage_estimate,
+        }
+
+
+@dataclass
+class DatasetRedactionResult:
+    """Result returned by :func:`redact_dataset`."""
+
+    output_path: Path
+    summary: DatasetRedactionSummary
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        return {
+            "output_path": str(self.output_path),
+            "summary": self.summary.to_dict(),
+        }
 
 
 # Type alias for progress callback
@@ -789,3 +853,326 @@ def process_batch(
         progress_callback,
         on_progress=on_progress,
     )
+
+
+def redact_dataset(
+    path: Union[str, Path],
+    text_columns: Sequence[str],
+    *,
+    output_path: Optional[Union[str, Path]] = None,
+    policy: Optional[str] = None,
+    method: str = "mask",
+    model_name: str = _DEFAULT_PII_MODEL,
+    confidence_threshold: float = 0.7,
+    config: Optional[Any] = None,
+    lang: str = "en",
+    keep_year: bool = True,
+    date_shift_days: Optional[int] = None,
+    use_safety_sweep: bool = True,
+    encoding: str = "utf-8",
+    batch_size: int = 512,
+) -> DatasetRedactionResult:
+    """Redact selected free-text columns in a local dataset.
+
+    Supported input formats are ``.csv``, ``.jsonl``/``.ndjson``, and
+    ``.parquet``. CSV and JSONL files are streamed row-by-row. Parquet files
+    are processed in row batches through ``pyarrow`` when that optional
+    dependency is installed.
+
+    Args:
+        path: Input dataset path.
+        text_columns: Free-text column names to pass through ``deidentify``.
+        output_path: Destination path. Defaults to ``<stem>.redacted<suffix>``.
+        policy: Optional de-identification policy profile name.
+        method: De-identification method forwarded to ``deidentify``.
+        model_name: PII detection model.
+        confidence_threshold: Minimum confidence for redaction.
+        config: Optional OpenMed configuration.
+        lang: Language hint forwarded to ``deidentify``.
+        keep_year: Keep the year in date redaction where applicable.
+        date_shift_days: Optional fixed date shift.
+        use_safety_sweep: Enable deterministic structured-identifier sweep.
+        encoding: Text encoding for CSV/JSONL.
+        batch_size: Parquet row batch size.
+
+    Returns:
+        DatasetRedactionResult with output path and PHI-free audit summary.
+    """
+    input_path = Path(path)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Dataset not found: {input_path}")
+    if not input_path.is_file():
+        raise ValueError(f"Dataset path must be a file: {input_path}")
+
+    dataset_format = _infer_dataset_format(input_path)
+    normalized_columns = _normalize_text_columns(text_columns)
+    destination = (
+        Path(output_path)
+        if output_path is not None
+        else _default_output_path(
+            input_path,
+            dataset_format,
+        )
+    )
+    if input_path.resolve() == destination.resolve():
+        raise ValueError("output_path must not overwrite the input dataset")
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    summary = DatasetRedactionSummary(
+        input_format=dataset_format,
+        text_columns=list(normalized_columns),
+    )
+    deidentify_kwargs = {
+        "method": method,
+        "model_name": model_name,
+        "confidence_threshold": confidence_threshold,
+        "keep_year": keep_year,
+        "date_shift_days": date_shift_days,
+        "config": config,
+        "lang": lang,
+        "use_safety_sweep": use_safety_sweep,
+        "policy": policy,
+    }
+
+    if dataset_format == "csv":
+        _redact_csv_dataset(
+            input_path,
+            destination,
+            normalized_columns,
+            summary,
+            deidentify_kwargs,
+            encoding,
+        )
+    elif dataset_format == "jsonl":
+        _redact_jsonl_dataset(
+            input_path,
+            destination,
+            normalized_columns,
+            summary,
+            deidentify_kwargs,
+            encoding,
+        )
+    else:
+        _redact_parquet_dataset(
+            input_path,
+            destination,
+            normalized_columns,
+            summary,
+            deidentify_kwargs,
+            batch_size,
+        )
+
+    return DatasetRedactionResult(output_path=destination, summary=summary)
+
+
+def _infer_dataset_format(path: Path) -> DatasetFormat:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return "csv"
+    if suffix in {".jsonl", ".ndjson"}:
+        return "jsonl"
+    if suffix == ".parquet":
+        return "parquet"
+    raise ValueError(
+        "Unsupported dataset format. Expected .csv, .jsonl, .ndjson, or .parquet."
+    )
+
+
+def _default_output_path(path: Path, dataset_format: DatasetFormat) -> Path:
+    suffix = ".jsonl" if dataset_format == "jsonl" else path.suffix
+    return path.with_name(f"{path.stem}.redacted{suffix}")
+
+
+def _normalize_text_columns(text_columns: Sequence[str]) -> tuple[str, ...]:
+    columns: list[str] = []
+    seen: set[str] = set()
+    for column in text_columns:
+        name = str(column).strip()
+        if not name:
+            continue
+        if name not in seen:
+            seen.add(name)
+            columns.append(name)
+    if not columns:
+        raise ValueError("At least one text column must be selected")
+    return tuple(columns)
+
+
+def _validate_text_columns(
+    available: Sequence[str], text_columns: Sequence[str]
+) -> None:
+    missing = [column for column in text_columns if column not in available]
+    if missing:
+        raise ValueError(f"Missing text column(s): {', '.join(missing)}")
+
+
+def _redact_csv_dataset(
+    input_path: Path,
+    output_path: Path,
+    text_columns: Sequence[str],
+    summary: DatasetRedactionSummary,
+    deidentify_kwargs: Mapping[str, Any],
+    encoding: str,
+) -> None:
+    with input_path.open("r", encoding=encoding, newline="") as source:
+        reader = csv.DictReader(source)
+        fieldnames = reader.fieldnames
+        if not fieldnames:
+            raise ValueError("CSV input must include a header row")
+        _validate_text_columns(fieldnames, text_columns)
+
+        with output_path.open("w", encoding=encoding, newline="") as target:
+            writer = csv.DictWriter(target, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in reader:
+                writer.writerow(
+                    _redact_dataset_row(row, text_columns, summary, deidentify_kwargs)
+                )
+                summary.total_rows += 1
+
+
+def _redact_jsonl_dataset(
+    input_path: Path,
+    output_path: Path,
+    text_columns: Sequence[str],
+    summary: DatasetRedactionSummary,
+    deidentify_kwargs: Mapping[str, Any],
+    encoding: str,
+) -> None:
+    with (
+        input_path.open("r", encoding=encoding) as source,
+        output_path.open(
+            "w",
+            encoding=encoding,
+        ) as target,
+    ):
+        for line_number, line in enumerate(source, start=1):
+            if not line.strip():
+                target.write(line)
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict):
+                raise ValueError(f"JSONL row {line_number} must be an object")
+            redacted = _redact_dataset_row(
+                row,
+                text_columns,
+                summary,
+                deidentify_kwargs,
+            )
+            target.write(
+                json.dumps(redacted, ensure_ascii=False, separators=(",", ":"))
+            )
+            target.write("\n")
+            summary.total_rows += 1
+
+
+def _redact_parquet_dataset(
+    input_path: Path,
+    output_path: Path,
+    text_columns: Sequence[str],
+    summary: DatasetRedactionSummary,
+    deidentify_kwargs: Mapping[str, Any],
+    batch_size: int,
+) -> None:
+    try:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "Parquet dataset redaction requires pyarrow to be installed."
+        ) from exc
+
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+
+    parquet_file = pq.ParquetFile(input_path)
+    schema = parquet_file.schema_arrow
+    _validate_text_columns(schema.names, text_columns)
+    for column in text_columns:
+        field_type = schema.field(column).type
+        if not (
+            pa.types.is_string(field_type)
+            or pa.types.is_large_string(field_type)
+            or pa.types.is_null(field_type)
+        ):
+            raise ValueError(f"Parquet text column must be string-typed: {column}")
+
+    writer = None
+    try:
+        for record_batch in parquet_file.iter_batches(batch_size=batch_size):
+            table = pa.Table.from_batches([record_batch], schema=schema)
+            rows = [
+                _redact_dataset_row(row, text_columns, summary, deidentify_kwargs)
+                for row in table.to_pylist()
+            ]
+            summary.total_rows += len(rows)
+            redacted_table = pa.Table.from_pylist(rows, schema=schema)
+            if writer is None:
+                writer = pq.ParquetWriter(output_path, schema)
+            writer.write_table(redacted_table)
+
+        if writer is None:
+            writer = pq.ParquetWriter(output_path, schema)
+    finally:
+        if writer is not None:
+            writer.close()
+
+
+def _redact_dataset_row(
+    row: Mapping[str, Any],
+    text_columns: Sequence[str],
+    summary: DatasetRedactionSummary,
+    deidentify_kwargs: Mapping[str, Any],
+) -> Dict[str, Any]:
+    output = dict(row)
+    _validate_text_columns(tuple(output.keys()), text_columns)
+
+    for column in text_columns:
+        value = output[column]
+        if value is None:
+            continue
+        text = value if isinstance(value, str) else str(value)
+        if text == "":
+            continue
+
+        result = _deidentify_dataset_cell(text, deidentify_kwargs)
+        output[column] = result.deidentified_text
+        _update_redaction_summary(summary, text, result)
+
+    return output
+
+
+def _deidentify_dataset_cell(text: str, kwargs: Mapping[str, Any]) -> Any:
+    from openmed.core.pii import deidentify
+
+    return deidentify(text, **dict(kwargs))
+
+
+def _update_redaction_summary(
+    summary: DatasetRedactionSummary,
+    original_text: str,
+    result: Any,
+) -> None:
+    summary.processed_cells += 1
+    if result.deidentified_text != original_text:
+        summary.redacted_cells += 1
+
+    label_counts: Counter[str] = Counter()
+    residual_spans = 0
+    for entity in getattr(result, "pii_entities", []) or []:
+        label = str(
+            getattr(entity, "label", None)
+            or getattr(entity, "entity_type", None)
+            or "UNKNOWN"
+        )
+        label_counts[label] += 1
+        surface = getattr(entity, "text", None) or getattr(
+            entity, "original_text", None
+        )
+        if surface and surface in result.deidentified_text:
+            residual_spans += 1
+
+    for label, count in label_counts.items():
+        summary.per_label_counts[label] = summary.per_label_counts.get(label, 0) + count
+    summary.total_spans += sum(label_counts.values())
+    summary.residual_span_count += residual_spans

--- a/tests/unit/processing/test_redact_dataset.py
+++ b/tests/unit/processing/test_redact_dataset.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from openmed.cli import main_module
+from openmed.core.pii import DeidentificationResult, PIIEntity
+from openmed.processing.batch import redact_dataset
+
+
+def test_redact_dataset_csv_preserves_non_text_columns_and_summarizes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    input_path = tmp_path / "patients.csv"
+    output_path = tmp_path / "patients.redacted.csv"
+    input_path.write_text(
+        "id,note,age\n"
+        "1,Patient John Doe called 555-0101,42\n"
+        "2,Patient Jane Roe emailed jane@example.test,37\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("openmed.core.pii.deidentify", _fake_deidentify)
+
+    result = redact_dataset(
+        input_path,
+        text_columns=["note"],
+        output_path=output_path,
+        policy="strict_no_leak",
+    )
+
+    rows = list(csv.DictReader(output_path.open(encoding="utf-8", newline="")))
+    assert rows == [
+        {"id": "1", "note": "Patient [PERSON] called [PHONE]", "age": "42"},
+        {"id": "2", "note": "Patient [PERSON] emailed [EMAIL]", "age": "37"},
+    ]
+    assert result.summary.to_dict() == {
+        "input_format": "csv",
+        "text_columns": ["note"],
+        "total_rows": 2,
+        "processed_cells": 2,
+        "redacted_cells": 2,
+        "total_spans": 4,
+        "per_label_counts": {"EMAIL": 1, "PERSON": 2, "PHONE": 1},
+        "residual_span_count": 0,
+        "residual_leakage_estimate": 0.0,
+    }
+    _assert_summary_has_no_fixture_phi(result.summary.to_dict())
+
+
+def test_redact_dataset_jsonl_preserves_non_text_columns_and_summarizes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    input_path = tmp_path / "notes.jsonl"
+    output_path = tmp_path / "notes.redacted.jsonl"
+    rows = [
+        {
+            "id": 1,
+            "note": "Patient John Doe called 555-0101",
+            "status": "complete",
+        },
+        {
+            "id": 2,
+            "note": "Patient Jane Roe emailed jane@example.test",
+            "status": "queued",
+        },
+    ]
+    input_path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("openmed.core.pii.deidentify", _fake_deidentify)
+
+    result = redact_dataset(
+        input_path,
+        text_columns=["note"],
+        output_path=output_path,
+    )
+
+    redacted_rows = [
+        json.loads(line)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert redacted_rows == [
+        {"id": 1, "note": "Patient [PERSON] called [PHONE]", "status": "complete"},
+        {"id": 2, "note": "Patient [PERSON] emailed [EMAIL]", "status": "queued"},
+    ]
+    assert result.summary.total_rows == 2
+    assert result.summary.total_spans == 4
+    assert result.summary.per_label_counts == {"PERSON": 2, "PHONE": 1, "EMAIL": 1}
+    _assert_summary_has_no_fixture_phi(result.summary.to_dict())
+
+
+def test_redact_dataset_parquet_preserves_schema_when_pyarrow_is_available(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    pyarrow = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+
+    input_path = tmp_path / "patients.parquet"
+    output_path = tmp_path / "patients.redacted.parquet"
+    table = pyarrow.table(
+        {
+            "id": [1, 2],
+            "note": [
+                "Patient John Doe called 555-0101",
+                "Patient Jane Roe emailed jane@example.test",
+            ],
+            "age": [42, 37],
+        }
+    )
+    pq.write_table(table, input_path)
+    monkeypatch.setattr("openmed.core.pii.deidentify", _fake_deidentify)
+
+    result = redact_dataset(
+        input_path,
+        text_columns=["note"],
+        output_path=output_path,
+        batch_size=1,
+    )
+
+    redacted_rows = pq.read_table(output_path).to_pylist()
+    assert redacted_rows == [
+        {"id": 1, "note": "Patient [PERSON] called [PHONE]", "age": 42},
+        {"id": 2, "note": "Patient [PERSON] emailed [EMAIL]", "age": 37},
+    ]
+    assert result.summary.total_rows == 2
+    assert result.summary.total_spans == 4
+    assert result.summary.per_label_counts == {"PERSON": 2, "PHONE": 1, "EMAIL": 1}
+    _assert_summary_has_no_fixture_phi(result.summary.to_dict())
+
+
+def test_redact_dataset_cli_emits_phi_free_audit_summary(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    input_path = tmp_path / "patients.csv"
+    output_path = tmp_path / "patients.redacted.csv"
+    input_path.write_text(
+        "id,note\n1,Patient John Doe called 555-0101\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("openmed.core.pii.deidentify", _fake_deidentify)
+
+    exit_code = main_module.main(
+        [
+            "redact-dataset",
+            str(input_path),
+            "--text-columns",
+            "note",
+            "--output",
+            str(output_path),
+            "--policy",
+            "strict_no_leak",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    summary = json.loads(captured.out)
+    assert summary["total_spans"] == 2
+    assert summary["per_label_counts"] == {"PERSON": 1, "PHONE": 1}
+    assert "John Doe" not in output_path.read_text(encoding="utf-8")
+    assert "555-0101" not in output_path.read_text(encoding="utf-8")
+    _assert_summary_has_no_fixture_phi(summary)
+
+
+def test_redact_dataset_cli_can_disable_keep_year(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    input_path = tmp_path / "patients.csv"
+    output_path = tmp_path / "patients.redacted.csv"
+    input_path.write_text(
+        "id,note\n1,Patient John Doe called 555-0101\n",
+        encoding="utf-8",
+    )
+    calls: list[dict] = []
+
+    def fake_deidentify(text: str, **kwargs) -> DeidentificationResult:
+        calls.append(kwargs)
+        return _fake_deidentify(text, **kwargs)
+
+    monkeypatch.setattr("openmed.core.pii.deidentify", fake_deidentify)
+
+    exit_code = main_module.main(
+        [
+            "redact-dataset",
+            str(input_path),
+            "--text-column",
+            "note",
+            "--output",
+            str(output_path),
+            "--no-keep-year",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    assert calls
+    assert calls[0]["keep_year"] is False
+
+
+def test_redact_dataset_requires_text_columns(tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "patients.csv"
+    input_path.write_text("id,note\n1,No identifiers\n", encoding="utf-8")
+
+    exit_code = main_module.main(["redact-dataset", str(input_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "At least one --text-column" in captured.err
+
+
+def _fake_deidentify(text: str, **kwargs) -> DeidentificationResult:
+    replacements = {
+        "John Doe": ("[PERSON]", "PERSON"),
+        "Jane Roe": ("[PERSON]", "PERSON"),
+        "555-0101": ("[PHONE]", "PHONE"),
+        "jane@example.test": ("[EMAIL]", "EMAIL"),
+    }
+    redacted = text
+    entities: list[PIIEntity] = []
+    for surface, (replacement, label) in replacements.items():
+        start = text.find(surface)
+        if start == -1:
+            continue
+        entities.append(
+            PIIEntity(
+                text=surface,
+                label=label,
+                confidence=0.99,
+                start=start,
+                end=start + len(surface),
+                entity_type=label,
+                original_text=surface,
+                redacted_text=replacement,
+            )
+        )
+        redacted = redacted.replace(surface, replacement)
+
+    return DeidentificationResult(
+        original_text=text,
+        deidentified_text=redacted,
+        pii_entities=entities,
+        method=kwargs.get("method", "mask"),
+        timestamp=datetime.now(),
+    )
+
+
+def _assert_summary_has_no_fixture_phi(summary: dict) -> None:
+    payload = json.dumps(summary, sort_keys=True)
+    for token in ("John Doe", "Jane Roe", "555-0101", "jane@example.test"):
+        assert token not in payload


### PR DESCRIPTION
Closes #177.

## Summary
- adds a streaming dataset-redaction runner for selected free-text columns in CSV, JSONL/NDJSON, and optional Parquet inputs
- preserves non-text columns and writes a PHI-free aggregate audit summary with row/cell counts, per-label span counts, and residual-leakage estimate
- exposes the path through `openmed redact-dataset`
- documents the supported formats, explicit column selection, and PHI-free summary contract
- keeps the CLI usable for date behavior by supporting `--no-keep-year`

## Validation
- `.venv/bin/python scripts/release/check_repo_policy.py`
- `.venv/bin/python -m pytest tests/unit/processing/test_redact_dataset.py tests/unit/cli/test_cli_smoke.py tests/unit/test_batch.py -q`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m pytest tests/ -q`

Note: the Parquet fixture test is optional and skips locally unless `pyarrow` is installed.