### PR TITLE
feat(mlx): add OPENMED_MLX_MMAP toggle for memory-mapped weight loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (including prompt-injection and RAG-exfiltration leakage vectors) is named as a
   private-disclosure class.
 - Added LRU Cache implementation for analyze_text(), extract_pii(), and deidentify().
+- Added an `OPENMED_MLX_MMAP` toggle to `openmed.mlx.models.load_model`:
+  safetensors weights load through MLX's memory-mapped, lazy path by default
+  (keeping cold-start peak RSS low on the phone/laptop tiers), with
+  `OPENMED_MLX_MMAP=0` forcing eager materialization as a documented fallback
+  for debugging.
 
 ## [1.6.0] - 2026-06-22
 

--- a/openmed/mlx/models/__init__.py
+++ b/openmed/mlx/models/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -336,6 +337,46 @@ def _quantize_model_for_weights(
     return build_model(config, manifest=manifest)
 
 
+_MLX_MMAP_ENV = "OPENMED_MLX_MMAP"
+
+
+def _mlx_mmap_enabled() -> bool:
+    """Whether MLX weights use the memory-mapped (lazy) read path.
+
+    Controlled by the ``OPENMED_MLX_MMAP`` environment variable. Memory-mapped
+    loading is the default; set ``OPENMED_MLX_MMAP=0`` (or ``false``/``no``/
+    ``off``) to force the eager path, which materializes every tensor up front
+    — useful for debugging or deterministic memory profiling.
+    """
+    value = os.environ.get(_MLX_MMAP_ENV)
+    if value is None or not value.strip():
+        return True
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _load_mlx_weights(mx: Any, weights_path: Path) -> dict[str, Any]:
+    """Read MLX weights from *weights_path*, honoring the mmap toggle.
+
+    MLX reads ``.safetensors`` lazily and memory-mapped: tensors stay backed by
+    the file and are not resident until evaluated, which keeps cold-start peak
+    RSS low on the phone/laptop tiers. This is the default path. When mmap is
+    disabled via :func:`_mlx_mmap_enabled`, every tensor is eagerly evaluated
+    up front, reproducing the fully-materialized behavior as a documented
+    fallback.
+
+    Args:
+        mx: The imported ``mlx.core`` module.
+        weights_path: Path to a ``.safetensors`` or ``.npz`` weight file.
+
+    Returns:
+        Mapping of parameter name to MLX array.
+    """
+    weights = dict(mx.load(str(weights_path)))
+    if not _mlx_mmap_enabled() and weights:
+        mx.eval(*weights.values())
+    return weights
+
+
 def load_model(model_path: str | Path):
     """Load a converted MLX model from *model_path*."""
     try:
@@ -361,7 +402,7 @@ def load_model(model_path: str | Path):
         )
 
     if weights_path.suffix in {".safetensors", ".npz"}:
-        weights = dict(mx.load(str(weights_path)))
+        weights = _load_mlx_weights(mx, weights_path)
     else:
         raise FileNotFoundError(
             f"Unsupported MLX weight file: {weights_path}. "

--- a/tests/unit/mlx/test_mmap_loading.py
+++ b/tests/unit/mlx/test_mmap_loading.py
@@ -1,0 +1,101 @@
+"""Tests for the memory-mapped / lazy MLX weight-loading toggle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from openmed.mlx.models import _load_mlx_weights, _mlx_mmap_enabled
+
+
+def _module_importable(module_name: str) -> bool:
+    try:
+        __import__(module_name)
+    except Exception:
+        return False
+    return True
+
+
+_MLX_AVAILABLE = _module_importable("mlx.core")
+
+
+def test_mmap_enabled_by_default(monkeypatch):
+    monkeypatch.delenv("OPENMED_MLX_MMAP", raising=False)
+
+    assert _mlx_mmap_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_mmap_empty_value_falls_back_to_default(monkeypatch, value):
+    monkeypatch.setenv("OPENMED_MLX_MMAP", value)
+
+    assert _mlx_mmap_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "off", " off "])
+def test_mmap_disabled_for_falsey_values(monkeypatch, value):
+    monkeypatch.setenv("OPENMED_MLX_MMAP", value)
+
+    assert _mlx_mmap_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on"])
+def test_mmap_enabled_for_truthy_values(monkeypatch, value):
+    monkeypatch.setenv("OPENMED_MLX_MMAP", value)
+
+    assert _mlx_mmap_enabled() is True
+
+
+def test_load_mlx_weights_lazy_path_does_not_eval(monkeypatch):
+    monkeypatch.delenv("OPENMED_MLX_MMAP", raising=False)
+    arrays = {"a": object(), "b": object()}
+    fake_mx = SimpleNamespace(load=MagicMock(return_value=arrays), eval=MagicMock())
+
+    result = _load_mlx_weights(fake_mx, Path("weights.safetensors"))
+
+    fake_mx.load.assert_called_once_with("weights.safetensors")
+    fake_mx.eval.assert_not_called()
+    assert result == arrays
+
+
+def test_load_mlx_weights_eager_path_evaluates(monkeypatch):
+    monkeypatch.setenv("OPENMED_MLX_MMAP", "0")
+    arrays = {"a": object(), "b": object()}
+    fake_mx = SimpleNamespace(load=MagicMock(return_value=arrays), eval=MagicMock())
+
+    _load_mlx_weights(fake_mx, Path("weights.safetensors"))
+
+    fake_mx.eval.assert_called_once_with(*arrays.values())
+
+
+def test_load_mlx_weights_eager_path_handles_empty_weights(monkeypatch):
+    monkeypatch.setenv("OPENMED_MLX_MMAP", "0")
+    fake_mx = SimpleNamespace(load=MagicMock(return_value={}), eval=MagicMock())
+
+    result = _load_mlx_weights(fake_mx, Path("weights.safetensors"))
+
+    fake_mx.eval.assert_not_called()
+    assert result == {}
+
+
+@pytest.mark.skipif(not _MLX_AVAILABLE, reason="requires mlx")
+@pytest.mark.parametrize("mmap_flag", ["1", "0"])
+def test_load_mlx_weights_roundtrip_matches(tmp_path, monkeypatch, mmap_flag):
+    import mlx.core as mx
+
+    monkeypatch.setenv("OPENMED_MLX_MMAP", mmap_flag)
+    expected = {
+        "layer.weight": mx.array([[1.0, 2.0], [3.0, 4.0]]),
+        "layer.scales": mx.array([0.5, 0.25]),  # quantized-style aux tensor
+    }
+    weights_path = tmp_path / "weights.safetensors"
+    mx.save_safetensors(str(weights_path), expected)
+
+    loaded = _load_mlx_weights(mx, weights_path)
+
+    assert set(loaded) == set(expected)
+    for key, value in expected.items():
+        assert bool(mx.all(loaded[key] == value)), key


### PR DESCRIPTION
## Description
Hardens MLX safetensors loading in `openmed.mlx.models.load_model` and adds an `OPENMED_MLX_MMAP` toggle so callers can force eager loading for debugging. Closes #296.

**Implementation note (MLX API):** the issue lists "`mx.load` with mmap" as one option, but MLX 0.31's `mx.load(file, /, format=None, return_metadata=False, *, stream=None)` has no `mmap` parameter. MLX already reads `.safetensors` lazily and memory-mapped at the native level (tensors are not resident until evaluated), so this PR takes the issue's other stated option — lazy load — as the default "mmap path" and uses the toggle to force eager materialization as the documented fallback. The default loading behavior is therefore unchanged; the change adds the explicit toggle, documents the lazy/mmap behavior, and locks correctness in with tests. Happy to adjust if you'd prefer a different shape.

## Type of Change
- [x] Performance improvement
- [x] Test addition/improvement

## Changes Made
- `openmed/mlx/models/__init__.py`: route the safetensors/npz read through a new `_load_mlx_weights` helper. By default it uses MLX's lazy, memory-mapped path; when `OPENMED_MLX_MMAP` is `0`/`false`/`no`/`off` it eagerly evaluates every tensor up front as a documented fallback. Added `_mlx_mmap_enabled()` to parse the toggle (unset/empty → enabled).
- Quantized (`.scales`) and non-quantized checkpoints both load unchanged.
- `tests/unit/mlx/test_mmap_loading.py`: toggle parsing, eager/lazy `mx.eval` behavior (mocked, no MLX required), and a real-MLX safetensors round-trip with mmap enabled and disabled (skipped when MLX is unavailable).

## Testing
- [x] Added tests; full unit suite passes locally (`.venv/bin/python -m pytest tests/unit -q` → 2983 passed, 25 skipped), with MLX installed so the existing MLX loader tests exercise the change.

## Documentation
- [x] Added docstrings to the new helpers and updated `CHANGELOG.md`.

## Code Quality
- [x] Ran Ruff format and lint (`ruff format --check .` and `ruff check .` are clean repo-wide).
- [x] Performed a self-review.

## Dependencies
- [x] No new package dependencies.

## Related Issues
Closes #296
