### PR TITLE
Add clinical negation axis

### DIFF
--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -5,19 +5,33 @@ sdoh.py, and FHIR/OMOP exporters.
 """
 
 from .context import (
+    AFFIRMED,
     CERTAIN,
     CERTAINTY_VALUES,
     HISTORICAL,
     HYPOTHETICAL,
+    NEGATED,
+    NEGATION_VALUES,
     RECENT,
     TEMPORALITY_VALUES,
     UNCERTAIN,
     Certainty,
+    ClinicalContextResult,
+    Negation,
+    resolve_negation,
+    resolve_span_context,
     resolve_temporality,
     resolve_uncertainty,
 )
 
 __all__ = [
+    "AFFIRMED",
+    "NEGATED",
+    "NEGATION_VALUES",
+    "Negation",
+    "ClinicalContextResult",
+    "resolve_negation",
+    "resolve_span_context",
     "RECENT",
     "HISTORICAL",
     "HYPOTHETICAL",

--- a/openmed/clinical/context.py
+++ b/openmed/clinical/context.py
@@ -4,6 +4,11 @@ This module holds narrow, deterministic ConText layers that classify clinical
 spans from a target span plus optional modifier hits produced by the shared
 context engine.
 
+Negation classifies whether a clinical span is affirmed or negated. Downstream
+grounding layers map ``"negated"`` spans to FHIR
+``verificationStatus=refuted``; this module only exposes the per-span context
+axis and does not build grounded records.
+
 Temporality classifies the temporal status of a clinical span onto the original
 ConText three-value temporality scale:
 
@@ -24,7 +29,7 @@ hypothetical, or conditional. Uncertain spans are flagged, not dropped, so
 grounding layers can downweight or annotate unconfirmed conditions while still
 receiving the original span.
 
-Sibling axes (negation, experiencer) and absolute-date timeline normalization
+Sibling axes such as experiencer and absolute-date timeline normalization
 (TIMEX3) are handled by separate layers and are out of scope here.
 """
 
@@ -32,7 +37,16 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from typing import Any, Literal
+
+Negation = Literal["affirmed", "negated"]
+
+AFFIRMED: Negation = "affirmed"
+NEGATED: Negation = "negated"
+
+#: The negation values, ordered from default asserted polarity to refuted.
+NEGATION_VALUES = (AFFIRMED, NEGATED)
 
 RECENT = "recent"
 HISTORICAL = "historical"
@@ -112,6 +126,46 @@ UNCERTAINTY_CUES = (
     "if",
 )
 
+# ConText/NegEx-style negation cues. Phrases are matched before shorter cues,
+# so "no evidence of" is counted as one negation cue rather than "no" plus a
+# second incidental phrase.
+NEGATION_CUES = (
+    "no evidence of",
+    "no evidence",
+    "no sign of",
+    "no signs of",
+    "negative for",
+    "absence of",
+    "free of",
+    "ruled out",
+    "not present",
+    "denies",
+    "denied",
+    "deny",
+    "without",
+    "absent",
+    "never",
+    "none",
+    "not",
+    "no",
+)
+
+# Pseudo-negation cues contain negation words but do not refute the target
+# concept. They are masked before true negation cues are counted.
+PSEUDO_NEGATION_CUES = (
+    "no increase",
+    "no interval increase",
+    "no significant increase",
+    "not ruled out",
+    "not yet ruled out",
+    "not completely ruled out",
+    "not been ruled out",
+    "cannot be excluded",
+    "can't be excluded",
+    "cannot exclude",
+    "can't exclude",
+)
+
 
 def _cue_pattern(cues: Iterable[str]) -> re.Pattern[str]:
     alternation = "|".join(
@@ -124,6 +178,23 @@ def _cue_pattern(cues: Iterable[str]) -> re.Pattern[str]:
 _HISTORICAL_RE = _cue_pattern(HISTORICAL_CUES)
 _HYPOTHETICAL_RE = _cue_pattern(HYPOTHETICAL_CUES)
 _UNCERTAINTY_RE = _cue_pattern(UNCERTAINTY_CUES)
+_NEGATION_RE = _cue_pattern(NEGATION_CUES)
+_PSEUDO_NEGATION_RE = _cue_pattern(PSEUDO_NEGATION_CUES)
+
+
+@dataclass(frozen=True)
+class ClinicalContextResult:
+    """Per-span ConText decision result.
+
+    ``negation="negated"`` is the downstream signal for
+    ``verificationStatus=refuted`` when a grounding/FHIR layer materializes the
+    clinical span as a Condition. This object deliberately stays at the context
+    axis layer and does not construct that grounded record.
+    """
+
+    temporality: str
+    certainty: Certainty
+    negation: Negation
 
 
 def _text_of(obj: Any) -> str:
@@ -204,7 +275,53 @@ def resolve_uncertainty(span: Any, modifier_hits: Any = None) -> Certainty:
     return CERTAIN
 
 
+def _mask_pseudo_negation(text: str) -> str:
+    return _PSEUDO_NEGATION_RE.sub(lambda match: " " * len(match.group(0)), text)
+
+
+def resolve_negation(span: Any, modifier_hits: Any = None) -> Negation:
+    """Classify a clinical span as affirmed or negated.
+
+    ``span`` is the target clinical span -- a string, a span mapping with a
+    ``text``-like key, or any object exposing a ``text`` attribute.
+    ``modifier_hits`` is the optional collection of ConText negation cues
+    matched in the span's window. Each part is scanned independently so cues
+    are never created by concatenating unrelated fragments.
+
+    Pseudo-negation cues such as ``"no increase"``, ``"not ruled out"``, and
+    ``"cannot be excluded"`` are masked before true negation cues are counted.
+    An odd number of true cues returns ``"negated"``; an even number returns
+    ``"affirmed"``, which makes double-negation deterministic.
+    """
+
+    negation_cue_count = 0
+    for part in _text_parts(span, modifier_hits):
+        masked = _mask_pseudo_negation(part)
+        negation_cue_count += sum(1 for _ in _NEGATION_RE.finditer(masked))
+    return NEGATED if negation_cue_count % 2 else AFFIRMED
+
+
+def resolve_span_context(
+    span: Any,
+    modifier_hits: Any = None,
+) -> ClinicalContextResult:
+    """Return all currently implemented ConText decision axes for ``span``."""
+
+    return ClinicalContextResult(
+        temporality=resolve_temporality(span, modifier_hits),
+        certainty=resolve_uncertainty(span, modifier_hits),
+        negation=resolve_negation(span, modifier_hits),
+    )
+
+
 __all__ = [
+    "AFFIRMED",
+    "NEGATED",
+    "Negation",
+    "NEGATION_VALUES",
+    "NEGATION_CUES",
+    "PSEUDO_NEGATION_CUES",
+    "ClinicalContextResult",
     "RECENT",
     "HISTORICAL",
     "HYPOTHETICAL",
@@ -218,4 +335,6 @@ __all__ = [
     "CERTAINTY_VALUES",
     "UNCERTAINTY_CUES",
     "resolve_uncertainty",
+    "resolve_negation",
+    "resolve_span_context",
 ]

--- a/tests/unit/clinical/test_negation.py
+++ b/tests/unit/clinical/test_negation.py
@@ -87,8 +87,26 @@ def test_single_modifier_hit_string_is_supported():
     assert resolve_negation("sepsis", "no evidence of") == NEGATED
 
 
+def test_negation_cues_match_case_insensitively():
+    assert resolve_negation("NO EVIDENCE OF pneumonia") == NEGATED
+    assert resolve_negation("Pneumonia Cannot Be Excluded") == AFFIRMED
+
+
 def test_modifier_hits_do_not_create_cues_across_fragments():
     assert resolve_negation("n", ["o evidence of pneumonia"]) == AFFIRMED
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "notable pneumonia",
+        "nonelective surgery",
+        "deniesing typo",
+        "nose pain",
+    ],
+)
+def test_short_negation_cues_respect_word_boundaries(text):
+    assert resolve_negation(text) == AFFIRMED
 
 
 def test_span_context_result_exposes_negation_field():

--- a/tests/unit/clinical/test_negation.py
+++ b/tests/unit/clinical/test_negation.py
@@ -1,0 +1,130 @@
+"""Tests for the ConText negation axis."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.clinical import (
+    AFFIRMED,
+    NEGATED,
+    ClinicalContextResult,
+    resolve_negation,
+    resolve_span_context,
+)
+from openmed.clinical.context import (
+    NEGATION_CUES,
+    NEGATION_VALUES,
+    PSEUDO_NEGATION_CUES,
+)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "pneumonia",
+        "pneumonia confirmed on CT",
+        "acute renal failure",
+    ],
+)
+def test_asserted_findings_are_affirmed(text):
+    assert resolve_negation(text) == AFFIRMED
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "no evidence of pneumonia",
+        "no signs of pneumonia",
+        "negative for pneumonia",
+        "patient denies chest pain",
+        "without edema",
+        "pneumonia ruled out",
+        "absent breath sounds",
+    ],
+)
+def test_true_negation_cues_negate_span_text(text):
+    assert resolve_negation(text) == NEGATED
+
+
+@pytest.mark.parametrize(
+    "modifier",
+    [
+        "no evidence of",
+        "negative for",
+        "denies",
+        "without",
+        "ruled out",
+    ],
+)
+def test_modifier_hits_carry_negation_cues(modifier):
+    assert resolve_negation("pneumonia", [modifier]) == NEGATED
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "not ruled out pneumonia",
+        "pneumonia cannot be excluded",
+        "no increase in pulmonary edema",
+        "no significant increase in pneumonia",
+    ],
+)
+def test_pseudo_negation_cues_do_not_negate(text):
+    assert resolve_negation(text) == AFFIRMED
+
+
+def test_double_negation_is_deterministic():
+    assert resolve_negation("not without pneumonia") == AFFIRMED
+    assert resolve_negation("no evidence of pneumonia without edema") == AFFIRMED
+
+
+def test_modifier_hits_as_mappings():
+    hits = [{"text": "no evidence of"}]
+    assert resolve_negation({"text": "sepsis"}, hits) == NEGATED
+
+
+def test_single_modifier_hit_string_is_supported():
+    assert resolve_negation("sepsis", "no evidence of") == NEGATED
+
+
+def test_modifier_hits_do_not_create_cues_across_fragments():
+    assert resolve_negation("n", ["o evidence of pneumonia"]) == AFFIRMED
+
+
+def test_span_context_result_exposes_negation_field():
+    context = resolve_span_context("no evidence of pneumonia")
+
+    assert context.negation == NEGATED
+    assert context.temporality == "recent"
+    assert context.certainty == "certain"
+
+
+def test_pseudo_negation_is_affirmed_in_span_context_result():
+    context = resolve_span_context("pneumonia cannot be excluded")
+
+    assert context.negation == AFFIRMED
+
+
+def test_negated_maps_to_refuted_documented_on_context_result():
+    assert "verificationStatus=refuted" in (ClinicalContextResult.__doc__ or "")
+
+
+def test_result_is_always_a_valid_negation_value():
+    for text in ("pneumonia", "no evidence of pneumonia", "not ruled out pneumonia"):
+        assert resolve_negation(text) in NEGATION_VALUES
+
+
+def test_required_negation_cues_are_public():
+    for cue in (
+        "no evidence of",
+        "negative for",
+        "denies",
+        "without",
+        "ruled out",
+    ):
+        assert cue in NEGATION_CUES
+
+
+def test_required_pseudo_negation_cues_are_public():
+    for cue in ("no increase", "not ruled out", "cannot be excluded"):
+        assert cue in PSEUDO_NEGATION_CUES


### PR DESCRIPTION
## Description
Adds the narrow ConText negation axis for affirmed vs negated clinical spans.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `resolve_negation(span, modifier_hits)` with true negation cues and pseudo-negation masking.
- Added `ClinicalContextResult` and `resolve_span_context(...)` so negation is exposed per span.
- Documented `negated` as the downstream `verificationStatus=refuted` signal.
- Added tests for affirmed, negated, pseudo-negation, modifier hits, and deterministic double negation.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `python -m pytest tests/unit/clinical/test_negation.py tests/unit/clinical/test_uncertainty.py tests/unit/clinical/test_temporality.py -q`
- `ruff check --output-format=github .`
- `python -m pytest tests/ -q`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #276

## Screenshots/Examples
N/A