### PR TITLE
reject duplicate fixture IDs

### DIFF
--- a/openmed/eval/harness.py
+++ b/openmed/eval/harness.py
@@ -72,7 +72,9 @@ def load_fixtures(path: str | Path) -> list[BenchmarkFixture]:
     rows = raw.get("fixtures") if isinstance(raw, Mapping) else raw
     if not isinstance(rows, list):
         raise ValueError("benchmark fixture JSON must be a list or contain a fixtures list")
-    return [BenchmarkFixture.from_mapping(row) for row in rows]
+    fixtures = [BenchmarkFixture.from_mapping(row) for row in rows]
+    _validate_unique_fixture_ids(fixtures)
+    return fixtures
 
 
 def default_model_runner(
@@ -109,6 +111,7 @@ def run_benchmark(
     metadata: Mapping[str, Any] | None = None,
 ) -> BenchmarkReport:
     """Run *model_name* over fixtures and return a benchmark report."""
+    _validate_unique_fixture_ids(fixtures)
     model_runner = runner or _shared_default_model_runner()
     results: list[FixtureResult] = []
     peak_rss_start = _peak_rss_bytes()
@@ -244,6 +247,18 @@ def _shift_spans(spans: Iterable[EvalSpan], offset: int) -> list[EvalSpan]:
         replace(span, start=span.start + offset, end=span.end + offset)
         for span in spans
     ]
+
+
+def _validate_unique_fixture_ids(fixtures: Sequence[BenchmarkFixture]) -> None:
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for fixture in fixtures:
+        if fixture.fixture_id in seen and fixture.fixture_id not in duplicates:
+            duplicates.append(fixture.fixture_id)
+        seen.add(fixture.fixture_id)
+    if duplicates:
+        quoted = ", ".join(repr(value) for value in duplicates)
+        raise ValueError(f"duplicate benchmark fixture id(s): {quoted}")
 
 
 def _peak_rss_bytes() -> int | None:

--- a/tests/unit/eval/test_metrics.py
+++ b/tests/unit/eval/test_metrics.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 
-from openmed.eval.harness import BenchmarkFixture, run_benchmark
+from openmed.eval.harness import BenchmarkFixture, load_fixtures, run_benchmark
 from openmed.eval.metrics import (
     EvalSpan,
     compute_character_recall,
@@ -148,3 +148,38 @@ def test_harness_runs_with_injected_runner_without_loading_models():
     assert report.fixture_count == 1
     assert report.metrics["leakage"]["overall"] == 0.0
     assert report.metrics["exact_span_f1"]["f1"] == 1.0
+
+
+def test_harness_rejects_duplicate_fixture_ids(tmp_path):
+    rows = [
+        {
+            "id": "duplicate-note",
+            "text": "Patient John",
+            "language": "en",
+            "gold_spans": [{"start": 8, "end": 12, "label": "PERSON"}],
+        },
+        {
+            "id": "duplicate-note",
+            "text": "Patient Jane",
+            "language": "en",
+            "gold_spans": [{"start": 8, "end": 12, "label": "PERSON"}],
+        },
+    ]
+    fixture_path = tmp_path / "fixtures.json"
+    fixture_path.write_text(json.dumps({"fixtures": rows}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate benchmark fixture id"):
+        load_fixtures(fixture_path)
+
+    fixtures = [BenchmarkFixture.from_mapping(row) for row in rows]
+
+    def runner(fixture, model_name, device):
+        raise AssertionError("runner should not be called for duplicate fixture IDs")
+
+    with pytest.raises(ValueError, match="duplicate benchmark fixture id"):
+        run_benchmark(
+            fixtures,
+            suite="golden",
+            model_name="test-model",
+            runner=runner,
+        )


### PR DESCRIPTION
Fixes eval harness silently cooking the benchmark when two fixtures share the same ID.
