### PR TITLE
Add an openmed models recommend command for device-fit selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an `openmed models recommend --task <task> --language <lang> --tier
+  phone|laptop|workstation|server` command that reuses the manifest search core
+  and ranks on-device models by device-tier fit (via `recommended_tier` and, when
+  present, `peak_ram_mb` budgets), then smallest parameter count and highest
+  benchmark recall/F1, with `--json` output and a non-zero exit when nothing fits.
 - Expanded lab reference-range parsing in `openmed.clinical.lab_values` with
   tolerant separator/operator support and safer unknown explicit-flag handling.
 - Added a root `SECURITY.md` responsible-disclosure policy (private GitHub

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -23,7 +23,7 @@ from ..core.config import (
     set_config,
 )
 from ..core.model_registry import get_model_info
-from ..core.model_search import ModelSearchResult, search_models
+from ..core.model_search import ModelSearchResult, recommend_models, search_models
 from .calibrate import add_calibrate_command
 
 _ANALYZE_TEXT = None
@@ -462,6 +462,25 @@ def _add_models_command(subparsers: argparse._SubParsersAction) -> None:
         help="Exclude manifest rows with unknown parameter counts.",
     )
     models_search.set_defaults(handler=_handle_models_search)
+
+    models_recommend = models_sub.add_parser(
+        "recommend",
+        help="Recommend the best on-device model for a task and device tier.",
+    )
+    models_recommend.add_argument("--task", help="Filter by model task.")
+    models_recommend.add_argument("--language", help="Filter by language code.")
+    models_recommend.add_argument(
+        "--tier",
+        required=True,
+        choices=["phone", "laptop", "workstation", "server"],
+        help="Target device tier the recommended model must fit.",
+    )
+    models_recommend.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the ranked shortlist as a single JSON document.",
+    )
+    models_recommend.set_defaults(handler=_handle_models_recommend)
 
     models_freshness = models_sub.add_parser(
         "freshness",
@@ -966,6 +985,57 @@ def _handle_models_search(args: argparse.Namespace) -> int:
 
     sys.stdout.write(_format_model_search_table(results))
     return 0
+
+
+def _handle_models_recommend(args: argparse.Namespace) -> int:
+    try:
+        results = recommend_models(
+            device_tier=args.tier,
+            task=args.task,
+            language=args.language,
+        )
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"Failed to recommend models: {exc}\n")
+        return 1
+
+    if not results:
+        sys.stderr.write(
+            f"No model fits the '{args.tier}' device tier for the requested filters.\n"
+        )
+        return 1
+
+    if args.json:
+        payload = {
+            "tier": args.tier,
+            "task": args.task,
+            "language": args.language,
+            "recommended": results[0].repo_id,
+            "models": [_recommendation_to_dict(result) for result in results],
+        }
+        sys.stdout.write(f"{json.dumps(payload, indent=2)}\n")
+        return 0
+
+    sys.stdout.write(f"Recommended for {args.tier}: {results[0].repo_id}\n")
+    sys.stdout.write(_format_model_search_table(results))
+    return 0
+
+
+def _recommendation_to_dict(result: ModelSearchResult) -> dict[str, Any]:
+    row = result.manifest_row
+    return {
+        "repo_id": result.repo_id,
+        "family": result.family,
+        "task": result.task,
+        "languages": list(result.languages),
+        "tier": result.tier,
+        "param_count": result.param_count,
+        "formats": list(result.formats),
+        "license": result.license,
+        "recommended_tier": row.get("recommended_tier"),
+        "peak_ram_mb": row.get("peak_ram_mb"),
+        "latency_ms": row.get("latency_ms"),
+        "benchmark": result.benchmark,
+    }
 
 
 def _format_model_search_table(results: Sequence[ModelSearchResult]) -> str:

--- a/openmed/core/model_search.py
+++ b/openmed/core/model_search.py
@@ -162,8 +162,7 @@ def _recommendation_sort_key(
 
 def _has_tier_enrichment(result: ModelSearchResult, tier: str) -> bool:
     return (
-        _recommended_tier(result) is not None
-        or _peak_ram_mb(result, tier) is not None
+        _recommended_tier(result) is not None or _peak_ram_mb(result, tier) is not None
     )
 
 

--- a/openmed/core/model_search.py
+++ b/openmed/core/model_search.py
@@ -88,6 +88,130 @@ def search_models(
     return sorted(results, key=_result_sort_key)
 
 
+# Device tiers ordered from the most constrained to the least constrained.
+DEVICE_TIERS: tuple[str, ...] = ("phone", "laptop", "workstation", "server")
+_DEVICE_TIER_RANK = {name: index for index, name in enumerate(DEVICE_TIERS)}
+
+# Approximate usable RAM budgets (in MB) per device tier. These are only
+# consulted when a manifest row carries ``peak_ram_mb`` enrichment; rows without
+# it are retained and ranked by parameter count so the command degrades
+# gracefully before the enrichment task lands.
+_DEVICE_RAM_BUDGET_MB = {
+    "phone": 6_000,
+    "laptop": 16_000,
+    "workstation": 64_000,
+    "server": 512_000,
+}
+
+
+def recommend_models(
+    *,
+    device_tier: str,
+    task: str | None = None,
+    language: str | None = None,
+    manifest_path: str | Path | None = None,
+) -> list[ModelSearchResult]:
+    """Rank on-device models that fit ``device_tier`` for a task and language.
+
+    Task/language filtering reuses :func:`search_models`; this adds device-tier
+    fit and ranking on top. A row fits when its ``recommended_tier`` is no larger
+    than the requested tier and, when present, its ``peak_ram_mb`` is within the
+    tier budget. Rows lacking that enrichment are retained and ranked by
+    parameter count, so the command still returns a shortlist today.
+    """
+
+    tier = device_tier.casefold()
+    if tier not in _DEVICE_TIER_RANK:
+        raise ValueError(
+            f"Unknown device tier: {device_tier!r}. "
+            f"Expected one of: {', '.join(DEVICE_TIERS)}."
+        )
+
+    candidates = search_models(
+        task=task,
+        language=language,
+        manifest_path=manifest_path,
+    )
+    fitted = [result for result in candidates if _fits_device_tier(result, tier)]
+    return sorted(fitted, key=lambda result: _recommendation_sort_key(result, tier))
+
+
+def _fits_device_tier(result: ModelSearchResult, tier: str) -> bool:
+    recommended = _recommended_tier(result)
+    if recommended is not None and recommended in _DEVICE_TIER_RANK:
+        if _DEVICE_TIER_RANK[recommended] > _DEVICE_TIER_RANK[tier]:
+            return False
+
+    peak_ram = _peak_ram_mb(result, tier)
+    if peak_ram is not None and peak_ram > _DEVICE_RAM_BUDGET_MB[tier]:
+        return False
+
+    return True
+
+
+def _recommendation_sort_key(
+    result: ModelSearchResult, tier: str
+) -> tuple[int, float, float, str]:
+    return (
+        0 if _has_tier_enrichment(result, tier) else 1,
+        _size_metric(result, tier),
+        -_benchmark_score(result),
+        result.repo_id.casefold(),
+    )
+
+
+def _has_tier_enrichment(result: ModelSearchResult, tier: str) -> bool:
+    return (
+        _recommended_tier(result) is not None
+        or _peak_ram_mb(result, tier) is not None
+    )
+
+
+def _size_metric(result: ModelSearchResult, tier: str) -> float:
+    peak_ram = _peak_ram_mb(result, tier)
+    if peak_ram is not None:
+        return peak_ram
+    if result.param_count is not None:
+        return float(result.param_count)
+    return float("inf")
+
+
+def _benchmark_score(result: ModelSearchResult) -> float:
+    benchmark = result.benchmark
+    entries = benchmark if isinstance(benchmark, list) else [benchmark]
+    scores: list[float] = []
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        for key, value in entry.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            lowered = str(key).casefold()
+            if "recall" in lowered or "f1" in lowered:
+                scores.append(float(value))
+    return max(scores) if scores else 0.0
+
+
+def _recommended_tier(result: ModelSearchResult) -> str | None:
+    value = result.manifest_row.get("recommended_tier")
+    if isinstance(value, str) and value.strip():
+        return value.strip().casefold()
+    return None
+
+
+def _peak_ram_mb(result: ModelSearchResult, tier: str) -> float | None:
+    value = result.manifest_row.get("peak_ram_mb")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, Mapping):
+        candidate = value.get(tier)
+        if isinstance(candidate, (int, float)) and not isinstance(candidate, bool):
+            return float(candidate)
+    return None
+
+
 def _matches_query(row: Mapping[str, Any], query: ModelQuery) -> bool:
     if query.task and not _matches_text(row.get("task"), query.task):
         return False

--- a/tests/unit/cli/test_models_recommend_cli.py
+++ b/tests/unit/cli/test_models_recommend_cli.py
@@ -1,0 +1,229 @@
+"""Tests for the ``openmed models recommend`` command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openmed.cli import main_module
+from openmed.core.model_search import ModelSearchResult, recommend_models
+
+
+def _write_manifest(path: Path, rows: list[dict[str, Any]]) -> Path:
+    path.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_models_recommend_prints_ranked_table_and_passes_filters(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: dict[str, Any] = {}
+
+    def fake_recommend_models(**kwargs: Any) -> list[ModelSearchResult]:
+        calls.update(kwargs)
+        return [
+            ModelSearchResult(
+                repo_id="OpenMed/small-en",
+                family="NER",
+                task="token-classification",
+                languages=("en",),
+                param_count=33_000_000,
+            ),
+            ModelSearchResult(
+                repo_id="OpenMed/large-en",
+                family="NER",
+                task="token-classification",
+                languages=("en",),
+                param_count=434_000_000,
+            ),
+        ]
+
+    monkeypatch.setattr(main_module, "recommend_models", fake_recommend_models)
+
+    result = main_module.main(
+        [
+            "models",
+            "recommend",
+            "--task",
+            "token-classification",
+            "--language",
+            "en",
+            "--tier",
+            "phone",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Recommended for phone: OpenMed/small-en" in captured.out
+    # The ranked order is preserved: the smallest model is listed first.
+    assert captured.out.index("OpenMed/small-en") < captured.out.index(
+        "OpenMed/large-en"
+    )
+    assert captured.err == ""
+    assert calls == {
+        "device_tier": "phone",
+        "task": "token-classification",
+        "language": "en",
+    }
+
+
+def test_models_recommend_no_fit_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(main_module, "recommend_models", lambda **_kwargs: [])
+
+    result = main_module.main(
+        ["models", "recommend", "--task", "token-classification", "--tier", "phone"]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert captured.out == ""
+    assert "No model fits the 'phone' device tier" in captured.err
+
+
+def test_models_recommend_json_emits_single_document(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        main_module,
+        "recommend_models",
+        lambda **_kwargs: [
+            ModelSearchResult(
+                repo_id="OpenMed/small-en",
+                family="NER",
+                task="token-classification",
+                languages=("en",),
+                param_count=33_000_000,
+            )
+        ],
+    )
+
+    result = main_module.main(
+        [
+            "models",
+            "recommend",
+            "--task",
+            "token-classification",
+            "--language",
+            "en",
+            "--tier",
+            "phone",
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 0
+    payload = json.loads(captured.out)  # parses as a single JSON document
+    assert payload["tier"] == "phone"
+    assert payload["recommended"] == "OpenMed/small-en"
+    assert [model["repo_id"] for model in payload["models"]] == ["OpenMed/small-en"]
+
+
+def test_recommend_models_ranks_by_param_count_without_enrichment(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_manifest(
+        tmp_path / "models.jsonl",
+        [
+            {
+                "repo_id": "OpenMed/large",
+                "task": "token-classification",
+                "languages": ["en"],
+                "param_count": 434_000_000,
+            },
+            {
+                "repo_id": "OpenMed/small",
+                "task": "token-classification",
+                "languages": ["en"],
+                "param_count": 33_000_000,
+            },
+            {
+                "repo_id": "OpenMed/mid",
+                "task": "token-classification",
+                "languages": ["en"],
+                "param_count": 110_000_000,
+            },
+            {
+                "repo_id": "OpenMed/other-language",
+                "task": "token-classification",
+                "languages": ["fr"],
+                "param_count": 10_000_000,
+            },
+        ],
+    )
+
+    results = recommend_models(
+        device_tier="phone",
+        task="token-classification",
+        language="en",
+        manifest_path=manifest,
+    )
+
+    # Smallest tier-fitting model first; the French model is filtered out.
+    assert [result.repo_id for result in results] == [
+        "OpenMed/small",
+        "OpenMed/mid",
+        "OpenMed/large",
+    ]
+
+
+def test_recommend_models_filters_by_recommended_tier_and_ram(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_manifest(
+        tmp_path / "models.jsonl",
+        [
+            {
+                "repo_id": "OpenMed/phone-fit",
+                "task": "token-classification",
+                "languages": ["en"],
+                "param_count": 50_000_000,
+                "recommended_tier": "phone",
+                "peak_ram_mb": {"phone": 2_000},
+            },
+            {
+                "repo_id": "OpenMed/server-only",
+                "task": "token-classification",
+                "languages": ["en"],
+                "param_count": 20_000_000,
+                "recommended_tier": "server",
+            },
+            {
+                "repo_id": "OpenMed/too-much-ram",
+                "task": "token-classification",
+                "languages": ["en"],
+                "param_count": 10_000_000,
+                "peak_ram_mb": {"phone": 999_999},
+            },
+        ],
+    )
+
+    results = recommend_models(
+        device_tier="phone",
+        task="token-classification",
+        language="en",
+        manifest_path=manifest,
+    )
+
+    # ``server-only`` exceeds the tier; ``too-much-ram`` blows the RAM budget.
+    assert [result.repo_id for result in results] == ["OpenMed/phone-fit"]
+
+
+def test_recommend_models_rejects_unknown_device_tier(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        recommend_models(
+            device_tier="toaster",
+            manifest_path=tmp_path / "missing.jsonl",
+        )


### PR DESCRIPTION
## Description
Adds `openmed models recommend --task <task> --language <lang> --tier phone|laptop|workstation|server`. It reuses the manifest search core for task/language filtering, then keeps the models that fit the requested device tier and ranks them by tier fit, smallest size, and highest benchmark recall/F1. Supports `--json` and exits non-zero when nothing fits.

Fit uses each row's `recommended_tier` and, when present, `peak_ram_mb` budgets. Rows without that enrichment are retained and ranked by parameter count, so the command still returns a useful shortlist until the manifest enrichment lands.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Add `recommend_models()` and the device-tier / RAM-budget ranking helpers in `core/model_search.py`.
- Wire up the `models recommend` subcommand with `--task/--language/--tier/--json` in `cli/main.py`.
- Add a CHANGELOG entry and tests in `tests/unit/cli/test_models_recommend_cli.py`.

## Testing
- `.venv/bin/python -m pytest tests/ -q` -> 2115 passed, 28 skipped.

## Related Issues
Closes #522
