### PR TITLE
Add Android ML Kit OCR adapter

### DIFF
--- a/android/openmedkit/build.gradle.kts
+++ b/android/openmedkit/build.gradle.kts
@@ -27,6 +27,7 @@ android {
 
 dependencies {
     implementation("com.microsoft.onnxruntime:onnxruntime-android:1.20.0")
+    implementation("com.google.mlkit:text-recognition:16.0.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
 
     testImplementation("junit:junit:4.13.2")

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/ocr/FakeOcrAdapter.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/ocr/FakeOcrAdapter.kt
@@ -1,0 +1,20 @@
+package com.openmed.openmedkit.ocr
+
+import com.google.mlkit.vision.common.InputImage
+
+/**
+ * In-memory OCR adapter for deterministic JVM tests and demos.
+ */
+class FakeOcrAdapter(
+    private val result: OcrResult = OcrResult.empty(metadata = mapOf("engine" to "fake")),
+) : OcrAdapter {
+    val calls: List<InputImage>
+        get() = _calls.toList()
+
+    private val _calls = mutableListOf<InputImage>()
+
+    override suspend fun recognize(image: InputImage): OcrResult {
+        _calls += image
+        return result
+    }
+}

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/ocr/MlKitOcrAdapter.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/ocr/MlKitOcrAdapter.kt
@@ -1,0 +1,78 @@
+package com.openmed.openmedkit.ocr
+
+import android.graphics.Rect
+import com.google.android.gms.tasks.Task
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.Text
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import java.io.Closeable
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * ML Kit Text Recognition v2 adapter using the bundled Latin script model.
+ */
+class MlKitOcrAdapter(
+    private val recognizer: TextRecognizer =
+        TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS),
+) : OcrAdapter, Closeable {
+    override suspend fun recognize(image: InputImage): OcrResult =
+        recognizer.process(image)
+            .await()
+            .toOcrResult()
+
+    override fun close() {
+        recognizer.close()
+    }
+}
+
+private fun Text.toOcrResult(): OcrResult =
+    buildOcrResult(
+        blocks = textBlocks.map { block ->
+            RecognizedOcrBlock(
+                bbox = block.boundingBox.toOcrBoundingBox(),
+                lines = block.lines.map { line ->
+                    RecognizedOcrLine(
+                        bbox = line.boundingBox.toOcrBoundingBox(),
+                        tokens = line.elements.map { element ->
+                            RecognizedOcrToken(
+                                text = element.text,
+                                confidence = element.confidence.coerceConfidence(),
+                                bbox = element.boundingBox.toOcrBoundingBox(),
+                            )
+                        },
+                    )
+                },
+            )
+        },
+        metadata = mapOf("engine" to "mlkit-text-recognition-v2-latin"),
+    )
+
+private fun Rect?.toOcrBoundingBox(): OcrBoundingBox? =
+    this?.let { rect ->
+        OcrBoundingBox(
+            left = rect.left,
+            top = rect.top,
+            right = rect.right,
+            bottom = rect.bottom,
+        )
+    }
+
+private fun Float?.coerceConfidence(): Float =
+    (this ?: 0.0f).coerceIn(0.0f, 1.0f)
+
+private suspend fun <T> Task<T>.await(): T =
+    suspendCancellableCoroutine { continuation ->
+        addOnSuccessListener { result ->
+            continuation.resume(result)
+        }
+        addOnFailureListener { error ->
+            continuation.resumeWithException(error)
+        }
+        addOnCanceledListener {
+            continuation.cancel()
+        }
+    }

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/ocr/OcrAdapter.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/ocr/OcrAdapter.kt
@@ -1,0 +1,10 @@
+package com.openmed.openmedkit.ocr
+
+import com.google.mlkit.vision.common.InputImage
+
+/**
+ * On-device OCR adapter contract for Android OpenMedKit.
+ */
+fun interface OcrAdapter {
+    suspend fun recognize(image: InputImage): OcrResult
+}

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/ocr/OcrResult.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/ocr/OcrResult.kt
@@ -1,0 +1,157 @@
+package com.openmed.openmedkit.ocr
+
+/**
+ * Pixel-space rectangle for a recognized OCR token.
+ */
+data class OcrBoundingBox(
+    val left: Int,
+    val top: Int,
+    val right: Int,
+    val bottom: Int,
+)
+
+/**
+ * A recognized word-like OCR token with offsets into [OcrResult.text].
+ */
+data class OcrToken(
+    val text: String,
+    val start: Int,
+    val end: Int,
+    val confidence: Float,
+    val bbox: OcrBoundingBox? = null,
+    val page: Int = 0,
+) {
+    init {
+        require(start >= 0) { "start must be non-negative" }
+        require(end >= start) { "end must be greater than or equal to start" }
+        require(confidence in 0.0f..1.0f) { "confidence must be in [0, 1]" }
+        require(page >= 0) { "page must be non-negative" }
+    }
+}
+
+/**
+ * OCR output shared by Android adapters.
+ *
+ * [text] is the contiguous recognized text. Every token offset indexes into
+ * this string, making downstream de-identification spans portable across
+ * OpenMedKit surfaces.
+ */
+data class OcrResult(
+    val text: String,
+    val words: List<OcrToken>,
+    val metadata: Map<String, String> = emptyMap(),
+) {
+    val tokens: List<OcrToken>
+        get() = words
+
+    init {
+        words.forEach { token ->
+            require(token.end <= text.length) { "token end offset exceeds text length" }
+            require(text.substring(token.start, token.end) == token.text) {
+                "token offsets must index back into the recognized text"
+            }
+        }
+    }
+
+    companion object {
+        fun empty(metadata: Map<String, String> = emptyMap()): OcrResult =
+            OcrResult(text = "", words = emptyList(), metadata = metadata)
+    }
+}
+
+internal data class RecognizedOcrToken(
+    val text: String,
+    val confidence: Float,
+    val bbox: OcrBoundingBox? = null,
+    val page: Int = 0,
+)
+
+internal data class RecognizedOcrLine(
+    val tokens: List<RecognizedOcrToken>,
+    val bbox: OcrBoundingBox? = null,
+)
+
+internal data class RecognizedOcrBlock(
+    val lines: List<RecognizedOcrLine>,
+    val bbox: OcrBoundingBox? = null,
+)
+
+internal fun buildOcrResult(
+    blocks: List<RecognizedOcrBlock>,
+    metadata: Map<String, String> = emptyMap(),
+): OcrResult {
+    val text = StringBuilder()
+    val tokens = mutableListOf<OcrToken>()
+
+    var hasWrittenBlock = false
+    orderedByPagePosition(blocks).forEach { (_, block) ->
+        val orderedLines = orderedByPagePosition(block.lines)
+            .map { it.value }
+            .filter { line -> line.tokens.any { token -> token.text.isNotBlank() } }
+        if (orderedLines.isEmpty()) {
+            return@forEach
+        }
+
+        if (hasWrittenBlock) {
+            text.append("\n\n")
+        }
+        hasWrittenBlock = true
+
+        orderedLines.forEachIndexed { lineIndex, line ->
+            if (lineIndex > 0) {
+                text.append('\n')
+            }
+
+            orderedByPagePosition(line.tokens)
+                .map { it.value }
+                .filter { it.text.isNotBlank() }
+                .forEachIndexed { tokenIndex, token ->
+                    if (tokenIndex > 0) {
+                        text.append(' ')
+                    }
+
+                    val start = text.length
+                    text.append(token.text)
+                    val end = text.length
+                    tokens += OcrToken(
+                        text = token.text,
+                        start = start,
+                        end = end,
+                        confidence = token.confidence.coerceIn(0.0f, 1.0f),
+                        bbox = token.bbox,
+                        page = token.page,
+                    )
+                }
+        }
+    }
+
+    return OcrResult(text = text.toString(), words = tokens, metadata = metadata)
+}
+
+private fun <T> orderedByPagePosition(
+    items: List<T>,
+): List<IndexedValue<T>> where T : Any =
+    items.withIndex()
+        .sortedWith(
+            compareBy<IndexedValue<T>>(
+                { it.value.topOrMax() },
+                { it.value.leftOrMax() },
+                { it.index },
+            ),
+        )
+
+private fun Any.topOrMax(): Int =
+    when (this) {
+        is RecognizedOcrBlock -> bbox?.top
+        is RecognizedOcrLine -> bbox?.top
+        is RecognizedOcrToken -> bbox?.top
+        else -> null
+    } ?: Int.MAX_VALUE
+
+private fun Any.leftOrMax(): Int =
+    when (this) {
+        is RecognizedOcrBlock -> bbox?.left
+        is RecognizedOcrLine -> bbox?.left
+        is RecognizedOcrToken -> bbox?.left
+        else -> null
+    } ?: Int.MAX_VALUE

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/ocr/OcrOffsetMapTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/ocr/OcrOffsetMapTest.kt
@@ -1,0 +1,113 @@
+package com.openmed.openmedkit.ocr
+
+import android.graphics.Bitmap
+import com.google.mlkit.common.MlKit
+import com.google.mlkit.vision.common.InputImage
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [26])
+class OcrOffsetMapTest {
+    @Test
+    fun buildsOffsetsThatIndexBackIntoRecognizedText() {
+        val result = buildOcrResult(
+            listOf(
+                RecognizedOcrBlock(
+                    bbox = OcrBoundingBox(0, 0, 200, 40),
+                    lines = listOf(
+                        RecognizedOcrLine(
+                            bbox = OcrBoundingBox(0, 0, 200, 20),
+                            tokens = listOf(
+                                RecognizedOcrToken(
+                                    text = "Patient",
+                                    confidence = 0.96f,
+                                    bbox = OcrBoundingBox(0, 0, 60, 20),
+                                ),
+                                RecognizedOcrToken(
+                                    text = "Jordan",
+                                    confidence = 0.94f,
+                                    bbox = OcrBoundingBox(70, 0, 130, 20),
+                                ),
+                            ),
+                        ),
+                        RecognizedOcrLine(
+                            bbox = OcrBoundingBox(0, 22, 120, 40),
+                            tokens = listOf(
+                                RecognizedOcrToken(
+                                    text = "MRN-123",
+                                    confidence = 0.90f,
+                                    bbox = OcrBoundingBox(0, 22, 80, 40),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals("Patient Jordan\nMRN-123", result.text)
+        assertEquals(listOf("Patient", "Jordan", "MRN-123"), result.tokens.map { it.text })
+        result.tokens.forEach { token ->
+            assertEquals(token.text, result.text.substring(token.start, token.end))
+            assertTrue(token.confidence in 0.0f..1.0f)
+        }
+    }
+
+    @Test
+    fun ordersMultipleBlocksLinesAndTokensByPagePosition() {
+        val result = buildOcrResult(
+            listOf(
+                RecognizedOcrBlock(
+                    bbox = OcrBoundingBox(0, 100, 200, 130),
+                    lines = listOf(
+                        RecognizedOcrLine(
+                            bbox = OcrBoundingBox(0, 100, 200, 130),
+                            tokens = listOf(
+                                RecognizedOcrToken("second", 0.88f, OcrBoundingBox(0, 100, 60, 130)),
+                            ),
+                        ),
+                    ),
+                ),
+                RecognizedOcrBlock(
+                    bbox = OcrBoundingBox(0, 0, 200, 30),
+                    lines = listOf(
+                        RecognizedOcrLine(
+                            bbox = OcrBoundingBox(0, 0, 200, 30),
+                            tokens = listOf(
+                                RecognizedOcrToken("block", 0.92f, OcrBoundingBox(60, 0, 110, 30)),
+                                RecognizedOcrToken("first", 0.93f, OcrBoundingBox(0, 0, 50, 30)),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals("first block\n\nsecond", result.text)
+        assertEquals(
+            listOf(0 to 5, 6 to 11, 13 to 19),
+            result.tokens.map { it.start to it.end },
+        )
+    }
+
+    @Test
+    fun fakeAdapterReturnsEmptyResultWithoutRunningRecognizer() = runBlocking {
+        val adapter = FakeOcrAdapter()
+        MlKit.initialize(RuntimeEnvironment.getApplication())
+        val image = InputImage.fromBitmap(Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888), 0)
+
+        val result = adapter.recognize(image)
+
+        assertEquals("", result.text)
+        assertTrue(result.tokens.isEmpty())
+        assertEquals("fake", result.metadata["engine"])
+        assertEquals(1, adapter.calls.size)
+    }
+}


### PR DESCRIPTION
## Description
Adds an Android OpenMedKit OCR adapter backed by the bundled Latin ML Kit Text Recognition v2 model. The public OCR result exposes contiguous recognized text plus per-token offsets, confidence, optional bounding boxes, page metadata, and adapter metadata so downstream de-identification spans can index back into the OCR text.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added public Android OCR result types and an `OcrAdapter` contract.
- Added `MlKitOcrAdapter` using ML Kit Text Recognition v2 with the bundled Latin model.
- Added `FakeOcrAdapter` and JVM tests for offset-map construction, empty fake output, and multi-block ordering.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands:
- `ANDROID_HOME=/Users/maziyar/Library/Android/sdk ./gradlew test`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [ ] I have not added any new dependencies
- [x] OR I have added new dependencies and they are justified because: OM-387 requires an on-device Android OCR adapter backed by ML Kit Text Recognition v2; `com.google.mlkit:text-recognition` bundles the Latin model on device.

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #589

## Screenshots/Examples
Not applicable.
