### PR TITLE
fix: correct misleading TUI fallback message in CLI (Fixes #399)

### DIFF
--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -587,8 +587,9 @@ def _run_basic_tui_entry(
     model_display = model_name or "disease_detection_superclinical"
     if not sys.stdin.isatty():
         sys.stdout.write(
-            "OpenMed TUI entry is installed. Run it from an interactive "
-            "terminal to start the basic prompt.\n"
+            "OpenMed TUI is not installed. Run from an interactive "
+            "terminal to use the basic prompt, or install the TUI "
+            "for the full experience.\n"
         )
         return 0
 


### PR DESCRIPTION
Fixes #399

## Problem

In `openmed/cli/main.py`, the `_run_basic_tui_entry()` function (line 590) displays:

> "OpenMed TUI entry is installed. Run it from an interactive terminal to start the basic prompt."

But this function is only called as a **fallback** when the TUI import fails (line 568: `except ImportError`). The message incorrectly says the TUI "is installed" when it is actually **not** installed. This confuses users who see the message in non-interactive environments (pipes, CI, etc.).

## Solution

Corrected the message to accurately reflect that the TUI is not installed:

```
"OpenMed TUI is not installed. Run from an interactive terminal to use the basic prompt, or install the TUI for the full experience."
```

### Files Changed
- `openmed/cli/main.py` — Fixed misleading fallback message at line 590

### Verification
- The function `_run_basic_tui_entry` is only called from `_launch_tui` when `from openmed.tui import OpenMedTUI` raises `ImportError` (line 568)
- The corrected message now accurately describes the situation
- No other occurrences of the incorrect string exist in the codebase

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-19 | Fix misleading TUI fallback message in CLI | rtmalikian |

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
