### PR TITLE
Add a linkage attack mode against an external quasi-identifier table

### DIFF
--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -4,6 +4,7 @@ Intended contents include harness.py, metrics.py, suites/, golden/, report.py,
 calibrate.py, and release_gates.py.
 """
 
+from openmed.eval.attacks.linkage import LinkageAttackResult, linkage_attack
 from openmed.eval.attacks.reid import (
     ReidAttackResult,
     generate_reid_leaderboard,
@@ -154,6 +155,7 @@ __all__ = [
     "GOLDEN_EDGE_CASE_CATEGORIES",
     "HeatmapCell",
     "LeakageHeatmap",
+    "LinkageAttackResult",
     "GateCheck",
     "GateReport",
     "INT4_RECALL_DELTA_LIMIT",
@@ -209,6 +211,7 @@ __all__ = [
     "hash_fixture_set",
     "identity_perturbation",
     "invalidate",
+    "linkage_attack",
     "load",
     "load_calibration_samples",
     "load_calibration_thresholds",

--- a/openmed/eval/attacks/__init__.py
+++ b/openmed/eval/attacks/__init__.py
@@ -1,5 +1,6 @@
 """Adversarial evaluation attacks for benchmark reports."""
 
+from .linkage import LinkageAttackResult, linkage_attack
 from .reid import (
     MembershipInferenceResult,
     ReidAttackResult,
@@ -11,9 +12,11 @@ from .reid import (
 )
 
 __all__ = [
+    "LinkageAttackResult",
     "ReidAttackResult",
     "MembershipInferenceResult",
     "generate_reid_leaderboard",
+    "linkage_attack",
     "membership_inference_attack",
     "render_reid_leaderboard",
     "run_reid_attack",

--- a/openmed/eval/attacks/linkage.py
+++ b/openmed/eval/attacks/linkage.py
@@ -1,0 +1,142 @@
+"""External quasi-identifier linkage attack for de-identified records."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from openmed.risk.reid import _coerce_records, _normalize_qi_value, _profile_record
+
+
+@dataclass(frozen=True)
+class LinkageAttackResult:
+    """Result of joining de-identified records to an external QI table."""
+
+    unique_match_rate: float
+    ambiguous_match_rate: float
+    no_match_rate: float
+    unique_matches: int
+    ambiguous_matches: int
+    no_matches: int
+    record_count: int
+    details: tuple[dict[str, Any], ...]
+
+    def to_metric(self) -> dict[str, Any]:
+        """Return a JSON-serializable BenchmarkReport metric payload."""
+
+        details = [dict(detail) for detail in self.details]
+        return {
+            "linkage_unique_match_rate": float(self.unique_match_rate),
+            "unique_match_rate": float(self.unique_match_rate),
+            "ambiguous_match_rate": float(self.ambiguous_match_rate),
+            "no_match_rate": float(self.no_match_rate),
+            "unique_matches": int(self.unique_matches),
+            "ambiguous_matches": int(self.ambiguous_matches),
+            "no_matches": int(self.no_matches),
+            "denominator": int(self.record_count),
+            "details": details,
+        }
+
+
+def linkage_attack(
+    deidentified_records: Any,
+    quasi_id_table: Any,
+    quasi_identifiers: Sequence[str] | None = None,
+) -> LinkageAttackResult:
+    """Run a Sweeney-style external quasi-identifier linkage attack.
+
+    Args:
+        deidentified_records: De-identified records in any shape accepted by
+            ``risk_report``.
+        quasi_id_table: External auxiliary table containing the same
+            quasi-identifier fields or detectable quasi-identifier values.
+        quasi_identifiers: Explicit quasi-identifier field names. When omitted,
+            records are profiled with the same auto-detection path used by
+            ``risk_report``.
+
+    Returns:
+        A result with unique, ambiguous, and no-match rates plus per-record
+        match details. A record is counted as re-identified only when its QI
+        key maps to exactly one row in the external table.
+    """
+
+    deidentified = _coerce_records(deidentified_records, source="deidentified")
+    external_rows = _coerce_records(quasi_id_table, source="aux")
+
+    external_index: defaultdict[Any, list[dict[str, Any]]] = defaultdict(list)
+    for row in external_rows:
+        key, _ = _linkage_key(row, quasi_identifiers)
+        if not key:
+            continue
+        external_index[key].append(
+            {
+                "external_record_index": row.index,
+                "external_record_id": row.record_id,
+            }
+        )
+
+    unique_matches = 0
+    ambiguous_matches = 0
+    no_matches = 0
+    details: list[dict[str, Any]] = []
+    for record in deidentified:
+        key, json_key = _linkage_key(record, quasi_identifiers)
+        matches = external_index.get(key, []) if key else []
+        match_count = len(matches)
+
+        detail: dict[str, Any] = {
+            "record_index": record.index,
+            "record_id": record.record_id,
+            "key": json_key,
+            "match_count": match_count,
+        }
+        if match_count == 1:
+            unique_matches += 1
+            detail["outcome"] = "unique"
+            detail.update(matches[0])
+        elif match_count > 1:
+            ambiguous_matches += 1
+            detail["outcome"] = "ambiguous"
+        else:
+            no_matches += 1
+            detail["outcome"] = "no_match"
+        details.append(detail)
+
+    denominator = len(deidentified)
+    return LinkageAttackResult(
+        unique_match_rate=_rate(unique_matches, denominator),
+        ambiguous_match_rate=_rate(ambiguous_matches, denominator),
+        no_match_rate=_rate(no_matches, denominator),
+        unique_matches=unique_matches,
+        ambiguous_matches=ambiguous_matches,
+        no_matches=no_matches,
+        record_count=denominator,
+        details=tuple(details),
+    )
+
+
+def _linkage_key(
+    record: Any,
+    quasi_identifiers: Sequence[str] | None,
+) -> tuple[Any, list[Any]]:
+    if quasi_identifiers:
+        pairs = []
+        for field in sorted(quasi_identifiers):
+            normalized = _normalize_qi_value(field, record.fields.get(field, ""))
+            if not normalized:
+                return (), []
+            pairs.append((field, normalized))
+        return tuple(pairs), [[field, value] for field, value in pairs]
+
+    profile_key = _profile_record(record).key
+    json_key = [[category, list(values)] for category, values in profile_key]
+    return profile_key, json_key
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    return float(numerator / denominator) if denominator else 0.0
+
+
+__all__ = ["LinkageAttackResult", "linkage_attack"]

--- a/openmed/eval/attacks/reid.py
+++ b/openmed/eval/attacks/reid.py
@@ -15,6 +15,8 @@ from openmed.eval.golden import GoldenFixture, load_golden_fixtures
 from openmed.eval.report import BenchmarkReport
 from openmed.risk import risk_report
 
+from .linkage import linkage_attack
+
 
 @dataclass(frozen=True)
 class ReidAttackResult:
@@ -56,8 +58,11 @@ def run_reid_benchmark(
     *,
     suite: str = "golden",
     model_name: str = "privacy-filter",
+    attack_mode: str = "reid",
     deidentified_records: Sequence[Mapping[str, Any]] | None = None,
     auxiliary_records: Sequence[Mapping[str, Any]] | None = None,
+    quasi_id_table: Sequence[Mapping[str, Any]] | None = None,
+    quasi_identifiers: Sequence[str] | None = None,
     candidate_members: Sequence[Mapping[str, Any]] | None = None,
     output_json: str | Path | None = None,
     output_markdown: str | Path | None = None,
@@ -65,12 +70,54 @@ def run_reid_benchmark(
 ) -> BenchmarkReport:
     """Run the re-identification attack and return a BenchmarkReport.
 
-    When ``candidate_members`` is provided, the membership-inference probe runs
-    against the de-identified records and its result is added to the report
-    metrics under ``"membership_inference"``.
+    ``attack_mode="linkage"`` runs a first-class external quasi-identifier
+    linkage attack against ``quasi_id_table``. When ``candidate_members`` is
+    provided in the default ``"reid"`` mode, the membership-inference probe
+    runs against the de-identified records and its result is added to the
+    report metrics under ``"membership_inference"``.
     """
 
     fixtures = _load_suite_fixtures(suite)
+    if attack_mode not in {"reid", "linkage"}:
+        raise ValueError("attack_mode must be 'reid' or 'linkage'")
+
+    if attack_mode == "linkage":
+        if quasi_id_table is None:
+            raise ValueError("quasi_id_table is required for linkage mode")
+        deidentified = (
+            list(deidentified_records)
+            if deidentified_records is not None
+            else [_deidentified_record(fixture) for fixture in fixtures]
+        )
+        linkage_result = linkage_attack(
+            deidentified,
+            quasi_id_table,
+            quasi_identifiers=quasi_identifiers,
+        )
+        report = BenchmarkReport(
+            suite=suite,
+            model_name=model_name,
+            device="attack",
+            fixture_count=linkage_result.record_count,
+            generated_at=generated_at or _utc_now(),
+            metrics={
+                "linkage_unique_match_rate": linkage_result.unique_match_rate,
+                "linkage_attack": linkage_result.to_metric(),
+            },
+            metadata={
+                "attack": "linkage",
+                "leaderboard_metric": "linkage_unique_match_rate",
+            },
+        )
+        if output_json is not None:
+            report.write_json(output_json)
+        if output_markdown is not None:
+            Path(output_markdown).write_text(
+                render_reid_leaderboard([report]),
+                encoding="utf-8",
+            )
+        return report
+
     result = run_reid_attack(
         fixtures,
         deidentified_records=deidentified_records,

--- a/tests/fixtures/eval/external_quasi_id_table.json
+++ b/tests/fixtures/eval/external_quasi_id_table.json
@@ -1,0 +1,20 @@
+[
+  {
+    "record_id": "external-unique",
+    "age": "42 years old",
+    "zip": "02139",
+    "city": "Cambridge"
+  },
+  {
+    "record_id": "external-ambiguous-a",
+    "age": 71,
+    "zip": "60612",
+    "city": "Chicago"
+  },
+  {
+    "record_id": "external-ambiguous-b",
+    "age": "71",
+    "zip": "60612",
+    "city": "Chicago"
+  }
+]

--- a/tests/unit/eval/attacks/test_linkage_attack.py
+++ b/tests/unit/eval/attacks/test_linkage_attack.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.eval.attacks import LinkageAttackResult, linkage_attack
+from openmed.eval.attacks.reid import run_reid_benchmark
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "fixtures"
+    / "eval"
+    / "external_quasi_id_table.json"
+)
+
+
+def _external_qi_table() -> list[dict[str, object]]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_linkage_attack_reports_zero_when_no_record_matches_unique_row() -> None:
+    result = linkage_attack(
+        [{"record_id": "no-hit", "age": 88, "zip": "99999"}],
+        _external_qi_table(),
+        quasi_identifiers=["age", "zip"],
+    )
+
+    assert result.unique_match_rate == pytest.approx(0.0)
+    assert result.no_match_rate == pytest.approx(1.0)
+    assert result.unique_matches == 0
+    assert result.details[0]["outcome"] == "no_match"
+
+
+def test_linkage_attack_counts_unique_ambiguous_and_no_match_records() -> None:
+    result = linkage_attack(
+        [
+            {"record_id": "unique-hit", "age": 42, "zip": "02139"},
+            {"record_id": "ambiguous-hit", "age": "71 years old", "zip": "60612"},
+            {"record_id": "no-hit", "age": 55, "zip": "94110"},
+        ],
+        _external_qi_table(),
+        quasi_identifiers=["age", "zip"],
+    )
+
+    assert isinstance(result, LinkageAttackResult)
+    assert result.unique_match_rate == pytest.approx(1 / 3)
+    assert result.ambiguous_match_rate == pytest.approx(1 / 3)
+    assert result.no_match_rate == pytest.approx(1 / 3)
+    assert result.unique_matches == 1
+    assert result.ambiguous_matches == 1
+    assert result.no_matches == 1
+
+    unique_detail = result.details[0]
+    assert unique_detail["record_id"] == "unique-hit"
+    assert unique_detail["outcome"] == "unique"
+    assert unique_detail["external_record_id"] == "external-unique"
+
+    ambiguous_detail = result.details[1]
+    assert ambiguous_detail["outcome"] == "ambiguous"
+    assert ambiguous_detail["match_count"] == 2
+
+
+def test_run_reid_benchmark_exposes_linkage_metric_for_linkage_mode() -> None:
+    report = run_reid_benchmark(
+        suite="golden",
+        model_name="unit-model",
+        attack_mode="linkage",
+        deidentified_records=[
+            {"record_id": "unique-hit", "age": 42, "zip": "02139"},
+            {"record_id": "ambiguous-hit", "age": 71, "zip": "60612"},
+            {"record_id": "no-hit", "age": 55, "zip": "94110"},
+        ],
+        quasi_id_table=_external_qi_table(),
+        quasi_identifiers=["age", "zip"],
+        generated_at="2026-06-27T00:00:00+00:00",
+    )
+
+    assert report.metadata["attack"] == "linkage"
+    assert report.metrics["linkage_unique_match_rate"] == pytest.approx(1 / 3)
+    assert report.metrics["linkage_attack"]["unique_matches"] == 1
+    assert report.metrics["linkage_attack"]["ambiguous_matches"] == 1
+    assert report.metrics["linkage_attack"]["no_matches"] == 1


### PR DESCRIPTION
# Pull Request

## Description
Closes #501.

Adds a first-class external quasi-identifier linkage attack for de-identified records. The new mode joins records against a supplied synthetic auxiliary QI table, counts only k=1 external-table matches as unique re-links, and reports unique, ambiguous, and no-match rates for release-candidate benchmarking.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `linkage_attack(...)` and `LinkageAttackResult` under `openmed.eval.attacks`.
- Added `attack_mode="linkage"` support in `run_reid_benchmark` with a `linkage_unique_match_rate` metric.
- Added a small synthetic external quasi-identifier fixture and unit coverage for unique, ambiguous, and no-match linkage outcomes.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/unit/eval/attacks/test_linkage_attack.py tests/unit/eval/test_reid_attack.py -q`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #501

## Screenshots/Examples
Not applicable.
