### PR TITLE
Add cold_start_ms measurement to the eval harness

### DIFF
--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -1,0 +1,38 @@
+# Eval Harness & Metrics
+
+`run_benchmark` executes a model over a sequence of `BenchmarkFixture` objects and returns a
+`BenchmarkReport` whose `metrics` dict contains the standard OM-018 metric bundle.
+
+## Metric Bundle
+
+| Metric | Path | Gating? | Description |
+| --- | --- | --- | --- |
+| Latency p50 | `latency.p50_ms` | No | Median steady-state fixture latency in ms. |
+| Latency p95 | `latency.p95_ms` | No | 95th-percentile steady-state fixture latency in ms. |
+| Latency count | `latency.count` | No | Number of steady-state fixtures (excludes cold start). |
+| Cold-start latency | `latency.cold_start_ms` | No | Wall-clock latency of the first fixture call in ms. |
+| Peak RSS | `resources.peak_rss_bytes` | No | Peak resident set size in bytes during the run. |
+
+## Edge Metrics
+
+### cold_start_ms
+
+The harness records the wall-clock latency of the **first** fixture call separately. That call
+encloses model and tokenizer loading plus the first forward pass, so it is systematically higher
+than steady-state calls. The value is surfaced at:
+
+```
+report.metrics['latency']['cold_start_ms']
+```
+
+It is **excluded** from the steady-state `p50_ms`, `p95_ms`, and `count` values.
+
+!!! note "Reported, not gating"
+    `cold_start_ms` does not participate in any release gate. It is an observability metric
+    intended to track model-load overhead over time — not a pass/fail criterion.
+
+```python
+report = run_benchmark(fixtures, suite="my-suite", model_name="my-model", runner=runner)
+cold_ms = report.metrics["latency"]["cold_start_ms"]
+print(f"Cold-start latency: {cold_ms:.1f} ms")
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - Zero-shot Toolkit: zero-shot-ner.md
       - Examples & Copy/Paste Recipes: examples.md
       - Testing & QA: testing.md
+      - Eval Harness & Metrics: eval-harness.md
   - PII & De-identification:
       - PII Anonymization: anonymization.md
       - Smart Entity Merging: pii-smart-merging.md

--- a/openmed/eval/harness.py
+++ b/openmed/eval/harness.py
@@ -145,7 +145,8 @@ def run_benchmark(
     metrics = compute_metrics_bundle(
         gold_spans,
         predicted_spans,
-        latencies_ms=[result.latency_ms for result in results],
+        latencies_ms=[result.latency_ms for result in results[1:]],
+        cold_start_ms=(results[0].latency_ms if results else None),
         peak_rss_bytes=peak_rss,
         default_device=device,
         source_text=corpus_text,

--- a/openmed/eval/metrics.py
+++ b/openmed/eval/metrics.py
@@ -671,13 +671,20 @@ def compute_metrics_bundle(
     predicted_spans: Iterable[Any],
     *,
     latencies_ms: Sequence[int | float] = (),
+    cold_start_ms: float | None = None,
     peak_rss_bytes: int | None = None,
     model_size_bytes: int | None = None,
     default_language: str = "en",
     default_device: str = "cpu",
     source_text: str | None = None,
 ) -> dict[str, Any]:
-    """Compute the standard OM-018 benchmark metric bundle."""
+    """Compute the standard OM-018 benchmark metric bundle.
+
+    ``cold_start_ms`` is reported as a non-gating edge metric nested under
+    ``report.metrics['latency']['cold_start_ms']``. It is the first fixture
+    call's wall-clock latency (model/tokenizer load plus first forward pass)
+    and is excluded from the steady-state ``p50``/``p95``/``count`` sample.
+    """
     text_length = len(source_text) if source_text is not None else None
     return {
         "leakage": compute_leakage_rate(
@@ -723,7 +730,10 @@ def compute_metrics_bundle(
             default_device=default_device,
             source_text=source_text,
         ).to_dict(),
-        "latency": compute_latency_summary(latencies_ms).to_dict(),
+        "latency": {
+            **compute_latency_summary(latencies_ms).to_dict(),
+            "cold_start_ms": cold_start_ms,
+        },
         "resources": compute_resource_metrics(
             peak_rss_bytes=peak_rss_bytes,
             model_size_bytes=model_size_bytes,

--- a/tests/unit/eval/test_cold_start_metric.py
+++ b/tests/unit/eval/test_cold_start_metric.py
@@ -1,0 +1,60 @@
+"""Tests for the cold_start_ms edge metric surfaced by run_benchmark."""
+
+from __future__ import annotations
+
+import time
+
+from openmed.eval.harness import BenchmarkFixture, run_benchmark
+
+
+def _fixture(fid: str) -> BenchmarkFixture:
+    return BenchmarkFixture.from_mapping(
+        {
+            "id": fid,
+            "text": "Patient John",
+            "language": "en",
+            "gold_spans": [{"start": 8, "end": 12, "label": "PERSON"}],
+        }
+    )
+
+
+def _make_runner(cold_sleep_s: float):
+    call_count = [0]
+
+    def runner(fixture, model_name, device):
+        if call_count[0] == 0:
+            time.sleep(cold_sleep_s)
+        call_count[0] += 1
+        return [{"start": 8, "end": 12, "label": "PERSON"}]
+
+    return runner
+
+
+def test_cold_start_ms_field_is_present_and_populated():
+    """cold_start_ms key exists in latency dict and holds a positive value."""
+    fixtures = [_fixture("f1"), _fixture("f2")]
+    report = run_benchmark(
+        fixtures,
+        suite="cold-start-test",
+        model_name="test-model",
+        runner=_make_runner(cold_sleep_s=0.01),
+    )
+    latency = report.metrics["latency"]
+    assert "cold_start_ms" in latency
+    assert latency["cold_start_ms"] is not None
+    assert latency["cold_start_ms"] > 0.0
+    assert latency["count"] == 1
+
+
+def test_cold_start_ms_ge_first_steady_state_latency():
+    """cold_start_ms is >= p50 of steady-state calls and count excludes it."""
+    fixtures = [_fixture(f"f{i}") for i in range(4)]
+    report = run_benchmark(
+        fixtures,
+        suite="cold-start-test",
+        model_name="test-model",
+        runner=_make_runner(cold_sleep_s=0.02),
+    )
+    latency = report.metrics["latency"]
+    assert latency["cold_start_ms"] >= latency["p50_ms"]
+    assert latency["count"] == 3


### PR DESCRIPTION
## Description
Adds a `cold_start_ms` edge metric to the eval harness so artifacts with identical steady-state latency but different load times are distinguishable.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement
- [x] Documentation update

## Changes Made
- `openmed/eval/harness.py`: time the first fixture call (model/tokenizer load + first forward) separately as `cold_start_ms`; exclude it from the steady-state latency sample (`results[1:]`).
- `openmed/eval/metrics.py`: `compute_metrics_bundle` accepts `cold_start_ms` and surfaces it under `report.metrics['latency']['cold_start_ms']`, beside `p50_ms`/`p95_ms`/`count`.
- `tests/unit/eval/test_cold_start_metric.py`: assert the field is present and populated for a stub model, and that `cold_start_ms >= p50` of steady state.
- `docs/eval-harness.md` + `mkdocs.yml`: document it as a reported, non-gating edge metric.

## Documentation
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md <!-- feature PRs skip CHANGELOG per repo convention -->

## Dependencies
- [x] I have not added any new dependencies

## Related Issues
Closes #291

## Validation
- `.venv/bin/python -m pytest tests/ -q`  → 1338 passed, 22 skipped
