### PR TITLE
Add UK NHS Number and National Insurance health-ID validators

### DIFF
--- a/openmed/core/anonymizer/providers/clinical_ids.py
+++ b/openmed/core/anonymizer/providers/clinical_ids.py
@@ -26,6 +26,9 @@ deterministic:
   - Thai national ID (13 digits with a weighted mod-11 checksum)
   - Polish PESEL, Latvian personas kods, South Korean RRN, and Slovak rodne
     cislo
+  - UK NHS Number, a patient health identifier validated with the NHS
+    Modulus 11 check
+  - UK National Insurance Number (NINO)
   - Generic medical record numbers (MRN-XXXXXXX style)
   - US National Provider Identifier (Luhn over a "80840" prefix)
 """
@@ -465,6 +468,107 @@ class NPIProvider(BaseProvider):
 
 
 # ---------------------------------------------------------------------------
+# UK NHS Number and National Insurance Number
+# ---------------------------------------------------------------------------
+
+_UK_NINO_DISALLOWED_PREFIX_CHARS = frozenset("DFIQUV")
+_UK_NINO_DISALLOWED_SECOND_CHARS = _UK_NINO_DISALLOWED_PREFIX_CHARS | {"O"}
+_UK_NINO_DISALLOWED_PREFIXES = frozenset({"BG", "GB", "KN", "NK", "NT", "TN", "ZZ"})
+
+
+def validate_uk_nhs_number(text: str) -> bool:
+    """Validate a 10-digit UK NHS Number with the Modulus 11 checksum."""
+
+    digits = _digits_only(text)
+    if len(digits) != 10:
+        return False
+
+    numbers = [int(digit) for digit in digits]
+    total = sum(weight * value for weight, value in zip(range(10, 1, -1), numbers[:9]))
+    check = 11 - (total % 11)
+    if check == 11:
+        check = 0
+    if check == 10:
+        return False
+
+    return numbers[9] == check
+
+
+def generate_uk_nhs_number(*, rng: random.Random | None = None) -> str:
+    """Generate a UK NHS Number accepted by :func:`validate_uk_nhs_number`."""
+
+    source = rng or random.Random()
+    for _ in range(200):
+        body_digits = [source.randint(0, 9) for _ in range(9)]
+        if all(digit == 0 for digit in body_digits):
+            continue
+
+        total = sum(
+            weight * value for weight, value in zip(range(10, 1, -1), body_digits)
+        )
+        check = 11 - (total % 11)
+        if check == 11:
+            check = 0
+        if check == 10:
+            continue
+
+        return "".join(str(digit) for digit in body_digits) + str(check)
+
+    return "9434765919"
+
+
+def validate_uk_nino(text: str) -> bool:
+    """Validate a UK National Insurance Number's current structure."""
+
+    cleaned = re.sub(r"[\s-]", "", text).upper()
+    if not re.fullmatch(r"[A-Z]{2}\d{6}[A-D]", cleaned):
+        return False
+
+    prefix = cleaned[:2]
+    if prefix in _UK_NINO_DISALLOWED_PREFIXES:
+        return False
+    if prefix[0] in _UK_NINO_DISALLOWED_PREFIX_CHARS:
+        return False
+    if prefix[1] in _UK_NINO_DISALLOWED_SECOND_CHARS:
+        return False
+
+    return True
+
+
+class UKNHSNumberProvider(BaseProvider):
+    """Generates valid 10-digit UK NHS Numbers."""
+
+    def nhs_number(self) -> str:
+        return generate_uk_nhs_number(rng=self.generator.random)
+
+
+class UKNINOProvider(BaseProvider):
+    """Generates structurally valid UK National Insurance Numbers."""
+
+    _FIRST_LETTERS = tuple(
+        letter
+        for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        if letter not in _UK_NINO_DISALLOWED_PREFIX_CHARS
+    )
+    _SECOND_LETTERS = tuple(
+        letter
+        for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        if letter not in _UK_NINO_DISALLOWED_SECOND_CHARS
+    )
+
+    def nino(self) -> str:
+        rng = self.generator.random
+        while True:
+            prefix = rng.choice(self._FIRST_LETTERS) + rng.choice(self._SECOND_LETTERS)
+            if prefix not in _UK_NINO_DISALLOWED_PREFIXES:
+                break
+
+        digits = f"{rng.randint(0, 999999):06d}"
+        suffix = rng.choice("ABCD")
+        return f"{prefix} {digits[:2]} {digits[2:4]} {digits[4:]} {suffix}"
+
+
+# ---------------------------------------------------------------------------
 # Polish PESEL (11 digits, weighted checksum with embedded birth date)
 # ---------------------------------------------------------------------------
 
@@ -779,6 +883,8 @@ __all__ = [
     "ThaiNationalIdProvider",
     "SpanishDNIProvider",
     "SpanishNIEProvider",
+    "UKNHSNumberProvider",
+    "UKNINOProvider",
     "generate_indonesian_nik",
     "generate_teudat_zehut",
     "generate_korean_rrn",
@@ -790,6 +896,7 @@ __all__ = [
     "generate_spanish_nie",
     "generate_ssn",
     "generate_thai_national_id",
+    "generate_uk_nhs_number",
     "id_subtype_for_entity_type",
     "register_clinical_providers",
     "validate_iban",
@@ -797,4 +904,6 @@ __all__ = [
     "validate_npi",
     "validate_phone_us",
     "validate_ssn",
+    "validate_uk_nhs_number",
+    "validate_uk_nino",
 ]

--- a/openmed/core/anonymizer/providers/registry_ids.py
+++ b/openmed/core/anonymizer/providers/registry_ids.py
@@ -45,6 +45,8 @@ from openmed.core.pii_i18n import (
     validate_spanish_nie,
     validate_thai_national_id,
     validate_turkish_tckn,
+    validate_uk_nhs_number,
+    validate_uk_nino,
 )
 
 from .clinical_ids import (
@@ -60,6 +62,8 @@ from .clinical_ids import (
     SpanishDNIProvider,
     SpanishNIEProvider,
     ThaiNationalIdProvider,
+    UKNHSNumberProvider,
+    UKNINOProvider,
     validate_npi,
 )
 
@@ -325,6 +329,20 @@ def _register_builtin_specs() -> None:
         validate=validate_npi,
         faker_method="npi",
         faker_provider=NPIProvider,
+    )
+    _register_aliases(
+        ("en", "en_GB", "gb", "uk"),
+        id_type="nhs_number",
+        validate=validate_uk_nhs_number,
+        faker_method="nhs_number",
+        faker_provider=UKNHSNumberProvider,
+    )
+    _register_aliases(
+        ("en", "en_GB", "gb", "uk"),
+        id_type="nino",
+        validate=validate_uk_nino,
+        faker_method="nino",
+        faker_provider=UKNINOProvider,
     )
 
 

--- a/openmed/core/anonymizer/registry.py
+++ b/openmed/core/anonymizer/registry.py
@@ -167,7 +167,7 @@ _LOCALE_ID_METHODS = {
     "hi_IN": "aadhaar",
     "de_DE": "german_steuer_id",
     "en_US": "ssn",
-    "en_GB": "ssn",
+    "en_GB": "nino",
     "tr_TR": "ssn",
     "he_IL": "teudat_zehut",
     "id_ID": "indonesian_nik",

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -592,13 +592,19 @@ def _mutable_prediction_result(result: Any) -> Any:
     )
 
 
-def _apply_pii_smart_merging(result: Any, effective_model: str, lang: str) -> Any:
+def _apply_pii_smart_merging(
+    result: Any,
+    effective_model: str,
+    lang: str,
+    *,
+    locale: Optional[str] = None,
+) -> Any:
     """Apply semantic-unit PII merging to a prediction result."""
     from ..processing.outputs import EntityPrediction
     from .pii_entity_merger import merge_entities_with_semantic_units
     from .pii_i18n import get_patterns_for_language
 
-    lang_patterns = get_patterns_for_language(lang)
+    lang_patterns = get_patterns_for_language(lang, locale=locale)
     entity_dicts = [
         {
             "entity_type": e.label,
@@ -648,6 +654,7 @@ def _extract_pii_batch(
     normalize_accents: Optional[bool] = None,
     custom_recognizer: Any = None,
     *,
+    locale: Optional[str] = None,
     loader: Optional["ModelLoader"] = None,
     privacy_filter_pipeline: Optional[Any] = None,
     **pipeline_kwargs: Any,
@@ -738,7 +745,7 @@ def _extract_pii_batch(
 
     if use_smart_merging and not uses_privacy_filter:
         results = [
-            _apply_pii_smart_merging(result, effective_model, lang)
+            _apply_pii_smart_merging(result, effective_model, lang, locale=locale)
             for result in results
         ]
 
@@ -774,6 +781,7 @@ def extract_pii(
     max_cache_entries: int = 128,
     normalize_accents: Optional[bool] = None,
     *,
+    locale: Optional[str] = None,
     loader: Optional["ModelLoader"] = None,
     custom_recognizer: Any = None,
 ) -> PredictionResult:
@@ -857,6 +865,7 @@ def extract_pii(
         use_smart_merging=use_smart_merging,
         lang=lang,
         normalize_accents=normalize_accents,
+        locale=locale,
         loader=loader,
         custom_recognizer=custom_recognizer,
     )[0]
@@ -910,6 +919,7 @@ def _apply_safety_sweep_to_result(
     pii_result: Any,
     *,
     lang: str,
+    locale: Optional[str] = None,
 ) -> tuple[Any, int]:
     """Run the deterministic sweep and record its net span contribution."""
     from .quality_gates import validate_entity_spans
@@ -920,7 +930,7 @@ def _apply_safety_sweep_to_result(
     )
 
     before_count = len(pii_result.entities)
-    entities = safety_sweep(text, pii_result.entities, lang=lang)
+    entities = safety_sweep(text, pii_result.entities, lang=lang, locale=locale)
     added_count = len(entities) - before_count
 
     metadata = dict(getattr(pii_result, "metadata", None) or {})
@@ -1650,6 +1660,7 @@ def _deidentify_batch(
         use_smart_merging=use_smart_merging,
         lang=lang,
         normalize_accents=normalize_accents,
+        locale=locale,
         custom_recognizer=recognizer,
         loader=loader,
         privacy_filter_pipeline=privacy_filter_pipeline,
@@ -1663,6 +1674,7 @@ def _deidentify_batch(
                 stripped_text,
                 pii_result,
                 lang=lang,
+                locale=locale,
             )
             _suppress_custom_allowed_entities(stripped_text, pii_result, recognizer)
             swept_results.append(pii_result)

--- a/openmed/core/pii_i18n.py
+++ b/openmed/core/pii_i18n.py
@@ -9,6 +9,11 @@ from __future__ import annotations
 import re
 from typing import Dict, List, Optional, Set
 
+from .anonymizer.providers.clinical_ids import (
+    validate_uk_nhs_number,
+    validate_uk_nino,
+)
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -1029,6 +1034,41 @@ LANGUAGE_MONTH_NAMES: Dict[str, List[str]] = {
 # ---------------------------------------------------------------------------
 
 from .pii_entity_merger import PIIPattern  # noqa: E402
+
+_UK_ENGLISH_PII_PATTERNS: List[PIIPattern] = [
+    # UK NHS Number (10 digits, optional 3-3-4 spacing, Modulus 11 check).
+    PIIPattern(
+        r"\b\d{3}\s?\d{3}\s?\d{4}\b",
+        "national_id",
+        priority=11,
+        base_score=0.45,
+        context_words=[
+            "nhs",
+            "nhs number",
+            "nhs no",
+            "patient number",
+            "health identifier",
+        ],
+        context_boost=0.45,
+        validator=validate_uk_nhs_number,
+    ),
+    # UK National Insurance Number (NINO).
+    PIIPattern(
+        r"\b[A-Z]{2}\s?\d{2}\s?\d{2}\s?\d{2}\s?[A-D]\b",
+        "national_id",
+        priority=10,
+        base_score=0.45,
+        context_words=[
+            "national insurance",
+            "national insurance number",
+            "nino",
+            "ni number",
+        ],
+        context_boost=0.45,
+        validator=validate_uk_nino,
+        flags=re.IGNORECASE,
+    ),
+]
 
 _FRENCH_PII_PATTERNS: List[PIIPattern] = [
     # French dates DD/MM/YYYY
@@ -2647,6 +2687,10 @@ LANGUAGE_PII_PATTERNS: Dict[str, List[PIIPattern]] = {
     "sk": _SLOVAK_PII_PATTERNS,
 }
 
+LOCALE_PII_PATTERNS: Dict[str, List[PIIPattern]] = {
+    "en_gb": _UK_ENGLISH_PII_PATTERNS,
+}
+
 
 # ---------------------------------------------------------------------------
 # Language-specific fake data
@@ -3049,17 +3093,46 @@ LANGUAGE_FAKE_DATA: Dict[str, Dict[str, List[str]]] = {
 # ---------------------------------------------------------------------------
 
 
-def get_patterns_for_language(lang: str) -> List[PIIPattern]:
+def _normalize_pattern_language(lang: str) -> str:
+    return lang.strip().replace("-", "_").split("_", 1)[0].casefold()
+
+
+def _normalize_pattern_locale(locale: str) -> str:
+    return locale.strip().replace("-", "_").casefold()
+
+
+def _locale_pattern_keys(lang: str, locale: str | None) -> list[str]:
+    keys: list[str] = []
+    if locale:
+        keys.append(_normalize_pattern_locale(locale))
+    if "_" in lang or "-" in lang:
+        keys.append(_normalize_pattern_locale(lang))
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for key in keys:
+        if key and key not in seen:
+            deduped.append(key)
+            seen.add(key)
+    return deduped
+
+
+def get_patterns_for_language(lang: str, locale: str | None = None) -> List[PIIPattern]:
     """Return combined PII patterns for the given language.
 
     English patterns (email, URL, IP, etc.) are universal and always
     included. Language-specific patterns (dates, phones, national IDs,
-    addresses) are added on top.
+    addresses) are added on top. Locale-specific overlays, such as
+    ``en_GB`` UK identifiers, are appended when ``locale`` is provided or
+    when ``lang`` includes a region code.
 
     Args:
-        lang: ISO 639-1 language code. Model-backed languages are listed in
+        lang: ISO 639-1 language code, optionally with a region suffix for
+            pattern lookup. Model-backed languages are listed in
             :data:`SUPPORTED_LANGUAGES`; national-ID-only languages are listed
             in :data:`NATIONAL_ID_ONLY_LANGUAGES`.
+        locale: Optional locale override (for example, ``"en_GB"``) whose
+            locale-specific deterministic patterns should also be active.
 
     Returns:
         List of PIIPattern instances for the language
@@ -3068,7 +3141,8 @@ def get_patterns_for_language(lang: str) -> List[PIIPattern]:
         ValueError: If the language is not supported
     """
     supported_pattern_languages = SUPPORTED_LANGUAGES | NATIONAL_ID_ONLY_LANGUAGES
-    if lang not in supported_pattern_languages:
+    base_lang = _normalize_pattern_language(lang)
+    if base_lang not in supported_pattern_languages:
         raise ValueError(
             f"Unsupported language '{lang}'. "
             f"Supported: {sorted(supported_pattern_languages)}"
@@ -3079,9 +3153,11 @@ def get_patterns_for_language(lang: str) -> List[PIIPattern]:
     # English patterns serve as universal base
     base = list(PII_PATTERNS)
 
-    if lang == "en":
-        return base
+    combined = base
+    if base_lang != "en":
+        combined = combined + LANGUAGE_PII_PATTERNS.get(base_lang, [])
 
-    # Add language-specific patterns
-    lang_patterns = LANGUAGE_PII_PATTERNS.get(lang, [])
-    return base + lang_patterns
+    for locale_key in _locale_pattern_keys(lang, locale):
+        combined = combined + LOCALE_PII_PATTERNS.get(locale_key, [])
+
+    return combined

--- a/openmed/core/safety_sweep.py
+++ b/openmed/core/safety_sweep.py
@@ -48,13 +48,13 @@ def _overlaps(start: int, end: int, spans: Sequence[Any]) -> bool:
     return False
 
 
-def _patterns_for_language(lang: str) -> list[PIIPattern]:
-    if lang == "en":
+def _patterns_for_language(lang: str, locale: str | None = None) -> list[PIIPattern]:
+    if lang == "en" and locale is None:
         return list(PII_PATTERNS)
 
     from .pii_i18n import get_patterns_for_language
 
-    return list(get_patterns_for_language(lang))
+    return list(get_patterns_for_language(lang, locale=locale))
 
 
 def _validated(pattern: PIIPattern, text: str) -> bool:
@@ -149,6 +149,7 @@ def safety_sweep(
     spans: Sequence[Any],
     *,
     lang: str = "en",
+    locale: str | None = None,
     patterns: Sequence[PIIPattern] | None = None,
 ) -> list[Any]:
     """Add deterministic structured identifier spans not covered by ML spans.
@@ -162,7 +163,9 @@ def safety_sweep(
     selected: list[_Candidate] = []
     active_spans: list[Any] = list(existing)
     sweep_patterns = (
-        list(patterns) if patterns is not None else _patterns_for_language(lang)
+        list(patterns)
+        if patterns is not None
+        else _patterns_for_language(lang, locale=locale)
     )
 
     for candidate in _collect_candidates(text, sweep_patterns):

--- a/tests/unit/core/test_uk_health_ids.py
+++ b/tests/unit/core/test_uk_health_ids.py
@@ -1,0 +1,90 @@
+"""Tests for UK NHS Number and National Insurance ID support."""
+
+from __future__ import annotations
+
+from faker import Faker
+
+from openmed.core.anonymizer.providers.clinical_ids import (
+    register_clinical_providers,
+    validate_uk_nhs_number,
+    validate_uk_nino,
+)
+from openmed.core.anonymizer.providers.registry_ids import get_national_id
+from openmed.core.pii import extract_pii
+from openmed.processing.outputs import PredictionResult
+
+
+def test_validate_uk_nhs_number_accepts_published_test_number():
+    assert validate_uk_nhs_number("943 476 5919")
+    assert validate_uk_nhs_number("9434765919")
+
+
+def test_validate_uk_nhs_number_rejects_remainder_10_body():
+    # First nine digits sum to 12, so sum % 11 == 1 and check digit would be 10.
+    assert not validate_uk_nhs_number("000 020 0000")
+
+
+def test_validate_uk_nino_accepts_and_rejects_structural_cases():
+    assert validate_uk_nino("AB 12 34 56 C")
+
+    assert not validate_uk_nino("BG 12 34 56 C")
+    assert not validate_uk_nino("AB 12 34 56 E")
+    assert not validate_uk_nino("AO 12 34 56 C")
+
+
+def test_uk_registry_specs_generate_valid_surrogates():
+    faker = Faker("en_GB")
+    register_clinical_providers(faker)
+    faker.seed_instance(42)
+
+    for id_type in ("nhs_number", "nino"):
+        spec = get_national_id("en", id_type)
+        assert spec is not None
+        surrogate = getattr(faker, spec.faker_method)()
+        assert spec.validate(surrogate), f"{id_type} generated {surrogate!r}"
+
+
+def test_extract_pii_en_gb_locale_yields_uk_identifier_spans(monkeypatch):
+    text = (
+        "NHS Number 943 476 5919 and National Insurance number "
+        "AB 12 34 56 C were verified."
+    )
+
+    def fake_analyze_text(inference_text, **kwargs):
+        return PredictionResult(
+            text=inference_text,
+            entities=[],
+            model_name=kwargs["model_name"],
+            timestamp="2026-01-01T00:00:00",
+        )
+
+    import openmed
+
+    monkeypatch.setattr(openmed, "analyze_text", fake_analyze_text)
+
+    result = extract_pii(
+        text,
+        model_name="fixture-pii-model",
+        lang="en",
+        locale="en_GB",
+    )
+
+    spans = {
+        (entity.text, entity.label, entity.start, entity.end)
+        for entity in result.entities
+    }
+    nhs_start = text.index("943 476 5919")
+    nino_start = text.index("AB 12 34 56 C")
+
+    assert (
+        "943 476 5919",
+        "national_id",
+        nhs_start,
+        nhs_start + len("943 476 5919"),
+    ) in spans
+    assert (
+        "AB 12 34 56 C",
+        "national_id",
+        nino_start,
+        nino_start + len("AB 12 34 56 C"),
+    ) in spans


### PR DESCRIPTION
Closes #427.

## Summary
- Add UK NHS Number and National Insurance Number validators with matching Faker-backed surrogate providers.
- Register both UK ID types in the national-ID provider registry.
- Activate NHS Number and NINO pattern detection for en_GB locale context with span-offset coverage.

## Validation
- make lint
- make format-check
- .venv/bin/python -m pytest tests/ -q
