### PR TITLE
fix: replace bare assert with proper exceptions in production code

### DIFF
--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -317,7 +317,8 @@ def analyze_text(
                 len(current_indices) >= max_chunk_sentences
                 or span_length > max_chunk_chars
             ):
-                assert current_start is not None and current_end is not None
+                if current_start is None or current_end is None:
+                    raise RuntimeError("chunk boundary unexpectedly None")
                 chunk_descriptors.append(
                     {
                         "text": validated_text[current_start:current_end],
@@ -334,7 +335,8 @@ def analyze_text(
                 current_end = seg_end
 
         if current_indices:
-            assert current_start is not None and current_end is not None
+            if current_start is None or current_end is None:
+                raise RuntimeError("chunk boundary unexpectedly None")
             chunk_descriptors.append(
                 {
                     "text": validated_text[current_start:current_end],

--- a/openmed/core/models.py
+++ b/openmed/core/models.py
@@ -182,7 +182,7 @@ class ModelLoader:
 
         except Exception as e:
             logger.error(f"Failed to load model {full_model_name}: {e}")
-            raise ValueError(f"Could not load model {full_model_name}: {e}")
+            raise ValueError(f"Could not load model {full_model_name}: {e}") from e
 
     def create_pipeline(
         self,

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -214,7 +214,7 @@ def _is_privacy_filter_artifact_path(model_name: str) -> bool:
             continue
 
         try:
-            payload = json.loads(candidate.read_text())
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
 

--- a/openmed/core/repro_hash.py
+++ b/openmed/core/repro_hash.py
@@ -46,6 +46,7 @@ def resolve_git_sha(*, cwd: str | Path | None = None) -> str:
             ["git", "rev-parse", "HEAD"],
             cwd=str(cwd) if cwd is not None else None,
             text=True,
+            encoding="utf-8",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=True,

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -1922,6 +1922,7 @@ def _open_or_update_issue(*, repo: str, title: str, body: str) -> int | None:
             ],
             input=body,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         return existing
@@ -1940,6 +1941,7 @@ def _open_or_update_issue(*, repo: str, title: str, body: str) -> int | None:
         ],
         input=body,
         text=True,
+        encoding="utf-8",
         check=True,
         capture_output=True,
     )
@@ -1963,6 +1965,7 @@ def _find_open_issue(*, repo: str, title: str) -> int | None:
             "number,title",
         ],
         text=True,
+        encoding="utf-8",
         check=True,
         capture_output=True,
     )

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -222,7 +222,9 @@ def create_app() -> FastAPI:
         runtime = _get_service_runtime(request)
         if payload.all:
             return runtime.unload_all_models()
-        assert payload.model_name is not None
+        if payload.model_name is None:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=400, detail="model_name is required when 'all' is not set")
         return runtime.unload_model(payload.model_name)
 
     @app.post("/analyze")

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -224,7 +224,10 @@ def create_app() -> FastAPI:
             return runtime.unload_all_models()
         if payload.model_name is None:
             from fastapi import HTTPException
-            raise HTTPException(status_code=400, detail="model_name is required when 'all' is not set")
+
+            raise HTTPException(
+                status_code=400, detail="model_name is required when 'all' is not set"
+            )
         return runtime.unload_model(payload.model_name)
 
     @app.post("/analyze")

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -171,7 +171,8 @@ if PYDANTIC_V2:
         @classmethod
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold must be a valid number")
             return normalized
 
         @field_validator("keep_alive", mode="before")
@@ -211,7 +212,8 @@ if PYDANTIC_V2:
         @classmethod
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold must be a valid number")
             return normalized
 
         @field_validator("policy", mode="before")
@@ -308,7 +310,8 @@ else:
         @validator("confidence_threshold")
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold must be a valid number")
             return normalized
 
         @validator("keep_alive", pre=True)
@@ -344,7 +347,8 @@ else:
         @validator("confidence_threshold")
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold must be a valid number")
             return normalized
 
         @validator("policy", pre=True)


### PR DESCRIPTION
## Problem

 statements are stripped when Python runs with  (optimize) flag, silently disabling these validations in production.

## Changes

| File | Old | New |
|------|-----|-----|
|  (4x) |  |  |
|  |  |  |
|  (2x) |  |  |

All files pass . No functional behavior changes when assertions hold.