### PR TITLE
feat(service): split liveness/readiness probes and add graceful shutdown

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -461,6 +461,28 @@
         "summary": "Health"
       }
     },
+    "/livez": {
+      "get": {
+        "operationId": "livez_livez_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Livez Livez Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Livez"
+      }
+    },
     "/models/loaded": {
       "get": {
         "operationId": "loaded_models_models_loaded_get",
@@ -599,6 +621,22 @@
           }
         },
         "summary": "Pii Extract"
+      }
+    },
+    "/readyz": {
+      "get": {
+        "operationId": "readyz_readyz_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Readyz"
       }
     }
   }

--- a/docs/rest-service.md
+++ b/docs/rest-service.md
@@ -4,6 +4,8 @@ OpenMed `v0.6.2` hardens the FastAPI service introduced in `v0.6.1` with shared
 model reuse, explicit model unloading, and idle model cleanup:
 
 - `GET /health`
+- `GET /livez`
+- `GET /readyz`
 - `GET /models/loaded`
 - `POST /models/unload`
 - `POST /analyze`
@@ -103,6 +105,17 @@ non-batch-compatible settings are still coalesced but executed independently.
 `OPENMED_SERVICE_BATCH_MAX_WAIT_MS` is a non-negative wait window in
 milliseconds.
 
+Optional graceful-shutdown drain timeout:
+
+```bash
+OPENMED_SERVICE_SHUTDOWN_DRAIN_SECONDS=30 uvicorn openmed.service.app:app --host 0.0.0.0 --port 8080
+```
+
+`OPENMED_SERVICE_SHUTDOWN_DRAIN_SECONDS` is a non-negative number of seconds.
+During shutdown, readiness is flipped off, new model-backed work is rejected,
+and the service waits up to this timeout for in-flight `/analyze`,
+`/pii/extract`, and `/pii/deidentify` requests to finish. The default is `30`.
+
 ## Reliability Changes
 
 - Requests now run against one shared service runtime per process, including a shared `OpenMedConfig` and bounded warm-pool loader.
@@ -112,6 +125,8 @@ milliseconds.
 - `OPENMED_SERVICE_MAX_RESIDENT_MODELS` evicts the least-recently-used idle model when mixed-model traffic exceeds the configured resident limit.
 - Inference requests accept `keep_alive` to schedule model unloading after the model becomes idle.
 - Dynamic request batching can be enabled for compatible `/analyze` and `/pii/extract` traffic with `OPENMED_SERVICE_BATCHING_ENABLED=true`.
+- `/livez` reports process liveness, `/readyz` reports startup readiness, and `/health` remains the backward-compatible health alias.
+- Graceful shutdown rejects new model-backed requests and drains in-flight model-backed requests for up to `OPENMED_SERVICE_SHUTDOWN_DRAIN_SECONDS`.
 - Non-2xx responses use one JSON envelope across validation, bad-request, timeout, and internal errors.
 - `/pii/deidentify` still accepts the legacy `shift_dates` boolean, but it is now a deprecated alias for `method="shift_dates"`.
 
@@ -129,6 +144,33 @@ Health response:
   "profile": "prod"
 }
 ```
+
+`GET /health` remains the backward-compatible health alias.
+
+### `GET /livez`
+
+Liveness response:
+
+```json
+{
+  "status": "ok",
+  "service": "openmed-rest"
+}
+```
+
+### `GET /readyz`
+
+Readiness response after startup preload completes:
+
+```json
+{
+  "status": "ready",
+  "service": "openmed-rest"
+}
+```
+
+Before startup readiness, `/readyz` returns `503` with `error.code` set to
+`not_ready`.
 
 ### `GET /models/loaded`
 
@@ -240,7 +282,7 @@ All non-2xx responses use this shape:
 ```json
 {
   "error": {
-    "code": "validation_error|bad_request|timeout|internal_error",
+    "code": "validation_error|bad_request|timeout|not_ready|internal_error",
     "message": "human-readable summary",
     "details": null
   }

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -27,6 +27,7 @@ from .schemas import (
 )
 
 SERVICE_NAME = "openmed-rest"
+_MODEL_BACKED_PATHS = frozenset({"/analyze", "/pii/extract", "/pii/deidentify"})
 _ServicePayload = Dict[str, Any]
 _AnalyzeBatcher = DynamicBatcher["_AnalyzeBatchJob", _ServicePayload]
 _PIIExtractBatcher = DynamicBatcher["_PIIExtractBatchJob", _ServicePayload]
@@ -194,11 +195,28 @@ def create_app() -> FastAPI:
     async def lifespan(fastapi_app: FastAPI):
         runtime = ServiceRuntime.from_env()
         _attach_runtime(fastapi_app, runtime)
+        fastapi_app.state.ready = False
+        fastapi_app.state.shutting_down = False
+        fastapi_app.state.inflight = 0
 
         if runtime.preload_models:
             await run_in_threadpool(runtime.preload)
 
-        yield
+        fastapi_app.state.ready = True
+
+        try:
+            yield
+        finally:
+            fastapi_app.state.ready = False
+            fastapi_app.state.shutting_down = True
+            loop = asyncio.get_event_loop()
+            deadline = loop.time() + float(
+                getattr(runtime, "shutdown_drain_seconds", 0.0) or 0.0
+            )
+            while getattr(fastapi_app.state, "inflight", 0) > 0 and (
+                loop.time() < deadline
+            ):
+                await asyncio.sleep(0.05)
 
     app = FastAPI(
         title="OpenMed REST API",
@@ -206,6 +224,25 @@ def create_app() -> FastAPI:
         description="Hardened REST API for OpenMed text analysis and PII workflows.",
         lifespan=lifespan,
     )
+
+    @app.middleware("http")
+    async def _readiness_middleware(request: Request, call_next):
+        path = request.url.path
+        if path in _MODEL_BACKED_PATHS:
+            state = request.app.state
+            if getattr(state, "shutting_down", False):
+                return _error_response(
+                    503,
+                    "not_ready",
+                    "Service is shutting down and not accepting new requests",
+                    details=None,
+                )
+            state.inflight = getattr(state, "inflight", 0) + 1
+            try:
+                return await call_next(request)
+            finally:
+                state.inflight = getattr(state, "inflight", 0) - 1
+        return await call_next(request)
 
     @app.exception_handler(RequestValidationError)
     async def _request_validation_handler(
@@ -268,6 +305,21 @@ def create_app() -> FastAPI:
             "version": openmed.__version__,
             "profile": runtime.profile,
         }
+
+    @app.get("/livez")
+    async def livez() -> Dict[str, str]:
+        return {"status": "ok", "service": SERVICE_NAME}
+
+    @app.get("/readyz")
+    async def readyz(request: Request):
+        if getattr(request.app.state, "ready", False):
+            return {"status": "ready", "service": SERVICE_NAME}
+        return _error_response(
+            503,
+            "not_ready",
+            "Service preload has not completed",
+            details=None,
+        )
 
     @app.get("/models/loaded")
     async def loaded_models(request: Request) -> Dict[str, Any]:

--- a/openmed/service/runtime.py
+++ b/openmed/service/runtime.py
@@ -20,8 +20,10 @@ SERVICE_MAX_RESIDENT_ENV_VAR = "OPENMED_SERVICE_MAX_RESIDENT_MODELS"
 SERVICE_BATCHING_ENABLED_ENV_VAR = "OPENMED_SERVICE_BATCHING_ENABLED"
 SERVICE_BATCH_MAX_SIZE_ENV_VAR = "OPENMED_SERVICE_BATCH_MAX_SIZE"
 SERVICE_BATCH_MAX_WAIT_MS_ENV_VAR = "OPENMED_SERVICE_BATCH_MAX_WAIT_MS"
+SERVICE_SHUTDOWN_DRAIN_ENV_VAR = "OPENMED_SERVICE_SHUTDOWN_DRAIN_SECONDS"
 DEFAULT_SERVICE_BATCH_MAX_SIZE = 8
 DEFAULT_SERVICE_BATCH_MAX_WAIT_MS = 5.0
+DEFAULT_SERVICE_SHUTDOWN_DRAIN_SECONDS = 30.0
 
 _BATCHING_ENABLED_VALUES = {"1", "true", "yes", "on", "enabled"}
 _BATCHING_DISABLED_VALUES = {"0", "false", "no", "off", "disabled"}
@@ -86,6 +88,24 @@ def parse_service_batch_max_wait_ms(raw_value: Optional[str]) -> float:
     return parsed
 
 
+def parse_shutdown_drain_seconds(raw_value: Optional[str]) -> float:
+    """Parse the configured graceful-shutdown drain window in seconds."""
+    if raw_value is None or not raw_value.strip():
+        return DEFAULT_SERVICE_SHUTDOWN_DRAIN_SECONDS
+
+    try:
+        parsed = float(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{SERVICE_SHUTDOWN_DRAIN_ENV_VAR} must be a non-negative number"
+        ) from exc
+    if parsed < 0:
+        raise ValueError(
+            f"{SERVICE_SHUTDOWN_DRAIN_ENV_VAR} must be greater than or equal to 0"
+        )
+    return parsed
+
+
 def parse_service_batching_config() -> ServiceBatchingConfig:
     """Read dynamic-batching settings from the current process environment."""
     return ServiceBatchingConfig(
@@ -132,6 +152,7 @@ class ServiceRuntime:
     preload_models: Tuple[str, ...] = ()
     max_resident_models: Optional[int] = None
     default_keep_alive_seconds: Optional[float] = None
+    shutdown_drain_seconds: float = DEFAULT_SERVICE_SHUTDOWN_DRAIN_SECONDS
     batching: ServiceBatchingConfig = field(default_factory=ServiceBatchingConfig)
     _loader_factory: Optional[Callable[[OpenMedConfig], ModelLoader]] = None
     _loader: Optional[ModelLoader] = None
@@ -155,6 +176,9 @@ class ServiceRuntime:
             preload_models=preload_models,
             max_resident_models=max_resident_models,
             default_keep_alive_seconds=keep_alive,
+            shutdown_drain_seconds=parse_shutdown_drain_seconds(
+                os.getenv(SERVICE_SHUTDOWN_DRAIN_ENV_VAR)
+            ),
             batching=batching,
             _loader_factory=ModelLoader,
         )

--- a/tests/unit/service/test_readiness_liveness.py
+++ b/tests/unit/service/test_readiness_liveness.py
@@ -1,0 +1,129 @@
+"""Readiness, liveness, and shutdown tests for the REST service."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from openmed.service import runtime as service_runtime
+from openmed.service.app import create_app
+
+_SERVICE_ENV_VARS = (
+    "OPENMED_SERVICE_PRELOAD_MODELS",
+    "OPENMED_SERVICE_KEEP_ALIVE",
+    "OPENMED_SERVICE_MAX_RESIDENT_MODELS",
+    "OPENMED_SERVICE_MAX_TEXT_LENGTH",
+    "OPENMED_SERVICE_BATCHING_ENABLED",
+    "OPENMED_SERVICE_BATCH_MAX_SIZE",
+    "OPENMED_SERVICE_BATCH_MAX_WAIT_MS",
+    "OPENMED_SERVICE_SHUTDOWN_DRAIN_SECONDS",
+)
+
+
+class FakeLoader:
+    """Minimal model loader double for service startup tests."""
+
+    def __init__(self, config: Any):
+        self.config = config
+
+    def create_pipeline(self, model_name: str, **_: Any) -> object:
+        return object()
+
+    def resolve_model_name(self, model_name: str) -> str:
+        return model_name
+
+
+@pytest.fixture(autouse=True)
+def clean_service_env(monkeypatch):
+    monkeypatch.setenv("OPENMED_PROFILE", "test")
+    for env_var in _SERVICE_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def fake_loader(monkeypatch):
+    monkeypatch.setattr(service_runtime, "ModelLoader", FakeLoader)
+
+
+def _assert_error_payload(response, status_code: int, code: str) -> dict[str, Any]:
+    assert response.status_code == status_code
+    payload = response.json()
+    assert payload["error"]["code"] == code
+    assert "message" in payload["error"]
+    assert "details" in payload["error"]
+    return payload
+
+
+def test_livez_ok_before_preload():
+    app = create_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    try:
+        response = client.get("/livez")
+    finally:
+        client.close()
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "service": "openmed-rest"}
+
+
+def test_readyz_503_before_preload():
+    app = create_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    try:
+        response = client.get("/readyz")
+    finally:
+        client.close()
+
+    _assert_error_payload(response, 503, "not_ready")
+
+
+def test_readyz_200_after_preload():
+    app = create_app()
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/readyz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready", "service": "openmed-rest"}
+
+
+def test_health_alias_still_ok():
+    app = create_app()
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["service"] == "openmed-rest"
+    assert payload["profile"] == "test"
+
+
+def test_shutdown_flips_ready_and_drains(monkeypatch):
+    monkeypatch.setenv("OPENMED_SERVICE_SHUTDOWN_DRAIN_SECONDS", "0.2")
+    app = create_app()
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/readyz")
+        assert response.status_code == 200
+        client.app.state.inflight = 1
+        shutdown_start = time.perf_counter()
+
+    elapsed = time.perf_counter() - shutdown_start
+    assert app.state.ready is False
+    assert app.state.shutting_down is True
+    assert elapsed >= 0.15
+
+
+def test_model_request_rejected_during_shutdown():
+    app = create_app()
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        client.app.state.shutting_down = True
+        response = client.post("/analyze", json={"text": "sample"})
+
+    _assert_error_payload(response, 503, "not_ready")


### PR DESCRIPTION
# Pull Request

## Description
Splits liveness from readiness on the REST service and adds graceful shutdown, addressing #668. Previously the single `GET /health` endpoint always returned ok once the process was up, so an orchestrator could route traffic to a service whose warm-pool models were still cold, and there was no draining of in-flight work on `SIGTERM`. This is infra-only work: the warm-pool preload and runtime already existed and are untouched.

Splitting liveness (process up) from readiness (preload done, accepting traffic) and draining in-flight requests on shutdown makes the service safe to deploy behind a load balancer or in Kubernetes: probes can distinguish "restart me" from "don't route to me yet," and in-flight de-identification requests are no longer dropped on rolling restarts.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Add `GET /livez` (process liveness, ok whenever the process is running).
- Add `GET /readyz` (`200` once startup preload completes or immediately when no preload is configured; `503` with the `not_ready` error envelope otherwise). `GET /health` is unchanged and kept as a backward-compatible alias.
- Track readiness on `app.state`, set true at the end of the lifespan preload step and false during shutdown.
- On shutdown, flip readiness off, refuse new model-backed requests (`/analyze`, `/pii/extract`, `/pii/deidentify`) with `503 not_ready` via middleware, and bounded-drain in-flight model-backed work before the lifespan exits.
- Add `OPENMED_SERVICE_SHUTDOWN_DRAIN_SECONDS` (default `30`) with a parser/field on `ServiceRuntime`.
- Regenerate `docs/api/openapi.json` for the new routes and document probe/drain semantics in `docs/rest-service.md`.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

New `tests/unit/service/test_readiness_liveness.py` covers: `/livez` ok before preload; `/readyz` 503 before preload and 200 after; `/health` alias still ok; no-preload readiness immediate; shutdown flips readiness off and bounded-drains an in-flight request; model-backed requests rejected during shutdown. `python -m pytest tests/unit/service/ -q` -> `81 passed` (includes the regenerated OpenAPI spec check).

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #668

## Screenshots/Examples
Not applicable; this is an infra change to HTTP probe routing and shutdown behaviour.
