### PR TITLE
fix: remove duplicate _add_benchmark_command call in CLI parser (Fixes #389)

### DIFF
--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -396,44 +396,6 @@ def _add_pii_command(subparsers: argparse._SubParsersAction) -> None:
     batch_parser.set_defaults(handler=_handle_pii_batch)
 
 
-def _add_benchmark_command(subparsers: argparse._SubParsersAction) -> None:
-    benchmark_parser = subparsers.add_parser(
-        "benchmark", help="Run OpenMed benchmark suites."
-    )
-    benchmark_sub = benchmark_parser.add_subparsers(dest="benchmark_command")
-
-    pii_parser = benchmark_sub.add_parser(
-        "pii", help="Run PII/PHI de-identification benchmark suites."
-    )
-    pii_parser.add_argument(
-        "--suite",
-        default="shield",
-        help="Benchmark suite name.",
-    )
-    pii_parser.add_argument(
-        "--models",
-        nargs="+",
-        required=True,
-        help="One or more model identifiers. Comma-separated values are accepted.",
-    )
-    pii_parser.add_argument(
-        "--device",
-        default="cpu",
-        help="Device tier label recorded in the benchmark report.",
-    )
-    pii_parser.add_argument(
-        "--output",
-        type=Path,
-        help="Write BenchmarkReport JSON to this path instead of stdout.",
-    )
-    pii_parser.add_argument(
-        "--full-shield",
-        action="store_true",
-        help="Use the approved-access full SHIELD corpus instead of the public sample.",
-    )
-    pii_parser.set_defaults(handler=_handle_benchmark_pii)
-
-
 def _add_tui_command(subparsers: argparse._SubParsersAction) -> None:
     tui_parser = subparsers.add_parser(
         "tui", help="Launch interactive terminal UI for clinical NER analysis."
@@ -553,14 +515,24 @@ def _add_benchmark_command(subparsers: argparse._SubParsersAction) -> None:
     )
     pii_parser.add_argument(
         "--suite",
-        choices=["golden"],
-        default="golden",
-        help="Benchmark suite to run.",
+        default=None,
+        help="Benchmark suite to run. Defaults to shield, or golden for re-id attacks.",
+    )
+    pii_parser.add_argument(
+        "--models",
+        nargs="+",
+        default=None,
+        help="One or more model identifiers. Comma-separated values are accepted.",
+    )
+    pii_parser.add_argument(
+        "--device",
+        default="cpu",
+        help="Device tier label recorded in the benchmark report.",
     )
     pii_parser.add_argument(
         "--model",
-        default="privacy-filter",
-        help="Model identifier to record in the report.",
+        default=None,
+        help="Model identifier to record in the re-id report.",
     )
     pii_parser.add_argument(
         "--output",
@@ -579,6 +551,11 @@ def _add_benchmark_command(subparsers: argparse._SubParsersAction) -> None:
         choices=["markdown", "json"],
         default="markdown",
         help="Generated leaderboard format.",
+    )
+    pii_parser.add_argument(
+        "--full-shield",
+        action="store_true",
+        help="Use the approved-access full SHIELD corpus instead of the public sample.",
     )
     pii_parser.set_defaults(handler=_handle_benchmark_pii)
 
@@ -795,15 +772,18 @@ def _handle_batch(args: argparse.Namespace) -> int:
 
 
 def _handle_benchmark_pii(args: argparse.Namespace) -> int:
+    if args.attack == "reid":
+        return _handle_benchmark_pii_reid(args)
+
     from openmed.eval.harness import run_benchmark
     from openmed.eval.suites import SHIELD, load_suite_fixtures, suite_metadata
 
-    models = _parse_model_args(args.models)
+    models = _parse_model_args(args.models or [])
     if not models:
         sys.stderr.write("At least one model identifier is required.\n")
         return 1
 
-    suite = str(args.suite)
+    suite = str(args.suite or SHIELD)
     try:
         if suite == SHIELD:
             use_sample = not bool(args.full_shield)
@@ -910,11 +890,7 @@ def _handle_models_info(args: argparse.Namespace) -> int:
     return 0
 
 
-def _handle_benchmark_pii(args: argparse.Namespace) -> int:
-    if args.attack != "reid":
-        sys.stderr.write("PII benchmark currently requires --attack reid.\n")
-        return 1
-
+def _handle_benchmark_pii_reid(args: argparse.Namespace) -> int:
     from openmed.eval.attacks.reid import (
         render_reid_leaderboard,
         run_reid_benchmark,
@@ -922,8 +898,8 @@ def _handle_benchmark_pii(args: argparse.Namespace) -> int:
 
     try:
         report = run_reid_benchmark(
-            suite=args.suite,
-            model_name=args.model,
+            suite=args.suite or "golden",
+            model_name=args.model or "privacy-filter",
             output_json=args.output,
         )
         if args.leaderboard_output is not None:

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -127,7 +127,6 @@ def build_parser() -> argparse.ArgumentParser:
     _add_models_command(subparsers)
     _add_config_command(subparsers)
     add_calibrate_command(subparsers)
-    _add_benchmark_command(subparsers)
     return parser
 
 

--- a/openmed/eval/harness.py
+++ b/openmed/eval/harness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import sys
 import time
@@ -236,6 +237,7 @@ def run_suite(
 
 def _shared_default_model_runner() -> ModelRunner:
     shared_loader: Any | None = None
+    accepts_loader = _runner_accepts_loader(default_model_runner)
 
     def run_fixture(
         fixture: BenchmarkFixture,
@@ -243,6 +245,8 @@ def _shared_default_model_runner() -> ModelRunner:
         device: str,
     ) -> Iterable[Any]:
         nonlocal shared_loader
+        if not accepts_loader:
+            return default_model_runner(fixture, model_name, device)
         if shared_loader is None:
             from openmed.core.models import ModelLoader
 
@@ -255,6 +259,18 @@ def _shared_default_model_runner() -> ModelRunner:
         )
 
     return run_fixture
+
+
+def _runner_accepts_loader(runner: Callable[..., Iterable[Any]]) -> bool:
+    try:
+        signature = inspect.signature(runner)
+    except (TypeError, ValueError):
+        return True
+
+    return any(
+        parameter.name == "loader" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
 
 
 def _attach_confidence_intervals(

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -65,6 +65,7 @@ REVIEWED_LICENSES = {
     "mkdocs-minify-plugin": "MIT",
     "mkdocstrings": "ISC",
     "mlx": "MIT",
+    "presidio-analyzer": "MIT",
     "pymdown-extensions": "MIT",
     "pysbd": "MIT",
     "rich": "MIT",

--- a/tests/unit/cli/test_cli_smoke.py
+++ b/tests/unit/cli/test_cli_smoke.py
@@ -46,6 +46,35 @@ def test_argparse_cli_prints_version() -> None:
     assert openmed.__version__ in result.stdout
 
 
+def test_argparse_cli_parses_benchmark_pii_modes() -> None:
+    parser = main_module.build_parser()
+
+    suite_args = parser.parse_args(
+        ["benchmark", "pii", "--suite", "shield", "--models", "fixture-model"]
+    )
+    assert suite_args.command == "benchmark"
+    assert suite_args.benchmark_command == "pii"
+    assert suite_args.attack is None
+    assert suite_args.models == ["fixture-model"]
+
+    attack_args = parser.parse_args(
+        [
+            "benchmark",
+            "pii",
+            "--attack",
+            "reid",
+            "--suite",
+            "golden",
+            "--model",
+            "unit-model",
+        ]
+    )
+    assert attack_args.command == "benchmark"
+    assert attack_args.benchmark_command == "pii"
+    assert attack_args.attack == "reid"
+    assert attack_args.model == "unit-model"
+
+
 def test_tui_entry_invokes_openmed_tui(monkeypatch: pytest.MonkeyPatch) -> None:
     launched: dict[str, object] = {}
 

--- a/tests/unit/eval/test_cold_start_metric.py
+++ b/tests/unit/eval/test_cold_start_metric.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+import sys
 import time
+from types import ModuleType, SimpleNamespace
 
+from openmed.eval import harness
 from openmed.eval.harness import BenchmarkFixture, run_benchmark
 
 
@@ -102,3 +104,27 @@ def test_default_runner_reuses_loader_for_steady_state_samples(monkeypatch):
     assert seen_loaders == [created_loaders[0]] * 3
     assert report.metrics["latency"]["cold_start_ms"] is not None
     assert report.metrics["latency"]["count"] == 2
+
+
+def test_replaced_default_runner_without_loader_keyword_skips_model_loader(monkeypatch):
+    """Patched default runners do not need optional model packages installed."""
+    fake_models = ModuleType("openmed.core.models")
+
+    def fail_loader():
+        raise AssertionError("ModelLoader should not be constructed")
+
+    fake_models.ModelLoader = fail_loader
+    monkeypatch.setitem(sys.modules, "openmed.core.models", fake_models)
+
+    def runner(fixture, model_name, device):
+        return [{"start": 8, "end": 12, "label": "PERSON"}]
+
+    monkeypatch.setattr(harness, "default_model_runner", runner)
+
+    report = run_benchmark(
+        [_fixture("f1"), _fixture("f2")],
+        suite="cold-start-test",
+        model_name="test-model",
+    )
+
+    assert report.metrics["latency"]["cold_start_ms"] is not None

--- a/tests/unit/eval/test_shield_suite.py
+++ b/tests/unit/eval/test_shield_suite.py
@@ -157,7 +157,7 @@ def test_cli_benchmark_pii_emits_shield_benchmark_report(
         lambda **kwargs: fixtures,
     )
 
-    def runner(fixture, model_name, device):
+    def runner(fixture, model_name, device, **_kwargs):
         return [
             {"start": span.start, "end": span.end, "label": span.label}
             for span in fixture.gold_spans

--- a/tests/unit/eval/test_shield_suite.py
+++ b/tests/unit/eval/test_shield_suite.py
@@ -157,7 +157,7 @@ def test_cli_benchmark_pii_emits_shield_benchmark_report(
         lambda **kwargs: fixtures,
     )
 
-    def runner(fixture, model_name, device, **_kwargs):
+    def runner(fixture, model_name, device):
         return [
             {"start": span.start, "end": span.end, "label": span.label}
             for span in fixture.gold_spans


### PR DESCRIPTION
Fixes #389

## Summary

- Removes the duplicate benchmark subcommand registration.
- Consolidates the benchmark PII parser and handler so SHIELD suite runs and re-identification attack runs both remain available.
- Adds CLI coverage for both benchmark PII modes and makes the reviewed Presidio analyzer license explicit for policy checks.
- Avoids constructing the shared benchmark model loader when the default runner has been replaced with a runner that does not accept a `loader` keyword, with regression coverage for that override path.

## Verification

- `.venv/bin/python -m pytest tests/unit/eval/test_cold_start_metric.py tests/unit/cli/test_cli_smoke.py tests/unit/eval/test_shield_suite.py::test_cli_benchmark_pii_emits_shield_benchmark_report tests/unit/eval/test_reid_attack.py::test_benchmark_pii_reid_cli_writes_report_and_leaderboard -q`
- `.venv/bin/python -m pytest tests/ -q`