### PR TITLE
feat: add a membership-inference probe to the re-identification attack modes

### DIFF
--- a/openmed/eval/attacks/__init__.py
+++ b/openmed/eval/attacks/__init__.py
@@ -1,8 +1,10 @@
 """Adversarial evaluation attacks for benchmark reports."""
 
 from .reid import (
+    MembershipInferenceResult,
     ReidAttackResult,
     generate_reid_leaderboard,
+    membership_inference_attack,
     render_reid_leaderboard,
     run_reid_attack,
     run_reid_benchmark,
@@ -10,7 +12,9 @@ from .reid import (
 
 __all__ = [
     "ReidAttackResult",
+    "MembershipInferenceResult",
     "generate_reid_leaderboard",
+    "membership_inference_attack",
     "render_reid_leaderboard",
     "run_reid_attack",
     "run_reid_benchmark",

--- a/openmed/eval/attacks/reid.py
+++ b/openmed/eval/attacks/reid.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from collections import defaultdict
+import re
+from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -57,11 +58,17 @@ def run_reid_benchmark(
     model_name: str = "privacy-filter",
     deidentified_records: Sequence[Mapping[str, Any]] | None = None,
     auxiliary_records: Sequence[Mapping[str, Any]] | None = None,
+    candidate_members: Sequence[Mapping[str, Any]] | None = None,
     output_json: str | Path | None = None,
     output_markdown: str | Path | None = None,
     generated_at: str | None = None,
 ) -> BenchmarkReport:
-    """Run the re-identification attack and return a BenchmarkReport."""
+    """Run the re-identification attack and return a BenchmarkReport.
+
+    When ``candidate_members`` is provided, the membership-inference probe runs
+    against the de-identified records and its result is added to the report
+    metrics under ``"membership_inference"``.
+    """
 
     fixtures = _load_suite_fixtures(suite)
     result = run_reid_attack(
@@ -69,20 +76,30 @@ def run_reid_benchmark(
         deidentified_records=deidentified_records,
         auxiliary_records=auxiliary_records,
     )
+    metrics: dict[str, Any] = {
+        "reid_leakage": {
+            "rate": result.rate,
+            "numerator": result.numerator,
+            "denominator": result.denominator,
+        },
+        "reidentification": result.to_metric(),
+    }
+    if candidate_members is not None:
+        deidentified = (
+            list(deidentified_records)
+            if deidentified_records is not None
+            else [_deidentified_record(fixture) for fixture in fixtures]
+        )
+        metrics["membership_inference"] = membership_inference_attack(
+            deidentified, candidate_members
+        ).to_metric()
     report = BenchmarkReport(
         suite=suite,
         model_name=model_name,
         device="attack",
         fixture_count=result.denominator,
         generated_at=generated_at or _utc_now(),
-        metrics={
-            "reid_leakage": {
-                "rate": result.rate,
-                "numerator": result.numerator,
-                "denominator": result.denominator,
-            },
-            "reidentification": result.to_metric(),
-        },
+        metrics=metrics,
         metadata={
             "attack": "reid",
             "leaderboard_metric": "reid_leakage_rate",
@@ -142,6 +159,148 @@ def run_reid_attack(
             "fixture_ids": [fixture.fixture_id for fixture in normalized_fixtures]
         },
     )
+
+
+_ID_FIELDS = ("record_id", "doc_id", "id")
+_TOKEN_RE = re.compile(r"[a-z0-9]{4,}")
+
+
+@dataclass(frozen=True)
+class MembershipInferenceResult:
+    """Membership-inference probe score over de-identified records.
+
+    ``advantage`` is the attacker accuracy above the 0.5 chance baseline:
+    confident-correct decisions count 1.0, confident-wrong 0.0, and records
+    with no distinguishing residual signal count as chance (0.5).
+    """
+
+    advantage: float
+    accuracy: float
+    record_count: int
+    confident_count: int
+    per_record: tuple[dict[str, Any], ...]
+    baseline: float = 0.5
+
+    def to_metric(self) -> dict[str, Any]:
+        return {
+            "advantage": float(self.advantage),
+            "accuracy": float(self.accuracy),
+            "baseline": float(self.baseline),
+            "record_count": int(self.record_count),
+            "confident_count": int(self.confident_count),
+            "per_record": [dict(row) for row in self.per_record],
+        }
+
+
+def membership_inference_attack(
+    deidentified_records: Sequence[Mapping[str, Any]],
+    candidate_members: Sequence[Mapping[str, Any]],
+    *,
+    threshold: int = 1,
+) -> MembershipInferenceResult:
+    """Score whether each de-identified record's source is in the candidates.
+
+    Each record is matched to candidates by residual quasi-identifier overlap
+    and surviving rare tokens. A token held by exactly one candidate is
+    *distinguishing*; when a record's distinguishing tokens point to a single
+    candidate (with at least ``threshold`` hits), the attacker confidently
+    predicts that candidate. The ground-truth source id is used only to score
+    correctness, never as an attack feature.
+    """
+    deidentified = list(deidentified_records)
+    candidates = list(candidate_members)
+
+    candidate_ids = [_record_id(record) for record in candidates]
+    candidate_features = _feature_sets(candidates)
+    token_to_candidates: defaultdict[str, set[str]] = defaultdict(set)
+    for cid, features in zip(candidate_ids, candidate_features):
+        for token in features:
+            token_to_candidates[token].add(cid)
+
+    deid_features = _feature_sets(deidentified)
+    known_ids = set(candidate_ids)
+
+    per_record: list[dict[str, Any]] = []
+    outcomes: list[float] = []
+    confident_count = 0
+    for record, features in zip(deidentified, deid_features):
+        record_id = _record_id(record)
+        hits: Counter[str] = Counter()
+        for token in features:
+            owners = token_to_candidates.get(token, set())
+            if len(owners) == 1:
+                hits[next(iter(owners))] += 1
+
+        best = _best_candidate(hits)
+        confident = best is not None and hits[best] >= threshold
+        true_source = record_id if record_id in known_ids else None
+
+        if confident:
+            confident_count += 1
+            outcome = 1.0 if best == true_source else 0.0
+        else:
+            outcome = 0.5  # no distinguishing signal -> chance
+        outcomes.append(outcome)
+
+        per_record.append(
+            {
+                "record_id": record_id,
+                "matched_candidate": best if confident else None,
+                "confidence": (hits[best] / len(features))
+                if confident and features
+                else 0.0,
+                "distinguishing_hits": int(hits[best]) if confident else 0,
+                "outcome": outcome,
+            }
+        )
+
+    accuracy = sum(outcomes) / len(outcomes) if outcomes else 0.5
+    return MembershipInferenceResult(
+        advantage=accuracy - 0.5,
+        accuracy=accuracy,
+        record_count=len(deidentified),
+        confident_count=confident_count,
+        per_record=tuple(per_record),
+    )
+
+
+def _best_candidate(hits: Counter[str]) -> str | None:
+    if not hits:
+        return None
+    # Deterministic: most hits, ties broken by sorted candidate id.
+    return min(sorted(hits), key=lambda cid: (-hits[cid], cid))
+
+
+def _feature_sets(records: Sequence[Mapping[str, Any]]) -> list[set[str]]:
+    """Residual features per record: reused QI values plus surviving tokens.
+
+    Identifier fields are excluded so the ground-truth id never leaks into the
+    attack features.
+    """
+    sanitized = [_without_id_fields(record) for record in records]
+    risk = risk_report(sanitized)
+    qi_by_index: defaultdict[int, set[str]] = defaultdict(set)
+    for qi in risk.get("quasi_identifiers") or ():
+        value = str(qi.get("normalized_value") or "").strip()
+        if value:
+            qi_by_index[int(qi.get("record_index", -1))].add(value)
+
+    feature_sets: list[set[str]] = []
+    for index, record in enumerate(records):
+        tokens = _residual_tokens(record)
+        feature_sets.append(tokens | qi_by_index.get(index, set()))
+    return feature_sets
+
+
+def _without_id_fields(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in record.items() if key not in _ID_FIELDS}
+
+
+def _residual_tokens(record: Mapping[str, Any]) -> set[str]:
+    text = " ".join(
+        str(value) for key, value in record.items() if key not in _ID_FIELDS
+    )
+    return set(_TOKEN_RE.findall(text.lower()))
 
 
 def generate_reid_leaderboard(
@@ -368,7 +527,9 @@ def _utc_now() -> str:
 
 __all__ = [
     "ReidAttackResult",
+    "MembershipInferenceResult",
     "generate_reid_leaderboard",
+    "membership_inference_attack",
     "render_reid_leaderboard",
     "run_reid_attack",
     "run_reid_benchmark",

--- a/tests/unit/eval/attacks/test_membership_inference.py
+++ b/tests/unit/eval/attacks/test_membership_inference.py
@@ -1,0 +1,88 @@
+"""Tests for the membership-inference re-identification probe (issue #511)."""
+
+from __future__ import annotations
+
+from openmed.eval.attacks import membership_inference_attack, run_reid_benchmark
+
+
+class TestMembershipInference:
+    def test_no_residual_signal_yields_zero_advantage(self):
+        candidates = [
+            {"record_id": "r1", "text": "Alice Smith visited clinic"},
+            {"record_id": "r2", "text": "Bob Smith visited clinic"},
+        ]
+        # Fully redacted: residual tokens are shared/common, not distinguishing.
+        deidentified = [
+            {"record_id": "r1", "text": "[NAME] visited clinic"},
+            {"record_id": "r2", "text": "[NAME] visited clinic"},
+        ]
+        result = membership_inference_attack(deidentified, candidates)
+        assert result.advantage == 0.0
+        assert all(row["matched_candidate"] is None for row in result.per_record)
+
+    def test_unique_residual_token_identifies_candidate(self):
+        candidates = [
+            {"record_id": "r1", "text": "Alice Zsoltay visited clinic"},
+            {"record_id": "r2", "text": "Bob Smith visited clinic"},
+        ]
+        deidentified = [
+            {"record_id": "r1", "text": "[NAME] Zsoltay visited clinic"},  # leaks
+            {"record_id": "r2", "text": "[NAME] [NAME] visited clinic"},
+        ]
+        result = membership_inference_attack(deidentified, candidates)
+        assert result.advantage > 0.0
+        matched = {
+            row["record_id"]: row["matched_candidate"] for row in result.per_record
+        }
+        assert matched["r1"] == "r1"
+        assert matched["r2"] is None
+
+    def test_deterministic_for_fixed_input(self):
+        candidates = [
+            {"record_id": "r1", "text": "Alice Zsoltay visited clinic"},
+            {"record_id": "r2", "text": "Bob Smith visited clinic"},
+        ]
+        deidentified = [
+            {"record_id": "r1", "text": "[NAME] Zsoltay visited clinic"},
+            {"record_id": "r2", "text": "[NAME] [NAME] visited clinic"},
+        ]
+        first = membership_inference_attack(deidentified, candidates)
+        second = membership_inference_attack(deidentified, candidates)
+        assert first.to_metric() == second.to_metric()
+
+    def test_advantage_is_accuracy_above_half(self):
+        candidates = [
+            {"record_id": "r1", "text": "Alice Zsoltay visited clinic"},
+            {"record_id": "r2", "text": "Bob Smith visited clinic"},
+        ]
+        deidentified = [
+            {"record_id": "r1", "text": "[NAME] Zsoltay visited clinic"},
+            {"record_id": "r2", "text": "[NAME] [NAME] visited clinic"},
+        ]
+        result = membership_inference_attack(deidentified, candidates)
+        assert result.advantage == result.accuracy - 0.5
+        assert result.baseline == 0.5
+
+
+class TestBenchmarkWiring:
+    def test_membership_inference_metric_appears_in_report(self):
+        candidates = [
+            {"record_id": "r1", "text": "Alice Zsoltay visited clinic"},
+            {"record_id": "r2", "text": "Bob Smith visited clinic"},
+        ]
+        deidentified = [
+            {"record_id": "r1", "text": "[NAME] Zsoltay visited clinic"},
+            {"record_id": "r2", "text": "[NAME] [NAME] visited clinic"},
+        ]
+        report = run_reid_benchmark(
+            deidentified_records=deidentified,
+            candidate_members=candidates,
+        )
+        assert "membership_inference" in report.metrics
+        assert "advantage" in report.metrics["membership_inference"]
+
+    def test_membership_inference_absent_without_candidates(self):
+        report = run_reid_benchmark(
+            deidentified_records=[{"record_id": "r1", "text": "[NAME] visited"}],
+        )
+        assert "membership_inference" not in report.metrics


### PR DESCRIPTION
Implements #511 (OM-321): adds a membership-inference probe alongside the existing leakage, surrogate-consistency and date-shift-inversion attack modes. Membership inference asks whether a candidate "member" record was the source of a de-identified record, using residual quasi-identifier overlap and surviving rare tokens — a distinct re-id threat from aux-table linkage.

## Changes

- **`openmed/eval/attacks/reid.py`**
  - `membership_inference_attack(deidentified_records, candidate_members, *, threshold=1)` scores each de-identified record against candidates. Feature set per record = reused QI normalized values + surviving rare tokens. A token held by **exactly one** candidate is *distinguishing*; when a records distinguishing tokens point to a single candidate (≥ `threshold` hits), the attacker confidently predicts it.
  - Returns `MembershipInferenceResult` with an **advantage** metric (attacker accuracy above the 0.5 chance baseline: confident-correct = 1.0, confident-wrong = 0.0, no-signal = 0.5), per-record confidence scores, and the matched candidate id when confident. The ground-truth source id is used **only** to score correctness — never as an attack feature (identifier fields are excluded from feature extraction).
  - Reuses `risk_report`s quasi-identifier profiling for QI extraction, so the probe is consistent with existing risk scoring.
  - `run_reid_benchmark(candidate_members=...)` adds a `membership_inference` metric (incl. `advantage`) to the `BenchmarkReport`.
- Exported from `openmed.eval.attacks`.

## Acceptance criteria

- [x] De-identified records with no distinguishing residual tokens → advantage ≈ 0.0.
- [x] A record leaking a unique residual token matching exactly one candidate → that candidate is identified and advantage is positive.
- [x] The `membership_inference` metric appears in the `BenchmarkReport` metrics from `run_reid_benchmark` when the mode is selected.
- [x] Deterministic for fixed input (set/sorted ops, no RNG).

## Testing

- New `tests/unit/eval/attacks/test_membership_inference.py` (6 tests). Full unit suite passes (`.venv/bin/python -m pytest tests/ -q` -> 2179 passed, 19 skipped).
- The only 2 failures in the full run are the pre-existing network-gated integration tests (`tests/integration/test_sentence_detection_real.py`); they fail identically on `master` offline and are unrelated.
- `ruff check` and `ruff format` clean. No new dependencies; synthetic fixtures only.

## Out of scope

- A learned membership-inference classifier.
- The aux-table linkage attack (separate mode).
- New public/gated corpora.

Closes #511