### PR TITLE
Fix Unicode offset redaction in pipeline

### DIFF
--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -397,6 +397,7 @@ class Pipeline:
         emission_pii_result = _remap_pii_result_to_original(
             pii_result,
             normalized,
+            self.hmac_secret,
         )
         deidentified = self.stage10_emit(
             normalized.original_text,
@@ -422,11 +423,16 @@ class Pipeline:
         final_spans = (
             sweep_spans if self.policy is not None else (sweep_spans or policy_spans)
         )
+        emission_spans = _remap_spans_to_original(
+            final_spans,
+            normalized,
+            self.hmac_secret,
+        )
         stage_results.append(
             PipelineStageResult(
                 10,
                 STAGE_NAMES[9],
-                spans=final_spans,
+                spans=emission_spans,
                 metadata={
                     "redacted_text_hash": hmac_text_hash(
                         deidentified.deidentified_text,
@@ -439,7 +445,7 @@ class Pipeline:
         audit_record = self._audit_record(
             context,
             stage_results,
-            final_spans,
+            emission_spans,
             redacted_text=deidentified.deidentified_text,
         )
 
@@ -448,7 +454,7 @@ class Pipeline:
             normalized_text=normalized.normalized_text,
             offset_map=normalized.offset_map,
             route=route,
-            spans=final_spans,
+            spans=emission_spans,
             stage_results=tuple(stage_results),
             redacted_text=deidentified.deidentified_text,
             audit_record=audit_record,
@@ -1071,12 +1077,16 @@ def _prediction_result_from_spans(
     )
 
 
-def _remap_pii_result_to_original(pii_result: Any, document: NormalizedDocument) -> Any:
+def _remap_pii_result_to_original(
+    pii_result: Any,
+    document: NormalizedDocument,
+    hmac_secret: str | bytes,
+) -> Any:
     """Clone a normalized-text PII result with entities mapped to original text."""
     remapped_result = copy.copy(pii_result)
     remapped_entities = []
     for entity in getattr(pii_result, "entities", ()):
-        remapped = _remap_entity_to_original(entity, document)
+        remapped = _remap_entity_to_original(entity, document, hmac_secret)
         if remapped is not None:
             remapped_entities.append(remapped)
     remapped_result.entities = remapped_entities
@@ -1090,6 +1100,7 @@ def _remap_pii_result_to_original(pii_result: Any, document: NormalizedDocument)
 def _remap_entity_to_original(
     entity: Any,
     document: NormalizedDocument,
+    hmac_secret: str | bytes,
 ) -> Any | None:
     bounds = _entity_bounds(entity, document.normalized_text)
     if bounds is None:
@@ -1110,14 +1121,51 @@ def _remap_entity_to_original(
     remapped.text = original_surface
 
     metadata = dict(getattr(entity, "metadata", None) or {})
+    normalized_surface = document.normalized_text[normalized_start:normalized_end]
+    metadata.pop("normalized_text", None)
     metadata.setdefault(
-        "normalized_text",
-        document.normalized_text[normalized_start:normalized_end],
+        "normalized_text_hash",
+        hmac_text_hash(normalized_surface, hmac_secret),
     )
     metadata.setdefault("normalized_start", normalized_start)
     metadata.setdefault("normalized_end", normalized_end)
     remapped.metadata = metadata
     return remapped
+
+
+def _remap_spans_to_original(
+    spans: Sequence[OpenMedSpan],
+    document: NormalizedDocument,
+    hmac_secret: str | bytes,
+) -> tuple[OpenMedSpan, ...]:
+    remapped_spans = []
+    for span in spans:
+        original_start, original_end = (
+            document.offset_map.normalized_span_to_original_offsets(
+                span.start,
+                span.end,
+            )
+        )
+        original_surface = document.original_text[original_start:original_end]
+        normalized_surface = document.normalized_text[span.start : span.end]
+        metadata = dict(span.metadata)
+        metadata.pop("normalized_text", None)
+        metadata.setdefault("normalized_start", span.start)
+        metadata.setdefault("normalized_end", span.end)
+        metadata.setdefault(
+            "normalized_text_hash",
+            hmac_text_hash(normalized_surface, hmac_secret),
+        )
+        remapped_spans.append(
+            replace(
+                span,
+                start=original_start,
+                end=original_end,
+                text_hash=hmac_text_hash(original_surface, hmac_secret),
+                metadata=metadata,
+            )
+        )
+    return tuple(remapped_spans)
 
 
 def _load_calibration_thresholds(

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import unicodedata
 from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Mapping, Optional, Sequence
@@ -329,7 +330,9 @@ class Pipeline:
                 getattr(pii_result, "entities", ()),
                 normalized.normalized_text,
                 context,
-                default_detector=f"model:{getattr(pii_result, 'model_name', route.model_name)}",
+                default_detector=(
+                    f"model:{getattr(pii_result, 'model_name', route.model_name)}"
+                ),
                 stage=STAGE_NAMES[4],
             )
             stage_results.append(
@@ -391,9 +394,13 @@ class Pipeline:
         effective_keep_mapping = keep_mapping or bool(
             self.policy is not None and self.policy.keep_mapping
         )
-        deidentified = self.stage10_emit(
-            normalized.normalized_text,
+        emission_pii_result = _remap_pii_result_to_original(
             pii_result,
+            normalized,
+        )
+        deidentified = self.stage10_emit(
+            normalized.original_text,
+            emission_pii_result,
             effective_method=effective_method,
             keep_year=keep_year,
             date_shift_days=date_shift_days,
@@ -714,7 +721,9 @@ class Pipeline:
             getattr(pii_result, "entities", ()),
             text,
             context,
-            default_detector=f"model:{getattr(pii_result, 'model_name', context.route.model_name)}",
+            default_detector=(
+                f"model:{getattr(pii_result, 'model_name', context.route.model_name)}"
+            ),
             stage=STAGE_NAMES[8],
         )
         return spans, {
@@ -1060,6 +1069,55 @@ def _prediction_result_from_spans(
         model_name=model_name,
         timestamp=datetime.now().isoformat(),
     )
+
+
+def _remap_pii_result_to_original(pii_result: Any, document: NormalizedDocument) -> Any:
+    """Clone a normalized-text PII result with entities mapped to original text."""
+    remapped_result = copy.copy(pii_result)
+    remapped_entities = []
+    for entity in getattr(pii_result, "entities", ()):
+        remapped = _remap_entity_to_original(entity, document)
+        if remapped is not None:
+            remapped_entities.append(remapped)
+    remapped_result.entities = remapped_entities
+    if hasattr(remapped_result, "text"):
+        remapped_result.text = document.original_text
+    if hasattr(remapped_result, "num_entities"):
+        remapped_result.num_entities = len(remapped_entities)
+    return remapped_result
+
+
+def _remap_entity_to_original(
+    entity: Any,
+    document: NormalizedDocument,
+) -> Any | None:
+    bounds = _entity_bounds(entity, document.normalized_text)
+    if bounds is None:
+        return None
+
+    normalized_start, normalized_end = bounds
+    original_start, original_end = (
+        document.offset_map.normalized_span_to_original_offsets(
+            normalized_start,
+            normalized_end,
+        )
+    )
+    original_surface = document.original_text[original_start:original_end]
+
+    remapped = copy.copy(entity)
+    remapped.start = original_start
+    remapped.end = original_end
+    remapped.text = original_surface
+
+    metadata = dict(getattr(entity, "metadata", None) or {})
+    metadata.setdefault(
+        "normalized_text",
+        document.normalized_text[normalized_start:normalized_end],
+    )
+    metadata.setdefault("normalized_start", normalized_start)
+    metadata.setdefault("normalized_end", normalized_end)
+    remapped.metadata = metadata
+    return remapped
 
 
 def _load_calibration_thresholds(

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -110,6 +110,7 @@ def test_deidentification_redacts_original_nfc_changed_entity_surface():
         use_safety_sweep=False,
     ).run(text, method="mask")
     entity = result.deidentification_result.pii_entities[0]
+    span = result.spans[0]
 
     assert result.deidentification_result.original_text == text
     assert entity.original_text == "Jose\u0301 Garcia"
@@ -118,6 +119,11 @@ def test_deidentification_redacts_original_nfc_changed_entity_surface():
         text.index("Jose\u0301 Garcia"),
         text.index("Jose\u0301 Garcia") + len("Jose\u0301 Garcia"),
     )
+    assert (span.start, span.end) == (entity.start, entity.end)
+    assert "normalized_text" not in (entity.metadata or {})
+    assert "normalized_text" not in span.metadata
+    assert (entity.metadata or {})["normalized_text_hash"].startswith("hmac-sha256:")
+    assert span.metadata["normalized_text_hash"].startswith("hmac-sha256:")
     assert result.redacted_text == "Patient [NAME] visited"
 
 
@@ -147,6 +153,7 @@ def test_deidentification_redacts_original_collapsed_whitespace_entity_surface()
         use_safety_sweep=False,
     ).run(text, method="mask")
     entity = result.deidentification_result.pii_entities[0]
+    span = result.spans[0]
 
     assert result.deidentification_result.original_text == text
     assert entity.original_text == "John   Doe"
@@ -155,6 +162,11 @@ def test_deidentification_redacts_original_collapsed_whitespace_entity_surface()
         text.index("John   Doe"),
         text.index("John   Doe") + len("John   Doe"),
     )
+    assert (span.start, span.end) == (entity.start, entity.end)
+    assert "normalized_text" not in (entity.metadata or {})
+    assert "normalized_text" not in span.metadata
+    assert (entity.metadata or {})["normalized_text_hash"].startswith("hmac-sha256:")
+    assert span.metadata["normalized_text_hash"].startswith("hmac-sha256:")
     assert result.redacted_text == "Patient [NAME] visited"
 
 

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -1,3 +1,4 @@
+import unicodedata
 from datetime import datetime
 
 from openmed.core.pipeline import Pipeline
@@ -33,6 +34,128 @@ def test_normalized_offsets_remap_combining_characters_to_original_positions():
         normalized_e,
         normalized_e + 1,
     ) == (original_e, original_combining + 1)
+
+
+def test_normalized_span_round_trips_nfc_length_change_to_original_surface():
+    text = "Patient Jose\u0301 Garcia visited"
+    document = Pipeline().stage1_normalize(text)
+    normalized_surface = "José Garcia"
+    normalized_start = document.normalized_text.index(normalized_surface)
+    normalized_end = normalized_start + len(normalized_surface)
+
+    original_start, original_end = (
+        document.offset_map.normalized_span_to_original_offsets(
+            normalized_start,
+            normalized_end,
+        )
+    )
+    original_surface = text[original_start:original_end]
+
+    assert original_surface == "Jose\u0301 Garcia"
+    assert unicodedata.normalize("NFC", original_surface) == normalized_surface
+    assert document.offset_map.original_span_to_normalized(
+        original_start,
+        original_end,
+    ) == (normalized_start, normalized_end)
+
+
+def test_normalized_span_round_trips_collapsed_whitespace_to_original_surface():
+    text = "Patient John   Doe visited"
+    document = Pipeline().stage1_normalize(text)
+    normalized_surface = "John Doe"
+    normalized_start = document.normalized_text.index(normalized_surface)
+    normalized_end = normalized_start + len(normalized_surface)
+
+    original_start, original_end = (
+        document.offset_map.normalized_span_to_original_offsets(
+            normalized_start,
+            normalized_end,
+        )
+    )
+    original_surface = text[original_start:original_end]
+
+    assert original_surface == "John   Doe"
+    assert Pipeline().stage1_normalize(original_surface).normalized_text == (
+        normalized_surface
+    )
+    assert document.offset_map.original_span_to_normalized(
+        original_start,
+        original_end,
+    ) == (normalized_start, normalized_end)
+
+
+def test_deidentification_redacts_original_nfc_changed_entity_surface():
+    text = "Patient Jose\u0301 Garcia visited"
+
+    def model_detector(text, **kwargs):
+        entity_text = "José Garcia"
+        start = text.index(entity_text)
+        return PredictionResult(
+            text=text,
+            entities=[
+                EntityPrediction(
+                    text=entity_text,
+                    label="NAME",
+                    start=start,
+                    end=start + len(entity_text),
+                    confidence=0.95,
+                )
+            ],
+            model_name=kwargs["model_name"],
+            timestamp=datetime.now().isoformat(),
+        )
+
+    result = Pipeline(
+        model_detector=model_detector,
+        use_safety_sweep=False,
+    ).run(text, method="mask")
+    entity = result.deidentification_result.pii_entities[0]
+
+    assert result.deidentification_result.original_text == text
+    assert entity.original_text == "Jose\u0301 Garcia"
+    assert entity.text == "Jose\u0301 Garcia"
+    assert (entity.start, entity.end) == (
+        text.index("Jose\u0301 Garcia"),
+        text.index("Jose\u0301 Garcia") + len("Jose\u0301 Garcia"),
+    )
+    assert result.redacted_text == "Patient [NAME] visited"
+
+
+def test_deidentification_redacts_original_collapsed_whitespace_entity_surface():
+    text = "Patient John   Doe visited"
+
+    def model_detector(text, **kwargs):
+        entity_text = "John Doe"
+        start = text.index(entity_text)
+        return PredictionResult(
+            text=text,
+            entities=[
+                EntityPrediction(
+                    text=entity_text,
+                    label="NAME",
+                    start=start,
+                    end=start + len(entity_text),
+                    confidence=0.95,
+                )
+            ],
+            model_name=kwargs["model_name"],
+            timestamp=datetime.now().isoformat(),
+        )
+
+    result = Pipeline(
+        model_detector=model_detector,
+        use_safety_sweep=False,
+    ).run(text, method="mask")
+    entity = result.deidentification_result.pii_entities[0]
+
+    assert result.deidentification_result.original_text == text
+    assert entity.original_text == "John   Doe"
+    assert entity.text == "John   Doe"
+    assert (entity.start, entity.end) == (
+        text.index("John   Doe"),
+        text.index("John   Doe") + len("John   Doe"),
+    )
+    assert result.redacted_text == "Patient [NAME] visited"
 
 
 def test_luhn_valid_mrn_is_detected_before_model_stage_runs():


### PR DESCRIPTION
Closes #514.\n\nMaps normalized detection spans back onto the original text before emission, so NFC length changes and collapsed whitespace redact the exact original characters. Adds regression tests for both cases.\n\nValidation:\n- python -m pytest tests/ -q\n- flake8 openmed/core/pipeline.py tests/unit/core/test_pipeline.py --max-line-length=88 --extend-ignore=E203,W503