### PR TITLE
Add container image signing and verification with sigstore in CI

### DIFF
--- a/.github/workflows/image-signing.yml
+++ b/.github/workflows/image-signing.yml
@@ -1,0 +1,199 @@
+name: Container Image Signing
+
+on:
+  workflow_run:
+    workflows:
+      - Container Multi-Arch
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      image_ref:
+        description: "Image tag or digest to sign, for example ghcr.io/maziyarpanahi/openmed:sha-<commit>"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+  OIDC_ISSUER: https://token.actions.githubusercontent.com
+  SIGNER_IDENTITY_RE: '^https://github.com/${{ github.repository }}/\.github/workflows/image-signing\.yml@refs/(heads/master|tags/v.*)$'
+
+jobs:
+  sign-and-verify:
+    name: Sign, attest, and verify image
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event != 'pull_request' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0.24.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve published image digest
+        id: image
+        shell: bash
+        env:
+          DISPATCH_IMAGE_REF: ${{ inputs.image_ref }}
+          WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${DISPATCH_IMAGE_REF:-}" ]; then
+            image_ref="${DISPATCH_IMAGE_REF}"
+            source_sha="${GITHUB_SHA}"
+          else
+            source_sha="${WORKFLOW_RUN_SHA:-$GITHUB_SHA}"
+            image_ref="${IMAGE_NAME}:sha-${source_sha:0:12}"
+          fi
+
+          digest="$(docker buildx imagetools inspect "$image_ref" --format '{{ .Manifest.Digest }}')"
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error title=Image digest lookup failed::Could not resolve a sha256 digest for $image_ref"
+            exit 1
+          fi
+
+          {
+            echo "image_ref=$image_ref"
+            echo "image_digest_ref=${IMAGE_NAME}@${digest}"
+            echo "digest=$digest"
+            echo "source_sha=$source_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate CycloneDX image SBOM
+        shell: bash
+        run: |
+          set -euo pipefail
+          syft "${{ steps.image.outputs.image_digest_ref }}" \
+            -o cyclonedx-json=sbom.cdx.json
+          jq -e '.bomFormat == "CycloneDX" and (.components | type == "array")' \
+            sbom.cdx.json > /dev/null
+
+      - name: Generate SLSA provenance predicate
+        shell: bash
+        env:
+          IMAGE_DIGEST_REF: ${{ steps.image.outputs.image_digest_ref }}
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+          SOURCE_SHA: ${{ steps.image.outputs.source_sha }}
+          SOURCE_REF: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+          PUBLISH_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          digest_hex="${IMAGE_DIGEST#sha256:}"
+          jq -n \
+            --arg build_type "https://github.com/Attestations/GitHubActionsWorkflow@v1" \
+            --arg image "$IMAGE_DIGEST_REF" \
+            --arg source_repo "https://github.com/${GITHUB_REPOSITORY}" \
+            --arg source_ref "$SOURCE_REF" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg publish_workflow ".github/workflows/container-multiarch.yml" \
+            --arg signing_workflow ".github/workflows/image-signing.yml" \
+            --arg signing_run "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --arg publish_run "${PUBLISH_RUN_ID:-manual}" \
+            --arg digest_hex "$digest_hex" \
+            '{
+              buildDefinition: {
+                buildType: $build_type,
+                externalParameters: {
+                  image: $image,
+                  sourceRepository: $source_repo,
+                  sourceRef: $source_ref,
+                  sourceSha: $source_sha,
+                  publishingWorkflow: $publish_workflow,
+                  signingWorkflow: $signing_workflow
+                },
+                internalParameters: {
+                  publishingWorkflowRunId: $publish_run,
+                  signingWorkflowRunId: env.GITHUB_RUN_ID
+                },
+                resolvedDependencies: [
+                  {
+                    uri: $source_repo,
+                    digest: {
+                      gitCommit: $source_sha
+                    }
+                  },
+                  {
+                    uri: $image,
+                    digest: {
+                      sha256: $digest_hex
+                    }
+                  }
+                ]
+              },
+              runDetails: {
+                builder: {
+                  id: ("https://github.com/" + env.GITHUB_REPOSITORY + "/" + $signing_workflow)
+                },
+                metadata: {
+                  invocationId: $signing_run
+                }
+              }
+            }' > provenance.json
+
+          jq -e --arg digest_hex "$digest_hex" '
+            .buildDefinition.externalParameters.image == env.IMAGE_DIGEST_REF and
+            .buildDefinition.resolvedDependencies[1].digest.sha256 == $digest_hex
+          ' provenance.json > /dev/null
+
+      - name: Sign image and attach attestations
+        shell: bash
+        env:
+          IMAGE_DIGEST_REF: ${{ steps.image.outputs.image_digest_ref }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "$IMAGE_DIGEST_REF"
+          cosign attest --yes \
+            --predicate sbom.cdx.json \
+            --type https://cyclonedx.org/bom \
+            "$IMAGE_DIGEST_REF"
+          cosign attest --yes \
+            --predicate provenance.json \
+            --type https://slsa.dev/provenance/v1 \
+            "$IMAGE_DIGEST_REF"
+
+      - name: Verify signature and attestations
+        shell: bash
+        env:
+          IMAGE_DIGEST_REF: ${{ steps.image.outputs.image_digest_ref }}
+        run: |
+          set -euo pipefail
+          cosign verify "$IMAGE_DIGEST_REF" \
+            --certificate-identity-regexp "$SIGNER_IDENTITY_RE" \
+            --certificate-oidc-issuer "$OIDC_ISSUER" > signature.json
+          cosign verify-attestation "$IMAGE_DIGEST_REF" \
+            --type https://cyclonedx.org/bom \
+            --certificate-identity-regexp "$SIGNER_IDENTITY_RE" \
+            --certificate-oidc-issuer "$OIDC_ISSUER" > sbom-attestation.jsonl
+          cosign verify-attestation "$IMAGE_DIGEST_REF" \
+            --type https://slsa.dev/provenance/v1 \
+            --certificate-identity-regexp "$SIGNER_IDENTITY_RE" \
+            --certificate-oidc-issuer "$OIDC_ISSUER" > provenance-attestation.jsonl
+
+          test -s signature.json
+          test -s sbom-attestation.jsonl
+          test -s provenance-attestation.jsonl

--- a/deploy/policy/image-verification.yaml
+++ b/deploy/policy/image-verification.yaml
@@ -1,0 +1,40 @@
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: openmed-ghcr-keyless-signatures
+spec:
+  mode: enforce
+  images:
+    - glob: ghcr.io/maziyarpanahi/openmed*
+  authorities:
+    - name: openmed-github-actions
+      keyless:
+        url: https://fulcio.sigstore.dev
+        identities:
+          - issuer: https://token.actions.githubusercontent.com
+            subjectRegExp: ^https://github.com/maziyarpanahi/openmed/\.github/workflows/image-signing\.yml@refs/(heads/master|tags/v.*)$
+      attestations:
+        - name: cyclonedx-sbom
+          predicateType: https://cyclonedx.org/bom
+          policy:
+            type: cue
+            data: |
+              predicateType: "https://cyclonedx.org/bom"
+              predicate: {
+                bomFormat: "CycloneDX"
+              }
+        - name: slsa-provenance
+          predicateType: https://slsa.dev/provenance/v1
+          policy:
+            type: cue
+            data: |
+              predicateType: "https://slsa.dev/provenance/v1"
+              predicate: {
+                buildDefinition: {
+                  externalParameters: {
+                    image: =~"^ghcr\\.io/maziyarpanahi/openmed@sha256:[0-9a-f]{64}$"
+                    publishingWorkflow: ".github/workflows/container-multiarch.yml"
+                    signingWorkflow: ".github/workflows/image-signing.yml"
+                  }
+                }
+              }

--- a/docs/deploy/multi-arch.md
+++ b/docs/deploy/multi-arch.md
@@ -66,4 +66,5 @@ CI validates each architecture by importing `openmed` inside the built image and
 running a synthetic de-identification path. Pull request runs build and smoke-test
 both architectures without publishing. Pushes to `master`, version tags, and
 manual dispatches publish manifest-list tags after the per-architecture smoke
-checks pass.
+checks pass. Published image digests are signed and attested by the follow-up
+[Container Image Signing](../supply-chain/image-signing.md) workflow.

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -34,3 +34,11 @@ attestations, giving each wheel and source distribution signed provenance from
 the release workflow identity. See the
 [PyPI Trusted Publishing](../release/trusted-publishing.md) guide for the PyPI
 configuration and token-retirement checklist.
+
+## Container image signatures
+
+Published service images are signed by digest with Sigstore keyless signing.
+The signing workflow also attaches signed CycloneDX SBOM and SLSA provenance
+attestations, then verifies the signature and both attestations before the run
+can pass. See [Container Image Signing](../supply-chain/image-signing.md) for
+verification commands and the cluster admission policy.

--- a/docs/supply-chain/image-signing.md
+++ b/docs/supply-chain/image-signing.md
@@ -1,0 +1,74 @@
+# Container Image Signing
+
+OpenMed signs each published service image with Sigstore keyless signing after
+the multi-architecture container workflow has pushed the manifest list to GHCR.
+The signing workflow resolves the immutable image digest, signs that digest with
+the GitHub Actions OIDC identity, attaches a CycloneDX image SBOM, attaches SLSA
+provenance, and verifies all three records before the job can pass.
+
+The signed image is:
+
+```text
+ghcr.io/maziyarpanahi/openmed@sha256:<digest>
+```
+
+Tags such as `latest`, `vX.Y.Z`, and `sha-<commit>` are convenience pointers.
+Verify the digest you deploy, not just a mutable tag.
+
+## Verify Locally
+
+Install `cosign`, then resolve the digest for the tag you plan to deploy:
+
+```bash
+image=ghcr.io/maziyarpanahi/openmed:latest
+digest="$(docker buildx imagetools inspect "$image" --format '{{ .Manifest.Digest }}')"
+image_ref="ghcr.io/maziyarpanahi/openmed@$digest"
+```
+
+Verify the keyless signature against the project workflow identity:
+
+```bash
+cosign verify "$image_ref" \
+  --certificate-identity-regexp '^https://github.com/maziyarpanahi/openmed/\.github/workflows/image-signing\.yml@refs/(heads/master|tags/v.*)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Verify the attached CycloneDX SBOM and SLSA provenance attestations:
+
+```bash
+cosign verify-attestation "$image_ref" \
+  --type https://cyclonedx.org/bom \
+  --certificate-identity-regexp '^https://github.com/maziyarpanahi/openmed/\.github/workflows/image-signing\.yml@refs/(heads/master|tags/v.*)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+cosign verify-attestation "$image_ref" \
+  --type https://slsa.dev/provenance/v1 \
+  --certificate-identity-regexp '^https://github.com/maziyarpanahi/openmed/\.github/workflows/image-signing\.yml@refs/(heads/master|tags/v.*)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+These commands fail closed: a missing signature, wrong issuer, wrong workflow
+identity, or missing attestation returns a non-zero exit code.
+
+## Admission Policy
+
+`deploy/policy/image-verification.yaml` contains a Sigstore Policy Controller
+`ClusterImagePolicy` for OpenMed images. Apply it after installing the controller:
+
+```bash
+kubectl apply -f deploy/policy/image-verification.yaml
+```
+
+The policy is in enforce mode. Pods that reference `ghcr.io/maziyarpanahi/openmed`
+images are admitted only when the image has:
+
+- a keyless Sigstore signature from the OpenMed signing workflow,
+- a signed CycloneDX SBOM attestation, and
+- a signed SLSA provenance attestation tied to the OpenMed container workflow.
+
+Keep image references digest-pinned in production manifests so admission verifies
+the exact artifact you reviewed:
+
+```yaml
+image: ghcr.io/maziyarpanahi/openmed@sha256:<digest>
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - Security & Disclosure: security/disclosure-policy.md
       - HF Write Token Policy: security/hf-token-policy.md
       - Supply Chain Controls: security/supply-chain.md
+      - Container Image Signing: supply-chain/image-signing.md
       - Software Bill of Materials: security/sbom.md
       - Release Streams & Channels: release/semver-and-channels.md
       - PyPI Trusted Publishing: release/trusted-publishing.md

--- a/tests/unit/deploy/test_image_signing.py
+++ b/tests/unit/deploy/test_image_signing.py
@@ -1,0 +1,76 @@
+"""Tests for container image signing workflow and policy metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "image-signing.yml"
+POLICY = ROOT / "deploy" / "policy" / "image-verification.yaml"
+DOCS = ROOT / "docs" / "supply-chain" / "image-signing.md"
+SUPPLY_CHAIN_DOCS = ROOT / "docs" / "security" / "supply-chain.md"
+MULTIARCH_DOCS = ROOT / "docs" / "deploy" / "multi-arch.md"
+MKDOCS = ROOT / "mkdocs.yml"
+
+
+def test_image_signing_workflow_signs_and_verifies_digest():
+    content = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "workflows:\n      - Container Multi-Arch" in content
+    assert "id-token: write" in content
+    assert "packages: write" in content
+    assert "sigstore/cosign-installer@v4.1.2" in content
+    assert "anchore/sbom-action/download-syft@v0.24.0" in content
+    assert "docker buildx imagetools inspect" in content
+    assert 'cosign sign --yes "$IMAGE_DIGEST_REF"' in content
+    assert 'cosign verify "$IMAGE_DIGEST_REF"' in content
+    assert '--certificate-identity-regexp "$SIGNER_IDENTITY_RE"' in content
+    assert '--certificate-oidc-issuer "$OIDC_ISSUER"' in content
+
+
+def test_image_signing_workflow_attests_sbom_and_provenance():
+    content = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'syft "${{ steps.image.outputs.image_digest_ref }}"' in content
+    assert "--type https://cyclonedx.org/bom" in content
+    assert "--type https://slsa.dev/provenance/v1" in content
+    assert 'cosign verify-attestation "$IMAGE_DIGEST_REF"' in content
+    assert "sbom-attestation.jsonl" in content
+    assert "provenance-attestation.jsonl" in content
+    assert ".github/workflows/container-multiarch.yml" in content
+    assert ".github/workflows/image-signing.yml" in content
+
+
+def test_image_verification_policy_enforces_keyless_signature_and_attestations():
+    content = POLICY.read_text(encoding="utf-8")
+
+    assert "kind: ClusterImagePolicy" in content
+    assert "mode: enforce" in content
+    assert "glob: ghcr.io/maziyarpanahi/openmed*" in content
+    assert "issuer: https://token.actions.githubusercontent.com" in content
+    assert (
+        "subjectRegExp: ^https://github.com/maziyarpanahi/openmed/\\.github/"
+        "workflows/image-signing\\.yml@refs/(heads/master|tags/v.*)$"
+    ) in content
+    assert "predicateType: https://cyclonedx.org/bom" in content
+    assert "predicateType: https://slsa.dev/provenance/v1" in content
+    assert 'bomFormat: "CycloneDX"' in content
+    assert 'publishingWorkflow: ".github/workflows/container-multiarch.yml"' in content
+
+
+def test_image_signing_docs_include_verification_and_admission_policy():
+    content = DOCS.read_text(encoding="utf-8")
+
+    assert 'cosign verify "$image_ref"' in content
+    assert 'cosign verify-attestation "$image_ref"' in content
+    assert "--type https://cyclonedx.org/bom" in content
+    assert "--type https://slsa.dev/provenance/v1" in content
+    assert "kubectl apply -f deploy/policy/image-verification.yaml" in content
+    assert "ghcr.io/maziyarpanahi/openmed@sha256:<digest>" in content
+    assert "image: ghcr.io/maziyarpanahi/openmed@sha256:<digest>" in content
+
+
+def test_image_signing_docs_are_linked_from_existing_docs_and_nav():
+    assert "supply-chain/image-signing.md" in MKDOCS.read_text(encoding="utf-8")
+    assert "Container Image Signing" in SUPPLY_CHAIN_DOCS.read_text(encoding="utf-8")
+    assert "Container Image Signing" in MULTIARCH_DOCS.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #809.

Adds post-publish container image signing for GHCR images. The workflow resolves the published digest, signs it keylessly with the GitHub Actions OIDC identity, attaches CycloneDX SBOM and SLSA provenance attestations, and verifies the signature plus both attestations. It also documents local verification and adds a cluster admission policy for rejecting unsigned or unattested OpenMed images.

Validation:
- .venv/bin/python -m pytest tests/ -q
- .venv/bin/mkdocs build --strict
- actionlint .github/workflows/image-signing.yml
- .venv/bin/python scripts/release/check_github_actions_refs.py
- uv run ruff check tests/unit/deploy/test_image_signing.py
- uv run ruff format --check tests/unit/deploy/test_image_signing.py