### PR TITLE
docs: add contributor onboarding guide

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,81 @@
+# New Contributor Onboarding
+
+Welcome! This guide walks you through your first contribution to OpenMed — from finding a `good first issue` to opening a clean pull request.
+
+## 1. Find a good first issue
+
+Browse the [issues page](https://github.com/maziyarpanahi/openmed/issues) and filter by the [`good first issue`](https://github.com/maziyarpanahi/openmed/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) label. Pick one that:
+
+- Has a clear description and acceptance criteria
+- Is narrowly scoped (ideally 1–2 files)
+- Doesn't reference billing, auth, or security surfaces
+- Has no open PRs claiming it (search `repo:maziyarpanahi/openmed "in:body #<ISSUE_NUMBER>"`)
+
+### Claiming an issue
+
+Comment on the issue to let the maintainers know you're working on it. A short "I'd like to take this" is enough — no formal assignment is required.
+
+## 2. Set up your environment
+
+```bash
+# Fork and clone the repo
+git clone https://github.com/<your-username>/openmed.git
+cd openmed
+
+# Install the dev dependencies
+uv pip install ".[dev]"
+
+# (Optional) Install pre-commit hooks
+pre-commit install
+```
+
+## 3. Run the tests
+
+Before making changes, confirm the baseline passes:
+
+```bash
+# Run the full test suite
+uv run pytest tests/ -q
+
+# Or run a scoped subset (replace with the relevant test path)
+uv run pytest tests/core/test_pii.py -q
+```
+
+## 4. Make your change
+
+- Create a branch from `master`:
+
+  ```bash
+  git checkout master
+  git pull origin master
+  git checkout -b fix/<short-description>
+  ```
+
+- Implement your change. Keep it focused on the issue scope.
+- Add or update tests if the issue asks for them.
+- Run `make format` and `make lint` before committing.
+
+## 5. Open a pull request
+
+```bash
+git add <changed-files>
+git commit -m "fix(scope): brief description"
+git push -u origin fix/<short-description>
+```
+
+Then open a PR using `gh pr create` or via the GitHub web UI. Fill in the PR template with:
+
+- A clear description of what you changed and why
+- Reference the issue number (`Closes #<number>`)
+- Your test plan (what you ran to verify the change)
+
+## Important rules
+
+- **No real PHI.** Never include real patient data, names, or identifiable health information in tests, examples, or documentation. Use synthetic data only.
+- **One PR per task.** Keep your pull request narrowly scoped to a single issue.
+- **Read the full contributing guide.** See [Contributing & Releases](contributing.md) for code style, release procedures, and documentation deployment details.
+
+## Need help?
+
+- Check the [FAQ](faq.md) for common questions.
+- File a new issue if you're stuck or need clarification on scope.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,6 +1,6 @@
 # New Contributor Onboarding
 
-Welcome! This guide walks you through your first contribution to OpenMed — from finding a `good first issue` to opening a clean pull request.
+Welcome! This guide walks you through your first contribution to OpenMed, from finding a `good first issue` to opening a clean pull request.
 
 ## 1. Find a good first issue
 
@@ -8,12 +8,16 @@ Browse the [issues page](https://github.com/maziyarpanahi/openmed/issues) and fi
 
 - Has a clear description and acceptance criteria
 - Is narrowly scoped (ideally 1–2 files)
-- Doesn't reference billing, auth, or security surfaces
+- Does not require maintainer-only credentials or access to private data
 - Has no open PRs claiming it (search `repo:maziyarpanahi/openmed "in:body #<ISSUE_NUMBER>"`)
 
 ### Claiming an issue
 
 Comment on the issue to let the maintainers know you're working on it. A short "I'd like to take this" is enough — no formal assignment is required.
+
+If the issue does not match the available templates, open a new item from the
+[issue forms](https://github.com/maziyarpanahi/openmed/issues/new/choose) and
+include the smallest reproducible scope you can.
 
 ## 2. Set up your environment
 
@@ -22,8 +26,9 @@ Comment on the issue to let the maintainers know you're working on it. A short "
 git clone https://github.com/<your-username>/openmed.git
 cd openmed
 
-# Install the dev dependencies
-uv pip install ".[dev]"
+# Create the local virtual environment and install dev dependencies
+uv venv
+uv pip install -e ".[dev]"
 
 # (Optional) Install pre-commit hooks
 pre-commit install
@@ -35,10 +40,10 @@ Before making changes, confirm the baseline passes:
 
 ```bash
 # Run the full test suite
-uv run pytest tests/ -q
+.venv/bin/python -m pytest tests/ -q
 
 # Or run a scoped subset (replace with the relevant test path)
-uv run pytest tests/core/test_pii.py -q
+.venv/bin/python -m pytest tests/unit/test_pii.py -q
 ```
 
 ## 4. Make your change

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Swift Package (OpenMedKit): swift-openmedkit.md
   - Project:
       - FAQ: faq.md
+      - Onboarding: onboarding.md
       - Contributing & Releases: contributing.md
       - HF Write Token Policy: security/hf-token-policy.md
       - Release Streams & Channels: release/semver-and-channels.md


### PR DESCRIPTION
## Problem

The repo has `docs/contributing.md` and community-health files, but there is no short, friendly onboarding page aimed specifically at first-time contributors: how to find a good-first-issue, clone and set up the `.venv`, run the targeted tests for the area they touch, and open a small focused PR.

## Fix

- Created `docs/onboarding.md` walking a brand-new contributor from finding a good-first-issue label, to environment setup, to running tests, to opening a PR.
- Documents the exact local workflow: `uv pip install ".[dev]"`, `uv run pytest tests/ -q`, `make format`, `make lint`.
- Links to `contributing.md` and states the no-real-PHI contribution rule.
- Added the page to `mkdocs.yml` nav under Project.

## Test Plan

- [x] `mkdocs build --strict` passes cleanly
- [x] Page appears in the nav under Project
- [x] Content covers all acceptance criteria from #476

Closes #476
