### PR TITLE
Publish an npm package wrapping the Transformers.js export with a typed de-identify API

### DIFF
--- a/js/openmedkit-web/package-lock.json
+++ b/js/openmedkit-web/package-lock.json
@@ -1,0 +1,2006 @@
+{
+  "name": "@openmed/openmedkit-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openmed/openmedkit-web",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "tsup": "^8.3.5",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@huggingface/transformers": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@huggingface/transformers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/js/openmedkit-web/package.json
+++ b/js/openmedkit-web/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@openmed/openmedkit-web",
+  "version": "0.1.0",
+  "description": "Typed web and Node de-identification helpers for OpenMed Transformers.js exports.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --sourcemap --clean --out-dir dist",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && npm run typecheck && npm run test:node",
+    "test:node": "tsx --test ../../tests/web/test_npm_deidentify.spec.ts"
+  },
+  "peerDependencies": {
+    "@huggingface/transformers": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@huggingface/transformers": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsup": "^8.3.5",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "Apache-2.0"
+}

--- a/js/openmedkit-web/src/decoder.ts
+++ b/js/openmedkit-web/src/decoder.ts
@@ -1,0 +1,494 @@
+import {
+  CANONICAL_LABELS,
+  type CanonicalLabel,
+  type DecodedEntitySpan,
+  type PolicyLabel,
+  type TokenClassificationEntity,
+  type TokenClassificationOutput,
+} from "./types";
+
+const CANONICAL_LABEL_SET = new Set<string>(CANONICAL_LABELS);
+
+const POLICY_LABEL_BY_CANONICAL: Record<CanonicalLabel, PolicyLabel> = {
+  ACCOUNT_NUMBER: "DIRECT_IDENTIFIER",
+  AGE: "QUASI_IDENTIFIER",
+  AMOUNT: "QUASI_IDENTIFIER",
+  API_KEY: "DIRECT_IDENTIFIER",
+  BIC: "DIRECT_IDENTIFIER",
+  BITCOIN_ADDRESS: "DIRECT_IDENTIFIER",
+  BUILDING_NUMBER: "DIRECT_IDENTIFIER",
+  CREDIT_CARD: "DIRECT_IDENTIFIER",
+  CREDIT_CARD_ISSUER: "QUASI_IDENTIFIER",
+  CURRENCY: "QUASI_IDENTIFIER",
+  CVV: "DIRECT_IDENTIFIER",
+  DATE: "QUASI_IDENTIFIER",
+  DATE_OF_BIRTH: "DIRECT_IDENTIFIER",
+  EMAIL: "DIRECT_IDENTIFIER",
+  ETHEREUM_ADDRESS: "DIRECT_IDENTIFIER",
+  EYE_COLOR: "QUASI_IDENTIFIER",
+  FIRST_NAME: "DIRECT_IDENTIFIER",
+  GENDER: "QUASI_IDENTIFIER",
+  GPS_COORDINATES: "DIRECT_IDENTIFIER",
+  HEIGHT: "QUASI_IDENTIFIER",
+  IBAN: "DIRECT_IDENTIFIER",
+  ID_NUM: "DIRECT_IDENTIFIER",
+  IMEI: "DIRECT_IDENTIFIER",
+  IP_ADDRESS: "DIRECT_IDENTIFIER",
+  JOB_DEPARTMENT: "QUASI_IDENTIFIER",
+  JOB_TITLE: "QUASI_IDENTIFIER",
+  LAST_NAME: "DIRECT_IDENTIFIER",
+  LITECOIN_ADDRESS: "DIRECT_IDENTIFIER",
+  LOCATION: "QUASI_IDENTIFIER",
+  MAC_ADDRESS: "DIRECT_IDENTIFIER",
+  MASKED_NUMBER: "DIRECT_IDENTIFIER",
+  MIDDLE_NAME: "DIRECT_IDENTIFIER",
+  OCCUPATION: "QUASI_IDENTIFIER",
+  ORDINAL_DIRECTION: "QUASI_IDENTIFIER",
+  ORGANIZATION: "QUASI_IDENTIFIER",
+  OTHER: "CLINICAL_CONCEPT",
+  PASSWORD: "DIRECT_IDENTIFIER",
+  PERSON: "DIRECT_IDENTIFIER",
+  PHONE: "DIRECT_IDENTIFIER",
+  PIN: "DIRECT_IDENTIFIER",
+  PREFIX: "DIRECT_IDENTIFIER",
+  SSN: "DIRECT_IDENTIFIER",
+  STREET_ADDRESS: "DIRECT_IDENTIFIER",
+  TIME: "QUASI_IDENTIFIER",
+  URL: "DIRECT_IDENTIFIER",
+  USER_AGENT: "DIRECT_IDENTIFIER",
+  USERNAME: "DIRECT_IDENTIFIER",
+  VEHICLE_REGISTRATION: "DIRECT_IDENTIFIER",
+  VIN: "DIRECT_IDENTIFIER",
+  ZIPCODE: "QUASI_IDENTIFIER",
+};
+
+const ALIAS_MAP: Record<string, CanonicalLabel> = {
+  accountname: "ACCOUNT_NUMBER",
+  accountnumber: "ACCOUNT_NUMBER",
+  address: "STREET_ADDRESS",
+  aadhaar: "ID_NUM",
+  age: "AGE",
+  amount: "AMOUNT",
+  apikey: "API_KEY",
+  bankaccount: "ACCOUNT_NUMBER",
+  bic: "BIC",
+  birthdate: "DATE_OF_BIRTH",
+  bitcoinaddress: "BITCOIN_ADDRESS",
+  buildingnumber: "BUILDING_NUMBER",
+  city: "LOCATION",
+  cnpj: "ID_NUM",
+  codicefiscale: "ID_NUM",
+  company: "ORGANIZATION",
+  country: "LOCATION",
+  county: "LOCATION",
+  cpf: "ID_NUM",
+  creditcard: "CREDIT_CARD",
+  creditcardissuer: "CREDIT_CARD_ISSUER",
+  creditcardnumber: "CREDIT_CARD",
+  creditdebitcard: "CREDIT_CARD",
+  currency: "CURRENCY",
+  currencycode: "CURRENCY",
+  currencyname: "CURRENCY",
+  currencysymbol: "CURRENCY",
+  cvv: "CVV",
+  date: "DATE",
+  dateofbirth: "DATE_OF_BIRTH",
+  department: "JOB_DEPARTMENT",
+  dni: "ID_NUM",
+  dob: "DATE_OF_BIRTH",
+  doctor: "PERSON",
+  email: "EMAIL",
+  emailaddress: "EMAIL",
+  employer: "ORGANIZATION",
+  ethereumaddress: "ETHEREUM_ADDRESS",
+  eyecolor: "EYE_COLOR",
+  familyname: "LAST_NAME",
+  fax: "PHONE",
+  firstname: "FIRST_NAME",
+  fullname: "PERSON",
+  gender: "GENDER",
+  givenname: "FIRST_NAME",
+  gps: "GPS_COORDINATES",
+  gpscoordinates: "GPS_COORDINATES",
+  height: "HEIGHT",
+  iban: "IBAN",
+  id: "ID_NUM",
+  identifier: "ID_NUM",
+  idnum: "ID_NUM",
+  imei: "IMEI",
+  ip: "IP_ADDRESS",
+  ipaddress: "IP_ADDRESS",
+  jobdepartment: "JOB_DEPARTMENT",
+  jobtitle: "JOB_TITLE",
+  lastname: "LAST_NAME",
+  licenseplate: "VEHICLE_REGISTRATION",
+  litecoinaddress: "LITECOIN_ADDRESS",
+  location: "LOCATION",
+  macaddress: "MAC_ADDRESS",
+  maskednumber: "MASKED_NUMBER",
+  medicalrecordnumber: "ID_NUM",
+  middlename: "MIDDLE_NAME",
+  mrn: "ID_NUM",
+  name: "PERSON",
+  nationalid: "ID_NUM",
+  nhs: "ID_NUM",
+  nhsnumber: "ID_NUM",
+  nie: "ID_NUM",
+  npi: "ID_NUM",
+  occupation: "OCCUPATION",
+  ordinaldirection: "ORDINAL_DIRECTION",
+  organization: "ORGANIZATION",
+  password: "PASSWORD",
+  patient: "PERSON",
+  person: "PERSON",
+  personalurl: "URL",
+  phone: "PHONE",
+  phonenumber: "PHONE",
+  pin: "PIN",
+  place: "LOCATION",
+  postalcode: "ZIPCODE",
+  postcode: "ZIPCODE",
+  prefix: "PREFIX",
+  profession: "OCCUPATION",
+  region: "LOCATION",
+  secondaryaddress: "STREET_ADDRESS",
+  sex: "GENDER",
+  socialsecuritynumber: "SSN",
+  ssn: "SSN",
+  state: "LOCATION",
+  steuerid: "ID_NUM",
+  street: "STREET_ADDRESS",
+  streetaddress: "STREET_ADDRESS",
+  surname: "LAST_NAME",
+  swift: "BIC",
+  telephone: "PHONE",
+  teudatzehut: "ID_NUM",
+  time: "TIME",
+  title: "PREFIX",
+  tz: "ID_NUM",
+  url: "URL",
+  urlpersonal: "URL",
+  useragent: "USER_AGENT",
+  userhandle: "USERNAME",
+  username: "USERNAME",
+  vin: "VIN",
+  vrm: "VEHICLE_REGISTRATION",
+  website: "URL",
+  zip: "ZIPCODE",
+  zipcode: "ZIPCODE",
+};
+
+type BoundaryTag = "B" | "I" | "E" | "S" | null;
+
+interface PreparedToken {
+  label: string;
+  boundary: BoundaryTag;
+  baseLabel: string;
+  canonicalLabel: CanonicalLabel;
+  policyLabel: PolicyLabel;
+  start: number;
+  end: number;
+  score: number | null;
+  index: number;
+}
+
+interface ActiveSpan {
+  baseLabel: string;
+  canonicalLabel: CanonicalLabel;
+  policyLabel: PolicyLabel;
+  start: number;
+  end: number;
+  scores: number[];
+  tokenCount: number;
+}
+
+export function normalizeLabel(label: string): CanonicalLabel {
+  if (!label) {
+    return "OTHER";
+  }
+  const key = labelKey(label);
+  if (!key) {
+    return "OTHER";
+  }
+  const alias = ALIAS_MAP[key];
+  if (alias) {
+    return alias;
+  }
+  const upper = label
+    .toUpperCase()
+    .replace(/[-\s]+/g, "_")
+    .replace(/[^A-Z0-9_]/g, "");
+  return CANONICAL_LABEL_SET.has(upper) ? (upper as CanonicalLabel) : "OTHER";
+}
+
+export function policyLabelFor(label: string): PolicyLabel {
+  return POLICY_LABEL_BY_CANONICAL[normalizeLabel(label)];
+}
+
+export function decodeBioTokenSpans(
+  text: string,
+  output: TokenClassificationOutput,
+  options: { threshold?: number } = {},
+): DecodedEntitySpan[] {
+  const threshold = options.threshold ?? 0;
+  const tokens = flattenTokenClassificationOutput(output)
+    .map((token, fallbackIndex) => prepareToken(token, fallbackIndex))
+    .filter((token): token is PreparedToken => token !== null)
+    .sort((left, right) => left.index - right.index || left.start - right.start);
+
+  const spans: DecodedEntitySpan[] = [];
+  let current: ActiveSpan | null = null;
+  let previousIndex: number | null = null;
+
+  for (const token of tokens) {
+    if (previousIndex !== null && token.index !== previousIndex + 1) {
+      if (current !== null) {
+        pushDecodedSpan(spans, current, text, threshold);
+        current = null;
+      }
+    }
+
+    if (token.boundary === null) {
+      if (current !== null) {
+        pushDecodedSpan(spans, current, text, threshold);
+        current = null;
+      }
+      previousIndex = token.index;
+      continue;
+    }
+
+    if (token.boundary === "S") {
+      if (current !== null) {
+        pushDecodedSpan(spans, current, text, threshold);
+      }
+      pushDecodedSpan(spans, activeSpanFromToken(token), text, threshold);
+      current = null;
+    } else if (token.boundary === "B") {
+      if (current !== null) {
+        pushDecodedSpan(spans, current, text, threshold);
+      }
+      current = activeSpanFromToken(token);
+    } else if (
+      token.boundary === "I" &&
+      current !== null &&
+      current.baseLabel === token.baseLabel
+    ) {
+      appendTokenToActiveSpan(current, token);
+    } else if (
+      token.boundary === "E" &&
+      current !== null &&
+      current.baseLabel === token.baseLabel
+    ) {
+      appendTokenToActiveSpan(current, token);
+      pushDecodedSpan(spans, current, text, threshold);
+      current = null;
+    } else {
+      if (current !== null) {
+        pushDecodedSpan(spans, current, text, threshold);
+      }
+      current = activeSpanFromToken(token);
+      if (token.boundary === "E") {
+        pushDecodedSpan(spans, current, text, threshold);
+        current = null;
+      }
+    }
+
+    previousIndex = token.index;
+  }
+
+  if (current !== null) {
+    pushDecodedSpan(spans, current, text, threshold);
+  }
+  return mergeAdjacentSpans(spans, text);
+}
+
+export function flattenTokenClassificationOutput(
+  output: TokenClassificationOutput,
+): TokenClassificationEntity[] {
+  if (output.length === 0) {
+    return [];
+  }
+  const first = output[0];
+  if (Array.isArray(first)) {
+    return (output as TokenClassificationEntity[][]).flat();
+  }
+  return output as TokenClassificationEntity[];
+}
+
+export function trimSpanWhitespace(
+  start: number,
+  end: number,
+  text: string,
+): { start: number; end: number } {
+  let nextStart = Math.max(0, Math.min(start, text.length));
+  let nextEnd = Math.max(nextStart, Math.min(end, text.length));
+  while (nextStart < nextEnd && /\s/.test(text[nextStart] ?? "")) {
+    nextStart += 1;
+  }
+  while (nextEnd > nextStart && /\s/.test(text[nextEnd - 1] ?? "")) {
+    nextEnd -= 1;
+  }
+  return { start: nextStart, end: nextEnd };
+}
+
+export function refinePrivacyFilterSpan(
+  label: string,
+  start: number,
+  end: number,
+  text: string,
+): { start: number; end: number } {
+  const trimmed = trimSpanWhitespace(start, end, text);
+  const spanText = text.slice(trimmed.start, trimmed.end);
+  const normalized = label.toLowerCase();
+  const structuredPatterns: Array<[string, RegExp]> = [
+    ["email", /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/],
+    ["url", /\b(?:https?:\/\/|www\.)[^\s,;)\]]+/],
+    ["phone", /(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}/],
+  ];
+
+  for (const [hint, pattern] of structuredPatterns) {
+    if (!normalized.includes(hint)) {
+      continue;
+    }
+    const match = pattern.exec(spanText);
+    if (match?.index !== undefined) {
+      return {
+        start: trimmed.start + match.index,
+        end: trimmed.start + match.index + match[0].length,
+      };
+    }
+  }
+
+  let nextEnd = trimmed.end;
+  const lowerSpan = spanText.toLowerCase();
+  for (const suffix of [" and", " or"]) {
+    if (lowerSpan.endsWith(suffix)) {
+      nextEnd -= suffix.length;
+      break;
+    }
+  }
+  return trimSpanWhitespace(trimmed.start, nextEnd, text);
+}
+
+function prepareToken(
+  token: TokenClassificationEntity,
+  fallbackIndex: number,
+): PreparedToken | null {
+  const label = token.entity_group ?? token.entity ?? "";
+  const start = Number(token.start);
+  const end = Number(token.end);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    return null;
+  }
+  const parsed = parseBoundaryLabel(label);
+  const canonicalLabel = normalizeLabel(parsed.baseLabel);
+  return {
+    label,
+    boundary: parsed.boundary,
+    baseLabel: parsed.baseLabel,
+    canonicalLabel,
+    policyLabel: POLICY_LABEL_BY_CANONICAL[canonicalLabel],
+    start,
+    end,
+    score: token.score === undefined ? null : Number(token.score),
+    index: token.index ?? fallbackIndex,
+  };
+}
+
+function activeSpanFromToken(token: PreparedToken): ActiveSpan {
+  return {
+    baseLabel: token.baseLabel,
+    canonicalLabel: token.canonicalLabel,
+    policyLabel: token.policyLabel,
+    start: token.start,
+    end: token.end,
+    scores: token.score === null ? [] : [token.score],
+    tokenCount: 1,
+  };
+}
+
+function appendTokenToActiveSpan(span: ActiveSpan, token: PreparedToken): void {
+  span.end = token.end;
+  if (token.score !== null) {
+    span.scores.push(token.score);
+  }
+  span.tokenCount += 1;
+}
+
+function pushDecodedSpan(
+  spans: DecodedEntitySpan[],
+  span: ActiveSpan,
+  text: string,
+  threshold: number,
+): void {
+  const refined = refinePrivacyFilterSpan(span.baseLabel, span.start, span.end, text);
+  if (refined.end <= refined.start) {
+    return;
+  }
+  const score =
+    span.scores.length > 0
+      ? span.scores.reduce((total, value) => total + value, 0) /
+        span.scores.length
+      : null;
+  if (score !== null && score < threshold) {
+    return;
+  }
+  spans.push({
+    entity_type: span.baseLabel,
+    canonical_label: span.canonicalLabel,
+    policy_label: span.policyLabel,
+    start: refined.start,
+    end: refined.end,
+    score,
+    token_count: span.tokenCount,
+  });
+}
+
+function parseBoundaryLabel(label: string): {
+  boundary: BoundaryTag;
+  baseLabel: string;
+} {
+  if (label === "O") {
+    return { boundary: null, baseLabel: "O" };
+  }
+  if (/^[BIES]-/.test(label)) {
+    return {
+      boundary: label[0] as Exclude<BoundaryTag, null>,
+      baseLabel: label.slice(2),
+    };
+  }
+  return { boundary: "B", baseLabel: label };
+}
+
+function labelKey(label: string): string {
+  const stripped = label.trim().replace(/^[BIES]-/, "");
+  return stripped.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function mergeAdjacentSpans(
+  spans: DecodedEntitySpan[],
+  text: string,
+): DecodedEntitySpan[] {
+  const merged: DecodedEntitySpan[] = [];
+  for (const span of spans) {
+    const previous = merged.at(-1);
+    if (
+      previous &&
+      previous.entity_type === span.entity_type &&
+      previous.end <= span.start &&
+      text.slice(previous.end, span.start).trim() === ""
+    ) {
+      previous.end = span.end;
+      previous.token_count += span.token_count;
+      if (previous.score !== null && span.score !== null) {
+        previous.score =
+          (previous.score + span.score) / 2;
+      } else {
+        previous.score = previous.score ?? span.score;
+      }
+      continue;
+    }
+    merged.push({ ...span });
+  }
+  return merged;
+}

--- a/js/openmedkit-web/src/index.ts
+++ b/js/openmedkit-web/src/index.ts
@@ -1,0 +1,173 @@
+import { decodeBioTokenSpans } from "./decoder";
+import { loadTokenClassificationPipeline } from "./model-loader";
+import {
+  OPENMED_SPAN_SCHEMA_VERSION,
+  type DeidentifyOptions,
+  type ExtractPiiOptions,
+  type OpenMedDeidentifyResult,
+  type OpenMedSpan,
+  type SpanAction,
+} from "./types";
+
+export {
+  CANONICAL_LABELS,
+  OPENMED_SPAN_SCHEMA_VERSION,
+  POLICY_LABELS,
+  SPAN_ACTIONS,
+} from "./types";
+export type {
+  CanonicalLabel,
+  DecodedEntitySpan,
+  DeidentifyOptions,
+  ExtractPiiOptions,
+  LoadModelOptions,
+  ModelLoader,
+  OpenMedDeidentifyResult,
+  OpenMedSpan,
+  PolicyLabel,
+  SpanAction,
+  TextHash,
+  TokenClassificationCallOptions,
+  TokenClassificationEntity,
+  TokenClassificationOutput,
+  TokenClassificationPipeline,
+  TransformersRuntime,
+} from "./types";
+export {
+  decodeBioTokenSpans,
+  flattenTokenClassificationOutput,
+  normalizeLabel,
+  policyLabelFor,
+  refinePrivacyFilterSpan,
+  trimSpanWhitespace,
+} from "./decoder";
+export {
+  isLocalModelReference,
+  loadTokenClassificationPipeline,
+} from "./model-loader";
+
+const DEFAULT_MODEL_ID = "OpenMed/privacy-filter-transformersjs";
+const DEFAULT_HASH_SECRET = "openmedkit-web";
+
+export async function extractPii(
+  text: string,
+  options: ExtractPiiOptions = {},
+): Promise<OpenMedSpan[]> {
+  const pipeline =
+    options.pipeline ??
+    (await (options.modelLoader ?? loadTokenClassificationPipeline)(
+      options.model ?? DEFAULT_MODEL_ID,
+      options.loaderOptions,
+    ));
+  const rawOutput = await pipeline(text, {
+    aggregation_strategy: "none",
+    ...(options.pipelineOptions ?? {}),
+  });
+  const decoded = decodeBioTokenSpans(text, rawOutput, {
+    threshold: options.threshold ?? 0,
+  });
+
+  const spans: OpenMedSpan[] = [];
+  for (const entity of decoded) {
+    const surface = text.slice(entity.start, entity.end);
+    spans.push({
+      schema_version: OPENMED_SPAN_SCHEMA_VERSION,
+      doc_id: options.docId ?? "document",
+      start: entity.start,
+      end: entity.end,
+      text_hash: await hmacTextHash(
+        surface,
+        options.hashSecret ?? DEFAULT_HASH_SECRET,
+      ),
+      entity_type: entity.entity_type,
+      canonical_label: entity.canonical_label,
+      policy_label: entity.policy_label,
+      regulatory_tags: [...(options.regulatoryTags ?? [])],
+      score: entity.score,
+      detector: options.detector ?? "transformersjs",
+      evidence: {
+        token_count: entity.token_count,
+      },
+      action: "keep",
+      replacement: null,
+      reversible_id: null,
+      section: options.section ?? null,
+      metadata: {
+        ...(options.model ? { model: options.model } : {}),
+        ...(options.metadata ?? {}),
+      },
+    });
+  }
+  return spans;
+}
+
+export async function deidentify(
+  text: string,
+  options: DeidentifyOptions = {},
+): Promise<OpenMedDeidentifyResult> {
+  const spans = await extractPii(text, options);
+  const redactionSpans = spans.map((span) => {
+    const replacement = options.replacement?.(span) ?? `[${span.canonical_label}]`;
+    return {
+      ...span,
+      action: "redact" as SpanAction,
+      replacement,
+    };
+  });
+  return {
+    text,
+    deidentifiedText: spansToRedactedText(text, redactionSpans),
+    spans: redactionSpans,
+  };
+}
+
+export function spansToRedactedText(text: string, spans: OpenMedSpan[]): string {
+  let redacted = text;
+  for (const span of [...spans].sort((left, right) => right.start - left.start)) {
+    redacted =
+      redacted.slice(0, span.start) +
+      (span.replacement ?? `[${span.canonical_label}]`) +
+      redacted.slice(span.end);
+  }
+  return redacted;
+}
+
+export async function hmacTextHash(
+  surface: string | Uint8Array,
+  secret: string | Uint8Array,
+): Promise<`hmac-sha256:${string}`> {
+  const payload = toBytes(surface);
+  const key = toBytes(secret);
+  const subtle = globalThis.crypto?.subtle;
+  if (subtle) {
+    const cryptoKey = await subtle.importKey(
+      "raw",
+      toArrayBuffer(key),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const signature = await subtle.sign("HMAC", cryptoKey, toArrayBuffer(payload));
+    return `hmac-sha256:${toHex(new Uint8Array(signature))}`;
+  }
+
+  const { createHmac } = await import("node:crypto");
+  const digest = createHmac("sha256", key).update(payload).digest("hex");
+  return `hmac-sha256:${digest}`;
+}
+
+function toBytes(value: string | Uint8Array): Uint8Array {
+  return typeof value === "string" ? new TextEncoder().encode(value) : value;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}

--- a/js/openmedkit-web/src/model-loader.ts
+++ b/js/openmedkit-web/src/model-loader.ts
@@ -1,0 +1,89 @@
+import type {
+  LoadModelOptions,
+  TokenClassificationPipeline,
+  TransformersRuntime,
+} from "./types";
+
+const TRANSFORMERS_JS_MODULE = "@huggingface/transformers";
+
+export async function loadTokenClassificationPipeline(
+  model: string,
+  options: LoadModelOptions = {},
+): Promise<TokenClassificationPipeline> {
+  const runtime = await resolveRuntime(options.runtime);
+  const localReference = isLocalModelReference(model);
+  const localFilesOnly = options.localFilesOnly ?? localReference;
+  const allowRemoteModels = options.allowRemoteModels ?? !localFilesOnly;
+  const previousAllowRemote = runtime.env?.allowRemoteModels;
+  const previousAllowLocal = runtime.env?.allowLocalModels;
+
+  if (runtime.env) {
+    runtime.env.allowLocalModels = true;
+    runtime.env.allowRemoteModels = allowRemoteModels;
+  }
+
+  try {
+    const pipelineOptions: Record<string, unknown> = {
+      ...(options.revision === undefined ? {} : { revision: options.revision }),
+      ...(options.quantized === undefined ? {} : { quantized: options.quantized }),
+      ...(options.dtype === undefined ? {} : { dtype: options.dtype }),
+      ...(options.device === undefined ? {} : { device: options.device }),
+      ...(options.pipelineOptions ?? {}),
+      local_files_only: localFilesOnly,
+      localFilesOnly,
+    };
+    return await runtime.pipeline(
+      "token-classification",
+      model,
+      pipelineOptions,
+    );
+  } finally {
+    if (runtime.env) {
+      if (previousAllowRemote === undefined) {
+        delete runtime.env.allowRemoteModels;
+      } else {
+        runtime.env.allowRemoteModels = previousAllowRemote;
+      }
+      if (previousAllowLocal === undefined) {
+        delete runtime.env.allowLocalModels;
+      } else {
+        runtime.env.allowLocalModels = previousAllowLocal;
+      }
+    }
+  }
+}
+
+export function isLocalModelReference(model: string): boolean {
+  if (model.startsWith("file://")) {
+    return true;
+  }
+  if (
+    model.startsWith("/") ||
+    model.startsWith("./") ||
+    model.startsWith("../") ||
+    model.startsWith("~")
+  ) {
+    return true;
+  }
+  return /^[A-Za-z]:[\\/]/.test(model);
+}
+
+async function resolveRuntime(
+  runtime?: LoadModelOptions["runtime"],
+): Promise<TransformersRuntime> {
+  if (typeof runtime === "function") {
+    return runtime();
+  }
+  if (runtime) {
+    return runtime;
+  }
+  const moduleName = TRANSFORMERS_JS_MODULE;
+  try {
+    return (await import(moduleName)) as TransformersRuntime;
+  } catch (error) {
+    throw new Error(
+      "Install @huggingface/transformers or pass a token-classification pipeline.",
+      { cause: error },
+    );
+  }
+}

--- a/js/openmedkit-web/src/types.ts
+++ b/js/openmedkit-web/src/types.ts
@@ -1,0 +1,187 @@
+export const OPENMED_SPAN_SCHEMA_VERSION = 1 as const;
+
+export const CANONICAL_LABELS = [
+  "ACCOUNT_NUMBER",
+  "AGE",
+  "AMOUNT",
+  "API_KEY",
+  "BIC",
+  "BITCOIN_ADDRESS",
+  "BUILDING_NUMBER",
+  "CREDIT_CARD",
+  "CREDIT_CARD_ISSUER",
+  "CURRENCY",
+  "CVV",
+  "DATE",
+  "DATE_OF_BIRTH",
+  "EMAIL",
+  "ETHEREUM_ADDRESS",
+  "EYE_COLOR",
+  "FIRST_NAME",
+  "GENDER",
+  "GPS_COORDINATES",
+  "HEIGHT",
+  "IBAN",
+  "ID_NUM",
+  "IMEI",
+  "IP_ADDRESS",
+  "JOB_DEPARTMENT",
+  "JOB_TITLE",
+  "LAST_NAME",
+  "LITECOIN_ADDRESS",
+  "LOCATION",
+  "MAC_ADDRESS",
+  "MASKED_NUMBER",
+  "MIDDLE_NAME",
+  "OCCUPATION",
+  "ORDINAL_DIRECTION",
+  "ORGANIZATION",
+  "OTHER",
+  "PASSWORD",
+  "PERSON",
+  "PHONE",
+  "PIN",
+  "PREFIX",
+  "SSN",
+  "STREET_ADDRESS",
+  "TIME",
+  "URL",
+  "USER_AGENT",
+  "USERNAME",
+  "VEHICLE_REGISTRATION",
+  "VIN",
+  "ZIPCODE"
+] as const;
+
+export type CanonicalLabel = (typeof CANONICAL_LABELS)[number];
+
+export const POLICY_LABELS = [
+  "DIRECT_IDENTIFIER",
+  "QUASI_IDENTIFIER",
+  "CLINICAL_CONCEPT"
+] as const;
+
+export type PolicyLabel = (typeof POLICY_LABELS)[number];
+
+export const SPAN_ACTIONS = [
+  "keep",
+  "redact",
+  "replace",
+  "mask",
+  "hash",
+  "format_preserve"
+] as const;
+
+export type SpanAction = (typeof SPAN_ACTIONS)[number];
+
+export type TextHash = `hmac-sha256:${string}`;
+
+export interface OpenMedSpan {
+  schema_version: typeof OPENMED_SPAN_SCHEMA_VERSION;
+  doc_id: string;
+  start: number;
+  end: number;
+  text_hash: TextHash;
+  entity_type: string;
+  canonical_label: CanonicalLabel;
+  policy_label: PolicyLabel;
+  regulatory_tags: string[];
+  score: number | null;
+  detector: string | null;
+  evidence: Record<string, unknown>;
+  action: SpanAction;
+  replacement: string | null;
+  reversible_id: string | null;
+  section: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface TokenClassificationEntity {
+  entity?: string;
+  entity_group?: string;
+  score?: number;
+  word?: string;
+  start: number;
+  end: number;
+  index?: number;
+}
+
+export type TokenClassificationOutput =
+  | TokenClassificationEntity[]
+  | TokenClassificationEntity[][];
+
+export interface TokenClassificationCallOptions {
+  aggregation_strategy?: "none" | "simple" | "first" | "average" | "max";
+  ignore_labels?: string[];
+  [key: string]: unknown;
+}
+
+export type TokenClassificationPipeline = (
+  text: string,
+  options?: TokenClassificationCallOptions,
+) => TokenClassificationOutput | Promise<TokenClassificationOutput>;
+
+export interface DecodedEntitySpan {
+  entity_type: string;
+  canonical_label: CanonicalLabel;
+  policy_label: PolicyLabel;
+  start: number;
+  end: number;
+  score: number | null;
+  token_count: number;
+}
+
+export interface ExtractPiiOptions {
+  pipeline?: TokenClassificationPipeline;
+  model?: string;
+  modelLoader?: ModelLoader;
+  loaderOptions?: LoadModelOptions;
+  threshold?: number;
+  docId?: string;
+  hashSecret?: string | Uint8Array;
+  detector?: string | null;
+  lang?: string;
+  section?: string | null;
+  regulatoryTags?: string[];
+  metadata?: Record<string, unknown>;
+  pipelineOptions?: TokenClassificationCallOptions;
+}
+
+export interface DeidentifyOptions extends ExtractPiiOptions {
+  replacement?: (span: OpenMedSpan) => string;
+}
+
+export interface OpenMedDeidentifyResult {
+  text: string;
+  deidentifiedText: string;
+  spans: OpenMedSpan[];
+}
+
+export interface LoadModelOptions {
+  localFilesOnly?: boolean;
+  allowRemoteModels?: boolean;
+  revision?: string;
+  quantized?: boolean;
+  dtype?: string;
+  device?: string;
+  runtime?: TransformersRuntime | (() => Promise<TransformersRuntime>);
+  pipelineOptions?: Record<string, unknown>;
+}
+
+export interface TransformersRuntime {
+  pipeline: (
+    task: "token-classification",
+    model: string,
+    options?: Record<string, unknown>,
+  ) => Promise<TokenClassificationPipeline> | TokenClassificationPipeline;
+  env?: {
+    allowRemoteModels?: boolean;
+    allowLocalModels?: boolean;
+    [key: string]: unknown;
+  };
+}
+
+export type ModelLoader = (
+  model: string,
+  options?: LoadModelOptions,
+) => Promise<TokenClassificationPipeline>;

--- a/js/openmedkit-web/tsconfig.json
+++ b/js/openmedkit-web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tests/web/__snapshots__/openmedkit-web-public-api.json
+++ b/tests/web/__snapshots__/openmedkit-web-public-api.json
@@ -1,0 +1,27 @@
+{
+  "exports": [
+    "CANONICAL_LABELS",
+    "OPENMED_SPAN_SCHEMA_VERSION",
+    "POLICY_LABELS",
+    "SPAN_ACTIONS",
+    "decodeBioTokenSpans",
+    "deidentify",
+    "extractPii",
+    "flattenTokenClassificationOutput",
+    "hmacTextHash",
+    "isLocalModelReference",
+    "loadTokenClassificationPipeline",
+    "normalizeLabel",
+    "policyLabelFor",
+    "refinePrivacyFilterSpan",
+    "spansToRedactedText",
+    "trimSpanWhitespace"
+  ],
+  "packageExports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  }
+}

--- a/tests/web/fixtures/npm_deidentify_golden.json
+++ b/tests/web/fixtures/npm_deidentify_golden.json
@@ -1,0 +1,75 @@
+{
+  "deidentifiedText": "Patient [PERSON], DOB [DATE_OF_BIRTH], email [EMAIL].",
+  "spans": [
+    {
+      "action": "redact",
+      "canonical_label": "PERSON",
+      "detector": "fixture-token-classifier",
+      "doc_id": "web-fixture",
+      "end": 20,
+      "entity_type": "NAME",
+      "evidence": {
+        "token_count": 2
+      },
+      "metadata": {
+        "fixture": "python-generated"
+      },
+      "policy_label": "DIRECT_IDENTIFIER",
+      "regulatory_tags": [],
+      "replacement": "[PERSON]",
+      "reversible_id": null,
+      "schema_version": 1,
+      "score": 0.98,
+      "section": null,
+      "start": 8,
+      "text_hash": "hmac-sha256:942b7c85d5cfd4db8a8c20839d5743df174b44edb79d5016f478a8e4297a5fb3"
+    },
+    {
+      "action": "redact",
+      "canonical_label": "DATE_OF_BIRTH",
+      "detector": "fixture-token-classifier",
+      "doc_id": "web-fixture",
+      "end": 36,
+      "entity_type": "DATE_OF_BIRTH",
+      "evidence": {
+        "token_count": 1
+      },
+      "metadata": {
+        "fixture": "python-generated"
+      },
+      "policy_label": "DIRECT_IDENTIFIER",
+      "regulatory_tags": [],
+      "replacement": "[DATE_OF_BIRTH]",
+      "reversible_id": null,
+      "schema_version": 1,
+      "score": 0.96,
+      "section": null,
+      "start": 26,
+      "text_hash": "hmac-sha256:c66f92b448894b016f2b71555eba31acac911c8bfb8f2d30215dd076ac9b19d3"
+    },
+    {
+      "action": "redact",
+      "canonical_label": "EMAIL",
+      "detector": "fixture-token-classifier",
+      "doc_id": "web-fixture",
+      "end": 61,
+      "entity_type": "EMAIL",
+      "evidence": {
+        "token_count": 1
+      },
+      "metadata": {
+        "fixture": "python-generated"
+      },
+      "policy_label": "DIRECT_IDENTIFIER",
+      "regulatory_tags": [],
+      "replacement": "[EMAIL]",
+      "reversible_id": null,
+      "schema_version": 1,
+      "score": 0.98,
+      "section": null,
+      "start": 44,
+      "text_hash": "hmac-sha256:7900c832abc555d87e2efc8dd37fa329844c78ba1495b567a39cc108c7429d1d"
+    }
+  ],
+  "text": "Patient Alice Nguyen, DOB 1979-04-12, email alice@example.org."
+}

--- a/tests/web/test_npm_deidentify.py
+++ b/tests/web/test_npm_deidentify.py
@@ -1,0 +1,36 @@
+"""Pytest bridge for the OpenMedKit web npm package checks."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_DIR = ROOT / "js" / "openmedkit-web"
+
+
+def test_openmedkit_web_package_checks() -> None:
+    node = shutil.which("node")
+    npm = shutil.which("npm")
+    if node is None or npm is None:
+        pytest.skip("node and npm are required for OpenMedKit web package checks")
+
+    _run([npm, "ci"])
+    _run([npm, "test"])
+
+
+def _run(command: list[str]) -> None:
+    completed = subprocess.run(
+        command,
+        cwd=PACKAGE_DIR,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert completed.returncode == 0, completed.stdout

--- a/tests/web/test_npm_deidentify.spec.ts
+++ b/tests/web/test_npm_deidentify.spec.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+
+import type {
+  OpenMedDeidentifyResult,
+  OpenMedSpan,
+  TokenClassificationPipeline,
+  TransformersRuntime,
+} from "../../js/openmedkit-web/src/index";
+
+const rootDir = fileURLToPath(new URL("../..", import.meta.url));
+const packageDir = join(rootDir, "js", "openmedkit-web");
+const distUrl = pathToFileURL(join(packageDir, "dist", "index.js")).href;
+
+const fixturePath = join(
+  rootDir,
+  "tests",
+  "web",
+  "fixtures",
+  "npm_deidentify_golden.json",
+);
+const publicSurfaceSnapshotPath = join(
+  rootDir,
+  "tests",
+  "web",
+  "__snapshots__",
+  "openmedkit-web-public-api.json",
+);
+
+test("deidentify returns OpenMedSpan records matching the Python golden", async () => {
+  const api = await loadApi();
+  const expected = JSON.parse(
+    await readFile(fixturePath, "utf8"),
+  ) as OpenMedDeidentifyResult;
+
+  const result = (await api.deidentify(expected.text, {
+    pipeline: fixturePipeline,
+    docId: "web-fixture",
+    hashSecret: "test-secret",
+    detector: "fixture-token-classifier",
+    metadata: { fixture: "python-generated" },
+  })) as OpenMedDeidentifyResult;
+
+  assert.equal(result.text, expected.text);
+  assert.equal(result.deidentifiedText, expected.deidentifiedText);
+  assertSpansClose(result.spans, expected.spans);
+});
+
+test("public runtime surface is snapshot-tested", async () => {
+  const api = await loadApi();
+  const snapshot = JSON.parse(
+    await readFile(publicSurfaceSnapshotPath, "utf8"),
+  ) as { exports: string[]; packageExports: unknown };
+  const packageJson = JSON.parse(
+    await readFile(join(packageDir, "package.json"), "utf8"),
+  ) as { exports: unknown };
+
+  assert.deepEqual(Object.keys(api).sort(), snapshot.exports);
+  assert.deepEqual(packageJson.exports, snapshot.packageExports);
+});
+
+test("local model loading is offline-only by default", async () => {
+  const api = await loadApi();
+  const runtime: TransformersRuntime = {
+    env: {
+      allowLocalModels: false,
+      allowRemoteModels: true,
+    },
+    pipeline: async (_task, model, options) => {
+      assert.equal(model, "/models/openmed-transformersjs");
+      assert.equal(runtime.env?.allowRemoteModels, false);
+      assert.equal(runtime.env?.allowLocalModels, true);
+      assert.equal(options?.local_files_only, true);
+      assert.equal(options?.localFilesOnly, true);
+      return fixturePipeline;
+    },
+  };
+
+  const loaded = (await api.loadTokenClassificationPipeline(
+    "/models/openmed-transformersjs",
+    { runtime },
+  )) as TokenClassificationPipeline;
+
+  assert.equal(loaded, fixturePipeline);
+  assert.equal(runtime.env?.allowRemoteModels, true);
+  assert.equal(runtime.env?.allowLocalModels, false);
+});
+
+async function loadApi() {
+  return import(distUrl);
+}
+
+const fixturePipeline: TokenClassificationPipeline = (text) => {
+  const aliceStart = text.indexOf("Alice");
+  const nguyenStart = text.indexOf("Nguyen");
+  const dobStart = text.indexOf("1979-04-12");
+  const emailStart = text.indexOf("alice@example.org");
+  return [
+    {
+      entity: "B-NAME",
+      score: 0.99,
+      word: "Alice",
+      start: aliceStart,
+      end: aliceStart + "Alice".length,
+      index: 0,
+    },
+    {
+      entity: "E-NAME",
+      score: 0.97,
+      word: "Nguyen",
+      start: nguyenStart,
+      end: nguyenStart + "Nguyen".length,
+      index: 1,
+    },
+    {
+      entity: "S-DATE_OF_BIRTH",
+      score: 0.96,
+      word: "1979-04-12",
+      start: dobStart,
+      end: dobStart + "1979-04-12".length,
+      index: 2,
+    },
+    {
+      entity: "S-EMAIL",
+      score: 0.98,
+      word: "alice@example.org",
+      start: emailStart,
+      end: emailStart + "alice@example.org".length,
+      index: 3,
+    },
+  ];
+};
+
+function assertSpansClose(actual: OpenMedSpan[], expected: OpenMedSpan[]) {
+  assert.equal(actual.length, expected.length);
+  for (const [index, actualSpan] of actual.entries()) {
+    const expectedSpan = expected[index];
+    assert.ok(expectedSpan, `missing expected span at ${index}`);
+    const { score: actualScore, ...actualRest } = actualSpan;
+    const { score: expectedScore, ...expectedRest } = expectedSpan;
+    assert.deepEqual(actualRest, expectedRest);
+    assert.ok(actualScore !== null);
+    assert.ok(expectedScore !== null);
+    assert.ok(Math.abs(actualScore - expectedScore) <= 1e-12);
+  }
+}


### PR DESCRIPTION
Closes #795.

Adds the js/openmedkit-web npm package with typed extractPii() and deidentify() APIs, BIO/BIOES span decoding, offline-aware local model loading, and web package tests against a Python-generated OpenMedSpan golden. The package builds ESM and CJS outputs and keeps local model paths offline-only by default.

Tests:
- PATH=/Users/maziyar/.nvm/versions/node/v25.2.1/bin:$PATH npm test
- .venv/bin/python -m pytest tests/ -q