### PR TITLE
Feature/lab parser

### DIFF
--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -16,6 +16,13 @@ from .context import (
     resolve_temporality,
     resolve_uncertainty,
 )
+from .lab_values import (
+    LAB_FLAG_ADVISORY,
+    AbnormalFlag,
+    ReferenceRange,
+    derive_abnormal_flag,
+    parse_reference_range,
+)
 
 __all__ = [
     "RECENT",
@@ -28,4 +35,9 @@ __all__ = [
     "UNCERTAIN",
     "CERTAINTY_VALUES",
     "resolve_uncertainty",
+    "AbnormalFlag",
+    "ReferenceRange",
+    "LAB_FLAG_ADVISORY",
+    "parse_reference_range",
+    "derive_abnormal_flag",
 ]

--- a/openmed/clinical/lab_values.py
+++ b/openmed/clinical/lab_values.py
@@ -1,21 +1,17 @@
 import re
-from typing import Dict, Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
-# ADVISORY DISCLAIMER: Derived flags are heuristic and not a substitute 
+# ADVISORY DISCLAIMER: Derived flags are heuristic and not a substitute
 # for the originating laboratory's own formal diagnostic flagging.
+
 
 def parse_reference_range(text: str) -> Dict[str, Any]:
     """
     Parses a reference range text string into numeric boundary limits.
     Supports formats like '135-145', '0.5 - 1.2', '<5', '>10'.
     """
-    result = {
-        "low": None, 
-        "high": None, 
-        "low_inclusive": True, 
-        "high_inclusive": True
-    }
-    
+    result = {"low": None, "high": None, "low_inclusive": True, "high_inclusive": True}
+
     if not text or not isinstance(text, str):
         return result
 
@@ -46,9 +42,9 @@ def parse_reference_range(text: str) -> Dict[str, Any]:
 
 
 def derive_abnormal_flag(
-    value: Union[int, float, str], 
-    reference_range: Dict[str, Any], 
-    explicit_flag: Optional[str] = None
+    value: Union[int, float, str],
+    reference_range: Dict[str, Any],
+    explicit_flag: Optional[str] = None,
 ) -> str:
     """
     Derives clinical abnormality status based on parsed bounds or explicit flags.

--- a/openmed/clinical/lab_values.py
+++ b/openmed/clinical/lab_values.py
@@ -1,0 +1,93 @@
+import re
+from typing import Dict, Any, Optional, Union
+
+# ADVISORY DISCLAIMER: Derived flags are heuristic and not a substitute 
+# for the originating laboratory's own formal diagnostic flagging.
+
+def parse_reference_range(text: str) -> Dict[str, Any]:
+    """
+    Parses a reference range text string into numeric boundary limits.
+    Supports formats like '135-145', '0.5 - 1.2', '<5', '>10'.
+    """
+    result = {
+        "low": None, 
+        "high": None, 
+        "low_inclusive": True, 
+        "high_inclusive": True
+    }
+    
+    if not text or not isinstance(text, str):
+        return result
+
+    text = text.strip()
+
+    # Pattern 1: Standard Range (e.g., "135-145" or "0.5 - 1.2")
+    range_match = re.match(r"^([0-9.]+)\s*-\s*([0-9.]+)$", text)
+    if range_match:
+        result["low"] = float(range_match.group(1))
+        result["high"] = float(range_match.group(2))
+        return result
+
+    # Pattern 2: Less than (e.g., "<5")
+    lt_match = re.match(r"^<\s*([0-9.]+)$", text)
+    if lt_match:
+        result["high"] = float(lt_match.group(1))
+        result["high_inclusive"] = False
+        return result
+
+    # Pattern 3: Greater than (e.g., ">10")
+    gt_match = re.match(r"^>\s*([0-9.]+)$", text)
+    if gt_match:
+        result["low"] = float(gt_match.group(1))
+        result["low_inclusive"] = False
+        return result
+
+    return result
+
+
+def derive_abnormal_flag(
+    value: Union[int, float, str], 
+    reference_range: Dict[str, Any], 
+    explicit_flag: Optional[str] = None
+) -> str:
+    """
+    Derives clinical abnormality status based on parsed bounds or explicit flags.
+    """
+    if explicit_flag:
+        flag_upper = explicit_flag.upper().strip()
+        if flag_upper in ["H", "HIGH"]:
+            return "high"
+        if flag_upper in ["L", "LOW"]:
+            return "low"
+        if flag_upper in ["CRITICAL", "C"]:
+            return "critical"
+
+    try:
+        numeric_value = float(value)
+    except (ValueError, TypeError):
+        return "unknown"
+
+    if not reference_range or not isinstance(reference_range, dict):
+        return "unknown"
+
+    low = reference_range.get("low")
+    high = reference_range.get("high")
+
+    if low is None and high is None:
+        return "unknown"
+
+    if low is not None:
+        if reference_range.get("low_inclusive", True):
+            if numeric_value < low:
+                return "low"
+        elif numeric_value <= low:
+            return "low"
+
+    if high is not None:
+        if reference_range.get("high_inclusive", True):
+            if numeric_value > high:
+                return "high"
+        elif numeric_value >= high:
+            return "high"
+
+    return "normal"

--- a/openmed/clinical/lab_values.py
+++ b/openmed/clinical/lab_values.py
@@ -1,89 +1,217 @@
+"""Deterministic laboratory reference-range helpers."""
+
+from __future__ import annotations
+
+import math
 import re
-from typing import Any, Dict, Optional, Union
+from collections.abc import Mapping
+from typing import Literal, TypedDict
 
-# ADVISORY DISCLAIMER: Derived flags are heuristic and not a substitute
-# for the originating laboratory's own formal diagnostic flagging.
+AbnormalFlag = Literal["low", "normal", "high", "critical", "unknown"]
 
 
-def parse_reference_range(text: str) -> Dict[str, Any]:
+class ReferenceRange(TypedDict):
+    """Parsed numeric reference-range bounds."""
+
+    low: float | None
+    high: float | None
+    low_inclusive: bool
+    high_inclusive: bool
+
+
+LAB_FLAG_ADVISORY = (
+    "Derived lab abnormal flags are heuristic and are not a substitute for the "
+    "originating laboratory's own formal diagnostic flagging."
+)
+
+_NUMERIC = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)"
+_RANGE_RE = re.compile(rf"^(?P<low>{_NUMERIC})\s*-\s*(?P<high>{_NUMERIC})$")
+_ONE_SIDED_RE = re.compile(rf"^(?P<operator><=|>=|<|>)\s*(?P<bound>{_NUMERIC})$")
+
+_EXPLICIT_FLAGS: Mapping[str, AbnormalFlag] = {
+    "H": "high",
+    "HIGH": "high",
+    "L": "low",
+    "LOW": "low",
+    "C": "critical",
+    "CRIT": "critical",
+    "CRITICAL": "critical",
+    "HH": "critical",
+    "LL": "critical",
+    "N": "normal",
+    "NORMAL": "normal",
+}
+
+
+def _empty_reference_range() -> ReferenceRange:
+    return {
+        "low": None,
+        "high": None,
+        "low_inclusive": True,
+        "high_inclusive": True,
+    }
+
+
+def _finite_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def parse_reference_range(text: object) -> ReferenceRange:
+    """Parse a laboratory reference range into numeric bounds.
+
+    Supported forms are closed ranges such as ``"135-145"`` and
+    ``"0.5 - 1.2"``, plus one-sided bounds such as ``"<5"``, ``"<=5"``,
+    ``">10"``, and ``">=10"``. Units are intentionally ignored rather than
+    parsed or converted.
+
+    Args:
+        text: Raw reference-range text.
+
+    Returns:
+        A mapping with ``low``, ``high``, ``low_inclusive``, and
+        ``high_inclusive`` keys. Unparseable or contradictory ranges return
+        empty bounds instead of guessing.
     """
-    Parses a reference range text string into numeric boundary limits.
-    Supports formats like '135-145', '0.5 - 1.2', '<5', '>10'.
-    """
-    result = {"low": None, "high": None, "low_inclusive": True, "high_inclusive": True}
 
-    if not text or not isinstance(text, str):
+    result = _empty_reference_range()
+    if not isinstance(text, str):
         return result
 
-    text = text.strip()
-
-    # Pattern 1: Standard Range (e.g., "135-145" or "0.5 - 1.2")
-    range_match = re.match(r"^([0-9.]+)\s*-\s*([0-9.]+)$", text)
-    if range_match:
-        result["low"] = float(range_match.group(1))
-        result["high"] = float(range_match.group(2))
+    normalized = text.strip()
+    if not normalized:
         return result
 
-    # Pattern 2: Less than (e.g., "<5")
-    lt_match = re.match(r"^<\s*([0-9.]+)$", text)
-    if lt_match:
-        result["high"] = float(lt_match.group(1))
-        result["high_inclusive"] = False
+    if range_match := _RANGE_RE.fullmatch(normalized):
+        low = _finite_float(range_match.group("low"))
+        high = _finite_float(range_match.group("high"))
+        if low is None or high is None or low > high:
+            return result
+        result["low"] = low
+        result["high"] = high
         return result
 
-    # Pattern 3: Greater than (e.g., ">10")
-    gt_match = re.match(r"^>\s*([0-9.]+)$", text)
-    if gt_match:
-        result["low"] = float(gt_match.group(1))
-        result["low_inclusive"] = False
+    if one_sided_match := _ONE_SIDED_RE.fullmatch(normalized):
+        bound = _finite_float(one_sided_match.group("bound"))
+        if bound is None:
+            return result
+
+        operator = one_sided_match.group("operator")
+        if operator.startswith("<"):
+            result["high"] = bound
+            result["high_inclusive"] = operator == "<="
+        else:
+            result["low"] = bound
+            result["low_inclusive"] = operator == ">="
         return result
 
     return result
 
 
+def _bool_or_default(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    return default
+
+
+def _normalize_reference_range(
+    reference_range: Mapping[str, object] | str | None,
+) -> ReferenceRange:
+    if isinstance(reference_range, str):
+        return parse_reference_range(reference_range)
+    if not isinstance(reference_range, Mapping):
+        return _empty_reference_range()
+
+    raw_low = reference_range.get("low")
+    raw_high = reference_range.get("high")
+    low = _finite_float(raw_low)
+    high = _finite_float(raw_high)
+
+    if raw_low is not None and low is None:
+        return _empty_reference_range()
+    if raw_high is not None and high is None:
+        return _empty_reference_range()
+    if low is not None and high is not None and low > high:
+        return _empty_reference_range()
+
+    return {
+        "low": low,
+        "high": high,
+        "low_inclusive": _bool_or_default(
+            reference_range.get("low_inclusive"),
+            True,
+        ),
+        "high_inclusive": _bool_or_default(
+            reference_range.get("high_inclusive"),
+            True,
+        ),
+    }
+
+
 def derive_abnormal_flag(
-    value: Union[int, float, str],
-    reference_range: Dict[str, Any],
-    explicit_flag: Optional[str] = None,
-) -> str:
+    value: object,
+    reference_range: Mapping[str, object] | str | None,
+    explicit_flag: str | None = None,
+) -> AbnormalFlag:
+    """Derive a laboratory abnormal flag from a value and reference range.
+
+    Explicit laboratory flags for high, low, normal, or critical values are
+    honored before derived comparisons. Critical thresholds beyond the
+    reference range are out of scope unless the explicit flag marks the value
+    critical. This helper is unit-agnostic and does not perform conversion.
+
+    Args:
+        value: Numeric lab result value.
+        reference_range: Parsed range mapping or raw range text.
+        explicit_flag: Optional originating-lab flag such as ``"H"``, ``"L"``,
+            or ``"critical"``.
+
+    Returns:
+        ``"low"``, ``"normal"``, ``"high"``, ``"critical"``, or ``"unknown"``.
+        Non-numeric values and unparseable ranges return ``"unknown"``.
     """
-    Derives clinical abnormality status based on parsed bounds or explicit flags.
-    """
+
     if explicit_flag:
-        flag_upper = explicit_flag.upper().strip()
-        if flag_upper in ["H", "HIGH"]:
-            return "high"
-        if flag_upper in ["L", "LOW"]:
-            return "low"
-        if flag_upper in ["CRITICAL", "C"]:
-            return "critical"
+        normalized_flag = explicit_flag.strip().upper()
+        if normalized_flag in _EXPLICIT_FLAGS:
+            return _EXPLICIT_FLAGS[normalized_flag]
 
-    try:
-        numeric_value = float(value)
-    except (ValueError, TypeError):
+    numeric_value = _finite_float(value)
+    if numeric_value is None:
         return "unknown"
 
-    if not reference_range or not isinstance(reference_range, dict):
-        return "unknown"
-
-    low = reference_range.get("low")
-    high = reference_range.get("high")
-
+    parsed_range = _normalize_reference_range(reference_range)
+    low = parsed_range["low"]
+    high = parsed_range["high"]
     if low is None and high is None:
         return "unknown"
 
     if low is not None:
-        if reference_range.get("low_inclusive", True):
-            if numeric_value < low:
-                return "low"
-        elif numeric_value <= low:
+        if parsed_range["low_inclusive"] and numeric_value < low:
+            return "low"
+        if not parsed_range["low_inclusive"] and numeric_value <= low:
             return "low"
 
     if high is not None:
-        if reference_range.get("high_inclusive", True):
-            if numeric_value > high:
-                return "high"
-        elif numeric_value >= high:
+        if parsed_range["high_inclusive"] and numeric_value > high:
+            return "high"
+        if not parsed_range["high_inclusive"] and numeric_value >= high:
             return "high"
 
     return "normal"
+
+
+__all__ = [
+    "AbnormalFlag",
+    "LAB_FLAG_ADVISORY",
+    "ReferenceRange",
+    "derive_abnormal_flag",
+    "parse_reference_range",
+]

--- a/tests/unit/clinical/test_lab_values.py
+++ b/tests/unit/clinical/test_lab_values.py
@@ -1,0 +1,23 @@
+import pytest
+from openmed.clinical.lab_values import parse_reference_range, derive_abnormal_flag
+
+def test_lab_value_parsing_and_flagging():
+    # Test Range Parsing
+    assert parse_reference_range('135-145')["low"] == 135
+    assert parse_reference_range('135-145')["high"] == 145
+    assert parse_reference_range('<5')["high"] == 5
+    assert parse_reference_range('<5')["low"] is None
+    assert parse_reference_range('0.5 - 1.2')["low"] == 0.5
+
+    # Test Flag Derivation from Bounds
+    parsed_range = {"low": 135, "high": 145, "low_inclusive": True, "high_inclusive": True}
+    assert derive_abnormal_flag(130, parsed_range) == 'low'
+    assert derive_abnormal_flag(140, parsed_range) == 'normal'
+    assert derive_abnormal_flag(150, parsed_range) == 'high'
+
+    # Test Explicit Flags overriding values
+    assert derive_abnormal_flag(140, parsed_range, explicit_flag='H') == 'high'
+
+    # Test Fallbacks to Unknown
+    assert derive_abnormal_flag('invalid_numeric', parsed_range) == 'unknown'
+    assert derive_abnormal_flag(140, {"low": None, "high": None}) == 'unknown'

--- a/tests/unit/clinical/test_lab_values.py
+++ b/tests/unit/clinical/test_lab_values.py
@@ -1,17 +1,68 @@
+"""Tests for laboratory reference-range helpers."""
+
+from __future__ import annotations
+
 import pytest
 
-from openmed.clinical.lab_values import derive_abnormal_flag, parse_reference_range
+from openmed.clinical import (
+    LAB_FLAG_ADVISORY,
+    derive_abnormal_flag,
+    parse_reference_range,
+)
 
 
-def test_lab_value_parsing_and_flagging():
-    # Test Range Parsing
-    assert parse_reference_range("135-145")["low"] == 135
-    assert parse_reference_range("135-145")["high"] == 145
-    assert parse_reference_range("<5")["high"] == 5
-    assert parse_reference_range("<5")["low"] is None
-    assert parse_reference_range("0.5 - 1.2")["low"] == 0.5
+def test_parse_closed_reference_range():
+    parsed = parse_reference_range("135-145")
+    assert parsed == {
+        "low": 135.0,
+        "high": 145.0,
+        "low_inclusive": True,
+        "high_inclusive": True,
+    }
 
-    # Test Flag Derivation from Bounds
+
+def test_parse_decimal_reference_range_with_spaces():
+    parsed = parse_reference_range("0.5 - 1.2")
+    assert parsed["low"] == 0.5
+    assert parsed["high"] == 1.2
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("<5", {"low": None, "high": 5.0, "high_inclusive": False}),
+        ("<=5", {"low": None, "high": 5.0, "high_inclusive": True}),
+        (">10", {"low": 10.0, "high": None, "low_inclusive": False}),
+        (">=10", {"low": 10.0, "high": None, "low_inclusive": True}),
+    ],
+)
+def test_parse_one_sided_reference_ranges(text, expected):
+    parsed = parse_reference_range(text)
+    for key, value in expected.items():
+        assert parsed[key] == value
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "not a range",
+        "1..2 - 3",
+        "145-135",
+        "5 mg/dL",
+        "5-",
+    ],
+)
+def test_parse_unparseable_reference_range_returns_empty_bounds(text):
+    assert parse_reference_range(text) == {
+        "low": None,
+        "high": None,
+        "low_inclusive": True,
+        "high_inclusive": True,
+    }
+
+
+def test_derive_abnormal_flag_from_parsed_bounds():
     parsed_range = {
         "low": 135,
         "high": 145,
@@ -19,12 +70,57 @@ def test_lab_value_parsing_and_flagging():
         "high_inclusive": True,
     }
     assert derive_abnormal_flag(130, parsed_range) == "low"
+    assert derive_abnormal_flag(135, parsed_range) == "normal"
     assert derive_abnormal_flag(140, parsed_range) == "normal"
+    assert derive_abnormal_flag(145, parsed_range) == "normal"
     assert derive_abnormal_flag(150, parsed_range) == "high"
 
-    # Test Explicit Flags overriding values
-    assert derive_abnormal_flag(140, parsed_range, explicit_flag="H") == "high"
 
-    # Test Fallbacks to Unknown
-    assert derive_abnormal_flag("invalid_numeric", parsed_range) == "unknown"
-    assert derive_abnormal_flag(140, {"low": None, "high": None}) == "unknown"
+def test_derive_abnormal_flag_from_raw_range_text():
+    assert derive_abnormal_flag(130, "135-145") == "low"
+    assert derive_abnormal_flag(140, "135-145") == "normal"
+    assert derive_abnormal_flag(150, "135-145") == "high"
+
+
+def test_exclusive_one_sided_bounds_are_honored():
+    assert derive_abnormal_flag(5, "<5") == "high"
+    assert derive_abnormal_flag(4.9, "<5") == "normal"
+    assert derive_abnormal_flag(10, ">10") == "low"
+    assert derive_abnormal_flag(10.1, ">10") == "normal"
+
+
+@pytest.mark.parametrize(
+    ("explicit_flag", "expected"),
+    [
+        ("H", "high"),
+        ("high", "high"),
+        ("L", "low"),
+        ("low", "low"),
+        ("C", "critical"),
+        ("critical", "critical"),
+    ],
+)
+def test_explicit_flags_override_derived_value(explicit_flag, expected):
+    assert derive_abnormal_flag(140, "135-145", explicit_flag=explicit_flag) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "reference_range"),
+    [
+        ("invalid_numeric", {"low": 135, "high": 145}),
+        ("5 mg/dL", "<5"),
+        (140, "not a range"),
+        (140, {"low": None, "high": None}),
+        (140, {"low": "not numeric", "high": 145}),
+    ],
+)
+def test_derive_abnormal_flag_returns_unknown_when_it_cannot_derive(
+    value,
+    reference_range,
+):
+    assert derive_abnormal_flag(value, reference_range) == "unknown"
+
+
+def test_lab_flag_advisory_documents_heuristic_scope():
+    assert "heuristic" in LAB_FLAG_ADVISORY
+    assert "originating laboratory" in LAB_FLAG_ADVISORY

--- a/tests/unit/clinical/test_lab_values.py
+++ b/tests/unit/clinical/test_lab_values.py
@@ -1,23 +1,30 @@
 import pytest
-from openmed.clinical.lab_values import parse_reference_range, derive_abnormal_flag
+
+from openmed.clinical.lab_values import derive_abnormal_flag, parse_reference_range
+
 
 def test_lab_value_parsing_and_flagging():
     # Test Range Parsing
-    assert parse_reference_range('135-145')["low"] == 135
-    assert parse_reference_range('135-145')["high"] == 145
-    assert parse_reference_range('<5')["high"] == 5
-    assert parse_reference_range('<5')["low"] is None
-    assert parse_reference_range('0.5 - 1.2')["low"] == 0.5
+    assert parse_reference_range("135-145")["low"] == 135
+    assert parse_reference_range("135-145")["high"] == 145
+    assert parse_reference_range("<5")["high"] == 5
+    assert parse_reference_range("<5")["low"] is None
+    assert parse_reference_range("0.5 - 1.2")["low"] == 0.5
 
     # Test Flag Derivation from Bounds
-    parsed_range = {"low": 135, "high": 145, "low_inclusive": True, "high_inclusive": True}
-    assert derive_abnormal_flag(130, parsed_range) == 'low'
-    assert derive_abnormal_flag(140, parsed_range) == 'normal'
-    assert derive_abnormal_flag(150, parsed_range) == 'high'
+    parsed_range = {
+        "low": 135,
+        "high": 145,
+        "low_inclusive": True,
+        "high_inclusive": True,
+    }
+    assert derive_abnormal_flag(130, parsed_range) == "low"
+    assert derive_abnormal_flag(140, parsed_range) == "normal"
+    assert derive_abnormal_flag(150, parsed_range) == "high"
 
     # Test Explicit Flags overriding values
-    assert derive_abnormal_flag(140, parsed_range, explicit_flag='H') == 'high'
+    assert derive_abnormal_flag(140, parsed_range, explicit_flag="H") == "high"
 
     # Test Fallbacks to Unknown
-    assert derive_abnormal_flag('invalid_numeric', parsed_range) == 'unknown'
-    assert derive_abnormal_flag(140, {"low": None, "high": None}) == 'unknown'
+    assert derive_abnormal_flag("invalid_numeric", parsed_range) == "unknown"
+    assert derive_abnormal_flag(140, {"low": None, "high": None}) == "unknown"


### PR DESCRIPTION
## Description
This PR introduces a standalone utility in the clinical module to parse laboratory reference ranges and dynamically derive clinical abnormality flags. It operates deterministically and remains completely dependency-free.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made
- **Created `openmed/clinical/lab_values.py`**: Implemented `parse_reference_range` using regular expressions to handle standard hyphenated boundaries (`135-145`), fractional values, and one-sided inequality guards (`<5`, `>10`).
- **Added Flag Derivation**: Implemented `derive_abnormal_flag` to compare numeric inputs against parsed boundary values while ensuring explicit laboratory flags (`H`, `L`, `C`) are strictly honored. Includes a default fallback to `'unknown'` for non-numeric inputs.
- **Wrote Unit Tests**: Added a full validation suite tracking inside `tests/unit/clinical/test_lab_values.py`.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Code Quality
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies

## Related Issues
Closes #524