### PR TITLE
Implement a corpus-level re-identification risk upper-bound estimator with provable k-anonymity, l-diversity, and t-closeness enforcement

### DIFF
--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -558,6 +558,7 @@ class ReleaseGate:
             )
         )
         checks.append(_g8_check(metadata))
+        checks.append(_k_floor_check(metrics, metadata))
 
         blocked_formats = tuple(
             sorted(
@@ -1405,6 +1406,107 @@ def _g8_check(metadata: Mapping[str, Any]) -> GateCheck:
             "problems": problems,
         },
     )
+
+
+def _k_floor_check(
+    metrics: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+) -> GateCheck:
+    evidence = _k_floor_evidence(metrics, metadata)
+    target_k = _optional_int(evidence.get("target_k"))
+    if target_k is None:
+        return GateCheck("k_floor", True, reason="not applicable")
+    if target_k < 1:
+        return GateCheck(
+            "k_floor",
+            False,
+            reason="target_k must be >= 1",
+            details={"target_k": target_k},
+        )
+
+    measured_k = _optional_int(evidence.get("measured_k"))
+    max_bound = _optional_float(evidence.get("max_reidentification_upper_bound"))
+    self_check = evidence.get("numeric_self_check")
+    self_check_passed = None
+    if isinstance(self_check, Mapping) and "passed" in self_check:
+        self_check_passed = bool(self_check.get("passed"))
+
+    violations: dict[str, Any] = {}
+    if measured_k is None:
+        violations["measured_k"] = "missing"
+    elif measured_k < target_k:
+        violations["measured_k"] = {"observed": measured_k, "target": target_k}
+
+    target_bound = 1.0 / target_k
+    if max_bound is None:
+        violations["max_reidentification_upper_bound"] = "missing"
+    elif max_bound > target_bound + 1e-12:
+        violations["max_reidentification_upper_bound"] = {
+            "observed": max_bound,
+            "limit": target_bound,
+        }
+
+    if self_check_passed is False:
+        violations["numeric_self_check"] = self_check
+
+    return GateCheck(
+        "k_floor",
+        not violations,
+        reason="ok" if not violations else "realized k or bound violates policy",
+        details={
+            "target_k": target_k,
+            "measured_k": measured_k,
+            "target_bound": target_bound,
+            "max_reidentification_upper_bound": max_bound,
+            "violations": violations,
+        },
+    )
+
+
+def _k_floor_evidence(
+    metrics: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+) -> dict[str, Any]:
+    source = _first_mapping(
+        metadata.get("kanon_enforcement"),
+        metrics.get("kanon_enforcement"),
+        metadata.get("k_anonymity_enforcement"),
+        metrics.get("k_anonymity_enforcement"),
+        metadata.get("k_floor"),
+        metrics.get("k_floor"),
+        metadata.get("kanon"),
+        metrics.get("kanon"),
+    )
+    target_k = _first_value(
+        source.get("target_k"),
+        metadata.get("target_k"),
+        metrics.get("target_k"),
+        _nested(metadata, "privacy_policy", "target_k"),
+        _nested(metrics, "privacy_policy", "target_k"),
+    )
+    kanon = _mapping(source.get("kanon"))
+    bounds = _mapping(source.get("bounds"))
+    return {
+        "target_k": target_k,
+        "measured_k": _first_value(
+            source.get("measured_k"),
+            source.get("realized_k"),
+            source.get("k"),
+            kanon.get("k"),
+            metadata.get("measured_k"),
+            metrics.get("measured_k"),
+        ),
+        "max_reidentification_upper_bound": _first_value(
+            source.get("max_reidentification_upper_bound"),
+            bounds.get("max_reidentification_upper_bound"),
+            metadata.get("max_reidentification_upper_bound"),
+            metrics.get("max_reidentification_upper_bound"),
+        ),
+        "numeric_self_check": _first_value(
+            source.get("numeric_self_check"),
+            bounds.get("numeric_self_check"),
+        ),
+    }
 
 
 def _report_payload(report: BenchmarkReport | Mapping[str, Any]) -> dict[str, Any]:

--- a/openmed/risk/__init__.py
+++ b/openmed/risk/__init__.py
@@ -13,7 +13,7 @@ from .budget import (
     evaluate_budget,
 )
 from .dashboard import render_risk_dashboard, write_risk_dashboard
-from .kanon import kanon_report
+from .kanon import build_generalization_hierarchies, enforce_kanon, kanon_report
 from .reid import risk_report
 
 __all__ = [
@@ -27,6 +27,8 @@ __all__ = [
     "budget_for_policy",
     "evaluate_budget",
     "risk_report",
+    "build_generalization_hierarchies",
+    "enforce_kanon",
     "kanon_report",
     "diff_audit_reports",
     "AuditDiff",

--- a/openmed/risk/dashboard.py
+++ b/openmed/risk/dashboard.py
@@ -150,7 +150,8 @@ def render_risk_dashboard(
 
     Args:
         risk: Mapping returned by :func:`openmed.risk.risk_report`.
-        kanon: Optional mapping returned by :func:`openmed.risk.kanon_report`.
+        kanon: Optional mapping returned by :func:`openmed.risk.kanon_report`
+            or :func:`openmed.risk.enforce_kanon`.
         title: Optional document and page title. Defaults to a stable title.
 
     Returns:
@@ -307,6 +308,9 @@ def _render_quasi_identifiers(quasi_identifiers: Any) -> str:
 
 
 def _render_kanon(kanon: Mapping[str, Any]) -> str:
+    if isinstance(kanon.get("kanon"), Mapping):
+        return _render_kanon_enforcement(kanon)
+
     size_distribution = _as_sequence(kanon.get("class_size_distribution") or ())
     class_rows = _equivalence_class_rows(kanon.get("equivalence_classes") or ())
 
@@ -346,6 +350,84 @@ def _render_kanon(kanon: Mapping[str, Any]) -> str:
         )
     else:
         sections.append('<p class="empty">No equivalence classes reported.</p>')
+
+    sections.append("</section>")
+    return "\n".join(sections)
+
+
+def _render_kanon_enforcement(enforcement: Mapping[str, Any]) -> str:
+    kanon = _mapping(enforcement.get("kanon"))
+    generalization = _mapping(enforcement.get("generalization"))
+    bounds = _mapping(enforcement.get("bounds"))
+    self_check = _mapping(bounds.get("numeric_self_check"))
+    selected_levels = _mapping(generalization.get("levels"))
+
+    sections = [
+        '<section aria-labelledby="kanon-enforcement">',
+        '<h2 id="kanon-enforcement">K-Anonymity Enforcement</h2>',
+        '<div class="metric-grid">',
+        _metric("Target k", _format_count(enforcement.get("target_k"))),
+        _metric("Measured k", _format_count(kanon.get("k"))),
+        _metric("Released", _format_count(enforcement.get("released_count"))),
+        _metric("Suppressed", _format_count(enforcement.get("suppressed_count"))),
+        _metric(
+            "Max re-id bound",
+            _format_rate(bounds.get("max_reidentification_upper_bound")),
+        ),
+        _metric("Bound check", "pass" if self_check.get("passed") else "fail"),
+        "</div>",
+    ]
+
+    if selected_levels:
+        sections.extend(
+            [
+                "<h2>Selected Generalization</h2>",
+                _table(
+                    ["Field", "Level", "Name", "Loss"],
+                    [
+                        [
+                            field,
+                            _display(_mapping(level).get("level")),
+                            _display(_mapping(level).get("name")),
+                            _display(_mapping(level).get("loss")),
+                        ]
+                        for field, level in sorted(selected_levels.items())
+                    ],
+                ),
+            ]
+        )
+
+    sections.extend(
+        [
+            "<h2>Enforced Equivalence Classes</h2>",
+            _table(
+                ["Key", "Size", "Members", "l-diversity", "t-closeness"],
+                _equivalence_class_rows(kanon.get("equivalence_classes") or ()),
+            )
+            if kanon.get("equivalence_classes")
+            else '<p class="empty">No equivalence classes reported.</p>',
+        ]
+    )
+
+    suppressed = _as_sequence(enforcement.get("suppressed_records") or ())
+    if suppressed:
+        sections.extend(
+            [
+                "<h2>Suppressed Records</h2>",
+                _table(
+                    ["Offset", "Record hash", "Reason"],
+                    [
+                        [
+                            _display(_mapping(record).get("offset")),
+                            _display(_mapping(record).get("record_hash")),
+                            _display(_mapping(record).get("reason")),
+                        ]
+                        for record in suppressed
+                        if isinstance(record, Mapping)
+                    ],
+                ),
+            ]
+        )
 
     sections.append("</section>")
     return "\n".join(sections)
@@ -480,6 +562,10 @@ def _as_sequence(value: Any) -> list[Any]:
     if isinstance(value, Sequence):
         return list(value)
     return [value]
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
 
 
 def _format_rate(value: Any) -> str:

--- a/openmed/risk/kanon.py
+++ b/openmed/risk/kanon.py
@@ -1,9 +1,10 @@
-"""k-anonymity, l-diversity and t-closeness measurement for tabular records.
+"""k-anonymity, l-diversity and t-closeness for tabular records.
 
-These are *measurement-only* disclosure-control metrics over already
-de-identified records. They report on the realized privacy of an output; they
-do NOT generalize, suppress or microaggregate to achieve a target k (that is
-the ARX-style engine, a separate epic).
+The module exposes both measurement and a small full-domain enforcement
+engine for structured quasi-identifiers. Enforcement searches the
+generalization lattice over age, geography, date and user-supplied hierarchies,
+then suppresses only the equivalence classes that still violate the policy and
+fit within the declared suppression cap.
 
 Quasi-identifier handling reuses :mod:`openmed.risk.reid` so equivalence-class
 keys match :func:`openmed.risk.risk_report`: auto-detection uses the same
@@ -15,14 +16,49 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from collections import Counter, defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
+from itertools import product
 from typing import Any, Mapping, Sequence
 
-from .reid import _coerce_records, _normalize_qi_value, _profile_record
+from openmed.core.audit import stable_hash
 
-__all__ = ["kanon_report"]
+from .reid import (
+    _coerce_records,
+    _field_category,
+    _field_is_direct_identifier,
+    _normalize_qi_value,
+    _profile_record,
+)
+
+__all__ = ["build_generalization_hierarchies", "enforce_kanon", "kanon_report"]
 
 _SUPPORTED_T_DISTANCES = ("variational",)
+_SUPPRESSED_VALUE = "*"
+_SUPPORTED_USER_LEVEL_KEYS = frozenset({"name", "values", "default", "loss"})
+
+
+@dataclass(frozen=True)
+class _GeneralizationLevel:
+    name: str
+    loss: float
+    transform: Callable[[Any], str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "loss": float(self.loss)}
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    node: tuple[int, ...]
+    records: tuple[dict[str, Any], ...]
+    report: Mapping[str, Any]
+    suppressed_positions: tuple[int, ...]
+    information_loss: float
+    generalization_loss: float
+    suppression_loss: float
 
 
 def kanon_report(
@@ -147,6 +183,181 @@ def kanon_report(
     }
 
 
+def build_generalization_hierarchies(
+    records: Any,
+    quasi_identifiers: Sequence[str] | None = None,
+    *,
+    hierarchies: Mapping[str, Sequence[Mapping[str, Any]]] | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Return the field-level generalization hierarchies used by enforcement.
+
+    Default hierarchies cover common structured quasi-identifiers: ages roll up
+    from exact ages to five-year, ten-year, twenty-year and suppressed bands;
+    dates roll up to month, year, decade and suppression; geography rolls up
+    from exact values to postal/state-style regions and suppression. A
+    user-supplied hierarchy may provide levels with ``name``, ``values``,
+    optional ``default`` and optional ``loss`` keys.
+    """
+
+    coerced = _coerce_records(records, source="deidentified")
+    qis = _resolve_quasi_identifier_fields(coerced, quasi_identifiers)
+    levels = _build_hierarchy_levels(coerced, qis, hierarchies)
+    return {
+        field: [level.to_dict() for level in field_levels]
+        for field, field_levels in levels.items()
+    }
+
+
+def enforce_kanon(
+    records: Any,
+    quasi_identifiers: Sequence[str] | None = None,
+    sensitive_attributes: Sequence[str] | None = None,
+    *,
+    target_k: int = 2,
+    target_l: int = 1,
+    target_t: float = 1.0,
+    suppression_limit: int | None = None,
+    suppression_rate: float = 0.0,
+    hierarchies: Mapping[str, Sequence[Mapping[str, Any]]] | None = None,
+    remove_direct_identifiers: bool = True,
+) -> dict[str, Any]:
+    """Generalize and suppress records until the declared k/l/t policy holds.
+
+    The search is full-domain: one level per quasi-identifier is applied to the
+    whole corpus, then violating equivalence classes are suppressed if the
+    suppression cap allows it. The selected node minimizes a documented
+    information-loss metric over the exhaustive lattice, so small-fixture
+    optimum checks can use zero tolerance.
+
+    Proof sketch for the identity bound: after enforcement, each released
+    equivalence class contains at least ``target_k`` records. Any attacker that
+    matches only on released quasi-identifiers cannot distinguish records inside
+    a class, so each released record has re-identification probability at most
+    ``1 / class_size <= 1 / target_k``. l-diversity and t-closeness are emitted
+    as separate sensitive-attribute disclosure bounds; they do not reduce the
+    identity bound itself, but they do tighten the reported upper bound for
+    sensitive value confidence and the joint identity-plus-sensitive event.
+    """
+
+    _validate_policy(target_k, target_l, target_t, suppression_rate)
+    coerced = _coerce_records(records, source="deidentified")
+    qis = _resolve_quasi_identifier_fields(coerced, quasi_identifiers)
+    sensitive = sorted(str(attr) for attr in sensitive_attributes or [])
+    if target_l > 1 and not sensitive:
+        raise ValueError("target_l > 1 requires at least one sensitive attribute")
+    if target_t < 1.0 and not sensitive:
+        raise ValueError("target_t < 1.0 requires at least one sensitive attribute")
+
+    if not coerced:
+        empty_report = kanon_report(
+            [], quasi_identifiers=qis, sensitive_attributes=sensitive
+        )
+        return {
+            "schema_version": 1,
+            "record_count": 0,
+            "released_count": 0,
+            "suppressed_count": 0,
+            "target_k": int(target_k),
+            "target_l": int(target_l),
+            "target_t": float(target_t),
+            "quasi_identifiers": qis,
+            "sensitive_attributes": sensitive,
+            "records": [],
+            "kanon": empty_report,
+            "suppressed_records": [],
+            "generalization": {
+                "node": {},
+                "levels": {},
+                "information_loss": 0.0,
+                "generalization_loss": 0.0,
+                "suppression_loss": 0.0,
+                "optimality_tolerance": 0.0,
+            },
+            "bounds": _bound_report(
+                [],
+                empty_report,
+                (),
+                target_k=target_k,
+                target_l=target_l,
+                target_t=target_t,
+                sensitive_attributes=sensitive,
+            ),
+        }
+
+    levels = _build_hierarchy_levels(coerced, qis, hierarchies)
+    budget = _suppression_budget(
+        len(coerced),
+        suppression_limit=suppression_limit,
+        suppression_rate=suppression_rate,
+    )
+    candidate = _search_lattice(
+        coerced,
+        qis,
+        sensitive,
+        levels,
+        target_k=target_k,
+        target_l=target_l,
+        target_t=target_t,
+        suppression_budget=budget,
+        remove_direct_identifiers=remove_direct_identifiers,
+    )
+    if candidate is None:
+        raise ValueError(
+            "No generalization satisfies the requested k/l/t targets within "
+            f"the suppression cap ({budget} of {len(coerced)} records)."
+        )
+
+    field_order = tuple(qis)
+    node_by_field = {
+        field: {
+            "level": candidate.node[index],
+            **levels[field][candidate.node[index]].to_dict(),
+        }
+        for index, field in enumerate(field_order)
+    }
+    suppressed = _suppressed_records(
+        coerced,
+        candidate.suppressed_positions,
+        reason="privacy_class_violation",
+    )
+    bounds = _bound_report(
+        candidate.records,
+        candidate.report,
+        candidate.suppressed_positions,
+        target_k=target_k,
+        target_l=target_l,
+        target_t=target_t,
+        sensitive_attributes=sensitive,
+    )
+    return {
+        "schema_version": 1,
+        "record_count": len(coerced),
+        "released_count": len(candidate.records),
+        "suppressed_count": len(candidate.suppressed_positions),
+        "suppression_limit": budget,
+        "target_k": int(target_k),
+        "target_l": int(target_l),
+        "target_t": float(target_t),
+        "quasi_identifiers": field_order,
+        "sensitive_attributes": sensitive,
+        "records": [dict(record) for record in candidate.records],
+        "kanon": candidate.report,
+        "suppressed_records": suppressed,
+        "generalization": {
+            "node": {
+                field: candidate.node[index] for index, field in enumerate(field_order)
+            },
+            "levels": node_by_field,
+            "information_loss": candidate.information_loss,
+            "generalization_loss": candidate.generalization_loss,
+            "suppression_loss": candidate.suppression_loss,
+            "optimality_tolerance": 0.0,
+            "search": "full-domain exhaustive lattice",
+        },
+        "bounds": bounds,
+    }
+
+
 def _equivalence_key(
     record: Any,
     quasi_identifiers: Sequence[str] | None,
@@ -214,3 +425,710 @@ def _reported_quasi_identifiers(
         for entry in cls["key"]:
             categories.add(str(entry[0]))
     return sorted(categories)
+
+
+def _validate_policy(
+    target_k: int,
+    target_l: int,
+    target_t: float,
+    suppression_rate: float,
+) -> None:
+    if target_k < 1:
+        raise ValueError("target_k must be >= 1")
+    if target_l < 1:
+        raise ValueError("target_l must be >= 1")
+    if not 0.0 <= float(target_t) <= 1.0:
+        raise ValueError("target_t must be between 0.0 and 1.0")
+    if not 0.0 <= float(suppression_rate) <= 1.0:
+        raise ValueError("suppression_rate must be between 0.0 and 1.0")
+
+
+def _resolve_quasi_identifier_fields(
+    records: Sequence[Any],
+    quasi_identifiers: Sequence[str] | None,
+) -> list[str]:
+    if quasi_identifiers:
+        return sorted({str(field) for field in quasi_identifiers})
+
+    fields: set[str] = set()
+    for record in records:
+        for field in record.fields:
+            if _field_category(field) is not None:
+                fields.add(str(field))
+    if fields:
+        return sorted(fields)
+
+    categories: set[str] = set()
+    for record in records:
+        profile = _profile_record(record)
+        for category, values in profile.key:
+            if values:
+                categories.add(category)
+    return sorted(categories)
+
+
+def _build_hierarchy_levels(
+    records: Sequence[Any],
+    quasi_identifiers: Sequence[str],
+    supplied: Mapping[str, Sequence[Mapping[str, Any]]] | None,
+) -> dict[str, tuple[_GeneralizationLevel, ...]]:
+    supplied = supplied or {}
+    result: dict[str, tuple[_GeneralizationLevel, ...]] = {}
+    for field in quasi_identifiers:
+        if field in supplied:
+            result[field] = _user_hierarchy(field, supplied[field])
+        else:
+            result[field] = _default_hierarchy(field, records)
+    return result
+
+
+def _user_hierarchy(
+    field: str,
+    levels: Sequence[Mapping[str, Any]],
+) -> tuple[_GeneralizationLevel, ...]:
+    if not levels:
+        raise ValueError(f"Hierarchy for {field!r} must contain at least one level")
+
+    built: list[_GeneralizationLevel] = []
+    max_index = max(1, len(levels) - 1)
+    for index, level in enumerate(levels):
+        unknown = set(level) - _SUPPORTED_USER_LEVEL_KEYS
+        if unknown:
+            raise ValueError(
+                f"Unsupported hierarchy keys for {field!r}: {sorted(unknown)}"
+            )
+        values = level.get("values")
+        if values is not None and not isinstance(values, Mapping):
+            raise ValueError(f"Hierarchy level {field!r}[{index}] values must be a map")
+        value_map = {str(key): str(value) for key, value in dict(values or {}).items()}
+        default = level.get("default")
+        loss = _optional_float(level.get("loss"))
+        if loss is None:
+            loss = index / max_index
+
+        def transform(
+            value: Any,
+            *,
+            mapping: Mapping[str, str] = value_map,
+            default_value: Any = default,
+        ) -> str:
+            exact = str(value)
+            normalized = _normalize_qi_value(field, value)
+            if exact in mapping:
+                return mapping[exact]
+            if normalized in mapping:
+                return mapping[normalized]
+            if default_value is not None:
+                return str(default_value)
+            return normalized
+
+        built.append(
+            _GeneralizationLevel(
+                name=str(level.get("name") or f"level_{index}"),
+                loss=float(loss),
+                transform=transform,
+            )
+        )
+    return tuple(built)
+
+
+def _default_hierarchy(
+    field: str,
+    records: Sequence[Any],
+) -> tuple[_GeneralizationLevel, ...]:
+    category = _field_category(field) or field
+    if category == "age":
+        return (
+            _level("exact", 0.0, lambda value: _normalize_qi_value("age", value)),
+            _level("age_5_year_band", 0.25, lambda value: _age_band(value, 5)),
+            _level("age_10_year_band", 0.5, lambda value: _age_band(value, 10)),
+            _level("age_20_year_band", 0.75, lambda value: _age_band(value, 20)),
+            _level("suppressed", 1.0, lambda value: _SUPPRESSED_VALUE),
+        )
+    if category == "date":
+        return (
+            _level("exact", 0.0, lambda value: _normalize_qi_value("date", value)),
+            _level("month", 0.25, _date_month),
+            _level("year", 0.5, _date_year),
+            _level("decade", 0.75, _date_decade),
+            _level("suppressed", 1.0, lambda value: _SUPPRESSED_VALUE),
+        )
+    if category == "geography":
+        return (
+            _level("exact", 0.0, lambda value: _normalize_qi_value("geography", value)),
+            _level("regional", 0.4, _geography_region),
+            _level("broad_region", 0.7, _geography_broad_region),
+            _level("suppressed", 1.0, lambda value: _SUPPRESSED_VALUE),
+        )
+
+    values = {
+        _normalize_qi_value(field, record.fields.get(field, ""))
+        for record in records
+        if record.fields.get(field) is not None
+    }
+    has_prefix_signal = any(len(value) > 1 for value in values)
+    if has_prefix_signal:
+        return (
+            _level("exact", 0.0, lambda value: _normalize_qi_value(field, value)),
+            _level("prefix", 0.5, lambda value: _generic_prefix(field, value)),
+            _level("suppressed", 1.0, lambda value: _SUPPRESSED_VALUE),
+        )
+    return (
+        _level("exact", 0.0, lambda value: _normalize_qi_value(field, value)),
+        _level("suppressed", 1.0, lambda value: _SUPPRESSED_VALUE),
+    )
+
+
+def _level(
+    name: str,
+    loss: float,
+    transform: Callable[[Any], str],
+) -> _GeneralizationLevel:
+    return _GeneralizationLevel(name=name, loss=loss, transform=transform)
+
+
+def _age_band(value: Any, width: int) -> str:
+    normalized = _normalize_qi_value("age", value)
+    parsed = _optional_int(normalized)
+    if parsed is None:
+        return _SUPPRESSED_VALUE
+    lower = (parsed // width) * width
+    upper = lower + width - 1
+    return f"{lower}-{upper}"
+
+
+def _date_parts(value: Any) -> tuple[int, int | None] | None:
+    text = _normalize_qi_value("date", value)
+    match = re.match(r"^(\d{4})(?:[-/](\d{1,2}))?", text)
+    if not match:
+        return None
+    year = _optional_int(match.group(1))
+    month = _optional_int(match.group(2))
+    if year is None:
+        return None
+    if month is not None and not 1 <= month <= 12:
+        month = None
+    return year, month
+
+
+def _date_month(value: Any) -> str:
+    parts = _date_parts(value)
+    if parts is None:
+        return _SUPPRESSED_VALUE
+    year, month = parts
+    if month is None:
+        return str(year)
+    return f"{year:04d}-{month:02d}"
+
+
+def _date_year(value: Any) -> str:
+    parts = _date_parts(value)
+    if parts is None:
+        return _SUPPRESSED_VALUE
+    return f"{parts[0]:04d}"
+
+
+def _date_decade(value: Any) -> str:
+    parts = _date_parts(value)
+    if parts is None:
+        return _SUPPRESSED_VALUE
+    decade = (parts[0] // 10) * 10
+    return f"{decade:04d}s"
+
+
+def _geography_region(value: Any) -> str:
+    text = _normalize_qi_value("geography", value)
+    digits = re.sub(r"\D", "", text)
+    if len(digits) >= 5:
+        return f"{digits[:3]}**"
+    if "," in text:
+        return text.rsplit(",", 1)[-1].strip() or _SUPPRESSED_VALUE
+    pieces = text.split()
+    if len(pieces) > 1:
+        return pieces[-1]
+    return text[:3] + "*" if len(text) > 3 else text or _SUPPRESSED_VALUE
+
+
+def _geography_broad_region(value: Any) -> str:
+    text = _normalize_qi_value("geography", value)
+    digits = re.sub(r"\D", "", text)
+    if len(digits) >= 5:
+        return f"{digits[:2]}***"
+    region = _geography_region(text)
+    return region[:1] + "*" if len(region) > 1 else region
+
+
+def _generic_prefix(field: str, value: Any) -> str:
+    normalized = _normalize_qi_value(field, value)
+    if not normalized:
+        return _SUPPRESSED_VALUE
+    return normalized[:1] + "*"
+
+
+def _suppression_budget(
+    record_count: int,
+    *,
+    suppression_limit: int | None,
+    suppression_rate: float,
+) -> int:
+    if suppression_limit is not None and suppression_limit < 0:
+        raise ValueError("suppression_limit must be >= 0")
+    rate_budget = math.floor(record_count * suppression_rate)
+    if suppression_limit is None:
+        return rate_budget
+    if suppression_rate > 0.0:
+        return min(int(suppression_limit), rate_budget)
+    return int(suppression_limit)
+
+
+def _search_lattice(
+    records: Sequence[Any],
+    quasi_identifiers: Sequence[str],
+    sensitive_attributes: Sequence[str],
+    levels: Mapping[str, Sequence[_GeneralizationLevel]],
+    *,
+    target_k: int,
+    target_l: int,
+    target_t: float,
+    suppression_budget: int,
+    remove_direct_identifiers: bool,
+) -> _Candidate | None:
+    field_order = tuple(quasi_identifiers)
+    candidates: list[_Candidate] = []
+    ranges = [range(len(levels[field])) for field in field_order]
+    for node in product(*ranges):
+        candidate = _evaluate_lattice_node(
+            records,
+            field_order,
+            sensitive_attributes,
+            levels,
+            node,
+            target_k=target_k,
+            target_l=target_l,
+            target_t=target_t,
+            suppression_budget=suppression_budget,
+            remove_direct_identifiers=remove_direct_identifiers,
+        )
+        if candidate is not None:
+            candidates.append(candidate)
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda candidate: (
+            candidate.information_loss,
+            candidate.suppression_loss,
+            sum(candidate.node),
+            candidate.node,
+        )
+    )
+    return candidates[0]
+
+
+def _evaluate_lattice_node(
+    records: Sequence[Any],
+    quasi_identifiers: Sequence[str],
+    sensitive_attributes: Sequence[str],
+    levels: Mapping[str, Sequence[_GeneralizationLevel]],
+    node: tuple[int, ...],
+    *,
+    target_k: int,
+    target_l: int,
+    target_t: float,
+    suppression_budget: int,
+    remove_direct_identifiers: bool,
+) -> _Candidate | None:
+    transformed = tuple(
+        _transform_record(
+            record,
+            quasi_identifiers,
+            levels,
+            node,
+            remove_direct_identifiers=remove_direct_identifiers,
+        )
+        for record in records
+    )
+    suppressed: set[int] = set()
+
+    while True:
+        remaining_positions = [
+            position
+            for position in range(len(transformed))
+            if position not in suppressed
+        ]
+        if not remaining_positions:
+            return None
+        remaining_records = [transformed[position] for position in remaining_positions]
+        report = kanon_report(
+            remaining_records,
+            quasi_identifiers=quasi_identifiers,
+            sensitive_attributes=sensitive_attributes,
+        )
+        failing_positions = _failing_positions(
+            report,
+            remaining_positions,
+            target_k=target_k,
+            target_l=target_l,
+            target_t=target_t,
+            sensitive_attributes=sensitive_attributes,
+        )
+        if not failing_positions:
+            break
+        before = len(suppressed)
+        suppressed.update(failing_positions)
+        if len(suppressed) > suppression_budget or len(suppressed) == before:
+            return None
+
+    final_positions = [
+        position for position in range(len(transformed)) if position not in suppressed
+    ]
+    if not final_positions:
+        return None
+    final_records = tuple(transformed[position] for position in final_positions)
+    final_report = kanon_report(
+        final_records,
+        quasi_identifiers=quasi_identifiers,
+        sensitive_attributes=sensitive_attributes,
+    )
+    if not _report_satisfies(
+        final_report,
+        target_k=target_k,
+        target_l=target_l,
+        target_t=target_t,
+        sensitive_attributes=sensitive_attributes,
+    ):
+        return None
+
+    generalization_loss = _generalization_loss(quasi_identifiers, levels, node)
+    suppression_loss = len(suppressed) / len(records) if records else 0.0
+    information_loss = generalization_loss + suppression_loss
+    return _Candidate(
+        node=node,
+        records=final_records,
+        report=final_report,
+        suppressed_positions=tuple(sorted(suppressed)),
+        information_loss=information_loss,
+        generalization_loss=generalization_loss,
+        suppression_loss=suppression_loss,
+    )
+
+
+def _transform_record(
+    record: Any,
+    quasi_identifiers: Sequence[str],
+    levels: Mapping[str, Sequence[_GeneralizationLevel]],
+    node: Sequence[int],
+    *,
+    remove_direct_identifiers: bool,
+) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    for name, value in record.fields.items():
+        if remove_direct_identifiers and _field_is_direct_identifier(name):
+            continue
+        fields[name] = value
+
+    for index, field in enumerate(quasi_identifiers):
+        if remove_direct_identifiers and _field_is_direct_identifier(field):
+            fields.pop(field, None)
+            continue
+        level = levels[field][node[index]]
+        fields[field] = level.transform(record.fields.get(field, ""))
+    return fields
+
+
+def _failing_positions(
+    report: Mapping[str, Any],
+    position_map: Sequence[int],
+    *,
+    target_k: int,
+    target_l: int,
+    target_t: float,
+    sensitive_attributes: Sequence[str],
+) -> set[int]:
+    failing: set[int] = set()
+    for cls in report.get("equivalence_classes", []):
+        if not isinstance(cls, Mapping):
+            continue
+        if _class_satisfies(
+            cls,
+            target_k=target_k,
+            target_l=target_l,
+            target_t=target_t,
+            sensitive_attributes=sensitive_attributes,
+        ):
+            continue
+        for member in cls.get("members", []):
+            parsed = _optional_int(member)
+            if parsed is not None and 0 <= parsed < len(position_map):
+                failing.add(position_map[parsed])
+    return failing
+
+
+def _report_satisfies(
+    report: Mapping[str, Any],
+    *,
+    target_k: int,
+    target_l: int,
+    target_t: float,
+    sensitive_attributes: Sequence[str],
+) -> bool:
+    if int(report.get("record_count", 0)) <= 0:
+        return False
+    if int(report.get("k", 0)) < target_k:
+        return False
+    for cls in report.get("equivalence_classes", []):
+        if not isinstance(cls, Mapping):
+            return False
+        if not _class_satisfies(
+            cls,
+            target_k=target_k,
+            target_l=target_l,
+            target_t=target_t,
+            sensitive_attributes=sensitive_attributes,
+        ):
+            return False
+    return True
+
+
+def _class_satisfies(
+    cls: Mapping[str, Any],
+    *,
+    target_k: int,
+    target_l: int,
+    target_t: float,
+    sensitive_attributes: Sequence[str],
+) -> bool:
+    if int(cls.get("size", 0)) < target_k:
+        return False
+    l_diversity = _mapping(cls.get("l_diversity"))
+    t_closeness = _mapping(cls.get("t_closeness"))
+    for attr in sensitive_attributes:
+        attr_l = _mapping(l_diversity.get(attr))
+        if int(attr_l.get("distinct", 0)) < target_l:
+            return False
+        parsed_t = _optional_float(t_closeness.get(attr))
+        if parsed_t is None or parsed_t > target_t + 1e-12:
+            return False
+    return True
+
+
+def _generalization_loss(
+    quasi_identifiers: Sequence[str],
+    levels: Mapping[str, Sequence[_GeneralizationLevel]],
+    node: Sequence[int],
+) -> float:
+    if not quasi_identifiers:
+        return 0.0
+    return sum(
+        float(levels[field][node[index]].loss)
+        for index, field in enumerate(quasi_identifiers)
+    ) / len(quasi_identifiers)
+
+
+def _suppressed_records(
+    records: Sequence[Any],
+    positions: Sequence[int],
+    *,
+    reason: str,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "record_index": int(position),
+            "offset": int(position),
+            "record_hash": stable_hash(records[position].fields),
+            "reason": reason,
+        }
+        for position in positions
+    ]
+
+
+def _bound_report(
+    records: Sequence[Mapping[str, Any]],
+    report: Mapping[str, Any],
+    suppressed_positions: Sequence[int],
+    *,
+    target_k: int,
+    target_l: int,
+    target_t: float,
+    sensitive_attributes: Sequence[str],
+) -> dict[str, Any]:
+    class_by_member: dict[int, Mapping[str, Any]] = {}
+    for cls in report.get("equivalence_classes", []):
+        if not isinstance(cls, Mapping):
+            continue
+        for member in cls.get("members", []):
+            parsed = _optional_int(member)
+            if parsed is not None:
+                class_by_member[parsed] = cls
+
+    global_dist = {
+        attr: _distribution(
+            str(record.get(attr))
+            for record in records
+            if attr in record and record.get(attr) is not None
+        )
+        for attr in sensitive_attributes
+    }
+    per_record = []
+    violations = []
+    target_bound = 1.0 / target_k
+    for index, record in enumerate(records):
+        cls = class_by_member.get(index)
+        class_size = int(cls.get("size", 0)) if cls is not None else 0
+        identity_bound = 1.0 / class_size if class_size else 1.0
+        sensitive_bounds = _sensitive_bounds(
+            records,
+            cls,
+            record,
+            global_dist,
+            sensitive_attributes,
+        )
+        joint_bound = min(
+            [
+                identity_bound,
+                *[
+                    bound["value_confidence_upper_bound"]
+                    for bound in sensitive_bounds.values()
+                ],
+            ]
+        )
+        if identity_bound > target_bound + 1e-12:
+            violations.append(
+                {
+                    "record_index": index,
+                    "bound": identity_bound,
+                    "target_bound": target_bound,
+                }
+            )
+        per_record.append(
+            {
+                "record_index": index,
+                "record_hash": stable_hash(record),
+                "equivalence_class_size": class_size,
+                "reidentification_upper_bound": identity_bound,
+                "sensitive_attribute_upper_bounds": sensitive_bounds,
+                "joint_sensitive_reidentification_upper_bound": joint_bound,
+            }
+        )
+
+    max_bound = max(
+        (item["reidentification_upper_bound"] for item in per_record),
+        default=0.0,
+    )
+    l_ok = _l_targets_satisfied(report, sensitive_attributes, target_l)
+    t_ok = _t_targets_satisfied(report, sensitive_attributes, target_t)
+    numeric_self_check = {
+        "passed": not violations and l_ok and t_ok,
+        "identity_bound_violations": violations,
+        "l_diversity_satisfied": l_ok,
+        "t_closeness_satisfied": t_ok,
+    }
+    return {
+        "proof_sketch": (
+            "Released records are partitioned by the published "
+            "quasi-identifier key. Each class has size at least target_k, so "
+            "any quasi-identifier-only linkage attack has probability at most "
+            "1/class_size for each member, which is <= 1/target_k. Distinct "
+            "l-diversity and variational t-closeness are checked per class and "
+            "reported as sensitive-attribute confidence caps."
+        ),
+        "target_reidentification_upper_bound": target_bound,
+        "max_reidentification_upper_bound": max_bound,
+        "target_k": int(target_k),
+        "target_l": int(target_l),
+        "target_t": float(target_t),
+        "suppressed_count": len(suppressed_positions),
+        "numeric_self_check": numeric_self_check,
+        "per_record": per_record,
+    }
+
+
+def _sensitive_bounds(
+    records: Sequence[Mapping[str, Any]],
+    cls: Mapping[str, Any] | None,
+    record: Mapping[str, Any],
+    global_dist: Mapping[str, Mapping[str, float]],
+    sensitive_attributes: Sequence[str],
+) -> dict[str, dict[str, Any]]:
+    if cls is None:
+        return {}
+    members = [
+        parsed
+        for parsed in (_optional_int(member) for member in cls.get("members", []))
+        if parsed is not None and 0 <= parsed < len(records)
+    ]
+    class_size = len(members)
+    result: dict[str, dict[str, Any]] = {}
+    for attr in sensitive_attributes:
+        values = [str(records[index].get(attr)) for index in members]
+        counts = Counter(values)
+        record_value = str(record.get(attr))
+        observed = counts.get(record_value, 0) / class_size if class_size else 1.0
+        attr_t = _optional_float(_mapping(cls.get("t_closeness")).get(attr)) or 0.0
+        t_cap = min(1.0, global_dist.get(attr, {}).get(record_value, 0.0) + attr_t)
+        distinct = int(
+            _mapping(_mapping(cls.get("l_diversity")).get(attr)).get("distinct", 0)
+        )
+        result[attr] = {
+            "distinct_values": distinct,
+            "class_value_frequency": counts.get(record_value, 0),
+            "value_confidence_upper_bound": min(observed, t_cap),
+            "t_closeness_cap": t_cap,
+        }
+    return result
+
+
+def _l_targets_satisfied(
+    report: Mapping[str, Any],
+    sensitive_attributes: Sequence[str],
+    target_l: int,
+) -> bool:
+    for cls in report.get("equivalence_classes", []):
+        if not isinstance(cls, Mapping):
+            return False
+        l_diversity = _mapping(cls.get("l_diversity"))
+        for attr in sensitive_attributes:
+            attr_l = _mapping(l_diversity.get(attr))
+            if int(attr_l.get("distinct", 0)) < target_l:
+                return False
+    return True
+
+
+def _t_targets_satisfied(
+    report: Mapping[str, Any],
+    sensitive_attributes: Sequence[str],
+    target_t: float,
+) -> bool:
+    for cls in report.get("equivalence_classes", []):
+        if not isinstance(cls, Mapping):
+            return False
+        t_closeness = _mapping(cls.get("t_closeness"))
+        for attr in sensitive_attributes:
+            parsed = _optional_float(t_closeness.get(attr))
+            if parsed is None or parsed > target_t + 1e-12:
+                return False
+    return True
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _optional_int(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/unit/eval/test_release_gates.py
+++ b/tests/unit/eval/test_release_gates.py
@@ -379,6 +379,58 @@ def test_g8_consumes_strict_quality_gate_output(tmp_path: Path, monkeypatch) -> 
     assert _check(result, "G8").details["spans_checked"] == 3
 
 
+def test_k_floor_release_gate_passes_signed_enforcement_evidence(
+    tmp_path: Path,
+) -> None:
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metric_updates={
+                "kanon_enforcement": {
+                    "target_k": 2,
+                    "kanon": {"k": 2},
+                    "bounds": {
+                        "max_reidentification_upper_bound": 0.5,
+                        "numeric_self_check": {"passed": True},
+                    },
+                }
+            },
+        ),
+        _baseline(),
+    )
+
+    assert result.decision == RELEASABLE
+    assert result.verify(SIGNING_KEY)
+    assert _check(result, "k_floor").passed is True
+
+
+def test_k_floor_release_gate_fails_realized_k_below_target(
+    tmp_path: Path,
+) -> None:
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metric_updates={
+                "kanon_enforcement": {
+                    "target_k": 3,
+                    "kanon": {"k": 2},
+                    "bounds": {
+                        "max_reidentification_upper_bound": 0.5,
+                        "numeric_self_check": {"passed": False},
+                    },
+                }
+            },
+        ),
+        _baseline(),
+    )
+
+    check = _check(result, "k_floor")
+    assert result.decision == QUARANTINED
+    assert result.verify(SIGNING_KEY)
+    assert check.passed is False
+    assert check.details["violations"]["measured_k"] == {"observed": 2, "target": 3}
+
+
 def test_g4_computes_quant_delta_from_fp_parent_recall(tmp_path: Path) -> None:
     result = _gate().evaluate(
         _report(

--- a/tests/unit/risk/test_kanon_enforcement.py
+++ b/tests/unit/risk/test_kanon_enforcement.py
@@ -1,0 +1,224 @@
+"""Tests for corpus-level k-anonymity enforcement."""
+
+from __future__ import annotations
+
+from itertools import product
+
+import pytest
+
+import openmed.risk.kanon as kanon_module
+from openmed.risk import enforce_kanon, risk_report
+
+QIS = ["age", "zip", "visit_date"]
+
+
+def _balanced_records() -> list[dict[str, object]]:
+    return [
+        {
+            "patient_name": "Alice Jones",
+            "age": 31,
+            "zip": "10001",
+            "visit_date": "2024-01-01",
+            "disease": "flu",
+        },
+        {
+            "patient_name": "Bob Smith",
+            "age": 32,
+            "zip": "10002",
+            "visit_date": "2024-01-02",
+            "disease": "cold",
+        },
+        {
+            "patient_name": "Carol Lee",
+            "age": 41,
+            "zip": "20001",
+            "visit_date": "2024-01-03",
+            "disease": "flu",
+        },
+        {
+            "patient_name": "Dan Patel",
+            "age": 42,
+            "zip": "20002",
+            "visit_date": "2024-01-04",
+            "disease": "cold",
+        },
+    ]
+
+
+def test_enforce_kanon_meets_k_l_t_and_reports_provable_bounds() -> None:
+    records = _balanced_records()
+
+    enforced = enforce_kanon(
+        records,
+        quasi_identifiers=QIS,
+        sensitive_attributes=["disease"],
+        target_k=2,
+        target_l=2,
+        target_t=0.0,
+    )
+
+    assert enforced["kanon"]["k"] >= 2
+    assert enforced["released_count"] == len(records)
+    assert enforced["bounds"]["max_reidentification_upper_bound"] <= 0.5
+    assert enforced["bounds"]["numeric_self_check"]["passed"] is True
+    for item in enforced["bounds"]["per_record"]:
+        assert item["reidentification_upper_bound"] <= 0.5
+
+
+def test_enforcement_removes_direct_identifier_fields_from_released_records() -> None:
+    records = _balanced_records()
+
+    enforced = enforce_kanon(
+        records,
+        quasi_identifiers=QIS,
+        sensitive_attributes=["disease"],
+        target_k=2,
+        target_l=2,
+        target_t=0.0,
+    )
+
+    assert all("patient_name" not in record for record in enforced["records"])
+    leakage = risk_report(enforced["records"], original=records)
+    assert leakage["leakage_rate"] == 0.0
+
+
+def test_suppression_cap_reports_records_by_offset_and_hash_only() -> None:
+    records = [
+        {"age": 30, "zip": "10001", "visit_date": "2024-01-01", "disease": "flu"},
+        {"age": 30, "zip": "10001", "visit_date": "2024-01-01", "disease": "cold"},
+        {
+            "age": 40,
+            "zip": "20001",
+            "visit_date": "2024-01-01",
+            "disease": "asthma",
+        },
+        {"age": 40, "zip": "20001", "visit_date": "2024-01-01", "disease": "flu"},
+        {"age": 99, "zip": "99999", "visit_date": "1901-01-01", "disease": "rare"},
+    ]
+
+    enforced = enforce_kanon(
+        records,
+        quasi_identifiers=QIS,
+        sensitive_attributes=["disease"],
+        target_k=2,
+        suppression_limit=1,
+    )
+
+    assert enforced["suppressed_count"] == 1
+    suppressed = enforced["suppressed_records"][0]
+    assert suppressed["offset"] == 4
+    assert suppressed["record_hash"].startswith("sha256:")
+    assert "rare" not in str(suppressed)
+    assert enforced["kanon"]["k"] >= 2
+
+
+def _brute_force_best_loss(records: list[dict[str, object]]) -> float:
+    coerced = kanon_module._coerce_records(records, source="deidentified")
+    levels = kanon_module._build_hierarchy_levels(coerced, QIS, None)
+    candidates = []
+    ranges = [range(len(levels[field])) for field in QIS]
+    for node in product(*ranges):
+        candidate = kanon_module._evaluate_lattice_node(
+            coerced,
+            QIS,
+            ["disease"],
+            levels,
+            node,
+            target_k=2,
+            target_l=1,
+            target_t=1.0,
+            suppression_budget=0,
+            remove_direct_identifiers=True,
+        )
+        if candidate is not None:
+            candidates.append(candidate.information_loss)
+    assert candidates
+    return min(candidates)
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        _balanced_records(),
+        [
+            {"age": 31, "zip": "10001", "visit_date": "2024-01-01", "disease": "a"},
+            {"age": 33, "zip": "10002", "visit_date": "2024-01-02", "disease": "b"},
+            {"age": 35, "zip": "10003", "visit_date": "2024-01-03", "disease": "a"},
+            {"age": 37, "zip": "10004", "visit_date": "2024-01-04", "disease": "b"},
+        ],
+        [
+            {"age": 51, "zip": "60601", "visit_date": "2024-02-01", "disease": "x"},
+            {"age": 52, "zip": "60602", "visit_date": "2024-02-11", "disease": "y"},
+            {"age": 61, "zip": "60603", "visit_date": "2025-02-01", "disease": "x"},
+            {"age": 62, "zip": "60604", "visit_date": "2025-02-11", "disease": "y"},
+        ],
+    ],
+)
+def test_lattice_search_matches_exhaustive_optimum_on_synthetic_corpora(
+    records: list[dict[str, object]],
+) -> None:
+    enforced = enforce_kanon(
+        records,
+        quasi_identifiers=QIS,
+        sensitive_attributes=["disease"],
+        target_k=2,
+    )
+
+    assert enforced["generalization"]["optimality_tolerance"] == 0.0
+    assert enforced["generalization"]["information_loss"] == pytest.approx(
+        _brute_force_best_loss(records)
+    )
+
+
+def test_k_anonymity_monotonicity_over_coarser_lattice_nodes() -> None:
+    records = _balanced_records()
+    coerced = kanon_module._coerce_records(records, source="deidentified")
+    levels = kanon_module._build_hierarchy_levels(coerced, QIS, None)
+    ranges = [range(len(levels[field])) for field in QIS]
+    nodes = list(product(*ranges))
+    satisfying = {
+        node
+        for node in nodes
+        if kanon_module.kanon_report(
+            [
+                kanon_module._transform_record(
+                    record,
+                    QIS,
+                    levels,
+                    node,
+                    remove_direct_identifiers=True,
+                )
+                for record in coerced
+            ],
+            quasi_identifiers=QIS,
+            sensitive_attributes=["disease"],
+        )["k"]
+        >= 2
+    }
+
+    assert satisfying
+    for node in satisfying:
+        for coarser in nodes:
+            if all(coarser[index] >= node[index] for index in range(len(QIS))):
+                report = kanon_module.kanon_report(
+                    [
+                        kanon_module._transform_record(
+                            record,
+                            QIS,
+                            levels,
+                            coarser,
+                            remove_direct_identifiers=True,
+                        )
+                        for record in coerced
+                    ],
+                    quasi_identifiers=QIS,
+                    sensitive_attributes=["disease"],
+                )
+                assert report["k"] >= 2
+
+
+def test_enforcement_is_exported_from_risk_package() -> None:
+    import openmed.risk as risk
+
+    assert hasattr(risk, "enforce_kanon")
+    assert "enforce_kanon" in risk.__all__

--- a/tests/unit/risk/test_risk_dashboard.py
+++ b/tests/unit/risk/test_risk_dashboard.py
@@ -6,6 +6,7 @@ import re
 from html.parser import HTMLParser
 
 from openmed.risk import (
+    enforce_kanon,
     kanon_report,
     render_risk_dashboard,
     risk_report,
@@ -132,6 +133,27 @@ def test_render_risk_dashboard_includes_kanon_section_when_supplied():
     assert "Class Size Distribution" in html
     assert "Equivalence Classes" in html
     assert "l-diversity" in html
+
+
+def test_render_risk_dashboard_includes_enforcement_section_when_supplied():
+    records = [
+        {"age": 30, "zip": "10001", "visit_date": "2024-01-01", "disease": "flu"},
+        {"age": 31, "zip": "10002", "visit_date": "2024-01-02", "disease": "cold"},
+    ]
+    risk = risk_report(records)
+    enforced = enforce_kanon(
+        records,
+        quasi_identifiers=["age", "zip", "visit_date"],
+        sensitive_attributes=["disease"],
+        target_k=2,
+    )
+
+    html = render_risk_dashboard(risk, kanon=enforced)
+
+    assert "K-Anonymity Enforcement" in html
+    assert "Selected Generalization" in html
+    assert "Max re-id bound" in html
+    assert "Bound check" in html
 
 
 def test_write_risk_dashboard_writes_balanced_html_and_returns_path(tmp_path):


### PR DESCRIPTION
# Pull Request

## Description
Closes #979.

Implements corpus-level k-anonymity enforcement for structured quasi-identifiers with full-domain generalization, bounded suppression, per-record identity-risk upper bounds, dashboard rendering, and signed release-gate k-floor evidence.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `enforce_kanon` with default age, geography, and date hierarchies plus user-supplied hierarchy support.
- Added exhaustive full-domain lattice search with suppression caps, information-loss scoring, per-record bound reports, and numeric self-checks.
- Added dashboard rendering for enforcement results and a signed release-gate `k_floor` check.
- Added tests for enforced k/l/t targets, direct-identifier leakage, suppression evidence, lattice optimality, monotonicity, dashboard rendering, and release-gate verdicts.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #979

## Screenshots/Examples
Not applicable.
