### PR TITLE
fix(mlx,coreml): add encoding='utf-8' to open() calls in model conversion and inference

### DIFF
--- a/openmed/coreml/convert.py
+++ b/openmed/coreml/convert.py
@@ -395,7 +395,7 @@ def _id2label_dict(id2label) -> dict[str, str]:
 
 def _write_id2label(output_path: Path, id2label) -> None:
     id2label_path = output_path.parent / f"{output_path.stem}_id2label.json"
-    with open(id2label_path, "w") as f:
+    with open(id2label_path, "w", encoding="utf-8") as f:
         json.dump(_id2label_dict(id2label), f, indent=2)
 
 

--- a/openmed/mlx/artifact.py
+++ b/openmed/mlx/artifact.py
@@ -72,7 +72,7 @@ def read_manifest(model_dir: str | Path) -> dict[str, Any] | None:
     manifest_path = Path(model_dir) / MANIFEST_FILENAME
     if not manifest_path.exists():
         return None
-    with open(manifest_path) as f:
+    with open(manifest_path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -85,7 +85,7 @@ def load_artifact_config(
     config_name = "config.json"
     if manifest is not None:
         config_name = manifest.get("config_path", config_name)
-    with open(model_dir / config_name) as f:
+    with open(model_dir / config_name, encoding="utf-8") as f:
         config = json.load(f)
     return manifest, config
 
@@ -228,6 +228,6 @@ def write_manifest(
         manifest["runtime"] = runtime
 
     manifest_path = model_dir / MANIFEST_FILENAME
-    with open(manifest_path, "w") as f:
+    with open(manifest_path, "w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=2)
     return manifest_path

--- a/openmed/mlx/convert.py
+++ b/openmed/mlx/convert.py
@@ -467,11 +467,11 @@ def save_mlx_model(
     _cleanup_other_weight_files(weights_path)
     config_to_save["_mlx_weights_format"] = weights_format
 
-    with open(output_dir / "config.json", "w") as f:
+    with open(output_dir / "config.json", "w", encoding="utf-8") as f:
         json.dump(config_to_save, f, indent=2)
 
     if "id2label" in config_to_save:
-        with open(output_dir / "id2label.json", "w") as f:
+        with open(output_dir / "id2label.json", "w", encoding="utf-8") as f:
             json.dump(config_to_save["id2label"], f, indent=2)
 
     _finalize_artifact(
@@ -532,11 +532,11 @@ def save_numpy_model(
     _cleanup_other_weight_files(weights_path)
     config_to_save["_mlx_weights_format"] = weights_format
 
-    with open(output_dir / "config.json", "w") as f:
+    with open(output_dir / "config.json", "w", encoding="utf-8") as f:
         json.dump(config_to_save, f, indent=2)
 
     if "id2label" in config_to_save:
-        with open(output_dir / "id2label.json", "w") as f:
+        with open(output_dir / "id2label.json", "w", encoding="utf-8") as f:
             json.dump(config_to_save["id2label"], f, indent=2)
 
     _finalize_artifact(

--- a/openmed/mlx/inference.py
+++ b/openmed/mlx/inference.py
@@ -57,7 +57,7 @@ def _tokenizer_has_list_extra_special_tokens(reference: str | Path) -> bool:
         return False
 
     try:
-        with open(tokenizer_config) as f:
+        with open(tokenizer_config, encoding="utf-8") as f:
             config = json.load(f)
     except (OSError, json.JSONDecodeError):
         return False
@@ -1188,7 +1188,7 @@ def _resolve_mlx_model(
             )
 
         try:
-            with open(local / "config.json") as f:
+            with open(local / "config.json", encoding="utf-8") as f:
                 local_config = json.load(f)
         except Exception:
             local_config = {}

--- a/openmed/mlx/models/bert_tc.py
+++ b/openmed/mlx/models/bert_tc.py
@@ -198,7 +198,7 @@ def load_model(model_path: str | Path) -> BertForTokenClassification:
     """
     model_path = Path(model_path)
 
-    with open(model_path / "config.json") as f:
+    with open(model_path / "config.json", encoding="utf-8") as f:
         config = json.load(f)
 
     model = BertForTokenClassification(config)


### PR DESCRIPTION
## Summary
Add `encoding='utf-8'` to 10 text-mode `open()` calls across MLX and CoreML conversion/inference code.

## Problem
`open()` without explicit encoding uses the platform default (`cp1252` on Windows, `ASCII` on some Linux configs). This silently corrupts non-ASCII characters in JSON config files (model labels, tokenizer vocab) when written on Windows and read back on Linux/macOS.

## Changes
| File | Calls | Fix |
|------|-------|-----|
| `coreml/convert.py` | 1 | `open(path, "w")` → `open(path, "w", encoding="utf-8")` |
| `mlx/artifact.py` | 3 | Add `encoding="utf-8"` to manifest read/write |
| `mlx/convert.py` | 4 | Add `encoding="utf-8"` to config/id2label writes |
| `mlx/models/bert_tc.py` | 1 | Add `encoding="utf-8"` to config read |
| `mlx/inference.py` | 1 | Add `encoding="utf-8"` to tokenizer config read |

All calls read/write JSON files that may contain non-ASCII text (multilingual model labels, tokenizer configs). Binary-mode calls (`open(..., 'rb')`) are not affected.