### PR TITLE
fix: sync dev extra lock metadata

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3052,6 +3052,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "python-dateutil" },
     { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -3155,6 +3156,7 @@ requires-dist = [
     { name = "pytesseract", marker = "extra == 'multimodal'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "python-dateutil", marker = "extra == 'dev'", specifier = ">=2.8" },
     { name = "python-docx", marker = "extra == 'multimodal'", specifier = ">=1.1" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.18" },


### PR DESCRIPTION
## Description
- Sync `uv.lock` with the `python-dateutil` dev extra added on `master`.
- Restores `uv lock --check` after the recent merge sequence.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Chore

## Tests Run
- `uv lock --check`
- `.venv/bin/python scripts/release/check_license_policy.py`
- `PYTHONPATH=/Users/maziyar/Developer/openmed .venv/bin/python -m pytest tests/unit/test_pii.py tests/unit/service/test_openapi_spec.py tests/unit/release/test_license_policy.py -q`
- `.venv/bin/pre-commit run --files uv.lock pyproject.toml`

## Docs / Changelog
- Not applicable.

## Dependency Justification
- No new runtime dependency. This updates lock metadata for the existing dev extra.

## Linked Issue
- Not applicable.

## Screenshots / Output
- Not applicable.
