### PR TITLE
fix: escape user-controlled text in to_html to prevent XSS (Fixes #392)

### DIFF
--- a/openmed/processing/outputs.py
+++ b/openmed/processing/outputs.py
@@ -442,34 +442,35 @@ class OutputFormatter:
 
         html += f'<div class="text-content">\n'
 
-        # Highlight entities in text
-        highlighted_text = html_mod.escape(result.text)
-        offset = 0
-
         # Sort entities by start position
         sorted_entities = sorted(
             [e for e in result.entities if e.start is not None and e.end is not None],
             key=lambda x: x.start
         )
 
+        highlighted_parts: List[str] = []
+        cursor = 0
         for entity in sorted_entities:
-            start = entity.start + offset
-            end = entity.end + offset
+            start = entity.start
+            end = entity.end
+            if start < cursor or end <= start or end > len(result.text):
+                continue
 
             color = self._get_entity_color(entity.label)
+            label = html_mod.escape(str(entity.label))
+            class_label = html_mod.escape(str(entity.label).lower())
 
-            highlight_start = f'<span class="entity entity-{html_mod.escape(entity.label.lower())}" style="background-color: {color}; padding: 2px 4px; border-radius: 3px;" title="Label: {html_mod.escape(entity.label)}, Confidence: {entity.confidence:.3f}">'
-            highlight_end = '</span>'
-
-            highlighted_text = (
-                highlighted_text[:start] +
-                highlight_start +
-                highlighted_text[start:end] +
-                highlight_end +
-                highlighted_text[end:]
+            highlighted_parts.append(html_mod.escape(result.text[cursor:start]))
+            highlighted_parts.append(
+                f'<span class="entity entity-{class_label}" '
+                f'style="background-color: {color}; padding: 2px 4px; border-radius: 3px;" '
+                f'title="Label: {label}, Confidence: {entity.confidence:.3f}">'
+                f'{html_mod.escape(result.text[start:end])}</span>'
             )
+            cursor = end
 
-            offset += len(highlight_start) + len(highlight_end)
+        highlighted_parts.append(html_mod.escape(result.text[cursor:]))
+        highlighted_text = "".join(highlighted_parts)
 
         html += f'<p>{highlighted_text}</p>\n'
         html += f'</div>\n'

--- a/openmed/processing/outputs.py
+++ b/openmed/processing/outputs.py
@@ -1,5 +1,6 @@
 """Output formatting utilities for OpenMed."""
 
+import html as html_mod
 import json
 import unicodedata
 from typing import List, Dict, Any, Optional, Union, Tuple
@@ -433,8 +434,8 @@ class OutputFormatter:
         """
         html = f'<div class="openmed-result">\n'
         html += f'<h3>Analysis Results</h3>\n'
-        html += f'<p><strong>Model:</strong> {result.model_name}</p>\n'
-        html += f'<p><strong>Timestamp:</strong> {result.timestamp}</p>\n'
+        html += f'<p><strong>Model:</strong> {html_mod.escape(str(result.model_name))}</p>\n'
+        html += f'<p><strong>Timestamp:</strong> {html_mod.escape(str(result.timestamp))}</p>\n'
 
         if result.processing_time:
             html += f'<p><strong>Processing Time:</strong> {result.processing_time:.3f}s</p>\n'
@@ -442,7 +443,7 @@ class OutputFormatter:
         html += f'<div class="text-content">\n'
 
         # Highlight entities in text
-        highlighted_text = result.text
+        highlighted_text = html_mod.escape(result.text)
         offset = 0
 
         # Sort entities by start position
@@ -457,7 +458,7 @@ class OutputFormatter:
 
             color = self._get_entity_color(entity.label)
 
-            highlight_start = f'<span class="entity entity-{entity.label.lower()}" style="background-color: {color}; padding: 2px 4px; border-radius: 3px;" title="Label: {entity.label}, Confidence: {entity.confidence:.3f}">'
+            highlight_start = f'<span class="entity entity-{html_mod.escape(entity.label.lower())}" style="background-color: {color}; padding: 2px 4px; border-radius: 3px;" title="Label: {html_mod.escape(entity.label)}, Confidence: {entity.confidence:.3f}">'
             highlight_end = '</span>'
 
             highlighted_text = (
@@ -481,7 +482,7 @@ class OutputFormatter:
 
             for entity in result.entities:
                 confidence_str = f" (confidence: {entity.confidence:.3f})" if self.include_confidence else ""
-                html += f'<li><strong>{entity.label}:</strong> {entity.text}{confidence_str}</li>\n'
+                html += f'<li><strong>{html_mod.escape(entity.label)}:</strong> {html_mod.escape(entity.text)}{confidence_str}</li>\n'
 
             html += f'</ul>\n'
             html += f'</div>\n'

--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -299,6 +299,35 @@ class TestOutputFormatter:
         assert "diabetes" in html_output
         assert "test-model" in html_output
 
+    def test_to_html_escapes_user_controlled_values_preserving_offsets(self):
+        """Test HTML escaping without shifting entity offsets."""
+        text = 'Intro <script>alert("x")</script> patient Jane & Co'
+        start = text.index("Jane")
+        result = PredictionResult(
+            text=text,
+            entities=[
+                EntityPrediction(
+                    text="<b>Jane</b>",
+                    label='NAME" onclick="alert(1)',
+                    confidence=0.99,
+                    start=start,
+                    end=start + len("Jane"),
+                )
+            ],
+            model_name='model"><img src=x onerror=alert(1)>',
+            timestamp="2026-06-19T00:00:00Z<script>",
+        )
+
+        html_output = OutputFormatter().to_html(result)
+
+        assert "<script>" not in html_output
+        assert "<img" not in html_output
+        assert 'onclick="' not in html_output
+        assert "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;" in html_output
+        assert "model&quot;&gt;&lt;img src=x onerror=alert(1)&gt;" in html_output
+        assert "&lt;b&gt;Jane&lt;/b&gt;" in html_output
+        assert ">Jane</span>" in html_output
+
     def test_to_csv_rows(self, test_helpers, sample_predictions, sample_text):
         """Test CSV rows generation."""
         formatter = OutputFormatter()


### PR DESCRIPTION
Fixes #392

## Summary

- Escapes model, timestamp, source text, entity labels, and entity summary text before emitting HTML.
- Builds highlighted HTML from escaped text segments so original entity offsets stay valid when earlier text contains escapable characters.
- Adds regression coverage for script/image/event-attribute payloads and offset preservation.

## Verification

- `.venv/bin/python -m pytest tests/unit/test_processing.py -q`
- `.venv/bin/python -m pytest tests/ -q` against a temporary merge with updated `origin/master`