### PR TITLE
Add per-language locale and national-ID surrogate coherence regression suite

### DIFF
--- a/openmed/core/anonymizer/locales.py
+++ b/openmed/core/anonymizer/locales.py
@@ -64,14 +64,14 @@ _APPROXIMATE_LOCALES: Final = frozenset({"te"})
 # asserts that and the round-trip.
 NATIONAL_ID_PROVIDERS: Final[Mapping[str, tuple[str, str]]] = {
     "en": ("en_US", "ssn"),
-    "fr": ("fr_FR", "ssn"),               # NIR / INSEE
+    "fr": ("fr_FR", "ssn"),  # NIR / INSEE
     "de": ("de_DE", "german_steuer_id"),  # Steuer-ID
-    "it": ("it_IT", "ssn"),               # Codice Fiscale
-    "es": ("es_ES", "nie"),               # NIE
-    "nl": ("nl_NL", "ssn"),               # BSN
-    "hi": ("hi_IN", "aadhaar"),           # Aadhaar (Verhoeff)
-    "te": ("en_IN", "aadhaar"),           # Aadhaar via approximate en_IN
-    "pt": ("pt_BR", "cpf"),               # CPF (registered validators are Brazilian)
+    "it": ("it_IT", "ssn"),  # Codice Fiscale
+    "es": ("es_ES", "nie"),  # NIE
+    "nl": ("nl_NL", "ssn"),  # BSN
+    "hi": ("hi_IN", "aadhaar"),  # Aadhaar (Verhoeff)
+    "te": ("en_IN", "aadhaar"),  # Aadhaar via approximate en_IN
+    "pt": ("pt_BR", "cpf"),  # CPF (registered validators are Brazilian)
 }
 
 _warned: set[str] = set()

--- a/openmed/core/anonymizer/locales.py
+++ b/openmed/core/anonymizer/locales.py
@@ -10,12 +10,24 @@ Notes:
   callers as a ``UserWarning`` the first time it's used.
 - Portuguese defaults to ``pt_PT``; pass ``locale="pt_BR"`` explicitly to
   generate Brazilian-Portuguese surrogates (matters for CPF/CNPJ context).
+
+Regression contract (OM-135):
+- Every ``openmed.core.pii_i18n.SUPPORTED_LANGUAGES`` code must have a
+  :data:`LANG_TO_LOCALE` entry whose locale exists in Faker (or is a
+  documented approximation in :data:`_APPROXIMATE_LOCALES`).
+- Every language with a checksum-validated national ID must appear in
+  :data:`NATIONAL_ID_PROVIDERS`, and its generated surrogates must round-trip
+  that language's registered validator in :mod:`openmed.core.pii_i18n`.
+- Only the documented approximations may emit the locale ``UserWarning``.
+  ``tests/unit/core/test_locale_coherence.py`` gates all three so a new
+  language pack mis-wired to a wrong locale or provider fails loudly. Use
+  :func:`locale_coherence_report` for a per-language summary.
 """
 
 from __future__ import annotations
 
 import warnings
-from typing import Final, Mapping
+from typing import Final, List, Mapping, Optional, Tuple
 
 # Default Faker locale per OpenMed language code.
 LANG_TO_LOCALE: Final[Mapping[str, str]] = {
@@ -37,6 +49,30 @@ LANG_TO_LOCALE: Final[Mapping[str, str]] = {
 # Languages whose default locale is a known approximation rather than a
 # direct match. Used to emit a one-time warning so callers can override.
 _APPROXIMATE_LOCALES: Final = frozenset({"te"})
+
+
+# Per-language national-ID surrogate providers — the single source of truth for
+# the OM-135 round-trip fidelity suite. Maps each language that has a
+# checksum-validated national ID to the ``(faker_locale, faker_method)`` whose
+# generated surrogates pass that language's registered validator(s) in
+# :mod:`openmed.core.pii_i18n`. The locale here can differ from the language's
+# default display locale when the registered validators target another country's
+# format: Portuguese national-ID validation is Brazilian CPF/CNPJ, so ``pt``
+# draws ID surrogates from ``pt_BR`` even though its default locale (names,
+# addresses, ...) stays ``pt_PT``. The method must match the registry's
+# locale-aware dispatch (``registry._LOCALE_ID_METHODS``); the regression suite
+# asserts that and the round-trip.
+NATIONAL_ID_PROVIDERS: Final[Mapping[str, Tuple[str, str]]] = {
+    "en": ("en_US", "ssn"),
+    "fr": ("fr_FR", "ssn"),               # NIR / INSEE
+    "de": ("de_DE", "german_steuer_id"),  # Steuer-ID
+    "it": ("it_IT", "ssn"),               # Codice Fiscale
+    "es": ("es_ES", "nie"),               # NIE
+    "nl": ("nl_NL", "ssn"),               # BSN
+    "hi": ("hi_IN", "aadhaar"),           # Aadhaar (Verhoeff)
+    "te": ("en_IN", "aadhaar"),           # Aadhaar via approximate en_IN
+    "pt": ("pt_BR", "cpf"),               # CPF (registered validators are Brazilian)
+}
 
 _warned: set[str] = set()
 
@@ -71,4 +107,45 @@ def resolve_locale(lang: str, locale_override: str | None = None) -> str:
     return locale
 
 
-__all__ = ["LANG_TO_LOCALE", "resolve_locale"]
+def locale_coherence_report() -> List[dict]:
+    """Return one locale-coherence row per supported language.
+
+    Each row is a plain JSON-friendly ``dict`` (so the status/leaderboard work
+    can reuse it) with:
+
+      - ``language``: the OpenMed ISO 639-1 code.
+      - ``locale``: the default Faker locale it resolves to (no warning side
+        effect — read straight from :data:`LANG_TO_LOCALE`).
+      - ``approximate``: ``True`` when that default locale is a documented
+        approximation rather than a native match.
+      - ``id_providers``: national-ID Faker method names whose surrogates
+        round-trip the language's registered checksum validator (empty when the
+        language has no checksummed national-ID surrogate provider).
+      - ``id_locale``: the Faker locale those providers are drawn from, or
+        ``None``. Usually equals ``locale``; differs when the registered
+        validators target another country's format (e.g. ``pt`` -> ``pt_BR``).
+    """
+    from ..pii_i18n import SUPPORTED_LANGUAGES  # lazy: avoid import cycle
+
+    rows: List[dict] = []
+    for lang in sorted(SUPPORTED_LANGUAGES):
+        provider: Optional[Tuple[str, str]] = NATIONAL_ID_PROVIDERS.get(lang)
+        id_locale, id_method = provider if provider else (None, None)
+        rows.append(
+            {
+                "language": lang,
+                "locale": LANG_TO_LOCALE.get(lang, LANG_TO_LOCALE["en"]),
+                "approximate": lang in _APPROXIMATE_LOCALES,
+                "id_providers": [id_method] if id_method else [],
+                "id_locale": id_locale,
+            }
+        )
+    return rows
+
+
+__all__ = [
+    "LANG_TO_LOCALE",
+    "NATIONAL_ID_PROVIDERS",
+    "locale_coherence_report",
+    "resolve_locale",
+]

--- a/openmed/core/anonymizer/locales.py
+++ b/openmed/core/anonymizer/locales.py
@@ -27,7 +27,7 @@ Regression contract (OM-135):
 from __future__ import annotations
 
 import warnings
-from typing import Final, List, Mapping, Optional, Tuple
+from typing import Final, Mapping
 
 # Default Faker locale per OpenMed language code.
 LANG_TO_LOCALE: Final[Mapping[str, str]] = {
@@ -62,7 +62,7 @@ _APPROXIMATE_LOCALES: Final = frozenset({"te"})
 # addresses, ...) stays ``pt_PT``. The method must match the registry's
 # locale-aware dispatch (``registry._LOCALE_ID_METHODS``); the regression suite
 # asserts that and the round-trip.
-NATIONAL_ID_PROVIDERS: Final[Mapping[str, Tuple[str, str]]] = {
+NATIONAL_ID_PROVIDERS: Final[Mapping[str, tuple[str, str]]] = {
     "en": ("en_US", "ssn"),
     "fr": ("fr_FR", "ssn"),               # NIR / INSEE
     "de": ("de_DE", "german_steuer_id"),  # Steuer-ID
@@ -107,7 +107,7 @@ def resolve_locale(lang: str, locale_override: str | None = None) -> str:
     return locale
 
 
-def locale_coherence_report() -> List[dict]:
+def locale_coherence_report() -> list[dict[str, object]]:
     """Return one locale-coherence row per supported language.
 
     Each row is a plain JSON-friendly ``dict`` (so the status/leaderboard work
@@ -127,9 +127,9 @@ def locale_coherence_report() -> List[dict]:
     """
     from ..pii_i18n import SUPPORTED_LANGUAGES  # lazy: avoid import cycle
 
-    rows: List[dict] = []
+    rows: list[dict[str, object]] = []
     for lang in sorted(SUPPORTED_LANGUAGES):
-        provider: Optional[Tuple[str, str]] = NATIONAL_ID_PROVIDERS.get(lang)
+        provider: tuple[str, str] | None = NATIONAL_ID_PROVIDERS.get(lang)
         id_locale, id_method = provider if provider else (None, None)
         rows.append(
             {

--- a/tests/unit/core/test_locale_coherence.py
+++ b/tests/unit/core/test_locale_coherence.py
@@ -34,7 +34,6 @@ from openmed.core.anonymizer.registry import _LOCALE_ID_METHODS
 from openmed.core.pii_entity_merger import PII_PATTERNS
 from openmed.core.pii_i18n import LANGUAGE_PII_PATTERNS, SUPPORTED_LANGUAGES
 
-
 # Documented set of languages whose *default* Faker locale is an intentional
 # approximation. Kept here, independent of the code under test, so that wiring a
 # new pack to a wrong/approximate locale flips the assertions red until a human

--- a/tests/unit/core/test_locale_coherence.py
+++ b/tests/unit/core/test_locale_coherence.py
@@ -1,0 +1,187 @@
+"""Per-language locale + national-ID surrogate coherence suite (OM-135).
+
+A regression guard that keeps language packs honest as the count climbs from
+12 toward 20+. It asserts that:
+
+  (a) every ``SUPPORTED_LANGUAGES`` code maps to a real Faker locale (or a
+      documented approximation),
+  (b) generated national-ID surrogates pass the language's registered checksum
+      validator (round-trip surrogate fidelity),
+  (c) only documented approximations emit the locale ``UserWarning`` — so a new
+      pack mis-wired to a wrong locale fails loudly, and
+  (d) ``locale_coherence_report()`` stays a faithful per-language summary the
+      status/leaderboard work can reuse.
+
+The contract these tests gate lives in
+:mod:`openmed.core.anonymizer.locales`.
+"""
+
+import json
+import warnings
+
+import pytest
+from faker.config import AVAILABLE_LOCALES
+
+from openmed.core.anonymizer import Anonymizer
+from openmed.core.anonymizer import locales as L
+from openmed.core.anonymizer.locales import (
+    LANG_TO_LOCALE,
+    NATIONAL_ID_PROVIDERS,
+    locale_coherence_report,
+    resolve_locale,
+)
+from openmed.core.anonymizer.registry import _LOCALE_ID_METHODS
+from openmed.core.pii_entity_merger import PII_PATTERNS
+from openmed.core.pii_i18n import LANGUAGE_PII_PATTERNS, SUPPORTED_LANGUAGES
+
+
+# Documented set of languages whose *default* Faker locale is an intentional
+# approximation. Kept here, independent of the code under test, so that wiring a
+# new pack to a wrong/approximate locale flips the assertions red until a human
+# consciously updates this set.
+DOCUMENTED_APPROXIMATE = {"te"}
+
+# Languages that register a national-ID checksum validator but have no Faker
+# surrogate provider yet. Documented so a *new* such gap can't slip in silently.
+KNOWN_PROVIDERLESS_VALIDATORS = {"tr"}  # TCKN validator exists; no Faker TCKN provider
+
+# Number of surrogates sampled per language for the round-trip check.
+SAMPLE_SIZE = 40
+
+
+def _languages_with_national_id_validator():
+    return {
+        lang
+        for lang in SUPPORTED_LANGUAGES
+        if any(
+            p.validator is not None and p.entity_type == "national_id"
+            for p in LANGUAGE_PII_PATTERNS.get(lang, [])
+        )
+    }
+
+
+def _national_id_validators(lang):
+    """Registered national-ID checksum validators for ``lang``.
+
+    Prefer the language pack's own ``national_id`` validators; fall back to the
+    shared base SSN/national-ID validators for languages (e.g. English) whose
+    national ID is validated by the base pattern set.
+    """
+    lang_validators = [
+        p.validator
+        for p in LANGUAGE_PII_PATTERNS.get(lang, [])
+        if p.validator is not None and p.entity_type == "national_id"
+    ]
+    if lang_validators:
+        return lang_validators
+    return [
+        p.validator
+        for p in PII_PATTERNS
+        if p.validator is not None and p.entity_type in ("national_id", "ssn")
+    ]
+
+
+class TestLocaleResolution:
+    @pytest.mark.parametrize("lang", sorted(SUPPORTED_LANGUAGES))
+    def test_every_supported_language_has_locale_entry(self, lang):
+        assert lang in LANG_TO_LOCALE, f"{lang!r} missing LANG_TO_LOCALE entry"
+
+    @pytest.mark.parametrize("lang", sorted(SUPPORTED_LANGUAGES))
+    def test_resolved_locale_exists_in_faker(self, lang):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            locale = resolve_locale(lang)
+        assert locale, f"{lang!r} resolved to an empty locale"
+        assert locale in AVAILABLE_LOCALES or lang in L._APPROXIMATE_LOCALES, (
+            f"{lang!r} -> {locale!r} is not a real Faker locale and is not a "
+            "documented approximation"
+        )
+
+
+class TestNationalIdRoundTrip:
+    def test_contract_matches_registry_dispatch(self):
+        """Each provider's method must match the registry's locale dispatch and
+        point at a real Faker locale."""
+        for lang, (locale, method) in NATIONAL_ID_PROVIDERS.items():
+            assert locale in AVAILABLE_LOCALES, f"{lang!r} -> unknown locale {locale!r}"
+            assert _LOCALE_ID_METHODS.get(locale) == method, (
+                f"{lang!r} provider {method!r} disagrees with registry dispatch "
+                f"for {locale!r} ({_LOCALE_ID_METHODS.get(locale)!r})"
+            )
+
+    def test_providerless_validators_are_documented(self):
+        """A national-ID validator with no surrogate provider is a known gap;
+        a new one must be acknowledged here rather than slip in silently."""
+        without_provider = _languages_with_national_id_validator() - set(
+            NATIONAL_ID_PROVIDERS
+        )
+        assert without_provider == KNOWN_PROVIDERLESS_VALIDATORS, (
+            "languages with a national_id validator but no NATIONAL_ID_PROVIDERS "
+            f"entry changed: {sorted(without_provider)}"
+        )
+
+    @pytest.mark.parametrize("lang", sorted(NATIONAL_ID_PROVIDERS))
+    def test_generated_national_ids_pass_registered_validator(self, lang):
+        locale, _method = NATIONAL_ID_PROVIDERS[lang]
+        validators = _national_id_validators(lang)
+        assert validators, f"no national-ID validator registered for {lang!r}"
+        for seed in range(SAMPLE_SIZE):
+            anon = Anonymizer(lang=lang, consistent=True, seed=seed)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                surrogate = anon.surrogate("123456789", "national_id", locale=locale)
+            assert any(v(surrogate) for v in validators), (
+                f"{lang!r} surrogate {surrogate!r} (seed={seed}, locale={locale}) "
+                f"failed every registered validator "
+                f"{[v.__name__ for v in validators]}"
+            )
+
+
+class TestApproximateLocaleWarnings:
+    @pytest.mark.parametrize("lang", sorted(SUPPORTED_LANGUAGES))
+    def test_only_documented_approximations_warn(self, lang):
+        L._warned.clear()  # reset the one-time-warning cache for a clean read
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            resolve_locale(lang)
+        warned = any(issubclass(w.category, UserWarning) for w in caught)
+        assert warned == (lang in DOCUMENTED_APPROXIMATE), (
+            f"{lang!r}: emitted approximate-locale warning={warned}, "
+            f"expected {lang in DOCUMENTED_APPROXIMATE}"
+        )
+
+    def test_code_approximation_set_matches_documentation(self):
+        assert set(L._APPROXIMATE_LOCALES) == DOCUMENTED_APPROXIMATE
+
+
+class TestLocaleCoherenceReport:
+    def test_one_row_per_supported_language(self):
+        rows = locale_coherence_report()
+        assert len(rows) == len(SUPPORTED_LANGUAGES)
+        assert {r["language"] for r in rows} == set(SUPPORTED_LANGUAGES)
+
+    def test_row_shape_and_values(self):
+        rows = {r["language"]: r for r in locale_coherence_report()}
+        for lang, row in rows.items():
+            assert set(row) == {
+                "language",
+                "locale",
+                "approximate",
+                "id_providers",
+                "id_locale",
+            }
+            assert row["locale"] == LANG_TO_LOCALE[lang]
+            assert isinstance(row["approximate"], bool)
+            assert row["approximate"] == (lang in DOCUMENTED_APPROXIMATE)
+            assert isinstance(row["id_providers"], list)
+            if lang in NATIONAL_ID_PROVIDERS:
+                exp_locale, exp_method = NATIONAL_ID_PROVIDERS[lang]
+                assert row["id_providers"] == [exp_method]
+                assert row["id_locale"] == exp_locale
+            else:
+                assert row["id_providers"] == []
+                assert row["id_locale"] is None
+
+    def test_report_is_json_serializable(self):
+        # The status/leaderboard work serializes this; keep it JSON-friendly.
+        json.dumps(locale_coherence_report())


### PR DESCRIPTION
Closes #300

## Description
Adds the per-language surrogate-quality and Faker-locale coherence regression suite from #300, so language packs stay honest as the count climbs past 12.

## Type of Change
- [x] Test addition/improvement

## Changes Made
- Add `NATIONAL_ID_PROVIDERS` in `openmed/core/anonymizer/locales.py` as the single source of truth mapping each language with a checksum-validated national ID to its `(faker_locale, faker_method)` (e.g. `pt` draws ID surrogates from `pt_BR` since the registered validators are Brazilian CPF/CNPJ, while its default display locale stays `pt_PT`).
- Add `locale_coherence_report()` for a per-language summary of locale + national-ID provider wiring.
- Add `tests/unit/core/test_locale_coherence.py` covering: every supported language resolves to a real Faker locale (or a documented approximation), generated national-ID surrogates round-trip the language's registered checksum validator, only documented approximations emit the locale warning, and the report stays a faithful per-language summary.

## Testing
- `.venv/bin/python -m pytest tests/ -q` -> 1514 passed, 22 skipped

The remaining warnings are pre-existing SpanValidationWarnings from other suites, not from this change.