### PR TITLE
fix: handle missing candidate file gracefully in release gates (Fixes #396)

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -40,7 +40,7 @@ jobs:
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "No candidate report found at $CANDIDATE_REPORT — skipping release gates."
+            echo "No candidate report found at $CANDIDATE_REPORT; skipping release gates."
           fi
 
       - name: Run release gates

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -33,7 +33,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
 
+      - name: Check for candidate report
+        id: check-candidate
+        run: |
+          if [ -f "$CANDIDATE_REPORT" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No candidate report found at $CANDIDATE_REPORT — skipping release gates."
+          fi
+
       - name: Run release gates
+        if: steps.check-candidate.outputs.exists == 'true'
         id: gates
         continue-on-error: true
         env:
@@ -46,18 +57,18 @@ jobs:
             --repo "$GITHUB_REPOSITORY"
 
       - name: Upload gate report
-        if: always() && hashFiles('release-gate-report.json') != ''
+        if: always() && steps.check-candidate.outputs.exists == 'true' && hashFiles('release-gate-report.json') != ''
         uses: actions/upload-artifact@v4
         with:
           name: release-gate-report
           path: release-gate-report.json
 
       - name: Publish candidate
-        if: steps.gates.outcome == 'success'
+        if: steps.check-candidate.outputs.exists == 'true' && steps.gates.outcome == 'success'
         run: |
           echo "Release gates passed; publish step is unblocked."
 
       - name: Fail closed
-        if: steps.gates.outcome != 'success'
+        if: steps.check-candidate.outputs.exists == 'true' && steps.gates.outcome != 'success'
         run: |
           exit 1

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -1793,8 +1793,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
 
+    candidate_path = Path(args.candidate)
+    if not candidate_path.is_file():
+        print(
+            f"Candidate report not found: {candidate_path}. "
+            "Skipping release gate evaluation.",
+            file=sys.stderr,
+        )
+        return 0
+
     try:
-        candidate = _read_json_file(Path(args.candidate))
+        candidate = _read_json_file(candidate_path)
         baseline = _read_json_file(Path(args.baseline)) if args.baseline else None
         gate = ReleaseGate(
             milestone=args.milestone,

--- a/tests/unit/eval/test_release_gate_cli.py
+++ b/tests/unit/eval/test_release_gate_cli.py
@@ -115,3 +115,35 @@ def test_release_gate_cli_returns_nonzero_for_failed_gate(tmp_path: Path) -> Non
         check["gate"] == "G3" and check["passed"] is False
         for check in report["gate_results"]
     )
+
+
+def test_release_gate_cli_skips_missing_candidate_without_issue(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    missing_candidate = tmp_path / "missing-candidate.json"
+    output = tmp_path / "gate-report.json"
+
+    def fail_issue_creation(**kwargs):
+        raise AssertionError("missing candidate should not open a tracking issue")
+
+    monkeypatch.setattr(
+        release_gates,
+        "_open_or_update_tracking_issue_for_error",
+        fail_issue_creation,
+    )
+
+    exit_code = release_gates.main(
+        [
+            "--candidate",
+            str(missing_candidate),
+            "--output",
+            str(output),
+            "--issue-on-failure",
+        ]
+    )
+
+    assert exit_code == 0
+    assert not output.exists()
+    assert "Candidate report not found" in capsys.readouterr().err


### PR DESCRIPTION
Fixes #396

## Summary

- Skips release gate evaluation cleanly when the configured candidate report is absent.
- Adds a workflow candidate-file check so scheduled runs do not execute gate, upload, publish, or fail-closed steps without an input candidate.
- Adds regression coverage that the CLI skip returns 0, writes no report, and does not open a tracking issue.

## Verification

- `.venv/bin/python -m pytest tests/unit/eval/test_release_gate_cli.py -q`
- YAML parse check for `.github/workflows/release-gates.yml`
- `.venv/bin/python -m pytest tests/ -q` against a temporary merge with updated `origin/master`