### PR TITLE
fix(core,ner,service,eval): narrow broad except and add subprocess timeout

### DIFF
--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -278,12 +278,12 @@ def analyze_text(
             if desired_max_length is not None:
                 try:
                     tokenizer.model_max_length = int(desired_max_length)
-                except Exception:
+                except (AttributeError, TypeError, ValueError):
                     pass
         else:
             try:
                 tokenizer.model_max_length = 0
-            except Exception:
+            except (AttributeError, TypeError, ValueError):
                 pass
 
     raw_segments: List[sentence_utils.SentenceSpan] = []

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -2010,9 +2010,11 @@ def _open_or_update_issue(*, repo: str, title: str, body: str) -> int | None:
                 "--body-file",
                 "-",
             ],
+            timeout=30,
             input=body,
             text=True,
             check=True,
+            timeout=30,
         )
         return existing
 
@@ -2032,6 +2034,7 @@ def _open_or_update_issue(*, repo: str, title: str, body: str) -> int | None:
         text=True,
         check=True,
         capture_output=True,
+        timeout=30,
     )
     output = result.stdout.strip().rsplit("/", 1)[-1]
     return _optional_int(output.lstrip("#"))
@@ -2055,6 +2058,7 @@ def _find_open_issue(*, repo: str, title: str) -> int | None:
         text=True,
         check=True,
         capture_output=True,
+        timeout=30,
     )
     issues = json.loads(result.stdout or "[]")
     for issue in issues:

--- a/openmed/ner/families/gliner.py
+++ b/openmed/ner/families/gliner.py
@@ -104,7 +104,7 @@ def load_gliner_handle(
     if device and hasattr(model, "to"):
         try:
             model = model.to(device)
-        except Exception:  # pragma: no cover - defensive path
+        except (RuntimeError, OSError, ValueError):  # pragma: no cover - defensive path
             pass
 
     return GLiNERHandle(model_id=model_id, model=model)

--- a/openmed/ner/families/gliner2.py
+++ b/openmed/ner/families/gliner2.py
@@ -149,7 +149,7 @@ def load_gliner2_handle(
     if device and hasattr(model, "to"):
         try:
             model = model.to(device)
-        except Exception:  # pragma: no cover - defensive path
+        except (RuntimeError, OSError, ValueError):  # pragma: no cover - defensive path
             pass
 
     return GLiNER2Handle(model_id=model_id, model=model)

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -696,7 +696,7 @@ def _analyze_payload_batch(
     if tokenizer is not None and effective_max_length is not None:
         try:
             tokenizer.model_max_length = int(effective_max_length)
-        except Exception:
+        except (AttributeError, TypeError, ValueError):
             pass
 
     import time


### PR DESCRIPTION
## Problem

Two categories of issues:

### 1. Bare `except Exception: pass` masks real bugs

Four locations catch `Exception` and silently discard the error. This catches `SystemExit` and `KeyboardInterrupt`, and masks unexpected bugs that should propagate.

```python
# Before — catches everything, including SystemExit/KeyboardInterrupt
try:
    tokenizer.model_max_length = int(desired_max_length)
except Exception:
    pass

# After — only catches expected failure types
try:
    tokenizer.model_max_length = int(desired_max_length)
except (AttributeError, TypeError, ValueError):
    pass
```

| File | Context | Narrowed to |
|------|---------|-------------|
| `__init__.py:281,286` | `tokenizer.model_max_length` assignment | `AttributeError, TypeError, ValueError` |
| `ner/families/gliner.py:107` | `model.to(device)` | `RuntimeError, OSError, ValueError` |
| `ner/families/gliner2.py:152` | `model.to(device)` | `RuntimeError, OSError, ValueError` |
| `service/app.py:699` | `tokenizer.model_max_length` assignment | `AttributeError, TypeError, ValueError` |

### 2. `subprocess.run()` without timeout in `eval/release_gates.py`

Three `gh` CLI calls (`issue comment`, `issue create`, `issue list`) have no timeout and can hang indefinitely on network issues.

Added `timeout=30` (30 seconds) to all three calls.

## Impact

- **Severity**: P1 (exception narrowing) + P2 (subprocess timeout)
- **Scope**: 5 files, 9 lines changed
- **Risk**: Minimal — preserves defensive behavior, only narrows catch scope
