### PR TITLE
Extend model publishing to ONNX and quantized artifacts

### DIFF
--- a/openmed/core/hf_publish.py
+++ b/openmed/core/hf_publish.py
@@ -26,6 +26,28 @@ DEFAULT_MODEL_CARD_COMMIT_MESSAGE = "Update generated model card"
 _VERSION_SUFFIX_RE = re.compile(r"-v\d+(?=$|-)")
 _SAFE_REPO_RE = re.compile(r"[^A-Za-z0-9._-]+")
 _SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_ONNX_FORMAT_ALIASES = {
+    "onnx",
+    "onnx-fp32",
+    "onnx-float32",
+    "webgpu",
+    "onnx-webgpu",
+    "webgpu-onnx",
+}
+_QUANTIZED_FORMAT_ALIASES = {
+    "int8": "int8",
+    "8bit": "int8",
+    "8-bit": "int8",
+    "onnx-int8": "int8",
+    "int4": "int4",
+    "4bit": "int4",
+    "4-bit": "int4",
+    "onnx-int4": "int4",
+    "awq": "awq",
+    "openmed-awq": "awq",
+    "gptq": "gptq",
+    "openmed-gptq": "gptq",
+}
 
 
 class HfPublishError(RuntimeError):
@@ -146,7 +168,7 @@ def append_manifest_row(path: str | Path, row: dict[str, Any]) -> None:
                     continue
                 existing = json.loads(line)
                 if existing.get("repo_id") == row["repo_id"]:
-                    rows.append(row)
+                    rows.append(_merge_manifest_row(existing, row))
                     replaced = True
                 else:
                     rows.append(existing)
@@ -505,6 +527,11 @@ def _format_repo_suffix(format_name: str) -> str:
         return "mlx-4bit"
     if normalized == "coreml":
         return "coreml"
+    if normalized in _ONNX_FORMAT_ALIASES:
+        return "onnx"
+    quantized = _QUANTIZED_FORMAT_ALIASES.get(normalized)
+    if quantized is not None:
+        return f"onnx-{quantized}"
     return normalized
 
 
@@ -516,6 +543,13 @@ def _manifest_format_name(format_name: str) -> str:
         return "mlx-8bit"
     if normalized in {"mlx-4bit", "mlx-int4"}:
         return "mlx-4bit"
+    if normalized in {"onnx-fp32", "onnx-float32"}:
+        return "onnx"
+    if normalized in {"onnx-webgpu", "webgpu-onnx"}:
+        return "webgpu"
+    quantized = _QUANTIZED_FORMAT_ALIASES.get(normalized)
+    if quantized is not None:
+        return quantized
     return normalized
 
 
@@ -536,6 +570,23 @@ def _read_optional_json(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as handle:
         value = json.load(handle)
     return value if isinstance(value, dict) else {}
+
+
+def _merge_manifest_row(
+    existing: dict[str, Any],
+    replacement: dict[str, Any],
+) -> dict[str, Any]:
+    merged = dict(replacement)
+    existing_formats = existing.get("formats")
+    replacement_formats = replacement.get("formats")
+    if isinstance(existing_formats, list) and isinstance(replacement_formats, list):
+        merged["formats"] = _manifest_format_names(
+            [
+                *[str(item) for item in existing_formats],
+                *[str(item) for item in replacement_formats],
+            ]
+        )
+    return merged
 
 
 def _parse_json_object_arg(value: str) -> dict[str, Any]:

--- a/openmed/core/manifest_schema.py
+++ b/openmed/core/manifest_schema.py
@@ -49,6 +49,11 @@ ALLOWED_FORMATS = (
     "mlx-8bit",
     "mlx-4bit",
     "onnx",
+    "webgpu",
+    "int8",
+    "int4",
+    "awq",
+    "gptq",
     "gguf",
     "unknown",
 )

--- a/openmed/core/model_card.py
+++ b/openmed/core/model_card.py
@@ -63,6 +63,9 @@ def render_model_card(row: dict[str, Any]) -> str:
         "",
         _labels_block(labels),
     ]
+    artifact_lines = _artifact_format_block(formats)
+    if artifact_lines:
+        lines.extend(["", "## Artifact Format", "", *artifact_lines])
     distillation_lines = _distillation_block(row)
     if distillation_lines:
         lines.extend(["", "## Distillation Evidence", "", *distillation_lines])
@@ -125,6 +128,43 @@ def _labels_block(labels: list[str]) -> str:
     if not labels:
         return "Not specified."
     return ", ".join(f"`{label}`" for label in labels)
+
+
+def _artifact_format_block(formats: list[str]) -> list[str]:
+    runtime_formats = []
+    quantization_formats = []
+    for value in formats:
+        if _normalize_format(value) in {"onnx", "webgpu"}:
+            runtime_formats.append(value)
+        quantization = _quantization_label(value)
+        if quantization is not None:
+            quantization_formats.append(quantization)
+    if not runtime_formats and not quantization_formats:
+        return []
+
+    return [
+        "| Field | Value |",
+        "|---|---|",
+        f"| Runtime artifacts | {_comma_or_unspecified(runtime_formats)} |",
+        f"| Quantization | {_comma_or_unspecified(quantization_formats)} |",
+    ]
+
+
+def _normalize_format(value: str) -> str:
+    return value.lower().replace("_", "-")
+
+
+def _quantization_label(value: str) -> str | None:
+    normalized = _normalize_format(value)
+    if normalized in {"int8", "8bit", "8-bit", "onnx-int8"}:
+        return "int8"
+    if normalized in {"int4", "4bit", "4-bit", "onnx-int4"}:
+        return "int4"
+    if normalized in {"awq", "openmed-awq"}:
+        return "awq"
+    if normalized in {"gptq", "openmed-gptq"}:
+        return "gptq"
+    return None
 
 
 def _distillation_block(row: dict[str, Any]) -> list[str]:

--- a/tests/unit/core/test_hf_publish_onnx.py
+++ b/tests/unit/core/test_hf_publish_onnx.py
@@ -1,0 +1,204 @@
+"""Tests for ONNX and quantized Hugging Face publishing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openmed.core import hf_publish
+from openmed.core.hf_publish import publish_artifact
+from openmed.core.manifest_schema import validate_manifest_row
+
+
+class RepositoryNotFoundError(Exception):
+    pass
+
+
+class FakeApi:
+    def __init__(self, *, exists: bool = False) -> None:
+        self.exists = exists
+        self.created: list[dict[str, object]] = []
+        self.uploaded: list[dict[str, object]] = []
+        self.uploaded_cards: list[str] = []
+        self.info_calls: list[dict[str, object]] = []
+
+    def repo_info(self, **kwargs: object) -> object:
+        self.info_calls.append(kwargs)
+        if not self.exists:
+            raise RepositoryNotFoundError("not found")
+        return object()
+
+    def create_repo(self, **kwargs: object) -> None:
+        self.created.append(kwargs)
+        self.exists = True
+
+    def upload_folder(self, **kwargs: object) -> None:
+        self.uploaded.append(kwargs)
+        self.uploaded_cards.append(
+            (Path(str(kwargs["folder_path"])) / "README.md").read_text(encoding="utf-8")
+        )
+
+
+def test_publish_onnx_artifact_targets_onnx_repo_and_updates_manifest(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    artifact = _write_onnx_artifact(tmp_path)
+    manifest = tmp_path / "models.jsonl"
+    fake_api = FakeApi()
+    monkeypatch.setenv("HF_WRITE_TOKEN", "secret-token")
+
+    result = publish_artifact(
+        artifact_dir=artifact,
+        source_model_id="OpenMed/test-model",
+        format_name="onnx",
+        formats=["onnx", "webgpu"],
+        manifest_path=manifest,
+        api=fake_api,
+        released="2026-06-27",
+        git_sha="abc123",
+    )
+
+    assert result.repo_id == "OpenMed/test-model-v1-onnx"
+    assert result.manifest_row["formats"] == ["onnx", "webgpu"]
+    assert fake_api.created[0]["repo_id"] == "OpenMed/test-model-v1-onnx"
+    assert fake_api.uploaded[0]["repo_id"] == "OpenMed/test-model-v1-onnx"
+    assert "## Artifact Format" in fake_api.uploaded_cards[0]
+    assert "| Runtime artifacts | onnx, webgpu |" in fake_api.uploaded_cards[0]
+    assert "secret-token" not in fake_api.uploaded_cards[0]
+
+    rows = _manifest_rows(manifest)
+    assert rows == [result.manifest_row]
+    assert validate_manifest_row(rows[0], line_number=1) == []
+
+
+def test_publish_quantized_artifact_merges_format_without_duplicate(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    artifact = _write_onnx_artifact(tmp_path)
+    manifest = tmp_path / "models.jsonl"
+    existing = {
+        "repo_id": "OpenMed/test-model-v1-onnx-int8",
+        "formats": ["onnx"],
+    }
+    manifest.write_text(json.dumps(existing) + "\n", encoding="utf-8")
+    fake_api = FakeApi()
+    monkeypatch.setenv("HF_WRITE_TOKEN", "secret-token")
+
+    result = publish_artifact(
+        artifact_dir=artifact,
+        source_model_id="OpenMed/test-model",
+        format_name="int8",
+        formats=["onnx", "int8", "int8"],
+        manifest_path=manifest,
+        api=fake_api,
+        released="2026-06-27",
+        git_sha="abc123",
+    )
+
+    assert result.repo_id == "OpenMed/test-model-v1-onnx-int8"
+    assert result.manifest_row["formats"] == ["onnx", "int8"]
+    assert "| Quantization | int8 |" in fake_api.uploaded_cards[0]
+    rows = _manifest_rows(manifest)
+    assert rows[0]["formats"] == ["onnx", "int8"]
+    assert rows[0]["formats"].count("int8") == 1
+    assert validate_manifest_row(rows[0], line_number=1) == []
+
+
+def test_publish_onnx_rerun_skips_existing_repo_without_upload(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    artifact = _write_onnx_artifact(tmp_path)
+    fake_api = FakeApi(exists=True)
+    monkeypatch.setenv("HF_WRITE_TOKEN", "secret-token")
+
+    result = publish_artifact(
+        artifact_dir=artifact,
+        source_model_id="OpenMed/test-model",
+        format_name="onnx",
+        api=fake_api,
+        released="2026-06-27",
+        git_sha="abc123",
+    )
+
+    assert result.repo_id == "OpenMed/test-model-v1-onnx"
+    assert result.skipped is True
+    assert fake_api.info_calls == [
+        {
+            "repo_id": "OpenMed/test-model-v1-onnx",
+            "repo_type": "model",
+            "token": "secret-token",
+        }
+    ]
+    assert fake_api.created == []
+    assert fake_api.uploaded == []
+
+
+def test_publish_token_never_appears_in_logs_or_cli_output(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+    caplog,
+) -> None:
+    artifact = _write_onnx_artifact(tmp_path)
+    fake_api = FakeApi()
+    monkeypatch.setenv("HF_WRITE_TOKEN", "secret-token")
+    monkeypatch.setattr(hf_publish, "_load_hf_api", lambda: fake_api)
+
+    hf_publish.main(
+        [
+            "--model",
+            "OpenMed/test-model",
+            "--artifact-dir",
+            str(artifact),
+            "--format",
+            "onnx",
+            "--formats",
+            "onnx,webgpu",
+            "--manifest",
+            str(tmp_path / "models.jsonl"),
+            "--git-sha",
+            "abc123",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert "secret-token" not in captured.out
+    assert "secret-token" not in captured.err
+    assert "secret-token" not in caplog.text
+
+
+def _write_onnx_artifact(tmp_path: Path) -> Path:
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "bert",
+                "id2label": {"0": "O", "1": "B-PERSON", "2": "I-DATE"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact / "openmed-onnx.json").write_text(
+        json.dumps(
+            {
+                "format": "openmed-onnx",
+                "formats": ["onnx", "webgpu"],
+                "source_model_id": "OpenMed/test-model",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact / "model.onnx").write_bytes(b"onnx")
+    return artifact
+
+
+def _manifest_rows(path: Path) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]

--- a/tests/unit/mlx/test_hf_publish.py
+++ b/tests/unit/mlx/test_hf_publish.py
@@ -167,7 +167,7 @@ def test_publish_artifact_errors_when_token_is_missing(tmp_path, monkeypatch):
         )
 
 
-def test_manifest_append_replaces_existing_repo_row(tmp_path):
+def test_manifest_append_replaces_existing_repo_row_and_merges_formats(tmp_path):
     manifest = tmp_path / "models.jsonl"
     first = {"repo_id": "OpenMed/model", "formats": ["mlx-fp"]}
     second = {"repo_id": "OpenMed/model", "formats": ["coreml"]}
@@ -178,7 +178,7 @@ def test_manifest_append_replaces_existing_repo_row(tmp_path):
     rows = [
         json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines()
     ]
-    assert rows == [second]
+    assert rows == [{"repo_id": "OpenMed/model", "formats": ["mlx-fp", "coreml"]}]
 
 
 def test_conversion_modules_expose_publish_options():


### PR DESCRIPTION
## Description
Extends the model publishing path to normalize ONNX/WebGPU and quantized artifact formats, target ONNX variant repositories, merge manifest formats idempotently, and render artifact format plus quantization details in generated model cards.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added ONNX/WebGPU and quantized format normalization for repository names and manifest tags.
- Updated manifest append behavior to merge `formats[]` without duplicates for existing rows.
- Added generated model-card artifact format details for ONNX and quantized artifacts.
- Added unit coverage for ONNX publishing, quantized dedupe, existing-repo skip idempotency, and token non-disclosure.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #505

## Screenshots/Examples
Not applicable.
