### PR TITLE
Add a manifest schema validator command and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
 
+    - name: Validate model manifest schema
+      run: |
+        python -m scripts.manifest.validate_manifest
+
     - name: Test with pytest
       run: |
         pytest --cov=openmed --cov-report=xml --cov-report=term-missing

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -454,6 +454,18 @@ def _add_models_command(subparsers: argparse._SubParsersAction) -> None:
     )
     models_freshness.set_defaults(handler=_handle_models_freshness)
 
+    models_validate = models_sub.add_parser(
+        "validate",
+        help="Validate the canonical model manifest schema.",
+    )
+    models_validate.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="Path to a model manifest JSONL file.",
+    )
+    models_validate.set_defaults(handler=_handle_models_validate)
+
 
 def _add_config_command(subparsers: argparse._SubParsersAction) -> None:
     config_parser = subparsers.add_parser(
@@ -895,6 +907,26 @@ def _handle_models_freshness(args: argparse.Namespace) -> int:
     else:
         sys.stdout.write(metrics.to_markdown())
     return 0
+
+
+def _handle_models_validate(args: argparse.Namespace) -> int:
+    from openmed.core.manifest_schema import (
+        MANIFEST_PATH,
+        format_manifest_validation,
+        validate_manifest_file,
+    )
+
+    manifest_path = args.manifest or MANIFEST_PATH
+    try:
+        result = validate_manifest_file(manifest_path)
+    except OSError as exc:
+        sys.stderr.write(f"Failed to read manifest: {exc}\n")
+        return 1
+
+    output = sys.stderr if result.violations else sys.stdout
+    for line in format_manifest_validation(result):
+        output.write(f"{line}\n")
+    return 0 if result.ok else 1
 
 
 def _handle_benchmark_pii_reid(args: argparse.Namespace) -> int:

--- a/openmed/core/manifest_schema.py
+++ b/openmed/core/manifest_schema.py
@@ -1,0 +1,336 @@
+"""Schema validation for the canonical OpenMed model manifest."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+MANIFEST_PATH = Path(__file__).resolve().parents[2] / "models.jsonl"
+
+REQUIRED_FIELDS = frozenset(
+    {
+        "repo_id",
+        "family",
+        "task",
+        "languages",
+        "tier",
+        "param_count",
+        "architecture",
+        "base_model",
+        "formats",
+        "canonical_labels",
+        "benchmark",
+        "arxiv",
+        "license",
+        "reproducibility_hash",
+        "released",
+    }
+)
+BENCHMARK_FIELDS = frozenset({"dataset", "micro_f1", "recall"})
+
+ALLOWED_TIERS = ("Tiny", "Small", "Base", "Medium", "Large", "XLarge")
+ALLOWED_FORMATS = ("pytorch", "mlx-fp", "mlx-8bit", "onnx", "gguf", "unknown")
+ALLOWED_LICENSES = ("apache-2.0", "other")
+
+REPRODUCIBILITY_HASH_RE = re.compile(r"sha256:[0-9a-f]{64}$")
+RELEASED_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass(frozen=True)
+class ManifestViolation:
+    """A schema violation found on a manifest line."""
+
+    line_number: int
+    message: str
+
+    def __str__(self) -> str:
+        return f"line {self.line_number}: {self.message}"
+
+
+@dataclass(frozen=True)
+class ManifestValidationResult:
+    """Validation result for a model manifest."""
+
+    path: Path
+    row_count: int
+    violations: tuple[ManifestViolation, ...]
+
+    @property
+    def ok(self) -> bool:
+        """Return whether the manifest passed schema validation."""
+        return not self.violations
+
+
+def validate_manifest_file(
+    path: str | Path = MANIFEST_PATH,
+) -> ManifestValidationResult:
+    """Validate every JSONL row in *path* against the manifest schema."""
+    manifest_path = Path(path)
+    row_count = 0
+    violations: list[ManifestViolation] = []
+
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            row_count += 1
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                violations.append(
+                    ManifestViolation(
+                        line_number,
+                        f"invalid JSON: {exc.msg}",
+                    )
+                )
+                continue
+
+            violations.extend(validate_manifest_row(row, line_number))
+
+    return ManifestValidationResult(
+        path=manifest_path,
+        row_count=row_count,
+        violations=tuple(violations),
+    )
+
+
+def validate_manifest_row(row: Any, line_number: int) -> list[ManifestViolation]:
+    """Return schema violations for one decoded manifest row."""
+    violations: list[ManifestViolation] = []
+    if not isinstance(row, dict):
+        return [
+            ManifestViolation(
+                line_number,
+                "row must be a JSON object",
+            )
+        ]
+
+    fields = set(row)
+    for field in sorted(REQUIRED_FIELDS - fields):
+        violations.append(
+            ManifestViolation(line_number, f"missing required key: {field}")
+        )
+    for field in sorted(fields - REQUIRED_FIELDS):
+        violations.append(ManifestViolation(line_number, f"unexpected key: {field}"))
+
+    _validate_non_empty_string(violations, line_number, row, "family")
+    _validate_non_empty_string(violations, line_number, row, "task")
+    _validate_optional_string(violations, line_number, row, "architecture")
+    _validate_optional_string(violations, line_number, row, "base_model")
+    _validate_optional_string(violations, line_number, row, "arxiv")
+
+    if "repo_id" in row:
+        value = row["repo_id"]
+        if not isinstance(value, str) or not value.startswith("OpenMed/"):
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    "repo_id must be a string starting with 'OpenMed/'",
+                )
+            )
+
+    if "languages" in row:
+        _validate_string_list(violations, line_number, row["languages"], "languages")
+
+    if "tier" in row:
+        value = row["tier"]
+        if value is not None and not isinstance(value, str):
+            violations.append(
+                ManifestViolation(line_number, "tier must be a string or null")
+            )
+        elif value is not None and value not in ALLOWED_TIERS:
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    f"tier must be one of: {_allowed(ALLOWED_TIERS, allow_null=True)}",
+                )
+            )
+
+    if "param_count" in row:
+        value = row["param_count"]
+        if value is not None and (type(value) is not int or value <= 0):
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    "param_count must be a positive integer or null",
+                )
+            )
+
+    if "formats" in row:
+        value = row["formats"]
+        if not isinstance(value, list):
+            violations.append(ManifestViolation(line_number, "formats must be a list"))
+        elif not value:
+            violations.append(
+                ManifestViolation(line_number, "formats must not be empty")
+            )
+        else:
+            for index, format_name in enumerate(value):
+                if not isinstance(format_name, str):
+                    violations.append(
+                        ManifestViolation(
+                            line_number,
+                            f"formats[{index}] must be a string",
+                        )
+                    )
+                elif format_name not in ALLOWED_FORMATS:
+                    violations.append(
+                        ManifestViolation(
+                            line_number,
+                            f"formats must contain only: {_allowed(ALLOWED_FORMATS)}",
+                        )
+                    )
+
+    if "canonical_labels" in row:
+        _validate_string_list(
+            violations,
+            line_number,
+            row["canonical_labels"],
+            "canonical_labels",
+        )
+
+    if "benchmark" in row:
+        _validate_benchmark(violations, line_number, row["benchmark"])
+
+    if "license" in row:
+        value = row["license"]
+        if value is not None and not isinstance(value, str):
+            violations.append(
+                ManifestViolation(line_number, "license must be a string or null")
+            )
+        elif value is not None and value not in ALLOWED_LICENSES:
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    "license must be one of: "
+                    f"{_allowed(ALLOWED_LICENSES, allow_null=True)}",
+                )
+            )
+
+    if "reproducibility_hash" in row:
+        value = row["reproducibility_hash"]
+        if not isinstance(value, str) or not REPRODUCIBILITY_HASH_RE.fullmatch(value):
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    "reproducibility_hash must match "
+                    "sha256:<64 lowercase hex characters>",
+                )
+            )
+
+    if "released" in row:
+        value = row["released"]
+        if value is not None and not isinstance(value, str):
+            violations.append(
+                ManifestViolation(line_number, "released must be a string or null")
+            )
+        elif value is not None and not RELEASED_DATE_RE.fullmatch(value):
+            violations.append(
+                ManifestViolation(line_number, "released must match YYYY-MM-DD")
+            )
+
+    return violations
+
+
+def format_manifest_validation(result: ManifestValidationResult) -> list[str]:
+    """Format a validation result for CLI output."""
+    if result.ok:
+        return [f"{result.path}: OK ({result.row_count} rows checked)"]
+    return [str(violation) for violation in result.violations]
+
+
+def _validate_non_empty_string(
+    violations: list[ManifestViolation],
+    line_number: int,
+    row: Mapping[str, Any],
+    field: str,
+) -> None:
+    if field not in row:
+        return
+    value = row[field]
+    if not isinstance(value, str) or not value:
+        violations.append(
+            ManifestViolation(line_number, f"{field} must be a non-empty string")
+        )
+
+
+def _validate_optional_string(
+    violations: list[ManifestViolation],
+    line_number: int,
+    row: Mapping[str, Any],
+    field: str,
+) -> None:
+    if field not in row:
+        return
+    value = row[field]
+    if value is not None and not isinstance(value, str):
+        violations.append(
+            ManifestViolation(line_number, f"{field} must be a string or null")
+        )
+
+
+def _validate_string_list(
+    violations: list[ManifestViolation],
+    line_number: int,
+    value: Any,
+    field: str,
+) -> None:
+    if not isinstance(value, list):
+        violations.append(ManifestViolation(line_number, f"{field} must be a list"))
+        return
+
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            violations.append(
+                ManifestViolation(line_number, f"{field}[{index}] must be a string")
+            )
+
+
+def _validate_benchmark(
+    violations: list[ManifestViolation],
+    line_number: int,
+    value: Any,
+) -> None:
+    if not isinstance(value, dict):
+        violations.append(ManifestViolation(line_number, "benchmark must be an object"))
+        return
+
+    fields = set(value)
+    for field in sorted(BENCHMARK_FIELDS - fields):
+        violations.append(
+            ManifestViolation(line_number, f"benchmark missing required key: {field}")
+        )
+    if "dataset" in value and value["dataset"] is not None:
+        if not isinstance(value["dataset"], str):
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    "benchmark.dataset must be a string or null",
+                )
+            )
+    for metric in ("micro_f1", "recall"):
+        if metric not in value or value[metric] is None:
+            continue
+        if not isinstance(value[metric], (int, float)) or isinstance(
+            value[metric], bool
+        ):
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    f"benchmark.{metric} must be a number or null",
+                )
+            )
+
+
+def _allowed(values: tuple[str, ...], *, allow_null: bool = False) -> str:
+    allowed = list(values)
+    if allow_null:
+        allowed.append("null")
+    if len(allowed) == 1:
+        return allowed[0]
+    return f"{', '.join(allowed[:-1])}, or {allowed[-1]}"

--- a/scripts/manifest/validate_manifest.py
+++ b/scripts/manifest/validate_manifest.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate the canonical OpenMed model manifest."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence, TextIO
+
+from openmed.core.manifest_schema import (
+    format_manifest_validation,
+    validate_manifest_file,
+)
+
+DEFAULT_MANIFEST = Path("models.jsonl")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the manifest validator argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Validate models.jsonl against the canonical OpenMed schema."
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="Path to the manifest JSONL file to validate.",
+    )
+    return parser
+
+
+def run(
+    manifest: Path,
+    *,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    """Validate *manifest*, write a human-readable verdict, and return an exit code."""
+    stdout = stdout or sys.stdout
+    stderr = stderr or sys.stderr
+    try:
+        result = validate_manifest_file(manifest)
+    except OSError as exc:
+        stderr.write(f"Failed to read manifest: {exc}\n")
+        return 1
+
+    output = stderr if result.violations else stdout
+    for line in format_manifest_validation(result):
+        output.write(f"{line}\n")
+    return 0 if result.ok else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the manifest validator CLI."""
+    args = build_parser().parse_args(argv)
+    return run(args.manifest)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/core/test_manifest_schema.py
+++ b/tests/unit/core/test_manifest_schema.py
@@ -3,32 +3,18 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 
 from openmed.core import model_registry
+from openmed.core.manifest_schema import (
+    REQUIRED_FIELDS,
+    validate_manifest_row,
+)
 from scripts.manifest import generate_manifest
 
 ROOT = Path(__file__).resolve().parents[3]
 MANIFEST_PATH = ROOT / "models.jsonl"
 REFRESH_WORKFLOW = ROOT / ".github" / "workflows" / "manifest-refresh.yml"
-REQUIRED_FIELDS = {
-    "repo_id",
-    "family",
-    "task",
-    "languages",
-    "tier",
-    "param_count",
-    "architecture",
-    "base_model",
-    "formats",
-    "canonical_labels",
-    "benchmark",
-    "arxiv",
-    "license",
-    "reproducibility_hash",
-    "released",
-}
 
 
 def _rows():
@@ -45,31 +31,11 @@ def test_manifest_exists_and_has_unique_repo_ids():
 
 
 def test_every_manifest_row_matches_schema():
-    for row in _rows():
+    violations = []
+    for line_number, row in enumerate(_rows(), start=1):
         assert set(row) == REQUIRED_FIELDS
-        assert isinstance(row["repo_id"], str) and row["repo_id"].startswith("OpenMed/")
-        assert isinstance(row["family"], str) and row["family"]
-        assert isinstance(row["task"], str) and row["task"]
-        assert isinstance(row["languages"], list)
-        assert all(isinstance(language, str) for language in row["languages"])
-        assert row["tier"] is None or isinstance(row["tier"], str)
-        assert row["param_count"] is None or (
-            isinstance(row["param_count"], int) and row["param_count"] > 0
-        )
-        assert row["architecture"] is None or isinstance(row["architecture"], str)
-        assert row["base_model"] is None or isinstance(row["base_model"], str)
-        assert isinstance(row["formats"], list) and row["formats"]
-        assert all(isinstance(format_name, str) for format_name in row["formats"])
-        assert isinstance(row["canonical_labels"], list)
-        assert all(isinstance(label, str) for label in row["canonical_labels"])
-        assert isinstance(row["benchmark"], dict)
-        assert {"dataset", "micro_f1", "recall"} <= set(row["benchmark"])
-        assert row["arxiv"] is None or isinstance(row["arxiv"], str)
-        assert row["license"] is None or isinstance(row["license"], str)
-        assert re.fullmatch(r"sha256:[0-9a-f]{64}", row["reproducibility_hash"])
-        assert row["released"] is None or re.fullmatch(
-            r"\d{4}-\d{2}-\d{2}", row["released"]
-        )
+        violations.extend(str(item) for item in validate_manifest_row(row, line_number))
+    assert violations == []
 
 
 def test_registry_model_ids_are_derived_from_manifest():

--- a/tests/unit/core/test_manifest_validator.py
+++ b/tests/unit/core/test_manifest_validator.py
@@ -1,0 +1,112 @@
+"""Tests for the standalone model manifest validator."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from openmed.cli import main_module
+from openmed.core.manifest_schema import (
+    format_manifest_validation,
+    validate_manifest_file,
+)
+from scripts.manifest import validate_manifest
+
+ROOT = Path(__file__).resolve().parents[3]
+MANIFEST_PATH = ROOT / "models.jsonl"
+
+
+VALID_ROW = {
+    "repo_id": "OpenMed/example-model",
+    "family": "NER",
+    "task": "token-classification",
+    "languages": ["en"],
+    "tier": "Small",
+    "param_count": 44_000_000,
+    "architecture": "bert",
+    "base_model": "OpenMed/base-model",
+    "formats": ["pytorch"],
+    "canonical_labels": ["DISEASE"],
+    "benchmark": {"dataset": None, "micro_f1": None, "recall": None},
+    "arxiv": None,
+    "license": "apache-2.0",
+    "reproducibility_hash": f"sha256:{'a' * 64}",
+    "released": "2026-06-24",
+}
+
+
+def test_committed_manifest_validates() -> None:
+    result = validate_manifest_file(MANIFEST_PATH)
+
+    assert result.ok, "\n".join(format_manifest_validation(result))
+    assert result.row_count > 0
+
+
+def test_broken_manifest_reports_all_line_numbered_violations(tmp_path: Path) -> None:
+    manifest = _write_broken_manifest(tmp_path)
+
+    result = validate_manifest_file(manifest)
+
+    assert result.ok is False
+    assert [str(violation) for violation in result.violations] == [
+        "line 1: missing required key: repo_id",
+        "line 2: license must be one of: apache-2.0, other, or null",
+        "line 3: reproducibility_hash must match sha256:<64 lowercase hex characters>",
+    ]
+
+
+def test_module_validator_exits_zero_for_committed_manifest(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = validate_manifest.main(["--manifest", str(MANIFEST_PATH)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "OK" in captured.out
+    assert captured.err == ""
+
+
+def test_openmed_models_validate_shares_validator_verdict(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest = _write_broken_manifest(tmp_path)
+
+    script_exit = validate_manifest.main(["--manifest", str(manifest)])
+    script_output = capsys.readouterr()
+    cli_exit = main_module.main(["models", "validate", "--manifest", str(manifest)])
+    cli_output = capsys.readouterr()
+
+    assert script_exit == cli_exit == 1
+    assert script_output.out == cli_output.out == ""
+    assert script_output.err == cli_output.err
+
+
+def _write_broken_manifest(tmp_path: Path) -> Path:
+    rows = []
+
+    missing_repo_id = _row()
+    del missing_repo_id["repo_id"]
+    rows.append(missing_repo_id)
+
+    bad_license = _row(license="gpl-3.0")
+    rows.append(bad_license)
+
+    bad_hash = _row(reproducibility_hash="sha256:not-a-real-hash")
+    rows.append(bad_hash)
+
+    manifest = tmp_path / "models.jsonl"
+    manifest.write_text(
+        "".join(json.dumps(row, separators=(",", ":")) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    row = deepcopy(VALID_ROW)
+    row.update(overrides)
+    return row


### PR DESCRIPTION
## Description
Adds a shared manifest schema validator for `models.jsonl`, a standalone `python -m scripts.manifest.validate_manifest` command, and an `openmed models validate` CLI subcommand. This gives contributors a local and CI-enforced check that reports every malformed row with line numbers before manifest changes are committed.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added shared manifest schema validation for required keys, field types, tier/format/license enums, dates, and reproducibility hashes.
- Added `python -m scripts.manifest.validate_manifest` and `openmed models validate` entry points that share the validator verdict.
- Added unit coverage for the committed manifest and a deliberately broken fixture that reports all line-numbered failures.
- Added a CI step that validates the model manifest schema before pytest.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m scripts.manifest.validate_manifest`
- `PYTHONPATH=/Users/maziyar/Developer/openmed-om294 .venv/bin/openmed models validate`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #490

## Screenshots/Examples
```console
$ python -m scripts.manifest.validate_manifest
models.jsonl: OK (1518 rows checked)
```
