### PR TITLE
fix: reject duplicate resource ids in FHIR Bundle assembler

### DIFF
--- a/openmed/clinical/exporters/fhir/bundle.py
+++ b/openmed/clinical/exporters/fhir/bundle.py
@@ -65,6 +65,15 @@ def to_bundle(
     -------
     dict
         A ``resourceType=Bundle`` mapping with one entry per resource.
+
+    Raises
+    ------
+    ValueError
+        If a resource lacks a ``resourceType``, or if two resources share the
+        same ``resourceType`` and ``id``. Duplicate ids would silently
+        overwrite one another in the internal reference map, corrupting
+        cross-references, so they are rejected explicitly. Resources without
+        an ``id`` remain valid (they are simply unreferenceable).
     """
 
     entries: list[dict[str, Any]] = []
@@ -83,7 +92,14 @@ def to_bundle(
     for urn, resource in zip(urns, resources):
         resource_id = resource.get("id")
         if resource_id is not None:
-            reference_map[f"{resource['resourceType']}/{resource_id}"] = urn
+            ref_key = f"{resource['resourceType']}/{resource_id}"
+            if ref_key in reference_map:
+                raise ValueError(
+                    f"duplicate resource id {ref_key!r}: two resources share "
+                    "the same resourceType and id, which would silently "
+                    "corrupt internal cross-references"
+                )
+            reference_map[ref_key] = urn
 
     emit_request = bundle_type in _REQUEST_BUNDLE_TYPES
     for urn, resource in zip(urns, resources):

--- a/tests/unit/clinical/test_fhir_bundle.py
+++ b/tests/unit/clinical/test_fhir_bundle.py
@@ -209,3 +209,56 @@ def test_rewrite_references_is_pure_helper():
     assert rewritten["result"][0]["reference"] == "urn:uuid:abc"
     # original untouched
     assert node["result"][0]["reference"] == "Observation/obs1"
+
+
+class TestDuplicateResourceIds:
+    """Regression tests for duplicate ``ResourceType/id`` detection (OM-340)."""
+
+    def test_duplicate_resource_id_raises(self):
+        # Two resources with the same resourceType and id would silently
+        # overwrite each other in the reference map, corrupting cross-
+        # references. The assembler must reject this explicitly.
+        resources = [
+            {"resourceType": "Observation", "id": "obs1", "status": "final"},
+            {"resourceType": "Observation", "id": "obs1", "status": "final"},
+        ]
+        with pytest.raises(ValueError, match="duplicate resource id"):
+            to_bundle(resources, doc_id="doc-1")
+
+    def test_duplicate_id_error_names_colliding_key(self):
+        resources = [
+            {"resourceType": "Patient", "id": "pat1"},
+            {"resourceType": "Patient", "id": "pat1"},
+        ]
+        with pytest.raises(ValueError, match=r"Patient/pat1"):
+            to_bundle(resources, doc_id="doc-1")
+
+    def test_resources_without_id_do_not_collide(self):
+        # Resources without an id are unreferenceable, which is valid; two
+        # id-less resources of the same type must not raise.
+        resources = [
+            {"resourceType": "Observation", "status": "final"},
+            {"resourceType": "Observation", "status": "final"},
+        ]
+        bundle = to_bundle(resources, doc_id="doc-1")
+        assert len(bundle["entry"]) == 2
+
+    def test_same_id_different_resource_type_is_allowed(self):
+        # "Observation/1" and "Patient/1" are distinct keys, so no collision.
+        resources = [
+            {"resourceType": "Observation", "id": "1", "status": "final"},
+            {"resourceType": "Patient", "id": "1"},
+        ]
+        bundle = to_bundle(resources, doc_id="doc-1")
+        assert len(bundle["entry"]) == 2
+
+    def test_duplicate_id_raises_before_any_entry_emitted(self):
+        # The error should surface regardless of where the duplicate appears
+        # in the input sequence.
+        resources = [
+            {"resourceType": "Condition", "id": "c1"},
+            {"resourceType": "Observation", "id": "obs1"},
+            {"resourceType": "Condition", "id": "c1"},
+        ]
+        with pytest.raises(ValueError, match=r"Condition/c1"):
+            to_bundle(resources, doc_id="doc-1")


### PR DESCRIPTION
## Description
`to_bundle` builds `reference_map` keyed by `"ResourceType/id"`. When two resources share the same type and id, the second silently overwrites the first, corrupting internal cross-references. This PR detects the collision and raises a clear `ValueError` naming the colliding key. Resources without an `id` remain valid (unreferenceable).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Detect duplicate `"ResourceType/id"` keys in `reference_map` and raise `ValueError`
- Document the duplicate-id contract in the `to_bundle` docstring (`Raises` section)
- Add 5 regression tests covering collision detection, error message content, id-less resources, distinct types with same id, and position independence

## Testing
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally (1609 passed, 22 skipped)

## Code Quality
- [x] I ran `ruff check` and `ruff format --check` — all passed
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies

## Related Issues
Closes #530