### PR TITLE
Add log-pipeline redaction filter

### DIFF
--- a/examples/log-redaction/README.md
+++ b/examples/log-redaction/README.md
@@ -1,0 +1,54 @@
+# Log Redaction Example
+
+This example shows how to use OpenMed as an NDJSON transform for structured log
+events before they reach a centralized observability store.
+
+Input events are one JSON object per line:
+
+```json
+{"timestamp":"2026-07-01T10:00:00Z","service":"api","message":"Patient Jane Roe called 555-0100","trace_id":"abc"}
+{"timestamp":"2026-07-01T10:00:01Z","service":"worker","error":{"message":"Follow up with john.doe@example.org"},"trace_id":"def"}
+```
+
+Run the stdin/stdout transform:
+
+```bash
+python -m openmed.integrations.log_redactor \
+  --field message \
+  --field error.message \
+  < raw-events.ndjson \
+  > redacted-events.ndjson
+```
+
+The transform preserves event order and non-target fields while replacing
+configured text fields:
+
+```json
+{"timestamp":"2026-07-01T10:00:00Z","service":"api","message":"Patient [NAME] called [PHONE]","trace_id":"abc"}
+{"timestamp":"2026-07-01T10:00:01Z","service":"worker","error":{"message":"Follow up with [EMAIL]"},"trace_id":"def"}
+```
+
+Python callers can embed the same filter:
+
+```python
+from openmed.integrations.log_redactor import redact_log_events
+
+events = [
+    {
+        "service": "api",
+        "message": "Patient Jane Roe called 555-0100",
+        "trace_id": "abc",
+    },
+]
+
+redacted = list(
+    redact_log_events(
+        events,
+        message_fields=("message",),
+        batch_size=16,
+    )
+)
+```
+
+Diagnostics report only counts, line numbers, and safe failure summaries. They
+do not echo raw event bodies.

--- a/openmed/integrations/__init__.py
+++ b/openmed/integrations/__init__.py
@@ -1,0 +1,21 @@
+"""Integration helpers for OpenMed deployments."""
+
+from .log_redactor import (
+    DEFAULT_LOG_MESSAGE_FIELDS,
+    DEFAULT_LOG_REDACTION_MODEL,
+    LogRedactorConfig,
+    LogRedactorError,
+    redact_log_events,
+    redact_ndjson_lines,
+    redact_ndjson_stream,
+)
+
+__all__ = [
+    "DEFAULT_LOG_MESSAGE_FIELDS",
+    "DEFAULT_LOG_REDACTION_MODEL",
+    "LogRedactorConfig",
+    "LogRedactorError",
+    "redact_log_events",
+    "redact_ndjson_lines",
+    "redact_ndjson_stream",
+]

--- a/openmed/integrations/log_redactor.py
+++ b/openmed/integrations/log_redactor.py
@@ -1,0 +1,412 @@
+"""NDJSON log-event redaction filters for structured event streams."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, TextIO
+
+from openmed.core.pii_i18n import DEFAULT_PII_MODELS
+from openmed.processing.batch import process_batch
+
+DEFAULT_LOG_MESSAGE_FIELDS = ("message",)
+DEFAULT_LOG_REDACTION_MODEL = DEFAULT_PII_MODELS["en"]
+
+
+class LogRedactorError(RuntimeError):
+    """Raised when a log stream cannot be redacted safely."""
+
+
+@dataclass(frozen=True)
+class LogRedactorConfig:
+    """Configuration for structured log event redaction.
+
+    Args:
+        message_fields: Top-level or dotted event fields containing log text.
+        batch_size: Number of events to accumulate before redaction.
+        model_name: PII model passed to :func:`openmed.process_batch`.
+        method: De-identification method passed to batch de-identification.
+        confidence_threshold: Detection confidence threshold.
+        deidentify_kwargs: Extra keyword arguments forwarded to batch
+            de-identification.
+    """
+
+    message_fields: tuple[str, ...] = DEFAULT_LOG_MESSAGE_FIELDS
+    batch_size: int = 16
+    model_name: str = DEFAULT_LOG_REDACTION_MODEL
+    method: str = "mask"
+    confidence_threshold: float | None = 0.7
+    deidentify_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        fields = _normalize_message_fields(self.message_fields)
+        object.__setattr__(self, "message_fields", fields)
+        if self.batch_size < 1:
+            raise ValueError("batch_size must be positive")
+
+
+@dataclass(frozen=True)
+class _Target:
+    event_index: int
+    field_name: str
+    path: tuple[str, ...]
+    text: str
+
+
+def redact_log_events(
+    events: Iterable[Mapping[str, Any]],
+    *,
+    message_fields: Sequence[str] = DEFAULT_LOG_MESSAGE_FIELDS,
+    batch_size: int = 16,
+    model_name: str = DEFAULT_LOG_REDACTION_MODEL,
+    method: str = "mask",
+    confidence_threshold: float | None = 0.7,
+    **deidentify_kwargs: Any,
+) -> Iterator[dict[str, Any]]:
+    """Yield redacted copies of structured log events.
+
+    Only configured string fields are redacted. Missing fields and non-string
+    fields are preserved unchanged, as are all non-target event fields.
+
+    Args:
+        events: Structured log events to redact.
+        message_fields: Top-level or dotted event fields containing log text.
+        batch_size: Number of events to accumulate before redaction.
+        model_name: PII model passed to batch de-identification.
+        method: De-identification method.
+        confidence_threshold: Minimum confidence for PII detection.
+        **deidentify_kwargs: Extra keyword arguments forwarded to batch
+            de-identification.
+
+    Yields:
+        Redacted event copies in the same order as the input events.
+    """
+
+    config = LogRedactorConfig(
+        message_fields=tuple(message_fields),
+        batch_size=batch_size,
+        model_name=model_name,
+        method=method,
+        confidence_threshold=confidence_threshold,
+        deidentify_kwargs=deidentify_kwargs,
+    )
+
+    batch: list[Mapping[str, Any]] = []
+    for event in events:
+        if not isinstance(event, Mapping):
+            raise TypeError("log events must be mappings")
+        batch.append(event)
+        if len(batch) >= config.batch_size:
+            yield from _redact_event_batch(batch, config)
+            batch = []
+
+    if batch:
+        yield from _redact_event_batch(batch, config)
+
+
+def redact_ndjson_stream(
+    input_stream: TextIO,
+    output_stream: TextIO,
+    *,
+    message_fields: Sequence[str] = DEFAULT_LOG_MESSAGE_FIELDS,
+    batch_size: int = 16,
+    model_name: str = DEFAULT_LOG_REDACTION_MODEL,
+    method: str = "mask",
+    confidence_threshold: float | None = 0.7,
+    **deidentify_kwargs: Any,
+) -> int:
+    """Redact NDJSON events from ``input_stream`` into ``output_stream``.
+
+    Args:
+        input_stream: Text stream containing one JSON object per line.
+        output_stream: Text stream receiving redacted JSON objects.
+        message_fields: Top-level or dotted event fields containing log text.
+        batch_size: Number of events to accumulate before redaction.
+        model_name: PII model passed to batch de-identification.
+        method: De-identification method.
+        confidence_threshold: Minimum confidence for PII detection.
+        **deidentify_kwargs: Extra keyword arguments forwarded to batch
+            de-identification.
+
+    Returns:
+        Number of JSON events emitted. Blank input lines are ignored.
+    """
+
+    emitted = 0
+    for event in redact_log_events(
+        _iter_ndjson_events(input_stream),
+        message_fields=message_fields,
+        batch_size=batch_size,
+        model_name=model_name,
+        method=method,
+        confidence_threshold=confidence_threshold,
+        **deidentify_kwargs,
+    ):
+        output_stream.write(_to_ndjson_line(event))
+        emitted += 1
+    return emitted
+
+
+def redact_ndjson_lines(
+    lines: Iterable[str],
+    *,
+    message_fields: Sequence[str] = DEFAULT_LOG_MESSAGE_FIELDS,
+    batch_size: int = 16,
+    model_name: str = DEFAULT_LOG_REDACTION_MODEL,
+    method: str = "mask",
+    confidence_threshold: float | None = 0.7,
+    **deidentify_kwargs: Any,
+) -> Iterator[str]:
+    """Yield redacted NDJSON lines from an iterable of raw lines.
+
+    Args:
+        lines: Raw NDJSON input lines.
+        message_fields: Top-level or dotted event fields containing log text.
+        batch_size: Number of events to accumulate before redaction.
+        model_name: PII model passed to batch de-identification.
+        method: De-identification method.
+        confidence_threshold: Minimum confidence for PII detection.
+        **deidentify_kwargs: Extra keyword arguments forwarded to batch
+            de-identification.
+
+    Yields:
+        Redacted NDJSON lines.
+    """
+
+    for event in redact_log_events(
+        _iter_ndjson_events(lines),
+        message_fields=message_fields,
+        batch_size=batch_size,
+        model_name=model_name,
+        method=method,
+        confidence_threshold=confidence_threshold,
+        **deidentify_kwargs,
+    ):
+        yield _to_ndjson_line(event)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    """Run the stdin/stdout NDJSON redaction transform."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    input_stream = stdin if stdin is not None else sys.stdin
+    output_stream = stdout if stdout is not None else sys.stdout
+    error_stream = stderr if stderr is not None else sys.stderr
+
+    try:
+        redact_ndjson_stream(
+            input_stream,
+            output_stream,
+            message_fields=tuple(args.field),
+            batch_size=args.batch_size,
+            model_name=args.model_name,
+            method=args.method,
+            confidence_threshold=args.confidence_threshold,
+            lang=args.lang,
+            policy=args.policy,
+            use_safety_sweep=args.use_safety_sweep,
+        )
+    except (LogRedactorError, TypeError, ValueError) as exc:
+        error_stream.write(f"log redaction failed: {exc}\n")
+        return 1
+
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Redact PHI from configured fields in NDJSON log events.",
+    )
+    parser.add_argument(
+        "--field",
+        action="append",
+        default=[],
+        help=(
+            "Log event field to redact. Repeat for multiple fields. "
+            "Dotted paths such as error.message are supported."
+        ),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=16,
+        help="Number of events to buffer before redaction.",
+    )
+    parser.add_argument(
+        "--model-name",
+        default=DEFAULT_LOG_REDACTION_MODEL,
+        help="PII model identifier passed to OpenMed batch de-identification.",
+    )
+    parser.add_argument(
+        "--method",
+        default="mask",
+        choices=("mask", "remove", "replace", "hash", "shift_dates"),
+        help="De-identification method.",
+    )
+    parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.7,
+        help="Minimum PII detection confidence.",
+    )
+    parser.add_argument(
+        "--lang",
+        default="en",
+        help="Language hint forwarded to de-identification.",
+    )
+    parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy profile forwarded to de-identification.",
+    )
+    parser.add_argument(
+        "--use-safety-sweep",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable or disable regex safety sweep fallback.",
+    )
+    return parser
+
+
+def _iter_ndjson_events(input_stream: Iterable[str]) -> Iterator[dict[str, Any]]:
+    for line_number, raw_line in enumerate(input_stream, start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise LogRedactorError(
+                f"invalid JSON object at input line {line_number}"
+            ) from None
+        if not isinstance(event, dict):
+            raise LogRedactorError(
+                f"input line {line_number} must contain a JSON object"
+            )
+        yield event
+
+
+def _to_ndjson_line(event: Mapping[str, Any]) -> str:
+    return json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
+
+
+def _redact_event_batch(
+    events: Sequence[Mapping[str, Any]],
+    config: LogRedactorConfig,
+) -> list[dict[str, Any]]:
+    outputs = [copy.deepcopy(dict(event)) for event in events]
+    targets = _collect_targets(outputs, config.message_fields)
+    if not targets:
+        return outputs
+
+    texts = [target.text for target in targets]
+    ids = [f"event_{target.event_index}:{target.field_name}" for target in targets]
+
+    try:
+        batch_result = process_batch(
+            texts,
+            model_name=config.model_name,
+            ids=ids,
+            operation="deidentify",
+            batch_size=config.batch_size,
+            confidence_threshold=config.confidence_threshold,
+            method=config.method,
+            continue_on_error=False,
+            **dict(config.deidentify_kwargs),
+        )
+    except Exception:
+        raise LogRedactorError("failed to redact a log event batch") from None
+
+    items = list(getattr(batch_result, "items", []))
+    if len(items) != len(targets):
+        raise LogRedactorError("log redaction returned an unexpected result count")
+
+    for target, item in zip(targets, items):
+        if not getattr(item, "success", False):
+            raise LogRedactorError("failed to redact a configured log field")
+        result = getattr(item, "result", None)
+        redacted_text = getattr(result, "deidentified_text", None)
+        if not isinstance(redacted_text, str):
+            raise LogRedactorError("log redaction returned an invalid result")
+        _set_path(outputs[target.event_index], target.path, redacted_text)
+
+    return outputs
+
+
+def _collect_targets(
+    events: Sequence[Mapping[str, Any]],
+    fields: Sequence[str],
+) -> list[_Target]:
+    targets: list[_Target] = []
+    for event_index, event in enumerate(events):
+        for field_name in fields:
+            path = _resolve_path(event, field_name)
+            if path is None:
+                continue
+            value = _get_path(event, path)
+            if isinstance(value, str) and value:
+                targets.append(
+                    _Target(
+                        event_index=event_index,
+                        field_name=field_name,
+                        path=path,
+                        text=value,
+                    )
+                )
+    return targets
+
+
+def _normalize_message_fields(fields: Sequence[str]) -> tuple[str, ...]:
+    normalized = tuple(field.strip() for field in fields if field.strip())
+    return normalized or DEFAULT_LOG_MESSAGE_FIELDS
+
+
+def _resolve_path(
+    event: Mapping[str, Any],
+    field_name: str,
+) -> tuple[str, ...] | None:
+    if field_name in event:
+        return (field_name,)
+
+    path = tuple(part for part in field_name.split(".") if part)
+    if not path:
+        return None
+    try:
+        _get_path(event, path)
+    except (KeyError, TypeError):
+        return None
+    return path
+
+
+def _get_path(event: Mapping[str, Any], path: Sequence[str]) -> Any:
+    current: Any = event
+    for part in path:
+        if not isinstance(current, Mapping) or part not in current:
+            raise KeyError(part)
+        current = current[part]
+    return current
+
+
+def _set_path(event: dict[str, Any], path: Sequence[str], value: str) -> None:
+    current: dict[str, Any] = event
+    for part in path[:-1]:
+        next_value = current[part]
+        if not isinstance(next_value, dict):
+            raise LogRedactorError("configured log field path is not an object")
+        current = next_value
+    current[path[-1]] = value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/integrations/test_log_redactor.py
+++ b/tests/unit/integrations/test_log_redactor.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from openmed.integrations import log_redactor
+
+
+def _fake_batch_result(texts: list[str]) -> SimpleNamespace:
+    items = [
+        SimpleNamespace(
+            success=True,
+            result=SimpleNamespace(deidentified_text=_fake_redact_text(text)),
+        )
+        for text in texts
+    ]
+    return SimpleNamespace(items=items)
+
+
+def _fake_redact_text(text: str) -> str:
+    return (
+        text.replace("Jane Roe", "[NAME]")
+        .replace("John Doe", "[NAME]")
+        .replace("555-0100", "[PHONE]")
+        .replace("jane.roe@example.org", "[EMAIL]")
+    )
+
+
+def _jsonl(events: list[dict[str, Any]]) -> str:
+    return "".join(json.dumps(event) + "\n" for event in events)
+
+
+def test_ndjson_stream_redacts_configured_message_fields_and_preserves_metadata(
+    monkeypatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        calls.append({"texts": list(texts), "kwargs": dict(kwargs)})
+        return _fake_batch_result(list(texts))
+
+    monkeypatch.setattr(log_redactor, "process_batch", fake_process_batch)
+    events = [
+        {
+            "sequence": 1,
+            "service": "api",
+            "message": "Patient Jane Roe called 555-0100",
+            "metadata": {"trace_id": "abc", "severity": "warning"},
+        },
+        {
+            "sequence": 2,
+            "service": "worker",
+            "error": {"message": "Escalated John Doe to triage"},
+            "metadata": {"trace_id": "def", "severity": "error"},
+        },
+        {
+            "sequence": 3,
+            "service": "api",
+            "message": "Heartbeat from scheduler",
+            "metadata": {"trace_id": "ghi", "severity": "info"},
+        },
+    ]
+    input_stream = io.StringIO(_jsonl(events))
+    output_stream = io.StringIO()
+
+    emitted = log_redactor.redact_ndjson_stream(
+        input_stream,
+        output_stream,
+        message_fields=("message", "error.message"),
+        batch_size=2,
+        model_name="pii-model",
+        method="mask",
+        use_safety_sweep=False,
+    )
+
+    rows = [json.loads(line) for line in output_stream.getvalue().splitlines()]
+    assert emitted == 3
+    assert [row["sequence"] for row in rows] == [1, 2, 3]
+    assert [row["metadata"] for row in rows] == [event["metadata"] for event in events]
+    assert rows[0]["message"] == "Patient [NAME] called [PHONE]"
+    assert rows[1]["error"]["message"] == "Escalated [NAME] to triage"
+    assert rows[2]["message"] == "Heartbeat from scheduler"
+    assert "Jane Roe" not in output_stream.getvalue()
+    assert "John Doe" not in output_stream.getvalue()
+    assert "555-0100" not in output_stream.getvalue()
+    assert [call["texts"] for call in calls] == [
+        ["Patient Jane Roe called 555-0100", "Escalated John Doe to triage"],
+        ["Heartbeat from scheduler"],
+    ]
+    assert calls[0]["kwargs"]["operation"] == "deidentify"
+    assert calls[0]["kwargs"]["batch_size"] == 2
+    assert calls[0]["kwargs"]["continue_on_error"] is False
+    assert calls[0]["kwargs"]["use_safety_sweep"] is False
+
+
+def test_embeddable_callable_batches_events_and_preserves_order(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        calls.append(list(texts))
+        return _fake_batch_result(list(texts))
+
+    monkeypatch.setattr(log_redactor, "process_batch", fake_process_batch)
+    events = [
+        {"event_id": f"evt-{index}", "message": f"Patient Jane Roe #{index}"}
+        for index in range(5)
+    ]
+
+    rows = list(
+        log_redactor.redact_log_events(
+            events,
+            message_fields=("message",),
+            batch_size=2,
+            use_safety_sweep=False,
+        )
+    )
+
+    assert [row["event_id"] for row in rows] == [
+        "evt-0",
+        "evt-1",
+        "evt-2",
+        "evt-3",
+        "evt-4",
+    ]
+    assert all("Jane Roe" not in row["message"] for row in rows)
+    assert calls == [
+        ["Patient Jane Roe #0", "Patient Jane Roe #1"],
+        ["Patient Jane Roe #2", "Patient Jane Roe #3"],
+        ["Patient Jane Roe #4"],
+    ]
+
+
+def test_cli_diagnostics_do_not_echo_malformed_raw_phi() -> None:
+    stdin = io.StringIO('{"message":"Patient Jane Roe called"\n')
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    code = log_redactor.main(
+        ["--field", "message"],
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert code == 1
+    assert stdout.getvalue() == ""
+    assert "input line 1" in stderr.getvalue()
+    assert "Jane Roe" not in stderr.getvalue()
+
+
+def test_cli_diagnostics_do_not_echo_batch_error_phi(monkeypatch) -> None:
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        raise RuntimeError(f"model failed on {texts[0]}")
+
+    monkeypatch.setattr(log_redactor, "process_batch", fake_process_batch)
+    stdin = io.StringIO(json.dumps({"message": "Patient Jane Roe called"}) + "\n")
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    code = log_redactor.main(
+        ["--field", "message"],
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert code == 1
+    assert stdout.getvalue() == ""
+    assert "failed to redact a log event batch" in stderr.getvalue()
+    assert "Jane Roe" not in stderr.getvalue()


### PR DESCRIPTION
## Description
Adds a structured NDJSON log redaction integration that batches configured message fields through OpenMed batch de-identification while preserving event order and non-target metadata.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `openmed.integrations.log_redactor` with embeddable event redaction, NDJSON stream helpers, and a stdin/stdout module entry point.
- Batched configured top-level or dotted message fields through `process_batch(operation="deidentify")` while preserving event count, order, and non-target fields.
- Added offline tests for redaction behavior, ordering, metadata preservation, batching, and PHI-safe diagnostics.
- Added an example README for using the NDJSON transform and Python callable.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `PATH=".venv/bin:$PATH" make format`
- `PATH=".venv/bin:$PATH" make lint`
- `PATH=".venv/bin:$PATH" make format-check`
- `.venv/bin/python -m pytest tests/unit/integrations/test_log_redactor.py -q`
- `.venv/bin/python -m pytest tests/ -q`

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #803

## Screenshots/Examples
See `examples/log-redaction/README.md` for NDJSON and Python usage examples.
