### PR TITLE
fix: reject duplicate FHIR resource ids

### DIFF
--- a/openmed/clinical/exporters/fhir/bundle.py
+++ b/openmed/clinical/exporters/fhir/bundle.py
@@ -52,6 +52,8 @@ def to_bundle(
     resources:
         The standalone FHIR resources to wrap, in the order they should appear
         in the Bundle. Each must be a mapping carrying a ``resourceType``.
+        Resources with an ``id`` must have a unique ``ResourceType/id`` within
+        the Bundle; resources without an ``id`` are left unreferenceable.
     doc_id:
         Stable identifier for the source document. Together with the resource
         index it seeds the deterministic ``urn:uuid`` ``fullUrl`` of each
@@ -83,7 +85,10 @@ def to_bundle(
     for urn, resource in zip(urns, resources):
         resource_id = resource.get("id")
         if resource_id is not None:
-            reference_map[f"{resource['resourceType']}/{resource_id}"] = urn
+            reference_key = f"{resource['resourceType']}/{resource_id}"
+            if reference_key in reference_map:
+                raise ValueError(f"duplicate FHIR resource id: {reference_key}")
+            reference_map[reference_key] = urn
 
     emit_request = bundle_type in _REQUEST_BUNDLE_TYPES
     for urn, resource in zip(urns, resources):

--- a/tests/unit/clinical/test_fhir_bundle.py
+++ b/tests/unit/clinical/test_fhir_bundle.py
@@ -94,6 +94,17 @@ class TestBundleStructure:
         with pytest.raises(ValueError):
             to_bundle([{"id": "x"}], doc_id="doc-1")
 
+    def test_duplicate_resource_type_id_raises(self):
+        resources = [
+            {"resourceType": "Observation", "id": "obs1"},
+            {"resourceType": "Observation", "id": "obs1"},
+        ]
+
+        with pytest.raises(
+            ValueError, match="duplicate FHIR resource id: Observation/obs1"
+        ):
+            to_bundle(resources, doc_id="doc-1")
+
 
 class TestReferenceResolution:
     def test_internal_references_rewritten_to_full_urls(self):

--- a/tests/unit/clinical/test_fhir_bundle.py
+++ b/tests/unit/clinical/test_fhir_bundle.py
@@ -105,6 +105,22 @@ class TestBundleStructure:
         ):
             to_bundle(resources, doc_id="doc-1")
 
+    def test_resources_without_ids_do_not_collide(self):
+        resources = [
+            {"resourceType": "Observation", "status": "final"},
+            {
+                "resourceType": "DiagnosticReport",
+                "id": "dr1",
+                "result": [{"reference": "Observation/obs1"}],
+            },
+        ]
+
+        bundle = to_bundle(resources, doc_id="doc-1")
+
+        assert len(bundle["entry"]) == 2
+        report = bundle["entry"][1]["resource"]
+        assert report["result"][0]["reference"] == "Observation/obs1"
+
 
 class TestReferenceResolution:
     def test_internal_references_rewritten_to_full_urls(self):


### PR DESCRIPTION
## Description
Closes #530.

Reject duplicate FHIR `ResourceType/id` keys while building the Bundle reference map. This prevents a later resource from silently overwriting an earlier resource with the same reference key.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Raise `ValueError` when two resources share the same `ResourceType/id` key.
- Include the colliding key in the error message.
- Document the duplicate-id contract in `to_bundle`.
- Add regression coverage for duplicate `Observation/obs1` resources.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `.venv/bin/python -m pytest tests/unit/clinical/test_fhir_bundle.py -q`
- `.venv/bin/python -m pytest tests/ -q`
- `PATH=.venv/bin:$PATH make format`
- `PATH=.venv/bin:$PATH make lint`
- `PATH=.venv/bin:$PATH make format-check`
- `PATH=.venv/bin:$PATH pre-commit run --files openmed/clinical/exporters/fhir/bundle.py tests/unit/clinical/test_fhir_bundle.py`
- `git diff --check`

## Documentation
- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

No changelog entry was added for this small bug fix.

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

No Swift/OpenMedKit files were changed, and no new complex code comments were needed.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #530

## Screenshots/Examples
Not applicable.
