### PR TITLE
fix(core,eval,ner,risk): guard json.loads against JSONDecodeError

### DIFF
--- a/openmed/core/audit.py
+++ b/openmed/core/audit.py
@@ -352,7 +352,11 @@ class AuditReport:
 
     @classmethod
     def from_json(cls, data: str | bytes) -> "AuditReport":
-        return cls.from_dict(json.loads(data))
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON for AuditReport: {exc}") from exc
+        return cls.from_dict(parsed)
 
     def sign(
         self,

--- a/openmed/core/surrogate_vault.py
+++ b/openmed/core/surrogate_vault.py
@@ -201,7 +201,10 @@ class JsonFileSurrogateStore(InMemorySurrogateStore):
                 raise FileNotFoundError(vault_path)
             return cls(vault_path, autosave=autosave)
 
-        payload = json.loads(vault_path.read_text(encoding="utf-8"))
+        try:
+            payload = json.loads(vault_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Corrupt surrogate vault {vault_path}: {exc}") from exc
         loaded = InMemorySurrogateStore.from_payload(payload)
         return cls(vault_path, loaded.entries(), autosave=autosave)
 

--- a/openmed/core/thresholds.py
+++ b/openmed/core/thresholds.py
@@ -66,7 +66,10 @@ def load_thresholds(path: str | Path | None = None) -> dict[str, Any]:
         with resource.open("r", encoding="utf-8") as handle:
             payload = json.load(handle)
     else:
-        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        try:
+            payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in threshold file {path}: {exc}") from exc
     validate_threshold_matrix(payload)
     return payload
 

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -391,7 +391,11 @@ class GateReport:
 
     @classmethod
     def from_json(cls, data: str | bytes) -> "GateReport":
-        return cls.from_dict(json.loads(data))
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON for GateReport: {exc}") from exc
+        return cls.from_dict(parsed)
 
 
 class ReleaseGate:
@@ -2056,7 +2060,10 @@ def _find_open_issue(*, repo: str, title: str) -> int | None:
         check=True,
         capture_output=True,
     )
-    issues = json.loads(result.stdout or "[]")
+    try:
+        issues = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
     for issue in issues:
         if isinstance(issue, Mapping) and issue.get("title") == title:
             return _optional_int(issue.get("number"))

--- a/openmed/ner/indexing.py
+++ b/openmed/ner/indexing.py
@@ -350,7 +350,10 @@ def load_index(path: Optional[Path] = None) -> ModelIndex:
     if not index_path.exists():
         raise FileNotFoundError(f"Index file not found: {index_path}")
 
-    payload = json.loads(index_path.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in index file {index_path}: {exc}") from exc
 
     models_payload = payload.get("models", [])
     meta = payload.get("meta", {})

--- a/openmed/ner/labels.py
+++ b/openmed/ner/labels.py
@@ -45,7 +45,10 @@ def _load_from_resource() -> Mapping[str, Iterable[str]]:
 
 def _load_from_path(path: Path) -> Mapping[str, Iterable[str]]:
     text = Path(path).read_text(encoding="utf-8")
-    return json.loads(text)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in label file: {exc}") from exc
 
 
 def _normalise_label_map(raw: Mapping[str, Iterable[str]]) -> Dict[str, List[str]]:

--- a/openmed/ner/labels.py
+++ b/openmed/ner/labels.py
@@ -48,7 +48,7 @@ def _load_from_path(path: Path) -> Mapping[str, Iterable[str]]:
     try:
         return json.loads(text)
     except json.JSONDecodeError as exc:
-        raise ValueError(f"Invalid JSON in label file: {exc}") from exc
+        raise ValueError(f"Invalid JSON in label file {path}: {exc}") from exc
 
 
 def _normalise_label_map(raw: Mapping[str, Iterable[str]]) -> Dict[str, List[str]]:

--- a/openmed/risk/audit_diff.py
+++ b/openmed/risk/audit_diff.py
@@ -347,7 +347,10 @@ def _coerce_report(report: AuditReportInput) -> dict[str, Any]:
     if isinstance(report, Mapping):
         return copy.deepcopy(dict(report))
     if isinstance(report, (str, Path)):
-        payload = json.loads(Path(report).read_text(encoding="utf-8"))
+        try:
+            payload = json.loads(Path(report).read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in audit report {report}: {exc}") from exc
     elif hasattr(report, "to_dict") and callable(report.to_dict):
         payload = report.to_dict()
     else:

--- a/tests/unit/core/test_audit_report.py
+++ b/tests/unit/core/test_audit_report.py
@@ -90,6 +90,11 @@ def test_report_json_round_trip_is_byte_stable_and_hash_recomputes():
     assert verify_repro_hash(json.loads(payload))
 
 
+def test_report_from_json_rejects_malformed_payload():
+    with pytest.raises(ValueError, match="Invalid JSON for AuditReport"):
+        AuditReport.from_json("{")
+
+
 def test_report_sign_verify_and_tamper_detection():
     report = _report().sign("release-key", key_id="test-key")
 

--- a/tests/unit/core/test_surrogate_vault.py
+++ b/tests/unit/core/test_surrogate_vault.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable
 
+import pytest
+
 from openmed.core.pii import deidentify, reidentify
 from openmed.core.surrogate_vault import (
     HMAC_SCHEME,
@@ -111,6 +113,16 @@ def test_json_vault_persists_only_hmac_hashes_and_surrogates(monkeypatch, tmp_pa
     assert all(
         entry["text_hash"].startswith(f"{HMAC_SCHEME}:") for entry in payload["entries"]
     )
+
+
+def test_json_vault_load_rejects_malformed_json(tmp_path):
+    path = tmp_path / "surrogate-vault.json"
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Corrupt surrogate vault") as exc_info:
+        SurrogateVault.from_file(path, hmac_secret="unit-test-hmac-secret")
+
+    assert str(path) in str(exc_info.value)
 
 
 def test_json_vault_reload_continues_stable_surrogates(monkeypatch, tmp_path):

--- a/tests/unit/core/test_thresholds_matrix.py
+++ b/tests/unit/core/test_thresholds_matrix.py
@@ -1,6 +1,8 @@
 import json
 from importlib import resources
 
+import pytest
+
 from openmed.core.arbitration import MODE_BALANCED, MODE_HIGH_RECALL_UNION, arbitrate
 from openmed.core.cascade import R2_BASE, CascadeRouter
 from openmed.core.pipeline import Pipeline
@@ -113,6 +115,16 @@ def test_fit_and_update_thresholds_return_valid_versioned_matrix():
     assert (
         lookup_threshold("EMAIL", "en", "balanced", matrix=updated)["keep_floor"] == 0.4
     )
+
+
+def test_load_thresholds_rejects_malformed_json(tmp_path):
+    path = tmp_path / "thresholds.json"
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid JSON in threshold file") as exc_info:
+        load_thresholds(path)
+
+    assert str(path) in str(exc_info.value)
 
 
 def test_arbitration_reads_matrix_keep_floor_by_mode():

--- a/tests/unit/eval/test_release_gates.py
+++ b/tests/unit/eval/test_release_gates.py
@@ -176,6 +176,26 @@ def test_release_gate_passes_and_emits_signed_section_64_report(
     assert restored.to_json() == result.to_json()
 
 
+def test_gate_report_from_json_rejects_malformed_payload() -> None:
+    with pytest.raises(ValueError, match="Invalid JSON for GateReport"):
+        GateReport.from_json("{")
+
+
+def test_find_open_issue_returns_none_for_malformed_gh_json(monkeypatch) -> None:
+    class Result:
+        stdout = "{"
+
+    monkeypatch.setattr(
+        release_gates.subprocess,
+        "run",
+        lambda *args, **kwargs: Result(),
+    )
+
+    assert (
+        release_gates._find_open_issue(repo="owner/repo", title="Gate failure") is None
+    )
+
+
 @pytest.mark.parametrize(
     ("gate_name", "metric_updates", "metadata_updates"),
     [

--- a/tests/unit/ner/test_indexing.py
+++ b/tests/unit/ner/test_indexing.py
@@ -72,3 +72,13 @@ def test_write_and_load_index_roundtrip(temp_models_dir: Path, tmp_path: Path) -
     assert isinstance(loaded, ModelIndex)
     assert len(loaded.models) == len(index.models)
     assert loaded.unique_domains == index.unique_domains
+
+
+def test_load_index_rejects_malformed_json(tmp_path: Path) -> None:
+    path = tmp_path / "index.json"
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid JSON in index file") as exc_info:
+        load_index(path)
+
+    assert str(path) in str(exc_info.value)

--- a/tests/unit/ner/test_label_map_consistency.py
+++ b/tests/unit/ner/test_label_map_consistency.py
@@ -20,7 +20,11 @@ from openmed.core.model_registry import (
     get_model_suggestions,
 )
 from openmed.core.pii_entity_merger import is_more_specific, normalize_label
-from openmed.ner.labels import available_domains, get_default_labels
+from openmed.ner.labels import (
+    available_domains,
+    get_default_labels,
+    load_default_label_map,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -75,6 +79,16 @@ class TestDefaultsJsonInvariants:
                     f"Domain {domain!r} label {label!r} drifts from the "
                     "letters-only display-label style"
                 )
+
+
+def test_load_default_label_map_rejects_malformed_override(tmp_path: Path) -> None:
+    path = tmp_path / "labels.json"
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid JSON in label file") as exc_info:
+        load_default_label_map(path)
+
+    assert str(path) in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/risk/test_audit_diff.py
+++ b/tests/unit/risk/test_audit_diff.py
@@ -6,6 +6,8 @@ import copy
 import json
 from pathlib import Path
 
+import pytest
+
 from openmed.core.audit import hash_text
 from openmed.risk import diff_audit_reports
 
@@ -161,3 +163,13 @@ def test_to_dict_is_json_serializable_and_deterministic_for_paths(
     assert json.loads(json.dumps(first, sort_keys=True)) == first
     assert first["summary"]["added_spans"] == 1
     assert first["added_spans"][0]["label"] == "PHONE"
+
+
+def test_diff_audit_reports_rejects_malformed_json_path(tmp_path: Path) -> None:
+    path = tmp_path / "audit-report.json"
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid JSON in audit report") as exc_info:
+        diff_audit_reports(path, _report())
+
+    assert str(path) in str(exc_info.value)


### PR DESCRIPTION
## Problem

Multiple modules call `json.loads()` on file contents, API responses, and subprocess output without catching `JSONDecodeError`. A corrupt file, malformed API response, or unexpected subprocess output causes an unhandled crash with a raw traceback.

## Affected Locations

| File | Function | Input Source |
|------|----------|-------------|
| `core/surrogate_vault.py:204` | `SurrogateVault.open()` | Vault file on disk |
| `core/thresholds.py:69` | `_load_threshold_matrix()` | Threshold config file |
| `core/audit.py:355` | `AuditReport.from_json()` | String/bytes input |
| `eval/release_gates.py:394` | `GateReport.from_json()` | String/bytes input |
| `eval/release_gates.py:2059` | `_find_github_issue()` | `pip-audit` subprocess output |
| `ner/indexing.py:353` | `load_index()` | Index file on disk |
| `ner/labels.py:48` | `_load_from_path()` | Label file on disk |
| `risk/audit_diff.py:350` | `_coerce_report()` | Audit report file |

## Fix

Each `json.loads()` is wrapped in `try/except json.JSONDecodeError` with a descriptive `ValueError` including the file path and error detail:

```python
# Before
payload = json.loads(Path(path).read_text(encoding="utf-8"))

# After
try:
    payload = json.loads(Path(path).read_text(encoding="utf-8"))
except json.JSONDecodeError as exc:
    raise ValueError(f"Invalid JSON in threshold file {path}: {exc}") from exc
```

For the subprocess output case (`release_gates.py:2059`), the function returns `None` on invalid JSON since it's a lookup helper.

## Impact

- **Severity**: P1 — crash on corrupt/malformed input files
- **Scope**: 7 files, 34 lines added
- **Risk**: Minimal — only adds error handling, raises `ValueError` instead of raw `JSONDecodeError`
