### PR TITLE
Add dependency audit gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,17 +89,20 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install bandit[toml] safety
+        pip install -e ".[dev]"
+        pip install bandit[toml] pip-audit
 
-    - name: Run security check with bandit
+    - name: Run Bandit report
       run: |
-        bandit -r openmed -f json -o bandit-report.json
-      continue-on-error: true
+        bandit -r openmed -f json -o bandit-report.json --exit-zero
 
-    - name: Run safety check
+    - name: Enforce high-severity Bandit findings
       run: |
-        safety check --json --output safety-report.json
-      continue-on-error: true
+        bandit -r openmed --severity-level high --confidence-level medium
+
+    - name: Run pip-audit dependency gate
+      run: |
+        python scripts/security/pip_audit_gate.py
 
     - name: Upload security reports
       uses: actions/upload-artifact@v4
@@ -107,7 +110,7 @@ jobs:
         name: security-reports
         path: |
           bandit-report.json
-          safety-report.json
+          pip-audit-report.json
       if: always()
 
   build:

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -8,9 +8,11 @@ blockers when a fixed version is available.
 The CI security job installs OpenMed with development extras, then runs
 `scripts/security/pip_audit_gate.py`. The gate wraps `pip-audit`, writes
 `pip-audit-report.json`, and fails when an advisory has a known fixed version.
+Fixable advisories must be resolved by upgrading the affected dependency.
 
 The gate allows time-boxed ignores from `docs/security/pip-audit-ignore.toml`
-for advisories that do not have a usable fix yet. Each ignore must include:
+for advisories that do not have a usable fix yet. Unfixable advisories without
+an active ignore fail CI so exceptions stay visible. Each ignore must include:
 
 - `id`: the vulnerability ID reported by `pip-audit`
 - `reason`: why the advisory cannot be fixed immediately

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -1,0 +1,33 @@
+# Dependency Policy
+
+OpenMed treats vulnerable Python dependencies and GitHub Actions as release
+blockers when a fixed version is available.
+
+## CI Scanner
+
+The CI security job installs OpenMed with development extras, then runs
+`scripts/security/pip_audit_gate.py`. The gate wraps `pip-audit`, writes
+`pip-audit-report.json`, and fails when an advisory has a known fixed version.
+
+The gate allows time-boxed ignores from `docs/security/pip-audit-ignore.toml`
+for advisories that do not have a usable fix yet. Each ignore must include:
+
+- `id`: the vulnerability ID reported by `pip-audit`
+- `reason`: why the advisory cannot be fixed immediately
+- `review_by`: an ISO date for re-checking the exception
+
+Expired ignores fail CI. Remove an ignore as soon as the dependency can be
+upgraded.
+
+## Dependabot
+
+Dependabot checks Python packages and GitHub Actions weekly. Python dependency
+updates are grouped into one pull request, and GitHub Actions updates are
+grouped into one pull request. Dependabot PRs are reviewed and tested manually;
+auto-merge is intentionally out of scope.
+
+## Static Analysis
+
+Bandit still runs in CI. The full report is uploaded as `bandit-report.json`,
+and the job blocks on high-severity findings so new critical issues are not
+lost in the existing lower-severity backlog.

--- a/docs/security/pip-audit-ignore.toml
+++ b/docs/security/pip-audit-ignore.toml
@@ -1,0 +1,11 @@
+# Time-boxed pip-audit ignores.
+#
+# Keep this list empty by default. If an advisory has no usable fix, add an
+# entry with a reason and review_by date, then remove it as soon as possible.
+#
+# Example:
+# [[ignore]]
+# id = "PYSEC-0000-000"
+# package = "example"
+# reason = "No fixed version is available; feature is not reachable in CI."
+# review_by = "2026-09-30"

--- a/scripts/security/pip_audit_gate.py
+++ b/scripts/security/pip_audit_gate.py
@@ -97,9 +97,10 @@ def load_ignores(path: Path, today: dt.date) -> set[str]:
     return ignored
 
 
-def run_pip_audit(ignored_ids: set[str], report_path: Path) -> dict[str, Any]:
+def run_pip_audit(report_path: Path) -> dict[str, Any]:
     """Run pip-audit and return its JSON payload."""
     report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.unlink(missing_ok=True)
     command = [
         sys.executable,
         "-m",
@@ -111,8 +112,6 @@ def run_pip_audit(ignored_ids: set[str], report_path: Path) -> dict[str, Any]:
         "--progress-spinner",
         "off",
     ]
-    for vuln_id in sorted(ignored_ids):
-        command.extend(["--ignore-vuln", vuln_id])
 
     result = subprocess.run(
         command,
@@ -129,6 +128,8 @@ def run_pip_audit(ignored_ids: set[str], report_path: Path) -> dict[str, Any]:
         print(result.stderr, end="", file=sys.stderr)
     if not report_path.exists():
         raise RuntimeError("pip-audit did not write a JSON report")
+    if result.returncode not in (0, 1):
+        raise RuntimeError(f"pip-audit exited with status {result.returncode}")
 
     try:
         return json.loads(report_path.read_text())
@@ -139,15 +140,38 @@ def run_pip_audit(ignored_ids: set[str], report_path: Path) -> dict[str, Any]:
 def fixable_vulnerabilities(report: dict[str, Any]) -> list[tuple[str, str, list[str]]]:
     """Return vulnerabilities that have at least one known fixed version."""
     fixable: list[tuple[str, str, list[str]]] = []
+    for name, vuln_id, fix_versions in iter_vulnerabilities(report):
+        if fix_versions:
+            fixable.append((name, vuln_id, fix_versions))
+    return fixable
+
+
+def iter_vulnerabilities(report: dict[str, Any]) -> list[tuple[str, str, list[str]]]:
+    """Return all vulnerabilities from a pip-audit report."""
+    vulnerabilities: list[tuple[str, str, list[str]]] = []
     for dependency in report.get("dependencies", []):
         name = dependency.get("name", "<unknown>")
         for vulnerability in dependency.get("vulns", []):
-            fix_versions = vulnerability.get("fix_versions") or []
-            if fix_versions:
-                fixable.append(
-                    (name, vulnerability.get("id", "<unknown>"), fix_versions)
+            vulnerabilities.append(
+                (
+                    name,
+                    vulnerability.get("id", "<unknown>"),
+                    vulnerability.get("fix_versions") or [],
                 )
-    return fixable
+            )
+    return vulnerabilities
+
+
+def unignored_unfixable_vulnerabilities(
+    report: dict[str, Any],
+    ignored_ids: set[str],
+) -> list[tuple[str, str]]:
+    """Return unfixable vulnerabilities that are missing an active ignore."""
+    unignored: list[tuple[str, str]] = []
+    for name, vuln_id, fix_versions in iter_vulnerabilities(report):
+        if not fix_versions and vuln_id not in ignored_ids:
+            unignored.append((name, vuln_id))
+    return unignored
 
 
 def main() -> int:
@@ -155,22 +179,31 @@ def main() -> int:
     args = parse_args()
     try:
         ignored_ids = load_ignores(args.ignore_file, dt.date.today())
-        report = run_pip_audit(ignored_ids, args.report)
+        report = run_pip_audit(args.report)
     except (FileNotFoundError, RuntimeError, ValueError) as exc:
         print(f"pip-audit gate failed: {exc}", file=sys.stderr)
         return 1
 
     fixable = fixable_vulnerabilities(report)
-    if not fixable:
-        print("pip-audit gate passed: no fixable vulnerabilities found")
+    unignored_unfixable = unignored_unfixable_vulnerabilities(report, ignored_ids)
+    if not fixable and not unignored_unfixable:
+        print("pip-audit gate passed: no unreviewed vulnerabilities found")
         return 0
 
-    print("pip-audit gate failed: fixable vulnerabilities found", file=sys.stderr)
-    for package, vuln_id, fix_versions in fixable:
+    if fixable:
+        print("pip-audit gate failed: fixable vulnerabilities found", file=sys.stderr)
+        for package, vuln_id, fix_versions in fixable:
+            print(
+                f"- {package}: {vuln_id} fixed by {', '.join(fix_versions)}",
+                file=sys.stderr,
+            )
+    if unignored_unfixable:
         print(
-            f"- {package}: {vuln_id} fixed by {', '.join(fix_versions)}",
+            "pip-audit gate failed: unfixable vulnerabilities need reviewed ignores",
             file=sys.stderr,
         )
+        for package, vuln_id in unignored_unfixable:
+            print(f"- {package}: {vuln_id}", file=sys.stderr)
     return 1
 
 

--- a/scripts/security/pip_audit_gate.py
+++ b/scripts/security/pip_audit_gate.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Run pip-audit with a reviewed ignore list and fixable-CVE gate."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_IGNORE_FILE = ROOT / "docs/security/pip-audit-ignore.toml"
+DEFAULT_REPORT = ROOT / "pip-audit-report.json"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ignore-file",
+        type=Path,
+        default=DEFAULT_IGNORE_FILE,
+        help="TOML file with reviewed vulnerability ignores.",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=DEFAULT_REPORT,
+        help="Path for the pip-audit JSON report.",
+    )
+    return parser.parse_args()
+
+
+def parse_review_date(value: object, vuln_id: str) -> dt.date:
+    """Return a review date from a TOML date or ISO date string."""
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+    if isinstance(value, str):
+        try:
+            return dt.date.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"ignore entry {vuln_id!r} has invalid review_by date {value!r}"
+            ) from exc
+    raise ValueError(f"ignore entry {vuln_id!r} must include review_by as YYYY-MM-DD")
+
+
+def load_ignores(path: Path, today: dt.date) -> set[str]:
+    """Load non-expired vulnerability IDs from the ignore list."""
+    if not path.exists():
+        raise FileNotFoundError(f"ignore file not found: {path}")
+
+    data = tomllib.loads(path.read_text())
+    entries = data.get("ignore", [])
+    if not isinstance(entries, list):
+        raise ValueError("'ignore' must be a TOML array")
+
+    ignored: set[str] = set()
+    errors: list[str] = []
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            errors.append(f"ignore entry #{index} must be a table")
+            continue
+
+        vuln_id = str(entry.get("id", "")).strip()
+        reason = str(entry.get("reason", "")).strip()
+        review_by = entry.get("review_by")
+
+        if not vuln_id:
+            errors.append(f"ignore entry #{index} is missing id")
+            continue
+        if not reason:
+            errors.append(f"ignore entry {vuln_id!r} is missing reason")
+        try:
+            review_date = parse_review_date(review_by, vuln_id)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        if review_date < today:
+            errors.append(
+                f"ignore entry {vuln_id!r} expired on {review_date.isoformat()}"
+            )
+        ignored.add(vuln_id)
+
+    if errors:
+        raise ValueError("\n".join(errors))
+    return ignored
+
+
+def run_pip_audit(ignored_ids: set[str], report_path: Path) -> dict[str, Any]:
+    """Run pip-audit and return its JSON payload."""
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        "-m",
+        "pip_audit",
+        "--format",
+        "json",
+        "--output",
+        str(report_path),
+        "--progress-spinner",
+        "off",
+    ]
+    for vuln_id in sorted(ignored_ids):
+        command.extend(["--ignore-vuln", vuln_id])
+
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    if not report_path.exists():
+        raise RuntimeError("pip-audit did not write a JSON report")
+
+    try:
+        return json.loads(report_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"pip-audit wrote invalid JSON: {exc}") from exc
+
+
+def fixable_vulnerabilities(report: dict[str, Any]) -> list[tuple[str, str, list[str]]]:
+    """Return vulnerabilities that have at least one known fixed version."""
+    fixable: list[tuple[str, str, list[str]]] = []
+    for dependency in report.get("dependencies", []):
+        name = dependency.get("name", "<unknown>")
+        for vulnerability in dependency.get("vulns", []):
+            fix_versions = vulnerability.get("fix_versions") or []
+            if fix_versions:
+                fixable.append(
+                    (name, vulnerability.get("id", "<unknown>"), fix_versions)
+                )
+    return fixable
+
+
+def main() -> int:
+    """Run the dependency vulnerability gate."""
+    args = parse_args()
+    try:
+        ignored_ids = load_ignores(args.ignore_file, dt.date.today())
+        report = run_pip_audit(ignored_ids, args.report)
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        print(f"pip-audit gate failed: {exc}", file=sys.stderr)
+        return 1
+
+    fixable = fixable_vulnerabilities(report)
+    if not fixable:
+        print("pip-audit gate passed: no fixable vulnerabilities found")
+        return 0
+
+    print("pip-audit gate failed: fixable vulnerabilities found", file=sys.stderr)
+    for package, vuln_id, fix_versions in fixable:
+        print(
+            f"- {package}: {vuln_id} fixed by {', '.join(fix_versions)}",
+            file=sys.stderr,
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/security/test_pip_audit_gate.py
+++ b/tests/unit/security/test_pip_audit_gate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import datetime as dt
 import importlib.util
 from pathlib import Path
@@ -32,6 +33,93 @@ def test_fixable_vulnerabilities_only_returns_advisories_with_fixes() -> None:
     assert pip_audit_gate.fixable_vulnerabilities(report) == [
         ("fixed-package", "PYSEC-2026-1", ["1.2.3"]),
     ]
+
+
+def test_fixable_vulnerabilities_are_not_suppressed_by_ignores() -> None:
+    report = {
+        "dependencies": [
+            {
+                "name": "fixed-package",
+                "vulns": [{"id": "PYSEC-2026-1", "fix_versions": ["1.2.3"]}],
+            },
+        ],
+    }
+
+    assert pip_audit_gate.fixable_vulnerabilities(report) == [
+        ("fixed-package", "PYSEC-2026-1", ["1.2.3"]),
+    ]
+
+
+def test_unfixable_vulnerabilities_honor_active_ignores() -> None:
+    report = {
+        "dependencies": [
+            {
+                "name": "reviewed-package",
+                "vulns": [{"id": "PYSEC-2026-2", "fix_versions": []}],
+            },
+            {
+                "name": "unreviewed-package",
+                "vulns": [{"id": "PYSEC-2026-3", "fix_versions": []}],
+            },
+        ],
+    }
+
+    assert pip_audit_gate.unignored_unfixable_vulnerabilities(
+        report,
+        ignored_ids={"PYSEC-2026-2"},
+    ) == [("unreviewed-package", "PYSEC-2026-3")]
+
+
+def test_gate_fails_fixable_vulnerability_even_when_ignored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report = {
+        "dependencies": [
+            {
+                "name": "fixed-package",
+                "vulns": [{"id": "PYSEC-2026-1", "fix_versions": ["1.2.3"]}],
+            },
+        ],
+    }
+    monkeypatch.setattr(
+        pip_audit_gate,
+        "parse_args",
+        lambda: argparse.Namespace(
+            ignore_file=tmp_path / "ignore.toml",
+            report=tmp_path / "report.json",
+        ),
+    )
+    monkeypatch.setattr(pip_audit_gate, "load_ignores", lambda *_: {"PYSEC-2026-1"})
+    monkeypatch.setattr(pip_audit_gate, "run_pip_audit", lambda *_: report)
+
+    assert pip_audit_gate.main() == 1
+
+
+def test_gate_passes_reviewed_unfixable_vulnerability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report = {
+        "dependencies": [
+            {
+                "name": "unfixed-package",
+                "vulns": [{"id": "PYSEC-2026-2", "fix_versions": []}],
+            },
+        ],
+    }
+    monkeypatch.setattr(
+        pip_audit_gate,
+        "parse_args",
+        lambda: argparse.Namespace(
+            ignore_file=tmp_path / "ignore.toml",
+            report=tmp_path / "report.json",
+        ),
+    )
+    monkeypatch.setattr(pip_audit_gate, "load_ignores", lambda *_: {"PYSEC-2026-2"})
+    monkeypatch.setattr(pip_audit_gate, "run_pip_audit", lambda *_: report)
+
+    assert pip_audit_gate.main() == 0
 
 
 def test_load_ignores_requires_non_expired_review_date(tmp_path: Path) -> None:

--- a/tests/unit/security/test_pip_audit_gate.py
+++ b/tests/unit/security/test_pip_audit_gate.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "scripts/security/pip_audit_gate.py"
+SPEC = importlib.util.spec_from_file_location("pip_audit_gate", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+pip_audit_gate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(pip_audit_gate)
+
+
+def test_fixable_vulnerabilities_only_returns_advisories_with_fixes() -> None:
+    report = {
+        "dependencies": [
+            {
+                "name": "fixed-package",
+                "vulns": [
+                    {"id": "PYSEC-2026-1", "fix_versions": ["1.2.3"]},
+                    {"id": "PYSEC-2026-2", "fix_versions": []},
+                ],
+            },
+            {"name": "clean-package", "vulns": []},
+        ],
+    }
+
+    assert pip_audit_gate.fixable_vulnerabilities(report) == [
+        ("fixed-package", "PYSEC-2026-1", ["1.2.3"]),
+    ]
+
+
+def test_load_ignores_requires_non_expired_review_date(tmp_path: Path) -> None:
+    ignore_file = tmp_path / "pip-audit-ignore.toml"
+    ignore_file.write_text(
+        """
+[[ignore]]
+id = "PYSEC-2026-3"
+reason = "No fixed version is available yet."
+review_by = "2026-08-01"
+""".strip()
+    )
+
+    assert pip_audit_gate.load_ignores(
+        ignore_file,
+        today=dt.date(2026, 6, 16),
+    ) == {"PYSEC-2026-3"}
+
+
+def test_load_ignores_rejects_expired_entries(tmp_path: Path) -> None:
+    ignore_file = tmp_path / "pip-audit-ignore.toml"
+    ignore_file.write_text(
+        """
+[[ignore]]
+id = "PYSEC-2026-4"
+reason = "No fixed version is available yet."
+review_by = "2026-01-01"
+""".strip()
+    )
+
+    with pytest.raises(ValueError, match="expired"):
+        pip_audit_gate.load_ignores(ignore_file, today=dt.date(2026, 6, 16))


### PR DESCRIPTION
Closes #256. Adds a pip-audit dependency gate with a time-boxed ignore file, weekly grouped Dependabot updates for pip and GitHub Actions, and keeps Bandit visible while blocking high-severity findings.