### PR TITLE
fix(core,processing): add 'from e' to re-raised exceptions and remove redundant IOError

### DIFF
--- a/openmed/coreml/convert.py
+++ b/openmed/coreml/convert.py
@@ -108,7 +108,7 @@ def convert(
     except ImportError as e:
         raise ImportError(
             f"Missing dependency: {e}. Install with: pip install openmed[coreml]"
-        )
+        ) from e
 
     source_config = AutoConfig.from_pretrained(model_id, cache_dir=cache_dir)
     model_type = resolve_supported_model_type(source_config)

--- a/openmed/processing/batch.py
+++ b/openmed/processing/batch.py
@@ -385,7 +385,7 @@ class BatchProcessor:
                         source=str(path),
                     )
                 )
-            except (OSError, IOError) as e:
+            except OSError as e:
                 logger.warning("Failed to read file %s: %s", path, e)
                 if not self.continue_on_error:
                     raise


### PR DESCRIPTION
## Summary
Two fixes for exception handling quality:

1. **`coreml/convert.py`**: Add `from e` to `ImportError` re-raise to preserve the original traceback chain. Without it, debugging missing dependency errors loses the root cause.

2. **`processing/batch.py`**: Remove redundant `IOError` from `except (OSError, IOError)` tuple. Since Python 3.3, `IOError` is an alias for `OSError` — the tuple is equivalent to just `except OSError`.

## Changes
| File | Change |
|------|--------|
| `coreml/convert.py` | `raise ImportError(...)` → `raise ImportError(...) from e` |
| `processing/batch.py` | `except (OSError, IOError)` → `except OSError` |