### PR TITLE
Add Gradle build config and version catalog for the android/ project

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,4 +1,5 @@
 .gradle/
+.kotlin/
 build/
-*/build/
+**/build/
 local.properties

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,23 @@
+# OpenMedKit Android
+
+This directory contains the Gradle build for the `:openmedkit` Android library.
+The project is intentionally small until the Android API surface lands in later
+tasks.
+
+## Build Locally
+
+Install JDK 11 and Android SDK Platform 33, then run:
+
+```bash
+cd android
+./gradlew test
+```
+
+Dependency resolution is limited to Google Maven and Maven Central. Dependency
+and plugin versions are declared in `gradle/libs.versions.toml`; avoid hardcoding
+library versions in module build files.
+
+The library currently targets SDK 33 and sets `minSdk` to 26. Android 8.0 is the
+baseline for on-device inference work because it preserves broad device support
+while keeping runtime, storage, and execution APIs modern enough for the planned
+local-first pipeline.

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.library") version "7.4.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,0 +1,21 @@
+[versions]
+agp = "7.4.2"
+kotlin = "1.8.22"
+kotlinx-coroutines = "1.8.1"
+kotlinx-serialization-json = "1.5.1"
+mlkit-text-recognition = "16.0.1"
+onnxruntime = "1.20.0"
+junit = "4.13.2"
+robolectric = "4.11.1"
+
+[libraries]
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkit-text-recognition" }
+onnxruntime-android = { module = "com.microsoft.onnxruntime:onnxruntime-android", version.ref = "onnxruntime" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+
+[plugins]
+android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=bed1da33cca0f557ab13691c77f38bb67388119e4794d113e051039b80af9bb1
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME

--- a/android/gradlew.bat
+++ b/android/gradlew.bat
@@ -1,0 +1,91 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+
+@if "%DEBUG%"=="" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if %ERRORLEVEL% equ 0 goto execute
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto execute
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+
+:end
+@rem End local scope for the variables with windows NT shell
+if %ERRORLEVEL% equ 0 goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code.
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/android/openmedkit/README.md
+++ b/android/openmedkit/README.md
@@ -2,11 +2,11 @@
 
 `android/openmedkit/` is the Kotlin Android library module for OpenMedKit.
 It is a Gradle `com.android.library` module under the top-level `android/`
-build and uses the package namespace `com.openmed.openmedkit`.
+build and uses the Android namespace `org.openmed.openmedkit`.
 
 ## Layout
 
-- `src/main/kotlin/com/openmed/openmedkit/` contains the public Kotlin API.
+- `src/main/kotlin/com/openmed/openmedkit/` contains the current public Kotlin API.
 - `src/main/AndroidManifest.xml` is intentionally minimal for the library.
 - `src/test/kotlin/com/openmed/openmedkit/` contains local JVM unit tests
   running with JUnit and Robolectric.

--- a/android/openmedkit/build.gradle.kts
+++ b/android/openmedkit/build.gradle.kts
@@ -1,14 +1,17 @@
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
 }
 
 android {
-    namespace = "com.openmed.openmedkit"
+    namespace = "org.openmed.openmedkit"
     compileSdk = 33
 
     defaultConfig {
+        // Android 8.0+ keeps on-device inference support aligned with current
+        // runtime and filesystem APIs without forcing recent-only devices.
         minSdk = 26
+        targetSdk = 33
     }
 
     compileOptions {
@@ -25,11 +28,16 @@ android {
     }
 }
 
-dependencies {
-    implementation("com.microsoft.onnxruntime:onnxruntime-android:1.20.0")
-    implementation("com.google.mlkit:text-recognition:16.0.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+kotlin {
+    jvmToolchain(11)
+}
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("org.robolectric:robolectric:4.11.1")
+dependencies {
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.mlkit.text.recognition)
+    implementation(libs.onnxruntime.android)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
 }

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -2,7 +2,16 @@ pluginManagement {
     repositories {
         google()
         mavenCentral()
-        gradlePluginPortal()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            when (requested.id.id) {
+                "com.android.library" ->
+                    useModule("com.android.tools.build:gradle:${requested.version}")
+                "org.jetbrains.kotlin.android" ->
+                    useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:${requested.version}")
+            }
+        }
     }
 }
 
@@ -15,4 +24,7 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "openmed-android"
+
 include(":openmedkit")
+// Reserved for a future app/demo module; enable once android/sample exists.
+// include(":sample")


### PR DESCRIPTION
Closes #573.

## Summary
- Add the Android version catalog and move Android plugin/dependency versions into `gradle/libs.versions.toml`.
- Keep dependency resolution limited to Google Maven and Maven Central while wiring the root and `:openmedkit` Gradle builds to catalog aliases.
- Pin the Gradle 7.6.4 wrapper checksum, add the Windows wrapper script, set the required `org.openmed.openmedkit` namespace, and document local Android builds.

## Tests
- `cd android && ./gradlew test`
- `.venv/bin/python -m pytest tests/ -q`