### PR TITLE
Add a CI lockfile-drift gate verifying uv.lock matches pyproject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,26 @@ jobs:
       run: |
         python scripts/release/check_license_policy.py
 
+  lockfile-drift:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v8.2.0
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          pyproject.toml
+          uv.lock
+
+    - name: Check uv.lock matches pyproject.toml
+      run: |
+        if ! uv lock --check; then
+          echo "::error title=uv.lock is out of date::Run 'uv lock' and commit the updated uv.lock."
+          exit 1
+        fi
+
   lint:
     needs: repo-policy
     runs-on: ubuntu-latest

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -1,0 +1,21 @@
+# Supply Chain Controls
+
+OpenMed commits `uv.lock` so Python dependency resolution is reproducible
+across local development and CI. Pull requests and pushes run a dedicated
+lockfile drift gate:
+
+```bash
+uv lock --check
+```
+
+The gate verifies that `uv.lock` still matches `pyproject.toml` without
+installing the full development environment. If a dependency or optional extra
+changes, regenerate the lockfile locally before pushing:
+
+```bash
+uv lock
+```
+
+Commit the updated `uv.lock` with the dependency change. The CI failure message
+uses the same remediation: `Run 'uv lock' and commit the updated uv.lock.`
+Do not edit the lockfile by hand.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Contributing & Releases: contributing.md
       - Security & Disclosure: security/disclosure-policy.md
       - HF Write Token Policy: security/hf-token-policy.md
+      - Supply Chain Controls: security/supply-chain.md
       - Release Streams & Channels: release/semver-and-channels.md
       - Generative Model Policy: generative-model-policy.md
       - API Reference: api-reference.md


### PR DESCRIPTION
# Pull Request

## Description
Adds a fast CI lockfile-drift gate that verifies `uv.lock` matches `pyproject.toml` with `uv lock --check`, and documents the local `uv lock` remediation command when the gate fails.

Closes #664.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Changes Made
- Added an isolated `lockfile-drift` CI job on the existing push and pull request workflow triggers.
- Added `docs/security/supply-chain.md` with the local `uv lock` regeneration command.
- Added the new supply-chain page to the MkDocs navigation.

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `uv lock --check`
- Temporary drift check: edited `pyproject.toml` in an exported repository copy without updating `uv.lock` and confirmed `uv lock --check` fails with the `uv lock` remediation.
- `.venv/bin/python -m pytest tests/ -q`
- `git diff --check`
- Parsed `.github/workflows/ci.yml` with PyYAML.

Additional docs check:
- `make docs-build` was attempted after installing locked docs extras with `uv sync --frozen --extra docs --extra dev`; it is blocked by an existing `docs/pii-smart-merging.md` highlighting error: `NoneType` object has no attribute `replace`.

## Documentation
- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

No Python or Swift source files changed; the relevant validation was the lockfile check, workflow YAML parse, whitespace check, and full pytest suite.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #664

## Screenshots/Examples
Not applicable.
