### PR TITLE
Wire release gates into CI fail-closed with scored quality_gates and quant-delta

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -1,0 +1,63 @@
+name: Release Gates
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate:
+        description: Path to the candidate benchmark report JSON.
+        required: false
+        default: artifacts/release-candidate.json
+  schedule:
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  release-gates:
+    runs-on: ubuntu-latest
+    env:
+      CANDIDATE_REPORT: ${{ github.event.inputs.candidate || 'artifacts/release-candidate.json' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Run release gates
+        id: gates
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python -m openmed.eval.release_gates \
+            --candidate "$CANDIDATE_REPORT" \
+            --output release-gate-report.json \
+            --issue-on-failure \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Upload gate report
+        if: always() && hashFiles('release-gate-report.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-gate-report
+          path: release-gate-report.json
+
+      - name: Publish candidate
+        if: steps.gates.outcome == 'success'
+        run: |
+          echo "Release gates passed; publish step is unblocked."
+
+      - name: Fail closed
+        if: steps.gates.outcome != 'success'
+        run: |
+          exit 1

--- a/openmed/core/quality_gates.py
+++ b/openmed/core/quality_gates.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, List, Mapping, Sequence, Tuple, TypeVar
 
 from .labels import normalize_label
@@ -68,6 +69,72 @@ _HIGH_RISK_LABEL_RANKS = {
 
 class SpanValidationWarning(UserWarning):
     """Raised when an entity span fails a boundary check."""
+
+
+@dataclass(frozen=True)
+class SpanIssue:
+    """One invalid span found during strict validation."""
+
+    index: int
+    label: str
+    start: int | None
+    end: int | None
+    text: str
+    problems: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "label": self.label,
+            "start": self.start,
+            "end": self.end,
+            "text": self.text,
+            "problems": list(self.problems),
+        }
+
+
+@dataclass(frozen=True)
+class OverlapFinding:
+    """One overlapping span pair found during strict validation."""
+
+    first: Mapping[str, Any]
+    second: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"first": dict(self.first), "second": dict(self.second)}
+
+
+@dataclass(frozen=True)
+class SpanValidationResult:
+    """Structured span-validation evidence for release gates."""
+
+    total_spans: int
+    valid_spans: int
+    invalid_spans: int
+    offsetless_spans: int
+    offending_spans: tuple[SpanIssue, ...] = field(default_factory=tuple)
+    overlap_findings: tuple[OverlapFinding, ...] = field(default_factory=tuple)
+    overlaps_resolved: int = 0
+    residual_overlaps: int = 0
+
+    @property
+    def passed(self) -> bool:
+        return self.invalid_spans == 0 and self.residual_overlaps == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_spans": self.total_spans,
+            "valid_spans": self.valid_spans,
+            "invalid_spans": self.invalid_spans,
+            "offsetless_spans": self.offsetless_spans,
+            "offending_spans": [issue.to_dict() for issue in self.offending_spans],
+            "overlap_findings": [
+                finding.to_dict() for finding in self.overlap_findings
+            ],
+            "overlaps_resolved": self.overlaps_resolved,
+            "residual_overlaps": self.residual_overlaps,
+            "passed": self.passed,
+        }
 
 
 def _span_value(entity: Any, key: str) -> Any:
@@ -146,6 +213,75 @@ def _valid_offsets(start: Any, end: Any) -> bool:
     return isinstance(start, int) and isinstance(end, int) and start < end
 
 
+def _set_span_valid(entity: Any, valid: bool) -> None:
+    metadata = _span_value(entity, "metadata")
+    if metadata is None:
+        metadata = {}
+    if isinstance(metadata, Mapping):
+        metadata = dict(metadata)
+    metadata["span_valid"] = valid
+    if isinstance(entity, Mapping):
+        entity["metadata"] = metadata
+    else:
+        entity.metadata = metadata
+
+
+def _span_text(entity: Any) -> str:
+    return str(_span_value(entity, "text") or "")
+
+
+def _span_summary(entity: Any, index: int | None = None) -> dict[str, Any]:
+    start, end = _span_bounds(entity)
+    summary: dict[str, Any] = {
+        "label": normalize_label(_entity_label(entity)),
+        "start": start,
+        "end": end,
+        "text": _span_text(entity),
+    }
+    if index is not None:
+        summary["index"] = index
+    return summary
+
+
+def _span_problems(entity: Any, text: str) -> list[str] | None:
+    text_len = len(text)
+    problems: list[str] = []
+    start, end = _span_bounds(entity)
+
+    if start is None or end is None:
+        return None
+
+    if start >= end:
+        if start == end:
+            problems.append("zero-length span")
+        else:
+            problems.append(f"inverted span (start={start} >= end={end})")
+
+    if start < 0:
+        problems.append(f"negative start ({start})")
+
+    if end > text_len:
+        problems.append(f"end ({end}) exceeds text length ({text_len})")
+
+    if not problems and start >= 0 and end <= text_len:
+        actual = text[start:end]
+        entity_text = _span_text(entity)
+        if actual != entity_text:
+            if " ".join(actual.split()) == " ".join(entity_text.split()):
+                logger.info(
+                    "SpanValidation: Entity %r @ [%d:%d]: "
+                    "whitespace-only text difference (span=%r, stored=%r)",
+                    _entity_label(entity), start, end, actual, entity_text,
+                )
+            else:
+                problems.append(
+                    f"text mismatch: span gives {actual!r}, "
+                    f"entity stores {entity_text!r}"
+                )
+
+    return problems
+
+
 def validate_entity_spans(
     entities: List["EntityPrediction"],
     text: str,
@@ -164,47 +300,12 @@ def validate_entity_spans(
 
     Returns the *same* list (never filters entities out).
     """
-    text_len = len(text)
-
     for entity in entities:
-        problems: list[str] = []
         start = entity.start
         end = entity.end
-
-        if start is None or end is None:
-            # Entities without offsets cannot be validated.
+        problems = _span_problems(entity, text)
+        if problems is None:
             continue
-
-        # --- invariant checks ---
-        if start >= end:
-            if start == end:
-                problems.append("zero-length span")
-            else:
-                problems.append(f"inverted span (start={start} >= end={end})")
-
-        if start < 0:
-            problems.append(f"negative start ({start})")
-
-        if end > text_len:
-            problems.append(f"end ({end}) exceeds text length ({text_len})")
-
-        # --- text-match check (only when bounds are sane) ---
-        if not problems and start >= 0 and end <= text_len:
-            actual = text[start:end]
-            if actual != entity.text:
-                # Allow whitespace-only differences (common after span
-                # trimming) — downgrade to INFO instead of a full warning.
-                if " ".join(actual.split()) == " ".join(entity.text.split()):
-                    logger.info(
-                        "SpanValidation: Entity %r @ [%d:%d]: "
-                        "whitespace-only text difference (span=%r, stored=%r)",
-                        entity.label, start, end, actual, entity.text,
-                    )
-                else:
-                    problems.append(
-                        f"text mismatch: span gives {actual!r}, "
-                        f"entity stores {entity.text!r}"
-                    )
 
         # --- report ---
         if problems:
@@ -216,11 +317,70 @@ def validate_entity_spans(
             warnings.warn(msg, SpanValidationWarning, stacklevel=2)
 
         # Tag metadata so downstream code can inspect validity.
-        meta = entity.metadata if entity.metadata is not None else {}
-        meta["span_valid"] = len(problems) == 0
-        entity.metadata = meta
+        _set_span_valid(entity, len(problems) == 0)
 
     return entities
+
+
+def validate_entity_spans_strict(
+    entities: Sequence[EntityT],
+    text: str,
+) -> SpanValidationResult:
+    """Return structured span-validation evidence without emitting warnings.
+
+    The warn-only validator above remains the default runtime API. Release gates
+    use this strict/scored path so invalid spans and unresolved overlaps become
+    machine-readable gate evidence.
+    """
+
+    offending: list[SpanIssue] = []
+    valid_spans = 0
+    offsetless_spans = 0
+
+    for index, entity in enumerate(entities):
+        problems = _span_problems(entity, text)
+        start, end = _span_bounds(entity)
+        if problems is None:
+            offsetless_spans += 1
+            continue
+
+        if problems:
+            _set_span_valid(entity, False)
+            offending.append(
+                SpanIssue(
+                    index=index,
+                    label=normalize_label(_entity_label(entity)),
+                    start=start,
+                    end=end,
+                    text=_span_text(entity),
+                    problems=tuple(problems),
+                )
+            )
+        else:
+            valid_spans += 1
+            _set_span_valid(entity, True)
+
+    overlaps = detect_overlapping_entities(list(entities))
+    resolved = resolve_overlapping_entities(entities)
+    residual = detect_overlapping_entities(resolved)
+    overlap_findings = tuple(
+        OverlapFinding(
+            first=_span_summary(first),
+            second=_span_summary(second),
+        )
+        for first, second in overlaps
+    )
+
+    return SpanValidationResult(
+        total_spans=len(entities),
+        valid_spans=valid_spans,
+        invalid_spans=len(offending),
+        offsetless_spans=offsetless_spans,
+        offending_spans=tuple(offending),
+        overlap_findings=overlap_findings,
+        overlaps_resolved=max(len(entities) - len(resolved), 0),
+        residual_overlaps=len(residual),
+    )
 
 
 def resolve_overlapping_entities(

--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -52,6 +52,12 @@ from openmed.eval.release_gates import (
     ModelStewardConfig,
     ReleaseGate,
 )
+from openmed.eval.quant_delta import (
+    INT4_RECALL_DELTA_LIMIT,
+    INT8_RECALL_DELTA_LIMIT,
+    QuantRecallDeltaResult,
+    evaluate_quant_recall_delta,
+)
 from openmed.eval.tiers import TIERS
 
 
@@ -68,8 +74,11 @@ __all__ = [
     "FixtureResult",
     "GateCheck",
     "GateReport",
+    "INT4_RECALL_DELTA_LIMIT",
+    "INT8_RECALL_DELTA_LIMIT",
     "ModelStewardConfig",
     "QUARANTINED",
+    "QuantRecallDeltaResult",
     "ReidAttackResult",
     "RELEASABLE",
     "ReleaseGate",
@@ -89,6 +98,7 @@ __all__ = [
     "compute_resource_metrics",
     "compute_surrogate_consistency",
     "default_suite_calibration_samples",
+    "evaluate_quant_recall_delta",
     "fit_calibration_thresholds",
     "generate_reid_leaderboard",
     "load_calibration_samples",

--- a/openmed/eval/quant_delta.py
+++ b/openmed/eval/quant_delta.py
@@ -1,0 +1,280 @@
+"""Quantized-artifact recall delta gates.
+
+The release gate compares quantized artifacts to their full-precision parent on
+G1 and G2 labels. A format is blocked only when that format's recall loss meets
+or exceeds its threshold.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from openmed.core.labels import normalize_label
+
+
+INT8_RECALL_DELTA_LIMIT = 0.005
+INT4_RECALL_DELTA_LIMIT = 0.010
+
+G1_G2_LABELS = frozenset(
+    {
+        "ACCOUNT_NUMBER",
+        "AGE",
+        "API_KEY",
+        "BUILDING_NUMBER",
+        "CREDIT_CARD",
+        "DATE",
+        "DATE_OF_BIRTH",
+        "EMAIL",
+        "FIRST_NAME",
+        "GPS_COORDINATES",
+        "IBAN",
+        "ID_NUM",
+        "LAST_NAME",
+        "LOCATION",
+        "MIDDLE_NAME",
+        "PERSON",
+        "PHONE",
+        "SSN",
+        "STREET_ADDRESS",
+        "TIME",
+        "URL",
+        "USERNAME",
+        "ZIPCODE",
+    }
+)
+
+
+@dataclass(frozen=True)
+class QuantRecallDeltaResult:
+    """Structured quantization recall-delta gate evidence."""
+
+    format: str
+    quantized: bool
+    passed: bool
+    limit: float | None = None
+    max_delta: float | None = None
+    per_label_delta: Mapping[str, float] = field(default_factory=dict)
+    offending_labels: Mapping[str, Mapping[str, float]] = field(default_factory=dict)
+    labels_evaluated: tuple[str, ...] = ()
+    source: str = "not_applicable"
+
+    @property
+    def blocking_format(self) -> str | None:
+        if self.quantized and not self.passed:
+            return self.format
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "format": self.format,
+            "quantized": self.quantized,
+            "passed": self.passed,
+            "limit": self.limit,
+            "max_delta": self.max_delta,
+            "per_label_delta": dict(self.per_label_delta),
+            "offending_labels": {
+                label: dict(details)
+                for label, details in self.offending_labels.items()
+            },
+            "labels_evaluated": list(self.labels_evaluated),
+            "source": self.source,
+        }
+        return payload
+
+
+def evaluate_quant_recall_delta(
+    *,
+    format_name: str,
+    candidate_recall: Mapping[str, Any],
+    parent_recall: Mapping[str, Any] | None = None,
+    precomputed_delta: Any = None,
+    labels: Sequence[str] | None = None,
+) -> QuantRecallDeltaResult:
+    """Evaluate quantized recall loss for *format_name*.
+
+    ``precomputed_delta`` may be a scalar, a per-label mapping, or a mapping
+    keyed by format. Without precomputed evidence, ``parent_recall`` is compared
+    to ``candidate_recall`` on G1+G2 labels.
+    """
+
+    normalized_format = _normalise_dimension(format_name)
+    limit = limit_for_format(format_name)
+    if limit is None:
+        return QuantRecallDeltaResult(
+            format=format_name,
+            quantized=False,
+            passed=True,
+        )
+
+    selected_labels = {
+        normalize_label(str(label)) for label in (labels or sorted(G1_G2_LABELS))
+    }
+    delta_payload = _select_precomputed_delta(precomputed_delta, normalized_format)
+    if delta_payload is not None:
+        if isinstance(delta_payload, Mapping):
+            per_label = _normalise_delta_map(delta_payload, selected_labels)
+            return _result_from_delta_map(
+                format_name=format_name,
+                limit=limit,
+                per_label_delta=per_label,
+                source="precomputed_per_label_delta",
+            )
+
+        parsed = _normalise_precomputed_delta(delta_payload)
+        if parsed is None:
+            return _missing_result(format_name, limit)
+        return _result_from_delta_map(
+            format_name=format_name,
+            limit=limit,
+            per_label_delta={"OVERALL": parsed},
+            source="precomputed_delta",
+        )
+
+    if parent_recall is None:
+        return _missing_result(format_name, limit)
+
+    parent = _normalise_recall_map(parent_recall)
+    candidate = _normalise_recall_map(candidate_recall)
+    per_label: dict[str, float] = {}
+    for label in sorted(selected_labels & set(parent)):
+        parent_value = parent[label]
+        candidate_value = candidate.get(label, 0.0)
+        per_label[label] = max(parent_value - candidate_value, 0.0)
+
+    if not per_label:
+        return _missing_result(format_name, limit)
+
+    return _result_from_delta_map(
+        format_name=format_name,
+        limit=limit,
+        per_label_delta=per_label,
+        source="computed_from_parent",
+    )
+
+
+def is_quantized_format(format_name: str) -> bool:
+    return limit_for_format(format_name) is not None
+
+
+def limit_for_format(format_name: str) -> float | None:
+    normalized = _normalise_dimension(format_name)
+    if "int8" in normalized or "8bit" in normalized or "8-bit" in normalized:
+        return INT8_RECALL_DELTA_LIMIT
+    if "int4" in normalized or "4bit" in normalized or "4-bit" in normalized:
+        return INT4_RECALL_DELTA_LIMIT
+    return None
+
+
+def _result_from_delta_map(
+    *,
+    format_name: str,
+    limit: float,
+    per_label_delta: Mapping[str, float],
+    source: str,
+) -> QuantRecallDeltaResult:
+    deltas = {label: float(value) for label, value in sorted(per_label_delta.items())}
+    max_delta = max(deltas.values()) if deltas else None
+    offending = {
+        label: {"delta": delta, "limit": limit}
+        for label, delta in deltas.items()
+        if delta >= limit
+    }
+    return QuantRecallDeltaResult(
+        format=format_name,
+        quantized=True,
+        passed=not offending and max_delta is not None,
+        limit=limit,
+        max_delta=max_delta,
+        per_label_delta=deltas,
+        offending_labels=offending,
+        labels_evaluated=tuple(deltas),
+        source=source,
+    )
+
+
+def _missing_result(format_name: str, limit: float) -> QuantRecallDeltaResult:
+    return QuantRecallDeltaResult(
+        format=format_name,
+        quantized=True,
+        passed=False,
+        limit=limit,
+        source="missing_evidence",
+    )
+
+
+def _select_precomputed_delta(value: Any, normalized_format: str) -> Any:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        return value
+
+    for key, item in value.items():
+        if _normalise_dimension(str(key)) == normalized_format:
+            return item
+
+    return value
+
+
+def _normalise_delta_map(
+    values: Mapping[str, Any],
+    labels: set[str],
+) -> dict[str, float]:
+    result: dict[str, float] = {}
+    for label, value in values.items():
+        canonical = "OVERALL" if str(label).upper() == "OVERALL" else normalize_label(str(label))
+        if canonical not in labels and canonical != "OVERALL":
+            continue
+        parsed = _normalise_precomputed_delta(value)
+        if parsed is not None:
+            result[canonical] = parsed
+    return result
+
+
+def _normalise_recall_map(values: Mapping[str, Any]) -> dict[str, float]:
+    result: dict[str, float] = {}
+    for label, value in values.items():
+        parsed = _optional_float(value)
+        if parsed is None:
+            continue
+        if parsed > 1.0:
+            parsed = parsed / 100.0
+        canonical = "OVERALL" if str(label).upper() == "OVERALL" else normalize_label(str(label))
+        result[canonical] = parsed
+    return result
+
+
+def _normalise_precomputed_delta(value: Any) -> float | None:
+    parsed = _optional_float(value)
+    if parsed is None:
+        return None
+    delta = abs(parsed)
+    if delta > 0.05:
+        return delta / 100.0
+    return delta
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _normalise_dimension(value: str) -> str:
+    return str(value).strip().lower().replace("_", "-")
+
+
+__all__ = [
+    "G1_G2_LABELS",
+    "INT4_RECALL_DELTA_LIMIT",
+    "INT8_RECALL_DELTA_LIMIT",
+    "QuantRecallDeltaResult",
+    "evaluate_quant_recall_delta",
+    "is_quantized_format",
+    "limit_for_format",
+]

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -7,20 +7,24 @@ it, and emits a signed, reproducible gate report.
 
 from __future__ import annotations
 
+import argparse
 import copy
 import hashlib
 import hmac
 import json
 import math
 import os
-import warnings
+import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from openmed.core import baseline as baseline_store
+from openmed.core import model_registry
 from openmed.core import policy as policy_module
 from openmed.core import quality_gates
+from openmed.core.pii_i18n import SUPPORTED_LANGUAGES
 from openmed.core.audit import AuditSignature, stable_hash
 from openmed.core.labels import normalize_label
 from openmed.core.thresholds import (
@@ -29,6 +33,12 @@ from openmed.core.thresholds import (
     validate_threshold_matrix,
 )
 from openmed.eval.metrics import normalize_eval_spans
+from openmed.eval.quant_delta import (
+    INT4_RECALL_DELTA_LIMIT,
+    INT8_RECALL_DELTA_LIMIT,
+    QuantRecallDeltaResult,
+    evaluate_quant_recall_delta,
+)
 from openmed.eval.report import BenchmarkReport
 
 
@@ -40,8 +50,8 @@ G1A_V20_RECALL_FLOOR = 0.995
 G1B_RECALL_FLOOR = 0.995
 G2_V16_RECALL_FLOOR = 0.980
 G2_V20_RECALL_FLOOR = 0.990
-G4_INT8_DELTA_LIMIT = 0.005
-G4_INT4_DELTA_LIMIT = 0.010
+G4_INT8_DELTA_LIMIT = INT8_RECALL_DELTA_LIMIT
+G4_INT4_DELTA_LIMIT = INT4_RECALL_DELTA_LIMIT
 G7_RECALL_DROP_LIMIT = 0.002
 RESIDUAL_LEAKAGE_SOFT_CEILING = 0.005
 
@@ -122,6 +132,10 @@ _TIER_BUDGETS = {
     "large": {"ram_mb": 4096.0, "p50_ms": 250.0, "p95_ms": 800.0},
     "accurate": {"ram_mb": 8192.0, "p50_ms": 400.0, "p95_ms": 1200.0},
 }
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_MANIFEST_PATH = _REPO_ROOT / "models.jsonl"
+_DEFAULT_README_PATH = _REPO_ROOT / "README.md"
 
 
 @dataclass(frozen=True)
@@ -464,7 +478,16 @@ class ReleaseGate:
         per_label_precision = _per_label_precision(metrics, metadata)
         critical_leakage_count = _critical_leakage_count(metrics, metadata)
         residual_leakage_rate = _residual_leakage_rate(metrics, metadata)
-        quant_delta = _quant_recall_delta(metrics, metadata, identity["format"])
+        quant_delta_result = evaluate_quant_recall_delta(
+            format_name=identity["format"],
+            candidate_recall=per_label_recall,
+            parent_recall=_quant_parent_recall(metrics, metadata),
+            precomputed_delta=_precomputed_quant_recall_delta(
+                metrics,
+                metadata,
+                identity["format"],
+            ),
+        )
         p50_ms, p95_ms = _latency(metrics, metadata)
         ram_mb = _ram_mb(metrics, metadata)
         baseline_entry = self._resolve_baseline(identity, baseline)
@@ -485,7 +508,7 @@ class ReleaseGate:
         checks.append(self._g1b_check(per_label_recall, recall_denominators))
         checks.append(self._g2_check(per_label_recall, recall_denominators))
         checks.append(_g3_check(critical_leakage_count))
-        checks.append(_g4_check(identity["format"], quant_delta))
+        checks.append(_g4_check(quant_delta_result))
         checks.append(_g5_check(identity["tier"], p50_ms, p95_ms, ram_mb))
         checks.append(_g6_check(p50_ms, p95_ms))
         checks.append(
@@ -518,7 +541,7 @@ class ReleaseGate:
             per_label_precision=per_label_precision,
             critical_leakage_count=critical_leakage_count,
             residual_leakage_rate=residual_leakage_rate,
-            quant_recall_delta=quant_delta,
+            quant_recall_delta=quant_delta_result.max_delta,
             p50_ms=p50_ms,
             p95_ms=p95_ms,
             ram_mb=ram_mb,
@@ -655,37 +678,398 @@ def _manifest_coherence_check(
             details={"missing": missing},
         )
 
+    mismatches: dict[str, Any] = {}
     manifest = _mapping(metadata.get("manifest"))
-    mismatches: dict[str, dict[str, Any]] = {}
     if manifest:
-        manifest_fields = {
-            "repo_id": manifest.get("repo_id"),
-            "family": manifest.get("family"),
-            "tier": manifest.get("tier"),
-            "param_count": manifest.get("param_count"),
-            "format": manifest.get("format") or manifest.get("model_format"),
-        }
-        for key, manifest_value in manifest_fields.items():
-            if manifest_value is None:
-                continue
-            candidate_value = identity.get(key)
-            if key == "param_count":
-                manifest_value = _optional_int(manifest_value)
-            if str(manifest_value) != str(candidate_value):
-                mismatches[key] = {
-                    "manifest": manifest_value,
-                    "candidate": candidate_value,
+        mismatches.update(
+            _manifest_row_mismatches(
+                manifest,
+                identity,
+                source="candidate_manifest",
+            )
+        )
+
+    manifest_path = _manifest_path(metadata)
+    manifest_rows: list[dict[str, Any]] = []
+    manifest_row: Mapping[str, Any] | None = None
+    if manifest_path is not None:
+        try:
+            manifest_rows = _load_manifest_rows(manifest_path)
+        except (OSError, ValueError) as exc:
+            mismatches["manifest_file"] = {
+                "path": str(manifest_path),
+                "error": str(exc),
+            }
+        else:
+            manifest_row = _find_manifest_row(manifest_rows, str(identity["repo_id"]))
+            if manifest_row is not None:
+                mismatches.update(
+                    _manifest_row_mismatches(
+                        manifest_row,
+                        identity,
+                        source="models_jsonl",
+                    )
+                )
+            elif _requires_manifest_row(metadata, manifest):
+                mismatches["manifest_row"] = {
+                    "repo_id": identity["repo_id"],
+                    "path": str(manifest_path),
+                    "error": "candidate repo_id is absent from manifest",
                 }
+
+    if manifest_rows:
+        mismatches.update(_manifest_surface_mismatches(manifest_rows, metadata, manifest_path))
+
+    card = _model_card_metadata(metadata)
+    if card and manifest_row is not None:
+        card_mismatches = _model_card_mismatches(card, manifest_row)
+        if card_mismatches:
+            mismatches["model_card"] = card_mismatches
 
     if mismatches:
         return GateCheck(
             "manifest_coherence",
             False,
-            reason="candidate metadata does not match manifest",
+            reason="candidate metadata or repository surfaces drift from manifest",
             details={"mismatches": mismatches},
         )
 
-    return GateCheck("manifest_coherence", True)
+    return GateCheck(
+        "manifest_coherence",
+        True,
+        details={
+            "manifest_path": str(manifest_path) if manifest_path is not None else None,
+            "manifest_rows": len(manifest_rows),
+            "candidate_manifest_row": manifest_row is not None,
+        },
+    )
+
+
+def _manifest_row_mismatches(
+    row: Mapping[str, Any],
+    identity: Mapping[str, Any],
+    *,
+    source: str,
+) -> dict[str, Any]:
+    mismatches: dict[str, Any] = {}
+    manifest_fields = {
+        "repo_id": row.get("repo_id"),
+        "family": row.get("family"),
+        "tier": row.get("tier"),
+        "param_count": row.get("param_count"),
+    }
+    for key, manifest_value in manifest_fields.items():
+        if manifest_value is None:
+            continue
+        candidate_value = identity.get(key)
+        if key == "param_count":
+            manifest_value = _optional_int(manifest_value)
+        if str(manifest_value) != str(candidate_value):
+            mismatches[f"{source}.{key}"] = {
+                "manifest": manifest_value,
+                "candidate": candidate_value,
+            }
+
+    candidate_format = str(identity.get("format") or "")
+    manifest_format = row.get("format") or row.get("model_format")
+    manifest_formats = row.get("formats")
+    if isinstance(manifest_formats, Sequence) and not isinstance(
+        manifest_formats,
+        (str, bytes),
+    ):
+        formats = {str(item) for item in manifest_formats}
+        if candidate_format not in formats:
+            mismatches[f"{source}.format"] = {
+                "manifest": sorted(formats),
+                "candidate": candidate_format,
+            }
+    elif manifest_format is not None and str(manifest_format) != candidate_format:
+        mismatches[f"{source}.format"] = {
+            "manifest": manifest_format,
+            "candidate": candidate_format,
+        }
+    return mismatches
+
+
+def _manifest_surface_mismatches(
+    rows: Sequence[Mapping[str, Any]],
+    metadata: Mapping[str, Any],
+    manifest_path: Path | None,
+) -> dict[str, Any]:
+    mismatches: dict[str, Any] = {}
+    default_manifest = _is_default_path(manifest_path, _DEFAULT_MANIFEST_PATH)
+
+    readme_path = _optional_path(metadata.get("readme_path"))
+    if readme_path is None and default_manifest:
+        readme_path = _DEFAULT_README_PATH
+    if readme_path is not None:
+        readme_mismatches = _readme_manifest_mismatches(rows, readme_path)
+        if readme_mismatches:
+            mismatches["readme"] = readme_mismatches
+
+    registry_ids = _string_set(metadata.get("registry_model_ids"))
+    if registry_ids:
+        missing = sorted(_manifest_repo_ids(rows) - registry_ids)
+        if missing:
+            mismatches["registry"] = {"missing_repo_ids": missing}
+    elif default_manifest:
+        registry_repo_ids = {
+            info.model_id for info in model_registry.OPENMED_MODELS.values()
+        }
+        missing = sorted(_manifest_repo_ids(rows) - registry_repo_ids)
+        if missing:
+            mismatches["registry"] = {"missing_repo_ids": missing}
+
+    supported_languages = _string_set(metadata.get("supported_languages"))
+    if not supported_languages and default_manifest:
+        supported_languages = set(SUPPORTED_LANGUAGES)
+    if supported_languages:
+        manifest_languages = _manifest_pii_languages(rows)
+        if manifest_languages != supported_languages:
+            mismatches["pii_languages"] = {
+                "manifest": sorted(manifest_languages),
+                "supported": sorted(supported_languages),
+            }
+
+    return mismatches
+
+
+def _readme_manifest_mismatches(
+    rows: Sequence[Mapping[str, Any]],
+    readme_path: Path,
+) -> dict[str, Any]:
+    if not readme_path.exists():
+        return {"path": str(readme_path), "error": "README evidence is missing"}
+
+    text = readme_path.read_text(encoding="utf-8")
+    declared = _readme_declared_counts(text)
+    mismatches: dict[str, Any] = {}
+    model_count = len(rows)
+    pii_count = len([row for row in rows if _is_pii_manifest_row(row)])
+    pii_languages = _manifest_pii_languages(rows)
+
+    if declared.get("models") is not None and model_count < declared["models"]:
+        mismatches["models"] = {
+            "readme_floor": declared["models"],
+            "manifest": model_count,
+        }
+    if declared.get("pii_checkpoints") is not None and pii_count < declared["pii_checkpoints"]:
+        mismatches["pii_checkpoints"] = {
+            "readme_floor": declared["pii_checkpoints"],
+            "manifest": pii_count,
+        }
+    if declared.get("languages") is not None and len(pii_languages) != declared["languages"]:
+        mismatches["languages"] = {
+            "readme": declared["languages"],
+            "manifest": len(pii_languages),
+        }
+    return mismatches
+
+
+def _readme_declared_counts(text: str) -> dict[str, int]:
+    import re
+
+    counts: dict[str, int] = {}
+    model_matches = [
+        _parse_count(match.group(1))
+        for match in re.finditer(
+            r"(\d[\d,]*)\+?\s+(?:specialized\s+medical\s+)?models\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+    ]
+    if model_matches:
+        counts["models"] = max(model_matches)
+
+    language_match = re.search(
+        r"(\d[\d,]*)\+?\s+languages?\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if language_match:
+        counts["languages"] = _parse_count(language_match.group(1))
+
+    pii_match = re.search(
+        r"(\d[\d,]*)\+?\s+PII\s+checkpoints?\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if pii_match:
+        counts["pii_checkpoints"] = _parse_count(pii_match.group(1))
+    return counts
+
+
+def _model_card_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    card = _mapping(metadata.get("model_card"))
+    if card:
+        return card
+    card_path = _optional_path(metadata.get("model_card_path"))
+    if card_path is None or not card_path.exists():
+        return {}
+    return _parse_model_card_front_matter(card_path.read_text(encoding="utf-8"))
+
+
+def _model_card_mismatches(
+    card: Mapping[str, Any],
+    row: Mapping[str, Any],
+) -> dict[str, Any]:
+    mismatches: dict[str, Any] = {}
+    card_license = card.get("license")
+    if card_license and row.get("license") and str(card_license) != str(row["license"]):
+        mismatches["license"] = {
+            "card": card_license,
+            "manifest": row["license"],
+        }
+
+    card_task = card.get("pipeline_tag") or card.get("task")
+    if card_task and row.get("task") and str(card_task) != str(row["task"]):
+        mismatches["task"] = {"card": card_task, "manifest": row["task"]}
+
+    card_languages = _string_set(card.get("language") or card.get("languages"))
+    manifest_languages = _string_set(row.get("languages"))
+    if card_languages and manifest_languages and card_languages != manifest_languages:
+        mismatches["languages"] = {
+            "card": sorted(card_languages),
+            "manifest": sorted(manifest_languages),
+        }
+    return mismatches
+
+
+def _parse_model_card_front_matter(text: str) -> dict[str, Any]:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+
+    data: dict[str, Any] = {}
+    current_key: str | None = None
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "---":
+            break
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- ") and current_key:
+            data.setdefault(current_key, []).append(stripped[2:].strip().strip("'\""))
+            continue
+        if ":" not in stripped:
+            current_key = None
+            continue
+        key, value = stripped.split(":", 1)
+        current_key = key.strip()
+        value = value.strip()
+        if not value:
+            data[current_key] = []
+        elif value.startswith("[") and value.endswith("]"):
+            data[current_key] = [
+                item.strip().strip("'\"")
+                for item in value[1:-1].split(",")
+                if item.strip()
+            ]
+        else:
+            data[current_key] = value.strip("'\"")
+    return data
+
+
+def _manifest_path(metadata: Mapping[str, Any]) -> Path | None:
+    explicit = _optional_path(
+        _first_value(metadata.get("manifest_path"), metadata.get("models_manifest_path"))
+    )
+    if explicit is not None:
+        return explicit
+    if _DEFAULT_MANIFEST_PATH.exists():
+        return _DEFAULT_MANIFEST_PATH
+    return None
+
+
+def _load_manifest_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid JSON on line {line_number}: {exc}") from exc
+            if isinstance(row, Mapping):
+                rows.append(dict(row))
+    return rows
+
+
+def _find_manifest_row(
+    rows: Sequence[Mapping[str, Any]],
+    repo_id: str,
+) -> Mapping[str, Any] | None:
+    for row in rows:
+        if row.get("repo_id") == repo_id:
+            return row
+    return None
+
+
+def _requires_manifest_row(
+    metadata: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+) -> bool:
+    return bool(
+        manifest
+        or metadata.get("require_manifest_row")
+        or metadata.get("manifest_path")
+        or metadata.get("models_manifest_path")
+    )
+
+
+def _manifest_repo_ids(rows: Sequence[Mapping[str, Any]]) -> set[str]:
+    return {
+        str(row["repo_id"])
+        for row in rows
+        if isinstance(row.get("repo_id"), str) and row.get("repo_id")
+    }
+
+
+def _manifest_pii_languages(rows: Sequence[Mapping[str, Any]]) -> set[str]:
+    languages: set[str] = set()
+    for row in rows:
+        if not _is_pii_manifest_row(row):
+            continue
+        languages.update(_string_set(row.get("languages")))
+    return languages
+
+
+def _is_pii_manifest_row(row: Mapping[str, Any]) -> bool:
+    repo_id = str(row.get("repo_id") or "").lower()
+    family = str(row.get("family") or "").lower()
+    return family == "pii" or "pii" in repo_id or "privacy" in repo_id
+
+
+def _string_set(value: Any) -> set[str]:
+    if isinstance(value, str):
+        return {value}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return {str(item) for item in value if str(item)}
+    return set()
+
+
+def _optional_path(value: Any) -> Path | None:
+    if value is None:
+        return None
+    text = str(value)
+    if not text:
+        return None
+    return Path(text)
+
+
+def _is_default_path(path: Path | None, default: Path) -> bool:
+    if path is None:
+        return False
+    try:
+        return path.resolve() == default.resolve()
+    except OSError:
+        return False
+
+
+def _parse_count(value: str) -> int:
+    return int(value.replace(",", ""))
 
 
 def _calibration_check(metadata: Mapping[str, Any], profile: Any | None) -> GateCheck:
@@ -761,29 +1145,30 @@ def _g3_check(critical_leakage_count: int) -> GateCheck:
     )
 
 
-def _g4_check(format_name: str, quant_delta: float | None) -> GateCheck:
-    normalized = _normalise_dimension(format_name)
-    if "int8" in normalized or "8bit" in normalized or "8-bit" in normalized:
-        limit = G4_INT8_DELTA_LIMIT
-    elif "int4" in normalized or "4bit" in normalized or "4-bit" in normalized:
-        limit = G4_INT4_DELTA_LIMIT
-    else:
-        return GateCheck("G4", True, reason="not applicable")
+def _g4_check(result: QuantRecallDeltaResult) -> GateCheck:
+    if not result.quantized:
+        return GateCheck(
+            "G4",
+            True,
+            reason="not applicable",
+            details=result.to_dict(),
+        )
 
-    if quant_delta is None:
+    if result.source == "missing_evidence":
         return GateCheck(
             "G4",
             False,
             reason="quantized artifacts require recall delta evidence",
-            blocking_format=format_name,
+            details=result.to_dict(),
+            blocking_format=result.format,
         )
-    delta = _normalise_delta(quant_delta)
+
     return GateCheck(
         "G4",
-        delta < limit,
-        reason="ok" if delta < limit else "quantized recall delta exceeds limit",
-        details={"delta": delta, "limit": limit},
-        blocking_format=None if delta < limit else format_name,
+        result.passed,
+        reason="ok" if result.passed else "quantized recall delta exceeds limit",
+        details=result.to_dict(),
+        blocking_format=result.blocking_format,
     )
 
 
@@ -930,33 +1315,14 @@ def _g8_check(metadata: Mapping[str, Any]) -> GateCheck:
             problems.append({"fixture_index": index, "error": str(exc)})
             continue
 
-        checked += len(entities)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            quality_gates.validate_entity_spans(entities, text)
-        invalid_entities = [
-            entity
-            for entity in entities
-            if isinstance(entity.metadata, Mapping)
-            and entity.metadata.get("span_valid") is False
-        ]
-        if caught or invalid_entities:
+        scored = quality_gates.validate_entity_spans_strict(entities, text)
+        checked += scored.total_spans
+        resolved_overlaps += scored.overlaps_resolved
+        if not scored.passed:
             problems.append(
                 {
                     "fixture_index": index,
-                    "span_warnings": [str(item.message) for item in caught],
-                    "invalid_spans": len(invalid_entities),
-                }
-            )
-
-        resolved = quality_gates.resolve_overlapping_entities(entities)
-        resolved_overlaps += max(len(entities) - len(resolved), 0)
-        residual_overlaps = quality_gates.detect_overlapping_entities(resolved)
-        if residual_overlaps:
-            problems.append(
-                {
-                    "fixture_index": index,
-                    "residual_overlaps": len(residual_overlaps),
+                    "span_validation": scored.to_dict(),
                 }
             )
 
@@ -1105,11 +1471,11 @@ def _residual_leakage_rate(
     return 1.0 if parsed is None else parsed
 
 
-def _quant_recall_delta(
+def _precomputed_quant_recall_delta(
     metrics: Mapping[str, Any],
     metadata: Mapping[str, Any],
     format_name: str,
-) -> float | None:
+) -> Any:
     raw = _first_value(
         metadata.get("quant_recall_delta"),
         metrics.get("quant_recall_delta"),
@@ -1119,9 +1485,25 @@ def _quant_recall_delta(
         format_key = _normalise_dimension(format_name)
         for key, value in raw.items():
             if _normalise_dimension(str(key)) == format_key:
-                return _optional_float(value)
-        return None
-    return _optional_float(raw)
+                return value
+    return raw
+
+
+def _quant_parent_recall(
+    metrics: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    parent = _first_mapping(
+        metadata.get("fp_parent_per_label_recall"),
+        metadata.get("parent_per_label_recall"),
+        metadata.get("fp32_per_label_recall"),
+        metrics.get("fp_parent_per_label_recall"),
+        metrics.get("parent_per_label_recall"),
+        metrics.get("fp32_per_label_recall"),
+        _nested(metrics, "quantization", "fp_parent_per_label_recall"),
+        _nested(metrics, "quantization", "parent_per_label_recall"),
+    )
+    return parent or None
 
 
 def _latency(
@@ -1236,13 +1618,6 @@ def _is_v2_or_later(milestone: str) -> bool:
     return major >= 2
 
 
-def _normalise_delta(value: float) -> float:
-    delta = abs(float(value))
-    if delta > 0.05:
-        return delta / 100.0
-    return delta
-
-
 def _normalise_tier(tier: str) -> str:
     return _TIER_ALIASES.get(_normalise_dimension(tier), _normalise_dimension(tier))
 
@@ -1348,6 +1723,257 @@ def _key_bytes(key: bytes | str) -> bytes:
     raise TypeError("signing key must be bytes or str")
 
 
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the OpenMed release gate harness against a candidate "
+            "benchmark report and fail closed on any gate failure."
+        )
+    )
+    parser.add_argument(
+        "--candidate",
+        required=True,
+        help="Path to a candidate BenchmarkReport JSON payload.",
+    )
+    parser.add_argument(
+        "--baseline",
+        help="Optional baseline JSON payload. Defaults to the baseline store.",
+    )
+    parser.add_argument(
+        "--baseline-store",
+        default=str(baseline_store.BASELINE_PATH),
+        help="Path to the last-green baseline store.",
+    )
+    parser.add_argument(
+        "--output",
+        default="release-gate-report.json",
+        help="Path to write the signed gate report JSON.",
+    )
+    parser.add_argument(
+        "--milestone",
+        default="v1.6",
+        help="Milestone version used for release thresholds.",
+    )
+    parser.add_argument(
+        "--policy",
+        default="hipaa_safe_harbor",
+        help="Policy profile used when the candidate report omits one.",
+    )
+    parser.add_argument(
+        "--thresholds-matrix",
+        help="Optional thresholds matrix JSON path.",
+    )
+    parser.add_argument(
+        "--signing-key",
+        help="Signing key. Defaults to OPENMED_RELEASE_GATE_KEY or local key.",
+    )
+    parser.add_argument(
+        "--key-id",
+        default="release-gate",
+        help="Signing key identifier recorded in the gate report.",
+    )
+    parser.add_argument(
+        "--issue-on-failure",
+        action="store_true",
+        help="Open or update a tracking issue when the candidate is quarantined.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "maziyarpanahi/openmed"),
+        help="Repository used for failure tracking issues.",
+    )
+    parser.add_argument(
+        "--tracking-issue-title",
+        help="Override the failure tracking issue title.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        candidate = _read_json_file(Path(args.candidate))
+        baseline = _read_json_file(Path(args.baseline)) if args.baseline else None
+        gate = ReleaseGate(
+            milestone=args.milestone,
+            policy=args.policy,
+            baseline_path=args.baseline_store,
+            thresholds_matrix_path=args.thresholds_matrix,
+            signing_key=args.signing_key,
+            key_id=args.key_id,
+        )
+        report = gate.evaluate(candidate, baseline)
+    except Exception as exc:
+        message = f"release gate evaluation failed before a report was produced: {exc}"
+        print(message, file=sys.stderr)
+        if args.issue_on_failure:
+            _open_or_update_tracking_issue_for_error(
+                repo=args.repo,
+                title=args.tracking_issue_title or "Release gate evaluation failed",
+                message=message,
+            )
+        return 2
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report.to_json() + "\n", encoding="utf-8")
+    print(report.to_json())
+
+    if report.decision != RELEASABLE:
+        if args.issue_on_failure:
+            _open_or_update_tracking_issue(
+                report,
+                repo=args.repo,
+                title=args.tracking_issue_title,
+            )
+        return 1
+    return 0
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"{path} must contain a JSON object")
+    return dict(payload)
+
+
+def _open_or_update_tracking_issue(
+    report: GateReport,
+    *,
+    repo: str,
+    title: str | None = None,
+) -> int | None:
+    issue_title = title or f"Release gate failure for {report.repo_id}"
+    failing = [check for check in report.gate_results if not check.passed]
+    body = _tracking_issue_body(report, failing)
+    return _open_or_update_issue(repo=repo, title=issue_title, body=body)
+
+
+def _open_or_update_tracking_issue_for_error(
+    *,
+    repo: str,
+    title: str,
+    message: str,
+) -> int | None:
+    body = "\n".join(
+        [
+            "## Summary",
+            "",
+            "The release gate job failed before producing a gate report.",
+            "",
+            "## Failure",
+            "",
+            f"- `{message}`",
+            "",
+        ]
+    )
+    return _open_or_update_issue(repo=repo, title=title, body=body)
+
+
+def _open_or_update_issue(*, repo: str, title: str, body: str) -> int | None:
+    existing = _find_open_issue(repo=repo, title=title)
+    if existing is not None:
+        subprocess.run(
+            [
+                "gh",
+                "issue",
+                "comment",
+                str(existing),
+                "--repo",
+                repo,
+                "--body-file",
+                "-",
+            ],
+            input=body,
+            text=True,
+            check=True,
+        )
+        return existing
+
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--title",
+            title,
+            "--body-file",
+            "-",
+        ],
+        input=body,
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+    output = result.stdout.strip().rsplit("/", 1)[-1]
+    return _optional_int(output.lstrip("#"))
+
+
+def _find_open_issue(*, repo: str, title: str) -> int | None:
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--search",
+            f"{title} in:title",
+            "--json",
+            "number,title",
+        ],
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+    issues = json.loads(result.stdout or "[]")
+    for issue in issues:
+        if isinstance(issue, Mapping) and issue.get("title") == title:
+            return _optional_int(issue.get("number"))
+    return None
+
+
+def _tracking_issue_body(
+    report: GateReport,
+    failing: Sequence[GateCheck],
+) -> str:
+    lines = [
+        "## Summary",
+        "",
+        f"Release gates quarantined `{report.repo_id}`.",
+        "",
+        "## Gate report",
+        "",
+        f"- Decision: `{report.decision}`",
+        f"- Family: `{report.family}`",
+        f"- Tier: `{report.tier}`",
+        f"- Format: `{report.format}`",
+        f"- Eval set hash: `{report.eval_set_hash}`",
+        f"- Leakage fixture hash: `{report.leakage_fixture_hash}`",
+        f"- Repro hash: `{report.repro_hash}`",
+        "",
+        "## Failing gates",
+        "",
+    ]
+    for check in failing:
+        lines.append(f"- `{check.gate}`: {check.reason}")
+    lines.extend(["", "## Blocking formats", ""])
+    if report.blocked_formats:
+        for format_name in report.blocked_formats:
+            lines.append(f"- `{format_name}`")
+    else:
+        lines.append("- None")
+    lines.append("")
+    return "\n".join(lines)
+
+
 __all__ = [
     "G1A_V16_RECALL_FLOOR",
     "G1A_V20_RECALL_FLOOR",
@@ -1364,4 +1990,10 @@ __all__ = [
     "GateReport",
     "ModelStewardConfig",
     "ReleaseGate",
+    "build_arg_parser",
+    "main",
 ]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/eval/test_quant_delta.py
+++ b/tests/unit/eval/test_quant_delta.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from openmed.eval.quant_delta import evaluate_quant_recall_delta
+
+
+def test_int8_delta_below_half_point_passes() -> None:
+    result = evaluate_quant_recall_delta(
+        format_name="mlx-8bit",
+        candidate_recall={"PERSON": 0.986},
+        parent_recall={"PERSON": 0.990},
+    )
+
+    assert result.passed is True
+    assert result.max_delta == pytest.approx(0.004)
+    assert result.blocking_format is None
+
+
+def test_int8_delta_at_half_point_fails() -> None:
+    result = evaluate_quant_recall_delta(
+        format_name="mlx-8bit",
+        candidate_recall={"PERSON": 0.985},
+        parent_recall={"PERSON": 0.990},
+    )
+
+    assert result.passed is False
+    assert result.blocking_format == "mlx-8bit"
+    assert result.offending_labels["PERSON"]["limit"] == 0.005
+
+
+def test_int4_delta_at_one_point_fails() -> None:
+    result = evaluate_quant_recall_delta(
+        format_name="mlx-4bit",
+        candidate_recall={"DATE": 0.970},
+        parent_recall={"DATE": 0.980},
+    )
+
+    assert result.passed is False
+    assert result.blocking_format == "mlx-4bit"
+    assert result.offending_labels["DATE"]["limit"] == 0.010
+
+
+def test_precomputed_per_format_delta_blocks_only_that_format() -> None:
+    int8 = evaluate_quant_recall_delta(
+        format_name="mlx-8bit",
+        candidate_recall={"PERSON": 0.99},
+        precomputed_delta={"mlx-8bit": {"PERSON": 0.006}, "mlx-4bit": 0.0},
+    )
+    int4 = evaluate_quant_recall_delta(
+        format_name="mlx-4bit",
+        candidate_recall={"PERSON": 0.99},
+        precomputed_delta={"mlx-8bit": {"PERSON": 0.006}, "mlx-4bit": 0.0},
+    )
+
+    assert int8.passed is False
+    assert int8.blocking_format == "mlx-8bit"
+    assert int4.passed is True
+    assert int4.blocking_format is None

--- a/tests/unit/eval/test_release_gate_cli.py
+++ b/tests/unit/eval/test_release_gate_cli.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openmed.eval import release_gates
+
+
+def _candidate(*, critical_leakage_count: int = 0) -> dict[str, object]:
+    return {
+        "suite": "golden",
+        "model_name": "unit-model",
+        "device": "cpu",
+        "fixture_count": 1,
+        "generated_at": "2026-06-15T00:00:00+00:00",
+        "metadata": {
+            "repo_id": "OpenMed/unit-model",
+            "family": "PII",
+            "tier": "Tiny",
+            "param_count": 44_000_000,
+            "format": "mlx-fp",
+            "eval_set_hash": "sha256:eval",
+            "leakage_fixture_hash": "sha256:leakage",
+            "policy": "hipaa_safe_harbor",
+            "thresholds": {"PERSON": {"en": 0.9}},
+            "calibration_report": {"schema_version": 1, "groups": []},
+            "span_fixtures": [
+                {
+                    "text": "Patient John on 2026-01-02 has ID 123.",
+                    "predicted_spans": [
+                        {"start": 8, "end": 12, "label": "PERSON"},
+                        {"start": 16, "end": 26, "label": "DATE"},
+                        {"start": 34, "end": 37, "label": "ID_NUM"},
+                    ],
+                }
+            ],
+        },
+        "metrics": {
+            "per_label_recall": {
+                "PERSON": 0.990,
+                "DATE": 0.990,
+                "ID_NUM": 0.990,
+                "API_KEY": 0.995,
+            },
+            "per_label_precision": {
+                "PERSON": 0.98,
+                "DATE": 0.98,
+                "ID_NUM": 0.98,
+                "API_KEY": 0.99,
+            },
+            "critical_leakage_count": critical_leakage_count,
+            "leakage": {
+                "overall": 0.0,
+                "leaked_chars_by_label": {},
+                "total_chars_by_label": {
+                    "PERSON": 4,
+                    "DATE": 10,
+                    "ID_NUM": 3,
+                    "API_KEY": 8,
+                },
+            },
+            "latency": {"p50_ms": 50.0, "p95_ms": 120.0},
+            "resources": {"peak_rss_mib": 128.0},
+        },
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_release_gate_cli_returns_zero_for_releasable_candidate(tmp_path: Path) -> None:
+    candidate = _write_json(tmp_path / "candidate.json", _candidate())
+    output = tmp_path / "gate-report.json"
+
+    exit_code = release_gates.main(
+        [
+            "--candidate",
+            str(candidate),
+            "--output",
+            str(output),
+            "--signing-key",
+            "unit-key",
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["decision"] == "RELEASABLE"
+
+
+def test_release_gate_cli_returns_nonzero_for_failed_gate(tmp_path: Path) -> None:
+    candidate = _write_json(
+        tmp_path / "candidate.json",
+        _candidate(critical_leakage_count=1),
+    )
+    output = tmp_path / "gate-report.json"
+
+    exit_code = release_gates.main(
+        [
+            "--candidate",
+            str(candidate),
+            "--output",
+            str(output),
+            "--signing-key",
+            "unit-key",
+        ]
+    )
+
+    assert exit_code == 1
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["decision"] == "QUARANTINED"
+    assert any(
+        check["gate"] == "G3" and check["passed"] is False
+        for check in report["gate_results"]
+    )

--- a/tests/unit/eval/test_release_gates.py
+++ b/tests/unit/eval/test_release_gates.py
@@ -316,26 +316,87 @@ def test_g7_blocks_recall_regression_and_residual_leakage(tmp_path: Path) -> Non
     assert "residual_leakage_regression" in check.details["violations"]
 
 
-def test_g8_calls_quality_gate_span_primitives(tmp_path: Path, monkeypatch) -> None:
-    calls = {"validate": 0, "resolve": 0, "detect": 0}
+def test_g8_consumes_strict_quality_gate_output(tmp_path: Path, monkeypatch) -> None:
+    calls = {"strict": 0}
+    original = release_gates.quality_gates.validate_entity_spans_strict
 
-    def validate(entities, text):
-        calls["validate"] += 1
-        return entities
+    def strict(entities, text):
+        calls["strict"] += 1
+        return original(entities, text)
 
-    def resolve(entities):
-        calls["resolve"] += 1
-        return list(entities)
-
-    def detect(entities):
-        calls["detect"] += 1
-        return []
-
-    monkeypatch.setattr(release_gates.quality_gates, "validate_entity_spans", validate)
-    monkeypatch.setattr(release_gates.quality_gates, "resolve_overlapping_entities", resolve)
-    monkeypatch.setattr(release_gates.quality_gates, "detect_overlapping_entities", detect)
+    monkeypatch.setattr(
+        release_gates.quality_gates,
+        "validate_entity_spans_strict",
+        strict,
+    )
 
     result = _gate().evaluate(_report(tmp_path), _baseline())
 
     assert result.decision == RELEASABLE
-    assert calls == {"validate": 1, "resolve": 1, "detect": 1}
+    assert calls == {"strict": 1}
+    assert _check(result, "G8").details["spans_checked"] == 3
+
+
+def test_g4_computes_quant_delta_from_fp_parent_recall(tmp_path: Path) -> None:
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metadata_updates={"format": "mlx-8bit"},
+            metric_updates={
+                "quant_recall_delta": None,
+                "per_label_recall": {
+                    "PERSON": 0.991,
+                    "DATE": 0.990,
+                    "ID_NUM": 0.990,
+                    "API_KEY": 0.995,
+                },
+                "fp_parent_per_label_recall": {"PERSON": 0.996},
+            },
+        ),
+        _baseline(),
+    )
+
+    check = _check(result, "G4")
+    assert result.decision == QUARANTINED
+    assert result.quant_recall_delta == pytest.approx(0.005)
+    assert check.passed is False
+    assert check.details["offending_labels"]["PERSON"]["limit"] == 0.005
+    assert result.blocked_formats == ("mlx-8bit",)
+
+
+def test_manifest_coherence_fails_when_readme_count_drifts(tmp_path: Path) -> None:
+    manifest = tmp_path / "models.jsonl"
+    manifest.write_text(
+        json.dumps(
+            {
+                "repo_id": "OpenMed/unit-model",
+                "family": "PII",
+                "task": "token-classification",
+                "languages": ["en"],
+                "tier": "Tiny",
+                "param_count": 44_000_000,
+                "formats": ["mlx-fp"],
+                "license": "apache-2.0",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text("2 models\n", encoding="utf-8")
+
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metadata_updates={
+                "manifest_path": str(manifest),
+                "readme_path": str(readme),
+            },
+        ),
+        _baseline(),
+    )
+
+    check = _check(result, "manifest_coherence")
+    assert result.decision == QUARANTINED
+    assert check.passed is False
+    assert check.details["mismatches"]["readme"]["models"]["readme_floor"] == 2

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -11,6 +11,7 @@ from openmed.core.quality_gates import (
     detect_overlapping_entities,
     resolve_overlapping_entities,
     validate_entity_spans,
+    validate_entity_spans_strict,
 )
 from openmed.processing.outputs import EntityPrediction
 
@@ -307,6 +308,24 @@ class TestResolveOverlappingEntities:
         assert result is entities
         assert len(entities) == 2
         assert len(detect_overlapping_entities(entities)) == 1
+
+    def test_strict_validation_returns_scored_structured_output(self):
+        text = "Patient John Doe visited"
+        entities = [
+            _ent("John Doe", label="PERSON", start=8, end=16),
+            _ent("Jane", label="PERSON", start=8, end=12),
+            _ent("missing", label="ID_NUM", start=30, end=37),
+        ]
+
+        result = validate_entity_spans_strict(entities, text)
+
+        assert result.passed is False
+        assert result.total_spans == 3
+        assert result.invalid_spans == 2
+        assert result.valid_spans == 1
+        assert result.overlaps_resolved == 1
+        assert result.to_dict()["offending_spans"][0]["problems"]
+        assert result.to_dict()["overlap_findings"][0]["first"]["label"] == "PERSON"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #127.

Adds a fail-closed release gate workflow and module entrypoint, structured strict span scoring for quality_gates, per-format quant recall delta checks, and manifest coherence checks spanning the committed manifest, README counts, registry coverage, supported PII languages, and model-card evidence. The gate report now carries quant delta details and blocked formats so publish steps stay skipped when any gate fails.

Tests:
- `.venv/bin/python -m pytest tests/ -q`