### PR TITLE
Add core policy compiler coverage proofs

### DIFF
--- a/openmed/core/detector_plugins.py
+++ b/openmed/core/detector_plugins.py
@@ -56,6 +56,7 @@ from dataclasses import dataclass
 from threading import RLock
 from typing import Any, Callable
 
+from .labels import CANONICAL_LABELS, normalize_label
 from .schemas.span import OpenMedSpan
 
 DETECTOR_ENTRY_POINT_GROUP = "openmed.detectors"
@@ -68,6 +69,55 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
+class DetectorCapability:
+    """Compile-time detector coverage used by policy proof checks."""
+
+    name: str
+    stage: str
+    covered_labels: Sequence[str] | str
+    languages: Sequence[str] | str = ("*",)
+    provenance_prefix: str = "builtin"
+
+    def __post_init__(self) -> None:
+        name = str(self.name).strip()
+        if not name:
+            raise ValueError("DetectorCapability.name must be non-empty")
+        if ":" in name:
+            raise ValueError("DetectorCapability.name must not contain ':'")
+
+        stage = _normalize_stage(self.stage)
+        languages = _normalize_languages(self.languages)
+        covered_labels = _normalize_covered_labels(self.covered_labels)
+        provenance_prefix = str(self.provenance_prefix or "builtin").strip().rstrip(":")
+        if not provenance_prefix:
+            raise ValueError("DetectorCapability.provenance_prefix must be non-empty")
+
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "stage", stage)
+        object.__setattr__(self, "languages", languages)
+        object.__setattr__(self, "covered_labels", covered_labels)
+        object.__setattr__(self, "provenance_prefix", provenance_prefix)
+
+    @property
+    def detector_id(self) -> str:
+        """Return the stable detector identifier used in compiled plans."""
+
+        return f"{self.provenance_prefix}:{self.name}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible capability record."""
+
+        return {
+            "name": self.name,
+            "stage": self.stage,
+            "detector_id": self.detector_id,
+            "covered_labels": list(self.covered_labels),
+            "languages": list(self.languages),
+            "provenance_prefix": self.provenance_prefix,
+        }
+
+
+@dataclass(frozen=True)
 class DetectorSpec:
     """Registration contract for an in-pipeline detector plugin."""
 
@@ -76,6 +126,7 @@ class DetectorSpec:
     languages: Sequence[str] | str
     detect: DetectCallable
     provenance_prefix: str = "plugin"
+    covered_labels: Sequence[str] | str = ()
 
     def __post_init__(self) -> None:
         name = str(self.name).strip()
@@ -89,6 +140,10 @@ class DetectorSpec:
         stage = _normalize_stage(self.stage)
         languages = _normalize_languages(self.languages)
         provenance_prefix = str(self.provenance_prefix or "plugin").strip().rstrip(":")
+        covered_labels = _normalize_covered_labels(
+            self.covered_labels,
+            allow_empty=True,
+        )
         if not provenance_prefix:
             raise ValueError("DetectorSpec.provenance_prefix must be non-empty")
 
@@ -96,6 +151,20 @@ class DetectorSpec:
         object.__setattr__(self, "stage", stage)
         object.__setattr__(self, "languages", languages)
         object.__setattr__(self, "provenance_prefix", provenance_prefix)
+        object.__setattr__(self, "covered_labels", covered_labels)
+
+    def capability(self) -> DetectorCapability | None:
+        """Return this plugin's policy-compiler capability, if declared."""
+
+        if not self.covered_labels:
+            return None
+        return DetectorCapability(
+            name=self.name,
+            stage=self.stage,
+            covered_labels=self.covered_labels,
+            languages=self.languages,
+            provenance_prefix=self.provenance_prefix,
+        )
 
 
 DETECTOR_REGISTRY: dict[str, dict[str, DetectorSpec]] = {
@@ -131,6 +200,57 @@ def iter_detectors(stage: str, lang: str | None = None) -> tuple[DetectorSpec, .
         specs = tuple(DETECTOR_REGISTRY.get(normalized_stage, {}).values())
     return tuple(
         spec for spec in specs if _language_matches(spec.languages, normalized_lang)
+    )
+
+
+def default_detector_capabilities() -> tuple[DetectorCapability, ...]:
+    """Return built-in detector coverage available to compiled policies."""
+
+    return (
+        DetectorCapability(
+            name="privacy_label_model",
+            stage="fast_pii",
+            covered_labels=tuple(sorted(CANONICAL_LABELS)),
+        ),
+    )
+
+
+def iter_detector_capabilities(
+    stage: str | None = None,
+    lang: str | None = None,
+    *,
+    include_builtin: bool = True,
+) -> tuple[DetectorCapability, ...]:
+    """Return declared detector capabilities for policy compilation."""
+
+    normalized_stage = _normalize_stage(stage) if stage is not None else None
+    normalized_lang = _normalize_language(lang or "*")
+    capabilities: list[DetectorCapability] = []
+
+    if include_builtin:
+        capabilities.extend(default_detector_capabilities())
+
+    discover_detectors()
+    with _DISCOVERY_LOCK:
+        specs = tuple(
+            spec
+            for registry_stage in sorted(DETECTOR_REGISTRY)
+            for spec in DETECTOR_REGISTRY.get(registry_stage, {}).values()
+        )
+
+    for spec in specs:
+        if normalized_stage is not None and spec.stage != normalized_stage:
+            continue
+        if not _language_matches(spec.languages, normalized_lang):
+            continue
+        capability = spec.capability()
+        if capability is not None:
+            capabilities.append(capability)
+
+    return tuple(
+        capability
+        for capability in capabilities
+        if normalized_stage is None or capability.stage == normalized_stage
     )
 
 
@@ -220,6 +340,36 @@ def _normalize_language(lang: str) -> str:
     return str(lang or "*").strip().lower().replace("_", "-")
 
 
+def _normalize_covered_labels(
+    labels: Sequence[str] | str,
+    *,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    if isinstance(labels, str):
+        values = (labels,)
+    else:
+        values = tuple(labels)
+    if len(values) == 1 and str(values[0]).strip().lower() in {"*", "all", "any"}:
+        return tuple(sorted(CANONICAL_LABELS))
+
+    normalized: set[str] = set()
+    for value in values:
+        label = str(value).strip()
+        if not label:
+            continue
+        canonical = normalize_label(label)
+        if canonical != label:
+            raise ValueError(
+                "covered_labels must use canonical labels, "
+                f"got {label!r} for {canonical!r}"
+            )
+        normalized.add(canonical)
+
+    if not normalized and not allow_empty:
+        raise ValueError("covered_labels must not be empty")
+    return tuple(sorted(normalized))
+
+
 def _language_matches(languages: Sequence[str], lang: str) -> bool:
     language_set = set(languages)
     return bool(language_set & LANGUAGE_WILDCARDS) or lang in language_set
@@ -238,10 +388,13 @@ __all__ = [
     "DETECTOR_ENTRY_POINT_GROUP",
     "DETECTOR_REGISTRY",
     "DETECTOR_STAGES",
+    "DetectorCapability",
     "DetectorSpec",
     "DetectCallable",
+    "default_detector_capabilities",
     "detector_provenance",
     "discover_detectors",
+    "iter_detector_capabilities",
     "iter_detectors",
     "register_detector",
 ]

--- a/openmed/core/policy.py
+++ b/openmed/core/policy.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from functools import lru_cache
 from importlib import resources
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from .arbitration import MODE_BALANCED, MODE_HIGH_RECALL_UNION
+from .detector_plugins import DetectorCapability, default_detector_capabilities
 from .labels import CANONICAL_LABELS, POLICY_LABELS, normalize_label, policy_label_for
 from .schemas.span import ACTION_VALUES
 
@@ -150,6 +152,280 @@ class PolicyProfile:
         )
 
 
+@dataclass(frozen=True)
+class PolicyRequirement:
+    """A canonical label that a policy requires the runtime to protect."""
+
+    label: str
+    policy_label: str
+    minimum_action: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-compatible requirement record."""
+
+        return {
+            "label": self.label,
+            "policy_label": self.policy_label,
+            "minimum_action": self.minimum_action,
+        }
+
+
+@dataclass(frozen=True)
+class PolicyPlanEntry:
+    """Executable detector/action assignment for one required label."""
+
+    label: str
+    policy_label: str
+    detector_id: str
+    detector_stage: str
+    action: str
+    required_action: str
+
+    def __post_init__(self) -> None:
+        label = _canonical_label(self.label, "label")
+        policy_label = str(self.policy_label)
+        if policy_label != policy_label_for(label):
+            raise ValueError(
+                f"policy_label for {label} must be {policy_label_for(label)!r}"
+            )
+        object.__setattr__(self, "label", label)
+        object.__setattr__(self, "policy_label", policy_label)
+        object.__setattr__(self, "action", _action(self.action, "action"))
+        object.__setattr__(
+            self,
+            "required_action",
+            _action(self.required_action, "required_action"),
+        )
+        if not str(self.detector_id).strip():
+            raise ValueError("detector_id must be non-empty")
+        if not str(self.detector_stage).strip():
+            raise ValueError("detector_stage must be non-empty")
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-compatible plan entry."""
+
+        return {
+            "label": self.label,
+            "policy_label": self.policy_label,
+            "detector_id": self.detector_id,
+            "detector_stage": self.detector_stage,
+            "action": self.action,
+            "required_action": self.required_action,
+        }
+
+
+@dataclass(frozen=True)
+class PolicyActionPlan:
+    """Compiled policy plan with no implicit label fall-through."""
+
+    policy_name: str
+    schema_version: int
+    default_action: str
+    allow_default_fallthrough: bool
+    entries: tuple[PolicyPlanEntry, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "policy_name", _non_empty_str(self.policy_name, "policy_name")
+        )
+        object.__setattr__(
+            self, "default_action", _action(self.default_action, "default_action")
+        )
+        object.__setattr__(
+            self,
+            "entries",
+            tuple(sorted(self.entries, key=lambda entry: entry.label)),
+        )
+
+    def entry_for(self, label: str) -> PolicyPlanEntry | None:
+        """Return the plan entry for ``label`` if present."""
+
+        canonical = normalize_label(label)
+        for entry in self.entries:
+            if entry.label == canonical:
+                return entry
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible plan."""
+
+        return {
+            "policy_name": self.policy_name,
+            "schema_version": self.schema_version,
+            "default_action": self.default_action,
+            "allow_default_fallthrough": self.allow_default_fallthrough,
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        """Return the stable content hash for this plan."""
+
+        return _stable_json_hash(self.to_dict())
+
+
+@dataclass(frozen=True)
+class PolicyCoverageWitness:
+    """Machine-checkable witness for one required-label coverage claim."""
+
+    label: str
+    policy_label: str
+    detector_id: str
+    detector_stage: str
+    action: str
+    required_action: str
+    detector_covers_label: bool
+    action_meets_requirement: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible witness."""
+
+        return {
+            "label": self.label,
+            "policy_label": self.policy_label,
+            "detector_id": self.detector_id,
+            "detector_stage": self.detector_stage,
+            "action": self.action,
+            "required_action": self.required_action,
+            "detector_covers_label": self.detector_covers_label,
+            "action_meets_requirement": self.action_meets_requirement,
+        }
+
+
+@dataclass(frozen=True)
+class PolicyCoverageViolation:
+    """Stable diagnostic emitted by policy compilation or verification."""
+
+    code: str
+    label: str
+    message: str
+    required_action: str | None = None
+    observed_action: str | None = None
+    detector_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible diagnostic."""
+
+        return {
+            "code": self.code,
+            "label": self.label,
+            "message": self.message,
+            "required_action": self.required_action,
+            "observed_action": self.observed_action,
+            "detector_id": self.detector_id,
+        }
+
+
+@dataclass(frozen=True)
+class PolicyCoverageProof:
+    """Independent coverage proof for a compiled policy plan."""
+
+    policy_name: str
+    plan_fingerprint: str
+    required_labels: tuple[str, ...]
+    witnesses: tuple[PolicyCoverageWitness, ...]
+    uncovered_labels: tuple[str, ...] = ()
+    fallthrough_labels: tuple[str, ...] = ()
+    weak_actions: tuple[PolicyCoverageViolation, ...] = ()
+    invalid_detectors: tuple[PolicyCoverageViolation, ...] = ()
+
+    @property
+    def covered_label_count(self) -> int:
+        """Return the number of required labels with valid witnesses."""
+
+        covered = {
+            witness.label
+            for witness in self.witnesses
+            if witness.detector_covers_label and witness.action_meets_requirement
+        }
+        return len(covered)
+
+    @property
+    def coverage_percent(self) -> float:
+        """Return required-label coverage as a percentage."""
+
+        if not self.required_labels:
+            return 100.0
+        return 100.0 * self.covered_label_count / len(self.required_labels)
+
+    @property
+    def verified(self) -> bool:
+        """Return whether the proof has no coverage or strength violations."""
+
+        return not (
+            self.uncovered_labels
+            or self.fallthrough_labels
+            or self.weak_actions
+            or self.invalid_detectors
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible proof object."""
+
+        return {
+            "policy_name": self.policy_name,
+            "plan_fingerprint": self.plan_fingerprint,
+            "required_labels": list(self.required_labels),
+            "covered_label_count": self.covered_label_count,
+            "coverage_percent": self.coverage_percent,
+            "verified": self.verified,
+            "witnesses": [witness.to_dict() for witness in self.witnesses],
+            "uncovered_labels": list(self.uncovered_labels),
+            "fallthrough_labels": list(self.fallthrough_labels),
+            "weak_actions": [violation.to_dict() for violation in self.weak_actions],
+            "invalid_detectors": [
+                violation.to_dict() for violation in self.invalid_detectors
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class CompiledPolicy:
+    """Compiler output containing the executable plan and verified proof."""
+
+    policy_name: str
+    plan: PolicyActionPlan
+    proof: PolicyCoverageProof
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible compiler artifact."""
+
+        return {
+            "policy_name": self.policy_name,
+            "plan": self.plan.to_dict(),
+            "proof": self.proof.to_dict(),
+        }
+
+
+class PolicyCoverageError(ValueError):
+    """Base class for policy coverage proof failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        uncovered_labels: Sequence[str] = (),
+        fallthrough_labels: Sequence[str] = (),
+        weak_actions: Sequence[PolicyCoverageViolation] = (),
+        invalid_detectors: Sequence[PolicyCoverageViolation] = (),
+        proof: PolicyCoverageProof | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.uncovered_labels = tuple(uncovered_labels)
+        self.fallthrough_labels = tuple(fallthrough_labels)
+        self.weak_actions = tuple(weak_actions)
+        self.invalid_detectors = tuple(invalid_detectors)
+        self.proof = proof
+
+
+class PolicyCompilationError(PolicyCoverageError):
+    """Raised when a policy cannot be lowered into a covered plan."""
+
+
+class PolicyVerificationError(PolicyCoverageError):
+    """Raised when an independently checked plan/proof is invalid."""
+
+
 def canonical_policy_name(name: str | PolicyName) -> str:
     """Resolve aliases and validate a policy profile name."""
 
@@ -177,6 +453,212 @@ def list_policies() -> tuple[str, ...]:
     """Return the canonical policy names."""
 
     return CANONICAL_POLICY_NAMES
+
+
+def policy_requirements(
+    profile: str | PolicyName | PolicyProfile,
+) -> tuple[PolicyRequirement, ...]:
+    """Return labels whose configured policy action requires protection."""
+
+    loaded = load_policy(profile)
+    requirements: list[PolicyRequirement] = []
+    for label in sorted(CANONICAL_LABELS):
+        minimum_action = _minimum_required_action(loaded, label)
+        if _action_strength(minimum_action) <= _action_strength("keep"):
+            continue
+        requirements.append(
+            PolicyRequirement(
+                label=label,
+                policy_label=policy_label_for(label),
+                minimum_action=minimum_action,
+            )
+        )
+    return tuple(requirements)
+
+
+def compile_policy(
+    profile: str | PolicyName | PolicyProfile,
+    *,
+    detector_capabilities: Sequence[DetectorCapability] | None = None,
+    allow_default_fallthrough: bool = False,
+) -> CompiledPolicy:
+    """Compile a policy into a detector/action plan and verified proof."""
+
+    loaded = load_policy(profile)
+    capabilities = (
+        tuple(detector_capabilities)
+        if detector_capabilities is not None
+        else default_detector_capabilities()
+    )
+    capabilities_by_label = _capabilities_by_label(capabilities)
+    requirements = policy_requirements(loaded)
+
+    entries: list[PolicyPlanEntry] = []
+    uncovered_labels: list[str] = []
+    for requirement in requirements:
+        candidates = capabilities_by_label.get(requirement.label, ())
+        if not candidates:
+            uncovered_labels.append(requirement.label)
+            continue
+        detector = candidates[0]
+        entries.append(
+            PolicyPlanEntry(
+                label=requirement.label,
+                policy_label=requirement.policy_label,
+                detector_id=detector.detector_id,
+                detector_stage=detector.stage,
+                action=loaded.action_for(requirement.label),
+                required_action=requirement.minimum_action,
+            )
+        )
+
+    if uncovered_labels:
+        raise PolicyCompilationError(
+            _coverage_error_message(
+                "policy compilation failed",
+                loaded.name,
+                uncovered_labels=tuple(uncovered_labels),
+            ),
+            uncovered_labels=tuple(sorted(uncovered_labels)),
+        )
+
+    plan = PolicyActionPlan(
+        policy_name=loaded.name,
+        schema_version=loaded.schema_version,
+        default_action=loaded.default_action,
+        allow_default_fallthrough=allow_default_fallthrough,
+        entries=tuple(entries),
+    )
+    proof = verify_policy_plan(
+        loaded,
+        plan,
+        detector_capabilities=capabilities,
+        allow_default_fallthrough=allow_default_fallthrough,
+    )
+    return CompiledPolicy(policy_name=loaded.name, plan=plan, proof=proof)
+
+
+def verify_policy_plan(
+    profile: str | PolicyName | PolicyProfile,
+    plan: PolicyActionPlan,
+    *,
+    detector_capabilities: Sequence[DetectorCapability] | None = None,
+    allow_default_fallthrough: bool | None = None,
+    raise_on_error: bool = True,
+) -> PolicyCoverageProof:
+    """Independently verify detector coverage and action strength for a plan."""
+
+    loaded = load_policy(profile)
+    capabilities = (
+        tuple(detector_capabilities)
+        if detector_capabilities is not None
+        else default_detector_capabilities()
+    )
+    capabilities_by_id = {
+        capability.detector_id: capability for capability in capabilities
+    }
+    capabilities_by_label = _capabilities_by_label(capabilities)
+    requirements = policy_requirements(loaded)
+    required_labels = tuple(requirement.label for requirement in requirements)
+    entries_by_label = {entry.label: entry for entry in plan.entries}
+    default_fallthrough_allowed = (
+        plan.allow_default_fallthrough
+        if allow_default_fallthrough is None
+        else allow_default_fallthrough
+    )
+
+    witnesses: list[PolicyCoverageWitness] = []
+    uncovered_labels: list[str] = []
+    fallthrough_labels: list[str] = []
+    weak_actions: list[PolicyCoverageViolation] = []
+    invalid_detectors: list[PolicyCoverageViolation] = []
+
+    for requirement in requirements:
+        entry = entries_by_label.get(requirement.label)
+        if entry is None:
+            if not capabilities_by_label.get(requirement.label):
+                uncovered_labels.append(requirement.label)
+            elif not default_fallthrough_allowed:
+                fallthrough_labels.append(requirement.label)
+            continue
+
+        capability = capabilities_by_id.get(entry.detector_id)
+        detector_covers_label = bool(
+            capability is not None and requirement.label in capability.covered_labels
+        )
+        action_meets_requirement = _action_meets_floor(
+            entry.action,
+            requirement.minimum_action,
+        )
+        witnesses.append(
+            PolicyCoverageWitness(
+                label=requirement.label,
+                policy_label=requirement.policy_label,
+                detector_id=entry.detector_id,
+                detector_stage=entry.detector_stage,
+                action=entry.action,
+                required_action=requirement.minimum_action,
+                detector_covers_label=detector_covers_label,
+                action_meets_requirement=action_meets_requirement,
+            )
+        )
+
+        if not detector_covers_label:
+            invalid_detectors.append(
+                PolicyCoverageViolation(
+                    code="POLICY_DETECTOR_DOES_NOT_COVER_LABEL",
+                    label=requirement.label,
+                    detector_id=entry.detector_id,
+                    message=(
+                        f"detector {entry.detector_id!r} does not cover "
+                        f"required label {requirement.label}"
+                    ),
+                )
+            )
+        if not action_meets_requirement:
+            weak_actions.append(
+                PolicyCoverageViolation(
+                    code="POLICY_ACTION_TOO_WEAK",
+                    label=requirement.label,
+                    required_action=requirement.minimum_action,
+                    observed_action=entry.action,
+                    detector_id=entry.detector_id,
+                    message=(
+                        f"action {entry.action!r} is weaker than required "
+                        f"{requirement.minimum_action!r} for {requirement.label}"
+                    ),
+                )
+            )
+
+    proof = PolicyCoverageProof(
+        policy_name=loaded.name,
+        plan_fingerprint=plan.fingerprint,
+        required_labels=required_labels,
+        witnesses=tuple(witnesses),
+        uncovered_labels=tuple(sorted(uncovered_labels)),
+        fallthrough_labels=tuple(sorted(fallthrough_labels)),
+        weak_actions=tuple(weak_actions),
+        invalid_detectors=tuple(invalid_detectors),
+    )
+    if raise_on_error and not proof.verified:
+        raise PolicyVerificationError(
+            _coverage_error_message(
+                "policy verification failed",
+                loaded.name,
+                uncovered_labels=proof.uncovered_labels,
+                fallthrough_labels=proof.fallthrough_labels,
+                weak_labels=tuple(violation.label for violation in proof.weak_actions),
+                invalid_detector_labels=tuple(
+                    violation.label for violation in proof.invalid_detectors
+                ),
+            ),
+            uncovered_labels=proof.uncovered_labels,
+            fallthrough_labels=proof.fallthrough_labels,
+            weak_actions=proof.weak_actions,
+            invalid_detectors=proof.invalid_detectors,
+            proof=proof,
+        )
+    return proof
 
 
 def lint_policy(
@@ -285,6 +767,104 @@ def _action(value: Any, field_name: str) -> str:
     return action
 
 
+def _canonical_label(value: str, field_name: str) -> str:
+    label = str(value)
+    canonical = normalize_label(label)
+    if canonical != label:
+        raise ValueError(f"{field_name} must use canonical labels, got {label!r}")
+    return canonical
+
+
+def _capabilities_by_label(
+    capabilities: Sequence[DetectorCapability],
+) -> dict[str, tuple[DetectorCapability, ...]]:
+    by_label: dict[str, list[DetectorCapability]] = {
+        label: [] for label in sorted(CANONICAL_LABELS)
+    }
+    for capability in capabilities:
+        for label in capability.covered_labels:
+            by_label[label].append(capability)
+    return {
+        label: tuple(
+            sorted(
+                label_capabilities,
+                key=lambda capability: (
+                    _detector_stage_order(capability.stage),
+                    capability.detector_id,
+                ),
+            )
+        )
+        for label, label_capabilities in by_label.items()
+    }
+
+
+def _detector_stage_order(stage: str) -> int:
+    return {
+        "deterministic": 0,
+        "fast_pii": 1,
+        "clinical_phi": 2,
+    }.get(stage, 99)
+
+
+def _minimum_required_action(profile: PolicyProfile, label: str) -> str:
+    canonical_label = normalize_label(label)
+    explicit_action = profile.action_for(canonical_label)
+    category_floor = profile.policy_label_actions.get(
+        policy_label_for(canonical_label),
+        profile.default_action,
+    )
+    return max((explicit_action, category_floor), key=_action_strength)
+
+
+def _action_strength(action: str) -> int:
+    from .redaction_strength import action_strength
+
+    return action_strength(action)
+
+
+def _action_meets_floor(action: str, floor: str) -> bool:
+    from .redaction_strength import action_meets_floor
+
+    return action_meets_floor(action, floor)
+
+
+def _coverage_error_message(
+    prefix: str,
+    policy_name: str,
+    *,
+    uncovered_labels: Sequence[str] = (),
+    fallthrough_labels: Sequence[str] = (),
+    weak_labels: Sequence[str] = (),
+    invalid_detector_labels: Sequence[str] = (),
+) -> str:
+    parts = [f"{prefix} for policy {policy_name!r}"]
+    if uncovered_labels:
+        parts.append(f"uncovered labels: {', '.join(sorted(uncovered_labels))}")
+    if fallthrough_labels:
+        parts.append(
+            "labels would fall through to the default action: "
+            + ", ".join(sorted(fallthrough_labels))
+        )
+    if weak_labels:
+        parts.append(f"weak actions: {', '.join(sorted(weak_labels))}")
+    if invalid_detector_labels:
+        parts.append(
+            "invalid detector witnesses: " + ", ".join(sorted(invalid_detector_labels))
+        )
+    return "; ".join(parts)
+
+
+def _stable_json_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
 def _policy_label_actions(value: Mapping[str, Any]) -> dict[str, str]:
     if not isinstance(value, Mapping):
         raise ValueError("policy_label_actions must be an object")
@@ -332,10 +912,23 @@ __all__ = [
     "CANONICAL_POLICY_NAMES",
     "CURRENT_POLICY_SCHEMA_VERSION",
     "POLICY_ALIASES",
+    "CompiledPolicy",
+    "PolicyActionPlan",
+    "PolicyCompilationError",
+    "PolicyCoverageError",
+    "PolicyCoverageProof",
+    "PolicyCoverageViolation",
+    "PolicyCoverageWitness",
     "PolicyName",
+    "PolicyPlanEntry",
     "PolicyProfile",
+    "PolicyRequirement",
+    "PolicyVerificationError",
     "canonical_policy_name",
+    "compile_policy",
     "lint_policy",
     "list_policies",
     "load_policy",
+    "policy_requirements",
+    "verify_policy_plan",
 ]

--- a/tests/unit/core/test_policy_compiler.py
+++ b/tests/unit/core/test_policy_compiler.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from openmed.core.detector_plugins import DetectorCapability
+from openmed.core.labels import CANONICAL_LABELS, PERSON
+from openmed.core.policy import (
+    PolicyCompilationError,
+    PolicyVerificationError,
+    compile_policy,
+    list_policies,
+    load_policy,
+    policy_requirements,
+    verify_policy_plan,
+)
+
+
+def _capability_without(*labels: str) -> DetectorCapability:
+    covered = tuple(sorted(CANONICAL_LABELS - set(labels)))
+    return DetectorCapability(
+        name="synthetic_policy_detector",
+        stage="fast_pii",
+        covered_labels=covered,
+    )
+
+
+def test_all_bundled_policies_compile_to_verified_coverage_proofs():
+    for policy_name in list_policies():
+        compiled = compile_policy(policy_name)
+        required_labels = {
+            requirement.label for requirement in policy_requirements(policy_name)
+        }
+
+        assert compiled.policy_name == policy_name
+        assert compiled.proof.verified is True
+        assert compiled.proof.coverage_percent == 100.0
+        assert {entry.label for entry in compiled.plan.entries} == required_labels
+        assert {
+            witness.label for witness in compiled.proof.witnesses
+        } == required_labels
+
+        checked = verify_policy_plan(
+            load_policy(policy_name),
+            compiled.plan,
+        )
+        assert checked.verified is True
+        assert checked.plan_fingerprint == compiled.plan.fingerprint
+
+
+def test_compiler_reports_precise_uncovered_label_for_synthetic_gap():
+    profile = load_policy("hipaa_safe_harbor")
+
+    with pytest.raises(PolicyCompilationError, match=PERSON) as exc_info:
+        compile_policy(
+            profile,
+            detector_capabilities=(_capability_without(PERSON),),
+        )
+
+    assert exc_info.value.uncovered_labels == (PERSON,)
+    assert "uncovered labels: PERSON" in str(exc_info.value)
+
+
+def test_independent_checker_rejects_weaker_tampered_plan_action():
+    profile = load_policy("hipaa_safe_harbor")
+    capability = DetectorCapability(
+        name="complete_policy_detector",
+        stage="fast_pii",
+        covered_labels="*",
+    )
+    compiled = compile_policy(profile, detector_capabilities=(capability,))
+    weakened_entries = tuple(
+        replace(entry, action="keep") if entry.label == PERSON else entry
+        for entry in compiled.plan.entries
+    )
+    weakened_plan = replace(compiled.plan, entries=weakened_entries)
+
+    with pytest.raises(PolicyVerificationError, match=PERSON) as exc_info:
+        verify_policy_plan(
+            profile,
+            weakened_plan,
+            detector_capabilities=(capability,),
+        )
+
+    assert exc_info.value.weak_actions[0].label == PERSON
+    assert exc_info.value.weak_actions[0].observed_action == "keep"
+    assert exc_info.value.proof is not None
+    assert exc_info.value.proof.verified is False


### PR DESCRIPTION
## Description
Implements the first OM-621 child issue by adding detector capability metadata and a core policy compiler that lowers policy requirements into detector/action plans with independently verified coverage proofs. The proof re-derives required labels from explicit actions plus policy-label category floors and rejects uncovered detector gaps, fall-through, invalid detector witnesses, and weaker-than-required actions.

## Change type
- Feature

## Tests
- make lint
- make format-check
- .venv/bin/python -m pytest tests/ -q

## Docs / changelog
No user-facing docs or changelog changes for this core slice.

## Linked issue
Closes #1044.
Refs #984.

## Screenshots
N/A