### PR TITLE
feat:added FHIR OperationOutcome builder for exporter and validation results

### DIFF
--- a/docs/fhir-interop.md
+++ b/docs/fhir-interop.md
@@ -1,0 +1,145 @@
+# FHIR Interop Helpers
+
+OpenMed exposes small FHIR R4 helpers for producing resources that downstream
+FHIR servers and clients already understand. These helpers are local and
+mechanical: they shape data you provide, but they do not call external
+validators or network services.
+
+## OperationOutcome
+
+Use `to_operation_outcome()` when an exporter, operation wrapper, or validation
+pass needs to report errors, warnings, or informational notes in a FHIR-native
+shape.
+
+```python
+from openmed.clinical.exporters.fhir import (
+    OperationOutcomeIssue,
+    to_operation_outcome,
+)
+
+outcome = to_operation_outcome(
+    [
+        OperationOutcomeIssue(
+            severity="error",
+            code="required",
+            diagnostics="Patient.name is required.",
+            expression="Patient.name",
+        ),
+        {
+            "severity": "warning",
+            "code": "code-invalid",
+            "diagnostics": "Unknown LOINC code.",
+            "expression": "Observation.code.coding[0]",
+        },
+    ]
+)
+```
+
+The returned resource is an R4 `OperationOutcome`:
+
+```python
+{
+    "resourceType": "OperationOutcome",
+    "issue": [
+        {
+            "severity": "error",
+            "code": "required",
+            "diagnostics": "Patient.name is required.",
+            "expression": ["Patient.name"],
+        },
+        {
+            "severity": "warning",
+            "code": "code-invalid",
+            "diagnostics": "Unknown LOINC code.",
+            "expression": ["Observation.code.coding[0]"],
+        },
+    ],
+}
+```
+
+Each issue must use FHIR R4 issue-severity values: `fatal`, `error`, `warning`,
+or `information`. Issue codes must come from the R4 issue-type value set, such
+as `invalid`, `structure`, `required`, `value`, `invariant`, `processing`,
+`business-rule`, `exception`, or `informational`.
+
+When there are no findings, `to_operation_outcome([])` returns a valid all-ok
+resource with one informational issue:
+
+```python
+{
+    "resourceType": "OperationOutcome",
+    "issue": [
+        {
+            "severity": "information",
+            "code": "informational",
+            "diagnostics": "No issues detected.",
+        }
+    ],
+}
+```
+
+For compatibility with older or ad-hoc result objects, `from_validation_result()`
+accepts duck-typed shapes such as:
+
+```python
+from openmed.clinical.exporters.fhir import from_validation_result
+
+result = {
+    "errors": [
+        {
+            "message": "Malformed Patient resource.",
+            "path": "Patient",
+        }
+    ],
+    "warnings": ["Bundle.entry[0] has an unsupported profile."],
+}
+
+outcome = from_validation_result(result)
+```
+
+`from_validation_result()` is an adapter only. It does not implement structural
+validation, US Core conformance checks, or the FHIR `$de-identify` operation.
+Those producers should emit issue-like objects and pass them through this shared
+builder.
+
+## Privacy Boundary
+
+FHIR `OperationOutcome.issue.diagnostics` is human-readable and may be logged by
+servers, clients, gateways, or observability tools. Do not put raw PHI or direct
+identifiers in diagnostics. Prefer `expression` paths, offsets, hashes,
+provenance identifiers, and risk scores when reporting where a problem occurred.
+
+OpenMed emits R4 `issue.expression` for element paths. It accepts legacy
+`location` as input for adapter compatibility, but it never emits
+`issue.location` because that field is deprecated in FHIR R4.
+
+## Bundles
+
+Use `to_bundle()` to assemble standalone FHIR resources into a deterministic R4
+`Bundle`.
+
+```python
+from openmed.clinical.exporters.fhir import to_bundle
+
+bundle = to_bundle(
+    [
+        {
+            "resourceType": "Observation",
+            "id": "obs1",
+            "status": "final",
+            "code": {"text": "Glucose"},
+        },
+        {
+            "resourceType": "DiagnosticReport",
+            "id": "report1",
+            "status": "final",
+            "result": [{"reference": "Observation/obs1"}],
+        },
+    ],
+    doc_id="note-123",
+)
+```
+
+The helper assigns stable `urn:uuid` `fullUrl` values and rewrites internal
+references that point to resources present in the bundle. It does not synthesize
+missing resources and does not validate external FHIR profiles.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
       - PII Anonymization: anonymization.md
       - Smart Entity Merging: pii-smart-merging.md
       - Compliance Posture: compliance.md
+      - FHIR Interop Helpers: fhir-interop.md
   - Apple Silicon & Mobile:
       - MLX Backend: mlx-backend.md
       - CoreML Packaging: coreml-export.md

--- a/openmed/clinical/exporters/fhir/__init__.py
+++ b/openmed/clinical/exporters/fhir/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from .bundle import to_bundle
+from .operation_outcome import from_validation_result, to_operation_outcome
 
-__all__ = ["to_bundle"]
+__all__ = ["to_bundle", "to_operation_outcome", "from_validation_result"]

--- a/openmed/clinical/exporters/fhir/__init__.py
+++ b/openmed/clinical/exporters/fhir/__init__.py
@@ -3,6 +3,15 @@
 from __future__ import annotations
 
 from .bundle import to_bundle
-from .operation_outcome import from_validation_result, to_operation_outcome
+from .operation_outcome import (
+    OperationOutcomeIssue,
+    from_validation_result,
+    to_operation_outcome,
+)
 
-__all__ = ["to_bundle", "to_operation_outcome", "from_validation_result"]
+__all__ = [
+    "to_bundle",
+    "OperationOutcomeIssue",
+    "to_operation_outcome",
+    "from_validation_result",
+]

--- a/openmed/clinical/exporters/fhir/operation_outcome.py
+++ b/openmed/clinical/exporters/fhir/operation_outcome.py
@@ -1,0 +1,294 @@
+"""Build R4 ``OperationOutcome`` resources from internal result objects.
+
+The FHIR-native way to report errors, warnings, and informational notes from an
+operation or a validation pass is the ``OperationOutcome`` resource. OpenMed's
+interop surfaces -- the ``$de-identify`` wrapper, the structural validator, and
+the US Core conformance checks -- each return their own ad-hoc result objects.
+This module is the single shared adapter that turns those internal results into
+a standard ``OperationOutcome`` that any FHIR server or client understands.
+
+Two entry points are exposed:
+
+* :func:`to_operation_outcome` takes an iterable of *issues* (mappings or
+  duck-typed objects carrying ``severity``/``code``/optional ``diagnostics``/
+  optional ``expression`` or ``expressions``) and returns a valid R4
+  ``OperationOutcome`` mapping.
+* :func:`from_validation_result` adapts a validator/conformance result object
+  (anything exposing an ``issues`` collection, or ``errors``/``warnings``/
+  ``information`` buckets) into issues and delegates to
+  :func:`to_operation_outcome`.
+
+Severities are constrained to the FHIR ``issue-severity`` value set
+(``fatal``/``error``/``warning``/``information``) and codes to the
+``issue-type`` value set. An empty issue list yields a clean ``all-ok``
+information outcome, because an ``OperationOutcome`` must always carry at least
+one ``issue``.
+
+The builder is purely mechanical: it never inspects PHI, only the structural
+metadata of each issue (severity, code, a human-readable diagnostic string, and
+a FHIRPath-style location).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+__all__ = ["to_operation_outcome", "from_validation_result"]
+
+# FHIR R4 ``issue-severity`` value set.
+# https://hl7.org/fhir/R4/valueset-issue-severity.html
+_SEVERITIES = frozenset({"fatal", "error", "warning", "information"})
+
+# FHIR R4 ``issue-type`` value set (the codes used for ``OperationOutcome.issue.code``).
+# https://hl7.org/fhir/R4/valueset-issue-type.html
+_ISSUE_TYPES = frozenset(
+    {
+        "invalid",
+        "structure",
+        "required",
+        "value",
+        "invariant",
+        "security",
+        "login",
+        "unknown",
+        "expired",
+        "forbidden",
+        "suppressed",
+        "processing",
+        "not-supported",
+        "duplicate",
+        "multiple-matches",
+        "not-found",
+        "deleted",
+        "too-long",
+        "code-invalid",
+        "extension",
+        "too-costly",
+        "business-rule",
+        "conflict",
+        "transient",
+        "lock-error",
+        "no-store",
+        "exception",
+        "timeout",
+        "incomplete",
+        "throttled",
+        "informational",
+    }
+)
+
+# Default issue type when a caller supplies an issue without one.
+_DEFAULT_CODE = "processing"
+# Default issue type for validator/conformance findings (a structural problem).
+_DEFAULT_VALIDATION_CODE = "invalid"
+
+# The canonical "everything validated cleanly" outcome.
+_ALL_OK_DIAGNOSTICS = "No issues detected."
+
+
+def to_operation_outcome(issues: Any) -> dict[str, Any]:
+    """Build an R4 ``OperationOutcome`` from an iterable of issues.
+
+    Args:
+        issues: An iterable of issue-like items, a single issue mapping, or
+            ``None``. Each item may be a mapping or a duck-typed object exposing
+            ``severity``, ``code``, optional ``diagnostics``, and an optional
+            FHIRPath location as ``expression`` (str or list) or ``expressions``
+            (list). Plain strings are treated as the issue's ``diagnostics``.
+
+    Returns:
+        A ``resourceType=OperationOutcome`` mapping with one ``issue`` per input
+        item. When ``issues`` is empty, a single ``information``/
+        ``informational`` "all-ok" issue is returned.
+
+    Raises:
+        ValueError: If an issue carries a severity outside the FHIR
+            ``issue-severity`` value set or a code outside the ``issue-type``
+            value set.
+    """
+
+    built = [_build_issue(raw) for raw in _iter_issues(issues)]
+    if not built:
+        built = [_all_ok_issue()]
+    return {"resourceType": "OperationOutcome", "issue": built}
+
+
+def from_validation_result(result: Any) -> dict[str, Any]:
+    """Adapt a validator/conformance result into an ``OperationOutcome``.
+
+    Recognises two common result shapes via duck typing:
+
+    * a result exposing an ``issues`` collection (mapping key or attribute),
+      where each entry is itself an issue-like item; or
+    * a result exposing ``fatals``/``errors``/``warnings``/``information``
+      (a.k.a. ``informational``) buckets, where each entry is a string or an
+      issue-like item. Entries in a bucket inherit that bucket's severity and a
+      validation-appropriate default code (``invalid``) unless they override it.
+
+    Args:
+        result: The validator or US Core ``ConformanceResult`` object, or
+            ``None``.
+
+    Returns:
+        A valid R4 ``OperationOutcome``; an all-ok information outcome when the
+        result reports no issues.
+    """
+
+    return to_operation_outcome(_extract_issues(result))
+
+
+# --- internal helpers -------------------------------------------------------
+
+# (attribute/key, severity, default issue-type) for the bucket-style results.
+_RESULT_BUCKETS = (
+    ("fatals", "fatal", _DEFAULT_VALIDATION_CODE),
+    ("errors", "error", _DEFAULT_VALIDATION_CODE),
+    ("warnings", "warning", _DEFAULT_VALIDATION_CODE),
+    ("information", "information", "informational"),
+    ("informational", "information", "informational"),
+)
+
+
+def _iter_issues(issues: Any) -> list[Any]:
+    """Normalise the ``issues`` argument into a list of raw issue items."""
+
+    if issues is None:
+        return []
+    if isinstance(issues, Mapping):
+        return [issues]
+    if isinstance(issues, (str, bytes)):
+        raise TypeError(
+            "to_operation_outcome expects an iterable of issues, not a string"
+        )
+    if isinstance(issues, Iterable):
+        return list(issues)
+    raise TypeError(f"unsupported issues type: {type(issues).__name__!r}")
+
+
+def _extract_issues(result: Any) -> list[Any]:
+    """Pull issue-like items out of a validator/conformance result object."""
+
+    if result is None:
+        return []
+
+    issues = _get(result, "issues")
+    if issues is not None:
+        return list(issues)
+
+    collected: list[Any] = []
+    for attr, severity, default_code in _RESULT_BUCKETS:
+        bucket = _get(result, attr)
+        if not bucket:
+            continue
+        for item in bucket:
+            collected.append(_bucket_issue(item, severity, default_code))
+    return collected
+
+
+def _bucket_issue(item: Any, severity: str, default_code: str) -> dict[str, Any]:
+    """Coerce a single bucket entry into a raw issue mapping with a severity."""
+
+    if isinstance(item, str):
+        return {"severity": severity, "code": default_code, "diagnostics": item}
+    if isinstance(item, Mapping):
+        merged = dict(item)
+        merged.setdefault("severity", severity)
+        merged.setdefault("code", default_code)
+        return merged
+    return {
+        "severity": _get(item, "severity", severity),
+        "code": _get(item, "code", default_code),
+        "diagnostics": _get(item, "diagnostics"),
+        "expression": _get(item, "expression"),
+        "expressions": _get(item, "expressions"),
+    }
+
+
+def _build_issue(raw: Any) -> dict[str, Any]:
+    """Build one validated ``OperationOutcome.issue`` from a raw issue item.
+
+    The OpenMed-owned issue shape is ``severity`` (required), ``code``
+    (required), optional ``diagnostics``, and an optional FHIRPath location
+    given as either ``expression`` (str or list) or ``expressions`` (list). A
+    bare string is treated as the issue ``diagnostics``. The emitted R4 issue
+    always uses ``expression`` (``location`` is deprecated in R4 and never
+    emitted).
+    """
+
+    if isinstance(raw, str):
+        severity, code, diagnostics, expression = "error", _DEFAULT_CODE, raw, None
+    else:
+        severity = _get(raw, "severity", "error")
+        code = _get(raw, "code", _DEFAULT_CODE)
+        diagnostics = _get(raw, "diagnostics")
+        expression = _get(raw, "expressions")
+        if expression is None:
+            expression = _get(raw, "expression")
+
+    issue: dict[str, Any] = {
+        "severity": _normalize_severity(severity),
+        "code": _normalize_code(code),
+    }
+    if diagnostics is not None:
+        issue["diagnostics"] = str(diagnostics)
+    expressions = _normalize_expression(expression)
+    if expressions:
+        issue["expression"] = expressions
+    return issue
+
+
+def _all_ok_issue() -> dict[str, Any]:
+    """Return the canonical ``information``/``informational`` all-ok issue."""
+
+    return {
+        "severity": "information",
+        "code": "informational",
+        "diagnostics": _ALL_OK_DIAGNOSTICS,
+    }
+
+
+def _normalize_severity(severity: Any) -> str:
+    """Validate ``severity`` against the FHIR ``issue-severity`` value set."""
+
+    if not isinstance(severity, str):
+        raise ValueError(f"issue severity must be a string, got {severity!r}")
+    canonical = severity.strip().lower()
+    if canonical not in _SEVERITIES:
+        raise ValueError(
+            f"invalid issue severity {severity!r}; "
+            f"expected one of {sorted(_SEVERITIES)}"
+        )
+    return canonical
+
+
+def _normalize_code(code: Any) -> str:
+    """Validate ``code`` against the FHIR ``issue-type`` value set."""
+
+    if not isinstance(code, str):
+        raise ValueError(f"issue code must be a string, got {code!r}")
+    canonical = code.strip().lower()
+    if canonical not in _ISSUE_TYPES:
+        raise ValueError(
+            f"invalid issue code {code!r}; not in the FHIR issue-type value set"
+        )
+    return canonical
+
+
+def _normalize_expression(expression: Any) -> list[str]:
+    """Normalise a FHIRPath ``expression`` into a list of non-empty strings."""
+
+    if expression is None:
+        return []
+    if isinstance(expression, str):
+        return [expression] if expression else []
+    if isinstance(expression, (list, tuple)):
+        return [str(item) for item in expression if item is not None and str(item)]
+    return [str(expression)]
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from a mapping or an object's attribute, else ``default``."""
+
+    if isinstance(obj, Mapping):
+        return obj.get(key, default)
+    return getattr(obj, key, default)

--- a/openmed/clinical/exporters/fhir/operation_outcome.py
+++ b/openmed/clinical/exporters/fhir/operation_outcome.py
@@ -31,9 +31,27 @@ a FHIRPath-style location).
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
 
-__all__ = ["to_operation_outcome", "from_validation_result"]
+__all__ = ["OperationOutcomeIssue", "to_operation_outcome", "from_validation_result"]
+
+
+@dataclass(frozen=True)
+class OperationOutcomeIssue:
+    """OpenMed-owned issue shape that maps directly to ``OperationOutcome.issue``.
+
+    ``severity`` and ``code`` must already be FHIR R4 issue-severity and
+    issue-type codes. ``expression`` is a FHIRPath-style location and is emitted
+    as R4 ``issue.expression``.
+    """
+
+    severity: str
+    code: str
+    diagnostics: str | None = None
+    expression: str | Sequence[str] | None = None
+
 
 # FHIR R4 ``issue-severity`` value set.
 # https://hl7.org/fhir/R4/valueset-issue-severity.html
@@ -77,8 +95,6 @@ _ISSUE_TYPES = frozenset(
     }
 )
 
-# Default issue type when a caller supplies an issue without one.
-_DEFAULT_CODE = "processing"
 # Default issue type for validator/conformance findings (a structural problem).
 _DEFAULT_VALIDATION_CODE = "invalid"
 
@@ -91,10 +107,10 @@ def to_operation_outcome(issues: Any) -> dict[str, Any]:
 
     Args:
         issues: An iterable of issue-like items, a single issue mapping, or
-            ``None``. Each item may be a mapping or a duck-typed object exposing
-            ``severity``, ``code``, optional ``diagnostics``, and an optional
-            FHIRPath location as ``expression`` (str or list) or ``expressions``
-            (list). Plain strings are treated as the issue's ``diagnostics``.
+            ``None``. Each item may be an :class:`OperationOutcomeIssue`, a
+            mapping, or a duck-typed object exposing ``severity`` and ``code``,
+            optional ``diagnostics``/``message``, and an optional FHIRPath
+            location as ``expression`` (str or list) or ``expressions`` (list).
 
     Returns:
         A ``resourceType=OperationOutcome`` mapping with one ``issue`` per input
@@ -102,9 +118,10 @@ def to_operation_outcome(issues: Any) -> dict[str, Any]:
         ``informational`` "all-ok" issue is returned.
 
     Raises:
+        TypeError: If an issue item is not mapping/object shaped.
         ValueError: If an issue carries a severity outside the FHIR
-            ``issue-severity`` value set or a code outside the ``issue-type``
-            value set.
+            ``issue-severity`` value set, a code outside the ``issue-type``
+            value set, or omits required ``severity``/``code`` fields.
     """
 
     built = [_build_issue(raw) for raw in _iter_issues(issues)]
@@ -139,14 +156,30 @@ def from_validation_result(result: Any) -> dict[str, Any]:
 
 # --- internal helpers -------------------------------------------------------
 
-# (attribute/key, severity, default issue-type) for the bucket-style results.
+# (attribute/key, severity, default issue-type) for bucket-style results.
 _RESULT_BUCKETS = (
+    ("fatal", "fatal", _DEFAULT_VALIDATION_CODE),
     ("fatals", "fatal", _DEFAULT_VALIDATION_CODE),
+    ("error", "error", _DEFAULT_VALIDATION_CODE),
     ("errors", "error", _DEFAULT_VALIDATION_CODE),
+    ("warning", "warning", _DEFAULT_VALIDATION_CODE),
     ("warnings", "warning", _DEFAULT_VALIDATION_CODE),
+    ("info", "information", "informational"),
     ("information", "information", "informational"),
     ("informational", "information", "informational"),
 )
+
+_DIAGNOSTIC_KEYS = ("diagnostics", "message", "detail")
+_EXPRESSION_KEYS = (
+    "expressions",
+    "expression",
+    "path",
+    "fhir_path",
+    "fhirpath",
+    "field",
+    "location",  # accepted as legacy input only; never emitted as R4 location
+)
+_MISSING = object()
 
 
 def _iter_issues(issues: Any) -> list[Any]:
@@ -173,16 +206,28 @@ def _extract_issues(result: Any) -> list[Any]:
 
     issues = _get(result, "issues")
     if issues is not None:
-        return list(issues)
+        return _iter_issues(issues)
 
     collected: list[Any] = []
     for attr, severity, default_code in _RESULT_BUCKETS:
         bucket = _get(result, attr)
         if not bucket:
             continue
-        for item in bucket:
+        for item in _iter_bucket(bucket):
             collected.append(_bucket_issue(item, severity, default_code))
     return collected
+
+
+def _iter_bucket(bucket: Any) -> list[Any]:
+    """Normalise a severity bucket into raw entries without splitting strings."""
+
+    if isinstance(bucket, Mapping):
+        return [bucket]
+    if isinstance(bucket, (str, bytes)):
+        return [bucket.decode() if isinstance(bucket, bytes) else bucket]
+    if isinstance(bucket, Iterable):
+        return list(bucket)
+    return [bucket]
 
 
 def _bucket_issue(item: Any, severity: str, default_code: str) -> dict[str, Any]:
@@ -192,15 +237,16 @@ def _bucket_issue(item: Any, severity: str, default_code: str) -> dict[str, Any]
         return {"severity": severity, "code": default_code, "diagnostics": item}
     if isinstance(item, Mapping):
         merged = dict(item)
-        merged.setdefault("severity", severity)
-        merged.setdefault("code", default_code)
+        if merged.get("severity") is None:
+            merged["severity"] = severity
+        if merged.get("code") is None:
+            merged["code"] = default_code
         return merged
     return {
-        "severity": _get(item, "severity", severity),
-        "code": _get(item, "code", default_code),
-        "diagnostics": _get(item, "diagnostics"),
-        "expression": _get(item, "expression"),
-        "expressions": _get(item, "expressions"),
+        "severity": _get(item, "severity") or severity,
+        "code": _get(item, "code") or default_code,
+        "diagnostics": _first_present(item, _DIAGNOSTIC_KEYS),
+        "expression": _first_present(item, _EXPRESSION_KEYS),
     }
 
 
@@ -209,21 +255,21 @@ def _build_issue(raw: Any) -> dict[str, Any]:
 
     The OpenMed-owned issue shape is ``severity`` (required), ``code``
     (required), optional ``diagnostics``, and an optional FHIRPath location
-    given as either ``expression`` (str or list) or ``expressions`` (list). A
-    bare string is treated as the issue ``diagnostics``. The emitted R4 issue
-    always uses ``expression`` (``location`` is deprecated in R4 and never
-    emitted).
+    given as either ``expression`` (str or list) or ``expressions`` (list). The
+    emitted R4 issue always uses ``expression`` (``location`` is deprecated in
+    R4 and never emitted).
     """
 
-    if isinstance(raw, str):
-        severity, code, diagnostics, expression = "error", _DEFAULT_CODE, raw, None
-    else:
-        severity = _get(raw, "severity", "error")
-        code = _get(raw, "code", _DEFAULT_CODE)
-        diagnostics = _get(raw, "diagnostics")
-        expression = _get(raw, "expressions")
-        if expression is None:
-            expression = _get(raw, "expression")
+    if isinstance(raw, (str, bytes)) or not _is_issue_like(raw):
+        raise TypeError(
+            "each issue must be a mapping, OperationOutcomeIssue, or object "
+            "with severity/code fields"
+        )
+
+    severity = _required(raw, "severity")
+    code = _required(raw, "code")
+    diagnostics = _first_present(raw, _DIAGNOSTIC_KEYS)
+    expression = _first_present(raw, _EXPRESSION_KEYS)
 
     issue: dict[str, Any] = {
         "severity": _normalize_severity(severity),
@@ -235,6 +281,24 @@ def _build_issue(raw: Any) -> dict[str, Any]:
     if expressions:
         issue["expression"] = expressions
     return issue
+
+
+def _is_issue_like(raw: Any) -> bool:
+    """Return whether ``raw`` can reasonably represent one issue."""
+
+    return isinstance(raw, (OperationOutcomeIssue, Mapping)) or (
+        _get(raw, "severity", _MISSING) is not _MISSING
+        or _get(raw, "code", _MISSING) is not _MISSING
+    )
+
+
+def _required(obj: Any, key: str) -> Any:
+    """Read a required issue field from ``obj``."""
+
+    value = _get(obj, key, _MISSING)
+    if value is _MISSING or value is None:
+        raise ValueError(f"issue {key!r} is required")
+    return value
 
 
 def _all_ok_issue() -> dict[str, Any]:
@@ -280,10 +344,26 @@ def _normalize_expression(expression: Any) -> list[str]:
     if expression is None:
         return []
     if isinstance(expression, str):
+        expression = expression.strip()
         return [expression] if expression else []
     if isinstance(expression, (list, tuple)):
-        return [str(item) for item in expression if item is not None and str(item)]
-    return [str(expression)]
+        return [
+            normalized
+            for item in expression
+            if item is not None and (normalized := str(item).strip())
+        ]
+    normalized = str(expression).strip()
+    return [normalized] if normalized else []
+
+
+def _first_present(obj: Any, keys: Sequence[str]) -> Any:
+    """Return the first non-``None`` key/attribute value from ``obj``."""
+
+    for key in keys:
+        value = _get(obj, key, _MISSING)
+        if value is not _MISSING and value is not None:
+            return value
+    return None
 
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:

--- a/openmed/clinical/exporters/fhir/operation_outcome.py
+++ b/openmed/clinical/exporters/fhir/operation_outcome.py
@@ -1,11 +1,10 @@
 """Build R4 ``OperationOutcome`` resources from internal result objects.
 
 The FHIR-native way to report errors, warnings, and informational notes from an
-operation or a validation pass is the ``OperationOutcome`` resource. OpenMed's
-interop surfaces -- the ``$de-identify`` wrapper, the structural validator, and
-the US Core conformance checks -- each return their own ad-hoc result objects.
-This module is the single shared adapter that turns those internal results into
-a standard ``OperationOutcome`` that any FHIR server or client understands.
+operation or a validation pass is the ``OperationOutcome`` resource. This module
+is the shared adapter that lets current and future OpenMed interop surfaces
+report their internal findings as a standard ``OperationOutcome`` that FHIR
+servers and clients already understand.
 
 Two entry points are exposed:
 
@@ -26,7 +25,9 @@ one ``issue``.
 
 The builder is purely mechanical: it never inspects PHI, only the structural
 metadata of each issue (severity, code, a human-readable diagnostic string, and
-a FHIRPath-style location).
+a FHIRPath-style location). Callers are responsible for keeping diagnostics
+sanitized and should use expressions, offsets, hashes, or risk scores rather
+than raw identifiers.
 """
 
 from __future__ import annotations
@@ -42,9 +43,15 @@ __all__ = ["OperationOutcomeIssue", "to_operation_outcome", "from_validation_res
 class OperationOutcomeIssue:
     """OpenMed-owned issue shape that maps directly to ``OperationOutcome.issue``.
 
-    ``severity`` and ``code`` must already be FHIR R4 issue-severity and
-    issue-type codes. ``expression`` is a FHIRPath-style location and is emitted
-    as R4 ``issue.expression``.
+    Attributes:
+        severity: FHIR R4 issue-severity code: ``fatal``, ``error``,
+            ``warning``, or ``information``.
+        code: FHIR R4 issue-type code such as ``invalid``, ``structure``,
+            ``required``, ``processing``, or ``informational``.
+        diagnostics: Optional human-readable detail. Keep this sanitized; do not
+            include raw PHI or direct identifiers.
+        expression: Optional FHIRPath-style location. Emitted as R4
+            ``issue.expression``.
     """
 
     severity: str

--- a/tests/unit/clinical/test_fhir_operation_outcome.py
+++ b/tests/unit/clinical/test_fhir_operation_outcome.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 import pytest
 
 from openmed.clinical.exporters.fhir import (
+    OperationOutcomeIssue,
     from_validation_result,
     to_operation_outcome,
 )
@@ -67,12 +68,24 @@ class TestToOperationOutcome:
         assert len(outcome["issue"]) == 1
         assert outcome["issue"][0]["severity"] == "fatal"
 
-    def test_string_issue_becomes_diagnostics(self):
-        outcome = to_operation_outcome(["something went wrong"])
-        issue = outcome["issue"][0]
-        assert issue["severity"] == "error"
-        assert issue["code"] == "processing"
-        assert issue["diagnostics"] == "something went wrong"
+    def test_dataclass_issue_maps_to_outcome(self):
+        outcome = to_operation_outcome(
+            [
+                OperationOutcomeIssue(
+                    severity="error",
+                    code="processing",
+                    diagnostics="Could not process Bundle.entry[0]",
+                    expression="Bundle.entry[0]",
+                )
+            ]
+        )
+
+        assert outcome["issue"][0] == {
+            "severity": "error",
+            "code": "processing",
+            "diagnostics": "Could not process Bundle.entry[0]",
+            "expression": ["Bundle.entry[0]"],
+        }
 
     def test_severity_is_case_normalised(self):
         outcome = to_operation_outcome([{"severity": "Warning", "code": "invalid"}])
@@ -112,9 +125,41 @@ class TestToOperationOutcome:
         with pytest.raises(ValueError, match="invalid issue code"):
             to_operation_outcome([{"severity": "error", "code": "not-a-code"}])
 
+    def test_missing_severity_raises(self):
+        with pytest.raises(ValueError, match="issue 'severity' is required"):
+            to_operation_outcome([{"code": "invalid"}])
+
+    def test_missing_code_raises(self):
+        with pytest.raises(ValueError, match="issue 'code' is required"):
+            to_operation_outcome([{"severity": "error"}])
+
+    def test_unsupported_issue_item_raises(self):
+        with pytest.raises(TypeError, match="severity/code fields"):
+            to_operation_outcome([123])
+
+    def test_string_issue_item_rejected(self):
+        with pytest.raises(TypeError, match="severity/code fields"):
+            to_operation_outcome(["something went wrong"])
+
     def test_string_argument_rejected(self):
         with pytest.raises(TypeError):
             to_operation_outcome("oops")
+
+    def test_legacy_location_input_is_emitted_as_expression(self):
+        outcome = to_operation_outcome(
+            [
+                {
+                    "severity": "warning",
+                    "code": "structure",
+                    "diagnostics": "Deprecated path key",
+                    "location": "Patient.name",
+                }
+            ]
+        )
+
+        issue = outcome["issue"][0]
+        assert issue["expression"] == ["Patient.name"]
+        assert "location" not in issue
 
 
 @dataclass
@@ -192,4 +237,53 @@ class TestFromValidationResult:
             "severity": "fatal",
             "code": "structure",
             "diagnostics": "bad json",
+        }
+
+    def test_mapping_result_with_single_issue_mapping(self):
+        result = {
+            "issues": {
+                "severity": "error",
+                "code": "invalid",
+                "diagnostics": "Malformed Patient resource",
+            }
+        }
+
+        outcome = from_validation_result(result)
+
+        assert outcome["issue"] == [
+            {
+                "severity": "error",
+                "code": "invalid",
+                "diagnostics": "Malformed Patient resource",
+            }
+        ]
+
+    def test_bucket_string_is_not_split_into_characters(self):
+        outcome = from_validation_result({"errors": "Patient.name is required"})
+
+        assert outcome["issue"] == [
+            {
+                "severity": "error",
+                "code": "invalid",
+                "diagnostics": "Patient.name is required",
+            }
+        ]
+
+    def test_bucket_entries_accept_message_and_path_aliases(self):
+        result = {
+            "warnings": [
+                {
+                    "message": "Unmapped code",
+                    "path": "Observation.code.coding[0]",
+                }
+            ]
+        }
+
+        outcome = from_validation_result(result)
+
+        assert outcome["issue"][0] == {
+            "severity": "warning",
+            "code": "invalid",
+            "diagnostics": "Unmapped code",
+            "expression": ["Observation.code.coding[0]"],
         }

--- a/tests/unit/clinical/test_fhir_operation_outcome.py
+++ b/tests/unit/clinical/test_fhir_operation_outcome.py
@@ -1,0 +1,195 @@
+"""Tests for the FHIR R4 OperationOutcome builder (OM-360)."""
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from openmed.clinical.exporters.fhir import (
+    from_validation_result,
+    to_operation_outcome,
+)
+
+
+class TestToOperationOutcome:
+    def test_error_and_warning_issues_map_to_outcome(self):
+        issues = [
+            {
+                "severity": "error",
+                "code": "required",
+                "diagnostics": "Patient.name is required",
+                "expression": "Patient.name",
+            },
+            {
+                "severity": "warning",
+                "code": "code-invalid",
+                "diagnostics": "Unknown LOINC code",
+                "expression": ["Observation.code.coding[0]"],
+            },
+        ]
+
+        outcome = to_operation_outcome(issues)
+
+        assert outcome["resourceType"] == "OperationOutcome"
+        assert len(outcome["issue"]) == 2
+
+        first, second = outcome["issue"]
+        assert first == {
+            "severity": "error",
+            "code": "required",
+            "diagnostics": "Patient.name is required",
+            "expression": ["Patient.name"],
+        }
+        assert second == {
+            "severity": "warning",
+            "code": "code-invalid",
+            "diagnostics": "Unknown LOINC code",
+            "expression": ["Observation.code.coding[0]"],
+        }
+
+    def test_empty_issue_list_yields_all_ok_information_outcome(self):
+        outcome = to_operation_outcome([])
+
+        assert outcome["resourceType"] == "OperationOutcome"
+        assert len(outcome["issue"]) == 1
+        issue = outcome["issue"][0]
+        assert issue["severity"] == "information"
+        assert issue["code"] == "informational"
+        assert issue["diagnostics"]
+
+    def test_none_yields_all_ok_outcome(self):
+        outcome = to_operation_outcome(None)
+        assert outcome["issue"][0]["severity"] == "information"
+
+    def test_single_mapping_is_treated_as_one_issue(self):
+        outcome = to_operation_outcome(
+            {"severity": "fatal", "code": "exception", "diagnostics": "boom"}
+        )
+        assert len(outcome["issue"]) == 1
+        assert outcome["issue"][0]["severity"] == "fatal"
+
+    def test_string_issue_becomes_diagnostics(self):
+        outcome = to_operation_outcome(["something went wrong"])
+        issue = outcome["issue"][0]
+        assert issue["severity"] == "error"
+        assert issue["code"] == "processing"
+        assert issue["diagnostics"] == "something went wrong"
+
+    def test_severity_is_case_normalised(self):
+        outcome = to_operation_outcome([{"severity": "Warning", "code": "invalid"}])
+        assert outcome["issue"][0]["severity"] == "warning"
+
+    def test_non_canonical_severity_alias_is_rejected(self):
+        with pytest.raises(ValueError, match="invalid issue severity"):
+            to_operation_outcome([{"severity": "info", "code": "informational"}])
+
+    def test_diagnostics_and_expression_are_optional(self):
+        outcome = to_operation_outcome([{"severity": "error", "code": "invalid"}])
+        issue = outcome["issue"][0]
+        assert issue == {"severity": "error", "code": "invalid"}
+        assert "diagnostics" not in issue
+        assert "expression" not in issue
+
+    def test_expressions_plural_becomes_expression_list(self):
+        outcome = to_operation_outcome(
+            [
+                {
+                    "severity": "error",
+                    "code": "invalid",
+                    "diagnostics": "bad",
+                    "expressions": ["Patient.gender", "Patient.name"],
+                }
+            ]
+        )
+        issue = outcome["issue"][0]
+        assert issue["diagnostics"] == "bad"
+        assert issue["expression"] == ["Patient.gender", "Patient.name"]
+
+    def test_invalid_severity_raises(self):
+        with pytest.raises(ValueError, match="invalid issue severity"):
+            to_operation_outcome([{"severity": "critical", "code": "invalid"}])
+
+    def test_invalid_code_raises(self):
+        with pytest.raises(ValueError, match="invalid issue code"):
+            to_operation_outcome([{"severity": "error", "code": "not-a-code"}])
+
+    def test_string_argument_rejected(self):
+        with pytest.raises(TypeError):
+            to_operation_outcome("oops")
+
+
+@dataclass
+class _Issue:
+    severity: str
+    code: str
+    diagnostics: str | None = None
+    expression: str | None = None
+
+
+@dataclass
+class _ConformanceResult:
+    issues: list = field(default_factory=list)
+
+
+@dataclass
+class _BucketResult:
+    errors: list = field(default_factory=list)
+    warnings: list = field(default_factory=list)
+    information: list = field(default_factory=list)
+
+
+class TestFromValidationResult:
+    def test_adapts_issue_objects(self):
+        result = _ConformanceResult(
+            issues=[
+                _Issue("error", "required", "Missing identifier", "Patient.identifier"),
+                _Issue("warning", "code-invalid", "Unmapped code", "Condition.code"),
+            ]
+        )
+
+        outcome = from_validation_result(result)
+
+        assert [i["severity"] for i in outcome["issue"]] == ["error", "warning"]
+        assert [i["code"] for i in outcome["issue"]] == ["required", "code-invalid"]
+        assert outcome["issue"][0]["expression"] == ["Patient.identifier"]
+
+    def test_adapts_bucketed_errors_and_warnings(self):
+        result = _BucketResult(
+            errors=["Patient.name is required"],
+            warnings=[
+                {"diagnostics": "deprecated field", "expression": "Patient.animal"}
+            ],
+        )
+
+        outcome = from_validation_result(result)
+
+        error_issue, warning_issue = outcome["issue"]
+        assert error_issue["severity"] == "error"
+        assert error_issue["code"] == "invalid"
+        assert error_issue["diagnostics"] == "Patient.name is required"
+
+        assert warning_issue["severity"] == "warning"
+        assert warning_issue["code"] == "invalid"
+        assert warning_issue["expression"] == ["Patient.animal"]
+
+    def test_clean_result_yields_all_ok(self):
+        outcome = from_validation_result(_ConformanceResult(issues=[]))
+        assert len(outcome["issue"]) == 1
+        assert outcome["issue"][0]["severity"] == "information"
+        assert outcome["issue"][0]["code"] == "informational"
+
+    def test_none_result_yields_all_ok(self):
+        outcome = from_validation_result(None)
+        assert outcome["issue"][0]["severity"] == "information"
+
+    def test_mapping_result_with_issues_key(self):
+        result = {
+            "issues": [
+                {"severity": "fatal", "code": "structure", "diagnostics": "bad json"}
+            ]
+        }
+        outcome = from_validation_result(result)
+        assert outcome["issue"][0] == {
+            "severity": "fatal",
+            "code": "structure",
+            "diagnostics": "bad json",
+        }


### PR DESCRIPTION
# Pull Request

## Description
Adds a shared R4 `OperationOutcome` builder so every interop surface (exporters, the `$de-identify` wrapper, future structural/US Core validators) has a FHIR-native way to report errors, warnings, and informational notes.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Changes Made
- Add `openmed/clinical/exporters/fhir/operation_outcome.py` with `to_operation_outcome(issues)` producing a valid R4 `OperationOutcome`; issues use an OpenMed-owned shape (`severity`, `code`, optional `diagnostics`, optional `expression`/`expressions`).
- Add `from_validation_result(result)`: a conservative, duck-typed adapter for `result.issues` or `errors`/`warnings`/`fatals`/`information` buckets and their mapping equivalents (no validator/US Core checker built here).
- Validate severities to `fatal|error|warning|information` and codes to the R4 `issue-type` value set; use `issue.expression` for element paths (R4-deprecated `location` is never emitted); empty issue list yields an all-ok information outcome.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #545

## Code Example
```python
from openmed.clinical.exporters.fhir import to_operation_outcome
to_operation_outcome([
    {"severity": "error", "code": "required",
     "diagnostics": "Patient.name is required", "expression": "Patient.name"},
])
# {
#   "resourceType": "OperationOutcome",
#   "issue": [
#     {"severity": "error", "code": "required",
#      "diagnostics": "Patient.name is required",
#      "expression": ["Patient.name"]}
#   ]
# }
to_operation_outcome([])
# {"resourceType": "OperationOutcome",
#  "issue": [{"severity": "information", "code": "informational",
#             "diagnostics": "No issues detected."}]}
```