### PR TITLE
feat: add docker-compose.yml with HF cache volume and healthcheckout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,16 @@
 services:
   app:
-    build: .
+    build:
+      context: .
     ports:
       - "8080:8080"
     environment:
-      - OPENMED_PROFILE=prod
+      OPENMED_PROFILE: ${OPENMED_PROFILE:-prod}
+      OPENMED_CACHE_DIR: ${OPENMED_CACHE_DIR:-/root/.cache/huggingface/openmed}
+      OPENMED_SERVICE_PRELOAD_MODELS: ${OPENMED_SERVICE_PRELOAD_MODELS:-}
+      HF_TOKEN: ${HF_TOKEN:-}
     volumes:
-      - HF_CACHE:/root/.cache/huggingface
+      - hf-cache:/root/.cache/huggingface
 
 volumes:
-  HF_CACHE:
+  hf-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - OPENMED_PROFILE=prod
+    volumes:
+      - HF_CACHE:/root/.cache/huggingface
+
+volumes:
+  HF_CACHE:

--- a/docs/rest-service.md
+++ b/docs/rest-service.md
@@ -248,8 +248,11 @@ docker run --rm -p 8080:8080 \
 
 ### Docker Compose
 
-Use the provided `docker-compose.yml` to build and start the service with a single command.
-The Compose setup maps port **8080**, sets `OPENMED_PROFILE=prod`, and persists the HF model cache in a named volume so models are not re-downloaded on restart.
+Use the provided `docker-compose.yml` to build and start the service with a
+single command. The Compose setup maps port **8080**, sets
+`OPENMED_PROFILE=prod`, and persists the Hugging Face cache in a named volume.
+`OPENMED_CACHE_DIR` points inside that mounted cache so service model downloads
+are reused across restarts.
 
 ```bash
 docker compose up -d
@@ -262,10 +265,16 @@ docker compose ps
 # The STATUS column should show "(healthy)"
 ```
 
-Stop and clean up:
+Stop the container:
 
 ```bash
 docker compose down
+```
+
+To remove the persisted model cache too, delete the named volume:
+
+```bash
+docker compose down --volumes
 ```
 
 Smoke check:
@@ -274,4 +283,7 @@ Smoke check:
 curl http://127.0.0.1:8080/health
 ```
 
-> **Tip:** For sensitive environment variables (e.g. `HF_TOKEN`), store them in a `.env` file and add `.env` to `.gitignore` — never commit secrets to version control.
+Optional values such as `HF_TOKEN`, `OPENMED_PROFILE`,
+`OPENMED_CACHE_DIR`, and `OPENMED_SERVICE_PRELOAD_MODELS` can be supplied from a
+local `.env` file. Keep `.env` ignored and never commit secrets to version
+control.

--- a/docs/rest-service.md
+++ b/docs/rest-service.md
@@ -246,8 +246,32 @@ docker run --rm -p 8080:8080 \
   openmed:0.6.2
 ```
 
+### Docker Compose
+
+Use the provided `docker-compose.yml` to build and start the service with a single command.
+The Compose setup maps port **8080**, sets `OPENMED_PROFILE=prod`, and persists the HF model cache in a named volume so models are not re-downloaded on restart.
+
+```bash
+docker compose up -d
+```
+
+Verify the service started correctly:
+
+```bash
+docker compose ps
+# The STATUS column should show "(healthy)"
+```
+
+Stop and clean up:
+
+```bash
+docker compose down
+```
+
 Smoke check:
 
 ```bash
 curl http://127.0.0.1:8080/health
 ```
+
+> **Tip:** For sensitive environment variables (e.g. `HF_TOKEN`), store them in a `.env` file and add `.env` to `.gitignore` — never commit secrets to version control.

--- a/tests/unit/service/test_docker_compose.py
+++ b/tests/unit/service/test_docker_compose.py
@@ -1,30 +1,47 @@
-"""Unit tests for docker-compose.yml"""
+"""Unit tests for docker-compose.yml."""
 
 from pathlib import Path
 
 import yaml
 
 BASE_DIR = Path(__file__).resolve().parents[3]
-COMPOSE_DIR = BASE_DIR / "docker-compose.yml"
+COMPOSE_FILE = BASE_DIR / "docker-compose.yml"
 
 
-def test_docker_compose():
-    with open(COMPOSE_DIR, "r", encoding="utf-8") as f:
-        docker_compose = yaml.safe_load(f)
-        assert docker_compose is not None
+def _load_compose() -> dict:
+    with COMPOSE_FILE.open(encoding="utf-8") as handle:
+        compose = yaml.safe_load(handle)
+    assert isinstance(compose, dict)
+    return compose
 
 
-def test_docker_compose_ports():
-    with open(COMPOSE_DIR, "r", encoding="utf-8") as f:
-        docker_compose = yaml.safe_load(f)
-        assert "8080:8080" in docker_compose["services"]["app"]["ports"]
+def _app_service(compose: dict) -> dict:
+    service = compose["services"]["app"]
+    assert isinstance(service, dict)
+    return service
 
 
-def test_docker_compose_volumes():
-    with open(COMPOSE_DIR, "r", encoding="utf-8") as f:
-        docker_compose = yaml.safe_load(f)
-        assert docker_compose["volumes"]["HF_CACHE"] is None
-        assert (
-            "HF_CACHE:/root/.cache/huggingface"
-            in docker_compose["services"]["app"]["volumes"]
-        )
+def test_docker_compose_builds_local_dockerfile():
+    service = _app_service(_load_compose())
+
+    assert service["build"] == {"context": "."}
+
+
+def test_docker_compose_maps_service_port():
+    service = _app_service(_load_compose())
+
+    assert "8080:8080" in service["ports"]
+
+
+def test_docker_compose_persists_hf_and_openmed_model_cache():
+    compose = _load_compose()
+    service = _app_service(compose)
+    environment = service["environment"]
+
+    assert "hf-cache" in compose["volumes"]
+    assert "hf-cache:/root/.cache/huggingface" in service["volumes"]
+    assert environment["OPENMED_PROFILE"] == "${OPENMED_PROFILE:-prod}"
+    assert (
+        environment["OPENMED_CACHE_DIR"]
+        == "${OPENMED_CACHE_DIR:-/root/.cache/huggingface/openmed}"
+    )

--- a/tests/unit/service/test_docker_compose.py
+++ b/tests/unit/service/test_docker_compose.py
@@ -1,0 +1,30 @@
+"""Unit tests for docker-compose.yml"""
+
+from pathlib import Path
+
+import yaml
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+COMPOSE_DIR = BASE_DIR / "docker-compose.yml"
+
+
+def test_docker_compose():
+    with open(COMPOSE_DIR, "r", encoding="utf-8") as f:
+        docker_compose = yaml.safe_load(f)
+        assert docker_compose is not None
+
+
+def test_docker_compose_ports():
+    with open(COMPOSE_DIR, "r", encoding="utf-8") as f:
+        docker_compose = yaml.safe_load(f)
+        assert "8080:8080" in docker_compose["services"]["app"]["ports"]
+
+
+def test_docker_compose_volumes():
+    with open(COMPOSE_DIR, "r", encoding="utf-8") as f:
+        docker_compose = yaml.safe_load(f)
+        assert docker_compose["volumes"]["HF_CACHE"] is None
+        assert (
+            "HF_CACHE:/root/.cache/huggingface"
+            in docker_compose["services"]["app"]["volumes"]
+        )


### PR DESCRIPTION
# Pull Request

## Description
Add a `docker-compose.yml` that wraps the existing Dockerfile, making the REST service one-command runnable with a persisted HuggingFace model cache so models are not re-downloaded on every restart.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- **docker-compose.yml** — builds from the local Dockerfile, maps port `8080`, sets `OPENMED_PROFILE=prod`, and mounts a named volume `HF_CACHE` at `/root/.cache/huggingface` for model persistence. The existing HEALTHCHECK from the Dockerfile is reused automatically.
- **docs/rest-service.md** — documents the `docker compose up` → verify → down workflow under a new "Docker Compose" subsection, and adds a tip about using `.env` for sensitive variables (no secrets committed).
- **tests/unit/service/test_docker_compose.py** — smoke test that parses `docker-compose.yml` as valid YAML, asserts port `8080` mapping, and verifies the `HF_CACHE` named volume is declared and mounted.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

## Documentation
- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [ ] I have squashed/organized my commits appropriately

## Related Issues
Closes #477 
Related to #477

## Screenshots/Examples
**pytest-pass**

<img width="752" height="158" alt="image" src="https://github.com/user-attachments/assets/e7c7e2fa-1299-4a1a-aeae-30acd3a76054" />

**health-check**

<img width="696" height="25" alt="image" src="https://github.com/user-attachments/assets/d261283f-a949-4763-b797-c6ea9d30aa6c" />


**docker-compose-check**

<img width="1197" height="66" alt="image" src="https://github.com/user-attachments/assets/c626f25f-9f2b-4ee3-8544-e6f4d9a4ab9b" />



