### PR TITLE
fix: add explicit UTF-8 encoding to subprocess and file I/O calls

### DIFF
--- a/openmed/core/models.py
+++ b/openmed/core/models.py
@@ -182,7 +182,7 @@ class ModelLoader:
 
         except Exception as e:
             logger.error(f"Failed to load model {full_model_name}: {e}")
-            raise ValueError(f"Could not load model {full_model_name}: {e}")
+            raise ValueError(f"Could not load model {full_model_name}: {e}") from e
 
     def create_pipeline(
         self,

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -214,7 +214,7 @@ def _is_privacy_filter_artifact_path(model_name: str) -> bool:
             continue
 
         try:
-            payload = json.loads(candidate.read_text())
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
 

--- a/openmed/core/repro_hash.py
+++ b/openmed/core/repro_hash.py
@@ -46,6 +46,7 @@ def resolve_git_sha(*, cwd: str | Path | None = None) -> str:
             ["git", "rev-parse", "HEAD"],
             cwd=str(cwd) if cwd is not None else None,
             text=True,
+            encoding="utf-8",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=True,

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -1922,6 +1922,7 @@ def _open_or_update_issue(*, repo: str, title: str, body: str) -> int | None:
             ],
             input=body,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         return existing
@@ -1940,6 +1941,7 @@ def _open_or_update_issue(*, repo: str, title: str, body: str) -> int | None:
         ],
         input=body,
         text=True,
+        encoding="utf-8",
         check=True,
         capture_output=True,
     )
@@ -1963,6 +1965,7 @@ def _find_open_issue(*, repo: str, title: str) -> int | None:
             "number,title",
         ],
         text=True,
+        encoding="utf-8",
         check=True,
         capture_output=True,
     )


### PR DESCRIPTION
## Summary

Four code-quality fixes that prevent silent data corruption on Windows and preserve debuggability:

1. **`core/pii.py`**: `read_text()` without `encoding=` uses the platform default (cp1252 on Windows), which can corrupt non-ASCII characters in mapping file paths. Added `encoding="utf-8"`.

2. **`core/models.py`**: `raise ValueError(...)` inside `except Exception as e:` without `from e` discards the original traceback, making model-load failures harder to debug. Added `from e`.

3. **`core/repro_hash.py`**: `subprocess.run(text=True)` without `encoding=` uses the platform default for decoding git output. Git always outputs UTF-8. Added `encoding="utf-8"`.

4. **`eval/release_gates.py`**: Same `subprocess.run(text=True)` issue in three `gh` CLI calls (issue comment, create, list). Added `encoding="utf-8"` to all three.

## Why it matters

On Windows, `text=True` without explicit encoding defaults to the system locale (often cp1252), which silently corrupts non-ASCII characters. This affects reproducibility hashes, PII mapping round-trips, and CI issue creation in non-English locales.