### PR TITLE
Add OpenMedKit local-first guards

### DIFF
--- a/docs/swift-openmedkit.md
+++ b/docs/swift-openmedkit.md
@@ -32,6 +32,25 @@ ModernBERT, Longformer, EuroBERT, Qwen3, and additional architecture families ar
 
 iOS Simulator is **not** a Swift MLX validation target.
 
+## Local-First And Safety Posture
+
+OpenMedKit inference is local-first. After model and tokenizer assets are loaded
+from a bundled directory or local cache, `analyzeText(...)`, `extractPII(...)`,
+and `extractPIIChunked(...)` run on-device without network I/O. The package has
+no telemetry path by default and does not send clinical text, entity spans,
+identifiers, prompts, or usage data to OpenMed or third parties.
+
+Model download helpers such as `OpenMedModelStore.downloadMLXModel(...)` are
+explicit preparation APIs. Production apps that require strict offline behavior
+should bundle model/tokenizer assets or pre-seed the cache and run inference
+from those local assets.
+
+Internal diagnostics route through a structured safe logging shim. Entity
+descriptions and span summaries include labels, offsets, confidence, and
+SHA-256 span hashes rather than raw identifier text. OpenMedKit is not a medical
+device and does not make autonomous clinical decisions; validation, review
+workflow, and regulatory classification remain application responsibilities.
+
 ## Apple Platform Matrix
 
 | Use case | Recommended path |

--- a/swift/OpenMedKit/README.md
+++ b/swift/OpenMedKit/README.md
@@ -1,0 +1,30 @@
+# OpenMedKit
+
+OpenMedKit is the Swift package for running OpenMed models in iOS, iPadOS, and
+macOS apps with MLX or CoreML backends.
+
+## Local-First Guarantees
+
+- Inference is on-device after model and tokenizer assets are loaded.
+- `analyzeText(...)`, `extractPII(...)`, and `extractPIIChunked(...)` do not
+  perform network I/O.
+- Telemetry is off by default. The package does not send usage, prompts,
+  clinical text, entities, or identifiers to OpenMed or third parties.
+- PHI should stay on device. Public download helpers may fetch model artifacts,
+  but they are explicit model-preparation APIs and are not required for
+  inference when assets are bundled or cached locally.
+
+## No-PHI Logging
+
+OpenMedKit routes internal inference diagnostics through `SafeLog`, a structured
+logging shim that records operation names, counts, labels, offsets, confidence,
+and span hashes rather than raw matched text. `EntityPrediction.description` is
+also PHI-safe, so printing an entity emits offsets and a SHA-256 span hash
+instead of the original identifier text.
+
+## Clinical Safety
+
+OpenMedKit is not a medical device. It is a developer library for local clinical
+NLP and PII detection. Applications using it remain responsible for clinical
+validation, user-facing safety controls, review workflows, and regulatory
+classification.

--- a/swift/OpenMedKit/Sources/OpenMedKit/EntityPrediction.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/EntityPrediction.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// A single entity predicted by the NER pipeline.
@@ -24,10 +25,19 @@ public struct EntityPrediction: Codable, Equatable, Sendable {
         self.start = start
         self.end = end
     }
+
+    /// Stable SHA-256 digest of the matched text span for PHI-safe diagnostics.
+    public var textHash: String {
+        let digest = SHA256.hash(data: Data(text.utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return "sha256:\(hex)"
+    }
 }
 
 extension EntityPrediction: CustomStringConvertible {
     public var description: String {
-        "[\(label)] \"\(text)\" (\(start):\(end)) conf=\(String(format: "%.2f", confidence))"
+        let formattedConfidence = String(format: "%.2f", confidence)
+        return
+            "[\(label)] span=(\(start):\(end)) text_hash=\(textHash) conf=\(formattedConfidence)"
     }
 }

--- a/swift/OpenMedKit/Sources/OpenMedKit/OpenMedKit.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/OpenMedKit.swift
@@ -8,6 +8,12 @@ import Tokenizers
 /// Provides NER and PII detection using either CoreML or MLX models
 /// produced by the OpenMed Python library.
 ///
+/// Inference is local-first: after model and tokenizer assets are loaded from a
+/// local bundle or cache, `analyzeText(...)` and `extractPII(...)` run on-device
+/// and do not perform network I/O or telemetry. Download helpers are explicit
+/// model-preparation APIs, not inference requirements. OpenMedKit is not a
+/// medical device and does not make autonomous clinical decisions.
+///
 /// ## Quick Start
 ///
 /// ```swift
@@ -17,7 +23,7 @@ import Tokenizers
 /// let openmed = try OpenMed(backend: .mlx(modelDirectoryURL: modelDirectory))
 /// let entities = try openmed.extractPII("Patient John Doe, SSN 123-45-6789")
 /// for entity in entities {
-///     print(entity)  // [first_name] "John Doe" (8:16) conf=0.95
+///     let safeDescription = entity.description
 /// }
 /// ```
 public final class OpenMed {
@@ -121,30 +127,49 @@ public final class OpenMed {
         _ text: String,
         confidenceThreshold: Float = 0.5
     ) throws -> [EntityPrediction] {
-        let entities: [EntityPrediction]
-        switch runtime {
-        case .coreML(let pipeline):
-            let (inputIDs, attentionMask, _, offsets) = try tokenize(text)
-            entities = try pipeline.predict(
-                inputIds: inputIDs,
-                attentionMask: attentionMask,
-                offsets: offsets,
-                text: text
-            )
-        case .mlx(let pipeline):
-            let (inputIDs, attentionMask, tokenTypeIDs, offsets) = try tokenize(text)
-            entities = try pipeline.predict(
-                inputIDs: inputIDs,
-                attentionMask: attentionMask,
-                tokenTypeIDs: tokenTypeIDs,
-                offsets: offsets,
-                text: text
-            )
-        case .privacyFilter(let pipeline):
-            entities = try pipeline.predict(text)
-        }
+        SafeLog.log(.inferenceStarted(operation: .analyzeText))
+        do {
+            let entities: [EntityPrediction]
+            switch runtime {
+            case .coreML(let pipeline):
+                let (inputIDs, attentionMask, _, offsets) = try tokenize(text)
+                entities = try pipeline.predict(
+                    inputIds: inputIDs,
+                    attentionMask: attentionMask,
+                    offsets: offsets,
+                    text: text
+                )
+            case .mlx(let pipeline):
+                let (inputIDs, attentionMask, tokenTypeIDs, offsets) = try tokenize(text)
+                entities = try pipeline.predict(
+                    inputIDs: inputIDs,
+                    attentionMask: attentionMask,
+                    tokenTypeIDs: tokenTypeIDs,
+                    offsets: offsets,
+                    text: text
+                )
+            case .privacyFilter(let pipeline):
+                entities = try pipeline.predict(text)
+            }
 
-        return entities.filter { $0.confidence >= confidenceThreshold }
+            let filteredEntities = entities.filter { $0.confidence >= confidenceThreshold }
+            SafeLog.log(
+                .inferenceCompleted(
+                    operation: .analyzeText,
+                    entityCount: filteredEntities.count
+                )
+            )
+            return filteredEntities
+        } catch {
+            SafeLog.log(
+                .inferenceFailed(
+                    operation: .analyzeText,
+                    errorType: String(describing: type(of: error))
+                ),
+                level: .error
+            )
+            throw error
+        }
     }
 
     /// Run PII detection on the given text with OpenMed's smart post-processing.
@@ -157,30 +182,51 @@ public final class OpenMed {
         confidenceThreshold: Float = 0.5,
         useSmartMerging: Bool = true
     ) throws -> [EntityPrediction] {
-        let entities = try analyzeText(text, confidenceThreshold: confidenceThreshold)
-        let repairedEntities = PostProcessing.repairEntitySpans(entities, text: text)
+        SafeLog.log(.inferenceStarted(operation: .extractPII))
+        do {
+            let entities = try analyzeText(text, confidenceThreshold: confidenceThreshold)
+            let repairedEntities = PostProcessing.repairEntitySpans(entities, text: text)
 
-        guard useSmartMerging else {
-            return repairedEntities
-        }
+            let piiEntities: [EntityPrediction]
+            if useSmartMerging {
+                switch runtime {
+                case .privacyFilter:
+                    piiEntities = PostProcessing.mergePIIEntities(
+                        repairedEntities,
+                        text: text,
+                        useSemanticPatterns: true,
+                        preferModelLabels: true,
+                        allowSemanticOnlyMatches: false,
+                        allowSemanticLabelExpansion: false
+                    )
+                case .coreML, .mlx:
+                    piiEntities = PostProcessing.mergePIIEntities(
+                        repairedEntities,
+                        text: text,
+                        useSemanticPatterns: true,
+                        preferModelLabels: true
+                    )
+                }
+            } else {
+                piiEntities = repairedEntities
+            }
 
-        switch runtime {
-        case .privacyFilter:
-            return PostProcessing.mergePIIEntities(
-                repairedEntities,
-                text: text,
-                useSemanticPatterns: true,
-                preferModelLabels: true,
-                allowSemanticOnlyMatches: false,
-                allowSemanticLabelExpansion: false
+            SafeLog.log(
+                .inferenceCompleted(
+                    operation: .extractPII,
+                    entityCount: piiEntities.count
+                )
             )
-        case .coreML, .mlx:
-            return PostProcessing.mergePIIEntities(
-                repairedEntities,
-                text: text,
-                useSemanticPatterns: true,
-                preferModelLabels: true
+            return piiEntities
+        } catch {
+            SafeLog.log(
+                .inferenceFailed(
+                    operation: .extractPII,
+                    errorType: String(describing: type(of: error))
+                ),
+                level: .error
             )
+            throw error
         }
     }
 
@@ -196,38 +242,64 @@ public final class OpenMed {
         tokenOverlap: Int = 32,
         useSmartMerging: Bool = true
     ) throws -> [EntityPrediction] {
-        let chunks = try makeTokenChunks(
-            for: text,
-            chunkTokenLimit: chunkTokenLimit,
-            tokenOverlap: tokenOverlap
-        )
-        guard chunks.count > 1 else {
-            return try extractPII(
-                text,
-                confidenceThreshold: confidenceThreshold,
+        SafeLog.log(.inferenceStarted(operation: .extractPIIChunked))
+        do {
+            let chunks = try makeTokenChunks(
+                for: text,
+                chunkTokenLimit: chunkTokenLimit,
+                tokenOverlap: tokenOverlap
+            )
+            guard chunks.count > 1 else {
+                let piiEntities = try extractPII(
+                    text,
+                    confidenceThreshold: confidenceThreshold,
+                    useSmartMerging: useSmartMerging
+                )
+                SafeLog.log(
+                    .inferenceCompleted(
+                        operation: .extractPIIChunked,
+                        entityCount: piiEntities.count
+                    )
+                )
+                return piiEntities
+            }
+
+            var chunkEntities: [EntityPrediction] = []
+            for chunk in chunks {
+                let chunkText = Self.substring(text, start: chunk.start, end: chunk.end)
+                let entities = try extractPII(
+                    chunkText,
+                    confidenceThreshold: confidenceThreshold,
+                    useSmartMerging: useSmartMerging
+                )
+                chunkEntities.append(
+                    contentsOf: entities.compactMap { entity in
+                        Self.offset(entity, by: chunk.start, in: text)
+                    })
+            }
+
+            let piiEntities = mergeChunkedPIIEntities(
+                chunkEntities,
+                text: text,
                 useSmartMerging: useSmartMerging
             )
-        }
-
-        var chunkEntities: [EntityPrediction] = []
-        for chunk in chunks {
-            let chunkText = Self.substring(text, start: chunk.start, end: chunk.end)
-            let entities = try extractPII(
-                chunkText,
-                confidenceThreshold: confidenceThreshold,
-                useSmartMerging: useSmartMerging
+            SafeLog.log(
+                .inferenceCompleted(
+                    operation: .extractPIIChunked,
+                    entityCount: piiEntities.count
+                )
             )
-            chunkEntities.append(
-                contentsOf: entities.compactMap { entity in
-                    Self.offset(entity, by: chunk.start, in: text)
-                })
+            return piiEntities
+        } catch {
+            SafeLog.log(
+                .inferenceFailed(
+                    operation: .extractPIIChunked,
+                    errorType: String(describing: type(of: error))
+                ),
+                level: .error
+            )
+            throw error
         }
-
-        return mergeChunkedPIIEntities(
-            chunkEntities,
-            text: text,
-            useSmartMerging: useSmartMerging
-        )
     }
 
     // MARK: - Private
@@ -783,7 +855,10 @@ public final class OpenMed {
             throw TokenizerError.missingConfig
         }
 
-        let (data, response) = try await URLSession.shared.data(from: url)
+        let (data, response) = try await OpenMedNetworkAccess.data(
+            from: url,
+            operation: .tokenizerAssetDownload
+        )
         guard let http = response as? HTTPURLResponse else {
             throw TokenizerError.missingConfig
         }

--- a/swift/OpenMedKit/Sources/OpenMedKit/OpenMedModelStore.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/OpenMedModelStore.swift
@@ -310,7 +310,10 @@ public enum OpenMedModelStore {
         var request = URLRequest(url: remoteURL)
         request.setValue("application/octet-stream", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await OpenMedNetworkAccess.data(
+            for: request,
+            operation: .modelArtifactDownload
+        )
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OpenMedModelStoreError.invalidResponse(remoteURL)
         }

--- a/swift/OpenMedKit/Sources/OpenMedKit/OpenMedNetworkAccess.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/OpenMedNetworkAccess.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+enum OpenMedNetworkOperation: String, Sendable {
+    case modelArtifactDownload
+    case tokenizerAssetDownload
+}
+
+enum OpenMedNetworkAccess {
+    typealias Observer = (_ operation: OpenMedNetworkOperation, _ url: URL) -> Void
+
+    private static let lock = NSLock()
+    private static var observer: Observer?
+
+    static func withObserver<T>(
+        _ newObserver: @escaping Observer,
+        _ body: () throws -> T
+    ) rethrows -> T {
+        lock.lock()
+        let previousObserver = observer
+        observer = newObserver
+        lock.unlock()
+
+        defer {
+            lock.lock()
+            observer = previousObserver
+            lock.unlock()
+        }
+
+        return try body()
+    }
+
+    static func data(
+        from url: URL,
+        operation: OpenMedNetworkOperation
+    ) async throws -> (Data, URLResponse) {
+        notify(operation: operation, url: url)
+        return try await URLSession.shared.data(from: url)
+    }
+
+    static func data(
+        for request: URLRequest,
+        operation: OpenMedNetworkOperation
+    ) async throws -> (Data, URLResponse) {
+        if let url = request.url {
+            notify(operation: operation, url: url)
+        }
+        return try await URLSession.shared.data(for: request)
+    }
+
+    private static func notify(operation: OpenMedNetworkOperation, url: URL) {
+        let currentObserver: Observer?
+
+        lock.lock()
+        currentObserver = observer
+        lock.unlock()
+
+        currentObserver?(operation, url)
+    }
+}

--- a/swift/OpenMedKit/Sources/OpenMedKit/SafeLog.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/SafeLog.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+enum SafeLog {
+    enum Level: String, Sendable {
+        case debug
+        case info
+        case warning
+        case error
+    }
+
+    enum Operation: String, Sendable {
+        case analyzeText
+        case extractPII
+        case extractPIIChunked
+    }
+
+    enum Event: Sendable {
+        case inferenceStarted(operation: Operation)
+        case inferenceCompleted(operation: Operation, entityCount: Int)
+        case inferenceFailed(operation: Operation, errorType: String)
+    }
+
+    struct SpanSummary: Equatable, Sendable {
+        let label: String
+        let start: Int
+        let end: Int
+        let confidence: Float
+        let textHash: String
+    }
+
+    typealias Sink = (
+        _ level: Level,
+        _ event: String,
+        _ metadata: [String: String]
+    ) -> Void
+
+    private static let lock = NSLock()
+    private static var sink: Sink?
+
+    static func withSink<T>(_ newSink: @escaping Sink, _ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        let previousSink = sink
+        sink = newSink
+        lock.unlock()
+
+        defer {
+            lock.lock()
+            sink = previousSink
+            lock.unlock()
+        }
+
+        return try body()
+    }
+
+    static func log(_ event: Event, level: Level = .debug) {
+        let (eventName, metadata) = event.payload
+        let currentSink: Sink?
+
+        lock.lock()
+        currentSink = sink
+        lock.unlock()
+
+        currentSink?(level, eventName, metadata)
+    }
+
+    static func summarize(_ entity: EntityPrediction) -> SpanSummary {
+        SpanSummary(
+            label: entity.label,
+            start: entity.start,
+            end: entity.end,
+            confidence: entity.confidence,
+            textHash: entity.textHash
+        )
+    }
+}
+
+extension SafeLog.Event {
+    fileprivate var payload: (String, [String: String]) {
+        switch self {
+        case .inferenceStarted(let operation):
+            return (
+                "openmed.inference.started",
+                ["operation": operation.rawValue]
+            )
+        case .inferenceCompleted(let operation, let entityCount):
+            return (
+                "openmed.inference.completed",
+                [
+                    "operation": operation.rawValue,
+                    "entity_count": String(entityCount),
+                ]
+            )
+        case .inferenceFailed(let operation, let errorType):
+            return (
+                "openmed.inference.failed",
+                [
+                    "operation": operation.rawValue,
+                    "error_type": errorType,
+                ]
+            )
+        }
+    }
+}

--- a/swift/OpenMedKit/Tests/OpenMedKitTests/LocalFirstGuardTests.swift
+++ b/swift/OpenMedKit/Tests/OpenMedKitTests/LocalFirstGuardTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+
+@testable import OpenMedKit
+
+final class LocalFirstGuardTests: XCTestCase {
+    func testEntityDescriptionDoesNotExposeRawSpanText() {
+        let entity = EntityPrediction(
+            label: "full_name",
+            text: "John Doe",
+            confidence: 0.95,
+            start: 8,
+            end: 16
+        )
+
+        XCTAssertFalse(entity.description.contains("John"))
+        XCTAssertFalse(entity.description.contains("Doe"))
+        XCTAssertTrue(entity.description.contains("full_name"))
+        XCTAssertTrue(entity.description.contains("span=(8:16)"))
+        XCTAssertTrue(entity.description.contains("text_hash=sha256:"))
+    }
+
+    func testSafeLogSpanSummaryUsesOffsetsLabelsAndHashes() {
+        let entity = EntityPrediction(
+            label: "ssn",
+            text: "123-45-6789",
+            confidence: 0.99,
+            start: 18,
+            end: 29
+        )
+
+        let summary = SafeLog.summarize(entity)
+
+        XCTAssertEqual(summary.label, "ssn")
+        XCTAssertEqual(summary.start, 18)
+        XCTAssertEqual(summary.end, 29)
+        XCTAssertEqual(summary.confidence, 0.99, accuracy: 0.0001)
+        XCTAssertEqual(summary.textHash, entity.textHash)
+        XCTAssertFalse(summary.textHash.contains("123"))
+        XCTAssertFalse(summary.textHash.contains("6789"))
+    }
+
+    func testSafeLogEventsDoNotEmitRawSpanText() {
+        var renderedEvents: [String] = []
+
+        SafeLog.withSink(
+            { level, event, metadata in
+                renderedEvents.append(
+                    ([level.rawValue, event] + metadata.map { "\($0.key)=\($0.value)" })
+                        .joined(separator: " ")
+                )
+            },
+            {
+                SafeLog.log(.inferenceStarted(operation: .extractPII))
+                SafeLog.log(.inferenceCompleted(operation: .extractPII, entityCount: 2))
+                SafeLog.log(
+                    .inferenceFailed(
+                        operation: .analyzeText,
+                        errorType: "TokenizerError"
+                    ),
+                    level: .error
+                )
+            }
+        )
+
+        let combined = renderedEvents.joined(separator: "\n")
+        XCTAssertTrue(combined.contains("openmed.inference.started"))
+        XCTAssertTrue(combined.contains("operation=extractPII"))
+        XCTAssertTrue(combined.contains("entity_count=2"))
+        XCTAssertFalse(combined.contains("John Doe"))
+        XCTAssertFalse(combined.contains("123-45-6789"))
+    }
+
+    func testSourceLoggingRoutesThroughSafeLog() throws {
+        let offenders = try sourceFiles().compactMap { url -> String? in
+            guard url.lastPathComponent != "SafeLog.swift" else {
+                return nil
+            }
+            let contents = try String(contentsOf: url, encoding: .utf8)
+            let hasDirectLog =
+                contents.contains("print(")
+                || contents.contains("NSLog(")
+                || contents.contains("os_log(")
+                || contents.contains("Logger(")
+            return hasDirectLog ? url.lastPathComponent : nil
+        }
+
+        XCTAssertEqual(offenders, [])
+    }
+
+    func testSourceNetworkAccessRoutesThroughExplicitDownloadSeam() throws {
+        let offenders = try sourceFiles().compactMap { url -> String? in
+            guard url.lastPathComponent != "OpenMedNetworkAccess.swift" else {
+                return nil
+            }
+            let contents = try String(contentsOf: url, encoding: .utf8)
+            return contents.contains("URLSession.shared") ? url.lastPathComponent : nil
+        }
+
+        XCTAssertEqual(offenders, [])
+    }
+
+    func testInferenceBodiesDoNotCallNetworkSeam() throws {
+        let source = try String(
+            contentsOf: sourceRoot().appending(path: "OpenMedKit.swift"),
+            encoding: .utf8
+        )
+
+        for body in [
+            try functionBody(named: "analyzeText", in: source),
+            try functionBody(named: "extractPII", in: source),
+            try functionBody(named: "extractPIIChunked", in: source),
+        ] {
+            XCTAssertFalse(body.contains("OpenMedNetworkAccess"))
+            XCTAssertFalse(body.contains("URLSession"))
+        }
+    }
+
+    private func sourceFiles() throws -> [URL] {
+        let root = sourceRoot()
+        guard
+            let enumerator = FileManager.default.enumerator(
+                at: root,
+                includingPropertiesForKeys: nil
+            )
+        else {
+            return []
+        }
+
+        return enumerator.compactMap { item in
+            guard let url = item as? URL, url.pathExtension == "swift" else {
+                return nil
+            }
+            return url
+        }
+    }
+
+    private func sourceRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: "Sources/OpenMedKit", directoryHint: .isDirectory)
+    }
+
+    private func functionBody(named name: String, in source: String) throws -> String {
+        guard
+            let signatureRange = source.range(of: "public func \(name)("),
+            let bodyStart = source[signatureRange.upperBound...].firstIndex(of: "{")
+        else {
+            throw GuardTestError.missingFunction(name)
+        }
+
+        var depth = 0
+        var cursor = bodyStart
+        while cursor < source.endIndex {
+            let character = source[cursor]
+            if character == "{" {
+                depth += 1
+            } else if character == "}" {
+                depth -= 1
+                if depth == 0 {
+                    return String(source[bodyStart...cursor])
+                }
+            }
+            cursor = source.index(after: cursor)
+        }
+
+        throw GuardTestError.missingFunction(name)
+    }
+
+    private enum GuardTestError: Error {
+        case missingFunction(String)
+    }
+}

--- a/swift/OpenMedKit/Tests/OpenMedKitTests/OpenMedMLXTests.swift
+++ b/swift/OpenMedKit/Tests/OpenMedKitTests/OpenMedMLXTests.swift
@@ -704,8 +704,8 @@ final class OpenMedMLXTests: XCTestCase {
                 useSmartMerging: true
             )
 
-            print("=== SAMPLE OCR TEXT ===")
-            print(ocrText)
+            print("=== SAMPLE OCR SUMMARY ===")
+            print("characters=\(ocrText.count)")
             print("=== SAMPLE RAW ENTITIES ===")
             print(rawEntities.map(\.description).joined(separator: "\n"))
             print("=== SAMPLE FINAL PII ENTITIES ===")


### PR DESCRIPTION
## Description
Adds local-first/no-PHI guardrails to the existing OpenMedKit Swift package. Issue #570 names an `android/` module, but no Android/Gradle project exists on current `master`, so this applies the same contract to the available mobile package surface.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `SafeLog` for structured internal inference diagnostics without raw span text.
- Made `EntityPrediction.description` PHI-safe by emitting labels, offsets, confidence, and SHA-256 span hashes instead of matched text.
- Routed model/tokenizer download calls through `OpenMedNetworkAccess` so network access is explicit and test-observable.
- Added guard tests for safe logging, PHI-safe descriptions, source logging, and inference bodies avoiding network seams.
- Documented OpenMedKit local-first, telemetry-off, on-device-PHI, and not-a-medical-device posture.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `python -m pytest tests/ -q` -> 1872 passed, 22 skipped
- `ruff check --output-format=github .`
- `swiftc -parse swift/OpenMedKit/Sources/OpenMedKit/EntityPrediction.swift swift/OpenMedKit/Sources/OpenMedKit/SafeLog.swift swift/OpenMedKit/Sources/OpenMedKit/OpenMedNetworkAccess.swift`

Local Swift blockers:
- `swift test` cannot run here because the active Command Line Tools install cannot resolve XCTest without full Xcode.
- `swift build` cannot complete with local Swift 5.10 because `mlx-swift` resolves to a Swift tools 5.12 package.
- `make format-swift` / `make lint-swift` cannot run here because this local toolchain does not include `swift-format`.

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings in the checks that could run locally

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Addresses #570 for the existing Swift/OpenMedKit package surface.

## Screenshots/Examples
N/A