### PR TITLE
docs: add automated clinical domains markdown generator and doc-drift test

### DIFF
--- a/docs/clinical-domains.md
+++ b/docs/clinical-domains.md
@@ -1,0 +1,166 @@
+**Disclaimer:** Deterministic status vocabulary helpers for SDOH cue normalization. The helpers in this module normalize explicit status cues into compact canonical values for downstream SDOH extractors. Outputs are advisory labels for review and downstream processing, not clinical decisions. They deliberately do not infer a status from absence of mention; text with no configured cue returns 'unknown' unless an explicit context axis is supplied by the caller.
+
+### Biomedical
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Disease | CLINICAL_CONCEPT | low | ICD-10-CM, SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+| Drug | CLINICAL_CONCEPT | low | RxNorm, SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+| Gene | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Organism | CLINICAL_CONCEPT | low | SNOMED, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### Clinical
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Problem | CLINICAL_CONCEPT | low | ICD-10-CM, SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+| Treatment | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Test | CLINICAL_CONCEPT | low | LOINC, SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+| BodyPart | CLINICAL_CONCEPT | low | SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+
+### Genomic
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Variant | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Gene | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Transcript | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Phenotype | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### Finance
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Company | QUASI_IDENTIFIER | medium | None | tests/fixtures/clinical/context_traps.jsonl |
+| Ticker | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Instrument | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Event | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### Legal
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Case | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Court | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Judge | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Statute | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### News
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Person | DIRECT_IDENTIFIER | high | None | tests/fixtures/clinical/context_traps.jsonl |
+| Organization | QUASI_IDENTIFIER | medium | None | tests/fixtures/clinical/context_traps.jsonl |
+| Location | QUASI_IDENTIFIER | medium | None | tests/fixtures/clinical/context_traps.jsonl |
+| Date | QUASI_IDENTIFIER | medium | None | tests/fixtures/clinical/context_traps.jsonl |
+
+### Ecommerce
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Product | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Brand | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Price | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Attribute | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### Cybersecurity
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Vulnerability | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| CVE | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Software | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Vendor | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### Chemistry
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Compound | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Reaction | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Property | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Unit | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### Organism
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Species | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Strain | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Taxon | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Habitat | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### Education
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Course | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Topic | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Institution | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Degree | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### Social
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Person | DIRECT_IDENTIFIER | high | None | tests/fixtures/clinical/context_traps.jsonl |
+| Handle | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Hashtag | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| URL | DIRECT_IDENTIFIER | high | None | tests/fixtures/clinical/context_traps.jsonl |
+
+### Public Health
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Condition | CLINICAL_CONCEPT | low | ICD-10-CM, SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+| Intervention | CLINICAL_CONCEPT | low | SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+| Outcome | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Population | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### Cardiology
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| CardiacFinding | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| ECGFinding | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| EjectionFraction | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| CardiacProcedure | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| CardiacDevice | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Anatomy | CLINICAL_CONCEPT | low | SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+
+### Microbiology
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Microorganism | CLINICAL_CONCEPT | low | SNOMED, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Antibiotic | CLINICAL_CONCEPT | low | RxNorm, SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+| Susceptibility | CLINICAL_CONCEPT | low | LOINC, SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+| SpecimenSource | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| CultureResult | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+
+### Dermatology
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| SkinLesion | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Morphology | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Distribution | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Anatomy | CLINICAL_CONCEPT | low | SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+
+### Ophthalmology
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| EyeFinding | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| VisualAcuity | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| IntraocularPressure | CLINICAL_CONCEPT | low | SNOMED, ICD-10-CM, HPO, RxNorm, LOINC | tests/fixtures/clinical/context_traps.jsonl |
+| Anatomy | CLINICAL_CONCEPT | low | SNOMED | tests/fixtures/clinical/context_traps.jsonl |
+
+### Generic
+
+| Label | Category | Risk Level | System Hints | Fixture Path |
+|-------|----------|------------|--------------|--------------|
+| Person | DIRECT_IDENTIFIER | high | None | tests/fixtures/clinical/context_traps.jsonl |
+| Organization | QUASI_IDENTIFIER | medium | None | tests/fixtures/clinical/context_traps.jsonl |
+| Location | QUASI_IDENTIFIER | medium | None | tests/fixtures/clinical/context_traps.jsonl |
+| Date | QUASI_IDENTIFIER | medium | None | tests/fixtures/clinical/context_traps.jsonl |

--- a/openmed/ner/labels.py
+++ b/openmed/ner/labels.py
@@ -3,10 +3,18 @@
 from __future__ import annotations
 
 import json
+import os
 from functools import lru_cache
 from importlib import resources
 from pathlib import Path
 from typing import Dict, Iterable, List, Mapping, Optional
+
+from openmed.core.labels import (
+    normalize_label,
+    policy_label_for,
+    risk_level_for,
+    system_hints_for,
+)
 
 _RESOURCE_PACKAGE = "openmed.zero_shot.data.label_maps"
 _DEFAULT_RESOURCE = "defaults.json"
@@ -112,9 +120,60 @@ def reload_default_label_map() -> Dict[str, List[str]]:
     return load_default_label_map()
 
 
+def generate_clinical_domains_markdown() -> str:
+    """Offline, generate the clinical domains markdown documentation string."""
+    disclaimer = (
+        "Deterministic status vocabulary helpers for SDOH cue normalization. "
+        "The helpers in this module normalize explicit status cues into compact "
+        "canonical values for downstream SDOH extractors. Outputs are advisory "
+        "labels for review and downstream processing, not clinical decisions. "
+        "They deliberately do not infer a status from absence of mention; text "
+        "with no configured cue returns 'unknown' unless an explicit context "
+        "axis is supplied by the caller."
+    )
+
+    final_markdown = f"**Disclaimer:** {disclaimer}\n\n"
+
+    default_label_map = load_default_label_map()
+
+    # Create a markdown string for each domain and its labels
+    for domain, labels in default_label_map.items():
+        table_header = f"### {domain.replace('_', ' ').title()}\n\n"
+        table_header += (
+            "| Label | Category | Risk Level | System Hints | Fixture Path |\n"
+        )
+        table_header += (
+            "|-------|----------|------------|--------------|--------------|\n"
+        )
+
+        domain_markdown = table_header
+
+        for label in labels:
+            normalized_label = normalize_label(label)
+            category = policy_label_for(normalized_label)
+            risk_level = risk_level_for(normalized_label)
+            system_hints = system_hints_for(normalized_label)
+            system_hints_str = ", ".join(system_hints) if system_hints else "None"
+            fixture_path = "tests/fixtures/clinical/context_traps.jsonl"
+
+            domain_markdown += f"| {label} | {category} | {risk_level} | {system_hints_str} | {fixture_path} |\n"
+
+        final_markdown += domain_markdown + "\n"
+
+    return final_markdown
+
+
 __all__ = [
     "load_default_label_map",
     "reload_default_label_map",
     "get_default_labels",
     "available_domains",
+    "generate_clinical_domains_markdown",
 ]
+
+if __name__ == "__main__":
+    # Generate the clinical domains markdown and save to docs
+    markdown_output = generate_clinical_domains_markdown()
+    output_path = os.path.join("docs", "clinical-domains.md")
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(markdown_output)

--- a/tests/unit/ner/test_clinical_domains_doc.py
+++ b/tests/unit/ner/test_clinical_domains_doc.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from openmed.ner.labels import generate_clinical_domains_markdown
+
+
+def test_doc_drift_clinical_domains_markdown():
+    """Ensure there is no documentation drift in the clinical domains markdown file."""
+    doc_path = Path("docs/clinical-domains.md")
+
+    assert doc_path.exists(), "docs/clinical-domains.md does not exist."
+
+    expected_content = doc_path.read_text(encoding="utf-8")
+    actual_content = generate_clinical_domains_markdown()
+
+    assert actual_content == expected_content, (
+        "docs/clinical-domains.md is out of date. "
+        "Run 'python openmed/ner/labels.py' to update it."
+    )


### PR DESCRIPTION
# Pull Request

## Description
Automates the generation of the `clinical-domains.md` documentation and tests for doc-drift. It loops through each domain and it's labels, then formats. (It uses the core/labels.py methods to fetch the metadata). Fails if the generated markdown does not match the file already existing.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added the generation function to `openmed/ner/labels.py` 
- Added a test in `tests/unit/ner/test_clinical_domains_doc.py` to enforce accuracy.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #953

## Screenshots/Examples
N/A