### PR TITLE
Add reversible pseudonymization with a rotating surrogate vault

### DIFF
--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -63,11 +63,15 @@ from .core.streaming import (
     deidentify_stream,
 )
 from .core.surrogate_vault import (
+    ENCRYPTION_SCHEME,
     InMemorySurrogateStore,
     JsonFileSurrogateStore,
     SurrogateEntry,
     SurrogateKey,
+    SurrogateSource,
     SurrogateVault,
+    VaultConsistencyReport,
+    VaultRotationResult,
 )
 from .mlx.lm import OpenMedMLXLanguageModel, generate_text
 from .processing import (
@@ -692,6 +696,10 @@ __all__ = [
     "SurrogateVault",
     "SurrogateKey",
     "SurrogateEntry",
+    "SurrogateSource",
+    "VaultConsistencyReport",
+    "VaultRotationResult",
     "InMemorySurrogateStore",
     "JsonFileSurrogateStore",
+    "ENCRYPTION_SCHEME",
 ]

--- a/openmed/core/__init__.py
+++ b/openmed/core/__init__.py
@@ -23,11 +23,15 @@ from .script_detect import (
     segment_by_script,
 )
 from .surrogate_vault import (
+    ENCRYPTION_SCHEME,
     InMemorySurrogateStore,
     JsonFileSurrogateStore,
     SurrogateEntry,
     SurrogateKey,
+    SurrogateSource,
     SurrogateVault,
+    VaultConsistencyReport,
+    VaultRotationResult,
 )
 
 __all__ = [
@@ -47,8 +51,12 @@ __all__ = [
     "SurrogateVault",
     "SurrogateKey",
     "SurrogateEntry",
+    "SurrogateSource",
+    "VaultConsistencyReport",
+    "VaultRotationResult",
     "InMemorySurrogateStore",
     "JsonFileSurrogateStore",
+    "ENCRYPTION_SCHEME",
     "PROFILE_PRESETS",
     "list_profiles",
     "get_profile",

--- a/openmed/core/surrogate_vault.py
+++ b/openmed/core/surrogate_vault.py
@@ -2,25 +2,36 @@
 
 The vault stores mappings from ``(canonical_label, lang, text_hash)`` to the
 selected surrogate value. ``text_hash`` is an HMAC-SHA256 digest of the source
-surface; raw source identifiers are never stored. Vault files are still
-pseudonymous linkage artifacts, so protect them as sensitive data.
+surface; raw source identifiers are never stored. Persisted vault payloads
+encrypt surrogate values under a versioned epoch key so the file at rest does
+not reveal replacement identifiers.
 """
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import json
 import os
 import tempfile
-from dataclasses import dataclass
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
 from pathlib import Path
 from threading import RLock
-from typing import Any, Callable, Iterable, Mapping
+from typing import Any, Callable
 
 from .labels import normalize_label
 from .schemas.span import hmac_text_hash
 
-SCHEMA_VERSION = 1
+LEGACY_SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 HMAC_SCHEME = "hmac-sha256"
+ENCRYPTION_SCHEME = "hmac-sha256-stream-xor+hmac-sha256"
+
+_EPOCH_PREFIX = "epoch"
+_KEY_ID_BYTES = 8
+_NONCE_BYTES = 16
 
 
 @dataclass(frozen=True, order=True)
@@ -61,28 +72,34 @@ class SurrogateKey:
 
 @dataclass(frozen=True)
 class SurrogateEntry:
-    """Persisted vault entry."""
+    """Persisted vault entry decrypted into memory."""
 
     key: SurrogateKey
     surrogate: str
+    key_id: str = ""
 
     def __post_init__(self) -> None:
         if not self.surrogate:
             raise ValueError("surrogate must be non-empty")
+        if self.key_id is not None and not isinstance(self.key_id, str):
+            raise TypeError("key_id must be a string")
 
     def to_dict(self) -> dict[str, str]:
         """Serialize this entry to deterministic JSON-compatible fields."""
 
-        return {
+        payload = {
             **self.key.to_dict(),
             "surrogate": self.surrogate,
         }
+        if self.key_id:
+            payload["key_id"] = self.key_id
+        return payload
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "SurrogateEntry":
-        """Deserialize one persisted vault entry."""
+        """Deserialize one legacy plaintext vault entry."""
 
-        allowed = {"canonical_label", "lang", "text_hash", "surrogate"}
+        allowed = {"canonical_label", "lang", "text_hash", "surrogate", "key_id"}
         unknown = set(payload) - allowed
         if unknown:
             raise ValueError(
@@ -92,71 +109,328 @@ class SurrogateEntry:
         return cls(
             key=SurrogateKey.from_dict(payload),
             surrogate=str(payload["surrogate"]),
+            key_id=str(payload.get("key_id") or ""),
         )
+
+
+@dataclass(frozen=True)
+class SurrogateSource:
+    """Source descriptor used only in memory for rotation verification."""
+
+    source_text: str = field(repr=False)
+    label: str
+    lang: str = "en"
+
+    def __post_init__(self) -> None:
+        if not self.source_text:
+            raise ValueError("source_text must be non-empty")
+        if not self.label:
+            raise ValueError("label must be non-empty")
+        if not self.lang:
+            object.__setattr__(self, "lang", "en")
+
+
+@dataclass(frozen=True)
+class VaultConsistencyReport:
+    """Privacy-safe result from checking source-to-surrogate consistency."""
+
+    checked: int
+    matched: int
+    missing: tuple[str, ...] = ()
+    mismatched: tuple[str, ...] = ()
+
+    @property
+    def passed(self) -> bool:
+        """Return whether every checked source preserved its surrogate."""
+
+        return not self.missing and not self.mismatched and self.checked == self.matched
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this report without raw source surfaces."""
+
+        return {
+            "checked": self.checked,
+            "matched": self.matched,
+            "missing": list(self.missing),
+            "mismatched": list(self.mismatched),
+            "passed": self.passed,
+        }
+
+
+@dataclass(frozen=True)
+class VaultRotationResult:
+    """Result from an epoch rotation or revocation migration."""
+
+    previous_key_id: str
+    current_key_id: str
+    migrated_entries: int
+    revoked_key_ids: tuple[str, ...] = ()
+    consistency: VaultConsistencyReport | None = None
+
+
+@dataclass(frozen=True)
+class _EpochKey:
+    sequence: int
+    key_id: str
+    linkage_key: bytes = field(repr=False)
+    encryption_key: bytes = field(repr=False)
+
+
+class _EpochManager:
+    """Derive one-way epoch keys from the caller-supplied local secret."""
+
+    def __init__(
+        self,
+        secret: str | bytes,
+        *,
+        current_sequence: int = 1,
+        revoked_key_ids: Iterable[str] = (),
+    ) -> None:
+        self._root_secret = _secret_bytes(secret)
+        if current_sequence < 1:
+            raise ValueError("current_sequence must be >= 1")
+        self.current_sequence = int(current_sequence)
+        self.revoked_key_ids = set(map(str, revoked_key_ids))
+
+    @property
+    def current_key(self) -> _EpochKey:
+        return self.derive(self.current_sequence)
+
+    def derive(self, sequence: int) -> _EpochKey:
+        """Return derived material for an epoch sequence."""
+
+        if sequence < 1:
+            raise ValueError("sequence must be >= 1")
+
+        seed = hmac.new(
+            self._root_secret,
+            b"openmed-surrogate-vault:epoch-seed:1",
+            hashlib.sha256,
+        ).digest()
+        for step in range(2, sequence + 1):
+            seed = hmac.new(
+                seed,
+                f"openmed-surrogate-vault:epoch-next:{step}".encode("ascii"),
+                hashlib.sha256,
+            ).digest()
+
+        key_id_digest = hmac.new(
+            seed,
+            b"openmed-surrogate-vault:key-id",
+            hashlib.sha256,
+        ).hexdigest()[: _KEY_ID_BYTES * 2]
+        linkage_key = (
+            self._root_secret
+            if sequence == 1
+            else hmac.new(
+                seed,
+                b"openmed-surrogate-vault:linkage",
+                hashlib.sha256,
+            ).digest()
+        )
+        encryption_key = hmac.new(
+            seed,
+            b"openmed-surrogate-vault:encryption",
+            hashlib.sha256,
+        ).digest()
+        return _EpochKey(
+            sequence=sequence,
+            key_id=f"{_EPOCH_PREFIX}-{sequence:04d}-{key_id_digest}",
+            linkage_key=linkage_key,
+            encryption_key=encryption_key,
+        )
+
+    def payload(self) -> dict[str, Any]:
+        """Return persisted epoch metadata without key material."""
+
+        current = self.current_key
+        return {
+            "current_epoch": {
+                "sequence": current.sequence,
+                "key_id": current.key_id,
+            },
+            "revoked_key_ids": sorted(self.revoked_key_ids),
+        }
 
 
 class InMemorySurrogateStore:
     """In-memory store for surrogate vault entries."""
 
-    def __init__(self, entries: Iterable[SurrogateEntry] = ()) -> None:
-        self._entries: dict[SurrogateKey, str] = {}
+    def __init__(
+        self,
+        entries: Iterable[SurrogateEntry] = (),
+        *,
+        epoch_manager: _EpochManager | None = None,
+    ) -> None:
+        self._entries: dict[SurrogateKey, SurrogateEntry] = {}
         self._lock = RLock()
+        self._epoch_manager = epoch_manager
         for entry in entries:
-            self.set(entry.key, entry.surrogate)
+            self.set(entry.key, entry.surrogate, key_id=entry.key_id)
+
+    @property
+    def epoch_manager(self) -> _EpochManager | None:
+        """Return the store's epoch manager, if encrypted persistence is active."""
+
+        return self._epoch_manager
+
+    def set_epoch_manager(self, epoch_manager: _EpochManager) -> None:
+        """Attach epoch metadata and key IDs to existing in-memory entries."""
+
+        with self._lock:
+            self._epoch_manager = epoch_manager
+            current_key_id = epoch_manager.current_key.key_id
+            self._entries = {
+                key: SurrogateEntry(
+                    entry.key, entry.surrogate, entry.key_id or current_key_id
+                )
+                for key, entry in self._entries.items()
+            }
 
     def get(self, key: SurrogateKey) -> str | None:
         """Return the surrogate for ``key``, if present."""
 
         with self._lock:
-            return self._entries.get(key)
+            entry = self._entries.get(key)
+            return entry.surrogate if entry is not None else None
 
-    def set(self, key: SurrogateKey, surrogate: str) -> None:
+    def set(
+        self,
+        key: SurrogateKey,
+        surrogate: str,
+        *,
+        key_id: str | None = None,
+    ) -> None:
         """Store ``surrogate`` for ``key``."""
 
         if not surrogate:
             raise ValueError("surrogate must be non-empty")
         with self._lock:
             current = self._entries.get(key)
-            if current is not None and current != surrogate:
+            if current is not None and current.surrogate != surrogate:
                 raise ValueError("surrogate key already maps to a different value")
-            self._entries[key] = surrogate
+            effective_key_id = key_id
+            if effective_key_id is None and self._epoch_manager is not None:
+                effective_key_id = self._epoch_manager.current_key.key_id
+            self._entries[key] = SurrogateEntry(
+                key,
+                surrogate,
+                str(effective_key_id or ""),
+            )
+
+    def replace_entries(self, entries: Iterable[SurrogateEntry]) -> None:
+        """Replace all entries atomically inside the in-memory store."""
+
+        next_entries: dict[SurrogateKey, SurrogateEntry] = {}
+        for entry in entries:
+            current = next_entries.get(entry.key)
+            if current is not None and current.surrogate != entry.surrogate:
+                raise ValueError("surrogate key already maps to a different value")
+            next_entries[entry.key] = entry
+        with self._lock:
+            self._entries = next_entries
 
     def entries(self) -> tuple[SurrogateEntry, ...]:
         """Return entries sorted by their privacy-safe key."""
 
         with self._lock:
-            return tuple(
-                SurrogateEntry(key, self._entries[key]) for key in sorted(self._entries)
-            )
+            return tuple(self._entries[key] for key in sorted(self._entries))
 
     def used_surrogates(self, *, canonical_label: str, lang: str) -> set[str]:
         """Return surrogates already used for the label/language bucket."""
 
         with self._lock:
             return {
-                surrogate
-                for key, surrogate in self._entries.items()
+                entry.surrogate
+                for key, entry in self._entries.items()
                 if key.canonical_label == canonical_label and key.lang == lang
             }
 
     def to_payload(self) -> dict[str, Any]:
         """Serialize the store without any raw source surfaces."""
 
-        return {
+        if self._epoch_manager is None:
+            return {
+                "schema_version": LEGACY_SCHEMA_VERSION,
+                "hmac_scheme": HMAC_SCHEME,
+                "entries": [entry.to_dict() for entry in self.entries()],
+            }
+        current_key = self._epoch_manager.current_key
+        payload = {
             "schema_version": SCHEMA_VERSION,
             "hmac_scheme": HMAC_SCHEME,
-            "entries": [entry.to_dict() for entry in self.entries()],
+            "encryption_scheme": ENCRYPTION_SCHEME,
+            **self._epoch_manager.payload(),
+            "entries": [],
         }
+        entries_payload: list[dict[str, str]] = []
+        for entry in self.entries():
+            key_id = entry.key_id or current_key.key_id
+            if key_id != current_key.key_id:
+                raise ValueError(
+                    "surrogate vault contains entries outside the current epoch"
+                )
+            entries_payload.append(_encrypted_entry_payload(entry, current_key))
+        payload["entries"] = entries_payload
+        return payload
 
     @classmethod
-    def from_payload(cls, payload: Mapping[str, Any]) -> "InMemorySurrogateStore":
+    def from_payload(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        hmac_secret: str | bytes | None = None,
+    ) -> "InMemorySurrogateStore":
         """Load a store from a JSON-compatible payload."""
 
         schema_version = int(payload.get("schema_version", 0))
+        if schema_version == LEGACY_SCHEMA_VERSION:
+            return cls._from_legacy_payload(payload, hmac_secret=hmac_secret)
         if schema_version != SCHEMA_VERSION:
             raise ValueError(
                 f"unsupported surrogate vault schema_version {schema_version!r}"
             )
+
+        hmac_scheme = str(payload.get("hmac_scheme", ""))
+        if hmac_scheme != HMAC_SCHEME:
+            raise ValueError(f"unsupported surrogate vault hmac_scheme {hmac_scheme!r}")
+        encryption_scheme = str(payload.get("encryption_scheme", ""))
+        if encryption_scheme != ENCRYPTION_SCHEME:
+            raise ValueError(
+                f"unsupported surrogate vault encryption_scheme {encryption_scheme!r}"
+            )
+        if hmac_secret is None:
+            raise ValueError("hmac_secret is required to decrypt surrogate vault")
+
+        current_epoch = payload.get("current_epoch")
+        if not isinstance(current_epoch, Mapping):
+            raise ValueError("surrogate vault current_epoch must be an object")
+        manager = _EpochManager(
+            hmac_secret,
+            current_sequence=int(current_epoch.get("sequence", 0)),
+            revoked_key_ids=payload.get("revoked_key_ids") or (),
+        )
+        current_key = manager.current_key
+        persisted_key_id = str(current_epoch.get("key_id", ""))
+        if persisted_key_id != current_key.key_id:
+            raise ValueError("surrogate vault key_id does not match hmac_secret")
+
+        entries_payload = payload.get("entries", [])
+        if not isinstance(entries_payload, list):
+            raise ValueError("surrogate vault entries must be a list")
+
+        entries = [
+            _decrypt_entry_payload(entry, current_key) for entry in entries_payload
+        ]
+        return cls(entries, epoch_manager=manager)
+
+    @classmethod
+    def _from_legacy_payload(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        hmac_secret: str | bytes | None,
+    ) -> "InMemorySurrogateStore":
         hmac_scheme = str(payload.get("hmac_scheme", ""))
         if hmac_scheme != HMAC_SCHEME:
             raise ValueError(f"unsupported surrogate vault hmac_scheme {hmac_scheme!r}")
@@ -165,8 +439,19 @@ class InMemorySurrogateStore:
         if not isinstance(entries_payload, list):
             raise ValueError("surrogate vault entries must be a list")
 
-        entries = [SurrogateEntry.from_dict(entry) for entry in entries_payload]
-        return cls(entries)
+        manager = _EpochManager(hmac_secret) if hmac_secret is not None else None
+        current_key_id = manager.current_key.key_id if manager is not None else ""
+        entries = [
+            SurrogateEntry.from_dict(entry_payload) for entry_payload in entries_payload
+        ]
+        if current_key_id:
+            entries = [
+                SurrogateEntry(
+                    entry.key, entry.surrogate, entry.key_id or current_key_id
+                )
+                for entry in entries
+            ]
+        return cls(entries, epoch_manager=manager)
 
 
 class JsonFileSurrogateStore(InMemorySurrogateStore):
@@ -178,11 +463,12 @@ class JsonFileSurrogateStore(InMemorySurrogateStore):
         entries: Iterable[SurrogateEntry] = (),
         *,
         autosave: bool = True,
+        epoch_manager: _EpochManager | None = None,
     ) -> None:
         self.path = Path(path)
         self.autosave = bool(autosave)
         self._hydrating = True
-        super().__init__(entries)
+        super().__init__(entries, epoch_manager=epoch_manager)
         self._hydrating = False
 
     @classmethod
@@ -192,6 +478,7 @@ class JsonFileSurrogateStore(InMemorySurrogateStore):
         *,
         create: bool = True,
         autosave: bool = True,
+        hmac_secret: str | bytes | None = None,
     ) -> "JsonFileSurrogateStore":
         """Load a JSON-backed store from ``path``."""
 
@@ -199,19 +486,34 @@ class JsonFileSurrogateStore(InMemorySurrogateStore):
         if not vault_path.exists():
             if not create:
                 raise FileNotFoundError(vault_path)
-            return cls(vault_path, autosave=autosave)
+            manager = _EpochManager(hmac_secret) if hmac_secret is not None else None
+            return cls(vault_path, autosave=autosave, epoch_manager=manager)
 
         try:
             payload = json.loads(vault_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
             raise ValueError(f"Corrupt surrogate vault {vault_path}: {exc}") from exc
-        loaded = InMemorySurrogateStore.from_payload(payload)
-        return cls(vault_path, loaded.entries(), autosave=autosave)
+        loaded = InMemorySurrogateStore.from_payload(
+            payload,
+            hmac_secret=hmac_secret,
+        )
+        return cls(
+            vault_path,
+            loaded.entries(),
+            autosave=autosave,
+            epoch_manager=loaded.epoch_manager,
+        )
 
-    def set(self, key: SurrogateKey, surrogate: str) -> None:
+    def set(
+        self,
+        key: SurrogateKey,
+        surrogate: str,
+        *,
+        key_id: str | None = None,
+    ) -> None:
         """Store an entry and save it atomically when autosave is enabled."""
 
-        super().set(key, surrogate)
+        super().set(key, surrogate, key_id=key_id)
         if getattr(self, "autosave", False) and not getattr(
             self,
             "_hydrating",
@@ -251,6 +553,7 @@ class JsonFileSurrogateStore(InMemorySurrogateStore):
 
 
 SurrogateFactory = Callable[[int], str]
+ConsistencySnapshot = Mapping[str, str]
 
 
 def _contains_source_surface(candidate: str, source_text: str) -> bool:
@@ -263,8 +566,9 @@ class SurrogateVault:
     """Stable cross-document surrogate mapper.
 
     Args:
-        hmac_secret: Secret used to HMAC source surfaces. The secret is required
-            to reopen a vault consistently and is never persisted.
+        hmac_secret: Secret used to HMAC source surfaces and derive local epoch
+            keys. The secret is required to reopen a vault consistently and is
+            never persisted.
         store: Optional backing store. Defaults to an in-memory store.
     """
 
@@ -274,16 +578,18 @@ class SurrogateVault:
         *,
         store: InMemorySurrogateStore | None = None,
     ) -> None:
-        if isinstance(hmac_secret, str):
-            if not hmac_secret:
-                raise ValueError("hmac_secret must be non-empty")
-        elif isinstance(hmac_secret, bytes):
-            if not hmac_secret:
-                raise ValueError("hmac_secret must be non-empty")
-        else:
-            raise TypeError("hmac_secret must be str or bytes")
+        _secret_bytes(hmac_secret)
         self.hmac_secret = hmac_secret
-        self.store = store or InMemorySurrogateStore()
+        if store is None:
+            store = InMemorySurrogateStore(
+                epoch_manager=_EpochManager(hmac_secret),
+            )
+        elif store.epoch_manager is None:
+            store.set_epoch_manager(_EpochManager(hmac_secret))
+        self.store = store
+        if self.store.epoch_manager is None:
+            raise ValueError("surrogate vault store is missing epoch metadata")
+        self._epoch_manager = self.store.epoch_manager
 
     @classmethod
     def in_memory(cls, hmac_secret: str | bytes) -> "SurrogateVault":
@@ -300,7 +606,7 @@ class SurrogateVault:
         create: bool = True,
         autosave: bool = True,
     ) -> "SurrogateVault":
-        """Create a vault backed by a deterministic JSON file."""
+        """Create a vault backed by a deterministic encrypted JSON file."""
 
         return cls(
             hmac_secret,
@@ -308,19 +614,39 @@ class SurrogateVault:
                 path,
                 create=create,
                 autosave=autosave,
+                hmac_secret=hmac_secret,
             ),
         )
 
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}("
-            f"entries={len(self.entries())}, hmac_scheme={HMAC_SCHEME!r})"
+            f"entries={len(self.entries())}, hmac_scheme={HMAC_SCHEME!r}, "
+            f"current_key_id={self.current_key_id!r})"
         )
 
-    def text_hash(self, source_text: str | bytes) -> str:
-        """Return the vault HMAC for ``source_text``."""
+    @property
+    def current_key_id(self) -> str:
+        """Return the active key epoch identifier."""
 
-        return hmac_text_hash(source_text, self.hmac_secret)
+        return self._epoch_manager.current_key.key_id
+
+    @property
+    def current_epoch_sequence(self) -> int:
+        """Return the active epoch sequence."""
+
+        return self._epoch_manager.current_sequence
+
+    @property
+    def revoked_key_ids(self) -> tuple[str, ...]:
+        """Return revoked epoch identifiers."""
+
+        return tuple(sorted(self._epoch_manager.revoked_key_ids))
+
+    def text_hash(self, source_text: str | bytes) -> str:
+        """Return the current-epoch vault HMAC for ``source_text``."""
+
+        return hmac_text_hash(source_text, self._epoch_manager.current_key.linkage_key)
 
     def key_for(
         self,
@@ -331,12 +657,9 @@ class SurrogateVault:
     ) -> SurrogateKey:
         """Build a privacy-safe vault key for one source identifier."""
 
-        effective_lang = str(lang or "en")
-        canonical_label = normalize_label(str(label), effective_lang)
-        return SurrogateKey(
-            canonical_label=canonical_label,
-            lang=effective_lang,
-            text_hash=self.text_hash(source_text),
+        return self._key_for_epoch(
+            _source(source_text=source_text, label=label, lang=lang),
+            self._epoch_manager.current_key,
         )
 
     def get(
@@ -386,13 +709,159 @@ class SurrogateVault:
                 base = key.canonical_label
             surrogate = f"{base}_{suffix}"
 
-        self.store.set(key, surrogate)
+        self.store.set(key, surrogate, key_id=self.current_key_id)
         return surrogate
 
     def entries(self) -> tuple[SurrogateEntry, ...]:
         """Return the current sorted vault entries."""
 
         return self.store.entries()
+
+    def consistency_snapshot(
+        self,
+        sources: Iterable[SurrogateSource | Mapping[str, Any] | tuple[Any, ...]],
+    ) -> dict[str, str]:
+        """Capture a privacy-safe source-to-surrogate proof for verification."""
+
+        snapshot: dict[str, str] = {}
+        for source in _sources(sources):
+            surrogate = self.get(
+                source.source_text,
+                label=source.label,
+                lang=source.lang,
+            )
+            if surrogate is not None:
+                snapshot[self._source_proof(source)] = self._surrogate_proof(surrogate)
+        return snapshot
+
+    def verify_consistency(
+        self,
+        snapshot: ConsistencySnapshot,
+        sources: Iterable[SurrogateSource | Mapping[str, Any] | tuple[Any, ...]],
+    ) -> VaultConsistencyReport:
+        """Verify that sources still resolve to their snapshotted surrogates."""
+
+        missing: list[str] = []
+        mismatched: list[str] = []
+        matched = 0
+        checked = 0
+        for source in _sources(sources):
+            checked += 1
+            proof = self._source_proof(source)
+            expected = snapshot.get(proof)
+            current = self.get(
+                source.source_text,
+                label=source.label,
+                lang=source.lang,
+            )
+            if expected is None or current is None:
+                missing.append(proof)
+            elif self._surrogate_proof(current) != expected:
+                mismatched.append(proof)
+            else:
+                matched += 1
+        return VaultConsistencyReport(
+            checked=checked,
+            matched=matched,
+            missing=tuple(missing),
+            mismatched=tuple(mismatched),
+        )
+
+    def rotate(
+        self,
+        sources: Iterable[SurrogateSource | Mapping[str, Any] | tuple[Any, ...]] = (),
+        *,
+        target_sequence: int | None = None,
+        revoke_previous: bool = False,
+    ) -> VaultRotationResult:
+        """Rotate to a new epoch, re-keying and re-encrypting all entries.
+
+        Existing vaults do not persist raw source surfaces, so non-empty vaults
+        require a caller-supplied source catalog to rederive current and target
+        epoch HMAC keys. The catalog is consumed in memory only and is never
+        serialized.
+        """
+
+        source_items = _sources(sources)
+        previous_sequence = self._epoch_manager.current_sequence
+        previous_key = self._epoch_manager.current_key
+        next_sequence = target_sequence or previous_sequence + 1
+        if next_sequence < previous_sequence:
+            raise ValueError("target_sequence cannot move the vault backward")
+        if next_sequence == previous_sequence:
+            if revoke_previous:
+                raise ValueError("revoking the active epoch requires a new epoch")
+            snapshot = self.consistency_snapshot(source_items)
+            return VaultRotationResult(
+                previous_key_id=previous_key.key_id,
+                current_key_id=previous_key.key_id,
+                migrated_entries=0,
+                consistency=self.verify_consistency(snapshot, source_items),
+            )
+
+        current_entries = self.entries()
+        snapshot = self.consistency_snapshot(source_items)
+        target_key = self._epoch_manager.derive(next_sequence)
+        remapped = self._remap_entries(
+            current_entries,
+            sources=source_items,
+            from_key=previous_key,
+            to_key=target_key,
+        )
+        old_sequence = self._epoch_manager.current_sequence
+        old_revoked = set(self._epoch_manager.revoked_key_ids)
+
+        try:
+            self._epoch_manager.current_sequence = next_sequence
+            if revoke_previous:
+                self._epoch_manager.revoked_key_ids.add(previous_key.key_id)
+            self.store.replace_entries(remapped)
+            consistency = self.verify_consistency(snapshot, source_items)
+            if not consistency.passed:
+                raise ValueError("surrogate consistency verification failed")
+            self._save_if_file_backed()
+        except Exception:
+            self._epoch_manager.current_sequence = old_sequence
+            self._epoch_manager.revoked_key_ids = old_revoked
+            self.store.replace_entries(current_entries)
+            raise
+
+        return VaultRotationResult(
+            previous_key_id=previous_key.key_id,
+            current_key_id=target_key.key_id,
+            migrated_entries=len(current_entries),
+            revoked_key_ids=tuple(sorted(self._epoch_manager.revoked_key_ids)),
+            consistency=consistency,
+        )
+
+    def revoke_current_epoch(
+        self,
+        sources: Iterable[SurrogateSource | Mapping[str, Any] | tuple[Any, ...]] = (),
+        *,
+        target_sequence: int | None = None,
+    ) -> VaultRotationResult:
+        """Mark the active epoch compromised and re-encrypt into a new epoch."""
+
+        return self.rotate(
+            sources,
+            target_sequence=target_sequence,
+            revoke_previous=True,
+        )
+
+    def revoke_epoch(self, key_id: str) -> VaultRotationResult:
+        """Mark an inactive epoch revoked without changing current entries."""
+
+        key_id = str(key_id)
+        if key_id == self.current_key_id:
+            raise ValueError("use revoke_current_epoch() for the active epoch")
+        self._epoch_manager.revoked_key_ids.add(key_id)
+        self._save_if_file_backed()
+        return VaultRotationResult(
+            previous_key_id=self.current_key_id,
+            current_key_id=self.current_key_id,
+            migrated_entries=0,
+            revoked_key_ids=tuple(sorted(self._epoch_manager.revoked_key_ids)),
+        )
 
     def to_payload(self) -> dict[str, Any]:
         """Serialize the vault store without persisting the HMAC secret."""
@@ -407,13 +876,262 @@ class SurrogateVault:
             raise TypeError("this surrogate vault store is not file-backed")
         save()
 
+    def _key_for_epoch(self, source: SurrogateSource, epoch: _EpochKey) -> SurrogateKey:
+        effective_lang = str(source.lang or "en")
+        canonical_label = normalize_label(str(source.label), effective_lang)
+        return SurrogateKey(
+            canonical_label=canonical_label,
+            lang=effective_lang,
+            text_hash=hmac_text_hash(source.source_text, epoch.linkage_key),
+        )
+
+    def _source_proof(self, source: SurrogateSource) -> str:
+        effective_lang = str(source.lang or "en")
+        canonical_label = normalize_label(str(source.label), effective_lang)
+        material = json.dumps(
+            {
+                "canonical_label": canonical_label,
+                "lang": effective_lang,
+                "source_text": source.source_text,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        digest = hmac.new(
+            _secret_bytes(self.hmac_secret),
+            b"openmed-surrogate-vault:consistency-proof:" + material,
+            hashlib.sha256,
+        ).hexdigest()
+        return f"{HMAC_SCHEME}:{digest}"
+
+    def _surrogate_proof(self, surrogate: str) -> str:
+        digest = hmac.new(
+            _secret_bytes(self.hmac_secret),
+            b"openmed-surrogate-vault:surrogate-proof:" + surrogate.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return f"{HMAC_SCHEME}:{digest}"
+
+    def _remap_entries(
+        self,
+        entries: tuple[SurrogateEntry, ...],
+        *,
+        sources: tuple[SurrogateSource, ...],
+        from_key: _EpochKey,
+        to_key: _EpochKey,
+    ) -> tuple[SurrogateEntry, ...]:
+        source_by_key = {
+            self._key_for_epoch(source, from_key): source for source in sources
+        }
+        remapped: dict[SurrogateKey, SurrogateEntry] = {}
+        missing: list[str] = []
+        for entry in entries:
+            source = source_by_key.get(entry.key)
+            if source is None:
+                missing.append(entry.key.text_hash)
+                continue
+            next_key = self._key_for_epoch(source, to_key)
+            next_entry = SurrogateEntry(next_key, entry.surrogate, to_key.key_id)
+            current = remapped.get(next_key)
+            if current is not None and current.surrogate != next_entry.surrogate:
+                raise ValueError("rotation would collapse two surrogates into one key")
+            remapped[next_key] = next_entry
+        if missing:
+            raise ValueError(
+                "source catalog is missing entries for text hashes: "
+                + ", ".join(sorted(missing))
+            )
+        return tuple(remapped[key] for key in sorted(remapped))
+
+    def _save_if_file_backed(self) -> None:
+        save = getattr(self.store, "save", None)
+        if save is not None:
+            save()
+
+
+def _encrypted_entry_payload(
+    entry: SurrogateEntry, epoch_key: _EpochKey
+) -> dict[str, str]:
+    aad = _entry_aad(entry.key, epoch_key.key_id)
+    plaintext = entry.surrogate.encode("utf-8")
+    nonce = hmac.new(
+        epoch_key.encryption_key,
+        b"openmed-surrogate-vault:nonce:" + aad,
+        hashlib.sha256,
+    ).digest()[:_NONCE_BYTES]
+    stream = _keystream(epoch_key.encryption_key, nonce, len(plaintext))
+    ciphertext = _xor_bytes(plaintext, stream)
+    tag = _tag(epoch_key.encryption_key, aad, nonce, ciphertext)
+    return {
+        **entry.key.to_dict(),
+        "key_id": epoch_key.key_id,
+        "surrogate_ciphertext": _b64encode(ciphertext),
+        "surrogate_nonce": _b64encode(nonce),
+        "surrogate_tag": f"{HMAC_SCHEME}:{tag}",
+    }
+
+
+def _decrypt_entry_payload(
+    payload: Mapping[str, Any],
+    epoch_key: _EpochKey,
+) -> SurrogateEntry:
+    allowed = {
+        "canonical_label",
+        "lang",
+        "text_hash",
+        "key_id",
+        "surrogate_ciphertext",
+        "surrogate_nonce",
+        "surrogate_tag",
+    }
+    unknown = set(payload) - allowed
+    if unknown:
+        raise ValueError(
+            "encrypted surrogate vault entries may not contain fields: "
+            + ", ".join(sorted(map(str, unknown)))
+        )
+    key = SurrogateKey.from_dict(payload)
+    key_id = str(payload["key_id"])
+    if key_id != epoch_key.key_id:
+        raise ValueError("surrogate vault entry key_id is not the current epoch")
+    aad = _entry_aad(key, key_id)
+    ciphertext = _b64decode(str(payload["surrogate_ciphertext"]))
+    nonce = _b64decode(str(payload["surrogate_nonce"]))
+    persisted_tag = str(payload["surrogate_tag"])
+    expected_tag = (
+        f"{HMAC_SCHEME}:{_tag(epoch_key.encryption_key, aad, nonce, ciphertext)}"
+    )
+    if not hmac.compare_digest(persisted_tag, expected_tag):
+        raise ValueError("surrogate vault entry authentication failed")
+    stream = _keystream(epoch_key.encryption_key, nonce, len(ciphertext))
+    surrogate = _xor_bytes(ciphertext, stream).decode("utf-8")
+    return SurrogateEntry(key, surrogate, key_id)
+
+
+def _entry_aad(key: SurrogateKey, key_id: str) -> bytes:
+    return json.dumps(
+        {
+            **key.to_dict(),
+            "encryption_scheme": ENCRYPTION_SCHEME,
+            "hmac_scheme": HMAC_SCHEME,
+            "key_id": key_id,
+            "schema_version": SCHEMA_VERSION,
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _tag(key: bytes, aad: bytes, nonce: bytes, ciphertext: bytes) -> str:
+    mac_key = hmac.new(
+        key,
+        b"openmed-surrogate-vault:mac",
+        hashlib.sha256,
+    ).digest()
+    return hmac.new(
+        mac_key,
+        aad + b"\x00" + nonce + b"\x00" + ciphertext,
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _keystream(key: bytes, nonce: bytes, length: int) -> bytes:
+    stream_key = hmac.new(
+        key,
+        b"openmed-surrogate-vault:stream",
+        hashlib.sha256,
+    ).digest()
+    blocks: list[bytes] = []
+    counter = 0
+    while sum(len(block) for block in blocks) < length:
+        blocks.append(
+            hmac.new(
+                stream_key,
+                nonce + counter.to_bytes(8, "big"),
+                hashlib.sha256,
+            ).digest()
+        )
+        counter += 1
+    return b"".join(blocks)[:length]
+
+
+def _xor_bytes(left: bytes, right: bytes) -> bytes:
+    return bytes(left_byte ^ right_byte for left_byte, right_byte in zip(left, right))
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.b64encode(value).decode("ascii")
+
+
+def _b64decode(value: str) -> bytes:
+    return base64.b64decode(value.encode("ascii"), validate=True)
+
+
+def _secret_bytes(secret: str | bytes) -> bytes:
+    if isinstance(secret, str):
+        if not secret:
+            raise ValueError("hmac_secret must be non-empty")
+        return secret.encode("utf-8")
+    if isinstance(secret, bytes):
+        if not secret:
+            raise ValueError("hmac_secret must be non-empty")
+        return secret
+    raise TypeError("hmac_secret must be str or bytes")
+
+
+def _source(*, source_text: str, label: str, lang: str = "en") -> SurrogateSource:
+    return SurrogateSource(
+        source_text=str(source_text), label=str(label), lang=str(lang or "en")
+    )
+
+
+def _sources(
+    sources: Iterable[SurrogateSource | Mapping[str, Any] | tuple[Any, ...]],
+) -> tuple[SurrogateSource, ...]:
+    return tuple(_coerce_source(source) for source in sources)
+
+
+def _coerce_source(
+    source: SurrogateSource | Mapping[str, Any] | tuple[Any, ...],
+) -> SurrogateSource:
+    if isinstance(source, SurrogateSource):
+        return source
+    if isinstance(source, Mapping):
+        text = source.get("source_text", source.get("text"))
+        if text is None:
+            raise ValueError("source mappings must include source_text or text")
+        return _source(
+            source_text=str(text),
+            label=str(source["label"]),
+            lang=str(source.get("lang") or "en"),
+        )
+    if isinstance(source, tuple):
+        if len(source) == 2:
+            source_text, label = source
+            return _source(source_text=str(source_text), label=str(label), lang="en")
+        if len(source) == 3:
+            source_text, label, lang = source
+            return _source(
+                source_text=str(source_text),
+                label=str(label),
+                lang=str(lang or "en"),
+            )
+    raise TypeError("sources must be SurrogateSource, mapping, or tuple values")
+
 
 __all__ = [
+    "ENCRYPTION_SCHEME",
     "HMAC_SCHEME",
+    "LEGACY_SCHEMA_VERSION",
     "SCHEMA_VERSION",
     "InMemorySurrogateStore",
     "JsonFileSurrogateStore",
     "SurrogateEntry",
     "SurrogateKey",
+    "SurrogateSource",
     "SurrogateVault",
+    "VaultConsistencyReport",
+    "VaultRotationResult",
 ]

--- a/tests/unit/core/test_surrogate_vault.py
+++ b/tests/unit/core/test_surrogate_vault.py
@@ -7,10 +7,14 @@ from collections.abc import Iterable
 
 import pytest
 
+from openmed.core import surrogate_vault as vault_module
 from openmed.core.pii import deidentify, reidentify
+from openmed.core.schemas.span import hmac_text_hash
 from openmed.core.surrogate_vault import (
+    ENCRYPTION_SCHEME,
     HMAC_SCHEME,
     SCHEMA_VERSION,
+    SurrogateSource,
     SurrogateVault,
 )
 from openmed.processing.outputs import EntityPrediction, PredictionResult
@@ -74,8 +78,11 @@ def test_shared_vault_reuses_surrogates_across_deidentify_calls(monkeypatch):
     assert "Bruno Quill" not in third.deidentified_text
 
 
-def test_json_vault_persists_only_hmac_hashes_and_surrogates(monkeypatch, tmp_path):
-    """Persisted vault files do not include raw source identifiers."""
+def test_json_vault_persists_only_hmac_hashes_and_encrypted_surrogates(
+    monkeypatch,
+    tmp_path,
+):
+    """Persisted vault files do not include raw sources or plaintext surrogates."""
 
     def fake_extract(text: str, *args, **kwargs) -> PredictionResult:
         surfaces = [
@@ -87,7 +94,7 @@ def test_json_vault_persists_only_hmac_hashes_and_surrogates(monkeypatch, tmp_pa
     path = tmp_path / "surrogate-vault.json"
     vault = SurrogateVault.from_file(path, hmac_secret="unit-test-hmac-secret")
 
-    deidentify(
+    result = deidentify(
         "Alice Zephyr and Bruno Quill enrolled.",
         method="replace",
         surrogate_vault=vault,
@@ -97,22 +104,42 @@ def test_json_vault_persists_only_hmac_hashes_and_surrogates(monkeypatch, tmp_pa
     raw_json = path.read_text(encoding="utf-8")
     assert "Alice Zephyr" not in raw_json
     assert "Bruno Quill" not in raw_json
+    assert all(
+        entity.surrogate not in raw_json
+        for entity in result.pii_entities
+        if entity.surrogate is not None
+    )
 
     payload = json.loads(raw_json)
     assert payload["schema_version"] == SCHEMA_VERSION
     assert payload["hmac_scheme"] == HMAC_SCHEME
+    assert payload["encryption_scheme"] == ENCRYPTION_SCHEME
+    assert payload["current_epoch"]["key_id"] == vault.current_key_id
     assert len(payload["entries"]) == 2
     assert [entry["canonical_label"] for entry in payload["entries"]] == [
         "PERSON",
         "PERSON",
     ]
     assert all(
-        set(entry) == {"canonical_label", "lang", "text_hash", "surrogate"}
+        set(entry)
+        == {
+            "canonical_label",
+            "lang",
+            "text_hash",
+            "key_id",
+            "surrogate_ciphertext",
+            "surrogate_nonce",
+            "surrogate_tag",
+        }
         for entry in payload["entries"]
     )
     assert all(
         entry["text_hash"].startswith(f"{HMAC_SCHEME}:") for entry in payload["entries"]
     )
+    assert all(entry["key_id"] == vault.current_key_id for entry in payload["entries"])
+
+    with pytest.raises(ValueError, match="key_id|authentication"):
+        SurrogateVault.from_file(path, hmac_secret="wrong-secret")
 
 
 def test_json_vault_load_rejects_malformed_json(tmp_path):
@@ -179,3 +206,150 @@ def test_vault_backed_replace_keeps_reidentify_roundtrip(monkeypatch):
     assert all(
         entry.key.text_hash.startswith(f"{HMAC_SCHEME}:") for entry in vault.entries()
     )
+    assert all(entry.key_id == vault.current_key_id for entry in vault.entries())
+
+
+def test_rotation_preserves_cross_document_surrogates():
+    sources = (
+        SurrogateSource("Alice Zephyr", "NAME"),
+        SurrogateSource("Bruno Quill", "NAME"),
+    )
+    vault = SurrogateVault.in_memory("unit-test-hmac-secret")
+    expected = {
+        "Alice Zephyr": "Casey Example",
+        "Bruno Quill": "Riley Sample",
+    }
+    for source in sources:
+        vault.get_or_create(
+            source.source_text,
+            label=source.label,
+            lang=source.lang,
+            create_surrogate=lambda attempt, source=source: expected[
+                source.source_text
+            ],
+        )
+
+    before = {
+        source.source_text: vault.get(
+            source.source_text,
+            label=source.label,
+            lang=source.lang,
+        )
+        for source in sources
+    }
+    old_hashes = {entry.key.text_hash for entry in vault.entries()}
+
+    result = vault.rotate(sources, target_sequence=2)
+
+    assert result.migrated_entries == 2
+    assert result.consistency is not None
+    assert result.consistency.passed
+    assert vault.current_epoch_sequence == 2
+    for source in sources:
+        assert (
+            vault.get(source.source_text, label=source.label, lang=source.lang)
+            == before[source.source_text]
+        )
+    assert {entry.key.text_hash for entry in vault.entries()}.isdisjoint(old_hashes)
+    assert all(entry.key_id == vault.current_key_id for entry in vault.entries())
+
+
+def test_current_epoch_key_cannot_link_prior_epoch_hashes():
+    source = SurrogateSource("Alice Zephyr", "NAME")
+    vault = SurrogateVault.in_memory("unit-test-hmac-secret")
+    vault.get_or_create(
+        source.source_text,
+        label=source.label,
+        create_surrogate=lambda attempt: "Casey Example",
+    )
+    prior_key = vault._epoch_manager.current_key
+    prior_payload = vault.to_payload()
+    prior_text_hash = vault.entries()[0].key.text_hash
+
+    vault.rotate((source,), target_sequence=2)
+
+    current_key = vault._epoch_manager.current_key
+    assert current_key.key_id != prior_key.key_id
+    assert current_key.linkage_key != prior_key.linkage_key
+    assert (
+        hmac_text_hash(source.source_text, current_key.linkage_key) != prior_text_hash
+    )
+    with pytest.raises(ValueError, match="key_id|authentication"):
+        vault_module._decrypt_entry_payload(prior_payload["entries"][0], current_key)
+
+
+def test_revoke_current_epoch_reencrypts_forward_and_retires_old_key(tmp_path):
+    source = SurrogateSource("Alice Zephyr", "NAME")
+    path = tmp_path / "surrogate-vault.json"
+    vault = SurrogateVault.from_file(path, hmac_secret="unit-test-hmac-secret")
+    vault.get_or_create(
+        source.source_text,
+        label=source.label,
+        create_surrogate=lambda attempt: "Casey Example",
+    )
+    retired_key = vault._epoch_manager.current_key
+    old_payload = json.loads(path.read_text(encoding="utf-8"))
+    assert (
+        vault_module._decrypt_entry_payload(
+            old_payload["entries"][0], retired_key
+        ).surrogate
+        == "Casey Example"
+    )
+
+    result = vault.revoke_current_epoch((source,), target_sequence=2)
+
+    assert retired_key.key_id in result.revoked_key_ids
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert retired_key.key_id in payload["revoked_key_ids"]
+    assert retired_key.key_id not in {entry["key_id"] for entry in payload["entries"]}
+    with pytest.raises(ValueError, match="key_id|authentication"):
+        vault_module._decrypt_entry_payload(payload["entries"][0], retired_key)
+    assert (
+        vault.get(source.source_text, label=source.label, lang=source.lang)
+        == "Casey Example"
+    )
+
+
+def test_rotation_is_atomic_and_idempotent_after_interrupted_save(
+    monkeypatch,
+    tmp_path,
+):
+    sources = (
+        SurrogateSource("Alice Zephyr", "NAME"),
+        SurrogateSource("Bruno Quill", "NAME"),
+    )
+    path = tmp_path / "surrogate-vault.json"
+    vault = SurrogateVault.from_file(path, hmac_secret="unit-test-hmac-secret")
+    for source in sources:
+        vault.get_or_create(
+            source.source_text,
+            label=source.label,
+            create_surrogate=lambda attempt, source=source: f"{source.label}-{attempt}",
+        )
+    original_payload = path.read_text(encoding="utf-8")
+
+    def fail_replace(src, dst):
+        raise RuntimeError("simulated interruption")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(vault_module.os, "replace", fail_replace)
+        with pytest.raises(RuntimeError, match="simulated interruption"):
+            vault.rotate(sources, target_sequence=2)
+
+    assert path.read_text(encoding="utf-8") == original_payload
+    assert vault.current_epoch_sequence == 1
+    assert len(vault.entries()) == 2
+
+    reloaded = SurrogateVault.from_file(path, hmac_secret="unit-test-hmac-secret")
+    result = reloaded.rotate(sources, target_sequence=2)
+    assert result.consistency is not None
+    assert result.consistency.passed
+    assert len(reloaded.entries()) == 2
+    resumed_payload = path.read_text(encoding="utf-8")
+
+    idempotent = reloaded.rotate(sources, target_sequence=2)
+    assert idempotent.migrated_entries == 0
+    assert idempotent.consistency is not None
+    assert idempotent.consistency.passed
+    assert path.read_text(encoding="utf-8") == resumed_payload
+    assert len(reloaded.entries()) == 2


### PR DESCRIPTION
# Pull Request

## Description
Closes #985.

Adds a versioned surrogate vault epoch model with encrypted persisted surrogate values, forward-only rotation, active-epoch revocation, and a consistency verifier for source-to-surrogate mappings. The de-identification API remains stable while file-backed vaults no longer persist plaintext surrogates.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added key epochs, key IDs, encrypted surrogate payloads, rotation, revocation, and consistency verification to the surrogate vault.
- Preserved legacy plaintext vault loading while writing the new encrypted schema for active vaults.
- Exported the new vault helper types and expanded vault tests around rotation, forward secrecy, encrypted-at-rest scans, revocation, and interrupted migration recovery.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- make format
- make lint
- make format-check
- .venv/bin/python -m pytest tests/unit/core/test_surrogate_vault.py -q
- .venv/bin/python -m pytest tests/unit/core/test_policy_profiles.py tests/unit/test_pii.py -q
- .venv/bin/python -m pytest tests/ -q

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #985

## Screenshots/Examples
N/A