### PR TITLE
Add fairness eval by demographic group

### DIFF
--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -26,6 +26,12 @@ from openmed.eval.calibrate import (
     load_calibration_thresholds,
     write_calibration_artifacts,
 )
+from openmed.eval.fairness import (
+    UNSPECIFIED_GROUP,
+    FairnessGroupMetrics,
+    FairnessReport,
+    fairness_report,
+)
 from openmed.eval.harness import (
     BenchmarkFixture,
     FixtureResult,
@@ -75,6 +81,8 @@ __all__ = [
     "CalibrationThresholdSet",
     "DEVICE_TIERS",
     "EvalSpan",
+    "FairnessGroupMetrics",
+    "FairnessReport",
     "FixtureResult",
     "GateCheck",
     "GateReport",
@@ -86,6 +94,7 @@ __all__ = [
     "ReidAttackResult",
     "RELEASABLE",
     "ReleaseGate",
+    "UNSPECIFIED_GROUP",
     "artifact_dir_for",
     "build_thresholds_payload",
     "coerce_calibration_thresholds",
@@ -103,6 +112,7 @@ __all__ = [
     "compute_surrogate_consistency",
     "default_suite_calibration_samples",
     "evaluate_quant_recall_delta",
+    "fairness_report",
     "fit_calibration_thresholds",
     "generate_reid_leaderboard",
     "load_calibration_samples",

--- a/openmed/eval/fairness.py
+++ b/openmed/eval/fairness.py
@@ -1,0 +1,278 @@
+"""Fairness metrics for de-identification leakage across surrogate groups."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from openmed.core.quality_gates import validate_entity_spans
+from openmed.eval.golden import load_benchmark_fixtures
+from openmed.eval.harness import (
+    BenchmarkFixture,
+    ModelRunner,
+    default_model_runner,
+)
+from openmed.eval.metrics import (
+    EvalSpan,
+    compute_character_recall,
+    compute_leakage_rate,
+    normalize_eval_spans,
+)
+from openmed.eval.suites import GOLDEN, load_suite_fixtures, validate_suite_name
+
+UNSPECIFIED_GROUP = "unspecified"
+
+_GROUP_METADATA_KEYS = ("group", "demographic_group", "surrogate_group")
+
+
+@dataclass(frozen=True)
+class FairnessGroupMetrics:
+    """Leakage and recall for one demographic surrogate group."""
+
+    leakage_rate: float
+    recall: float
+    leaked_chars: int
+    covered_chars: int
+    total_chars: int
+    span_count: int
+
+    def to_dict(self) -> dict[str, int | float]:
+        """Return a JSON-ready mapping."""
+        return {
+            "leakage_rate": self.leakage_rate,
+            "recall": self.recall,
+            "leaked_chars": self.leaked_chars,
+            "covered_chars": self.covered_chars,
+            "total_chars": self.total_chars,
+            "span_count": self.span_count,
+        }
+
+    def __getitem__(self, key: str) -> int | float:
+        return self.to_dict()[key]
+
+
+@dataclass(frozen=True)
+class FairnessReport:
+    """Fairness report over gold PHI groups for one model and suite."""
+
+    suite: str
+    model_name: str
+    fixture_count: int
+    per_group: dict[str, FairnessGroupMetrics]
+    leakage_disparity: float
+    worst_group_leakage: float
+    worst_group: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-ready mapping."""
+        return {
+            "suite": self.suite,
+            "model_name": self.model_name,
+            "fixture_count": self.fixture_count,
+            "per_group": {
+                group: metrics.to_dict()
+                for group, metrics in sorted(self.per_group.items())
+            },
+            "leakage_disparity": self.leakage_disparity,
+            "worst_group_leakage": self.worst_group_leakage,
+            "worst_group": self.worst_group,
+        }
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_dict()[key]
+
+
+@dataclass
+class _GroupCounts:
+    leaked_chars: int = 0
+    covered_chars: int = 0
+    total_chars: int = 0
+    span_count: int = 0
+
+
+def fairness_report(
+    model: str | ModelRunner,
+    suite: str | Sequence[BenchmarkFixture | Mapping[str, Any]],
+    *,
+    runner: ModelRunner | None = None,
+    device: str = "cpu",
+    suite_kwargs: Mapping[str, Any] | None = None,
+) -> FairnessReport:
+    """Run a model and report leakage/recall by gold-span group.
+
+    Args:
+        model: Model identifier, or a runner callable with the harness
+            ``ModelRunner`` signature.
+        suite: Named suite such as ``"golden"``, or concrete benchmark
+            fixtures/mappings.
+        runner: Optional runner to use when ``model`` is a string identifier.
+        device: Device tag passed to the model runner and prediction
+            normalization.
+        suite_kwargs: Optional keyword arguments for named suite loaders.
+
+    Returns:
+        A fairness report with per-group leakage, recall, leakage disparity,
+        and worst-group leakage.
+    """
+    suite_name, fixtures = _load_fairness_fixtures(suite, suite_kwargs=suite_kwargs)
+    model_name, model_runner = _resolve_model_runner(model, runner)
+    counts: defaultdict[str, _GroupCounts] = defaultdict(_GroupCounts)
+
+    for fixture in fixtures:
+        predicted_spans = _predict_fixture(
+            fixture,
+            model_name=model_name,
+            model_runner=model_runner,
+            device=device,
+        )
+        for group, gold_spans in _gold_spans_by_group(fixture.gold_spans).items():
+            leakage = compute_leakage_rate(
+                gold_spans,
+                predicted_spans,
+                default_language=fixture.language,
+                default_device=device,
+                source_text=fixture.text,
+            )
+            recall = compute_character_recall(
+                gold_spans,
+                predicted_spans,
+                default_language=fixture.language,
+                default_device=device,
+                source_text=fixture.text,
+            )
+            group_counts = counts[group]
+            group_counts.leaked_chars += leakage.leaked_chars
+            group_counts.covered_chars += int(recall.numerator)
+            group_counts.total_chars += leakage.total_chars
+            group_counts.span_count += len(gold_spans)
+
+    per_group = {
+        group: _group_metrics(group_counts)
+        for group, group_counts in sorted(counts.items())
+    }
+    leakage_rates = [metrics.leakage_rate for metrics in per_group.values()]
+    worst_group = _worst_group(per_group)
+    worst_group_leakage = (
+        per_group[worst_group].leakage_rate if worst_group is not None else 0.0
+    )
+
+    return FairnessReport(
+        suite=suite_name,
+        model_name=model_name,
+        fixture_count=len(fixtures),
+        per_group=per_group,
+        leakage_disparity=(
+            max(leakage_rates) - min(leakage_rates) if leakage_rates else 0.0
+        ),
+        worst_group_leakage=worst_group_leakage,
+        worst_group=worst_group,
+    )
+
+
+def _load_fairness_fixtures(
+    suite: str | Sequence[BenchmarkFixture | Mapping[str, Any]],
+    *,
+    suite_kwargs: Mapping[str, Any] | None,
+) -> tuple[str, list[BenchmarkFixture]]:
+    if not isinstance(suite, str):
+        return "custom", [_coerce_fixture(item) for item in suite]
+
+    suite_name = validate_suite_name(suite)
+    kwargs = dict(suite_kwargs or {})
+    if suite_name == GOLDEN:
+        return suite_name, load_benchmark_fixtures(**kwargs)
+    return suite_name, load_suite_fixtures(suite_name, **kwargs)
+
+
+def _coerce_fixture(
+    fixture: BenchmarkFixture | Mapping[str, Any],
+) -> BenchmarkFixture:
+    if isinstance(fixture, BenchmarkFixture):
+        return fixture
+    return BenchmarkFixture.from_mapping(fixture)
+
+
+def _resolve_model_runner(
+    model: str | ModelRunner,
+    runner: ModelRunner | None,
+) -> tuple[str, ModelRunner]:
+    if runner is not None:
+        return str(model), runner
+    if not isinstance(model, str) and callable(model):
+        name = getattr(model, "__name__", model.__class__.__name__)
+        return str(name), model
+    return str(model), default_model_runner
+
+
+def _predict_fixture(
+    fixture: BenchmarkFixture,
+    *,
+    model_name: str,
+    model_runner: ModelRunner,
+    device: str,
+) -> tuple[EvalSpan, ...]:
+    raw_predictions = list(model_runner(fixture, model_name, device))
+    predicted_spans = tuple(
+        normalize_eval_spans(
+            raw_predictions,
+            default_language=fixture.language,
+            default_device=device,
+            source_text=fixture.text,
+        )
+    )
+    validate_entity_spans(
+        [span.to_entity() for span in predicted_spans],
+        fixture.text,
+    )
+    return predicted_spans
+
+
+def _gold_spans_by_group(spans: Sequence[EvalSpan]) -> dict[str, list[EvalSpan]]:
+    grouped: defaultdict[str, list[EvalSpan]] = defaultdict(list)
+    for span in spans:
+        grouped[_group_for_span(span)].append(span)
+    return dict(grouped)
+
+
+def _group_for_span(span: EvalSpan) -> str:
+    for key in _GROUP_METADATA_KEYS:
+        value = span.metadata.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return UNSPECIFIED_GROUP
+
+
+def _group_metrics(counts: _GroupCounts) -> FairnessGroupMetrics:
+    leakage_rate = _safe_rate(counts.leaked_chars, counts.total_chars, 0.0)
+    recall = _safe_rate(counts.covered_chars, counts.total_chars, 1.0)
+    return FairnessGroupMetrics(
+        leakage_rate=leakage_rate,
+        recall=recall,
+        leaked_chars=counts.leaked_chars,
+        covered_chars=counts.covered_chars,
+        total_chars=counts.total_chars,
+        span_count=counts.span_count,
+    )
+
+
+def _worst_group(
+    per_group: Mapping[str, FairnessGroupMetrics],
+) -> str | None:
+    if not per_group:
+        return None
+    return max(per_group, key=lambda group: per_group[group].leakage_rate)
+
+
+def _safe_rate(numerator: int, denominator: int, zero_denominator: float) -> float:
+    if denominator == 0:
+        return zero_denominator
+    return float(numerator) / float(denominator)
+
+
+__all__ = [
+    "UNSPECIFIED_GROUP",
+    "FairnessGroupMetrics",
+    "FairnessReport",
+    "fairness_report",
+]

--- a/openmed/eval/golden/loader.py
+++ b/openmed/eval/golden/loader.py
@@ -205,8 +205,12 @@ def _span_to_mapping(span: EvalSpan) -> dict[str, Any]:
         "label": span.label,
         "text": span.text,
     }
-    if span.metadata:
-        row["metadata"] = _plain_mapping(span.metadata)
+    metadata = dict(span.metadata)
+    group = metadata.pop("group", None)
+    if group is not None and str(group).strip():
+        row["group"] = str(group).strip()
+    if metadata:
+        row["metadata"] = _plain_mapping(metadata)
     return row
 
 

--- a/openmed/eval/metrics.py
+++ b/openmed/eval/metrics.py
@@ -264,6 +264,10 @@ def normalize_eval_span(
     metadata = _read_mapping(data, "metadata") or {}
     if not isinstance(metadata, Mapping):
         metadata = {"value": metadata}
+    metadata = dict(metadata)
+    raw_group = _read_value(data, "group")
+    if raw_group is not None and str(raw_group).strip():
+        metadata["group"] = str(raw_group).strip()
 
     start = _read_int(data, "start")
     end = _read_int(data, "end")
@@ -310,7 +314,7 @@ def normalize_eval_span(
         text=str(text or ""),
         language=language,
         device=str(raw_device),
-        metadata=dict(metadata),
+        metadata=metadata,
     )
 
 

--- a/tests/unit/eval/test_fairness_report.py
+++ b/tests/unit/eval/test_fairness_report.py
@@ -1,0 +1,145 @@
+"""Unit tests for fairness reporting over demographic surrogate groups."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.eval import UNSPECIFIED_GROUP, fairness_report
+from openmed.eval.golden import GoldenFixture
+from openmed.eval.harness import BenchmarkFixture
+
+
+def test_fairness_report_detects_group_leakage_disparity() -> None:
+    fixture = BenchmarkFixture.from_mapping(
+        {
+            "id": "fairness-leakage",
+            "text": "Patient Asha Patel met John Smith.",
+            "language": "en",
+            "gold_spans": [
+                {
+                    "start": 8,
+                    "end": 18,
+                    "label": "PERSON",
+                    "group": "south_asian_names",
+                },
+                {
+                    "start": 23,
+                    "end": 33,
+                    "label": "PERSON",
+                    "group": "anglophone_names",
+                },
+            ],
+        }
+    )
+
+    def runner(fixture, model_name, device):
+        assert model_name == "group-test-model"
+        assert device == "cpu"
+        return [{"start": 23, "end": 33, "label": "PERSON"}]
+
+    report = fairness_report(
+        "group-test-model",
+        [fixture],
+        runner=runner,
+    )
+
+    assert report.per_group["south_asian_names"].leakage_rate == 1.0
+    assert report.per_group["south_asian_names"].recall == 0.0
+    assert report.per_group["anglophone_names"].leakage_rate == 0.0
+    assert report.per_group["anglophone_names"].recall == 1.0
+    assert report.leakage_disparity == pytest.approx(1.0)
+    assert report.worst_group_leakage == pytest.approx(1.0)
+    assert report.worst_group == "south_asian_names"
+
+
+def test_fairness_report_balanced_groups_have_zero_disparity() -> None:
+    fixture = BenchmarkFixture.from_mapping(
+        {
+            "id": "fairness-balanced",
+            "text": "Patient Asha Patel met John Smith.",
+            "language": "en",
+            "gold_spans": [
+                {
+                    "start": 8,
+                    "end": 18,
+                    "label": "PERSON",
+                    "group": "south_asian_names",
+                },
+                {
+                    "start": 23,
+                    "end": 33,
+                    "label": "PERSON",
+                    "group": "anglophone_names",
+                },
+            ],
+        }
+    )
+
+    def runner(fixture, model_name, device):
+        return [
+            {"start": 8, "end": 18, "label": "PERSON"},
+            {"start": 23, "end": 33, "label": "PERSON"},
+        ]
+
+    report = fairness_report(runner, [fixture])
+
+    assert report.per_group["south_asian_names"].leakage_rate == 0.0
+    assert report.per_group["anglophone_names"].leakage_rate == 0.0
+    assert report.leakage_disparity == pytest.approx(0.0)
+    assert report.worst_group_leakage == pytest.approx(0.0)
+
+
+def test_fairness_report_buckets_ungrouped_gold_spans_as_unspecified() -> None:
+    fixture = BenchmarkFixture.from_mapping(
+        {
+            "id": "fairness-unspecified",
+            "text": "Patient Maria Gomez called.",
+            "language": "en",
+            "gold_spans": [
+                {"start": 8, "end": 19, "label": "PERSON"},
+            ],
+        }
+    )
+
+    def runner(fixture, model_name, device):
+        return []
+
+    report = fairness_report("group-test-model", [fixture], runner=runner)
+
+    assert set(report.per_group) == {UNSPECIFIED_GROUP}
+    assert report.per_group[UNSPECIFIED_GROUP].leakage_rate == 1.0
+    assert report.per_group[UNSPECIFIED_GROUP].recall == 0.0
+
+
+def test_golden_fixture_schema_preserves_optional_span_group() -> None:
+    fixture = GoldenFixture.from_mapping(
+        {
+            "id": "golden-fairness-group",
+            "language": "en",
+            "text": "Patient Asha Patel.",
+            "gold_spans": [
+                {
+                    "start": 8,
+                    "end": 18,
+                    "label": "PERSON",
+                    "text": "Asha Patel",
+                    "group": "south_asian_names",
+                },
+            ],
+            "metadata": {
+                "category": "multilingual",
+                "expected_output": {
+                    "method": "mask",
+                    "text": "Patient [PERSON].",
+                },
+                "synthetic": True,
+            },
+        }
+    )
+
+    span = fixture.gold_spans[0]
+    mapping = fixture.to_mapping()
+
+    assert span.metadata["group"] == "south_asian_names"
+    assert mapping["gold_spans"][0]["group"] == "south_asian_names"
+    assert GoldenFixture.from_mapping(mapping).to_mapping() == mapping


### PR DESCRIPTION
## Description
- Adds `openmed.eval.fairness.fairness_report` for character-weighted leakage and recall by gold-span demographic surrogate group.
- Reports leakage disparity and worst-group leakage as headline fairness metrics.
- Preserves optional top-level `group` tags on golden fixture spans and buckets missing tags as `unspecified`.

## Change type
Feature

## Tests run
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/unit/eval/test_fairness_report.py -q`
- `.venv/bin/python -m pytest tests/ -q`

## Docs or changelog
Not updated; the new eval API is covered by unit tests.

## Dependency justification
No new dependencies.

## Screenshots or example output
Not applicable.

Closes #430
