### PR TITLE
Document the device-tier SLO table and compliance posture

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,0 +1,40 @@
+# Compliance Posture
+
+OpenMed provides evidence for local validation: audit reports, leakage metrics,
+residual-risk scores, reproducible benchmark runs, and policy-profile outputs.
+OpenMed does not self-certify compliance. Users validate against their own data,
+jurisdiction, deployment controls, and counsel.
+
+No de-identification tool can guarantee compliance or zero residual risk. Validate locally before any production or clinical use.
+
+## Framework Split
+
+| Framework | What OpenMed supplies | What the user still owns |
+|---|---|---|
+| **HIPAA Safe Harbor** (`policy="hipaa_safe_harbor"`) | Profile mapping `CANONICAL_LABELS` to the 18 identifier classes, many-to-one; per-class leakage metrics; audit trail. | Confirming all 18 classes for their data; the "no actual knowledge" judgment. |
+| **HIPAA Expert Determination** (`policy="hipaa_expert_review_assist"`) | Reproducible leakage/residual-risk and adversarial re-id results as documentation. | Engaging a qualified expert; the determination. |
+| **GDPR pseudonymization** (`policy="gdpr_pseudonymization"`) | Reversible `replace` with separable key mapping; deterministic surrogates; transform audit. | Key custody, re-id governance, lawful basis, DPIA. |
+| **EU AI Act high-risk** | Logging through audit reports, documentation through cards, human oversight through review bundles, robustness through harness and golden suites, and cybersecurity through signing, local-only execution, and no raw logging. | Conformity assessment, registration, and deployment obligations. |
+
+## Evidence Links
+
+- [Audit reports](https://github.com/maziyarpanahi/openmed/blob/master/openmed/core/audit.py)
+  provide deterministic span provenance, residual-risk snapshots, manifest
+  hashes, and optional signatures for de-identification runs.
+- [Leakage metrics](./eval-harness.md#metric-bundle) are emitted in
+  `BenchmarkReport` output for reproducible benchmark runs.
+- [Residual re-identification risk](https://github.com/maziyarpanahi/openmed/blob/master/openmed/risk/reid.py)
+  reports leakage and auxiliary linkage risk for text or table records.
+- [Policy profiles](https://github.com/maziyarpanahi/openmed/tree/master/openmed/core/policies)
+  capture the canonical policy literals and default action posture used by the
+  runtime.
+
+## Policy Literals
+
+Use these exact literals in docs, examples, and deployment configuration:
+
+| Literal | Posture | Default action bias | Arbitration mode |
+|---|---|---|---|
+| `hipaa_safe_harbor` | Redact all 18 HIPAA identifiers, no exceptions. | `remove`/`mask` | High-recall union; safety sweep mandatory; residual-risk ~0. |
+| `hipaa_expert_review_assist` | Flag + surrogate, leave clinical content; produce expert-review audit. | `replace` surrogates | Balanced, with reviewer escalation on low confidence. |
+| `gdpr_pseudonymization` | Reversible pseudonyms, mapping retained under key. | `replace` + `reversible_id` | Balanced; `keep_mapping=True`; HMAC reversible IDs. |

--- a/docs/tiers.md
+++ b/docs/tiers.md
@@ -1,0 +1,44 @@
+# Device Tiers and SLOs
+
+The device tier is the contract a checkpoint promises a device. Fitting the
+declared tier is a hard gate for release checks, while model quality gates are
+measured separately.
+
+Param ranges map existing OpenMed size labels and are illustrative pending
+manifest generation. The gate reads the manifest's real `param_count`, not the
+tier word or the exact M-counts below.
+
+| Tier | Param range (illustrative) | Existing sizes | Reference device | Target RAM (resident) | Target latency (p50 / p95, ~1 page) | Default format |
+|------|----------------------------|----------------|------------------|----------------------|--------------------------------------|----------------|
+| **Tiny** *(default mobile; incl. distilled Nano floor)* | ~10–135M (Nano 10–30M distilled; Small-44M, LiteClinical-66M) | Small/Lite | Phone / tablet (Apple Silicon), embedded | ≤ 350 MB (Nano ≤ 150 MB) | ≤ 60 ms / ≤ 150 ms (Nano ≤ 25 / ≤ 60 ms) | INT8 (MLX-8bit / CoreML) |
+| **Base** *(laptop default)* | ~135–280M (Base-125/135/184M, TinyMed-135M) | Base | Laptop CPU, modest GPU | ≤ 900 MB | ≤ 150 ms / ≤ 400 ms | INT8 (FP fallback) |
+| **Large** *(workstation)* | ~430–570M (SuperClinical-434M, ~568M) | Large | Workstation GPU | ≤ 4 GB | ≤ 250 ms / ≤ 800 ms | FP16 (INT8 if recall holds) |
+| **Accurate / XLarge** *(server)* | ~600M+ / MoE (incl. ~1.4B privacy-filter) | XLarge / MoE | Server GPU | ≤ 8 GB (MoE) | ≤ 400 ms / ≤ 1200 ms | FP16 (INT8 if recall holds) |
+
+## Machine-Readable Budgets
+
+`openmed.eval.tiers.TIERS` is the machine-readable SLO source for gate
+harnesses. It exposes four named rows: `Tiny`, `Base`, `Large`, and
+`Accurate-XLarge`. Each row carries:
+
+| Field | Meaning |
+|---|---|
+| `ram_mb_max` | Maximum resident RAM budget for the tier. |
+| `p50_ms_max` | Maximum p50 latency budget for approximately one page. |
+| `p95_ms_max` | Maximum p95 latency budget for approximately one page. |
+| `default_format` | Default release artifact format for the tier. |
+
+The `Large` and `Accurate-XLarge` RAM values are represented as 4096 MB and
+8192 MB in code.
+
+## Notes
+
+- **Tier ≠ tier word across families** ("Large" = 434M for token-class NER but
+  ~459–568M elsewhere; "Base" = 184M or 220M depending on family). The manifest
+  carries the real `param_count`; tier words on cards are descriptive only.
+- **Nano** is a **distillation target** folded into the Tiny tier, not a
+  separate scheme.
+- **Default selection** off the manifest's `tier`: Tiny on mobile, Base on
+  laptop, Large/Accurate only when the caller opts in or recall demands it.
+- The latency/RAM budgets above are the **single per-tier SLO source**; the
+  §3 engine and §7 gates reference this table, not separate numbers.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,9 +28,11 @@ nav:
       - Examples & Copy/Paste Recipes: examples.md
       - Testing & QA: testing.md
       - Eval Harness & Metrics: eval-harness.md
+      - Device Tiers & SLOs: tiers.md
   - PII & De-identification:
       - PII Anonymization: anonymization.md
       - Smart Entity Merging: pii-smart-merging.md
+      - Compliance Posture: compliance.md
   - Apple Silicon & Mobile:
       - MLX Backend: mlx-backend.md
       - CoreML Packaging: coreml-export.md

--- a/openmed/cli/__init__.py
+++ b/openmed/cli/__init__.py
@@ -2,6 +2,8 @@
 
 from . import main as main_module
 
+COMPLIANCE_CAVEAT = main_module.COMPLIANCE_CAVEAT
+
 # Some test cases patch these attributes on ``openmed.cli.main_module`` directly.
 # Ensure they always exist even if the implementation defers importing heavy
 # dependencies until runtime.
@@ -15,4 +17,4 @@ def main(argv=None):
     return main_module.main(argv)
 
 
-__all__ = ["main", "main_module"]
+__all__ = ["COMPLIANCE_CAVEAT", "main", "main_module"]

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -90,12 +90,19 @@ def _lazy_api():
 
 Handler = Callable[[argparse.Namespace], int]
 
+COMPLIANCE_CAVEAT = (
+    "No de-identification tool can guarantee compliance or zero residual risk. "
+    "Validate locally before any production or clinical use."
+)
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Create the top-level CLI argument parser."""
     parser = argparse.ArgumentParser(
         prog="openmed",
         description="Command-line utilities for OpenMed medical NLP models.",
+        epilog=COMPLIANCE_CAVEAT,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--config-path",

--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -22,6 +22,7 @@ from openmed.eval.metrics import (
     compute_surrogate_consistency,
 )
 from openmed.eval.report import BenchmarkReport
+from openmed.eval.tiers import TIERS
 
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "DEVICE_TIERS",
     "EvalSpan",
     "FixtureResult",
+    "TIERS",
     "compute_character_recall",
     "compute_clinical_utility_loss",
     "compute_date_shift_consistency",

--- a/openmed/eval/tiers.py
+++ b/openmed/eval/tiers.py
@@ -1,0 +1,36 @@
+"""Canonical device-tier SLO budgets for evaluation gates."""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+TIERS: Final[dict[str, dict[str, int | str]]] = {
+    "Tiny": {
+        "ram_mb_max": 350,
+        "p50_ms_max": 60,
+        "p95_ms_max": 150,
+        "default_format": "INT8 (MLX-8bit / CoreML)",
+    },
+    "Base": {
+        "ram_mb_max": 900,
+        "p50_ms_max": 150,
+        "p95_ms_max": 400,
+        "default_format": "INT8 (FP fallback)",
+    },
+    "Large": {
+        "ram_mb_max": 4096,
+        "p50_ms_max": 250,
+        "p95_ms_max": 800,
+        "default_format": "FP16 (INT8 if recall holds)",
+    },
+    "Accurate-XLarge": {
+        "ram_mb_max": 8192,
+        "p50_ms_max": 400,
+        "p95_ms_max": 1200,
+        "default_format": "FP16 (INT8 if recall holds)",
+    },
+}
+
+
+__all__ = ["TIERS"]

--- a/tests/unit/eval/test_tiers.py
+++ b/tests/unit/eval/test_tiers.py
@@ -1,0 +1,85 @@
+"""Tests for canonical device-tier budgets and compliance caveats."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openmed.cli import COMPLIANCE_CAVEAT, main_module
+from openmed.eval import TIERS
+
+
+ROOT = Path(__file__).resolve().parents[3]
+REQUIRED_FIELDS = {"ram_mb_max", "p50_ms_max", "p95_ms_max", "default_format"}
+
+
+def test_all_device_tiers_expose_gate_budget_fields() -> None:
+    assert tuple(TIERS) == ("Tiny", "Base", "Large", "Accurate-XLarge")
+
+    for tier in TIERS.values():
+        assert REQUIRED_FIELDS <= set(tier)
+        assert isinstance(tier["ram_mb_max"], int)
+        assert isinstance(tier["p50_ms_max"], int)
+        assert isinstance(tier["p95_ms_max"], int)
+        assert isinstance(tier["default_format"], str)
+
+
+def test_tier_budget_values_match_section_6_2() -> None:
+    assert TIERS["Tiny"]["ram_mb_max"] == 350
+    assert TIERS["Tiny"]["p50_ms_max"] == 60
+    assert TIERS["Tiny"]["p95_ms_max"] == 150
+    assert TIERS["Base"]["ram_mb_max"] == 900
+    assert TIERS["Base"]["p50_ms_max"] == 150
+    assert TIERS["Base"]["p95_ms_max"] == 400
+    assert TIERS["Large"]["ram_mb_max"] == 4096
+    assert TIERS["Large"]["p50_ms_max"] == 250
+    assert TIERS["Large"]["p95_ms_max"] == 800
+    assert TIERS["Accurate-XLarge"]["ram_mb_max"] == 8192
+    assert TIERS["Accurate-XLarge"]["p50_ms_max"] == 400
+    assert TIERS["Accurate-XLarge"]["p95_ms_max"] == 1200
+
+
+def test_tier_docs_capture_four_rows_and_budgets() -> None:
+    text = (ROOT / "docs" / "tiers.md").read_text(encoding="utf-8")
+
+    for expected in (
+        "Tiny",
+        "Base",
+        "Large",
+        "Accurate / XLarge",
+        "≤ 350 MB",
+        "≤ 900 MB",
+        "≤ 4 GB",
+        "≤ 8 GB",
+        "≤ 60 ms / ≤ 150 ms",
+        "≤ 150 ms / ≤ 400 ms",
+        "≤ 250 ms / ≤ 800 ms",
+        "≤ 400 ms / ≤ 1200 ms",
+    ):
+        assert expected in text
+
+
+def test_compliance_caveat_appears_in_docs_and_cli_help() -> None:
+    compliance = (ROOT / "docs" / "compliance.md").read_text(encoding="utf-8")
+    help_text = main_module.build_parser().format_help()
+
+    assert COMPLIANCE_CAVEAT in compliance
+    assert COMPLIANCE_CAVEAT in help_text
+
+
+def test_compliance_doc_covers_frameworks_and_evidence_links() -> None:
+    text = (ROOT / "docs" / "compliance.md").read_text(encoding="utf-8")
+
+    for expected in (
+        "HIPAA Safe Harbor",
+        'policy="hipaa_safe_harbor"',
+        "HIPAA Expert Determination",
+        'policy="hipaa_expert_review_assist"',
+        "GDPR pseudonymization",
+        'policy="gdpr_pseudonymization"',
+        "EU AI Act high-risk",
+        "OpenMed does not self-certify compliance",
+        "Audit reports",
+        "Leakage metrics",
+        "Residual re-identification risk",
+    ):
+        assert expected in text


### PR DESCRIPTION
Closes #137.

Adds the canonical device-tier SLO documentation and machine-readable tier budget map, documents the compliance posture split, and surfaces the compliance caveat in CLI help.

Validation:
- .venv/bin/python -m pytest tests/ -q
- .venv/bin/python -m mkdocs build --strict
