### PR TITLE
docs: add root CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer, Maziyar Panahi, privately through the
+contact details on their [GitHub profile](https://github.com/maziyarpanahi).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to OpenMed
+
+Thanks for helping improve OpenMed — bug reports, features, docs, and
+translations are all welcome. By participating you agree to our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+> [!IMPORTANT]
+> **Security and privacy come first.** OpenMed de-identifies PHI. **Never** open
+> a public issue for a vulnerability, and **never** include real patient data in
+> an issue, pull request, test, or fixture — see [SECURITY.md](SECURITY.md). Any
+> test data committed to the repository must be synthetic.
+
+This page is a quick start. The full tooling, documentation, and release guide
+lives in **[docs/contributing.md](docs/contributing.md)**.
+
+## Development setup
+
+```bash
+uv pip install -e ".[dev]"      # editable install with test + lint deps
+# stack extras as needed, e.g. ".[dev,hf]" for Hugging Face model work
+pre-commit install              # auto-format staged files on commit
+```
+
+## Run the checks before opening a PR
+
+```bash
+.venv/bin/python -m pytest tests/ -q     # run the test suite
+make format                              # apply canonical Ruff formatting
+make lint                                # lint
+make format-check                        # CI-parity format check
+```
+
+Ruff is the single source of truth for Python lint, import ordering, and
+formatting — do not run Black, isort, or flake8. For Swift changes under
+`swift/OpenMedKit`, run `make format-swift` and `make lint-swift`.
+
+## Pull requests
+
+- Keep each PR focused on a single feature or fix; avoid unrelated formatting
+  churn.
+- Write clear, imperative commit messages (the project uses concise prefixes
+  such as `fix:`, `feat:`, and `docs:`).
+- Reference the issue you are closing and complete the
+  [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
+- Update `CHANGELOG.md` and the docs when behavior changes.
+- For privacy-sensitive paths, add tests for direct-identifier recall, critical
+  leakage, and span integrity (see [docs/contributing.md](docs/contributing.md)).
+
+## Reporting issues
+
+- **Bugs and features:** use the
+  [issue templates](https://github.com/maziyarpanahi/openmed/issues/new/choose).
+- **Security vulnerabilities** (including redaction bypass or PHI/PII leakage):
+  report privately per [SECURITY.md](SECURITY.md) — never as a public issue.
+
+For the complete contributor and release workflow, see
+**[docs/contributing.md](docs/contributing.md)**.

--- a/README.md
+++ b/README.md
@@ -400,9 +400,10 @@ a local-first guardian for your most private data.
 
 ## Contributing
 
-Contributions welcome — bug reports, feature requests, and PRs alike.
+Contributions welcome — bug reports, feature requests, and PRs alike. Please read the [Contributing guide](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md) first.
 
 - [Open an issue](https://github.com/maziyarpanahi/openmed/issues)
+- [Contributing guide](CONTRIBUTING.md) · [Code of Conduct](CODE_OF_CONDUCT.md) · [Security policy](SECURITY.md)
 - **Translations welcome** — help complete the other-language READMEs linked in the switcher at the top.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  
+
 <img src="docs/brand/openmed-mascot-lockup.png" alt="OpenMed — local-first healthcare AI" width="400" />
 
 <h2>Local-first healthcare AI that never leaves the device</h2>


### PR DESCRIPTION
## Summary
Closes #279 (OM-114). Adds the two remaining repo-root community-health files; the third (`SECURITY.md`) already landed via #648. Docs-only change, rebased on current `master`.

## Changes
- **`CONTRIBUTING.md`** (new) — quick-start onboarding: dev setup (`uv pip install -e ".[dev]"`, `pre-commit install`), the pre-PR checks (`.venv/bin/python -m pytest tests/ -q`, `make format` / `make lint` / `make format-check`), and PR/commit conventions. Links to `docs/contributing.md` to avoid duplicating the full guide. Leads with a security/privacy callout (no public vuln reports, no real PHI in issues/tests/fixtures).
- **`CODE_OF_CONDUCT.md`** (new) — Contributor Covenant 2.1, verbatim so GitHub's community-profile detector recognizes it.
- **`README.md`** — links the Contributing guide, Code of Conduct, and Security policy from the `## Contributing` section.

## Acceptance criteria (#279)
- [x] `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md` exist at repo root and are linked from the README
- [x] `SECURITY.md` states a disclosure channel and the no-real-PHI-in-reports instruction (via #648)
- [x] Files are detected by the GitHub community profile (filename + standard CC 2.1 text)
- [x] Docs-only — no Python touched, so the test suite is unaffected

## Maintainer note
The `CODE_OF_CONDUCT.md` enforcement contact points to the maintainer's GitHub profile rather than a fabricated inbox. If you prefer, substitute a **monitored** dedicated conduct email — a one-line change.
