### PR TITLE
Add concept normalization with a pluggable terminology backend and caching

### DIFF
--- a/openmed/clinical/exporters/__init__.py
+++ b/openmed/clinical/exporters/__init__.py
@@ -7,9 +7,11 @@ from .code_provenance import (
     stamp_coding_provenance,
 )
 from .codeable_concept_check import (
+    CONCEPT_NORMALIZATION_PROVENANCE_EXTENSION_URL,
     CodeableConceptFinding,
     CodeableConceptFindingCode,
     check_codeable_concept,
+    codeable_concept_from_ranked_candidates,
 )
 from .flat_table import (
     FLAT_TABLE_COLUMNS,
@@ -21,10 +23,12 @@ from .flat_table import (
 
 __all__ = [
     "CODE_SYSTEM_VERSION_SOURCE_EXTENSION_URL",
+    "CONCEPT_NORMALIZATION_PROVENANCE_EXTENSION_URL",
     "CodeableConceptFinding",
     "CodeableConceptFindingCode",
     "FLAT_TABLE_COLUMNS",
     "check_codeable_concept",
+    "codeable_concept_from_ranked_candidates",
     "flatten_clinical_entities",
     "flatten_entities",
     "stamp_coding_provenance",

--- a/openmed/clinical/exporters/codeable_concept_check.py
+++ b/openmed/clinical/exporters/codeable_concept_check.py
@@ -1,4 +1,4 @@
-"""Structural consistency checks for FHIR R4 ``CodeableConcept`` mappings.
+"""FHIR R4 ``CodeableConcept`` assembly and structural consistency checks.
 
 This module checks local shape and text/display consistency only. It does not
 validate codes, displays, systems, or bindings against a terminology service,
@@ -10,10 +10,16 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal, TypedDict
 
+from openmed.clinical.normalization import RankedConcept
+
+from .codeable_concept_simple import codeable_concept, coding
+
 __all__ = [
+    "CONCEPT_NORMALIZATION_PROVENANCE_EXTENSION_URL",
     "CodeableConceptFinding",
     "CodeableConceptFindingCode",
     "check_codeable_concept",
+    "codeable_concept_from_ranked_candidates",
 ]
 
 CodeableConceptFindingCode = Literal[
@@ -50,6 +56,9 @@ _EMPTY_CODING_DIAGNOSTICS = (
 _TEXT_DISPLAY_DIAGNOSTICS = (
     "CodeableConcept.text must match at least one coding.display when both are "
     "available, or a coding display must provide the fallback label."
+)
+CONCEPT_NORMALIZATION_PROVENANCE_EXTENSION_URL = (
+    "https://openmed.ai/fhir/StructureDefinition/concept-normalization-provenance"
 )
 
 
@@ -120,6 +129,62 @@ def check_codeable_concept(
             item["expression"],
         ),
     )
+
+
+def codeable_concept_from_ranked_candidates(
+    candidates: Sequence[RankedConcept],
+    *,
+    text: str | None = None,
+    max_codings: int = 5,
+) -> dict[str, Any]:
+    """Build a FHIR R4 ``CodeableConcept`` from ranked normalized concepts.
+
+    Each emitted ``Coding`` carries the terminology system/code/display plus a
+    provenance extension with the mention offsets, confidence, and backend
+    identity used to produce the candidate.
+    """
+
+    if not candidates:
+        raise ValueError("at least one ranked candidate is required")
+    if max_codings <= 0:
+        raise ValueError("max_codings must be positive")
+
+    codings = [
+        _coding_from_ranked_candidate(candidate)
+        for candidate in candidates[:max_codings]
+    ]
+    return codeable_concept(codings, text=text)
+
+
+def _coding_from_ranked_candidate(candidate: RankedConcept) -> dict[str, Any]:
+    concept = candidate.concept
+    result = coding(concept.system_uri, concept.code, concept.display)
+    if concept.version is not None:
+        result["version"] = concept.version
+    result["extension"] = [_normalization_provenance_extension(candidate)]
+    return result
+
+
+def _normalization_provenance_extension(
+    candidate: RankedConcept,
+) -> dict[str, Any]:
+    provenance = candidate.provenance
+    extensions: list[dict[str, Any]] = [
+        {"url": "confidence", "valueDecimal": candidate.confidence},
+        {"url": "backendName", "valueString": provenance.backend_name},
+        {"url": "backendVersion", "valueString": provenance.backend_version},
+    ]
+    if provenance.mention_start is not None:
+        extensions.append(
+            {"url": "mentionStart", "valueInteger": provenance.mention_start}
+        )
+    if provenance.mention_end is not None:
+        extensions.append({"url": "mentionEnd", "valueInteger": provenance.mention_end})
+
+    return {
+        "url": CONCEPT_NORMALIZATION_PROVENANCE_EXTENSION_URL,
+        "extension": extensions,
+    }
 
 
 def _finding(

--- a/openmed/clinical/normalization/__init__.py
+++ b/openmed/clinical/normalization/__init__.py
@@ -1,0 +1,53 @@
+"""Clinical concept normalization with pluggable terminology backends."""
+
+from __future__ import annotations
+
+from .backend import (
+    SYNTHETIC_CODE_SYSTEMS,
+    SYNTHETIC_CONCEPTS,
+    BackendIdentity,
+    CodeSystemMetadata,
+    SyntheticTerminologyBackend,
+    TerminologyBackend,
+    TerminologyConcept,
+    normalize_surface,
+    validate_backend_identity,
+)
+from .cache import (
+    ConceptNormalizationCache,
+    NormalizationCacheStats,
+    make_normalization_cache_key,
+)
+from .ranker import (
+    SYNTHETIC_GOLD_SET,
+    CandidateProvenance,
+    ConceptNormalizer,
+    NormalizationEvaluationResult,
+    NormalizationGoldCase,
+    RankedConcept,
+    evaluate_normalization_gold,
+    generate_query_variants,
+)
+
+__all__ = [
+    "BackendIdentity",
+    "CandidateProvenance",
+    "CodeSystemMetadata",
+    "ConceptNormalizationCache",
+    "ConceptNormalizer",
+    "NormalizationCacheStats",
+    "NormalizationEvaluationResult",
+    "NormalizationGoldCase",
+    "RankedConcept",
+    "SYNTHETIC_CODE_SYSTEMS",
+    "SYNTHETIC_CONCEPTS",
+    "SYNTHETIC_GOLD_SET",
+    "SyntheticTerminologyBackend",
+    "TerminologyBackend",
+    "TerminologyConcept",
+    "evaluate_normalization_gold",
+    "generate_query_variants",
+    "make_normalization_cache_key",
+    "normalize_surface",
+    "validate_backend_identity",
+]

--- a/openmed/clinical/normalization/backend.py
+++ b/openmed/clinical/normalization/backend.py
@@ -1,0 +1,307 @@
+"""Terminology backend contracts for clinical concept normalization.
+
+OpenMed ships only a permissively licensed synthetic backend here. Real
+terminology catalogs stay outside the package and are accessed through the
+``TerminologyBackend`` protocol implemented by the caller.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "BackendIdentity",
+    "CodeSystemMetadata",
+    "SYNTHETIC_CODE_SYSTEMS",
+    "SYNTHETIC_CONCEPTS",
+    "SyntheticTerminologyBackend",
+    "TerminologyBackend",
+    "TerminologyConcept",
+    "normalize_surface",
+    "validate_backend_identity",
+]
+
+
+_NON_ALNUM_RE = re.compile(r"[^0-9a-z]+")
+
+
+def normalize_surface(text: str) -> str:
+    """Return a deterministic, case-insensitive surface form.
+
+    The normalization is intentionally mechanical and local: Unicode
+    compatibility normalization, case-folding, punctuation folding to spaces,
+    and whitespace collapse. It never consults a terminology catalog.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    value = unicodedata.normalize("NFKC", text).casefold()
+    value = _NON_ALNUM_RE.sub(" ", value)
+    return " ".join(value.split())
+
+
+@dataclass(frozen=True)
+class BackendIdentity:
+    """Stable identity used to isolate cache entries by backend version."""
+
+    name: str
+    version: str
+
+    def __post_init__(self) -> None:
+        validate_backend_identity(self)
+
+    def cache_payload(self) -> dict[str, str]:
+        """Return the JSON-safe identity payload included in cache keys."""
+
+        return {"name": self.name, "version": self.version}
+
+
+@dataclass(frozen=True)
+class CodeSystemMetadata:
+    """Metadata for one code system exposed by a terminology backend."""
+
+    system_id: str
+    uri: str
+    version: str
+    license: str = "synthetic"
+
+
+@dataclass(frozen=True)
+class TerminologyConcept:
+    """One coded concept returned by a terminology backend."""
+
+    system_id: str
+    system_uri: str
+    code: str
+    display: str
+    aliases: tuple[str, ...] = field(default_factory=tuple)
+    version: str | None = None
+    source: str = "synthetic"
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """Return the stable dedupe key for this concept."""
+
+        return (self.system_uri, self.code)
+
+    @property
+    def normalized_terms(self) -> tuple[str, ...]:
+        """Return normalized display and alias surfaces for matching."""
+
+        return _unique_ordered(
+            normalize_surface(term) for term in (self.display, *self.aliases)
+        )
+
+
+@runtime_checkable
+class TerminologyBackend(Protocol):
+    """Protocol implemented by caller-supplied terminology adapters."""
+
+    @property
+    def identity(self) -> BackendIdentity:
+        """Return a non-empty backend name and version for cache isolation."""
+
+    def lookup(self, normalized: str) -> Sequence[TerminologyConcept]:
+        """Return concepts whose display or alias exactly matches ``normalized``."""
+
+    def candidates(self, tokens: Sequence[str]) -> Sequence[TerminologyConcept]:
+        """Return candidate concepts sharing at least one blocking token."""
+
+    def code_systems(self) -> Sequence[CodeSystemMetadata]:
+        """Return code-system metadata exposed by the backend."""
+
+
+SYNTHETIC_CODE_SYSTEMS: tuple[CodeSystemMetadata, ...] = (
+    CodeSystemMetadata(
+        system_id="synthetic-condition",
+        uri="https://openmed.ai/fhir/CodeSystem/synthetic-condition",
+        version="2026.06-synthetic",
+    ),
+    CodeSystemMetadata(
+        system_id="synthetic-observation",
+        uri="https://openmed.ai/fhir/CodeSystem/synthetic-observation",
+        version="2026.06-synthetic",
+    ),
+    CodeSystemMetadata(
+        system_id="synthetic-treatment",
+        uri="https://openmed.ai/fhir/CodeSystem/synthetic-treatment",
+        version="2026.06-synthetic",
+    ),
+)
+
+_SYSTEM_BY_ID = {system.system_id: system for system in SYNTHETIC_CODE_SYSTEMS}
+
+SYNTHETIC_CONCEPTS: tuple[TerminologyConcept, ...] = (
+    TerminologyConcept(
+        system_id="synthetic-condition",
+        system_uri=_SYSTEM_BY_ID["synthetic-condition"].uri,
+        code="SYN-COND-001",
+        display="Aster fever",
+        aliases=("aster pyrexia", "a fever pattern"),
+        version=_SYSTEM_BY_ID["synthetic-condition"].version,
+    ),
+    TerminologyConcept(
+        system_id="synthetic-condition",
+        system_uri=_SYSTEM_BY_ID["synthetic-condition"].uri,
+        code="SYN-COND-002",
+        display="Beryl cough pattern",
+        aliases=("beryl cough", "bc pattern"),
+        version=_SYSTEM_BY_ID["synthetic-condition"].version,
+    ),
+    TerminologyConcept(
+        system_id="synthetic-condition",
+        system_uri=_SYSTEM_BY_ID["synthetic-condition"].uri,
+        code="SYN-COND-003",
+        display="Corin skin flare",
+        aliases=("corin rash", "skin flare corin"),
+        version=_SYSTEM_BY_ID["synthetic-condition"].version,
+    ),
+    TerminologyConcept(
+        system_id="synthetic-condition",
+        system_uri=_SYSTEM_BY_ID["synthetic-condition"].uri,
+        code="SYN-COND-004",
+        display="Dax ankle strain",
+        aliases=("dax ankle sprain", "ankle strain dax"),
+        version=_SYSTEM_BY_ID["synthetic-condition"].version,
+    ),
+    TerminologyConcept(
+        system_id="synthetic-observation",
+        system_uri=_SYSTEM_BY_ID["synthetic-observation"].uri,
+        code="SYN-OBS-001",
+        display="Elin sugar panel",
+        aliases=("elin glucose panel", "esp"),
+        version=_SYSTEM_BY_ID["synthetic-observation"].version,
+    ),
+    TerminologyConcept(
+        system_id="synthetic-observation",
+        system_uri=_SYSTEM_BY_ID["synthetic-observation"].uri,
+        code="SYN-OBS-002",
+        display="Faren breath score",
+        aliases=("faren breathing score", "fbs"),
+        version=_SYSTEM_BY_ID["synthetic-observation"].version,
+    ),
+    TerminologyConcept(
+        system_id="synthetic-observation",
+        system_uri=_SYSTEM_BY_ID["synthetic-observation"].uri,
+        code="SYN-OBS-003",
+        display="Galen red cell count",
+        aliases=("galen rcc", "grcc"),
+        version=_SYSTEM_BY_ID["synthetic-observation"].version,
+    ),
+    TerminologyConcept(
+        system_id="synthetic-observation",
+        system_uri=_SYSTEM_BY_ID["synthetic-observation"].uri,
+        code="SYN-OBS-004",
+        display="Halo pain scale",
+        aliases=("halo pain rating", "hps"),
+        version=_SYSTEM_BY_ID["synthetic-observation"].version,
+    ),
+    TerminologyConcept(
+        system_id="synthetic-treatment",
+        system_uri=_SYSTEM_BY_ID["synthetic-treatment"].uri,
+        code="SYN-TREAT-001",
+        display="Iona sleep coaching",
+        aliases=("iona sleep plan", "isc"),
+        version=_SYSTEM_BY_ID["synthetic-treatment"].version,
+    ),
+    TerminologyConcept(
+        system_id="synthetic-treatment",
+        system_uri=_SYSTEM_BY_ID["synthetic-treatment"].uri,
+        code="SYN-TREAT-002",
+        display="Juno blue tablet",
+        aliases=("juno tablet blue", "jbt"),
+        version=_SYSTEM_BY_ID["synthetic-treatment"].version,
+    ),
+)
+
+
+class SyntheticTerminologyBackend:
+    """Small in-memory backend using synthetic concepts only."""
+
+    def __init__(
+        self,
+        *,
+        identity: BackendIdentity | None = None,
+        concepts: Sequence[TerminologyConcept] = SYNTHETIC_CONCEPTS,
+        systems: Sequence[CodeSystemMetadata] = SYNTHETIC_CODE_SYSTEMS,
+    ) -> None:
+        self._identity = identity or BackendIdentity(
+            name="openmed-synthetic-terminology",
+            version="2026.06",
+        )
+        self._concepts = tuple(concepts)
+        self._systems = tuple(systems)
+        self._lookup_index: dict[str, list[TerminologyConcept]] = defaultdict(list)
+        self._token_index: dict[str, list[TerminologyConcept]] = defaultdict(list)
+        for concept in self._concepts:
+            for normalized in concept.normalized_terms:
+                self._lookup_index[normalized].append(concept)
+                for token in normalized.split():
+                    self._token_index[token].append(concept)
+
+    @property
+    def identity(self) -> BackendIdentity:
+        return self._identity
+
+    def lookup(self, normalized: str) -> tuple[TerminologyConcept, ...]:
+        normalized = normalize_surface(normalized)
+        return tuple(self._lookup_index.get(normalized, ()))
+
+    def candidates(self, tokens: Sequence[str]) -> tuple[TerminologyConcept, ...]:
+        keys = []
+        for token in tokens:
+            normalized = normalize_surface(token)
+            if normalized:
+                keys.append(normalized)
+        seen: set[tuple[str, str]] = set()
+        results: list[TerminologyConcept] = []
+        for token in keys:
+            for concept in self._token_index.get(token, ()):
+                if concept.key in seen:
+                    continue
+                seen.add(concept.key)
+                results.append(concept)
+        return tuple(results)
+
+    def code_systems(self) -> tuple[CodeSystemMetadata, ...]:
+        return self._systems
+
+
+def validate_backend_identity(identity: object) -> BackendIdentity:
+    """Return a validated backend identity or raise a cache-safety error."""
+
+    if isinstance(identity, BackendIdentity):
+        name = identity.name
+        version = identity.version
+    elif isinstance(identity, Mapping):
+        name = identity.get("name")
+        version = identity.get("version")
+    else:
+        name = getattr(identity, "name", None)
+        version = getattr(identity, "version", None)
+
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("terminology backend identity must include a name")
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError("terminology backend identity must include a version")
+    return (
+        identity
+        if isinstance(identity, BackendIdentity)
+        else BackendIdentity(name=name.strip(), version=version.strip())
+    )
+
+
+def _unique_ordered(values: Sequence[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return tuple(result)

--- a/openmed/clinical/normalization/cache.py
+++ b/openmed/clinical/normalization/cache.py
@@ -1,0 +1,113 @@
+"""Content-addressed in-memory cache for concept normalization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from openmed.core.result_cache import ResultCache, freeze_value
+
+from .backend import BackendIdentity, TerminologyBackend, normalize_surface
+
+__all__ = [
+    "ConceptNormalizationCache",
+    "NormalizationCacheStats",
+    "make_normalization_cache_key",
+]
+
+
+@dataclass(frozen=True)
+class NormalizationCacheStats:
+    """Hit/miss counters for a concept normalization cache."""
+
+    hits: int
+    misses: int
+    writes: int
+    size: int
+
+    @property
+    def hit_rate(self) -> float:
+        """Return hits divided by cache reads."""
+
+        total = self.hits + self.misses
+        if total == 0:
+            return 0.0
+        return self.hits / total
+
+
+class ConceptNormalizationCache:
+    """Bounded in-memory cache keyed by mention text and backend identity."""
+
+    def __init__(self, max_entries: int = 1024) -> None:
+        self._store = ResultCache(max_entries=max_entries)
+        self._hits = 0
+        self._misses = 0
+        self._writes = 0
+
+    def get(self, normalized_mention: str, backend: TerminologyBackend) -> Any | None:
+        """Return a cached ranking tuple, if present."""
+
+        key = self.key_for(normalized_mention, backend)
+        value = self._store.get(key)
+        if value is None:
+            self._misses += 1
+            return None
+        self._hits += 1
+        return value
+
+    def set(
+        self,
+        normalized_mention: str,
+        backend: TerminologyBackend,
+        value: Any,
+    ) -> None:
+        """Store ``value`` for ``normalized_mention`` and ``backend``."""
+
+        key = self.key_for(normalized_mention, backend)
+        self._store.set(key, value)
+        self._writes += 1
+
+    def key_for(self, normalized_mention: str, backend: TerminologyBackend) -> str:
+        """Return the content-addressed cache key for a backend lookup."""
+
+        return make_normalization_cache_key(normalized_mention, backend.identity)
+
+    def clear(self) -> None:
+        """Drop cached rankings and reset counters."""
+
+        self._store.clear()
+        self._hits = 0
+        self._misses = 0
+        self._writes = 0
+
+    def stats(self) -> NormalizationCacheStats:
+        """Return current cache counters."""
+
+        return NormalizationCacheStats(
+            hits=self._hits,
+            misses=self._misses,
+            writes=self._writes,
+            size=len(self._store),
+        )
+
+
+def make_normalization_cache_key(
+    normalized_mention: str,
+    backend_identity: BackendIdentity,
+) -> str:
+    """Return a hashed cache key that never embeds raw mention text."""
+
+    identity = backend_identity.cache_payload()
+    payload = {
+        "backend": identity,
+        "normalized_mention": normalize_surface(normalized_mention),
+    }
+    serialized = json.dumps(
+        freeze_value(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    return f"concept-normalization:{digest}"

--- a/openmed/clinical/normalization/ranker.py
+++ b/openmed/clinical/normalization/ranker.py
@@ -1,0 +1,471 @@
+"""Deterministic candidate generation, ranking, and synthetic evaluation."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+
+from .backend import (
+    SYNTHETIC_CONCEPTS,
+    BackendIdentity,
+    TerminologyBackend,
+    TerminologyConcept,
+    normalize_surface,
+    validate_backend_identity,
+)
+from .cache import ConceptNormalizationCache
+
+__all__ = [
+    "CandidateProvenance",
+    "ConceptNormalizer",
+    "NormalizationEvaluationResult",
+    "NormalizationGoldCase",
+    "RankedConcept",
+    "SYNTHETIC_GOLD_SET",
+    "evaluate_normalization_gold",
+    "generate_query_variants",
+]
+
+
+DEFAULT_ABBREVIATION_EXPANSIONS: dict[str, tuple[str, ...]] = {
+    "af": ("aster fever",),
+    "bc": ("beryl cough",),
+    "esp": ("elin sugar panel",),
+    "fbs": ("faren breath score",),
+    "grcc": ("galen red cell count",),
+    "hps": ("halo pain scale",),
+    "isc": ("iona sleep coaching",),
+    "jbt": ("juno blue tablet",),
+}
+
+
+@dataclass(frozen=True)
+class CandidateProvenance:
+    """Provenance carried with one ranked concept candidate."""
+
+    mention_start: int | None
+    mention_end: int | None
+    matched_term_hash: str
+    backend_name: str
+    backend_version: str
+    query_variant_count: int
+
+
+@dataclass(frozen=True)
+class RankedConcept:
+    """A coded concept ranked for a mention."""
+
+    concept: TerminologyConcept
+    confidence: float
+    score: float
+    features: tuple[tuple[str, float], ...]
+    provenance: CandidateProvenance
+
+    @property
+    def feature_map(self) -> dict[str, float]:
+        """Return ranking features as a JSON-friendly mapping."""
+
+        return dict(self.features)
+
+
+@dataclass(frozen=True)
+class NormalizationGoldCase:
+    """Synthetic gold case used by CI-gated normalization evaluation."""
+
+    mention: str
+    expected_system_uri: str
+    expected_code: str
+    start: int | None = None
+    end: int | None = None
+
+    @property
+    def expected_key(self) -> tuple[str, str]:
+        return (self.expected_system_uri, self.expected_code)
+
+
+@dataclass(frozen=True)
+class NormalizationEvaluationResult:
+    """Accuracy and cache metrics for a concept-normalization run."""
+
+    case_count: int
+    top1_accuracy: float
+    top5_accuracy: float
+    cache_hit_rate: float
+
+
+SYNTHETIC_GOLD_SET: tuple[NormalizationGoldCase, ...] = (
+    NormalizationGoldCase(
+        mention="Aster pyrexia",
+        expected_system_uri=SYNTHETIC_CONCEPTS[0].system_uri,
+        expected_code=SYNTHETIC_CONCEPTS[0].code,
+        start=4,
+        end=17,
+    ),
+    NormalizationGoldCase(
+        mention="AF",
+        expected_system_uri=SYNTHETIC_CONCEPTS[0].system_uri,
+        expected_code=SYNTHETIC_CONCEPTS[0].code,
+        start=21,
+        end=23,
+    ),
+    NormalizationGoldCase(
+        mention="beryl cough",
+        expected_system_uri=SYNTHETIC_CONCEPTS[1].system_uri,
+        expected_code=SYNTHETIC_CONCEPTS[1].code,
+        start=8,
+        end=19,
+    ),
+    NormalizationGoldCase(
+        mention="skin flare corin",
+        expected_system_uri=SYNTHETIC_CONCEPTS[2].system_uri,
+        expected_code=SYNTHETIC_CONCEPTS[2].code,
+        start=0,
+        end=16,
+    ),
+    NormalizationGoldCase(
+        mention="dax ankle sprain",
+        expected_system_uri=SYNTHETIC_CONCEPTS[3].system_uri,
+        expected_code=SYNTHETIC_CONCEPTS[3].code,
+        start=5,
+        end=21,
+    ),
+    NormalizationGoldCase(
+        mention="ESP",
+        expected_system_uri=SYNTHETIC_CONCEPTS[4].system_uri,
+        expected_code=SYNTHETIC_CONCEPTS[4].code,
+        start=2,
+        end=5,
+    ),
+    NormalizationGoldCase(
+        mention="faren breathing score",
+        expected_system_uri=SYNTHETIC_CONCEPTS[5].system_uri,
+        expected_code=SYNTHETIC_CONCEPTS[5].code,
+        start=11,
+        end=33,
+    ),
+    NormalizationGoldCase(
+        mention="galen rcc",
+        expected_system_uri=SYNTHETIC_CONCEPTS[6].system_uri,
+        expected_code=SYNTHETIC_CONCEPTS[6].code,
+        start=12,
+        end=21,
+    ),
+    NormalizationGoldCase(
+        mention="halo pain rating",
+        expected_system_uri=SYNTHETIC_CONCEPTS[7].system_uri,
+        expected_code=SYNTHETIC_CONCEPTS[7].code,
+        start=0,
+        end=16,
+    ),
+    NormalizationGoldCase(
+        mention="jbt",
+        expected_system_uri=SYNTHETIC_CONCEPTS[9].system_uri,
+        expected_code=SYNTHETIC_CONCEPTS[9].code,
+        start=40,
+        end=43,
+    ),
+)
+
+
+class ConceptNormalizer:
+    """Normalize clinical mention strings to ranked coded concepts."""
+
+    def __init__(
+        self,
+        backend: TerminologyBackend,
+        *,
+        cache: ConceptNormalizationCache | None = None,
+        abbreviation_expansions: Mapping[str, str | Sequence[str]] | None = None,
+        max_candidates: int = 10,
+        max_ngram: int = 4,
+    ) -> None:
+        self.backend = backend
+        self.identity = validate_backend_identity(backend.identity)
+        self.cache = cache
+        self.max_candidates = max_candidates
+        self.max_ngram = max_ngram
+        self.abbreviation_expansions = _normalize_expansions(
+            abbreviation_expansions or DEFAULT_ABBREVIATION_EXPANSIONS
+        )
+
+    def normalize(
+        self,
+        mention: str,
+        *,
+        start: int | None = None,
+        end: int | None = None,
+        use_cache: bool = True,
+    ) -> tuple[RankedConcept, ...]:
+        """Return ranked coded candidates for ``mention``."""
+
+        _validate_offsets(start, end)
+        normalized = normalize_surface(mention)
+        if self.cache is not None and use_cache:
+            cached = self.cache.get(normalized, self.backend)
+            if cached is not None:
+                return cached
+
+        ranked = self._rank_uncached(
+            normalized=normalized,
+            start=start,
+            end=end,
+        )
+        if self.cache is not None and use_cache:
+            self.cache.set(normalized, self.backend, ranked)
+        return ranked
+
+    def _rank_uncached(
+        self,
+        *,
+        normalized: str,
+        start: int | None,
+        end: int | None,
+    ) -> tuple[RankedConcept, ...]:
+        query_variants = generate_query_variants(
+            normalized,
+            abbreviation_expansions=self.abbreviation_expansions,
+            max_ngram=self.max_ngram,
+        )
+        candidates: dict[tuple[str, str], TerminologyConcept] = {}
+        for query in query_variants:
+            for concept in self.backend.lookup(query):
+                candidates.setdefault(concept.key, concept)
+        for query in query_variants:
+            for concept in self.backend.candidates(query.split()):
+                candidates.setdefault(concept.key, concept)
+
+        ranked = [
+            _rank_candidate(
+                concept=concept,
+                normalized_mention=normalized,
+                identity=self.identity,
+                start=start,
+                end=end,
+                query_variants=query_variants,
+            )
+            for concept in candidates.values()
+        ]
+        return tuple(sorted(ranked, key=_rank_sort_key)[: self.max_candidates])
+
+
+def generate_query_variants(
+    mention: str,
+    *,
+    abbreviation_expansions: Mapping[str, Sequence[str]] | None = None,
+    max_ngram: int = 4,
+) -> tuple[str, ...]:
+    """Return exact, abbreviation-expanded, and n-gram query variants."""
+
+    normalized = normalize_surface(mention)
+    tokens = normalized.split()
+    variants: list[str] = [normalized] if normalized else []
+    expansions = abbreviation_expansions or {}
+
+    expanded_phrases = _expanded_phrases(tokens, expansions)
+    variants.extend(expanded_phrases)
+
+    for phrase in (normalized, *expanded_phrases):
+        phrase_tokens = phrase.split()
+        for ngram in _ngrams(phrase_tokens, max_ngram=max_ngram):
+            variants.append(ngram)
+
+    return _unique_ordered(variants)
+
+
+def evaluate_normalization_gold(
+    normalizer: ConceptNormalizer,
+    gold_cases: Sequence[NormalizationGoldCase] = SYNTHETIC_GOLD_SET,
+    *,
+    repeated_workload_repeats: int = 2,
+) -> NormalizationEvaluationResult:
+    """Evaluate top-k accuracy and cache hit-rate on synthetic gold cases."""
+
+    if not gold_cases:
+        raise ValueError("gold_cases must not be empty")
+
+    top1_hits = 0
+    top5_hits = 0
+    for case in gold_cases:
+        ranked = normalizer.normalize(case.mention, start=case.start, end=case.end)
+        keys = [candidate.concept.key for candidate in ranked]
+        if keys[:1] == [case.expected_key]:
+            top1_hits += 1
+        if case.expected_key in keys[:5]:
+            top5_hits += 1
+
+    for _ in range(repeated_workload_repeats):
+        for case in gold_cases:
+            normalizer.normalize(case.mention, start=case.start, end=case.end)
+
+    cache_hit_rate = 0.0
+    if normalizer.cache is not None:
+        cache_hit_rate = normalizer.cache.stats().hit_rate
+
+    return NormalizationEvaluationResult(
+        case_count=len(gold_cases),
+        top1_accuracy=top1_hits / len(gold_cases),
+        top5_accuracy=top5_hits / len(gold_cases),
+        cache_hit_rate=cache_hit_rate,
+    )
+
+
+def _rank_candidate(
+    *,
+    concept: TerminologyConcept,
+    normalized_mention: str,
+    identity: BackendIdentity,
+    start: int | None,
+    end: int | None,
+    query_variants: tuple[str, ...],
+) -> RankedConcept:
+    terms = concept.normalized_terms
+    best_term = max(
+        terms,
+        key=lambda term: _term_score(normalized_mention, query_variants, term),
+    )
+    features = _feature_values(normalized_mention, query_variants, best_term)
+    score = _weighted_score(features)
+    confidence = round(max(0.0, min(1.0, score)), 6)
+    return RankedConcept(
+        concept=concept,
+        confidence=confidence,
+        score=round(score, 6),
+        features=tuple(sorted(features.items())),
+        provenance=CandidateProvenance(
+            mention_start=start,
+            mention_end=end,
+            matched_term_hash=_hash_text(best_term),
+            backend_name=identity.name,
+            backend_version=identity.version,
+            query_variant_count=len(query_variants),
+        ),
+    )
+
+
+def _feature_values(
+    normalized_mention: str,
+    query_variants: Sequence[str],
+    term: str,
+) -> dict[str, float]:
+    mention_tokens = set(normalized_mention.split())
+    term_tokens = set(term.split())
+    overlap = 0.0
+    if mention_tokens or term_tokens:
+        overlap = len(mention_tokens & term_tokens) / max(
+            len(mention_tokens | term_tokens),
+            1,
+        )
+
+    exact = float(term in query_variants or normalized_mention == term)
+    char_similarity = SequenceMatcher(None, normalized_mention, term).ratio()
+    acronym = float(_acronym(term) == normalized_mention and bool(normalized_mention))
+    expanded_exact = float(term in query_variants and normalized_mention != term)
+    length_fit = 1.0 - (
+        abs(len(normalized_mention.split()) - len(term.split()))
+        / max(len(normalized_mention.split()), len(term.split()), 1)
+    )
+    return {
+        "acronym": acronym,
+        "char_similarity": char_similarity,
+        "exact": exact,
+        "expanded_exact": expanded_exact,
+        "length_fit": length_fit,
+        "token_overlap": overlap,
+    }
+
+
+def _weighted_score(features: Mapping[str, float]) -> float:
+    return (
+        0.72 * features["exact"]
+        + 0.12 * features["token_overlap"]
+        + 0.08 * features["char_similarity"]
+        + 0.04 * features["length_fit"]
+        + 0.08 * features["expanded_exact"]
+        + 0.04 * features["acronym"]
+    )
+
+
+def _term_score(
+    normalized_mention: str,
+    query_variants: Sequence[str],
+    term: str,
+) -> tuple[float, str]:
+    features = _feature_values(normalized_mention, query_variants, term)
+    return (_weighted_score(features), term)
+
+
+def _rank_sort_key(candidate: RankedConcept) -> tuple[float, str, str, str]:
+    return (
+        -candidate.score,
+        candidate.concept.system_uri,
+        candidate.concept.code,
+        candidate.concept.display,
+    )
+
+
+def _normalize_expansions(
+    expansions: Mapping[str, str | Sequence[str]],
+) -> dict[str, tuple[str, ...]]:
+    normalized: dict[str, tuple[str, ...]] = {}
+    for abbreviation, values in expansions.items():
+        key = normalize_surface(abbreviation)
+        if isinstance(values, str):
+            raw_values = (values,)
+        else:
+            raw_values = tuple(values)
+        normalized[key] = tuple(
+            value for value in (normalize_surface(item) for item in raw_values) if value
+        )
+    return normalized
+
+
+def _expanded_phrases(
+    tokens: Sequence[str],
+    expansions: Mapping[str, Sequence[str]],
+) -> tuple[str, ...]:
+    phrases: list[str] = []
+    for index, token in enumerate(tokens):
+        for expansion in expansions.get(token, ()):
+            replaced = [*tokens]
+            replaced[index : index + 1] = expansion.split()
+            phrases.append(" ".join(replaced))
+    return _unique_ordered(phrases)
+
+
+def _ngrams(tokens: Sequence[str], *, max_ngram: int) -> tuple[str, ...]:
+    result: list[str] = []
+    max_size = min(max_ngram, len(tokens))
+    for size in range(max_size, 0, -1):
+        for start in range(0, len(tokens) - size + 1):
+            result.append(" ".join(tokens[start : start + size]))
+    return tuple(result)
+
+
+def _acronym(term: str) -> str:
+    return "".join(token[:1] for token in term.split() if token)
+
+
+def _hash_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _unique_ordered(values: Sequence[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return tuple(result)
+
+
+def _validate_offsets(start: int | None, end: int | None) -> None:
+    if start is None and end is None:
+        return
+    if not isinstance(start, int) or not isinstance(end, int):
+        raise ValueError("start and end offsets must be provided together")
+    if start < 0 or end < start:
+        raise ValueError("start/end offsets must be non-negative and ordered")

--- a/openmed/core/result_cache.py
+++ b/openmed/core/result_cache.py
@@ -20,12 +20,20 @@ class ResultCache:
         self.cache = OrderedDict()
         self._lock = RLock()
 
+    def __len__(self):
+        with self._lock:
+            return len(self.cache)
+
     def get(self, key):
         with self._lock:
             if key in self.cache:
                 self.cache.move_to_end(key)
                 return self.cache[key]
             return None
+
+    def clear(self):
+        with self._lock:
+            self.cache.clear()
 
     def set(self, key, result):
         if self.max_entries <= 0:

--- a/tests/unit/clinical/exporters/test_normalized_codeable_concept.py
+++ b/tests/unit/clinical/exporters/test_normalized_codeable_concept.py
@@ -1,0 +1,44 @@
+"""Tests for normalized concepts flowing into FHIR CodeableConcept."""
+
+from __future__ import annotations
+
+from openmed.clinical.exporters import (
+    CONCEPT_NORMALIZATION_PROVENANCE_EXTENSION_URL,
+    check_codeable_concept,
+    codeable_concept_from_ranked_candidates,
+)
+from openmed.clinical.normalization import (
+    ConceptNormalizer,
+    SyntheticTerminologyBackend,
+)
+
+
+def test_ranked_candidates_export_to_codeable_concept_with_offsets():
+    ranked = ConceptNormalizer(SyntheticTerminologyBackend()).normalize(
+        "Aster pyrexia",
+        start=4,
+        end=17,
+    )
+
+    concept = codeable_concept_from_ranked_candidates(
+        ranked,
+        text="Aster fever",
+        max_codings=1,
+    )
+
+    coding = concept["coding"][0]
+    assert coding["system"] == ranked[0].concept.system_uri
+    assert coding["code"] == "SYN-COND-001"
+    assert coding["display"] == "Aster fever"
+    assert coding["version"] == "2026.06-synthetic"
+
+    provenance = coding["extension"][0]
+    assert provenance["url"] == CONCEPT_NORMALIZATION_PROVENANCE_EXTENSION_URL
+    extension_values = {
+        extension["url"]: extension for extension in provenance["extension"]
+    }
+    assert extension_values["mentionStart"]["valueInteger"] == 4
+    assert extension_values["mentionEnd"]["valueInteger"] == 17
+    assert extension_values["confidence"]["valueDecimal"] >= 0.8
+    assert extension_values["backendVersion"]["valueString"] == "2026.06"
+    assert check_codeable_concept(concept) == []

--- a/tests/unit/clinical/test_normalization.py
+++ b/tests/unit/clinical/test_normalization.py
@@ -1,0 +1,191 @@
+"""Tests for synthetic concept normalization (OM-613)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from openmed.clinical.normalization import (
+    SYNTHETIC_CONCEPTS,
+    SYNTHETIC_GOLD_SET,
+    BackendIdentity,
+    ConceptNormalizationCache,
+    ConceptNormalizer,
+    SyntheticTerminologyBackend,
+    TerminologyConcept,
+    evaluate_normalization_gold,
+    generate_query_variants,
+    make_normalization_cache_key,
+    normalize_surface,
+)
+
+
+class CountingBackend(SyntheticTerminologyBackend):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.lookup_calls = 0
+        self.candidate_calls = 0
+
+    def lookup(self, normalized):
+        self.lookup_calls += 1
+        return super().lookup(normalized)
+
+    def candidates(self, tokens):
+        self.candidate_calls += 1
+        return super().candidates(tokens)
+
+    @property
+    def call_count(self):
+        return self.lookup_calls + self.candidate_calls
+
+
+def test_synthetic_backend_exact_lookup_and_metadata():
+    backend = SyntheticTerminologyBackend()
+
+    concepts = backend.lookup(normalize_surface("Aster pyrexia"))
+
+    assert concepts[0].code == "SYN-COND-001"
+    assert concepts[0].system_uri.startswith("https://openmed.ai/fhir/CodeSystem/")
+    assert backend.identity.name == "openmed-synthetic-terminology"
+    assert backend.identity.version == "2026.06"
+    assert {system.system_id for system in backend.code_systems()} == {
+        "synthetic-condition",
+        "synthetic-observation",
+        "synthetic-treatment",
+    }
+
+
+def test_candidate_generation_expands_abbreviations_and_ngrams():
+    variants = generate_query_variants(
+        "AF pattern",
+        abbreviation_expansions={"af": ("aster fever",)},
+        max_ngram=2,
+    )
+
+    assert variants[0] == "af pattern"
+    assert "aster fever pattern" in variants
+    assert "aster fever" in variants
+    assert "fever pattern" in variants
+
+
+def test_ranker_returns_confidence_and_offset_provenance():
+    normalizer = ConceptNormalizer(SyntheticTerminologyBackend())
+
+    ranked = normalizer.normalize("AF", start=21, end=23)
+
+    assert ranked[0].concept.code == "SYN-COND-001"
+    assert ranked[0].confidence >= 0.8
+    assert ranked[0].provenance.mention_start == 21
+    assert ranked[0].provenance.mention_end == 23
+    assert ranked[0].provenance.backend_version == "2026.06"
+    assert ranked[0].provenance.query_variant_count >= 1
+    assert "AF" not in ranked[0].provenance.matched_term_hash
+
+
+def test_synthetic_gold_accuracy_and_cache_hit_rate_are_ci_gated():
+    cache = ConceptNormalizationCache(max_entries=32)
+    normalizer = ConceptNormalizer(SyntheticTerminologyBackend(), cache=cache)
+
+    result = evaluate_normalization_gold(normalizer, SYNTHETIC_GOLD_SET)
+
+    assert result.case_count == len(SYNTHETIC_GOLD_SET)
+    assert result.top1_accuracy >= 0.80
+    assert result.top5_accuracy >= 0.92
+    assert result.cache_hit_rate >= 0.5
+
+
+def test_cache_equivalence_and_repeated_mentions_skip_backend_calls():
+    backend = CountingBackend()
+    cache = ConceptNormalizationCache(max_entries=8)
+    cached_normalizer = ConceptNormalizer(backend, cache=cache)
+    uncached_normalizer = ConceptNormalizer(SyntheticTerminologyBackend())
+
+    uncached = uncached_normalizer.normalize("Aster pyrexia", use_cache=False)
+    first = cached_normalizer.normalize("Aster pyrexia")
+    calls_after_first = backend.call_count
+    second = cached_normalizer.normalize("Aster pyrexia")
+
+    assert first == uncached
+    assert second == first
+    assert backend.call_count == calls_after_first
+    assert cache.stats().hit_rate == 0.5
+    assert cache.stats().size == 1
+
+
+def test_concept_cache_is_bounded_and_evicts_least_recent_entry():
+    backend = CountingBackend()
+    cache = ConceptNormalizationCache(max_entries=2)
+    normalizer = ConceptNormalizer(backend, cache=cache)
+
+    normalizer.normalize("Aster pyrexia")
+    normalizer.normalize("beryl cough")
+    normalizer.normalize("corin rash")
+    calls_after_eviction = backend.call_count
+    normalizer.normalize("Aster pyrexia")
+
+    assert cache.stats().size == 2
+    assert backend.call_count > calls_after_eviction
+
+
+def test_cache_key_includes_backend_identity_version():
+    identity_v1 = BackendIdentity("synthetic-test", "v1")
+    identity_v2 = BackendIdentity("synthetic-test", "v2")
+
+    key_v1 = make_normalization_cache_key("Aster pyrexia", identity_v1)
+    key_v2 = make_normalization_cache_key("Aster pyrexia", identity_v2)
+
+    assert key_v1 != key_v2
+    assert "Aster" not in key_v1
+    assert "pyrexia" not in key_v1
+
+
+def test_swapping_backends_does_not_return_cross_backend_stale_codes():
+    base = SYNTHETIC_CONCEPTS[0]
+    alternate = replace(base, code="SYN-COND-ALT", display="Aster fever alternate")
+    cache = ConceptNormalizationCache(max_entries=8)
+    normalizer_v1 = ConceptNormalizer(
+        SyntheticTerminologyBackend(
+            identity=BackendIdentity("synthetic-swap", "v1"),
+            concepts=(base,),
+        ),
+        cache=cache,
+    )
+    normalizer_v2 = ConceptNormalizer(
+        SyntheticTerminologyBackend(
+            identity=BackendIdentity("synthetic-swap", "v2"),
+            concepts=(alternate,),
+        ),
+        cache=cache,
+    )
+
+    first = normalizer_v1.normalize("Aster fever")
+    second = normalizer_v2.normalize("Aster fever alternate")
+
+    assert first[0].concept.code == "SYN-COND-001"
+    assert second[0].concept.code == "SYN-COND-ALT"
+    assert cache.stats().misses == 2
+
+
+def test_backend_identity_requires_name_and_version():
+    with pytest.raises(ValueError, match="version"):
+        BackendIdentity("synthetic-test", "")
+
+
+def test_custom_backend_can_supply_synthetic_concepts_only():
+    custom = TerminologyConcept(
+        system_id="synthetic-condition",
+        system_uri="https://openmed.ai/fhir/CodeSystem/synthetic-condition",
+        code="SYN-CUSTOM-001",
+        display="Kilo balance cue",
+        aliases=("kbc",),
+        version="2026.06-synthetic",
+    )
+    normalizer = ConceptNormalizer(
+        SyntheticTerminologyBackend(concepts=(custom,)),
+        abbreviation_expansions={"kbc": "kilo balance cue"},
+    )
+
+    ranked = normalizer.normalize("KBC")
+
+    assert ranked[0].concept.code == "SYN-CUSTOM-001"

--- a/tests/unit/clinical/test_normalization_repository_scan.py
+++ b/tests/unit/clinical/test_normalization_repository_scan.py
@@ -1,0 +1,49 @@
+"""Repository checks for terminology isolation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+NORMALIZATION_ROOT = REPO_ROOT / "openmed" / "clinical" / "normalization"
+PAYLOAD_SUFFIXES = {
+    ".csv",
+    ".db",
+    ".json",
+    ".jsonl",
+    ".parquet",
+    ".sqlite",
+    ".tsv",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+RESTRICTED_EXPORT_MARKERS = (
+    "MRCONSO",
+    "RXNCONSO",
+    "sct2_Description",
+    "LOINC_NUM",
+    "HCPCS",
+)
+
+
+def test_normalization_package_bundles_no_terminology_payload_files():
+    payload_files = [
+        path.relative_to(REPO_ROOT)
+        for path in NORMALIZATION_ROOT.rglob("*")
+        if path.is_file() and path.suffix.lower() in PAYLOAD_SUFFIXES
+    ]
+
+    assert payload_files == []
+
+
+def test_only_synthetic_backend_is_shipped_in_normalization_package():
+    source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in NORMALIZATION_ROOT.rglob("*.py")
+        if path.is_file()
+    )
+
+    assert "SyntheticTerminologyBackend" in source
+    for marker in RESTRICTED_EXPORT_MARKERS:
+        assert marker not in source


### PR DESCRIPTION
Closes #976.

Adds a terminology backend protocol, synthetic in-memory backend, deterministic candidate generation and ranking, a bounded backend-versioned normalization cache, FHIR CodeableConcept export provenance, and CI-gated synthetic accuracy/cache/isolation coverage.