### PR TITLE
Add model card preview command

### DIFF
--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 import json
 import sys
 from pathlib import Path
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 from ..__about__ import __version__
 from ..core.config import (
@@ -22,7 +23,8 @@ from ..core.config import (
     save_profile,
     set_config,
 )
-from ..core.model_registry import get_model_info
+from ..core.model_card import render_model_card
+from ..core.model_registry import MANIFEST_PATH, get_model_info, load_manifest_rows
 from ..core.model_search import ModelSearchResult, recommend_models, search_models
 from .calibrate import add_calibrate_command
 
@@ -482,6 +484,29 @@ def _add_models_command(subparsers: argparse._SubParsersAction) -> None:
         help="Emit the ranked shortlist as a single JSON document.",
     )
     models_recommend.set_defaults(handler=_handle_models_recommend)
+
+    models_card = models_sub.add_parser(
+        "card",
+        help="Render a README model card from the canonical manifest.",
+    )
+    models_card.add_argument(
+        "repo_id",
+        help="Hugging Face repository id to resolve from models.jsonl.",
+    )
+    card_output = models_card.add_mutually_exclusive_group()
+    card_output.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        help="Optional path to write the rendered README Markdown.",
+    )
+    card_output.add_argument(
+        "--check",
+        type=Path,
+        metavar="README",
+        help="Compare an existing README against the rendered card.",
+    )
+    models_card.set_defaults(handler=_handle_models_card)
 
     models_freshness = models_sub.add_parser(
         "freshness",
@@ -1038,6 +1063,54 @@ def _handle_models_recommend(args: argparse.Namespace) -> int:
     sys.stdout.write(f"Recommended for {args.tier}: {results[0].repo_id}\n")
     sys.stdout.write(_format_model_search_table(results))
     return 0
+
+
+def _handle_models_card(args: argparse.Namespace) -> int:
+    try:
+        row = _find_manifest_row(args.repo_id)
+        rendered = render_model_card(dict(row))
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"Failed to render model card: {exc}\n")
+        return 1
+
+    if args.check is not None:
+        try:
+            existing = args.check.read_text(encoding="utf-8")
+        except OSError as exc:
+            sys.stderr.write(f"Failed to read README for comparison: {exc}\n")
+            return 1
+
+        if existing == rendered:
+            return 0
+
+        diff = difflib.unified_diff(
+            existing.splitlines(keepends=True),
+            rendered.splitlines(keepends=True),
+            fromfile=str(args.check),
+            tofile=f"rendered:{args.repo_id}",
+        )
+        sys.stdout.writelines(diff)
+        return 1
+
+    if args.output is not None:
+        try:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered, encoding="utf-8")
+        except OSError as exc:
+            sys.stderr.write(f"Failed to write model card: {exc}\n")
+            return 1
+        return 0
+
+    sys.stdout.write(rendered)
+    return 0
+
+
+def _find_manifest_row(repo_id: str) -> Mapping[str, Any]:
+    rows = load_manifest_rows(MANIFEST_PATH)
+    for row in rows:
+        if row.get("repo_id") == repo_id:
+            return row
+    raise ValueError(f"repo_id not found in model manifest: {repo_id}")
 
 
 def _recommendation_to_dict(result: ModelSearchResult) -> dict[str, Any]:

--- a/tests/unit/cli/test_models_card_cli.py
+++ b/tests/unit/cli/test_models_card_cli.py
@@ -1,0 +1,131 @@
+"""Tests for the ``openmed models card`` command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openmed.cli import main_module
+from openmed.core.model_card import render_model_card
+
+
+def _manifest_row() -> dict[str, Any]:
+    return {
+        "repo_id": "OpenMed/unit-card-model",
+        "family": "PII",
+        "task": "token-classification",
+        "languages": ["en"],
+        "tier": "Small",
+        "param_count": 44_000_000,
+        "architecture": "deberta-v2",
+        "base_model": "OpenMed/base-unit-card-model",
+        "formats": ["mlx-fp", "pytorch"],
+        "canonical_labels": ["PERSON", "DATE", "ID_NUM"],
+        "benchmark": {
+            "dataset": "synthetic-card-fixture",
+            "micro_f1": 0.9823,
+            "recall": 0.991,
+        },
+        "arxiv": "2508.01630",
+        "license": "apache-2.0",
+        "reproducibility_hash": (
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        ),
+        "released": "2026-06-14",
+    }
+
+
+def test_models_card_prints_publish_time_markdown(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    row = _manifest_row()
+    monkeypatch.setattr(main_module, "load_manifest_rows", lambda path: [row])
+
+    result = main_module.main(["models", "card", row["repo_id"]])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.out == render_model_card(row)
+    assert captured.err == ""
+
+
+def test_models_card_writes_output_file(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    row = _manifest_row()
+    output = tmp_path / "cards" / "README.md"
+    monkeypatch.setattr(main_module, "load_manifest_rows", lambda path: [row])
+
+    result = main_module.main(
+        ["models", "card", row["repo_id"], "--output", str(output)]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert output.read_text(encoding="utf-8") == render_model_card(row)
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_models_card_check_exits_zero_when_readme_matches(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    row = _manifest_row()
+    readme = tmp_path / "README.md"
+    readme.write_text(render_model_card(row), encoding="utf-8")
+    monkeypatch.setattr(main_module, "load_manifest_rows", lambda path: [row])
+
+    result = main_module.main(
+        ["models", "card", row["repo_id"], "--check", str(readme)]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_models_card_check_exits_nonzero_with_unified_diff_on_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    row = _manifest_row()
+    readme = tmp_path / "README.md"
+    readme.write_text("# stale card\n", encoding="utf-8")
+    monkeypatch.setattr(main_module, "load_manifest_rows", lambda path: [row])
+
+    result = main_module.main(
+        ["models", "card", row["repo_id"], "--check", str(readme)]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert captured.err == ""
+    assert f"--- {readme}" in captured.out
+    assert "+++ rendered:OpenMed/unit-card-model" in captured.out
+    assert "-# stale card" in captured.out
+    assert "+# unit-card-model" in captured.out
+
+
+def test_models_card_unknown_repo_id_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        main_module, "load_manifest_rows", lambda path: [_manifest_row()]
+    )
+
+    result = main_module.main(["models", "card", "OpenMed/missing-model"])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert captured.out == ""
+    assert "repo_id not found in model manifest: OpenMed/missing-model" in captured.err


### PR DESCRIPTION
# Pull Request

## Description
Adds `openmed models card <repo_id>` so maintainers can preview the generated README model card locally from the canonical manifest. The command can print Markdown, write it to `--output`, or compare it with an existing README via `--check`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added the `models card` subcommand to render a manifest row through the existing model-card renderer.
- Added `--output` and `--check README` modes, including unified diff output on drift.
- Added CLI tests for rendering, file output, matching checks, drift checks, and unknown repository ids.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `.venv/bin/python -m pytest tests/unit/cli/test_models_card_cli.py tests/unit/core/test_model_card.py -q`
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

No documentation or changelog update was needed for this narrow CLI addition.

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

No Swift files were changed.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #527

## Screenshots/Examples
Example usage:

```bash
openmed models card OpenMed/unit-card-model
openmed models card OpenMed/unit-card-model --check README.md
```
