### PR TITLE
feat: add CycloneDX SBOM generation, CI artifact, and release attachment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,40 @@ jobs:
           pip-audit-report.json
       if: always()
 
+  sbom:
+    needs: repo-policy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v8.2.0
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          pyproject.toml
+          uv.lock
+
+    - name: Sync runtime environment
+      run: |
+        uv sync --frozen --python 3.11
+
+    - name: Generate CycloneDX SBOM
+      run: |
+        uv run --no-project --with 'cyclonedx-bom>=4.6,<7' python scripts/security/generate_sbom.py
+
+    - name: Upload SBOM artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: sbom
+        path: sbom.cdx.json
+      if: always()
+
   spacy-integration:
     needs: [repo-policy, lint]
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,3 +99,27 @@ jobs:
           HATCH_KEYRING: disabled
         run: |
           hatch publish
+
+      # SBOM generation runs after publish and is fail-open: a hiccup in any of
+      # these steps must never block an otherwise-successful release.
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.2.0
+        continue-on-error: true
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Generate CycloneDX SBOM
+        continue-on-error: true
+        run: |
+          uv sync --frozen --python 3.11
+          uv run --no-project --with 'cyclonedx-bom>=4.6,<7' python scripts/security/generate_sbom.py
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: sbom.cdx.json
+          if-no-files-found: warn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/openmed
+    permissions:
+      contents: write  # attach the SBOM asset to the tagged GitHub release
 
     steps:
       - uses: actions/checkout@v7
@@ -123,3 +125,13 @@ jobs:
           name: sbom
           path: sbom.cdx.json
           if-no-files-found: warn
+
+      - name: Attach SBOM to the tagged GitHub release
+        if: github.ref_type == 'tag' && hashFiles('sbom.cdx.json') != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" sbom.cdx.json --clobber \
+            || gh release create "$GITHUB_REF_NAME" sbom.cdx.json \
+                 --title "$GITHUB_REF_NAME" --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,8 @@ Thumbs.db
 # Security reports
 bandit-report.json
 safety-report.json
+pip-audit-report.json
+sbom.cdx.json
 
 # Temporary files
 *.tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added CycloneDX 1.6 SBOM generation (`scripts/security/generate_sbom.py`,
   `make sbom`) that inventories `openmed` and its runtime dependencies; a CI
   `sbom` job uploads `sbom.cdx.json` on every push and pull request, and the
-  publish workflow attaches it to tagged releases (fail-open).
+  publish workflow attaches it as an asset on each tagged GitHub release
+  (fail-open).
 - Expanded lab reference-range parsing in `openmed.clinical.lab_values` with
   tolerant separator/operator support and safer unknown explicit-flag handling.
 - Added a root `SECURITY.md` responsible-disclosure policy (private GitHub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added CycloneDX 1.6 SBOM generation (`scripts/security/generate_sbom.py`,
+  `make sbom`) that inventories `openmed` and its runtime dependencies; a CI
+  `sbom` job uploads `sbom.cdx.json` on every push and pull request, and the
+  publish workflow attaches it to tagged releases (fail-open).
 - Expanded lab reference-range parsing in `openmed.clinical.lab_values` with
   tolerant separator/operator support and safer unknown explicit-flag handling.
 - Added a root `SECURITY.md` responsible-disclosure policy (private GitHub

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for openmed package management
 
-.PHONY: help build publish release clean install lint format format-check lint-swift format-swift quality test docs-serve docs-build docs-stage docs-deploy
+.PHONY: help build publish release clean install lint format format-check lint-swift format-swift quality test sbom docs-serve docs-build docs-stage docs-deploy
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -50,6 +50,11 @@ quality: lint format-check test ## Run the local quality gate
 test: ## Run the test suite
 	@echo "🧪 Running tests..."
 	pytest
+
+sbom: ## Generate a CycloneDX 1.6 SBOM (sbom.cdx.json) for the runtime dependencies
+	@echo "📦 Generating CycloneDX SBOM..."
+	uv sync --frozen
+	uv run --no-project --with 'cyclonedx-bom>=4.6,<7' python scripts/security/generate_sbom.py
 
 docs-serve: ## Run the MkDocs dev server with live reload
 	@echo "📚 Serving docs at http://127.0.0.1:8008 ..."

--- a/docs/security/sbom.md
+++ b/docs/security/sbom.md
@@ -1,0 +1,69 @@
+# Software Bill of Materials (SBOM)
+
+OpenMed publishes a [CycloneDX](https://cyclonedx.org/) software bill of
+materials so downstream healthcare integrators can inventory the dependency tree
+and answer a supply-chain audit. The SBOM names `openmed` as the root component
+and lists the dependencies resolved in the target environment.
+
+## Generate it locally
+
+```bash
+make sbom
+```
+
+This syncs the locked **runtime** environment and writes `sbom.cdx.json`
+(CycloneDX 1.6 JSON) to the repository root. Equivalent one-liner:
+
+```bash
+uv sync --frozen
+uv run --no-project --with 'cyclonedx-bom>=4.6,<7' \
+  python scripts/security/generate_sbom.py
+```
+
+The generator
+([`scripts/security/generate_sbom.py`](https://github.com/maziyarpanahi/openmed/blob/master/scripts/security/generate_sbom.py))
+introspects the environment with `cyclonedx-py environment`, then stamps the
+package version onto the root component — hatch resolves the version
+dynamically from `openmed/__about__.py`, which PEP 621 metadata alone cannot
+express.
+
+`sbom.cdx.json` is a generated artifact and is **not** committed (see
+`.gitignore`).
+
+## Cover specific extras
+
+By default the SBOM reflects the base runtime dependencies (`openmed` plus
+`pysbd` and `Faker`). To capture a particular install profile, sync that extra
+first, then regenerate:
+
+```bash
+uv sync --frozen --extra service --extra hf
+uv run --no-project --with 'cyclonedx-bom>=4.6,<7' \
+  python scripts/security/generate_sbom.py
+```
+
+## Where it is published
+
+- **CI** — the `sbom` job in `.github/workflows/ci.yml` regenerates the SBOM on
+  every push and pull request and uploads `sbom.cdx.json` as the `sbom`
+  artifact.
+- **Releases** — `.github/workflows/publish.yml` regenerates and uploads the
+  SBOM alongside each tagged PyPI publish. SBOM generation there is fail-open and
+  never blocks a release.
+
+## Consume and verify
+
+The generator validates the document against the CycloneDX 1.6 schema before
+writing it. Downstream, load `sbom.cdx.json` into any CycloneDX-aware tool — for
+example [Dependency-Track](https://dependencytrack.org/) — or scan it for known
+vulnerabilities:
+
+```bash
+grype sbom:sbom.cdx.json     # or: trivy sbom sbom.cdx.json
+```
+
+To confirm the inventory yourself, regenerate it with `make sbom` and diff the
+`components` list; only the timestamp and serial number change between runs.
+
+See also [Supply Chain Controls](supply-chain.md) and the
+[Dependency Policy](dependency-policy.md).

--- a/docs/security/sbom.md
+++ b/docs/security/sbom.md
@@ -47,9 +47,10 @@ uv run --no-project --with 'cyclonedx-bom>=4.6,<7' \
 - **CI** — the `sbom` job in `.github/workflows/ci.yml` regenerates the SBOM on
   every push and pull request and uploads `sbom.cdx.json` as the `sbom`
   artifact.
-- **Releases** — `.github/workflows/publish.yml` regenerates and uploads the
-  SBOM alongside each tagged PyPI publish. SBOM generation there is fail-open and
-  never blocks a release.
+- **Releases** — on each tagged publish, `.github/workflows/publish.yml`
+  regenerates the SBOM and attaches `sbom.cdx.json` as an asset on the GitHub
+  release for that tag (it is also kept as a workflow artifact). SBOM handling
+  there is fail-open and never blocks a release.
 
 ## Consume and verify
 

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -19,3 +19,9 @@ uv lock
 Commit the updated `uv.lock` with the dependency change. The CI failure message
 uses the same remediation: `Run 'uv lock' and commit the updated uv.lock.`
 Do not edit the lockfile by hand.
+
+## Software bill of materials
+
+CI and every tagged release also generate a CycloneDX SBOM (`sbom.cdx.json`)
+inventorying the dependency tree. See the
+[Software Bill of Materials](sbom.md) guide to regenerate or consume it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Security & Disclosure: security/disclosure-policy.md
       - HF Write Token Policy: security/hf-token-policy.md
       - Supply Chain Controls: security/supply-chain.md
+      - Software Bill of Materials: security/sbom.md
       - Release Streams & Channels: release/semver-and-channels.md
       - Generative Model Policy: generative-model-policy.md
       - API Reference: api-reference.md

--- a/scripts/security/generate_sbom.py
+++ b/scripts/security/generate_sbom.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Generate a CycloneDX 1.6 SBOM for OpenMed's runtime environment.
+
+Produces ``sbom.cdx.json`` describing ``openmed`` (the root component) plus the
+runtime dependencies installed in the target virtual environment. Companion to
+the other supply-chain helpers under ``scripts/security/``.
+
+OpenMed's version is dynamic (hatch reads it from ``openmed/__about__.py``), so
+``cyclonedx-py --pyproject`` cannot resolve it from the PEP 621 metadata; we
+stamp the real version and PURL onto the root component after generation.
+
+Usage::
+
+    uv sync --frozen
+    uv run --no-project --with 'cyclonedx-bom>=4.6,<7' \
+        python scripts/security/generate_sbom.py
+
+The target environment defaults to ``.venv`` and can be overridden with the
+``SBOM_PYTHON`` environment variable (a path to a venv or interpreter).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+OUTFILE = ROOT / "sbom.cdx.json"
+ABOUT = ROOT / "openmed" / "__about__.py"
+PYPROJECT = ROOT / "pyproject.toml"
+SPEC_VERSION = "1.6"
+
+
+def read_version() -> str:
+    """Parse ``__version__`` from ``openmed/__about__.py`` without importing it."""
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', ABOUT.read_text(encoding="utf-8"))
+    if not match:
+        raise SystemExit(f"could not parse __version__ from {ABOUT}")
+    return match.group(1)
+
+
+def target_environment() -> str:
+    """Resolve the environment cyclonedx-py should introspect."""
+    override = os.environ.get("SBOM_PYTHON")
+    if override:
+        return override
+    venv = ROOT / ".venv"
+    if not venv.exists():
+        raise SystemExit(
+            f"runtime environment {venv} not found; run 'uv sync --frozen' first "
+            "or set SBOM_PYTHON"
+        )
+    return str(venv)
+
+
+def main() -> int:
+    version = read_version()
+    subprocess.run(
+        [
+            "cyclonedx-py",
+            "environment",
+            target_environment(),
+            "--pyproject",
+            str(PYPROJECT),
+            "--mc-type",
+            "library",
+            "--sv",
+            SPEC_VERSION,
+            "--of",
+            "JSON",
+            "-o",
+            str(OUTFILE),
+        ],
+        check=True,
+    )
+
+    bom = json.loads(OUTFILE.read_text(encoding="utf-8"))
+    component = bom.setdefault("metadata", {}).setdefault("component", {})
+    component["version"] = version
+    component["purl"] = f"pkg:pypi/openmed@{version}"
+    component.setdefault("bom-ref", f"openmed@{version}")
+    OUTFILE.write_text(json.dumps(bom, indent=2) + "\n", encoding="utf-8")
+
+    print(
+        f"wrote {OUTFILE.relative_to(ROOT)}: openmed {version} + "
+        f"{len(bom.get('components', []))} runtime dependencies "
+        f"(CycloneDX {bom.get('specVersion')})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Closes #255 (OM-090). Generates a CycloneDX 1.6 SBOM inventorying `openmed` and its runtime dependencies, uploads it as a CI artifact on every push/PR, and attaches it to tagged releases. Rebased on current `master`.

## Changes
- **`scripts/security/generate_sbom.py`** (new) — runs `cyclonedx-py environment` against the locked **runtime** venv with `--pyproject --mc-type library`, then stamps the package version + PURL onto the root component (openmed's version is dynamic via hatch, so PEP 621 metadata alone leaves it unset). Mirrors the existing `scripts/security/pip_audit_gate.py`.
- **`Makefile`** — `make sbom` target (`uv sync --frozen` + the generator).
- **`.github/workflows/ci.yml`** — new `sbom` job uploads `sbom.cdx.json` on every push and PR (`if: always()`).
- **`.github/workflows/publish.yml`** — generates + uploads the SBOM **after** `hatch publish`, fully **fail-open** (`continue-on-error` on setup + generation, `if-no-files-found: warn`) so a SBOM hiccup can never block a release. Kept out of `dist/` so `twine`/`hatch` never see it.
- **`docs/security/sbom.md`** + mkdocs nav + cross-link from `supply-chain.md`; **`.gitignore`** the generated `sbom.cdx.json`; CHANGELOG entry.

## Acceptance criteria (#255)
- [x] Documented command produces a valid CycloneDX 1.6 JSON SBOM listing `openmed` + runtime deps (`make sbom` → `openmed@1.6.0` root + `pysbd`, `Faker`)
- [x] CI uploads `sbom.cdx.json` as an artifact on every push and PR
- [x] The publish workflow includes the SBOM with each tagged release
- [x] `docs/security/sbom.md` explains how to regenerate and consume it
- [x] No Python imported by the package changed; CI exercises the full test suite

## Deliberate deviations (noted per the issue's own alternatives)
- **No `sbom` pyproject extra** — used the issue's "documented one-liner" path (`make sbom` + `uv run --with`), consistent with how the repo runs `bandit`/`pip-audit`/`build`. This avoids a `uv.lock` change and the lockfile-drift gate. (A declared extra would also be the wrong env to introspect — it would put the SBOM tool in the resolved environment.)
- The SBOM is the **base runtime** by default; `sbom.md` documents generating for specific extras (e.g. `--extra service --extra hf`).

## Verification (local)
- `make sbom` → valid CycloneDX 1.6, subject `openmed@1.6.0` (type library) + `pysbd`/`Faker`, dependency graph present
- `mkdocs build --strict` passes (new nav page + links)
- repo CI gates pass locally: `check_repo_policy.py`, `check_github_actions_refs.py`, `check_license_policy.py`
- Ruff check/format + pre-commit (yaml, secrets, whitespace) clean; both workflows parse as valid YAML
