### PR TITLE
feat: add the FHIR CodeableConcept builder and codes->span mapping core

### DIFF
--- a/openmed/clinical/exporters/__init__.py
+++ b/openmed/clinical/exporters/__init__.py
@@ -6,6 +6,12 @@ from .code_provenance import (
     CODE_SYSTEM_VERSION_SOURCE_EXTENSION_URL,
     stamp_coding_provenance,
 )
+from .codeable_concept import (
+    SYSTEM_URI,
+    GroundedSpan,
+    build_reverse_index,
+    to_codeable_concept,
+)
 from .codeable_concept_check import (
     CodeableConceptFinding,
     CodeableConceptFindingCode,
@@ -24,10 +30,14 @@ __all__ = [
     "CodeableConceptFinding",
     "CodeableConceptFindingCode",
     "FLAT_TABLE_COLUMNS",
+    "SYSTEM_URI",
+    "GroundedSpan",
+    "build_reverse_index",
     "check_codeable_concept",
     "flatten_clinical_entities",
     "flatten_entities",
     "stamp_coding_provenance",
+    "to_codeable_concept",
     "to_csv",
     "to_dataframe",
 ]

--- a/openmed/clinical/exporters/codeable_concept.py
+++ b/openmed/clinical/exporters/codeable_concept.py
@@ -1,0 +1,100 @@
+"""Grounding-aware FHIR CodeableConcept core.
+
+Converts a grounded span (its surface text, char offsets, and per-system linker
+:class:`~openmed.clinical.grounding.Candidate` codes) into a canonical FHIR R4
+``CodeableConcept`` with the correct HL7 system URIs, plus a reverse
+``(system, code) -> source offsets`` index for code->span highlighting in review
+UIs. This is the shared foundation the per-resource FHIR exporters consume.
+
+Mechanical Coding/CodeableConcept shaping and deterministic ordering are reused
+from :mod:`.codeable_concept_simple` (the single source of truth for vocabulary
+id -> HL7 system URI); this module maps the grounding linker system tokens
+(``RXNORM``/``ICD10CM``/...) onto those URIs and adds UMLS.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from openmed.clinical.grounding import Candidate
+
+from .codeable_concept_simple import codeable_concept as _build_codeable_concept
+from .codeable_concept_simple import system_uri as _system_uri
+
+# Grounding linker system token -> canonical HL7 FHIR R4 system URI. The shared
+# vocabularies derive from the single-source-of-truth map; UMLS is not in it.
+SYSTEM_URI: dict[str, str] = {
+    "RXNORM": _system_uri("rxnorm"),
+    "ICD10CM": _system_uri("icd-10-cm"),
+    "LOINC": _system_uri("loinc"),
+    "SNOMED": _system_uri("snomed"),
+    "HPO": _system_uri("hpo"),
+    "UMLS": "http://terminology.hl7.org/CodeSystem/umls",
+}
+
+__all__ = ["SYSTEM_URI", "GroundedSpan", "to_codeable_concept", "build_reverse_index"]
+
+
+@dataclass(frozen=True)
+class GroundedSpan:
+    """A source span with its grounding candidates.
+
+    ``text`` is the source surface (used as ``CodeableConcept.text``),
+    ``start``/``end`` are character offsets into the source document, and
+    ``candidates`` are the per-system linker results.
+    """
+
+    text: str
+    start: int
+    end: int
+    candidates: tuple[Candidate, ...] = ()
+
+
+def to_codeable_concept(grounded_span: GroundedSpan) -> dict[str, Any]:
+    """Build a FHIR R4 ``CodeableConcept`` for a grounded span.
+
+    Each candidate becomes a ``Coding`` with the canonical HL7 system URI, code,
+    display, and an extension-free internal ``_score`` (the linker score, for
+    downstream filtering). Codings are ordered deterministically by the shared
+    system priority; ``.text`` is the source surface. A span with no candidates
+    yields a text-only concept.
+    """
+    if not grounded_span.candidates:
+        return {"text": grounded_span.text}
+
+    codings = [
+        {
+            "system": _uri_for(candidate.system),
+            "code": candidate.code,
+            "display": candidate.display,
+            "_score": float(candidate.score),
+        }
+        for candidate in grounded_span.candidates
+    ]
+    return _build_codeable_concept(codings, text=grounded_span.text)
+
+
+def build_reverse_index(
+    grounded_spans: Iterable[GroundedSpan],
+) -> dict[tuple[str, str], list[tuple[int, int]]]:
+    """Map ``(system_uri, code)`` to the source ``(start, end)`` offsets.
+
+    Enables code->span highlighting in review UIs. Offsets accumulate in span
+    order so the result is deterministic.
+    """
+    index: dict[tuple[str, str], list[tuple[int, int]]] = {}
+    for span in grounded_spans:
+        for candidate in span.candidates:
+            key = (_uri_for(candidate.system), candidate.code)
+            index.setdefault(key, []).append((span.start, span.end))
+    return index
+
+
+def _uri_for(system: str) -> str:
+    try:
+        return SYSTEM_URI[system]
+    except KeyError:
+        raise ValueError(
+            f"Unknown grounding system {system!r}. Known: {sorted(SYSTEM_URI)}."
+        ) from None

--- a/openmed/clinical/grounding/__init__.py
+++ b/openmed/clinical/grounding/__init__.py
@@ -1,0 +1,26 @@
+"""Clinical concept grounding: map clinical spans to coded vocabulary concepts.
+
+Provides the shared, reusable surface for the free-vocabulary linkers
+(RxNorm/ICD-10-CM/LOINC/HPO): the :class:`Candidate` type, a lightweight
+:func:`load_vocab` index loader, and a linker registry. Importing this package
+registers the bundled linkers by system key.
+"""
+
+from __future__ import annotations
+
+# Importing the linkers package registers them in the registry (e.g. "rxnorm").
+from . import linkers as _linkers  # noqa: F401  (import for registration side effect)
+from .registry import available_linkers, get_linker, register_linker
+from .types import Candidate
+from .vocab import VocabEntry, VocabIndex, load_vocab, normalize_term
+
+__all__ = [
+    "Candidate",
+    "VocabEntry",
+    "VocabIndex",
+    "load_vocab",
+    "normalize_term",
+    "register_linker",
+    "get_linker",
+    "available_linkers",
+]

--- a/openmed/clinical/grounding/linkers/__init__.py
+++ b/openmed/clinical/grounding/linkers/__init__.py
@@ -1,0 +1,7 @@
+"""Concept-grounding linkers. Importing a linker registers it by system key."""
+
+from __future__ import annotations
+
+from .rxnorm import RxNormLinker
+
+__all__ = ["RxNormLinker"]

--- a/openmed/clinical/grounding/linkers/rxnorm.py
+++ b/openmed/clinical/grounding/linkers/rxnorm.py
@@ -1,0 +1,92 @@
+"""RxNorm approximate-match linker for medication spans.
+
+Reference implementation for the free-vocabulary linkers (ICD-10-CM, LOINC,
+HPO follow the same pattern). Candidate generation is two-stage: exact alias
+match first, then approximate match (rapidfuzz) over synonyms. Exact matching
+and importing this module work without the optional ``grounding`` extra; the
+approximate stage is skipped when rapidfuzz is not installed.
+"""
+
+from __future__ import annotations
+
+from openmed.core.labels import MEDICATION, normalize_label
+
+from ..registry import register_linker
+from ..types import Candidate
+from ..vocab import VocabEntry, VocabIndex, normalize_term
+
+SYSTEM = "RXNORM"
+
+_DEFAULT_TOP_K = 5
+_DEFAULT_MIN_SCORE = 0.6
+
+
+class RxNormLinker:
+    """Map medication text to ranked RxNorm ``Candidate`` codes."""
+
+    system = "rxnorm"
+
+    def __init__(self, vocab: VocabIndex) -> None:
+        self._vocab = vocab
+
+    def link(
+        self,
+        text: str,
+        *,
+        top_k: int = _DEFAULT_TOP_K,
+        min_score: float = _DEFAULT_MIN_SCORE,
+        canonical_label: str | None = None,
+        fuzzy: bool = True,
+    ) -> list[Candidate]:
+        """Return ranked RxNorm candidates for ``text``.
+
+        Only operates on medication spans: if ``canonical_label`` is given and
+        does not normalize to ``MEDICATION``, an empty list is returned.
+        """
+        if (
+            canonical_label is not None
+            and normalize_label(canonical_label) != MEDICATION
+        ):
+            return []
+
+        query = normalize_term(text)
+        if not query:
+            return []
+
+        best: dict[str, Candidate] = {}
+        for entry in self._vocab.exact(query):
+            best[entry.code] = Candidate(SYSTEM, entry.code, entry.display, 1.0)
+
+        if fuzzy:
+            for entry, score in self._approximate(query):
+                if score < min_score:
+                    continue
+                existing = best.get(entry.code)
+                if existing is None or score > existing.score:
+                    best[entry.code] = Candidate(
+                        SYSTEM, entry.code, entry.display, score
+                    )
+
+        # Deterministic ranking: score desc, then code asc for ties.
+        ranked = sorted(
+            best.values(), key=lambda candidate: (-candidate.score, candidate.code)
+        )
+        return ranked[:top_k]
+
+    def _approximate(self, query: str) -> list[tuple[VocabEntry, float]]:
+        try:
+            from rapidfuzz import fuzz
+        except ImportError:  # pragma: no cover - exercised without the extra
+            return []
+
+        best_score: dict[str, float] = {}
+        best_entry: dict[str, VocabEntry] = {}
+        for alias, entry in self._vocab.iter_alias_entries():
+            score = fuzz.ratio(query, alias) / 100.0
+            if score > best_score.get(entry.code, 0.0):
+                best_score[entry.code] = score
+                best_entry[entry.code] = entry
+        return [(best_entry[code], score) for code, score in best_score.items()]
+
+
+register_linker("rxnorm", RxNormLinker)

--- a/openmed/clinical/grounding/registry.py
+++ b/openmed/clinical/grounding/registry.py
@@ -1,0 +1,29 @@
+"""Linker registry so ``ground(systems=[...])`` (a later task) can dispatch.
+
+Linkers register themselves under a vocabulary system key (e.g. ``"rxnorm"``).
+The registry stores a callable ``(vocab) -> linker`` factory so callers can
+build a linker with their own vocabulary data.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+LinkerFactory = Callable[..., Any]
+
+_LINKERS: dict[str, LinkerFactory] = {}
+
+
+def register_linker(system: str, factory: LinkerFactory) -> None:
+    """Register a linker factory under a vocabulary ``system`` key."""
+    _LINKERS[system] = factory
+
+
+def get_linker(system: str) -> LinkerFactory:
+    """Return the linker factory registered for ``system`` (raises KeyError)."""
+    return _LINKERS[system]
+
+
+def available_linkers() -> list[str]:
+    """Return the sorted list of registered linker system keys."""
+    return sorted(_LINKERS)

--- a/openmed/clinical/grounding/types.py
+++ b/openmed/clinical/grounding/types.py
@@ -1,0 +1,20 @@
+"""Shared types for clinical concept grounding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A ranked grounding candidate: a coded concept for a clinical span.
+
+    ``system`` is the vocabulary (e.g. ``"RXNORM"``), ``code`` its identifier
+    (e.g. an RxCUI), ``display`` a human-readable name, and ``score`` a
+    ``0.0``-``1.0`` match confidence (``1.0`` for an exact alias match).
+    """
+
+    system: str
+    code: str
+    display: str
+    score: float

--- a/openmed/clinical/grounding/vocab.py
+++ b/openmed/clinical/grounding/vocab.py
@@ -1,0 +1,103 @@
+"""Lightweight free-vocabulary index for concept-grounding linkers.
+
+The loader accepts either a JSONL file path or in-memory rows, so no full
+vocabulary is bundled: callers provide their own (open) vocabulary data at
+runtime, while tests use a small committed fixture. Each row carries a code, a
+display name, and synonyms/aliases; key names are matched leniently so the same
+loader serves RxNorm, ICD-10-CM, LOINC and HPO.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping, Sequence
+
+_CODE_KEYS = ("code", "rxcui", "cui", "id")
+_DISPLAY_KEYS = ("display", "name", "str", "label")
+_SYNONYM_KEYS = ("synonyms", "aliases", "terms")
+
+
+def normalize_term(term: Any) -> str:
+    """Casefold, trim and collapse whitespace for alias matching."""
+    return " ".join(str(term).strip().casefold().split())
+
+
+@dataclass(frozen=True)
+class VocabEntry:
+    """One vocabulary concept: a code, display name and its aliases."""
+
+    code: str
+    display: str
+    synonyms: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class VocabIndex:
+    """An indexed vocabulary with exact-alias lookup and alias iteration."""
+
+    entries: tuple[VocabEntry, ...]
+    alias_map: Mapping[str, tuple[VocabEntry, ...]]
+
+    def exact(self, term: str) -> list[VocabEntry]:
+        """Return entries whose alias exactly matches ``term`` (normalized)."""
+        return list(self.alias_map.get(normalize_term(term), ()))
+
+    def iter_alias_entries(self) -> Iterator[tuple[str, VocabEntry]]:
+        """Yield ``(normalized_alias, entry)`` for every alias in the index."""
+        for entry in self.entries:
+            for synonym in entry.synonyms:
+                yield normalize_term(synonym), entry
+
+
+def load_vocab(source: str | Path | Iterable[Mapping[str, Any]]) -> VocabIndex:
+    """Load a vocabulary from a JSONL path or an iterable of row mappings."""
+    entries = tuple(_entry_from_row(row) for row in _iter_rows(source))
+
+    alias_map: dict[str, list[VocabEntry]] = {}
+    for entry in entries:
+        aliases = entry.synonyms or (entry.display,)
+        for alias in aliases:
+            key = normalize_term(alias)
+            if not key:
+                continue
+            bucket = alias_map.setdefault(key, [])
+            if entry not in bucket:
+                bucket.append(entry)
+
+    return VocabIndex(
+        entries=entries,
+        alias_map={key: tuple(value) for key, value in alias_map.items()},
+    )
+
+
+def _iter_rows(
+    source: str | Path | Iterable[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    if isinstance(source, (str, Path)):
+        with open(source, encoding="utf-8") as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+    return [dict(row) for row in source]
+
+
+def _entry_from_row(row: Mapping[str, Any]) -> VocabEntry:
+    code = _first(row, _CODE_KEYS)
+    if code is None:
+        raise ValueError(f"vocabulary row is missing a code field: {row!r}")
+    display = _first(row, _DISPLAY_KEYS, default=code)
+    synonyms = _first(row, _SYNONYM_KEYS, default=None)
+    if isinstance(synonyms, Sequence) and not isinstance(synonyms, (str, bytes)):
+        synonym_tuple = tuple(str(item) for item in synonyms)
+    else:
+        synonym_tuple = (str(display),)
+    return VocabEntry(code=str(code), display=str(display), synonyms=synonym_tuple)
+
+
+def _first(
+    row: Mapping[str, Any], keys: tuple[str, ...], *, default: Any = None
+) -> Any:
+    for key in keys:
+        if key in row and row[key] is not None:
+            return row[key]
+    return default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
   "pandas>=2.0",
   "polars>=0.20",
   "python-dateutil>=2.8",
+  "rapidfuzz>=3",
   "ruff==0.15.20",
   "tomli>=2.0; python_version < '3.11'",
 ]
@@ -101,6 +102,10 @@ multimodal = [
 
 # PaddleOCR is a heavy, platform-sensitive backend (pulls in paddlepaddle), so
 # it is opt-in rather than bundled into the general multimodal extra.
+grounding = [
+  "rapidfuzz>=3",
+]
+
 ocr-paddle = [
   "paddleocr>=2.7",
 ]

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -99,6 +99,7 @@ REVIEWED_LICENSES = {
     "python-doctr": "Apache-2.0",
     "pytesseract": "Apache-2.0",
     "python-docx": "MIT",
+    "rapidfuzz": "MIT",
     "rich": "MIT",
     "safetensors": "Apache-2.0",
     "spacy": "MIT",

--- a/tests/fixtures/clinical/grounding/rxnorm_sample.jsonl
+++ b/tests/fixtures/clinical/grounding/rxnorm_sample.jsonl
@@ -1,0 +1,5 @@
+{"code": "1191", "display": "aspirin", "synonyms": ["aspirin", "acetylsalicylic acid", "ASA"]}
+{"code": "161", "display": "acetaminophen", "synonyms": ["acetaminophen", "paracetamol", "Tylenol", "APAP"]}
+{"code": "6809", "display": "metformin", "synonyms": ["metformin", "Glucophage"]}
+{"code": "29046", "display": "lisinopril", "synonyms": ["lisinopril", "Prinivil", "Zestril"]}
+{"code": "5640", "display": "ibuprofen", "synonyms": ["ibuprofen", "Advil", "Motrin"]}

--- a/tests/unit/clinical/test_codeable_concept.py
+++ b/tests/unit/clinical/test_codeable_concept.py
@@ -1,0 +1,95 @@
+"""Tests for the grounding-aware FHIR CodeableConcept core (issue #271)."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.clinical.exporters.codeable_concept import (
+    SYSTEM_URI,
+    GroundedSpan,
+    build_reverse_index,
+    to_codeable_concept,
+)
+from openmed.clinical.grounding import Candidate
+
+RXNORM_URI = "http://www.nlm.nih.gov/research/umls/rxnorm"
+SNOMED_URI = "http://snomed.info/sct"
+
+
+def _metformin_span() -> GroundedSpan:
+    return GroundedSpan(
+        text="metformin",
+        start=10,
+        end=19,
+        candidates=(
+            Candidate("RXNORM", "6809", "metformin", 1.0),
+            Candidate("SNOMED", "372567009", "Metformin", 0.8),
+        ),
+    )
+
+
+class TestSystemUri:
+    def test_canonical_hl7_uris(self):
+        assert SYSTEM_URI["RXNORM"] == RXNORM_URI
+        assert SYSTEM_URI["ICD10CM"] == "http://hl7.org/fhir/sid/icd-10-cm"
+        assert SYSTEM_URI["LOINC"] == "http://loinc.org"
+        assert SYSTEM_URI["SNOMED"] == SNOMED_URI
+        assert SYSTEM_URI["HPO"] == "http://human-phenotype-ontology.org"
+        assert SYSTEM_URI["UMLS"] == "http://terminology.hl7.org/CodeSystem/umls"
+
+
+class TestToCodeableConcept:
+    def test_multi_system_span_emits_canonical_uris_and_text(self):
+        cc = to_codeable_concept(_metformin_span())
+        assert cc["text"] == "metformin"
+        systems = {c["system"] for c in cc["coding"]}
+        assert systems == {RXNORM_URI, SNOMED_URI}
+        codes = {c["system"]: c["code"] for c in cc["coding"]}
+        assert codes[RXNORM_URI] == "6809"
+
+    def test_coding_order_is_deterministic_by_system_priority(self):
+        cc = to_codeable_concept(_metformin_span())
+        # SNOMED sorts before RxNorm in the shared default system priority.
+        assert cc["coding"][0]["system"] == SNOMED_URI
+        assert to_codeable_concept(_metformin_span()) == cc  # deterministic
+
+    def test_linker_score_carried_in_internal_field(self):
+        cc = to_codeable_concept(_metformin_span())
+        by_system = {c["system"]: c for c in cc["coding"]}
+        assert by_system[RXNORM_URI]["_score"] == 1.0
+        assert by_system[SNOMED_URI]["_score"] == 0.8
+
+    def test_span_without_candidates_is_text_only(self):
+        span = GroundedSpan(text="unknown drug", start=0, end=12, candidates=())
+        cc = to_codeable_concept(span)
+        assert cc == {"text": "unknown drug"}
+
+    def test_unknown_system_raises(self):
+        span = GroundedSpan(
+            text="x", start=0, end=1, candidates=(Candidate("NOPE", "1", "x", 1.0),)
+        )
+        with pytest.raises(ValueError):
+            to_codeable_concept(span)
+
+
+class TestReverseIndex:
+    def test_maps_system_code_to_source_offsets(self):
+        index = build_reverse_index([_metformin_span()])
+        assert index[(RXNORM_URI, "6809")] == [(10, 19)]
+        assert index[(SNOMED_URI, "372567009")] == [(10, 19)]
+
+    def test_accumulates_multiple_spans_for_same_code(self):
+        span_a = GroundedSpan(
+            text="aspirin",
+            start=0,
+            end=7,
+            candidates=(Candidate("RXNORM", "1191", "aspirin", 1.0),),
+        )
+        span_b = GroundedSpan(
+            text="aspirin",
+            start=20,
+            end=27,
+            candidates=(Candidate("RXNORM", "1191", "aspirin", 1.0),),
+        )
+        index = build_reverse_index([span_a, span_b])
+        assert index[(RXNORM_URI, "1191")] == [(0, 7), (20, 27)]

--- a/tests/unit/clinical/test_linker_rxnorm.py
+++ b/tests/unit/clinical/test_linker_rxnorm.py
@@ -1,0 +1,98 @@
+"""Tests for the RxNorm approximate-match linker and grounding scaffolding (#267)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openmed.clinical.grounding import (
+    Candidate,
+    available_linkers,
+    get_linker,
+    load_vocab,
+)
+from openmed.clinical.grounding.linkers.rxnorm import RxNormLinker
+
+FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "clinical"
+    / "grounding"
+    / "rxnorm_sample.jsonl"
+)
+
+
+@pytest.fixture
+def linker() -> RxNormLinker:
+    return RxNormLinker(load_vocab(FIXTURE))
+
+
+class TestVocabLoader:
+    def test_loads_from_path(self):
+        vocab = load_vocab(FIXTURE)
+        assert vocab.exact("aspirin")
+
+    def test_loads_from_in_memory_rows(self):
+        vocab = load_vocab(
+            [{"code": "1", "display": "widget", "synonyms": ["widget", "gadget"]}]
+        )
+        assert vocab.exact("gadget")
+
+
+class TestExactMatch:
+    def test_link_exact_returns_expected_rxcui_top1(self, linker):
+        candidates = linker.link("aspirin")
+        assert candidates
+        top = candidates[0]
+        assert isinstance(top, Candidate)
+        assert top.system == "RXNORM"
+        assert top.code == "1191"
+        assert top.display == "aspirin"
+        assert top.score == pytest.approx(1.0)
+
+    def test_link_matches_brand_synonym(self, linker):
+        candidates = linker.link("Tylenol")
+        assert candidates[0].code == "161"
+
+    def test_out_of_vocabulary_returns_empty_or_low_score(self, linker):
+        candidates = linker.link("qwertabcdrug")
+        assert candidates == [] or all(c.score < 0.5 for c in candidates)
+
+    def test_deterministic_across_runs(self, linker):
+        first = linker.link("acetaminophen")
+        second = linker.link("acetaminophen")
+        assert first == second
+
+
+class TestApproximateMatch:
+    def test_misspelling_links_within_threshold(self, linker):
+        pytest.importorskip("rapidfuzz")
+        candidates = linker.link("asprin")  # missing 'a'
+        assert candidates
+        assert candidates[0].code == "1191"
+        assert candidates[0].score < 1.0
+
+    def test_top_k_limits_results(self, linker):
+        pytest.importorskip("rapidfuzz")
+        candidates = linker.link("metformin", top_k=2)
+        assert len(candidates) <= 2
+
+
+class TestMedicationGate:
+    def test_gate_blocks_non_medication_label(self, linker):
+        assert linker.link("aspirin", canonical_label="DATE") == []
+
+    def test_gate_allows_drug_alias(self, linker):
+        # 'drug' normalizes to MEDICATION via the canonical label taxonomy.
+        assert linker.link("aspirin", canonical_label="drug")
+
+
+class TestRegistry:
+    def test_rxnorm_linker_is_discoverable(self):
+        assert "rxnorm" in available_linkers()
+        assert get_linker("rxnorm") is RxNormLinker
+
+    def test_unknown_system_raises(self):
+        with pytest.raises(KeyError):
+            get_linker("does-not-exist")

--- a/uv.lock
+++ b/uv.lock
@@ -3371,6 +3371,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "python-dateutil" },
+    { name = "rapidfuzz" },
     { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -3393,6 +3394,9 @@ gliner = [
 ]
 gptq = [
     { name = "auto-gptq" },
+]
+grounding = [
+    { name = "rapidfuzz" },
 ]
 hf = [
     { name = "accelerate" },
@@ -3525,6 +3529,8 @@ requires-dist = [
     { name = "python-doctr", marker = "extra == 'multimodal'", specifier = ">=1.0" },
     { name = "python-docx", marker = "extra == 'multimodal'", specifier = ">=1.1" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rapidfuzz", marker = "extra == 'dev'", specifier = ">=3" },
+    { name = "rapidfuzz", marker = "extra == 'grounding'", specifier = ">=3" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
     { name = "safetensors", marker = "extra == 'mlx'", specifier = ">=0.4" },
@@ -3543,7 +3549,7 @@ requires-dist = [
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'service'", specifier = ">=0.29" },
 ]
-provides-extras = ["awq", "cli", "coreml", "dev", "docs", "duckdb", "gliner", "gptq", "hf", "kafka", "langchain", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "pandas", "philter", "polars", "presidio", "pydeid", "service", "spacy"]
+provides-extras = ["awq", "cli", "coreml", "dev", "docs", "duckdb", "gliner", "gptq", "grounding", "hf", "kafka", "langchain", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "pandas", "philter", "polars", "presidio", "pydeid", "service", "spacy"]
 
 [[package]]
 name = "orjson"


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #1134 (#267).** This branch is based on the RxNorm-linker branch for the grounding `Candidate` type. Until #1134 merges, the diff below also shows its changes; I will rebase onto `master` once #1134 lands so this PR shows only the CodeableConcept changes. (Sibling of #1135; both branch off #267.)

Implements #271 (OM-106): the grounding-aware FHIR `CodeableConcept` core the per-resource FHIR/OMOP exporters consume. It converts a grounded span (surface text, char offsets, and per-system linker `Candidate`s) into a canonical FHIR R4 `CodeableConcept`, plus a reverse `(system, code) -> source offsets` index for code->span highlighting.

## Changes

- **`clinical/exporters/codeable_concept.py`**
  - `GroundedSpan(text, start, end, candidates)` — a source span with its grounding candidates.
  - `to_codeable_concept(grounded_span)` — emits `coding[].system` as the exact HL7 canonical URIs, `coding[].code`/`display`, `.text` from the source surface, and an **extension-free internal `_score`** (linker score) for downstream filtering. Coding order is deterministic; a span with no candidates yields a text-only concept.
  - `build_reverse_index(spans)` — maps `(system_uri, code)` to source `(start, end)` offsets.
  - `SYSTEM_URI` — linker system tokens (RXNORM/ICD10CM/LOINC/SNOMED/HPO/UMLS) -> canonical HL7 URIs, **derived from the `codeable_concept_simple` single-source-of-truth map** (plus UMLS), and reuses its mechanical Coding/CodeableConcept shaping and deterministic ordering rather than re-implementing it.

## Acceptance criteria

- [x] `to_codeable_concept` emits `coding[].system` as the exact HL7 canonical URIs for RxNorm/ICD-10-CM/LOINC/SNOMED/HPO/UMLS.
- [x] Coding order is deterministic and `.text` equals the source span surface.
- [x] The reverse index returns the originating span offsets for a given `(system, code)`.

## Testing

- New `tests/unit/clinical/test_codeable_concept.py` (8 tests). Full unit suite passes (`.venv/bin/python -m pytest tests/ -q` -> 3061 passed, 28 skipped).
- The only 2 failures in the full run are the pre-existing network-gated integration tests (`tests/integration/test_sentence_detection_real.py`); identical on `master` offline, unrelated.
- `ruff check`/`format` clean. No new dependencies.

## Out of scope

- Building full FHIR resources (per-resource exporter tasks).
- OMOP concept_id resolution (Athena task).
- Value-set membership validation.

Closes #271