### PR TITLE
feat: add dermatology and ophthalmology domains to NER catalog

### DIFF
--- a/openmed/core/model_registry.py
+++ b/openmed/core/model_registry.py
@@ -183,6 +183,15 @@ _CATEGORY_ENTITY_TYPES = {
         "CARDIAC_DEVICE",
         "ANATOMY",
     ],
+    # Forward metadata for future Dermatology/Ophthalmology models; no such
+    # model is registered today (see issue #318).
+    "Dermatology": ["SKIN_LESION", "MORPHOLOGY", "DISTRIBUTION", "ANATOMY"],
+    "Ophthalmology": [
+        "EYE_FINDING",
+        "VISUAL_ACUITY",
+        "INTRAOCULAR_PRESSURE",
+        "ANATOMY",
+    ],
     "Privacy": _PII_ENTITY_TYPES,
 }
 
@@ -647,6 +656,14 @@ _CATEGORY_KEYWORDS: Dict[str, Tuple[str, str]] = {
     "ecg|ekg|ejection fraction|arrhythmia|stent|pacemaker|murmur|st elevation|echocardiogram|cardiac|cardiolog": (
         "Cardiology",
         "Contains cardiology terms",
+    ),
+    "rash|lesion|macule|papule|erythema|pruritus|biopsy of skin|dermatolog|skin": (
+        "Dermatology",
+        "Contains dermatology terms",
+    ),
+    "visual acuity|intraocular pressure|retina|cornea|glaucoma|fundus|ophthalmolog": (
+        "Ophthalmology",
+        "Contains ophthalmology terms",
     ),
     "heart|lung|brain|liver|kidney|organ": (
         "Anatomy",

--- a/openmed/zero_shot/data/label_maps/defaults.json
+++ b/openmed/zero_shot/data/label_maps/defaults.json
@@ -13,5 +13,7 @@
   "social": ["Person", "Handle", "Hashtag", "URL"],
   "public_health": ["Condition", "Intervention", "Outcome", "Population"],
   "cardiology": ["CardiacFinding", "ECGFinding", "EjectionFraction", "CardiacProcedure", "CardiacDevice", "Anatomy"],
+  "dermatology": ["SkinLesion", "Morphology", "Distribution", "Anatomy"],
+  "ophthalmology": ["EyeFinding", "VisualAcuity", "IntraocularPressure", "Anatomy"],
   "generic": ["Person", "Organization", "Location", "Date"]
 }

--- a/tests/unit/ner/test_label_map_consistency.py
+++ b/tests/unit/ner/test_label_map_consistency.py
@@ -135,6 +135,81 @@ class TestCardiologyRouting:
 
 
 # ---------------------------------------------------------------------------
+# Dermatology and ophthalmology domains (issue #318)
+# ---------------------------------------------------------------------------
+
+
+class TestSpecialtyDomains:
+    EXPECTED = {
+        "dermatology": ["SkinLesion", "Morphology", "Distribution", "Anatomy"],
+        "ophthalmology": [
+            "EyeFinding",
+            "VisualAcuity",
+            "IntraocularPressure",
+            "Anatomy",
+        ],
+    }
+
+    def test_domains_in_available_domains(self):
+        domains = available_domains()
+        assert "dermatology" in domains
+        assert "ophthalmology" in domains
+
+    def test_get_default_labels_returns_expected_sets(self):
+        for domain, expected in self.EXPECTED.items():
+            labels = get_default_labels(domain)
+            assert labels  # non-empty
+            assert labels == expected
+
+    def test_specialty_labels_have_no_duplicates(self):
+        for domain in self.EXPECTED:
+            labels = get_default_labels(domain)
+            lowered = [label.lower() for label in labels]
+            assert len(lowered) == len(set(lowered))
+
+
+# ---------------------------------------------------------------------------
+# Dermatology and ophthalmology routing in model_registry (issue #318)
+# ---------------------------------------------------------------------------
+
+
+class TestSpecialtyRouting:
+    DERM_TEXT = "Erythematous macule with pruritus noted on the forearm"
+    OPHTH_TEXT = (
+        "Fundus exam shows elevated intraocular pressure consistent with glaucoma"
+    )
+
+    def test_match_categories_routes_dermatology(self):
+        categories = [
+            category for category, _reason in _match_categories(self.DERM_TEXT)
+        ]
+        assert "Dermatology" in categories
+
+    def test_match_categories_routes_ophthalmology(self):
+        categories = [
+            category for category, _reason in _match_categories(self.OPHTH_TEXT)
+        ]
+        assert "Ophthalmology" in categories
+
+    def test_specialties_are_registry_metadata_not_live_categories(self):
+        # Forward metadata for future models; no specialty model exists today.
+        from openmed.core.model_registry import CATEGORIES
+
+        for category in ("Dermatology", "Ophthalmology"):
+            assert category in _CATEGORY_ENTITY_TYPES
+            assert category not in CATEGORIES
+
+    def test_get_model_suggestions_behavior_unchanged_for_specialties(self):
+        for text in (self.DERM_TEXT, self.OPHTH_TEXT):
+            suggestions = get_model_suggestions(text)
+            assert suggestions  # still returns something useful
+            assert all(
+                info.category not in {"Dermatology", "Ophthalmology"}
+                for _key, info, _reason in suggestions
+            )
+
+
+# ---------------------------------------------------------------------------
 # normalize_label idempotency
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #551 (#317).** This branch is based on the cardiology-domain branch, which introduces the `_match_categories` routing helper this PR reuses. Until #551 merges, the diff below also shows its changes; I will rebase onto `master` once #551 lands so this PR shows only the dermatology/ophthalmology changes. Please review #551 first.

Implements #318 (OM-153): adds `dermatology` and `ophthalmology` domains to the zero-shot default label map plus keyword routing, so specialty notes (skin lesions, eye findings) stop falling back to generic clinical labels.

This follows the exact approach you confirmed for the cardiology domain in #317: route via the `_match_categories` helper with `get_model_suggestions` behavior unchanged (**1(a)**), and use display labels consistent with existing domains rather than introducing a clinical canonical-label system (**2(a)**).

## Changes

- **`openmed/zero_shot/data/label_maps/defaults.json`** — new `dermatology` (`SkinLesion, Morphology, Distribution, Anatomy`) and `ophthalmology` (`EyeFinding, VisualAcuity, IntraocularPressure, Anatomy`) domains, in the existing letters-only display-label style.
- **`openmed/core/model_registry.py`**
  - Added dermatology (`rash, lesion, macule, papule, erythema, pruritus, biopsy of skin, dermatolog, skin`) and ophthalmology (`visual acuity, intraocular pressure, retina, cornea, glaucoma, fundus, ophthalmolog`) patterns to `_CATEGORY_KEYWORDS`, so specialty text routes to its category via `_match_categories` independently of whether a specialty model is registered.
  - `get_model_suggestions()` user-facing behavior is unchanged: with no specialty model registered, specialty text still falls back to general medical suggestions.
  - Added `_CATEGORY_ENTITY_TYPES["Dermatology"]` and `["Ophthalmology"]` as forward registry metadata for future specialty models (none exists today).
- **`tests/unit/ner/test_label_map_consistency.py`** — tests for `available_domains()` / `get_default_labels()` for both domains, non-empty labels, no duplicates, `_match_categories` routing for a dermatology and an ophthalmology sentence, and that `get_model_suggestions` behavior is unchanged.

`openmed/core/labels.py` is intentionally untouched, consistent with the #317 decision.

## Acceptance criteria

- [x] `available_domains()` includes both `dermatology` and `ophthalmology` with non-empty label sets.
- [x] A dermatology sentence routes to `Dermatology` and an ophthalmology sentence routes to `Ophthalmology` (via `_match_categories`, per the #317 routing approach).
- [x] Labels are covered by tests (expected sets, no duplicates, and the cross-domain style-consistency check). **Note:** per the #317 resolution, labels are *not* normalised against the PII/PHI `CANONICAL_LABELS` taxonomy and no clinical canonical-label system is introduced; if you would prefer a different label-assertion here, happy to adjust.
- [x] `_CATEGORY_ENTITY_TYPES` has `Dermatology`/`Ophthalmology`; `CATEGORIES` has neither (no model exists yet).

## Testing

- New specialty tests pass; full unit suite passes (`.venv/bin/python -m pytest tests/ -q` -> 1626 passed, 12 skipped).
- The only 2 failures in the full run are pre-existing, network-gated integration tests (`tests/integration/test_sentence_detection_real.py`, which download `dslim/bert-base-NER`); they fail identically on `master` offline and are unrelated to this change.
- `ruff check` and `ruff format` clean on the changed files.

## Out of scope

- Training specialty models (routing/labels only).
- Image-based dermatology (text only).
- A clinical canonical-label system.

Closes #318