### PR TITLE
Convert Android ONNX models to ORT mobile format with a minimal-build op config

### DIFF
--- a/docs/export-onnx-android.md
+++ b/docs/export-onnx-android.md
@@ -10,12 +10,16 @@ Mobile with the `android` ONNX profile:
   --profile android
 ```
 
-The profile writes two ONNX graphs:
+The profile writes two ONNX graphs and, when ONNX Runtime's ORT conversion
+tooling is installed, an ORT mobile artifact plus the minimal-build operator
+configuration:
 
 ```text
 dist/example-android-onnx/
   model.onnx
   model_fp16.onnx
+  model.ort
+  model.required_operators_and_types.config
   config.json
   id2label.json
   openmed-onnx.json
@@ -23,6 +27,13 @@ dist/example-android-onnx/
 
 `model.onnx` is the fp32 graph. `model_fp16.onnx` stores fp16 weights while
 keeping public input and output tensor types stable for Android callers.
+`model.ort` is the ORT mobile-format model generated from `model.onnx`.
+`model.required_operators_and_types.config` is the required-operators/types
+file to pass into an ONNX Runtime Android minimal build.
+
+If the optional ONNX Runtime conversion tooling is not available, export still
+finishes with the `.onnx` artifacts and logs a dependency-only skip reason. The
+message does not include source model text or sample input content.
 
 ## Graph Contract
 
@@ -42,15 +53,32 @@ configuration need a predictable graph contract. The dynamic `batch` and
 `sequence` axes are retained so one exported artifact can serve variable
 request batches and note lengths on device.
 
+## ORT Mobile Minimal Build
+
+The ORT mobile step uses ONNX Runtime's Python conversion tool with the fixed
+optimization style, Android ARM target platform, and type reduction enabled.
+The resulting `model.required_operators_and_types.config` can be passed to the
+ONNX Runtime build as the include-ops config, for example:
+
+```bash
+./build.sh \
+  --android \
+  --minimal_build \
+  --include_ops_by_config dist/example-android-onnx/model.required_operators_and_types.config
+```
+
+Building the actual Android AAR is a separate Android-module task; this export
+only writes the model and operator/type configuration consumed by that build.
+
 ## Mobile Compatibility Metadata
 
 `openmed-onnx.json` records the Android artifacts with the format string
-`onnx-android`. Each artifact entry includes profile metadata with the opset,
-tensor contract, execution-provider hints (`NNAPI`, `XNNPACK`), graph
-operators, and any operators that are outside OpenMed's Android mobile safe
-set.
+`onnx-android`. When ORT conversion succeeds, the manifest also records an
+`ort-android` artifact. Its metadata includes the `model.ort` path, the
+required-operators/types config path, the fixed optimization style, Android ARM
+target platform, type-reduction status, opset, and graph operators.
 
 Unsupported operators are reported as warnings and recorded in artifact
 metadata. The converter does not delete, rewrite, or silently drop graph nodes;
-the warnings are used by the later `.ort` and Android runtime tasks to decide
-whether a model needs a fallback or exporter adjustment.
+the warnings are used by the Android runtime tasks to decide whether a model
+needs a fallback or exporter adjustment.

--- a/openmed/onnx/__init__.py
+++ b/openmed/onnx/__init__.py
@@ -12,7 +12,10 @@ __all__ = [
     "AndroidProfileValidation",
     "ExportArtifact",
     "OnnxConversionResult",
+    "ORT_ANDROID_FORMAT",
+    "OrtMobileConversionResult",
     "convert",
+    "convert_android_onnx_to_ort",
     "export_android_fp16",
     "export_onnx",
     "export_transformersjs_bundle",
@@ -35,6 +38,13 @@ def __getattr__(name: str) -> Any:
             return getattr(module, name)
         if name.startswith(("export_transformersjs", "validate_transformersjs")):
             module = import_module("openmed.onnx.transformersjs")
+            return getattr(module, name)
+        if (
+            name.startswith("ORT_")
+            or name.startswith("OrtMobile")
+            or name == "convert_android_onnx_to_ort"
+        ):
+            module = import_module("openmed.onnx.ort_mobile")
             return getattr(module, name)
         module = import_module("openmed.onnx.convert")
         return getattr(module, name)

--- a/openmed/onnx/convert.py
+++ b/openmed/onnx/convert.py
@@ -28,6 +28,10 @@ from openmed.onnx.android_profile import (
     export_android_fp16,
     validate_android_profile,
 )
+from openmed.onnx.ort_mobile import (
+    ORT_ANDROID_FORMAT,
+    convert_android_onnx_to_ort,
+)
 from openmed.onnx.transformersjs import (
     DEFAULT_BUNDLE_DIRNAME,
     TRANSFORMERSJS_FORMAT,
@@ -266,6 +270,20 @@ def convert(
                 metadata=android_fp16_validation.to_metadata(),
             ),
         ]
+        ort_result = convert_android_onnx_to_ort(
+            onnx_path,
+            output_dir=output_dir,
+            validation=android_validation,
+        )
+        if not ort_result.skipped and ort_result.ort_path is not None:
+            artifacts.append(
+                ExportArtifact(
+                    format=ORT_ANDROID_FORMAT,
+                    path=ort_result.ort_path,
+                    precision="float32",
+                    metadata=ort_result.to_metadata(output_dir),
+                )
+            )
     else:
         artifacts = [
             ExportArtifact(format="onnx", path=onnx_path, precision="float32"),

--- a/openmed/onnx/ort_mobile.py
+++ b/openmed/onnx/ort_mobile.py
@@ -1,0 +1,148 @@
+"""ONNX Runtime Mobile conversion helpers for Android ONNX artifacts."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openmed.onnx.android_profile import (
+    ANDROID_PROFILE_NAME,
+    AndroidProfileValidation,
+    validate_android_profile,
+)
+
+logger = logging.getLogger(__name__)
+
+ORT_ANDROID_FORMAT = "ort-android"
+ORT_MODEL_FILENAME = "model.ort"
+ORT_REQUIRED_OPERATORS_CONFIG_FILENAME = "model.required_operators_and_types.config"
+ORT_REQUIRED_OPERATORS_CONFIG_TYPE = "required_operators_and_types"
+ORT_OPTIMIZATION_STYLE = "Fixed"
+ORT_TARGET_PLATFORM = "arm"
+ORT_CONVERSION_UNAVAILABLE_REASON = (
+    "ONNX Runtime ORT mobile conversion tooling is unavailable; install the "
+    "onnx extra with `pip install openmed[onnx]` to emit .ort artifacts."
+)
+
+
+class OrtMobileConversionUnavailable(ImportError):
+    """Raised when optional ONNX Runtime mobile conversion tooling is missing."""
+
+
+@dataclass(frozen=True)
+class OrtMobileConversionResult:
+    """Paths and metadata from an Android ORT mobile conversion attempt."""
+
+    source_onnx_path: Path
+    ort_path: Path | None = None
+    op_config_path: Path | None = None
+    validation: AndroidProfileValidation | None = None
+    skipped: bool = False
+    skip_reason: str | None = None
+
+    def to_metadata(self, root: Path) -> dict[str, Any]:
+        """Return JSON-serializable manifest metadata for an ORT artifact."""
+
+        metadata: dict[str, Any] = {
+            "format": ORT_ANDROID_FORMAT,
+            "profile": ANDROID_PROFILE_NAME,
+            "source_onnx_path": _relative_manifest_path(self.source_onnx_path, root),
+            "optimization_style": ORT_OPTIMIZATION_STYLE,
+            "target_platform": ORT_TARGET_PLATFORM,
+            "op_config_type": ORT_REQUIRED_OPERATORS_CONFIG_TYPE,
+            "enable_type_reduction": True,
+        }
+        if self.ort_path is not None:
+            metadata["ort_path"] = _relative_manifest_path(self.ort_path, root)
+        if self.op_config_path is not None:
+            metadata["op_config_path"] = _relative_manifest_path(
+                self.op_config_path,
+                root,
+            )
+        if self.validation is not None:
+            metadata["operators"] = list(self.validation.operators)
+            metadata["opset"] = self.validation.opset
+        return metadata
+
+
+def convert_android_onnx_to_ort(
+    onnx_path: str | Path,
+    *,
+    output_dir: str | Path | None = None,
+    validation: AndroidProfileValidation | None = None,
+) -> OrtMobileConversionResult:
+    """Convert an Android-profile ONNX model into ORT mobile format."""
+
+    source_path = Path(onnx_path)
+    artifact_dir = Path(output_dir) if output_dir is not None else source_path.parent
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        ort_tools = _load_ort_tools()
+    except OrtMobileConversionUnavailable as exc:
+        reason = str(exc)
+        logger.info("Skipping Android ORT mobile conversion: %s", reason)
+        return OrtMobileConversionResult(
+            source_onnx_path=source_path,
+            skipped=True,
+            skip_reason=reason,
+        )
+
+    validation = validation or validate_android_profile(source_path)
+    fixed_style = getattr(ort_tools.OptimizationStyle, ORT_OPTIMIZATION_STYLE)
+    ort_tools.convert_onnx_models_to_ort(
+        source_path,
+        output_dir=artifact_dir,
+        optimization_styles=[fixed_style],
+        target_platform=ORT_TARGET_PLATFORM,
+        save_optimized_onnx_model=False,
+        allow_conversion_failures=False,
+        enable_type_reduction=True,
+    )
+
+    ort_path = artifact_dir / source_path.with_suffix(".ort").name
+    op_config_path = artifact_dir / (
+        source_path.stem + ".required_operators_and_types.config"
+    )
+    _require_generated_file(ort_path, "ORT mobile model")
+    _require_generated_file(op_config_path, "ORT required-operators config")
+
+    return OrtMobileConversionResult(
+        source_onnx_path=source_path,
+        ort_path=ort_path,
+        op_config_path=op_config_path,
+        validation=validation,
+    )
+
+
+def _load_ort_tools() -> Any:
+    try:
+        from onnxruntime.tools import convert_onnx_models_to_ort as ort_tools
+    except ImportError as exc:
+        raise OrtMobileConversionUnavailable(ORT_CONVERSION_UNAVAILABLE_REASON) from exc
+
+    required = (
+        "OptimizationStyle",
+        "convert_onnx_models_to_ort",
+    )
+    if any(not hasattr(ort_tools, name) for name in required):
+        raise OrtMobileConversionUnavailable(ORT_CONVERSION_UNAVAILABLE_REASON)
+    if not hasattr(ort_tools.OptimizationStyle, ORT_OPTIMIZATION_STYLE):
+        raise OrtMobileConversionUnavailable(ORT_CONVERSION_UNAVAILABLE_REASON)
+    return ort_tools
+
+
+def _require_generated_file(path: Path, description: str) -> None:
+    if not path.is_file():
+        raise RuntimeError(f"ONNX Runtime did not produce the {description}: {path}")
+
+
+def _relative_manifest_path(path: Path, root: Path) -> str:
+    path = path.resolve()
+    root = root.resolve()
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()

--- a/tests/unit/onnx/test_android_onnx_profile.py
+++ b/tests/unit/onnx/test_android_onnx_profile.py
@@ -181,6 +181,15 @@ def test_convert_android_profile_records_fp32_fp16_artifacts_and_metadata(
     monkeypatch.setattr(
         module, "validate_android_profile", fake_validate_android_profile
     )
+    monkeypatch.setattr(
+        module,
+        "convert_android_onnx_to_ort",
+        lambda *args, **kwargs: types.SimpleNamespace(
+            skipped=True,
+            ort_path=None,
+            skip_reason="tooling unavailable",
+        ),
+    )
     monkeypatch.setattr(module, "save_source_assets", fake_save_source_assets)
     monkeypatch.setattr(
         module,

--- a/tests/unit/onnx/test_ort_mobile_conversion.py
+++ b/tests/unit/onnx/test_ort_mobile_conversion.py
@@ -1,0 +1,247 @@
+"""Tests for Android ONNX Runtime Mobile conversion artifacts."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _convert_module():
+    return importlib.import_module("openmed.onnx.convert")
+
+
+def _ort_module():
+    return importlib.import_module("openmed.onnx.ort_mobile")
+
+
+def test_convert_android_onnx_to_ort_writes_model_and_op_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _ort_module()
+    onnx_path = tmp_path / "model.onnx"
+    onnx_path.write_bytes(b"onnx")
+    validation = types.SimpleNamespace(operators=("Add", "MatMul"), opset=18)
+
+    def fake_convert_onnx_models_to_ort(
+        model_path_or_dir,
+        *,
+        output_dir=None,
+        optimization_styles=None,
+        target_platform=None,
+        save_optimized_onnx_model=True,
+        allow_conversion_failures=True,
+        enable_type_reduction=False,
+    ):
+        assert model_path_or_dir == onnx_path
+        assert output_dir == tmp_path
+        assert optimization_styles == ["Fixed"]
+        assert target_platform == "arm"
+        assert save_optimized_onnx_model is False
+        assert allow_conversion_failures is False
+        assert enable_type_reduction is True
+        (tmp_path / "model.ort").write_bytes(b"ort")
+        (tmp_path / "model.required_operators_and_types.config").write_text(
+            ";18;Add,MatMul\n",
+            encoding="utf-8",
+        )
+
+    fake_tools = types.SimpleNamespace(
+        OptimizationStyle=types.SimpleNamespace(Fixed="Fixed"),
+        convert_onnx_models_to_ort=fake_convert_onnx_models_to_ort,
+    )
+    monkeypatch.setattr(module, "_load_ort_tools", lambda: fake_tools)
+
+    result = module.convert_android_onnx_to_ort(
+        onnx_path,
+        output_dir=tmp_path,
+        validation=validation,
+    )
+
+    assert result.skipped is False
+    assert result.ort_path == tmp_path / "model.ort"
+    assert (
+        result.op_config_path == tmp_path / "model.required_operators_and_types.config"
+    )
+    assert result.ort_path.exists()
+    op_config = result.op_config_path.read_text(encoding="utf-8")
+    assert "Add" in op_config
+    assert "MatMul" in op_config
+    assert result.to_metadata(tmp_path) == {
+        "format": "ort-android",
+        "profile": "android",
+        "source_onnx_path": "model.onnx",
+        "optimization_style": "Fixed",
+        "target_platform": "arm",
+        "op_config_type": "required_operators_and_types",
+        "enable_type_reduction": True,
+        "ort_path": "model.ort",
+        "op_config_path": "model.required_operators_and_types.config",
+        "operators": ["Add", "MatMul"],
+        "opset": 18,
+    }
+
+
+def test_convert_android_profile_records_ort_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _convert_module()
+    ort_module = _ort_module()
+
+    def fake_export_onnx(model_id, output_path, **kwargs):
+        path = Path(output_path)
+        path.write_bytes(b"onnx")
+        return path
+
+    def fake_export_android_fp16(onnx_path, output_path, **kwargs):
+        path = Path(output_path)
+        path.write_bytes(b"fp16")
+        return path
+
+    validation = types.SimpleNamespace(
+        operators=("Add", "MatMul"),
+        opset=module.ANDROID_ONNX_OPSET,
+        to_metadata=lambda: {
+            "profile": "android",
+            "opset": module.ANDROID_ONNX_OPSET,
+            "inputs": [],
+            "outputs": [],
+            "operators": ["Add", "MatMul"],
+            "unsupported_ops": [],
+            "warnings": [],
+        },
+    )
+
+    def fake_save_source_assets(model_id, output_dir, **kwargs):
+        output_dir = Path(output_dir)
+        config = {
+            "model_type": "bert",
+            "id2label": {"0": "O"},
+            "max_sequence_length": kwargs["max_seq_length"],
+        }
+        (output_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        (output_dir / "id2label.json").write_text('{"0": "O"}', encoding="utf-8")
+        return config, []
+
+    def fake_convert_onnx_models_to_ort(*args, output_dir=None, **kwargs):
+        assert kwargs["enable_type_reduction"] is True
+        output_dir = Path(output_dir)
+        (output_dir / "model.ort").write_bytes(b"ort")
+        (output_dir / "model.required_operators_and_types.config").write_text(
+            ";18;Add,MatMul\n",
+            encoding="utf-8",
+        )
+
+    fake_tools = types.SimpleNamespace(
+        OptimizationStyle=types.SimpleNamespace(Fixed="Fixed"),
+        convert_onnx_models_to_ort=fake_convert_onnx_models_to_ort,
+    )
+
+    monkeypatch.setattr(module, "export_onnx", fake_export_onnx)
+    monkeypatch.setattr(module, "export_android_fp16", fake_export_android_fp16)
+    monkeypatch.setattr(module, "validate_android_profile", lambda *args: validation)
+    monkeypatch.setattr(module, "save_source_assets", fake_save_source_assets)
+    monkeypatch.setattr(ort_module, "_load_ort_tools", lambda: fake_tools)
+
+    result = module.convert(
+        "OpenMed/test-model", tmp_path / "artifact", profile="android"
+    )
+
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert result.formats == ["onnx-android", "ort-android"]
+    assert [item["path"] for item in manifest["artifacts"]] == [
+        "model.onnx",
+        "model_fp16.onnx",
+        "model.ort",
+    ]
+    ort_artifact = manifest["artifacts"][2]
+    assert ort_artifact["format"] == "ort-android"
+    assert ort_artifact["metadata"]["format"] == "ort-android"
+    assert ort_artifact["metadata"]["ort_path"] == "model.ort"
+    assert (
+        ort_artifact["metadata"]["op_config_path"]
+        == "model.required_operators_and_types.config"
+    )
+    assert ort_artifact["metadata"]["operators"] == ["Add", "MatMul"]
+    assert (result.output_dir / "model.ort").exists()
+    assert "MatMul" in (
+        result.output_dir / "model.required_operators_and_types.config"
+    ).read_text(encoding="utf-8")
+
+
+def test_convert_android_profile_skips_ort_when_tooling_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    module = _convert_module()
+    ort_module = _ort_module()
+
+    def fake_export_onnx(model_id, output_path, **kwargs):
+        path = Path(output_path)
+        path.write_bytes(b"onnx")
+        return path
+
+    def fake_export_android_fp16(onnx_path, output_path, **kwargs):
+        path = Path(output_path)
+        path.write_bytes(b"fp16")
+        return path
+
+    validation = types.SimpleNamespace(
+        operators=("Add",),
+        opset=module.ANDROID_ONNX_OPSET,
+        to_metadata=lambda: {
+            "profile": "android",
+            "opset": module.ANDROID_ONNX_OPSET,
+            "operators": ["Add"],
+            "unsupported_ops": [],
+            "warnings": [],
+        },
+    )
+
+    def fake_save_source_assets(model_id, output_dir, **kwargs):
+        output_dir = Path(output_dir)
+        config = {
+            "model_type": "bert",
+            "id2label": {"0": "O"},
+            "max_sequence_length": kwargs["max_seq_length"],
+        }
+        (output_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        (output_dir / "id2label.json").write_text('{"0": "O"}', encoding="utf-8")
+        return config, []
+
+    def raise_unavailable():
+        raise ort_module.OrtMobileConversionUnavailable(
+            ort_module.ORT_CONVERSION_UNAVAILABLE_REASON
+        )
+
+    monkeypatch.setattr(module, "export_onnx", fake_export_onnx)
+    monkeypatch.setattr(module, "export_android_fp16", fake_export_android_fp16)
+    monkeypatch.setattr(module, "validate_android_profile", lambda *args: validation)
+    monkeypatch.setattr(module, "save_source_assets", fake_save_source_assets)
+    monkeypatch.setattr(ort_module, "_load_ort_tools", raise_unavailable)
+    caplog.set_level(logging.INFO, logger="openmed.onnx.ort_mobile")
+
+    result = module.convert(
+        "Patient John Doe",
+        tmp_path / "artifact",
+        profile="android",
+    )
+
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert (result.output_dir / "model.onnx").exists()
+    assert "ort-android" not in manifest["formats"]
+    assert [item["path"] for item in manifest["artifacts"]] == [
+        "model.onnx",
+        "model_fp16.onnx",
+    ]
+    assert "Skipping Android ORT mobile conversion" in caplog.text
+    assert "pip install openmed[onnx]" in caplog.text
+    assert "Patient" not in caplog.text
+    assert "John Doe" not in caplog.text


### PR DESCRIPTION
## Description
Adds Android ORT mobile conversion after the Android ONNX export so successful exports can include `model.ort` and `model.required_operators_and_types.config` alongside the existing ONNX artifacts. If the optional converter is unavailable, the Android export still completes and records a dependency-only skip reason in logs.

Closes #578.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added an Android ORT mobile conversion helper that emits `model.ort`, a required-operators/types config, and manifest metadata.
- Wired Android-profile conversion to record an `ort-android` artifact when conversion succeeds while preserving `.onnx` output when the converter is unavailable.
- Documented the new Android export outputs and minimal-build config flow.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/ -q`
- `make docs-build`
- Synthetic Android-profile ORT conversion smoke test with optional ONNX dependencies

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #578

## Screenshots/Examples
Not applicable.
