### PR TITLE
fix: pin mlx-swift for iOS builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/ml-explore/mlx-swift.git",
-            from: "0.31.3"
+            exact: "0.31.3"
         ),
         .package(
             url: "https://github.com/weichsel/ZIPFoundation.git",

--- a/swift/OpenMedKit/Package.swift
+++ b/swift/OpenMedKit/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         // swift-transformers for HuggingFace-compatible tokenization
         .package(url: "https://github.com/huggingface/swift-transformers.git", from: "0.1.12"),
-        .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.31.3"),
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.3"),
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.19"),
     ],
     targets: [


### PR DESCRIPTION
## Summary
- pin mlx-swift exactly at 0.31.3 in both Swift package manifests
- prevent Xcode package resolution from floating the iOS build to mlx-swift 0.31.5

## Root cause
The Swift package manifests used a lower-bound dependency on mlx-swift. The root lockfile still recorded 0.31.3, but the nested OpenMedKit Xcode build path resolved packages independently and selected the newer compatible 0.31.5 tag, where the upstream encuda target fails for iOS simulator compilation.

## Validation
- scripts/lint_swift.sh
- swift test from a clean temporary worktree: 63 executed, 14 skipped, 0 failures
- xcodebuild build -scheme OpenMedKit -destination 'generic/platform=iOS Simulator' -skipPackagePluginValidation from a clean temporary worktree resolved mlx-swift at 0.31.3; local execution then stopped because this Xcode install is missing the Metal toolchain component