### PR TITLE
Add the temporality axis (recent / historical / hypothetical)

### DIFF
--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -3,3 +3,19 @@
 Intended contents include sections.py, context.py, grounding.py, relations.py,
 sdoh.py, and FHIR/OMOP exporters.
 """
+
+from .context import (
+    HISTORICAL,
+    HYPOTHETICAL,
+    RECENT,
+    TEMPORALITY_VALUES,
+    resolve_temporality,
+)
+
+__all__ = [
+    "RECENT",
+    "HISTORICAL",
+    "HYPOTHETICAL",
+    "TEMPORALITY_VALUES",
+    "resolve_temporality",
+]

--- a/openmed/clinical/context.py
+++ b/openmed/clinical/context.py
@@ -63,7 +63,10 @@ HYPOTHETICAL_CUES = (
 
 
 def _cue_pattern(cues: Iterable[str]) -> re.Pattern[str]:
-    alternation = "|".join(re.escape(cue) for cue in sorted(cues, key=len, reverse=True))
+    alternation = "|".join(
+        r"\s+".join(re.escape(part) for part in cue.split())
+        for cue in sorted(cues, key=len, reverse=True)
+    )
     return re.compile(rf"(?<!\w)(?:{alternation})(?!\w)", re.IGNORECASE)
 
 
@@ -91,6 +94,18 @@ def _text_of(obj: Any) -> str:
     return ""
 
 
+def _text_parts(span: Any, modifier_hits: Any) -> tuple[str, ...]:
+    parts = [_text_of(span)]
+    if modifier_hits is not None and not isinstance(modifier_hits, (str, Mapping)):
+        if isinstance(modifier_hits, Iterable):
+            parts.extend(_text_of(hit) for hit in modifier_hits)
+        else:
+            parts.append(_text_of(modifier_hits))
+    else:
+        parts.append(_text_of(modifier_hits))
+    return tuple(part for part in parts if part)
+
+
 def resolve_temporality(span: Any, modifier_hits: Any = None) -> str:
     """Classify the ConText temporality of ``span``.
 
@@ -108,20 +123,11 @@ def resolve_temporality(span: Any, modifier_hits: Any = None) -> str:
     occurred, which takes precedence over where in time it would sit.
     """
 
-    parts = [_text_of(span)]
-    if modifier_hits is not None and not isinstance(modifier_hits, (str, Mapping)):
-        if isinstance(modifier_hits, Iterable):
-            parts.extend(_text_of(hit) for hit in modifier_hits)
-        else:
-            parts.append(_text_of(modifier_hits))
-    else:
-        parts.append(_text_of(modifier_hits))
+    parts = _text_parts(span, modifier_hits)
 
-    haystack = " ".join(part for part in parts if part)
-
-    if _HYPOTHETICAL_RE.search(haystack):
+    if any(_HYPOTHETICAL_RE.search(part) for part in parts):
         return HYPOTHETICAL
-    if _HISTORICAL_RE.search(haystack):
+    if any(_HISTORICAL_RE.search(part) for part in parts):
         return HISTORICAL
     return RECENT
 

--- a/openmed/clinical/context.py
+++ b/openmed/clinical/context.py
@@ -1,0 +1,137 @@
+"""ConText temporality axis for clinical spans (OM-141, roadmap 5.2).
+
+This module is the narrow temporality decision layer of the shared ConText
+engine.  It classifies the temporal status of a clinical span onto the
+original ConText three-value temporality scale:
+
+* ``"recent"``       -- the finding is current / active (the default).
+* ``"historical"``   -- the finding belongs to the patient's past history.
+* ``"hypothetical"`` -- the finding is conditional and not asserted as present.
+
+The historical-versus-current distinction is what separates a resolved past
+problem from an active one (``"history of MI"`` versus ``"acute MI"``).
+Downstream FHIR/OMOP records consume this axis to drive
+``clinicalStatus`` / ``onset``: a ``"historical"`` span maps to an inactive or
+resolved ``clinicalStatus`` and a past ``onset``, whereas a ``"recent"`` span
+maps to an active ``clinicalStatus``.  A ``"hypothetical"`` span is not asserted
+to be present at all and should not be recorded as an active condition.
+
+Sibling axes (negation, uncertainty, experiencer) and absolute-date timeline
+normalization (TIMEX3) are handled by separate layers and are out of scope
+here.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+RECENT = "recent"
+HISTORICAL = "historical"
+HYPOTHETICAL = "hypothetical"
+
+#: The temporality values, ordered from default to most specific.
+TEMPORALITY_VALUES = (RECENT, HISTORICAL, HYPOTHETICAL)
+
+# Ported ConText temporal lexicon.  Cues are matched case-insensitively and on
+# token boundaries so abbreviations such as ``h/o`` and ``s/p`` match cleanly
+# without firing inside unrelated words.
+HISTORICAL_CUES = (
+    "history of",
+    "hx of",
+    "h/o",
+    "status post",
+    "s/p",
+    "previous",
+    "previously",
+    "prior",
+    "in the past",
+    "past medical history",
+    "pmh",
+    "resolved",
+)
+
+HYPOTHETICAL_CUES = (
+    "if",
+    "should",
+    "in case of",
+    "in case",
+    "in the event of",
+    "unless",
+)
+
+
+def _cue_pattern(cues: Iterable[str]) -> re.Pattern[str]:
+    alternation = "|".join(re.escape(cue) for cue in sorted(cues, key=len, reverse=True))
+    return re.compile(rf"(?<!\w)(?:{alternation})(?!\w)", re.IGNORECASE)
+
+
+_HISTORICAL_RE = _cue_pattern(HISTORICAL_CUES)
+_HYPOTHETICAL_RE = _cue_pattern(HYPOTHETICAL_CUES)
+
+
+def _text_of(obj: Any) -> str:
+    """Best-effort extraction of cue/span text from heterogeneous inputs."""
+
+    if obj is None:
+        return ""
+    if isinstance(obj, str):
+        return obj
+    if isinstance(obj, Mapping):
+        for key in ("text", "phrase", "cue", "literal", "word", "value", "surface"):
+            value = obj.get(key)
+            if isinstance(value, str):
+                return value
+        return ""
+    for attr in ("text", "phrase", "cue", "literal", "word", "value", "surface"):
+        value = getattr(obj, attr, None)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def resolve_temporality(span: Any, modifier_hits: Any = None) -> str:
+    """Classify the ConText temporality of ``span``.
+
+    ``span`` is the target clinical span -- a string, a span mapping with a
+    ``text``-like key, or any object exposing a ``text`` attribute.
+    ``modifier_hits`` is the optional collection of ConText modifier cues the
+    shared engine matched in the span's window (cue strings, or mappings/objects
+    exposing a ``text``-like field).  The span surface itself is also scanned so
+    the layer is usable standalone when no separate modifier hits are supplied.
+
+    Returns one of ``"recent"``, ``"historical"`` or ``"hypothetical"``.
+    ``"recent"`` is the default when no temporal cue is found.  When both a
+    hypothetical and a historical cue are present the span is treated as
+    ``"hypothetical"``: a conditional statement is not asserted to have
+    occurred, which takes precedence over where in time it would sit.
+    """
+
+    parts = [_text_of(span)]
+    if modifier_hits is not None and not isinstance(modifier_hits, (str, Mapping)):
+        if isinstance(modifier_hits, Iterable):
+            parts.extend(_text_of(hit) for hit in modifier_hits)
+        else:
+            parts.append(_text_of(modifier_hits))
+    else:
+        parts.append(_text_of(modifier_hits))
+
+    haystack = " ".join(part for part in parts if part)
+
+    if _HYPOTHETICAL_RE.search(haystack):
+        return HYPOTHETICAL
+    if _HISTORICAL_RE.search(haystack):
+        return HISTORICAL
+    return RECENT
+
+
+__all__ = [
+    "RECENT",
+    "HISTORICAL",
+    "HYPOTHETICAL",
+    "TEMPORALITY_VALUES",
+    "HISTORICAL_CUES",
+    "HYPOTHETICAL_CUES",
+    "resolve_temporality",
+]

--- a/tests/unit/clinical/test_temporality.py
+++ b/tests/unit/clinical/test_temporality.py
@@ -53,6 +53,18 @@ def test_hypothetical_cue_families(text):
     assert resolve_temporality(text) == HYPOTHETICAL
 
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("history\nof MI", HISTORICAL),
+        ("status\tpost CABG", HISTORICAL),
+        ("in case\nof bleeding", HYPOTHETICAL),
+    ],
+)
+def test_multiword_cues_tolerate_clinical_whitespace(text, expected):
+    assert resolve_temporality(text) == expected
+
+
 def test_default_is_recent_without_cues():
     assert resolve_temporality("chest pain") == RECENT
     assert resolve_temporality("acute MI", []) == RECENT
@@ -68,6 +80,10 @@ def test_modifier_hits_carry_the_cue():
 def test_modifier_hits_as_mappings():
     hits = [{"text": "status post"}]
     assert resolve_temporality({"text": "CABG"}, hits) == HISTORICAL
+
+
+def test_modifier_hits_do_not_create_cues_across_fragments():
+    assert resolve_temporality("in", ["case of bleeding"]) == RECENT
 
 
 def test_span_mapping_is_supported():

--- a/tests/unit/clinical/test_temporality.py
+++ b/tests/unit/clinical/test_temporality.py
@@ -1,0 +1,89 @@
+"""Tests for the ConText temporality axis (OM-141)."""
+
+import pytest
+
+from openmed.clinical import resolve_temporality
+from openmed.clinical.context import (
+    HISTORICAL,
+    HYPOTHETICAL,
+    RECENT,
+    TEMPORALITY_VALUES,
+)
+
+
+def test_history_of_is_historical():
+    assert resolve_temporality("history of MI") == "historical"
+
+
+def test_acute_is_recent_by_default():
+    assert resolve_temporality("acute MI") == "recent"
+
+
+def test_conditional_is_hypothetical():
+    assert resolve_temporality("if chest pain recurs") == "hypothetical"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "h/o myocardial infarction",
+        "hx of stroke",
+        "status post CABG",
+        "s/p appendectomy",
+        "previous pneumonia",
+        "pneumonia resolved",
+        "fracture in the past",
+        "prior DVT",
+    ],
+)
+def test_historical_cue_families(text):
+    assert resolve_temporality(text) == HISTORICAL
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "should fever develop",
+        "in case of bleeding",
+        "in the event of shock",
+        "unless symptoms worsen",
+    ],
+)
+def test_hypothetical_cue_families(text):
+    assert resolve_temporality(text) == HYPOTHETICAL
+
+
+def test_default_is_recent_without_cues():
+    assert resolve_temporality("chest pain") == RECENT
+    assert resolve_temporality("acute MI", []) == RECENT
+
+
+def test_modifier_hits_carry_the_cue():
+    # The target span is just the concept; the cue arrives via the shared
+    # ConText engine's modifier hits rather than being embedded in the span.
+    assert resolve_temporality("MI", ["history of"]) == HISTORICAL
+    assert resolve_temporality("chest pain", ["if"]) == HYPOTHETICAL
+
+
+def test_modifier_hits_as_mappings():
+    hits = [{"text": "status post"}]
+    assert resolve_temporality({"text": "CABG"}, hits) == HISTORICAL
+
+
+def test_span_mapping_is_supported():
+    assert resolve_temporality({"text": "history of MI"}) == HISTORICAL
+
+
+def test_hypothetical_takes_precedence_over_historical():
+    # A conditional clause is not asserted to have occurred, so it wins.
+    assert resolve_temporality("if history of MI recurs") == HYPOTHETICAL
+
+
+def test_cue_matching_respects_word_boundaries():
+    # "if" must not fire inside "stiff"; "prior" stays a whole-word cue.
+    assert resolve_temporality("stiff neck") == RECENT
+
+
+def test_result_is_always_a_valid_temporality_value():
+    for text in ("acute MI", "history of MI", "if chest pain recurs"):
+        assert resolve_temporality(text) in TEMPORALITY_VALUES


### PR DESCRIPTION
## Description
Closes #306. Adds the ConText temporality decision layer for clinical spans: `resolve_temporality(span, modifier_hits=None)` classifies a span onto the three-value temporality scale (`recent` / `historical` / `hypothetical`), defaulting to `recent`. Cues are matched case-insensitively on token boundaries so abbreviations like `h/o` and `s/p` match cleanly without firing inside other words (e.g. `if` won't fire in `stiff`). When both cue families are present, `hypothetical` wins, since a conditional isn't asserted to have occurred.

The span surface and the optional `modifier_hits` from the shared ConText engine are both scanned, so the layer works either standalone or fed by the engine. Downstream this drives `clinicalStatus`/`onset` in the FHIR/OMOP exporters (historical -> inactive/resolved + past onset; recent -> active).

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- `openmed/clinical/context.py` (new): `resolve_temporality` plus the ported historical/hypothetical lexicons and value constants.
- `openmed/clinical/__init__.py`: export `resolve_temporality`, the three value constants, and `TEMPORALITY_VALUES`, matching the `openmed/risk` package pattern.
- `tests/unit/clinical/test_temporality.py` (new): 22 tests covering the required cases, full cue families, the default, the `modifier_hits` path, span mappings, precedence, and word-boundary safety.

## Testing
- `.venv/bin/python -m pytest tests/unit/clinical/test_temporality.py -q` -> 22 passed
- `.venv/bin/python -m pytest tests/ -q` -> 1459 passed, 22 skipped
- `bandit -q openmed/clinical/context.py` -> clean
- Removing `context.py` + the export makes the new test fail at import, confirming it fails without the change.

## Related Issues
Closes #306