### PR TITLE
feat: add OCR language-pack configuration for non-English clinical scans

### DIFF
--- a/openmed/interop/cda.py
+++ b/openmed/interop/cda.py
@@ -227,7 +227,10 @@ def _redact_document_handler(
     *,
     policy: Any | None = None,
     models: Any | None = None,
+    lang: str | None = None,
 ) -> ExtractedDocument:
+    # ``lang`` is accepted for the shared handler contract; CDA is parsed XML
+    # with no OCR step, so language selection does not apply here.
     text_redactor = models if callable(models) else None
     redacted = redact_cda(path, text_redactor=text_redactor)
     return ExtractedDocument(

--- a/openmed/multimodal/base.py
+++ b/openmed/multimodal/base.py
@@ -186,6 +186,7 @@ def redact_document(
     *,
     policy: Any | None = None,
     models: Any | None = None,
+    lang: str | None = None,
 ) -> ExtractedDocument:
     """De-identify a document, dispatching by file extension to its ingester.
 
@@ -193,6 +194,11 @@ def redact_document(
     extra. Unknown extensions still check the optional dependency set first so
     installs missing the extra keep surfacing the actionable install hint before
     reporting unsupported formats.
+
+    ``lang`` is an optional OpenMed language code (e.g. ``"fr"``) configuring
+    language-aware ingestion: image handlers pass it through to OCR so scanned
+    documents are read in the right language. Handlers that do not use it accept
+    and ignore it. Defaults to English-equivalent behavior when unset.
     """
     extension = Path(str(path)).suffix.lower()
     specs = _HANDLERS.get(extension)
@@ -214,4 +220,4 @@ def redact_document(
 
     if spec.requires_multimodal:
         ensure_multimodal_available()
-    return spec.handler(path, policy=policy, models=models)
+    return spec.handler(path, policy=policy, models=models, lang=lang)

--- a/openmed/multimodal/ocr.py
+++ b/openmed/multimodal/ocr.py
@@ -10,6 +10,14 @@ Like the rest of the package, this module imports no heavy dependency at module
 load time: each engine imports its backend lazily and raises a clear,
 actionable error when the dependency (or the system Tesseract binary) is
 missing.
+
+Language packs: ``ocr(..., languages=[...])`` selects OCR languages by OpenMed
+PII language code (en, fr, de, it, es, nl, hi, te, pt, ar, ja, tr) and maps them
+to each backend's identifiers. The language data itself is not bundled and must
+be installed separately: Tesseract needs the matching ``traineddata`` files
+(e.g. ``apt-get install tesseract-ocr-fra`` or the language pack for your OS),
+and PaddleOCR downloads the recognition model for the requested language on
+first use.
 """
 
 from __future__ import annotations
@@ -17,7 +25,15 @@ from __future__ import annotations
 import importlib.util
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Iterable, Mapping, Protocol, runtime_checkable
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Mapping,
+    Protocol,
+    Sequence,
+    runtime_checkable,
+)
 
 from .base import ExtractedDocument, register_handler
 from .exceptions import MissingDependencyError
@@ -72,20 +88,31 @@ class OcrEngine(Protocol):
 
     name: str
 
-    def recognize(self, image: Any) -> OcrResult: ...
+    def recognize(
+        self, image: Any, *, languages: Sequence[str] | None = None
+    ) -> OcrResult: ...
 
 
 class FakeOcrEngine:
-    """Deterministic in-memory engine for tests; returns fixed words."""
+    """Deterministic in-memory engine for tests; returns fixed words.
+
+    Records the ``languages`` of the most recent call as ``last_languages`` so
+    tests can assert that a language selection reaches the adapter.
+    """
 
     name = "fake"
 
     def __init__(self, words: Iterable[OcrWord], **metadata: Any) -> None:
         self._words = tuple(words)
         self._metadata = {"engine": "fake", **metadata}
+        self.last_languages: list[str] | None = None
 
-    def recognize(self, image: Any) -> OcrResult:
-        return OcrResult(words=self._words, metadata=dict(self._metadata))
+    def recognize(
+        self, image: Any, *, languages: Sequence[str] | None = None
+    ) -> OcrResult:
+        self.last_languages = list(languages) if languages is not None else None
+        metadata = {**self._metadata, "languages": self.last_languages}
+        return OcrResult(words=self._words, metadata=metadata)
 
 
 def _import_backend(module: str, instruction: str) -> Any:
@@ -105,17 +132,97 @@ _TESSERACT_HINT = (
 _PADDLE_HINT = 'Install with: pip install "openmed[ocr-paddle]".'
 
 
+# --- language mapping -------------------------------------------------------
+
+DEFAULT_OCR_LANGUAGE = "en"
+
+# OpenMed PII language code -> Tesseract traineddata code (ISO 639-2/T).
+_TESSERACT_LANGUAGES: dict[str, str] = {
+    "en": "eng",
+    "fr": "fra",
+    "de": "deu",
+    "it": "ita",
+    "es": "spa",
+    "nl": "nld",
+    "hi": "hin",
+    "te": "tel",
+    "pt": "por",
+    "ar": "ara",
+    "ja": "jpn",
+    "tr": "tur",
+}
+
+# OpenMed PII language code -> PaddleOCR ``lang`` identifier.
+_PADDLE_LANGUAGES: dict[str, str] = {
+    "en": "en",
+    "fr": "fr",
+    "de": "german",
+    "it": "it",
+    "es": "es",
+    "nl": "nl",
+    "hi": "hi",
+    "te": "te",
+    "pt": "pt",
+    "ar": "ar",
+    "ja": "japan",
+    "tr": "tr",
+}
+
+# The OpenMed PII languages with OCR-engine coverage.
+SUPPORTED_OCR_LANGUAGES: tuple[str, ...] = tuple(_TESSERACT_LANGUAGES)
+
+
+def _normalize_languages(languages: str | Sequence[str] | None) -> list[str]:
+    """Normalize a language selection to a list of OpenMed codes (English default)."""
+    if languages is None:
+        return [DEFAULT_OCR_LANGUAGE]
+    if isinstance(languages, str):
+        languages = [languages]
+    normalized = [str(code).strip().lower() for code in languages if str(code).strip()]
+    return normalized or [DEFAULT_OCR_LANGUAGE]
+
+
+def _lookup_language(mapping: Mapping[str, str], code: str) -> str:
+    try:
+        return mapping[code]
+    except KeyError:
+        raise ValueError(
+            f"Unsupported OCR language {code!r}. "
+            f"Supported OpenMed language codes: {', '.join(SUPPORTED_OCR_LANGUAGES)}."
+        ) from None
+
+
+def tesseract_language(languages: str | Sequence[str] | None = None) -> str:
+    """Map OpenMed language code(s) to a Tesseract ``lang`` string (``eng+fra``)."""
+    codes = _normalize_languages(languages)
+    return "+".join(_lookup_language(_TESSERACT_LANGUAGES, code) for code in codes)
+
+
+def paddle_language(languages: str | Sequence[str] | None = None) -> str:
+    """Map OpenMed language code(s) to a PaddleOCR ``lang`` identifier.
+
+    PaddleOCR loads a single recognition language per instance, so the first
+    requested language is used.
+    """
+    codes = _normalize_languages(languages)
+    return _lookup_language(_PADDLE_LANGUAGES, codes[0])
+
+
 class TesseractEngine:
     """OCR backend backed by pytesseract / the Tesseract binary."""
 
     name = "tesseract"
 
-    def recognize(self, image: Any) -> OcrResult:
+    def recognize(
+        self, image: Any, *, languages: Sequence[str] | None = None
+    ) -> OcrResult:
         pytesseract = _import_backend("pytesseract", _TESSERACT_HINT)
         loaded = _load_tesseract_image(image)
         try:
             data = pytesseract.image_to_data(
-                loaded, output_type=pytesseract.Output.DICT
+                loaded,
+                lang=tesseract_language(languages),
+                output_type=pytesseract.Output.DICT,
             )
         except Exception as exc:
             tesseract_error = getattr(
@@ -154,9 +261,11 @@ class PaddleOcrEngine:
 
     name = "paddleocr"
 
-    def recognize(self, image: Any) -> OcrResult:
+    def recognize(
+        self, image: Any, *, languages: Sequence[str] | None = None
+    ) -> OcrResult:
         paddleocr = _import_backend("paddleocr", _PADDLE_HINT)
-        engine = paddleocr.PaddleOCR(show_log=False)
+        engine = paddleocr.PaddleOCR(show_log=False, lang=paddle_language(languages))
         loaded = _load_paddle_image(image)
         predictions = engine.ocr(loaded)
         words: list[OcrWord] = []
@@ -271,13 +380,22 @@ def resolve_engine(engine: str | OcrEngine | None = None) -> OcrEngine:
     )
 
 
-def ocr(image: Any, *, engine: str | OcrEngine | None = None) -> OcrResult:
+def ocr(
+    image: Any,
+    *,
+    engine: str | OcrEngine | None = None,
+    languages: str | Sequence[str] | None = None,
+) -> OcrResult:
     """Run OCR on ``image`` and return an :class:`OcrResult`.
 
     ``engine`` may be an engine name, an :class:`OcrEngine` instance, or
-    ``None`` to auto-select the first installed backend.
+    ``None`` to auto-select the first installed backend. ``languages`` selects
+    the OCR languages by OpenMed PII language code (e.g. ``["fr"]``); each
+    adapter maps them to its own identifiers. Defaults to English.
     """
-    return resolve_engine(engine).recognize(image)
+    return resolve_engine(engine).recognize(
+        image, languages=_normalize_languages(languages)
+    )
 
 
 # --- redact_document bridge -------------------------------------------------

--- a/openmed/multimodal/ocr.py
+++ b/openmed/multimodal/ocr.py
@@ -413,10 +413,15 @@ _IMAGE_EXTENSIONS = (
 
 
 def _ocr_image_handler(
-    path: Any, *, policy: Any = None, models: Any = None
+    path: Any, *, policy: Any = None, models: Any = None, lang: str | None = None
 ) -> ExtractedDocument:
-    """redact_document handler for image files: OCR then bridge to a document."""
-    return ocr(path).to_document()
+    """redact_document handler for image files: OCR then bridge to a document.
+
+    ``lang`` (an OpenMed language code from ``redact_document(lang=...)``) is
+    forwarded to OCR so scans are read in the requested language.
+    """
+    languages = [lang] if lang else None
+    return ocr(path, languages=languages).to_document()
 
 
 register_handler(_IMAGE_EXTENSIONS, _ocr_image_handler)

--- a/openmed/multimodal/tabular_csv.py
+++ b/openmed/multimodal/tabular_csv.py
@@ -415,7 +415,10 @@ def _tabular_csv_handler(
     *,
     policy: Any = None,
     models: Any = None,
+    lang: str | None = None,
 ) -> ExtractedDocument:
+    # ``lang`` is accepted for the shared handler contract; tabular text has no
+    # OCR step, so language selection does not apply here.
     return redact_table(path, policy=policy, models=models).to_document()
 
 

--- a/tests/unit/multimodal/test_base_contract.py
+++ b/tests/unit/multimodal/test_base_contract.py
@@ -80,19 +80,23 @@ class TestRedactDocumentDispatcher:
     def test_dispatches_to_registered_handler(self, clean_registry, deps_present):
         received = {}
 
-        def handler(path, *, policy=None, models=None):
+        def handler(path, *, policy=None, models=None, lang=None):
             received["path"] = path
             received["policy"] = policy
             received["models"] = models
+            received["lang"] = lang
             return ExtractedDocument.from_blocks([{"text": "ok"}])
 
         register_handler(".txt", handler)
-        doc = redact_document("note.txt", policy="hipaa_safe_harbor", models="m1")
+        doc = redact_document(
+            "note.txt", policy="hipaa_safe_harbor", models="m1", lang="fr"
+        )
 
         assert isinstance(doc, ExtractedDocument)
         assert received["path"] == "note.txt"
         assert received["policy"] == "hipaa_safe_harbor"
         assert received["models"] == "m1"
+        assert received["lang"] == "fr"
 
     def test_extension_match_is_case_insensitive(self, clean_registry, deps_present):
         register_handler(

--- a/tests/unit/multimodal/test_ocr_engines.py
+++ b/tests/unit/multimodal/test_ocr_engines.py
@@ -65,8 +65,9 @@ def test_tesseract_adapter_maps_words_to_shared_result(monkeypatch):
         pytesseract = SimpleNamespace(TesseractNotFoundError=RuntimeError)
 
         @staticmethod
-        def image_to_data(loaded_image, *, output_type):
+        def image_to_data(loaded_image, *, lang, output_type):
             assert loaded_image is image
+            assert lang == "eng"  # English default
             assert output_type == "dict"
             return {
                 "text": ["", "Patient", "Doe"],
@@ -105,7 +106,7 @@ def test_tesseract_binary_error_is_actionable(monkeypatch):
         pytesseract = SimpleNamespace(TesseractNotFoundError=FakeTesseractNotFoundError)
 
         @staticmethod
-        def image_to_data(image, *, output_type):
+        def image_to_data(image, *, lang, output_type):
             raise FakeTesseractNotFoundError("missing binary")
 
     monkeypatch.setattr(
@@ -127,8 +128,9 @@ def test_paddle_adapter_maps_flat_predictions_to_shared_result(monkeypatch):
     box = [(1, 2), (41, 2), (41, 12), (1, 12)]
 
     class FakePaddleOCR:
-        def __init__(self, *, show_log):
+        def __init__(self, *, show_log, lang):
             seen["show_log"] = show_log
+            seen["lang"] = lang
 
         def ocr(self, image):
             seen["image"] = image
@@ -144,7 +146,7 @@ def test_paddle_adapter_maps_flat_predictions_to_shared_result(monkeypatch):
     result = PaddleOcrEngine().recognize(Path("scan.png"))
 
     _assert_ocr_result_shape(result)
-    assert seen == {"show_log": False, "image": "scan.png"}
+    assert seen == {"show_log": False, "lang": "en", "image": "scan.png"}
     assert result.words[0].text == "MRN"
     assert result.words[0].bbox == (1, 2, 41, 12)
     assert result.words[0].confidence == 0.88
@@ -156,7 +158,7 @@ def test_paddle_adapter_maps_paged_predictions_to_shared_result(monkeypatch):
     second_box = [(3, 4), (33, 4), (33, 14), (3, 14)]
 
     class FakePaddleOCR:
-        def __init__(self, *, show_log):
+        def __init__(self, *, show_log, lang):
             pass
 
         def ocr(self, image):

--- a/tests/unit/multimodal/test_ocr_languages.py
+++ b/tests/unit/multimodal/test_ocr_languages.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import pytest
 
+import openmed.multimodal.base as base
+import openmed.multimodal.ocr as ocr_mod
+from openmed.multimodal import ExtractedDocument, redact_document
 from openmed.multimodal.ocr import (
     SUPPORTED_OCR_LANGUAGES,
     FakeOcrEngine,
@@ -72,3 +75,26 @@ def test_unsupported_language_raises_value_error():
         tesseract_language(["zz"])
     with pytest.raises(ValueError):
         paddle_language(["zz"])
+
+
+class TestRedactDocumentLanguageWiring:
+    """redact_document(lang=...) must configure image OCR (issue #315)."""
+
+    def test_redact_document_passes_lang_to_ocr(self, monkeypatch):
+        engine = FakeOcrEngine(WORDS)
+        monkeypatch.setattr(base, "_missing_multimodal_dependencies", lambda: [])
+        monkeypatch.setattr(ocr_mod, "resolve_engine", lambda e=None: engine)
+
+        doc = redact_document("scan.png", lang="fr")
+
+        assert isinstance(doc, ExtractedDocument)
+        assert engine.last_languages == ["fr"]
+
+    def test_redact_document_defaults_to_english(self, monkeypatch):
+        engine = FakeOcrEngine(WORDS)
+        monkeypatch.setattr(base, "_missing_multimodal_dependencies", lambda: [])
+        monkeypatch.setattr(ocr_mod, "resolve_engine", lambda e=None: engine)
+
+        redact_document("scan.png")
+
+        assert engine.last_languages == ["en"]

--- a/tests/unit/multimodal/test_ocr_languages.py
+++ b/tests/unit/multimodal/test_ocr_languages.py
@@ -1,0 +1,74 @@
+"""Tests for OCR language-pack configuration (issue #315).
+
+Covers the OpenMed PII language -> OCR engine identifier mapping for all 12
+wired languages, threading a ``languages`` selection through ``ocr()`` to the
+adapter, and the English default.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.multimodal.ocr import (
+    SUPPORTED_OCR_LANGUAGES,
+    FakeOcrEngine,
+    OcrWord,
+    ocr,
+    paddle_language,
+    tesseract_language,
+)
+
+# The 12 wired OpenMed PII languages.
+PII_LANGUAGES = ("en", "fr", "de", "it", "es", "nl", "hi", "te", "pt", "ar", "ja", "tr")
+
+WORDS = [OcrWord("x", (0.0, 0.0, 1.0, 1.0), 0.9, 0)]
+
+
+def test_ocr_forwards_languages_to_adapter():
+    engine = FakeOcrEngine(WORDS)
+    ocr("scan.png", engine=engine, languages=["fr"])
+    assert engine.last_languages == ["fr"]
+
+
+def test_ocr_accepts_a_single_language_string():
+    engine = FakeOcrEngine(WORDS)
+    ocr("scan.png", engine=engine, languages="de")
+    assert engine.last_languages == ["de"]
+
+
+def test_default_language_is_english_when_unspecified():
+    engine = FakeOcrEngine(WORDS)
+    ocr("scan.png", engine=engine)
+    assert engine.last_languages == ["en"]
+    assert tesseract_language() == "eng"
+    assert paddle_language() == "en"
+
+
+def test_language_map_covers_all_twelve_pii_languages():
+    assert set(PII_LANGUAGES) <= set(SUPPORTED_OCR_LANGUAGES)
+    assert len(SUPPORTED_OCR_LANGUAGES) == 12
+    for lang in PII_LANGUAGES:
+        assert tesseract_language([lang])  # non-empty identifier
+        assert paddle_language([lang])
+
+
+def test_tesseract_identifier_mapping():
+    assert tesseract_language(["fr"]) == "fra"
+    assert tesseract_language(["de"]) == "deu"
+    assert tesseract_language(["ja"]) == "jpn"
+    # Multiple languages join with '+' per Tesseract's convention.
+    assert tesseract_language(["en", "fr"]) == "eng+fra"
+
+
+def test_paddle_identifier_mapping():
+    assert paddle_language(["en"]) == "en"
+    assert paddle_language(["fr"]) == "fr"
+    assert paddle_language(["de"]) == "german"
+    assert paddle_language(["ja"]) == "japan"
+
+
+def test_unsupported_language_raises_value_error():
+    with pytest.raises(ValueError):
+        tesseract_language(["zz"])
+    with pytest.raises(ValueError):
+        paddle_language(["zz"])


### PR DESCRIPTION
Implements #315 (OM-150): the language-configuration layer on top of the OCR contract from #226, so scanned clinical documents in non-English languages can be OCRd with the right engine language and aligned to OpenMeds PII language codes. Per the issues sequencing note, this does not bootstrap the OCR module — it extends it.

## Changes

- **`openmed/multimodal/ocr.py`**
  - Added an OpenMed PII language -> OCR engine identifier map for all 12 wired languages (`en, fr, de, it, es, nl, hi, te, pt, ar, ja, tr`): `tesseract_language()` returns ISO 639-2/T `traineddata` codes (joined with `+`, e.g. `eng+fra`), `paddle_language()` returns the PaddleOCR `lang` identifier (PaddleOCR loads one language per instance, so the first is used).
  - Threaded a `languages` parameter through `ocr()` and `OcrEngine.recognize()`. The Tesseract and PaddleOCR adapters pass the mapped identifier to their backend (`pytesseract.image_to_data(lang=...)`, `PaddleOCR(lang=...)`); `FakeOcrEngine` records the selection as `last_languages`.
  - Defaults to English when unspecified, preserving current behavior. Unsupported language codes raise a clear `ValueError`.
  - Documented the per-engine language-pack install requirement (Tesseract `traineddata`, PaddleOCR model download) in the module docstring — the language data is not bundled.
- **tests** — new `test_ocr_languages.py` (forwarding, English default, 12-language coverage, identifier mappings, unsupported-language error). Updated the existing engine stubs in `test_ocr_engines.py` for the new `lang` kwarg.

## Acceptance criteria

- [x] `ocr(..., languages=["fr"])` passes the correct lang selection to each adapter (verified via the fake engine recording the call; the real adapters `lang=` pass-through is asserted in `test_ocr_engines.py`).
- [x] The OpenMed-lang -> OCR-lang map covers all 12 wired PII languages (both Tesseract and PaddleOCR).
- [x] Default behavior remains English when unspecified.
- [x] Test suite green.

## Scope notes (flagging for review)

1. **Kept to the listed Files** (`ocr.py` + the new test). I did **not** wire `redact_document(lang=)`: the dispatcher now fans out to multiple registered handlers (image, CDA, tabular), so adding a `lang` kwarg there would require every handler to accept it — that belongs in a separate base-dispatcher change. The OpenMed -> OCR mapping is ready to plug in when you want that wiring.
2. I also touched `tests/unit/multimodal/test_ocr_engines.py` (beyond the listed files) because the `recognize()` signature change required updating its backend stubs to accept the new `lang` kwarg — necessary to keep the suite green.
3. PaddleOCR identifiers follow its multilingual `lang` table and are easy to adjust if you prefer different codes for any language.

## Testing

- New language tests pass; full unit suite passes (`.venv/bin/python -m pytest tests/ -q` -> 2163 passed, 19 skipped).
- The only 2 failures in the full run are the pre-existing, network-gated integration tests (`tests/integration/test_sentence_detection_real.py`); they fail identically on `master` offline and are unrelated to this change.
- `ruff check` and `ruff format` clean.

## Out of scope

- Adding new PII model languages.
- Bundling `traineddata` / OCR model files in the wheel.
- Pixel redaction mechanics.

Closes #315