### PR TITLE
feat: add cardiology domain to NER catalog and zero-shot label maps

### DIFF
--- a/openmed/core/model_registry.py
+++ b/openmed/core/model_registry.py
@@ -173,6 +173,16 @@ _CATEGORY_ENTITY_TYPES = {
     "Protein": ["GENE_OR_GENE_PRODUCT", "PROTEIN"],
     "Pathology": ["DISEASE", "PATHOLOGY"],
     "Hematology": ["CANCER", "DISEASE"],
+    # Forward metadata for future Cardiology models; no Cardiology model is
+    # registered today (see issue #317).
+    "Cardiology": [
+        "CARDIAC_FINDING",
+        "ECG_FINDING",
+        "EJECTION_FRACTION",
+        "CARDIAC_PROCEDURE",
+        "CARDIAC_DEVICE",
+        "ANATOMY",
+    ],
     "Privacy": _PII_ENTITY_TYPES,
 }
 
@@ -617,53 +627,74 @@ def get_all_models() -> Dict[str, ModelInfo]:
     return OPENMED_MODELS.copy()
 
 
+_CATEGORY_KEYWORDS: Dict[str, Tuple[str, str]] = {
+    "pii|deidentif|hipaa|phi|protected health|patient name|ssn|medical record|privacy|anonymiz": (
+        "Privacy",
+        "Contains PII/de-identification terms",
+    ),
+    "cancer|tumor|oncolog|malign|chemotherapy|radiation": (
+        "Oncology",
+        "Contains cancer/oncology terms",
+    ),
+    "drug|medication|pharma|dose|mg|pill|tablet|cisplatin": (
+        "Pharmaceutical",
+        "Contains pharmaceutical terms",
+    ),
+    "gene|dna|protein|mutation|chromosome": (
+        "Genomics",
+        "Contains genomic/genetic terms",
+    ),
+    "ecg|ekg|ejection fraction|arrhythmia|stent|pacemaker|murmur|st elevation|echocardiogram|cardiac|cardiolog": (
+        "Cardiology",
+        "Contains cardiology terms",
+    ),
+    "heart|lung|brain|liver|kidney|organ": (
+        "Anatomy",
+        "Contains anatomical terms",
+    ),
+    "bacteria|virus|organism|species": (
+        "Species",
+        "Contains organism/species terms",
+    ),
+    "disease|condition|disorder|syndrome": (
+        "Disease",
+        "Contains disease/condition terms",
+    ),
+    "pathology|histology|biopsy": (
+        "Pathology",
+        "Contains pathological terms",
+    ),
+    "blood|lymph|leukemia|lymphoma": (
+        "Hematology",
+        "Contains hematological terms",
+    ),
+}
+
+
+def _match_categories(text: str) -> List[Tuple[str, str]]:
+    """Return ``(category, reason)`` pairs whose keywords match ``text``.
+
+    This is the routing layer behind :func:`get_model_suggestions`. It reports
+    a category whenever the text matches its keywords, independently of whether
+    any model is registered for that category (e.g. ``Cardiology`` has keyword
+    routing but no registered model yet).
+    """
+
+    text_lower = text.lower()
+    return [
+        (category, reason)
+        for pattern, (category, reason) in _CATEGORY_KEYWORDS.items()
+        if re.search(pattern, text_lower)
+    ]
+
+
 def get_model_suggestions(text: str) -> List[Tuple[str, ModelInfo, str]]:
     """Suggest appropriate models based on text content."""
-    text_lower = text.lower()
     suggestions: List[Tuple[str, ModelInfo, str]] = []
-    keywords = {
-        "pii|deidentif|hipaa|phi|protected health|patient name|ssn|medical record|privacy|anonymiz": (
-            "Privacy",
-            "Contains PII/de-identification terms",
-        ),
-        "cancer|tumor|oncolog|malign|chemotherapy|radiation": (
-            "Oncology",
-            "Contains cancer/oncology terms",
-        ),
-        "drug|medication|pharma|dose|mg|pill|tablet|cisplatin": (
-            "Pharmaceutical",
-            "Contains pharmaceutical terms",
-        ),
-        "gene|dna|protein|mutation|chromosome": (
-            "Genomics",
-            "Contains genomic/genetic terms",
-        ),
-        "heart|lung|brain|liver|kidney|organ": (
-            "Anatomy",
-            "Contains anatomical terms",
-        ),
-        "bacteria|virus|organism|species": (
-            "Species",
-            "Contains organism/species terms",
-        ),
-        "disease|condition|disorder|syndrome": (
-            "Disease",
-            "Contains disease/condition terms",
-        ),
-        "pathology|histology|biopsy": (
-            "Pathology",
-            "Contains pathological terms",
-        ),
-        "blood|lymph|leukemia|lymphoma": (
-            "Hematology",
-            "Contains hematological terms",
-        ),
-    }
 
-    for pattern, (category, reason) in keywords.items():
-        if re.search(pattern, text_lower):
-            for key in CATEGORIES.get(category, [])[:3]:
-                suggestions.append((key, OPENMED_MODELS[key], reason))
+    for category, reason in _match_categories(text):
+        for key in CATEGORIES.get(category, [])[:3]:
+            suggestions.append((key, OPENMED_MODELS[key], reason))
 
     if not suggestions:
         for key in SIZE_RECOMMENDATIONS.get("balanced", [])[:3]:

--- a/openmed/zero_shot/data/label_maps/defaults.json
+++ b/openmed/zero_shot/data/label_maps/defaults.json
@@ -12,5 +12,6 @@
   "education": ["Course", "Topic", "Institution", "Degree"],
   "social": ["Person", "Handle", "Hashtag", "URL"],
   "public_health": ["Condition", "Intervention", "Outcome", "Population"],
+  "cardiology": ["CardiacFinding", "ECGFinding", "EjectionFraction", "CardiacProcedure", "CardiacDevice", "Anatomy"],
   "generic": ["Person", "Organization", "Location", "Date"]
 }

--- a/tests/unit/ner/test_label_map_consistency.py
+++ b/tests/unit/ner/test_label_map_consistency.py
@@ -7,12 +7,19 @@ and model registry entity_types to catch configuration drift.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
 
-from openmed.core.model_registry import OPENMED_MODELS
+from openmed.core.model_registry import (
+    _CATEGORY_ENTITY_TYPES,
+    OPENMED_MODELS,
+    _match_categories,
+    get_model_suggestions,
+)
 from openmed.core.pii_entity_merger import is_more_specific, normalize_label
+from openmed.ner.labels import available_domains, get_default_labels
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -58,6 +65,73 @@ class TestDefaultsJsonInvariants:
 
     def test_generic_domain_has_labels(self, label_maps):
         assert len(label_maps["generic"]) >= 1
+
+    def test_labels_follow_consistent_style(self, label_maps):
+        """Every domain label is a single letters-only token (no spaces/digits)."""
+        for domain, labels in label_maps.items():
+            for label in labels:
+                assert re.fullmatch(r"[A-Za-z]+", label), (
+                    f"Domain {domain!r} label {label!r} drifts from the "
+                    "letters-only display-label style"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Cardiology domain (issue #317)
+# ---------------------------------------------------------------------------
+
+
+class TestCardiologyDomain:
+    EXPECTED_LABELS = [
+        "CardiacFinding",
+        "ECGFinding",
+        "EjectionFraction",
+        "CardiacProcedure",
+        "CardiacDevice",
+        "Anatomy",
+    ]
+
+    def test_cardiology_in_available_domains(self):
+        assert "cardiology" in available_domains()
+
+    def test_get_default_labels_returns_cardiology_set(self):
+        labels = get_default_labels("cardiology")
+        assert labels  # non-empty
+        assert labels == self.EXPECTED_LABELS
+
+    def test_cardiology_labels_have_no_duplicates(self):
+        labels = get_default_labels("cardiology")
+        lowered = [label.lower() for label in labels]
+        assert len(lowered) == len(set(lowered))
+
+
+# ---------------------------------------------------------------------------
+# Cardiology routing in model_registry (issue #317)
+# ---------------------------------------------------------------------------
+
+
+class TestCardiologyRouting:
+    CARDIO_TEXT = "Echocardiogram shows reduced ejection fraction of 35%"
+
+    def test_match_categories_routes_cardiology(self):
+        categories = [
+            category for category, _reason in _match_categories(self.CARDIO_TEXT)
+        ]
+        assert "Cardiology" in categories
+
+    def test_cardiology_is_registry_metadata_not_a_live_category(self):
+        # Forward metadata for future models; no Cardiology model exists today.
+        assert "Cardiology" in _CATEGORY_ENTITY_TYPES
+        from openmed.core.model_registry import CATEGORIES
+
+        assert "Cardiology" not in CATEGORIES
+
+    def test_get_model_suggestions_behavior_unchanged_for_cardiology(self):
+        # With no Cardiology model registered, suggestions fall back to general
+        # medical models rather than surfacing unrelated cardiology results.
+        suggestions = get_model_suggestions(self.CARDIO_TEXT)
+        assert suggestions  # still returns something useful
+        assert all(info.category != "Cardiology" for _key, info, _reason in suggestions)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements #317 (OM-152): adds a `cardiology` domain to the zero-shot default label map plus cardiology keyword routing, so cardiology notes (ECG findings, ejection fraction, cardiac procedures/devices) stop falling back to generic clinical labels.

Per the discussion on the issue, this follows **1(a)** (routing helper, `get_model_suggestions` behavior unchanged) and **2(a)** (display labels consistent with existing domains; no new clinical canonical-label system).

## Changes

- **`openmed/zero_shot/data/label_maps/defaults.json`** — new `cardiology` domain using the existing letters-only display-label style: `CardiacFinding, ECGFinding, EjectionFraction, CardiacProcedure, CardiacDevice, Anatomy`.
- **`openmed/core/model_registry.py`**
  - Extracted the keyword->category matching out of `get_model_suggestions` into a `_match_categories(text)` helper that returns `(category, reason)` pairs, so cardiology text routes to the `Cardiology` category independently of whether a Cardiology model is registered.
  - `get_model_suggestions()` user-facing behavior is unchanged: with no Cardiology model registered, cardiology text still falls back to general medical suggestions rather than surfacing unrelated results.
  - Added `_CATEGORY_ENTITY_TYPES["Cardiology"]` as forward registry metadata for future Cardiology models (none exists today).
- **`tests/unit/ner/test_label_map_consistency.py`** — tests for `available_domains()` / `get_default_labels("cardiology")`, non-empty labels, no duplicates, a label-style-consistency check across all domains, `_match_categories` routing for the echocardiogram example, and that `get_model_suggestions` behavior is unchanged.

`openmed/core/labels.py` is intentionally untouched — per the issue discussion, the strict `CANONICAL_LABELS` taxonomy there is the PII/PHI policy taxonomy, not a clinical zero-shot taxonomy, and no broad clinical canonical-label system is introduced in this issue.

## Acceptance criteria

- [x] `get_default_labels("cardiology")` returns a non-empty label set and `available_domains()` includes `cardiology`.
- [x] Cardiology text (e.g. `Echocardiogram shows reduced ejection fraction of 35%`) routes to the `Cardiology` category via `_match_categories`.
- [x] The cardiology domain reuses the existing display-label style (asserted by a style-consistency test across all domains).
- [x] `_CATEGORY_ENTITY_TYPES["Cardiology"]` added as forward metadata; `CATEGORIES` still has no `Cardiology` key (no model exists yet).

## Testing

- New cardiology tests pass; full unit suite passes (`.venv/bin/python -m pytest tests/ -q` -> 1619 passed, 12 skipped).
- The only 2 failures in the full run are pre-existing, network-gated integration tests (`tests/integration/test_sentence_detection_real.py`, which download `dslim/bert-base-NER`); they fail identically on `master` offline and are unrelated to this change.
- `ruff check` and `ruff format` clean on the changed files.

## Out of scope

- Training a cardiology model (routing/labels only).
- ECG signal processing (text only).
- A clinical canonical-label system.

Closes #317