### PR TITLE
fix(core,coreml): replace assert with ValueError and add from e to re-raised ImportError

### DIFF
--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -400,7 +400,11 @@ def analyze_text(
                 current_end = seg_end
 
         if current_indices:
-            assert current_start is not None and current_end is not None
+            if current_start is None or current_end is None:
+                raise ValueError(
+                    f"Internal error: chunk descriptor has indices but no span "
+                    f"(start={current_start}, end={current_end})"
+                )
             chunk_descriptors.append(
                 {
                     "text": validated_text[current_start:current_end],

--- a/openmed/coreml/convert.py
+++ b/openmed/coreml/convert.py
@@ -108,7 +108,7 @@ def convert(
     except ImportError as e:
         raise ImportError(
             f"Missing dependency: {e}. Install with: pip install openmed[coreml]"
-        )
+        ) from e
 
     source_config = AutoConfig.from_pretrained(model_id, cache_dir=cache_dir)
     model_type = resolve_supported_model_type(source_config)


### PR DESCRIPTION
## Changes

### 1. Replace `assert` with `ValueError` in chunk descriptor validation

**File**: `openmed/__init__.py`

`assert` statements are stripped when Python runs with `-O` (optimize) flag, silently skipping the check. Replace with an explicit `ValueError` that provides diagnostic information (start/end values) and always executes regardless of optimization level.

### 2. Add `from e` to re-raised `ImportError` in CoreML conversion

**File**: `openmed/coreml/convert.py`

The `ImportError` re-raise was missing `from e`, which discards the original traceback. Adding `from e` preserves the full exception chain for debugging missing dependency issues.

## Testing

- `python3 -m py_compile openmed/__init__.py` — OK
- `python3 -m py_compile openmed/coreml/convert.py` — OK