### PR TITLE
Add multi-arch amd64/arm64 container builds with manifest lists in CI

### DIFF
--- a/.github/workflows/container-multiarch.yml
+++ b/.github/workflows/container-multiarch.yml
@@ -1,0 +1,167 @@
+name: Container Multi-Arch
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/container-multiarch.yml"
+      - "deploy/docker/Dockerfile"
+      - "Dockerfile"
+      - ".dockerignore"
+      - "openmed/**"
+      - "pyproject.toml"
+      - "uv.lock"
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  smoke:
+    name: Build and smoke (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+          - platform: linux/arm64
+            arch: arm64
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build smoke image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          load: true
+          push: false
+          tags: openmed-smoke:${{ matrix.arch }}
+          cache-from: type=gha,scope=openmed-${{ matrix.arch }}
+          cache-to: type=gha,scope=openmed-${{ matrix.arch }},mode=max
+
+      - name: Run synthetic de-identification smoke
+        run: |
+          docker run --rm -i --platform "${{ matrix.platform }}" \
+            openmed-smoke:${{ matrix.arch }} python - <<'PY'
+          from datetime import datetime
+          from unittest.mock import patch
+
+          import openmed
+          from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+          text = "Patient Casey Example called 555-0100."
+          prediction = PredictionResult(
+              text=text,
+              entities=[
+                  EntityPrediction(
+                      text="Casey Example",
+                      label="NAME",
+                      confidence=0.99,
+                      start=8,
+                      end=21,
+                  ),
+                  EntityPrediction(
+                      text="555-0100",
+                      label="PHONE",
+                      confidence=0.99,
+                      start=29,
+                      end=37,
+                  ),
+              ],
+              model_name="synthetic-container-smoke",
+              timestamp=datetime(2026, 1, 1, 0, 0, 0).isoformat(),
+          )
+
+          with patch("openmed.core.pii.extract_pii", return_value=prediction):
+              result = openmed.deidentify(text, method="mask", keep_mapping=True)
+
+          assert result.deidentified_text == "Patient [NAME] called [PHONE]."
+          assert len(result.pii_entities) == 2
+          print(f"OpenMed {openmed.__version__} synthetic de-identification passed")
+          PY
+
+  publish:
+    name: Publish manifest list
+    runs-on: ubuntu-latest
+    needs: smoke
+    if: github.event_name != 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        shell: bash
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${IMAGE_NAME}:sha-${GITHUB_SHA::12}"
+            if [ "${GITHUB_REF_TYPE}" = "branch" ] && [ "${GITHUB_REF_NAME}" = "master" ]; then
+              echo "${IMAGE_NAME}:latest"
+            fi
+            if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+              echo "${IMAGE_NAME}:${GITHUB_REF_NAME}"
+            fi
+            if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+              echo "${IMAGE_NAME}:manual-${GITHUB_RUN_NUMBER}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push manifest list
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          provenance: false
+          cache-from: |
+            type=gha,scope=openmed-amd64
+            type=gha,scope=openmed-arm64
+          cache-to: type=gha,scope=openmed-manifest,mode=max
+
+      - name: Verify manifest platforms
+        shell: bash
+        run: |
+          image="${IMAGE_NAME}:sha-${GITHUB_SHA::12}"
+          docker buildx imagetools inspect "$image" | tee manifest.txt
+          grep -Eq 'Platform:[[:space:]]+linux/amd64' manifest.txt
+          grep -Eq 'Platform:[[:space:]]+linux/arm64' manifest.txt

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,10 @@
-FROM python:3.11-slim@sha256:b27df5841f3355e9473f9a516d38a6783b6c8dfeacaf2d14a240f443b368ddb6
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$TARGETPLATFORM python:3.11-slim@sha256:b27df5841f3355e9473f9a516d38a6783b6c8dfeacaf2d14a240f443b368ddb6
+
+ARG BUILDPLATFORM
+ARG TARGETARCH
+ARG TARGETPLATFORM
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -10,7 +16,7 @@ WORKDIR /app
 COPY . /app
 
 RUN python -m pip install --upgrade pip \
-    && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
+    && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu "torch>=2.1,<3" \
     && pip install --no-cache-dir ".[hf,service]"
 
 EXPOSE 8080

--- a/docs/deploy/multi-arch.md
+++ b/docs/deploy/multi-arch.md
@@ -1,0 +1,69 @@
+# Multi-Arch Container Images
+
+OpenMed publishes a service container image for both `linux/amd64` and
+`linux/arm64`. The multi-platform tags are manifest lists, so Docker, containerd,
+Kubernetes, and compatible runtimes select the native image for the node that
+pulls the tag.
+
+The supported production platforms are:
+
+| Platform | Typical hosts |
+|---|---|
+| `linux/amd64` | x86_64 servers, most CI runners, Intel or AMD developer machines |
+| `linux/arm64` | AWS Graviton, Ampere servers, Apple-silicon Docker Desktop |
+
+The image is published to GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/maziyarpanahi/openmed:latest
+```
+
+To force a specific architecture, pass `--platform`:
+
+```bash
+docker pull --platform linux/arm64 ghcr.io/maziyarpanahi/openmed:latest
+docker pull --platform linux/amd64 ghcr.io/maziyarpanahi/openmed:latest
+```
+
+Run the service with the same environment variables used by the local Docker
+and Compose workflows:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e OPENMED_PROFILE=prod \
+  -e OPENMED_SERVICE_KEEP_ALIVE=10m \
+  ghcr.io/maziyarpanahi/openmed:latest
+```
+
+Inspect the manifest list before promoting a tag:
+
+```bash
+docker buildx imagetools inspect ghcr.io/maziyarpanahi/openmed:latest
+```
+
+The output should include both `linux/amd64` and `linux/arm64` platform entries.
+
+## Local Builds
+
+The production Dockerfile lives at `deploy/docker/Dockerfile` and pins its
+Python base image by digest. Build a native local image with:
+
+```bash
+docker build -f deploy/docker/Dockerfile -t openmed:local .
+```
+
+For a registry-backed multi-platform build, use Buildx:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -f deploy/docker/Dockerfile \
+  -t ghcr.io/maziyarpanahi/openmed:dev \
+  --push .
+```
+
+CI validates each architecture by importing `openmed` inside the built image and
+running a synthetic de-identification path. Pull request runs build and smoke-test
+both architectures without publishing. Pushes to `master`, version tags, and
+manual dispatches publish manifest-list tags after the per-architecture smoke
+checks pass.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
   - Core Guides:
       - Analyze Text Helper: analyze-text.md
       - REST Service (MVP): rest-service.md
+      - Multi-Arch Containers: deploy/multi-arch.md
       - ModelLoader & Pipelines: model-loader.md
       - Model Registry: model-registry.md
       - Model Manifest: model-manifest.md

--- a/tests/unit/deploy/test_container_multiarch.py
+++ b/tests/unit/deploy/test_container_multiarch.py
@@ -1,0 +1,62 @@
+"""Tests for multi-architecture container build metadata."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+DEPLOY_DOCKERFILE = ROOT / "deploy" / "docker" / "Dockerfile"
+ROOT_DOCKERFILE = ROOT / "Dockerfile"
+WORKFLOW = ROOT / ".github" / "workflows" / "container-multiarch.yml"
+DOCS = ROOT / "docs" / "deploy" / "multi-arch.md"
+MKDOCS = ROOT / "mkdocs.yml"
+
+PINNED_PYTHON_BASE_RE = re.compile(
+    r"^FROM(?: --platform=\$TARGETPLATFORM)? "
+    r"python:3\.11-slim@sha256:[0-9a-f]{64}$",
+    re.MULTILINE,
+)
+
+
+def test_deployment_dockerfile_uses_digest_pinned_python_base():
+    content = DEPLOY_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert PINNED_PYTHON_BASE_RE.search(content)
+
+
+def test_root_dockerfile_keeps_compose_base_digest_pinned():
+    content = ROOT_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert PINNED_PYTHON_BASE_RE.search(content)
+
+
+def test_multiarch_workflow_builds_manifest_and_smokes_each_platform():
+    content = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "docker/build-push-action@v6" in content
+    assert "platforms: linux/amd64,linux/arm64" in content
+    assert "docker buildx imagetools inspect" in content
+    assert "grep -Eq 'Platform:[[:space:]]+linux/amd64'" in content
+    assert "grep -Eq 'Platform:[[:space:]]+linux/arm64'" in content
+    assert "type=gha,scope=openmed-${{ matrix.arch }}" in content
+    assert "openmed.deidentify" in content
+    assert "linux/amd64" in content
+    assert "linux/arm64" in content
+
+
+def test_multiarch_docs_cover_supported_platforms_and_pull_commands():
+    content = DOCS.read_text(encoding="utf-8")
+
+    assert "ghcr.io/maziyarpanahi/openmed:latest" in content
+    assert "docker pull --platform linux/arm64" in content
+    assert "docker pull --platform linux/amd64" in content
+    assert "docker buildx imagetools inspect" in content
+    assert "`linux/amd64`" in content
+    assert "`linux/arm64`" in content
+
+
+def test_multiarch_docs_are_in_mkdocs_nav():
+    content = MKDOCS.read_text(encoding="utf-8")
+
+    assert "deploy/multi-arch.md" in content


### PR DESCRIPTION
Closes #806.

Adds a Buildx-based multi-architecture container workflow for the OpenMed service, with per-architecture amd64/arm64 smoke builds, layer cache scopes, and a publishing job that pushes GHCR manifest-list tags after verification. Adds the pinned production Dockerfile under deploy/docker, pins the existing root Dockerfile base digest, and documents supported platforms, pull commands, and local Buildx usage.

Validation:
- .venv/bin/python -m pytest tests/ -q
- make docs-build
- .venv/bin/python scripts/release/check_github_actions_refs.py
- actionlint .github/workflows/container-multiarch.yml
- uv run ruff check tests/unit/deploy/test_container_multiarch.py
