### PR TITLE
fix: roll up contributor validation, HTML, and release gate fixes

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -33,7 +33,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
 
+      - name: Check for candidate report
+        id: check-candidate
+        run: |
+          if [ -f "$CANDIDATE_REPORT" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No candidate report found at $CANDIDATE_REPORT — skipping release gates."
+          fi
+
       - name: Run release gates
+        if: steps.check-candidate.outputs.exists == 'true'
         id: gates
         continue-on-error: true
         env:
@@ -46,18 +57,18 @@ jobs:
             --repo "$GITHUB_REPOSITORY"
 
       - name: Upload gate report
-        if: always() && hashFiles('release-gate-report.json') != ''
+        if: always() && steps.check-candidate.outputs.exists == 'true' && hashFiles('release-gate-report.json') != ''
         uses: actions/upload-artifact@v4
         with:
           name: release-gate-report
           path: release-gate-report.json
 
       - name: Publish candidate
-        if: steps.gates.outcome == 'success'
+        if: steps.check-candidate.outputs.exists == 'true' && steps.gates.outcome == 'success'
         run: |
           echo "Release gates passed; publish step is unblocked."
 
       - name: Fail closed
-        if: steps.gates.outcome != 'success'
+        if: steps.check-candidate.outputs.exists == 'true' && steps.gates.outcome != 'success'
         run: |
           exit 1

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -1793,8 +1793,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
 
+    candidate_path = Path(args.candidate)
+    if not candidate_path.is_file():
+        print(
+            f"Candidate report not found: {candidate_path}. "
+            "Skipping release gate evaluation.",
+            file=sys.stderr,
+        )
+        return 0
+
     try:
-        candidate = _read_json_file(Path(args.candidate))
+        candidate = _read_json_file(candidate_path)
         baseline = _read_json_file(Path(args.baseline)) if args.baseline else None
         gate = ReleaseGate(
             milestone=args.milestone,

--- a/openmed/processing/outputs.py
+++ b/openmed/processing/outputs.py
@@ -1,5 +1,6 @@
 """Output formatting utilities for OpenMed."""
 
+import html as html_mod
 import json
 import unicodedata
 from typing import List, Dict, Any, Optional, Union, Tuple
@@ -433,8 +434,8 @@ class OutputFormatter:
         """
         html = f'<div class="openmed-result">\n'
         html += f'<h3>Analysis Results</h3>\n'
-        html += f'<p><strong>Model:</strong> {result.model_name}</p>\n'
-        html += f'<p><strong>Timestamp:</strong> {result.timestamp}</p>\n'
+        html += f'<p><strong>Model:</strong> {html_mod.escape(str(result.model_name))}</p>\n'
+        html += f'<p><strong>Timestamp:</strong> {html_mod.escape(str(result.timestamp))}</p>\n'
 
         if result.processing_time:
             html += f'<p><strong>Processing Time:</strong> {result.processing_time:.3f}s</p>\n'
@@ -442,7 +443,7 @@ class OutputFormatter:
         html += f'<div class="text-content">\n'
 
         # Highlight entities in text
-        highlighted_text = result.text
+        highlighted_text = html_mod.escape(result.text)
         offset = 0
 
         # Sort entities by start position
@@ -457,7 +458,7 @@ class OutputFormatter:
 
             color = self._get_entity_color(entity.label)
 
-            highlight_start = f'<span class="entity entity-{entity.label.lower()}" style="background-color: {color}; padding: 2px 4px; border-radius: 3px;" title="Label: {entity.label}, Confidence: {entity.confidence:.3f}">'
+            highlight_start = f'<span class="entity entity-{html_mod.escape(entity.label.lower())}" style="background-color: {color}; padding: 2px 4px; border-radius: 3px;" title="Label: {html_mod.escape(entity.label)}, Confidence: {entity.confidence:.3f}">'
             highlight_end = '</span>'
 
             highlighted_text = (
@@ -481,7 +482,7 @@ class OutputFormatter:
 
             for entity in result.entities:
                 confidence_str = f" (confidence: {entity.confidence:.3f})" if self.include_confidence else ""
-                html += f'<li><strong>{entity.label}:</strong> {entity.text}{confidence_str}</li>\n'
+                html += f'<li><strong>{html_mod.escape(entity.label)}:</strong> {html_mod.escape(entity.text)}{confidence_str}</li>\n'
 
             html += f'</ul>\n'
             html += f'</div>\n'

--- a/openmed/utils/validation.py
+++ b/openmed/utils/validation.py
@@ -194,8 +194,10 @@ def _contains_suspicious_content(text: str) -> bool:
     if special_char_ratio > 0.5:
         return True
 
-    # Check for binary or encoded content
-    if re.search(r'[^\x00-\x7F]{50,}', text):
+    # Check for binary or encoded content (control characters excluding
+    # common whitespace).  Do NOT reject non-ASCII text — CJK, Arabic,
+    # Devanagari and other scripts legitimately contain long non-ASCII runs.
+    if re.search(r'[\x00-\x08\x0e-\x1f\x7f]{10,}', text):
         return True
 
     return False


### PR DESCRIPTION
## Summary
- preserve the contributor commits for the CJK validation, HTML escaping, and release-gate candidate fixes in one branch
- keep the TUI fallback change out because it fails the current CLI fallback test and remains closed separately

## Verification
- .venv/bin/python -m pytest tests/ -q (`1614 passed, 1 skipped`)
- .venv/bin/python scripts/release/check_license_policy.py
- .venv/bin/python scripts/release/check_repo_policy.py
- CI passed for repo-policy, security, secret-scan, test matrix, and build

Closes #391
Closes #392
Closes #396