### PR TITLE
Port the de-identify engine with mask, remove, replace, and hash actions

### DIFF
--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/deid/DeidentifyEngine.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/deid/DeidentifyEngine.kt
@@ -1,0 +1,242 @@
+package com.openmed.openmedkit.deid
+
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Rewrites detected identifier spans into de-identified text.
+ *
+ * The engine accepts original-text offsets and applies replacements from
+ * right to left, so each span is replaced at its original offsets even when
+ * earlier spans expand or shrink the output.
+ */
+class DeidentifyEngine(
+    hashSalt: ByteArray = DEFAULT_HASH_SALT.toByteArray(StandardCharsets.UTF_8),
+) {
+    private val hashKey = hashSalt.copyOf()
+
+    init {
+        require(hashKey.isNotEmpty()) { "hashSalt must not be empty" }
+    }
+
+    fun deidentify(
+        text: String,
+        spans: List<OpenMedSpan>,
+        method: DeidentifyMethod,
+    ): DeidentifyResult = deidentify(text, spans) { method }
+
+    fun deidentify(
+        text: String,
+        spans: List<OpenMedSpan>,
+        actionsByLabel: Map<String, DeidentifyMethod>,
+        defaultMethod: DeidentifyMethod = DeidentifyMethod.MASK,
+    ): DeidentifyResult {
+        val normalizedActions = actionsByLabel.mapKeys { normalizeLabel(it.key) }
+        return deidentify(text, spans) { span ->
+            normalizedActions[normalizeLabel(span.canonicalLabel)] ?: defaultMethod
+        }
+    }
+
+    fun deidentify(
+        text: String,
+        spans: List<OpenMedSpan>,
+        actionForSpan: (OpenMedSpan) -> DeidentifyMethod,
+    ): DeidentifyResult {
+        if (spans.isEmpty()) {
+            return DeidentifyResult(text, emptyList())
+        }
+
+        validateBounds(text, spans)
+        val replacementState = ReplacementState()
+        val orderedSpans = resolveOverlaps(spans)
+        val actions = mutableListOf<DeidentifyAction>()
+        var outputDelta = 0
+
+        for (span in orderedSpans) {
+            val method = actionForSpan(span)
+            val surface = text.substring(span.start, span.end)
+            val label = normalizeLabel(span.canonicalLabel)
+            val textHash = hmacDigest(label, surface)
+            val replacement = replacementFor(method, label, surface, replacementState)
+            val outputStart = span.start + outputDelta
+            val outputEnd = outputStart + replacement.length
+            val appliedSpan = span.copy(
+                canonicalLabel = label,
+                textHash = textHash,
+                action = method,
+                replacement = replacement,
+            )
+
+            actions += DeidentifyAction(
+                span = appliedSpan,
+                method = method,
+                replacement = replacement,
+                outputStart = outputStart,
+                outputEnd = outputEnd,
+            )
+            outputDelta += replacement.length - (span.end - span.start)
+        }
+
+        val redacted = StringBuilder(text)
+        for (action in actions.asReversed()) {
+            redacted.replace(action.span.start, action.span.end, action.replacement)
+        }
+
+        return DeidentifyResult(redacted.toString(), actions)
+    }
+
+    private fun validateBounds(text: String, spans: List<OpenMedSpan>) {
+        for (span in spans) {
+            require(span.end <= text.length) {
+                "span end ${span.end} exceeds text length ${text.length}"
+            }
+            require(span.end > span.start) {
+                "span must cover at least one character"
+            }
+        }
+    }
+
+    private fun resolveOverlaps(spans: List<OpenMedSpan>): List<OpenMedSpan> {
+        val sorted = spans.sortedWith(
+            compareBy<OpenMedSpan> { it.start }
+                .thenByDescending { it.end }
+                .thenByDescending { it.score ?: -1.0 }
+                .thenBy { normalizeLabel(it.canonicalLabel) },
+        )
+        val resolved = mutableListOf<OpenMedSpan>()
+        var current = sorted.first()
+        var selected = current
+
+        for (next in sorted.drop(1)) {
+            if (next.start < current.end) {
+                selected = chooseOverlapLabel(selected, next)
+                current = selected.copy(
+                    start = min(current.start, next.start),
+                    end = max(current.end, next.end),
+                    textHash = null,
+                    action = null,
+                    replacement = null,
+                )
+            } else {
+                resolved += current
+                current = next
+                selected = next
+            }
+        }
+
+        resolved += current
+        return resolved
+    }
+
+    private fun chooseOverlapLabel(left: OpenMedSpan, right: OpenMedSpan): OpenMedSpan {
+        val leftScore = left.score ?: -1.0
+        val rightScore = right.score ?: -1.0
+        if (rightScore != leftScore) {
+            return if (rightScore > leftScore) right else left
+        }
+
+        val leftLength = left.end - left.start
+        val rightLength = right.end - right.start
+        if (rightLength != leftLength) {
+            return if (rightLength > leftLength) right else left
+        }
+
+        return if (right.start < left.start) right else left
+    }
+
+    private fun replacementFor(
+        method: DeidentifyMethod,
+        label: String,
+        surface: String,
+        state: ReplacementState,
+    ): String {
+        return when (method) {
+            DeidentifyMethod.MASK -> state.tokenFor(
+                method = method,
+                label = label,
+                surface = surface,
+            ) { tokenLabel, index -> bracketedToken(tokenLabel, index) }
+
+            DeidentifyMethod.REMOVE -> ""
+            DeidentifyMethod.REPLACE -> state.tokenFor(
+                method = method,
+                label = label,
+                surface = surface,
+            ) { tokenLabel, index -> surrogateToken(tokenLabel, index) }
+
+            DeidentifyMethod.HASH -> hmacDigest(label, surface)
+        }
+    }
+
+    private fun bracketedToken(label: String, index: Int): String {
+        return if (index == 1) "[$label]" else "[${label}_$index]"
+    }
+
+    private fun surrogateToken(label: String, index: Int): String {
+        return if (index == 1) {
+            "${label}_SURROGATE"
+        } else {
+            "${label}_SURROGATE_$index"
+        }
+    }
+
+    private fun hmacDigest(label: String, surface: String): String {
+        val mac = Mac.getInstance(HMAC_SHA256)
+        mac.init(SecretKeySpec(hashKey, HMAC_SHA256))
+        val payload = "$label\u0000$surface".toByteArray(StandardCharsets.UTF_8)
+        return "hmac-sha256:${mac.doFinal(payload).toHex()}"
+    }
+
+    private data class ReplacementKey(
+        val method: DeidentifyMethod,
+        val label: String,
+        val surface: String,
+    )
+
+    private class ReplacementState {
+        private val counters = mutableMapOf<String, Int>()
+        private val tokens = mutableMapOf<ReplacementKey, String>()
+
+        fun tokenFor(
+            method: DeidentifyMethod,
+            label: String,
+            surface: String,
+            format: (String, Int) -> String,
+        ): String {
+            val key = ReplacementKey(method, label, surface)
+            return tokens.getOrPut(key) {
+                val nextIndex = (counters[label] ?: 0) + 1
+                counters[label] = nextIndex
+                format(label, nextIndex)
+            }
+        }
+    }
+
+    private fun ByteArray.toHex(): String {
+        val chars = CharArray(size * 2)
+        forEachIndexed { index, byte ->
+            val value = byte.toInt() and 0xff
+            chars[index * 2] = HEX_CHARS[value ushr 4]
+            chars[index * 2 + 1] = HEX_CHARS[value and 0x0f]
+        }
+        return String(chars)
+    }
+
+    companion object {
+        private const val DEFAULT_HASH_SALT = "openmed-android-deidentify-v1"
+        private const val HMAC_SHA256 = "HmacSHA256"
+        private val HEX_CHARS = "0123456789abcdef".toCharArray()
+
+        fun normalizeLabel(label: String): String {
+            val normalized = label.trim()
+                .uppercase(Locale.US)
+                .replace(Regex("[^A-Z0-9]+"), "_")
+                .trim('_')
+            return normalized.ifEmpty { "PII" }
+        }
+    }
+}

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/deid/DeidentifyMethod.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/deid/DeidentifyMethod.kt
@@ -1,0 +1,11 @@
+package com.openmed.openmedkit.deid
+
+/**
+ * Supported text rewrite strategies for Android de-identification.
+ */
+enum class DeidentifyMethod {
+    MASK,
+    REMOVE,
+    REPLACE,
+    HASH,
+}

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/deid/DeidentifyResult.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/deid/DeidentifyResult.kt
@@ -1,0 +1,51 @@
+package com.openmed.openmedkit.deid
+
+/**
+ * Android-side OpenMed span contract used by the de-identification engine.
+ *
+ * The span intentionally stores offsets, labels, hashes, and replacements only.
+ * It never stores the raw identifier text.
+ */
+data class OpenMedSpan(
+    val start: Int,
+    val end: Int,
+    val canonicalLabel: String,
+    val score: Double? = null,
+    val textHash: String? = null,
+    val action: DeidentifyMethod? = null,
+    val replacement: String? = null,
+) {
+    init {
+        require(start >= 0) { "start must be non-negative" }
+        require(end >= start) { "end must be greater than or equal to start" }
+        require(canonicalLabel.isNotBlank()) { "canonicalLabel must be non-blank" }
+        if (score != null) {
+            require(score in 0.0..1.0) { "score must be between 0.0 and 1.0" }
+        }
+    }
+}
+
+/**
+ * One applied rewrite action.
+ *
+ * [span] keeps original document offsets. [outputStart] and [outputEnd] point
+ * at the replacement in the redacted text.
+ */
+data class DeidentifyAction(
+    val span: OpenMedSpan,
+    val method: DeidentifyMethod,
+    val replacement: String,
+    val outputStart: Int,
+    val outputEnd: Int,
+)
+
+/**
+ * Result of applying de-identification actions to a document.
+ */
+data class DeidentifyResult(
+    val redactedText: String,
+    val actions: List<DeidentifyAction>,
+) {
+    val appliedSpans: List<OpenMedSpan>
+        get() = actions.map { it.span }
+}

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/deid/DeidentifyEngineTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/deid/DeidentifyEngineTest.kt
@@ -1,0 +1,219 @@
+package com.openmed.openmedkit.deid
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.util.logging.Handler
+import java.util.logging.Level
+import java.util.logging.LogRecord
+import java.util.logging.Logger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeidentifyEngineTest {
+    private val engine = DeidentifyEngine("unit-test-salt".toByteArray())
+
+    @Test
+    fun maskUsesConsistentPlaceholdersForRepeatedIdentifiers() {
+        val text = "John Doe emailed john@example.com and John Doe replied."
+        val spans = listOf(
+            spanOf(text, "John Doe", "name"),
+            spanOf(text, "john@example.com", "email"),
+            spanOf(text, "John Doe", "name", fromIndex = text.lastIndexOf("John Doe")),
+        )
+
+        val result = engine.deidentify(text, spans, DeidentifyMethod.MASK)
+
+        assertEquals(
+            "[NAME] emailed [EMAIL] and [NAME] replied.",
+            result.redactedText,
+        )
+        assertEquals(listOf("[NAME]", "[EMAIL]", "[NAME]"), replacements(result))
+        assertFalse(result.toString().contains("John Doe"))
+        assertFalse(result.toString().contains("john@example.com"))
+    }
+
+    @Test
+    fun removeDeletesSpansWithoutChangingUnaffectedText() {
+        val text = "Call John at 555-1212."
+        val result = engine.deidentify(
+            text,
+            listOf(
+                spanOf(text, "John", "name"),
+                spanOf(text, "555-1212", "phone"),
+            ),
+            DeidentifyMethod.REMOVE,
+        )
+
+        assertEquals("Call  at .", result.redactedText)
+        assertEquals(listOf("", ""), replacements(result))
+    }
+
+    @Test
+    fun replaceUsesPerLabelSurrogateTokens() {
+        val text = "John met Mary. John left."
+        val spans = listOf(
+            spanOf(text, "John", "name"),
+            spanOf(text, "Mary", "name"),
+            spanOf(text, "John", "name", fromIndex = text.lastIndexOf("John")),
+        )
+
+        val result = engine.deidentify(text, spans, DeidentifyMethod.REPLACE)
+
+        assertEquals(
+            "NAME_SURROGATE met NAME_SURROGATE_2. NAME_SURROGATE left.",
+            result.redactedText,
+        )
+        assertEquals(
+            listOf("NAME_SURROGATE", "NAME_SURROGATE_2", "NAME_SURROGATE"),
+            replacements(result),
+        )
+    }
+
+    @Test
+    fun hashUsesStableSaltedDigestWithoutPlaintext() {
+        val text = "MRN 12345 matched MRN 12345."
+        val spans = listOf(
+            spanOf(text, "12345", "medical_record_number"),
+            spanOf(text, "12345", "medical_record_number", fromIndex = text.lastIndexOf("12345")),
+        )
+
+        val result = engine.deidentify(text, spans, DeidentifyMethod.HASH)
+        val first = result.actions[0].replacement
+        val second = result.actions[1].replacement
+
+        assertEquals(first, second)
+        assertTrue(first.matches(Regex("hmac-sha256:[0-9a-f]{64}")))
+        assertFalse(result.redactedText.contains("12345"))
+        assertFalse(result.toString().contains("12345"))
+    }
+
+    @Test
+    fun labelActionMapCanApplyMixedMethods() {
+        val text = "John called 555-1212 about MRN 12345."
+        val result = engine.deidentify(
+            text,
+            listOf(
+                spanOf(text, "John", "name"),
+                spanOf(text, "555-1212", "phone"),
+                spanOf(text, "12345", "medical_record_number"),
+            ),
+            mapOf(
+                "NAME" to DeidentifyMethod.MASK,
+                "PHONE" to DeidentifyMethod.REMOVE,
+                "MEDICAL_RECORD_NUMBER" to DeidentifyMethod.HASH,
+            ),
+        )
+
+        assertTrue(result.redactedText.startsWith("[NAME] called  about MRN hmac-sha256:"))
+        assertFalse(result.redactedText.contains("John"))
+        assertFalse(result.redactedText.contains("555-1212"))
+        assertFalse(result.redactedText.contains("12345"))
+    }
+
+    @Test
+    fun overlappingSpansAreCollapsedAndAdjacentSpansRemainSeparate() {
+        val text = "JohnDoe555"
+        val spans = listOf(
+            OpenMedSpan(start = 0, end = 7, canonicalLabel = "name", score = 0.95),
+            OpenMedSpan(start = 4, end = 7, canonicalLabel = "last_name", score = 0.80),
+            OpenMedSpan(start = 7, end = 10, canonicalLabel = "phone", score = 0.90),
+        )
+
+        val result = engine.deidentify(text, spans, DeidentifyMethod.MASK)
+
+        assertEquals("[NAME][PHONE]", result.redactedText)
+        assertEquals(listOf(0 to 7, 7 to 10), result.actions.map { it.span.start to it.span.end })
+    }
+
+    @Test
+    fun outputOffsetsReflectEarlierReplacementDeltas() {
+        val text = "A John B 555-1212 C"
+        val spans = listOf(
+            spanOf(text, "John", "name"),
+            spanOf(text, "555-1212", "phone"),
+        )
+
+        val result = engine.deidentify(text, spans, DeidentifyMethod.MASK)
+
+        assertEquals("A [NAME] B [PHONE] C", result.redactedText)
+        assertEquals(2, result.actions[0].span.start)
+        assertEquals(6, result.actions[0].span.end)
+        assertEquals(2, result.actions[0].outputStart)
+        assertEquals(8, result.actions[0].outputEnd)
+        assertEquals(result.redactedText.indexOf("[PHONE]"), result.actions[1].outputStart)
+        assertEquals(result.actions[1].outputStart + "[PHONE]".length, result.actions[1].outputEnd)
+    }
+
+    @Test
+    fun deidentificationDoesNotEmitRawIdentifiersToLogs() {
+        val text = "Jane Patient called 555-1212."
+        val logger = Logger.getLogger("")
+        val handler = RecordingHandler()
+        val oldOut = System.out
+        val oldErr = System.err
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+
+        logger.addHandler(handler)
+        logger.level = Level.ALL
+        System.setOut(PrintStream(stdout))
+        System.setErr(PrintStream(stderr))
+        try {
+            val result = engine.deidentify(
+                text,
+                listOf(
+                    spanOf(text, "Jane Patient", "name"),
+                    spanOf(text, "555-1212", "phone"),
+                ),
+                DeidentifyMethod.HASH,
+            )
+
+            assertFalse(result.toString().contains("Jane Patient"))
+            assertFalse(result.toString().contains("555-1212"))
+        } finally {
+            System.setOut(oldOut)
+            System.setErr(oldErr)
+            logger.removeHandler(handler)
+        }
+
+        val logOutput = handler.messages.joinToString("\n")
+        assertFalse(logOutput.contains("Jane Patient"))
+        assertFalse(logOutput.contains("555-1212"))
+        assertFalse(stdout.toString().contains("Jane Patient"))
+        assertFalse(stderr.toString().contains("555-1212"))
+    }
+
+    private fun spanOf(
+        text: String,
+        surface: String,
+        canonicalLabel: String,
+        fromIndex: Int = 0,
+    ): OpenMedSpan {
+        val start = text.indexOf(surface, fromIndex)
+        require(start >= 0) { "surface not found: $surface" }
+        return OpenMedSpan(
+            start = start,
+            end = start + surface.length,
+            canonicalLabel = canonicalLabel,
+            score = 0.99,
+        )
+    }
+
+    private fun replacements(result: DeidentifyResult): List<String> {
+        return result.actions.map { it.replacement }
+    }
+
+    private class RecordingHandler : Handler() {
+        val messages = mutableListOf<String>()
+
+        override fun publish(record: LogRecord) {
+            messages += record.message.orEmpty()
+        }
+
+        override fun flush() = Unit
+
+        override fun close() = Unit
+    }
+}


### PR DESCRIPTION
Closes #581.

Adds the Android de-identification engine for mask, remove, replace, and hash actions. The engine normalizes labels, resolves overlapping spans into non-overlapping ranges, applies replacements from right to left to preserve original offsets, emits stable per-document placeholders and surrogate tokens, and records applied actions without retaining raw identifier text.

Validation:
- cd android && ./gradlew test
- .venv/bin/python -m pytest tests/ -q
