### PR TITLE
Add a CI secret-scanning gate to block committed credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,32 @@ jobs:
           pip-audit-report.json
       if: always()
 
+  secret-scan:
+    runs-on: ubuntu-latest
+    needs: repo-policy
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.27.2/gitleaks_8.27.2_linux_x64.tar.gz \
+            | tar -xz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+
+      - name: Scan repo for secrets
+        run: gitleaks detect --source=. --config=.gitleaks.toml --exit-code=1
+
+      - name: Gate test — verify scanner catches fake token
+        run: |
+          gitleaks detect --source=tests/fixtures/fake_secret.txt --no-git --exit-code=1 \
+            && { echo "FAIL: scanner missed the fake token"; exit 1; } \
+            || echo "PASS: fake token detected as expected"
+
+
   build:
-    needs: [repo-policy, test, security]
+    needs: [repo-policy, test, security, secret-scan]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,20 +89,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev]"
-        pip install bandit[toml] pip-audit
+        pip install bandit[toml] safety
 
-    - name: Run Bandit report
+    - name: Run security check with bandit
       run: |
-        bandit -r openmed -f json -o bandit-report.json --exit-zero
+        bandit -r openmed -f json -o bandit-report.json
+      continue-on-error: true
 
-    - name: Enforce high-severity Bandit findings
+    - name: Run safety check
       run: |
-        bandit -r openmed --severity-level high --confidence-level medium
-
-    - name: Run pip-audit dependency gate
-      run: |
-        python scripts/security/pip_audit_gate.py
+        safety check --json --output safety-report.json
+      continue-on-error: true
 
     - name: Upload security reports
       uses: actions/upload-artifact@v4
@@ -110,32 +107,36 @@ jobs:
         name: security-reports
         path: |
           bandit-report.json
-          pip-audit-report.json
+          safety-report.json
       if: always()
 
   secret-scan:
-    runs-on: ubuntu-latest
     needs: repo-policy
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - uses: actions/checkout@v4
 
-      - name: Install gitleaks
-        run: |
-          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.27.2/gitleaks_8.27.2_linux_x64.tar.gz \
-            | tar -xz gitleaks
-          sudo mv gitleaks /usr/local/bin/gitleaks
+    - name: Verify gitleaks canary
+      run: |
+        mkdir -p "$RUNNER_TEMP/gitleaks-canary"
+        cat > "$RUNNER_TEMP/gitleaks-canary/creds.txt" <<'EOF'
+        HF_TOKEN=hf_FAKE000000000000000000000000000000000000
+        EOF
+        if docker run --rm \
+          -v "$RUNNER_TEMP/gitleaks-canary:/scan:ro" \
+          -v "$PWD/.gitleaks.toml:/config/.gitleaks.toml:ro" \
+          ghcr.io/gitleaks/gitleaks:v8.30.1 \
+          dir --config /config/.gitleaks.toml --redact --no-banner --verbose /scan; then
+          echo "::error title=Gitleaks canary was not detected::Expected fake token fixture to fail the scan"
+          exit 1
+        fi
 
-      - name: Scan repo for secrets
-        run: gitleaks detect --source=. --config=.gitleaks.toml --exit-code=1
-
-      - name: Gate test — verify scanner catches fake token
-        run: |
-          gitleaks detect --source=tests/fixtures/fake_secret.txt --no-git --exit-code=1 \
-            && { echo "FAIL: scanner missed the fake token"; exit 1; } \
-            || echo "PASS: fake token detected as expected"
-
+    - name: Scan repository for committed secrets
+      run: |
+        docker run --rm \
+          -v "$PWD:/repo:ro" \
+          ghcr.io/gitleaks/gitleaks:v8.30.1 \
+          dir --config /repo/.gitleaks.toml --redact --no-banner --verbose /repo
 
   build:
     needs: [repo-policy, test, security, secret-scan]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,17 +89,20 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install bandit[toml] safety
+        pip install -e ".[dev]"
+        pip install bandit[toml] pip-audit
 
-    - name: Run security check with bandit
+    - name: Run Bandit report
       run: |
-        bandit -r openmed -f json -o bandit-report.json
-      continue-on-error: true
+        bandit -r openmed -f json -o bandit-report.json --exit-zero
 
-    - name: Run safety check
+    - name: Enforce high-severity Bandit findings
       run: |
-        safety check --json --output safety-report.json
-      continue-on-error: true
+        bandit -r openmed --severity-level high --confidence-level medium
+
+    - name: Run pip-audit dependency gate
+      run: |
+        python scripts/security/pip_audit_gate.py
 
     - name: Upload security reports
       uses: actions/upload-artifact@v4
@@ -107,36 +110,76 @@ jobs:
         name: security-reports
         path: |
           bandit-report.json
-          safety-report.json
+          pip-audit-report.json
       if: always()
 
   secret-scan:
     needs: repo-policy
     runs-on: ubuntu-latest
+    env:
+      GITLEAKS_VERSION: "8.30.1"
+      GITLEAKS_LINUX_X64_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-    - name: Verify gitleaks canary
+    - name: Install gitleaks
       run: |
-        mkdir -p "$RUNNER_TEMP/gitleaks-canary"
-        cat > "$RUNNER_TEMP/gitleaks-canary/creds.txt" <<'EOF'
-        HF_TOKEN=hf_FAKE000000000000000000000000000000000000
-        EOF
-        if docker run --rm \
-          -v "$RUNNER_TEMP/gitleaks-canary:/scan:ro" \
-          -v "$PWD/.gitleaks.toml:/config/.gitleaks.toml:ro" \
-          ghcr.io/gitleaks/gitleaks:v8.30.1 \
-          dir --config /config/.gitleaks.toml --redact --no-banner --verbose /scan; then
-          echo "::error title=Gitleaks canary was not detected::Expected fake token fixture to fail the scan"
+        archive="/tmp/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+        curl -sSfL \
+          "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          -o "$archive"
+        echo "${GITLEAKS_LINUX_X64_SHA256}  $archive" | sha256sum -c -
+        tar -xzf "$archive" -C /tmp gitleaks
+        sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+        gitleaks version
+
+    - name: Verify secret scanner canary
+      run: |
+        canary_dir="$(mktemp -d)"
+        cp tests/fixtures/secret_scan_canary.txt "$canary_dir/canary.txt"
+        set +e
+        gitleaks dir \
+          --config .gitleaks.toml \
+          --redact \
+          --no-banner \
+          --report-format json \
+          --report-path "$RUNNER_TEMP/gitleaks-canary.json" \
+          "$canary_dir"
+        canary_status=$?
+        set -e
+        if [ "$canary_status" -eq 0 ]; then
+          echo "::error title=Secret scanner canary was not detected::Expected the synthetic canary to fail outside its allowlisted fixture path"
           exit 1
         fi
+        if [ "$canary_status" -ne 1 ]; then
+          echo "::error title=Secret scanner canary failed unexpectedly::Scanner exited with status $canary_status"
+          exit "$canary_status"
+        fi
 
-    - name: Scan repository for committed secrets
+    - name: Scan committed changes for secrets
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PUSH_BEFORE_SHA: ${{ github.event.before }}
       run: |
-        docker run --rm \
-          -v "$PWD:/repo:ro" \
-          ghcr.io/gitleaks/gitleaks:v8.30.1 \
-          dir --config /repo/.gitleaks.toml --redact --no-banner --verbose /repo
+        zero_sha="0000000000000000000000000000000000000000"
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          scan_range="${PR_BASE_SHA}..${PR_HEAD_SHA}"
+        elif [ -n "$PUSH_BEFORE_SHA" ] && [ "$PUSH_BEFORE_SHA" != "$zero_sha" ]; then
+          scan_range="${PUSH_BEFORE_SHA}..${GITHUB_SHA}"
+        else
+          scan_range="${GITHUB_SHA}^..${GITHUB_SHA}"
+        fi
+        gitleaks git \
+          --config .gitleaks.toml \
+          --redact \
+          --no-banner \
+          --verbose \
+          --log-opts "$scan_range" \
+          .
 
   build:
     needs: [repo-policy, test, security, secret-scan]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+title = "OpenMed Secret Scanning Config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Paths exempted from secret scanning"
+paths = [
+  '''tests/fixtures/fake_secret\.txt''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,10 +1,35 @@
-title = "OpenMed Secret Scanning Config"
+title = "OpenMed secret scanning"
 
 [extend]
 useDefault = true
 
-[allowlist]
-description = "Paths exempted from secret scanning"
-paths = [
-  '''tests/fixtures/fake_secret\.txt''',
-]
+[[rules]]
+id = "local-secret-file"
+description = "Local credential files must not be committed"
+path = '''(^|/)(creds\.txt|\.pypirc|secrets\.json)$'''
+regex = '''(?m).+'''
+tags = ["credentials", "local-secret-file"]
+
+[[allowlists]]
+targetRules = ["generic-api-key"]
+description = "Synthetic secret labels in the privacy filter example"
+condition = "AND"
+regexTarget = "line"
+paths = ['''examples/privacy_filter_book/app\.py$''']
+regexes = ['''\("secret", "(VIOLET-WINDSOR-1944|KRONEN-29-ALPHA|silver-maple-lune-88)"\)''']
+
+[[allowlists]]
+targetRules = ["generic-api-key"]
+description = "Swift demo note describes tokenization, not a token value"
+condition = "AND"
+regexTarget = "line"
+paths = ['''swift/OpenMedDemo/OpenMedDemo/ContentView\.swift$''']
+regexes = ['''o200k_base tokenization, BIOES/Viterbi decoding''']
+
+[[allowlists]]
+targetRules = ["generic-api-key"]
+description = "Cloudflare Web Analytics beacon token is public site metadata"
+condition = "AND"
+regexTarget = "line"
+paths = ['''docs/website/index\.html$''']
+regexes = ['''data-cf-beacon=.*"token": "[0-9a-f]{32}"''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,11 +4,23 @@ title = "OpenMed secret scanning"
 useDefault = true
 
 [[rules]]
-id = "local-secret-file"
+id = "local-credential-file"
 description = "Local credential files must not be committed"
-path = '''(^|/)(creds\.txt|\.pypirc|secrets\.json)$'''
+path = '''(^|/)(creds\.txt|\.pypirc|secrets\.json|\.env(\..*)?)$'''
 regex = '''(?m).+'''
 tags = ["credentials", "local-secret-file"]
+
+[[rules]]
+id = "openmed-secret-scan-canary"
+description = "Synthetic canary used to verify the secret scanner gate"
+regex = '''OPENMED_SECRET_SCAN_CANARY_[A-Z0-9]{32}'''
+keywords = ["OPENMED_SECRET_SCAN_CANARY_"]
+tags = ["secret-scanner-canary"]
+
+[[allowlists]]
+targetRules = ["openmed-secret-scan-canary"]
+description = "Committed canary fixture; CI copies it to a non-allowlisted path to prove detection still works"
+paths = ['''tests/fixtures/secret_scan_canary\.txt$''']
 
 [[allowlists]]
 targetRules = ["generic-api-key"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,9 @@ repos:
     hooks:
       - id: pydocstyle
         args: [--convention=google]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.27.2
+    hooks:
+      - id: gitleaks
+        args: [--config=.gitleaks.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,14 +28,16 @@ repos:
         args: [-c, pyproject.toml]
         additional_dependencies: ["bandit[toml]"]
 
+  - repo: local
+    hooks:
+      - id: gitleaks
+        name: Detect hardcoded secrets
+        entry: ghcr.io/gitleaks/gitleaks:v8.30.1 git --pre-commit --redact --staged --verbose --config .gitleaks.toml
+        language: docker_image
+        pass_filenames: false
+
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.3.0
     hooks:
       - id: pydocstyle
         args: [--convention=google]
-
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.27.2
-    hooks:
-      - id: gitleaks
-        args: [--config=.gitleaks.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,13 +28,11 @@ repos:
         args: [-c, pyproject.toml]
         additional_dependencies: ["bandit[toml]"]
 
-  - repo: local
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
     hooks:
       - id: gitleaks
-        name: Detect hardcoded secrets
-        entry: ghcr.io/gitleaks/gitleaks:v8.30.1 git --pre-commit --redact --staged --verbose --config .gitleaks.toml
-        language: docker_image
-        pass_filenames: false
+        args: [--config=.gitleaks.toml]
 
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.3.0

--- a/docs/security/secret-handling.md
+++ b/docs/security/secret-handling.md
@@ -5,7 +5,7 @@ secrets. Keep local credentials in untracked files such as `creds.txt`,
 `.pypirc`, `secrets.json`, or local environment files.
 
 Use GitHub Actions secrets or environment secrets for CI credentials. For
-Hugging Face tokens, follow `docs/security/hf-token-policy.md`.
+model publishing credentials, follow `docs/security/hf-token-policy.md`.
 
 ## Local Checks
 
@@ -15,8 +15,8 @@ Install the repository hooks before committing:
 pre-commit install
 ```
 
-The Gitleaks hook uses the pinned Docker image from `.pre-commit-config.yaml`,
-so Docker must be available locally.
+The secret-scanning hook is pinned in `.pre-commit-config.yaml` and uses the
+rules in `.gitleaks.toml`.
 
 Run the staged-change secret scanner manually when changing auth, release, or
 CI files:
@@ -27,10 +27,11 @@ pre-commit run gitleaks
 
 ## CI Gate
 
-CI runs Gitleaks with `.gitleaks.toml` on every pull request and push. The
-workflow also creates a fake token in a temporary `creds.txt` file and expects
-Gitleaks to fail that canary scan. If the canary passes, CI fails because the
-secret-scanning gate is not working.
+CI installs the pinned scanner release after verifying its checksum, then scans
+the committed changes in every pull request and push. The workflow also copies
+`tests/fixtures/secret_scan_canary.txt` to a temporary, non-allowlisted path
+and expects the scanner to fail that canary scan. If the canary is missed, CI
+fails because the gate is not working.
 
 Repository admins should also enable GitHub secret scanning and push protection
 where the repository plan supports it.
@@ -38,7 +39,7 @@ where the repository plan supports it.
 ## False Positives
 
 Prefer replacing realistic-looking examples with placeholders such as
-`<HF_TOKEN>` or `<PYPI_TOKEN>`. If a false positive cannot be avoided, add the
+`<TOKEN>` or `<PYPI_TOKEN>`. If a false positive cannot be avoided, add the
 narrowest possible allowlist entry in `.gitleaks.toml`, scoped by path and
 pattern, and explain the reason in the pull request.
 

--- a/docs/security/secret-handling.md
+++ b/docs/security/secret-handling.md
@@ -1,17 +1,49 @@
-# Secret Handling Policy
+# Secret Handling
 
-## What Gets Scanned
+OpenMed must not commit credentials, private tokens, patient data, or other
+secrets. Keep local credentials in untracked files such as `creds.txt`,
+`.pypirc`, `secrets.json`, or local environment files.
 
-OpenMed uses [gitleaks](https://github.com/gitleaks/gitleaks) to scan every commit and PR for accidentally committed credentials. The scanner covers:
+Use GitHub Actions secrets or environment secrets for CI credentials. For
+Hugging Face tokens, follow `docs/security/hf-token-policy.md`.
 
-- Hugging Face tokens (`hf_*`)
-- PyPI tokens (`.pypirc` format)
-- Generic API keys and high-entropy strings
+## Local Checks
 
-## Local Setup
-
-After cloning the repo, run once:
+Install the repository hooks before committing:
 
 ```bash
-pip install pre-commit
 pre-commit install
+```
+
+The Gitleaks hook uses the pinned Docker image from `.pre-commit-config.yaml`,
+so Docker must be available locally.
+
+Run the staged-change secret scanner manually when changing auth, release, or
+CI files:
+
+```bash
+pre-commit run gitleaks
+```
+
+## CI Gate
+
+CI runs Gitleaks with `.gitleaks.toml` on every pull request and push. The
+workflow also creates a fake token in a temporary `creds.txt` file and expects
+Gitleaks to fail that canary scan. If the canary passes, CI fails because the
+secret-scanning gate is not working.
+
+Repository admins should also enable GitHub secret scanning and push protection
+where the repository plan supports it.
+
+## False Positives
+
+Prefer replacing realistic-looking examples with placeholders such as
+`<HF_TOKEN>` or `<PYPI_TOKEN>`. If a false positive cannot be avoided, add the
+narrowest possible allowlist entry in `.gitleaks.toml`, scoped by path and
+pattern, and explain the reason in the pull request.
+
+## If A Secret Is Committed
+
+Revoke or rotate the credential immediately. Remove it from the branch before
+merging, and avoid posting real secret values or private data in issues, pull
+requests, logs, or screenshots.

--- a/docs/security/secret-handling.md
+++ b/docs/security/secret-handling.md
@@ -1,0 +1,17 @@
+# Secret Handling Policy
+
+## What Gets Scanned
+
+OpenMed uses [gitleaks](https://github.com/gitleaks/gitleaks) to scan every commit and PR for accidentally committed credentials. The scanner covers:
+
+- Hugging Face tokens (`hf_*`)
+- PyPI tokens (`.pypirc` format)
+- Generic API keys and high-entropy strings
+
+## Local Setup
+
+After cloning the repo, run once:
+
+```bash
+pip install pre-commit
+pre-commit install

--- a/tests/fixtures/secret_scan_canary.txt
+++ b/tests/fixtures/secret_scan_canary.txt
@@ -1,0 +1,2 @@
+# Synthetic canary used to verify the secret scanner gate.
+OPENMED_SECRET_SCAN_CANARY_0123456789ABCDEF0123456789ABCDEF

--- a/tests/unit/security/test_secret_scanning_gate.py
+++ b/tests/unit/security/test_secret_scanning_gate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -10,47 +9,38 @@ CANARY = ROOT / "tests/fixtures/secret_scan_canary.txt"
 WORKFLOW = ROOT / ".github/workflows/ci.yml"
 
 
-def _gitleaks_config() -> dict[str, object]:
-    return tomllib.loads(CONFIG.read_text())
+def _gitleaks_config_text() -> str:
+    return CONFIG.read_text()
 
 
 def test_canary_fixture_matches_project_specific_rule() -> None:
-    config = _gitleaks_config()
-    rules = {rule["id"]: rule for rule in config["rules"]}
-    canary_rule = rules["openmed-secret-scan-canary"]
+    config = _gitleaks_config_text()
+    pattern_match = re.search(
+        r"id = \"openmed-secret-scan-canary\".*?regex = '''(.+?)'''",
+        config,
+        flags=re.DOTALL,
+    )
 
-    assert re.search(canary_rule["regex"], CANARY.read_text()) is not None
+    assert pattern_match is not None
+    assert re.search(pattern_match.group(1), CANARY.read_text()) is not None
 
 
 def test_canary_fixture_is_the_only_canary_allowlist_path() -> None:
-    config = _gitleaks_config()
-    matching_allowlists = [
-        allowlist
-        for allowlist in config["allowlists"]
-        if allowlist.get("targetRules") == ["openmed-secret-scan-canary"]
-    ]
+    config = _gitleaks_config_text()
 
-    assert matching_allowlists == [
-        {
-            "targetRules": ["openmed-secret-scan-canary"],
-            "description": (
-                "Committed canary fixture; CI copies it to a non-allowlisted path "
-                "to prove detection still works"
-            ),
-            "paths": [r"tests/fixtures/secret_scan_canary\.txt$"],
-        }
-    ]
+    assert config.count('targetRules = ["openmed-secret-scan-canary"]') == 1
+    assert "Committed canary fixture" in config
+    assert r"tests/fixtures/secret_scan_canary\.txt$" in config
 
 
 def test_local_credential_files_are_explicitly_flagged() -> None:
-    config = _gitleaks_config()
-    rules = {rule["id"]: rule for rule in config["rules"]}
-    credential_rule = rules["local-credential-file"]
+    config = _gitleaks_config_text()
 
-    assert "creds\\.txt" in credential_rule["path"]
-    assert "\\.pypirc" in credential_rule["path"]
-    assert "secrets\\.json" in credential_rule["path"]
-    assert "\\.env" in credential_rule["path"]
+    assert 'id = "local-credential-file"' in config
+    assert r"creds\.txt" in config
+    assert r"\.pypirc" in config
+    assert r"secrets\.json" in config
+    assert r"\.env" in config
 
 
 def test_workflow_runs_canary_before_secret_scan() -> None:

--- a/tests/unit/security/test_secret_scanning_gate.py
+++ b/tests/unit/security/test_secret_scanning_gate.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+CONFIG = ROOT / ".gitleaks.toml"
+CANARY = ROOT / "tests/fixtures/secret_scan_canary.txt"
+WORKFLOW = ROOT / ".github/workflows/ci.yml"
+
+
+def _gitleaks_config() -> dict[str, object]:
+    return tomllib.loads(CONFIG.read_text())
+
+
+def test_canary_fixture_matches_project_specific_rule() -> None:
+    config = _gitleaks_config()
+    rules = {rule["id"]: rule for rule in config["rules"]}
+    canary_rule = rules["openmed-secret-scan-canary"]
+
+    assert re.search(canary_rule["regex"], CANARY.read_text()) is not None
+
+
+def test_canary_fixture_is_the_only_canary_allowlist_path() -> None:
+    config = _gitleaks_config()
+    matching_allowlists = [
+        allowlist
+        for allowlist in config["allowlists"]
+        if allowlist.get("targetRules") == ["openmed-secret-scan-canary"]
+    ]
+
+    assert matching_allowlists == [
+        {
+            "targetRules": ["openmed-secret-scan-canary"],
+            "description": (
+                "Committed canary fixture; CI copies it to a non-allowlisted path "
+                "to prove detection still works"
+            ),
+            "paths": [r"tests/fixtures/secret_scan_canary\.txt$"],
+        }
+    ]
+
+
+def test_local_credential_files_are_explicitly_flagged() -> None:
+    config = _gitleaks_config()
+    rules = {rule["id"]: rule for rule in config["rules"]}
+    credential_rule = rules["local-credential-file"]
+
+    assert "creds\\.txt" in credential_rule["path"]
+    assert "\\.pypirc" in credential_rule["path"]
+    assert "secrets\\.json" in credential_rule["path"]
+    assert "\\.env" in credential_rule["path"]
+
+
+def test_workflow_runs_canary_before_secret_scan() -> None:
+    workflow = WORKFLOW.read_text()
+
+    canary_step = workflow.index("Verify secret scanner canary")
+    scan_step = workflow.index("Scan committed changes for secrets")
+    assert canary_step < scan_step
+    assert "secret_scan_canary.txt" in workflow
+    assert "gitleaks git" in workflow
+    assert "secret-scan" in workflow


### PR DESCRIPTION
Closes #269.

Consolidates the existing secret-scanning gate work from #365 and #356 into one origin branch. Adds a pinned local hook, a checksum-verified CI scanner install, a committed synthetic canary that is allowlisted only at its fixture path, narrow allowlists for existing benign examples, and policy docs for secret handling and false-positive review.

Verification:
- .venv/bin/python -m pytest tests/ -q
- Secret scanner commit-range scan over origin/master..HEAD
- Dockerized full archive scan and canary detection