### PR TITLE
docs: cover v1.6 and v1.7 release features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 <p><b>Turn clinical text into structured insight with one line of code.</b><br/>
 Entity extraction, PII de-identification, and 1,000+ specialized medical models that run entirely on
-your own hardware — from a one-liner in Python to a native Swift app on iPhone, powered by Apple MLX.
+your own hardware — from a one-liner in Python to native Swift apps, REST services,
+and browser token classification through Transformers.js/WebGPU.
 No cloud. No vendor lock-in. No patient data leaving your network.</p>
 
 <p>
@@ -23,6 +24,7 @@ No cloud. No vendor lock-in. No patient data leaving your network.</p>
 <p>
   <a href="swift/OpenMedKit"><img alt="Swift — OpenMedKit" src="https://img.shields.io/badge/Swift-OpenMedKit-0D6E6E?style=for-the-badge&logo=swift&logoColor=white"></a>
   <a href="docs/mlx-backend.md"><img alt="Apple Silicon — MLX" src="https://img.shields.io/badge/Apple_Silicon-MLX-0E1116?style=for-the-badge&logo=apple&logoColor=white"></a>
+  <a href="docs/export-transformersjs.md"><img alt="Browser — Transformers.js" src="https://img.shields.io/badge/Browser-Transformers.js-128787?style=for-the-badge&logo=javascript&logoColor=white"></a>
   <a href="docs/swift-openmedkit.md"><img alt="Platforms" src="https://img.shields.io/badge/Runs_on-iOS,_iPadOS,_macOS-1C2128?style=for-the-badge&logo=apple&logoColor=white"></a>
   <a href="https://openmed.life/docs"><img alt="Docs" src="https://img.shields.io/badge/Docs-openmed.life-128787?style=for-the-badge&logo=readthedocs&logoColor=white"></a>
 </p>
@@ -100,15 +102,16 @@ A state-of-the-art clinical NER model running locally — no API key, no network
 | Patient data leaves your network      |        **Never**         |   Sent to the vendor   |
 | Cost                                  |    Free & open-source    |    Per-call pricing    |
 | Specialized medical models            |          1,000+          |        Limited         |
-| Languages                             |           13+            |         Varies         |
+| Languages                             |            15            |         Varies         |
 | Offline / air-gapped                  |            ✅            |           ❌           |
 | Apple Silicon (MLX) acceleration      |            ✅            |          n/a           |
 | Native iOS / macOS apps               |   ✅ via OpenMedKit      |           ❌           |
+| Browser/WebGPU token classification   | ✅ via Transformers.js   |         Varies         |
 | Vendor lock-in                        |    None — Apache-2.0     |          Yes           |
 
 - **Specialized models** — 1,000+ curated biomedical & clinical models, many outperforming proprietary stacks.
 - **HIPAA-aware de-identification** — all 18 Safe Harbor identifiers, smart entity merging, format-preserving fakes.
-- **Runs everywhere** — CPU, CUDA, Apple Silicon (MLX), and natively in iOS/macOS apps via OpenMedKit.
+- **Runs everywhere** — CPU, CUDA, Apple Silicon (MLX), iOS/macOS via OpenMedKit, REST services, and browser/WebGPU bundles via Transformers.js.
 - **One-line deployment** — Python API, Dockerized REST service, or batch pipelines.
 - **Zero lock-in** — Apache-2.0, your infrastructure, your data.
 
@@ -222,6 +225,31 @@ p.process_texts([...])
 </tr>
 </table>
 
+**Browser / WebGPU**
+
+Package ONNX token-classification exports for in-browser inference through
+Transformers.js:
+
+```bash
+python -m openmed.onnx.convert \
+  --model OpenMed/example-token-classifier \
+  --output dist/example-onnx \
+  --include-transformersjs
+```
+
+```javascript
+import { pipeline } from "@huggingface/transformers";
+
+const detector = await pipeline(
+  "token-classification",
+  "/models/openmed-pii/transformersjs",
+  { device: "webgpu" },
+);
+const entities = await detector("Patient Casey Example called 212-555-0198.");
+```
+
+[Transformers.js export guide](docs/export-transformersjs.md)
+
 **Offline / air-gapped?** Point `model_name` (or `model_id`) at a local directory and OpenMed loads it without contacting the Hugging Face Hub:
 
 ```python
@@ -268,9 +296,10 @@ deidentify(text, method="shift_dates", date_shift_days=180)
 ```
 
 - **Smart entity merging** keeps `01/15/1970` whole instead of fragmenting it.
+- **Policy-aware pipelines** add HIPAA/GDPR/research profiles, calibrated thresholds, signed audit reports, redaction previews, and minimum-necessary action selection.
 - **Faker-backed obfuscation** with custom clinical-ID providers (CPF, CNPJ, BSN, NIR, Codice Fiscale, NIE, Aadhaar, Steuer-ID, NPI).
 - **HIPAA**: all 18 Safe Harbor identifiers, configurable confidence thresholds.
-- **Batch PII** (v1.5.5): extract or de-identify across many documents with `BatchProcessor(operation="extract_pii" | "deidentify", batch_size=16)`.
+- **Batch and streaming PII**: extract or de-identify across many documents with `BatchProcessor(operation="extract_pii" | "deidentify", batch_size=16)` or incremental streaming helpers.
 
 <div align="center">
   <img src="docs/assets/pii-batch-benchmark.png" alt="Batch PII processing throughput — up to 3.3x on CPU and 2.2x on MLX" width="840" />
@@ -360,7 +389,10 @@ curl -X POST http://127.0.0.1:8080/pii/extract \
   -d '{"text":"Paciente: Maria Garcia, DNI: 12345678Z","lang":"es"}'
 ```
 
-**Model lifecycle (v1.5.5):** free memory on demand with `GET /models/loaded`, `POST /models/unload`, and a `keep_alive` idle window:
+**Model lifecycle and service controls:** free memory on demand with
+`GET /models/loaded`, `POST /models/unload`, and a `keep_alive` idle window;
+v1.7 also adds warm pools, dynamic batching, request coalescing, rate and
+concurrency limits, `/livez`, `/readyz`, and opt-in metrics:
 
 ```bash
 OPENMED_SERVICE_KEEP_ALIVE=10m uvicorn openmed.service.app:app --host 0.0.0.0 --port 8080
@@ -380,6 +412,8 @@ Full guides at **[openmed.life/docs](https://openmed.life/docs/)**.
 | [Getting Started](https://openmed.life/docs/) | [Analyze Text](https://openmed.life/docs/analyze-text) | [Model Registry](https://openmed.life/docs/model-registry) |
 | [FAQ](docs/faq.md) | [Anonymization](docs/anonymization.md) | [Batch Processing](https://openmed.life/docs/batch-processing) |
 | [Configuration Profiles](https://openmed.life/docs/profiles) | [REST Service](docs/rest-service.md) | [MLX Backend](docs/mlx-backend.md) |
+| [Transformers.js Export](docs/export-transformersjs.md) | [FHIR Interop](docs/fhir-interop.md) | [HL7 v2 De-identification](docs/hl7v2-deidentification.md) |
+| [v1.6-v1.7 Feature Coverage](docs/release/v1.6-v1.7-feature-coverage.md) | [OpenMed 1.7.0 Release Notes](docs/release/v1.7.0.md) | [Examples](docs/examples.md) |
 | [Release Streams](docs/release/semver-and-channels.md) | [Generative Model Policy](docs/generative-model-policy.md) | [Contributing](docs/contributing.md) |
 | [Security Policy](SECURITY.md) | [Compliance Posture](docs/compliance.md) | |
 
@@ -420,7 +454,7 @@ Never include real patient data in a report.
 
 ## Credits
 
-OpenMed builds on excellent open-source work — particular thanks to **OpenAI** (the [Privacy Filter](https://huggingface.co/openai/privacy-filter) architecture), **NVIDIA** (the [Nemotron PII dataset](https://huggingface.co/datasets/nvidia/Nemotron-PII-v1)), **Hugging Face** (`transformers` & the model ecosystem), **Apple** ([MLX](https://github.com/ml-explore/mlx)), and the **[Faker](https://faker.readthedocs.io/)** maintainers.
+OpenMed builds on excellent open-source work — particular thanks to **OpenAI** (the [Privacy Filter](https://huggingface.co/openai/privacy-filter) architecture), **NVIDIA** (the [Nemotron PII dataset](https://huggingface.co/datasets/nvidia/Nemotron-PII-v1)), **Hugging Face** (`transformers`, Transformers.js & the model ecosystem), **Apple** ([MLX](https://github.com/ml-explore/mlx)), and the **[Faker](https://faker.readthedocs.io/)** maintainers.
 
 ## License
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,7 +1,8 @@
 # Examples & Copy/Paste Recipes
 
-This page curates the most useful samples already in the repository so you can jump straight to runnable notebooks or
-scripts.
+This page curates the most useful samples already in the repository so you can
+jump straight to runnable notebooks or scripts. The v1.6 and v1.7 examples use
+synthetic data and are safe to run during release review.
 
 ## Notebooks (`examples/notebooks/`)
 
@@ -20,15 +21,41 @@ Run them with VS Code, Jupyter, or Google Colab—each relies on the same `uv pi
 | `examples/pii_model_comparison.py` | Compares multiple PII models across shared sample text and summarizes extraction quality. |
 | `examples/pii_batch_processing.py` | Runs batch PII extraction and de-identification with `BatchProcessor(operation=...)`. |
 | `examples/pii_multilingual_new_languages.py` | Exercises Dutch, Hindi, Telugu, Portuguese, Arabic, Japanese, and Turkish registry entries, locale-specific regex matches, and optional live extraction with the new public checkpoints. |
+| `examples/v16_policy_audit_release_gates.py` | Demonstrates v1.6 policy profiles, canonical spans, signed audit reports, review bundles, redaction previews, leakage heatmaps, and k-anonymity metrics without model downloads. |
+| `examples/v17_multimodal_browser_interop.py` | Demonstrates v1.7 multimodal and interop surfaces: AsciiDoc offset projection, OCR contracts, chat JSONL, CSV manifests, FHIR, HL7 v2, and Transformers.js browser bundle checks. |
+| `examples/first_five_minutes_redact_extract_fhir.py` | Walks through synthetic redaction, deterministic clinical extraction, and FHIR Bundle assembly. |
 | `scripts/smoke_gliner.py` | Runs a bounded set of GLiNER models/texts to confirm zero-shot dependencies are installed before releasing. |
 | `tests/run-tests.sh` | Convenience runner that stitches together unit, integration, and smoke tests; extend it to include docs builds and API smoke checks. |
 
+Run the v1.6 and v1.7 release examples:
+
+```bash
+uv run python examples/v16_policy_audit_release_gates.py
+uv run python examples/v17_multimodal_browser_interop.py
+```
+
+For the full coverage map, see
+[OpenMed v1.6-v1.7 Feature Coverage](./release/v1.6-v1.7-feature-coverage.md).
+
+## v1.7 multimodal, interop, and browser recipes
+
+The v1.7 examples are grouped around the main new public surfaces:
+
+- Multimodal text contracts: `ExtractedDocument`, `SourceSpan`, OCR result
+  projection, Markdown/AsciiDoc extraction, and metadata-safe source mapping.
+- Structured health data: FHIR `$de-identify`, FHIR Bulk NDJSON, deterministic
+  FHIR Bundles, `OperationOutcome`, HL7 v2 field redaction, and CSV/TSV
+  PHI-column manifests.
+- Browser deployment: ONNX/WebGPU artifacts packaged for Transformers.js, with
+  the expected `transformersjs/` file layout checked before publishing.
+
 ## Apple Silicon & Swift recipes
 
-OpenMed `1.5.5` includes release-critical Apple entry points:
+OpenMed `1.7.0` includes release-critical Apple and browser entry points:
 
 - [MLX Backend](./mlx-backend.md) for Python on Apple Silicon Macs, including Privacy Filter, OpenMed Multilingual Privacy Filter, and experimental GLiNER-family artifacts
 - [OpenMedKit (Swift Package)](./swift-openmedkit.md) for macOS, iOS, and iPadOS apps
+- [Transformers.js Export](./export-transformersjs.md) for browser token classification through ONNX/WebGPU artifacts
 
 Python MLX quick check:
 
@@ -50,6 +77,13 @@ let openmed = try OpenMed(backend: .mlx(modelDirectoryURL: modelDirectory))
 let entities = try openmed.extractPII("Patient John Doe, DOB 1990-05-15")
 ```
 
+Browser bundle smoke check:
+
+```bash
+uv run python -m openmed.onnx.transformersjs \
+  --onnx-export-dir dist/example-onnx
+```
+
 ## Copy-ready snippets
 
 You can find these directly in the docs:
@@ -59,6 +93,7 @@ You can find these directly in the docs:
 - [LangChain Redaction Wrapper](./integrations-langchain.md) — RAG context redaction before model calls.
 - [MLX Backend](./mlx-backend.md) — Apple Silicon Python runtime and artifact packaging.
 - [OpenMedKit (Swift)](./swift-openmedkit.md) — native app runtime for macOS, iOS, and iPadOS.
+- [Transformers.js Export](./export-transformersjs.md) — browser/WebGPU packaging for token classification.
 - [ModelLoader & Pipelines](./model-loader.md) — caching, token helpers, multi-model setups.
 - [Advanced NER & Output Formatting](./output-formatting.md) — span filtering and conversions.
 - [Zero-shot Toolkit](./zero-shot-ner.md) — indexing, label defaults, and inference APIs.
@@ -71,6 +106,8 @@ set -euo pipefail
 
 uv pip install ".[hf,docs]"
 python examples/pii_model_comparison.py > artifacts/result.txt
+uv run python examples/v16_policy_audit_release_gates.py > artifacts/v16.json
+uv run python examples/v17_multimodal_browser_interop.py > artifacts/v17.json
 uv run mkdocs build --strict
 python scripts/smoke_gliner.py --limit 1 --threshold 0.5
 ```

--- a/docs/export-transformersjs.md
+++ b/docs/export-transformersjs.md
@@ -68,3 +68,31 @@ validate_transformersjs_bundle("dist/example-onnx/transformersjs")
 The repository also includes a headless Node smoke fixture at
 `tests/fixtures/onnx/transformersjs_smoke.mjs`. It verifies the same file
 layout and tensor contract from the generated `transformersjs-contract.json`.
+
+## Browser usage
+
+Once the `transformersjs/` directory is served by your application or copied
+into a static model asset path, load it with Transformers.js:
+
+```javascript
+import { pipeline } from "@huggingface/transformers";
+
+const detector = await pipeline(
+  "token-classification",
+  "/models/openmed-pii/transformersjs",
+  { device: "webgpu" },
+);
+
+const entities = await detector("Patient Casey Example called 212-555-0198.");
+```
+
+Use the browser bundle for local-first token classification where PHI should
+stay inside the user's browser session. The export step only packages model
+artifacts; it does not change Hugging Face repository visibility.
+
+For an offline synthetic walkthrough that prints the expected bundle files and
+browser load snippet, run:
+
+```bash
+uv run python examples/v17_multimodal_browser_interop.py
+```

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -1,51 +1,88 @@
 # Feature Map & Capabilities
 
-This page inventories every surfaced capability in OpenMed so you can see how the docs map back to the codebase. Use it
-as the starting point when you are unsure which page (or module) to visit.
+This page inventories the main surfaced capabilities in OpenMed and maps them
+back to source modules, docs, and runnable examples. For release-specific
+coverage, see
+[OpenMed v1.6-v1.7 Feature Coverage](./release/v1.6-v1.7-feature-coverage.md).
 
-## Model lifecycle
-
-| Area | What it covers | Where to look |
-| --- | --- | --- |
-| Model registry | Curated metadata (`ModelInfo`, categories, suggestions) for every OpenMed Hugging Face release. | `openmed/core/model_registry.py`, [Model Registry](./model-registry.md) |
-| Discovery & loading | Hugging Face discovery, optional auth, caching, tokenizers, pipeline helpers. | `openmed/core/models.py`, [ModelLoader & Pipelines](./model-loader.md) |
-| One-call inference | `analyze_text`, validation, pySBD segmentation, output formatting for dict/JSON/HTML/CSV. | `openmed/__init__.py:analyze_text`, [Analyze Text Helper](./analyze-text.md) |
-| PII detection & de-identification | `extract_pii`, `deidentify`, smart entity merging, HIPAA Safe Harbor compliance. | `openmed/core/pii.py`, `openmed/core/pii_entity_merger.py`, [PII Detection & Smart Merging](./pii-smart-merging.md) |
-| Zero-shot toolkit | GLiNER-powered indexing, label maps, adapters, smoke scripts. | `openmed/zero_shot/**`, [Zero-shot Toolkit](./zero-shot-ner.md) |
-
-## Processing & outputs
+## Privacy And De-identification
 
 | Area | What it covers | Where to look |
 | --- | --- | --- |
-| Advanced NER filtering | Entity spanning, score filtering, punct stripping, BIO-aware grouping. | `openmed/processing/advanced_ner.py`, [Advanced NER & Output Formatting](./output-formatting.md) |
-| Formatting utilities | `PredictionResult`, copy-ready dict/JSON/HTML/CSV outputs, metadata injection. | `openmed/processing/outputs.py`, [Advanced NER & Output Formatting](./output-formatting.md) |
-| Text utilities | Sentence detection, tokenization helpers, text cleaning. | `openmed/processing/`, [ModelLoader & Pipelines](./model-loader.md) |
+| Policy-aware de-identification | `deidentify`, policy profiles, calibrated thresholds, arbitration, cascade routing, safety sweeps, custom recognizers, and clinical term protection. | `openmed/core/pii.py`, `openmed/core/pipeline.py`, `openmed/core/policy.py`, `openmed/core/clinical_protect.py`, [PII Anonymization](./anonymization.md) |
+| Canonical span contracts | Versioned `OpenMedSpan`, schema fingerprints, redaction action schemas, provenance, and compatibility gates. | `openmed/core/schemas/`, [De-identification API](./api/deidentification.md), `examples/v16_policy_audit_release_gates.py` |
+| Audit and review evidence | Signed audit reports, reproducibility hashes, review bundles, FHIR `Provenance`/`AuditEvent`, audit diffs, and PHI-safe previews. | `openmed/core/audit.py`, `openmed/core/redaction_preview.py`, `openmed/risk/audit_diff.py`, `openmed/clinical/exporters/fhir/provenance.py`, `examples/v16_policy_audit_release_gates.py` |
+| Runtime de-identification features | `DeidentificationResult.to_dataframe`, surrogate vaults, patient-keyed date shifting, format-preserving redaction, minimum-necessary action selection, streaming redaction, explain traces, section stamping, and risk budgets. | `openmed/core/pii.py`, `openmed/core/surrogate_vault.py`, `openmed/core/date_shift.py`, `openmed/core/anonymizer/format_preserve.py`, `openmed/core/redaction_strength.py`, `openmed/core/streaming.py`, `openmed/core/explain.py`, `openmed/risk/budget.py` |
+| Multilingual PII | 15 supported PII language codes: ar, de, en, es, fr, he, hi, id, it, ja, nl, pt, te, th, and tr; locale validators, script detection, date/number normalization, and deterministic locale PHI generation. | `openmed/core/pii_i18n.py`, `openmed/core/script_detect.py`, `openmed/core/locale_formats.py`, `openmed/training/synthetic/locale_phi.py`, `examples/pii_multilingual_new_languages.py` |
 
-## Tooling & ops
+## Multimodal And Structured Inputs
 
 | Area | What it covers | Where to look |
 | --- | --- | --- |
-| Configuration | YAML/ENV + per-run overrides via `OpenMedConfig`; profile-aware runtime settings. | `openmed/core/config.py`, [Configuration & Validation](./configuration.md) |
-| Configuration Profiles | Built-in profiles (dev, prod, test, fast) + custom profiles. | `openmed/core/config.py`, [Configuration Profiles](./profiles.md) |
-| Batch Processing | Multi-text/file processing with progress and aggregation. | `openmed/processing/batch.py`, [Batch Processing](./batch-processing.md) |
-| REST Service | FastAPI endpoints exposing analyze/PII APIs for containerized deployment. | `openmed/service/app.py`, [REST Service (MVP)](./rest-service.md) |
-| Performance Profiling | Timing utilities, metrics, and profiling decorators. | `openmed/utils/profiling.py`, [Performance Profiling](./profiling.md) |
-| Testing | `tests/run-tests.sh`, unit/integration markers, smoke runners. | `tests/`, [Testing & QA](./testing.md) |
-| Examples | Notebooks, scripts, and analysis snippets in `examples/`. | `examples/`, [Examples & Copy/Paste Recipes](./examples.md) |
-| Automation | Make targets, GitHub Actions (CI, publish, docs). | `Makefile`, `.github/workflows/*.yml`, [Contributing & Releases](./contributing.md) |
+| Multimodal document contract | `ExtractedDocument`, `SourceSpan`, lazy handler registration, source-offset mapping, and dispatcher-based redaction. | `openmed/multimodal/base.py`, `examples/v17_multimodal_browser_interop.py` |
+| OCR and scanned documents | Shared OCR result contract, fake test engine, Tesseract, PaddleOCR, EasyOCR, docTR, OCR language selection, and available-engine discovery. | `openmed/multimodal/ocr.py`, `tests/unit/multimodal/test_ocr_engines.py`, `examples/v17_multimodal_browser_interop.py` |
+| Markup and metadata | Markdown/AsciiDoc extraction, source text redaction, image/PDF/DOCX metadata scrubbing, and residual metadata verification. | `openmed/multimodal/documents_markdown.py`, `openmed/multimodal/metadata_scrub.py`, `examples/v17_multimodal_browser_interop.py` |
+| Chat logs and tabular data | JSONL chat-log redaction with speaker pseudonymization, CSV/TSV PHI column classification, column actions, and PHI-safe manifests. | `openmed/multimodal/chatlog_jsonl.py`, `openmed/multimodal/tabular_csv.py`, `examples/v17_multimodal_browser_interop.py` |
 
-## Suggested reading order
+## Health-data Interop
 
-1. [Quick Start](./getting-started.md) — install + first inference.
-2. [Analyze Text Helper](./analyze-text.md) — single-call orchestration.
-3. [PII Detection & Smart Merging](./pii-smart-merging.md) — de-identification (v0.5.0).
-4. [Batch Processing](./batch-processing.md) — multi-text processing.
-5. [REST Service (MVP)](./rest-service.md) — HTTP API + Docker runtime.
-6. [ModelLoader & Pipelines](./model-loader.md) — lower-level control.
-7. [Model Registry](./model-registry.md) — pick the right checkpoint.
-8. [Configuration Profiles](./profiles.md) — dev/prod/test profiles.
-9. [Advanced NER & Output Formatting](./output-formatting.md) — polish predictions.
-10. [Zero-shot Toolkit](./zero-shot-ner.md) — GLiNER workflows.
-11. [Performance Profiling](./profiling.md) — timing and metrics.
-12. [Examples](./examples.md) — runnable notebooks and scripts.
-13. [Testing & QA](./testing.md) + [Contributing](./contributing.md) — team processes.
+| Area | What it covers | Where to look |
+| --- | --- | --- |
+| FHIR helpers | Deterministic R4 Bundles, stable `urn:uuid` references, `OperationOutcome`, `Provenance`, `AuditEvent`, CodeableConcept builders/checkers, and coding provenance. | `openmed/clinical/exporters/fhir/`, `openmed/clinical/exporters/codeable_concept_simple.py`, `openmed/clinical/exporters/codeable_concept_check.py`, [FHIR Interop Helpers](./fhir-interop.md) |
+| FHIR operations and bulk export | `$de-identify` resource/Bundle wrappers and FHIR Bulk NDJSON de-identification summaries. | `openmed/interop/fhir_operations.py`, `openmed/interop/fhir_bulk.py`, `examples/v17_multimodal_browser_interop.py` |
+| HL7 v2 and CDA/C-CDA | HL7 v2 segment/field redaction, CDA/C-CDA XML de-identification, and multimodal XML dispatch. | `openmed/interop/hl7v2.py`, `openmed/interop/cda.py`, [HL7 v2 De-identification](./hl7v2-deidentification.md) |
+| Optional adapters | Presidio, PHILTER, pyDeid, GLiNER-BioMed, LangChain, and spaCy adapter surfaces. | `openmed/interop/`, [LangChain Redaction Wrapper](./integrations-langchain.md), [spaCy Pipeline Component](./spacy-component.md) |
+
+## Clinical Extraction
+
+| Area | What it covers | Where to look |
+| --- | --- | --- |
+| Clinical context | Negation, temporality, uncertainty, experiencer, section-aware priors, and context offsets. | `openmed/clinical/context.py`, [Clinical Context & Extraction Depth](./clinical/context-and-extraction.md) |
+| Clinical normalization | Labs, vitals, medication sigs, problem-list status, summary cards, microbiology, dermatology/ophthalmology labels, status vocabulary, and flat-table export. | `openmed/clinical/`, `openmed/clinical/exporters/flat_table.py`, [Clinical Context & Extraction Depth](./clinical/context-and-extraction.md) |
+| Zero-shot domains | GLiNER label maps, clinical NER families, cardiology, dermatology, ophthalmology, microbiology, nutrition, and routing metadata. | `openmed/zero_shot/`, `openmed/ner/families/`, [Zero-shot Toolkit](./zero-shot-ner.md), `examples/clinical_ner_families.py` |
+
+## Models, Backends, And Browser Export
+
+| Area | What it covers | Where to look |
+| --- | --- | --- |
+| Model registry and manifests | Curated metadata, manifest schema validation, manifest diffs, model recommendations, model card generation, and publishing metadata. | `models.jsonl`, `openmed/core/model_registry.py`, `openmed/core/manifest_schema.py`, `openmed/core/manifest_diff.py`, `openmed/core/model_card.py`, [Model Registry](./model-registry.md), [Model Manifest](./model-manifest.md) |
+| One-call inference | `analyze_text`, typed `AnalyzeResult`, validation, grouping, and dict/JSON/HTML/CSV formatting. | `openmed/__init__.py`, `openmed/core/results.py`, [Analyze Text Helper](./analyze-text.md) |
+| Loader and batch processing | Model loading, cache reuse, tokenizer caching, batch `analyze_text`, batch PII extraction, and ordered de-identification output. | `openmed/core/models.py`, `openmed/processing/tokenizer_cache.py`, `openmed/processing/batch.py`, [ModelLoader & Pipelines](./model-loader.md), [Batch Processing](./batch-processing.md) |
+| Apple runtimes | Python MLX, Laneformer MLX-LM, Swift OpenMedKit, Core ML export, MLX quantized export, and PyTorch MPS selection/tuning. | `openmed/mlx/`, `openmed/coreml/`, `openmed/torch/device.py`, `swift/OpenMedKit`, [MLX Backend](./mlx-backend.md), [Swift Package](./swift-openmedkit.md), [CoreML Packaging](./coreml-export.md), [Torch MPS Performance](./performance-mps.md) |
+| Quantized and browser formats | AWQ, GPTQ, bitsandbytes loading, ONNX/WebGPU, Transformers.js bundle export, and ONNX/quantized manifest metadata. | `openmed/torch/quantize_awq.py`, `openmed/torch/quantize_gptq.py`, `openmed/torch/loader_quant.py`, `openmed/onnx/`, [AWQ Export](./export-awq.md), [GPTQ Export](./export-gptq.md), [Transformers.js Export](./export-transformersjs.md) |
+| Training infrastructure | DAPT corpus assembly, Mode-A distillation, DirectID contracts, hard-negative sampling, active learning, adjudication, and span-relation graph decoding. | `openmed/training/`, `openmed/core/decoding/graph.py` |
+
+## Service, Clients, And Operations
+
+| Area | What it covers | Where to look |
+| --- | --- | --- |
+| REST service | FastAPI endpoints, shared runtime, model warm pools, dynamic batching, request coalescing, rate/concurrency limits, trusted hosts, CORS, `/livez`, `/readyz`, and metrics. | `openmed/service/`, [REST Service](./rest-service.md) |
+| Typed clients | Python service client and TypeScript REST client parity. | `openmed/service/client.py`, `clients/typescript/`, `clients/typescript/README.md` |
+| Streaming and connectors | Core incremental de-identification and Kafka streaming de-identification. | `openmed/core/streaming.py`, `openmed/processing/kafka_connector.py` |
+| CLI | `openmed deid`, FHIR bundle, model recommendation/diff/card, policy diff/lint, doctor, gates preview/bundle, audit/risk, active learning, benchmark, and calibration commands. | `openmed/cli/`, [Contributing & Releases](./contributing.md) |
+
+## Evaluation, Risk, And Release Evidence
+
+| Area | What it covers | Where to look |
+| --- | --- | --- |
+| Evaluation harness | Benchmark reports, public biomedical NER, DrugProt, i2b2 loader stubs, SHIELD, clinical PHI manifests, dataset cards, coverage, section recall, caching, fairness, robustness, and error analysis. | `openmed/eval/`, [Eval Harness & Metrics](./eval-harness.md), [Golden Benchmark](./benchmarks/golden.md) |
+| Leakage and utility evidence | Leakage heatmaps, model scorecards, threshold sweeps, paired significance, flaky-run detection, calibration reliability, over-redaction, utility loss, policy compliance, and benchmark history diffs. | `openmed/eval/leakage_heatmap.py`, `openmed/eval/scorecard.py`, `openmed/eval/threshold_sweep.py`, `openmed/eval/utility.py`, `openmed/eval/history.py` |
+| Risk metrics | Re-identification risk, membership/linkage probes, k-anonymity, l-diversity, t-closeness, risk budgets, dashboards, and audit diffs. | `openmed/risk/`, `openmed/eval/attacks/`, `examples/v16_policy_audit_release_gates.py` |
+| Release gates and status | Fail-closed gates, evidence bundles, last-green baseline, device tiers, nano certification, status pages, and leaderboard pages. | `openmed/eval/release_gates.py`, `openmed/eval/evidence_bundle.py`, `openmed/eval/tiers.py`, `openmed/eval/nano_cert.py`, `docs/status/`, `docs/leaderboard/`, [Release Streams & Channels](./release/semver-and-channels.md) |
+
+## Security And Supply Chain
+
+| Area | What it covers | Where to look |
+| --- | --- | --- |
+| Responsible disclosure | Private vulnerability reporting, security issue routing, breach notification runbook, and breach report template. | `SECURITY.md`, `docs/security/disclosure-policy.md`, `docs/compliance/breach-notification-runbook.md`, `docs/compliance/templates/breach-report-template.md` |
+| Dependency and release controls | License policy, pip-audit ignores, SBOM generation, reproducible locks, GitHub Actions ref validation, lockfile drift, repo policy, and doctest-backed examples. | `docs/security/`, `scripts/release/`, `docs/contributing/reproducible-dependencies.md`, `tests/unit/release/`, `tests/unit/test_doctests.py` |
+| Privacy-safe diagnostics | PHI-safe progress callbacks, NDJSON errors, active-learning records, hashed examples, explain traces, dataset cards, metadata scrubbing, and no-raw-PHI guidance. | `openmed/multimodal/metadata_scrub.py`, `openmed/training/active_learning.py`, `openmed/eval/dataset_card.py`, `docs/compliance.md`, `docs/security/secret-handling.md` |
+
+## Suggested Reading Order
+
+1. [Quick Start](./getting-started.md) - install plus first inference.
+2. [OpenMed v1.6-v1.7 Feature Coverage](./release/v1.6-v1.7-feature-coverage.md) - verify release coverage across docs and examples.
+3. [Examples](./examples.md) - runnable notebooks and scripts.
+4. [PII Anonymization](./anonymization.md) - de-identification methods and policy workflows.
+5. [REST Service](./rest-service.md), [Swift Package](./swift-openmedkit.md), and [Transformers.js Export](./export-transformersjs.md) - deployment surfaces.
+6. [Eval Harness & Metrics](./eval-harness.md), [Device Tiers & SLOs](./tiers.md), and [Release Streams & Channels](./release/semver-and-channels.md) - release evidence and operations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,41 @@
 # OpenMed Documentation
 
-OpenMed bundles curated biomedical models, advanced extraction utilities, and one-call orchestration so you can ship
-clinical NLP workflows without wrangling infrastructure. This documentation keeps the most copied snippets and workflows
-close at hand—each section is Markdown-first, searchable, and optimized for quick scanning or copy/paste into notebooks.
+OpenMed bundles curated biomedical models, advanced de-identification,
+multimodal intake, structured health-data utilities, and one-call
+orchestration so you can ship clinical NLP workflows without wrangling
+infrastructure. This documentation keeps copied snippets and workflows close
+at hand: each section is Markdown-first, searchable, and optimized for quick
+scanning or copy/paste into notebooks.
 
-OpenMed `1.5.5` expands multilingual PII and the Apple story:
+OpenMed `1.7.0` extends the v1.6 privacy foundation into a broader local-first
+clinical data platform:
 
-- **Python MLX** on Apple Silicon Macs through `openmed[mlx]`
-- **OpenMedKit** for native macOS, iOS, and iPadOS apps
-- **Shared MLX artifacts** so Python and Swift can consume the same packaged model layout
-- **Arabic, Japanese, and Turkish PII extraction** with SDK defaults, localized regexes, anonymizer locales, and preconverted MLX routing for supported checkpoints
-- **Native Privacy Filter, OpenAI Nemotron Privacy Filter, OpenMed Multilingual Privacy Filter, and experimental GLiNER-family runtimes** for local-first PII, classification, and relation extraction workflows
+- **Policy-aware de-identification** with signed audit reports, reproducibility
+  hashes, review bundles, redaction previews, and release gates.
+- **Multimodal and structured inputs** across OCR, images, PDFs, Markdown,
+  AsciiDoc, CSV/TSV, JSONL chat logs, HL7 v2, CDA/C-CDA, FHIR operations, and
+  FHIR Bulk NDJSON.
+- **Python, Swift, REST, TypeScript, and browser paths** including OpenMedKit,
+  typed REST clients, ONNX/WebGPU, and Transformers.js export bundles.
+- **15 supported PII language codes: ar, de, en, es, fr, he, hi, id, it, ja,
+  nl, pt, te, th, and tr** with locale-aware validation and surrogate
+  generation.
+- **Release evidence** for leakage heatmaps, model scorecards, threshold
+  sweeps, k-anonymity/l-diversity/t-closeness, utility loss, SBOMs, and
+  reproducible dependency locks.
 
 ## What you get
 
 - **Curated registries** – discoverable Hugging Face models with metadata (domain, size, device guidance).
 - **One-line orchestration** – `analyze_text` wraps validation, inference, and formatting for scripts, notebooks, or services.
-- **PII detection & de-identification** – HIPAA-compliant smart entity merging for production-ready de-identification.
+- **PII detection & de-identification** – HIPAA-aware smart entity merging,
+  policy profiles, signed audit reports, and production-ready de-identification.
 - **Apple Silicon acceleration** – MLX-backed Python inference plus Swift-native app integration through `OpenMedKit`.
-- **REST service MVP** – FastAPI endpoints for `/health`, `/analyze`, `/pii/extract`, and `/pii/deidentify`.
+- **REST service** – FastAPI endpoints for `/livez`, `/readyz`, `/analyze`,
+  `/pii/extract`, `/pii/deidentify`, warm pools, batching, metrics, and
+  typed Python/TypeScript clients.
+- **Browser export** – ONNX/WebGPU bundles for Transformers.js token
+  classification in browser runtimes.
 - **Advanced NER post-processing** – score-aware grouping, PHI-friendly filtering, and CSV/JSON/HTML export helpers.
 - **Composable config** – `OpenMedConfig` reads YAML/ENV so deployments stay reproducible across laptops and clusters.
 
@@ -50,18 +67,21 @@ uv run python examples/pii_model_comparison.py
 The rest of the docs expand on this snippet—head to **Quick Start** for the end-to-end setup, then explore the guides for
 configuration, zero-shot GLiNER workflows, and advanced processing helpers.
 
-## 1.5.5 release highlights
+## 1.6 and 1.7 release highlights
 
-- [MLX Backend](./mlx-backend.md) – Python MLX on Apple Silicon, Privacy Filter family support, 28 new Arabic/Japanese/Turkish PII MLX artifacts, shared artifact packaging, and backend auto-detection.
-- [OpenMedKit (Swift Package)](./swift-openmedkit.md) – native macOS/iOS/iPadOS integration with MLX, CoreML, Privacy Filter, OpenMed Multilingual Privacy Filter, and experimental GLiNER-family APIs.
-- [CoreML Packaging](./coreml-export.md) – current status of the bundled Apple model route alongside the new MLX flow.
-- [Examples & Copy/Paste Recipes](./examples.md) – release-friendly snippets for Python, PII, batch jobs, and Apple runtimes.
+- [OpenMed v1.6-v1.7 Feature Coverage](./release/v1.6-v1.7-feature-coverage.md) – coverage checklist across examples, docs, website, and source modules.
+- [OpenMed 1.7.0 Release Notes](./release/v1.7.0.md) – detailed release inventory and migration notes.
+- [Examples & Copy/Paste Recipes](./examples.md) – release-friendly snippets for Python, PII, batch jobs, Apple runtimes, browser export, multimodal inputs, and FHIR/HL7.
+- [Transformers.js Export](./export-transformersjs.md) – browser/WebGPU packaging for token classification bundles.
+- [FHIR Interop Helpers](./fhir-interop.md) and [HL7 v2 De-identification](./hl7v2-deidentification.md) – structured health-data workflows.
+- [MLX Backend](./mlx-backend.md), [OpenMedKit](./swift-openmedkit.md), and [CoreML Packaging](./coreml-export.md) – local Apple runtime paths.
 
 ## How these docs are structured
 
 1. [Quick Start](./getting-started.md) – fastest path to a working environment plus a copy/paste script.
 2. [Feature Map](./feature-map.md) – see how every capability maps back to the code.
-3. Core guides:
+3. [v1.6-v1.7 Feature Coverage](./release/v1.6-v1.7-feature-coverage.md) – verify release feature coverage across examples and docs.
+4. Core guides:
    - [Analyze Text Helper](./analyze-text.md) for single-call inference.
    - [REST Service (MVP)](./rest-service.md) for Dockerized HTTP endpoints.
    - [PII Detection & Smart Merging](./pii-smart-merging.md) for HIPAA-compliant de-identification (v0.5.0).
@@ -80,5 +100,5 @@ configuration, zero-shot GLiNER workflows, and advanced processing helpers.
    - [Release Streams & Channels](./release/semver-and-channels.md) – model artifact and library release policy.
    - [Generative Model Policy](./generative-model-policy.md) – approved and prohibited model-assisted workflows.
 
-Need something that is not here yet? Drop an issue on GitHub and mention the missing recipe. Every addition is just a
-Markdown file away.
+Need something that is not here yet? Drop an issue on GitHub and mention the
+missing recipe. Every addition is just a Markdown file away.

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ uv run python examples/pii_model_comparison.py
 The rest of the docs expand on this snippet—head to **Quick Start** for the end-to-end setup, then explore the guides for
 configuration, zero-shot GLiNER workflows, and advanced processing helpers.
 
-## 1.6 and 1.7 release highlights
+## Latest release highlights
 
 - [OpenMed v1.6-v1.7 Feature Coverage](./release/v1.6-v1.7-feature-coverage.md) – coverage checklist across examples, docs, website, and source modules.
 - [OpenMed 1.7.0 Release Notes](./release/v1.7.0.md) – detailed release inventory and migration notes.

--- a/docs/release/v1.6-v1.7-feature-coverage.md
+++ b/docs/release/v1.6-v1.7-feature-coverage.md
@@ -1,0 +1,60 @@
+# OpenMed v1.6-v1.7 Feature Coverage
+
+This checklist maps the v1.6 and v1.7 feature groups to runnable examples,
+docs, website surfaces, and source modules. All examples use synthetic data.
+
+## Runnable Examples
+
+| Example | Covers |
+| --- | --- |
+| `examples/v16_policy_audit_release_gates.py` | v1.6 policy profiles, canonical spans, signed audit reports, review bundles, redaction previews, minimum-necessary action selection, leakage heatmaps, and k-anonymity evidence. |
+| `examples/v17_multimodal_browser_interop.py` | v1.7 AsciiDoc offset extraction, OCR contracts, JSONL chat-log redaction, CSV manifests, FHIR `$de-identify`, FHIR Bulk NDJSON, deterministic FHIR Bundles, HL7 v2 redaction, `OperationOutcome`, and Transformers.js browser bundle checks. |
+| `examples/first_five_minutes_redact_extract_fhir.py` | First-five-minutes synthetic flow from PII redaction to deterministic FHIR resources. |
+| `examples/clinical_ner_families.py` | Offline-friendly clinical NER family selection and mocked extraction. |
+| `examples/pii_batch_processing.py` | Batch extraction/de-identification with shared loader reuse and ordered output. |
+| `examples/pii_multilingual_new_languages.py` | Multilingual registry, regex, and optional live-model smoke coverage. |
+
+## v1.6 Coverage
+
+| Feature group | Coverage |
+| --- | --- |
+| Policy-aware de-identification runtime, canonical `OpenMedSpan`, policy profiles, thresholds, arbitration, cascade routing, and safety sweeps | `openmed/core/pipeline.py`, `openmed/core/policy.py`, `openmed/core/schemas/span.py`, `openmed/core/thresholds.py`, `docs/anonymization.md`, `docs/pii-smart-merging.md`, `examples/v16_policy_audit_release_gates.py`. |
+| Signed reproducible audit reports, residual-risk metadata, hashes, and HMAC signatures | `openmed/core/audit.py`, `docs/api/deidentification.md`, `docs/security/disclosure-policy.md`, `examples/v16_policy_audit_release_gates.py`. |
+| Re-identification risk, adversarial risk benchmarks, and SHIELD/DUA-gated eval stubs | `openmed/risk/`, `openmed/eval/attacks/`, `openmed/eval/suites/shield.py`, `docs/eval-harness.md`, `docs/benchmarks/golden.md`. |
+| Leakage-first evaluation, synthetic golden fixtures, bootstrap confidence intervals, cold-start latency, and public/reference adapters | `openmed/eval/`, `openmed/eval/golden/README.md`, `docs/eval-harness.md`, `docs/benchmarks/golden.md`. |
+| Release gates, last-green baselines, calibration artifacts, quantization recall deltas, status pages, and leaderboard pages | `openmed/eval/release_gates.py`, `scripts/status/generate_status.py`, `docs/status/`, `docs/leaderboard/`, `docs/release/semver-and-channels.md`, `docs/release/v1.7.0.md`. |
+| Clinical and interoperability utilities: ConText, Athena/Usagi, Presidio, deterministic FHIR Bundles | `openmed/clinical/context.py`, `openmed/interop/athena.py`, `openmed/interop/presidio.py`, `openmed/clinical/exporters/fhir/`, `docs/clinical/context-and-extraction.md`, `docs/fhir-interop.md`. |
+| Cardiology zero-shot label-map domain and clinical NER family routing | `openmed/zero_shot/`, `openmed/ner/families/`, `docs/zero-shot-ner.md`, `examples/clinical_ner_families.py`. |
+| Canonical model manifest, manifest validation/diff, model card generation, and artifact publishing metadata | `models.jsonl`, `openmed/core/manifest_schema.py`, `openmed/core/manifest_diff.py`, `openmed/core/model_card.py`, `docs/model-manifest.md`, `docs/model-registry.md`. |
+| CLI benchmark/calibration/de-identification and release tooling | `openmed/cli/`, `scripts/release/`, `docs/contributing.md`, `docs/testing.md`. |
+| Governance, compliance, security, device tiers, FAQ, API reference, release channels, status, leaderboard, and notebook docs | `docs/compliance.md`, `docs/security/`, `docs/tiers.md`, `docs/faq.md`, `docs/api-reference.md`, `docs/release/semver-and-channels.md`, `examples/notebooks/README.md`. |
+
+## v1.7 Coverage
+
+| Feature group | Coverage |
+| --- | --- |
+| Multimodal document primitives, source spans, lazy handlers, OCR, image/PDF redaction, Markdown/AsciiDoc extraction, metadata scrubbing, and JSONL chat logs | `openmed/multimodal/`, `examples/v17_multimodal_browser_interop.py`, `docs/examples.md`, `docs/feature-map.md`. |
+| OCR engines for Tesseract, PaddleOCR, EasyOCR, docTR, fake test engines, language selection, and engine discovery | `openmed/multimodal/ocr.py`, `tests/unit/multimodal/test_ocr_engines.py`, `examples/v17_multimodal_browser_interop.py`. |
+| CDA/C-CDA, HL7 v2, CSV/TSV, FHIR `$de-identify`, FHIR Bulk NDJSON, deterministic Bundles, `OperationOutcome`, `Provenance`, `AuditEvent`, CodeableConcept checks, and flat-table export | `openmed/interop/`, `openmed/clinical/exporters/`, `docs/fhir-interop.md`, `docs/hl7v2-deidentification.md`, `examples/first_five_minutes_redact_extract_fhir.py`, `examples/v17_multimodal_browser_interop.py`. |
+| Clinical extraction and normalization for labs, vitals, medication sigs, problem lists, summary cards, microbiology, dermatology, ophthalmology, clinical labels, context, and clinical-term protection | `openmed/clinical/`, `openmed/core/clinical_protect.py`, `docs/clinical/context-and-extraction.md`, `docs/feature-map.md`. |
+| Nutrition and diet-order zero-shot labels, policy coverage, routing metadata, and synthetic fixtures | `openmed/core/labels.py`, `openmed/zero_shot/`, `tests/fixtures/`, `docs/feature-map.md`, `docs/release/v1.7.0.md`. |
+| Indonesian, Thai, Hebrew RTL, PESEL, Korean RRN, Unicode script detection, locale checksum registries, locale PHI generation, and date/number normalization | `openmed/core/pii_i18n.py`, `openmed/core/script_detect.py`, `openmed/core/locale_formats.py`, `openmed/training/synthetic/locale_phi.py`, `examples/pii_multilingual_new_languages.py`. |
+| Runtime features: `DeidentificationResult.to_dataframe`, redaction previews, surrogate vaults, patient-keyed date shifting, format-preserving redaction, minimum-necessary selection, streaming de-identification, typed analyze results, explain traces, section stamping, and risk budgets | `openmed/core/pii.py`, `openmed/core/results.py`, `openmed/core/redaction_preview.py`, `openmed/core/surrogate_vault.py`, `openmed/core/date_shift.py`, `openmed/core/anonymizer/format_preserve.py`, `openmed/core/redaction_strength.py`, `openmed/core/streaming.py`, `openmed/core/explain.py`, `openmed/risk/budget.py`, `docs/anonymization.md`, `examples/v16_policy_audit_release_gates.py`. |
+| CLI surfaces for de-ID, FHIR bundle, model recommendation/diff, policy diff, doctor, gates preview/bundle, audit/risk, and active learning | `openmed/cli/main.py`, `openmed/cli/gates.py`, `openmed/cli/active_learning.py`, `docs/contributing.md`, `docs/release/v1.7.0.md`. |
+| Service features: warm pools, dynamic batching, request coalescing, rate/concurrency limits, liveness/readiness, metrics, Python client, TypeScript client, and load testing | `openmed/service/`, `clients/typescript/`, `openmed/eval/load_test.py`, `docs/rest-service.md`, `clients/typescript/README.md`. |
+| Evaluation, release evidence, and risk tooling: DrugProt, biomedical NER, i2b2, dataset cards, coverage, section recall, caches, fairness, robustness, leakage heatmaps, membership/linkage attacks, k-anonymity, scorecards, threshold sweeps, flaky detection, significance, calibration reliability, utility loss, policy compliance, history diffs, nano certification, dashboards, and evidence bundles | `openmed/eval/`, `openmed/risk/`, `docs/eval-harness.md`, `docs/status/`, `docs/leaderboard/`, `examples/v16_policy_audit_release_gates.py`. |
+| Models, backends, and training: Laneformer MLX-LM, MLX INT4 certification, Core ML INT8 export, AWQ/GPTQ, bitsandbytes, attention backend selection, MPS tuning, ONNX/WebGPU, Transformers.js, tokenizer caching, distillation, DAPT, DirectID, hard negatives, graph decoding, and publish metadata | `openmed/mlx/`, `openmed/coreml/`, `openmed/torch/`, `openmed/onnx/`, `openmed/processing/tokenizer_cache.py`, `openmed/training/`, `openmed/core/decoding/graph.py`, `docs/mlx-backend.md`, `docs/export-mlx-quant.md`, `docs/coreml-export.md`, `docs/export-awq.md`, `docs/export-gptq.md`, `docs/performance-mps.md`, `docs/export-transformersjs.md`, `examples/v17_multimodal_browser_interop.py`. |
+| PHILTER, pyDeid, GLiNER-BioMed, LangChain, and spaCy adapter surfaces | `openmed/interop/`, `docs/integrations-langchain.md`, `docs/spacy-component.md`, `docs/feature-map.md`. |
+| New policy profiles and Swift policy-driven de-identification | `openmed/core/policies/`, `swift/OpenMedKit`, `docs/anonymization.md`, `docs/swift-openmedkit.md`. |
+| Security, supply chain, SBOM, reproducible locks, dependency policy, breach response, onboarding, release docs, doctest-backed examples, and PHI-safe diagnostics | `SECURITY.md`, `docs/security/`, `docs/compliance/`, `docs/contributing/reproducible-dependencies.md`, `docs/onboarding.md`, `scripts/release/`, `tests/unit/test_doctests.py`. |
+
+## Public Surfaces Updated
+
+- README: highlights local-first Python, Swift, REST, and browser/WebGPU paths.
+- Docs landing page: v1.7 overview and links to feature coverage.
+- Examples guide: new v1.6/v1.7 scripts plus existing first-five-minutes,
+  multilingual, batch, notebook, and Apple recipes.
+- Feature map: expanded from the older core-guide inventory to the v1.6/v1.7
+  capability map.
+- Static website: v1.7 meta/hero/runtime/privacy copy updated for multimodal,
+  FHIR/HL7, Transformers.js, and 15 supported PII language codes.

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OpenMed — Clinical AI that never leaves the device</title>
     <meta name="description"
-        content="OpenMed 1.7.0 brings policy-aware de-identification, signed audit reports, release gates, cardiology zero-shot labels, 1,000+ open-source healthcare LLM models, and Swift-native OpenMedKit, Apache-2.0 end to end." />
+        content="OpenMed 1.7.0 brings multimodal de-identification, OCR, FHIR and HL7 helpers, signed audit evidence, Transformers.js browser export, 1,000+ open-source healthcare LLM models, and Swift-native OpenMedKit." />
     <meta name="keywords"
         content="OpenMed, state-of-the-art LLMs for healthcare, healthcare AI, clinical AI models, biomedical NER, zero-shot medical AI, clinical LLMs, medical language models, healthcare machine learning, clinical LLM workflows, medical AI, biomedical AI, SOTA healthcare models, Maziyar Panahi, Hugging Face, Apache-2.0, SageMaker, clinical decision support, medical text analysis" />
     <meta name="author" content="Maziyar Panahi" />
@@ -20,7 +20,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="OpenMed — Clinical AI that never leaves the device" />
     <meta property="og:description"
-        content="OpenMed 1.7.0 — policy-aware de-identification, signed audit reports, fail-closed release gates, cardiology zero-shot labels, 1,000+ healthcare LLM models, and one local-first runtime across Python and Swift." />
+        content="OpenMed 1.7.0 — multimodal de-identification, OCR, FHIR/HL7, release evidence, Transformers.js browser export, 1,000+ healthcare LLM models, and local-first runtimes across Python, Swift, REST, and WebGPU." />
     <meta property="og:url" content="https://openmed.life/" />
     <meta property="og:site_name" content="OpenMed" />
     <meta property="og:image" content="https://openmed.life/og.png?v=20260425" />
@@ -34,7 +34,7 @@
     <meta name="twitter:creator" content="@MaziyarPanahi" />
     <meta name="twitter:title" content="OpenMed — Clinical AI that never leaves the device" />
     <meta name="twitter:description"
-        content="OpenMed 1.7.0 · policy-aware de-identification · signed audit reports · release gates · cardiology zero-shot labels · unified privacy routing · Swift-native OpenMedKit." />
+        content="OpenMed 1.7.0 · multimodal de-identification · OCR · FHIR/HL7 · signed audit evidence · Transformers.js browser export · Swift-native OpenMedKit." />
     <meta name="twitter:image" content="https://openmed.life/og.png?v=20260425" />
     <meta name="twitter:image:alt" content="OpenMed social preview showing local-first healthcare LLMs and an interactive clinical NER terminal." />
 
@@ -60,7 +60,7 @@
         "name": "OpenMed Clinical LLM Suite",
         "operatingSystem": "macOS, iOS, iPadOS, Cloud, On-Premises",
         "applicationCategory": "AIApplication",
-        "description": "OpenMed Clinical LLM Suite provides open-source healthcare language models, biomedical named-entity recognition, Python MLX acceleration, and Swift-native deployment toolkits for compliant medical workflows.",
+        "description": "OpenMed Clinical LLM Suite provides open-source healthcare language models, biomedical named-entity recognition, multimodal de-identification, Python MLX acceleration, browser Transformers.js export, and Swift-native deployment toolkits for compliant medical workflows.",
         "softwareVersion": "1.7.0",
         "url": "https://openmed.life/",
         "provider": { "@type": "Organization", "name": "OpenMed", "url": "https://openmed.life/" },
@@ -157,12 +157,12 @@
     <section id="home" class="hero bg-grid" data-screen>
         <div class="container hero-grid">
             <div>
-                <div class="eyebrow">OpenMed 1.7.0 · policy-aware de-identification · release gates</div>
+                <div class="eyebrow">OpenMed 1.7.0 · multimodal de-identification · browser export</div>
                 <h1 class="display-xl hero-title">
                     Clinical AI that never leaves the <span class="serif-italic">device</span>.
                 </h1>
                 <p class="body-lg hero-desc">
-                    1,000+ state-of-the-art healthcare LLM models, Nemotron Privacy Filter MLX, Faker-backed de-identification, PII across 15 supported languages (ar, de, en, es, fr, he, hi, id, it, ja, nl, pt, te, th, tr), and 25+ curated datasets — one local-first runtime story across Python MLX on Apple Silicon and Swift-native OpenMedKit.
+                    1,000+ state-of-the-art healthcare LLM models, Nemotron Privacy Filter MLX, OCR and multimodal redaction, FHIR/HL7 helpers, PII across 15 supported PII language codes: ar, de, en, es, fr, he, hi, id, it, ja, nl, pt, te, th, and tr, plus browser token classification through Transformers.js/WebGPU.
                 </p>
 
                 <div class="hero-ctas">
@@ -198,7 +198,7 @@
                         <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                             <path d="M4 12c0-4 3-7 8-7s8 3 8 7-3 7-8 7-8-3-8-7zm4-1a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm8 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zM9 14c.8 1.1 2 1.7 3 1.7s2.2-.6 3-1.7" />
                         </svg>
-                        1,000+ models
+                        Browser WebGPU
                     </span>
                     <span>·</span>
                     <span class="pip">
@@ -274,8 +274,8 @@
                     <div class="statband-label">PII Entities</div>
                 </div>
                 <div class="statband-cell">
-                    <div class="statband-num">12</div>
-                    <div class="statband-label">Languages</div>
+                    <div class="statband-num">15</div>
+                    <div class="statband-label">PII Languages</div>
                 </div>
                 <div class="statband-cell">
                     <div class="statband-num">&lt;1.2kg</div>
@@ -372,10 +372,10 @@
             <div class="section-head">
                 <div class="eyebrow">The runtime story</div>
                 <h2 class="display-lg" style="max-width:20ch">
-                    One <span class="serif-italic">MLX</span> story across Python and Swift.
+                    One local-first story across Python, Swift, REST, and browser.
                 </h2>
                 <p class="body-lg" style="max-width:62ch;margin-top:16px">
-                    Prototype with Python MLX on Apple Silicon, then ship the same local-first PII and clinical LLM experience inside native Swift apps with OpenMedKit — same artifacts, same behavior.
+                    Prototype with Python MLX on Apple Silicon, ship native Swift apps with OpenMedKit, expose typed REST clients, or package ONNX/WebGPU artifacts for in-browser token classification through Transformers.js.
                 </p>
             </div>
 
@@ -418,12 +418,12 @@
                             <line x1="4" y1="21" x2="20" y2="21" />
                         </svg>
                     </div>
-                    <div class="eyebrow muted">Shared MLX artifacts</div>
-                    <h3 class="heading-md">Move from notebooks to native apps with less friction</h3>
+                    <div class="eyebrow muted">Browser / WebGPU</div>
+                    <h3 class="heading-md">Run token classification in the browser</h3>
                     <p class="body-sm">
-                        The same MLX artifacts power the Python and Swift paths — including <span class="code-inline">OpenMed/privacy-filter-nemotron-mlx</span> and the 8-bit variant — so you can prototype in a notebook, then ship the identical model into a native app without a second packaging track.
+                        Export ONNX token-classification artifacts into the <span class="code-inline">transformersjs/</span> layout and load them with Transformers.js for WebGPU-backed browser inference.
                     </p>
-                    <a class="link-arrow" href="docs/mlx-backend/#mlx-and-swift-apps">See the shared artifact story →</a>
+                    <a class="link-arrow" href="docs/export-transformersjs/">Read the Transformers.js export guide →</a>
                 </div>
             </div>
         </div>
@@ -440,7 +440,7 @@
                     Clinical text de-identification, built for <span class="serif-italic">HIPAA &amp; GDPR</span>.
                 </h2>
                 <p class="body-lg" style="max-width:62ch;margin-top:16px">
-                    Language-aware PII models across 13 supported languages. Process data locally — your PHI never leaves your environment.
+                    Language-aware PII models across 15 supported PII language codes: ar, de, en, es, fr, he, hi, id, it, ja, nl, pt, te, th, and tr. Process data locally — your PHI never leaves your environment.
                 </p>
             </div>
 

--- a/examples/v16_policy_audit_release_gates.py
+++ b/examples/v16_policy_audit_release_gates.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""v1.6 policy, audit, risk, and release-evidence walkthrough.
+
+This example is intentionally synthetic and offline-friendly. It constructs a
+small de-identification result directly so reviewers can inspect the v1.6
+contracts without downloading a model on first run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+logging.getLogger("openmed.core.models").setLevel(logging.ERROR)
+
+from openmed.core.audit import (
+    AuditReport,
+    AuditSpan,
+    DetectorInfo,
+    hash_text,
+    manifest_hash,
+    verify_repro_hash,
+)
+from openmed.core.labels import PERSON, PHONE
+from openmed.core.pii import DeidentificationResult, PIIEntity
+from openmed.core.policy import list_policies, load_policy
+from openmed.core.redaction_preview import redaction_preview
+from openmed.core.redaction_strength import select_minimum_necessary
+from openmed.core.schemas.span import OpenMedSpan, hmac_text_hash
+from openmed.eval.leakage_heatmap import compute_leakage_heatmap
+from openmed.risk.kanon import kanon_report
+
+SYNTHETIC_TEXT = "Patient Casey Example called 212-555-0198 about metformin follow-up."
+DEIDENTIFIED_TEXT = "Patient [PERSON] called [PHONE] about metformin follow-up."
+AUDIT_KEY = "example-release-key-not-for-production"
+SPAN_HASH_KEY = "example-span-hmac-key-not-for-production"
+
+
+def _span(text: str, value: str) -> tuple[int, int]:
+    start = text.index(value)
+    return start, start + len(value)
+
+
+def build_result() -> DeidentificationResult:
+    """Build a representative v1.6 de-identification result."""
+    person_start, person_end = _span(SYNTHETIC_TEXT, "Casey Example")
+    phone_start, phone_end = _span(SYNTHETIC_TEXT, "212-555-0198")
+    return DeidentificationResult(
+        original_text=SYNTHETIC_TEXT,
+        deidentified_text=DEIDENTIFIED_TEXT,
+        pii_entities=[
+            PIIEntity(
+                text="Casey Example",
+                label=PERSON,
+                start=person_start,
+                end=person_end,
+                confidence=0.99,
+                redacted_text="[PERSON]",
+                canonical_label=PERSON,
+                sources=["model", "safety_sweep"],
+                threshold=0.7,
+                action="mask",
+            ),
+            PIIEntity(
+                text="212-555-0198",
+                label=PHONE,
+                start=phone_start,
+                end=phone_end,
+                confidence=1.0,
+                redacted_text="[PHONE]",
+                canonical_label=PHONE,
+                sources=["safety_sweep"],
+                threshold=0.7,
+                action="mask",
+            ),
+        ],
+        method="mask",
+        timestamp=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        mapping={"[PERSON]": "Casey Example", "[PHONE]": "212-555-0198"},
+        metadata={"policy": "hipaa_safe_harbor", "example": "v1.6"},
+    )
+
+
+def build_audit_report(result: DeidentificationResult) -> AuditReport:
+    """Build and sign a deterministic audit report for the synthetic result."""
+    profile = load_policy("hipaa_safe_harbor")
+    spans = [
+        AuditSpan(
+            start=entity.start or 0,
+            end=entity.end or 0,
+            label=entity.label,
+            canonical_label=entity.canonical_label or entity.label,
+            sources=list(entity.sources),
+            confidence=entity.confidence,
+            threshold=entity.threshold or 0.0,
+            action=entity.action or result.method,
+            surrogate=entity.redacted_text,
+            text_hash=hash_text(entity.text),
+            evidence=entity.evidence,
+            context={},
+        )
+        for entity in result.pii_entities
+    ]
+    report = AuditReport(
+        policy=profile.name,
+        resolved_profile=profile.to_dict(),
+        detectors=[
+            DetectorInfo(
+                source="example",
+                model_id="synthetic-offline-detector",
+                model_format="fixture",
+            )
+        ],
+        safety_sweep={"enabled": True, "matches": 1},
+        spans=spans,
+        thresholds={PERSON: 0.7, PHONE: 0.7},
+        residual_risk={"critical_leakage": 0, "review_required": False},
+        openmed_version="1.6.0+example",
+        manifest_hash=manifest_hash(),
+        document_length=len(result.original_text),
+        input_hash=hash_text(result.original_text),
+        deidentified_text_hash=hash_text(result.deidentified_text),
+    )
+    return report.sign(AUDIT_KEY, key_id="local-demo")
+
+
+def build_span_contract(result: DeidentificationResult) -> OpenMedSpan:
+    """Show the canonical span schema used by the policy pipeline."""
+    entity = result.pii_entities[0]
+    return OpenMedSpan(
+        doc_id="synthetic-note-001",
+        start=entity.start or 0,
+        end=entity.end or 0,
+        text_hash=hmac_text_hash(entity.text, SPAN_HASH_KEY),
+        entity_type=entity.label,
+        canonical_label=entity.canonical_label or entity.label,
+        score=entity.confidence,
+        detector="synthetic-offline-detector",
+        action=entity.action or "mask",
+        replacement=entity.redacted_text,
+        section="assessment",
+    )
+
+
+def build_release_evidence_summary() -> dict[str, Any]:
+    """Compute small release-evidence metrics from synthetic spans/records."""
+    name_start, name_end = _span(SYNTHETIC_TEXT, "Casey Example")
+    phone_start, phone_end = _span(SYNTHETIC_TEXT, "212-555-0198")
+    gold = [
+        {"start": name_start, "end": name_end, "label": PERSON, "lang": "en"},
+        {"start": phone_start, "end": phone_end, "label": PHONE, "lang": "en"},
+    ]
+    predicted = [
+        {"start": name_start, "end": name_start + 6, "label": PERSON, "lang": "en"},
+        {"start": phone_start, "end": phone_end, "label": PHONE, "lang": "en"},
+    ]
+    heatmap = compute_leakage_heatmap(gold, predicted, source_text=SYNTHETIC_TEXT)
+    kanon = kanon_report(
+        [
+            {"age_band": "40-49", "zip3": "100", "condition": "diabetes"},
+            {"age_band": "40-49", "zip3": "100", "condition": "diabetes"},
+            {"age_band": "50-59", "zip3": "941", "condition": "asthma"},
+        ],
+        quasi_identifiers=["age_band", "zip3"],
+        sensitive_attributes=["condition"],
+    )
+    return {
+        "leakage_total": heatmap.total.to_dict(),
+        "worst_leakage_cells": [cell.to_dict() for cell in heatmap.worst_cells],
+        "kanon": {
+            "k": kanon["k"],
+            "class_count": kanon["class_count"],
+            "quasi_identifiers": kanon["quasi_identifiers"],
+        },
+    }
+
+
+def main() -> None:
+    result = build_result()
+    report = build_audit_report(result)
+    minimum_profile = select_minimum_necessary(
+        "clinical_minimal_redaction",
+        target_posture="hipaa_safe_harbor",
+        risk_level_by_label={PERSON: "high", PHONE: "high"},
+        name="example_minimum_necessary",
+    )
+    payload = {
+        "policies_available": list(list_policies()),
+        "preview": redaction_preview(SYNTHETIC_TEXT, result),
+        "audit": {
+            "repro_hash": report.repro_hash,
+            "signature_key_id": report.signature.key_id if report.signature else None,
+            "signature_verified": report.verify(
+                AUDIT_KEY,
+                original_text=result.original_text,
+                deidentified_text=result.deidentified_text,
+            ),
+            "repro_hash_verified": verify_repro_hash(report),
+            "review_bundle": report.export_review_bundle(),
+        },
+        "span_contract": build_span_contract(result).to_dict(),
+        "minimum_necessary": {
+            "name": minimum_profile.name,
+            "comparison_to_base": minimum_profile.metadata["minimum_necessary"][
+                "comparison_to_base"
+            ],
+            "person_action": minimum_profile.action_for(PERSON),
+            "phone_action": minimum_profile.action_for(PHONE),
+        },
+        "release_evidence": build_release_evidence_summary(),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/v17_multimodal_browser_interop.py
+++ b/examples/v17_multimodal_browser_interop.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""v1.7 multimodal, interop, and browser-export walkthrough.
+
+All inputs are synthetic. The example injects a tiny local redactor so it can
+exercise the public APIs without model downloads or network calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from typing import Any
+
+logging.getLogger("openmed.core.models").setLevel(logging.ERROR)
+
+from openmed.clinical.exporters.fhir import to_bundle, to_operation_outcome
+from openmed.interop.fhir_bulk import deidentify_ndjson
+from openmed.interop.fhir_operations import de_identify_resource
+from openmed.interop.hl7v2 import redact_hl7v2
+from openmed.multimodal import (
+    FakeOcrEngine,
+    OcrWord,
+    available_ocr_engines,
+    extract_asciidoc,
+    redact_chatlog_jsonl,
+    redact_source_text,
+    redact_table,
+)
+from openmed.multimodal.ocr import ocr
+from openmed.onnx.transformersjs import find_missing_bundle_files
+
+ASCII_DOC_NOTE = """= Synthetic Handoff
+
+Patient:: Casey Example
+MRN:: MRN-12345
+Assessment:: Diabetes follow-up, BP 128/76.
+"""
+
+CHAT_JSONL = """\
+{"conversation_id":"demo-1","messages":[{"role":"user","name":"casey","content":"My name is Casey Example and my phone is 212-555-0198."}]}
+"""
+
+CSV_TEXT = """\
+patient_name,mrn,dob,note
+Casey Example,MRN-12345,1975-04-03,Call 212-555-0198 before discharge
+"""
+
+FHIR_PATIENT = {
+    "resourceType": "Patient",
+    "id": "synthetic-patient",
+    "name": [{"text": "Casey Example"}],
+    "telecom": [{"system": "phone", "value": "212-555-0198"}],
+}
+
+HL7_MESSAGE = (
+    "\r".join(
+        [
+            "MSH|^~\\&|OPENMED|LAB|EHR|HOSP|202607010900||ADT^A01|MSG1|P|2.5",
+            "PID|1||MRN-12345||Example^Casey||19750403|F|||1 Main St^^Boston^MA",
+            "OBX|1|TX|NOTE||Call Casey Example at 212-555-0198 before discharge",
+        ]
+    )
+    + "\r"
+)
+
+BROWSER_PIPELINE_SNIPPET = """\
+import { pipeline } from "@huggingface/transformers";
+
+const detector = await pipeline(
+  "token-classification",
+  "/models/openmed-pii/transformersjs",
+  { device: "webgpu" },
+);
+const entities = await detector("Patient Casey Example called 212-555-0198.");
+"""
+
+
+def redact_text(text: str) -> str:
+    """Small deterministic redactor for this synthetic example."""
+    return (
+        text.replace("Casey Example", "[PERSON]")
+        .replace("Example^Casey", "[PERSON]")
+        .replace("casey", "speaker_1")
+        .replace("212-555-0198", "[PHONE]")
+        .replace("MRN-12345", "ID_HASH_6b1d")
+        .replace("1975-04-03", "1975-04-10")
+    )
+
+
+def deidentifier(text: str, **_: Any) -> SimpleNamespace:
+    """FHIR/HL7-compatible deidentifier object."""
+    return SimpleNamespace(deidentified_text=redact_text(text))
+
+
+def run_markup_example() -> dict[str, Any]:
+    """Extract AsciiDoc text and project normalized redaction to source text."""
+    document = extract_asciidoc(ASCII_DOC_NOTE)
+    start = document.text.index("Casey Example")
+    redacted_source = redact_source_text(
+        document,
+        [(start, start + len("Casey Example"), "[PERSON]")],
+    )
+    return {
+        "format": document.metadata["format"],
+        "span_count": len(document.spans),
+        "redacted_source": redacted_source,
+    }
+
+
+def run_ocr_example() -> dict[str, Any]:
+    """Run the shared OCR contract through the deterministic fake engine."""
+    engine = FakeOcrEngine(
+        [
+            OcrWord("Patient", (10.0, 20.0, 70.0, 35.0), 0.98),
+            OcrWord("Casey", (80.0, 20.0, 125.0, 35.0), 0.97),
+            OcrWord("Example", (130.0, 20.0, 190.0, 35.0), 0.97),
+        ],
+        source="synthetic-image",
+    )
+    result = ocr("synthetic-image-bytes", engine=engine, languages=["en", "fr"])
+    document = result.to_document()
+    return {
+        "available_engines": list(available_ocr_engines()),
+        "selected_languages": engine.last_languages,
+        "text": result.text,
+        "first_word_bbox": document.spans[0].bbox,
+    }
+
+
+def run_chat_and_table_examples() -> dict[str, Any]:
+    """Redact chat JSONL and CSV/TSV-like tabular data."""
+    chat = redact_chatlog_jsonl(
+        CHAT_JSONL,
+        text_redactor=redact_text,
+        pseudonymize_speakers=True,
+    )
+    table = redact_table(
+        CSV_TEXT,
+        text_redactor=redact_text,
+        date_shift_days=7,
+    )
+    return {
+        "chat_summary": chat.summary.to_dict(),
+        "chat_text": chat.text,
+        "table_manifest": list(table.manifest),
+        "table_text": table.text,
+    }
+
+
+def run_fhir_and_hl7_examples(tmp_dir: Path) -> dict[str, Any]:
+    """Run FHIR resource, FHIR Bulk NDJSON, Bundle, and HL7 v2 paths."""
+    resource = de_identify_resource(FHIR_PATIENT, deidentifier=deidentifier)
+    ndjson_in = tmp_dir / "Patient.ndjson"
+    ndjson_out = tmp_dir / "out" / "Patient.ndjson"
+    ndjson_in.write_text(json.dumps(FHIR_PATIENT) + "\n", encoding="utf-8")
+    summary = deidentify_ndjson(
+        ndjson_in,
+        ndjson_out,
+        deidentifier=deidentifier,
+    )
+    bundle = to_bundle(
+        [
+            resource,
+            {
+                "resourceType": "Observation",
+                "id": "bp-1",
+                "status": "final",
+                "subject": {"reference": "Patient/synthetic-patient"},
+                "code": {"text": "Blood pressure"},
+                "valueString": "BP 128/76",
+            },
+        ],
+        doc_id="synthetic-fhir-example",
+    )
+    outcome = to_operation_outcome(
+        [
+            {
+                "severity": "information",
+                "code": "informational",
+                "diagnostics": "Synthetic de-identification completed.",
+                "expression": "Patient.name",
+            }
+        ]
+    )
+    hl7 = redact_hl7v2(
+        HL7_MESSAGE,
+        deidentifier=deidentifier,
+        date_shift_days=7,
+    )
+    return {
+        "resource": resource,
+        "bulk_summary": asdict(summary),
+        "bulk_text": ndjson_out.read_text(encoding="utf-8").strip(),
+        "bundle_type": bundle["type"],
+        "bundle_entry_count": len(bundle["entry"]),
+        "operation_outcome": outcome,
+        "hl7": hl7,
+    }
+
+
+def run_transformersjs_example(tmp_dir: Path) -> dict[str, Any]:
+    """Show the browser bundle contract and the client-side load snippet."""
+    bundle_dir = tmp_dir / "transformersjs"
+    bundle_dir.mkdir()
+    missing = find_missing_bundle_files(bundle_dir)
+    return {
+        "expected_bundle_files": missing,
+        "browser_pipeline_snippet": BROWSER_PIPELINE_SNIPPET,
+    }
+
+
+def main() -> None:
+    with TemporaryDirectory() as temp_dir:
+        tmp_dir = Path(temp_dir)
+        payload = {
+            "markup": run_markup_example(),
+            "ocr": run_ocr_example(),
+            "chat_and_table": run_chat_and_table_examples(),
+            "fhir_and_hl7": run_fhir_and_hl7_examples(tmp_dir),
+            "transformersjs": run_transformersjs_example(tmp_dir),
+        }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Overview:
       - Welcome: index.md
       - Feature Map: feature-map.md
+      - v1.6-v1.7 Feature Coverage: release/v1.6-v1.7-feature-coverage.md
       - Quick Start: getting-started.md
   - Core Guides:
       - Analyze Text Helper: analyze-text.md


### PR DESCRIPTION
# Pull Request

## Description

Adds v1.6 and v1.7 feature coverage across runnable examples, README, docs, and the static website. The update highlights policy-aware de-identification, audit/release evidence, multimodal and structured inputs, FHIR/HL7 interoperability, and browser/WebGPU use through Transformers.js.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test addition/improvement
- [ ] CI/CD changes

## Changes Made

- Added a synthetic v1.6 example for policy profiles, canonical spans, signed audit reports, review bundles, release gates, redaction previews, leakage heatmaps, and k-anonymity.
- Added a synthetic v1.7 example for AsciiDoc offsets, OCR contracts, JSONL chat, CSV manifests, FHIR `$de-identify`, FHIR Bulk NDJSON, HL7v2 redaction, and Transformers.js browser bundle expectations.
- Added a v1.6/v1.7 release coverage page and linked it from the docs navigation.
- Updated README, docs overview, examples, feature map, Transformers.js export docs, and website copy for the current v1.7 surface.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:

```bash
uv run --extra dev ruff check examples/v16_policy_audit_release_gates.py examples/v17_multimodal_browser_interop.py
uv run --extra dev ruff format --check examples/v16_policy_audit_release_gates.py examples/v17_multimodal_browser_interop.py
uv run python examples/v16_policy_audit_release_gates.py
uv run python examples/v17_multimodal_browser_interop.py
uv run --extra docs mkdocs build --strict
uv run --extra dev pytest tests/unit/core/test_supported_languages_source_of_truth.py -q
uv run python scripts/release/check_repo_policy.py
git diff --cached --check
```

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to any new functions/classes
- [ ] I have updated the CHANGELOG.md if applicable

## Code Quality

- [ ] I have run `make format` to format the code
- [ ] I have run `make lint` to check for linting issues
- [ ] I have run `make format-check` to verify formatting
- [ ] I have run `make format-swift` and `make lint-swift` if touching Swift code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies

- [x] No new dependencies added
- [ ] New dependencies added (explain below)

No dependency changes.

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit message follows the project's conventions
- [x] I have added/updated tests as needed
- [x] I have updated documentation as needed
- [x] My changes are covered by existing or new tests
- [x] I have checked that my changes don't break existing functionality

## Related Issues

None.

## Screenshots/Examples

New example entry points:

```bash
uv run python examples/v16_policy_audit_release_gates.py
uv run python examples/v17_multimodal_browser_interop.py
```
