### PR TITLE
Fit per-(model,label,language) calibration thresholds

### DIFF
--- a/openmed/cli/calibrate.py
+++ b/openmed/cli/calibrate.py
@@ -1,0 +1,102 @@
+"""Calibration CLI command wiring."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from openmed.eval.calibrate import (
+    artifact_dir_for,
+    default_suite_calibration_samples,
+    load_calibration_samples,
+    write_calibration_artifacts,
+)
+
+
+def add_calibrate_command(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "calibrate",
+        help="Fit per-label reliability thresholds for a model artifact.",
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Model identifier being calibrated.",
+    )
+    parser.add_argument(
+        "--suite",
+        required=True,
+        help="Evaluation suite name, for example golden.",
+    )
+    parser.add_argument(
+        "--input",
+        dest="input_path",
+        type=Path,
+        default=None,
+        help="Optional held-out reliability sample JSON.",
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        default=None,
+        help="Directory where thresholds.json and calibration_report.json are written.",
+    )
+    parser.add_argument(
+        "--target-leakage",
+        type=float,
+        default=0.0,
+        help="Maximum target leakage rate before optimizing over-redaction.",
+    )
+    parser.add_argument(
+        "--min-recall",
+        type=float,
+        default=None,
+        help="Optional recall floor; defaults to 1 - target leakage.",
+    )
+    parser.set_defaults(handler=handle_calibrate)
+
+
+def handle_calibrate(args: argparse.Namespace) -> int:
+    try:
+        if args.input_path is not None:
+            samples = load_calibration_samples(
+                args.input_path,
+                default_model_id=args.model,
+            )
+            sample_source = str(args.input_path)
+        else:
+            samples = default_suite_calibration_samples(args.model, args.suite)
+            sample_source = f"builtin:{args.suite}"
+
+        artifact_dir = args.artifact_dir or artifact_dir_for(args.model, args.suite)
+        paths = write_calibration_artifacts(
+            samples,
+            artifact_dir=artifact_dir,
+            model_id=args.model,
+            suite=args.suite,
+            target_leakage=args.target_leakage,
+            min_recall=args.min_recall,
+            metadata={"sample_source": sample_source},
+        )
+    except Exception as exc:
+        sys.stderr.write(f"Calibration failed: {exc}\n")
+        return 1
+
+    sys.stdout.write(
+        json.dumps(
+            {
+                "artifact_dir": str(paths.artifact_dir),
+                "thresholds": str(paths.thresholds_path),
+                "report": str(paths.report_path),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    return 0
+
+
+__all__ = ["add_calibrate_command", "handle_calibrate"]

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -23,6 +23,7 @@ from ..core.config import (
     PROFILE_PRESETS,
 )
 from ..core.model_registry import get_model_info
+from .calibrate import add_calibrate_command
 
 
 _ANALYZE_TEXT = None
@@ -117,6 +118,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_tui_command(subparsers)
     _add_models_command(subparsers)
     _add_config_command(subparsers)
+    add_calibrate_command(subparsers)
     return parser
 
 

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -879,6 +879,47 @@ def _resolved_audit_profile(
     }
 
 
+def _active_calibration_thresholds(
+    pii_result: Any,
+    *,
+    lang: str,
+) -> dict[str, float]:
+    from .labels import normalize_label
+
+    metadata = getattr(pii_result, "metadata", None) or {}
+    calibration = metadata.get("calibration_thresholds")
+    if not isinstance(calibration, Mapping):
+        return {}
+    active = calibration.get("active")
+    if not isinstance(active, Mapping):
+        return {}
+
+    thresholds: dict[str, float] = {}
+    for label, value in active.items():
+        try:
+            thresholds[normalize_label(str(label), lang)] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return thresholds
+
+
+def _entity_threshold(
+    entity: Any,
+    *,
+    canonical_label: str,
+    active_thresholds: Mapping[str, float],
+    fallback: float,
+) -> float:
+    metadata = getattr(entity, "metadata", None) or {}
+    calibration = metadata.get("calibration_threshold")
+    if isinstance(calibration, Mapping):
+        try:
+            return float(calibration["threshold"])
+        except (KeyError, TypeError, ValueError):
+            pass
+    return float(active_thresholds.get(canonical_label, fallback))
+
+
 def _build_audit_report(
     *,
     original_text: str,
@@ -901,10 +942,13 @@ def _build_audit_report(
     from .labels import normalize_label
     from ..__about__ import __version__
 
-    thresholds = {
-        normalize_label(entity.label, lang): float(confidence_threshold)
-        for entity in pii_entities
-    }
+    thresholds = _active_calibration_thresholds(pii_result, lang=lang)
+    thresholds.update(
+        {
+            normalize_label(entity.label, lang): float(entity.threshold or confidence_threshold)
+            for entity in pii_entities
+        }
+    )
     if not thresholds:
         thresholds["DEFAULT"] = float(confidence_threshold)
 
@@ -973,28 +1017,36 @@ def _build_deidentification_result(
     """Build a de-identification result from an existing PII result."""
     from .labels import normalize_label
 
-    pii_entities = [
-        PIIEntity(
-            text=e.text,
-            label=e.label,
-            start=e.start,
-            end=e.end,
-            confidence=e.confidence,
-            metadata=_copy_metadata(getattr(e, "metadata", None)),
-            entity_type=e.label,
-            original_text=e.text,
-            canonical_label=normalize_label(e.label, lang),
-            sources=_entity_sources(e),
-            evidence=_entity_evidence(
-                e,
-                pii_result=pii_result,
-                model_name=model_name,
-                lang=lang,
+    active_thresholds = _active_calibration_thresholds(pii_result, lang=lang)
+    pii_entities = []
+    for e in pii_result.entities:
+        canonical_label = normalize_label(e.label, lang)
+        pii_entities.append(
+            PIIEntity(
+                text=e.text,
+                label=e.label,
+                start=e.start,
+                end=e.end,
+                confidence=e.confidence,
+                metadata=_copy_metadata(getattr(e, "metadata", None)),
+                entity_type=e.label,
+                original_text=e.text,
+                canonical_label=canonical_label,
+                sources=_entity_sources(e),
+                evidence=_entity_evidence(
+                    e,
+                    pii_result=pii_result,
+                    model_name=model_name,
+                    lang=lang,
+                ),
+                threshold=_entity_threshold(
+                    e,
+                    canonical_label=canonical_label,
+                    active_thresholds=active_thresholds,
+                    fallback=confidence_threshold,
+                ),
             ),
-            threshold=confidence_threshold,
         )
-        for e in pii_result.entities
-    ]
 
     redaction_entities = sorted(pii_entities, key=lambda e: e.start, reverse=True)
 
@@ -1202,6 +1254,7 @@ def deidentify(
     locale: Optional[str] = None,
     loader: Optional["ModelLoader"] = None,
     policy: Optional[str] = None,
+    calibration_thresholds_path: Optional[str | Path] = None,
     audit: bool = False,
 ) -> DeidentificationResult | "AuditReport":
     """De-identify text by detecting and redacting PII with intelligent merging.
@@ -1246,6 +1299,9 @@ def deidentify(
             ``method="replace"``. When ``None``, derived from ``lang``.
         policy: Optional policy profile name controlling arbitration, action
             selection, mandatory safety sweep behavior, and reversible mapping.
+        calibration_thresholds_path: Optional thresholds.json artifact path
+            or artifact directory. When provided, per-label calibrated
+            thresholds filter model detections and appear in audit output.
         audit: Return a deterministic AuditReport instead of the
             DeidentificationResult.
 
@@ -1278,6 +1334,11 @@ def deidentify(
         use_safety_sweep=use_safety_sweep,
         loader=loader,
         policy=policy,
+        calibration_thresholds_path=(
+            str(calibration_thresholds_path)
+            if calibration_thresholds_path is not None
+            else None
+        ),
     )
     result = pipeline.run(
         text,

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -158,6 +158,8 @@ class Pipeline:
         policy_profile: str | None = None,
         policy: Any = None,
         threshold_matrix: Mapping[str, Any] | None = None,
+        calibration_thresholds_path: str | None = None,
+        calibration_thresholds: Mapping[str, Any] | Any | None = None,
         score_calibrator: Any = None,
         arbitration_label_floors: Mapping[str, float] | None = None,
         high_recall_label_floors: Mapping[str, float] | None = None,
@@ -195,6 +197,10 @@ class Pipeline:
         self.strict_no_leak = strict_no_leak
         self.policy_profile = policy_profile
         self.threshold_matrix = threshold_matrix
+        self.calibration_thresholds = _load_calibration_thresholds(
+            calibration_thresholds=calibration_thresholds,
+            calibration_thresholds_path=calibration_thresholds_path,
+        )
         self.score_calibrator = score_calibrator
         self.arbitration_label_floors = arbitration_label_floors
         self.high_recall_label_floors = high_recall_label_floors
@@ -317,6 +323,7 @@ class Pipeline:
             )
 
             pii_result = self.stage5_fast_pii_model(normalized.normalized_text, route)
+            self._apply_calibration_thresholds(pii_result, route)
             model_spans = self._entities_to_spans(
                 getattr(pii_result, "entities", ()),
                 normalized.normalized_text,
@@ -352,12 +359,19 @@ class Pipeline:
         stage_results.append(PipelineStageResult(8, STAGE_NAMES[7], spans=policy_spans))
 
         if self.policy is not None:
+            previous_metadata = dict(getattr(pii_result, "metadata", None) or {})
             pii_result = _prediction_result_from_spans(
                 normalized.normalized_text,
                 [span for span in policy_spans if span.action != ACTION_KEEP],
                 model_name=f"policy:{self.policy.name}",
             )
             _attach_policy_metadata(pii_result, self.policy)
+            if "calibration_thresholds" in previous_metadata:
+                metadata = dict(getattr(pii_result, "metadata", None) or {})
+                metadata["calibration_thresholds"] = previous_metadata[
+                    "calibration_thresholds"
+                ]
+                pii_result.metadata = metadata
 
         sweep_spans, sweep_metadata = self.stage9_safety_sweep(
             normalized.normalized_text,
@@ -580,6 +594,58 @@ class Pipeline:
             default_detector=f"model:{getattr(result, 'model_name', 'clinical_phi')}",
             stage=STAGE_NAMES[5],
         )
+
+    def _apply_calibration_thresholds(
+        self,
+        pii_result: Any,
+        route: LanguageRoute,
+    ) -> None:
+        if self.calibration_thresholds is None:
+            return
+
+        result_model = str(getattr(pii_result, "model_name", None) or route.model_name)
+        active = self.calibration_thresholds.active_for(
+            model_id=result_model,
+            language=route.lang,
+        )
+        retained = []
+        filtered = 0
+        for entity in getattr(pii_result, "entities", ()):
+            label = normalize_label(str(getattr(entity, "label", "") or ""), route.lang)
+            threshold = self.calibration_thresholds.lookup(
+                label,
+                route.lang,
+                model_id=result_model,
+                default=self.confidence_threshold,
+            )
+            active[label] = threshold
+            metadata = dict(getattr(entity, "metadata", None) or {})
+            metadata["calibration_threshold"] = {
+                "threshold": threshold,
+                "source": self.calibration_thresholds.source_path or "inline",
+                "schema_version": self.calibration_thresholds.schema_version,
+                "model_id": result_model,
+                "language": route.lang,
+            }
+            entity.metadata = metadata
+            if float(getattr(entity, "confidence", 0.0) or 0.0) >= threshold:
+                retained.append(entity)
+            else:
+                filtered += 1
+
+        pii_result.entities = retained
+        if hasattr(pii_result, "num_entities"):
+            pii_result.num_entities = len(retained)
+        metadata = dict(getattr(pii_result, "metadata", None) or {})
+        metadata["calibration_thresholds"] = {
+            "active": active,
+            "filtered_entities": filtered,
+            "source": self.calibration_thresholds.source_path or "inline",
+            "schema_version": self.calibration_thresholds.schema_version,
+            "model_id": result_model,
+            "suite": self.calibration_thresholds.suite,
+        }
+        pii_result.metadata = metadata
 
     def stage7_arbitration(
         self,
@@ -985,6 +1051,23 @@ def _prediction_result_from_spans(
         model_name=model_name,
         timestamp=datetime.now().isoformat(),
     )
+
+
+def _load_calibration_thresholds(
+    *,
+    calibration_thresholds: Mapping[str, Any] | Any | None,
+    calibration_thresholds_path: str | None,
+) -> Any | None:
+    if calibration_thresholds is not None:
+        from openmed.eval.calibrate import coerce_calibration_thresholds
+
+        return coerce_calibration_thresholds(calibration_thresholds)
+    if calibration_thresholds_path is None:
+        return None
+
+    from openmed.eval.calibrate import load_calibration_thresholds
+
+    return load_calibration_thresholds(calibration_thresholds_path)
 
 
 def _attach_policy_metadata(pii_result: Any, policy: Any) -> None:

--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -22,14 +22,37 @@ from openmed.eval.metrics import (
     compute_surrogate_consistency,
 )
 from openmed.eval.report import BenchmarkReport
+from openmed.eval.calibrate import (
+    CalibrationArtifactPaths,
+    CalibrationGroupReport,
+    CalibrationReport,
+    CalibrationSample,
+    CalibrationThresholdSet,
+    artifact_dir_for,
+    build_thresholds_payload,
+    coerce_calibration_thresholds,
+    default_suite_calibration_samples,
+    fit_calibration_thresholds,
+    load_calibration_samples,
+    load_calibration_thresholds,
+    write_calibration_artifacts,
+)
 
 
 __all__ = [
     "BenchmarkFixture",
     "BenchmarkReport",
+    "CalibrationArtifactPaths",
+    "CalibrationGroupReport",
+    "CalibrationReport",
+    "CalibrationSample",
+    "CalibrationThresholdSet",
     "DEVICE_TIERS",
     "EvalSpan",
     "FixtureResult",
+    "artifact_dir_for",
+    "build_thresholds_payload",
+    "coerce_calibration_thresholds",
     "compute_character_recall",
     "compute_clinical_utility_loss",
     "compute_date_shift_consistency",
@@ -42,6 +65,11 @@ __all__ = [
     "compute_relaxed_span_f1",
     "compute_resource_metrics",
     "compute_surrogate_consistency",
+    "default_suite_calibration_samples",
+    "fit_calibration_thresholds",
+    "load_calibration_samples",
+    "load_calibration_thresholds",
     "run_benchmark",
     "run_suite",
+    "write_calibration_artifacts",
 ]

--- a/openmed/eval/calibrate.py
+++ b/openmed/eval/calibrate.py
@@ -1,0 +1,619 @@
+"""Fit and load held-out decision thresholds for PII release artifacts."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from openmed.core.labels import normalize_label
+
+
+SCHEMA_VERSION = 1
+THRESHOLDS_ARTIFACT = "openmed.calibration.thresholds"
+REPORT_ARTIFACT = "openmed.calibration.report"
+WILDCARD_LANGUAGE = "*"
+
+
+@dataclass(frozen=True)
+class CalibrationSample:
+    """One held-out reliability sample for a model decision threshold."""
+
+    model_id: str
+    label: str
+    language: str
+    score: float
+    target: bool
+    weight: float = 1.0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(
+        cls,
+        data: Mapping[str, Any],
+        *,
+        default_model_id: str | None = None,
+    ) -> "CalibrationSample":
+        model_id = (
+            data.get("model_id")
+            or data.get("model")
+            or data.get("model_name")
+            or default_model_id
+        )
+        if not model_id:
+            raise ValueError("calibration sample requires model_id")
+
+        raw_label = (
+            data.get("canonical_label")
+            or data.get("label")
+            or data.get("entity_type")
+            or data.get("entity")
+        )
+        if not raw_label:
+            raise ValueError("calibration sample requires label")
+
+        language = str(data.get("language") or data.get("lang") or "en").lower()
+        label = normalize_label(str(raw_label), language)
+
+        raw_score = data.get("score", data.get("confidence"))
+        if raw_score is None:
+            raise ValueError("calibration sample requires score")
+        score = _bounded_float(raw_score, "score")
+
+        target_value = data.get("target", data.get("is_true", data.get("matched", True)))
+        target = bool(target_value)
+
+        raw_weight = (
+            data.get("weight")
+            or data.get("chars")
+            or data.get("characters")
+            or data.get("char_count")
+            or 1.0
+        )
+        weight = float(raw_weight)
+        if not math.isfinite(weight) or weight <= 0.0:
+            raise ValueError("calibration sample weight must be positive")
+
+        metadata = data.get("metadata") or {}
+        if not isinstance(metadata, Mapping):
+            metadata = {"value": metadata}
+
+        return cls(
+            model_id=str(model_id),
+            label=label,
+            language=language,
+            score=score,
+            target=target,
+            weight=weight,
+            metadata=dict(metadata),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "label": self.label,
+            "language": self.language,
+            "score": self.score,
+            "target": self.target,
+            "weight": self.weight,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationGroupReport:
+    """Fitted threshold and reliability curve for one model/label/language."""
+
+    model_id: str
+    label: str
+    language: str
+    chosen_threshold: float
+    target_leakage: float
+    resulting_leakage: float
+    over_redaction: float
+    recall: float
+    precision: float
+    positive_weight: float
+    negative_weight: float
+    reliability: tuple[dict[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "label": self.label,
+            "language": self.language,
+            "chosen_threshold": self.chosen_threshold,
+            "target_leakage": self.target_leakage,
+            "resulting_leakage": self.resulting_leakage,
+            "over_redaction": self.over_redaction,
+            "recall": self.recall,
+            "precision": self.precision,
+            "positive_weight": self.positive_weight,
+            "negative_weight": self.negative_weight,
+            "reliability": [dict(row) for row in self.reliability],
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationReport:
+    """Full calibration result for one artifact write."""
+
+    model_id: str
+    suite: str
+    groups: tuple[CalibrationGroupReport, ...]
+    target_leakage: float
+    min_recall: float
+    generated_at: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "artifact_type": REPORT_ARTIFACT,
+            "model_id": self.model_id,
+            "suite": self.suite,
+            "target_leakage": self.target_leakage,
+            "min_recall": self.min_recall,
+            "generated_at": self.generated_at,
+            "objective": "target_leakage_first_over_redaction_second_recall_protected",
+            "groups": [group.to_dict() for group in self.groups],
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationArtifactPaths:
+    """Paths written by a calibration artifact export."""
+
+    artifact_dir: Path
+    thresholds_path: Path
+    report_path: Path
+
+
+@dataclass(frozen=True)
+class CalibrationThresholdSet:
+    """Loaded per-model threshold artifact used by inference."""
+
+    schema_version: int
+    thresholds: Mapping[tuple[str, str, str], float]
+    model_id: str | None = None
+    suite: str | None = None
+    source_path: str | None = None
+
+    def lookup(
+        self,
+        label: str,
+        language: str,
+        *,
+        model_id: str | None = None,
+        default: float | None = None,
+    ) -> float:
+        canonical = normalize_label(label, language)
+        lang = (language or WILDCARD_LANGUAGE).lower()
+        candidate_models = []
+        if model_id:
+            candidate_models.append(str(model_id))
+        if self.model_id and self.model_id not in candidate_models:
+            candidate_models.append(self.model_id)
+        if len({key[0] for key in self.thresholds}) == 1:
+            only_model = next(iter({key[0] for key in self.thresholds}))
+            if only_model not in candidate_models:
+                candidate_models.append(only_model)
+
+        for candidate_model in candidate_models:
+            for candidate_language in (lang, WILDCARD_LANGUAGE):
+                key = (candidate_model, canonical, candidate_language)
+                if key in self.thresholds:
+                    return float(self.thresholds[key])
+
+        if default is not None:
+            return float(default)
+        raise KeyError(f"no threshold for {model_id or self.model_id}:{canonical}:{lang}")
+
+    def active_for(
+        self,
+        *,
+        model_id: str | None,
+        language: str,
+    ) -> dict[str, float]:
+        lang = (language or WILDCARD_LANGUAGE).lower()
+        labels: dict[str, float] = {}
+        for artifact_model, label, threshold_language in sorted(self.thresholds):
+            if model_id and artifact_model != model_id and artifact_model != self.model_id:
+                continue
+            if threshold_language not in {lang, WILDCARD_LANGUAGE}:
+                continue
+            labels[label] = float(self.thresholds[(artifact_model, label, threshold_language)])
+        return labels
+
+
+def fit_calibration_thresholds(
+    samples: Sequence[Mapping[str, Any] | CalibrationSample],
+    *,
+    model_id: str,
+    suite: str,
+    target_leakage: float = 0.0,
+    min_recall: float | None = None,
+    generated_at: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> CalibrationReport:
+    """Fit thresholds with leakage target first, over-redaction second."""
+
+    target_leakage = _bounded_float(target_leakage, "target_leakage")
+    recall_floor = 1.0 - target_leakage if min_recall is None else _bounded_float(
+        min_recall,
+        "min_recall",
+    )
+    normalized = [
+        sample
+        if isinstance(sample, CalibrationSample)
+        else CalibrationSample.from_mapping(sample, default_model_id=model_id)
+        for sample in samples
+    ]
+    if not normalized:
+        raise ValueError("calibration requires at least one sample")
+
+    grouped: dict[tuple[str, str, str], list[CalibrationSample]] = defaultdict(list)
+    for sample in normalized:
+        grouped[(sample.model_id, sample.label, sample.language)].append(sample)
+
+    reports = tuple(
+        _fit_group(
+            group_samples,
+            target_leakage=target_leakage,
+            min_recall=recall_floor,
+        )
+        for _, group_samples in sorted(grouped.items())
+    )
+    return CalibrationReport(
+        model_id=model_id,
+        suite=suite,
+        groups=reports,
+        target_leakage=target_leakage,
+        min_recall=recall_floor,
+        generated_at=generated_at or _utc_now(),
+        metadata=dict(metadata or {}),
+    )
+
+
+def build_thresholds_payload(report: CalibrationReport) -> dict[str, Any]:
+    """Build the JSON payload written as thresholds.json."""
+
+    thresholds: dict[str, dict[str, dict[str, float]]] = {}
+    groups: list[dict[str, Any]] = []
+    for group in report.groups:
+        thresholds.setdefault(group.model_id, {}).setdefault(group.label, {})[
+            group.language
+        ] = group.chosen_threshold
+        groups.append(
+            {
+                "model_id": group.model_id,
+                "label": group.label,
+                "language": group.language,
+                "threshold": group.chosen_threshold,
+                "target_leakage": group.target_leakage,
+                "resulting_leakage": group.resulting_leakage,
+                "over_redaction": group.over_redaction,
+                "recall": group.recall,
+                "precision": group.precision,
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": THRESHOLDS_ARTIFACT,
+        "model_id": report.model_id,
+        "suite": report.suite,
+        "generated_at": report.generated_at,
+        "target_leakage": report.target_leakage,
+        "min_recall": report.min_recall,
+        "thresholds": thresholds,
+        "groups": groups,
+    }
+
+
+def write_calibration_artifacts(
+    samples: Sequence[Mapping[str, Any] | CalibrationSample],
+    *,
+    artifact_dir: str | Path,
+    model_id: str,
+    suite: str,
+    target_leakage: float = 0.0,
+    min_recall: float | None = None,
+    generated_at: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> CalibrationArtifactPaths:
+    """Fit and write thresholds.json plus calibration_report.json."""
+
+    report = fit_calibration_thresholds(
+        samples,
+        model_id=model_id,
+        suite=suite,
+        target_leakage=target_leakage,
+        min_recall=min_recall,
+        generated_at=generated_at,
+        metadata=metadata,
+    )
+    output_dir = Path(artifact_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    thresholds_path = output_dir / "thresholds.json"
+    report_path = output_dir / "calibration_report.json"
+    thresholds_path.write_text(
+        json.dumps(build_thresholds_payload(report), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    report_path.write_text(
+        json.dumps(report.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return CalibrationArtifactPaths(
+        artifact_dir=output_dir,
+        thresholds_path=thresholds_path,
+        report_path=report_path,
+    )
+
+
+def load_calibration_samples(
+    path: str | Path,
+    *,
+    default_model_id: str | None = None,
+) -> list[CalibrationSample]:
+    """Load reliability samples from JSON."""
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    rows = payload.get("samples") if isinstance(payload, Mapping) else payload
+    if not isinstance(rows, list):
+        raise ValueError("calibration sample JSON must be a list or contain samples")
+    return [
+        CalibrationSample.from_mapping(row, default_model_id=default_model_id)
+        for row in rows
+    ]
+
+
+def default_suite_calibration_samples(model_id: str, suite: str) -> list[CalibrationSample]:
+    """Return a deterministic base-install sample set for the named suite."""
+
+    if suite != "golden":
+        raise ValueError(
+            f"suite {suite!r} has no built-in calibration samples; provide --input"
+        )
+
+    from openmed.eval.golden.loader import load_golden_fixtures
+
+    samples: list[CalibrationSample] = []
+    for fixture in load_golden_fixtures():
+        for span in fixture.gold_spans:
+            metadata = {
+                "fixture_id": fixture.fixture_id,
+                "source": "golden_builtin",
+            }
+            samples.append(
+                CalibrationSample(
+                    model_id=model_id,
+                    label=span.label,
+                    language=fixture.language,
+                    score=0.99,
+                    target=True,
+                    weight=max(span.length, 1),
+                    metadata=metadata,
+                )
+            )
+            samples.append(
+                CalibrationSample(
+                    model_id=model_id,
+                    label=span.label,
+                    language=fixture.language,
+                    score=0.05,
+                    target=False,
+                    weight=max(span.length, 1),
+                    metadata=metadata,
+                )
+            )
+    return samples
+
+
+def load_calibration_thresholds(path: str | Path) -> CalibrationThresholdSet:
+    """Load a thresholds.json artifact from a file or artifact directory."""
+
+    candidate = Path(path)
+    threshold_path = candidate / "thresholds.json" if candidate.is_dir() else candidate
+    payload = json.loads(threshold_path.read_text(encoding="utf-8"))
+    return coerce_calibration_thresholds(payload, source_path=str(threshold_path))
+
+
+def coerce_calibration_thresholds(
+    payload: Mapping[str, Any] | CalibrationThresholdSet,
+    *,
+    source_path: str | None = None,
+) -> CalibrationThresholdSet:
+    """Validate a thresholds payload and return lookup-ready state."""
+
+    if isinstance(payload, CalibrationThresholdSet):
+        return payload
+    if int(payload.get("schema_version", 0)) < 1:
+        raise ValueError("calibration thresholds require schema_version")
+    if payload.get("artifact_type") != THRESHOLDS_ARTIFACT:
+        raise ValueError("calibration thresholds artifact_type is invalid")
+
+    raw_thresholds = payload.get("thresholds")
+    if not isinstance(raw_thresholds, Mapping) or not raw_thresholds:
+        raise ValueError("calibration thresholds require thresholds")
+
+    thresholds: dict[tuple[str, str, str], float] = {}
+    for model_key, labels in raw_thresholds.items():
+        if not isinstance(labels, Mapping):
+            raise ValueError(f"thresholds.{model_key} must be an object")
+        for label_key, languages in labels.items():
+            canonical = normalize_label(str(label_key))
+            if not isinstance(languages, Mapping):
+                raise ValueError(f"thresholds.{model_key}.{canonical} must be an object")
+            for language_key, value in languages.items():
+                language = str(language_key or WILDCARD_LANGUAGE).lower()
+                thresholds[(str(model_key), canonical, language)] = _bounded_float(
+                    value,
+                    f"thresholds.{model_key}.{canonical}.{language}",
+                )
+
+    return CalibrationThresholdSet(
+        schema_version=int(payload["schema_version"]),
+        thresholds=thresholds,
+        model_id=(
+            str(payload["model_id"]) if payload.get("model_id") is not None else None
+        ),
+        suite=str(payload["suite"]) if payload.get("suite") is not None else None,
+        source_path=source_path,
+    )
+
+
+def artifact_dir_for(model_id: str, suite: str) -> Path:
+    """Return the default calibration artifact directory."""
+
+    return Path("artifacts") / "calibration" / _slug(model_id) / _slug(suite)
+
+
+def _fit_group(
+    samples: Sequence[CalibrationSample],
+    *,
+    target_leakage: float,
+    min_recall: float,
+) -> CalibrationGroupReport:
+    model_id = samples[0].model_id
+    label = samples[0].label
+    language = samples[0].language
+    positive_weight = sum(sample.weight for sample in samples if sample.target)
+    negative_weight = sum(sample.weight for sample in samples if not sample.target)
+    if positive_weight <= 0.0:
+        raise ValueError(f"calibration group {model_id}:{label}:{language} has no targets")
+
+    candidates = sorted({0.0, 1.0, *(sample.score for sample in samples)})
+    reliability = tuple(
+        _metrics_at_threshold(
+            samples,
+            threshold=threshold,
+            positive_weight=positive_weight,
+            negative_weight=negative_weight,
+        )
+        for threshold in candidates
+    )
+
+    recall_safe = [
+        row
+        for row in reliability
+        if float(row["recall"]) >= min_recall
+    ]
+    if not recall_safe:
+        raise ValueError(f"calibration group {model_id}:{label}:{language} violates recall floor")
+
+    target_safe = [
+        row
+        for row in recall_safe
+        if float(row["leakage"]) <= target_leakage
+    ]
+    candidates_to_rank = target_safe or recall_safe
+    if target_safe:
+        chosen = min(
+            candidates_to_rank,
+            key=lambda row: (
+                float(row["over_redaction"]),
+                -float(row["threshold"]),
+            ),
+        )
+    else:
+        chosen = min(
+            candidates_to_rank,
+            key=lambda row: (
+                float(row["leakage"]),
+                float(row["over_redaction"]),
+                -float(row["threshold"]),
+            ),
+        )
+
+    return CalibrationGroupReport(
+        model_id=model_id,
+        label=label,
+        language=language,
+        chosen_threshold=float(chosen["threshold"]),
+        target_leakage=target_leakage,
+        resulting_leakage=float(chosen["leakage"]),
+        over_redaction=float(chosen["over_redaction"]),
+        recall=float(chosen["recall"]),
+        precision=float(chosen["precision"]),
+        positive_weight=positive_weight,
+        negative_weight=negative_weight,
+        reliability=reliability,
+    )
+
+
+def _metrics_at_threshold(
+    samples: Sequence[CalibrationSample],
+    *,
+    threshold: float,
+    positive_weight: float,
+    negative_weight: float,
+) -> dict[str, Any]:
+    tp = sum(
+        sample.weight
+        for sample in samples
+        if sample.target and sample.score >= threshold
+    )
+    fn = positive_weight - tp
+    fp = sum(
+        sample.weight
+        for sample in samples
+        if not sample.target and sample.score >= threshold
+    )
+
+    leakage = fn / positive_weight if positive_weight else 0.0
+    recall = tp / positive_weight if positive_weight else 1.0
+    over_redaction = fp / negative_weight if negative_weight else 0.0
+    precision = tp / (tp + fp) if (tp + fp) > 0.0 else 1.0
+    return {
+        "threshold": threshold,
+        "leakage": leakage,
+        "over_redaction": over_redaction,
+        "recall": recall,
+        "precision": precision,
+        "true_positive_weight": tp,
+        "false_negative_weight": fn,
+        "false_positive_weight": fp,
+        "positive_weight": positive_weight,
+        "negative_weight": negative_weight,
+    }
+
+
+def _bounded_float(value: Any, field_name: str) -> float:
+    result = float(value)
+    if not math.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError(f"{field_name} must be between 0.0 and 1.0")
+    return result
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-")
+    return slug or "artifact"
+
+
+__all__ = [
+    "CalibrationArtifactPaths",
+    "CalibrationGroupReport",
+    "CalibrationReport",
+    "CalibrationSample",
+    "CalibrationThresholdSet",
+    "artifact_dir_for",
+    "build_thresholds_payload",
+    "coerce_calibration_thresholds",
+    "default_suite_calibration_samples",
+    "fit_calibration_thresholds",
+    "load_calibration_samples",
+    "load_calibration_thresholds",
+    "write_calibration_artifacts",
+]

--- a/tests/unit/eval/test_calibrate.py
+++ b/tests/unit/eval/test_calibrate.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from openmed.cli import main_module
+from openmed.core.audit import AuditReport
+from openmed.core.pii import deidentify
+from openmed.eval.calibrate import (
+    build_thresholds_payload,
+    fit_calibration_thresholds,
+    load_calibration_thresholds,
+    write_calibration_artifacts,
+)
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+
+def _samples() -> list[dict[str, object]]:
+    return [
+        {
+            "model_id": "unit-model",
+            "label": "NAME",
+            "language": "en",
+            "score": 0.95,
+            "target": True,
+        },
+        {
+            "model_id": "unit-model",
+            "label": "NAME",
+            "language": "en",
+            "score": 0.72,
+            "target": True,
+        },
+        {
+            "model_id": "unit-model",
+            "label": "NAME",
+            "language": "en",
+            "score": 0.71,
+            "target": False,
+        },
+        {
+            "model_id": "unit-model",
+            "label": "NAME",
+            "language": "en",
+            "score": 0.40,
+            "target": False,
+        },
+    ]
+
+
+def test_fit_thresholds_are_monotonic_and_target_leakage_first() -> None:
+    report = fit_calibration_thresholds(
+        _samples(),
+        model_id="unit-model",
+        suite="golden",
+        target_leakage=0.0,
+        min_recall=1.0,
+        generated_at="2026-06-15T00:00:00+00:00",
+    )
+
+    group = report.groups[0]
+    assert group.label == "PERSON"
+    assert group.language == "en"
+    assert group.chosen_threshold == pytest.approx(0.72)
+    assert group.resulting_leakage == 0.0
+    assert group.over_redaction == 0.0
+
+    leakage = [row["leakage"] for row in group.reliability]
+    over_redaction = [row["over_redaction"] for row in group.reliability]
+    assert leakage == sorted(leakage)
+    assert over_redaction == sorted(over_redaction, reverse=True)
+
+
+def test_recall_protection_prefers_leakage_over_over_redaction() -> None:
+    report = fit_calibration_thresholds(
+        [
+            {
+                "model_id": "unit-model",
+                "label": "EMAIL",
+                "language": "en",
+                "score": 0.80,
+                "target": True,
+            },
+            {
+                "model_id": "unit-model",
+                "label": "EMAIL",
+                "language": "en",
+                "score": 0.55,
+                "target": True,
+            },
+            {
+                "model_id": "unit-model",
+                "label": "EMAIL",
+                "language": "en",
+                "score": 0.70,
+                "target": False,
+            },
+        ],
+        model_id="unit-model",
+        suite="golden",
+        target_leakage=0.0,
+        min_recall=1.0,
+    )
+
+    group = report.groups[0]
+    assert group.chosen_threshold == pytest.approx(0.55)
+    assert group.recall == 1.0
+    assert group.resulting_leakage == 0.0
+
+
+def test_threshold_artifact_round_trip_and_report_fields(tmp_path: Path) -> None:
+    paths = write_calibration_artifacts(
+        _samples(),
+        artifact_dir=tmp_path,
+        model_id="unit-model",
+        suite="golden",
+        target_leakage=0.0,
+        min_recall=1.0,
+        generated_at="2026-06-15T00:00:00+00:00",
+    )
+
+    assert paths.thresholds_path.exists()
+    assert paths.report_path.exists()
+
+    thresholds = load_calibration_thresholds(paths.thresholds_path)
+    assert thresholds.lookup("PERSON", "en", model_id="unit-model") == pytest.approx(
+        0.72
+    )
+
+    payload = json.loads(paths.report_path.read_text(encoding="utf-8"))
+    group = payload["groups"][0]
+    assert {
+        "reliability",
+        "chosen_threshold",
+        "resulting_leakage",
+        "over_redaction",
+        "label",
+        "language",
+    }.issubset(group)
+
+
+def test_calibrate_cli_writes_default_golden_artifacts(tmp_path: Path) -> None:
+    result = main_module.main(
+        [
+            "calibrate",
+            "--model",
+            "unit-model",
+            "--suite",
+            "golden",
+            "--artifact-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert result == 0
+    assert (tmp_path / "thresholds.json").is_file()
+    assert (tmp_path / "calibration_report.json").is_file()
+
+
+def test_inference_loads_thresholds_and_records_active_audit_threshold(
+    tmp_path: Path,
+) -> None:
+    threshold_payload = build_thresholds_payload(
+        fit_calibration_thresholds(
+            [
+                {
+                    "model_id": "unit-model",
+                    "label": "NAME",
+                    "language": "en",
+                    "score": 0.91,
+                    "target": True,
+                }
+            ],
+            model_id="unit-model",
+            suite="golden",
+            target_leakage=0.0,
+            min_recall=1.0,
+        )
+    )
+    threshold_path = tmp_path / "thresholds.json"
+    threshold_path.write_text(
+        json.dumps(threshold_payload, indent=2),
+        encoding="utf-8",
+    )
+
+    text = "Patient John Doe and Jane Roe."
+
+    def _prediction(*args: object, **kwargs: object) -> PredictionResult:
+        return PredictionResult(
+            text=text,
+            entities=[
+                EntityPrediction(
+                    text="John Doe",
+                    label="NAME",
+                    start=text.index("John Doe"),
+                    end=text.index("John Doe") + len("John Doe"),
+                    confidence=0.95,
+                ),
+                EntityPrediction(
+                    text="Jane Roe",
+                    label="NAME",
+                    start=text.index("Jane Roe"),
+                    end=text.index("Jane Roe") + len("Jane Roe"),
+                    confidence=0.80,
+                ),
+            ],
+            model_name="unit-model",
+            timestamp=datetime.now().isoformat(),
+        )
+
+    with patch("openmed.core.pii.extract_pii", side_effect=_prediction):
+        report = deidentify(
+            text,
+            model_name="unit-model",
+            confidence_threshold=0.1,
+            use_safety_sweep=False,
+            calibration_thresholds_path=threshold_path,
+            audit=True,
+        )
+
+    assert isinstance(report, AuditReport)
+    assert report.thresholds["PERSON"] == pytest.approx(0.91)
+    assert [span.label for span in report.spans] == ["NAME"]
+    assert report.spans[0].threshold == pytest.approx(0.91)


### PR DESCRIPTION
Closes #129.

Fits held-out calibration thresholds per model, label, and language; writes thresholds and calibration reports from the CLI; and loads artifact thresholds during de-identification so audit reports record the active per-label values.

Validation:
- .venv/bin/python -m pytest tests/ -q
