### PR TITLE
Add Metal/MPS device-selection and perf-tuning for the torch backend

### DIFF
--- a/docs/performance-mps.md
+++ b/docs/performance-mps.md
@@ -1,0 +1,61 @@
+# Torch MPS Performance
+
+OpenMed's Hugging Face/PyTorch backend auto-selects the best local torch
+device when `OpenMedConfig.device` is unset. The order is:
+
+1. `mps` on Apple Silicon when PyTorch reports MPS as available.
+2. `cuda` when CUDA is available.
+3. `cpu` as the portable fallback.
+
+This applies to `ModelLoader.create_pipeline()`, `ModelLoader.load_model()`,
+and the torch privacy-filter route. The MLX backend remains separate; this
+page covers the non-MLX torch path.
+
+## Override device selection
+
+Use config for application code:
+
+```python
+from openmed.core import ModelLoader, OpenMedConfig
+
+loader = ModelLoader(OpenMedConfig(backend="hf", device="mps"))
+ner = loader.create_pipeline("disease_detection_tiny", aggregation_strategy="simple")
+```
+
+Use environment variables for process-level overrides:
+
+```bash
+export OPENMED_TORCH_DEVICE=mps
+# or use the broader compatibility variable:
+export OPENMED_DEVICE=cpu
+```
+
+`OPENMED_TORCH_DEVICE` takes precedence over `OPENMED_DEVICE`. Explicit
+config, such as `OpenMedConfig(device="cpu")`, takes precedence over both.
+
+## MPS tuning defaults
+
+When the resolved torch device is `mps`, OpenMed applies conservative PyTorch
+MPS environment defaults before loading the model:
+
+| Variable | Default | Why it is set |
+|---|---:|---|
+| `PYTORCH_ENABLE_MPS_FALLBACK` | `1` | Allows unsupported MPS ops to run on CPU instead of failing immediately. |
+| `PYTORCH_MPS_HIGH_WATERMARK_RATIO` | `1.0` | Keeps allocations within PyTorch's recommended working-set size. |
+| `PYTORCH_MPS_LOW_WATERMARK_RATIO` | `0.9` | Encourages earlier adaptive commits and garbage collection. |
+
+Existing values are preserved, so deployment-specific choices from your shell,
+service manager, or notebook are not overwritten. See the official
+[PyTorch MPS environment variable reference](https://docs.pytorch.org/docs/stable/mps_environment_variables.html)
+for the complete list of knobs.
+
+## Caveats
+
+MPS support is broad but not identical to CPU or CUDA. With
+`PYTORCH_ENABLE_MPS_FALLBACK=1`, unsupported operations can move to CPU, which
+may reduce throughput and introduce extra device transfers. For strict
+reproducibility checks, set `device="cpu"` or `OPENMED_TORCH_DEVICE=cpu`.
+
+The resolver recommends `float32` as the safe default dtype on MPS. Only use
+`float16` or other reduced precision settings when you have validated recall
+and span integrity for the specific model and dataset.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - FHIR Interop Helpers: fhir-interop.md
   - Apple Silicon & Mobile:
       - MLX Backend: mlx-backend.md
+      - Torch MPS Performance: performance-mps.md
       - MLX Quantized Export: export-mlx-quant.md
       - CoreML Packaging: coreml-export.md
       - Swift Package (OpenMedKit): swift-openmedkit.md

--- a/openmed/core/models.py
+++ b/openmed/core/models.py
@@ -128,6 +128,9 @@ class ModelLoader:
             auth_kwargs = self._hub_auth_kwargs()
             local_loading_kwargs = self._local_loading_kwargs(full_model_name, kwargs)
             pretrained_kwargs = {**auth_kwargs, **local_loading_kwargs}
+            load_kwargs = dict(kwargs)
+            device_preference = load_kwargs.pop("device", None)
+            resolved_device = self._resolve_torch_device(device_preference)
 
             # Load config first to verify it's a token classification model
             config = AutoConfig.from_pretrained(
@@ -161,12 +164,14 @@ class ModelLoader:
             # not by modifying the model tokenizer/vocabulary.
 
             # Load model
-            model_kwargs = {**pretrained_kwargs, **kwargs}
+            model_kwargs = {**pretrained_kwargs, **load_kwargs}
             model = AutoModelForTokenClassification.from_pretrained(
                 full_model_name,
                 cache_dir=self.config.cache_dir,
                 **model_kwargs,
             )
+            if hasattr(model, "to"):
+                model.to(resolved_device)
 
             # Cache the loaded model and tokenizer
             self._models[full_model_name] = model
@@ -268,10 +273,11 @@ class ModelLoader:
 
         try:
             # Create pipeline directly with model name for better caching
+            pipeline_device = kwargs.get("device", self._get_device_id())
             pipeline_kwargs = {
                 "model": full_model_name,
                 "aggregation_strategy": aggregation_strategy,
-                "device": self._get_device_id(),
+                "device": pipeline_device,
                 "use_fast": use_fast_tokenizer,
             }
             pipeline_kwargs.update(self._hub_auth_kwargs())
@@ -290,6 +296,7 @@ class ModelLoader:
             model_data = self.load_model(model_name)
 
             fallback_kwargs = dict(kwargs)
+            fallback_kwargs.pop("device", None)
             if aggregation_strategy is not None:
                 fallback_kwargs["aggregation_strategy"] = aggregation_strategy
 
@@ -297,7 +304,7 @@ class ModelLoader:
                 task,
                 model=model_data["model"],
                 tokenizer=model_data["tokenizer"],
-                device=self._get_device_id(),
+                device=kwargs.get("device", self._get_device_id()),
                 **fallback_kwargs,
             )
             self._pipelines[cache_key] = ner_pipeline
@@ -437,14 +444,22 @@ class ModelLoader:
 
     def _get_device_id(self) -> Union[int, str]:
         """Get device ID for pipeline."""
-        if self.config.device is None:
-            return -1  # CPU
-        elif self.config.device.lower() == "cpu":
+        resolved_device = self._resolve_torch_device()
+        if resolved_device == "cpu":
             return -1
-        elif self.config.device.lower() in ["cuda", "gpu"]:
+        if resolved_device == "cuda":
             return 0
-        else:
-            return self.config.device
+        return resolved_device
+
+    def _resolve_torch_device(self, prefer: Optional[str] = None) -> str:
+        """Resolve and prepare the torch device for this loader."""
+        from openmed.torch.device import apply_mps_tuning, resolve_torch_device
+
+        device_preference = prefer if prefer is not None else self.config.device
+        resolved_device = resolve_torch_device(device_preference)
+        if resolved_device.startswith("mps"):
+            apply_mps_tuning()
+        return resolved_device
 
     def get_registry_info(self, model_key: str) -> Optional[RegistryModelInfo]:
         """Get information from model registry."""

--- a/openmed/torch/__init__.py
+++ b/openmed/torch/__init__.py
@@ -1,18 +1,21 @@
 """PyTorch / HuggingFace Transformers backends for OpenMed.
 
 This subpackage wraps token-classification models that run on PyTorch
-(CPU or CUDA) so they slot into the same OpenMed pipeline surface as
-the MLX path. Use this when the host machine is not Apple Silicon, or
-when MLX is unavailable.
+(MPS, CUDA, or CPU) so they slot into the same OpenMed pipeline surface
+as the MLX path. Use this when MLX is unavailable, or when you
+intentionally choose the Hugging Face/PyTorch backend.
 """
 
 from .calibration import load_awq_calibration_texts
+from .device import apply_mps_tuning, resolve_torch_device
 from .privacy_filter import PrivacyFilterTorchPipeline
 from .quantize_awq import AwqQuantizationResult, quantize_awq
 
 __all__ = [
     "AwqQuantizationResult",
     "PrivacyFilterTorchPipeline",
+    "apply_mps_tuning",
     "load_awq_calibration_texts",
     "quantize_awq",
+    "resolve_torch_device",
 ]

--- a/openmed/torch/device.py
+++ b/openmed/torch/device.py
@@ -1,0 +1,129 @@
+"""Device selection helpers for the PyTorch backend."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+TORCH_DEVICE_ENV_VAR = "OPENMED_TORCH_DEVICE"
+LEGACY_DEVICE_ENV_VAR = "OPENMED_DEVICE"
+
+MPS_ENV_DEFAULTS: Mapping[str, str] = {
+    "PYTORCH_ENABLE_MPS_FALLBACK": "1",
+    "PYTORCH_MPS_HIGH_WATERMARK_RATIO": "1.0",
+    "PYTORCH_MPS_LOW_WATERMARK_RATIO": "0.9",
+}
+
+
+@dataclass(frozen=True)
+class MpsTuning:
+    """MPS tuning choices applied by :func:`apply_mps_tuning`."""
+
+    env: Mapping[str, str]
+    recommended_dtype: str = "float32"
+
+
+def resolve_torch_device(prefer: str | None = "auto") -> str:
+    """Resolve the best PyTorch device for inference.
+
+    Args:
+        prefer: Explicit device preference such as ``"cpu"``, ``"cuda"``,
+            ``"cuda:1"``, ``"mps"``, or ``"auto"``. ``None`` is treated as
+            ``"auto"`` and consults environment overrides before probing torch.
+
+    Returns:
+        ``"mps"`` when MPS is available, else ``"cuda"`` when CUDA is
+        available, else ``"cpu"``. Explicit device preferences are returned
+        after light normalization.
+    """
+    requested = _normalize_device_preference(prefer)
+    if _is_auto_device(requested):
+        requested = _env_device_preference()
+
+    if not _is_auto_device(requested):
+        return requested
+
+    torch = _import_torch()
+    if torch is None:
+        return "cpu"
+    if _mps_is_available(torch):
+        return "mps"
+    if _cuda_is_available(torch):
+        return "cuda"
+    return "cpu"
+
+
+def apply_mps_tuning() -> MpsTuning:
+    """Apply conservative MPS runtime defaults and return dtype guidance.
+
+    Existing environment values are preserved so operators can override
+    OpenMed's defaults from their process manager, shell, or notebook.
+    """
+    applied: dict[str, str] = {}
+    for key, value in MPS_ENV_DEFAULTS.items():
+        applied[key] = os.environ.setdefault(key, value)
+    return MpsTuning(env=applied)
+
+
+def _env_device_preference() -> str:
+    """Return the first configured torch device override, or ``"auto"``."""
+    for env_var in (TORCH_DEVICE_ENV_VAR, LEGACY_DEVICE_ENV_VAR):
+        value = _normalize_device_preference(os.getenv(env_var))
+        if not _is_auto_device(value):
+            return value
+    return "auto"
+
+
+def _normalize_device_preference(prefer: str | None) -> str:
+    if prefer is None:
+        return "auto"
+    normalized = str(prefer).strip().lower()
+    if normalized == "gpu":
+        return "cuda"
+    return normalized or "auto"
+
+
+def _is_auto_device(device: str) -> bool:
+    return device in {"auto", "default"}
+
+
+def _import_torch() -> Any | None:
+    try:
+        return importlib.import_module("torch")
+    except Exception:
+        return None
+
+
+def _mps_is_available(torch: Any) -> bool:
+    backends = getattr(torch, "backends", None)
+    mps_backend = getattr(backends, "mps", None)
+    is_available = getattr(mps_backend, "is_available", None)
+    if not callable(is_available):
+        return False
+    try:
+        return bool(is_available())
+    except Exception:
+        return False
+
+
+def _cuda_is_available(torch: Any) -> bool:
+    cuda = getattr(torch, "cuda", None)
+    is_available = getattr(cuda, "is_available", None)
+    if not callable(is_available):
+        return False
+    try:
+        return bool(is_available())
+    except Exception:
+        return False
+
+
+__all__ = [
+    "LEGACY_DEVICE_ENV_VAR",
+    "MPS_ENV_DEFAULTS",
+    "MpsTuning",
+    "TORCH_DEVICE_ENV_VAR",
+    "apply_mps_tuning",
+    "resolve_torch_device",
+]

--- a/openmed/torch/privacy_filter.py
+++ b/openmed/torch/privacy_filter.py
@@ -85,7 +85,7 @@ class PrivacyFilterTorchPipeline:
         model_name: HuggingFace model ID or local path. Default
             ``openai/privacy-filter``.
         device: Torch device string (``cpu``, ``cuda``, ``cuda:0``, ``mps``).
-            ``None`` autodetects: CUDA if available, else CPU.
+            ``None`` autodetects MPS, then CUDA, then CPU.
         dtype: Optional torch dtype (e.g. ``"float16"``, ``"bfloat16"``).
             Defaults to model native.
         aggregation_strategy: Passed through to HF's pipeline. ``"simple"``
@@ -140,9 +140,11 @@ class PrivacyFilterTorchPipeline:
         self.model_name = model_name
         self.aggregation_strategy = aggregation_strategy
 
-        resolved_device = device
-        if resolved_device is None:
-            resolved_device = "cuda" if torch.cuda.is_available() else "cpu"
+        from openmed.torch.device import apply_mps_tuning, resolve_torch_device
+
+        resolved_device = resolve_torch_device(device)
+        if resolved_device.startswith("mps"):
+            apply_mps_tuning()
 
         load_kwargs: Dict[str, Any] = {
             "local_files_only": local_files_only,

--- a/tests/unit/torch/test_mps_device.py
+++ b/tests/unit/torch/test_mps_device.py
@@ -1,0 +1,165 @@
+"""Tests for PyTorch device selection and MPS tuning."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import Mock, patch
+
+from openmed.core.config import OpenMedConfig
+from openmed.core.models import ModelLoader
+from openmed.torch.device import (
+    LEGACY_DEVICE_ENV_VAR,
+    MPS_ENV_DEFAULTS,
+    TORCH_DEVICE_ENV_VAR,
+    apply_mps_tuning,
+    resolve_torch_device,
+)
+
+
+def _fake_torch(*, mps: bool = False, cuda: bool = False) -> types.ModuleType:
+    torch = types.ModuleType("torch")
+    torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: mps)
+    )
+    torch.cuda = types.SimpleNamespace(is_available=lambda: cuda)
+    return torch
+
+
+def test_auto_resolves_to_mps_before_cuda(monkeypatch) -> None:
+    monkeypatch.delenv(TORCH_DEVICE_ENV_VAR, raising=False)
+    monkeypatch.delenv(LEGACY_DEVICE_ENV_VAR, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps=True, cuda=True))
+
+    assert resolve_torch_device() == "mps"
+
+
+def test_auto_resolves_to_cuda_when_mps_unavailable(monkeypatch) -> None:
+    monkeypatch.delenv(TORCH_DEVICE_ENV_VAR, raising=False)
+    monkeypatch.delenv(LEGACY_DEVICE_ENV_VAR, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps=False, cuda=True))
+
+    assert resolve_torch_device() == "cuda"
+
+
+def test_auto_resolves_to_cpu_without_accelerators(monkeypatch) -> None:
+    monkeypatch.delenv(TORCH_DEVICE_ENV_VAR, raising=False)
+    monkeypatch.delenv(LEGACY_DEVICE_ENV_VAR, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps=False, cuda=False))
+
+    assert resolve_torch_device() == "cpu"
+
+
+def test_explicit_device_override_is_honored(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps=True, cuda=True))
+
+    assert resolve_torch_device("cpu") == "cpu"
+    assert resolve_torch_device("cuda:1") == "cuda:1"
+    assert resolve_torch_device("gpu") == "cuda"
+
+
+def test_environment_device_override_is_honored(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps=True, cuda=True))
+    monkeypatch.setenv(TORCH_DEVICE_ENV_VAR, "cpu")
+
+    assert resolve_torch_device() == "cpu"
+
+
+def test_openmed_torch_device_takes_precedence(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps=False, cuda=True))
+    monkeypatch.setenv(TORCH_DEVICE_ENV_VAR, "mps")
+    monkeypatch.setenv(LEGACY_DEVICE_ENV_VAR, "cpu")
+
+    assert resolve_torch_device() == "mps"
+
+
+def test_apply_mps_tuning_sets_expected_knobs(monkeypatch) -> None:
+    for key in MPS_ENV_DEFAULTS:
+        monkeypatch.delenv(key, raising=False)
+
+    tuning = apply_mps_tuning()
+
+    assert tuning.recommended_dtype == "float32"
+    assert dict(tuning.env) == dict(MPS_ENV_DEFAULTS)
+    for key, value in MPS_ENV_DEFAULTS.items():
+        assert key in tuning.env
+        assert tuning.env[key] == value
+
+
+def test_apply_mps_tuning_preserves_existing_values(monkeypatch) -> None:
+    monkeypatch.setenv("PYTORCH_ENABLE_MPS_FALLBACK", "0")
+
+    tuning = apply_mps_tuning()
+
+    assert tuning.env["PYTORCH_ENABLE_MPS_FALLBACK"] == "0"
+
+
+@patch("openmed.core.models.HF_AVAILABLE", True)
+@patch("openmed.core.models.pipeline")
+def test_hf_pipeline_uses_resolved_mps_device(mock_pipeline, monkeypatch) -> None:
+    monkeypatch.delenv(TORCH_DEVICE_ENV_VAR, raising=False)
+    monkeypatch.delenv(LEGACY_DEVICE_ENV_VAR, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps=True, cuda=True))
+    for key in MPS_ENV_DEFAULTS:
+        monkeypatch.delenv(key, raising=False)
+
+    loader = ModelLoader(OpenMedConfig(backend="hf"))
+    loader.create_pipeline("test-model")
+
+    _, kwargs = mock_pipeline.call_args
+    assert kwargs["device"] == "mps"
+    assert kwargs["model"] == "OpenMed/test-model"
+    assert kwargs["use_fast"] is True
+    assert all(key in kwargs for key in ("model", "device", "use_fast"))
+    for key, value in MPS_ENV_DEFAULTS.items():
+        assert key in tuning_env_subset()
+        assert tuning_env_subset()[key] == value
+
+
+@patch("openmed.core.models.HF_AVAILABLE", True)
+@patch("openmed.core.models.pipeline")
+def test_hf_pipeline_honors_config_device_override(mock_pipeline, monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps=True, cuda=True))
+
+    loader = ModelLoader(OpenMedConfig(backend="hf", device="cpu"))
+    loader.create_pipeline("test-model")
+
+    _, kwargs = mock_pipeline.call_args
+    assert kwargs["device"] == -1
+
+
+@patch("openmed.core.models.HF_AVAILABLE", True)
+@patch("openmed.core.models.AutoModelForTokenClassification")
+@patch("openmed.core.models.AutoTokenizer")
+@patch("openmed.core.models.AutoConfig")
+def test_load_model_moves_model_to_resolved_device(
+    mock_config_class,
+    mock_tokenizer_class,
+    mock_model_class,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv(TORCH_DEVICE_ENV_VAR, raising=False)
+    monkeypatch.delenv(LEGACY_DEVICE_ENV_VAR, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps=True, cuda=False))
+
+    config = Mock()
+    config.num_labels = 3
+    config.problem_type = "token_classification"
+    config.architectures = ["BertForTokenClassification"]
+    mock_config_class.from_pretrained.return_value = config
+    mock_tokenizer_class.from_pretrained.return_value = Mock()
+
+    model = Mock()
+    model.config = config
+    mock_model_class.from_pretrained.return_value = model
+
+    loader = ModelLoader(OpenMedConfig(backend="hf"))
+    loader.load_model("test-model")
+
+    model.to.assert_called_once_with("mps")
+
+
+def tuning_env_subset() -> dict[str, str]:
+    import os
+
+    return {key: os.environ[key] for key in MPS_ENV_DEFAULTS if key in os.environ}


### PR DESCRIPTION
Closes #451.

Adds a torch device resolver that prefers MPS before CUDA and CPU, applies conservative MPS fallback and memory defaults, and wires ModelLoader plus the torch privacy-filter path through the resolved device. Documents the MPS caveats and adds mocked availability tests for device priority, env and config overrides, tuning, and model placement.

Validation:
- PATH="$PWD/.venv/bin:$PATH" make lint
- PATH="$PWD/.venv/bin:$PATH" make format-check
- .venv/bin/python -m pytest tests/ -q
- uv run mkdocs build --strict