### PR TITLE
Build Android model catalog from manifest

### DIFF
--- a/android/openmedkit/build.gradle.kts
+++ b/android/openmedkit/build.gradle.kts
@@ -3,6 +3,37 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+val repoRoot = rootProject.projectDir.parentFile
+val generatedCatalogAssetsDir = layout.buildDirectory.dir("generated/assets/openmedCatalog")
+val generatedCatalogAsset = generatedCatalogAssetsDir.map {
+    it.file("openmed_model_catalog.jsonl")
+}
+val pythonExecutable = providers.gradleProperty("openmedPython")
+    .orElse(providers.environmentVariable("PYTHON"))
+    .orElse("python3")
+
+val generateAndroidModelCatalog by tasks.registering(Exec::class) {
+    val manifestFile = repoRoot.resolve("models.jsonl")
+    val scriptFile = repoRoot.resolve("scripts/android/build_android_catalog.py")
+
+    inputs.file(manifestFile)
+    inputs.file(scriptFile)
+    outputs.file(generatedCatalogAsset)
+
+    doFirst {
+        generatedCatalogAsset.get().asFile.parentFile.mkdirs()
+    }
+
+    commandLine(
+        pythonExecutable.get(),
+        scriptFile.absolutePath,
+        "--manifest",
+        manifestFile.absolutePath,
+        "--output",
+        generatedCatalogAsset.get().asFile.absolutePath,
+    )
+}
+
 android {
     namespace = "org.openmed.openmedkit"
     compileSdk = 33
@@ -26,10 +57,24 @@ android {
     testOptions {
         unitTests.isIncludeAndroidResources = true
     }
+
+    sourceSets {
+        getByName("main") {
+            assets.srcDir(generatedCatalogAssetsDir)
+        }
+    }
 }
 
 kotlin {
     jvmToolchain(11)
+}
+
+tasks.matching { it.name.endsWith("Assets") }.configureEach {
+    dependsOn(generateAndroidModelCatalog)
+}
+
+tasks.matching { it.name.startsWith("test") }.configureEach {
+    dependsOn(generateAndroidModelCatalog)
 }
 
 dependencies {

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/catalog/ModelCatalog.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/catalog/ModelCatalog.kt
@@ -1,0 +1,121 @@
+package com.openmed.openmedkit.catalog
+
+import android.content.Context
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.InputStreamReader
+
+/**
+ * Manifest-backed catalog entry for Android-runnable OpenMed models.
+ */
+data class ModelCatalogEntry(
+    val repoId: String,
+    val formats: List<String>,
+    val tier: String?,
+    val paramCount: Long?,
+    val languages: List<String>,
+    val license: String?,
+)
+
+/**
+ * Read-only on-device model catalog bundled with OpenMedKit.
+ */
+class ModelCatalog private constructor(
+    entries: List<ModelCatalogEntry>,
+) {
+    val entries: List<ModelCatalogEntry> = entries.toList()
+
+    fun filter(
+        format: String? = null,
+        tier: String? = null,
+        maxParamCount: Long? = null,
+        language: String? = null,
+        license: String? = null,
+    ): List<ModelCatalogEntry> = entries.filter { entry ->
+        matchesFormat(entry, format) &&
+            matchesToken(entry.tier, tier) &&
+            matchesMaxParamCount(entry.paramCount, maxParamCount) &&
+            matchesLanguage(entry, language) &&
+            matchesToken(entry.license, license)
+    }
+
+    fun byRepoId(repoId: String): ModelCatalogEntry? =
+        entries.firstOrNull { it.repoId == repoId }
+
+    companion object {
+        const val ASSET_NAME = "openmed_model_catalog.jsonl"
+
+        private val json = Json {
+            ignoreUnknownKeys = true
+        }
+
+        fun load(context: Context, assetName: String = ASSET_NAME): ModelCatalog =
+            context.assets.open(assetName).use { parse(it) }
+
+        fun parse(inputStream: InputStream): ModelCatalog =
+            BufferedReader(InputStreamReader(inputStream, Charsets.UTF_8)).use { reader ->
+                fromLines(reader.lineSequence())
+            }
+
+        fun fromJsonLines(jsonLines: String): ModelCatalog =
+            fromLines(jsonLines.lineSequence())
+
+        private fun fromLines(lines: Sequence<String>): ModelCatalog {
+            val entries = lines
+                .mapIndexedNotNull { index, line ->
+                    val trimmed = line.trim()
+                    if (trimmed.isEmpty()) {
+                        null
+                    } else {
+                        parseEntry(trimmed, index + 1)
+                    }
+                }
+                .toList()
+            return ModelCatalog(entries)
+        }
+
+        private fun parseEntry(line: String, lineNumber: Int): ModelCatalogEntry {
+            val jsonObject = json.parseToJsonElement(line).jsonObject
+            val repoId = jsonObject.stringValue("repo_id")
+                ?: throw IllegalArgumentException("Catalog entry missing repo_id on line $lineNumber")
+            return ModelCatalogEntry(
+                repoId = repoId,
+                formats = jsonObject.stringList("formats"),
+                tier = jsonObject.stringValue("tier"),
+                paramCount = jsonObject.longValue("param_count"),
+                languages = jsonObject.stringList("languages"),
+                license = jsonObject.stringValue("license"),
+            )
+        }
+
+        private fun JsonObject.stringValue(key: String): String? =
+            this[key]?.jsonPrimitive?.contentOrNull
+
+        private fun JsonObject.longValue(key: String): Long? =
+            this[key]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
+
+        private fun JsonObject.stringList(key: String): List<String> =
+            this[key]
+                ?.jsonArray
+                ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+                ?: emptyList()
+    }
+}
+
+private fun matchesFormat(entry: ModelCatalogEntry, format: String?): Boolean =
+    format == null || entry.formats.any { it.equals(format, ignoreCase = true) }
+
+private fun matchesToken(actual: String?, expected: String?): Boolean =
+    expected == null || actual?.equals(expected, ignoreCase = true) == true
+
+private fun matchesMaxParamCount(actual: Long?, maxParamCount: Long?): Boolean =
+    maxParamCount == null || actual?.let { it <= maxParamCount } == true
+
+private fun matchesLanguage(entry: ModelCatalogEntry, language: String?): Boolean =
+    language == null || entry.languages.any { it.equals(language, ignoreCase = true) }

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/catalog/ModelCatalogTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/catalog/ModelCatalogTest.kt
@@ -1,0 +1,90 @@
+package com.openmed.openmedkit.catalog
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [26])
+class ModelCatalogTest {
+    @Test
+    fun parsesCatalogEntries() {
+        val catalog = ModelCatalog.fromJsonLines(SAMPLE_CATALOG)
+
+        assertEquals(3, catalog.entries.size)
+        assertEquals(
+            ModelCatalogEntry(
+                repoId = "OpenMed/tiny-onnx",
+                formats = listOf("onnx", "onnx-int8"),
+                tier = "tiny",
+                paramCount = 33_000_000,
+                languages = listOf("en", "es"),
+                license = "apache-2.0",
+            ),
+            catalog.byRepoId("OpenMed/tiny-onnx"),
+        )
+    }
+
+    @Test
+    fun filtersByFormatTierParamCountLanguageAndLicense() {
+        val catalog = ModelCatalog.fromJsonLines(SAMPLE_CATALOG)
+
+        assertEquals(
+            listOf("OpenMed/tiny-onnx", "OpenMed/untiered-onnx"),
+            catalog.filter(format = "ONNX").map { it.repoId },
+        )
+        assertEquals(
+            listOf("OpenMed/tiny-onnx"),
+            catalog.filter(tier = "TINY").map { it.repoId },
+        )
+        assertEquals(
+            listOf("OpenMed/tiny-onnx"),
+            catalog.filter(maxParamCount = 50_000_000).map { it.repoId },
+        )
+        assertEquals(
+            listOf("OpenMed/tiny-onnx"),
+            catalog.filter(language = "ES").map { it.repoId },
+        )
+        assertEquals(
+            listOf("OpenMed/base-tflite"),
+            catalog.filter(license = "MIT").map { it.repoId },
+        )
+    }
+
+    @Test
+    fun supportsCombinedPredicates() {
+        val catalog = ModelCatalog.fromJsonLines(SAMPLE_CATALOG)
+
+        assertEquals(
+            listOf("OpenMed/base-tflite"),
+            catalog.filter(
+                format = "tflite-int8",
+                tier = "base",
+                maxParamCount = 200_000_000,
+                language = "fr",
+                license = "mit",
+            ).map { it.repoId },
+        )
+    }
+
+    @Test
+    fun loadsBundledCatalogAsset() {
+        val catalog = ModelCatalog.load(RuntimeEnvironment.getApplication())
+
+        assertNotNull(catalog)
+        assertTrue(catalog.entries.all { it.repoId.isNotBlank() })
+    }
+
+    private companion object {
+        private val SAMPLE_CATALOG = """
+            {"repo_id":"OpenMed/tiny-onnx","formats":["onnx","onnx-int8"],"tier":"tiny","param_count":33000000,"languages":["en","es"],"license":"apache-2.0"}
+            {"repo_id":"OpenMed/base-tflite","formats":["tflite-int8"],"tier":"base","param_count":125000000,"languages":["fr"],"license":"mit"}
+            {"repo_id":"OpenMed/untiered-onnx","formats":["onnx"],"tier":null,"param_count":null,"languages":[],"license":"bsd-3-clause"}
+        """.trimIndent()
+    }
+}

--- a/scripts/android/build_android_catalog.py
+++ b/scripts/android/build_android_catalog.py
@@ -97,9 +97,7 @@ def build_catalog_rows(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]
                 "formats": android_formats,
                 "tier": row.get("tier"),
                 "param_count": row.get("param_count"),
-                "languages": [
-                    str(language) for language in row.get("languages") or []
-                ],
+                "languages": [str(language) for language in row.get("languages") or []],
                 "license": str(license_name),
             }
         )

--- a/scripts/android/build_android_catalog.py
+++ b/scripts/android/build_android_catalog.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Build the Android on-device model catalog from the canonical manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence, TextIO
+
+DEFAULT_MANIFEST = Path("models.jsonl")
+DEFAULT_OUTPUT = Path("android/openmedkit/src/main/assets/openmed_model_catalog.jsonl")
+
+ANDROID_CATALOG_FILENAME = "openmed_model_catalog.jsonl"
+ANDROID_CATALOG_FIELDS = (
+    "repo_id",
+    "formats",
+    "tier",
+    "param_count",
+    "languages",
+    "license",
+)
+
+PERMISSIVE_LICENSES = {
+    "apache-2.0",
+    "bsd-2-clause",
+    "bsd-3-clause",
+    "cc-by-3.0",
+    "cc-by-4.0",
+    "cc0-1.0",
+    "isc",
+    "mit",
+    "unlicense",
+}
+
+
+def normalize_token(value: object) -> str:
+    """Return a lowercase, hyphen-normalized manifest token."""
+    return str(value).strip().lower().replace("_", "-")
+
+
+def is_permissive_license(value: object) -> bool:
+    """Return whether *value* is in the Android catalog license allowlist."""
+    if value is None:
+        return False
+    return normalize_token(value) in PERMISSIVE_LICENSES
+
+
+def is_android_runnable_format(value: object) -> bool:
+    """Return whether *value* describes an Android-runnable model artifact."""
+    normalized = normalize_token(value)
+    return normalized.startswith("onnx") or normalized.startswith("tflite")
+
+
+def load_manifest_rows(path: Path) -> list[dict[str, Any]]:
+    """Load JSONL manifest rows from *path*."""
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                message = f"{path}:{line_number}: invalid JSON: {exc.msg}"
+                raise ValueError(message) from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_number}: expected a JSON object")
+            rows.append(row)
+    return rows
+
+
+def build_catalog_rows(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Return Android catalog rows derived from canonical manifest *rows*."""
+    catalog_rows: list[dict[str, Any]] = []
+    for row in rows:
+        license_name = row.get("license")
+        if not is_permissive_license(license_name):
+            continue
+
+        android_formats = [
+            str(format_name)
+            for format_name in row.get("formats") or []
+            if is_android_runnable_format(format_name)
+        ]
+        if not android_formats:
+            continue
+
+        repo_id = row.get("repo_id")
+        if not repo_id:
+            continue
+
+        catalog_rows.append(
+            {
+                "repo_id": str(repo_id),
+                "formats": android_formats,
+                "tier": row.get("tier"),
+                "param_count": row.get("param_count"),
+                "languages": [
+                    str(language) for language in row.get("languages") or []
+                ],
+                "license": str(license_name),
+            }
+        )
+
+    return sorted(catalog_rows, key=lambda item: item["repo_id"].lower())
+
+
+def write_catalog(rows: Iterable[Mapping[str, Any]], output: Path) -> None:
+    """Write *rows* as deterministic JSONL to *output*."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            ordered = {field: row.get(field) for field in ANDROID_CATALOG_FIELDS}
+            handle.write(json.dumps(ordered, separators=(",", ":")))
+            handle.write("\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Derive the Android OpenMedKit model catalog from the canonical "
+            "models.jsonl manifest."
+        )
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="Path to the canonical model manifest JSONL file.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Path for the derived Android catalog JSONL asset.",
+    )
+    return parser
+
+
+def run(
+    manifest: Path,
+    output: Path,
+    *,
+    stdout: TextIO | None = None,
+) -> int:
+    """Build the Android catalog and return a process exit code."""
+    stdout = stdout or None
+    rows = load_manifest_rows(manifest)
+    catalog_rows = build_catalog_rows(rows)
+    write_catalog(catalog_rows, output)
+    if stdout is not None:
+        stdout.write(f"Wrote {len(catalog_rows)} catalog rows to {output}\n")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the Android catalog builder."""
+    args = build_parser().parse_args(argv)
+    return run(args.manifest, args.output)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/android/test_android_catalog_subset.py
+++ b/tests/unit/android/test_android_catalog_subset.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.android.build_android_catalog import (
+    ANDROID_CATALOG_FIELDS,
+    build_catalog_rows,
+    is_android_runnable_format,
+    is_permissive_license,
+    load_manifest_rows,
+    write_catalog,
+)
+
+
+def test_build_catalog_rows_filters_to_permissive_android_formats() -> None:
+    rows = [
+        {
+            "repo_id": "OpenMed/pytorch-only",
+            "formats": ["pytorch"],
+            "tier": "tiny",
+            "param_count": 1,
+            "languages": ["en"],
+            "license": "apache-2.0",
+        },
+        {
+            "repo_id": "OpenMed/onnx",
+            "formats": ["pytorch", "onnx", "onnx-int8"],
+            "tier": "tiny",
+            "param_count": 33_000_000,
+            "languages": ["en", "es"],
+            "license": "apache-2.0",
+        },
+        {
+            "repo_id": "OpenMed/tflite",
+            "formats": ["tflite-int8"],
+            "tier": "base",
+            "param_count": 125_000_000,
+            "languages": ["fr"],
+            "license": "MIT",
+        },
+        {
+            "repo_id": "OpenMed/restricted",
+            "formats": ["onnx"],
+            "tier": "base",
+            "param_count": 125_000_000,
+            "languages": ["en"],
+            "license": "gpl-3.0",
+        },
+        {
+            "repo_id": "OpenMed/mlx-quantized",
+            "formats": ["mlx-8bit"],
+            "tier": "base",
+            "param_count": 125_000_000,
+            "languages": ["en"],
+            "license": "apache-2.0",
+        },
+    ]
+
+    catalog_rows = build_catalog_rows(rows)
+
+    assert catalog_rows == [
+        {
+            "repo_id": "OpenMed/onnx",
+            "formats": ["onnx", "onnx-int8"],
+            "tier": "tiny",
+            "param_count": 33_000_000,
+            "languages": ["en", "es"],
+            "license": "apache-2.0",
+        },
+        {
+            "repo_id": "OpenMed/tflite",
+            "formats": ["tflite-int8"],
+            "tier": "base",
+            "param_count": 125_000_000,
+            "languages": ["fr"],
+            "license": "MIT",
+        },
+    ]
+
+
+def test_write_catalog_emits_compact_jsonl(tmp_path: Path) -> None:
+    output = tmp_path / "catalog.jsonl"
+    row = {
+        "repo_id": "OpenMed/onnx",
+        "formats": ["onnx"],
+        "tier": None,
+        "param_count": None,
+        "languages": ["en"],
+        "license": "apache-2.0",
+        "ignored": "not written",
+    }
+
+    write_catalog([row], output)
+
+    lines = output.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {field: row.get(field) for field in ANDROID_CATALOG_FIELDS}
+
+
+def test_committed_manifest_derives_only_safe_android_rows() -> None:
+    manifest_rows = load_manifest_rows(Path("models.jsonl"))
+
+    catalog_rows = build_catalog_rows(manifest_rows)
+
+    for row in catalog_rows:
+        assert is_permissive_license(row["license"])
+        assert row["repo_id"]
+        assert set(row) == set(ANDROID_CATALOG_FIELDS)
+        assert row["formats"]
+        assert all(is_android_runnable_format(format_name) for format_name in row["formats"])

--- a/tests/unit/android/test_android_catalog_subset.py
+++ b/tests/unit/android/test_android_catalog_subset.py
@@ -95,7 +95,9 @@ def test_write_catalog_emits_compact_jsonl(tmp_path: Path) -> None:
 
     lines = output.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
-    assert json.loads(lines[0]) == {field: row.get(field) for field in ANDROID_CATALOG_FIELDS}
+    assert json.loads(lines[0]) == {
+        field: row.get(field) for field in ANDROID_CATALOG_FIELDS
+    }
 
 
 def test_committed_manifest_derives_only_safe_android_rows() -> None:
@@ -108,4 +110,6 @@ def test_committed_manifest_derives_only_safe_android_rows() -> None:
         assert row["repo_id"]
         assert set(row) == set(ANDROID_CATALOG_FIELDS)
         assert row["formats"]
-        assert all(is_android_runnable_format(format_name) for format_name in row["formats"])
+        assert all(
+            is_android_runnable_format(format_name) for format_name in row["formats"]
+        )


### PR DESCRIPTION
Closes #592.

## Summary
- derives the Android catalog from models.jsonl during the OpenMedKit build
- adds a manifest-backed Kotlin catalog API with filters for format, tier, parameter count, language, and license
- covers parser/filter behavior and the Android subset license and format rules

## Validation
- Android unit test suite passed
- Python test suite passed
- targeted Python style check passed