### PR TITLE
Add membership-inference defense and trained-attacker evaluation

### DIFF
--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -823,6 +823,7 @@ class Pipeline:
             model_id=result_model,
             language=route.lang,
         )
+        defense = self.calibration_thresholds.membership_defense_policy
         retained = []
         filtered = 0
         for entity in getattr(pii_result, "entities", ()):
@@ -842,8 +843,21 @@ class Pipeline:
                 "model_id": result_model,
                 "language": route.lang,
             }
+            raw_confidence = float(getattr(entity, "confidence", 0.0) or 0.0)
+            defended_confidence = defense.apply_score(raw_confidence)
+            if defense.enabled:
+                metadata["membership_defense"] = {
+                    "enabled": True,
+                    "raw_confidence": raw_confidence,
+                    "defended_confidence": defended_confidence,
+                    "clip_min": defense.clip_min,
+                    "clip_max": defense.clip_max,
+                    "temperature": defense.temperature,
+                    "smoothing": defense.smoothing,
+                }
+                entity.confidence = defended_confidence
             entity.metadata = metadata
-            if float(getattr(entity, "confidence", 0.0) or 0.0) >= threshold:
+            if defended_confidence >= threshold:
                 retained.append(entity)
             else:
                 filtered += 1
@@ -859,6 +873,7 @@ class Pipeline:
             "schema_version": self.calibration_thresholds.schema_version,
             "model_id": result_model,
             "suite": self.calibration_thresholds.suite,
+            "membership_defense": defense.to_dict(),
         }
         pii_result.metadata = metadata
 

--- a/openmed/core/thresholds.py
+++ b/openmed/core/thresholds.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import math
 from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
@@ -17,6 +18,7 @@ DEFAULT_RESOURCE = "thresholds.json"
 DEFAULT_POLICY_PROFILE = "balanced"
 STRICT_NO_LEAK_PROFILE = "strict_no_leak"
 WILDCARD_LANGUAGE = "*"
+DEFAULT_MEMBERSHIP_ADVANTAGE_CEILING = 0.05
 
 
 @dataclass(frozen=True)
@@ -58,6 +60,78 @@ class RecallGuardResult:
         return f"protected recall below floor for {labels}"
 
 
+@dataclass(frozen=True)
+class MembershipDefensePolicy:
+    """Score defense applied before thresholding release detector outputs."""
+
+    enabled: bool = False
+    clip_min: float = 0.0
+    clip_max: float = 1.0
+    temperature: float = 1.0
+    smoothing: float = 0.0
+    recall_floor: float | None = None
+    advantage_ceiling: float = DEFAULT_MEMBERSHIP_ADVANTAGE_CEILING
+
+    @classmethod
+    def from_mapping(
+        cls,
+        value: Mapping[str, Any] | "MembershipDefensePolicy" | None,
+        *,
+        recall_floor: float | None = None,
+    ) -> "MembershipDefensePolicy":
+        if isinstance(value, MembershipDefensePolicy):
+            return value
+        source = dict(value or {})
+        policy = cls(
+            enabled=bool(source.get("enabled", False)),
+            clip_min=_bounded_probability(source.get("clip_min", 0.0), "clip_min"),
+            clip_max=_bounded_probability(source.get("clip_max", 1.0), "clip_max"),
+            temperature=_positive_float(source.get("temperature", 1.0), "temperature"),
+            smoothing=_bounded_probability(source.get("smoothing", 0.0), "smoothing"),
+            recall_floor=(
+                _bounded_probability(source.get("recall_floor"), "recall_floor")
+                if source.get("recall_floor") is not None
+                else recall_floor
+            ),
+            advantage_ceiling=_bounded_probability(
+                source.get(
+                    "advantage_ceiling",
+                    DEFAULT_MEMBERSHIP_ADVANTAGE_CEILING,
+                ),
+                "advantage_ceiling",
+            ),
+        )
+        if policy.clip_min > policy.clip_max:
+            raise ValueError("membership defense clip_min must be <= clip_max")
+        return policy
+
+    def to_dict(self) -> dict[str, float | bool | None]:
+        return {
+            "enabled": bool(self.enabled),
+            "clip_min": float(self.clip_min),
+            "clip_max": float(self.clip_max),
+            "temperature": float(self.temperature),
+            "smoothing": float(self.smoothing),
+            "recall_floor": (
+                None if self.recall_floor is None else float(self.recall_floor)
+            ),
+            "advantage_ceiling": float(self.advantage_ceiling),
+        }
+
+    def apply_score(self, score: float) -> float:
+        """Return the defended score used for inference thresholding."""
+
+        value = _bounded_probability(score, "score")
+        if not self.enabled:
+            return value
+
+        if self.temperature != 1.0:
+            value = _sigmoid(_logit(value) / self.temperature)
+        if self.smoothing:
+            value = 0.5 + ((value - 0.5) * (1.0 - self.smoothing))
+        return min(self.clip_max, max(self.clip_min, value))
+
+
 def load_thresholds(path: str | Path | None = None) -> dict[str, Any]:
     """Load and validate the versioned thresholds matrix."""
 
@@ -82,12 +156,20 @@ def validate_threshold_matrix(matrix: Mapping[str, Any]) -> None:
     profiles = matrix.get("profiles")
     if not isinstance(profiles, Mapping) or not profiles:
         raise ValueError("thresholds matrix requires profiles")
+    _validate_membership_defense(
+        matrix.get("membership_defense"),
+        "membership_defense",
+    )
 
     for profile_name, profile in profiles.items():
         if not isinstance(profile, Mapping):
             raise ValueError(f"profile {profile_name!r} must be an object")
         _validate_recall_floor(profile.get("recall_floor"), profile_name)
         _validate_entry(profile.get("default"), f"{profile_name}.default")
+        _validate_membership_defense(
+            profile.get("membership_defense"),
+            f"{profile_name}.membership_defense",
+        )
         labels = profile.get("labels") or {}
         if not isinstance(labels, Mapping):
             raise ValueError(f"profile {profile_name!r} labels must be an object")
@@ -157,6 +239,54 @@ def profile_recall_floor(
     validate_threshold_matrix(payload)
     profile_name = _resolve_profile_name(payload, policy_profile)
     return float(payload["profiles"][profile_name]["recall_floor"])
+
+
+def membership_defense_for_profile(
+    policy_profile: str = DEFAULT_POLICY_PROFILE,
+    *,
+    matrix: Mapping[str, Any] | None = None,
+    overrides: Mapping[str, Any] | MembershipDefensePolicy | None = None,
+) -> MembershipDefensePolicy:
+    """Resolve the membership-inference score defense for a policy profile."""
+
+    payload = matrix if matrix is not None else load_thresholds()
+    validate_threshold_matrix(payload)
+    profile_name = _resolve_profile_name(payload, policy_profile)
+    profile = payload["profiles"][profile_name]
+    base: dict[str, Any] = {}
+    matrix_default = payload.get("membership_defense")
+    if isinstance(matrix_default, Mapping):
+        base.update(matrix_default)
+    profile_value = profile.get("membership_defense")
+    if isinstance(profile_value, Mapping):
+        base.update(profile_value)
+    if overrides is not None:
+        if isinstance(overrides, MembershipDefensePolicy):
+            base.update(overrides.to_dict())
+        else:
+            base.update(dict(overrides))
+    return MembershipDefensePolicy.from_mapping(
+        base,
+        recall_floor=profile_recall_floor(profile_name, matrix=payload),
+    )
+
+
+def apply_membership_defense_to_score(
+    score: float,
+    *,
+    policy: MembershipDefensePolicy | Mapping[str, Any] | None = None,
+    policy_profile: str = DEFAULT_POLICY_PROFILE,
+    matrix: Mapping[str, Any] | None = None,
+) -> float:
+    """Apply the configured membership-inference defense to one score."""
+
+    if isinstance(policy, MembershipDefensePolicy):
+        defense = policy
+    elif policy is not None:
+        defense = MembershipDefensePolicy.from_mapping(policy)
+    else:
+        defense = membership_defense_for_profile(policy_profile, matrix=matrix)
+    return defense.apply_score(score)
 
 
 def label_keep_floors(
@@ -324,16 +454,61 @@ def _validate_entry(entry: Any, path: str) -> None:
         raise ValueError(f"{path}.action must be one of {ACTION_VALUES!r}")
 
 
+def _validate_membership_defense(entry: Any, path: str) -> None:
+    if entry is None:
+        return
+    if not isinstance(entry, Mapping):
+        raise ValueError(f"{path} must be an object")
+    MembershipDefensePolicy.from_mapping(entry)
+
+
+def _bounded_probability(value: Any, field_name: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be between 0.0 and 1.0") from exc
+    if not math.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError(f"{field_name} must be between 0.0 and 1.0")
+    return result
+
+
+def _positive_float(value: Any, field_name: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be positive") from exc
+    if not math.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{field_name} must be positive")
+    return result
+
+
+def _logit(score: float) -> float:
+    clipped = min(1.0 - 1e-12, max(1e-12, score))
+    return math.log(clipped / (1.0 - clipped))
+
+
+def _sigmoid(value: float) -> float:
+    if value >= 0.0:
+        z = math.exp(-value)
+        return 1.0 / (1.0 + z)
+    z = math.exp(value)
+    return z / (1.0 + z)
+
+
 __all__ = [
     "CURRENT_SCHEMA_VERSION",
     "DEFAULT_POLICY_PROFILE",
+    "DEFAULT_MEMBERSHIP_ADVANTAGE_CEILING",
+    "MembershipDefensePolicy",
     "RecallGuardResult",
     "STRICT_NO_LEAK_PROFILE",
     "Threshold",
+    "apply_membership_defense_to_score",
     "fit_thresholds",
     "label_keep_floors",
     "load_thresholds",
     "lookup_threshold",
+    "membership_defense_for_profile",
     "profile_recall_floor",
     "recall_floor_guard",
     "update_thresholds",

--- a/openmed/eval/attacks/__init__.py
+++ b/openmed/eval/attacks/__init__.py
@@ -4,21 +4,25 @@ from .linkage import LinkageAttackResult, linkage_attack
 from .reid import (
     MembershipInferenceResult,
     ReidAttackResult,
+    ShadowMembershipInferenceResult,
     generate_reid_leaderboard,
     membership_inference_attack,
     render_reid_leaderboard,
     run_reid_attack,
     run_reid_benchmark,
+    shadow_membership_inference_attack,
 )
 
 __all__ = [
     "LinkageAttackResult",
     "ReidAttackResult",
     "MembershipInferenceResult",
+    "ShadowMembershipInferenceResult",
     "generate_reid_leaderboard",
     "linkage_attack",
     "membership_inference_attack",
     "render_reid_leaderboard",
     "run_reid_attack",
     "run_reid_benchmark",
+    "shadow_membership_inference_attack",
 ]

--- a/openmed/eval/attacks/reid.py
+++ b/openmed/eval/attacks/reid.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
@@ -11,6 +12,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from openmed.core.audit import stable_hash
+from openmed.core.labels import normalize_label
+from openmed.core.thresholds import MembershipDefensePolicy
 from openmed.eval.golden import GoldenFixture, load_golden_fixtures
 from openmed.eval.report import BenchmarkReport
 from openmed.risk import risk_report
@@ -64,6 +68,10 @@ def run_reid_benchmark(
     quasi_id_table: Sequence[Mapping[str, Any]] | None = None,
     quasi_identifiers: Sequence[str] | None = None,
     candidate_members: Sequence[Mapping[str, Any]] | None = None,
+    shadow_member_records: Sequence[Mapping[str, Any]] | None = None,
+    shadow_heldout_records: Sequence[Mapping[str, Any]] | None = None,
+    membership_defense: Mapping[str, Any] | MembershipDefensePolicy | None = None,
+    membership_advantage_ceiling: float | None = None,
     output_json: str | Path | None = None,
     output_markdown: str | Path | None = None,
     generated_at: str | None = None,
@@ -140,6 +148,18 @@ def run_reid_benchmark(
         metrics["membership_inference"] = membership_inference_attack(
             deidentified, candidate_members
         ).to_metric()
+    if shadow_member_records is not None or shadow_heldout_records is not None:
+        if shadow_member_records is None or shadow_heldout_records is None:
+            raise ValueError(
+                "shadow_member_records and shadow_heldout_records must be provided "
+                "together"
+            )
+        metrics["membership_leakage"] = shadow_membership_inference_attack(
+            shadow_member_records,
+            shadow_heldout_records,
+            defense_policy=membership_defense,
+            advantage_ceiling=membership_advantage_ceiling,
+        ).to_metric()
     report = BenchmarkReport(
         suite=suite,
         model_name=model_name,
@@ -213,6 +233,43 @@ _TOKEN_RE = re.compile(r"[a-z0-9]{4,}")
 
 
 @dataclass(frozen=True)
+class ShadowMembershipInferenceResult:
+    """Trained shadow-model membership-inference score over detector outputs."""
+
+    attacker_auc: float
+    attacker_advantage: float
+    accuracy: float
+    decision_threshold: float
+    train_record_count: int
+    eval_record_count: int
+    member_count: int
+    heldout_count: int
+    advantage_ceiling: float
+    defense: Mapping[str, Any] = field(default_factory=dict)
+    per_label: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
+    feature_hash: str = ""
+
+    def to_metric(self) -> dict[str, Any]:
+        return {
+            "attacker_auc": float(self.attacker_auc),
+            "attacker_advantage": float(self.attacker_advantage),
+            "advantage": float(self.attacker_advantage),
+            "accuracy": float(self.accuracy),
+            "decision_threshold": float(self.decision_threshold),
+            "advantage_ceiling": float(self.advantage_ceiling),
+            "train_record_count": int(self.train_record_count),
+            "eval_record_count": int(self.eval_record_count),
+            "member_count": int(self.member_count),
+            "heldout_count": int(self.heldout_count),
+            "feature_hash": self.feature_hash,
+            "defense": dict(self.defense),
+            "per_label": {
+                label: dict(values) for label, values in sorted(self.per_label.items())
+            },
+        }
+
+
+@dataclass(frozen=True)
 class MembershipInferenceResult:
     """Membership-inference probe score over de-identified records.
 
@@ -229,13 +286,20 @@ class MembershipInferenceResult:
     baseline: float = 0.5
 
     def to_metric(self) -> dict[str, Any]:
+        matched_count = sum(
+            1 for row in self.per_record if row.get("matched_candidate") is not None
+        )
         return {
             "advantage": float(self.advantage),
             "accuracy": float(self.accuracy),
             "baseline": float(self.baseline),
             "record_count": int(self.record_count),
             "confident_count": int(self.confident_count),
-            "per_record": [dict(row) for row in self.per_record],
+            "matched_count": int(matched_count),
+            "record_hashes": [
+                stable_hash({"record_id": row.get("record_id")})
+                for row in self.per_record
+            ],
         }
 
 
@@ -309,6 +373,475 @@ def membership_inference_attack(
         confident_count=confident_count,
         per_record=tuple(per_record),
     )
+
+
+@dataclass(frozen=True)
+class _ShadowExample:
+    record_hash: str
+    member: bool
+    features: tuple[float, ...]
+    label_scores: Mapping[str, tuple[float, ...]]
+
+
+def shadow_membership_inference_attack(
+    member_records: Sequence[Mapping[str, Any]],
+    heldout_records: Sequence[Mapping[str, Any]],
+    *,
+    defense_policy: Mapping[str, Any] | MembershipDefensePolicy | None = None,
+    advantage_ceiling: float | None = None,
+    train_fraction: float = 0.5,
+) -> ShadowMembershipInferenceResult:
+    """Train and evaluate a shadow attacker over synthetic score records.
+
+    Records may expose detector scores as top-level ``score``/``confidence``/
+    ``logit`` values, a ``scores`` mapping, or span-like ``entities``/
+    ``spans``/``detections`` rows. Raw note text is ignored; the report
+    contains only aggregate metrics and stable hashes over score metadata.
+    """
+
+    if not member_records or not heldout_records:
+        raise ValueError("shadow membership attack requires member and held-out rows")
+    train_fraction = _bounded_fraction(train_fraction, "train_fraction")
+    defense = MembershipDefensePolicy.from_mapping(defense_policy)
+    ceiling = (
+        defense.advantage_ceiling
+        if advantage_ceiling is None
+        else _bounded_fraction(advantage_ceiling, "advantage_ceiling")
+    )
+
+    members = [
+        _shadow_example(record, member=True, defense=defense)
+        for record in member_records
+    ]
+    heldout = [
+        _shadow_example(record, member=False, defense=defense)
+        for record in heldout_records
+    ]
+    train, evaluation = _train_eval_split(
+        members,
+        heldout,
+        train_fraction=train_fraction,
+    )
+    attack = _evaluate_shadow_examples(train, evaluation)
+
+    per_label: dict[str, Mapping[str, Any]] = {}
+    labels = sorted(
+        {label for example in (*members, *heldout) for label in example.label_scores}
+    )
+    for label in labels:
+        label_train = [_label_example(example, label) for example in train]
+        label_eval = [_label_example(example, label) for example in evaluation]
+        label_attack = _evaluate_shadow_examples(label_train, label_eval)
+        per_label[label] = {
+            "attacker_auc": label_attack["auc"],
+            "attacker_advantage": label_attack["advantage"],
+            "member_count": sum(1 for example in label_eval if example.member),
+            "heldout_count": sum(1 for example in label_eval if not example.member),
+            "feature_hash": stable_hash(
+                {
+                    "label": label,
+                    "records": [example.record_hash for example in label_eval],
+                }
+            ),
+        }
+
+    return ShadowMembershipInferenceResult(
+        attacker_auc=attack["auc"],
+        attacker_advantage=attack["advantage"],
+        accuracy=attack["accuracy"],
+        decision_threshold=attack["threshold"],
+        train_record_count=len(train),
+        eval_record_count=len(evaluation),
+        member_count=len(members),
+        heldout_count=len(heldout),
+        advantage_ceiling=ceiling,
+        defense=defense.to_dict(),
+        per_label=per_label,
+        feature_hash=stable_hash(
+            {
+                "members": [example.record_hash for example in members],
+                "heldout": [example.record_hash for example in heldout],
+                "defense": defense.to_dict(),
+            }
+        ),
+    )
+
+
+def _shadow_example(
+    record: Mapping[str, Any],
+    *,
+    member: bool,
+    defense: MembershipDefensePolicy,
+) -> _ShadowExample:
+    events = _score_events(record, defense)
+    label_scores: defaultdict[str, list[float]] = defaultdict(list)
+    for label, score in events:
+        label_scores[label].append(score)
+    scores = [score for _, score in events]
+    return _ShadowExample(
+        record_hash=_record_hash(record),
+        member=member,
+        features=_aggregate_score_features(scores),
+        label_scores={
+            label: tuple(values) for label, values in sorted(label_scores.items())
+        },
+    )
+
+
+def _label_example(example: _ShadowExample, label: str) -> _ShadowExample:
+    return _ShadowExample(
+        record_hash=example.record_hash,
+        member=example.member,
+        features=_aggregate_score_features(example.label_scores.get(label, ())),
+        label_scores={label: example.label_scores.get(label, ())},
+    )
+
+
+def _score_events(
+    record: Mapping[str, Any],
+    defense: MembershipDefensePolicy,
+) -> list[tuple[str, float]]:
+    events: list[tuple[str, float]] = []
+    direct_score = _score_from_mapping(record)
+    if direct_score is not None:
+        events.append(
+            (
+                _label_from_mapping(record),
+                defense.apply_score(direct_score),
+            )
+        )
+
+    scores = record.get("scores")
+    if isinstance(scores, Mapping):
+        for label, value in scores.items():
+            _append_score_value(events, str(label), value, defense)
+    elif isinstance(scores, Sequence) and not isinstance(
+        scores,
+        (str, bytes, bytearray),
+    ):
+        for item in scores:
+            _append_score_value(events, "OVERALL", item, defense)
+
+    for key in ("spans", "entities", "detections", "predictions", "outputs"):
+        rows = record.get(key)
+        if not isinstance(rows, Sequence) or isinstance(
+            rows,
+            (str, bytes, bytearray),
+        ):
+            continue
+        for item in rows:
+            _append_score_value(events, "OVERALL", item, defense)
+
+    return events or [("OVERALL", defense.apply_score(0.0))]
+
+
+def _append_score_value(
+    events: list[tuple[str, float]],
+    fallback_label: str,
+    value: Any,
+    defense: MembershipDefensePolicy,
+) -> None:
+    if isinstance(value, Mapping):
+        score = _score_from_mapping(value)
+        if score is None:
+            nested_scores = value.get("scores")
+            if isinstance(nested_scores, Mapping):
+                for label, nested in nested_scores.items():
+                    _append_score_value(events, str(label), nested, defense)
+            return
+        events.append(
+            (
+                _label_from_mapping(value, fallback_label),
+                defense.apply_score(score),
+            )
+        )
+        return
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        for item in value:
+            _append_score_value(events, fallback_label, item, defense)
+        return
+    score = _coerce_score(value)
+    if score is not None:
+        events.append(
+            (
+                _normalise_attack_label(fallback_label),
+                defense.apply_score(score),
+            )
+        )
+
+
+def _score_from_mapping(value: Mapping[str, Any]) -> float | None:
+    if value.get("logit") is not None:
+        try:
+            return _sigmoid(float(value["logit"]))
+        except (TypeError, ValueError):
+            return None
+    for key in ("score", "confidence", "probability", "prob"):
+        score = _coerce_score(value.get(key))
+        if score is not None:
+            return score
+    return None
+
+
+def _label_from_mapping(
+    value: Mapping[str, Any],
+    fallback: str = "OVERALL",
+) -> str:
+    raw = (
+        value.get("canonical_label")
+        or value.get("label")
+        or value.get("entity_type")
+        or value.get("entity")
+        or fallback
+    )
+    language = str(value.get("language") or value.get("lang") or "en")
+    return _normalise_attack_label(str(raw), language=language)
+
+
+def _normalise_attack_label(label: str, *, language: str = "en") -> str:
+    if label.strip().upper() == "OVERALL":
+        return "OVERALL"
+    return normalize_label(label, language)
+
+
+def _coerce_score(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(score):
+        return None
+    return min(1.0, max(0.0, score))
+
+
+def _aggregate_score_features(scores: Sequence[float]) -> tuple[float, ...]:
+    if not scores:
+        return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    values = [min(1.0, max(0.0, float(score))) for score in scores]
+    count = len(values)
+    mean = sum(values) / count
+    variance = sum((score - mean) ** 2 for score in values) / count
+    margins = [abs(score - 0.5) * 2.0 for score in values]
+    return (
+        max(values),
+        mean,
+        min(values),
+        min(1.0, count / 10.0),
+        min(1.0, variance * 4.0),
+        sum(margins) / count,
+    )
+
+
+def _train_eval_split(
+    members: Sequence[_ShadowExample],
+    heldout: Sequence[_ShadowExample],
+    *,
+    train_fraction: float,
+) -> tuple[list[_ShadowExample], list[_ShadowExample]]:
+    train: list[_ShadowExample] = []
+    evaluation: list[_ShadowExample] = []
+    for examples in (members, heldout):
+        ordered = sorted(examples, key=lambda example: example.record_hash)
+        train_count = max(1, int(round(len(ordered) * train_fraction)))
+        if len(ordered) > 1:
+            train_count = min(train_count, len(ordered) - 1)
+        train.extend(ordered[:train_count])
+        evaluation.extend(ordered[train_count:] or ordered[:train_count])
+    return train, evaluation
+
+
+def _evaluate_shadow_examples(
+    train: Sequence[_ShadowExample],
+    evaluation: Sequence[_ShadowExample],
+) -> dict[str, float]:
+    weights = _train_logistic(train)
+    train_scores = [_predict_membership(weights, example.features) for example in train]
+    train_labels = [1 if example.member else 0 for example in train]
+    eval_scores = [
+        _predict_membership(weights, example.features) for example in evaluation
+    ]
+    eval_labels = [1 if example.member else 0 for example in evaluation]
+    threshold = _best_score_threshold(train_scores, train_labels)
+    accuracy = _threshold_accuracy(eval_scores, eval_labels, threshold)
+    return {
+        "auc": _auc(eval_scores, eval_labels),
+        "advantage": _max_tpr_minus_fpr(eval_scores, eval_labels),
+        "accuracy": accuracy,
+        "threshold": threshold,
+    }
+
+
+def _train_logistic(
+    examples: Sequence[_ShadowExample],
+    *,
+    epochs: int = 300,
+    learning_rate: float = 0.2,
+    l2: float = 0.001,
+) -> tuple[float, ...]:
+    width = max((len(example.features) for example in examples), default=0)
+    weights = [0.0] * (width + 1)
+    ordered = sorted(examples, key=lambda example: example.record_hash)
+    for _ in range(epochs):
+        for example in ordered:
+            label = 1.0 if example.member else 0.0
+            score = _predict_membership(tuple(weights), example.features)
+            error = score - label
+            weights[0] -= learning_rate * error
+            for index, value in enumerate(example.features, start=1):
+                weights[index] -= learning_rate * (error * value + l2 * weights[index])
+    return tuple(weights)
+
+
+def _predict_membership(weights: Sequence[float], features: Sequence[float]) -> float:
+    if not weights:
+        return 0.5
+    logit = float(weights[0])
+    for index, value in enumerate(features, start=1):
+        if index >= len(weights):
+            break
+        logit += float(weights[index]) * float(value)
+    return _sigmoid(logit)
+
+
+def _best_score_threshold(scores: Sequence[float], labels: Sequence[int]) -> float:
+    if not scores:
+        return 0.5
+    candidates = sorted(set(float(score) for score in scores))
+    return max(
+        candidates,
+        key=lambda threshold: (
+            _threshold_accuracy(scores, labels, threshold),
+            _tpr_minus_fpr(scores, labels, threshold),
+            -threshold,
+        ),
+    )
+
+
+def _threshold_accuracy(
+    scores: Sequence[float],
+    labels: Sequence[int],
+    threshold: float,
+) -> float:
+    if not scores:
+        return 0.5
+    correct = 0
+    for score, label in zip(scores, labels):
+        prediction = 1 if score >= threshold else 0
+        correct += int(prediction == label)
+    return correct / len(scores)
+
+
+def _max_tpr_minus_fpr(scores: Sequence[float], labels: Sequence[int]) -> float:
+    if not scores:
+        return 0.0
+    return max(
+        0.0,
+        *(_tpr_minus_fpr(scores, labels, threshold) for threshold in set(scores)),
+    )
+
+
+def _tpr_minus_fpr(
+    scores: Sequence[float],
+    labels: Sequence[int],
+    threshold: float,
+) -> float:
+    positives = sum(1 for label in labels if label == 1)
+    negatives = sum(1 for label in labels if label == 0)
+    if positives == 0 or negatives == 0:
+        return 0.0
+    true_positive = sum(
+        1 for score, label in zip(scores, labels) if label == 1 and score >= threshold
+    )
+    false_positive = sum(
+        1 for score, label in zip(scores, labels) if label == 0 and score >= threshold
+    )
+    return (true_positive / positives) - (false_positive / negatives)
+
+
+def _auc(scores: Sequence[float], labels: Sequence[int]) -> float:
+    positives = [score for score, label in zip(scores, labels) if label == 1]
+    negatives = [score for score, label in zip(scores, labels) if label == 0]
+    if not positives or not negatives:
+        return 0.5
+    wins = 0.0
+    for positive in positives:
+        for negative in negatives:
+            if positive > negative:
+                wins += 1.0
+            elif positive == negative:
+                wins += 0.5
+    return wins / (len(positives) * len(negatives))
+
+
+def _bounded_fraction(value: Any, field_name: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be between 0.0 and 1.0") from exc
+    if not math.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError(f"{field_name} must be between 0.0 and 1.0")
+    return result
+
+
+def _sigmoid(value: float) -> float:
+    if value >= 0.0:
+        z = math.exp(-value)
+        return 1.0 / (1.0 + z)
+    z = math.exp(value)
+    return z / (1.0 + z)
+
+
+def _record_hash(record: Mapping[str, Any]) -> str:
+    return stable_hash(_record_hash_material(record))
+
+
+def _record_hash_material(record: Mapping[str, Any]) -> dict[str, Any]:
+    material: dict[str, Any] = {}
+    for key, value in sorted(record.items()):
+        if str(key) in {"text", "note", "source_text", "raw_text"}:
+            material[str(key)] = {"sha256": stable_hash({"value": str(value)})}
+        elif str(key) in _ID_FIELDS:
+            material[str(key)] = str(value)
+        elif str(key) in {
+            "score",
+            "confidence",
+            "probability",
+            "prob",
+            "logit",
+            "scores",
+            "spans",
+            "entities",
+            "detections",
+            "predictions",
+            "outputs",
+            "label",
+            "canonical_label",
+            "entity_type",
+            "language",
+            "lang",
+        }:
+            material[str(key)] = _hash_safe_value(value)
+    return material
+
+
+def _hash_safe_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _hash_safe_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            if str(key) not in {"text", "note", "source_text", "raw_text"}
+        }
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        return [_hash_safe_value(item) for item in value]
+    return value
 
 
 def _best_candidate(hits: Counter[str]) -> str | None:
@@ -575,9 +1108,11 @@ def _utc_now() -> str:
 __all__ = [
     "ReidAttackResult",
     "MembershipInferenceResult",
+    "ShadowMembershipInferenceResult",
     "generate_reid_leaderboard",
     "membership_inference_attack",
     "render_reid_leaderboard",
     "run_reid_attack",
     "run_reid_benchmark",
+    "shadow_membership_inference_attack",
 ]

--- a/openmed/eval/calibrate.py
+++ b/openmed/eval/calibrate.py
@@ -6,12 +6,13 @@ import json
 import math
 import re
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from openmed.core.labels import normalize_label
+from openmed.core.thresholds import MembershipDefensePolicy
 
 SCHEMA_VERSION = 1
 THRESHOLDS_ARTIFACT = "openmed.calibration.thresholds"
@@ -150,6 +151,7 @@ class CalibrationReport:
     target_leakage: float
     min_recall: float
     generated_at: str
+    membership_defense: Mapping[str, Any] = field(default_factory=dict)
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -161,6 +163,7 @@ class CalibrationReport:
             "target_leakage": self.target_leakage,
             "min_recall": self.min_recall,
             "generated_at": self.generated_at,
+            "membership_defense": dict(self.membership_defense),
             "objective": "target_leakage_first_over_redaction_second_recall_protected",
             "groups": [group.to_dict() for group in self.groups],
             "metadata": dict(self.metadata),
@@ -184,7 +187,12 @@ class CalibrationThresholdSet:
     thresholds: Mapping[tuple[str, str, str], float]
     model_id: str | None = None
     suite: str | None = None
+    membership_defense: Mapping[str, Any] = field(default_factory=dict)
     source_path: str | None = None
+
+    @property
+    def membership_defense_policy(self) -> MembershipDefensePolicy:
+        return MembershipDefensePolicy.from_mapping(self.membership_defense)
 
     def lookup(
         self,
@@ -248,6 +256,7 @@ def fit_calibration_thresholds(
     suite: str,
     target_leakage: float = 0.0,
     min_recall: float | None = None,
+    membership_defense: Mapping[str, Any] | MembershipDefensePolicy | None = None,
     generated_at: str | None = None,
     metadata: Mapping[str, Any] | None = None,
 ) -> CalibrationReport:
@@ -270,6 +279,14 @@ def fit_calibration_thresholds(
     ]
     if not normalized:
         raise ValueError("calibration requires at least one sample")
+    defense_policy = MembershipDefensePolicy.from_mapping(
+        membership_defense,
+        recall_floor=recall_floor,
+    )
+    normalized = _apply_membership_defense_to_samples(
+        normalized,
+        defense_policy,
+    )
 
     grouped: dict[tuple[str, str, str], list[CalibrationSample]] = defaultdict(list)
     for sample in normalized:
@@ -290,6 +307,7 @@ def fit_calibration_thresholds(
         target_leakage=target_leakage,
         min_recall=recall_floor,
         generated_at=generated_at or _utc_now(),
+        membership_defense=defense_policy.to_dict(),
         metadata=dict(metadata or {}),
     )
 
@@ -325,6 +343,7 @@ def build_thresholds_payload(report: CalibrationReport) -> dict[str, Any]:
         "generated_at": report.generated_at,
         "target_leakage": report.target_leakage,
         "min_recall": report.min_recall,
+        "membership_defense": dict(report.membership_defense),
         "thresholds": thresholds,
         "groups": groups,
     }
@@ -338,6 +357,7 @@ def write_calibration_artifacts(
     suite: str,
     target_leakage: float = 0.0,
     min_recall: float | None = None,
+    membership_defense: Mapping[str, Any] | MembershipDefensePolicy | None = None,
     generated_at: str | None = None,
     metadata: Mapping[str, Any] | None = None,
 ) -> CalibrationArtifactPaths:
@@ -349,6 +369,7 @@ def write_calibration_artifacts(
         suite=suite,
         target_leakage=target_leakage,
         min_recall=min_recall,
+        membership_defense=membership_defense,
         generated_at=generated_at,
         metadata=metadata,
     )
@@ -483,6 +504,7 @@ def coerce_calibration_thresholds(
             str(payload["model_id"]) if payload.get("model_id") is not None else None
         ),
         suite=str(payload["suite"]) if payload.get("suite") is not None else None,
+        membership_defense=dict(payload.get("membership_defense") or {}),
         source_path=source_path,
     )
 
@@ -491,6 +513,17 @@ def artifact_dir_for(model_id: str, suite: str) -> Path:
     """Return the default calibration artifact directory."""
 
     return Path("artifacts") / "calibration" / _slug(model_id) / _slug(suite)
+
+
+def _apply_membership_defense_to_samples(
+    samples: Sequence[CalibrationSample],
+    policy: MembershipDefensePolicy,
+) -> list[CalibrationSample]:
+    if not policy.enabled:
+        return list(samples)
+    return [
+        replace(sample, score=policy.apply_score(sample.score)) for sample in samples
+    ]
 
 
 def _fit_group(

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -27,6 +27,7 @@ from openmed.core.audit import AuditSignature, stable_hash
 from openmed.core.labels import normalize_label
 from openmed.core.pii_i18n import SUPPORTED_LANGUAGES
 from openmed.core.thresholds import (
+    DEFAULT_MEMBERSHIP_ADVANTAGE_CEILING,
     load_thresholds,
     profile_recall_floor,
     validate_threshold_matrix,
@@ -557,6 +558,7 @@ class ReleaseGate:
                 target_leakage=target_leakage,
             )
         )
+        checks.append(_membership_leakage_check(metrics, metadata))
         checks.append(_g8_check(metadata))
 
         blocked_formats = tuple(
@@ -1349,6 +1351,96 @@ def _g7_check(
                 baseline_entry.get("key") if baseline_entry is not None else None
             ),
             "target_leakage": target_leakage,
+            "violations": violations,
+        },
+    )
+
+
+def _membership_leakage_check(
+    metrics: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+) -> GateCheck:
+    metric = _first_mapping(
+        metrics.get("membership_leakage"),
+        metrics.get("membership_inference"),
+        metadata.get("membership_leakage"),
+        metadata.get("membership_inference"),
+    )
+    required = bool(
+        metadata.get("membership_leakage_required")
+        or metadata.get("membership_inference_required")
+    )
+    if not metric:
+        return GateCheck(
+            "membership_leakage",
+            not required,
+            reason=(
+                "membership leakage evidence not provided"
+                if not required
+                else "membership leakage evidence is required"
+            ),
+            details={"required": required},
+        )
+
+    advantage = _optional_float(
+        _first_value(metric.get("attacker_advantage"), metric.get("advantage"))
+    )
+    attacker_auc = _optional_float(metric.get("attacker_auc"))
+    ceiling = _optional_float(
+        _first_value(
+            metric.get("advantage_ceiling"),
+            metadata.get("membership_advantage_ceiling"),
+            metadata.get("membership_inference_advantage_ceiling"),
+        )
+    )
+    if ceiling is None:
+        ceiling = DEFAULT_MEMBERSHIP_ADVANTAGE_CEILING
+    if advantage is None:
+        return GateCheck(
+            "membership_leakage",
+            False,
+            reason="membership attacker advantage is required",
+            details={"advantage_ceiling": ceiling},
+        )
+
+    per_label = _mapping(metric.get("per_label"))
+    label_violations: dict[str, Any] = {}
+    for label, values in per_label.items():
+        if not isinstance(values, Mapping):
+            continue
+        label_advantage = _optional_float(
+            _first_value(
+                values.get("attacker_advantage"),
+                values.get("advantage"),
+            )
+        )
+        if label_advantage is not None and label_advantage > ceiling:
+            label_violations[str(label)] = {
+                "observed": label_advantage,
+                "limit": ceiling,
+            }
+
+    violations: dict[str, Any] = {}
+    if advantage > ceiling:
+        violations["overall_advantage"] = {
+            "observed": advantage,
+            "limit": ceiling,
+        }
+    if label_violations:
+        violations["per_label_advantage"] = label_violations
+
+    return GateCheck(
+        "membership_leakage",
+        not violations,
+        reason=(
+            "ok" if not violations else "membership-inference advantage exceeds ceiling"
+        ),
+        details={
+            "attacker_advantage": advantage,
+            "attacker_auc": attacker_auc,
+            "advantage_ceiling": ceiling,
+            "feature_hash": metric.get("feature_hash"),
+            "defense": _mapping(metric.get("defense")),
             "violations": violations,
         },
     )

--- a/tests/unit/core/test_thresholds_matrix.py
+++ b/tests/unit/core/test_thresholds_matrix.py
@@ -8,9 +8,11 @@ from openmed.core.cascade import R2_BASE, CascadeRouter
 from openmed.core.pipeline import Pipeline
 from openmed.core.schemas.span import ACTION_VALUES, OpenMedSpan, hmac_text_hash
 from openmed.core.thresholds import (
+    DEFAULT_MEMBERSHIP_ADVANTAGE_CEILING,
     fit_thresholds,
     load_thresholds,
     lookup_threshold,
+    membership_defense_for_profile,
     recall_floor_guard,
     update_thresholds,
     validate_threshold_matrix,
@@ -115,6 +117,36 @@ def test_fit_and_update_thresholds_return_valid_versioned_matrix():
     assert (
         lookup_threshold("EMAIL", "en", "balanced", matrix=updated)["keep_floor"] == 0.4
     )
+
+
+def test_membership_defense_resolves_from_policy_profile():
+    matrix = load_thresholds()
+    matrix["profiles"]["balanced"]["membership_defense"] = {
+        "enabled": True,
+        "clip_min": 0.4,
+        "clip_max": 0.6,
+        "temperature": 2.0,
+        "smoothing": 0.5,
+    }
+
+    policy = membership_defense_for_profile("balanced", matrix=matrix)
+
+    assert policy.enabled is True
+    assert policy.recall_floor == matrix["profiles"]["balanced"]["recall_floor"]
+    assert policy.advantage_ceiling == DEFAULT_MEMBERSHIP_ADVANTAGE_CEILING
+    assert 0.5 <= policy.apply_score(0.99) <= 0.6
+
+
+def test_threshold_matrix_rejects_malformed_membership_defense():
+    matrix = load_thresholds()
+    matrix["profiles"]["balanced"]["membership_defense"] = {
+        "enabled": True,
+        "clip_min": 0.8,
+        "clip_max": 0.2,
+    }
+
+    with pytest.raises(ValueError, match="clip_min"):
+        validate_threshold_matrix(matrix)
 
 
 def test_load_thresholds_rejects_malformed_json(tmp_path):

--- a/tests/unit/eval/attacks/test_membership_inference.py
+++ b/tests/unit/eval/attacks/test_membership_inference.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from openmed.eval.attacks import membership_inference_attack, run_reid_benchmark
+import json
+
+from openmed.eval.attacks import (
+    membership_inference_attack,
+    run_reid_attack,
+    run_reid_benchmark,
+    shadow_membership_inference_attack,
+)
 
 
 class TestMembershipInference:
@@ -63,6 +70,96 @@ class TestMembershipInference:
         assert result.advantage == result.accuracy - 0.5
         assert result.baseline == 0.5
 
+    def test_metric_serialization_is_aggregate_only(self):
+        candidates = [
+            {"record_id": "r1", "text": "Alice Zsoltay visited clinic"},
+            {"record_id": "r2", "text": "Bob Smith visited clinic"},
+        ]
+        deidentified = [
+            {"record_id": "r1", "text": "[NAME] Zsoltay visited clinic"},
+            {"record_id": "r2", "text": "[NAME] [NAME] visited clinic"},
+        ]
+        metric = membership_inference_attack(deidentified, candidates).to_metric()
+
+        raw = json.dumps(metric, sort_keys=True)
+        assert "per_record" not in metric
+        assert "Zsoltay" not in raw
+        assert "Alice" not in raw
+        assert all(item.startswith("sha256:") for item in metric["record_hashes"])
+
+
+class TestShadowMembershipInference:
+    def test_trained_attacker_beats_random_on_leaky_scores(self):
+        members, heldout = _shadow_records()
+
+        result = shadow_membership_inference_attack(members, heldout)
+
+        assert result.attacker_auc > 0.9
+        assert result.attacker_advantage > 0.5
+        assert result.per_label["PERSON"]["attacker_advantage"] > 0.5
+
+    def test_defense_reduces_advantage_below_ceiling(self):
+        members, heldout = _shadow_records()
+
+        result = shadow_membership_inference_attack(
+            members,
+            heldout,
+            defense_policy={
+                "enabled": True,
+                "clip_min": 0.5,
+                "clip_max": 0.5,
+                "advantage_ceiling": 0.05,
+            },
+        )
+
+        assert result.attacker_auc == 0.5
+        assert result.attacker_advantage <= result.advantage_ceiling
+
+    def test_shadow_metric_contains_no_raw_phi(self):
+        members, heldout = _shadow_records()
+
+        metric = shadow_membership_inference_attack(
+            members,
+            heldout,
+        ).to_metric()
+
+        raw = json.dumps(metric, sort_keys=True)
+        assert "Alice" not in raw
+        assert "555-0101" not in raw
+        assert "text" not in raw
+        assert metric["feature_hash"].startswith("sha256:")
+
+    def test_defended_deidentified_outputs_have_zero_residual_leakage(self):
+        fixture = {
+            "id": "synthetic-1",
+            "language": "en",
+            "text": "Patient Alice Example called 555-0101.",
+            "gold_spans": [
+                {"start": 8, "end": 21, "label": "PERSON"},
+                {"start": 29, "end": 37, "label": "PHONE"},
+            ],
+            "metadata": {
+                "synthetic": True,
+                "category": "checksum_ids",
+                "expected_output": {
+                    "method": "mask",
+                    "text": "Patient [NAME] called [PHONE].",
+                },
+            },
+        }
+        result = run_reid_attack(
+            [fixture],
+            deidentified_records=[
+                {
+                    "record_id": "synthetic-1",
+                    "text": "Patient [NAME] called [PHONE].",
+                    "metadata": {"membership_defense": {"enabled": True}},
+                }
+            ],
+        )
+
+        assert result.to_metric()["leakage_rate"] == 0.0
+
 
 class TestBenchmarkWiring:
     def test_membership_inference_metric_appears_in_report(self):
@@ -80,9 +177,47 @@ class TestBenchmarkWiring:
         )
         assert "membership_inference" in report.metrics
         assert "advantage" in report.metrics["membership_inference"]
+        assert "per_record" not in report.metrics["membership_inference"]
+
+    def test_shadow_membership_metric_appears_in_report(self):
+        members, heldout = _shadow_records()
+        report = run_reid_benchmark(
+            shadow_member_records=members,
+            shadow_heldout_records=heldout,
+        )
+
+        assert "membership_leakage" in report.metrics
+        assert "attacker_auc" in report.metrics["membership_leakage"]
+        assert "per_label" in report.metrics["membership_leakage"]
 
     def test_membership_inference_absent_without_candidates(self):
         report = run_reid_benchmark(
             deidentified_records=[{"record_id": "r1", "text": "[NAME] visited"}],
         )
         assert "membership_inference" not in report.metrics
+
+
+def _shadow_records():
+    members = [
+        {
+            "record_id": f"m{i}",
+            "text": f"Patient Alice Example {i} called 555-0101.",
+            "entities": [
+                {"label": "PERSON", "score": 0.97 - (i * 0.005)},
+                {"label": "PHONE", "score": 0.96 - (i * 0.005)},
+            ],
+        }
+        for i in range(6)
+    ]
+    heldout = [
+        {
+            "record_id": f"h{i}",
+            "text": f"Patient Casey Example {i} called 555-0199.",
+            "entities": [
+                {"label": "PERSON", "score": 0.56 + (i * 0.005)},
+                {"label": "PHONE", "score": 0.55 + (i * 0.005)},
+            ],
+        }
+        for i in range(6)
+    ]
+    return members, heldout

--- a/tests/unit/eval/test_calibrate.py
+++ b/tests/unit/eval/test_calibrate.py
@@ -143,6 +143,46 @@ def test_threshold_artifact_round_trip_and_report_fields(tmp_path: Path) -> None
     }.issubset(group)
 
 
+def test_membership_defense_round_trips_in_calibration_artifact(
+    tmp_path: Path,
+) -> None:
+    paths = write_calibration_artifacts(
+        [
+            {
+                "model_id": "unit-model",
+                "label": "NAME",
+                "language": "en",
+                "score": 0.95,
+                "target": True,
+            }
+        ],
+        artifact_dir=tmp_path,
+        model_id="unit-model",
+        suite="golden",
+        target_leakage=0.0,
+        min_recall=1.0,
+        membership_defense={
+            "enabled": True,
+            "clip_min": 0.5,
+            "clip_max": 0.5,
+            "advantage_ceiling": 0.05,
+        },
+    )
+
+    thresholds = load_calibration_thresholds(paths.thresholds_path)
+    policy = thresholds.membership_defense_policy
+    payload = json.loads(paths.thresholds_path.read_text(encoding="utf-8"))
+    report_payload = json.loads(paths.report_path.read_text(encoding="utf-8"))
+
+    assert policy.enabled is True
+    assert policy.apply_score(0.99) == pytest.approx(0.5)
+    assert thresholds.lookup("PERSON", "en", model_id="unit-model") == pytest.approx(
+        0.5
+    )
+    assert payload["membership_defense"]["enabled"] is True
+    assert report_payload["groups"][0]["recall"] >= report_payload["min_recall"]
+
+
 def test_calibrate_cli_writes_default_golden_artifacts(tmp_path: Path) -> None:
     result = main_module.main(
         [
@@ -226,3 +266,76 @@ def test_inference_loads_thresholds_and_records_active_audit_threshold(
     assert report.thresholds["PERSON"] == pytest.approx(0.91)
     assert [span.label for span in report.spans] == ["NAME"]
     assert report.spans[0].threshold == pytest.approx(0.91)
+
+
+def test_membership_defense_applies_at_calibrated_inference_without_recall_drop(
+    tmp_path: Path,
+) -> None:
+    threshold_payload = build_thresholds_payload(
+        fit_calibration_thresholds(
+            [
+                {
+                    "model_id": "unit-model",
+                    "label": "NAME",
+                    "language": "en",
+                    "score": 0.95,
+                    "target": True,
+                }
+            ],
+            model_id="unit-model",
+            suite="golden",
+            target_leakage=0.0,
+            min_recall=1.0,
+            membership_defense={
+                "enabled": True,
+                "clip_min": 0.5,
+                "clip_max": 0.5,
+                "advantage_ceiling": 0.05,
+            },
+        )
+    )
+    threshold_path = tmp_path / "thresholds.json"
+    threshold_path.write_text(
+        json.dumps(threshold_payload, indent=2),
+        encoding="utf-8",
+    )
+
+    text = "Patient John Doe and Jane Roe."
+
+    def _prediction(*args: object, **kwargs: object) -> PredictionResult:
+        return PredictionResult(
+            text=text,
+            entities=[
+                EntityPrediction(
+                    text="John Doe",
+                    label="NAME",
+                    start=text.index("John Doe"),
+                    end=text.index("John Doe") + len("John Doe"),
+                    confidence=0.99,
+                ),
+                EntityPrediction(
+                    text="Jane Roe",
+                    label="NAME",
+                    start=text.index("Jane Roe"),
+                    end=text.index("Jane Roe") + len("Jane Roe"),
+                    confidence=0.80,
+                ),
+            ],
+            model_name="unit-model",
+            timestamp=datetime.now().isoformat(),
+        )
+
+    with patch("openmed.core.pii.extract_pii", side_effect=_prediction):
+        report = deidentify(
+            text,
+            model_name="unit-model",
+            confidence_threshold=0.1,
+            use_safety_sweep=False,
+            calibration_thresholds_path=threshold_path,
+            audit=True,
+        )
+
+    assert isinstance(report, AuditReport)
+    assert report.thresholds["PERSON"] == pytest.approx(0.5)
+    assert [span.label for span in report.spans] == ["NAME", "NAME"]
+    assert [span.confidence for span in report.spans] == pytest.approx([0.5, 0.5])

--- a/tests/unit/eval/test_release_gates.py
+++ b/tests/unit/eval/test_release_gates.py
@@ -358,6 +358,68 @@ def test_g7_blocks_recall_regression_and_residual_leakage(tmp_path: Path) -> Non
     assert "residual_leakage_regression" in check.details["violations"]
 
 
+def test_membership_leakage_gate_blocks_leaky_configuration(tmp_path: Path) -> None:
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metric_updates={
+                "membership_leakage": {
+                    "attacker_auc": 0.91,
+                    "attacker_advantage": 0.35,
+                    "advantage_ceiling": 0.05,
+                    "feature_hash": "sha256:features",
+                    "per_label": {
+                        "PERSON": {
+                            "attacker_advantage": 0.35,
+                            "feature_hash": "sha256:person",
+                        }
+                    },
+                }
+            },
+        ),
+        _baseline(),
+    )
+
+    check = _check(result, "membership_leakage")
+    assert result.decision == QUARANTINED
+    assert result.verify(SIGNING_KEY)
+    assert check.passed is False
+    assert "overall_advantage" in check.details["violations"]
+    assert "PERSON" in check.details["violations"]["per_label_advantage"]
+
+
+def test_membership_leakage_gate_passes_defended_configuration(
+    tmp_path: Path,
+) -> None:
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metric_updates={
+                "membership_leakage": {
+                    "attacker_auc": 0.5,
+                    "attacker_advantage": 0.0,
+                    "advantage_ceiling": 0.05,
+                    "feature_hash": "sha256:features",
+                    "defense": {"enabled": True, "clip_min": 0.5, "clip_max": 0.5},
+                    "per_label": {
+                        "PERSON": {
+                            "attacker_advantage": 0.0,
+                            "feature_hash": "sha256:person",
+                        }
+                    },
+                }
+            },
+        ),
+        _baseline(),
+    )
+
+    check = _check(result, "membership_leakage")
+    assert result.decision == RELEASABLE
+    assert result.verify(SIGNING_KEY)
+    assert check.passed is True
+    assert check.details["defense"]["enabled"] is True
+
+
 def test_g8_consumes_strict_quality_gate_output(tmp_path: Path, monkeypatch) -> None:
     calls = {"strict": 0}
     original = release_gates.quality_gates.validate_entity_spans_strict


### PR DESCRIPTION
Closes #981.

Task: OM-618.

Implements a deterministic shadow-score membership-leakage evaluation with aggregate-only metrics, adds configurable score clipping, smoothing, and temperature defense in calibration artifacts and calibrated inference, and wires a signed release-gate check that fails leaky attacker advantage while passing defended configurations.

Validation:
- make lint
- make format-check
- .venv/bin/python -m pytest tests/ -q