### PR TITLE
fix: use unique placeholders for repeated entity types in deidentify() (closes #222)

### DIFF
--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1070,6 +1070,7 @@ def _build_deidentification_result(
 
     deidentified = text
     mapping = {} if keep_mapping else None
+    entity_type_counts: dict[str, int] = {}
 
     for entity in redaction_entities:
         entity_method = _entity_redaction_method(entity, effective_method)
@@ -1083,6 +1084,23 @@ def _build_deidentification_result(
             lang=lang,
             anonymizer=anonymizer,
         )
+
+        # When the same placeholder would be produced for multiple entities
+        # (e.g. two PERSONs both masking to "[PERSON]"), append an occurrence
+        # counter so each mapping key is unique and round-trip is lossless.
+        if entity_method in ("mask", "remove") or (
+            entity_method == "shift_dates" and entity.entity_type != "DATE"
+        ):
+            etype = entity.entity_type
+            entity_type_counts[etype] = entity_type_counts.get(etype, 0) + 1
+            if entity_type_counts[etype] > 1:
+                # Insert counter before closing bracket for mask (e.g. [NAME_2])
+                # or append for non-bracket placeholders (e.g. remove returns "")
+                if redacted.endswith("]"):
+                    redacted = f"{redacted[:-1]}_{entity_type_counts[etype]}]"
+                elif redacted:
+                    redacted = f"{redacted}_{entity_type_counts[etype]}"
+
         entity.redacted_text = redacted
         if reversible_ids:
             entity.reversible_id = _build_reversible_id(

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1070,7 +1070,20 @@ def _build_deidentification_result(
 
     deidentified = text
     mapping = {} if keep_mapping else None
-    entity_type_counts: dict[str, int] = {}
+    entity_occurrence_indexes: dict[int, int] = {}
+    if keep_mapping:
+        entity_type_counts: dict[str, int] = {}
+        for entity in sorted(pii_entities, key=lambda e: e.start):
+            entity_method = _entity_redaction_method(entity, effective_method)
+            if entity_method == "mask" or (
+                entity_method == "shift_dates" and entity.entity_type != "DATE"
+            ):
+                entity_type_counts[entity.entity_type] = (
+                    entity_type_counts.get(entity.entity_type, 0) + 1
+                )
+                entity_occurrence_indexes[id(entity)] = entity_type_counts[
+                    entity.entity_type
+                ]
 
     for entity in redaction_entities:
         entity_method = _entity_redaction_method(entity, effective_method)
@@ -1085,21 +1098,14 @@ def _build_deidentification_result(
             anonymizer=anonymizer,
         )
 
-        # When the same placeholder would be produced for multiple entities
-        # (e.g. two PERSONs both masking to "[PERSON]"), append an occurrence
-        # counter so each mapping key is unique and round-trip is lossless.
-        if entity_method in ("mask", "remove") or (
-            entity_method == "shift_dates" and entity.entity_type != "DATE"
-        ):
-            etype = entity.entity_type
-            entity_type_counts[etype] = entity_type_counts.get(etype, 0) + 1
-            if entity_type_counts[etype] > 1:
-                # Insert counter before closing bracket for mask (e.g. [NAME_2])
-                # or append for non-bracket placeholders (e.g. remove returns "")
-                if redacted.endswith("]"):
-                    redacted = f"{redacted[:-1]}_{entity_type_counts[etype]}]"
-                elif redacted:
-                    redacted = f"{redacted}_{entity_type_counts[etype]}"
+        # Only make repeated placeholders unique for reversible mappings. Plain
+        # masking without keep_mapping keeps the legacy placeholder text.
+        occurrence_index = entity_occurrence_indexes.get(id(entity), 1)
+        if keep_mapping and redacted and occurrence_index > 1:
+            if redacted.endswith("]"):
+                redacted = f"{redacted[:-1]}_{occurrence_index}]"
+            else:
+                redacted = f"{redacted}_{occurrence_index}"
 
         entity.redacted_text = redacted
         if reversible_ids:

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1075,7 +1075,7 @@ def _build_deidentification_result(
         entity_type_counts: dict[str, int] = {}
         for entity in sorted(pii_entities, key=lambda e: e.start):
             entity_method = _entity_redaction_method(entity, effective_method)
-            if entity_method == "mask" or (
+            if entity_method in {"mask", "remove"} or (
                 entity_method == "shift_dates" and entity.entity_type != "DATE"
             ):
                 entity_type_counts[entity.entity_type] = (
@@ -1098,8 +1098,11 @@ def _build_deidentification_result(
             anonymizer=anonymizer,
         )
 
+        if keep_mapping and entity_method == "remove":
+            redacted = f"[{entity.entity_type}_REMOVED]"
+
         # Only make repeated placeholders unique for reversible mappings. Plain
-        # masking without keep_mapping keeps the legacy placeholder text.
+        # masking/removal without keep_mapping keeps the legacy redacted text.
         occurrence_index = entity_occurrence_indexes.get(id(entity), 1)
         if keep_mapping and redacted and occurrence_index > 1:
             if redacted.endswith("]"):

--- a/tests/unit/test_pii.py
+++ b/tests/unit/test_pii.py
@@ -1374,12 +1374,46 @@ class TestIntegration:
 
         deid_result = deidentify(original_text, method="mask", keep_mapping=True)
         # First NAME -> [NAME], second NAME -> [NAME_2]
-        assert "[NAME]" in deid_result.deidentified_text
-        assert "[NAME_2]" in deid_result.deidentified_text
+        assert deid_result.deidentified_text == "Dr. [NAME] met [NAME_2] today"
         assert deid_result.mapping is not None
 
         reidentified = reidentify(deid_result.deidentified_text, deid_result.mapping)
         assert reidentified == original_text
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_repeated_mask_without_mapping_keeps_default_placeholders(self, mock_extract):
+        """Repeated mask output is unchanged when no reversible mapping is requested."""
+        original_text = "Dr. Alice Smith met Bob Jones today"
+        mock_extract.return_value = PredictionResult(
+            text=original_text,
+            entities=[
+                EntityPrediction(
+                    text="Alice Smith",
+                    label="NAME",
+                    start=4,
+                    end=15,
+                    confidence=0.95,
+                ),
+                EntityPrediction(
+                    text="Bob Jones",
+                    label="NAME",
+                    start=20,
+                    end=29,
+                    confidence=0.93,
+                ),
+            ],
+            model_name="test",
+            timestamp=datetime.now().isoformat(),
+        )
+
+        deid_result = deidentify(original_text, method="mask", keep_mapping=False)
+
+        assert deid_result.deidentified_text == "Dr. [NAME] met [NAME] today"
+        assert [entity.redacted_text for entity in deid_result.pii_entities] == [
+            "[NAME]",
+            "[NAME]",
+        ]
+        assert deid_result.mapping is None
 
     @patch("openmed.core.pii.extract_pii")
     def test_roundtrip_two_dates_mask(self, mock_extract):
@@ -1440,6 +1474,43 @@ class TestIntegration:
 
         deid_result = deidentify(original_text, method="hash", keep_mapping=True)
         # Hash produces unique values per text, so no counter needed
+        reidentified = reidentify(deid_result.deidentified_text, deid_result.mapping)
+        assert reidentified == original_text
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_roundtrip_two_persons_replace(self, mock_extract):
+        """Test round-trip with two PERSON entities using replace method."""
+        original_text = "Alice Smith and Bob Jones"
+        mock_extract.return_value = PredictionResult(
+            text=original_text,
+            entities=[
+                EntityPrediction(
+                    text="Alice Smith",
+                    label="NAME",
+                    start=0,
+                    end=11,
+                    confidence=0.95,
+                ),
+                EntityPrediction(
+                    text="Bob Jones",
+                    label="NAME",
+                    start=16,
+                    end=25,
+                    confidence=0.93,
+                ),
+            ],
+            model_name="test",
+            timestamp=datetime.now().isoformat(),
+        )
+
+        deid_result = deidentify(
+            original_text,
+            method="replace",
+            keep_mapping=True,
+            consistent=True,
+            seed=123,
+        )
+
         reidentified = reidentify(deid_result.deidentified_text, deid_result.mapping)
         assert reidentified == original_text
 

--- a/tests/unit/test_pii.py
+++ b/tests/unit/test_pii.py
@@ -1358,3 +1358,107 @@ class TestIntegration:
         assert "method" in result_dict
         assert "timestamp" in result_dict
         assert "num_entities_redacted" in result_dict
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_roundtrip_two_persons_mask(self, mock_extract):
+        """Test round-trip with two distinct PERSON entities using mask (#204, #222)."""
+        original_text = "Dr. Alice Smith met Bob Jones today"
+        mock_extract.return_value = PredictionResult(
+            text=original_text,
+            entities=[
+                EntityPrediction(text="Alice Smith", label="NAME", start=4, end=15, confidence=0.95),
+                EntityPrediction(text="Bob Jones", label="NAME", start=20, end=29, confidence=0.93),
+            ],
+            model_name="test", timestamp=datetime.now().isoformat(),
+        )
+
+        deid_result = deidentify(original_text, method="mask", keep_mapping=True)
+        # First NAME -> [NAME], second NAME -> [NAME_2]
+        assert "[NAME]" in deid_result.deidentified_text
+        assert "[NAME_2]" in deid_result.deidentified_text
+        assert deid_result.mapping is not None
+
+        reidentified = reidentify(deid_result.deidentified_text, deid_result.mapping)
+        assert reidentified == original_text
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_roundtrip_two_dates_mask(self, mock_extract):
+        """Test round-trip with two distinct DATE entities using mask."""
+        original_text = "Born 1990-01-15 seen 2024-06-20"
+        mock_extract.return_value = PredictionResult(
+            text=original_text,
+            entities=[
+                EntityPrediction(text="1990-01-15", label="DATE", start=5, end=15, confidence=0.95),
+                EntityPrediction(text="2024-06-20", label="DATE", start=21, end=31, confidence=0.92),
+            ],
+            model_name="test", timestamp=datetime.now().isoformat(),
+        )
+
+        deid_result = deidentify(original_text, method="mask", keep_mapping=True)
+        assert "[DATE]" in deid_result.deidentified_text
+        assert "[DATE_2]" in deid_result.deidentified_text
+
+        reidentified = reidentify(deid_result.deidentified_text, deid_result.mapping)
+        assert reidentified == original_text
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_roundtrip_mixed_repeated_and_unique(self, mock_extract):
+        """Test round-trip with mixed repeated and unique entity types."""
+        original_text = "Alice and Bob called 555-1234 on 2024-01-01"
+        mock_extract.return_value = PredictionResult(
+            text=original_text,
+            entities=[
+                EntityPrediction(text="Alice", label="NAME", start=0, end=5, confidence=0.95),
+                EntityPrediction(text="Bob", label="NAME", start=10, end=13, confidence=0.93),
+                EntityPrediction(text="555-1234", label="PHONE", start=21, end=29, confidence=0.90),
+                EntityPrediction(text="2024-01-01", label="DATE", start=33, end=43, confidence=0.91),
+            ],
+            model_name="test", timestamp=datetime.now().isoformat(),
+        )
+
+        deid_result = deidentify(original_text, method="mask", keep_mapping=True)
+        assert "[NAME]" in deid_result.deidentified_text
+        assert "[NAME_2]" in deid_result.deidentified_text
+        assert "[PHONE]" in deid_result.deidentified_text
+        assert "[DATE]" in deid_result.deidentified_text
+
+        reidentified = reidentify(deid_result.deidentified_text, deid_result.mapping)
+        assert reidentified == original_text
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_roundtrip_two_persons_hash(self, mock_extract):
+        """Test round-trip with two PERSON entities using hash method."""
+        original_text = "Alice Smith and Bob Jones"
+        mock_extract.return_value = PredictionResult(
+            text=original_text,
+            entities=[
+                EntityPrediction(text="Alice Smith", label="NAME", start=0, end=11, confidence=0.95),
+                EntityPrediction(text="Bob Jones", label="NAME", start=16, end=25, confidence=0.93),
+            ],
+            model_name="test", timestamp=datetime.now().isoformat(),
+        )
+
+        deid_result = deidentify(original_text, method="hash", keep_mapping=True)
+        # Hash produces unique values per text, so no counter needed
+        reidentified = reidentify(deid_result.deidentified_text, deid_result.mapping)
+        assert reidentified == original_text
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_roundtrip_single_entity_unchanged(self, mock_extract):
+        """Test that single entities still produce simple placeholders (no counter)."""
+        original_text = "Patient John Doe"
+        mock_extract.return_value = PredictionResult(
+            text=original_text,
+            entities=[
+                EntityPrediction(text="John Doe", label="NAME", start=8, end=16, confidence=0.95),
+            ],
+            model_name="test", timestamp=datetime.now().isoformat(),
+        )
+
+        deid_result = deidentify(original_text, method="mask", keep_mapping=True)
+        # Single entity should NOT have a counter suffix
+        assert deid_result.deidentified_text == "Patient [NAME]"
+        assert "[NAME_2]" not in deid_result.deidentified_text
+
+        reidentified = reidentify(deid_result.deidentified_text, deid_result.mapping)
+        assert reidentified == original_text

--- a/tests/unit/test_pii.py
+++ b/tests/unit/test_pii.py
@@ -1515,6 +1515,42 @@ class TestIntegration:
         assert reidentified == original_text
 
     @patch("openmed.core.pii.extract_pii")
+    def test_roundtrip_two_persons_remove(self, mock_extract):
+        """Test round-trip with two PERSON entities using remove method."""
+        original_text = "Alice Smith and Bob Jones"
+        mock_extract.return_value = PredictionResult(
+            text=original_text,
+            entities=[
+                EntityPrediction(
+                    text="Alice Smith",
+                    label="NAME",
+                    start=0,
+                    end=11,
+                    confidence=0.95,
+                ),
+                EntityPrediction(
+                    text="Bob Jones",
+                    label="NAME",
+                    start=16,
+                    end=25,
+                    confidence=0.93,
+                ),
+            ],
+            model_name="test",
+            timestamp=datetime.now().isoformat(),
+        )
+
+        deid_result = deidentify(original_text, method="remove", keep_mapping=True)
+
+        assert deid_result.deidentified_text == "[NAME_REMOVED] and [NAME_REMOVED_2]"
+        assert deid_result.mapping == {
+            "[NAME_REMOVED]": "Alice Smith",
+            "[NAME_REMOVED_2]": "Bob Jones",
+        }
+        reidentified = reidentify(deid_result.deidentified_text, deid_result.mapping)
+        assert reidentified == original_text
+
+    @patch("openmed.core.pii.extract_pii")
     def test_roundtrip_single_entity_unchanged(self, mock_extract):
         """Test that single entities still produce simple placeholders (no counter)."""
         original_text = "Patient John Doe"


### PR DESCRIPTION
## Summary
Fixes `reidentify()` round-trip behavior for repeated entity types when `deidentify(..., keep_mapping=True)` stores reversible mappings.

The branch keeps plain mask/remove output unchanged when `keep_mapping=False`, assigns repeated placeholders in document order for reversible mappings, and includes regression coverage for mask, remove, hash, and replace round-trips.

Closes #222.

## Verification
- `.venv/bin/python -m pytest tests/unit/test_pii.py -q` (112 passed)
- `.venv/bin/python -m pytest tests/ -q` (1557 passed, 1 skipped)