### PR TITLE
Add bootstrap confidence intervals to benchmark metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added release changelog tooling that renders Keep a Changelog sections from Conventional Commits, computes the SemVer bump, and exposes the computed next version to the PyPI publish workflow.
+- Added `bootstrap_ci` and `compute_confidence_intervals` to `openmed.eval.metrics` and an opt-in `confidence_intervals` flag on the benchmark harness that attaches deterministic non-parametric bootstrap confidence intervals to the leakage, character recall, and span F1 metrics (off by default to keep fast runs cheap).
 
 ### Fixed
 

--- a/openmed/eval/harness.py
+++ b/openmed/eval/harness.py
@@ -10,7 +10,12 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
 from openmed.core.quality_gates import validate_entity_spans
-from openmed.eval.metrics import EvalSpan, compute_metrics_bundle, normalize_eval_spans
+from openmed.eval.metrics import (
+    EvalSpan,
+    compute_confidence_intervals,
+    compute_metrics_bundle,
+    normalize_eval_spans,
+)
 from openmed.eval.report import BenchmarkReport
 
 
@@ -109,8 +114,19 @@ def run_benchmark(
     runner: ModelRunner | None = None,
     generated_at: str | None = None,
     metadata: Mapping[str, Any] | None = None,
+    confidence_intervals: bool = False,
+    ci_resamples: int = 1000,
+    ci_alpha: float = 0.05,
+    ci_seed: int = 0,
 ) -> BenchmarkReport:
-    """Run *model_name* over fixtures and return a benchmark report."""
+    """Run *model_name* over fixtures and return a benchmark report.
+
+    When ``confidence_intervals`` is enabled (off by default to keep fast runs
+    cheap), a non-parametric bootstrap over documents attaches a
+    ``confidence_interval`` payload to the leakage, character recall, and exact
+    and relaxed span F1 metrics. The bootstrap is deterministic for a fixed
+    ``ci_seed``.
+    """
     _validate_unique_fixture_ids(fixtures)
     model_runner = runner or _shared_default_model_runner()
     results: list[FixtureResult] = []
@@ -157,6 +173,16 @@ def run_benchmark(
         default_device=device,
         source_text=corpus_text,
     )
+    if confidence_intervals:
+        metrics = _attach_confidence_intervals(
+            metrics,
+            fixtures,
+            results,
+            device=device,
+            n_resamples=ci_resamples,
+            alpha=ci_alpha,
+            seed=ci_seed,
+        )
 
     report_metadata = dict(metadata or {})
     report_metadata.setdefault("fixture_ids", [fixture.fixture_id for fixture in fixtures])
@@ -182,6 +208,10 @@ def run_suite(
     output_markdown: str | Path | None = None,
     generated_at: str | None = None,
     metadata: Mapping[str, Any] | None = None,
+    confidence_intervals: bool = False,
+    ci_resamples: int = 1000,
+    ci_alpha: float = 0.05,
+    ci_seed: int = 0,
 ) -> BenchmarkReport:
     """Load fixtures, run the benchmark, and optionally write reports."""
     report = run_benchmark(
@@ -192,6 +222,10 @@ def run_suite(
         runner=runner,
         generated_at=generated_at,
         metadata=metadata,
+        confidence_intervals=confidence_intervals,
+        ci_resamples=ci_resamples,
+        ci_alpha=ci_alpha,
+        ci_seed=ci_seed,
     )
     if output_json is not None:
         report.write_json(output_json)
@@ -221,6 +255,40 @@ def _shared_default_model_runner() -> ModelRunner:
         )
 
     return run_fixture
+
+
+def _attach_confidence_intervals(
+    metrics: Mapping[str, Any],
+    fixtures: Sequence[BenchmarkFixture],
+    results: Sequence[FixtureResult],
+    *,
+    device: str,
+    n_resamples: int,
+    alpha: float,
+    seed: int,
+) -> dict[str, Any]:
+    """Bootstrap per-document CIs and merge them into the metric bundle."""
+    result_by_id = {result.fixture_id: result for result in results}
+    per_document_spans = [
+        (
+            fixture.gold_spans,
+            getattr(result_by_id.get(fixture.fixture_id), "predicted_spans", ()),
+        )
+        for fixture in fixtures
+    ]
+    intervals = compute_confidence_intervals(
+        per_document_spans,
+        n_resamples=n_resamples,
+        alpha=alpha,
+        seed=seed,
+        default_device=device,
+    )
+    merged = dict(metrics)
+    for key, interval in intervals.items():
+        metric = merged.get(key)
+        if isinstance(metric, Mapping):
+            merged[key] = {**metric, "confidence_interval": interval}
+    return merged
 
 
 def _corpus_coordinates(

--- a/openmed/eval/metrics.py
+++ b/openmed/eval/metrics.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import random
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from math import ceil
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence
 
 from openmed.core.labels import CANONICAL_LABELS, normalize_label
 from openmed.core.pii_i18n import SUPPORTED_LANGUAGES
@@ -216,6 +217,36 @@ class ResourceMetrics:
         }
 
     def __getitem__(self, key: str) -> float | int | None:
+        return self.to_dict()[key]
+
+
+@dataclass(frozen=True)
+class BootstrapCI:
+    """A bootstrap confidence interval around a point estimate.
+
+    ``degenerate`` is set when the interval could not vary under resampling
+    (an empty or single-document corpus), in which case ``lower``/``upper``
+    collapse onto ``point`` -- a zero-width, explicitly flagged interval.
+    """
+
+    point: float
+    lower: float
+    upper: float
+    n_resamples: int
+    alpha: float
+    degenerate: bool = False
+
+    def to_dict(self) -> dict[str, float | int | bool]:
+        return {
+            "point": self.point,
+            "lower": self.lower,
+            "upper": self.upper,
+            "n_resamples": self.n_resamples,
+            "alpha": self.alpha,
+            "degenerate": self.degenerate,
+        }
+
+    def __getitem__(self, key: str) -> float | int | bool:
         return self.to_dict()[key]
 
 
@@ -741,6 +772,169 @@ def compute_metrics_bundle(
     }
 
 
+def bootstrap_ci(
+    per_document_values: Sequence[Any],
+    statistic: Callable[[Sequence[Any]], float],
+    *,
+    n_resamples: int = 1000,
+    alpha: float = 0.05,
+    seed: int = 0,
+) -> BootstrapCI:
+    """Non-parametric bootstrap confidence interval over documents.
+
+    ``per_document_values`` holds one entry per benchmark document (any value
+    ``statistic`` knows how to aggregate, e.g. a ``(numerator, denominator)``
+    pair). ``statistic`` maps a resampled list of those entries to a scalar
+    point estimate. Documents are drawn with replacement from a
+    ``random.Random(seed)`` stream, so a fixed ``seed`` is fully reproducible.
+
+    The returned interval always brackets the point estimate. Degenerate inputs
+    -- an empty corpus or a single document -- cannot vary under resampling and
+    yield a zero-width interval flagged with ``degenerate=True``.
+    """
+    values = list(per_document_values)
+    point = float(statistic(values))
+    if len(values) < 2:
+        return BootstrapCI(
+            point=point,
+            lower=point,
+            upper=point,
+            n_resamples=n_resamples,
+            alpha=alpha,
+            degenerate=True,
+        )
+
+    rng = random.Random(seed)
+    size = len(values)
+    samples: list[float] = []
+    for _ in range(n_resamples):
+        resample = [values[rng.randrange(size)] for _ in range(size)]
+        samples.append(float(statistic(resample)))
+    samples.sort()
+
+    lower = _percentile(samples, 100.0 * (alpha / 2.0))
+    upper = _percentile(samples, 100.0 * (1.0 - alpha / 2.0))
+    # Guarantee the point estimate is bracketed even when the bootstrap
+    # distribution is skewed to one side of it.
+    return BootstrapCI(
+        point=point,
+        lower=min(lower, point),
+        upper=max(upper, point),
+        n_resamples=n_resamples,
+        alpha=alpha,
+        degenerate=False,
+    )
+
+
+def compute_confidence_intervals(
+    per_document_spans: Sequence[tuple[Iterable[Any], Iterable[Any]]],
+    *,
+    n_resamples: int = 1000,
+    alpha: float = 0.05,
+    seed: int = 0,
+    default_language: str = "en",
+    default_device: str = "cpu",
+) -> dict[str, dict[str, Any]]:
+    """Bootstrap per-document CIs for leakage rate, character recall, and F1.
+
+    Each entry in ``per_document_spans`` is a ``(gold_spans, predicted_spans)``
+    pair for one benchmark document. Documents are resampled with replacement so
+    the intervals reflect document-level uncertainty in the corpus point
+    estimates. Returns a mapping keyed by metric name (``leakage``,
+    ``character_recall``, ``exact_span_f1``, ``relaxed_span_f1``) whose values
+    are :meth:`BootstrapCI.to_dict` payloads.
+    """
+    leakage_docs: list[tuple[int, int]] = []
+    recall_docs: list[tuple[int, int]] = []
+    exact_docs: list[tuple[int, int, int]] = []
+    relaxed_docs: list[tuple[int, int, int]] = []
+    for gold_spans, predicted_spans in per_document_spans:
+        leakage = compute_leakage_rate(
+            gold_spans,
+            predicted_spans,
+            default_language=default_language,
+            default_device=default_device,
+        )
+        leakage_docs.append((leakage.leaked_chars, leakage.total_chars))
+        recall = compute_character_recall(
+            gold_spans,
+            predicted_spans,
+            default_language=default_language,
+            default_device=default_device,
+        )
+        recall_docs.append((int(recall.numerator), int(recall.denominator)))
+        exact = compute_exact_span_f1(
+            gold_spans,
+            predicted_spans,
+            default_language=default_language,
+            default_device=default_device,
+        )
+        exact_docs.append(
+            (exact.true_positives, exact.false_positives, exact.false_negatives)
+        )
+        relaxed = compute_relaxed_span_f1(
+            gold_spans,
+            predicted_spans,
+            default_language=default_language,
+            default_device=default_device,
+        )
+        relaxed_docs.append(
+            (relaxed.true_positives, relaxed.false_positives, relaxed.false_negatives)
+        )
+
+    return {
+        "leakage": bootstrap_ci(
+            leakage_docs,
+            lambda docs: _ratio_over_docs(docs, zero_denominator=0.0),
+            n_resamples=n_resamples,
+            alpha=alpha,
+            seed=seed,
+        ).to_dict(),
+        "character_recall": bootstrap_ci(
+            recall_docs,
+            lambda docs: _ratio_over_docs(docs, zero_denominator=1.0),
+            n_resamples=n_resamples,
+            alpha=alpha,
+            seed=seed,
+        ).to_dict(),
+        "exact_span_f1": bootstrap_ci(
+            exact_docs,
+            _f1_over_docs,
+            n_resamples=n_resamples,
+            alpha=alpha,
+            seed=seed,
+        ).to_dict(),
+        "relaxed_span_f1": bootstrap_ci(
+            relaxed_docs,
+            _f1_over_docs,
+            n_resamples=n_resamples,
+            alpha=alpha,
+            seed=seed,
+        ).to_dict(),
+    }
+
+
+def _ratio_over_docs(
+    docs: Sequence[tuple[int | float, int | float]],
+    *,
+    zero_denominator: float,
+) -> float:
+    numerator = sum(item[0] for item in docs)
+    denominator = sum(item[1] for item in docs)
+    return _safe_rate(numerator, denominator, zero_denominator=zero_denominator)
+
+
+def _f1_over_docs(docs: Sequence[tuple[int, int, int]]) -> float:
+    true_positives = sum(item[0] for item in docs)
+    false_positives = sum(item[1] for item in docs)
+    false_negatives = sum(item[2] for item in docs)
+    return _f1_from_counts(
+        true_positives,
+        true_positives + false_positives,
+        true_positives + false_negatives,
+    ).f1
+
+
 def _read_value(data: Mapping[str, Any], key: str) -> Any:
     if key in data:
         return data[key]
@@ -895,6 +1089,7 @@ __all__ = [
     "ConsistencyMetric",
     "LatencyMetrics",
     "ResourceMetrics",
+    "BootstrapCI",
     "normalize_eval_span",
     "normalize_eval_spans",
     "compute_leakage_rate",
@@ -909,4 +1104,6 @@ __all__ = [
     "compute_latency_summary",
     "compute_resource_metrics",
     "compute_metrics_bundle",
+    "bootstrap_ci",
+    "compute_confidence_intervals",
 ]

--- a/tests/unit/eval/test_bootstrap_ci.py
+++ b/tests/unit/eval/test_bootstrap_ci.py
@@ -1,0 +1,178 @@
+"""Unit tests for bootstrap confidence intervals on benchmark metrics."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.eval.harness import BenchmarkFixture, run_benchmark
+from openmed.eval.metrics import (
+    BootstrapCI,
+    bootstrap_ci,
+    compute_confidence_intervals,
+)
+
+
+def _rate(docs):
+    """Aggregate ``(numerator, denominator)`` document pairs into a rate."""
+    numerator = sum(doc[0] for doc in docs)
+    denominator = sum(doc[1] for doc in docs)
+    return numerator / denominator if denominator else 0.0
+
+
+def test_bootstrap_ci_brackets_point_and_is_reproducible():
+    docs = [(2, 10), (0, 8), (5, 5), (1, 4), (3, 9), (0, 6), (4, 7), (2, 3)]
+
+    ci = bootstrap_ci(docs, _rate, n_resamples=200, alpha=0.05, seed=7)
+
+    assert isinstance(ci, BootstrapCI)
+    assert not ci.degenerate
+    assert ci.lower <= ci.point <= ci.upper
+    assert ci.point == pytest.approx(_rate(docs))
+
+    # A fixed seed is fully reproducible.
+    again = bootstrap_ci(docs, _rate, n_resamples=200, alpha=0.05, seed=7)
+    assert again.to_dict() == ci.to_dict()
+
+    # A different seed may shift the bounds but must still bracket the point.
+    other = bootstrap_ci(docs, _rate, n_resamples=200, alpha=0.05, seed=11)
+    assert other.lower <= other.point <= other.upper
+    assert other.to_dict() != ci.to_dict()
+
+
+def test_bootstrap_ci_single_document_is_zero_width_and_flagged():
+    ci = bootstrap_ci([(2, 10)], _rate, n_resamples=200, seed=0)
+
+    assert ci.degenerate is True
+    assert ci.point == pytest.approx(0.2)
+    assert ci.lower == ci.upper == pytest.approx(0.2)
+
+
+def test_bootstrap_ci_empty_corpus_is_zero_width_and_flagged():
+    ci = bootstrap_ci([], _rate, n_resamples=200, seed=0)
+
+    assert ci.degenerate is True
+    assert ci.point == 0.0
+    assert ci.lower == ci.upper == 0.0
+
+
+def test_bootstrap_ci_all_zero_sample_collapses_without_flag():
+    # Multiple documents that all evaluate to zero: every resample is zero, so
+    # the interval is zero-width but not flagged degenerate (it could have
+    # varied in principle).
+    docs = [(0, 10), (0, 5), (0, 8)]
+
+    ci = bootstrap_ci(docs, _rate, n_resamples=200, seed=3)
+
+    assert ci.degenerate is False
+    assert ci.point == 0.0
+    assert ci.lower == 0.0
+    assert ci.upper == 0.0
+
+
+def test_compute_confidence_intervals_covers_required_metrics():
+    per_document_spans = [
+        (
+            [{"start": 8, "end": 12, "label": "PERSON"}],
+            [{"start": 8, "end": 12, "label": "PERSON"}],
+        ),
+        (
+            [{"start": 4, "end": 15, "label": "SSN"}],
+            [],
+        ),
+    ]
+
+    intervals = compute_confidence_intervals(per_document_spans, n_resamples=200, seed=0)
+
+    assert set(intervals) == {
+        "leakage",
+        "character_recall",
+        "exact_span_f1",
+        "relaxed_span_f1",
+    }
+    for payload in intervals.values():
+        assert payload["lower"] <= payload["point"] <= payload["upper"]
+
+
+def _two_fixture_setup():
+    fixtures = [
+        BenchmarkFixture.from_mapping(
+            {
+                "id": "a",
+                "text": "Patient John",
+                "language": "en",
+                "gold_spans": [{"start": 8, "end": 12, "label": "PERSON"}],
+            }
+        ),
+        BenchmarkFixture.from_mapping(
+            {
+                "id": "b",
+                "text": "SSN 123-45-6789",
+                "language": "en",
+                "gold_spans": [{"start": 4, "end": 15, "label": "SSN"}],
+            }
+        ),
+    ]
+
+    def runner(fixture, model_name, device):
+        if fixture.fixture_id == "a":
+            return [{"start": 8, "end": 12, "label": "PERSON"}]
+        return []
+
+    return fixtures, runner
+
+
+def test_harness_omits_confidence_intervals_by_default():
+    fixtures, runner = _two_fixture_setup()
+
+    report = run_benchmark(
+        fixtures,
+        suite="golden",
+        model_name="test-model",
+        runner=runner,
+        generated_at="2026-06-11T00:00:00Z",
+    )
+
+    assert "confidence_interval" not in report.metrics["leakage"]
+    assert "confidence_interval" not in report.metrics["character_recall"]
+    assert "confidence_interval" not in report.metrics["exact_span_f1"]
+
+
+def test_harness_attaches_confidence_intervals_when_enabled():
+    fixtures, runner = _two_fixture_setup()
+
+    report = run_benchmark(
+        fixtures,
+        suite="golden",
+        model_name="test-model",
+        runner=runner,
+        generated_at="2026-06-11T00:00:00Z",
+        confidence_intervals=True,
+        ci_resamples=200,
+        ci_seed=0,
+    )
+
+    for key in ("leakage", "character_recall", "exact_span_f1", "relaxed_span_f1"):
+        ci = report.metrics[key]["confidence_interval"]
+        assert ci["lower"] <= ci["point"] <= ci["upper"]
+        assert ci["degenerate"] is False
+
+    # The CI point estimate matches the reported corpus point estimate.
+    assert report.metrics["leakage"]["confidence_interval"]["point"] == pytest.approx(
+        report.metrics["leakage"]["overall"]
+    )
+
+    # Reproducible under a fixed seed.
+    again = run_benchmark(
+        fixtures,
+        suite="golden",
+        model_name="test-model",
+        runner=runner,
+        generated_at="2026-06-11T00:00:00Z",
+        confidence_intervals=True,
+        ci_resamples=200,
+        ci_seed=0,
+    )
+    assert (
+        again.metrics["leakage"]["confidence_interval"]
+        == report.metrics["leakage"]["confidence_interval"]
+    )


### PR DESCRIPTION
Closes #298.

Adds a non-parametric, document-level bootstrap to `openmed.eval.metrics` (`bootstrap_ci` + `compute_confidence_intervals`) and an opt-in `confidence_intervals` flag on `run_benchmark`/`run_suite`. When enabled it attaches a `confidence_interval` payload to the leakage rate, character recall, and exact/relaxed span F1 metrics; it's off by default so fast runs are unchanged. Documents are resampled with replacement from a seeded `random.Random`, so a fixed `ci_seed` is fully reproducible, and degenerate inputs (empty or single-document corpora) yield a zero-width interval flagged `degenerate=True`. No new dependencies — it reuses the existing `_percentile`/`_safe_rate`/`_f1_from_counts` helpers and stdlib `random`.

Testing (`.venv/bin/python -m pytest tests/ -q`):
- The new `tests/unit/eval/test_bootstrap_ci.py` fails before the source change (ImportError on `BootstrapCI`) and passes after — 7 passed.
- Full suite: 1444 passed, 22 skipped (skips pre-existing and unrelated).