### PR TITLE
feat: declare the [multimodal] extra and ingest/redact contract

### DIFF
--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -1,5 +1,29 @@
 """Multimodal ingestion and redaction package for section 4.2.
 
-Intended contents include PDF/DOCX/HTML->text+offsets extraction, OCR, and
-image/DICOM redaction.
+Provides the shared ingest/redact contract (``ExtractedDocument`` and the
+``redact_document`` dispatcher) that PDF/DOCX/HTML/image/DICOM ingesters build
+on. The per-format parsers and OCR adapters live in sibling modules and are
+registered lazily via :func:`register_handler`; this package stays importable
+without the ``multimodal`` extra installed.
 """
+
+from __future__ import annotations
+
+from .base import (
+    ExtractedDocument,
+    SourceSpan,
+    ensure_multimodal_available,
+    redact_document,
+    register_handler,
+)
+from .exceptions import MissingDependencyError, UnsupportedDocumentError
+
+__all__ = [
+    "ExtractedDocument",
+    "SourceSpan",
+    "redact_document",
+    "register_handler",
+    "ensure_multimodal_available",
+    "MissingDependencyError",
+    "UnsupportedDocumentError",
+]

--- a/openmed/multimodal/base.py
+++ b/openmed/multimodal/base.py
@@ -1,0 +1,178 @@
+"""Shared ingest/redact contract for the multimodal subsystem.
+
+This module is the stable foundation every document/image/DICOM ingester builds
+on. It deliberately avoids importing heavy ingestion dependencies
+(pdfplumber/python-docx/Pillow) at module load time so that ``import openmed``
+and ``import openmed.multimodal`` stay lightweight; ingesters import their own
+dependencies lazily and surface a clear error when the ``multimodal`` extra is
+absent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+from .exceptions import MissingDependencyError, UnsupportedDocumentError
+
+# Module name -> distribution name for the dependencies in the [multimodal] extra.
+_MULTIMODAL_DEPENDENCIES: tuple[tuple[str, str], ...] = (
+    ("pdfplumber", "pdfplumber"),
+    ("docx", "python-docx"),
+    ("PIL", "Pillow"),
+)
+
+_MULTIMODAL_INSTALL_HINT = 'Install with: pip install "openmed[multimodal]".'
+
+
+def _missing_multimodal_dependencies() -> list[str]:
+    """Return the distribution names of any missing multimodal dependencies."""
+    import importlib.util
+
+    return [
+        distribution
+        for module, distribution in _MULTIMODAL_DEPENDENCIES
+        if importlib.util.find_spec(module) is None
+    ]
+
+
+def ensure_multimodal_available() -> None:
+    """Raise a clear error if the ``multimodal`` extra is not installed."""
+    missing = _missing_multimodal_dependencies()
+    if missing:
+        raise MissingDependencyError(
+            dependency=", ".join(missing),
+            instruction=_MULTIMODAL_INSTALL_HINT,
+        )
+
+
+@dataclass(frozen=True)
+class SourceSpan:
+    """Maps a character range in normalized text to a location in the source.
+
+    ``start``/``end`` are character offsets into :attr:`ExtractedDocument.text`
+    (``end`` exclusive). ``page`` is the 0-based source page and ``bbox`` is an
+    optional ``(x0, y0, x1, y1)`` bounding box. ``metadata`` carries per-block
+    details (block type, font, confidence, ...).
+    """
+
+    start: int
+    end: int
+    page: int = 0
+    bbox: tuple[float, float, float, float] | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExtractedDocument:
+    """Normalized text plus a char-offset -> source-location map.
+
+    This is the common contract returned by every per-format ingester. It lets
+    downstream redaction work on a single normalized string while still being
+    able to map any character offset back to its location in the source.
+    """
+
+    text: str
+    spans: tuple[SourceSpan, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_blocks(
+        cls,
+        blocks: Iterable[Mapping[str, Any]],
+        *,
+        separator: str = "\n",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "ExtractedDocument":
+        """Assemble a document from ordered source blocks.
+
+        Each block is a mapping with a required ``text`` key and optional
+        ``page``, ``bbox`` and ``metadata`` keys. Blocks are joined with
+        ``separator`` and a :class:`SourceSpan` is recorded for each.
+        """
+        parts: list[str] = []
+        spans: list[SourceSpan] = []
+        cursor = 0
+        for index, block in enumerate(blocks):
+            if index > 0:
+                parts.append(separator)
+                cursor += len(separator)
+            block_text = str(block["text"])
+            start = cursor
+            cursor += len(block_text)
+            parts.append(block_text)
+            spans.append(
+                SourceSpan(
+                    start=start,
+                    end=cursor,
+                    page=int(block.get("page", 0)),
+                    bbox=block.get("bbox"),
+                    metadata=dict(block.get("metadata", {})),
+                )
+            )
+        return cls(
+            text="".join(parts),
+            spans=tuple(spans),
+            metadata=dict(metadata or {}),
+        )
+
+    def location_at(self, offset: int) -> SourceSpan | None:
+        """Return the source span covering ``offset``, or ``None`` if unmapped."""
+        if offset < 0 or offset >= len(self.text):
+            return None
+        for span in self.spans:
+            if span.start <= offset < span.end:
+                return span
+        return None
+
+    def text_for(self, span: SourceSpan) -> str:
+        """Return the normalized text covered by ``span``."""
+        return self.text[span.start : span.end]
+
+
+# Document handlers are registered lazily by per-format ingester modules so the
+# dispatcher never needs editing when a new format lands.
+DocumentHandler = Callable[..., ExtractedDocument]
+
+_HANDLERS: dict[str, DocumentHandler] = {}
+
+
+def _normalize_extension(extension: str) -> str:
+    extension = extension.lower()
+    return extension if extension.startswith(".") else f".{extension}"
+
+
+def register_handler(
+    extensions: str | Iterable[str],
+    handler: DocumentHandler,
+) -> None:
+    """Register ``handler`` for one or more file extensions (e.g. ``".pdf"``)."""
+    if isinstance(extensions, str):
+        extensions = [extensions]
+    for extension in extensions:
+        _HANDLERS[_normalize_extension(extension)] = handler
+
+
+def redact_document(
+    path: str | Path,
+    *,
+    policy: Any | None = None,
+    models: Any | None = None,
+) -> ExtractedDocument:
+    """De-identify a document, dispatching by file extension to its ingester.
+
+    Raises :class:`MissingDependencyError` if the ``multimodal`` extra is not
+    installed, and :class:`UnsupportedDocumentError` if no handler is registered
+    for the file's extension.
+    """
+    ensure_multimodal_available()
+    extension = Path(str(path)).suffix.lower()
+    handler = _HANDLERS.get(extension)
+    if handler is None:
+        supported = ", ".join(sorted(_HANDLERS)) or "none"
+        raise UnsupportedDocumentError(
+            f"No multimodal handler registered for extension "
+            f"{extension or '(none)'!r}. Supported extensions: {supported}."
+        )
+    return handler(path, policy=policy, models=models)

--- a/openmed/multimodal/exceptions.py
+++ b/openmed/multimodal/exceptions.py
@@ -1,0 +1,23 @@
+"""Exceptions for the multimodal ingest/redact subsystem.
+
+Kept dependency-free so importing it never drags in heavy ingestion packages.
+"""
+
+from __future__ import annotations
+
+
+class MissingDependencyError(ImportError):
+    """Raised when the multimodal extra is required but not installed."""
+
+    def __init__(self, dependency: str, instruction: str) -> None:
+        message = (
+            f"Optional dependency '{dependency}' is required for this operation. "
+            f"{instruction}"
+        )
+        super().__init__(message)
+        self.dependency = dependency
+        self.instruction = instruction
+
+
+class UnsupportedDocumentError(ValueError):
+    """Raised when no handler is registered for a document's file type."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,12 @@ presidio = [
   "presidio-analyzer>=2.2.354,<3",
 ]
 
+multimodal = [
+  "pdfplumber>=0.11",
+  "python-docx>=1.1",
+  "Pillow>=10.0",
+]
+
 hf = [
   "transformers>=4.50",
   "huggingface-hub>=0.30",

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -29,6 +29,8 @@ ALLOWED_LICENSE_MARKERS = (
     "BSD-2-CLAUSE",
     "BSD-3-CLAUSE",
     "ISC",
+    "HPND",
+    "HISTORICAL PERMISSION NOTICE AND DISCLAIMER",
 )
 
 DISALLOWED_LICENSE_MARKERS = (
@@ -65,9 +67,12 @@ REVIEWED_LICENSES = {
     "mkdocs-minify-plugin": "MIT",
     "mkdocstrings": "ISC",
     "mlx": "MIT",
+    "pdfplumber": "MIT",
+    "pillow": "HPND",
     "presidio-analyzer": "MIT",
     "pymdown-extensions": "MIT",
     "pysbd": "MIT",
+    "python-docx": "MIT",
     "rich": "MIT",
     "safetensors": "Apache-2.0",
     "tiktoken": "MIT",

--- a/tests/unit/multimodal/test_base_contract.py
+++ b/tests/unit/multimodal/test_base_contract.py
@@ -1,0 +1,115 @@
+"""Tests for the multimodal ingest/redact contract.
+
+Covers the ``ExtractedDocument`` text<->offset round-trip and the
+extension-based ``redact_document`` dispatcher with its lazy handler registry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import openmed.multimodal.base as base
+from openmed.multimodal import (
+    ExtractedDocument,
+    SourceSpan,
+    redact_document,
+    register_handler,
+)
+from openmed.multimodal.exceptions import UnsupportedDocumentError
+
+
+@pytest.fixture
+def clean_registry():
+    """Snapshot and restore the handler registry around each test."""
+    saved = dict(base._HANDLERS)
+    base._HANDLERS.clear()
+    try:
+        yield
+    finally:
+        base._HANDLERS.clear()
+        base._HANDLERS.update(saved)
+
+
+@pytest.fixture
+def deps_present(monkeypatch):
+    """Pretend the multimodal extra is installed."""
+    monkeypatch.setattr(base, "_missing_multimodal_dependencies", lambda: [])
+
+
+BLOCKS = [
+    {"text": "Patient John Doe", "page": 1, "bbox": (0.0, 0.0, 1.0, 0.1)},
+    {"text": "MRN 12345", "page": 1, "bbox": (0.0, 0.2, 1.0, 0.3)},
+    {"text": "Discharged 2026-01-02", "page": 2},
+]
+
+
+class TestExtractedDocument:
+    def test_from_blocks_concatenates_text(self):
+        doc = ExtractedDocument.from_blocks(BLOCKS)
+        assert doc.text == "Patient John Doe\nMRN 12345\nDischarged 2026-01-02"
+        assert len(doc.spans) == 3
+
+    def test_spans_round_trip_text(self):
+        doc = ExtractedDocument.from_blocks(BLOCKS)
+        for block, span in zip(BLOCKS, doc.spans):
+            assert doc.text[span.start : span.end] == block["text"]
+            assert doc.text_for(span) == block["text"]
+
+    def test_location_at_resolves_source_location(self):
+        doc = ExtractedDocument.from_blocks(BLOCKS)
+        # An offset inside the second block resolves to page 1 with its bbox.
+        offset = doc.text.index("MRN")
+        span = doc.location_at(offset)
+        assert span is not None
+        assert span.page == 1
+        assert span.bbox == (0.0, 0.2, 1.0, 0.3)
+        assert doc.text_for(span) == "MRN 12345"
+
+    def test_location_at_out_of_range_returns_none(self):
+        doc = ExtractedDocument.from_blocks(BLOCKS)
+        assert doc.location_at(-1) is None
+        assert doc.location_at(len(doc.text) + 5) is None
+
+    def test_source_span_is_frozen(self):
+        span = SourceSpan(start=0, end=1)
+        with pytest.raises(Exception):
+            span.start = 5  # type: ignore[misc]
+
+
+class TestRedactDocumentDispatcher:
+    def test_dispatches_to_registered_handler(self, clean_registry, deps_present):
+        received = {}
+
+        def handler(path, *, policy=None, models=None):
+            received["path"] = path
+            received["policy"] = policy
+            received["models"] = models
+            return ExtractedDocument.from_blocks([{"text": "ok"}])
+
+        register_handler(".txt", handler)
+        doc = redact_document("note.txt", policy="hipaa_safe_harbor", models="m1")
+
+        assert isinstance(doc, ExtractedDocument)
+        assert received["path"] == "note.txt"
+        assert received["policy"] == "hipaa_safe_harbor"
+        assert received["models"] == "m1"
+
+    def test_extension_match_is_case_insensitive(self, clean_registry, deps_present):
+        register_handler(
+            ".txt", lambda path, **_: ExtractedDocument.from_blocks([{"text": "x"}])
+        )
+        assert isinstance(redact_document("NOTE.TXT"), ExtractedDocument)
+
+    def test_register_handler_accepts_multiple_extensions(
+        self, clean_registry, deps_present
+    ):
+        register_handler(
+            [".htm", ".html"],
+            lambda path, **_: ExtractedDocument.from_blocks([{"text": "x"}]),
+        )
+        assert isinstance(redact_document("a.htm"), ExtractedDocument)
+        assert isinstance(redact_document("a.html"), ExtractedDocument)
+
+    def test_unknown_extension_raises_unsupported(self, clean_registry, deps_present):
+        with pytest.raises(UnsupportedDocumentError):
+            redact_document("mystery.xyz")

--- a/tests/unit/multimodal/test_multimodal_extra.py
+++ b/tests/unit/multimodal/test_multimodal_extra.py
@@ -1,0 +1,63 @@
+"""Tests for the [multimodal] optional-dependency extra and import isolation.
+
+The multimodal foundation must not pull heavy ingestion dependencies
+(pdfplumber/python-docx/Pillow) into the base ``import openmed`` path, and
+``redact_document`` must raise a clear, actionable error naming the extra when
+those dependencies are absent.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from openmed.multimodal import redact_document
+from openmed.multimodal.exceptions import MissingDependencyError
+
+# Distribution package -> import module name for the multimodal extra.
+HEAVY_MODULES = ("pdfplumber", "docx", "PIL")
+
+
+def _import_then_check(import_line: str) -> set[str]:
+    """Import something in a clean subprocess and report which heavy modules loaded."""
+    code = (
+        f"import sys\n{import_line}\n"
+        f"loaded = [m for m in {HEAVY_MODULES!r} if m in sys.modules]\n"
+        "print(','.join(loaded))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {m for m in result.stdout.strip().split(",") if m}
+
+
+def test_importing_openmed_does_not_load_heavy_multimodal_deps():
+    assert _import_then_check("import openmed") == set()
+
+
+def test_importing_openmed_multimodal_does_not_load_heavy_deps():
+    # The foundation module itself must defer heavy imports to the ingesters.
+    assert _import_then_check("import openmed.multimodal") == set()
+
+
+def test_redact_document_raises_named_error_when_extra_missing(monkeypatch):
+    import openmed.multimodal.base as base
+
+    monkeypatch.setattr(
+        base, "_missing_multimodal_dependencies", lambda: ["pdfplumber"]
+    )
+    with pytest.raises(MissingDependencyError) as excinfo:
+        redact_document("note.pdf")
+
+    message = str(excinfo.value)
+    assert "multimodal" in message
+    assert "pdfplumber" in message
+
+
+def test_missing_dependency_error_is_importerror():
+    assert issubclass(MissingDependencyError, ImportError)


### PR DESCRIPTION
Implements #223 (OM-058): the single, stable foundation the multimodal ingestion line builds on — a declared `[multimodal]` pip extra and a small shared ingest/redact contract — so each later per-format PR registers a handler instead of re-wiring dependencies and the text<->offset surface.

This is foundation-only: **no per-format parsers and no OCR wiring** (those are #226 and later). It unblocks OM-060/061/062/064/082.

## Changes

- **`pyproject.toml`** — new `multimodal` optional-dependency extra (`pdfplumber`, `python-docx`, `Pillow`), kept out of the base install.
- **`openmed/multimodal/base.py`**
  - `ExtractedDocument` — normalized plain text plus a char-offset -> source-location map (`SourceSpan` with page, char range, optional bbox, and per-block metadata). Helpers: `from_blocks(...)`, `location_at(offset)`, `text_for(span)`.
  - Lazy extension -> handler registry via `register_handler(extensions, handler)`, so later format tasks register without editing the dispatcher.
  - `redact_document(path, *, policy=None, models=None)` dispatcher that routes by file extension.
- **Import isolation** — `base.py` has no module-level heavy imports, and `multimodal` ships its own lightweight `exceptions.py` (reusing `openmed.ner`s exception would have pulled in transformers/torch). Importing `openmed` or `openmed.multimodal` never imports pdfplumber/python-docx/Pillow. `redact_document` raises a clear `MissingDependencyError` naming the `multimodal` extra when deps are absent, and `UnsupportedDocumentError` for unregistered file types.
- **`openmed/multimodal/__init__.py`** — re-exports the public contract.
- **`scripts/release/check_license_policy.py`** — added reviewed license entries for the three new deps and added **HPND** (Pillows actual OSI-approved permissive license) to the allowed-marker list. Flagging this since it broadens the global permissive allowlist; happy to adjust if youd prefer a narrower handling.

## Acceptance criteria

- [x] `openmed.multimodal.redact_document` and `ExtractedDocument` are exposed (re-exported from the package).
- [x] Importing `openmed` does not import pdfplumber/python-docx/Pillow (asserted via a subprocess `sys.modules` inspection, so it is robust even when the extra is installed).
- [x] `redact_document` raises a clear, ImportError-style message naming the `multimodal` extra when deps are missing.
- [x] `ExtractedDocument` round-trips text<->offset map for a synthetic fixture.

## Testing

- New multimodal tests pass; full unit suite passes (`.venv/bin/python -m pytest tests/ -q` -> 1625 passed, 12 skipped).
- The only 2 failures in the full run are pre-existing, network-gated integration tests (`tests/integration/test_sentence_detection_real.py`, which download `dslim/bert-base-NER`); they fail identically on `master` offline and are unrelated to this change.
- `ruff check` and `ruff format` clean on the changed files.

## Out of scope

- Per-format parsers (PDF/DOCX/HTML/DICOM/image).
- OCR engine wiring (separate adapter task).
- The `[structured]` extra.

Closes #223