### PR TITLE
Migrate PyPI publishing to OIDC trusted publishing with signed attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,17 @@
-# Tags matching v* publish the openmed package to PyPI.
-# workflow_dispatch runs the same guarded publish job manually.
+# Tags matching v* build and publish the openmed package to PyPI.
 name: Publish to PyPI
 
 on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 jobs:
-  publish:
+  build:
+    name: Build distributions
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/openmed
     permissions:
-      contents: write  # attach the SBOM asset to the tagged GitHub release
+      contents: read
 
     steps:
       - uses: actions/checkout@v7
@@ -30,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build hatch
+          pip install build twine
 
       - name: Clean package cache
         run: |
@@ -91,16 +87,56 @@ jobs:
 
       - name: Check package
         run: |
-          pip install twine
           twine check dist/*
 
-      - name: Publish to PyPI
-        env:
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}
-          HATCH_KEYRING: disabled
-        run: |
-          hatch publish
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish distributions
+    needs: build
+    if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/openmed
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          attestations: true
+
+  sbom:
+    name: Generate release SBOM
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # attach the SBOM asset to the tagged GitHub release
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
 
       # SBOM generation runs after publish and is fail-open: a hiccup in any of
       # these steps must never block an otherwise-successful release.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,7 +41,7 @@ make lint-swift
 
 1. Bump the version via `make bump-patch` (or `bump-minor` / `bump-major`). These commands update `openmed/__about__.py`.
 2. Run `python3 -m build` (or `make build`) to produce wheels and sdists.
-3. Publish by pushing a tag (`vX.Y.Z`) to trigger `.github/workflows/publish.yml`.
+3. Confirm the PyPI Trusted Publisher setup in [PyPI Trusted Publishing](release/trusted-publishing.md), then publish by pushing a tag (`vX.Y.Z`) to trigger `.github/workflows/publish.yml`.
 4. Update `CHANGELOG.md` with release notes before tagging.
 
 ## Documentation deploys
@@ -72,6 +72,7 @@ to publish outside CI, run `make docs-deploy`; it mirrors the workflow by buildi
 ## Governance references
 
 - [Release Streams & Channels](release/semver-and-channels.md) defines model artifact and library release cadence.
+- [PyPI Trusted Publishing](release/trusted-publishing.md) documents package publishing, attestations, and token retirement.
 - [Generative Model Policy](generative-model-policy.md) defines approved and prohibited model-assisted workflows.
 
 Ported rule-set files must start with an upstream attribution header naming the

--- a/docs/release/trusted-publishing.md
+++ b/docs/release/trusted-publishing.md
@@ -1,0 +1,75 @@
+# PyPI Trusted Publishing
+
+OpenMed publishes the `openmed` wheel and source distribution through PyPI
+Trusted Publishing. The release workflow does not use a stored PyPI API token:
+GitHub issues an OIDC identity token to the protected publishing job, and PyPI
+exchanges that identity for a short-lived upload credential.
+
+## Workflow contract
+
+The only PyPI publishing workflow is `.github/workflows/publish.yml`.
+
+- It runs from `push` events for `v*` tags only.
+- It does not run from `pull_request` or forked pull request events.
+- The build job creates and checks the distributions without `id-token: write`.
+- The publish job downloads the built distributions, uses
+  `pypa/gh-action-pypi-publish`, and grants only `contents: read` plus
+  `id-token: write`.
+- The publish action is configured without `user`, `password`, or
+  `PYPI_API_TOKEN`.
+- PEP 740 Sigstore attestations are enabled for the PyPI upload, so each
+  distribution is published with signed provenance tied to the same OIDC
+  identity.
+
+Do not add a second PyPI publishing workflow. Do not add `hatch publish`,
+Twine upload credentials, or a `PYPI_API_TOKEN` secret back to release CI.
+
+## PyPI project setup
+
+Configure the trusted publisher on the PyPI `openmed` project before cutting a
+tagged release:
+
+1. Open the PyPI project settings for `openmed`.
+2. Add a GitHub trusted publisher with these values:
+   - Owner: `maziyarpanahi`
+   - Repository name: `openmed`
+   - Workflow name: `publish.yml`
+   - Environment name: `pypi`
+3. Ensure the GitHub `pypi` environment exists and is protected according to
+   the release policy.
+
+If PyPI reports an invalid publisher during release, check those four fields
+first. The workflow filename and environment name must match exactly.
+
+## Release checklist
+
+Before pushing a version tag:
+
+```bash
+grep -R "pypa/gh-action-pypi-publish" .github/workflows/*.yml
+if grep -R "PYPI_API_TOKEN\|hatch publish" .github/workflows/*.yml; then
+  echo "Legacy PyPI token publishing is still present"
+  exit 1
+fi
+.venv/bin/python -m pytest tests/ -q
+```
+
+The first command should identify exactly one workflow. The second command
+should find nothing. The test command must pass before the release tag is
+pushed.
+
+After the tagged publish succeeds, verify the PyPI release page lists provenance
+or attestations for the uploaded wheel and source distribution.
+
+## Token retirement
+
+Once the trusted publisher is configured and one tagged publish succeeds, retire
+the old PyPI token path:
+
+- Delete `PYPI_API_TOKEN` from repository secrets and from the `pypi`
+  environment secrets, if present.
+- Remove local `.pypirc` or shell-profile entries that were only used for
+  OpenMed package uploads.
+- Do not recreate a broad PyPI token for CI. If an emergency manual upload is
+  ever required, create a short-lived project-scoped token outside the normal CI
+  path and revoke it immediately after use.

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -25,3 +25,12 @@ Do not edit the lockfile by hand.
 CI and every tagged release also generate a CycloneDX SBOM (`sbom.cdx.json`)
 inventorying the dependency tree. See the
 [Software Bill of Materials](sbom.md) guide to regenerate or consume it.
+
+## PyPI provenance
+
+Tagged library releases use PyPI Trusted Publishing instead of a stored PyPI
+API token. The publish workflow uploads distributions with Sigstore
+attestations, giving each wheel and source distribution signed provenance from
+the release workflow identity. See the
+[PyPI Trusted Publishing](../release/trusted-publishing.md) guide for the PyPI
+configuration and token-retirement checklist.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - Supply Chain Controls: security/supply-chain.md
       - Software Bill of Materials: security/sbom.md
       - Release Streams & Channels: release/semver-and-channels.md
+      - PyPI Trusted Publishing: release/trusted-publishing.md
       - OpenMed 1.7.0 Release Notes: release/v1.7.0.md
       - Generative Model Policy: generative-model-policy.md
       - API Reference: api-reference.md

--- a/tests/unit/test_publish_workflow_version.py
+++ b/tests/unit/test_publish_workflow_version.py
@@ -32,14 +32,20 @@ def test_about_version_is_parseable_without_runtime_dependencies():
     assert re.fullmatch(r"\d+\.\d+\.\d+", match.group(1))
 
 
-def test_only_publish_workflow_runs_hatch_publish():
+def test_only_publish_workflow_uses_trusted_publishing_action():
     publishing_workflows = [
         workflow
         for workflow in WORKFLOWS_DIR.glob("*.yml")
-        if "hatch publish" in workflow.read_text(encoding="utf-8")
+        if "pypa/gh-action-pypi-publish" in workflow.read_text(encoding="utf-8")
     ]
 
     assert publishing_workflows == [PUBLISH_WORKFLOW]
+
+    for workflow in WORKFLOWS_DIR.glob("*.yml"):
+        content = workflow.read_text(encoding="utf-8")
+        assert "hatch publish" not in content
+        assert "PYPI_API_TOKEN" not in content
+        assert "HATCH_INDEX_AUTH" not in content
 
 
 def test_publish_workflow_keeps_release_gates():
@@ -47,7 +53,8 @@ def test_publish_workflow_keeps_release_gates():
 
     assert "fetch-depth: 0" in workflow
     assert "tags:\n      - 'v*'" in workflow
-    assert "workflow_dispatch:" in workflow
+    assert "workflow_dispatch:" not in workflow
+    assert "pull_request:" not in workflow
     assert "python scripts/release/check_repo_policy.py" in workflow
     assert "Compute release metadata" in workflow
     assert "python scripts/release/changelog.py" in workflow
@@ -55,4 +62,7 @@ def test_publish_workflow_keeps_release_gates():
     assert "Verify version matches tag" in workflow
     assert "twine check dist/*" in workflow
     assert "name: pypi" in workflow
-    assert "HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}" in workflow
+    assert "id-token: write" in workflow
+    assert "pypa/gh-action-pypi-publish@v1.14.0" in workflow
+    assert "attestations: true" in workflow
+    assert "HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}" not in workflow


### PR DESCRIPTION
Closes #244.

## Summary
- replace token-based package upload with PyPI Trusted Publishing in the tag-only publish workflow
- build and check distributions before the OIDC publish job, then publish with attestations enabled
- document PyPI Trusted Publisher setup, release checks, and token retirement

## Tests
- actionlint .github/workflows/publish.yml
- .venv/bin/mkdocs build --strict
- make format-check
- make lint
- .venv/bin/python -m pytest tests/ -q