### PR TITLE
Generalize the span decoder into a span-relation graph decoder

### DIFF
--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -38,8 +38,11 @@ from .context import (
 from .lab_values import (
     LAB_FLAG_ADVISORY,
     AbnormalFlag,
+    LabValueAttributeMention,
+    LabValueAttributeRole,
     ReferenceRange,
     derive_abnormal_flag,
+    link_lab_value_attributes,
     parse_reference_range,
 )
 from .medication_sig import (
@@ -123,10 +126,13 @@ __all__ = [
     "CERTAINTY_VALUES",
     "resolve_uncertainty",
     "AbnormalFlag",
+    "LabValueAttributeMention",
+    "LabValueAttributeRole",
     "ReferenceRange",
     "LAB_FLAG_ADVISORY",
     "parse_reference_range",
     "derive_abnormal_flag",
+    "link_lab_value_attributes",
     "CODING_COUNT_LABELS",
     "ENTITY_CATEGORY_LABELS",
     "ClinicalSummaryCard",

--- a/openmed/clinical/lab_values.py
+++ b/openmed/clinical/lab_values.py
@@ -7,7 +7,22 @@ import re
 from collections.abc import Mapping
 from typing import Literal, TypedDict
 
+from openmed.core.decoding import (
+    EdgeCardinality,
+    SpanEdge,
+    SpanGraph,
+    SpanGraphConstraints,
+    SpanNode,
+    decode_span_graph,
+)
+
 AbnormalFlag = Literal["low", "normal", "high", "critical", "unknown"]
+LabValueAttributeRole = Literal[
+    "lab_name",
+    "lab_value",
+    "reference_range",
+    "abnormal_flag",
+]
 
 
 class ReferenceRange(TypedDict):
@@ -17,6 +32,19 @@ class ReferenceRange(TypedDict):
     high: float | None
     low_inclusive: bool
     high_inclusive: bool
+
+
+class LabValueAttributeMention(TypedDict, total=False):
+    """Already-detected lab mention used by the lab attribute graph linker."""
+
+    id: str
+    label: LabValueAttributeRole
+    role: LabValueAttributeRole
+    type: LabValueAttributeRole
+    start: int
+    end: int
+    score: float
+    text_hash: str
 
 
 LAB_FLAG_ADVISORY = (
@@ -54,6 +82,19 @@ _EXPLICIT_FLAGS: Mapping[str, AbnormalFlag] = {
     "N": "normal",
     "NORMAL": "normal",
 }
+
+_LAB_VALUE_GRAPH_CONSTRAINTS = SpanGraphConstraints(
+    type_compatibility={
+        "has_value": (("lab_name", "lab_value"),),
+        "has_reference_range": (("lab_value", "reference_range"),),
+        "has_abnormal_flag": (("lab_value", "abnormal_flag"),),
+    },
+    cardinality={
+        "has_value": EdgeCardinality.one_to_one(),
+        "has_reference_range": EdgeCardinality.one_to_one(),
+        "has_abnormal_flag": EdgeCardinality.one_to_one(),
+    },
+)
 
 
 def _empty_reference_range() -> ReferenceRange:
@@ -222,10 +263,163 @@ def derive_abnormal_flag(
     return "normal"
 
 
+def link_lab_value_attributes(
+    mentions: list[LabValueAttributeMention | Mapping[str, object]],
+    *,
+    max_distance: int = 80,
+) -> SpanGraph:
+    """Link lab name/value/range/flag mentions into a constrained span graph.
+
+    The helper consumes mentions already found by an upstream extractor and
+    uses deterministic proximity scores plus graph constraints to attach one
+    value to one lab name, and optional range / abnormal flag attributes to one
+    value. It does not perform clinical interpretation or unit conversion.
+    """
+
+    if max_distance < 0:
+        raise ValueError("max_distance must be non-negative")
+
+    nodes = [
+        _coerce_lab_attribute_node(raw_mention, index)
+        for index, raw_mention in enumerate(mentions)
+    ]
+    candidates: list[SpanEdge] = []
+    candidates.extend(
+        _lab_attribute_edges(
+            nodes,
+            head_label="lab_name",
+            tail_label="lab_value",
+            edge_label="has_value",
+            max_distance=max_distance,
+        )
+    )
+    candidates.extend(
+        _lab_attribute_edges(
+            nodes,
+            head_label="lab_value",
+            tail_label="reference_range",
+            edge_label="has_reference_range",
+            max_distance=max_distance,
+        )
+    )
+    candidates.extend(
+        _lab_attribute_edges(
+            nodes,
+            head_label="lab_value",
+            tail_label="abnormal_flag",
+            edge_label="has_abnormal_flag",
+            max_distance=max_distance,
+        )
+    )
+    return decode_span_graph(
+        nodes,
+        candidates,
+        constraints=_LAB_VALUE_GRAPH_CONSTRAINTS,
+    )
+
+
+def _coerce_lab_attribute_node(
+    raw_mention: LabValueAttributeMention | Mapping[str, object],
+    index: int,
+) -> SpanNode:
+    if not isinstance(raw_mention, Mapping):
+        raise TypeError("lab attribute mentions must be mappings")
+
+    raw_label = (
+        raw_mention.get("label") or raw_mention.get("role") or raw_mention.get("type")
+    )
+    label = _lab_attribute_label(raw_label)
+    try:
+        start = int(raw_mention["start"])
+        end = int(raw_mention["end"])
+    except KeyError as exc:
+        raise KeyError("lab attribute mentions require start and end offsets") from exc
+    score = raw_mention.get("score")
+    text_hash = raw_mention.get("text_hash")
+    node_id = raw_mention.get("id") or f"{label}:{start}:{end}:{index}"
+    return SpanNode(
+        node_id=str(node_id),
+        start=start,
+        end=end,
+        label=label,
+        score=float(score) if score is not None else None,
+        text_hash=str(text_hash) if text_hash is not None else None,
+    )
+
+
+def _lab_attribute_label(raw_label: object) -> LabValueAttributeRole:
+    if not isinstance(raw_label, str):
+        raise TypeError("lab attribute mention label must be a string")
+    normalized = raw_label.strip().casefold()
+    if normalized in {"lab", "lab_name", "test", "analyte"}:
+        return "lab_name"
+    if normalized in {"value", "lab_value", "result"}:
+        return "lab_value"
+    if normalized in {"range", "reference_range", "ref_range"}:
+        return "reference_range"
+    if normalized in {"flag", "abnormal_flag", "abnormality"}:
+        return "abnormal_flag"
+    allowed = "lab_name, lab_value, reference_range, abnormal_flag"
+    raise ValueError(f"unknown lab attribute label {raw_label!r}; expected {allowed}")
+
+
+def _lab_attribute_edges(
+    nodes: list[SpanNode],
+    *,
+    head_label: LabValueAttributeRole,
+    tail_label: LabValueAttributeRole,
+    edge_label: str,
+    max_distance: int,
+) -> list[SpanEdge]:
+    heads = [node for node in nodes if node.label == head_label]
+    tails = [node for node in nodes if node.label == tail_label]
+    edges: list[SpanEdge] = []
+    for head in heads:
+        for tail in tails:
+            distance = _span_gap(head, tail)
+            if distance > max_distance:
+                continue
+            edges.append(
+                SpanEdge(
+                    head=head.node_id,
+                    tail=tail.node_id,
+                    label=edge_label,
+                    score=_lab_attribute_score(head, tail, distance, max_distance),
+                )
+            )
+    return edges
+
+
+def _span_gap(head: SpanNode, tail: SpanNode) -> int:
+    if head.end < tail.start:
+        return tail.start - head.end
+    if tail.end < head.start:
+        return head.start - tail.end
+    return 0
+
+
+def _lab_attribute_score(
+    head: SpanNode,
+    tail: SpanNode,
+    distance: int,
+    max_distance: int,
+) -> float:
+    head_score = float(head.score if head.score is not None else 1.0)
+    tail_score = float(tail.score if tail.score is not None else 1.0)
+    if max_distance == 0:
+        proximity = 1.0 if distance == 0 else 0.0
+    else:
+        proximity = max(0.0, 1.0 - (distance / (max_distance + 1)))
+    return (0.7 * ((head_score + tail_score) / 2.0)) + (0.3 * proximity)
+
+
 __all__ = [
     "AbnormalFlag",
     "LAB_FLAG_ADVISORY",
+    "LabValueAttributeMention",
+    "LabValueAttributeRole",
     "ReferenceRange",
     "derive_abnormal_flag",
+    "link_lab_value_attributes",
     "parse_reference_range",
 ]

--- a/openmed/core/decoding/__init__.py
+++ b/openmed/core/decoding/__init__.py
@@ -1,10 +1,21 @@
-"""Backend-agnostic decoding utilities (Viterbi, BIOES span construction).
+"""Backend-agnostic decoding utilities.
 
 These utilities are extracted from the MLX privacy-filter pipeline so they
 can be reused by the PyTorch wrapper as well. They depend only on the
-standard library — no torch, no mlx.
+standard library: no torch, no mlx.
 """
 
+from .graph import (
+    EdgeCardinality,
+    EdgeDecisionTrace,
+    GraphExplainReport,
+    SpanEdge,
+    SpanGraph,
+    SpanGraphConstraints,
+    SpanNode,
+    decode_span_graph,
+    edge_f1,
+)
 from .spans import refine_privacy_filter_span, trim_span_whitespace
 from .viterbi import (
     VITERBI_BIAS_KEYS,
@@ -16,9 +27,18 @@ from .viterbi import (
 )
 
 __all__ = [
+    "EdgeCardinality",
+    "EdgeDecisionTrace",
+    "GraphExplainReport",
+    "SpanEdge",
+    "SpanGraph",
+    "SpanGraphConstraints",
+    "SpanNode",
     "TokenLabelInfo",
     "VITERBI_BIAS_KEYS",
     "build_label_info",
+    "decode_span_graph",
+    "edge_f1",
     "labels_to_token_spans",
     "refine_privacy_filter_span",
     "trim_span_whitespace",

--- a/openmed/core/decoding/graph.py
+++ b/openmed/core/decoding/graph.py
@@ -1,0 +1,777 @@
+"""Pure-Python span-relation graph decoding utilities.
+
+The decoder consumes already-located spans and candidate typed, directed
+relations between them. It maximizes retained edge score subject to declarative
+constraints, then emits a deterministic graph plus an explanation for kept and
+pruned candidates. The module intentionally depends only on the standard
+library so it can be shared by MLX, PyTorch, and deterministic clinical
+extractors without importing an array framework.
+
+Tie-break order is stable and documented: maximize total retained edge score,
+then retain the larger number of edges when scores tie, then choose the
+lexicographically smallest canonical edge-key tuple. Canonical keys are built
+from edge label, head span key, tail span key, and node ids.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+GRAPH_EXPLAIN_SCHEMA_VERSION = 1
+
+EdgeDecisionStatus = Literal["kept", "pruned"]
+ConstraintViolation = tuple[str, str]
+
+_EPSILON = 1e-12
+
+
+@dataclass(frozen=True)
+class SpanNode:
+    """One decoded span node available to relation decoding.
+
+    Args:
+        node_id: Stable node identifier used by candidate edges.
+        start: Inclusive character offset.
+        end: Exclusive character offset.
+        label: Span type or clinical role.
+        score: Optional span confidence used for provenance.
+        text_hash: Optional safe hash of the span surface text.
+        metadata: Additional JSON-compatible provenance.
+    """
+
+    node_id: str
+    start: int
+    end: int
+    label: str
+    score: float | None = None
+    text_hash: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.node_id:
+            raise ValueError("node_id must be non-empty")
+        if not self.label:
+            raise ValueError("label must be non-empty")
+        if not isinstance(self.start, int) or not isinstance(self.end, int):
+            raise TypeError("start and end must be integers")
+        if self.start < 0 or self.end < self.start:
+            raise ValueError("node offsets must satisfy 0 <= start <= end")
+        if self.score is not None and not math.isfinite(float(self.score)):
+            raise ValueError("score must be finite when provided")
+        object.__setattr__(self, "node_id", str(self.node_id))
+        object.__setattr__(self, "label", str(self.label))
+        object.__setattr__(self, "metadata", _plain_mapping(self.metadata))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible node representation."""
+
+        return {
+            "id": self.node_id,
+            "start": self.start,
+            "end": self.end,
+            "label": self.label,
+            "score": self.score,
+            "text_hash": self.text_hash,
+            "metadata": copy.deepcopy(dict(self.metadata)),
+        }
+
+
+@dataclass(frozen=True)
+class SpanEdge:
+    """One typed, directed candidate or decoded graph edge."""
+
+    head: str
+    tail: str
+    label: str
+    score: float
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.head or not self.tail:
+            raise ValueError("edge head and tail must be non-empty node ids")
+        if not self.label:
+            raise ValueError("edge label must be non-empty")
+        if not math.isfinite(float(self.score)):
+            raise ValueError("edge score must be finite")
+        object.__setattr__(self, "head", str(self.head))
+        object.__setattr__(self, "tail", str(self.tail))
+        object.__setattr__(self, "label", str(self.label))
+        object.__setattr__(self, "score", float(self.score))
+        object.__setattr__(self, "metadata", _plain_mapping(self.metadata))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible edge representation."""
+
+        return {
+            "head": self.head,
+            "tail": self.tail,
+            "label": self.label,
+            "score": self.score,
+            "metadata": copy.deepcopy(dict(self.metadata)),
+        }
+
+
+@dataclass(frozen=True)
+class EdgeCardinality:
+    """Per-label cardinality limits for decoded graph edges."""
+
+    max_outgoing_per_head: int | None = None
+    max_incoming_per_tail: int | None = None
+
+    def __post_init__(self) -> None:
+        for field_name in ("max_outgoing_per_head", "max_incoming_per_tail"):
+            value = getattr(self, field_name)
+            if value is not None and value < 1:
+                raise ValueError(f"{field_name} must be positive when provided")
+
+    @classmethod
+    def one_to_one(cls) -> "EdgeCardinality":
+        """Return a one-to-one cardinality rule for one edge label."""
+
+        return cls(max_outgoing_per_head=1, max_incoming_per_tail=1)
+
+    @classmethod
+    def one_to_many(cls) -> "EdgeCardinality":
+        """Return a one-to-many rule for one edge label."""
+
+        return cls(max_incoming_per_tail=1)
+
+    @classmethod
+    def many_to_one(cls) -> "EdgeCardinality":
+        """Return a many-to-one rule for one edge label."""
+
+        return cls(max_outgoing_per_head=1)
+
+    @classmethod
+    def many_to_many(cls) -> "EdgeCardinality":
+        """Return an unconstrained cardinality rule for one edge label."""
+
+        return cls()
+
+
+@dataclass(frozen=True)
+class SpanGraphConstraints:
+    """Declarative edge-admissibility constraints.
+
+    Args:
+        allowed_edge_labels: Optional closed set of allowed edge labels.
+        type_compatibility: Mapping from edge label to allowed
+            ``(head_node_label, tail_node_label)`` pairs.
+        cardinality: Mapping from edge label to incoming/outgoing limits.
+        acyclic_edge_labels: Edge labels that must remain acyclic when decoded.
+        allow_self_edges: Whether an edge may point from a node to itself.
+    """
+
+    allowed_edge_labels: Iterable[str] | None = None
+    type_compatibility: Mapping[str, Iterable[tuple[str, str]]] = field(
+        default_factory=dict
+    )
+    cardinality: Mapping[str, EdgeCardinality] = field(default_factory=dict)
+    acyclic_edge_labels: Iterable[str] = field(default_factory=tuple)
+    allow_self_edges: bool = False
+
+    def __post_init__(self) -> None:
+        allowed = (
+            None
+            if self.allowed_edge_labels is None
+            else frozenset(str(label) for label in self.allowed_edge_labels)
+        )
+        compatibility = {
+            str(label): frozenset((str(head), str(tail)) for head, tail in pairs)
+            for label, pairs in self.type_compatibility.items()
+        }
+        cardinality = {str(label): rule for label, rule in self.cardinality.items()}
+        acyclic = frozenset(str(label) for label in self.acyclic_edge_labels)
+        object.__setattr__(self, "allowed_edge_labels", allowed)
+        object.__setattr__(self, "type_compatibility", compatibility)
+        object.__setattr__(self, "cardinality", cardinality)
+        object.__setattr__(self, "acyclic_edge_labels", acyclic)
+
+    def has_dynamic_constraints(self) -> bool:
+        """Return whether constraints require subset-level search."""
+
+        return bool(self.cardinality or self.acyclic_edge_labels)
+
+    def local_violation(
+        self,
+        edge: SpanEdge,
+        nodes_by_id: Mapping[str, SpanNode],
+    ) -> ConstraintViolation | None:
+        """Return the first single-edge constraint violation, if any."""
+
+        if edge.head not in nodes_by_id:
+            return (
+                "node_exists:head",
+                f"head node {edge.head!r} is not present in the graph",
+            )
+        if edge.tail not in nodes_by_id:
+            return (
+                "node_exists:tail",
+                f"tail node {edge.tail!r} is not present in the graph",
+            )
+        if not self.allow_self_edges and edge.head == edge.tail:
+            return ("self_edge", "self edges are disabled")
+
+        allowed_labels = self.allowed_edge_labels
+        if allowed_labels is not None and edge.label not in allowed_labels:
+            return (
+                f"edge_label:{edge.label}",
+                f"edge label {edge.label!r} is not in the allowed label set",
+            )
+
+        allowed_pairs = self.type_compatibility.get(edge.label)
+        if allowed_pairs is not None:
+            pair = (nodes_by_id[edge.head].label, nodes_by_id[edge.tail].label)
+            if pair not in allowed_pairs:
+                return (
+                    f"type_compatibility:{edge.label}",
+                    (
+                        f"edge label {edge.label!r} does not allow "
+                        f"{pair[0]!r} -> {pair[1]!r}"
+                    ),
+                )
+        return None
+
+
+@dataclass(frozen=True)
+class EdgeDecisionTrace:
+    """Explanation for one candidate edge decision."""
+
+    edge: SpanEdge
+    status: EdgeDecisionStatus
+    reason: str
+    constraint: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible decision representation."""
+
+        return {
+            "edge": self.edge.to_dict(),
+            "status": self.status,
+            "reason": self.reason,
+            "constraint": self.constraint,
+        }
+
+
+@dataclass(frozen=True)
+class GraphExplainReport:
+    """Safe explanation report for a decoded span graph."""
+
+    decisions: tuple[EdgeDecisionTrace, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = GRAPH_EXPLAIN_SCHEMA_VERSION
+
+    def render(self, fmt: Literal["text", "dict"] = "text") -> str | dict[str, Any]:
+        """Render this report as compact text or a JSON-compatible dictionary."""
+
+        if fmt == "dict":
+            return self.to_dict()
+        if fmt != "text":
+            raise ValueError("fmt must be 'text' or 'dict'")
+
+        kept = sum(1 for decision in self.decisions if decision.status == "kept")
+        pruned = len(self.decisions) - kept
+        lines = [f"SpanGraph explain trace (kept={kept}, pruned={pruned})"]
+        for decision in self.decisions:
+            edge = decision.edge
+            constraint = decision.constraint or "none"
+            lines.append(
+                (
+                    f"{decision.status} {edge.label} {edge.head}->{edge.tail} "
+                    f"score={edge.score} constraint={constraint} "
+                    f"reason={decision.reason}"
+                )
+            )
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible report."""
+
+        return {
+            "schema_version": self.schema_version,
+            "metadata": _json_safe(self.metadata),
+            "edges": [decision.to_dict() for decision in self.decisions],
+        }
+
+
+@dataclass(frozen=True)
+class SpanGraph:
+    """Decoded span-relation graph with deterministic node and edge order."""
+
+    nodes: tuple[SpanNode, ...]
+    edges: tuple[SpanEdge, ...]
+    decisions: tuple[EdgeDecisionTrace, ...] = ()
+    score: float = 0.0
+
+    def explain(self) -> GraphExplainReport:
+        """Return kept/pruned edge decisions for this graph."""
+
+        return GraphExplainReport(
+            decisions=self.decisions,
+            metadata={
+                "node_count": len(self.nodes),
+                "edge_count": len(self.edges),
+                "score": self.score,
+            },
+        )
+
+    def edge_keys(self) -> tuple[tuple[str, str, str], ...]:
+        """Return compact edge keys useful for tests and metrics."""
+
+        return tuple((edge.label, edge.head, edge.tail) for edge in self.edges)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible graph representation."""
+
+        return {
+            "nodes": [node.to_dict() for node in self.nodes],
+            "edges": [edge.to_dict() for edge in self.edges],
+            "score": self.score,
+            "explain": self.explain().to_dict(),
+        }
+
+
+def decode_span_graph(
+    nodes: Sequence[SpanNode],
+    candidate_edges: Sequence[SpanEdge],
+    *,
+    constraints: SpanGraphConstraints | None = None,
+    min_edge_score: float | None = None,
+) -> SpanGraph:
+    """Decode a maximum-score span-relation graph.
+
+    Args:
+        nodes: Span nodes available to the graph.
+        candidate_edges: Candidate typed, directed edges between nodes.
+        constraints: Optional declarative constraints.
+        min_edge_score: Optional local score floor. Edges below the floor are
+            explained as pruned by ``score_floor`` before global decoding.
+
+    Returns:
+        A deterministic :class:`SpanGraph` containing retained edges and
+        explanations for every candidate edge.
+    """
+
+    resolved_constraints = constraints or SpanGraphConstraints()
+    node_tuple = tuple(nodes)
+    nodes_by_id = _nodes_by_id(node_tuple)
+    ordered_nodes = tuple(sorted(node_tuple, key=_node_sort_key))
+    duplicate_decisions, deduped_edges = _dedupe_candidate_edges(
+        candidate_edges,
+        nodes_by_id,
+    )
+
+    local_decisions: list[EdgeDecisionTrace] = list(duplicate_decisions)
+    valid_edges: list[SpanEdge] = []
+    for edge in deduped_edges:
+        violation = resolved_constraints.local_violation(edge, nodes_by_id)
+        if violation is None and min_edge_score is not None:
+            if edge.score < min_edge_score:
+                violation = (
+                    "score_floor",
+                    (
+                        f"edge score {edge.score} is below "
+                        f"min_edge_score {min_edge_score}"
+                    ),
+                )
+        if violation is not None:
+            constraint, reason = violation
+            local_decisions.append(
+                EdgeDecisionTrace(
+                    edge=edge,
+                    status="pruned",
+                    reason=reason,
+                    constraint=constraint,
+                )
+            )
+            continue
+        valid_edges.append(edge)
+
+    if resolved_constraints.has_dynamic_constraints():
+        selected_edges = _decode_with_dynamic_constraints(
+            valid_edges,
+            resolved_constraints,
+            nodes_by_id,
+        )
+    else:
+        selected_edges = tuple(edge for edge in valid_edges if edge.score >= 0.0)
+
+    ordered_edges = tuple(
+        sorted(selected_edges, key=lambda edge: _edge_canonical_key(edge, nodes_by_id))
+    )
+    decisions = _build_decisions(
+        kept_edges=ordered_edges,
+        valid_edges=valid_edges,
+        local_decisions=local_decisions,
+        constraints=resolved_constraints,
+        nodes_by_id=nodes_by_id,
+    )
+    return SpanGraph(
+        nodes=ordered_nodes,
+        edges=ordered_edges,
+        decisions=decisions,
+        score=sum(edge.score for edge in ordered_edges),
+    )
+
+
+def edge_f1(
+    predicted_edges: Iterable[tuple[str, str, str]],
+    gold_edges: Iterable[tuple[str, str, str]],
+) -> float:
+    """Return exact-match F1 for compact ``(label, head, tail)`` edge keys."""
+
+    predicted = set(predicted_edges)
+    gold = set(gold_edges)
+    if not predicted and not gold:
+        return 1.0
+    if not predicted or not gold:
+        return 0.0
+    true_positive = len(predicted & gold)
+    precision = true_positive / len(predicted)
+    recall = true_positive / len(gold)
+    if precision + recall == 0.0:
+        return 0.0
+    return 2.0 * precision * recall / (precision + recall)
+
+
+def _nodes_by_id(nodes: Sequence[SpanNode]) -> dict[str, SpanNode]:
+    nodes_by_id: dict[str, SpanNode] = {}
+    for node in nodes:
+        if node.node_id in nodes_by_id:
+            raise ValueError(f"duplicate SpanNode id {node.node_id!r}")
+        nodes_by_id[node.node_id] = node
+    return nodes_by_id
+
+
+def _dedupe_candidate_edges(
+    edges: Sequence[SpanEdge],
+    nodes_by_id: Mapping[str, SpanNode],
+) -> tuple[tuple[EdgeDecisionTrace, ...], tuple[SpanEdge, ...]]:
+    decisions: list[EdgeDecisionTrace] = []
+    deduped: dict[tuple[str, str, str], SpanEdge] = {}
+    for edge in edges:
+        key = (edge.head, edge.tail, edge.label)
+        current = deduped.get(key)
+        if current is None:
+            deduped[key] = edge
+            continue
+        if _duplicate_edge_is_better(edge, current, nodes_by_id):
+            decisions.append(
+                EdgeDecisionTrace(
+                    edge=current,
+                    status="pruned",
+                    reason="a higher-priority duplicate candidate was kept",
+                    constraint="duplicate_edge",
+                )
+            )
+            deduped[key] = edge
+        else:
+            decisions.append(
+                EdgeDecisionTrace(
+                    edge=edge,
+                    status="pruned",
+                    reason="a higher-priority duplicate candidate was kept",
+                    constraint="duplicate_edge",
+                )
+            )
+    return (
+        tuple(
+            sorted(
+                decisions,
+                key=lambda decision: _decision_sort_key(decision, nodes_by_id),
+            )
+        ),
+        tuple(
+            sorted(
+                deduped.values(), key=lambda edge: _edge_search_key(edge, nodes_by_id)
+            )
+        ),
+    )
+
+
+def _duplicate_edge_is_better(
+    candidate: SpanEdge,
+    current: SpanEdge,
+    nodes_by_id: Mapping[str, SpanNode],
+) -> bool:
+    if candidate.score != current.score:
+        return candidate.score > current.score
+    return _metadata_key(candidate) < _metadata_key(current) or (
+        _metadata_key(candidate) == _metadata_key(current)
+        and _edge_canonical_key(candidate, nodes_by_id)
+        < _edge_canonical_key(current, nodes_by_id)
+    )
+
+
+def _decode_with_dynamic_constraints(
+    edges: Sequence[SpanEdge],
+    constraints: SpanGraphConstraints,
+    nodes_by_id: Mapping[str, SpanNode],
+) -> tuple[SpanEdge, ...]:
+    ordered_edges = tuple(
+        sorted(edges, key=lambda edge: _edge_search_key(edge, nodes_by_id))
+    )
+    positive_suffix = [0.0] * (len(ordered_edges) + 1)
+    for index in range(len(ordered_edges) - 1, -1, -1):
+        positive_suffix[index] = positive_suffix[index + 1] + max(
+            ordered_edges[index].score,
+            0.0,
+        )
+
+    best_score = -math.inf
+    best_edges: tuple[SpanEdge, ...] = ()
+
+    def visit(index: int, selected: list[SpanEdge], score: float) -> None:
+        nonlocal best_score, best_edges
+        if score + positive_suffix[index] < best_score - _EPSILON:
+            return
+        if index == len(ordered_edges):
+            selected_tuple = tuple(selected)
+            if _solution_is_better(
+                score,
+                selected_tuple,
+                best_score,
+                best_edges,
+                nodes_by_id,
+            ):
+                best_score = score
+                best_edges = selected_tuple
+            return
+
+        edge = ordered_edges[index]
+        if _dynamic_violation(edge, selected, constraints) is None:
+            selected.append(edge)
+            visit(index + 1, selected, score + edge.score)
+            selected.pop()
+        visit(index + 1, selected, score)
+
+    visit(0, [], 0.0)
+    return best_edges
+
+
+def _solution_is_better(
+    score: float,
+    edges: Sequence[SpanEdge],
+    best_score: float,
+    best_edges: Sequence[SpanEdge],
+    nodes_by_id: Mapping[str, SpanNode],
+) -> bool:
+    if score > best_score + _EPSILON:
+        return True
+    if score < best_score - _EPSILON:
+        return False
+    if len(edges) != len(best_edges):
+        return len(edges) > len(best_edges)
+    return _solution_key(edges, nodes_by_id) < _solution_key(best_edges, nodes_by_id)
+
+
+def _solution_key(
+    edges: Sequence[SpanEdge],
+    nodes_by_id: Mapping[str, SpanNode],
+) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        _edge_canonical_key(edge, nodes_by_id)
+        for edge in sorted(
+            edges, key=lambda edge: _edge_canonical_key(edge, nodes_by_id)
+        )
+    )
+
+
+def _build_decisions(
+    *,
+    kept_edges: Sequence[SpanEdge],
+    valid_edges: Sequence[SpanEdge],
+    local_decisions: Sequence[EdgeDecisionTrace],
+    constraints: SpanGraphConstraints,
+    nodes_by_id: Mapping[str, SpanNode],
+) -> tuple[EdgeDecisionTrace, ...]:
+    kept_keys = {(edge.head, edge.tail, edge.label) for edge in kept_edges}
+    selected = tuple(kept_edges)
+    decisions: list[EdgeDecisionTrace] = list(local_decisions)
+
+    for edge in kept_edges:
+        decisions.append(
+            EdgeDecisionTrace(
+                edge=edge,
+                status="kept",
+                reason="selected by maximum-score graph decode",
+            )
+        )
+
+    for edge in valid_edges:
+        key = (edge.head, edge.tail, edge.label)
+        if key in kept_keys:
+            continue
+        violation = _dynamic_violation(edge, selected, constraints)
+        if violation is not None:
+            constraint, reason = violation
+        elif edge.score < 0.0:
+            constraint = "objective:non_negative_edge_score"
+            reason = "negative edge score would lower the maximum total score"
+        else:
+            constraint = "global_decode:tiebreak"
+            reason = "edge lost the documented deterministic tie-break"
+        decisions.append(
+            EdgeDecisionTrace(
+                edge=edge,
+                status="pruned",
+                reason=reason,
+                constraint=constraint,
+            )
+        )
+
+    return tuple(
+        sorted(
+            decisions, key=lambda decision: _decision_sort_key(decision, nodes_by_id)
+        )
+    )
+
+
+def _dynamic_violation(
+    edge: SpanEdge,
+    selected_edges: Sequence[SpanEdge],
+    constraints: SpanGraphConstraints,
+) -> ConstraintViolation | None:
+    cardinality = constraints.cardinality.get(edge.label)
+    if cardinality is not None:
+        outgoing = sum(
+            1
+            for selected in selected_edges
+            if selected.label == edge.label and selected.head == edge.head
+        )
+        if (
+            cardinality.max_outgoing_per_head is not None
+            and outgoing >= cardinality.max_outgoing_per_head
+        ):
+            return (
+                f"cardinality:{edge.label}:max_outgoing_per_head",
+                (
+                    f"head {edge.head!r} already has {outgoing} outgoing "
+                    f"{edge.label!r} edge(s)"
+                ),
+            )
+        incoming = sum(
+            1
+            for selected in selected_edges
+            if selected.label == edge.label and selected.tail == edge.tail
+        )
+        if (
+            cardinality.max_incoming_per_tail is not None
+            and incoming >= cardinality.max_incoming_per_tail
+        ):
+            return (
+                f"cardinality:{edge.label}:max_incoming_per_tail",
+                (
+                    f"tail {edge.tail!r} already has {incoming} incoming "
+                    f"{edge.label!r} edge(s)"
+                ),
+            )
+
+    acyclic_labels = constraints.acyclic_edge_labels
+    if edge.label in acyclic_labels and _creates_cycle(
+        edge, selected_edges, acyclic_labels
+    ):
+        return (
+            f"acyclicity:{edge.label}",
+            f"adding {edge.head!r} -> {edge.tail!r} would create a cycle",
+        )
+    return None
+
+
+def _creates_cycle(
+    edge: SpanEdge,
+    selected_edges: Sequence[SpanEdge],
+    acyclic_labels: frozenset[str],
+) -> bool:
+    adjacency: dict[str, set[str]] = {}
+    for selected in selected_edges:
+        if selected.label in acyclic_labels:
+            adjacency.setdefault(selected.head, set()).add(selected.tail)
+    return _has_path(edge.tail, edge.head, adjacency)
+
+
+def _has_path(source: str, target: str, adjacency: Mapping[str, set[str]]) -> bool:
+    stack = [source]
+    seen: set[str] = set()
+    while stack:
+        node_id = stack.pop()
+        if node_id == target:
+            return True
+        if node_id in seen:
+            continue
+        seen.add(node_id)
+        stack.extend(adjacency.get(node_id, ()))
+    return False
+
+
+def _node_sort_key(node: SpanNode) -> tuple[int, int, str, str]:
+    return (node.start, node.end, node.label, node.node_id)
+
+
+def _edge_search_key(
+    edge: SpanEdge,
+    nodes_by_id: Mapping[str, SpanNode],
+) -> tuple[Any, ...]:
+    return (-edge.score, *_edge_canonical_key(edge, nodes_by_id))
+
+
+def _edge_canonical_key(
+    edge: SpanEdge,
+    nodes_by_id: Mapping[str, SpanNode],
+) -> tuple[Any, ...]:
+    head_key = (
+        _node_sort_key(nodes_by_id[edge.head]) if edge.head in nodes_by_id else ()
+    )
+    tail_key = (
+        _node_sort_key(nodes_by_id[edge.tail]) if edge.tail in nodes_by_id else ()
+    )
+    return (edge.label, head_key, tail_key, edge.head, edge.tail)
+
+
+def _decision_sort_key(
+    decision: EdgeDecisionTrace,
+    nodes_by_id: Mapping[str, SpanNode],
+) -> tuple[Any, ...]:
+    status_order = 0 if decision.status == "kept" else 1
+    return (
+        *_edge_canonical_key(decision.edge, nodes_by_id),
+        status_order,
+        decision.constraint or "",
+    )
+
+
+def _metadata_key(edge: SpanEdge) -> str:
+    return repr(sorted(edge.metadata.items(), key=lambda item: str(item[0])))
+
+
+def _plain_mapping(mapping: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): _json_safe(value) for key, value in mapping.items()}
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, set | frozenset):
+        return sorted(_json_safe(item) for item in value)
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    return repr(value)
+
+
+__all__ = [
+    "EdgeCardinality",
+    "EdgeDecisionTrace",
+    "GraphExplainReport",
+    "SpanEdge",
+    "SpanGraph",
+    "SpanGraphConstraints",
+    "SpanNode",
+    "decode_span_graph",
+    "edge_f1",
+]

--- a/openmed/core/explain.py
+++ b/openmed/core/explain.py
@@ -240,6 +240,25 @@ def explain(result: PipelineResult) -> ExplainReport:
     )
 
 
+def explain_span_graph(
+    graph: Any,
+    fmt: Literal["text", "dict"] = "dict",
+) -> str | dict[str, Any]:
+    """Render a span-relation graph explanation with the core explain contract.
+
+    ``SpanGraph`` explanations follow the same safe-report convention as the
+    pipeline trace: offsets, labels, scores, and constraint names are included,
+    but source surface text is not emitted.
+    """
+
+    if not hasattr(graph, "explain"):
+        raise TypeError("graph must provide an explain() method")
+    report = graph.explain()
+    if not hasattr(report, "render"):
+        raise TypeError("graph.explain() must return a renderable report")
+    return report.render(fmt=fmt)
+
+
 def render(
     report: ExplainReport,
     fmt: Literal["text", "dict"] = "text",

--- a/openmed/mlx/inference.py
+++ b/openmed/mlx/inference.py
@@ -16,8 +16,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
 from openmed.core.decoding import (
+    SpanEdge,
+    SpanNode,
     TokenLabelInfo,
     build_label_info,
+    decode_span_graph,
     labels_to_token_spans,
     refine_privacy_filter_span,
     trim_span_whitespace,
@@ -975,30 +978,85 @@ class GLiNERRelexMLXPipeline(_BaseExperimentalMLXPipeline):
         pair_idx = relation_outputs["pair_idx"][0].tolist()
         pair_mask = relation_outputs["pair_mask"][0].tolist()
 
-        extracted_relations: list[dict[str, Any]] = []
-        for pair_index, is_valid in enumerate(pair_mask):
-            if not is_valid:
-                continue
-            head_index, tail_index = pair_idx[pair_index]
-            if head_index >= len(entities) or tail_index >= len(entities):
-                continue
-            for relation_index in range(relation_prompt_count):
-                score = float(pair_scores[pair_index][relation_index])
-                if score < relation_threshold:
-                    continue
-                extracted_relations.append(
-                    {
-                        "label": str(relations[relation_index]),
-                        "score": score,
-                        "head": entities[head_index],
-                        "tail": entities[tail_index],
-                    }
-                )
-
         return {
             "entities": entities,
-            "relations": extracted_relations,
+            "relations": _decode_relation_graph(
+                entities=entities,
+                pair_scores=pair_scores,
+                pair_idx=pair_idx,
+                pair_mask=pair_mask,
+                relations=relations,
+                relation_prompt_count=relation_prompt_count,
+                relation_threshold=relation_threshold,
+            ),
         }
+
+
+def _decode_relation_graph(
+    *,
+    entities: Sequence[dict[str, Any]],
+    pair_scores: Sequence[Sequence[float]],
+    pair_idx: Sequence[Sequence[int]],
+    pair_mask: Sequence[bool],
+    relations: Sequence[str],
+    relation_prompt_count: int,
+    relation_threshold: float,
+) -> list[dict[str, Any]]:
+    """Decode relation candidates through the shared SpanGraph decoder."""
+
+    nodes = [
+        SpanNode(
+            node_id=str(entity["id"]),
+            start=int(entity["start"]),
+            end=int(entity["end"]),
+            label=str(entity["label"]),
+            score=float(entity["score"]),
+        )
+        for entity in entities
+    ]
+    candidates: list[SpanEdge] = []
+    for pair_index, is_valid in enumerate(pair_mask):
+        if (
+            not is_valid
+            or pair_index >= len(pair_idx)
+            or pair_index >= len(pair_scores)
+        ):
+            continue
+        head_index, tail_index = pair_idx[pair_index]
+        if (
+            head_index < 0
+            or tail_index < 0
+            or head_index >= len(entities)
+            or tail_index >= len(entities)
+        ):
+            continue
+        score_row = pair_scores[pair_index]
+        for relation_index in range(
+            min(relation_prompt_count, len(relations), len(score_row))
+        ):
+            score = float(score_row[relation_index])
+            if score < relation_threshold:
+                continue
+            candidates.append(
+                SpanEdge(
+                    head=str(head_index),
+                    tail=str(tail_index),
+                    label=str(relations[relation_index]),
+                    score=score,
+                )
+            )
+
+    graph = decode_span_graph(nodes, candidates)
+    entity_by_id = {str(entity["id"]): entity for entity in entities}
+    return [
+        {
+            "label": edge.label,
+            "score": edge.score,
+            "head": entity_by_id[edge.head],
+            "tail": entity_by_id[edge.tail],
+        }
+        for edge in graph.edges
+    ]
 
 
 # -- MLX model registry -------------------------------------------------------

--- a/tests/unit/clinical/test_lab_values.py
+++ b/tests/unit/clinical/test_lab_values.py
@@ -7,6 +7,7 @@ import pytest
 from openmed.clinical import (
     LAB_FLAG_ADVISORY,
     derive_abnormal_flag,
+    link_lab_value_attributes,
     parse_reference_range,
 )
 
@@ -141,3 +142,46 @@ def test_derive_abnormal_flag_returns_unknown_when_it_cannot_derive(
 def test_lab_flag_advisory_documents_heuristic_scope():
     assert "heuristic" in LAB_FLAG_ADVISORY
     assert "originating laboratory" in LAB_FLAG_ADVISORY
+
+
+def test_link_lab_value_attributes_uses_constrained_span_graph():
+    graph = link_lab_value_attributes(
+        [
+            {
+                "id": "sodium",
+                "label": "lab_name",
+                "start": 0,
+                "end": 6,
+                "score": 0.95,
+            },
+            {
+                "id": "sodium-value",
+                "label": "lab_value",
+                "start": 7,
+                "end": 10,
+                "score": 0.95,
+            },
+            {
+                "id": "sodium-range",
+                "label": "reference_range",
+                "start": 12,
+                "end": 19,
+                "score": 0.9,
+            },
+            {
+                "id": "sodium-low",
+                "label": "abnormal_flag",
+                "start": 21,
+                "end": 24,
+                "score": 0.9,
+            },
+        ],
+        max_distance=20,
+    )
+
+    assert set(graph.edge_keys()) == {
+        ("has_value", "sodium", "sodium-value"),
+        ("has_reference_range", "sodium-value", "sodium-range"),
+        ("has_abnormal_flag", "sodium-value", "sodium-low"),
+    }
+    assert graph.explain().to_dict()["metadata"]["edge_count"] == 3

--- a/tests/unit/core/test_span_graph_decoding.py
+++ b/tests/unit/core/test_span_graph_decoding.py
@@ -1,0 +1,244 @@
+"""Tests for pure-Python span-relation graph decoding."""
+
+from __future__ import annotations
+
+import ast
+import random
+from collections import Counter
+from pathlib import Path
+
+from openmed.core.decoding import (
+    EdgeCardinality,
+    SpanEdge,
+    SpanGraph,
+    SpanGraphConstraints,
+    SpanNode,
+    decode_span_graph,
+    edge_f1,
+)
+from openmed.core.explain import explain_span_graph
+
+
+def _node(node_id: str, start: int, label: str) -> SpanNode:
+    return SpanNode(node_id=node_id, start=start, end=start + 1, label=label)
+
+
+def test_decode_span_graph_finds_global_matching_optimum() -> None:
+    nodes = [
+        _node("med-a", 0, "medication"),
+        _node("med-b", 10, "medication"),
+        _node("attr-x", 20, "attribute"),
+        _node("attr-y", 30, "attribute"),
+        _node("attr-z", 40, "attribute"),
+    ]
+    edges = [
+        SpanEdge("med-a", "attr-x", "links", 10.0),
+        SpanEdge("med-a", "attr-y", "links", 9.0),
+        SpanEdge("med-b", "attr-x", "links", 9.0),
+        SpanEdge("med-b", "attr-z", "links", 1.0),
+    ]
+    constraints = SpanGraphConstraints(
+        type_compatibility={"links": (("medication", "attribute"),)},
+        cardinality={"links": EdgeCardinality.one_to_one()},
+    )
+
+    graph = decode_span_graph(nodes, edges, constraints=constraints)
+
+    assert graph.score == 18.0
+    assert set(graph.edge_keys()) == {
+        ("links", "med-a", "attr-y"),
+        ("links", "med-b", "attr-x"),
+    }
+
+
+def test_decode_span_graph_is_stable_under_input_reordering() -> None:
+    nodes = [
+        _node("lab", 0, "lab_name"),
+        _node("value-a", 10, "lab_value"),
+        _node("value-b", 20, "lab_value"),
+        _node("problem-a", 30, "problem"),
+        _node("problem-b", 40, "problem"),
+    ]
+    edges = [
+        SpanEdge("lab", "value-a", "has_value", 0.9),
+        SpanEdge("lab", "value-b", "has_value", 0.4),
+        SpanEdge("problem-a", "problem-b", "contains", 0.8),
+    ]
+    constraints = SpanGraphConstraints(
+        type_compatibility={
+            "has_value": (("lab_name", "lab_value"),),
+            "contains": (("problem", "problem"),),
+        },
+        cardinality={"has_value": EdgeCardinality.one_to_one()},
+        acyclic_edge_labels=("contains",),
+    )
+    expected = decode_span_graph(nodes, edges, constraints=constraints).edge_keys()
+
+    for seed in range(50):
+        rng = random.Random(seed)
+        shuffled_nodes = list(nodes)
+        shuffled_edges = list(edges)
+        rng.shuffle(shuffled_nodes)
+        rng.shuffle(shuffled_edges)
+
+        graph = decode_span_graph(
+            shuffled_nodes,
+            shuffled_edges,
+            constraints=constraints,
+        )
+
+        assert graph.edge_keys() == expected
+
+
+def test_synthetic_graph_gate_prevents_violations_and_meets_edge_f1() -> None:
+    constraints = SpanGraphConstraints(
+        type_compatibility={
+            "has_value": (("lab_name", "lab_value"),),
+            "contains": (("problem", "problem"),),
+        },
+        cardinality={"has_value": EdgeCardinality.one_to_one()},
+        acyclic_edge_labels=("contains",),
+    )
+    predicted_edges: set[tuple[str, str, str]] = set()
+    gold_edges: set[tuple[str, str, str]] = set()
+
+    for case_id in range(200):
+        graph, gold = _synthetic_graph_case(case_id, constraints)
+        _assert_graph_constraints_hold(graph, constraints)
+        predicted_edges.update(graph.edge_keys())
+        gold_edges.update(gold)
+
+    assert edge_f1(predicted_edges, gold_edges) >= 0.85
+
+
+def test_explain_span_graph_names_constraints_for_pruned_edges() -> None:
+    nodes = [
+        _node("lab", 0, "lab_name"),
+        _node("value-a", 10, "lab_value"),
+        _node("value-b", 20, "lab_value"),
+        _node("problem-a", 30, "problem"),
+        _node("problem-b", 40, "problem"),
+    ]
+    edges = [
+        SpanEdge("lab", "value-a", "has_value", 1.0),
+        SpanEdge("lab", "value-b", "has_value", 0.9),
+        SpanEdge("problem-a", "value-a", "has_value", 0.8),
+        SpanEdge("problem-a", "problem-b", "contains", 1.0),
+        SpanEdge("problem-b", "problem-a", "contains", 0.9),
+    ]
+    constraints = SpanGraphConstraints(
+        type_compatibility={
+            "has_value": (("lab_name", "lab_value"),),
+            "contains": (("problem", "problem"),),
+        },
+        cardinality={"has_value": EdgeCardinality.one_to_one()},
+        acyclic_edge_labels=("contains",),
+    )
+
+    graph = decode_span_graph(nodes, edges, constraints=constraints)
+    report = explain_span_graph(graph, fmt="dict")
+    pruned_constraints = {
+        decision["constraint"]
+        for decision in report["edges"]
+        if decision["status"] == "pruned"
+    }
+
+    assert "type_compatibility:has_value" in pruned_constraints
+    assert "cardinality:has_value:max_outgoing_per_head" in pruned_constraints
+    assert "acyclicity:contains" in pruned_constraints
+
+
+def test_graph_module_import_guard_has_no_array_frameworks() -> None:
+    graph_path = (
+        Path(__file__).parents[3] / "openmed" / "core" / "decoding" / "graph.py"
+    )
+    tree = ast.parse(graph_path.read_text(encoding="utf-8"))
+    imported_roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_roots.add(node.module.split(".")[0])
+
+    assert imported_roots.isdisjoint({"jax", "mlx", "numpy", "tensorflow", "torch"})
+
+
+def _synthetic_graph_case(
+    case_id: int,
+    constraints: SpanGraphConstraints,
+) -> tuple[SpanGraph, set[tuple[str, str, str]]]:
+    prefix = f"case-{case_id}"
+    offset = case_id * 100
+    nodes = [
+        _node(f"{prefix}-lab", offset, "lab_name"),
+        _node(f"{prefix}-value-a", offset + 10, "lab_value"),
+        _node(f"{prefix}-value-b", offset + 20, "lab_value"),
+        _node(f"{prefix}-problem-a", offset + 30, "problem"),
+        _node(f"{prefix}-problem-b", offset + 40, "problem"),
+        _node(f"{prefix}-problem-c", offset + 50, "problem"),
+    ]
+    gold = {
+        ("has_value", f"{prefix}-lab", f"{prefix}-value-a"),
+        ("contains", f"{prefix}-problem-a", f"{prefix}-problem-b"),
+        ("contains", f"{prefix}-problem-b", f"{prefix}-problem-c"),
+    }
+    edges = [
+        SpanEdge(f"{prefix}-lab", f"{prefix}-value-a", "has_value", 0.95),
+        SpanEdge(f"{prefix}-lab", f"{prefix}-value-b", "has_value", 0.25),
+        SpanEdge(f"{prefix}-problem-a", f"{prefix}-value-a", "has_value", 0.99),
+        SpanEdge(f"{prefix}-problem-a", f"{prefix}-problem-b", "contains", 0.90),
+        SpanEdge(f"{prefix}-problem-b", f"{prefix}-problem-c", "contains", 0.85),
+        SpanEdge(f"{prefix}-problem-c", f"{prefix}-problem-a", "contains", 0.10),
+    ]
+    return decode_span_graph(nodes, edges, constraints=constraints), gold
+
+
+def _assert_graph_constraints_hold(
+    graph: SpanGraph,
+    constraints: SpanGraphConstraints,
+) -> None:
+    nodes_by_id = {node.node_id: node for node in graph.nodes}
+    counts_out: Counter[tuple[str, str]] = Counter()
+    counts_in: Counter[tuple[str, str]] = Counter()
+    adjacency: dict[str, set[str]] = {}
+
+    for edge in graph.edges:
+        assert constraints.local_violation(edge, nodes_by_id) is None
+        counts_out[(edge.label, edge.head)] += 1
+        counts_in[(edge.label, edge.tail)] += 1
+        if edge.label in constraints.acyclic_edge_labels:
+            adjacency.setdefault(edge.head, set()).add(edge.tail)
+
+    for label, rule in constraints.cardinality.items():
+        if rule.max_outgoing_per_head is not None:
+            assert all(
+                count <= rule.max_outgoing_per_head
+                for (edge_label, _), count in counts_out.items()
+                if edge_label == label
+            )
+        if rule.max_incoming_per_tail is not None:
+            assert all(
+                count <= rule.max_incoming_per_tail
+                for (edge_label, _), count in counts_in.items()
+                if edge_label == label
+            )
+
+    for node_id in adjacency:
+        assert not _can_reach(node_id, node_id, adjacency, set())
+
+
+def _can_reach(
+    source: str,
+    target: str,
+    adjacency: dict[str, set[str]],
+    seen: set[str],
+) -> bool:
+    for next_node in adjacency.get(source, set()):
+        if next_node == target:
+            return True
+        if next_node in seen:
+            continue
+        seen.add(next_node)
+        if _can_reach(next_node, target, adjacency, seen):
+            return True
+    return False

--- a/tests/unit/mlx/test_mlx_inference.py
+++ b/tests/unit/mlx/test_mlx_inference.py
@@ -480,6 +480,52 @@ class TestExperimentalMLXPipelineDispatch:
 class TestExperimentalGLiNERDecoding:
     """Regression tests for GLiNER-family prompt and span decoding helpers."""
 
+    def test_relex_relation_candidates_decode_through_span_graph(self):
+        from openmed.core.decoding import decode_span_graph
+        from openmed.mlx.inference import _decode_relation_graph
+
+        entities = [
+            {
+                "id": 0,
+                "text": "metformin",
+                "label": "medication",
+                "score": 0.95,
+                "start": 0,
+                "end": 9,
+            },
+            {
+                "id": 1,
+                "text": "nausea",
+                "label": "problem",
+                "score": 0.90,
+                "start": 18,
+                "end": 24,
+            },
+        ]
+
+        with patch(
+            "openmed.mlx.inference.decode_span_graph",
+            wraps=decode_span_graph,
+        ) as mock_decode:
+            relations = _decode_relation_graph(
+                entities=entities,
+                pair_scores=[[0.91, 0.20], [0.10, 0.86]],
+                pair_idx=[[0, 1], [1, 0]],
+                pair_mask=[True, True],
+                relations=["causes", "treated_by"],
+                relation_prompt_count=2,
+                relation_threshold=0.5,
+            )
+
+        assert mock_decode.called
+        assert {
+            (relation["label"], relation["head"]["id"], relation["tail"]["id"])
+            for relation in relations
+        } == {
+            ("causes", 0, 1),
+            ("treated_by", 1, 0),
+        }
+
     def test_gliner_word_splitter_matches_upstream_whitespace_splitter(self):
         from openmed.mlx.inference import _split_words_with_offsets
 


### PR DESCRIPTION
## Description
Generalizes span decoding into a reusable pure-Python span-relation graph decoder with typed directed edges, declarative constraints, deterministic global selection, and safe explanations. Closes #971.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `SpanGraph`, `SpanNode`, `SpanEdge`, constraint rules, exact constrained decoding, edge F1, and graph explanations in `openmed/core/decoding/graph.py`.
- Routed relation candidates and lab-value attribute linking through the shared span graph decoder while preserving existing output shapes.
- Added synthetic 200-case graph consistency, determinism, import-guard, explanation, and consumer tests.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #971

## Screenshots/Examples
Not applicable.
