### PR TITLE
Define the nightly trust results schema

### DIFF
--- a/docs/status/open-benchmark-publication.md
+++ b/docs/status/open-benchmark-publication.md
@@ -1,0 +1,120 @@
+# Open Benchmark Publication Plan
+
+This plan defines the open, reproducible publication surface for the trust
+status epic. It is not a closed leaderboard: every published number must trace
+back to committed result JSON, a reproducibility hash, and the renderer that
+turned those inputs into a page.
+
+## Current Public Artifacts
+
+| Artifact | Role |
+|---|---|
+| `models.jsonl` | Canonical model manifest and release metadata. |
+| `gates/baseline.json` | Last-green baseline store per family, tier, and format. |
+| `docs/benchmarks/golden.report.json` | Committed benchmark report evidence. |
+| `docs/benchmarks/golden.md` | Human-readable benchmark card generated from the report. |
+| `docs/status/index.md` | Trust status page generated from manifest, baseline, and reports. |
+| `docs/leaderboard/index.md` | Open benchmark publication table generated from the same sources. |
+| `scripts/status/generate_status.py` | Renderer that keeps status, benchmark cards, and publication rows aligned. |
+
+## Publication Principles
+
+- Source data is committed and inspectable.
+- Result pages are generated from JSON inputs, not hand-edited claims.
+- Rows represent reproducible benchmark evidence rather than private rankings.
+- Competitor or baseline rows without source reports must say that evidence is
+  unavailable rather than implying a measured result.
+- No raw clinical text, private corpus rows, or unreleasable identifiers are
+  committed.
+
+## Result Row Contract
+
+Open publication rows reuse the status contract in
+`docs/status/trust-status-contract.md`.
+Each published row must include or derive:
+
+| Field | Meaning |
+|---|---|
+| `family` | Model family. |
+| `tier` | Model tier, or `null`. |
+| `device` | Runtime used by the harness. |
+| `format` | Published artifact format. |
+| `current_leakage` | Decimal leakage rate from `BenchmarkReport.metrics`. |
+| `last_green_release` | Last passing release date from `gates/baseline.json`. |
+| `last_regression` | Most recent known regression date, if any. |
+| `last_rollback` | Rollback date for the latest known regression, if any. |
+| `harness_freshness` | `BenchmarkReport.generated_at` for the newest successful run. |
+| `evidence` | Report suite or committed artifact path. |
+| `reproducibility_hash` | `sha256:<64 lower hex>` hash for the recipe, data manifest, base model, and `git_sha`. |
+
+## Reproducibility Hash Convention
+
+Use `openmed.core.repro_hash.compute_reproducibility_hash` and store the
+result as `sha256:<64 lower hex>`. The canonical payload has exactly these
+top-level inputs:
+
+```json
+{
+  "base_model": "...",
+  "data_manifest": {},
+  "git_sha": "abc123",
+  "recipe": {}
+}
+```
+
+The function sorts mapping keys, preserves list order, sorts sets by
+representation, hashes bytes, hashes file paths by content, and hashes
+directories by their sorted file list. This makes equivalent recipe and data
+manifest dictionaries produce the same hash even when keys are written in a
+different order.
+
+## Publish And Refresh Flow
+
+1. Produce or refresh one or more `BenchmarkReport` JSON files.
+2. Update `models.jsonl` and `gates/baseline.json` only through the release
+   helpers that validate schema and hash format.
+3. Regenerate the public artifacts:
+
+   ```bash
+   .venv/bin/python scripts/status/generate_status.py \
+     --report docs/benchmarks/golden.report.json
+   ```
+
+4. Review the generated diff for source paths, hashes, leakage, last-green
+   dates, regression and rollback metadata, and freshness.
+5. Run the repository test suite:
+
+   ```bash
+   .venv/bin/python -m pytest tests/ -q
+   ```
+
+6. Publish only the committed JSON and generated pages. Do not publish manually
+   edited result rows.
+
+## Child Issue Handoff
+
+The epic has been decomposed into independently mergeable slices:
+
+- #374 defines the nightly trust-results schema and publication contract.
+- #375 renders the trust status page from nightly results.
+- #376 selects the public status hosting surface.
+- #377 adds the nightly trust status refresh.
+- #378 publishes the first open SHIELD baseline results.
+
+The current repository already publishes the committed golden baseline through
+`docs/benchmarks/golden.report.json`, `docs/benchmarks/golden.md`,
+`docs/status/index.md`, and `docs/leaderboard/index.md`. #378 is responsible
+for adding the first SHIELD baseline numbers once the scheduled status path and
+hosting decision are in place.
+
+## Review Checklist
+
+Before a publication update is accepted:
+
+- every new result has committed JSON evidence;
+- every measured row has `harness_freshness`;
+- every release or benchmark row has a valid `reproducibility_hash`;
+- every hash input is documented enough for another maintainer to recompute it;
+- generated pages are reproducible from the committed inputs;
+- the update does not convert the open results table into a closed or gated
+  leaderboard.

--- a/docs/status/trust-status-contract.md
+++ b/docs/status/trust-status-contract.md
@@ -1,0 +1,133 @@
+# Trust Status Contract
+
+This document defines the committed contract for the trust status surface.
+The rendered page at `docs/status/index.md` is produced by
+`scripts/status/generate_status.py` from repository-owned inputs. The next
+renderer slice is tracked in #375 and should consume this contract rather than
+introducing a second status shape.
+
+## Source Inputs
+
+| Input | Current path | Role |
+|---|---|---|
+| Model manifest | `models.jsonl` | Canonical model family, tier, format, release, and manifest reproducibility data. |
+| Last-green baseline store | `gates/baseline.json` | Release baseline per family, tier, and format. |
+| Benchmark reports | `docs/benchmarks/*.report.json` | Latest harness metrics and run timestamp for each tested model. |
+| Status renderer | `scripts/status/generate_status.py` | Joins the manifest, baseline store, and reports into status and leaderboard rows. |
+
+The row key is `baseline_key(family, tier, format)` from
+`openmed.core.baseline`. Key parts are lowercased, `_` is normalized to `-`,
+and a missing tier is stored as `none`.
+
+## Required Row Fields
+
+Each status row is keyed by family, tier, and format. A future nightly JSON
+bundle may denormalize the values below, but it must keep these names and
+meanings stable:
+
+| Field | Required | Source | Meaning |
+|---|---:|---|---|
+| `key` | yes | `baseline_key(...)` | Stable join key for baseline and report lookups. |
+| `family` | yes | `models.jsonl` | Model family displayed on status and publication pages. |
+| `tier` | yes | `models.jsonl` | Model tier, or `null` when the manifest has no tier. |
+| `device` | yes | `BenchmarkReport.device` | Device or runtime used by the latest harness report. |
+| `format` | yes | `models.jsonl` / report metadata | Artifact format that the row represents. |
+| `model_count` | yes | manifest aggregate | Number of manifest rows in this family, tier, and format group. |
+| `current_leakage` | yes | `metrics.leakage.overall` or `metrics.leakage_rate.overall` | Decimal leakage rate in the range `[0, 1]`; render as a percent. |
+| `last_green_release` | yes | baseline `released` | Last release date that passed gates, formatted as `YYYY-MM-DD`. |
+| `last_regression` | yes | baseline `metadata.last_regression` | Most recent known regression date, or `null`. |
+| `last_rollback` | yes | baseline `metadata.last_rollback` | Rollback date for the latest known regression, or `null`. |
+| `harness_freshness` | yes | `BenchmarkReport.generated_at` | Timestamp for the latest successful harness run, formatted as UTC ISO 8601. |
+| `status` | yes | renderer | `green`, `amber`, or `red`. |
+| `evidence` | yes | report suite / artifact path | Human-inspectable evidence for the row, such as `golden` or a report path. |
+| `reproducibility_hash` | yes | manifest or baseline | Stable `sha256:<64 lower hex>` hash for the release or benchmark row. |
+
+Missing report data currently renders as `n/a` and `amber`. The scheduled
+nightly refresh should fail clearly when a required input is malformed or when
+freshness is older than the accepted nightly window.
+
+## Nightly Bundle Shape
+
+The nightly job may write a bundle for downstream static rendering. It should be
+deterministic JSON with sorted keys and no raw clinical text:
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-14T00:00:00Z",
+  "source_revision": "abc123",
+  "inputs": {
+    "baseline": "gates/baseline.json",
+    "manifest": "models.jsonl",
+    "reports": ["docs/benchmarks/golden.report.json"]
+  },
+  "rows": [
+    {
+      "current_leakage": 0.0,
+      "device": "mlx-fp",
+      "evidence": "golden",
+      "family": "PII",
+      "format": "mlx-fp",
+      "harness_freshness": "2026-06-14T00:00:00Z",
+      "key": "pii::small::mlx-fp",
+      "last_green_release": "2026-04-14",
+      "last_regression": null,
+      "last_rollback": null,
+      "model_count": 50,
+      "reproducibility_hash": "sha256:4818bdef580eb406f5cc665cc0892aefab1fd90c8743822d843dd48f135bde34",
+      "status": "green",
+      "tier": "Small"
+    }
+  ]
+}
+```
+
+Rows are sorted by `key`. Consumers must ignore unknown fields so future
+children can add latency, RAM, confidence intervals, or device-tier metadata
+without breaking the status page.
+
+## Reproducibility Hash
+
+Use `openmed.core.repro_hash.compute_reproducibility_hash` for benchmark and
+release rows. The hash is:
+
+```text
+sha256(canonical_json({
+  "base_model": base_model,
+  "data_manifest": data_manifest,
+  "git_sha": git_sha,
+  "recipe": recipe
+}))
+```
+
+Normalization is the implementation in `openmed/core/repro_hash.py`:
+
+- mappings are sorted by string key;
+- lists and tuples keep order;
+- sets are sorted by representation;
+- bytes are replaced by their SHA-256 digest;
+- file paths are represented by path plus file digest;
+- directory paths are represented by path plus a sorted list of file digests.
+
+The stored value must use the form `sha256:<64 lower hex>`. The input
+components are intentionally explicit:
+
+- `recipe`: training, conversion, quantization, or evaluation recipe;
+- `data_manifest`: dataset name, split, revision, filters, and fixture digest;
+- `base_model`: source model identifier or immutable local model digest;
+- `git_sha`: repository revision that produced the artifact or benchmark row.
+
+## Relationship To Current Outputs
+
+The current status and publication outputs already reuse the OM-021/#104
+renderer:
+
+- `docs/status/index.md` renders the status table fields from manifest,
+  baseline, and `BenchmarkReport` inputs.
+- `docs/leaderboard/index.md` renders the open benchmark rows from the same
+  source inputs.
+- `docs/benchmarks/golden.report.json` and `docs/benchmarks/golden.md` provide
+  committed report evidence for the current golden harness row.
+
+#375 should make the status rendering job read a nightly bundle with this shape
+while preserving the current generated status columns.

--- a/tests/unit/eval/test_status_publication_contract.py
+++ b/tests/unit/eval/test_status_publication_contract.py
@@ -1,0 +1,81 @@
+"""Tests for the documented status and publication contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+STATUS_CONTRACT = ROOT / "docs" / "status" / "trust-status-contract.md"
+PUBLICATION_PLAN = ROOT / "docs" / "status" / "open-benchmark-publication.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_status_contract_documents_required_row_fields() -> None:
+    text = _read(STATUS_CONTRACT)
+
+    for field in (
+        "key",
+        "family",
+        "tier",
+        "device",
+        "format",
+        "model_count",
+        "current_leakage",
+        "last_green_release",
+        "last_regression",
+        "last_rollback",
+        "harness_freshness",
+        "status",
+        "evidence",
+        "reproducibility_hash",
+    ):
+        assert f"`{field}`" in text
+
+    for source_path in (
+        "models.jsonl",
+        "gates/baseline.json",
+        "docs/benchmarks/golden.report.json",
+        "docs/status/index.md",
+        "docs/leaderboard/index.md",
+        "scripts/status/generate_status.py",
+    ):
+        assert source_path in text
+
+    assert "OM-021/#104" in text
+
+
+def test_publication_plan_is_open_and_reproducible() -> None:
+    text = _read(PUBLICATION_PLAN)
+    lowered = text.lower()
+
+    assert "not a closed leaderboard" in lowered
+    assert "committed result json" in lowered
+    assert "hand-edited" in lowered
+
+    for source_path in (
+        "models.jsonl",
+        "gates/baseline.json",
+        "docs/benchmarks/golden.report.json",
+        "docs/benchmarks/golden.md",
+        "docs/status/trust-status-contract.md",
+        "docs/status/index.md",
+        "docs/leaderboard/index.md",
+    ):
+        assert source_path in text
+
+
+def test_reproducibility_hash_convention_is_pinned() -> None:
+    combined = _read(STATUS_CONTRACT) + "\n" + _read(PUBLICATION_PLAN)
+
+    for token in (
+        "compute_reproducibility_hash",
+        "recipe",
+        "data_manifest",
+        "base_model",
+        "git_sha",
+        "sha256:<64 lower hex>",
+    ):
+        assert token in combined


### PR DESCRIPTION
Closes #374.
Related to #145.

## Description
Defines the first OM-039 child slice: the nightly trust-results schema and open benchmark publication contract that later status rendering, hosting, scheduling, and SHIELD baseline publication slices will consume.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `docs/status/trust-status-contract.md` with required status row fields, nightly bundle shape, freshness semantics, and reproducibility hash rules.
- Added `docs/status/open-benchmark-publication.md` to keep public results inspectable, reproducible, and explicitly not a closed leaderboard.
- Added a contract test that pins the required docs fields, OM-021/#104 reuse traceability, downstream #375 handoff, and publication/hash references.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `.venv/bin/python -m pytest tests/unit/eval/test_status_publication_contract.py -q`
- `.venv/bin/ruff check tests/unit/eval/test_status_publication_contract.py`
- `.venv/bin/ruff format --check tests/unit/eval/test_status_publication_contract.py`
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/ -q`
- `.venv/bin/python scripts/release/check_repo_policy.py`
- `make docs-build`

## Documentation
- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

Changelog is not updated because this is a roadmap contract/documentation slice, not a released user-facing feature.

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Swift checks are not applicable; this PR does not touch Swift/OpenMedKit files.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #374
Related to #145

## Screenshots/Examples
Not applicable; this is a docs and contract-test change with no rendered UI changes.