### PR TITLE
fix: shift dates for the default model by matching the canonical label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `method="shift_dates"` now shifts dates for the default English model instead of masking them. `_redact_entity` (and the `keep_mapping` occurrence counter) compared the raw `entity.entity_type` against the literal `"DATE"`, but the default model `OpenMed-PII-SuperClinical-Small-44M-v1` emits a lowercase `date` label, so date spans silently fell through to `[DATE]` placeholders. Date detection now uses the canonical label (`entity.canonical_label`, falling back to `normalize_label`), guarded by a regression test.
 - REST/MCP request schemas now accept `ar`, `ja`, and `tr` for the `lang` field. These languages have published PII models and are listed in `SUPPORTED_LANGUAGES`, but the `lang` `Literal` in `openmed/service/schemas.py` was never updated, so the service rejected them with a 422 even though the Python API and the models worked. The four `lang` annotations now share a single `PIILanguage` alias kept in sync with `SUPPORTED_LANGUAGES` (guarded by a regression test).
 
 ## [1.5.5] - 2026-06-08

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1093,7 +1093,7 @@ def _build_deidentification_result(
         for entity in sorted(pii_entities, key=lambda e: e.start):
             entity_method = _entity_redaction_method(entity, effective_method)
             if entity_method in {"mask", "remove"} or (
-                entity_method == "shift_dates" and entity.entity_type != "DATE"
+                entity_method == "shift_dates" and not _is_date_entity(entity, lang)
             ):
                 entity_type_counts[entity.entity_type] = (
                     entity_type_counts.get(entity.entity_type, 0) + 1
@@ -1402,6 +1402,21 @@ def deidentify(
     return result.deidentification_result
 
 
+def _is_date_entity(entity: PIIEntity, lang: str = "en") -> bool:
+    """Return True if ``entity`` is a DATE span.
+
+    ``entity.entity_type`` holds the raw model label, whose spelling and case
+    vary across models (the default English model emits lowercase ``"date"``),
+    so comparing it to the literal ``"DATE"`` misses dates for most models. The
+    canonical label normalizes these to ``DATE``; fall back to normalizing the
+    raw label when ``canonical_label`` is unset.
+    """
+    from .labels import DATE, normalize_label
+
+    canonical = entity.canonical_label or normalize_label(entity.entity_type, lang)
+    return canonical == DATE
+
+
 def _redact_entity(
     entity: PIIEntity,
     method: DeidentificationMethod,
@@ -1450,7 +1465,7 @@ def _redact_entity(
 
     elif method == "shift_dates":
         # Shift dates by offset
-        if entity.entity_type == "DATE" and date_shift_days is not None:
+        if _is_date_entity(entity, lang) and date_shift_days is not None:
             return _shift_date(entity.text, date_shift_days, keep_year, lang=lang)
         else:
             # Non-date entities get masked

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1408,13 +1408,13 @@ def _is_date_entity(entity: PIIEntity, lang: str = "en") -> bool:
     ``entity.entity_type`` holds the raw model label, whose spelling and case
     vary across models (the default English model emits lowercase ``"date"``),
     so comparing it to the literal ``"DATE"`` misses dates for most models. The
-    canonical label normalizes these to ``DATE``; fall back to normalizing the
-    raw label when ``canonical_label`` is unset.
+    canonical label normalizes these to a date label; fall back to normalizing
+    the raw label when ``canonical_label`` is unset.
     """
-    from .labels import DATE, normalize_label
+    from .labels import DATE, DATE_OF_BIRTH, normalize_label
 
     canonical = entity.canonical_label or normalize_label(entity.entity_type, lang)
-    return canonical == DATE
+    return canonical in {DATE, DATE_OF_BIRTH}
 
 
 def _redact_entity(

--- a/tests/unit/test_pii.py
+++ b/tests/unit/test_pii.py
@@ -693,6 +693,25 @@ class TestRedactEntity:
         result = _redact_entity(entity, "shift_dates", date_shift_days=30)
         assert result == "[NAME]"
 
+    def test_redact_shift_dates_uses_canonical_label(self):
+        """shift_dates must shift dates whose raw label is not literally 'DATE'.
+
+        The default English model emits a lowercase ``date`` label; comparing
+        the raw ``entity_type`` to ``"DATE"`` made such dates silently fall
+        through to masking. Regression test for the canonical-label fix.
+        """
+        entity = PIIEntity(
+            text="01/15/2020",
+            label="date",
+            start=0,
+            end=10,
+            confidence=0.90,
+            entity_type="date",
+            canonical_label="DATE",
+        )
+        result = _redact_entity(entity, "shift_dates", date_shift_days=30)
+        assert result == "02/14/2020"
+
 
 # ---------------------------------------------------------------------------
 # _generate_fake_pii Tests

--- a/tests/unit/test_pii.py
+++ b/tests/unit/test_pii.py
@@ -579,6 +579,89 @@ class TestDeidentify:
         assert result.deidentified_text == "DOB 02/14/2020"
 
     @patch("openmed.core.pii.extract_pii")
+    def test_deidentify_shift_dates_uses_lowercase_default_model_label(
+        self, mock_extract
+    ):
+        """Default English model lowercase ``date`` labels must shift."""
+        mock_extract.return_value = PredictionResult(
+            text="DOB 01/15/2020",
+            entities=[
+                EntityPrediction(
+                    text="01/15/2020", label="date", start=4, end=14, confidence=0.95
+                )
+            ],
+            model_name="OpenMed-PII-SuperClinical-Small-44M-v1",
+            timestamp=datetime.now().isoformat(),
+        )
+
+        result = deidentify(
+            "DOB 01/15/2020",
+            method="shift_dates",
+            date_shift_days=30,
+        )
+
+        assert result.deidentified_text == "DOB 02/14/2020"
+        assert "[DATE]" not in result.deidentified_text
+        assert "[date]" not in result.deidentified_text
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_deidentify_shift_dates_recognizes_date_of_birth_label(self, mock_extract):
+        """Raw ``date_of_birth`` labels normalize to a date label before shifting."""
+        mock_extract.return_value = PredictionResult(
+            text="DOB 01/15/2020",
+            entities=[
+                EntityPrediction(
+                    text="01/15/2020",
+                    label="date_of_birth",
+                    start=4,
+                    end=14,
+                    confidence=0.95,
+                )
+            ],
+            model_name="test",
+            timestamp=datetime.now().isoformat(),
+        )
+
+        result = deidentify(
+            "DOB 01/15/2020",
+            method="shift_dates",
+            date_shift_days=30,
+        )
+
+        assert result.deidentified_text == "DOB 02/14/2020"
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_shift_dates_keep_mapping_does_not_suffix_shifted_dates(self, mock_extract):
+        """Shifted dates should not be counted as mask placeholders."""
+        text = "DOB 01/15/2020 and 01/16/2020"
+        mock_extract.return_value = PredictionResult(
+            text=text,
+            entities=[
+                EntityPrediction(
+                    text="01/15/2020", label="date", start=4, end=14, confidence=0.95
+                ),
+                EntityPrediction(
+                    text="01/16/2020", label="date", start=19, end=29, confidence=0.95
+                ),
+            ],
+            model_name="OpenMed-PII-SuperClinical-Small-44M-v1",
+            timestamp=datetime.now().isoformat(),
+        )
+
+        result = deidentify(
+            text,
+            method="shift_dates",
+            date_shift_days=30,
+            keep_mapping=True,
+        )
+
+        assert result.deidentified_text == "DOB 02/14/2020 and 02/15/2020"
+        assert result.mapping == {
+            "02/14/2020": "01/15/2020",
+            "02/15/2020": "01/16/2020",
+        }
+
+    @patch("openmed.core.pii.extract_pii")
     def test_deidentify_shift_dates_alias_promotes_method(self, mock_extract):
         """Test the legacy shift_dates boolean is treated as an alias."""
         mock_extract.return_value = PredictionResult(


### PR DESCRIPTION
## Description
`method="shift_dates"` silently masked dates for the default English model instead of shifting them.

In `_redact_entity` and the `keep_mapping` occurrence counter in `_build_deidentification_result`, a span was treated as a date by comparing the raw `entity.entity_type` to the literal `"DATE"`. But `entity_type` holds the model's raw label, and the default model `OpenMed-PII-SuperClinical-Small-44M-v1` emits a lowercase `date`. So date spans never matched and fell through to `[DATE]` mask placeholders — `shift_dates` degraded to masking for the default model.

Fix: decide date-ness from the canonical label via a small `_is_date_entity` helper (`entity.canonical_label`, falling back to `normalize_label(entity.entity_type, lang)`), applied at both sites.

## Change type
Bug fix (no API change, no new dependency).

## Tests run
- `pytest tests/unit/test_pii.py` — 113 passed (adds `test_redact_shift_dates_uses_canonical_label`, which fails on the base branch and passes here).
- `ruff check` / `ruff format --check` — clean.

## Docs / changelog
Added an entry under `[Unreleased] > Fixed` in `CHANGELOG.md`.

## Linked issue
Fixes #513 (addresses #408).
