### PR TITLE
fix: guard json.loads against JSONDecodeError in eval, training, cli, and core modules

### DIFF
--- a/openmed/cli/active_learning.py
+++ b/openmed/cli/active_learning.py
@@ -89,16 +89,24 @@ def _load_records(paths: Iterable[Path]) -> Iterable[Mapping[str, Any]]:
     for path in paths:
         text = path.read_text(encoding="utf-8")
         if path.suffix == ".jsonl":
-            for line in text.splitlines():
+            for line_number, line in enumerate(text.splitlines(), start=1):
                 if not line.strip():
                     continue
-                record = json.loads(line)
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"{path}:{line_number}: invalid JSON: {exc}"
+                    ) from exc
                 if not isinstance(record, Mapping):
                     raise ValueError(f"{path} contains a non-object JSONL row")
                 yield record
             continue
 
-        payload = json.loads(text)
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path}: invalid JSON: {exc}") from exc
         if isinstance(payload, Mapping):
             yield payload
         elif isinstance(payload, list):

--- a/openmed/core/custom_recognizer.py
+++ b/openmed/core/custom_recognizer.py
@@ -319,11 +319,17 @@ def _load_config(config: Mapping[str, Any] | str | Path) -> Mapping[str, Any]:
     path = Path(config).expanduser()
     suffix = path.suffix.lower()
     if suffix == ".json":
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSON in {path}: {exc}") from exc
     elif suffix in {".yaml", ".yml"}:
         import yaml
 
-        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        try:
+            payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise ValueError(f"invalid YAML in {path}: {exc}") from exc
     else:
         raise ValueError("custom recognizer config path must be JSON or YAML")
 

--- a/openmed/core/policy_lint.py
+++ b/openmed/core/policy_lint.py
@@ -229,7 +229,10 @@ def _load_path_payload(path: Path) -> dict[str, Any]:
 
 
 def _loads_tracking_duplicates(raw_json: str) -> Mapping[str, Any]:
-    return json.loads(raw_json, object_pairs_hook=_duplicate_tracking_hook)
+    try:
+        return json.loads(raw_json, object_pairs_hook=_duplicate_tracking_hook)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON: {exc}") from exc
 
 
 def _duplicate_tracking_hook(

--- a/openmed/core/schemas/span.py
+++ b/openmed/core/schemas/span.py
@@ -151,8 +151,11 @@ class OpenMedSpan:
     @classmethod
     def from_json(cls, text: str) -> "OpenMedSpan":
         """Deserialize a span from JSON text."""
-
-        return cls.from_dict(json.loads(text))
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSON: {exc}") from exc
+        return cls.from_dict(data)
 
 
 @dataclass(frozen=True)
@@ -237,7 +240,10 @@ def load_schema_snapshot(path: str | Path | None = None) -> dict[str, dict[str, 
         resource = resources.files(SCHEMA_PACKAGE).joinpath("schema-fingerprints.json")
         with resource.open("r", encoding="utf-8") as handle:
             return json.load(handle)
-    return json.loads(Path(path).read_text(encoding="utf-8"))
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
 
 
 def compare_schema_drift(

--- a/openmed/eval/calibrate.py
+++ b/openmed/eval/calibrate.py
@@ -378,7 +378,10 @@ def load_calibration_samples(
 ) -> list[CalibrationSample]:
     """Load reliability samples from JSON."""
 
-    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
     rows = payload.get("samples") if isinstance(payload, Mapping) else payload
     if not isinstance(rows, list):
         raise ValueError("calibration sample JSON must be a list or contain samples")
@@ -437,7 +440,10 @@ def load_calibration_thresholds(path: str | Path) -> CalibrationThresholdSet:
 
     candidate = Path(path)
     threshold_path = candidate / "thresholds.json" if candidate.is_dir() else candidate
-    payload = json.loads(threshold_path.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(threshold_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{threshold_path}: invalid JSON: {exc}") from exc
     return coerce_calibration_thresholds(payload, source_path=str(threshold_path))
 
 

--- a/openmed/eval/datasets/biomedical_ner.py
+++ b/openmed/eval/datasets/biomedical_ner.py
@@ -873,12 +873,23 @@ def _tag_names_from_dataset(dataset: Any) -> tuple[str, ...]:
 
 def _load_mapping_rows(path: Path) -> list[Mapping[str, Any]]:
     if path.suffix.lower() in {".jsonl", ".ndjson"}:
-        return [
-            json.loads(line)
-            for line in path.read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        ]
-    raw = json.loads(path.read_text(encoding="utf-8"))
+        rows: list[Mapping[str, Any]] = []
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if not line.strip():
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"{path}:{line_number}: invalid JSON: {exc}"
+                ) from exc
+        return rows
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
     if isinstance(raw, Mapping):
         rows = (
             raw.get("records")

--- a/openmed/eval/datasets/public.py
+++ b/openmed/eval/datasets/public.py
@@ -336,13 +336,24 @@ def _load_rows(path: Path) -> list[Mapping[str, Any]]:
         return rows
 
     if path.suffix.lower() in {".jsonl", ".ndjson"}:
-        return [
-            json.loads(line)
-            for line in path.read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        ]
+        rows: list[Mapping[str, Any]] = []
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if not line.strip():
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"{path}:{line_number}: invalid JSON: {exc}"
+                ) from exc
+        return rows
 
-    raw = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
     if isinstance(raw, Mapping):
         rows = (
             raw.get("records")

--- a/openmed/eval/harness.py
+++ b/openmed/eval/harness.py
@@ -78,15 +78,27 @@ def load_fixtures(path: str | Path) -> list[BenchmarkFixture]:
     """
     fixture_path = Path(path)
     if fixture_path.suffix.lower() == ".jsonl":
-        fixtures = [
-            BenchmarkFixture.from_mapping(json.loads(line))
-            for line in fixture_path.read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        ]
+        fixtures = []
+        for line_number, line in enumerate(
+            fixture_path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if not line.strip():
+                continue
+            try:
+                fixtures.append(
+                    BenchmarkFixture.from_mapping(json.loads(line))
+                )
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"{fixture_path}:{line_number}: invalid JSON: {exc}"
+                ) from exc
         _validate_unique_fixture_ids(fixtures)
         return fixtures
 
-    raw = json.loads(fixture_path.read_text(encoding="utf-8"))
+    try:
+        raw = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{fixture_path}: invalid JSON: {exc}") from exc
     rows = raw.get("fixtures") if isinstance(raw, Mapping) else raw
     if not isinstance(rows, list):
         raise ValueError(

--- a/openmed/eval/suites/policy_compliance.py
+++ b/openmed/eval/suites/policy_compliance.py
@@ -129,7 +129,12 @@ def load_policy_compliance_fixtures(
             stripped = line.strip()
             if not stripped:
                 continue
-            payload = json.loads(stripped)
+            try:
+                payload = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"{fixture_path}:{line_number}: invalid JSON: {exc}"
+                ) from exc
             if not isinstance(payload, Mapping):
                 raise ValueError(
                     f"{fixture_path}:{line_number} must contain a JSON object"

--- a/openmed/eval/utility.py
+++ b/openmed/eval/utility.py
@@ -399,7 +399,10 @@ def _coerce_fixtures(
 
 def _load_fixtures(path: str | Path) -> list[BenchmarkFixture]:
     fixture_path = Path(path)
-    raw = json.loads(fixture_path.read_text(encoding="utf-8"))
+    try:
+        raw = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{fixture_path}: invalid JSON: {exc}") from exc
     rows = raw.get("fixtures") if isinstance(raw, Mapping) else raw
     if not isinstance(rows, list):
         raise ValueError(

--- a/openmed/training/active_learning.py
+++ b/openmed/training/active_learning.py
@@ -299,7 +299,10 @@ class ActiveLearningQueue:
         for line in self.event_log.read_text(encoding="utf-8").splitlines():
             if not line.strip():
                 continue
-            event = json.loads(line)
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
             if not isinstance(event, Mapping):
                 continue
             event_type = event.get("event")

--- a/scripts/security/generate_sbom.py
+++ b/scripts/security/generate_sbom.py
@@ -76,9 +76,13 @@ def main() -> int:
             str(OUTFILE),
         ],
         check=True,
+        timeout=300,
     )
 
-    bom = json.loads(OUTFILE.read_text(encoding="utf-8"))
+    try:
+        bom = json.loads(OUTFILE.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"SBOM output is invalid JSON: {exc}") from exc
     component = bom.setdefault("metadata", {}).setdefault("component", {})
     component["version"] = version
     component["purl"] = f"pkg:pypi/openmed@{version}"

--- a/scripts/security/pip_audit_gate.py
+++ b/scripts/security/pip_audit_gate.py
@@ -120,6 +120,7 @@ def run_pip_audit(report_path: Path) -> dict[str, Any]:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
+        timeout=300,
     )
 
     if result.stdout:
@@ -132,7 +133,7 @@ def run_pip_audit(report_path: Path) -> dict[str, Any]:
         raise RuntimeError(f"pip-audit exited with status {result.returncode}")
 
     try:
-        return json.loads(report_path.read_text())
+        return json.loads(report_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"pip-audit wrote invalid JSON: {exc}") from exc
 


### PR DESCRIPTION
## Summary

Add `try/except json.JSONDecodeError` guards to 15 unguarded `json.loads` calls across 11 modules that parse external input (files, JSONL lines, user-provided paths). A malformed JSON payload would otherwise crash with an unhandled `JSONDecodeError` instead of a descriptive `ValueError`.

Also fix:
- Add `timeout=300` to `subprocess.run` calls in `scripts/security/`
- Add `encoding='utf-8'` to `read_text()` in `pip_audit_gate.py`
- Add `yaml.YAMLError` guard in `core/custom_recognizer.py`

## Affected modules (13 files)

| Module | Fix |
|--------|-----|
| `eval/harness.py` | Guard JSONL per-line + JSON file loading |
| `eval/utility.py` | Guard fixture JSON file loading |
| `eval/calibrate.py` | Guard calibration samples + thresholds loading |
| `eval/datasets/public.py` | Guard JSONL per-line + JSON file loading |
| `eval/datasets/biomedical_ner.py` | Guard JSONL per-line + JSON file loading |
| `eval/suites/policy_compliance.py` | Guard JSONL per-line parsing |
| `training/active_learning.py` | Guard event log JSONL parsing |
| `cli/active_learning.py` | Guard JSONL per-line + JSON file loading |
| `core/custom_recognizer.py` | Guard JSON + YAML config loading |
| `core/policy_lint.py` | Guard policy JSON parsing |
| `core/schemas/span.py` | Guard `from_json()` + `load_schema_snapshot()` |
| `scripts/security/generate_sbom.py` | Add subprocess timeout + JSON guard |
| `scripts/security/pip_audit_gate.py` | Add subprocess timeout + encoding |

## Pattern

Each fix wraps `json.loads()` in `try/except json.JSONDecodeError` and re-raises as `ValueError` with a descriptive message including the file path and (for JSONL) line number. This follows the existing pattern used in modules like `core/manifest_schema.py`, `core/model_registry.py`, and `eval/release_gates.py`.

For event log parsing in `training/active_learning.py`, malformed lines are silently skipped (using `continue`) since the event log is advisory and shouldn't block the queue.