### PR TITLE
feat: add k-anonymity, l-diversity and t-closeness measurement for tabular outputs

### DIFF
--- a/openmed/risk/__init__.py
+++ b/openmed/risk/__init__.py
@@ -4,6 +4,7 @@ Intended contents include quasi-identifier detection, uniqueness/k-anonymity
 measurement, and adversarial re-identification analysis.
 """
 
+from .kanon import kanon_report
 from .reid import risk_report
 
-__all__ = ["risk_report"]
+__all__ = ["risk_report", "kanon_report"]

--- a/openmed/risk/kanon.py
+++ b/openmed/risk/kanon.py
@@ -1,0 +1,216 @@
+"""k-anonymity, l-diversity and t-closeness measurement for tabular records.
+
+These are *measurement-only* disclosure-control metrics over already
+de-identified records. They report on the realized privacy of an output; they
+do NOT generalize, suppress or microaggregate to achieve a target k (that is
+the ARX-style engine, a separate epic).
+
+Quasi-identifier handling reuses :mod:`openmed.risk.reid` so equivalence-class
+keys match :func:`openmed.risk.risk_report`: auto-detection uses the same
+``_profile_record`` key, and an explicit ``quasi_identifiers`` list builds the
+class key from those fields with the same value normalization.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import Counter, defaultdict
+from typing import Any, Mapping, Sequence
+
+from .reid import _coerce_records, _normalize_qi_value, _profile_record
+
+__all__ = ["kanon_report"]
+
+_SUPPORTED_T_DISTANCES = ("variational",)
+
+
+def kanon_report(
+    records: Any,
+    quasi_identifiers: Sequence[str] | None = None,
+    sensitive_attributes: Sequence[str] | None = None,
+    *,
+    l_metric: str = "distinct",
+    t_distance: str = "variational",
+) -> dict[str, Any]:
+    """Measure k-anonymity, l-diversity and t-closeness for ``records``.
+
+    Args:
+        records: Tabular records in any shape accepted by ``risk_report``
+            (mapping, sequence of mappings, or a DataFrame-like object).
+        quasi_identifiers: Explicit quasi-identifier field names. When omitted,
+            quasi-identifiers are auto-detected consistently with
+            ``risk_report``'s profiling.
+        sensitive_attributes: Field names whose distribution drives l-diversity
+            and t-closeness. When omitted, only k-anonymity is reported.
+        l_metric: Reserved selector for the headline l-diversity metric; both
+            distinct count and Shannon entropy are always reported per class.
+        t_distance: Distance used for t-closeness. Only ``"variational"``
+            (total-variation distance) is currently supported.
+
+    Returns:
+        A deterministic, JSON-serializable mapping with equivalence-class sizes,
+        k (min class size), per-class l-diversity and t-closeness, and the
+        worst-case (overall) l-diversity and t-closeness.
+    """
+    if t_distance not in _SUPPORTED_T_DISTANCES:
+        raise ValueError(
+            f"Unsupported t_distance {t_distance!r}; "
+            f"supported: {', '.join(_SUPPORTED_T_DISTANCES)}."
+        )
+
+    coerced = _coerce_records(records, source="deidentified")
+    sensitive = list(sensitive_attributes or [])
+
+    members: defaultdict[Any, list[int]] = defaultdict(list)
+    json_keys: dict[Any, list[Any]] = {}
+    sensitive_values: dict[int, dict[str, str]] = {}
+
+    for record in coerced:
+        hash_key, json_key = _equivalence_key(record, quasi_identifiers)
+        members[hash_key].append(record.index)
+        json_keys.setdefault(hash_key, json_key)
+        sensitive_values[record.index] = {
+            attr: str(record.fields.get(attr)) for attr in sensitive
+        }
+
+    global_dist = {
+        attr: _distribution(
+            sensitive_values[idx][attr]
+            for idx in sensitive_values
+            if attr in sensitive_values[idx]
+        )
+        for attr in sensitive
+    }
+
+    classes = []
+    for hash_key in members:
+        indices = sorted(members[hash_key])
+        per_class_l: dict[str, Any] = {}
+        per_class_t: dict[str, float] = {}
+        for attr in sensitive:
+            values = [sensitive_values[idx][attr] for idx in indices]
+            counts = Counter(values)
+            per_class_l[attr] = {
+                "distinct": len(counts),
+                "entropy": _entropy(counts),
+            }
+            per_class_t[attr] = _variational_distance(
+                _distribution(values), global_dist[attr]
+            )
+        classes.append(
+            {
+                "key": json_keys[hash_key],
+                "size": len(indices),
+                "members": indices,
+                "l_diversity": per_class_l,
+                "t_closeness": per_class_t,
+            }
+        )
+
+    classes.sort(key=lambda cls: json.dumps(cls["key"], sort_keys=True))
+
+    sizes = [cls["size"] for cls in classes]
+    overall_l = {
+        attr: {
+            "min_distinct": min(
+                (cls["l_diversity"][attr]["distinct"] for cls in classes),
+                default=0,
+            ),
+            "min_entropy": min(
+                (cls["l_diversity"][attr]["entropy"] for cls in classes),
+                default=0.0,
+            ),
+        }
+        for attr in sensitive
+    }
+    overall_t = {
+        attr: max(
+            (cls["t_closeness"][attr] for cls in classes),
+            default=0.0,
+        )
+        for attr in sensitive
+    }
+
+    return {
+        "record_count": len(coerced),
+        "quasi_identifiers": _reported_quasi_identifiers(quasi_identifiers, classes),
+        "sensitive_attributes": sorted(sensitive),
+        "k": min(sizes) if sizes else 0,
+        "class_count": len(classes),
+        "class_size_distribution": _size_distribution(sizes),
+        "equivalence_classes": classes,
+        "l_diversity": overall_l,
+        "t_closeness": overall_t,
+        "l_metric": l_metric,
+        "t_distance": t_distance,
+    }
+
+
+def _equivalence_key(
+    record: Any,
+    quasi_identifiers: Sequence[str] | None,
+) -> tuple[Any, list[Any]]:
+    """Return (hashable grouping key, JSON-serializable key) for a record."""
+    if quasi_identifiers:
+        pairs = tuple(
+            (field, _normalize_qi_value(field, record.fields.get(field, "")))
+            for field in sorted(quasi_identifiers)
+        )
+        return pairs, [[field, value] for field, value in pairs]
+
+    profile_key = _profile_record(record).key
+    json_key = [[category, list(values)] for category, values in profile_key]
+    return profile_key, json_key
+
+
+def _distribution(values: Any) -> dict[str, float]:
+    counts = Counter(values)
+    total = sum(counts.values())
+    if total == 0:
+        return {}
+    return {value: count / total for value, count in counts.items()}
+
+
+def _entropy(counts: Mapping[str, int]) -> float:
+    total = sum(counts.values())
+    if total == 0:
+        return 0.0
+    entropy = 0.0
+    for count in counts.values():
+        if count == 0:
+            continue
+        probability = count / total
+        entropy -= probability * math.log2(probability)
+    # Normalize -0.0 to 0.0 for clean, JSON-stable output.
+    return entropy + 0.0
+
+
+def _variational_distance(
+    class_dist: Mapping[str, float],
+    global_dist: Mapping[str, float],
+) -> float:
+    values = set(class_dist) | set(global_dist)
+    total = sum(
+        abs(class_dist.get(value, 0.0) - global_dist.get(value, 0.0))
+        for value in values
+    )
+    return 0.5 * total
+
+
+def _size_distribution(sizes: Sequence[int]) -> list[list[int]]:
+    counts = Counter(sizes)
+    return [[size, counts[size]] for size in sorted(counts)]
+
+
+def _reported_quasi_identifiers(
+    quasi_identifiers: Sequence[str] | None,
+    classes: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    if quasi_identifiers:
+        return sorted(quasi_identifiers)
+    categories: set[str] = set()
+    for cls in classes:
+        for entry in cls["key"]:
+            categories.add(str(entry[0]))
+    return sorted(categories)

--- a/tests/unit/risk/test_kanon.py
+++ b/tests/unit/risk/test_kanon.py
@@ -1,0 +1,141 @@
+"""Tests for k-anonymity / l-diversity / t-closeness measurement (issue #500)."""
+
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+from openmed.risk import kanon_report
+
+
+def _classes_by_size(report):
+    return sorted(c["size"] for c in report["equivalence_classes"])
+
+
+class TestKAnonymity:
+    RECORDS = [
+        {"age": 30, "zip": "1000", "disease": "flu"},
+        {"age": 30, "zip": "1000", "disease": "cold"},
+        {"age": 41, "zip": "2000", "disease": "flu"},  # singleton
+    ]
+
+    def test_k_min_and_singleton_class(self):
+        report = kanon_report(
+            self.RECORDS,
+            quasi_identifiers=["age", "zip"],
+            sensitive_attributes=["disease"],
+        )
+        assert report["k"] == 1
+        assert report["class_count"] == 2
+        assert _classes_by_size(report) == [1, 2]
+        singletons = [c for c in report["equivalence_classes"] if c["size"] == 1]
+        assert len(singletons) == 1
+
+    def test_higher_k_when_all_classes_share_key(self):
+        records = [
+            {"age": 30, "zip": "1000", "disease": "flu"},
+            {"age": 30, "zip": "1000", "disease": "cold"},
+        ]
+        report = kanon_report(
+            records, quasi_identifiers=["age", "zip"], sensitive_attributes=["disease"]
+        )
+        assert report["k"] == 2
+        assert report["class_count"] == 1
+
+
+class TestLDiversity:
+    def test_distinct_is_one_when_each_class_has_single_value(self):
+        records = [
+            {"age": 30, "zip": "1000", "disease": "flu"},
+            {"age": 30, "zip": "1000", "disease": "flu"},
+            {"age": 41, "zip": "2000", "disease": "cold"},
+        ]
+        report = kanon_report(
+            records, quasi_identifiers=["age", "zip"], sensitive_attributes=["disease"]
+        )
+        for cls in report["equivalence_classes"]:
+            assert cls["l_diversity"]["disease"]["distinct"] == 1
+            assert cls["l_diversity"]["disease"]["entropy"] == 0.0
+        assert report["l_diversity"]["disease"]["min_distinct"] == 1
+
+    def test_distinct_counts_multiple_sensitive_values(self):
+        records = [
+            {"g": "A", "disease": "flu"},
+            {"g": "A", "disease": "cold"},
+        ]
+        report = kanon_report(
+            records, quasi_identifiers=["g"], sensitive_attributes=["disease"]
+        )
+        cls = report["equivalence_classes"][0]
+        assert cls["l_diversity"]["disease"]["distinct"] == 2
+        assert cls["l_diversity"]["disease"]["entropy"] == pytest.approx(1.0)
+
+
+class TestTCloseness:
+    def test_class_matching_global_distribution_is_zero(self):
+        records = [
+            {"g": "A", "disease": "flu"},
+            {"g": "A", "disease": "cold"},
+            {"g": "B", "disease": "flu"},
+            {"g": "B", "disease": "cold"},
+        ]
+        report = kanon_report(
+            records, quasi_identifiers=["g"], sensitive_attributes=["disease"]
+        )
+        for cls in report["equivalence_classes"]:
+            assert cls["t_closeness"]["disease"] == pytest.approx(0.0, abs=1e-9)
+        assert report["t_closeness"]["disease"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_skewed_class_has_positive_distance(self):
+        records = [
+            {"g": "A", "disease": "flu"},
+            {"g": "A", "disease": "flu"},
+            {"g": "B", "disease": "cold"},
+            {"g": "B", "disease": "cold"},
+        ]
+        report = kanon_report(
+            records, quasi_identifiers=["g"], sensitive_attributes=["disease"]
+        )
+        # Global is 50/50; each class is 100% one value -> TV distance 0.5.
+        assert report["t_closeness"]["disease"] == pytest.approx(0.5)
+
+
+class TestContract:
+    RECORDS = [
+        {"age": 30, "zip": "1000", "disease": "flu"},
+        {"age": 30, "zip": "1000", "disease": "cold"},
+        {"age": 41, "zip": "2000", "disease": "flu"},
+    ]
+
+    def test_deterministic_and_json_serializable(self):
+        kwargs = dict(
+            quasi_identifiers=["age", "zip"], sensitive_attributes=["disease"]
+        )
+        first = kanon_report(self.RECORDS, **kwargs)
+        second = kanon_report(self.RECORDS, **kwargs)
+        assert first == second
+        assert json.loads(json.dumps(first)) == first
+
+    def test_importable_and_exported(self):
+        import openmed.risk as risk
+
+        assert hasattr(risk, "kanon_report")
+        assert "kanon_report" in risk.__all__
+
+    def test_no_sensitive_attributes_reports_k_only(self):
+        report = kanon_report(self.RECORDS, quasi_identifiers=["age", "zip"])
+        assert report["k"] == 1
+        assert report["l_diversity"] == {}
+        assert report["t_closeness"] == {}
+
+    def test_auto_quasi_identifier_detection_runs(self):
+        # Without explicit QIs, fall back to risk_report-consistent profiling.
+        records = [
+            {"text": "SSN 123-45-6789"},
+            {"text": "SSN 987-65-4321"},
+        ]
+        report = kanon_report(records, sensitive_attributes=None)
+        assert report["k"] >= 1
+        assert json.loads(json.dumps(report)) == report


### PR DESCRIPTION
Implements #500 (OM-307): adds the standard disclosure-control trio as **measurement-only** metrics over de-identified tabular records. `risk_report()` already computes `k_min`/uniqueness; this adds per-equivalence-class k-anonymity, l-diversity and t-closeness so privacy reviewers can see leakage that aggregate uniqueness misses.

This is **not** the ARX generalization/suppression engine (OM-044) — it only reports on existing outputs.

## Changes

- **`openmed/risk/kanon.py`** — `kanon_report(records, quasi_identifiers=None, sensitive_attributes=None, *, l_metric="distinct", t_distance="variational")` returning:
  - equivalence-class sizes + **k** (min class size) + class-size distribution,
  - per-class **l-diversity** (distinct count + Shannon entropy),
  - per-class **t-closeness** (total-variation distance between the class sensitive distribution and the global one),
  - worst-case **overall** l (min distinct) and t (max class distance).
- **Reuses `reid.py`** (`_coerce_records`, `_profile_record`, `_normalize_qi_value`) so the equivalence-class key derivation matches `risk_report()`: auto-detection uses the same `_profile_record` key, and an explicit `quasi_identifiers` list builds the key from those fields with the same normalization — QIs are not re-derived differently.
- Output is **deterministic** (sorted classes, JSON-safe size distribution/keys) and **JSON-serializable** (`json.dumps` round-trips). Exported from `openmed.risk`.

## Acceptance criteria

- [x] A table with two records sharing a QI key + one singleton reports `k=1` and lists the singleton equivalence class.
- [x] When every class has a single sensitive value, l-diversity (distinct) is 1 per class and overall l is 1.
- [x] t-closeness for a class whose sensitive distribution equals the global is `0.0` (within tolerance); a skewed class is positive.
- [x] Output is deterministic across repeated calls and `json.dumps` round-trips.
- [x] `openmed.risk.kanon_report` is importable from the package root and in `__all__`.

## Testing

- New `tests/unit/risk/test_kanon.py` (10 tests). Full unit suite passes (`.venv/bin/python -m pytest tests/ -q` -> 2183 passed, 19 skipped).
- The only 2 failures in the full run are the pre-existing network-gated integration tests (`tests/integration/test_sentence_detection_real.py`); they fail identically on `master` offline and are unrelated.
- `ruff check` and `ruff format` clean. No new dependencies.

## Out of scope

- ARX-style generalization/suppression/microaggregation to achieve a target k (OM-044).
- Text re-identification scoring (already in `risk_report`).
- Differential-privacy noise mechanisms.

Closes #500