### PR TITLE
feat(examples): add interactive Gradio de-identification demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `examples/gradio_deid_app.py`, an interactive Gradio demo that runs
+  `deidentify` over synthetic text with a `mask`/`replace`/`hash` method
+  selector and shows the redacted output alongside the detected PII entities.
+  `gradio` stays an optional, example-local dependency with a graceful install
+  hint, and the example is covered by import-safe smoke tests.
 - Added CycloneDX 1.6 SBOM generation (`scripts/security/generate_sbom.py`,
   `make sbom`) that inventories `openmed` and its runtime dependencies; a CI
   `sbom` job uploads `sbom.cdx.json` on every push and pull request, and the

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -20,6 +20,7 @@ Run them with VS Code, Jupyter, or Google Colab—each relies on the same `uv pi
 | `examples/pii_model_comparison.py` | Compares multiple PII models across shared sample text and summarizes extraction quality. |
 | `examples/pii_batch_processing.py` | Runs batch PII extraction and de-identification with `BatchProcessor(operation=...)`. |
 | `examples/pii_multilingual_new_languages.py` | Exercises Dutch, Hindi, Telugu, Portuguese, Arabic, Japanese, and Turkish registry entries, locale-specific regex matches, and optional live extraction with the new public checkpoints. |
+| `examples/gradio_deid_app.py` | Interactive Gradio UI to paste synthetic text, pick a `mask`/`replace`/`hash` method, and view the de-identified output plus detected entities (optional `pip install gradio`). |
 | `scripts/smoke_gliner.py` | Runs a bounded set of GLiNER models/texts to confirm zero-shot dependencies are installed before releasing. |
 | `tests/run-tests.sh` | Convenience runner that stitches together unit, integration, and smoke tests; extend it to include docs builds and API smoke checks. |
 

--- a/examples/gradio_deid_app.py
+++ b/examples/gradio_deid_app.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Interactive Gradio demo for OpenMed de-identification.
+
+Paste a *synthetic* clinical note, choose a redaction method, and see the
+de-identified text next to the PII entities OpenMed detected — no code
+required. This is the lowest-friction way to try ``deidentify`` before
+wiring it into a pipeline.
+
+Run::
+
+    pip install gradio
+    python examples/gradio_deid_app.py
+
+Only synthetic, non-PHI sample text is used here. Never paste real patient
+data into a demo UI (see ``SECURITY.md``). ``gradio`` is an optional,
+example-local dependency — it is not part of the core package.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from openmed import deidentify
+
+GRADIO_INSTALL_HINT = (
+    "Gradio is required for this demo. Install it with: pip install gradio"
+)
+DEIDENTIFICATION_METHODS = ("mask", "replace", "hash")
+ENTITY_TABLE_HEADERS = ("Label", "Text", "Start", "End", "Confidence")
+
+SYNTHETIC_CLINICAL_TEXT = (
+    "Synthetic note: John Doe (MRN 123456) was seen on 01/15/2023 by "
+    "Dr. Alice Smith. Reach the patient at john.doe@example.com or "
+    "(415) 555-0142."
+)
+
+
+@dataclass(frozen=True)
+class DeidentificationView:
+    """UI-ready view of one de-identification run.
+
+    Attributes:
+        deidentified_text: The redacted text returned by ``deidentify``.
+        entity_rows: Detected PII entities flattened into table rows.
+    """
+
+    deidentified_text: str
+    entity_rows: list[list[str]]
+
+
+def entities_to_rows(entities: list[Any]) -> list[list[str]]:
+    """Flatten detected PII entities into stringified table rows.
+
+    Args:
+        entities: ``PIIEntity`` objects from a de-identification result.
+
+    Returns:
+        One ``[label, text, start, end, confidence]`` row per entity, with
+        every cell coerced to ``str`` so the UI can render them directly.
+    """
+    rows: list[list[str]] = []
+    for entity in entities:
+        confidence = getattr(entity, "confidence", None)
+        rows.append(
+            [
+                str(getattr(entity, "label", "") or ""),
+                str(getattr(entity, "text", "") or ""),
+                str(getattr(entity, "start", "")),
+                str(getattr(entity, "end", "")),
+                "" if confidence is None else f"{float(confidence):.2f}",
+            ]
+        )
+    return rows
+
+
+def run_deidentification(text: str, method: str) -> DeidentificationView:
+    """De-identify *text* with *method* and adapt the result for the UI.
+
+    This wraps the public :func:`openmed.deidentify` API. Model access (and
+    any one-time download) happens here when invoked, never at import time,
+    which keeps the module import-safe for tests.
+
+    Args:
+        text: Input text to de-identify.
+        method: One of :data:`DEIDENTIFICATION_METHODS`
+            (``"mask"``, ``"replace"``, or ``"hash"``).
+
+    Returns:
+        A :class:`DeidentificationView` with the redacted text and a flat
+        entity table.
+
+    Raises:
+        ValueError: If *method* is not a supported method.
+    """
+    if method not in DEIDENTIFICATION_METHODS:
+        raise ValueError(
+            f"Unsupported method {method!r}; choose one of {DEIDENTIFICATION_METHODS}."
+        )
+    result = deidentify(text, method=method)
+    return DeidentificationView(
+        deidentified_text=result.deidentified_text,
+        entity_rows=entities_to_rows(result.pii_entities),
+    )
+
+
+def build_demo() -> Any:
+    """Build the Gradio Blocks UI without launching a server.
+
+    Returns:
+        A ``gradio.Blocks`` instance ready for ``.launch()``.
+
+    Raises:
+        SystemExit: With an actionable install hint when the optional
+            ``gradio`` dependency is not available.
+    """
+    try:
+        import gradio as gr
+    except ImportError as exc:  # pragma: no cover - covered via monkeypatch
+        raise SystemExit(GRADIO_INSTALL_HINT) from exc
+
+    def _on_submit(text: str, method: str) -> tuple[str, list[list[str]]]:
+        view = run_deidentification(text, method)
+        return view.deidentified_text, view.entity_rows
+
+    with gr.Blocks(title="OpenMed de-identification") as demo:
+        gr.Markdown(
+            "# OpenMed de-identification demo\n"
+            "Paste a **synthetic** clinical note (never real PHI), pick a "
+            "method, and inspect both the redacted text and the detected "
+            "entities."
+        )
+        with gr.Row():
+            text_in = gr.Textbox(
+                label="Input text",
+                value=SYNTHETIC_CLINICAL_TEXT,
+                lines=6,
+            )
+            method_in = gr.Radio(
+                choices=list(DEIDENTIFICATION_METHODS),
+                value="mask",
+                label="Method",
+            )
+        submit = gr.Button("De-identify", variant="primary")
+        text_out = gr.Textbox(label="De-identified text", lines=6)
+        entities_out = gr.Dataframe(
+            headers=list(ENTITY_TABLE_HEADERS),
+            label="Detected PII entities",
+            wrap=True,
+        )
+        submit.click(_on_submit, [text_in, method_in], [text_out, entities_out])
+    return demo
+
+
+def main() -> None:
+    """Launch the de-identification demo locally."""
+    build_demo().launch()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_examples_smoke.py
+++ b/tests/unit/test_examples_smoke.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import ast
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-from examples import clinical_ner_families
+import pytest
+
+from examples import clinical_ner_families, gradio_deid_app
 
 
 def test_clinical_ner_families_example_is_syntactically_valid():
@@ -91,3 +94,69 @@ def test_clinical_ner_families_reports_offline_unavailable(capsys):
     captured = capsys.readouterr().out
     assert "Disease: model unavailable offline" in captured
     assert "cached files not found" in captured
+
+
+def test_gradio_deid_app_is_syntactically_valid():
+    source = Path("examples/gradio_deid_app.py").read_text(encoding="utf-8")
+
+    ast.parse(source)
+
+
+def test_gradio_deid_app_exposes_public_surface():
+    assert gradio_deid_app.DEIDENTIFICATION_METHODS == ("mask", "replace", "hash")
+    assert callable(gradio_deid_app.build_demo)
+    assert callable(gradio_deid_app.run_deidentification)
+    assert "Synthetic note" in gradio_deid_app.SYNTHETIC_CLINICAL_TEXT
+
+
+def test_gradio_deid_app_builds_entity_rows():
+    entities = [
+        SimpleNamespace(label="NAME", text="John Doe", start=0, end=8, confidence=0.97),
+        SimpleNamespace(
+            label="EMAIL", text="j@x.org", start=20, end=27, confidence=0.5
+        ),
+    ]
+
+    rows = gradio_deid_app.entities_to_rows(entities)
+
+    assert rows == [
+        ["NAME", "John Doe", "0", "8", "0.97"],
+        ["EMAIL", "j@x.org", "20", "27", "0.50"],
+    ]
+
+
+def test_gradio_deid_app_run_uses_deidentify_without_network(monkeypatch):
+    calls = []
+
+    def fake_deidentify(text, *, method):
+        calls.append((text, method))
+        return SimpleNamespace(
+            deidentified_text="[NAME] was seen.",
+            pii_entities=[
+                SimpleNamespace(
+                    label="NAME", text="John Doe", start=0, end=8, confidence=0.9
+                )
+            ],
+        )
+
+    monkeypatch.setattr(gradio_deid_app, "deidentify", fake_deidentify)
+
+    view = gradio_deid_app.run_deidentification("John Doe was seen.", "mask")
+
+    assert calls == [("John Doe was seen.", "mask")]
+    assert view.deidentified_text == "[NAME] was seen."
+    assert view.entity_rows == [["NAME", "John Doe", "0", "8", "0.90"]]
+
+
+def test_gradio_deid_app_rejects_unknown_method():
+    with pytest.raises(ValueError, match="Unsupported method"):
+        gradio_deid_app.run_deidentification("text", "encrypt")
+
+
+def test_gradio_deid_app_missing_gradio_prints_hint(monkeypatch):
+    monkeypatch.setitem(sys.modules, "gradio", None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        gradio_deid_app.build_demo()
+
+    assert "pip install gradio" in str(excinfo.value)


### PR DESCRIPTION
## Description
Adds an interactive Gradio demo so users can try `deidentify` without writing code — paste synthetic text, pick a method, and see the redacted output alongside the detected entities. Closes #484.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made
- `examples/gradio_deid_app.py`: single-file Gradio app with a `mask`/`replace`/`hash` method selector, a detected-entity table, an optional-`gradio` guard with a clear install hint, and synthetic-only sample text.
- Import-safe smoke tests in `tests/unit/test_examples_smoke.py` (AST parse, public surface, pure row-building, a mocked `deidentify` call with no network, bad-method handling, and the missing-gradio hint).
- Updated `docs/examples.md` and `CHANGELOG.md`.

## Testing
- [x] I have added tests that prove the feature works.
- [x] New and existing unit tests pass locally with my changes (`.venv/bin/python -m pytest tests/unit -q` → 2960 passed, 36 skipped).

## Documentation
- [x] I have updated the documentation accordingly.
- [x] I have added docstrings to new functions/classes.
- [x] I have updated the CHANGELOG.md.

## Code Quality
- [x] I ran Ruff format and lint (`ruff format --check .` and `ruff check .` are clean repo-wide).
- [x] I have performed a self-review of my own code.

## Dependencies
- [x] I have not added any new package dependencies — `gradio` stays an optional, example-local import and is not added to project dependencies.

## Related Issues
Closes #484
