### PR TITLE
Harden workflow dispatch model inputs

### DIFF
--- a/.github/workflows/convert-models.yml
+++ b/.github/workflows/convert-models.yml
@@ -44,15 +44,34 @@ jobs:
         pip install -e ".[mlx,hf]"
 
     - name: Convert model to MLX
+      env:
+        MODEL_ID: ${{ github.event.inputs.model_id }}
+        QUANTIZE: ${{ github.event.inputs.quantize }}
       run: |
-        QUANTIZE_ARG=""
-        if [ "${{ github.event.inputs.quantize }}" != "none" ]; then
-          QUANTIZE_ARG="--quantize ${{ github.event.inputs.quantize }}"
+        set -euo pipefail
+
+        if [[ ! "$MODEL_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+          echo "::error title=Invalid model_id::Use a Hugging Face repo id such as org/model with letters, numbers, dots, underscores, and hyphens."
+          exit 1
         fi
+
+        case "$QUANTIZE" in
+          none)
+            QUANTIZE_ARGS=()
+            ;;
+          4|8)
+            QUANTIZE_ARGS=(--quantize "$QUANTIZE")
+            ;;
+          *)
+            echo "::error title=Invalid quantize::Use one of: none, 4, 8."
+            exit 1
+            ;;
+        esac
+
         python -m openmed.mlx.convert \
-          --model "${{ github.event.inputs.model_id }}" \
+          --model "$MODEL_ID" \
           --output ./mlx-output \
-          $QUANTIZE_ARG
+          "${QUANTIZE_ARGS[@]}"
 
     - name: List output files
       run: ls -la mlx-output/
@@ -82,9 +101,18 @@ jobs:
         pip install -e ".[coreml]"
 
     - name: Convert model to CoreML
+      env:
+        MODEL_ID: ${{ github.event.inputs.model_id }}
       run: |
+        set -euo pipefail
+
+        if [[ ! "$MODEL_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+          echo "::error title=Invalid model_id::Use a Hugging Face repo id such as org/model with letters, numbers, dots, underscores, and hyphens."
+          exit 1
+        fi
+
         python -m openmed.coreml.convert \
-          --model "${{ github.event.inputs.model_id }}" \
+          --model "$MODEL_ID" \
           --output ./OpenMedModel.mlpackage
 
     - name: List output files
@@ -150,16 +178,34 @@ jobs:
       if: contains(github.event.inputs.formats, 'mlx')
       env:
         HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+        MODEL_ID: ${{ github.event.inputs.model_id }}
+        QUANTIZE: ${{ github.event.inputs.quantize }}
       run: |
+        set -euo pipefail
+
+        if [[ ! "$MODEL_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+          echo "::error title=Invalid model_id::Use a Hugging Face repo id such as org/model with letters, numbers, dots, underscores, and hyphens."
+          exit 1
+        fi
+
         FORMAT="mlx-fp"
-        if [ "${{ github.event.inputs.quantize }}" = "8" ]; then
-          FORMAT="mlx-8bit"
-        fi
-        if [ "${{ github.event.inputs.quantize }}" = "4" ]; then
-          FORMAT="mlx-4bit"
-        fi
+        case "$QUANTIZE" in
+          none)
+            ;;
+          8)
+            FORMAT="mlx-8bit"
+            ;;
+          4)
+            FORMAT="mlx-4bit"
+            ;;
+          *)
+            echo "::error title=Invalid quantize::Use one of: none, 4, 8."
+            exit 1
+            ;;
+        esac
+
         python -m openmed.core.hf_publish \
-          --model "${{ github.event.inputs.model_id }}" \
+          --model "$MODEL_ID" \
           --artifact-dir publish-artifacts/mlx-output \
           --format "$FORMAT" \
           --manifest models.jsonl \
@@ -182,9 +228,17 @@ jobs:
       if: contains(github.event.inputs.formats, 'coreml')
       env:
         HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+        MODEL_ID: ${{ github.event.inputs.model_id }}
       run: |
+        set -euo pipefail
+
+        if [[ ! "$MODEL_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+          echo "::error title=Invalid model_id::Use a Hugging Face repo id such as org/model with letters, numbers, dots, underscores, and hyphens."
+          exit 1
+        fi
+
         python -m openmed.core.hf_publish \
-          --model "${{ github.event.inputs.model_id }}" \
+          --model "$MODEL_ID" \
           --artifact-dir publish-artifacts/coreml-output \
           --format coreml \
           --manifest models.jsonl \

--- a/tests/unit/test_convert_workflow_hf_token.py
+++ b/tests/unit/test_convert_workflow_hf_token.py
@@ -59,6 +59,14 @@ def test_convert_workflow_passes_dispatch_inputs_through_safe_env_vars():
     )
 
 
+def test_convert_workflow_keeps_dispatch_inputs_out_of_shell_blocks():
+    workflow = CONVERT_WORKFLOW.read_text(encoding="utf-8")
+    run_blocks = re.findall(r"(?m)^\s+run: \|\n((?:^\s{8,}.*\n?)+)", workflow)
+
+    assert run_blocks
+    assert "github.event.inputs" not in "\n".join(run_blocks)
+
+
 def test_hf_token_policy_documents_scope_storage_rotation_and_revocation():
     policy = HF_TOKEN_POLICY.read_text(encoding="utf-8")
 

--- a/tests/unit/test_convert_workflow_hf_token.py
+++ b/tests/unit/test_convert_workflow_hf_token.py
@@ -44,6 +44,21 @@ def test_convert_workflow_publishes_downloaded_conversion_artifacts():
     assert "published-model-manifest" in workflow
 
 
+def test_convert_workflow_passes_dispatch_inputs_through_safe_env_vars():
+    workflow = CONVERT_WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow.count("MODEL_ID: ${{ github.event.inputs.model_id }}") == 4
+    assert workflow.count("QUANTIZE: ${{ github.event.inputs.quantize }}") == 2
+    assert workflow.count('--model "$MODEL_ID"') == 4
+    assert workflow.count('case "$QUANTIZE" in') == 2
+    assert workflow.count('[[ ! "$MODEL_ID" =~') == 4
+    assert '--model "${{ github.event.inputs.model_id }}"' not in workflow
+    assert '[ "${{ github.event.inputs.quantize }}"' not in workflow
+    assert (
+        'QUANTIZE_ARG="--quantize ${{ github.event.inputs.quantize }}"' not in workflow
+    )
+
+
 def test_hf_token_policy_documents_scope_storage_rotation_and_revocation():
     policy = HF_TOKEN_POLICY.read_text(encoding="utf-8")
 


### PR DESCRIPTION
# Pull Request

## Description
Harden the model conversion workflow so manually supplied dispatch inputs are treated as shell data before model conversion or publishing steps run.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Route workflow dispatch model and quantization inputs through step environment variables before shell use.
- Validate Hugging Face repo IDs and accepted quantization values in each affected shell block.
- Pass model IDs to Python commands via "$MODEL_ID" rather than embedding workflow expressions inside command arguments.
- Add regression coverage for the workflow policy in the Hugging Face token workflow tests.

## Root Cause
The workflow embedded manual dispatch values directly into multiline shell commands. Shell syntax in those values could be evaluated before the Python command received its arguments, including in publish steps that expose the Hugging Face write token.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `PATH="$PWD/.venv/bin:$PATH" make format`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `PATH="$PWD/.venv/bin:$PATH" make format-check`
- `.venv/bin/python -m pytest tests/unit/test_convert_workflow_hf_token.py -q`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md
- No documentation changes were needed for this workflow hardening.

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
No issue linked.

## Screenshots/Examples
Not applicable.
