### PR TITLE
Add a privacy-gateway pipeline that de-identifies text before external model calls

### DIFF
--- a/examples/privacy_gateway_quickstart.py
+++ b/examples/privacy_gateway_quickstart.py
@@ -1,0 +1,37 @@
+"""Synthetic privacy-gateway quickstart.
+
+This example shows the local flow for external model calls:
+
+1. redact text on device,
+2. send only redacted text to a user-supplied callable,
+3. restore identifiers locally from the in-memory mapping.
+"""
+
+from __future__ import annotations
+
+from openmed.interop.gateway import PrivacyGateway
+
+
+def external_model_stub(redacted_text: str) -> str:
+    """Stand in for a cloud model without making a network call."""
+
+    if "Casey Example" in redacted_text or "555-0100" in redacted_text:
+        raise RuntimeError("external callable received an unredacted identifier")
+    return f"Follow-up summary for: {redacted_text}"
+
+
+def main() -> None:
+    gateway = PrivacyGateway()
+    text = "Patient Casey Example can be reached at 555-0100."
+
+    redacted_text, mapping = gateway.redact(text)
+    gateway.input_guardrail(mapping)(redacted_text)
+
+    model_response = external_model_stub(redacted_text)
+    restored_response = gateway.output_guardrail(mapping)(model_response)
+
+    print(restored_response)
+
+
+if __name__ == "__main__":
+    main()

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -2597,7 +2597,7 @@ def _format_date_like_original(
 
 def reidentify(
     deidentified_text: str,
-    mapping: dict[str, str],
+    mapping: Mapping[str, str],
 ) -> str:
     """Re-identify text using stored mapping.
 

--- a/openmed/interop/__init__.py
+++ b/openmed/interop/__init__.py
@@ -73,6 +73,14 @@ _ADAPTERS: Final[dict[str, AdapterSpec]] = {
     ),
 }
 
+_GATEWAY_EXPORTS: Final[dict[str, str]] = {
+    "PrivacyGateway": "PrivacyGateway",
+    "PrivacyGatewayConfig": "PrivacyGatewayConfig",
+    "RedactionMapping": "RedactionMapping",
+    "assert_redacted": "assert_redacted",
+    "restore_text": "restore_text",
+}
+
 
 def available_adapters() -> tuple[str, ...]:
     """Return registered adapter names without importing adapter modules."""
@@ -111,16 +119,27 @@ def _normalize_adapter_name(name: str) -> str:
     return str(name or "").strip().lower().replace("-", "_")
 
 
-def __getattr__(name: str) -> ModuleType:
+def __getattr__(name: str) -> Any:
     if name in _ADAPTERS:
         return get_adapter(name)
+    if name == "gateway":
+        return import_module("openmed.interop.gateway")
+    if name in _GATEWAY_EXPORTS:
+        module = import_module("openmed.interop.gateway")
+        return getattr(module, _GATEWAY_EXPORTS[name])
     raise AttributeError(name)
 
 
 __all__ = [
     "AdapterSpec",
+    "PrivacyGateway",
+    "PrivacyGatewayConfig",
+    "RedactionMapping",
     "adapter_tool_definitions",
     "adapter_spec",
+    "assert_redacted",
     "available_adapters",
+    "gateway",
     "get_adapter",
+    "restore_text",
 ]

--- a/openmed/interop/gateway.py
+++ b/openmed/interop/gateway.py
@@ -1,0 +1,267 @@
+"""Privacy gateway wrappers for external text model calls.
+
+The gateway keeps the reversible redaction mapping in memory, sends only
+redacted text to user-supplied callables, and restores identifiers locally from
+the callable response.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, field
+from functools import wraps
+from pathlib import Path
+from typing import Any
+
+Deidentifier = Callable[..., Any]
+Reidentifier = Callable[[str, Mapping[str, str]], str]
+TextModelCall = Callable[..., str]
+
+
+class RedactionMapping(Mapping[str, str]):
+    """In-memory redaction mapping with a PHI-safe representation."""
+
+    __slots__ = ("_data",)
+
+    def __init__(self, mapping: Mapping[str, str] | None = None) -> None:
+        self._data = dict(mapping or {})
+
+    def __getitem__(self, key: str) -> str:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __repr__(self) -> str:
+        entry = "entry" if len(self) == 1 else "entries"
+        return f"{self.__class__.__name__}(<{len(self)} {entry}>)"
+
+    __str__ = __repr__
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a shallow copy for APIs that require a concrete ``dict``."""
+
+        return dict(self._data)
+
+
+@dataclass(frozen=True)
+class PrivacyGatewayConfig:
+    """Runtime options forwarded to ``openmed.core.pii.deidentify``."""
+
+    method: str = "mask"
+    model_name: str | None = None
+    confidence_threshold: float = 0.7
+    keep_year: bool = False
+    shift_dates: bool | None = None
+    date_shift_days: int | None = None
+    patient_key: str | bytes | None = None
+    date_shift_max_days: int | None = None
+    date_shift_secret: str | bytes | None = None
+    use_smart_merging: bool = True
+    lang: str = "en"
+    normalize_accents: bool | None = None
+    use_safety_sweep: bool = True
+    consistent: bool = False
+    seed: int | None = None
+    locale: str | None = None
+    policy: str | None = None
+    calibration_thresholds_path: str | Path | None = None
+    extra_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_deidentify_kwargs(self) -> dict[str, Any]:
+        """Return keyword arguments for a reversible gateway redaction pass."""
+
+        kwargs: dict[str, Any] = {
+            "method": self.method,
+            "confidence_threshold": float(self.confidence_threshold),
+            "keep_year": self.keep_year,
+            "shift_dates": self.shift_dates,
+            "date_shift_days": self.date_shift_days,
+            "patient_key": self.patient_key,
+            "date_shift_max_days": self.date_shift_max_days,
+            "date_shift_secret": self.date_shift_secret,
+            "keep_mapping": True,
+            "use_smart_merging": self.use_smart_merging,
+            "lang": self.lang,
+            "normalize_accents": self.normalize_accents,
+            "use_safety_sweep": self.use_safety_sweep,
+            "consistent": self.consistent,
+            "seed": self.seed,
+            "locale": self.locale,
+            "policy": self.policy,
+            "calibration_thresholds_path": self.calibration_thresholds_path,
+        }
+        if self.model_name is not None:
+            kwargs["model_name"] = self.model_name
+
+        kwargs.update(dict(self.extra_kwargs))
+        kwargs["keep_mapping"] = True
+        kwargs["audit"] = False
+        return {key: value for key, value in kwargs.items() if value is not None}
+
+
+class PrivacyGateway:
+    """Run redact -> external callable -> restore for text model calls."""
+
+    def __init__(
+        self,
+        *,
+        config: PrivacyGatewayConfig | None = None,
+        deidentifier: Deidentifier | None = None,
+        reidentifier: Reidentifier | None = None,
+    ) -> None:
+        self.config = config or PrivacyGatewayConfig()
+        self._deidentifier = deidentifier
+        self._reidentifier = reidentifier
+
+    def redact(self, text: str) -> tuple[str, RedactionMapping]:
+        """Return redacted text plus an in-memory restore mapping."""
+
+        result = self._deidentifier_or_default()(
+            text,
+            **self.config.to_deidentify_kwargs(),
+        )
+        clean_text = _result_text(result)
+        mapping = _result_mapping(result)
+        return clean_text, RedactionMapping(mapping)
+
+    def restore(self, text: str, mapping: Mapping[str, str]) -> str:
+        """Restore redacted identifiers in ``text`` from ``mapping``."""
+
+        if not mapping:
+            return text
+        restored = self._reidentifier_or_default()(text, RedactionMapping(mapping))
+        if not isinstance(restored, str):
+            raise TypeError("reidentifier must return a string")
+        return restored
+
+    def assert_redacted(self, text: str, mapping: Mapping[str, str]) -> str:
+        """Return ``text`` if no mapped original identifiers are present."""
+
+        return assert_redacted(text, mapping)
+
+    def input_guardrail(self, mapping: Mapping[str, str]) -> Callable[[str], str]:
+        """Create a pre-call guardrail that rejects known identifier leaks."""
+
+        protected_mapping = RedactionMapping(mapping)
+
+        def guardrail(text: str) -> str:
+            return self.assert_redacted(text, protected_mapping)
+
+        return guardrail
+
+    def output_guardrail(self, mapping: Mapping[str, str]) -> Callable[[str], str]:
+        """Create a post-call guardrail that restores local identifiers."""
+
+        protected_mapping = RedactionMapping(mapping)
+
+        def guardrail(text: str) -> str:
+            return self.restore(text, protected_mapping)
+
+        return guardrail
+
+    def guarded(self, call: TextModelCall) -> TextModelCall:
+        """Wrap ``call`` so it only receives redacted text."""
+
+        @wraps(call)
+        def wrapper(text: str, *args: Any, **kwargs: Any) -> str:
+            clean_text, mapping = self.redact(text)
+            self.assert_redacted(clean_text, mapping)
+            response = call(clean_text, *args, **kwargs)
+            if not isinstance(response, str):
+                raise TypeError("guarded callable must return a string")
+            return self.restore(response, mapping)
+
+        return wrapper
+
+    def _deidentifier_or_default(self) -> Deidentifier:
+        if self._deidentifier is not None:
+            return self._deidentifier
+
+        from openmed.core.pii import deidentify
+
+        return deidentify
+
+    def _reidentifier_or_default(self) -> Reidentifier:
+        if self._reidentifier is not None:
+            return self._reidentifier
+
+        from openmed.core.pii import reidentify
+
+        return reidentify
+
+
+def assert_redacted(text: str, mapping: Mapping[str, str]) -> str:
+    """Raise if ``text`` still contains any original mapped identifier."""
+
+    leak_count = _known_identifier_leak_count(text, mapping)
+    if leak_count:
+        noun = "identifier" if leak_count == 1 else "identifiers"
+        raise ValueError(
+            f"text contains {leak_count} original {noun}; redact before external call"
+        )
+    return text
+
+
+def restore_text(
+    text: str,
+    mapping: Mapping[str, str],
+    *,
+    reidentifier: Reidentifier | None = None,
+) -> str:
+    """Restore ``text`` using ``mapping`` without constructing a gateway."""
+
+    restore = reidentifier
+    if restore is None:
+        from openmed.core.pii import reidentify
+
+        restore = reidentify
+    return restore(text, RedactionMapping(mapping))
+
+
+def _result_text(result: Any) -> str:
+    if isinstance(result, str):
+        raise TypeError("deidentifier must return an object with deidentified_text")
+    try:
+        clean_text = result.deidentified_text
+    except AttributeError as exc:
+        raise TypeError(
+            "deidentifier must return an object with deidentified_text"
+        ) from exc
+    if not isinstance(clean_text, str):
+        raise TypeError("deidentifier result deidentified_text must be a string")
+    return clean_text
+
+
+def _result_mapping(result: Any) -> Mapping[str, str]:
+    mapping = getattr(result, "mapping", None) or {}
+    if not isinstance(mapping, Mapping):
+        raise TypeError("deidentifier result mapping must be a mapping")
+    return {str(key): str(value) for key, value in mapping.items()}
+
+
+def _known_identifier_leak_count(
+    text: str,
+    mapping: Mapping[str, str],
+) -> int:
+    originals = {
+        original
+        for original in mapping.values()
+        if isinstance(original, str) and original
+    }
+    return sum(1 for original in originals if original in text)
+
+
+__all__ = [
+    "Deidentifier",
+    "PrivacyGateway",
+    "PrivacyGatewayConfig",
+    "RedactionMapping",
+    "Reidentifier",
+    "TextModelCall",
+    "assert_redacted",
+    "restore_text",
+]

--- a/tests/unit/interop/test_privacy_gateway.py
+++ b/tests/unit/interop/test_privacy_gateway.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from openmed.core.pii import reidentify
+from openmed.interop import (
+    PrivacyGateway,
+    RedactionMapping,
+    assert_redacted,
+)
+from openmed.interop import (
+    gateway as gateway_module,
+)
+
+ORIGINAL_TEXT = "Patient Casey Example can be reached at casey@example.test."
+REDACTED_TEXT = "Patient [NAME] can be reached at [EMAIL]."
+MAPPING = {
+    "[NAME]": "Casey Example",
+    "[EMAIL]": "casey@example.test",
+}
+
+
+def fake_deidentify(text: str, **kwargs):
+    assert text == ORIGINAL_TEXT
+    assert kwargs["method"] == "mask"
+    assert kwargs["keep_mapping"] is True
+    assert kwargs["audit"] is False
+    return SimpleNamespace(deidentified_text=REDACTED_TEXT, mapping=MAPPING)
+
+
+def test_guarded_passes_only_redacted_text_and_restores_response():
+    gateway = PrivacyGateway(deidentifier=fake_deidentify)
+    seen_by_external: list[str] = []
+
+    def external_call(text: str) -> str:
+        seen_by_external.append(text)
+        assert "Casey Example" not in text
+        assert "casey@example.test" not in text
+        return "Send a portal message to [NAME] at [EMAIL]."
+
+    guarded = gateway.guarded(external_call)
+
+    result = guarded(ORIGINAL_TEXT)
+
+    assert seen_by_external == [REDACTED_TEXT]
+    assert result == "Send a portal message to Casey Example at casey@example.test."
+
+
+def test_redact_restore_round_trip_reproduces_original_identifiers():
+    gateway = PrivacyGateway(deidentifier=fake_deidentify)
+
+    clean_text, mapping = gateway.redact(ORIGINAL_TEXT)
+    restored = gateway.restore(clean_text, mapping)
+
+    assert clean_text == REDACTED_TEXT
+    assert isinstance(mapping, RedactionMapping)
+    assert mapping["[NAME]"] == "Casey Example"
+    assert restored == ORIGINAL_TEXT
+
+
+def test_mapping_representation_and_gateway_logs_do_not_expose_identifiers(caplog):
+    caplog.set_level(logging.DEBUG)
+    gateway = PrivacyGateway(deidentifier=fake_deidentify)
+
+    _, mapping = gateway.redact(ORIGINAL_TEXT)
+    logging.getLogger(__name__).warning("mapping=%s", mapping)
+    logging.getLogger(__name__).warning("mapping=%r", mapping)
+
+    assert "Casey Example" not in repr(mapping)
+    assert "casey@example.test" not in repr(mapping)
+    assert "Casey Example" not in caplog.text
+    assert "casey@example.test" not in caplog.text
+
+
+def test_input_guardrail_rejects_known_identifier_leak_without_echoing_phi():
+    mapping = RedactionMapping(MAPPING)
+
+    with pytest.raises(ValueError) as exc_info:
+        assert_redacted("Patient Casey Example reached out.", mapping)
+
+    message = str(exc_info.value)
+    assert "Casey Example" not in message
+    assert "casey@example.test" not in message
+    assert "1 original identifier" in message
+
+
+def test_input_and_output_guardrail_bindings_are_composable():
+    gateway = PrivacyGateway(deidentifier=fake_deidentify, reidentifier=reidentify)
+    clean_text, mapping = gateway.redact(ORIGINAL_TEXT)
+
+    protected_prompt = gateway.input_guardrail(mapping)(clean_text)
+    external_response = protected_prompt.replace("Patient", "Summary for")
+    restored = gateway.output_guardrail(mapping)(external_response)
+
+    assert protected_prompt == REDACTED_TEXT
+    assert restored == "Summary for Casey Example can be reached at casey@example.test."
+
+
+def test_gateway_exports_are_available_without_adapter_registry_churn():
+    assert gateway_module.PrivacyGateway is PrivacyGateway


### PR DESCRIPTION
## Description
Closes #1103.

Adds a dependency-light privacy gateway that de-identifies text before a user-supplied external model callable receives it, keeps the reversible mapping in memory, and restores identifiers locally from the callable response.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `PrivacyGateway`, `PrivacyGatewayConfig`, `RedactionMapping`, and guardrail helpers in `openmed.interop.gateway`.
- Exposed the gateway lazily from `openmed.interop` without adding optional adapter imports.
- Added a synthetic quickstart showing redact, external-call stub, and restore.
- Added unit tests for guarded calls, round-trip restoration, redaction checks, and PHI-safe mapping logging.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/unit/interop/test_privacy_gateway.py -q`
- `.venv/bin/python -m pytest tests/unit/interop/test_core_does_not_import_adapters.py tests/unit/interop/test_langchain_redaction.py -q`
- `.venv/bin/python -m pytest tests/unit/test_pii.py -q`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Related Issues
Closes #1103
