### PR TITLE
Add NDJSON FHIR bulk-export ingestion and de-identification

### DIFF
--- a/openmed/interop/fhir_bulk.py
+++ b/openmed/interop/fhir_bulk.py
@@ -1,0 +1,316 @@
+"""Streaming FHIR Bulk Data NDJSON de-identification helpers.
+
+FHIR Bulk Data Access exports resources as newline-delimited JSON files, often
+one file per resource type. This module keeps that workflow local and
+streaming: it reads one line at a time, applies the existing FHIR
+``$de-identify`` operation logic, and writes de-identified NDJSON without
+loading a whole export file into memory.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .fhir_operations import Deidentifier, de_identify_resource
+
+__all__ = [
+    "BulkExportSummary",
+    "FHIRNDJSONLineError",
+    "NDJSONFileSummary",
+    "NDJSONLineError",
+    "deidentify_export",
+    "deidentify_ndjson",
+    "iter_ndjson",
+]
+
+_DEFAULT_POLICY = "hipaa_safe_harbor"
+_DEFAULT_METHOD = "replace"
+
+
+@dataclass(frozen=True)
+class NDJSONLineError:
+    """PHI-safe description of one failed NDJSON line.
+
+    Attributes:
+        line_number: One-based physical line number in the input file.
+        message: Sanitized parse or processing error. The raw line content is
+            intentionally excluded because it may contain PHI.
+    """
+
+    line_number: int
+    message: str
+
+
+class FHIRNDJSONLineError(ValueError):
+    """Raised by :func:`iter_ndjson` when a line cannot be parsed as a resource."""
+
+    def __init__(self, path: Path, line_number: int, message: str) -> None:
+        self.path = path
+        self.line_number = line_number
+        self.message = message
+        super().__init__(f"{path}: line {line_number}: {message}")
+
+    def to_summary_error(self) -> NDJSONLineError:
+        """Return a PHI-safe summary error for this parse failure."""
+
+        return NDJSONLineError(
+            line_number=self.line_number,
+            message=self.message,
+        )
+
+
+@dataclass(frozen=True)
+class NDJSONFileSummary:
+    """Processing summary for one NDJSON input file."""
+
+    source: str
+    destination: str
+    lines_processed: int = 0
+    resources_deidentified: int = 0
+    blank_lines: int = 0
+    errors: tuple[NDJSONLineError, ...] = ()
+
+    @property
+    def error_count(self) -> int:
+        """Return the number of malformed or unprocessable input lines."""
+
+        return len(self.errors)
+
+    @property
+    def ok(self) -> bool:
+        """Return whether the file completed without per-line errors."""
+
+        return not self.errors
+
+
+@dataclass(frozen=True)
+class BulkExportSummary:
+    """Aggregate summary for a directory-level bulk export pass."""
+
+    input_dir: str
+    output_dir: str
+    files: tuple[NDJSONFileSummary, ...] = field(default_factory=tuple)
+
+    @property
+    def file_count(self) -> int:
+        """Return the number of NDJSON files processed."""
+
+        return len(self.files)
+
+    @property
+    def lines_processed(self) -> int:
+        """Return the total number of physical lines read."""
+
+        return sum(file.lines_processed for file in self.files)
+
+    @property
+    def resources_deidentified(self) -> int:
+        """Return the total number of resources written."""
+
+        return sum(file.resources_deidentified for file in self.files)
+
+    @property
+    def errors(self) -> tuple[NDJSONLineError, ...]:
+        """Return all per-line errors across files."""
+
+        return tuple(error for file in self.files for error in file.errors)
+
+
+def iter_ndjson(path: str | Path) -> Iterator[dict[str, Any]]:
+    """Yield parsed FHIR resources from an NDJSON file lazily.
+
+    Blank lines are skipped. Malformed JSON lines and non-object JSON values
+    raise :class:`FHIRNDJSONLineError` with the physical line number.
+
+    Args:
+        path: File containing one JSON resource per line.
+
+    Yields:
+        Parsed resource mappings in input order.
+    """
+
+    source = Path(path)
+    with source.open("r", encoding="utf-8") as stream:
+        for line_number, line in enumerate(stream, start=1):
+            if not line.strip():
+                continue
+            yield _parse_resource_line(source, line, line_number)
+
+
+def deidentify_ndjson(
+    in_path: str | Path,
+    out_path: str | Path,
+    *,
+    policy: str = _DEFAULT_POLICY,
+    method: str = _DEFAULT_METHOD,
+    deidentifier: Deidentifier | None = None,
+) -> NDJSONFileSummary:
+    """Stream one NDJSON file through FHIR resource de-identification.
+
+    Malformed or unprocessable lines are recorded in the returned summary and
+    skipped, allowing later valid lines to continue processing. Error messages
+    include line numbers but never raw line content.
+
+    Args:
+        in_path: Input NDJSON file.
+        out_path: Destination NDJSON file.
+        policy: Privacy policy profile passed to the FHIR operation wrapper.
+        method: De-identification method passed to the FHIR operation wrapper.
+        deidentifier: Optional privacy pipeline override, mainly for tests.
+
+    Returns:
+        A file summary with line counts, successful resources, and errors.
+    """
+
+    source = Path(in_path)
+    destination = Path(out_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    lines_processed = 0
+    resources_deidentified = 0
+    blank_lines = 0
+    errors: list[NDJSONLineError] = []
+
+    with (
+        source.open("r", encoding="utf-8") as input_stream,
+        destination.open("w", encoding="utf-8") as output_stream,
+    ):
+        for line_number, line in enumerate(input_stream, start=1):
+            lines_processed += 1
+            if not line.strip():
+                blank_lines += 1
+                continue
+
+            try:
+                resource = _parse_resource_line(source, line, line_number)
+                transformed = de_identify_resource(
+                    resource,
+                    policy=policy,
+                    method=method,
+                    deidentifier=deidentifier,
+                )
+            except FHIRNDJSONLineError as exc:
+                errors.append(exc.to_summary_error())
+                continue
+            except (TypeError, ValueError) as exc:
+                errors.append(
+                    NDJSONLineError(
+                        line_number=line_number,
+                        message=_sanitize_error_message(exc),
+                    )
+                )
+                continue
+
+            json.dump(
+                transformed,
+                output_stream,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            output_stream.write("\n")
+            resources_deidentified += 1
+
+    return NDJSONFileSummary(
+        source=str(source),
+        destination=str(destination),
+        lines_processed=lines_processed,
+        resources_deidentified=resources_deidentified,
+        blank_lines=blank_lines,
+        errors=tuple(errors),
+    )
+
+
+def deidentify_export(
+    in_dir: str | Path,
+    out_dir: str | Path,
+    *,
+    policy: str = _DEFAULT_POLICY,
+    method: str = _DEFAULT_METHOD,
+    deidentifier: Deidentifier | None = None,
+) -> BulkExportSummary:
+    """De-identify every ``*.ndjson`` file in a FHIR bulk export directory.
+
+    The output directory mirrors the input directory's relative NDJSON file
+    layout. Non-NDJSON files are ignored.
+
+    Args:
+        in_dir: Directory containing per-resource-type NDJSON files.
+        out_dir: Destination directory for de-identified NDJSON files.
+        policy: Privacy policy profile passed to each file processor.
+        method: De-identification method passed to each file processor.
+        deidentifier: Optional privacy pipeline override, mainly for tests.
+
+    Returns:
+        An aggregate summary with one :class:`NDJSONFileSummary` per file.
+
+    Raises:
+        ValueError: If ``in_dir`` is not a directory.
+    """
+
+    source_root = Path(in_dir)
+    destination_root = Path(out_dir)
+    if not source_root.is_dir():
+        raise ValueError(f"input export path is not a directory: {source_root}")
+    destination_root.mkdir(parents=True, exist_ok=True)
+
+    summaries: list[NDJSONFileSummary] = []
+    for source in sorted(source_root.rglob("*.ndjson")):
+        if not source.is_file():
+            continue
+        relative = source.relative_to(source_root)
+        destination = destination_root / relative
+        summaries.append(
+            deidentify_ndjson(
+                source,
+                destination,
+                policy=policy,
+                method=method,
+                deidentifier=deidentifier,
+            )
+        )
+
+    return BulkExportSummary(
+        input_dir=str(source_root),
+        output_dir=str(destination_root),
+        files=tuple(summaries),
+    )
+
+
+def _parse_resource_line(
+    path: Path,
+    line: str,
+    line_number: int,
+) -> dict[str, Any]:
+    """Parse one NDJSON line as a FHIR resource mapping."""
+
+    try:
+        raw = json.loads(_strip_initial_bom(line, line_number))
+    except json.JSONDecodeError as exc:
+        raise FHIRNDJSONLineError(
+            path,
+            line_number,
+            f"malformed JSON: {exc.msg}",
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise FHIRNDJSONLineError(
+            path,
+            line_number,
+            "line must contain a JSON object",
+        )
+    return raw
+
+
+def _strip_initial_bom(line: str, line_number: int) -> str:
+    if line_number == 1:
+        return line.lstrip("\ufeff")
+    return line
+
+
+def _sanitize_error_message(exc: BaseException) -> str:
+    message = str(exc).strip()
+    return message or exc.__class__.__name__

--- a/tests/unit/interop/test_fhir_bulk_ndjson.py
+++ b/tests/unit/interop/test_fhir_bulk_ndjson.py
@@ -1,0 +1,226 @@
+"""Tests for streaming FHIR Bulk Data NDJSON de-identification."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from openmed.interop.fhir_bulk import (
+    FHIRNDJSONLineError,
+    deidentify_export,
+    deidentify_ndjson,
+    iter_ndjson,
+)
+
+
+@dataclass
+class _FakeResult:
+    deidentified_text: str
+
+
+def fake_deidentify(text, *, method="replace", policy="hipaa_safe_harbor"):
+    """Deterministic offline stand-in for the privacy pipeline."""
+
+    assert method == "replace"
+    assert policy in {"hipaa_safe_harbor", "unit_test_policy"}
+
+    redacted = text
+    for needle, replacement in (
+        ("123 Main Street", "[ADDRESS]"),
+        ("Jane Roe", "[NAME]"),
+        ("John Doe", "[NAME]"),
+        ("555-0100", "[PHONE]"),
+    ):
+        redacted = redacted.replace(needle, replacement)
+    return _FakeResult(deidentified_text=redacted)
+
+
+def _observation(resource_id: str, note_text: str) -> dict:
+    return {
+        "resourceType": "Observation",
+        "id": resource_id,
+        "status": "final",
+        "code": {
+            "coding": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "1234-5",
+                    "display": "Synthetic clinical note",
+                }
+            ],
+            "text": "Observation note for John Doe",
+        },
+        "subject": {
+            "reference": "Patient/pat-1",
+            "display": "John Doe",
+        },
+        "note": [{"text": note_text}],
+    }
+
+
+def _patient(resource_id: str) -> dict:
+    return {
+        "resourceType": "Patient",
+        "id": resource_id,
+        "name": [{"text": "Jane Roe"}],
+        "telecom": [{"system": "phone", "value": "555-0100"}],
+    }
+
+
+def _write_ndjson(path: Path, resources: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(resource) + "\n" for resource in resources),
+        encoding="utf-8",
+    )
+
+
+def _read_ndjson(path: Path) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_iter_ndjson_yields_lazily_and_reports_malformed_line_numbers(tmp_path):
+    in_path = tmp_path / "Observation.ndjson"
+    in_path.write_text(
+        json.dumps(_observation("obs-1", "Seen by John Doe.")) + "\n"
+        "{not valid json}\n" + json.dumps(_observation("obs-2", "Seen by Jane Roe.")),
+        encoding="utf-8",
+    )
+
+    resources = iter_ndjson(in_path)
+
+    assert next(resources)["id"] == "obs-1"
+    with pytest.raises(FHIRNDJSONLineError) as excinfo:
+        next(resources)
+    assert excinfo.value.line_number == 2
+    assert "malformed JSON" in excinfo.value.message
+
+
+def test_deidentify_ndjson_streams_resources_and_preserves_order(tmp_path):
+    in_path = tmp_path / "Observation.ndjson"
+    out_path = tmp_path / "out" / "Observation.ndjson"
+    _write_ndjson(
+        in_path,
+        [
+            _observation("obs-1", "John Doe lives at 123 Main Street."),
+            _observation("obs-2", "Jane Roe called from 555-0100."),
+        ],
+    )
+
+    summary = deidentify_ndjson(
+        in_path,
+        out_path,
+        policy="unit_test_policy",
+        method="replace",
+        deidentifier=fake_deidentify,
+    )
+
+    assert summary.lines_processed == 2
+    assert summary.resources_deidentified == 2
+    assert summary.blank_lines == 0
+    assert summary.errors == ()
+
+    output = _read_ndjson(out_path)
+    assert [resource["id"] for resource in output] == ["obs-1", "obs-2"]
+    assert output[0]["note"][0]["text"] == "[NAME] lives at [ADDRESS]."
+    assert output[1]["note"][0]["text"] == "[NAME] called from [PHONE]."
+    assert output[0]["subject"]["display"] == "[NAME]"
+    assert output[0]["subject"]["reference"] == "Patient/pat-1"
+    assert output[0]["code"]["coding"][0]["display"] == "Synthetic clinical note"
+
+
+def test_deidentify_ndjson_reports_bad_lines_without_stopping(tmp_path):
+    in_path = tmp_path / "Observation.ndjson"
+    out_path = tmp_path / "out" / "Observation.ndjson"
+    in_path.write_text(
+        json.dumps(_observation("obs-1", "Seen by John Doe.")) + "\n"
+        "{not valid json}\n"
+        "\n" + json.dumps(_observation("obs-2", "Seen by Jane Roe.")) + "\n",
+        encoding="utf-8",
+    )
+
+    summary = deidentify_ndjson(
+        in_path,
+        out_path,
+        deidentifier=fake_deidentify,
+    )
+
+    assert summary.lines_processed == 4
+    assert summary.resources_deidentified == 2
+    assert summary.blank_lines == 1
+    assert len(summary.errors) == 1
+    assert summary.errors[0].line_number == 2
+    assert "malformed JSON" in summary.errors[0].message
+    assert "John Doe" not in summary.errors[0].message
+
+    output = _read_ndjson(out_path)
+    assert [resource["id"] for resource in output] == ["obs-1", "obs-2"]
+    assert output[0]["note"][0]["text"] == "Seen by [NAME]."
+    assert output[1]["note"][0]["text"] == "Seen by [NAME]."
+
+
+def test_deidentify_ndjson_reports_non_resource_lines_without_stopping(tmp_path):
+    in_path = tmp_path / "Patient.ndjson"
+    out_path = tmp_path / "out" / "Patient.ndjson"
+    in_path.write_text(
+        json.dumps(_patient("pat-1")) + "\n"
+        "[]\n"
+        + json.dumps({"id": "missing-resource-type", "name": "John Doe"})
+        + "\n"
+        + json.dumps(_patient("pat-2"))
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = deidentify_ndjson(
+        in_path,
+        out_path,
+        deidentifier=fake_deidentify,
+    )
+
+    assert summary.lines_processed == 4
+    assert summary.resources_deidentified == 2
+    assert [error.line_number for error in summary.errors] == [2, 3]
+    assert summary.errors[0].message == "line must contain a JSON object"
+    assert summary.errors[1].message == "resource is missing 'resourceType'"
+
+    output = _read_ndjson(out_path)
+    assert [resource["id"] for resource in output] == ["pat-1", "pat-2"]
+    assert output[0]["name"][0]["text"] == "[NAME]"
+
+
+def test_deidentify_export_mirrors_ndjson_directory_structure(tmp_path):
+    in_dir = tmp_path / "bulk-export"
+    out_dir = tmp_path / "deidentified"
+    _write_ndjson(in_dir / "Patient.ndjson", [_patient("pat-1")])
+    _write_ndjson(
+        in_dir / "nested" / "Observation.ndjson",
+        [_observation("obs-1", "John Doe lives at 123 Main Street.")],
+    )
+    (in_dir / "README.txt").write_text("not part of the export\n", encoding="utf-8")
+
+    summary = deidentify_export(
+        in_dir,
+        out_dir,
+        deidentifier=fake_deidentify,
+    )
+
+    assert summary.file_count == 2
+    assert summary.lines_processed == 2
+    assert summary.resources_deidentified == 2
+    assert summary.errors == ()
+    assert (out_dir / "Patient.ndjson").is_file()
+    assert (out_dir / "nested" / "Observation.ndjson").is_file()
+    assert not (out_dir / "README.txt").exists()
+
+    patient = _read_ndjson(out_dir / "Patient.ndjson")[0]
+    observation = _read_ndjson(out_dir / "nested" / "Observation.ndjson")[0]
+    assert patient["name"][0]["text"] == "[NAME]"
+    assert observation["note"][0]["text"] == "[NAME] lives at [ADDRESS]."


### PR DESCRIPTION
# Pull Request

## Description
Adds streaming NDJSON ingestion and de-identification helpers for FHIR Bulk Data exports. The new interop module reads resources line by line, applies the existing FHIR resource de-identification wrapper, writes de-identified NDJSON in input order, and returns PHI-safe file/export summaries for audit use.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `openmed.interop.fhir_bulk` with `iter_ndjson`, `deidentify_ndjson`, and `deidentify_export`.
- Added PHI-safe per-line and per-file summaries for processed lines, de-identified resources, blank lines, and malformed-line errors.
- Added offline unit coverage for lazy iteration, preserved output order, directory mirroring, blank-line tolerance, and malformed-line continuation.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/unit/interop/test_fhir_bulk_ndjson.py -q`
- `.venv/bin/python -m pytest tests/ -q`

Result:
- `2285 passed, 31 skipped, 14 warnings`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #507

## Screenshots/Examples
Not applicable; this is streaming interop logic and tests only.
