### PR TITLE
Add an Android-tuned ONNX export profile for token-classification families

### DIFF
--- a/docs/export-onnx-android.md
+++ b/docs/export-onnx-android.md
@@ -1,0 +1,56 @@
+# Android ONNX Export
+
+OpenMed can export token-classification checkpoints for Android ONNX Runtime
+Mobile with the `android` ONNX profile:
+
+```bash
+.venv/bin/python -m openmed.onnx.convert \
+  --model OpenMed/example-token-classifier \
+  --output dist/example-android-onnx \
+  --profile android
+```
+
+The profile writes two ONNX graphs:
+
+```text
+dist/example-android-onnx/
+  model.onnx
+  model_fp16.onnx
+  config.json
+  id2label.json
+  openmed-onnx.json
+```
+
+`model.onnx` is the fp32 graph. `model_fp16.onnx` stores fp16 weights while
+keeping public input and output tensor types stable for Android callers.
+
+## Graph Contract
+
+The Android profile validates the exported graph with `onnx.checker` and then
+checks the token-classification contract used by OpenMedKit:
+
+- inputs: `input_ids`, `attention_mask`, and optional `token_type_ids`
+- input dtype: `int64`
+- output: `logits`
+- output dtype: `float32`
+- input axes: dynamic `batch` and dynamic `sequence`
+- output axes: dynamic `batch`, dynamic `sequence`, and static `labels`
+
+The profile fixes the ONNX opset at `18`. A fixed opset is required because the
+follow-up ONNX Runtime Mobile `.ort` conversion and minimal-build operator
+configuration need a predictable graph contract. The dynamic `batch` and
+`sequence` axes are retained so one exported artifact can serve variable
+request batches and note lengths on device.
+
+## Mobile Compatibility Metadata
+
+`openmed-onnx.json` records the Android artifacts with the format string
+`onnx-android`. Each artifact entry includes profile metadata with the opset,
+tensor contract, execution-provider hints (`NNAPI`, `XNNPACK`), graph
+operators, and any operators that are outside OpenMed's Android mobile safe
+set.
+
+Unsupported operators are reported as warnings and recorded in artifact
+metadata. The converter does not delete, rewrite, or silently drop graph nodes;
+the warnings are used by the later `.ort` and Android runtime tasks to decide
+whether a model needs a fallback or exporter adjustment.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Torch MPS Performance: performance-mps.md
       - MLX Quantized Export: export-mlx-quant.md
       - Transformers.js Export: export-transformersjs.md
+      - Android ONNX Export: export-onnx-android.md
       - CoreML Packaging: coreml-export.md
       - Swift Package (OpenMedKit): swift-openmedkit.md
   - Project:

--- a/openmed/onnx/__init__.py
+++ b/openmed/onnx/__init__.py
@@ -6,12 +6,18 @@ from importlib import import_module
 from typing import Any
 
 __all__ = [
+    "ANDROID_ONNX_FORMAT",
+    "ANDROID_ONNX_OPSET",
+    "ANDROID_PROFILE_NAME",
+    "AndroidProfileValidation",
     "ExportArtifact",
     "OnnxConversionResult",
     "convert",
+    "export_android_fp16",
     "export_onnx",
     "export_transformersjs_bundle",
     "export_webgpu",
+    "validate_android_profile",
     "validate_transformersjs_bundle",
     "validate_transformersjs_contract",
     "write_export_manifest",
@@ -22,6 +28,11 @@ def __getattr__(name: str) -> Any:
     """Load conversion helpers lazily so ``python -m`` stays warning-free."""
 
     if name in __all__:
+        if name.startswith(("ANDROID_", "Android", "export_android")) or (
+            name == "validate_android_profile"
+        ):
+            module = import_module("openmed.onnx.android_profile")
+            return getattr(module, name)
         if name.startswith(("export_transformersjs", "validate_transformersjs")):
             module = import_module("openmed.onnx.transformersjs")
             return getattr(module, name)

--- a/openmed/onnx/android_profile.py
+++ b/openmed/onnx/android_profile.py
@@ -1,0 +1,335 @@
+"""Android ONNX Runtime Mobile profile helpers for token classifiers.
+
+The Android profile exports token-classification graphs with a fixed ONNX
+opset, stable tensor names, and named dynamic axes. Batch and sequence axes stay
+dynamic so one artifact can serve variable Android inference batches, while the
+fixed opset keeps the graph predictable for the later ONNX Runtime Mobile
+``.ort`` conversion step.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+ANDROID_PROFILE_NAME = "android"
+ANDROID_ONNX_FORMAT = "onnx-android"
+ANDROID_ONNX_OPSET = 18
+ANDROID_FP16_FILENAME = "model_fp16.onnx"
+ANDROID_EXECUTION_PROVIDERS = ("NNAPI", "XNNPACK")
+
+ANDROID_REQUIRED_INPUTS = ("input_ids", "attention_mask")
+ANDROID_OPTIONAL_INPUTS = ("token_type_ids",)
+ANDROID_OUTPUTS = ("logits",)
+ANDROID_INPUT_DTYPE = "int64"
+ANDROID_LOGITS_DTYPE = "float32"
+
+_MOBILE_SAFE_OPS = frozenset(
+    {
+        "Add",
+        "And",
+        "ArgMax",
+        "Cast",
+        "Clip",
+        "Concat",
+        "Constant",
+        "ConstantOfShape",
+        "Div",
+        "Dropout",
+        "Equal",
+        "Erf",
+        "Exp",
+        "Expand",
+        "Gather",
+        "GatherElements",
+        "GatherND",
+        "Gelu",
+        "Gemm",
+        "Identity",
+        "LayerNormalization",
+        "Less",
+        "Log",
+        "MatMul",
+        "Mul",
+        "Neg",
+        "Not",
+        "Or",
+        "Pow",
+        "Range",
+        "ReduceMean",
+        "Reshape",
+        "Shape",
+        "Sigmoid",
+        "Slice",
+        "Softmax",
+        "Split",
+        "Sqrt",
+        "Squeeze",
+        "Sub",
+        "Tanh",
+        "Tile",
+        "Transpose",
+        "Unsqueeze",
+        "Where",
+    }
+)
+
+_ONNX_DTYPE_NAMES = {
+    1: "float32",
+    6: "int32",
+    7: "int64",
+    9: "bool",
+    10: "float16",
+    11: "float64",
+}
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AndroidProfileValidation:
+    """Validated graph contract and mobile compatibility warnings."""
+
+    path: Path
+    opset: int
+    inputs: tuple[dict[str, Any], ...]
+    outputs: tuple[dict[str, Any], ...]
+    operators: tuple[str, ...]
+    unsupported_ops: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return JSON-serializable artifact metadata for the export manifest."""
+
+        return {
+            "profile": ANDROID_PROFILE_NAME,
+            "opset": self.opset,
+            "execution_providers": list(ANDROID_EXECUTION_PROVIDERS),
+            "inputs": [dict(item) for item in self.inputs],
+            "outputs": [dict(item) for item in self.outputs],
+            "operators": list(self.operators),
+            "unsupported_ops": list(self.unsupported_ops),
+            "warnings": list(self.warnings),
+        }
+
+
+def export_android_fp16(
+    onnx_path: str | Path,
+    output_path: str | Path,
+    *,
+    keep_io_types: bool = True,
+    expected_opset: int = ANDROID_ONNX_OPSET,
+    validate: bool = True,
+) -> Path:
+    """Create an Android fp16-weight ONNX variant and validate its graph."""
+
+    try:
+        import onnx
+        from onnxruntime.transformers.float16 import convert_float_to_float16
+    except ImportError as exc:
+        raise ImportError(
+            "onnx and onnxruntime are required for Android fp16 export. "
+            "Install with: pip install openmed[onnx]"
+        ) from exc
+
+    onnx_path = Path(onnx_path)
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    model = onnx.load(str(onnx_path))
+    fp16_model = convert_float_to_float16(model, keep_io_types=keep_io_types)
+    onnx.save(fp16_model, str(output_path))
+    if validate:
+        validate_android_profile(output_path, expected_opset=expected_opset)
+    return output_path
+
+
+def validate_android_profile(
+    model_path: str | Path,
+    *,
+    expected_opset: int = ANDROID_ONNX_OPSET,
+) -> AndroidProfileValidation:
+    """Validate Android-profile tensor contract, opset, and mobile ops."""
+
+    path = Path(model_path)
+    model = _load_and_check_onnx(path)
+    opset = _default_opset(model)
+    if opset != expected_opset:
+        raise ValueError(
+            "Android ONNX profile requires opset "
+            f"{expected_opset}, found {opset} in {path}"
+        )
+
+    inputs, outputs = _validate_tensor_contract(model)
+    operators = _operators(model)
+    unsupported_ops = tuple(op for op in operators if op not in _MOBILE_SAFE_OPS)
+    warnings = tuple(
+        f"{op} is not in the Android ONNX Runtime Mobile NNAPI/XNNPACK safe set"
+        for op in unsupported_ops
+    )
+    for warning in warnings:
+        logger.warning("Android ONNX profile warning for %s: %s", path, warning)
+
+    return AndroidProfileValidation(
+        path=path,
+        opset=opset,
+        inputs=inputs,
+        outputs=outputs,
+        operators=operators,
+        unsupported_ops=unsupported_ops,
+        warnings=warnings,
+    )
+
+
+def _load_and_check_onnx(path: Path) -> Any:
+    try:
+        import onnx
+    except ImportError as exc:
+        raise ImportError(
+            "onnx is required to validate Android ONNX artifacts. "
+            "Install with: pip install openmed[onnx]"
+        ) from exc
+
+    model = onnx.load(str(path))
+    onnx.checker.check_model(model)
+    return model
+
+
+def _default_opset(model: Any) -> int:
+    for opset in getattr(model, "opset_import", ()):
+        if getattr(opset, "domain", "") in {"", "ai.onnx"}:
+            return int(getattr(opset, "version"))
+    raise ValueError("Android ONNX profile graph is missing the default opset")
+
+
+def _validate_tensor_contract(
+    model: Any,
+) -> tuple[tuple[dict[str, Any], ...], tuple[dict[str, Any], ...]]:
+    graph = model.graph
+    initializer_names = {getattr(item, "name", "") for item in graph.initializer}
+    graph_inputs = [
+        item
+        for item in graph.input
+        if getattr(item, "name", "") not in initializer_names
+    ]
+    input_by_name = {item.name: item for item in graph_inputs}
+    output_by_name = {item.name: item for item in graph.output}
+
+    missing_inputs = [
+        name for name in ANDROID_REQUIRED_INPUTS if name not in input_by_name
+    ]
+    if missing_inputs:
+        raise ValueError(
+            "Android ONNX profile model is missing inputs: " + ", ".join(missing_inputs)
+        )
+
+    allowed_inputs = set(ANDROID_REQUIRED_INPUTS) | set(ANDROID_OPTIONAL_INPUTS)
+    unexpected_inputs = sorted(set(input_by_name) - allowed_inputs)
+    if unexpected_inputs:
+        raise ValueError(
+            "Android ONNX profile model has unexpected inputs: "
+            + ", ".join(unexpected_inputs)
+        )
+
+    expected_input_order = [
+        *ANDROID_REQUIRED_INPUTS,
+        *[name for name in ANDROID_OPTIONAL_INPUTS if name in input_by_name],
+    ]
+    actual_input_order = [item.name for item in graph_inputs]
+    if actual_input_order != expected_input_order:
+        raise ValueError(
+            "Android ONNX profile inputs must be ordered as "
+            f"{', '.join(expected_input_order)}"
+        )
+
+    if list(output_by_name) != list(ANDROID_OUTPUTS):
+        raise ValueError(
+            "Android ONNX profile model must expose only "
+            f"{', '.join(ANDROID_OUTPUTS)} output"
+        )
+
+    inputs = []
+    for name in expected_input_order:
+        value_info = input_by_name[name]
+        _validate_dtype(value_info, ANDROID_INPUT_DTYPE)
+        _validate_axes(value_info, ("batch", "sequence"))
+        inputs.append(_value_info_contract(value_info, ("batch", "sequence")))
+
+    logits = output_by_name["logits"]
+    _validate_dtype(logits, ANDROID_LOGITS_DTYPE)
+    _validate_axes(logits, ("batch", "sequence", "labels"))
+    outputs = (_value_info_contract(logits, ("batch", "sequence", "labels")),)
+    return tuple(inputs), outputs
+
+
+def _validate_dtype(value_info: Any, expected_dtype: str) -> None:
+    actual = _dtype_name(value_info)
+    if actual != expected_dtype:
+        raise ValueError(
+            f"{value_info.name} must have dtype {expected_dtype}, found {actual}"
+        )
+
+
+def _validate_axes(value_info: Any, axes: Sequence[str]) -> None:
+    dims = _tensor_dims(value_info)
+    if len(dims) != len(axes):
+        raise ValueError(
+            f"{value_info.name} must have rank {len(axes)} for axes " + ", ".join(axes)
+        )
+
+    for index, axis in enumerate(axes):
+        dim = _dim_contract(dims[index])
+        if axis in {"batch", "sequence"}:
+            if dim["kind"] != "dynamic" or dim.get("name") != axis:
+                raise ValueError(f"{value_info.name} axis {axis} must be dynamic")
+        elif axis == "labels" and dim["kind"] != "static":
+            raise ValueError(f"{value_info.name} axis labels must be static")
+
+
+def _value_info_contract(value_info: Any, axes: Sequence[str]) -> dict[str, Any]:
+    return {
+        "name": value_info.name,
+        "dtype": _dtype_name(value_info),
+        "axes": list(axes),
+        "shape": [_dim_contract(dim) for dim in _tensor_dims(value_info)],
+    }
+
+
+def _tensor_dims(value_info: Any) -> Sequence[Any]:
+    try:
+        return value_info.type.tensor_type.shape.dim
+    except AttributeError as exc:
+        raise ValueError(f"{value_info.name} must have tensor shape metadata") from exc
+
+
+def _dtype_name(value_info: Any) -> str:
+    try:
+        elem_type = int(value_info.type.tensor_type.elem_type)
+    except AttributeError as exc:
+        raise ValueError(f"{value_info.name} must have tensor dtype metadata") from exc
+    return _ONNX_DTYPE_NAMES.get(elem_type, f"onnx:{elem_type}")
+
+
+def _dim_contract(dim: Any) -> dict[str, Any]:
+    dim_param = getattr(dim, "dim_param", "")
+    dim_value = getattr(dim, "dim_value", 0)
+    if dim_param:
+        return {"kind": "dynamic", "name": str(dim_param)}
+    if dim_value:
+        return {"kind": "static", "value": int(dim_value)}
+    return {"kind": "dynamic", "name": None}
+
+
+def _operators(model: Any) -> tuple[str, ...]:
+    operators = []
+    seen = set()
+    for node in getattr(model.graph, "node", ()):
+        op_type = str(getattr(node, "op_type", ""))
+        domain = str(getattr(node, "domain", ""))
+        key = op_type if domain in {"", "ai.onnx"} else f"{domain}:{op_type}"
+        if key and key not in seen:
+            seen.add(key)
+            operators.append(key)
+    return tuple(operators)

--- a/openmed/onnx/convert.py
+++ b/openmed/onnx/convert.py
@@ -1,4 +1,12 @@
-"""Convert token-classification checkpoints to ONNX and WebGPU artifacts."""
+"""Convert token-classification checkpoints to ONNX runtime artifacts.
+
+Use the default profile for a standard fp32 ONNX export plus the WebGPU fp16
+variant. Use ``--profile android`` for Android ONNX Runtime Mobile artifacts:
+``model.onnx`` and ``model_fp16.onnx`` are exported at the fixed Android opset
+with `input_ids` and `attention_mask` inputs, optional `token_type_ids`, a
+`logits` output, and named dynamic `batch` and `sequence` axes. The fixed opset
+keeps the graph stable for the later `.ort` mobile-format conversion step.
+"""
 
 from __future__ import annotations
 
@@ -12,6 +20,14 @@ from typing import Any, Mapping, Sequence
 
 from openmed.core.hf_publish import publish_artifact
 from openmed.mlx.artifact import find_tokenizer_files
+from openmed.onnx.android_profile import (
+    ANDROID_FP16_FILENAME,
+    ANDROID_ONNX_FORMAT,
+    ANDROID_ONNX_OPSET,
+    ANDROID_PROFILE_NAME,
+    export_android_fp16,
+    validate_android_profile,
+)
 from openmed.onnx.transformersjs import (
     DEFAULT_BUNDLE_DIRNAME,
     TRANSFORMERSJS_FORMAT,
@@ -26,6 +42,8 @@ MANIFEST_FORMAT = "openmed-onnx"
 MANIFEST_VERSION = 1
 DEFAULT_ONNX_FILENAME = "model.onnx"
 DEFAULT_WEBGPU_FILENAME = "model.webgpu.onnx"
+DEFAULT_ONNX_OPSET = 18
+DEFAULT_PROFILE_NAME = "default"
 DEFAULT_SAMPLE_TEXT = "Patient John Doe visited the clinic on 2024-01-15."
 
 
@@ -36,13 +54,17 @@ class ExportArtifact:
     format: str
     path: Path
     precision: str
+    metadata: Mapping[str, Any] | None = None
 
-    def to_manifest(self, root: Path) -> dict[str, str]:
-        return {
+    def to_manifest(self, root: Path) -> dict[str, Any]:
+        payload: dict[str, Any] = {
             "format": self.format,
             "path": self.path.relative_to(root).as_posix(),
             "precision": self.precision,
         }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
 
 
 @dataclass(frozen=True)
@@ -55,7 +77,7 @@ class OnnxConversionResult:
 
     @property
     def formats(self) -> list[str]:
-        return [artifact.format for artifact in self.artifacts]
+        return _dedupe_keep_order([artifact.format for artifact in self.artifacts])
 
 
 def export_onnx(
@@ -63,7 +85,8 @@ def export_onnx(
     output_path: str | Path,
     *,
     max_seq_length: int = 512,
-    opset: int = 18,
+    opset: int | None = None,
+    profile: str = DEFAULT_PROFILE_NAME,
     cache_dir: str | None = None,
     sample_text: str = DEFAULT_SAMPLE_TEXT,
 ) -> Path:
@@ -80,6 +103,8 @@ def export_onnx(
 
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    profile = _normalize_profile(profile)
+    resolved_opset = _resolve_opset(profile=profile, opset=opset)
 
     tokenizer = get_tokenizer_with_loader(
         model_id,
@@ -134,7 +159,7 @@ def export_onnx(
         export_kwargs = {
             "input_names": input_names,
             "output_names": ["logits"],
-            "opset_version": opset,
+            "opset_version": resolved_opset,
             "do_constant_folding": True,
         }
         export_kwargs.update(
@@ -143,6 +168,7 @@ def export_onnx(
                 export_fn=torch.onnx.export,
                 input_names=input_names,
                 max_seq_length=max_seq_length,
+                profile=profile,
             )
         )
         torch.onnx.export(
@@ -191,7 +217,8 @@ def convert(
     include_webgpu: bool = True,
     include_transformersjs: bool = False,
     max_seq_length: int = 512,
-    opset: int = 18,
+    opset: int | None = None,
+    profile: str = DEFAULT_PROFILE_NAME,
     cache_dir: str | None = None,
     publish_to_hub: bool = False,
     publish_repo_id: str | None = None,
@@ -206,19 +233,45 @@ def convert(
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+    profile = _normalize_profile(profile)
 
     onnx_path = export_onnx(
         model_id,
         output_dir / DEFAULT_ONNX_FILENAME,
         max_seq_length=max_seq_length,
         opset=opset,
+        profile=profile,
         cache_dir=cache_dir,
     )
-    artifacts = [
-        ExportArtifact(format="onnx", path=onnx_path, precision="float32"),
-    ]
 
-    if include_webgpu:
+    if profile == ANDROID_PROFILE_NAME:
+        android_validation = validate_android_profile(onnx_path)
+        android_fp16_path = export_android_fp16(
+            onnx_path,
+            output_dir / ANDROID_FP16_FILENAME,
+            validate=False,
+        )
+        android_fp16_validation = validate_android_profile(android_fp16_path)
+        artifacts = [
+            ExportArtifact(
+                format=ANDROID_ONNX_FORMAT,
+                path=onnx_path,
+                precision="float32",
+                metadata=android_validation.to_metadata(),
+            ),
+            ExportArtifact(
+                format=ANDROID_ONNX_FORMAT,
+                path=android_fp16_path,
+                precision="float16",
+                metadata=android_fp16_validation.to_metadata(),
+            ),
+        ]
+    else:
+        artifacts = [
+            ExportArtifact(format="onnx", path=onnx_path, precision="float32"),
+        ]
+
+    if profile != ANDROID_PROFILE_NAME and include_webgpu:
         webgpu_path = export_webgpu(
             onnx_path,
             output_dir / DEFAULT_WEBGPU_FILENAME,
@@ -232,6 +285,7 @@ def convert(
         output_dir,
         cache_dir=cache_dir,
         max_seq_length=max_seq_length,
+        require_id2label=profile == ANDROID_PROFILE_NAME,
     )
     if include_transformersjs:
         transformersjs_result = export_transformersjs_bundle(
@@ -290,6 +344,7 @@ def save_source_assets(
     *,
     cache_dir: str | None = None,
     max_seq_length: int = 512,
+    require_id2label: bool = False,
 ) -> tuple[dict[str, Any], list[str]]:
     """Save config, labels, and tokenizer assets beside exported artifacts."""
 
@@ -304,6 +359,8 @@ def save_source_assets(
     output_dir = Path(output_dir)
     config = AutoConfig.from_pretrained(model_id, cache_dir=cache_dir).to_dict()
     config["max_sequence_length"] = max_seq_length
+    if require_id2label:
+        config["id2label"] = _ensure_id2label(config)
 
     with (output_dir / "config.json").open("w", encoding="utf-8") as handle:
         json.dump(config, handle, indent=2)
@@ -403,16 +460,69 @@ def _dedupe_keep_order(items: Sequence[str]) -> list[str]:
     return result
 
 
+def _normalize_profile(profile: str) -> str:
+    normalized = profile.lower().replace("_", "-")
+    if normalized in {DEFAULT_PROFILE_NAME, "onnx"}:
+        return DEFAULT_PROFILE_NAME
+    if normalized == ANDROID_PROFILE_NAME:
+        return ANDROID_PROFILE_NAME
+    raise ValueError(
+        f"unsupported ONNX export profile {profile!r}; expected default or android"
+    )
+
+
+def _resolve_opset(*, profile: str, opset: int | None) -> int:
+    if profile == ANDROID_PROFILE_NAME:
+        if opset is not None and opset != ANDROID_ONNX_OPSET:
+            raise ValueError(
+                "Android ONNX profile requires fixed opset "
+                f"{ANDROID_ONNX_OPSET}; got {opset}"
+            )
+        return ANDROID_ONNX_OPSET
+    return DEFAULT_ONNX_OPSET if opset is None else opset
+
+
+def _ensure_id2label(config: Mapping[str, Any]) -> dict[str, str]:
+    id2label = config.get("id2label")
+    if isinstance(id2label, Mapping) and id2label:
+        return {str(key): str(value) for key, value in id2label.items()}
+
+    label2id = config.get("label2id")
+    if isinstance(label2id, Mapping) and label2id:
+        labels = sorted(
+            ((int(index), str(label)) for label, index in label2id.items()),
+            key=lambda item: item[0],
+        )
+        return {str(index): label for index, label in labels}
+
+    num_labels = config.get("num_labels")
+    if isinstance(num_labels, int) and num_labels > 0:
+        return {str(index): f"LABEL_{index}" for index in range(num_labels)}
+
+    raise ValueError("Android ONNX profile requires config.json id2label metadata")
+
+
 def _dynamic_export_kwargs(
     torch_module: Any,
     *,
     export_fn: Any,
     input_names: Sequence[str],
     max_seq_length: int,
+    profile: str = DEFAULT_PROFILE_NAME,
 ) -> dict[str, Any]:
     """Return Torch ONNX dynamic-shape kwargs for the installed exporter."""
 
     parameters = inspect.signature(export_fn).parameters
+    if profile == ANDROID_PROFILE_NAME:
+        kwargs: dict[str, Any] = {
+            "dynamic_axes": {
+                name: {0: "batch", 1: "sequence"} for name in [*input_names, "logits"]
+            }
+        }
+        if "dynamo" in parameters:
+            kwargs["dynamo"] = False
+        return kwargs
+
     if "dynamo" in parameters and "dynamic_shapes" in parameters:
         batch_dim = torch_module.export.Dim("batch", min=1)
         sequence_dim = torch_module.export.Dim(
@@ -454,12 +564,23 @@ def main() -> None:
         help="Also emit a Transformers.js bundle with model_quantized.onnx",
     )
     parser.add_argument(
+        "--profile",
+        choices=[DEFAULT_PROFILE_NAME, ANDROID_PROFILE_NAME],
+        default=DEFAULT_PROFILE_NAME,
+        help="Export profile. Use android for ONNX Runtime Mobile artifacts.",
+    )
+    parser.add_argument(
         "--max-seq-length",
         type=int,
         default=512,
         help="Maximum input sequence length",
     )
-    parser.add_argument("--opset", type=int, default=18, help="ONNX opset version")
+    parser.add_argument(
+        "--opset",
+        type=int,
+        default=None,
+        help="ONNX opset version; android always uses its fixed mobile opset",
+    )
     parser.add_argument(
         "--cache-dir", default=None, help="Hugging Face cache directory"
     )
@@ -508,6 +629,7 @@ def main() -> None:
         include_transformersjs=args.include_transformersjs,
         max_seq_length=args.max_seq_length,
         opset=args.opset,
+        profile=args.profile,
         cache_dir=args.cache_dir,
         publish_to_hub=args.publish_to_hub,
         publish_repo_id=args.publish_repo_id,

--- a/tests/unit/onnx/test_android_onnx_profile.py
+++ b/tests/unit/onnx/test_android_onnx_profile.py
@@ -1,0 +1,430 @@
+"""Tests for the Android ONNX Runtime Mobile export profile."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _android_module():
+    return importlib.import_module("openmed.onnx.android_profile")
+
+
+def _convert_module():
+    return importlib.import_module("openmed.onnx.convert")
+
+
+def test_committed_android_contract_fixture_asserts_names_dtypes_and_dynamic_axes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    module = _android_module()
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"onnx")
+    model = _fake_android_model(nodes=("MatMul", "CustomOp"))
+    checked = _install_fake_onnx(monkeypatch, model)
+    caplog.set_level(logging.WARNING)
+
+    validation = module.validate_android_profile(model_path)
+
+    assert checked == [model]
+    assert validation.opset == module.ANDROID_ONNX_OPSET
+    assert validation.inputs == (
+        {
+            "name": "input_ids",
+            "dtype": "int64",
+            "axes": ["batch", "sequence"],
+            "shape": [
+                {"kind": "dynamic", "name": "batch"},
+                {"kind": "dynamic", "name": "sequence"},
+            ],
+        },
+        {
+            "name": "attention_mask",
+            "dtype": "int64",
+            "axes": ["batch", "sequence"],
+            "shape": [
+                {"kind": "dynamic", "name": "batch"},
+                {"kind": "dynamic", "name": "sequence"},
+            ],
+        },
+    )
+    assert validation.outputs == (
+        {
+            "name": "logits",
+            "dtype": "float32",
+            "axes": ["batch", "sequence", "labels"],
+            "shape": [
+                {"kind": "dynamic", "name": "batch"},
+                {"kind": "dynamic", "name": "sequence"},
+                {"kind": "static", "value": 3},
+            ],
+        },
+    )
+    assert validation.unsupported_ops == ("CustomOp",)
+    assert "CustomOp is not in the Android ONNX Runtime Mobile" in caplog.text
+    assert validation.to_metadata()["profile"] == module.ANDROID_PROFILE_NAME
+
+
+def test_validate_android_profile_rejects_static_sequence_axis(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _android_module()
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"onnx")
+    _install_fake_onnx(monkeypatch, _fake_android_model(sequence_dynamic=False))
+
+    with pytest.raises(ValueError, match="axis sequence must be dynamic"):
+        module.validate_android_profile(model_path)
+
+
+def test_validate_android_profile_rejects_wrong_opset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _android_module()
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"onnx")
+    _install_fake_onnx(monkeypatch, _fake_android_model(opset=17))
+
+    with pytest.raises(ValueError, match="requires opset 18"):
+        module.validate_android_profile(model_path)
+
+
+def test_export_android_fp16_converts_weights_and_keeps_io_types(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _android_module()
+    input_path = tmp_path / "model.onnx"
+    output_path = tmp_path / "model_fp16.onnx"
+    input_path.write_bytes(b"onnx")
+    model = _fake_android_model()
+    saved = {}
+    _install_fake_onnx(monkeypatch, model, saved=saved)
+
+    runtime_mod = types.ModuleType("onnxruntime")
+    transformers_mod = types.ModuleType("onnxruntime.transformers")
+    float16_mod = types.ModuleType("onnxruntime.transformers.float16")
+
+    def fake_convert(model_obj, keep_io_types):
+        return {"fp16": model_obj, "keep_io_types": keep_io_types}
+
+    float16_mod.convert_float_to_float16 = fake_convert
+    monkeypatch.setitem(sys.modules, "onnxruntime", runtime_mod)
+    monkeypatch.setitem(sys.modules, "onnxruntime.transformers", transformers_mod)
+    monkeypatch.setitem(sys.modules, "onnxruntime.transformers.float16", float16_mod)
+
+    result = module.export_android_fp16(input_path, output_path)
+
+    assert result == output_path
+    assert output_path.read_bytes() == b"fp16"
+    assert saved["model"]["keep_io_types"] is True
+
+
+def test_convert_android_profile_records_fp32_fp16_artifacts_and_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _convert_module()
+    export_calls = []
+
+    def fake_export_onnx(model_id, output_path, **kwargs):
+        export_calls.append(kwargs)
+        path = Path(output_path)
+        path.write_bytes(b"onnx")
+        return path
+
+    def fake_export_android_fp16(onnx_path, output_path, **kwargs):
+        assert Path(onnx_path).name == "model.onnx"
+        path = Path(output_path)
+        path.write_bytes(b"fp16")
+        return path
+
+    def fake_validate_android_profile(model_path, **kwargs):
+        return types.SimpleNamespace(
+            to_metadata=lambda: {
+                "profile": "android",
+                "opset": module.ANDROID_ONNX_OPSET,
+                "inputs": [],
+                "outputs": [],
+                "unsupported_ops": [],
+                "warnings": [],
+            }
+        )
+
+    def fake_save_source_assets(model_id, output_dir, **kwargs):
+        assert kwargs["require_id2label"] is True
+        output_dir = Path(output_dir)
+        config = {
+            "model_type": "bert",
+            "id2label": {"0": "O", "1": "B-NAME"},
+            "max_sequence_length": kwargs["max_seq_length"],
+        }
+        (output_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        (output_dir / "id2label.json").write_text(
+            json.dumps(config["id2label"]),
+            encoding="utf-8",
+        )
+        return config, []
+
+    monkeypatch.setattr(module, "export_onnx", fake_export_onnx)
+    monkeypatch.setattr(module, "export_android_fp16", fake_export_android_fp16)
+    monkeypatch.setattr(
+        module, "validate_android_profile", fake_validate_android_profile
+    )
+    monkeypatch.setattr(module, "save_source_assets", fake_save_source_assets)
+    monkeypatch.setattr(
+        module,
+        "export_webgpu",
+        lambda *args, **kwargs: pytest.fail("android profile must not emit WebGPU"),
+    )
+
+    result = module.convert(
+        "OpenMed/test-model",
+        tmp_path / "artifact",
+        profile="android",
+        include_webgpu=True,
+    )
+
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert export_calls[0]["profile"] == "android"
+    assert result.formats == ["onnx-android"]
+    assert manifest["formats"] == ["onnx-android"]
+    assert [item["path"] for item in manifest["artifacts"]] == [
+        "model.onnx",
+        "model_fp16.onnx",
+    ]
+    assert [item["precision"] for item in manifest["artifacts"]] == [
+        "float32",
+        "float16",
+    ]
+    assert manifest["artifacts"][0]["format"] == "onnx-android"
+    assert manifest["artifacts"][0]["metadata"]["opset"] == module.ANDROID_ONNX_OPSET
+    config = json.loads((result.output_dir / "config.json").read_text())
+    assert config["id2label"] == {"0": "O", "1": "B-NAME"}
+
+
+def test_export_onnx_android_profile_uses_fixed_opset_and_named_dynamic_axes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _convert_module()
+    output_path = tmp_path / "model.onnx"
+    export_call = {}
+
+    torch_mod = types.ModuleType("torch")
+
+    class Module:
+        def eval(self) -> None:
+            pass
+
+    class NoGrad:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    def fake_export(
+        model,
+        args,
+        f,
+        *,
+        input_names=None,
+        output_names=None,
+        opset_version=None,
+        dynamo=True,
+        dynamic_shapes=None,
+        dynamic_axes=None,
+        do_constant_folding=True,
+    ):
+        export_call.update(
+            {
+                "args": args,
+                "input_names": input_names,
+                "output_names": output_names,
+                "opset_version": opset_version,
+                "dynamo": dynamo,
+                "dynamic_shapes": dynamic_shapes,
+                "dynamic_axes": dynamic_axes,
+                "do_constant_folding": do_constant_folding,
+            }
+        )
+        Path(f).write_bytes(b"onnx")
+
+    torch_mod.nn = types.SimpleNamespace(Module=Module)
+    torch_mod.no_grad = NoGrad
+    torch_mod.onnx = types.SimpleNamespace(export=fake_export)
+
+    class FakeTokenizer:
+        def __call__(self, texts, **kwargs):
+            assert len(texts) == 2
+            return {
+                "input_ids": [[101, 102], [101, 102]],
+                "attention_mask": [[1, 1], [1, 1]],
+                "token_type_ids": [[0, 0], [0, 0]],
+            }
+
+    class FakeModel(Module):
+        pass
+
+    transformers_mod = types.ModuleType("transformers")
+    transformers_mod.AutoTokenizer = types.SimpleNamespace(
+        from_pretrained=lambda *args, **kwargs: FakeTokenizer()
+    )
+    transformers_mod.AutoModelForTokenClassification = types.SimpleNamespace(
+        from_pretrained=lambda *args, **kwargs: FakeModel()
+    )
+    onnx_mod = types.ModuleType("onnx")
+    onnx_mod.load = lambda path: {"path": path}
+    onnx_mod.checker = types.SimpleNamespace(check_model=lambda model: None)
+
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    monkeypatch.setitem(sys.modules, "transformers", transformers_mod)
+    monkeypatch.setitem(sys.modules, "onnx", onnx_mod)
+
+    module.export_onnx(
+        "OpenMed/test-model",
+        output_path,
+        max_seq_length=32,
+        profile="android",
+    )
+
+    assert export_call["opset_version"] == module.ANDROID_ONNX_OPSET
+    assert export_call["dynamo"] is False
+    assert export_call["dynamic_shapes"] is None
+    assert export_call["input_names"] == [
+        "input_ids",
+        "attention_mask",
+        "token_type_ids",
+    ]
+    assert export_call["output_names"] == ["logits"]
+    assert export_call["dynamic_axes"] == {
+        "input_ids": {0: "batch", 1: "sequence"},
+        "attention_mask": {0: "batch", 1: "sequence"},
+        "token_type_ids": {0: "batch", 1: "sequence"},
+        "logits": {0: "batch", 1: "sequence"},
+    }
+
+
+def test_save_source_assets_populates_id2label_for_android(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _convert_module()
+
+    class FakeConfig:
+        def to_dict(self):
+            return {"model_type": "bert", "num_labels": 2}
+
+    class FakeTokenizer:
+        def save_pretrained(self, output_dir):
+            Path(output_dir, "tokenizer.json").write_text("{}", encoding="utf-8")
+
+    transformers_mod = types.ModuleType("transformers")
+    transformers_mod.AutoConfig = types.SimpleNamespace(
+        from_pretrained=lambda *args, **kwargs: FakeConfig()
+    )
+    transformers_mod.AutoTokenizer = types.SimpleNamespace(
+        from_pretrained=lambda *args, **kwargs: FakeTokenizer()
+    )
+
+    monkeypatch.setitem(sys.modules, "transformers", transformers_mod)
+    monkeypatch.setattr(
+        module,
+        "get_tokenizer_with_loader",
+        lambda model_id, loader, cache_dir=None: FakeTokenizer(),
+    )
+
+    config, tokenizer_files = module.save_source_assets(
+        "OpenMed/test-model",
+        tmp_path,
+        require_id2label=True,
+    )
+
+    assert config["id2label"] == {"0": "LABEL_0", "1": "LABEL_1"}
+    assert json.loads((tmp_path / "config.json").read_text())["id2label"] == {
+        "0": "LABEL_0",
+        "1": "LABEL_1",
+    }
+    assert "tokenizer.json" in tokenizer_files
+
+
+def _install_fake_onnx(
+    monkeypatch: pytest.MonkeyPatch,
+    model,
+    *,
+    saved: dict | None = None,
+) -> list:
+    checked = []
+    onnx_mod = types.ModuleType("onnx")
+    onnx_mod.load = lambda path: model
+    onnx_mod.checker = types.SimpleNamespace(
+        check_model=lambda model_obj: checked.append(model_obj)
+    )
+
+    def fake_save(model_obj, path):
+        if saved is not None:
+            saved["model"] = model_obj
+            saved["path"] = path
+        Path(path).write_bytes(b"fp16")
+
+    onnx_mod.save = fake_save
+    monkeypatch.setitem(sys.modules, "onnx", onnx_mod)
+    return checked
+
+
+def _fake_android_model(
+    *,
+    opset: int = 18,
+    nodes: tuple[str, ...] = ("MatMul", "Add"),
+    sequence_dynamic: bool = True,
+):
+    sequence_dim = _dim("sequence") if sequence_dynamic else _dim(value=512)
+    return types.SimpleNamespace(
+        opset_import=[types.SimpleNamespace(domain="", version=opset)],
+        graph=types.SimpleNamespace(
+            initializer=[],
+            input=[
+                _value_info("input_ids", [_dim("batch"), sequence_dim], elem_type=7),
+                _value_info(
+                    "attention_mask",
+                    [_dim("batch"), sequence_dim],
+                    elem_type=7,
+                ),
+            ],
+            output=[
+                _value_info(
+                    "logits",
+                    [_dim("batch"), sequence_dim, _dim(value=3)],
+                    elem_type=1,
+                )
+            ],
+            node=[types.SimpleNamespace(op_type=node, domain="") for node in nodes],
+        ),
+    )
+
+
+def _value_info(name: str, dims, *, elem_type: int):
+    return types.SimpleNamespace(
+        name=name,
+        type=types.SimpleNamespace(
+            tensor_type=types.SimpleNamespace(
+                elem_type=elem_type,
+                shape=types.SimpleNamespace(dim=dims),
+            ),
+        ),
+    )
+
+
+def _dim(name: str = "", *, value: int = 0):
+    return types.SimpleNamespace(dim_param=name, dim_value=value)


### PR DESCRIPTION
Closes #575.

## Summary
- Add an Android ONNX profile that exports model.onnx and model_fp16.onnx with fixed opset 18, named dynamic batch and sequence axes, stable token-classification IO, and onnx-android artifact metadata.
- Validate Android graphs with onnx.checker, tensor dtype and opset checks, plus recorded NNAPI/XNNPACK unsupported-op warnings.
- Document profile selection and add unit coverage for export orchestration, fp16 conversion, metadata, and id2label population.

## Tests
- make lint
- make format-check
- .venv/bin/python -m pytest tests/unit/onnx -q
- .venv/bin/python -m pytest tests/ -q