### PR TITLE
Add a Swift de-identification result-to-JSON exporter matching the Python schema

### DIFF
--- a/swift/OpenMedKit/Sources/OpenMedKit/DeidentificationResult.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/DeidentificationResult.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// Redaction methods currently supported by OpenMedKit de-identification.
+public enum DeidentificationMethod: String, Codable, Equatable, Sendable {
+    case mask
+    case remove
+}
+
+/// De-identification output encoded with the Python `DeidentificationResult.to_dict()`
+/// schema: snake_case top-level keys and `pii_entities` records containing
+/// `text`, `label`, `entity_type`, `start`, `end`, `confidence`, and `action`.
+public struct DeidentificationResult: Codable, Equatable, Sendable {
+    /// A single PII entity record in the Python-compatible export schema.
+    public struct PIIEntityRecord: Codable, Equatable, Sendable {
+        public let text: String
+        public let label: String
+        public let entityType: String
+        public let start: Int
+        public let end: Int
+        public let confidence: Float
+        public let action: String
+
+        public init(
+            text: String,
+            label: String,
+            entityType: String? = nil,
+            start: Int,
+            end: Int,
+            confidence: Float,
+            action: String
+        ) {
+            self.text = text
+            self.label = label
+            self.entityType = entityType ?? label
+            self.start = start
+            self.end = end
+            self.confidence = confidence
+            self.action = action
+        }
+
+        public init(entity: EntityPrediction, action: String) {
+            self.init(
+                text: entity.text,
+                label: entity.label,
+                entityType: entity.entityType,
+                start: entity.start,
+                end: entity.end,
+                confidence: entity.confidence,
+                action: action
+            )
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case text
+            case label
+            case entityType = "entity_type"
+            case start
+            case end
+            case confidence
+            case action
+        }
+    }
+
+    public let originalText: String
+    public let deidentifiedText: String
+    public let piiEntities: [PIIEntityRecord]
+    public let method: String
+    public let timestamp: Date
+    public let numEntitiesRedacted: Int
+    public let metadata: [String: String]
+
+    public init(
+        originalText: String,
+        deidentifiedText: String,
+        piiEntities: [PIIEntityRecord],
+        method: String,
+        timestamp: Date = Date(),
+        metadata: [String: String] = [:]
+    ) {
+        self.originalText = originalText
+        self.deidentifiedText = deidentifiedText
+        self.piiEntities = piiEntities
+        self.method = method
+        self.timestamp = timestamp
+        self.numEntitiesRedacted = piiEntities.count
+        self.metadata = metadata
+    }
+
+    public init(
+        originalText: String,
+        deidentifiedText: String,
+        entities: [EntityPrediction],
+        method: String,
+        timestamp: Date = Date(),
+        metadata: [String: String] = [:],
+        action: String? = nil
+    ) {
+        let entityAction = action ?? method
+        self.init(
+            originalText: originalText,
+            deidentifiedText: deidentifiedText,
+            piiEntities: entities.map {
+                PIIEntityRecord(entity: $0, action: entityAction)
+            },
+            method: method,
+            timestamp: timestamp,
+            metadata: metadata
+        )
+    }
+
+    public func encode(prettyPrinted: Bool = false) throws -> Data {
+        let encoder = JSONEncoder()
+        var formatting: JSONEncoder.OutputFormatting = [.sortedKeys]
+        if prettyPrinted {
+            formatting.insert(.prettyPrinted)
+        }
+        encoder.outputFormatting = formatting
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(self)
+    }
+
+    public func toJSON(prettyPrinted: Bool = false) throws -> String {
+        String(decoding: try encode(prettyPrinted: prettyPrinted), as: UTF8.self)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case originalText = "original_text"
+        case deidentifiedText = "deidentified_text"
+        case piiEntities = "pii_entities"
+        case method
+        case timestamp
+        case numEntitiesRedacted = "num_entities_redacted"
+        case metadata
+    }
+}

--- a/swift/OpenMedKit/Sources/OpenMedKit/EntityPrediction.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/EntityPrediction.swift
@@ -17,6 +17,11 @@ public struct EntityPrediction: Codable, Equatable, Sendable {
     /// End character offset in the original text (exclusive).
     public let end: Int
 
+    /// Python-compatible entity type used by de-identification exports.
+    public var entityType: String {
+        label
+    }
+
     public init(label: String, text: String, confidence: Float, start: Int, end: Int) {
         self.label = label
         self.text = text

--- a/swift/OpenMedKit/Sources/OpenMedKit/OpenMedKit.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/OpenMedKit.swift
@@ -184,6 +184,31 @@ public final class OpenMed {
         }
     }
 
+    /// Detect and de-identify PII, returning a Python-schema-compatible result.
+    public func deidentify(
+        _ text: String,
+        method: DeidentificationMethod = .mask,
+        confidenceThreshold: Float = 0.5,
+        useSmartMerging: Bool = true
+    ) throws -> DeidentificationResult {
+        let entities = try extractPII(
+            text,
+            confidenceThreshold: confidenceThreshold,
+            useSmartMerging: useSmartMerging
+        )
+        let deidentifiedText = Self.deidentifiedText(
+            text,
+            entities: entities,
+            method: method
+        )
+        return DeidentificationResult(
+            originalText: text,
+            deidentifiedText: deidentifiedText,
+            entities: entities,
+            method: method.rawValue
+        )
+    }
+
     /// Run PII detection over long text using overlapping token windows.
     ///
     /// The returned entity offsets always reference the original full text.
@@ -476,6 +501,49 @@ public final class OpenMed {
         let lowerBound = text.index(text.startIndex, offsetBy: start)
         let upperBound = text.index(lowerBound, offsetBy: end - start)
         return String(text[lowerBound..<upperBound])
+    }
+
+    private static func deidentifiedText(
+        _ text: String,
+        entities: [EntityPrediction],
+        method: DeidentificationMethod
+    ) -> String {
+        var redacted = text
+        for entity in entities.sorted(by: { $0.start > $1.start }) {
+            guard let range = characterRange(in: redacted, start: entity.start, end: entity.end) else {
+                continue
+            }
+            redacted.replaceSubrange(
+                range,
+                with: replacementText(for: entity, method: method)
+            )
+        }
+        return redacted
+    }
+
+    private static func replacementText(
+        for entity: EntityPrediction,
+        method: DeidentificationMethod
+    ) -> String {
+        switch method {
+        case .mask:
+            return "[\(entity.entityType.uppercased())]"
+        case .remove:
+            return ""
+        }
+    }
+
+    private static func characterRange(
+        in text: String,
+        start: Int,
+        end: Int
+    ) -> Range<String.Index>? {
+        guard start >= 0, end >= start, end <= text.count else {
+            return nil
+        }
+        let lowerBound = text.index(text.startIndex, offsetBy: start)
+        let upperBound = text.index(lowerBound, offsetBy: end - start)
+        return lowerBound..<upperBound
     }
 
     static func loadTokenizer(

--- a/swift/OpenMedKit/Tests/OpenMedKitTests/DeidentificationResultJSONTests.swift
+++ b/swift/OpenMedKit/Tests/OpenMedKitTests/DeidentificationResultJSONTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import XCTest
+
+@testable import OpenMedKit
+
+final class DeidentificationResultJSONTests: XCTestCase {
+    func testDeidentificationResultEncodesPythonSchemaKeys() throws {
+        let original = "Alex Example has ID TEST-123."
+        let entities = [
+            EntityPrediction(
+                label: "full_name",
+                text: "Alex Example",
+                confidence: 1.0,
+                start: 0,
+                end: 12
+            ),
+            EntityPrediction(
+                label: "medical_record_number",
+                text: "TEST-123",
+                confidence: 0.5,
+                start: 20,
+                end: 28
+            ),
+        ]
+        let result = DeidentificationResult(
+            originalText: original,
+            deidentifiedText: "[FULL_NAME] has ID [MEDICAL_RECORD_NUMBER].",
+            entities: entities,
+            method: "mask",
+            timestamp: Date(timeIntervalSince1970: 0)
+        )
+
+        let json = try result.toJSON()
+        let expected = """
+            {"deidentified_text":"[FULL_NAME] has ID [MEDICAL_RECORD_NUMBER].","metadata":{},"method":"mask","num_entities_redacted":2,"original_text":"Alex Example has ID TEST-123.","pii_entities":[{"action":"mask","confidence":1,"end":12,"entity_type":"full_name","label":"full_name","start":0,"text":"Alex Example"},{"action":"mask","confidence":0.5,"end":28,"entity_type":"medical_record_number","label":"medical_record_number","start":20,"text":"TEST-123"}],"timestamp":"1970-01-01T00:00:00Z"}
+            """
+        XCTAssertEqual(json, expected)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        let records = try XCTUnwrap(object["pii_entities"] as? [[String: Any]])
+        XCTAssertEqual(
+            Set(records[0].keys),
+            ["action", "confidence", "end", "entity_type", "label", "start", "text"]
+        )
+        XCTAssertNil(records[0]["entityType"])
+    }
+
+    func testDeidentificationResultJSONIsDeterministic() throws {
+        let result = DeidentificationResult(
+            originalText: "Sample patient token.",
+            deidentifiedText: "[FULL_NAME] token.",
+            piiEntities: [
+                .init(
+                    text: "Sample patient",
+                    label: "full_name",
+                    start: 0,
+                    end: 14,
+                    confidence: 1.0,
+                    action: "mask"
+                )
+            ],
+            method: "mask",
+            timestamp: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(try result.toJSON(), try result.toJSON())
+    }
+}


### PR DESCRIPTION
Closes #663.

## Summary
- Adds a Swift DeidentificationResult JSON exporter using the Python to_dict snake_case schema.
- Adds an OpenMed.deidentify convenience path for mask/remove result generation from existing PII extraction.
- Adds fixture-backed tests for entity key names and deterministic sorted-key JSON output.

## Tests
- make format-swift
- make lint-swift
- cd swift/OpenMedKit && swift test
- .venv/bin/python -m pytest tests/ -q