### PR TITLE
Add the LangChain redaction wrapper integration spike

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -56,6 +56,7 @@ You can find these directly in the docs:
 
 - [Analyze Text Helper](./analyze-text.md) — dict/JSON/HTML/CSV outputs with metadata.
 - [REST Service (MVP)](./rest-service.md) — FastAPI endpoints and Docker runbook.
+- [LangChain Redaction Wrapper](./integrations-langchain.md) — RAG context redaction before model calls.
 - [MLX Backend](./mlx-backend.md) — Apple Silicon Python runtime and artifact packaging.
 - [OpenMedKit (Swift)](./swift-openmedkit.md) — native app runtime for macOS, iOS, and iPadOS.
 - [ModelLoader & Pipelines](./model-loader.md) — caching, token helpers, multi-model setups.

--- a/docs/integrations-langchain.md
+++ b/docs/integrations-langchain.md
@@ -1,0 +1,77 @@
+# LangChain Redaction Wrapper
+
+OpenMed can run local de-identification as a chain stage so retrieved context is redacted before it reaches a model call. The integration is optional: importing `openmed` or `openmed.interop` does not import LangChain, and the runnable factory only needs the `langchain` extra when you create a runnable.
+
+```bash
+pip install "openmed[langchain]"
+```
+
+## Redact retrieved context before prompting
+
+The wrapper accepts strings, LangChain `Document` objects, lists or tuples of those values, and mapping payloads. This makes it useful in RAG pipelines where a retriever returns documents and a downstream prompt consumes their `page_content`.
+
+```python
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnablePassthrough
+
+from openmed.interop.langchain import create_redaction_runnable
+
+redact_context = create_redaction_runnable()
+
+prompt = ChatPromptTemplate.from_template(
+    "Use only the redacted clinical context below.\n\n"
+    "Context:\n{context}\n\n"
+    "Question: {question}"
+)
+
+chain = (
+    {
+        "context": retriever | redact_context,
+        "question": RunnablePassthrough(),
+    }
+    | prompt
+    | model
+)
+
+response = chain.invoke("What follow-up is documented for this patient?")
+```
+
+`create_redaction_runnable()` uses `openmed.core.pii.deidentify` with masking defaults. Tune those settings by passing `LangChainRedactionConfig`.
+
+```python
+from openmed.interop.langchain import (
+    LangChainRedactionConfig,
+    create_redaction_runnable,
+)
+
+redact_context = create_redaction_runnable(
+    config=LangChainRedactionConfig(
+        method="mask",
+        confidence_threshold=0.6,
+        lang="en",
+        use_safety_sweep=True,
+    )
+)
+```
+
+## Redact a specific payload field
+
+For chains that pass dictionaries between stages, set `input_key` to redact only the field that may contain PHI. Other fields, such as the user question, stay unchanged.
+
+```python
+from openmed.interop.langchain import create_redaction_runnable
+
+redact_payload = create_redaction_runnable(input_key="context")
+
+payload = redact_payload.invoke(
+    {
+        "context": "Patient Jane Roe called from jane.roe@example.com.",
+        "question": "Summarize the follow-up.",
+    }
+)
+
+assert payload["context"] == "Patient [PERSON] called from [EMAIL]."
+assert payload["question"] == "Summarize the follow-up."
+```
+
+Use the dependency-light `create_redaction_transform()` in tests or non-LangChain orchestration. It exposes `invoke`, `batch`, and `transform` without importing optional chain packages.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
   - PII & De-identification:
       - PII Anonymization: anonymization.md
       - Smart Entity Merging: pii-smart-merging.md
+      - LangChain Redaction Wrapper: integrations-langchain.md
       - Compliance Posture: compliance.md
       - FHIR Interop Helpers: fhir-interop.md
   - Apple Silicon & Mobile:

--- a/openmed/interop/__init__.py
+++ b/openmed/interop/__init__.py
@@ -23,6 +23,12 @@ class AdapterSpec:
 
 
 _ADAPTERS: Final[dict[str, AdapterSpec]] = {
+    "langchain": AdapterSpec(
+        name="langchain",
+        module="openmed.interop.langchain",
+        extra="langchain",
+        description="LangChain redaction runnable adapter",
+    ),
     "presidio": AdapterSpec(
         name="presidio",
         module="openmed.interop.presidio",

--- a/openmed/interop/langchain.py
+++ b/openmed/interop/langchain.py
@@ -1,0 +1,244 @@
+"""LangChain-compatible redaction transforms backed by OpenMed de-identification."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from copy import copy
+from dataclasses import dataclass, field
+from importlib import import_module as _import_module
+from pathlib import Path
+from typing import Any
+
+Deidentifier = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class LangChainRedactionConfig:
+    """Runtime options forwarded to OpenMed's de-identification engine."""
+
+    method: str = "mask"
+    model_name: str | None = None
+    confidence_threshold: float = 0.7
+    keep_year: bool = True
+    keep_mapping: bool = False
+    use_smart_merging: bool = True
+    lang: str = "en"
+    normalize_accents: bool | None = None
+    use_safety_sweep: bool = True
+    consistent: bool = False
+    seed: int | None = None
+    locale: str | None = None
+    policy: str | None = None
+    calibration_thresholds_path: str | Path | None = None
+    extra_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_deidentify_kwargs(self) -> dict[str, Any]:
+        """Return keyword arguments for ``openmed.core.pii.deidentify``."""
+
+        kwargs: dict[str, Any] = {
+            "method": self.method,
+            "confidence_threshold": self.confidence_threshold,
+            "keep_year": self.keep_year,
+            "keep_mapping": self.keep_mapping,
+            "use_smart_merging": self.use_smart_merging,
+            "lang": self.lang,
+            "normalize_accents": self.normalize_accents,
+            "use_safety_sweep": self.use_safety_sweep,
+            "consistent": self.consistent,
+            "seed": self.seed,
+            "locale": self.locale,
+            "policy": self.policy,
+            "calibration_thresholds_path": self.calibration_thresholds_path,
+        }
+        if self.model_name is not None:
+            kwargs["model_name"] = self.model_name
+
+        kwargs.update(dict(self.extra_kwargs))
+        return {key: value for key, value in kwargs.items() if value is not None}
+
+
+class OpenMedRedactionTransform:
+    """Redact strings, documents, lists, and mapping payloads before a chain call."""
+
+    def __init__(
+        self,
+        *,
+        config: LangChainRedactionConfig | None = None,
+        input_key: str | None = None,
+        output_key: str | None = None,
+        deidentifier: Deidentifier | None = None,
+    ) -> None:
+        self.config = config or LangChainRedactionConfig()
+        self.input_key = input_key
+        self.output_key = output_key
+        self._deidentifier = deidentifier
+
+    def invoke(
+        self,
+        input: Any,
+        config: Any | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Redact one input payload using the LangChain ``Runnable`` signature."""
+
+        del config, kwargs
+        return self._redact_value(input)
+
+    def batch(
+        self,
+        inputs: Sequence[Any],
+        config: Any | None = None,
+        **kwargs: Any,
+    ) -> list[Any]:
+        """Redact a batch of payloads using LangChain's synchronous batch shape."""
+
+        del config, kwargs
+        return [self.invoke(item) for item in inputs]
+
+    def transform(
+        self,
+        input: Iterable[Any],
+        config: Any | None = None,
+        **kwargs: Any,
+    ) -> Iterable[Any]:
+        """Yield redacted payloads for streaming-style chain stages."""
+
+        del config, kwargs
+        for item in input:
+            yield self.invoke(item)
+
+    def as_runnable(self, *, name: str = "openmed_redaction") -> Any:
+        """Return a LangChain ``RunnableLambda`` wrapping this transform."""
+
+        runnable_lambda = _load_runnable_lambda()
+        return runnable_lambda(self.invoke, name=name)
+
+    def _redact_value(self, value: Any) -> Any:
+        if isinstance(value, str):
+            return self._redact_text(value)
+        if _is_document_like(value):
+            return self._redact_document(value)
+        if isinstance(value, Mapping):
+            return self._redact_mapping(value)
+        if isinstance(value, list):
+            return [self._redact_value(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self._redact_value(item) for item in value)
+        return value
+
+    def _redact_mapping(self, value: Mapping[str, Any]) -> dict[str, Any]:
+        payload = dict(value)
+        if self.input_key is None:
+            return {key: self._redact_value(item) for key, item in payload.items()}
+
+        if self.input_key not in payload:
+            raise KeyError(
+                f"input key {self.input_key!r} not found in LangChain payload"
+            )
+
+        target_key = self.output_key or self.input_key
+        payload[target_key] = self._redact_value(payload[self.input_key])
+        return payload
+
+    def _redact_document(self, value: Any) -> Any:
+        redacted_content = self._redact_text(str(value.page_content))
+        if hasattr(value, "model_copy"):
+            return value.model_copy(update={"page_content": redacted_content})
+        if hasattr(value, "copy"):
+            return value.copy(update={"page_content": redacted_content})
+
+        cloned = copy(value)
+        cloned.page_content = redacted_content
+        return cloned
+
+    def _redact_text(self, text: str) -> str:
+        if text == "":
+            return text
+
+        result = self._deidentifier_or_default()(
+            text,
+            **self.config.to_deidentify_kwargs(),
+        )
+        if isinstance(result, str):
+            return result
+
+        try:
+            return str(result.deidentified_text)
+        except AttributeError as exc:
+            raise TypeError(
+                "deidentifier must return a string or an object with deidentified_text"
+            ) from exc
+
+    def _deidentifier_or_default(self) -> Deidentifier:
+        if self._deidentifier is not None:
+            return self._deidentifier
+
+        from openmed.core.pii import deidentify
+
+        return deidentify
+
+
+def create_redaction_transform(
+    *,
+    config: LangChainRedactionConfig | None = None,
+    input_key: str | None = None,
+    output_key: str | None = None,
+    deidentifier: Deidentifier | None = None,
+) -> OpenMedRedactionTransform:
+    """Create a dependency-light transform that can be wrapped as a runnable."""
+
+    return OpenMedRedactionTransform(
+        config=config,
+        input_key=input_key,
+        output_key=output_key,
+        deidentifier=deidentifier,
+    )
+
+
+def create_redaction_runnable(
+    *,
+    config: LangChainRedactionConfig | None = None,
+    input_key: str | None = None,
+    output_key: str | None = None,
+    deidentifier: Deidentifier | None = None,
+    name: str = "openmed_redaction",
+) -> Any:
+    """Create a LangChain runnable that redacts payloads before downstream steps."""
+
+    transform = create_redaction_transform(
+        config=config,
+        input_key=input_key,
+        output_key=output_key,
+        deidentifier=deidentifier,
+    )
+    return transform.as_runnable(name=name)
+
+
+def _load_runnable_lambda() -> Any:
+    try:
+        module = _import_module("langchain_core.runnables")
+    except ImportError as exc:
+        raise ImportError(
+            "LangChain support requires the 'langchain' extra. "
+            "Install with `pip install openmed[langchain]`."
+        ) from exc
+
+    try:
+        return module.RunnableLambda
+    except AttributeError as exc:
+        raise ImportError(
+            "LangChain support requires langchain-core with RunnableLambda."
+        ) from exc
+
+
+def _is_document_like(value: Any) -> bool:
+    return hasattr(value, "page_content") and isinstance(value.page_content, str)
+
+
+__all__ = [
+    "Deidentifier",
+    "LangChainRedactionConfig",
+    "OpenMedRedactionTransform",
+    "create_redaction_runnable",
+    "create_redaction_transform",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,10 @@ ocr-paddle = [
   "paddleocr>=2.7",
 ]
 
+langchain = [
+  "langchain-core>=0.2,<1",
+]
+
 hf = [
   "transformers>=4.50",
   "huggingface-hub>=0.30",

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -60,6 +60,7 @@ REVIEWED_LICENSES = {
     "griffe": "ISC",
     "huggingface-hub": "Apache-2.0",
     "httpx": "BSD-3-Clause",
+    "langchain-core": "MIT",
     "mcp": "MIT",
     "mkdocs": "BSD-2-Clause",
     "mkdocs-git-revision-date-localized-plugin": "MIT",

--- a/tests/unit/interop/test_langchain_redaction.py
+++ b/tests/unit/interop/test_langchain_redaction.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from openmed.interop import adapter_spec, available_adapters, get_adapter
+from openmed.interop import langchain as langchain_adapter
+
+
+class RunnableLambdaLike:
+    def __init__(self, func, name=None):
+        self.func = func
+        self.name = name
+
+    def invoke(self, value, config=None, **kwargs):
+        return self.func(value, config=config, **kwargs)
+
+    def __or__(self, other):
+        return ChainLike(self, other)
+
+
+class ChainLike:
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def invoke(self, value):
+        redacted = self.left.invoke(value)
+        return self.right.invoke(redacted)
+
+
+class CaptureModel:
+    def __init__(self):
+        self.seen = None
+
+    def invoke(self, value):
+        self.seen = value
+        return "model-result"
+
+
+@dataclass
+class DocumentLike:
+    page_content: str
+    metadata: dict[str, str]
+
+    def copy(self, update=None):
+        values = {
+            "page_content": self.page_content,
+            "metadata": dict(self.metadata),
+        }
+        values.update(update or {})
+        return DocumentLike(**values)
+
+
+def fake_deidentify(text: str, **kwargs):
+    assert kwargs["method"] == "mask"
+    redacted = (
+        text.replace("Jane Roe", "[PERSON]")
+        .replace("jane.roe@example.com", "[EMAIL]")
+        .replace("555-0100", "[PHONE]")
+    )
+    return SimpleNamespace(deidentified_text=redacted)
+
+
+def test_registry_loads_langchain_adapter_lazily():
+    adapter = get_adapter("langchain")
+
+    assert adapter is langchain_adapter
+    assert "langchain" in available_adapters()
+    assert adapter_spec("langchain").extra == "langchain"
+    assert hasattr(adapter, "create_redaction_runnable")
+
+
+def test_create_redaction_runnable_raises_clear_error_without_extra(monkeypatch):
+    def missing_dependency(name: str):
+        raise ImportError(name)
+
+    monkeypatch.setattr(langchain_adapter, "_import_module", missing_dependency)
+
+    with pytest.raises(ImportError, match=r"openmed\[langchain\]"):
+        langchain_adapter.create_redaction_runnable(deidentifier=fake_deidentify)
+
+
+def test_chain_style_flow_redacts_text_before_model(monkeypatch):
+    monkeypatch.setattr(
+        langchain_adapter,
+        "_import_module",
+        lambda name: SimpleNamespace(RunnableLambda=RunnableLambdaLike),
+    )
+    model = CaptureModel()
+    runnable = langchain_adapter.create_redaction_runnable(
+        deidentifier=fake_deidentify,
+    )
+
+    chain = runnable | model
+    result = chain.invoke(
+        "Patient Jane Roe can be reached at jane.roe@example.com or 555-0100."
+    )
+
+    assert result == "model-result"
+    assert model.seen == "Patient [PERSON] can be reached at [EMAIL] or [PHONE]."
+    assert "Jane Roe" not in model.seen
+    assert "jane.roe@example.com" not in model.seen
+
+
+def test_redaction_transform_handles_rag_document_payloads():
+    transform = langchain_adapter.create_redaction_transform(
+        input_key="context",
+        deidentifier=fake_deidentify,
+    )
+    document = DocumentLike(
+        page_content="Patient Jane Roe called from 555-0100.",
+        metadata={"source": "fixture"},
+    )
+
+    payload = transform.invoke(
+        {
+            "context": [document],
+            "question": "Summarize follow-up.",
+        }
+    )
+
+    assert payload["context"][0].page_content == "Patient [PERSON] called from [PHONE]."
+    assert payload["context"][0].metadata == {"source": "fixture"}
+    assert payload["question"] == "Summarize follow-up."
+    assert document.page_content == "Patient Jane Roe called from 555-0100."


### PR DESCRIPTION
Closes #165.

## Summary
- adds an optional LangChain-compatible redaction transform/runnable backed by OpenMed de-identification
- supports string, document-like, sequence, and mapping payloads for chain-style and RAG-style flows
- keeps LangChain behind the optional `langchain` extra and lazy adapter registry
- documents redaction-before-model usage in a RAG-style example
- adds tests for optional import behavior and redaction before downstream model invocation

## Validation
- `.venv/bin/python -m pytest tests/unit/interop/test_langchain_redaction.py tests/unit/interop/test_core_does_not_import_adapters.py tests/unit/release/test_license_policy.py -q`
- `.venv/bin/python scripts/release/check_repo_policy.py`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `make docs-build`
- `.venv/bin/python -m pytest tests/ -q`