### PR TITLE
Add DP surrogate budget accountant

### DIFF
--- a/openmed/risk/__init__.py
+++ b/openmed/risk/__init__.py
@@ -2,13 +2,22 @@
 
 from .audit_diff import AuditDiff, diff_audit_reports
 from .budget import (
+    DEFAULT_DP_SURROGATE_SENSITIVITIES,
     DEFAULT_POLICY_BUDGETS,
     DEFAULT_QI_WEIGHTS,
+    DEFAULT_RDP_ORDERS,
     DEFAULT_RISK_BUDGET,
+    DPSurrogateBudget,
+    DPSurrogateBudgetExceeded,
+    DPSurrogateComposition,
+    DPSurrogateSensitivity,
+    DPSurrogateSensitivityRegistry,
+    DPSurrogateSpend,
     RiskBudget,
     RiskBudgetExceeded,
     RiskBudgetVerdict,
     RiskBudgetViolation,
+    SurrogateDrawKind,
     budget_for_policy,
     evaluate_budget,
 )
@@ -17,13 +26,22 @@ from .kanon import kanon_report
 from .reid import risk_report
 
 __all__ = [
+    "DEFAULT_DP_SURROGATE_SENSITIVITIES",
     "DEFAULT_POLICY_BUDGETS",
     "DEFAULT_QI_WEIGHTS",
+    "DEFAULT_RDP_ORDERS",
     "DEFAULT_RISK_BUDGET",
+    "DPSurrogateBudget",
+    "DPSurrogateBudgetExceeded",
+    "DPSurrogateComposition",
+    "DPSurrogateSensitivity",
+    "DPSurrogateSensitivityRegistry",
+    "DPSurrogateSpend",
     "RiskBudget",
     "RiskBudgetExceeded",
     "RiskBudgetVerdict",
     "RiskBudgetViolation",
+    "SurrogateDrawKind",
     "budget_for_policy",
     "evaluate_budget",
     "risk_report",

--- a/openmed/risk/budget.py
+++ b/openmed/risk/budget.py
@@ -1,11 +1,14 @@
-"""Per-document residual-risk budget evaluation."""
+"""Per-document residual-risk and DP surrogate budget evaluation."""
 
 from __future__ import annotations
 
 import copy
+import hashlib
+import json
+import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal, cast
 
 from openmed.core.policy import CANONICAL_POLICY_NAMES, canonical_policy_name
 
@@ -27,6 +30,445 @@ DEFAULT_QI_WEIGHTS: Mapping[str, float] = {
     "rare_condition": 3.0,
     "*": 1.0,
 }
+
+SurrogateDrawKind = Literal["categorical", "numeric", "date_offset"]
+
+DEFAULT_RDP_ORDERS: tuple[float, ...] = (2.0, 4.0, 8.0, 16.0, 32.0, 64.0)
+DEFAULT_DP_SURROGATE_SENSITIVITIES: Mapping[
+    tuple[str, SurrogateDrawKind],
+    tuple[float, float],
+] = {
+    ("AGE", "numeric"): (1.0, 1.0),
+    ("DATE", "date_offset"): (1.0, 1.0),
+    ("EMAIL_ADDRESS", "categorical"): (1.0, 1.0),
+    ("ID", "categorical"): (1.0, 1.0),
+    ("LOCATION", "categorical"): (1.0, 1.0),
+    ("MEDICAL_RECORD_NUMBER", "categorical"): (1.0, 1.0),
+    ("NAME", "categorical"): (1.0, 1.0),
+    ("ORGANIZATION", "categorical"): (1.0, 1.0),
+    ("PERSON", "categorical"): (1.0, 1.0),
+    ("PHONE_NUMBER", "categorical"): (1.0, 1.0),
+}
+
+
+@dataclass(frozen=True)
+class DPSurrogateSensitivity:
+    """Sensitivity metadata for one canonical surrogate draw label."""
+
+    label: str
+    draw_kind: SurrogateDrawKind
+    l1: float = 1.0
+    l2: float = 1.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "label", _canonical_dp_label(self.label))
+        object.__setattr__(self, "draw_kind", _draw_kind(self.draw_kind))
+        object.__setattr__(self, "l1", _positive_float(self.l1, field_name="l1"))
+        object.__setattr__(self, "l2", _positive_float(self.l2, field_name="l2"))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-compatible sensitivity payload."""
+
+        return {
+            "label": self.label,
+            "draw_kind": self.draw_kind,
+            "l1": self.l1,
+            "l2": self.l2,
+        }
+
+
+@dataclass(frozen=True)
+class DPSurrogateSensitivityRegistry:
+    """Lookup table for per-label DP surrogate draw sensitivities."""
+
+    sensitivities: Mapping[
+        tuple[str, SurrogateDrawKind],
+        DPSurrogateSensitivity,
+    ] = field(default_factory=dict)
+    default_l1: float = 1.0
+    default_l2: float = 1.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "sensitivities",
+            {
+                (_canonical_dp_label(label), _draw_kind(draw_kind)): (
+                    sensitivity
+                    if isinstance(sensitivity, DPSurrogateSensitivity)
+                    else DPSurrogateSensitivity(
+                        label=label,
+                        draw_kind=draw_kind,
+                        l1=sensitivity[0],
+                        l2=sensitivity[1],
+                    )
+                )
+                for (label, draw_kind), sensitivity in self.sensitivities.items()
+            },
+        )
+        object.__setattr__(
+            self,
+            "default_l1",
+            _positive_float(self.default_l1, field_name="default_l1"),
+        )
+        object.__setattr__(
+            self,
+            "default_l2",
+            _positive_float(self.default_l2, field_name="default_l2"),
+        )
+
+    @classmethod
+    def defaults(cls) -> DPSurrogateSensitivityRegistry:
+        """Return the bundled registry for common PHI surrogate labels."""
+
+        return cls(
+            {
+                key: DPSurrogateSensitivity(
+                    label=key[0],
+                    draw_kind=key[1],
+                    l1=values[0],
+                    l2=values[1],
+                )
+                for key, values in DEFAULT_DP_SURROGATE_SENSITIVITIES.items()
+            }
+        )
+
+    def with_entry(
+        self,
+        label: str,
+        draw_kind: SurrogateDrawKind,
+        *,
+        l1: float = 1.0,
+        l2: float = 1.0,
+    ) -> DPSurrogateSensitivityRegistry:
+        """Return a copy with one sensitivity entry added or replaced."""
+
+        sensitivity = DPSurrogateSensitivity(
+            label=label,
+            draw_kind=draw_kind,
+            l1=l1,
+            l2=l2,
+        )
+        entries = dict(self.sensitivities)
+        entries[(sensitivity.label, sensitivity.draw_kind)] = sensitivity
+        return DPSurrogateSensitivityRegistry(
+            entries,
+            default_l1=self.default_l1,
+            default_l2=self.default_l2,
+        )
+
+    def for_label(
+        self,
+        label: str,
+        draw_kind: SurrogateDrawKind,
+    ) -> DPSurrogateSensitivity:
+        """Return sensitivity metadata for ``label`` and ``draw_kind``."""
+
+        canonical_label = _canonical_dp_label(label)
+        canonical_kind = _draw_kind(draw_kind)
+        sensitivity = self.sensitivities.get((canonical_label, canonical_kind))
+        if sensitivity is not None:
+            return sensitivity
+        return DPSurrogateSensitivity(
+            label=canonical_label,
+            draw_kind=canonical_kind,
+            l1=self.default_l1,
+            l2=self.default_l2,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-compatible registry payload."""
+
+        return {
+            "default_l1": self.default_l1,
+            "default_l2": self.default_l2,
+            "sensitivities": [
+                self.sensitivities[key].to_dict() for key in sorted(self.sensitivities)
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class DPSurrogateSpend:
+    """One privacy spend made by a surrogate draw."""
+
+    sequence: int
+    label: str
+    draw_kind: SurrogateDrawKind
+    mechanism: str
+    epsilon: float
+    delta: float = 0.0
+    l1_sensitivity: float = 1.0
+    l2_sensitivity: float = 1.0
+    rho: float | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "sequence",
+            _positive_int(self.sequence, field_name="sequence"),
+        )
+        object.__setattr__(self, "label", _canonical_dp_label(self.label))
+        object.__setattr__(self, "draw_kind", _draw_kind(self.draw_kind))
+        object.__setattr__(self, "mechanism", _non_empty_string(self.mechanism))
+        object.__setattr__(
+            self,
+            "epsilon",
+            _non_negative_float(self.epsilon, field_name="epsilon"),
+        )
+        object.__setattr__(
+            self,
+            "delta",
+            _delta_float(self.delta, field_name="delta"),
+        )
+        object.__setattr__(
+            self,
+            "l1_sensitivity",
+            _positive_float(self.l1_sensitivity, field_name="l1_sensitivity"),
+        )
+        object.__setattr__(
+            self,
+            "l2_sensitivity",
+            _positive_float(self.l2_sensitivity, field_name="l2_sensitivity"),
+        )
+        rho = self.rho
+        if rho is None:
+            rho = _rho_from_epsilon(self.epsilon)
+        object.__setattr__(self, "rho", _non_negative_float(rho, field_name="rho"))
+
+    def spend_hash(self, *, salt: str = "") -> str:
+        """Return a deterministic hash over non-PHI accounting metadata."""
+
+        payload = {
+            "delta": self.delta,
+            "draw_kind": self.draw_kind,
+            "epsilon": self.epsilon,
+            "l1_sensitivity": self.l1_sensitivity,
+            "l2_sensitivity": self.l2_sensitivity,
+            "label": self.label,
+            "mechanism": self.mechanism,
+            "rho": self.rho,
+            "salt": salt,
+            "sequence": self.sequence,
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    def to_dict(self, *, salt: str = "") -> dict[str, Any]:
+        """Return a deterministic JSON-compatible spend payload."""
+
+        return {
+            "sequence": self.sequence,
+            "label": self.label,
+            "draw_kind": self.draw_kind,
+            "mechanism": self.mechanism,
+            "epsilon": self.epsilon,
+            "delta": self.delta,
+            "l1_sensitivity": self.l1_sensitivity,
+            "l2_sensitivity": self.l2_sensitivity,
+            "rho": self.rho,
+            "spend_hash": self.spend_hash(salt=salt),
+        }
+
+
+@dataclass(frozen=True)
+class DPSurrogateComposition:
+    """Conservative composition totals for a DP surrogate run."""
+
+    query_count: int
+    basic_epsilon: float
+    basic_delta: float
+    zcdp_rho: float
+    zcdp_epsilon: float
+    rdp_epsilon: float
+    reported_epsilon: float
+    reported_delta: float
+    target_epsilon: float
+    target_delta: float
+    remaining_epsilon: float
+    remaining_delta: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-compatible composition payload."""
+
+        return {
+            "query_count": self.query_count,
+            "basic_epsilon": self.basic_epsilon,
+            "basic_delta": self.basic_delta,
+            "zcdp_rho": self.zcdp_rho,
+            "zcdp_epsilon": self.zcdp_epsilon,
+            "rdp_epsilon": self.rdp_epsilon,
+            "reported_epsilon": self.reported_epsilon,
+            "reported_delta": self.reported_delta,
+            "target_epsilon": self.target_epsilon,
+            "target_delta": self.target_delta,
+            "remaining_epsilon": self.remaining_epsilon,
+            "remaining_delta": self.remaining_delta,
+        }
+
+
+class DPSurrogateBudgetExceeded(ValueError):
+    """Raised when a surrogate draw would exceed the configured DP budget."""
+
+    def __init__(
+        self,
+        attempted_spend: DPSurrogateSpend,
+        attempted_composition: DPSurrogateComposition,
+    ) -> None:
+        self.attempted_spend = attempted_spend
+        self.attempted_composition = attempted_composition
+        super().__init__(
+            "DP surrogate budget exceeded: "
+            f"epsilon={attempted_composition.reported_epsilon:.6g}/"
+            f"{attempted_composition.target_epsilon:.6g}, "
+            f"delta={attempted_composition.basic_delta:.6g}/"
+            f"{attempted_composition.target_delta:.6g}"
+        )
+
+
+@dataclass
+class DPSurrogateBudget:
+    """Corpus-level DP accountant for surrogate generation."""
+
+    target_epsilon: float
+    target_delta: float
+    sensitivity_registry: DPSurrogateSensitivityRegistry = field(
+        default_factory=DPSurrogateSensitivityRegistry.defaults
+    )
+    rdp_orders: Sequence[float] = DEFAULT_RDP_ORDERS
+    _spends: list[DPSurrogateSpend] = field(default_factory=list, repr=False)
+
+    def __post_init__(self) -> None:
+        self.target_epsilon = _positive_float(
+            self.target_epsilon,
+            field_name="target_epsilon",
+        )
+        self.target_delta = _delta_float(
+            self.target_delta,
+            field_name="target_delta",
+        )
+        if not isinstance(
+            self.sensitivity_registry,
+            DPSurrogateSensitivityRegistry,
+        ):
+            self.sensitivity_registry = DPSurrogateSensitivityRegistry(
+                self.sensitivity_registry
+            )
+        self.rdp_orders = tuple(_rdp_order(order) for order in self.rdp_orders)
+        if not self.rdp_orders:
+            raise ValueError("rdp_orders must not be empty")
+        self._spends = list(self._spends)
+
+    @property
+    def spends(self) -> tuple[DPSurrogateSpend, ...]:
+        """Return spend records in draw order."""
+
+        return tuple(self._spends)
+
+    def spend(
+        self,
+        *,
+        label: str,
+        draw_kind: SurrogateDrawKind,
+        mechanism: str,
+        epsilon: float,
+        delta: float = 0.0,
+        rho: float | None = None,
+    ) -> DPSurrogateSpend:
+        """Record one surrogate draw spend or raise before mutating state."""
+
+        sensitivity = self.sensitivity_registry.for_label(label, draw_kind)
+        spend = DPSurrogateSpend(
+            sequence=len(self._spends) + 1,
+            label=sensitivity.label,
+            draw_kind=sensitivity.draw_kind,
+            mechanism=mechanism,
+            epsilon=epsilon,
+            delta=delta,
+            l1_sensitivity=sensitivity.l1,
+            l2_sensitivity=sensitivity.l2,
+            rho=rho,
+        )
+        attempted = self.composition(spends=(*self._spends, spend))
+        if _exceeds_budget(attempted):
+            raise DPSurrogateBudgetExceeded(spend, attempted)
+        self._spends.append(spend)
+        return spend
+
+    def can_spend(
+        self,
+        *,
+        label: str,
+        draw_kind: SurrogateDrawKind,
+        mechanism: str,
+        epsilon: float,
+        delta: float = 0.0,
+        rho: float | None = None,
+    ) -> bool:
+        """Return whether a spend would fit without recording it."""
+
+        try:
+            sensitivity = self.sensitivity_registry.for_label(label, draw_kind)
+            spend = DPSurrogateSpend(
+                sequence=len(self._spends) + 1,
+                label=sensitivity.label,
+                draw_kind=sensitivity.draw_kind,
+                mechanism=mechanism,
+                epsilon=epsilon,
+                delta=delta,
+                l1_sensitivity=sensitivity.l1,
+                l2_sensitivity=sensitivity.l2,
+                rho=rho,
+            )
+            return not _exceeds_budget(self.composition(spends=(*self._spends, spend)))
+        except (TypeError, ValueError):
+            return False
+
+    def composition(
+        self,
+        *,
+        spends: Sequence[DPSurrogateSpend] | None = None,
+    ) -> DPSurrogateComposition:
+        """Return conservative basic, zCDP, and RDP composition totals."""
+
+        selected_spends = tuple(spends if spends is not None else self._spends)
+        basic_epsilon = math.fsum(spend.epsilon for spend in selected_spends)
+        basic_delta = math.fsum(spend.delta for spend in selected_spends)
+        rho = math.fsum(spend.rho or 0.0 for spend in selected_spends)
+        conversion_delta = self.target_delta - basic_delta
+        zcdp_epsilon = _zcdp_epsilon(rho, conversion_delta)
+        rdp_epsilon = _rdp_epsilon(rho, conversion_delta, self.rdp_orders)
+        reported_epsilon = max(basic_epsilon, zcdp_epsilon, rdp_epsilon)
+        reported_delta = (
+            self.target_delta
+            if rho > 0.0 and conversion_delta > 0.0
+            else max(0.0, basic_delta)
+        )
+        return DPSurrogateComposition(
+            query_count=len(selected_spends),
+            basic_epsilon=basic_epsilon,
+            basic_delta=basic_delta,
+            zcdp_rho=rho,
+            zcdp_epsilon=zcdp_epsilon,
+            rdp_epsilon=rdp_epsilon,
+            reported_epsilon=reported_epsilon,
+            reported_delta=reported_delta,
+            target_epsilon=self.target_epsilon,
+            target_delta=self.target_delta,
+            remaining_epsilon=self.target_epsilon - reported_epsilon,
+            remaining_delta=self.target_delta - basic_delta,
+        )
+
+    def to_dict(self, *, salt: str = "") -> dict[str, Any]:
+        """Return a deterministic JSON-compatible accountant payload."""
+
+        return {
+            "target_epsilon": self.target_epsilon,
+            "target_delta": self.target_delta,
+            "composition": self.composition().to_dict(),
+            "sensitivity_registry": self.sensitivity_registry.to_dict(),
+            "spends": [spend.to_dict(salt=salt) for spend in self._spends],
+        }
 
 
 @dataclass(frozen=True)
@@ -239,6 +681,102 @@ def evaluate_budget(
     return verdict
 
 
+def _canonical_dp_label(value: Any) -> str:
+    label = _non_empty_string(value)
+    return label.upper().replace("-", "_").replace(" ", "_")
+
+
+def _draw_kind(value: Any) -> SurrogateDrawKind:
+    kind = _non_empty_string(value)
+    if kind not in {"categorical", "numeric", "date_offset"}:
+        raise ValueError(
+            "draw_kind must be one of categorical, numeric, or date_offset"
+        )
+    return cast(SurrogateDrawKind, kind)
+
+
+def _non_empty_string(value: Any) -> str:
+    parsed = str(value).strip()
+    if not parsed:
+        raise ValueError("value must not be empty")
+    return parsed
+
+
+def _positive_int(value: Any, *, field_name: str) -> int:
+    parsed = _non_negative_int(value, field_name=field_name)
+    if parsed <= 0:
+        raise ValueError(f"{field_name} must be positive")
+    return parsed
+
+
+def _positive_float(value: Any, *, field_name: str) -> float:
+    parsed = _finite_float(value, field_name=field_name)
+    if parsed <= 0.0:
+        raise ValueError(f"{field_name} must be positive")
+    return parsed
+
+
+def _non_negative_float(value: Any, *, field_name: str) -> float:
+    parsed = _finite_float(value, field_name=field_name)
+    if parsed < 0.0:
+        raise ValueError(f"{field_name} must be non-negative")
+    return parsed
+
+
+def _delta_float(value: Any, *, field_name: str) -> float:
+    parsed = _non_negative_float(value, field_name=field_name)
+    if parsed >= 1.0:
+        raise ValueError(f"{field_name} must be less than 1")
+    return parsed
+
+
+def _finite_float(value: Any, *, field_name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must not be a boolean")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a number") from exc
+    if not math.isfinite(parsed):
+        raise ValueError(f"{field_name} must be finite")
+    return parsed
+
+
+def _rdp_order(value: Any) -> float:
+    parsed = _finite_float(value, field_name="rdp_order")
+    if parsed <= 1.0:
+        raise ValueError("rdp_order must be greater than 1")
+    return parsed
+
+
+def _rho_from_epsilon(epsilon: float) -> float:
+    return (epsilon**2) / 2.0
+
+
+def _zcdp_epsilon(rho: float, delta: float) -> float:
+    if rho == 0.0:
+        return 0.0
+    if delta <= 0.0:
+        return math.inf
+    return rho + 2.0 * math.sqrt(rho * math.log(1.0 / delta))
+
+
+def _rdp_epsilon(rho: float, delta: float, orders: Sequence[float]) -> float:
+    if rho == 0.0:
+        return 0.0
+    if delta <= 0.0:
+        return math.inf
+    log_delta = math.log(1.0 / delta)
+    return min(order * rho + (log_delta / (order - 1.0)) for order in orders)
+
+
+def _exceeds_budget(composition: DPSurrogateComposition) -> bool:
+    return (
+        composition.reported_epsilon > composition.target_epsilon
+        or composition.basic_delta > composition.target_delta
+    )
+
+
 def _mapping(value: Any) -> Mapping[str, Any]:
     if hasattr(value, "to_dict"):
         value = value.to_dict()
@@ -395,13 +933,22 @@ def _violations(
 
 
 __all__ = [
+    "DEFAULT_DP_SURROGATE_SENSITIVITIES",
     "DEFAULT_POLICY_BUDGETS",
     "DEFAULT_QI_WEIGHTS",
+    "DEFAULT_RDP_ORDERS",
     "DEFAULT_RISK_BUDGET",
+    "DPSurrogateBudget",
+    "DPSurrogateBudgetExceeded",
+    "DPSurrogateComposition",
+    "DPSurrogateSensitivity",
+    "DPSurrogateSensitivityRegistry",
+    "DPSurrogateSpend",
     "RiskBudget",
     "RiskBudgetExceeded",
     "RiskBudgetVerdict",
     "RiskBudgetViolation",
+    "SurrogateDrawKind",
     "budget_for_policy",
     "evaluate_budget",
 ]

--- a/tests/unit/risk/test_dp_surrogate_budget.py
+++ b/tests/unit/risk/test_dp_surrogate_budget.py
@@ -1,0 +1,121 @@
+"""Tests for DP surrogate budget accounting."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.risk import (
+    DPSurrogateBudget,
+    DPSurrogateBudgetExceeded,
+    DPSurrogateSensitivity,
+    DPSurrogateSensitivityRegistry,
+)
+
+
+def test_dp_surrogate_budget_reports_conservative_composition():
+    budget = DPSurrogateBudget(target_epsilon=4.0, target_delta=1e-6)
+
+    budget.spend(
+        label="name",
+        draw_kind="categorical",
+        mechanism="exponential",
+        epsilon=0.05,
+    )
+    budget.spend(
+        label="date",
+        draw_kind="date_offset",
+        mechanism="discrete_laplace",
+        epsilon=0.05,
+    )
+
+    composition = budget.composition()
+
+    assert composition.query_count == 2
+    assert composition.reported_epsilon >= composition.basic_epsilon
+    assert composition.reported_epsilon >= composition.zcdp_epsilon
+    assert composition.reported_epsilon >= composition.rdp_epsilon
+    assert composition.remaining_epsilon == pytest.approx(
+        budget.target_epsilon - composition.reported_epsilon
+    )
+    assert composition.basic_delta == 0.0
+
+
+def test_dp_surrogate_budget_exhaustion_raises_before_recording():
+    budget = DPSurrogateBudget(target_epsilon=0.5, target_delta=1e-6)
+
+    budget.spend(
+        label="name",
+        draw_kind="categorical",
+        mechanism="exponential",
+        epsilon=0.01,
+    )
+    before = budget.spends
+
+    with pytest.raises(DPSurrogateBudgetExceeded) as excinfo:
+        budget.spend(
+            label="date",
+            draw_kind="date_offset",
+            mechanism="discrete_gaussian",
+            epsilon=0.2,
+        )
+
+    assert budget.spends == before
+    assert excinfo.value.attempted_spend.label == "DATE"
+    assert excinfo.value.attempted_composition.reported_epsilon > 0.5
+
+
+def test_dp_surrogate_sensitivity_registry_validates_and_exports_entries():
+    registry = DPSurrogateSensitivityRegistry.defaults().with_entry(
+        "medical-record-number",
+        "categorical",
+        l1=2.0,
+        l2=3.0,
+    )
+
+    sensitivity = registry.for_label("medical record number", "categorical")
+
+    assert sensitivity == DPSurrogateSensitivity(
+        label="MEDICAL_RECORD_NUMBER",
+        draw_kind="categorical",
+        l1=2.0,
+        l2=3.0,
+    )
+    assert registry.for_label("unknown", "numeric").to_dict() == {
+        "label": "UNKNOWN",
+        "draw_kind": "numeric",
+        "l1": 1.0,
+        "l2": 1.0,
+    }
+    with pytest.raises(ValueError, match="l1 must be positive"):
+        registry.with_entry("name", "categorical", l1=0.0)
+    with pytest.raises(ValueError, match="draw_kind"):
+        registry.for_label("name", "free_text")
+
+
+def test_dp_surrogate_accounting_payload_is_deterministic_and_hash_only():
+    budget = DPSurrogateBudget(target_epsilon=4.0, target_delta=1e-6)
+    spend = budget.spend(
+        label="person",
+        draw_kind="categorical",
+        mechanism="exponential",
+        epsilon=0.05,
+    )
+
+    first = budget.to_dict(salt="unit-test")
+    second = budget.to_dict(salt="unit-test")
+    encoded = json.dumps(first, sort_keys=True)
+
+    assert first == second
+    assert json.loads(encoded) == first
+    assert first["spends"][0]["spend_hash"] == spend.spend_hash(salt="unit-test")
+    assert "Alice" not in encoded
+    assert "surrogate" not in first["spends"][0]
+
+
+def test_exported_dp_surrogate_budget_api_is_available_from_package():
+    import openmed.risk as risk
+
+    assert hasattr(risk, "DPSurrogateBudget")
+    assert "DPSurrogateSensitivityRegistry" in risk.__all__


### PR DESCRIPTION
# Pull Request

## Description
Adds the first OM-615 child slice: a corpus-level DP surrogate budget accountant and sensitivity registry.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added DPSurrogateBudget, spend records, and conservative composition reports across basic, zCDP, and RDP accounting.
- Added a per-label sensitivity registry for categorical, numeric, and date-offset surrogate draw metadata.
- Exported the DP surrogate accounting API from openmed.risk and covered deterministic hashing, registry validation, conservative totals, and fail-before-record exhaustion.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- make format
- make lint
- make format-check
- .venv/bin/python -m pytest tests/ -q

Final pytest result: 2978 passed, 34 skipped.

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1028
Related to #978

## Screenshots/Examples
Not applicable.
