### PR TITLE
Add a policy-profile validator and linter with a CLI command

### DIFF
--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -135,6 +135,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_pii_command(subparsers)
     _add_benchmark_command(subparsers)
     _add_models_command(subparsers)
+    _add_policy_command(subparsers)
     _add_config_command(subparsers)
     add_calibrate_command(subparsers)
     return parser
@@ -587,6 +588,28 @@ def _add_config_command(subparsers: argparse._SubParsersAction) -> None:
     )
     profile_delete.add_argument("profile_name", help="Name of the profile to delete.")
     profile_delete.set_defaults(handler=_handle_profile_delete)
+
+
+def _add_policy_command(subparsers: argparse._SubParsersAction) -> None:
+    policy_parser = subparsers.add_parser(
+        "policy", help="Inspect and validate OpenMed policy profiles."
+    )
+    policy_sub = policy_parser.add_subparsers(dest="policy_command")
+
+    policy_lint = policy_sub.add_parser(
+        "lint",
+        help="Lint a bundled policy name or policy profile JSON file.",
+    )
+    policy_lint.add_argument(
+        "target",
+        help="Policy profile name or path to a policy profile JSON file.",
+    )
+    policy_lint.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return a non-zero exit code when warnings are present.",
+    )
+    policy_lint.set_defaults(handler=_handle_policy_lint)
 
 
 def _add_benchmark_command(subparsers: argparse._SubParsersAction) -> None:
@@ -1301,6 +1324,23 @@ def _coerce_value(key: str, value: str) -> Any:
         except ValueError:
             raise ValueError("timeout must be an integer") from None
     return value
+
+
+# ---------------------------------------------------------------------------
+# Policy Handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_policy_lint(args: argparse.Namespace) -> int:
+    from ..core.policy_lint import lint_policy
+
+    report = lint_policy(args.target)
+    sys.stdout.write(f"{json.dumps(report, indent=2, sort_keys=True)}\n")
+    if report["errors"]:
+        return 1
+    if args.strict and report["warnings"]:
+        return 1
+    return 0
 
 
 # ---------------------------------------------------------------------------

--- a/openmed/core/policy_lint.py
+++ b/openmed/core/policy_lint.py
@@ -1,0 +1,479 @@
+"""Policy profile linting for bundled and file-based profiles."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any, Mapping
+
+from .labels import (
+    CANONICAL_LABELS,
+    DIRECT_IDENTIFIER,
+    POLICY_LABELS,
+    policy_label_for,
+)
+from .policy import _profile_from_mapping, canonical_policy_name
+from .thresholds import load_thresholds
+
+POLICY_SOURCE_NOT_FOUND = "POLICY_SOURCE_NOT_FOUND"
+POLICY_JSON_INVALID = "POLICY_JSON_INVALID"
+POLICY_SCHEMA_INVALID = "POLICY_SCHEMA_INVALID"
+POLICY_UNKNOWN_ACTION_LABEL = "POLICY_UNKNOWN_ACTION_LABEL"
+POLICY_DUPLICATE_ACTION_LABEL = "POLICY_DUPLICATE_ACTION_LABEL"
+POLICY_ACTION_LABEL_SET_MISMATCH = "POLICY_ACTION_LABEL_SET_MISMATCH"
+POLICY_UNKNOWN_POLICY_LABEL = "POLICY_UNKNOWN_POLICY_LABEL"
+POLICY_DUPLICATE_POLICY_LABEL = "POLICY_DUPLICATE_POLICY_LABEL"
+POLICY_UNKNOWN_THRESHOLD_PROFILE = "POLICY_UNKNOWN_THRESHOLD_PROFILE"
+POLICY_HIPAA_DIRECT_IDENTIFIER_KEEP = "POLICY_HIPAA_DIRECT_IDENTIFIER_KEEP"
+POLICY_STRICT_POSTURE_KEEP_BIAS = "POLICY_STRICT_POSTURE_KEEP_BIAS"
+POLICY_STRICT_POSTURE_REQUIRES_SWEEP = "POLICY_STRICT_POSTURE_REQUIRES_SWEEP"
+POLICY_UNREACHABLE_POLICY_LABEL_ACTION = "POLICY_UNREACHABLE_POLICY_LABEL_ACTION"
+
+_SAFE_PATH_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_STRICT_POSTURES = frozenset(
+    {
+        "hipaa_safe_harbor_deidentification",
+        "maximum_recall_no_leak",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PolicyLintFinding:
+    """A stable, JSON-serializable policy lint finding."""
+
+    code: str
+    message: str
+    path: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the finding as plain JSON-compatible data."""
+
+        return {
+            "code": self.code,
+            "message": self.message,
+            "path": self.path,
+        }
+
+
+class _DuplicateTrackingDict(dict[str, Any]):
+    __slots__ = ("duplicate_keys",)
+
+    duplicate_keys: tuple[str, ...]
+
+
+def lint_policy(payload_or_path: Mapping[str, Any] | str | Path) -> dict[str, Any]:
+    """Lint a policy profile mapping, bundled policy name, or JSON file path.
+
+    The returned report intentionally includes only structural paths, stable
+    codes, and profile metadata needed to diagnose configuration issues. It
+    does not echo raw input payloads or free-form metadata values.
+    """
+
+    load_result = _load_payload(payload_or_path)
+    errors = list(load_result["errors"])
+    warnings: list[PolicyLintFinding] = []
+    payload = load_result["payload"]
+    source = str(load_result["source"])
+
+    if payload is not None and not isinstance(payload, Mapping):
+        errors.append(
+            PolicyLintFinding(
+                code=POLICY_SCHEMA_INVALID,
+                message="policy profile must be a JSON object",
+                path="$",
+            )
+        )
+
+    if isinstance(payload, Mapping):
+        errors.extend(_duplicate_key_errors(payload))
+        errors.extend(_action_label_errors(payload))
+        errors.extend(_policy_label_action_errors(payload))
+
+        schema_profile = None
+        try:
+            schema_profile = _profile_from_mapping(payload, source=source)
+        except (TypeError, ValueError):
+            if not errors:
+                errors.append(
+                    PolicyLintFinding(
+                        code=POLICY_SCHEMA_INVALID,
+                        message="policy profile failed built-in schema validation",
+                        path="$",
+                    )
+                )
+
+        errors.extend(_threshold_profile_errors(payload))
+
+        if schema_profile is not None:
+            warnings.extend(_posture_warnings(payload))
+            warnings.extend(_unreachable_policy_label_action_warnings(payload))
+
+    report_errors = [finding.to_dict() for finding in errors]
+    report_warnings = [finding.to_dict() for finding in warnings]
+    return {
+        "source": source,
+        "valid": not report_errors,
+        "error_count": len(report_errors),
+        "warning_count": len(report_warnings),
+        "errors": report_errors,
+        "warnings": report_warnings,
+    }
+
+
+def _load_payload(
+    payload_or_path: Mapping[str, Any] | str | Path,
+) -> dict[str, Any]:
+    if isinstance(payload_or_path, Mapping):
+        return {
+            "payload": payload_or_path,
+            "source": "mapping",
+            "errors": [],
+        }
+
+    if isinstance(payload_or_path, Path):
+        return _load_path_payload(payload_or_path)
+
+    raw_source = str(payload_or_path)
+    candidate = Path(raw_source)
+    if candidate.exists():
+        return _load_path_payload(candidate)
+    if candidate.suffix or "/" in raw_source or "\\" in raw_source:
+        return {
+            "payload": None,
+            "source": "path",
+            "errors": [
+                PolicyLintFinding(
+                    code=POLICY_SOURCE_NOT_FOUND,
+                    message="policy profile path was not found",
+                    path="$",
+                )
+            ],
+        }
+
+    try:
+        canonical_name = canonical_policy_name(raw_source)
+    except ValueError:
+        return {
+            "payload": None,
+            "source": "policy",
+            "errors": [
+                PolicyLintFinding(
+                    code=POLICY_SOURCE_NOT_FOUND,
+                    message="policy profile name was not found",
+                    path="$",
+                )
+            ],
+        }
+
+    resource = resources.files("openmed.core").joinpath(
+        "policies",
+        f"{canonical_name}.json",
+    )
+    try:
+        with resource.open("r", encoding="utf-8") as handle:
+            return {
+                "payload": _loads_tracking_duplicates(handle.read()),
+                "source": f"policy:{canonical_name}",
+                "errors": [],
+            }
+    except json.JSONDecodeError:
+        return {
+            "payload": None,
+            "source": f"policy:{canonical_name}",
+            "errors": [
+                PolicyLintFinding(
+                    code=POLICY_JSON_INVALID,
+                    message="policy profile JSON could not be parsed",
+                    path="$",
+                )
+            ],
+        }
+
+
+def _load_path_payload(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "payload": None,
+            "source": "path",
+            "errors": [
+                PolicyLintFinding(
+                    code=POLICY_SOURCE_NOT_FOUND,
+                    message="policy profile path was not found",
+                    path="$",
+                )
+            ],
+        }
+    try:
+        payload = _loads_tracking_duplicates(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {
+            "payload": None,
+            "source": "path",
+            "errors": [
+                PolicyLintFinding(
+                    code=POLICY_JSON_INVALID,
+                    message="policy profile JSON could not be parsed",
+                    path="$",
+                )
+            ],
+        }
+    return {
+        "payload": payload,
+        "source": "path",
+        "errors": [],
+    }
+
+
+def _loads_tracking_duplicates(raw_json: str) -> Mapping[str, Any]:
+    return json.loads(raw_json, object_pairs_hook=_duplicate_tracking_hook)
+
+
+def _duplicate_tracking_hook(
+    pairs: list[tuple[str, Any]],
+) -> _DuplicateTrackingDict:
+    result = _DuplicateTrackingDict()
+    duplicate_keys: list[str] = []
+    for key, value in pairs:
+        if key in result:
+            duplicate_keys.append(key)
+        result[key] = value
+    result.duplicate_keys = tuple(duplicate_keys)
+    return result
+
+
+def _duplicate_key_errors(payload: Mapping[str, Any]) -> list[PolicyLintFinding]:
+    findings: list[PolicyLintFinding] = []
+    for path, value in _walk_mappings(payload, "$"):
+        if not isinstance(value, _DuplicateTrackingDict):
+            continue
+        if path == "$.actions":
+            for key in value.duplicate_keys:
+                findings.append(
+                    PolicyLintFinding(
+                        code=POLICY_DUPLICATE_ACTION_LABEL,
+                        message="actions must not define the same label twice",
+                        path=_json_path(path, key),
+                    )
+                )
+        elif path == "$.policy_label_actions":
+            for key in value.duplicate_keys:
+                findings.append(
+                    PolicyLintFinding(
+                        code=POLICY_DUPLICATE_POLICY_LABEL,
+                        message="policy_label_actions must not define a label twice",
+                        path=_json_path(path, key),
+                    )
+                )
+    return findings
+
+
+def _walk_mappings(
+    value: Mapping[str, Any],
+    path: str,
+) -> list[tuple[str, Mapping[str, Any]]]:
+    nodes: list[tuple[str, Mapping[str, Any]]] = [(path, value)]
+    for key, child in value.items():
+        if isinstance(child, Mapping):
+            nodes.extend(_walk_mappings(child, _json_path(path, str(key))))
+    return nodes
+
+
+def _action_label_errors(payload: Mapping[str, Any]) -> list[PolicyLintFinding]:
+    actions = payload.get("actions")
+    if not isinstance(actions, Mapping):
+        return []
+
+    findings: list[PolicyLintFinding] = []
+    action_labels = {str(label) for label in actions}
+    for label in sorted(action_labels):
+        if label not in CANONICAL_LABELS:
+            findings.append(
+                PolicyLintFinding(
+                    code=POLICY_UNKNOWN_ACTION_LABEL,
+                    message="actions must use canonical OpenMed labels",
+                    path=_json_path("$.actions", label),
+                )
+            )
+
+    missing = sorted(CANONICAL_LABELS - action_labels)
+    if missing:
+        findings.append(
+            PolicyLintFinding(
+                code=POLICY_ACTION_LABEL_SET_MISMATCH,
+                message="actions must cover the canonical label set exactly",
+                path="$.actions",
+            )
+        )
+    return findings
+
+
+def _policy_label_action_errors(
+    payload: Mapping[str, Any],
+) -> list[PolicyLintFinding]:
+    policy_label_actions = payload.get("policy_label_actions") or {}
+    if not isinstance(policy_label_actions, Mapping):
+        return []
+
+    findings: list[PolicyLintFinding] = []
+    for label in sorted(str(label) for label in policy_label_actions):
+        if label not in POLICY_LABELS:
+            findings.append(
+                PolicyLintFinding(
+                    code=POLICY_UNKNOWN_POLICY_LABEL,
+                    message="policy_label_actions must use canonical policy labels",
+                    path=_json_path("$.policy_label_actions", label),
+                )
+            )
+    return findings
+
+
+def _threshold_profile_errors(
+    payload: Mapping[str, Any],
+) -> list[PolicyLintFinding]:
+    threshold_profile = payload.get("threshold_profile")
+    if not isinstance(threshold_profile, str):
+        return []
+
+    matrix = load_thresholds()
+    profiles = matrix.get("profiles") or {}
+    if threshold_profile in profiles:
+        return []
+    return [
+        PolicyLintFinding(
+            code=POLICY_UNKNOWN_THRESHOLD_PROFILE,
+            message="threshold_profile must reference the thresholds matrix",
+            path="$.threshold_profile",
+        )
+    ]
+
+
+def _posture_warnings(payload: Mapping[str, Any]) -> list[PolicyLintFinding]:
+    warnings: list[PolicyLintFinding] = []
+    posture = str(payload.get("posture") or "").lower()
+    hipaa_posture = posture.startswith("hipaa")
+    strict_posture = _is_strict_posture(payload)
+
+    policy_label_actions = payload.get("policy_label_actions") or {}
+    if (
+        hipaa_posture
+        and isinstance(policy_label_actions, Mapping)
+        and policy_label_actions.get(DIRECT_IDENTIFIER) == "keep"
+    ):
+        warnings.append(
+            PolicyLintFinding(
+                code=POLICY_HIPAA_DIRECT_IDENTIFIER_KEEP,
+                message="HIPAA posture keeps direct identifiers at policy-label level",
+                path=_json_path("$.policy_label_actions", DIRECT_IDENTIFIER),
+            )
+        )
+
+    actions = payload.get("actions") or {}
+    if hipaa_posture and isinstance(actions, Mapping):
+        for label, action in sorted(actions.items()):
+            canonical_label = str(label)
+            if (
+                canonical_label in CANONICAL_LABELS
+                and action == "keep"
+                and policy_label_for(canonical_label) == DIRECT_IDENTIFIER
+            ):
+                warnings.append(
+                    PolicyLintFinding(
+                        code=POLICY_HIPAA_DIRECT_IDENTIFIER_KEEP,
+                        message="HIPAA posture keeps a direct identifier label",
+                        path=_json_path("$.actions", canonical_label),
+                    )
+                )
+
+    if strict_posture and payload.get("safety_sweep_mandatory") is not True:
+        warnings.append(
+            PolicyLintFinding(
+                code=POLICY_STRICT_POSTURE_REQUIRES_SWEEP,
+                message="strict postures should require the deterministic safety sweep",
+                path="$.safety_sweep_mandatory",
+            )
+        )
+
+    default_action = payload.get("default_action")
+    default_action_bias = str(payload.get("default_action_bias") or "")
+    if strict_posture and (
+        default_action == "keep" or default_action_bias.startswith("keep")
+    ):
+        warnings.append(
+            PolicyLintFinding(
+                code=POLICY_STRICT_POSTURE_KEEP_BIAS,
+                message="strict postures should not default toward keeping labels",
+                path="$.default_action_bias",
+            )
+        )
+
+    return warnings
+
+
+def _unreachable_policy_label_action_warnings(
+    payload: Mapping[str, Any],
+) -> list[PolicyLintFinding]:
+    actions = payload.get("actions") or {}
+    policy_label_actions = payload.get("policy_label_actions") or {}
+    if not isinstance(actions, Mapping) or not isinstance(
+        policy_label_actions, Mapping
+    ):
+        return []
+
+    warnings: list[PolicyLintFinding] = []
+    for policy_label, fallback_action in sorted(policy_label_actions.items()):
+        if policy_label not in POLICY_LABELS:
+            continue
+        labels_for_policy = [
+            label
+            for label in CANONICAL_LABELS
+            if policy_label_for(label) == str(policy_label)
+        ]
+        if any(actions.get(label) == fallback_action for label in labels_for_policy):
+            continue
+        warnings.append(
+            PolicyLintFinding(
+                code=POLICY_UNREACHABLE_POLICY_LABEL_ACTION,
+                message="policy_label_actions entry is shadowed by explicit actions",
+                path=_json_path("$.policy_label_actions", str(policy_label)),
+            )
+        )
+    return warnings
+
+
+def _is_strict_posture(payload: Mapping[str, Any]) -> bool:
+    posture = str(payload.get("posture") or "").lower()
+    return (
+        bool(payload.get("strict_no_leak"))
+        or posture in _STRICT_POSTURES
+        or ("hipaa" in posture and "safe_harbor" in posture)
+        or "no_leak" in posture
+    )
+
+
+def _json_path(parent: str, key: str) -> str:
+    if _SAFE_PATH_KEY_RE.fullmatch(key):
+        return f"{parent}.{key}"
+    return f"{parent}[*]"
+
+
+__all__ = [
+    "PolicyLintFinding",
+    "lint_policy",
+    "POLICY_ACTION_LABEL_SET_MISMATCH",
+    "POLICY_DUPLICATE_ACTION_LABEL",
+    "POLICY_DUPLICATE_POLICY_LABEL",
+    "POLICY_HIPAA_DIRECT_IDENTIFIER_KEEP",
+    "POLICY_JSON_INVALID",
+    "POLICY_SCHEMA_INVALID",
+    "POLICY_SOURCE_NOT_FOUND",
+    "POLICY_STRICT_POSTURE_KEEP_BIAS",
+    "POLICY_STRICT_POSTURE_REQUIRES_SWEEP",
+    "POLICY_UNKNOWN_ACTION_LABEL",
+    "POLICY_UNKNOWN_POLICY_LABEL",
+    "POLICY_UNKNOWN_THRESHOLD_PROFILE",
+    "POLICY_UNREACHABLE_POLICY_LABEL_ACTION",
+]

--- a/tests/unit/cli/test_policy_lint_cli.py
+++ b/tests/unit/cli/test_policy_lint_cli.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.cli import main_module
+from openmed.core.labels import DIRECT_IDENTIFIER
+from openmed.core.policy import load_policy
+
+
+def _profile_payload(name: str = "hipaa_safe_harbor") -> dict[str, object]:
+    return copy.deepcopy(load_policy(name).to_dict())
+
+
+def _write_profile(tmp_path: Path, payload: dict[str, object]) -> Path:
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _stdout_report(capsys: pytest.CaptureFixture[str]) -> dict[str, object]:
+    return json.loads(capsys.readouterr().out)
+
+
+def test_policy_lint_cli_accepts_bundled_policy_name(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = main_module.main(["policy", "lint", "hipaa_safe_harbor"])
+    report = _stdout_report(capsys)
+
+    assert result == 0
+    assert report["error_count"] == 0
+    assert report["warning_count"] == 0
+
+
+def test_policy_lint_cli_exits_zero_on_clean_profile_path(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = _write_profile(tmp_path, _profile_payload())
+
+    result = main_module.main(["policy", "lint", str(path)])
+    report = _stdout_report(capsys)
+
+    assert result == 0
+    assert report["error_count"] == 0
+
+
+def test_policy_lint_cli_exits_nonzero_on_errors(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = _profile_payload()
+    payload["threshold_profile"] = "missing_threshold_profile"
+    path = _write_profile(tmp_path, payload)
+
+    result = main_module.main(["policy", "lint", str(path)])
+    report = _stdout_report(capsys)
+
+    assert result == 1
+    assert report["error_count"] == 1
+    assert report["errors"][0]["code"] == "POLICY_UNKNOWN_THRESHOLD_PROFILE"
+
+
+def test_policy_lint_cli_strict_exits_nonzero_on_warnings(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = _profile_payload()
+    policy_label_actions = payload["policy_label_actions"]
+    assert isinstance(policy_label_actions, dict)
+    policy_label_actions[DIRECT_IDENTIFIER] = "keep"
+    path = _write_profile(tmp_path, payload)
+
+    non_strict = main_module.main(["policy", "lint", str(path)])
+    non_strict_report = _stdout_report(capsys)
+    strict = main_module.main(["policy", "lint", "--strict", str(path)])
+    strict_report = _stdout_report(capsys)
+
+    assert non_strict == 0
+    assert non_strict_report["error_count"] == 0
+    assert non_strict_report["warning_count"] > 0
+    assert strict == 1
+    assert strict_report["error_count"] == 0
+    assert strict_report["warning_count"] > 0

--- a/tests/unit/core/test_policy_lint.py
+++ b/tests/unit/core/test_policy_lint.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from openmed.core.labels import CLINICAL_CONCEPT, DIRECT_IDENTIFIER
+from openmed.core.policy import CANONICAL_POLICY_NAMES, load_policy
+from openmed.core.policy_lint import (
+    POLICY_DUPLICATE_ACTION_LABEL,
+    POLICY_HIPAA_DIRECT_IDENTIFIER_KEEP,
+    POLICY_SCHEMA_INVALID,
+    POLICY_STRICT_POSTURE_REQUIRES_SWEEP,
+    POLICY_UNKNOWN_ACTION_LABEL,
+    POLICY_UNKNOWN_THRESHOLD_PROFILE,
+    POLICY_UNREACHABLE_POLICY_LABEL_ACTION,
+    lint_policy,
+)
+
+
+def _profile_payload(name: str = "hipaa_safe_harbor") -> dict[str, object]:
+    return copy.deepcopy(load_policy(name).to_dict())
+
+
+def _codes(report: dict[str, object], key: str) -> set[str]:
+    return {str(finding["code"]) for finding in report[key]}
+
+
+def _finding_paths(report: dict[str, object], code: str) -> set[str]:
+    return {
+        str(finding["path"])
+        for finding in report["errors"] + report["warnings"]
+        if finding["code"] == code
+    }
+
+
+def test_lint_policy_flags_unknown_action_label_and_threshold_profile() -> None:
+    payload = _profile_payload()
+    actions = payload["actions"]
+    assert isinstance(actions, dict)
+    actions["NOT_A_LABEL"] = "mask"
+    payload["threshold_profile"] = "missing_threshold_profile"
+
+    report = lint_policy(payload)
+
+    assert report["valid"] is False
+    assert POLICY_UNKNOWN_ACTION_LABEL in _codes(report, "errors")
+    assert POLICY_UNKNOWN_THRESHOLD_PROFILE in _codes(report, "errors")
+    assert "$.actions.NOT_A_LABEL" in _finding_paths(
+        report, POLICY_UNKNOWN_ACTION_LABEL
+    )
+    assert "$.threshold_profile" in _finding_paths(
+        report, POLICY_UNKNOWN_THRESHOLD_PROFILE
+    )
+
+
+def test_lint_policy_detects_duplicate_action_labels(tmp_path: Path) -> None:
+    raw_profile = json.dumps(_profile_payload(), indent=2)
+    raw_profile = raw_profile.replace(
+        '"PERSON": "mask"',
+        '"PERSON": "mask",\n    "PERSON": "hash"',
+        1,
+    )
+    profile_path = tmp_path / "policy.json"
+    profile_path.write_text(raw_profile, encoding="utf-8")
+
+    report = lint_policy(profile_path)
+
+    assert POLICY_DUPLICATE_ACTION_LABEL in _codes(report, "errors")
+    assert "$.actions.PERSON" in _finding_paths(report, POLICY_DUPLICATE_ACTION_LABEL)
+
+
+def test_lint_policy_rejects_non_object_json(tmp_path: Path) -> None:
+    profile_path = tmp_path / "policy.json"
+    profile_path.write_text("[]", encoding="utf-8")
+
+    report = lint_policy(profile_path)
+
+    assert POLICY_SCHEMA_INVALID in _codes(report, "errors")
+    assert "$" in _finding_paths(report, POLICY_SCHEMA_INVALID)
+
+
+def test_lint_policy_warns_when_hipaa_posture_keeps_direct_identifier() -> None:
+    payload = _profile_payload()
+    policy_label_actions = payload["policy_label_actions"]
+    assert isinstance(policy_label_actions, dict)
+    policy_label_actions[DIRECT_IDENTIFIER] = "keep"
+
+    report = lint_policy(payload)
+
+    assert report["valid"] is True
+    assert report["error_count"] == 0
+    assert POLICY_HIPAA_DIRECT_IDENTIFIER_KEEP in _codes(report, "warnings")
+    assert "$.policy_label_actions.DIRECT_IDENTIFIER" in _finding_paths(
+        report, POLICY_HIPAA_DIRECT_IDENTIFIER_KEEP
+    )
+
+
+def test_lint_policy_warns_when_strict_posture_omits_safety_sweep() -> None:
+    payload = _profile_payload("strict_no_leak")
+    payload["safety_sweep_mandatory"] = False
+
+    report = lint_policy(payload)
+
+    assert report["error_count"] == 0
+    assert POLICY_STRICT_POSTURE_REQUIRES_SWEEP in _codes(report, "warnings")
+    assert "$.safety_sweep_mandatory" in _finding_paths(
+        report, POLICY_STRICT_POSTURE_REQUIRES_SWEEP
+    )
+
+
+def test_lint_policy_warns_on_shadowed_policy_label_action() -> None:
+    payload = _profile_payload("clinical_minimal_redaction")
+    policy_label_actions = payload["policy_label_actions"]
+    assert isinstance(policy_label_actions, dict)
+    policy_label_actions[CLINICAL_CONCEPT] = "mask"
+
+    report = lint_policy(payload)
+
+    assert report["error_count"] == 0
+    assert POLICY_UNREACHABLE_POLICY_LABEL_ACTION in _codes(report, "warnings")
+    assert "$.policy_label_actions.CLINICAL_CONCEPT" in _finding_paths(
+        report, POLICY_UNREACHABLE_POLICY_LABEL_ACTION
+    )
+
+
+def test_bundled_policy_profiles_lint_clean() -> None:
+    for name in CANONICAL_POLICY_NAMES:
+        report = lint_policy(name)
+
+        assert report["error_count"] == 0, name
+        assert report["warning_count"] == 0, name
+
+
+def test_lint_report_is_json_serializable_without_raw_metadata() -> None:
+    payload = _profile_payload()
+    payload["metadata"] = {
+        "note": "Patient Jane Doe was seen on 2026-06-01",
+    }
+
+    report = lint_policy(payload)
+    serialized = json.dumps(report, sort_keys=True)
+
+    assert "Jane Doe" not in serialized
+    assert "2026-06-01" not in serialized


### PR DESCRIPTION
Closes #497.

Adds a JSON-serializable policy-profile linter with stable error and warning findings, detects invalid action labels, duplicate action labels, missing threshold profiles, risky HIPAA and strict-posture settings, and exposes it through `openmed policy lint <path|name>` with `--strict` warning handling. The bundled policy profiles are covered by fixtures and lint clean.