### PR TITLE
fix: consolidate validation, HTML, and release gate fixes

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -33,7 +33,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
 
+      - name: Check for candidate report
+        id: check-candidate
+        run: |
+          if [ -f "$CANDIDATE_REPORT" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No candidate report found at $CANDIDATE_REPORT; skipping release gates."
+          fi
+
       - name: Run release gates
+        if: steps.check-candidate.outputs.exists == 'true'
         id: gates
         continue-on-error: true
         env:
@@ -46,18 +57,18 @@ jobs:
             --repo "$GITHUB_REPOSITORY"
 
       - name: Upload gate report
-        if: always() && hashFiles('release-gate-report.json') != ''
+        if: always() && steps.check-candidate.outputs.exists == 'true' && hashFiles('release-gate-report.json') != ''
         uses: actions/upload-artifact@v4
         with:
           name: release-gate-report
           path: release-gate-report.json
 
       - name: Publish candidate
-        if: steps.gates.outcome == 'success'
+        if: steps.check-candidate.outputs.exists == 'true' && steps.gates.outcome == 'success'
         run: |
           echo "Release gates passed; publish step is unblocked."
 
       - name: Fail closed
-        if: steps.gates.outcome != 'success'
+        if: steps.check-candidate.outputs.exists == 'true' && steps.gates.outcome != 'success'
         run: |
           exit 1

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -1793,8 +1793,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
 
+    candidate_path = Path(args.candidate)
+    if not candidate_path.is_file():
+        print(
+            f"Candidate report not found: {candidate_path}. "
+            "Skipping release gate evaluation.",
+            file=sys.stderr,
+        )
+        return 0
+
     try:
-        candidate = _read_json_file(Path(args.candidate))
+        candidate = _read_json_file(candidate_path)
         baseline = _read_json_file(Path(args.baseline)) if args.baseline else None
         gate = ReleaseGate(
             milestone=args.milestone,

--- a/openmed/processing/outputs.py
+++ b/openmed/processing/outputs.py
@@ -1,5 +1,6 @@
 """Output formatting utilities for OpenMed."""
 
+import html as html_mod
 import json
 import unicodedata
 from typing import List, Dict, Any, Optional, Union, Tuple
@@ -433,17 +434,13 @@ class OutputFormatter:
         """
         html = f'<div class="openmed-result">\n'
         html += f'<h3>Analysis Results</h3>\n'
-        html += f'<p><strong>Model:</strong> {result.model_name}</p>\n'
-        html += f'<p><strong>Timestamp:</strong> {result.timestamp}</p>\n'
+        html += f'<p><strong>Model:</strong> {html_mod.escape(str(result.model_name))}</p>\n'
+        html += f'<p><strong>Timestamp:</strong> {html_mod.escape(str(result.timestamp))}</p>\n'
 
         if result.processing_time:
             html += f'<p><strong>Processing Time:</strong> {result.processing_time:.3f}s</p>\n'
 
         html += f'<div class="text-content">\n'
-
-        # Highlight entities in text
-        highlighted_text = result.text
-        offset = 0
 
         # Sort entities by start position
         sorted_entities = sorted(
@@ -451,24 +448,29 @@ class OutputFormatter:
             key=lambda x: x.start
         )
 
+        highlighted_parts: List[str] = []
+        cursor = 0
         for entity in sorted_entities:
-            start = entity.start + offset
-            end = entity.end + offset
+            start = entity.start
+            end = entity.end
+            if start < cursor or end <= start or end > len(result.text):
+                continue
 
             color = self._get_entity_color(entity.label)
+            label = html_mod.escape(str(entity.label))
+            class_label = html_mod.escape(str(entity.label).lower())
 
-            highlight_start = f'<span class="entity entity-{entity.label.lower()}" style="background-color: {color}; padding: 2px 4px; border-radius: 3px;" title="Label: {entity.label}, Confidence: {entity.confidence:.3f}">'
-            highlight_end = '</span>'
-
-            highlighted_text = (
-                highlighted_text[:start] +
-                highlight_start +
-                highlighted_text[start:end] +
-                highlight_end +
-                highlighted_text[end:]
+            highlighted_parts.append(html_mod.escape(result.text[cursor:start]))
+            highlighted_parts.append(
+                f'<span class="entity entity-{class_label}" '
+                f'style="background-color: {color}; padding: 2px 4px; border-radius: 3px;" '
+                f'title="Label: {label}, Confidence: {entity.confidence:.3f}">'
+                f'{html_mod.escape(result.text[start:end])}</span>'
             )
+            cursor = end
 
-            offset += len(highlight_start) + len(highlight_end)
+        highlighted_parts.append(html_mod.escape(result.text[cursor:]))
+        highlighted_text = "".join(highlighted_parts)
 
         html += f'<p>{highlighted_text}</p>\n'
         html += f'</div>\n'
@@ -481,7 +483,7 @@ class OutputFormatter:
 
             for entity in result.entities:
                 confidence_str = f" (confidence: {entity.confidence:.3f})" if self.include_confidence else ""
-                html += f'<li><strong>{entity.label}:</strong> {entity.text}{confidence_str}</li>\n'
+                html += f'<li><strong>{html_mod.escape(entity.label)}:</strong> {html_mod.escape(entity.text)}{confidence_str}</li>\n'
 
             html += f'</ul>\n'
             html += f'</div>\n'

--- a/openmed/utils/validation.py
+++ b/openmed/utils/validation.py
@@ -194,8 +194,9 @@ def _contains_suspicious_content(text: str) -> bool:
     if special_char_ratio > 0.5:
         return True
 
-    # Check for binary or encoded content
-    if re.search(r'[^\x00-\x7F]{50,}', text):
+    # Check for binary-like control content without rejecting legitimate
+    # non-ASCII clinical text.
+    if re.search(r'[\x00-\x08\x0e-\x1f\x7f]{10,}', text):
         return True
 
     return False

--- a/tests/unit/eval/test_release_gate_cli.py
+++ b/tests/unit/eval/test_release_gate_cli.py
@@ -115,3 +115,35 @@ def test_release_gate_cli_returns_nonzero_for_failed_gate(tmp_path: Path) -> Non
         check["gate"] == "G3" and check["passed"] is False
         for check in report["gate_results"]
     )
+
+
+def test_release_gate_cli_skips_missing_candidate_without_issue(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    missing_candidate = tmp_path / "missing-candidate.json"
+    output = tmp_path / "gate-report.json"
+
+    def fail_issue_creation(**kwargs):
+        raise AssertionError("missing candidate should not open a tracking issue")
+
+    monkeypatch.setattr(
+        release_gates,
+        "_open_or_update_tracking_issue_for_error",
+        fail_issue_creation,
+    )
+
+    exit_code = release_gates.main(
+        [
+            "--candidate",
+            str(missing_candidate),
+            "--output",
+            str(output),
+            "--issue-on-failure",
+        ]
+    )
+
+    assert exit_code == 0
+    assert not output.exists()
+    assert "Candidate report not found" in capsys.readouterr().err

--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -299,6 +299,35 @@ class TestOutputFormatter:
         assert "diabetes" in html_output
         assert "test-model" in html_output
 
+    def test_to_html_escapes_user_controlled_values_preserving_offsets(self):
+        """Test HTML escaping without shifting entity offsets."""
+        text = 'Intro <script>alert("x")</script> patient Jane & Co'
+        start = text.index("Jane")
+        result = PredictionResult(
+            text=text,
+            entities=[
+                EntityPrediction(
+                    text="<b>Jane</b>",
+                    label='NAME" onclick="alert(1)',
+                    confidence=0.99,
+                    start=start,
+                    end=start + len("Jane"),
+                )
+            ],
+            model_name='model"><img src=x onerror=alert(1)>',
+            timestamp="2026-06-19T00:00:00Z<script>",
+        )
+
+        html_output = OutputFormatter().to_html(result)
+
+        assert "<script>" not in html_output
+        assert "<img" not in html_output
+        assert 'onclick="' not in html_output
+        assert "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;" in html_output
+        assert "model&quot;&gt;&lt;img src=x onerror=alert(1)&gt;" in html_output
+        assert "&lt;b&gt;Jane&lt;/b&gt;" in html_output
+        assert ">Jane</span>" in html_output
+
     def test_to_csv_rows(self, test_helpers, sample_predictions, sample_text):
         """Test CSV rows generation."""
         formatter = OutputFormatter()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -260,3 +260,30 @@ class TestSuspiciousContentDetection:
         # Excessive special characters should be detected
         suspicious_text = "!@#$%^&*()_+" * 10
         assert _contains_suspicious_content(suspicious_text)
+
+    def test_suspicious_content_allows_cjk_clinical_text(self):
+        """Test that long CJK clinical notes are valid input."""
+        from openmed.utils.validation import _contains_suspicious_content
+
+        japanese_note = (
+            "患者は高血圧を患っており、心臓専門医による定期的なフォローアップが必要です。"
+            "現在の内服薬を継続し、次回外来で血圧と症状を再評価します。"
+        ) * 3
+        chinese_note = (
+            "患者有高血压病史，需要继续监测血压并记录头痛、胸闷或呼吸困难等症状。"
+            "建议按时服药，并在下次门诊复查。"
+        ) * 3
+
+        assert not _contains_suspicious_content(japanese_note)
+        assert not _contains_suspicious_content(chinese_note)
+        assert validate_input(japanese_note) == japanese_note
+
+    def test_suspicious_content_rejects_control_character_runs(self):
+        """Test detection of binary-like control character runs."""
+        from openmed.utils.validation import _contains_suspicious_content
+
+        suspicious_text = "Patient note" + ("\x00" * 10) + "trailer"
+
+        assert _contains_suspicious_content(suspicious_text)
+        with pytest.raises(ValueError, match="Input text contains suspicious content"):
+            validate_input(suspicious_text)


### PR DESCRIPTION
## Summary
- allow CJK clinical text while still rejecting binary-like control character runs
- escape HTML formatter output without shifting entity offsets
- skip scheduled release gates when no release candidate report exists

## Verification
- .venv/bin/python -m pytest tests/ -q
- .venv/bin/python scripts/release/check_license_policy.py

Closes #391
Closes #392
Closes #396