### PR TITLE
fix: never auto-select a zero-day date shift offset

### DIFF
--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1322,7 +1322,7 @@ def deidentify(
         confidence_threshold: Minimum confidence for redaction (default 0.7 for safety)
         keep_year: For dates, keep the year unchanged
         shift_dates: Deprecated alias for ``method="shift_dates"``.
-        date_shift_days: Specific number of days to shift (random if None)
+        date_shift_days: Specific number of days to shift (random non-zero if None)
         keep_mapping: Keep mapping for re-identification
         config: Optional configuration override
         use_smart_merging: Enable regex-based semantic unit merging (recommended)
@@ -1713,8 +1713,15 @@ def _random_nonzero_shift(low: int = -365, high: int = 365) -> int:
     Returns:
         A non-zero integer day offset within the range.
     """
-    sign = random.choice((-1, 1))
-    return sign * random.randint(1, high)
+    if low > high:
+        raise ValueError("low must be less than or equal to high")
+    if low == high == 0:
+        raise ValueError("range must contain at least one non-zero shift")
+
+    while True:
+        shift_days = random.randint(low, high)
+        if shift_days != 0:
+            return shift_days
 
 
 def _shift_date(

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1069,7 +1069,7 @@ def _build_deidentification_result(
     redaction_entities = sorted(pii_entities, key=lambda e: e.start, reverse=True)
 
     if effective_method == "shift_dates" and date_shift_days is None:
-        date_shift_days = random.randint(-365, 365)
+        date_shift_days = _random_nonzero_shift()
 
     anonymizer = None
     if effective_method == "replace" or any(
@@ -1698,6 +1698,23 @@ def _replace_year_safe(date_value: datetime, year: int) -> datetime:
     except ValueError:
         # The only date that can fail here is Feb 29 -> a non-leap year.
         return date_value.replace(year=year, month=2, day=28)
+
+
+def _random_nonzero_shift(low: int = -365, high: int = 365) -> int:
+    """Return a random non-zero day offset in ``[low, high]`` excluding 0.
+
+    A zero-day shift would leave clinical dates unchanged, silently defeating
+    de-identification, so the auto-selected offset must never be 0.
+
+    Args:
+        low: Minimum (most-negative) shift in days, inclusive.
+        high: Maximum (most-positive) shift in days, inclusive.
+
+    Returns:
+        A non-zero integer day offset within the range.
+    """
+    sign = random.choice((-1, 1))
+    return sign * random.randint(1, high)
 
 
 def _shift_date(

--- a/tests/unit/test_pii.py
+++ b/tests/unit/test_pii.py
@@ -705,18 +705,15 @@ class TestDeidentify:
             )
 
     @patch("openmed.core.pii.extract_pii")
-    def test_deidentify_auto_shift_dates_never_echoes_original_date(self, mock_extract):
+    def test_deidentify_auto_shift_dates_retries_zero_offset(
+        self, mock_extract, monkeypatch
+    ):
         """Auto-selected shift_dates offsets must never be a no-op.
 
         ``date_shift_days=None`` used to fall back to ``random.randint(-365,
         365)``, which is inclusive of 0 and silently left every date in the
-        document unchanged about 1 run in 731. Repeat the auto-selected path
-        enough times that the old bug would almost certainly have surfaced,
-        and assert the shifted date never equals the original.
-
-        ``keep_year=False`` keeps this deterministic: shifting a date by any
-        non-zero number of days always changes the calendar date, so this
-        assertion can never flake on a leap-year edge case.
+        document unchanged. Force the first draw to 0 so the regression is
+        deterministic.
         """
         original = "01/15/2020"
         mock_extract.return_value = PredictionResult(
@@ -729,15 +726,46 @@ class TestDeidentify:
             model_name="test",
             timestamp=datetime.now().isoformat(),
         )
+        draws = iter([0, 30])
 
-        for _ in range(200):
-            result = deidentify(
-                f"DOB {original}",
-                method="shift_dates",
-                date_shift_days=None,
-                keep_year=False,
-            )
-            assert original not in result.deidentified_text
+        def fake_randint(low, high):
+            assert (low, high) == (-365, 365)
+            return next(draws)
+
+        monkeypatch.setattr("openmed.core.pii.random.randint", fake_randint)
+
+        result = deidentify(
+            f"DOB {original}",
+            method="shift_dates",
+            date_shift_days=None,
+            keep_year=False,
+        )
+
+        assert result.deidentified_text == "DOB 02/14/2020"
+
+    @patch("openmed.core.pii.extract_pii")
+    def test_deidentify_explicit_zero_shift_remains_allowed(self, mock_extract):
+        """An explicit caller-supplied zero shift is a deliberate no-op."""
+        original = "01/15/2020"
+        mock_extract.return_value = PredictionResult(
+            text=f"DOB {original}",
+            entities=[
+                EntityPrediction(
+                    text=original, label="DATE", start=4, end=14, confidence=0.95
+                )
+            ],
+            model_name="test",
+            timestamp=datetime.now().isoformat(),
+        )
+
+        result = deidentify(
+            f"DOB {original}",
+            method="shift_dates",
+            date_shift_days=0,
+            keep_year=False,
+        )
+
+        assert result.deidentified_text == f"DOB {original}"
 
 
 # ---------------------------------------------------------------------------
@@ -922,17 +950,41 @@ class TestShiftDate:
 class TestRandomNonzeroShift:
     """Tests for the _random_nonzero_shift helper function."""
 
-    def test_random_nonzero_shift_never_zero(self):
-        """Every draw must be non-zero and within the default ±365 range."""
-        draws = {_random_nonzero_shift() for _ in range(10_000)}
-        assert 0 not in draws
-        assert all(-365 <= d <= 365 for d in draws)
+    def test_random_nonzero_shift_retries_zero(self, monkeypatch):
+        """A zero draw must be retried until a non-zero offset is selected."""
+        calls = []
+        draws = iter([0, -7])
 
-    def test_random_nonzero_shift_respects_custom_high(self):
-        """A narrower ``high`` bound must still exclude 0."""
-        draws = {_random_nonzero_shift(low=-10, high=10) for _ in range(2_000)}
-        assert 0 not in draws
-        assert all(-10 <= d <= 10 for d in draws)
+        def fake_randint(low, high):
+            calls.append((low, high))
+            return next(draws)
+
+        monkeypatch.setattr("openmed.core.pii.random.randint", fake_randint)
+
+        assert _random_nonzero_shift(low=-10, high=10) == -7
+        assert calls == [(-10, 10), (-10, 10)]
+
+    def test_random_nonzero_shift_respects_one_sided_ranges(self, monkeypatch):
+        """Ranges that do not contain zero should be passed through unchanged."""
+        calls = []
+        draws = iter([-3, 4])
+
+        def fake_randint(low, high):
+            calls.append((low, high))
+            return next(draws)
+
+        monkeypatch.setattr("openmed.core.pii.random.randint", fake_randint)
+
+        assert _random_nonzero_shift(low=-10, high=-1) == -3
+        assert _random_nonzero_shift(low=1, high=10) == 4
+        assert calls == [(-10, -1), (1, 10)]
+
+    def test_random_nonzero_shift_rejects_invalid_ranges(self):
+        """The configured range must contain at least one non-zero value."""
+        with pytest.raises(ValueError, match="low must be less"):
+            _random_nonzero_shift(low=10, high=-10)
+        with pytest.raises(ValueError, match="non-zero shift"):
+            _random_nonzero_shift(low=0, high=0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pii.py
+++ b/tests/unit/test_pii.py
@@ -12,6 +12,7 @@ from openmed.core.pii import (
     DeidentificationResult,
     PIIEntity,
     _generate_fake_pii,
+    _random_nonzero_shift,
     _redact_entity,
     _shift_date,
     _strip_accents,
@@ -703,6 +704,41 @@ class TestDeidentify:
                 date_shift_days=30,
             )
 
+    @patch("openmed.core.pii.extract_pii")
+    def test_deidentify_auto_shift_dates_never_echoes_original_date(self, mock_extract):
+        """Auto-selected shift_dates offsets must never be a no-op.
+
+        ``date_shift_days=None`` used to fall back to ``random.randint(-365,
+        365)``, which is inclusive of 0 and silently left every date in the
+        document unchanged about 1 run in 731. Repeat the auto-selected path
+        enough times that the old bug would almost certainly have surfaced,
+        and assert the shifted date never equals the original.
+
+        ``keep_year=False`` keeps this deterministic: shifting a date by any
+        non-zero number of days always changes the calendar date, so this
+        assertion can never flake on a leap-year edge case.
+        """
+        original = "01/15/2020"
+        mock_extract.return_value = PredictionResult(
+            text=f"DOB {original}",
+            entities=[
+                EntityPrediction(
+                    text=original, label="DATE", start=4, end=14, confidence=0.95
+                )
+            ],
+            model_name="test",
+            timestamp=datetime.now().isoformat(),
+        )
+
+        for _ in range(200):
+            result = deidentify(
+                f"DOB {original}",
+                method="shift_dates",
+                date_shift_days=None,
+                keep_year=False,
+            )
+            assert original not in result.deidentified_text
+
 
 # ---------------------------------------------------------------------------
 # _redact_entity Tests
@@ -876,6 +912,27 @@ class TestShiftDate:
         """
         result = _shift_date("02/28/2019", 366, keep_year=True)
         assert result == "02/28/2019"
+
+
+# ---------------------------------------------------------------------------
+# _random_nonzero_shift Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRandomNonzeroShift:
+    """Tests for the _random_nonzero_shift helper function."""
+
+    def test_random_nonzero_shift_never_zero(self):
+        """Every draw must be non-zero and within the default ±365 range."""
+        draws = {_random_nonzero_shift() for _ in range(10_000)}
+        assert 0 not in draws
+        assert all(-365 <= d <= 365 for d in draws)
+
+    def test_random_nonzero_shift_respects_custom_high(self):
+        """A narrower ``high`` bound must still exclude 0."""
+        draws = {_random_nonzero_shift(low=-10, high=10) for _ in range(2_000)}
+        assert 0 not in draws
+        assert all(-10 <= d <= 10 for d in draws)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description
`shift_dates` auto-selects a day offset via `random.randint(-365, 365)` when the
caller doesn't supply `date_shift_days`. That range is inclusive of 0, so roughly
1 run in 731 silently shifts every date in the document by zero days, leaving
all clinical dates (including DOBs and admission dates) completely unredacted
with no error or warning. This adds a small helper that guarantees the
auto-selected offset is non-zero, over the same ±365-day range.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Changes Made
- Add `_random_nonzero_shift()` in `openmed/core/pii.py`, returning a random
  non-zero day offset in `[-365, 365]` (sign + magnitude, magnitude drawn from
  `[1, 365]`).
- Use it in place of `random.randint(-365, 365)` for the auto-selected
  `shift_dates` offset.
- Add a property test (`TestRandomNonzeroShift`, 10k + 2k draws) confirming the
  helper never returns 0 and stays within range, including a custom `high`.
- Add a regression test (`test_deidentify_auto_shift_dates_never_echoes_original_date`)
  that runs the full auto-selected `shift_dates` path 200 times with
  `keep_year=False` and asserts the original date never reappears verbatim.
  `keep_year=False` makes the assertion deterministic: shifting a calendar
  date by any non-zero number of days always changes it, so this cannot flake
  on a leap-year edge case the way a `keep_year=True` check could.

Explicit caller-supplied `date_shift_days=0` is intentionally left unchanged by
this PR; that's a deliberate request, not the accidental no-op this fixes.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Ran:
- `pytest tests/unit/test_pii.py -q` → 119 passed
- `pytest tests/ -q` (full suite) → 1701 passed, 22 skipped, 0 failed

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

No user-facing behavior or API changes; the auto-selected offset still ranges
over ±365 days, just excluding 0. Didn't see a CHANGELOG entry convention for
fixes of this size — happy to add one if you'd like.

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
No existing issue tracks this; opening the PR directly since it's a small,
self-contained fix.

## Screenshots/Examples
Not applicable (backend logic fix, no UI surface).
