### PR TITLE
Add a FHIR transaction Bundle assembler with internal references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a FHIR R4 transaction Bundle assembler (`openmed.clinical.exporters.fhir.to_bundle`) that wraps a document's exported resources into a single Bundle, assigns deterministic `urn:uuid` `fullUrl` values (seeded by `doc_id` + resource index), rewrites in-Bundle references (`subject`/`result`/`encounter`) to those URNs, and emits per-entry `request` blocks for transaction/batch bundles.
 - Added release changelog tooling that renders Keep a Changelog sections from Conventional Commits, computes the SemVer bump, and exposes the computed next version to the PyPI publish workflow.
 
 ### Fixed

--- a/openmed/clinical/exporters/__init__.py
+++ b/openmed/clinical/exporters/__init__.py
@@ -1,0 +1,1 @@
+"""Exporters that turn clinical resources into interchange formats (FHIR/OMOP)."""

--- a/openmed/clinical/exporters/fhir/__init__.py
+++ b/openmed/clinical/exporters/fhir/__init__.py
@@ -1,0 +1,7 @@
+"""FHIR R4 export helpers for clinical resources."""
+
+from __future__ import annotations
+
+from .bundle import to_bundle
+
+__all__ = ["to_bundle"]

--- a/openmed/clinical/exporters/fhir/bundle.py
+++ b/openmed/clinical/exporters/fhir/bundle.py
@@ -1,0 +1,122 @@
+"""Assemble exported FHIR resources into a deterministic R4 transaction Bundle.
+
+Per-resource exporters emit standalone resources (``Condition``,
+``Observation``, ``DiagnosticReport``, ...). A FHIR server, however, ingests a
+single transaction *Bundle*, and the resources inside it must cross-reference
+one another through the Bundle (``Condition.subject`` -> Patient,
+``DiagnosticReport.result`` -> Observation, ``Observation.encounter`` ->
+Encounter).
+
+:func:`to_bundle` wraps a document's resources into a valid R4 Bundle:
+
+* every resource is given a stable ``urn:uuid`` ``fullUrl`` (seeded by
+  ``doc_id`` + resource index, so the output is byte-stable across runs);
+* every literal reference (``"ResourceType/id"``) that targets a resource
+  present in the Bundle is rewritten to point at that resource's ``fullUrl``,
+  so there are no dangling internal references;
+* for ``transaction``/``batch`` bundles, each entry carries the ``request``
+  block (``method``/``url``) a server needs to create the resource.
+
+The assembler is purely mechanical: it never synthesises resources (a Patient
+removed by de-identification stays absent) and does not validate profiles.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Mapping, Sequence
+
+__all__ = ["to_bundle"]
+
+# Fixed namespace so the generated ``urn:uuid`` values are reproducible across
+# runs and machines (uuid5 is a deterministic hash of namespace + name).
+_BUNDLE_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_URL, "https://openmed.ai/fhir/bundle")
+
+# Bundle types whose entries must carry a ``request`` block.
+_REQUEST_BUNDLE_TYPES = frozenset({"transaction", "batch"})
+
+
+def to_bundle(
+    resources: Sequence[Mapping[str, Any]],
+    *,
+    doc_id: str = "openmed-document",
+    bundle_type: str = "transaction",
+) -> dict[str, Any]:
+    """Assemble ``resources`` into a single R4 Bundle.
+
+    Parameters
+    ----------
+    resources:
+        The standalone FHIR resources to wrap, in the order they should appear
+        in the Bundle. Each must be a mapping carrying a ``resourceType``.
+    doc_id:
+        Stable identifier for the source document. Together with the resource
+        index it seeds the deterministic ``urn:uuid`` ``fullUrl`` of each
+        entry, so the same input always produces byte-identical output.
+    bundle_type:
+        The Bundle ``type`` (defaults to ``"transaction"``). For
+        ``transaction``/``batch`` bundles each entry also gets a ``request``
+        block.
+
+    Returns
+    -------
+    dict
+        A ``resourceType=Bundle`` mapping with one entry per resource.
+    """
+
+    entries: list[dict[str, Any]] = []
+    urns: list[str] = []
+    for index, resource in enumerate(resources):
+        if not isinstance(resource, Mapping) or "resourceType" not in resource:
+            raise ValueError(
+                f"resource at index {index} is not a FHIR resource "
+                "(missing 'resourceType')"
+            )
+        urns.append(_stable_urn(doc_id, index))
+
+    # Map ``"ResourceType/id"`` -> ``fullUrl`` so references can be resolved
+    # against the resources that are actually present in this Bundle.
+    reference_map: dict[str, str] = {}
+    for urn, resource in zip(urns, resources):
+        resource_id = resource.get("id")
+        if resource_id is not None:
+            reference_map[f"{resource['resourceType']}/{resource_id}"] = urn
+
+    emit_request = bundle_type in _REQUEST_BUNDLE_TYPES
+    for urn, resource in zip(urns, resources):
+        rewritten = _rewrite_references(resource, reference_map)
+        entry: dict[str, Any] = {"fullUrl": urn, "resource": rewritten}
+        if emit_request:
+            entry["request"] = {"method": "POST", "url": resource["resourceType"]}
+        entries.append(entry)
+
+    return {"resourceType": "Bundle", "type": bundle_type, "entry": entries}
+
+
+def _stable_urn(doc_id: str, index: int) -> str:
+    """Return a reproducible ``urn:uuid`` for ``doc_id`` at ``index``."""
+
+    name = f"{doc_id}:{index}"
+    return f"urn:uuid:{uuid.uuid5(_BUNDLE_NAMESPACE, name)}"
+
+
+def _rewrite_references(node: Any, reference_map: Mapping[str, str]) -> Any:
+    """Deep-copy ``node``, rewriting in-Bundle references to their ``fullUrl``.
+
+    Any ``{"reference": "ResourceType/id"}`` whose target is present in
+    ``reference_map`` is repointed at the corresponding ``urn:uuid``. References
+    to resources absent from the Bundle (e.g. a de-identified Patient) are left
+    untouched. The input is never mutated.
+    """
+
+    if isinstance(node, Mapping):
+        result: dict[str, Any] = {}
+        for key, value in node.items():
+            if key == "reference" and isinstance(value, str) and value in reference_map:
+                result[key] = reference_map[value]
+            else:
+                result[key] = _rewrite_references(value, reference_map)
+        return result
+    if isinstance(node, (list, tuple)):
+        return [_rewrite_references(item, reference_map) for item in node]
+    return node

--- a/openmed/clinical/exporters/fhir/bundle.py
+++ b/openmed/clinical/exporters/fhir/bundle.py
@@ -30,7 +30,10 @@ __all__ = ["to_bundle"]
 
 # Fixed namespace so the generated ``urn:uuid`` values are reproducible across
 # runs and machines (uuid5 is a deterministic hash of namespace + name).
-_BUNDLE_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_URL, "https://openmed.ai/fhir/bundle")
+_BUNDLE_NAMESPACE = uuid.uuid5(
+    uuid.NAMESPACE_URL,
+    "https://openmed.ai/fhir/bundle",
+)
 
 # Bundle types whose entries must carry a ``request`` block.
 _REQUEST_BUNDLE_TYPES = frozenset({"transaction", "batch"})
@@ -87,7 +90,10 @@ def to_bundle(
         rewritten = _rewrite_references(resource, reference_map)
         entry: dict[str, Any] = {"fullUrl": urn, "resource": rewritten}
         if emit_request:
-            entry["request"] = {"method": "POST", "url": resource["resourceType"]}
+            entry["request"] = {
+                "method": "POST",
+                "url": resource["resourceType"],
+            }
         entries.append(entry)
 
     return {"resourceType": "Bundle", "type": bundle_type, "entry": entries}
@@ -104,15 +110,19 @@ def _rewrite_references(node: Any, reference_map: Mapping[str, str]) -> Any:
     """Deep-copy ``node``, rewriting in-Bundle references to their ``fullUrl``.
 
     Any ``{"reference": "ResourceType/id"}`` whose target is present in
-    ``reference_map`` is repointed at the corresponding ``urn:uuid``. References
-    to resources absent from the Bundle (e.g. a de-identified Patient) are left
-    untouched. The input is never mutated.
+    ``reference_map`` is repointed at the corresponding ``urn:uuid``.
+    References to resources absent from the Bundle (e.g. a de-identified
+    Patient) are left untouched. The input is never mutated.
     """
 
     if isinstance(node, Mapping):
         result: dict[str, Any] = {}
         for key, value in node.items():
-            if key == "reference" and isinstance(value, str) and value in reference_map:
+            if (
+                key == "reference"
+                and isinstance(value, str)
+                and value in reference_map
+            ):
                 result[key] = reference_map[value]
             else:
                 result[key] = _rewrite_references(value, reference_map)

--- a/tests/unit/clinical/test_fhir_bundle.py
+++ b/tests/unit/clinical/test_fhir_bundle.py
@@ -1,0 +1,185 @@
+"""Tests for the FHIR R4 transaction Bundle assembler (OM-137)."""
+
+import json
+
+import pytest
+
+from openmed.clinical.exporters.fhir import to_bundle
+from openmed.clinical.exporters.fhir.bundle import _rewrite_references
+
+
+def _collect_references(node):
+    """Yield every ``reference`` string anywhere inside ``node``."""
+
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "reference" and isinstance(value, str):
+                yield value
+            else:
+                yield from _collect_references(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _collect_references(item)
+
+
+def _condition_observation_report():
+    """A minimal Condition + Observation + DiagnosticReport set.
+
+    ``DiagnosticReport.result`` points at the ``Observation`` and the
+    ``Condition.evidence`` cites it too, so every reference is internal.
+    """
+
+    observation = {
+        "resourceType": "Observation",
+        "id": "obs1",
+        "status": "final",
+        "code": {"text": "Glucose"},
+    }
+    report = {
+        "resourceType": "DiagnosticReport",
+        "id": "dr1",
+        "status": "final",
+        "result": [{"reference": "Observation/obs1"}],
+    }
+    condition = {
+        "resourceType": "Condition",
+        "id": "cond1",
+        "evidence": [{"detail": [{"reference": "Observation/obs1"}]}],
+    }
+    return [condition, observation, report]
+
+
+class TestBundleStructure:
+    def test_emits_transaction_bundle_with_one_entry_per_resource(self):
+        resources = _condition_observation_report()
+        bundle = to_bundle(resources, doc_id="doc-1")
+
+        assert bundle["resourceType"] == "Bundle"
+        assert bundle["type"] == "transaction"
+        assert len(bundle["entry"]) == len(resources)
+
+        for entry, resource in zip(bundle["entry"], resources):
+            assert entry["fullUrl"].startswith("urn:uuid:")
+            assert entry["resource"]["resourceType"] == resource["resourceType"]
+            assert entry["request"] == {
+                "method": "POST",
+                "url": resource["resourceType"],
+            }
+
+    def test_full_urls_are_unique(self):
+        bundle = to_bundle(_condition_observation_report(), doc_id="doc-1")
+        full_urls = [entry["fullUrl"] for entry in bundle["entry"]]
+        assert len(set(full_urls)) == len(full_urls)
+
+    def test_collection_bundle_has_no_request_block(self):
+        bundle = to_bundle(
+            _condition_observation_report(),
+            doc_id="doc-1",
+            bundle_type="collection",
+        )
+        assert bundle["type"] == "collection"
+        assert all("request" not in entry for entry in bundle["entry"])
+
+    def test_missing_resource_type_raises(self):
+        with pytest.raises(ValueError):
+            to_bundle([{"id": "x"}], doc_id="doc-1")
+
+
+class TestReferenceResolution:
+    def test_internal_references_rewritten_to_full_urls(self):
+        resources = _condition_observation_report()
+        bundle = to_bundle(resources, doc_id="doc-1")
+
+        full_urls = {entry["fullUrl"] for entry in bundle["entry"]}
+        observation_url = next(
+            entry["fullUrl"]
+            for entry in bundle["entry"]
+            if entry["resource"]["resourceType"] == "Observation"
+        )
+
+        report = next(
+            entry["resource"]
+            for entry in bundle["entry"]
+            if entry["resource"]["resourceType"] == "DiagnosticReport"
+        )
+        assert report["result"][0]["reference"] == observation_url
+
+        # No dangling references: every reference resolves to a fullUrl present
+        # in the Bundle.
+        references = list(_collect_references(bundle["entry"]))
+        assert references  # sanity: there are references to resolve
+        for reference in references:
+            assert reference in full_urls
+
+    def test_subject_result_encounter_all_resolved(self):
+        # A richer graph exercising the three reference fields called out by the
+        # issue (subject, result, encounter). The Patient/Encounter fixtures are
+        # only here to anchor those references; the assembler never synthesises
+        # them itself.
+        resources = [
+            {"resourceType": "Patient", "id": "pat1"},
+            {"resourceType": "Encounter", "id": "enc1",
+             "subject": {"reference": "Patient/pat1"}},
+            {"resourceType": "Condition", "id": "cond1",
+             "subject": {"reference": "Patient/pat1"},
+             "encounter": {"reference": "Encounter/enc1"}},
+            {"resourceType": "Observation", "id": "obs1",
+             "subject": {"reference": "Patient/pat1"},
+             "encounter": {"reference": "Encounter/enc1"}},
+            {"resourceType": "DiagnosticReport", "id": "dr1",
+             "subject": {"reference": "Patient/pat1"},
+             "result": [{"reference": "Observation/obs1"}]},
+        ]
+        bundle = to_bundle(resources, doc_id="patient-graph")
+
+        full_urls = {entry["fullUrl"] for entry in bundle["entry"]}
+        references = list(_collect_references(bundle["entry"]))
+        assert len(references) == 7
+        for reference in references:
+            assert reference.startswith("urn:uuid:")
+            assert reference in full_urls
+
+    def test_references_to_absent_resources_are_left_untouched(self):
+        # The targeted Patient is not part of the Bundle, so its reference is
+        # preserved verbatim rather than rewritten.
+        resources = [
+            {"resourceType": "Condition", "id": "cond1",
+             "subject": {"reference": "Patient/missing"}},
+        ]
+        bundle = to_bundle(resources, doc_id="doc-1")
+        condition = bundle["entry"][0]["resource"]
+        assert condition["subject"]["reference"] == "Patient/missing"
+
+    def test_input_resources_not_mutated(self):
+        resources = _condition_observation_report()
+        snapshot = json.dumps(resources, sort_keys=True)
+        to_bundle(resources, doc_id="doc-1")
+        assert json.dumps(resources, sort_keys=True) == snapshot
+
+
+class TestDeterminism:
+    def test_output_is_byte_stable_across_runs(self):
+        resources = _condition_observation_report()
+        first = to_bundle(resources, doc_id="doc-1")
+        second = to_bundle(resources, doc_id="doc-1")
+        assert json.dumps(first) == json.dumps(second)
+
+    def test_full_urls_seeded_by_doc_id_and_index(self):
+        resources = _condition_observation_report()
+        a = to_bundle(resources, doc_id="doc-A")
+        b = to_bundle(resources, doc_id="doc-B")
+        urls_a = [entry["fullUrl"] for entry in a["entry"]]
+        urls_b = [entry["fullUrl"] for entry in b["entry"]]
+        # Different document -> different urns; same document -> reproducible.
+        assert urls_a != urls_b
+        assert urls_a == [entry["fullUrl"] for entry in
+                          to_bundle(resources, doc_id="doc-A")["entry"]]
+
+
+def test_rewrite_references_is_pure_helper():
+    ref_map = {"Observation/obs1": "urn:uuid:abc"}
+    node = {"result": [{"reference": "Observation/obs1"}]}
+    rewritten = _rewrite_references(node, ref_map)
+    assert rewritten["result"][0]["reference"] == "urn:uuid:abc"
+    # original untouched
+    assert node["result"][0]["reference"] == "Observation/obs1"

--- a/tests/unit/clinical/test_fhir_bundle.py
+++ b/tests/unit/clinical/test_fhir_bundle.py
@@ -60,7 +60,10 @@ class TestBundleStructure:
 
         for entry, resource in zip(bundle["entry"], resources):
             assert entry["fullUrl"].startswith("urn:uuid:")
-            assert entry["resource"]["resourceType"] == resource["resourceType"]
+            assert (
+                entry["resource"]["resourceType"]
+                == resource["resourceType"]
+            )
             assert entry["request"] == {
                 "method": "POST",
                 "url": resource["resourceType"],
@@ -79,6 +82,19 @@ class TestBundleStructure:
         )
         assert bundle["type"] == "collection"
         assert all("request" not in entry for entry in bundle["entry"])
+
+    def test_batch_bundle_keeps_request_blocks(self):
+        resources = _condition_observation_report()
+        bundle = to_bundle(resources, doc_id="doc-1", bundle_type="batch")
+
+        assert bundle["type"] == "batch"
+        assert [
+            entry["request"]
+            for entry in bundle["entry"]
+        ] == [
+            {"method": "POST", "url": resource["resourceType"]}
+            for resource in resources
+        ]
 
     def test_missing_resource_type_raises(self):
         with pytest.raises(ValueError):
@@ -112,10 +128,10 @@ class TestReferenceResolution:
             assert reference in full_urls
 
     def test_subject_result_encounter_all_resolved(self):
-        # A richer graph exercising the three reference fields called out by the
-        # issue (subject, result, encounter). The Patient/Encounter fixtures are
-        # only here to anchor those references; the assembler never synthesises
-        # them itself.
+        # A richer graph exercising the three reference fields called out by
+        # the issue (subject, result, encounter). The Patient/Encounter
+        # fixtures are only here to anchor those references; the assembler
+        # never synthesises them itself.
         resources = [
             {"resourceType": "Patient", "id": "pat1"},
             {"resourceType": "Encounter", "id": "enc1",


### PR DESCRIPTION
Closes #302.

Adds `openmed.clinical.exporters.fhir.to_bundle`, which wraps a document's exported resources into a single R4 Bundle. Each entry gets a deterministic `urn:uuid` `fullUrl` (seeded by `doc_id` + resource index, so the output is byte-stable across runs); in-Bundle references (`subject`/`result`/`encounter`, and any other literal `ResourceType/id`) are rewritten to those URNs so there are no dangling internal references; and `transaction`/`batch` entries carry the `request` block a server needs to create each resource. References to resources absent from the Bundle (e.g. a de-identified Patient) are left untouched, and the input is never mutated. No new dependencies — stdlib `uuid` only.

Validation:
- `.venv/bin/python -m pytest tests/unit/clinical/test_fhir_bundle.py -q` → 11 passed
- `.venv/bin/python -m pytest tests/ -q` → 1448 passed, 22 skipped
- `.venv/bin/python -m bandit -r openmed/clinical/exporters/` → no issues