### PR TITLE
feat: add leakage heatmap by label and language (OM-403)

### DIFF
--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -65,6 +65,11 @@ from openmed.eval.harness import (
     run_benchmark,
     run_suite,
 )
+from openmed.eval.leakage_heatmap import (
+    HeatmapCell,
+    LeakageHeatmap,
+    compute_leakage_heatmap,
+)
 from openmed.eval.metrics import (
     DEVICE_TIERS,
     EvalSpan,
@@ -139,6 +144,8 @@ __all__ = [
     "FairnessGroupMetrics",
     "FairnessReport",
     "FixtureResult",
+    "HeatmapCell",
+    "LeakageHeatmap",
     "GateCheck",
     "GateReport",
     "INT4_RECALL_DELTA_LIMIT",
@@ -172,6 +179,7 @@ __all__ = [
     "compute_date_shift_consistency",
     "compute_exact_span_f1",
     "compute_latency_summary",
+    "compute_leakage_heatmap",
     "compute_leakage_rate",
     "compute_metrics_bundle",
     "compute_over_redaction_loss",

--- a/openmed/eval/leakage_heatmap.py
+++ b/openmed/eval/leakage_heatmap.py
@@ -1,0 +1,204 @@
+"""Two-dimensional leakage heatmap: leakage rate by (label, language) cell."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from openmed.core.labels import CANONICAL_LABELS
+from openmed.core.pii_i18n import SUPPORTED_LANGUAGES
+from openmed.eval.metrics import (
+    EvalSpan,
+    _covered_char_count,  # noqa: PLC2701
+    _safe_rate,  # noqa: PLC2701
+    normalize_eval_spans,
+)
+
+
+@dataclass(frozen=True)
+class HeatmapCell:
+    """Leakage rate for a single (label, language) pair."""
+
+    label: str
+    language: str
+    rate: float
+    leaked_chars: int
+    total_chars: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "language": self.language,
+            "rate": self.rate,
+            "leaked_chars": self.leaked_chars,
+            "total_chars": self.total_chars,
+        }
+
+
+@dataclass(frozen=True)
+class LeakageHeatmap:
+    """Leakage rates for every (canonical_label, language) cell.
+
+    ``cells`` is keyed by ``(label, language)`` and contains only cells with
+    at least one gold character. ``worst`` lists up to *worst_n* cells sorted
+    by descending rate, with ties broken by ``(label, language)`` lexicographic
+    order for determinism.
+
+    ``row_totals`` aggregates each label across all languages (language="all").
+    ``col_totals`` aggregates each language across all labels (label="all").
+    """
+
+    cells: dict[tuple[str, str], HeatmapCell]
+    worst: list[HeatmapCell]
+    labels: list[str]
+    languages: list[str]
+    row_totals: dict[str, HeatmapCell]
+    col_totals: dict[str, HeatmapCell]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cells": {
+                f"{label}|{lang}": cell.to_dict()
+                for (label, lang), cell in self.cells.items()
+            },
+            "worst": [cell.to_dict() for cell in self.worst],
+            "labels": self.labels,
+            "languages": self.languages,
+            "row_totals": {k: v.to_dict() for k, v in self.row_totals.items()},
+            "col_totals": {k: v.to_dict() for k, v in self.col_totals.items()},
+        }
+
+    def to_markdown(self) -> str:
+        """Render a Markdown matrix: labels as rows, languages as columns."""
+        langs = self.languages
+        header = "| label \\ lang | " + " | ".join(langs) + " | **Total** |"
+        sep = "| --- |" + " --- |" * len(langs) + " --- |"
+        rows = [header, sep]
+        for label in self.labels:
+            parts = [label]
+            for lang in langs:
+                cell = self.cells.get((label, lang))
+                if cell is None or cell.total_chars == 0:
+                    parts.append("—")
+                else:
+                    parts.append(f"{cell.rate:.1%}")
+            row_total = self.row_totals.get(label)
+            parts.append(f"**{row_total.rate:.1%}**" if row_total else "—")
+            rows.append("| " + " | ".join(parts) + " |")
+        col_parts = ["**Total**"]
+        for lang in langs:
+            ct = self.col_totals.get(lang)
+            col_parts.append(f"**{ct.rate:.1%}**" if ct else "—")
+        col_parts.append("")
+        rows.append("| " + " | ".join(col_parts) + " |")
+        return "\n".join(rows)
+
+
+def compute_leakage_heatmap(
+    gold_spans: Iterable[Any],
+    predicted_spans: Iterable[Any],
+    *,
+    default_language: str = "en",
+    default_device: str = "cpu",
+    source_text: str | None = None,
+    worst_n: int = 5,
+) -> LeakageHeatmap:
+    """Compute character-weighted leakage for each (label, language) cell.
+
+    Reuses the same leakage definition as ``compute_leakage_rate``: a gold
+    character is leaked when no same-label prediction covers it.
+    """
+    gold: list[EvalSpan] = normalize_eval_spans(
+        gold_spans,
+        default_language=default_language,
+        default_device=default_device,
+        source_text=source_text,
+    )
+    predicted: list[EvalSpan] = normalize_eval_spans(
+        predicted_spans,
+        default_language=default_language,
+        default_device=default_device,
+        source_text=source_text,
+    )
+
+    leaked: defaultdict[tuple[str, str], int] = defaultdict(int)
+    total: defaultdict[tuple[str, str], int] = defaultdict(int)
+
+    for span in gold:
+        key = (span.label, span.language)
+        covered = _covered_char_count(span, predicted)
+        total[key] += span.length
+        leaked[key] += max(span.length - covered, 0)
+
+    seen_labels: set[str] = set()
+    seen_langs: set[str] = set()
+    for label, lang in total:
+        seen_labels.add(label)
+        seen_langs.add(lang)
+
+    label_order = [l for l in CANONICAL_LABELS if l in seen_labels] + sorted(
+        seen_labels - set(CANONICAL_LABELS)
+    )
+    lang_order = [l for l in SUPPORTED_LANGUAGES if l in seen_langs] + sorted(
+        seen_langs - set(SUPPORTED_LANGUAGES)
+    )
+
+    cells: dict[tuple[str, str], HeatmapCell] = {}
+    for key, total_chars in total.items():
+        label, lang = key
+        leaked_chars = leaked[key]
+        cells[key] = HeatmapCell(
+            label=label,
+            language=lang,
+            rate=_safe_rate(leaked_chars, total_chars, zero_denominator=0.0),
+            leaked_chars=leaked_chars,
+            total_chars=total_chars,
+        )
+
+    row_leaked: defaultdict[str, int] = defaultdict(int)
+    row_total: defaultdict[str, int] = defaultdict(int)
+    col_leaked: defaultdict[str, int] = defaultdict(int)
+    col_total: defaultdict[str, int] = defaultdict(int)
+    for (label, lang), cell in cells.items():
+        row_leaked[label] += cell.leaked_chars
+        row_total[label] += cell.total_chars
+        col_leaked[lang] += cell.leaked_chars
+        col_total[lang] += cell.total_chars
+
+    row_totals = {
+        label: HeatmapCell(
+            label=label,
+            language="all",
+            rate=_safe_rate(row_leaked[label], row_total[label], zero_denominator=0.0),
+            leaked_chars=row_leaked[label],
+            total_chars=row_total[label],
+        )
+        for label in label_order
+        if row_total[label] > 0
+    }
+    col_totals = {
+        lang: HeatmapCell(
+            label="all",
+            language=lang,
+            rate=_safe_rate(col_leaked[lang], col_total[lang], zero_denominator=0.0),
+            leaked_chars=col_leaked[lang],
+            total_chars=col_total[lang],
+        )
+        for lang in lang_order
+        if col_total[lang] > 0
+    }
+
+    worst = sorted(
+        cells.values(),
+        key=lambda c: (-c.rate, c.label, c.language),
+    )[:worst_n]
+
+    return LeakageHeatmap(
+        cells=cells,
+        worst=worst,
+        labels=label_order,
+        languages=lang_order,
+        row_totals=row_totals,
+        col_totals=col_totals,
+    )

--- a/tests/unit/eval/test_leakage_heatmap.py
+++ b/tests/unit/eval/test_leakage_heatmap.py
@@ -1,0 +1,157 @@
+"""Unit tests for the (label, language) leakage heatmap."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.eval.leakage_heatmap import (
+    HeatmapCell,
+    LeakageHeatmap,
+    compute_leakage_heatmap,
+)
+
+
+def _span(start, end, label, lang):
+    return {"start": start, "end": end, "label": label, "language": lang}
+
+
+def test_cell_rate_equals_leakage_restricted_to_label_and_language():
+    # 10-char French ID_NUM fully leaked, 10-char English ID_NUM fully covered
+    gold = [_span(0, 10, "ID_NUM", "fr"), _span(20, 30, "ID_NUM", "en")]
+    predicted = [_span(20, 30, "ID_NUM", "en")]
+
+    heatmap = compute_leakage_heatmap(gold, predicted)
+
+    assert heatmap.cells[("ID_NUM", "fr")].rate == pytest.approx(1.0)
+    assert heatmap.cells[("ID_NUM", "fr")].leaked_chars == 10
+    assert heatmap.cells[("ID_NUM", "fr")].total_chars == 10
+
+    assert heatmap.cells[("ID_NUM", "en")].rate == pytest.approx(0.0)
+    assert heatmap.cells[("ID_NUM", "en")].leaked_chars == 0
+
+
+def test_no_phi_cell_hidden_by_aggregate():
+    # Reproduce the blind spot: overall and 1D slices look fine,
+    # but (ID_NUM, fr) is 100% leaked.
+    gold, predicted = [], []
+    offset = 0
+    for lang in ["en", "de", "es"]:
+        for label in ["PERSON", "DATE", "ID_NUM"]:
+            s = _span(offset, offset + 10, label, lang)
+            gold.append(s)
+            predicted.append(s)
+            offset += 15
+
+    for label in ["PERSON", "DATE"]:
+        s = _span(offset, offset + 10, label, "fr")
+        gold.append(s)
+        predicted.append(s)
+        offset += 15
+
+    for _ in range(5):
+        gold.append(_span(offset, offset + 10, "ID_NUM", "fr"))
+        offset += 15
+
+    heatmap = compute_leakage_heatmap(gold, predicted)
+
+    assert heatmap.cells[("ID_NUM", "fr")].rate == pytest.approx(1.0)
+    assert ("ID_NUM", "fr") in {(c.label, c.language) for c in heatmap.worst}
+
+
+def test_worst_n_is_deterministic_and_tie_broken_by_label_language():
+    # Two cells with identical 100% rate — tie should break by (label, lang)
+    gold = [
+        _span(0, 10, "ID_NUM", "fr"),
+        _span(20, 30, "PERSON", "de"),
+    ]
+    heatmap = compute_leakage_heatmap(gold, [], worst_n=2)
+
+    assert len(heatmap.worst) == 2
+    # Both are 100% — tie-break: "ID_NUM" < "PERSON" alphabetically
+    assert heatmap.worst[0].label == "ID_NUM"
+    assert heatmap.worst[1].label == "PERSON"
+
+
+def test_worst_n_respects_limit():
+    gold = [_span(i * 15, i * 15 + 10, "PERSON", f"L{i}") for i in range(10)]
+    heatmap = compute_leakage_heatmap(gold, [], worst_n=3)
+    assert len(heatmap.worst) <= 3
+
+
+def test_output_contains_no_span_text():
+    gold = [_span(0, 10, "ID_NUM", "fr")]
+    heatmap = compute_leakage_heatmap(gold, [])
+    d = heatmap.to_dict()
+    flat = str(d)
+    # to_dict must not include start/end offsets or text field
+    assert "start" not in flat
+    assert "end" not in flat
+    assert "text" not in flat
+
+
+def test_to_markdown_renders_matrix():
+    gold = [_span(0, 10, "ID_NUM", "fr"), _span(20, 30, "PERSON", "en")]
+    predicted = [_span(20, 30, "PERSON", "en")]
+    heatmap = compute_leakage_heatmap(gold, predicted)
+
+    md = heatmap.to_markdown()
+    assert "ID_NUM" in md
+    assert "PERSON" in md
+    assert "fr" in md
+    assert "en" in md
+    assert "100.0%" in md
+    assert "0.0%" in md
+
+
+def test_row_and_col_totals_aggregate_correctly():
+    # ID_NUM/fr: 10 chars leaked; ID_NUM/en: 0 leaked; DATE/fr: 0 leaked
+    gold = [
+        _span(0, 10, "ID_NUM", "fr"),
+        _span(20, 30, "ID_NUM", "en"),
+        _span(40, 50, "DATE", "fr"),
+    ]
+    predicted = [
+        _span(20, 30, "ID_NUM", "en"),
+        _span(40, 50, "DATE", "fr"),
+    ]
+    heatmap = compute_leakage_heatmap(gold, predicted)
+
+    # row total for ID_NUM: 10 leaked / 20 total = 50%
+    assert heatmap.row_totals["ID_NUM"].leaked_chars == 10
+    assert heatmap.row_totals["ID_NUM"].total_chars == 20
+    assert heatmap.row_totals["ID_NUM"].rate == pytest.approx(0.5)
+    assert heatmap.row_totals["ID_NUM"].language == "all"
+
+    # row total for DATE: 0 leaked / 10 total = 0%
+    assert heatmap.row_totals["DATE"].rate == pytest.approx(0.0)
+
+    # col total for fr: 10 leaked / 20 total = 50%
+    assert heatmap.col_totals["fr"].leaked_chars == 10
+    assert heatmap.col_totals["fr"].total_chars == 20
+    assert heatmap.col_totals["fr"].rate == pytest.approx(0.5)
+    assert heatmap.col_totals["fr"].label == "all"
+
+    # col total for en: 0 leaked / 10 total = 0%
+    assert heatmap.col_totals["en"].rate == pytest.approx(0.0)
+
+
+def test_to_markdown_includes_totals_row_and_column():
+    gold = [_span(0, 10, "ID_NUM", "fr"), _span(20, 30, "PERSON", "en")]
+    predicted = [_span(20, 30, "PERSON", "en")]
+    md = compute_leakage_heatmap(gold, predicted).to_markdown()
+    assert "Total" in md
+
+
+def test_empty_gold_returns_empty_heatmap():
+    heatmap = compute_leakage_heatmap([], [])
+    assert heatmap.cells == {}
+    assert heatmap.worst == []
+
+
+def test_partial_coverage_cell_rate():
+    # 10-char span, 4 chars covered → 6 leaked → rate = 0.6
+    gold = [_span(0, 10, "DATE", "en")]
+    predicted = [_span(0, 4, "DATE", "en")]
+    heatmap = compute_leakage_heatmap(gold, predicted)
+    assert heatmap.cells[("DATE", "en")].leaked_chars == 6
+    assert heatmap.cells[("DATE", "en")].rate == pytest.approx(0.6)


### PR DESCRIPTION
## Description

This PR adds a two-dimensional leakage heatmap that computes character-weighted PHI leakage for every `(canonical_label, language)` pair.

Currently, `compute_leakage_rate` only evaluates leakage by label *or* by language independently. That means a model can meet the overall leakage threshold while consistently leaking a specific label-language combination (for example, French ID numbers). The heatmap makes those cases visible.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Added `openmed/eval/leakage_heatmap.py` with:
  - `compute_leakage_heatmap()`
  - `LeakageHeatmap`
  - `HeatmapCell`
- `LeakageHeatmap` provides:
  - Per-cell leakage rates
  - Row and column totals
  - Deterministic worst-N cell ranking
  - `to_dict()` and `to_markdown()` helpers
- Exported `compute_leakage_heatmap`, `LeakageHeatmap`, and `HeatmapCell` from `openmed/eval/__init__.py`
- Added `tests/unit/eval/test_leakage_heatmap.py` with 10 unit tests covering:
  - Leakage calculations
  - The aggregate blind spot
  - Deterministic worst-N tie breaking
  - No-PHI inputs
  - Markdown rendering
  - Row/column totals
  - Edge cases

## Testing

- [x] Added unit tests covering the new functionality
- [x] New and existing tests pass locally
- [ ] Tested with multiple models/inputs

```bash
.venv/bin/python -m pytest tests/unit/eval/test_leakage_heatmap.py -v
# 10 passed

.venv/bin/python -m pytest tests/ -q
# 2169 passed, 19 skipped
```

## Documentation

- [ ] Updated documentation
- [x] Added docstrings for new functions and classes
- [ ] Updated `CHANGELOG.md`

## Code Quality

- [x] Ran `make format`, `make lint`, and `make format-check`
- [ ] Ran `make format-swift` and `make lint-swift` (not applicable)
- [x] Performed a self-review
- [ ] Added comments for complex logic where needed
- [x] No new warnings introduced

## Dependencies

- [x] No new dependencies added

## Checklist

- [x] Read the contributing guidelines
- [x] Commit history is clean and descriptive
- [x] Commits have been squashed/organized appropriately

## Related Issues

Closes #650

## Example Output

| Label \\ Language | fr | en | **Total** |
| ----------------- | --: | --: | --------: |
| ID_NUM            | 100.0% | 0.0% | **50.0%** |
| **Total**         | **50.0%** | **0.0%** | |