### PR TITLE
feat: add redaction preview helper

### DIFF
--- a/openmed/core/redaction_preview.py
+++ b/openmed/core/redaction_preview.py
@@ -1,0 +1,152 @@
+"""Safe, single-document previews for de-identification changes."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .audit import hash_text
+
+if TYPE_CHECKING:
+    from .pii import DeidentificationResult, PIIEntity
+
+
+@dataclass(frozen=True)
+class RedactionChange:
+    """One original-text span and its de-identification replacement."""
+
+    start: int
+    end: int
+    label: str
+    action: str
+    original_hash: str
+    replacement_hash: str
+    original: str | None = None
+    replacement: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation of this change."""
+        payload: dict[str, object] = {
+            "start": self.start,
+            "end": self.end,
+            "label": self.label,
+            "action": self.action,
+            "original_hash": self.original_hash,
+            "replacement_hash": self.replacement_hash,
+        }
+
+        if self.original is not None:
+            payload["original"] = self.original
+
+        if self.replacement is not None:
+            payload["replacement"] = self.replacement
+
+        return payload
+
+
+@dataclass(frozen=True)
+class RedactionPreview:
+    """Ordered preview records for one de-identification result."""
+
+    changes: tuple[RedactionChange, ...]
+    offsets_only: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable preview structure."""
+        return {
+            "offsets_only": self.offsets_only,
+            "changes": [change.to_dict() for change in self.changes],
+        }
+
+    def to_json(self) -> str:
+        """Return a deterministic JSON representation."""
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def to_text(self) -> str:
+        """Render a compact human-readable preview."""
+        heading = f"{len(self.changes)} redaction change(s)"
+        if self.offsets_only:
+            heading += " (offsets-only)"
+
+        lines = [heading]
+
+        for change in self.changes:
+            prefix = f"[{change.start}:{change.end}] {change.label} ({change.action})"
+
+            if self.offsets_only:
+                lines.append(
+                    f"{prefix}: {change.original_hash} -> {change.replacement_hash}"
+                )
+            else:
+                lines.append(f"{prefix}: {change.original!r} -> {change.replacement!r}")
+
+        return "\n".join(lines)
+
+
+def _entity_sort_key(entity: PIIEntity) -> tuple[int, int, str, str, str]:
+    """Return a deterministic ordering key for preview records."""
+    replacement = entity.redacted_text or ""
+
+    return (
+        int(entity.start),
+        int(entity.end),
+        str(entity.label),
+        str(entity.action or ""),
+        hash_text(replacement),
+    )
+
+
+def _validate_offsets(text: str, start: int, end: int) -> None:
+    """Reject offsets that do not point to a valid span in the supplied text."""
+    if start < 0 or end < start or end > len(text):
+        raise ValueError(
+            "PII entity offsets must satisfy "
+            f"0 <= start <= end <= len(text), got start={start}, end={end}"
+        )
+
+
+def redaction_preview(
+    text: str,
+    result: DeidentificationResult,
+    *,
+    offsets_only: bool = False,
+) -> RedactionPreview:
+    """Build a deterministic per-span preview of a de-identification result.
+
+    The entity offsets refer to ``text`` before redaction. In offsets-only mode,
+    plaintext surfaces are omitted while stable hashes remain available for
+    review and comparison.
+    """
+    changes: list[RedactionChange] = []
+
+    for entity in sorted(result.pii_entities, key=_entity_sort_key):
+        start = int(entity.start)
+        end = int(entity.end)
+        _validate_offsets(text, start, end)
+
+        original = text[start:end]
+        replacement = entity.redacted_text or ""
+
+        changes.append(
+            RedactionChange(
+                start=start,
+                end=end,
+                label=str(entity.label),
+                action=str(entity.action or ""),
+                original_hash=hash_text(original),
+                replacement_hash=hash_text(replacement),
+                original=None if offsets_only else original,
+                replacement=None if offsets_only else replacement,
+            )
+        )
+
+    return RedactionPreview(
+        changes=tuple(changes),
+        offsets_only=offsets_only,
+    )

--- a/tests/unit/core/test_redaction_preview.py
+++ b/tests/unit/core/test_redaction_preview.py
@@ -1,0 +1,123 @@
+"""Tests for single-document de-identification redaction previews."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from openmed.core.audit import hash_text
+from openmed.core.pii import DeidentificationResult, PIIEntity
+from openmed.core.redaction_preview import redaction_preview
+
+
+def _result() -> DeidentificationResult:
+    text = "Patient John Doe called 555-1234."
+
+    # Deliberately unordered: preview output must be ordered by offsets.
+    entities = [
+        PIIEntity(
+            text="555-1234",
+            label="PHONE",
+            start=24,
+            end=32,
+            confidence=0.99,
+            redacted_text="[PHONE]",
+            action="mask",
+        ),
+        PIIEntity(
+            text="John Doe",
+            label="NAME",
+            start=8,
+            end=16,
+            confidence=0.95,
+            redacted_text="[NAME]",
+            action="mask",
+        ),
+    ]
+
+    return DeidentificationResult(
+        original_text=text,
+        deidentified_text="Patient [NAME] called [PHONE].",
+        pii_entities=entities,
+        method="mask",
+        timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_redaction_preview_returns_sorted_full_change_records():
+    result = _result()
+
+    preview = redaction_preview(result.original_text, result)
+
+    assert [change.start for change in preview.changes] == [8, 24]
+    assert [change.end for change in preview.changes] == [16, 32]
+
+    assert preview.to_dict() == {
+        "offsets_only": False,
+        "changes": [
+            {
+                "start": 8,
+                "end": 16,
+                "label": "NAME",
+                "action": "mask",
+                "original": "John Doe",
+                "replacement": "[NAME]",
+                "original_hash": hash_text("John Doe"),
+                "replacement_hash": hash_text("[NAME]"),
+            },
+            {
+                "start": 24,
+                "end": 32,
+                "label": "PHONE",
+                "action": "mask",
+                "original": "555-1234",
+                "replacement": "[PHONE]",
+                "original_hash": hash_text("555-1234"),
+                "replacement_hash": hash_text("[PHONE]"),
+            },
+        ],
+    }
+
+
+def test_offsets_only_preview_contains_no_plaintext_surfaces():
+    result = _result()
+
+    preview = redaction_preview(result.original_text, result, offsets_only=True)
+    payload = preview.to_dict()
+    serialized = preview.to_json()
+
+    assert payload["offsets_only"] is True
+    assert set(payload["changes"][0]) == {
+        "start",
+        "end",
+        "label",
+        "action",
+        "original_hash",
+        "replacement_hash",
+    }
+
+    for surface in ("John Doe", "555-1234", "[NAME]", "[PHONE]"):
+        assert surface not in serialized
+
+    assert json.loads(serialized) == payload
+
+
+def test_preview_renders_readable_full_and_offsets_only_summaries():
+    result = _result()
+
+    full_text = redaction_preview(result.original_text, result).to_text()
+    offsets_only_text = redaction_preview(
+        result.original_text,
+        result,
+        offsets_only=True,
+    ).to_text()
+
+    assert "2 redaction change(s)" in full_text
+    assert "[8:16] NAME (mask)" in full_text
+    assert "John Doe" in full_text
+    assert "[NAME]" in full_text
+
+    assert "offsets-only" in offsets_only_text
+    assert "John Doe" not in offsets_only_text
+    assert "[NAME]" not in offsets_only_text
+    assert "sha256:" in offsets_only_text


### PR DESCRIPTION
## Description

Adds a single-document redaction preview helper for de-identification results.

The helper reuses the existing entity offsets, labels, actions, and generated replacement text from `DeidentificationResult`. It supports:

* Full local-review output with original and replacement surfaces
* Privacy-safe offsets-only output containing offsets, labels, actions, and stable hashes only
* Deterministic offset ordering
* JSON-serializable and compact text renderings

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [x] Test addition/improvement

## Changes Made

* Added `openmed/core/redaction_preview.py`
* Added deterministic, offset-ordered redaction change records
* Added full and offsets-only preview modes
* Reused the existing `hash_text()` helper for plaintext-safe hashes
* Added JSON and human-readable text rendering
* Added focused unit tests for ordering, privacy-safe output, JSON serialization, and text rendering

## Testing

* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested this change with different models/inputs

Validation run:

```text
2110 passed, 25 skipped, 17 warnings
```

Also ran:

```text
ruff format
ruff check
git diff --check
```

## Documentation

* [ ] I have updated the documentation accordingly
* [x] I have added docstrings to new functions/classes
* [ ] I have updated the CHANGELOG.md

## Code Quality

* [ ] I ran `make format`, `make lint`, and `make format-check`
  `make` is not available in my Windows environment; I ran the equivalent focused Ruff checks instead.
* [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings

## Dependencies

* [x] I have not added any new dependencies
* [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

* [x] I have read the contributing guidelines
* [x] My commits have clear, descriptive messages
* [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #666

## Screenshots/Examples

Example full preview:

```text
2 redaction change(s)
[8:16] NAME (mask): 'John Doe' -> '[NAME]'
[24:32] PHONE (mask): '555-1234' -> '[PHONE]'
```

Offsets-only mode excludes original and replacement plaintext while retaining stable hashes for review.
