### PR TITLE
Port the BIO/BIOES token-classification decoder to Kotlin

### DIFF
--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/decode/AggregationStrategy.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/decode/AggregationStrategy.kt
@@ -1,0 +1,10 @@
+package com.openmed.openmedkit.decode
+
+/**
+ * Score aggregation strategy for multi-token entity spans.
+ */
+enum class AggregationStrategy {
+    FIRST,
+    AVERAGE,
+    MAX,
+}

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/decode/TokenClassificationDecoder.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/decode/TokenClassificationDecoder.kt
@@ -1,0 +1,307 @@
+package com.openmed.openmedkit.decode
+
+import java.text.BreakIterator
+import java.util.Locale
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * A single per-token prediction before entity grouping.
+ */
+data class TokenPrediction(
+    val labelId: Int,
+    val label: String,
+    val score: Float,
+    val startOffset: Int,
+    val endOffset: Int,
+)
+
+/**
+ * A grouped entity prediction over the original text.
+ */
+data class EntityPrediction(
+    val label: String,
+    val text: String,
+    val confidence: Float,
+    val start: Int,
+    val end: Int,
+) {
+    val entityType: String
+        get() = label
+}
+
+/**
+ * Decodes BIO/BIOES token-classification predictions into grouped entity spans.
+ */
+object TokenClassificationDecoder {
+    fun decodeEntities(
+        tokens: List<TokenPrediction>,
+        text: String,
+        strategy: AggregationStrategy = AggregationStrategy.AVERAGE,
+    ): List<EntityPrediction> {
+        val entities = mutableListOf<EntityPrediction>()
+        val textIndex = CharacterIndex(text)
+
+        var currentLabel: String? = null
+        var currentStart = 0
+        var currentEnd = 0
+        var currentScores = mutableListOf<Float>()
+
+        fun flushCurrent() {
+            val label = currentLabel ?: return
+            entities.add(
+                makeEntity(
+                    label = label,
+                    start = currentStart,
+                    end = currentEnd,
+                    scores = currentScores,
+                    textIndex = textIndex,
+                    strategy = strategy,
+                )
+            )
+            currentLabel = null
+            currentScores = mutableListOf()
+        }
+
+        for (token in tokens) {
+            val parsedLabel = ParsedLabel.from(token.label)
+            if (parsedLabel == null) {
+                flushCurrent()
+                continue
+            }
+
+            when (parsedLabel.boundary) {
+                Boundary.SINGLE -> {
+                    flushCurrent()
+                    entities.add(
+                        makeEntity(
+                            label = parsedLabel.entityType,
+                            start = token.startOffset,
+                            end = token.endOffset,
+                            scores = listOf(token.score),
+                            textIndex = textIndex,
+                            strategy = strategy,
+                        )
+                    )
+                }
+
+                Boundary.BEGIN, Boundary.UNPREFIXED -> {
+                    flushCurrent()
+                    currentLabel = parsedLabel.entityType
+                    currentStart = token.startOffset
+                    currentEnd = token.endOffset
+                    currentScores = mutableListOf(token.score)
+                }
+
+                Boundary.INSIDE -> {
+                    if (currentLabel == null || currentLabel != parsedLabel.entityType) {
+                        flushCurrent()
+                        currentLabel = parsedLabel.entityType
+                        currentStart = token.startOffset
+                        currentEnd = token.endOffset
+                        currentScores = mutableListOf(token.score)
+                    } else {
+                        currentEnd = token.endOffset
+                        currentScores.add(token.score)
+                    }
+                }
+
+                Boundary.END -> {
+                    if (currentLabel == null || currentLabel != parsedLabel.entityType) {
+                        flushCurrent()
+                        entities.add(
+                            makeEntity(
+                                label = parsedLabel.entityType,
+                                start = token.startOffset,
+                                end = token.endOffset,
+                                scores = listOf(token.score),
+                                textIndex = textIndex,
+                                strategy = strategy,
+                            )
+                        )
+                    } else {
+                        currentEnd = token.endOffset
+                        currentScores.add(token.score)
+                        flushCurrent()
+                    }
+                }
+            }
+        }
+
+        flushCurrent()
+        return repairEntitySpans(entities, text)
+    }
+
+    fun repairEntitySpans(
+        entities: List<EntityPrediction>,
+        text: String,
+    ): List<EntityPrediction> {
+        if (text.isEmpty()) {
+            return entities
+        }
+
+        val textIndex = CharacterIndex(text)
+
+        return entities.map { entity ->
+            var start = max(0, min(entity.start, textIndex.length))
+            var end = max(start, min(entity.end, textIndex.length))
+
+            var extended = 0
+            while (end < textIndex.length && extended < 10) {
+                val character = textIndex.characterAt(end) ?: break
+                if (!isWordLike(character)) {
+                    break
+                }
+                end += 1
+                extended += 1
+            }
+
+            while (start < end && textIndex.characterAt(start)?.isWhitespaceCharacter() == true) {
+                start += 1
+            }
+
+            while (end > start && textIndex.characterAt(end - 1)?.isWhitespaceCharacter() == true) {
+                end -= 1
+            }
+
+            if (start >= end) {
+                return@map entity
+            }
+
+            val span = textIndex.substring(start, end)
+            if (span.trim { it.isWhitespace() }.isEmpty()) {
+                entity
+            } else {
+                entity.copy(text = span, start = start, end = end)
+            }
+        }
+    }
+
+    private fun makeEntity(
+        label: String,
+        start: Int,
+        end: Int,
+        scores: List<Float>,
+        textIndex: CharacterIndex,
+        strategy: AggregationStrategy,
+    ): EntityPrediction {
+        val confidence = when (strategy) {
+            AggregationStrategy.FIRST -> scores.firstOrNull() ?: 0.0f
+            AggregationStrategy.MAX -> scores.maxOrNull() ?: 0.0f
+            AggregationStrategy.AVERAGE -> scores.averageOrZero()
+        }
+
+        return EntityPrediction(
+            label = label,
+            text = textIndex.substring(start, end),
+            confidence = confidence,
+            start = start,
+            end = end,
+        )
+    }
+
+    private fun List<Float>.averageOrZero(): Float {
+        if (isEmpty()) {
+            return 0.0f
+        }
+        return sum() / size
+    }
+
+    private fun isWordLike(character: String): Boolean {
+        return character.codePoints().anyMatch { codePoint ->
+            when (Character.getType(codePoint)) {
+                Character.UPPERCASE_LETTER.toInt(),
+                Character.LOWERCASE_LETTER.toInt(),
+                Character.TITLECASE_LETTER.toInt(),
+                Character.MODIFIER_LETTER.toInt(),
+                Character.OTHER_LETTER.toInt(),
+                Character.NON_SPACING_MARK.toInt(),
+                Character.COMBINING_SPACING_MARK.toInt(),
+                Character.ENCLOSING_MARK.toInt(),
+                Character.DECIMAL_DIGIT_NUMBER.toInt(),
+                Character.LETTER_NUMBER.toInt(),
+                Character.OTHER_NUMBER.toInt(),
+                -> true
+
+                else -> false
+            }
+        }
+    }
+
+    private fun String.isWhitespaceCharacter(): Boolean {
+        return codePoints().allMatch { Character.isWhitespace(it) }
+    }
+
+    private enum class Boundary {
+        BEGIN,
+        INSIDE,
+        END,
+        SINGLE,
+        UNPREFIXED,
+    }
+
+    private data class ParsedLabel(
+        val entityType: String,
+        val boundary: Boundary,
+    ) {
+        companion object {
+            fun from(label: String): ParsedLabel? {
+                if (label == "O") {
+                    return null
+                }
+
+                if (label.length >= 2 && label[1] == '-') {
+                    val entityType = label.substring(2)
+                    return when (label[0]) {
+                        'B' -> ParsedLabel(entityType, Boundary.BEGIN)
+                        'I' -> ParsedLabel(entityType, Boundary.INSIDE)
+                        'E' -> ParsedLabel(entityType, Boundary.END)
+                        'S' -> ParsedLabel(entityType, Boundary.SINGLE)
+                        else -> ParsedLabel(label, Boundary.UNPREFIXED)
+                    }
+                }
+
+                return ParsedLabel(label, Boundary.UNPREFIXED)
+            }
+        }
+    }
+
+    private class CharacterIndex(text: String) {
+        private val source = text
+        private val boundaries: IntArray = buildBoundaries(text)
+
+        val length: Int = boundaries.size - 1
+
+        fun substring(start: Int, end: Int): String {
+            if (start < 0 || end < start || end > length) {
+                return ""
+            }
+            return source.substring(boundaries[start], boundaries[end])
+        }
+
+        fun characterAt(offset: Int): String? {
+            if (offset < 0 || offset >= length) {
+                return null
+            }
+            return source.substring(boundaries[offset], boundaries[offset + 1])
+        }
+
+        private fun buildBoundaries(text: String): IntArray {
+            val iterator = BreakIterator.getCharacterInstance(Locale.ROOT)
+            iterator.setText(text)
+
+            val result = mutableListOf<Int>()
+            var boundary = iterator.first()
+            while (boundary != BreakIterator.DONE) {
+                result.add(boundary)
+                boundary = iterator.next()
+            }
+
+            if (result.isEmpty() || result.last() != text.length) {
+                result.add(text.length)
+            }
+
+            return result.toIntArray()
+        }
+    }
+}

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/decode/TokenClassificationDecoderTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/decode/TokenClassificationDecoderTest.kt
@@ -1,0 +1,224 @@
+package com.openmed.openmedkit.decode
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [26])
+class TokenClassificationDecoderTest {
+    @Test
+    fun decodeEntitiesGroupsBioTokens() {
+        val text = "Patient John Doe visited"
+        val tokens = listOf(
+            token("B-first_name", 0.95f, 8, 12),
+            token("I-first_name", 0.90f, 13, 16),
+        )
+
+        val entities = TokenClassificationDecoder.decodeEntities(tokens, text)
+
+        assertEquals(1, entities.size)
+        assertEquals("first_name", entities[0].label)
+        assertEquals("John Doe", entities[0].text)
+        assertEquals(8, entities[0].start)
+        assertEquals(16, entities[0].end)
+        assertEquals(0.925f, entities[0].confidence, 0.001f)
+    }
+
+    @Test
+    fun decodeEntitiesSplitsAdjacentBeginningTagsWithSameLabel() {
+        val text = "John Jane"
+        val tokens = listOf(
+            token("B-NAME", 0.91f, 0, 4),
+            token("B-NAME", 0.87f, 5, 9),
+        )
+
+        val entities = TokenClassificationDecoder.decodeEntities(tokens, text)
+
+        assertEquals(
+            listOf(
+                EntityPrediction("NAME", "John", 0.91f, 0, 4),
+                EntityPrediction("NAME", "Jane", 0.87f, 5, 9),
+            ),
+            entities,
+        )
+    }
+
+    @Test
+    fun decodeEntitiesSplitsOnLabelChangeWithoutOutsideToken() {
+        val text = "John 1970"
+        val tokens = listOf(
+            token("B-NAME", 0.91f, 0, 4),
+            token("I-DATE", 0.88f, 5, 9),
+        )
+
+        val entities = TokenClassificationDecoder.decodeEntities(tokens, text)
+
+        assertEquals(
+            listOf(
+                EntityPrediction("NAME", "John", 0.91f, 0, 4),
+                EntityPrediction("DATE", "1970", 0.88f, 5, 9),
+            ),
+            entities,
+        )
+    }
+
+    @Test
+    fun decodeEntitiesHandlesOutsideTokensAndMultipleEntities() {
+        val text = "John Doe 555-1234"
+        val tokens = listOf(
+            token("B-first_name", 0.95f, 0, 4),
+            token("I-first_name", 0.90f, 5, 8),
+            token("O", 0.99f, 8, 9),
+            token("B-phone", 0.85f, 9, 17),
+        )
+
+        val entities = TokenClassificationDecoder.decodeEntities(tokens, text)
+
+        assertEquals(2, entities.size)
+        assertEquals("first_name", entities[0].label)
+        assertEquals("John Doe", entities[0].text)
+        assertEquals("phone", entities[1].label)
+        assertEquals("555-1234", entities[1].text)
+    }
+
+    @Test
+    fun decodeEntitiesSupportsBioesSingletonAndEndTags() {
+        val text = "Dr Ada Lovelace 555-0134"
+        val tokens = listOf(
+            token("B-NAME", 0.90f, 3, 6),
+            token("E-NAME", 0.80f, 7, 15),
+            token("S-PHONE", 0.95f, 16, 24),
+        )
+
+        val entities = TokenClassificationDecoder.decodeEntities(tokens, text)
+
+        assertEquals(
+            listOf(
+                EntityPrediction("NAME", "Ada Lovelace", 0.85f, 3, 15),
+                EntityPrediction("PHONE", "555-0134", 0.95f, 16, 24),
+            ),
+            entities,
+        )
+    }
+
+    @Test
+    fun decodeEntitiesTreatsMismatchedEndTagAsSingleton() {
+        val text = "Ada 1970"
+        val tokens = listOf(
+            token("B-NAME", 0.91f, 0, 3),
+            token("E-DATE", 0.89f, 4, 8),
+        )
+
+        val entities = TokenClassificationDecoder.decodeEntities(tokens, text)
+
+        assertEquals(
+            listOf(
+                EntityPrediction("NAME", "Ada", 0.91f, 0, 3),
+                EntityPrediction("DATE", "1970", 0.89f, 4, 8),
+            ),
+            entities,
+        )
+    }
+
+    @Test
+    fun decodeEntitiesUsesSelectedAggregationStrategy() {
+        val text = "John Doe"
+        val tokens = listOf(
+            token("B-NAME", 0.90f, 0, 4),
+            token("I-NAME", 0.80f, 5, 8),
+        )
+
+        val average = TokenClassificationDecoder.decodeEntities(
+            tokens,
+            text,
+            AggregationStrategy.AVERAGE,
+        )
+        val maximum = TokenClassificationDecoder.decodeEntities(tokens, text, AggregationStrategy.MAX)
+        val first = TokenClassificationDecoder.decodeEntities(tokens, text, AggregationStrategy.FIRST)
+
+        assertEquals(0.85f, average[0].confidence, 0.001f)
+        assertEquals(0.90f, maximum[0].confidence, 0.001f)
+        assertEquals(0.90f, first[0].confidence, 0.001f)
+    }
+
+    @Test
+    fun decodeEntitiesReturnsEmptyListForEmptyAndOutsideOnlyInputs() {
+        assertTrue(TokenClassificationDecoder.decodeEntities(emptyList(), "").isEmpty())
+
+        val text = "Hello world"
+        val tokens = listOf(
+            token("O", 0.99f, 0, 5),
+            token("O", 0.99f, 6, 11),
+        )
+
+        assertTrue(TokenClassificationDecoder.decodeEntities(tokens, text).isEmpty())
+    }
+
+    @Test
+    fun repairEntitySpansExtendsTruncatedEndToWordBoundary() {
+        val text = "Patient Maria Garcia"
+        val entities = listOf(
+            EntityPrediction("NAME", "Mari", 0.90f, 8, 12),
+        )
+
+        val repaired = TokenClassificationDecoder.repairEntitySpans(entities, text)
+
+        assertEquals(1, repaired.size)
+        assertEquals(EntityPrediction("NAME", "Maria", 0.90f, 8, 13), repaired[0])
+    }
+
+    @Test
+    fun repairEntitySpansExtendsUnicodeWordLikeCharacters() {
+        val text = "Patient María Garcia"
+        val entities = listOf(
+            EntityPrediction("NAME", "Mar", 0.90f, 8, 11),
+        )
+
+        val repaired = TokenClassificationDecoder.repairEntitySpans(entities, text)
+
+        assertEquals(EntityPrediction("NAME", "María", 0.90f, 8, 13), repaired[0])
+    }
+
+    @Test
+    fun repairEntitySpansTrimsWhitespaceAndClampsOffsets() {
+        val text = "  Patient Maria  "
+        val entities = listOf(
+            EntityPrediction("NAME", " Patient Maria  ", 0.90f, -4, 99),
+        )
+
+        val repaired = TokenClassificationDecoder.repairEntitySpans(entities, text)
+
+        assertEquals(EntityPrediction("NAME", "Patient Maria", 0.90f, 2, 15), repaired[0])
+    }
+
+    @Test
+    fun repairEntitySpansStopsWordExtensionAfterTenCharacters() {
+        val text = "Token Supercalifragilistic"
+        val entities = listOf(
+            EntityPrediction("WORD", "Supe", 0.80f, 6, 10),
+        )
+
+        val repaired = TokenClassificationDecoder.repairEntitySpans(entities, text)
+
+        assertEquals(EntityPrediction("WORD", "Supercalifragi", 0.80f, 6, 20), repaired[0])
+    }
+
+    private fun token(
+        label: String,
+        score: Float,
+        startOffset: Int,
+        endOffset: Int,
+    ): TokenPrediction {
+        return TokenPrediction(
+            labelId = 0,
+            label = label,
+            score = score,
+            startOffset = startOffset,
+            endOffset = endOffset,
+        )
+    }
+}


### PR DESCRIPTION
Closes #582.

Adds the Android OpenMedKit token-classification decoder for BIO and BIOES labels, including first/average/max score aggregation and Swift-matched span repair for clamped offsets, word-boundary extension, and whitespace trimming. The new unit tests cover multi-token grouping, adjacent and label-change boundaries, S-/E- handling, aggregation modes, and fixture-based repair behavior.

Validation:
- cd android && ./gradlew test
- .venv/bin/python -m pytest tests/ -q