### PR TITLE
Add eval dataset cards

### DIFF
--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -26,6 +26,13 @@ from openmed.eval.calibrate import (
     load_calibration_thresholds,
     write_calibration_artifacts,
 )
+from openmed.eval.dataset_card import (
+    DATASET_CARD_SUITES,
+    DatasetCard,
+    build_all_dataset_cards,
+    build_dataset_card,
+    render_dataset_card_markdown,
+)
 from openmed.eval.error_analysis import (
     ErrorAnalysisReport,
     ErrorSpanExample,
@@ -97,8 +104,10 @@ __all__ = [
     "CalibrationReport",
     "CalibrationSample",
     "CalibrationThresholdSet",
+    "DATASET_CARD_SUITES",
     "DEVICE_TIERS",
     "DEFAULT_PERTURBATIONS",
+    "DatasetCard",
     "EvalSpan",
     "ErrorAnalysisReport",
     "ErrorSpanExample",
@@ -121,6 +130,8 @@ __all__ = [
     "UNSPECIFIED_GROUP",
     "artifact_dir_for",
     "build_thresholds_payload",
+    "build_all_dataset_cards",
+    "build_dataset_card",
     "case_flip_perturbation",
     "character_typo_perturbation",
     "coerce_calibration_thresholds",
@@ -148,6 +159,7 @@ __all__ = [
     "ocr_noise_perturbation",
     "perturb_fixture",
     "render_reid_leaderboard",
+    "render_dataset_card_markdown",
     "robustness_report",
     "run_benchmark",
     "run_reid_attack",

--- a/openmed/eval/dataset_card.py
+++ b/openmed/eval/dataset_card.py
@@ -1,0 +1,284 @@
+"""Dataset cards for registered evaluation suites."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+from openmed.eval.datasets.licenses import DatasetLicense, license_for
+from openmed.eval.golden import GOLDEN_CATEGORIES, load_golden_fixtures
+from openmed.eval.suites import DRUGPROT, GOLDEN, SHIELD, suite_metadata
+
+DATASET_CARD_SUITES: tuple[str, ...] = (GOLDEN, SHIELD, DRUGPROT)
+_EXTERNAL_SUITES = {SHIELD, DRUGPROT}
+
+
+@dataclass(frozen=True)
+class DatasetCard:
+    """Provenance, license, and fixture summary for one eval dataset."""
+
+    dataset: str
+    source_url: str
+    license_id: str
+    redistribution: str
+    record_count: int
+    labels: tuple[str, ...] = field(default_factory=tuple)
+    languages: tuple[str, ...] = field(default_factory=tuple)
+    splits: tuple[str, ...] = field(default_factory=tuple)
+    provenance: str = ""
+    notes: str = ""
+    schema_version: str = "openmed.eval.dataset_card.v1"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "labels", _stable_unique(self.labels))
+        object.__setattr__(self, "languages", _stable_unique(self.languages))
+        object.__setattr__(self, "splits", _stable_unique(self.splits))
+        if self.record_count < 0:
+            raise ValueError("record_count must be non-negative")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-ready representation with no row text."""
+
+        return {
+            "dataset": self.dataset,
+            "labels": list(self.labels),
+            "languages": list(self.languages),
+            "license_id": self.license_id,
+            "notes": self.notes,
+            "provenance": self.provenance,
+            "record_count": self.record_count,
+            "redistribution": self.redistribution,
+            "schema_version": self.schema_version,
+            "source_url": self.source_url,
+            "splits": list(self.splits),
+        }
+
+    def to_json(self) -> str:
+        """Return byte-stable JSON for identical card contents."""
+
+        return (
+            json.dumps(
+                self.to_dict(),
+                ensure_ascii=True,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+
+    def to_markdown(self) -> str:
+        """Render a deterministic Markdown dataset card."""
+
+        rows = [
+            ("Dataset", self.dataset),
+            ("Source URL", self.source_url),
+            ("License", self.license_id),
+            ("Redistribution", self.redistribution),
+            ("Record count", str(self.record_count)),
+            ("Labels", _markdown_list(self.labels)),
+            ("Languages", _markdown_list(self.languages)),
+            ("Splits", _markdown_list(self.splits)),
+            ("Provenance", self.provenance),
+            ("Notes", self.notes),
+        ]
+        lines = [
+            f"# Dataset Card: {self.dataset}",
+            "",
+            "| Field | Value |",
+            "| --- | --- |",
+        ]
+        lines.extend(f"| {field} | {_markdown_cell(value)} |" for field, value in rows)
+        return "\n".join(lines) + "\n"
+
+
+def build_dataset_card(suite: str, **loader_kwargs: Any) -> DatasetCard:
+    """Build a dataset card for a concrete registered eval suite.
+
+    External corpora are summarized from metadata by default so this function
+    does not download rows. Pass suite loader keyword arguments, such as a
+    DrugProt ``path`` or SHIELD ``rows_loader``, to include fixture counts from
+    an explicitly supplied source.
+    """
+
+    if suite == GOLDEN:
+        return _golden_card(**loader_kwargs)
+    if suite == SHIELD:
+        return _shield_card(**loader_kwargs)
+    if suite == DRUGPROT:
+        return _drugprot_card(**loader_kwargs)
+    allowed = ", ".join(DATASET_CARD_SUITES)
+    raise ValueError(
+        f"unknown dataset card suite {suite!r}; expected one of: {allowed}"
+    )
+
+
+def build_all_dataset_cards(
+    suites: Sequence[str] | None = None,
+    *,
+    suite_kwargs: Mapping[str, Mapping[str, Any]] | None = None,
+) -> tuple[DatasetCard, ...]:
+    """Build dataset cards for all concrete registered eval suites."""
+
+    selected = DATASET_CARD_SUITES if suites is None else tuple(suites)
+    kwargs_by_suite = suite_kwargs or {}
+    return tuple(
+        build_dataset_card(suite, **dict(kwargs_by_suite.get(suite, {})))
+        for suite in selected
+    )
+
+
+def render_dataset_card_markdown(card: DatasetCard) -> str:
+    """Render a dataset card as deterministic Markdown."""
+
+    return card.to_markdown()
+
+
+def _golden_card(**loader_kwargs: Any) -> DatasetCard:
+    fixtures = load_golden_fixtures(**loader_kwargs)
+    license_metadata = license_for(GOLDEN)
+    labels = {span.label for fixture in fixtures for span in fixture.gold_spans}
+    languages = {fixture.language for fixture in fixtures}
+    return _card_from_license(
+        license_metadata,
+        record_count=len(fixtures),
+        labels=labels,
+        languages=languages,
+        splits=GOLDEN_CATEGORIES,
+        provenance="committed synthetic golden fixtures",
+    )
+
+
+def _shield_card(**loader_kwargs: Any) -> DatasetCard:
+    metadata = suite_metadata(SHIELD, use_sample=loader_kwargs.get("use_sample", True))
+    fixtures = _load_external_fixtures(SHIELD, loader_kwargs)
+    labels = _labels_from_mapping(metadata.get("label_mapping"))
+    languages = _fixture_languages(fixtures, fallback=("en",))
+    splits = _fixture_splits(fixtures, fallback=(str(metadata["split"]),))
+    return _card_from_license(
+        license_for(SHIELD),
+        record_count=len(fixtures),
+        labels=labels,
+        languages=languages,
+        splits=splits,
+        provenance=str(metadata["source_url"]),
+        notes=str(metadata["annotation"]),
+    )
+
+
+def _drugprot_card(**loader_kwargs: Any) -> DatasetCard:
+    metadata = suite_metadata(DRUGPROT, task=loader_kwargs.get("task", "ner"))
+    fixtures = _load_external_fixtures(DRUGPROT, loader_kwargs)
+    labels = _labels_from_mapping(metadata.get("entity_label_mapping"))
+    languages = _fixture_languages(fixtures, fallback=("en",))
+    splits = _fixture_splits(
+        fixtures,
+        fallback=(str(loader_kwargs.get("split", "training")),),
+    )
+    return _card_from_license(
+        license_for(DRUGPROT),
+        record_count=len(fixtures),
+        labels=labels,
+        languages=languages,
+        splits=splits,
+        provenance=str(metadata["doi"]),
+        notes=str(metadata["redistribution"]),
+    )
+
+
+def _card_from_license(
+    license_metadata: DatasetLicense,
+    *,
+    record_count: int,
+    labels: Iterable[str],
+    languages: Iterable[str],
+    splits: Iterable[str],
+    provenance: str,
+    notes: str = "",
+) -> DatasetCard:
+    return DatasetCard(
+        dataset=license_metadata.dataset,
+        source_url=license_metadata.source_url,
+        license_id=license_metadata.license_id,
+        redistribution=license_metadata.redistribution,
+        record_count=record_count,
+        labels=tuple(labels),
+        languages=tuple(languages),
+        splits=tuple(splits),
+        provenance=provenance,
+        notes=notes or license_metadata.notes,
+    )
+
+
+def _load_external_fixtures(suite: str, loader_kwargs: Mapping[str, Any]) -> list[Any]:
+    if not loader_kwargs:
+        return []
+    if suite in _EXTERNAL_SUITES and not _has_explicit_source(loader_kwargs):
+        return []
+
+    from openmed.eval.suites import load_suite_fixtures
+
+    return list(load_suite_fixtures(suite, **dict(loader_kwargs)))
+
+
+def _has_explicit_source(loader_kwargs: Mapping[str, Any]) -> bool:
+    explicit_keys = {"path", "rows_loader", "downloader"}
+    return any(loader_kwargs.get(key) is not None for key in explicit_keys)
+
+
+def _labels_from_mapping(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Mapping):
+        return ()
+    return _stable_unique(str(label) for label in value.values() if str(label))
+
+
+def _fixture_languages(
+    fixtures: Sequence[Any],
+    *,
+    fallback: Iterable[str],
+) -> tuple[str, ...]:
+    languages = {
+        str(getattr(fixture, "language", ""))
+        for fixture in fixtures
+        if str(getattr(fixture, "language", ""))
+    }
+    return _stable_unique(languages or fallback)
+
+
+def _fixture_splits(
+    fixtures: Sequence[Any],
+    *,
+    fallback: Iterable[str],
+) -> tuple[str, ...]:
+    splits = set()
+    for fixture in fixtures:
+        metadata = getattr(fixture, "metadata", None)
+        if isinstance(metadata, Mapping) and metadata.get("split") is not None:
+            splits.add(str(metadata["split"]))
+    return _stable_unique(splits or fallback)
+
+
+def _stable_unique(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(
+        sorted({str(value) for value in values if value is not None and str(value)})
+    )
+
+
+def _markdown_list(values: Sequence[str]) -> str:
+    if not values:
+        return ""
+    return ", ".join(f"`{value}`" for value in values)
+
+
+def _markdown_cell(value: str) -> str:
+    cleaned = value.replace("\n", " ").replace("|", "\\|").strip()
+    return cleaned or "not declared"
+
+
+__all__ = [
+    "DATASET_CARD_SUITES",
+    "DatasetCard",
+    "build_all_dataset_cards",
+    "build_dataset_card",
+    "render_dataset_card_markdown",
+]

--- a/openmed/eval/datasets/licenses.py
+++ b/openmed/eval/datasets/licenses.py
@@ -25,6 +25,13 @@ class DatasetLicense:
 
 
 PUBLIC_DATASET_LICENSES: Mapping[str, DatasetLicense] = {
+    "golden": DatasetLicense(
+        dataset="golden",
+        license_id="Apache-2.0",
+        source_url="openmed/eval/golden/fixtures",
+        redistribution="committed synthetic fixtures only",
+        notes="Synthetic-only fixtures; no real PHI and no DUA content.",
+    ),
     "shield": DatasetLicense(
         dataset="shield",
         license_id="access-controlled-full; public-sample",

--- a/tests/unit/eval/test_dataset_card.py
+++ b/tests/unit/eval/test_dataset_card.py
@@ -1,0 +1,137 @@
+"""Unit tests for eval dataset cards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from openmed.eval import (
+    DATASET_CARD_SUITES,
+    build_all_dataset_cards,
+    build_dataset_card,
+)
+from openmed.eval.datasets import license_for
+from openmed.eval.golden import GOLDEN_CATEGORIES, load_golden_fixtures
+from openmed.eval.suites import DRUGPROT, GOLDEN, SHIELD
+from openmed.eval.suites.shield import (
+    PUBLIC_SAMPLE_NOTES_CONFIG,
+    PUBLIC_SAMPLE_SPANS_CONFIG,
+)
+
+DRUGPROT_FIXTURE_DIR = (
+    Path(__file__).parents[2] / "fixtures" / "drugprot_synthetic" / "training"
+)
+
+
+def test_build_all_dataset_cards_is_offline_and_covers_concrete_suites() -> None:
+    cards = build_all_dataset_cards()
+
+    assert tuple(card.dataset for card in cards) == DATASET_CARD_SUITES
+    assert tuple(card.dataset for card in cards) == (GOLDEN, SHIELD, DRUGPROT)
+    for card in cards:
+        dataset_license = license_for(card.dataset)
+        assert card.license_id == dataset_license.license_id
+        assert card.source_url == dataset_license.source_url
+        assert card.redistribution == dataset_license.redistribution
+
+    external_counts = {
+        card.dataset: card.record_count
+        for card in cards
+        if card.dataset in {SHIELD, DRUGPROT}
+    }
+    assert external_counts == {SHIELD: 0, DRUGPROT: 0}
+
+
+def test_golden_card_counts_committed_fixtures_without_text() -> None:
+    fixtures = load_golden_fixtures()
+    card = build_dataset_card(GOLDEN)
+
+    assert card.record_count == len(fixtures)
+    assert card.splits == tuple(sorted(GOLDEN_CATEGORIES))
+    assert "SSN" in card.labels
+    assert "en" in card.languages
+
+    rendered = card.to_json() + card.to_markdown()
+    for fixture in fixtures:
+        assert fixture.text not in rendered
+
+
+def test_dataset_card_markdown_and_json_are_byte_stable() -> None:
+    first = build_dataset_card(GOLDEN)
+    second = build_dataset_card(GOLDEN)
+
+    assert first.to_markdown() == second.to_markdown()
+    assert first.to_json() == second.to_json()
+
+
+def test_shield_card_counts_explicit_rows_and_uses_license_registry() -> None:
+    text = "Jordan Smith 555-0100"
+    spans = [
+        _shield_span(text, "patient", "Jordan Smith"),
+        _shield_span(text, "phone", "555-0100"),
+    ]
+
+    def rows_loader(
+        repository: str,
+        config: str,
+        split: str,
+    ) -> list[Mapping[str, object]]:
+        del repository, split
+        if config == PUBLIC_SAMPLE_NOTES_CONFIG:
+            return [
+                {
+                    "note_id": "shield-card-1",
+                    "note_text": text,
+                    "note_type": "synthetic_unit",
+                }
+            ]
+        if config == PUBLIC_SAMPLE_SPANS_CONFIG:
+            return spans
+        raise AssertionError(f"unexpected config: {config}")
+
+    card = build_dataset_card(SHIELD, rows_loader=rows_loader)
+    dataset_license = license_for(SHIELD)
+
+    assert card.record_count == 1
+    assert card.license_id == dataset_license.license_id
+    assert card.source_url == dataset_license.source_url
+    assert card.labels == (
+        "AGE",
+        "DATE",
+        "ID_NUM",
+        "LOCATION",
+        "ORGANIZATION",
+        "PERSON",
+        "PHONE",
+        "URL",
+    )
+    assert card.languages == ("en",)
+    assert card.splits == ("train",)
+    assert text not in card.to_json()
+    assert text not in card.to_markdown()
+
+
+def test_drugprot_card_counts_explicit_fixture_path_without_text() -> None:
+    card = build_dataset_card(DRUGPROT, path=DRUGPROT_FIXTURE_DIR)
+    dataset_license = license_for(DRUGPROT)
+
+    assert card.record_count == 1
+    assert card.license_id == dataset_license.license_id
+    assert card.source_url == dataset_license.source_url
+    assert card.labels == ("OTHER",)
+    assert card.languages == ("en",)
+    assert card.splits == ("training",)
+
+    rendered = card.to_json() + card.to_markdown()
+    assert "Aspirin inhibits TP53" not in rendered
+    assert "Metformin activates EGFR" not in rendered
+
+
+def _shield_span(text: str, label: str, value: str) -> dict[str, object]:
+    start = text.index(value)
+    return {
+        "note_id": "shield-card-1",
+        "span_end": start + len(value),
+        "span_label": label,
+        "span_start": start,
+    }


### PR DESCRIPTION
# Pull Request

## Description
Adds deterministic dataset cards for the concrete eval suites so reviewers can inspect provenance, license, redistribution, counts, labels, languages, and splits without reconstructing metadata from adapter code.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `DatasetCard` with deterministic `to_dict()`, `to_json()`, and Markdown rendering.
- Added builders for `golden`, `shield`, and `drugprot` cards using existing license metadata, suite metadata, and explicit fixture loaders when supplied.
- Exported the dataset-card API from `openmed.eval` and added golden synthetic fixture license metadata.
- Added unit coverage for license/source matching, offline card generation, fixture counts, stable rendering, and no fixture text in card output.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/unit/eval/test_dataset_card.py -q`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #674

## Screenshots/Examples
Not applicable; API and test-only change.
