### PR TITLE
Add a per-section recall report for clinical notes

### DIFF
--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -87,6 +87,13 @@ from openmed.eval.robustness import (
     robustness_report,
     whitespace_noise_perturbation,
 )
+from openmed.eval.section_recall import (
+    UNSECTIONED_SECTION,
+    SectionRecallMetrics,
+    SectionRecallReport,
+    SectionSpan,
+    compute_section_recall,
+)
 from openmed.eval.tiers import TIERS
 
 __all__ = [
@@ -118,7 +125,11 @@ __all__ = [
     "ReleaseGate",
     "RobustnessReport",
     "RobustnessVariant",
+    "SectionRecallMetrics",
+    "SectionRecallReport",
+    "SectionSpan",
     "UNSPECIFIED_GROUP",
+    "UNSECTIONED_SECTION",
     "artifact_dir_for",
     "build_thresholds_payload",
     "case_flip_perturbation",
@@ -135,6 +146,7 @@ __all__ = [
     "compute_recall_slices",
     "compute_relaxed_span_f1",
     "compute_resource_metrics",
+    "compute_section_recall",
     "compute_surrogate_consistency",
     "default_suite_calibration_samples",
     "evaluate_quant_recall_delta",

--- a/openmed/eval/section_recall.py
+++ b/openmed/eval/section_recall.py
@@ -1,0 +1,468 @@
+"""Section-level character recall for clinical note de-identification."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openmed.eval.metrics import (
+    EvalSpan,
+    RateMetric,
+    compute_character_recall,
+    normalize_eval_span,
+    normalize_eval_spans,
+)
+
+UNSECTIONED_SECTION = "unsectioned"
+_SECTION_BOUNDARY_NAME_KEYS = ("section", "section_name", "name", "title", "label")
+_SECTION_TAG_KEYS = ("section", "section_name", "clinical_section")
+
+
+@dataclass(frozen=True)
+class SectionSpan:
+    """A named character range for a clinical note section."""
+
+    name: str
+    start: int
+    end: int
+
+    @property
+    def length(self) -> int:
+        """Return the non-negative section length."""
+        return max(self.end - self.start, 0)
+
+
+@dataclass(frozen=True)
+class SectionRecallMetrics:
+    """Character recall counts for one clinical note section."""
+
+    recall: float
+    covered_chars: int
+    total_chars: int
+
+    def to_dict(self) -> dict[str, int | float]:
+        """Return a deterministic JSON-ready metric payload."""
+        return {
+            "covered_chars": self.covered_chars,
+            "recall": self.recall,
+            "total_chars": self.total_chars,
+        }
+
+    def __getitem__(self, key: str) -> int | float:
+        return self.to_dict()[key]
+
+
+@dataclass(frozen=True)
+class SectionRecallReport:
+    """Serializable per-section character recall report."""
+
+    per_section: Mapping[str, SectionRecallMetrics]
+    overall: SectionRecallMetrics
+    worst_sections: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-ready report payload."""
+        return {
+            "overall": self.overall.to_dict(),
+            "per_section": {
+                section: metrics.to_dict()
+                for section, metrics in sorted(self.per_section.items())
+            },
+            "worst_sections": list(self.worst_sections),
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Serialize the report to deterministic JSON."""
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            indent=indent,
+            sort_keys=True,
+        )
+
+    def write_json(self, path: str | Path, *, indent: int = 2) -> Path:
+        """Write deterministic JSON to *path*."""
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(self.to_json(indent=indent) + "\n", encoding="utf-8")
+        return output_path
+
+    def to_markdown(self) -> str:
+        """Serialize the report to a deterministic Markdown table."""
+        lines = [
+            "| Section | Covered Chars | Total Chars | Recall |",
+            "|---|---:|---:|---:|",
+        ]
+        for section, metrics in _rank_sections(self.per_section):
+            lines.append(
+                "| "
+                f"{_markdown_cell(section)} | "
+                f"{metrics.covered_chars} | "
+                f"{metrics.total_chars} | "
+                f"{_format_rate(metrics.recall)} |"
+            )
+        return "\n".join(lines) + "\n"
+
+    def write_markdown(self, path: str | Path) -> Path:
+        """Write deterministic Markdown to *path*."""
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(self.to_markdown(), encoding="utf-8")
+        return output_path
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_dict()[key]
+
+
+def compute_section_recall(
+    note: str,
+    section_spans: Iterable[Any] | None,
+    gold_spans: Iterable[Any],
+    predicted_spans: Iterable[Any],
+    *,
+    default_language: str = "en",
+    default_device: str = "cpu",
+    unsectioned_name: str = UNSECTIONED_SECTION,
+) -> SectionRecallReport:
+    """Compute label-aware character recall by clinical note section.
+
+    Args:
+        note: Source clinical note text. The text is used only to normalize
+            span snippets for the shared eval metric helpers.
+        section_spans: Explicit section boundaries as ``SectionSpan`` values,
+            mappings, objects with ``name``/``start``/``end`` attributes, or
+            three-item tuples. When ``None``, section names are read from gold
+            span metadata/top-level fields and untagged spans are assigned to
+            ``unsectioned_name``.
+        gold_spans: Gold PHI spans.
+        predicted_spans: Predicted PHI spans.
+        default_language: Language passed through to eval span normalization.
+        default_device: Device passed through to eval span normalization.
+        unsectioned_name: Bucket for gold characters outside all declared
+            sections.
+
+    Returns:
+        A report containing only section names and aggregate counts/rates.
+    """
+    if not unsectioned_name.strip():
+        raise ValueError("unsectioned_name must be non-empty")
+
+    raw_gold = list(gold_spans)
+    gold = [
+        normalize_eval_span(
+            span,
+            default_language=default_language,
+            default_device=default_device,
+            source_text=note,
+        )
+        for span in raw_gold
+    ]
+    predicted = normalize_eval_spans(
+        predicted_spans,
+        default_language=default_language,
+        default_device=default_device,
+        source_text=note,
+    )
+
+    if section_spans is None:
+        section_gold = _gold_by_section_tags(
+            raw_gold,
+            gold,
+            unsectioned_name=unsectioned_name,
+        )
+        section_names = sorted(section_gold) or [unsectioned_name]
+    else:
+        sections = _normalize_sections(section_spans, note_length=len(note))
+        section_gold = _gold_by_section_ranges(
+            gold,
+            sections,
+            unsectioned_name=unsectioned_name,
+        )
+        section_names = sorted(
+            {section.name for section in sections}
+            | set(section_gold)
+            | {unsectioned_name}
+        )
+
+    per_section = {
+        section: _section_metrics(
+            section_gold.get(section, []),
+            predicted,
+            note=note,
+            default_language=default_language,
+            default_device=default_device,
+        )
+        for section in section_names
+    }
+    overall = _metric_to_section_metrics(
+        compute_character_recall(
+            gold,
+            predicted,
+            default_language=default_language,
+            default_device=default_device,
+            source_text=note,
+        )
+    )
+    worst_sections = _worst_sections(per_section)
+
+    return SectionRecallReport(
+        per_section=per_section,
+        overall=overall,
+        worst_sections=worst_sections,
+    )
+
+
+def _section_metrics(
+    gold_spans: Sequence[EvalSpan],
+    predicted_spans: Sequence[EvalSpan],
+    *,
+    note: str,
+    default_language: str,
+    default_device: str,
+) -> SectionRecallMetrics:
+    recall = compute_character_recall(
+        gold_spans,
+        predicted_spans,
+        default_language=default_language,
+        default_device=default_device,
+        source_text=note,
+    )
+    return _metric_to_section_metrics(recall)
+
+
+def _metric_to_section_metrics(metric: RateMetric) -> SectionRecallMetrics:
+    return SectionRecallMetrics(
+        recall=float(metric.rate),
+        covered_chars=int(metric.numerator),
+        total_chars=int(metric.denominator),
+    )
+
+
+def _normalize_sections(
+    section_spans: Iterable[Any],
+    *,
+    note_length: int,
+) -> list[SectionSpan]:
+    sections = [
+        _normalize_section(span, note_length=note_length) for span in section_spans
+    ]
+    sections.sort(key=lambda span: (span.start, span.end, span.name))
+    for previous, current in zip(sections, sections[1:]):
+        if previous.end > current.start:
+            raise ValueError(
+                "section_spans must not overlap: "
+                f"{previous.name!r} overlaps {current.name!r}"
+            )
+    return sections
+
+
+def _normalize_section(raw: Any, *, note_length: int) -> SectionSpan:
+    if isinstance(raw, SectionSpan):
+        section = raw
+    elif isinstance(raw, Mapping):
+        name = _first_present(raw, _SECTION_BOUNDARY_NAME_KEYS)
+        section = SectionSpan(
+            name=_coerce_section_name(name),
+            start=_coerce_int(raw.get("start"), field="start"),
+            end=_coerce_int(raw.get("end"), field="end"),
+        )
+    elif _is_three_item_sequence(raw):
+        section = _section_from_sequence(raw)
+    else:
+        name = _first_attr(raw, _SECTION_BOUNDARY_NAME_KEYS)
+        section = SectionSpan(
+            name=_coerce_section_name(name),
+            start=_coerce_int(getattr(raw, "start", None), field="start"),
+            end=_coerce_int(getattr(raw, "end", None), field="end"),
+        )
+
+    if section.start < 0:
+        raise ValueError("section start must be non-negative")
+    if section.end < section.start:
+        raise ValueError("section end must be greater than or equal to start")
+    if section.end > note_length:
+        raise ValueError("section end must not exceed note length")
+    return section
+
+
+def _section_from_sequence(raw: Sequence[Any]) -> SectionSpan:
+    first, second, third = raw
+    if isinstance(first, str):
+        name, start, end = first, second, third
+    elif isinstance(third, str):
+        start, end, name = first, second, third
+    else:
+        raise ValueError(
+            "section tuple must be (name, start, end) or (start, end, name)"
+        )
+    return SectionSpan(
+        name=_coerce_section_name(name),
+        start=_coerce_int(start, field="start"),
+        end=_coerce_int(end, field="end"),
+    )
+
+
+def _gold_by_section_ranges(
+    gold_spans: Sequence[EvalSpan],
+    sections: Sequence[SectionSpan],
+    *,
+    unsectioned_name: str,
+) -> dict[str, list[EvalSpan]]:
+    by_section: defaultdict[str, list[EvalSpan]] = defaultdict(list)
+    for span in gold_spans:
+        cursor = span.start
+        for section in sections:
+            if section.end <= cursor:
+                continue
+            if section.start >= span.end:
+                break
+            if cursor < section.start:
+                gap_end = min(section.start, span.end)
+                _append_fragment(by_section, unsectioned_name, span, cursor, gap_end)
+                cursor = gap_end
+            overlap_start = max(cursor, section.start)
+            overlap_end = min(span.end, section.end)
+            _append_fragment(by_section, section.name, span, overlap_start, overlap_end)
+            cursor = max(cursor, overlap_end)
+        _append_fragment(by_section, unsectioned_name, span, cursor, span.end)
+    return dict(by_section)
+
+
+def _gold_by_section_tags(
+    raw_gold: Sequence[Any],
+    gold_spans: Sequence[EvalSpan],
+    *,
+    unsectioned_name: str,
+) -> dict[str, list[EvalSpan]]:
+    by_section: defaultdict[str, list[EvalSpan]] = defaultdict(list)
+    for raw, span in zip(raw_gold, gold_spans):
+        section = _section_name_from_span(raw, span) or unsectioned_name
+        by_section[section].append(span)
+    return dict(by_section)
+
+
+def _append_fragment(
+    by_section: defaultdict[str, list[EvalSpan]],
+    section: str,
+    span: EvalSpan,
+    start: int,
+    end: int,
+) -> None:
+    if start >= end:
+        return
+    by_section[section].append(
+        EvalSpan(
+            start=start,
+            end=end,
+            label=span.label,
+            text=span.text,
+            language=span.language,
+            device=span.device,
+            metadata=span.metadata,
+        )
+    )
+
+
+def _section_name_from_span(raw: Any, span: EvalSpan) -> str | None:
+    if isinstance(raw, Mapping):
+        section = _first_present(raw, _SECTION_TAG_KEYS)
+        if section is not None:
+            return _coerce_section_name(section)
+    else:
+        section = _first_attr(raw, _SECTION_TAG_KEYS)
+        if section is not None:
+            return _coerce_section_name(section)
+    metadata_section = _first_present(span.metadata, _SECTION_TAG_KEYS)
+    if metadata_section is None:
+        return None
+    return _coerce_section_name(metadata_section)
+
+
+def _worst_sections(
+    per_section: Mapping[str, SectionRecallMetrics],
+) -> tuple[str, ...]:
+    populated = {
+        section: metrics
+        for section, metrics in per_section.items()
+        if metrics.total_chars > 0
+    }
+    if not populated:
+        return ()
+    worst_recall = min(metrics.recall for metrics in populated.values())
+    return tuple(
+        section
+        for section, metrics in sorted(populated.items())
+        if metrics.recall == worst_recall
+    )
+
+
+def _rank_sections(
+    per_section: Mapping[str, SectionRecallMetrics],
+) -> list[tuple[str, SectionRecallMetrics]]:
+    return sorted(
+        per_section.items(),
+        key=lambda item: (item[1].recall, item[0]),
+    )
+
+
+def _is_three_item_sequence(raw: Any) -> bool:
+    return (
+        isinstance(raw, Sequence)
+        and not isinstance(raw, (str, bytes, bytearray))
+        and len(raw) == 3
+    )
+
+
+def _first_present(mapping: Mapping[str, Any], keys: Sequence[str]) -> Any:
+    for key in keys:
+        value = mapping.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _first_attr(raw: Any, keys: Sequence[str]) -> Any:
+    for key in keys:
+        value = getattr(raw, key, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _coerce_section_name(value: Any) -> str:
+    if value is None:
+        raise ValueError("section must include a name")
+    name = str(value).strip()
+    if not name:
+        raise ValueError("section name must be non-empty")
+    return name
+
+
+def _coerce_int(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or value is None:
+        raise ValueError(f"section {field} must be an integer")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"section {field} must be an integer") from exc
+
+
+def _markdown_cell(value: str) -> str:
+    return value.replace("\n", " ").replace("\r", " ").replace("|", "\\|")
+
+
+def _format_rate(value: float) -> str:
+    return f"{value:.6f}"
+
+
+__all__ = [
+    "UNSECTIONED_SECTION",
+    "SectionRecallMetrics",
+    "SectionRecallReport",
+    "SectionSpan",
+    "compute_section_recall",
+]

--- a/tests/unit/eval/test_section_recall.py
+++ b/tests/unit/eval/test_section_recall.py
@@ -1,0 +1,154 @@
+"""Unit tests for clinical-note section recall reports."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.eval import compute_section_recall as exported_compute_section_recall
+from openmed.eval.section_recall import (
+    UNSECTIONED_SECTION,
+    SectionSpan,
+    compute_section_recall,
+)
+
+
+def test_section_recall_matches_hand_computed_values() -> None:
+    note = "HPI: John met Jane.\nMedications: Call 555-1212.\n"
+    hpi_end = note.index("\nMedications")
+    medication_start = note.index("Medications")
+    john_start = note.index("John")
+    jane_start = note.index("Jane")
+    phone_start = note.index("555-1212")
+
+    report = compute_section_recall(
+        note,
+        [
+            SectionSpan("HPI", 0, hpi_end),
+            SectionSpan("Medications", medication_start, len(note)),
+        ],
+        [
+            {"start": john_start, "end": john_start + 4, "label": "PERSON"},
+            {"start": jane_start, "end": jane_start + 4, "label": "PERSON"},
+            {"start": phone_start, "end": phone_start + 8, "label": "PHONE"},
+        ],
+        [
+            {"start": john_start, "end": john_start + 4, "label": "PERSON"},
+            {"start": jane_start, "end": jane_start + 2, "label": "PERSON"},
+        ],
+    )
+
+    assert exported_compute_section_recall is compute_section_recall
+    assert report.per_section["HPI"].covered_chars == 6
+    assert report.per_section["HPI"].total_chars == 8
+    assert report.per_section["HPI"].recall == pytest.approx(6 / 8)
+    assert report.per_section["Medications"].covered_chars == 0
+    assert report.per_section["Medications"].total_chars == 8
+    assert report.per_section["Medications"].recall == 0.0
+    assert report.overall.covered_chars == 6
+    assert report.overall.total_chars == 16
+    assert report.overall.recall == pytest.approx(6 / 16)
+    assert report.worst_sections == ("Medications",)
+
+
+def test_spans_outside_declared_sections_are_unsectioned() -> None:
+    note = "HPI: John met Jane.\nMedications: Call 555-1212.\n"
+    hpi_end = note.index("\nMedications")
+    phone_start = note.index("555-1212")
+
+    report = compute_section_recall(
+        note,
+        [("HPI", 0, hpi_end)],
+        [{"start": phone_start, "end": phone_start + 8, "label": "PHONE"}],
+        [{"start": phone_start, "end": phone_start + 4, "label": "PHONE"}],
+    )
+
+    assert report.per_section[UNSECTIONED_SECTION].covered_chars == 4
+    assert report.per_section[UNSECTIONED_SECTION].total_chars == 8
+    assert report.per_section[UNSECTIONED_SECTION].recall == pytest.approx(0.5)
+    assert report.worst_sections == (UNSECTIONED_SECTION,)
+
+
+def test_section_recall_serializes_counts_and_rates_deterministically() -> None:
+    note = "HPI: John met Jane.\nMedications: Call 555-1212.\n"
+    hpi_end = note.index("\nMedications")
+    medication_start = note.index("Medications")
+    john_start = note.index("John")
+    jane_start = note.index("Jane")
+    phone_start = note.index("555-1212")
+    report = compute_section_recall(
+        note,
+        [
+            {"name": "HPI", "start": 0, "end": hpi_end},
+            {"name": "Medications", "start": medication_start, "end": len(note)},
+        ],
+        [
+            {"start": john_start, "end": john_start + 4, "label": "PERSON"},
+            {"start": jane_start, "end": jane_start + 4, "label": "PERSON"},
+            {"start": phone_start, "end": phone_start + 8, "label": "PHONE"},
+        ],
+        [
+            {"start": john_start, "end": john_start + 4, "label": "PERSON"},
+            {"start": jane_start, "end": jane_start + 2, "label": "PERSON"},
+        ],
+    )
+
+    json_report = report.to_json()
+    markdown_report = report.to_markdown()
+
+    assert json_report == report.to_json()
+    assert json.loads(json_report) == {
+        "overall": {"covered_chars": 6, "recall": 0.375, "total_chars": 16},
+        "per_section": {
+            "HPI": {"covered_chars": 6, "recall": 0.75, "total_chars": 8},
+            "Medications": {
+                "covered_chars": 0,
+                "recall": 0.0,
+                "total_chars": 8,
+            },
+            "unsectioned": {"covered_chars": 0, "recall": 1.0, "total_chars": 0},
+        },
+        "worst_sections": ["Medications"],
+    }
+    assert markdown_report == report.to_markdown()
+    assert markdown_report == (
+        "| Section | Covered Chars | Total Chars | Recall |\n"
+        "|---|---:|---:|---:|\n"
+        "| Medications | 0 | 8 | 0.000000 |\n"
+        "| HPI | 6 | 8 | 0.750000 |\n"
+        "| unsectioned | 0 | 0 | 1.000000 |\n"
+    )
+    for forbidden in ("John", "Jane", "555-1212", "start", "end"):
+        assert forbidden not in json_report
+        assert forbidden not in markdown_report
+
+
+def test_section_tagged_gold_spans_can_drive_section_recall() -> None:
+    note = "HPI: John.\nFamily History: Jane.\n"
+    john_start = note.index("John")
+    jane_start = note.index("Jane")
+
+    report = compute_section_recall(
+        note,
+        None,
+        [
+            {
+                "start": john_start,
+                "end": john_start + 4,
+                "label": "PERSON",
+                "section": "HPI",
+            },
+            {
+                "start": jane_start,
+                "end": jane_start + 4,
+                "label": "PERSON",
+                "metadata": {"section": "Family History"},
+            },
+        ],
+        [{"start": john_start, "end": john_start + 4, "label": "PERSON"}],
+    )
+
+    assert report.per_section["HPI"].recall == 1.0
+    assert report.per_section["Family History"].recall == 0.0
+    assert report.worst_sections == ("Family History",)


### PR DESCRIPTION
## Description
Adds a section-level character recall report for clinical notes so eval output can show where de-identification recall is weakest across explicit note sections.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `openmed.eval.section_recall` with section range normalization, section metrics, reports, JSON output, and Markdown output.
- Aggregated gold PHI characters by explicit section ranges or section-tagged gold spans, with out-of-section characters placed in `unsectioned`.
- Exported the API from `openmed.eval` and added unit coverage for hand-computed recall, serialization stability, and unsectioned aggregation.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/ -q` (2111 passed, 25 skipped)

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #676

## Screenshots/Examples
Not applicable.
