### PR TITLE
fix(core): guard json.loads against JSONDecodeError in manifest parsing

### DIFF
--- a/openmed/core/hf_publish.py
+++ b/openmed/core/hf_publish.py
@@ -166,16 +166,16 @@ def append_manifest_row(path: str | Path, row: dict[str, Any]) -> None:
 
     if path.exists():
         with path.open("r", encoding="utf-8") as handle:
-            for line in handle:
+            for line_number, line in enumerate(handle, start=1):
                 if not line.strip():
                     continue
                 try:
                     existing = json.loads(line)
                 except json.JSONDecodeError:
                     logger.warning(
-                        "Skipping malformed JSONL line in %s: %s",
+                        "Skipping malformed JSONL line %s in %s",
+                        line_number,
                         path,
-                        line.strip()[:120],
                     )
                     continue
                 if existing.get("repo_id") == row["repo_id"]:

--- a/openmed/core/hf_publish.py
+++ b/openmed/core/hf_publish.py
@@ -607,9 +607,7 @@ def _parse_json_object_arg(value: str) -> dict[str, Any]:
     try:
         payload = json.loads(source)
     except json.JSONDecodeError as exc:
-        raise HfPublishError(
-            f"--baseline-metrics is not valid JSON: {exc}"
-        ) from exc
+        raise HfPublishError(f"--baseline-metrics is not valid JSON: {exc}") from exc
     if not isinstance(payload, dict):
         raise HfPublishError("--baseline-metrics must be a JSON object")
     return payload

--- a/openmed/core/hf_publish.py
+++ b/openmed/core/hf_publish.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import logging
 import os
 import re
 from dataclasses import dataclass
@@ -17,6 +18,8 @@ from openmed.core.model_card import DEFAULT_ARXIV, render_model_card, write_mode
 from openmed.core.model_registry import load_manifest_rows
 from openmed.core.repro_hash import compute_reproducibility_hash, resolve_git_sha
 from openmed.eval.report import read_reports, write_benchmark_cards, write_leaderboard
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_ORG = "OpenMed"
 DEFAULT_TOKEN_ENV = "HF_WRITE_TOKEN"
@@ -166,7 +169,15 @@ def append_manifest_row(path: str | Path, row: dict[str, Any]) -> None:
             for line in handle:
                 if not line.strip():
                     continue
-                existing = json.loads(line)
+                try:
+                    existing = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Skipping malformed JSONL line in %s: %s",
+                        path,
+                        line.strip()[:120],
+                    )
+                    continue
                 if existing.get("repo_id") == row["repo_id"]:
                     rows.append(_merge_manifest_row(existing, row))
                     replaced = True
@@ -593,7 +604,12 @@ def _parse_json_object_arg(value: str) -> dict[str, Any]:
     source = value
     if value.startswith("@"):
         source = Path(value[1:]).read_text(encoding="utf-8")
-    payload = json.loads(source)
+    try:
+        payload = json.loads(source)
+    except json.JSONDecodeError as exc:
+        raise HfPublishError(
+            f"--baseline-metrics is not valid JSON: {exc}"
+        ) from exc
     if not isinstance(payload, dict):
         raise HfPublishError("--baseline-metrics must be a JSON object")
     return payload

--- a/tests/unit/mlx/test_hf_publish.py
+++ b/tests/unit/mlx/test_hf_publish.py
@@ -11,6 +11,7 @@ import pytest
 
 from openmed.core.hf_publish import (
     HfPublishError,
+    _parse_json_object_arg,
     append_manifest_row,
     build_manifest_row,
     publish_artifact,
@@ -179,6 +180,32 @@ def test_manifest_append_replaces_existing_repo_row_and_merges_formats(tmp_path)
         json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines()
     ]
     assert rows == [{"repo_id": "OpenMed/model", "formats": ["mlx-fp", "coreml"]}]
+
+
+def test_manifest_append_skips_malformed_json_without_logging_row(tmp_path, caplog):
+    manifest = tmp_path / "models.jsonl"
+    secret = "patient-name-should-not-be-logged"
+    manifest.write_text(
+        f'{{"repo_id":"OpenMed/old","formats":["mlx-fp"]}}\n{secret}\n',
+        encoding="utf-8",
+    )
+
+    append_manifest_row(manifest, {"repo_id": "OpenMed/new", "formats": ["coreml"]})
+
+    rows = [
+        json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines()
+    ]
+    assert rows == [
+        {"repo_id": "OpenMed/old", "formats": ["mlx-fp"]},
+        {"repo_id": "OpenMed/new", "formats": ["coreml"]},
+    ]
+    assert "Skipping malformed JSONL line 2" in caplog.text
+    assert secret not in caplog.text
+
+
+def test_parse_json_object_arg_rejects_invalid_json():
+    with pytest.raises(HfPublishError, match="not valid JSON"):
+        _parse_json_object_arg('{"micro_f1":')
 
 
 def test_conversion_modules_expose_publish_options():


### PR DESCRIPTION
## Summary
Add `json.JSONDecodeError` guards to two `json.loads()` calls in `hf_publish.py`.

## Problem
1. **`append_manifest_row()`**: When reading a JSONL manifest, a single malformed line crashes the entire append operation with an unhelpful traceback.
2. **`_parse_json_object_arg()`**: When parsing user-provided `--baseline-metrics` (CLI arg or `@file`), invalid JSON produces a raw `JSONDecodeError` instead of a clear error message.

## Changes
- `append_manifest_row()`: Wrap `json.loads(line)` in try/except `JSONDecodeError`, log warning and skip bad lines
- `_parse_json_object_arg()`: Wrap `json.loads(source)` in try/except `JSONDecodeError`, raise `HfPublishError` with parse details
- Add missing `import logging` and module logger