### PR TITLE
fix: replace assert statements with ValueError in production code

### DIFF
--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -383,7 +383,8 @@ def analyze_text(
                 len(current_indices) >= max_chunk_sentences
                 or span_length > max_chunk_chars
             ):
-                assert current_start is not None and current_end is not None
+                if current_start is None or current_end is None:
+                    raise ValueError("chunk boundary is None after sentence accumulation")
                 chunk_descriptors.append(
                     {
                         "text": validated_text[current_start:current_end],
@@ -400,7 +401,8 @@ def analyze_text(
                 current_end = seg_end
 
         if current_indices:
-            assert current_start is not None and current_end is not None
+            if current_start is None or current_end is None:
+                    raise ValueError("chunk boundary is None after sentence accumulation")
             chunk_descriptors.append(
                 {
                     "text": validated_text[current_start:current_end],

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -438,7 +438,8 @@ def create_app() -> FastAPI:
         runtime = _get_service_runtime(request)
         if payload.all:
             return runtime.unload_all_models()
-        assert payload.model_name is not None
+        if payload.model_name is None:
+            raise ValueError("model_name is required when all=False")
         return runtime.unload_model(payload.model_name)
 
     @app.post("/analyze")

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -185,7 +185,8 @@ if PYDANTIC_V2:
         @classmethod
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold normalization returned None")
             return normalized
 
         @field_validator("keep_alive", mode="before")
@@ -225,7 +226,8 @@ if PYDANTIC_V2:
         @classmethod
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold normalization returned None")
             return normalized
 
         @field_validator("policy", mode="before")
@@ -322,7 +324,8 @@ else:
         @validator("confidence_threshold")
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold normalization returned None")
             return normalized
 
         @validator("keep_alive", pre=True)
@@ -358,7 +361,8 @@ else:
         @validator("confidence_threshold")
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold normalization returned None")
             return normalized
 
         @validator("policy", pre=True)


### PR DESCRIPTION
## Summary

Assert statements are stripped when Python runs with `-O` flag, silently removing validation checks. In a healthcare AI service, this is especially dangerous as it could allow invalid data to pass through validation without any error.

The latest commit (5c65797) already fixed asserts in `core` and `coreml` modules. This PR addresses the remaining asserts in the service layer and chunking logic.

## Changes

| File | Line | What it validates |
|------|------|-------------------|
| `openmed/__init__.py` | 386 | Chunk boundary (current_start/current_end) not None |
| `openmed/service/schemas.py` | 188 | confidence_threshold normalization (NER request) |
| `openmed/service/schemas.py` | 228 | confidence_threshold normalization (PII request) |
| `openmed/service/schemas.py` | 325 | confidence_threshold normalization (v1 NER request) |
| `openmed/service/schemas.py` | 361 | confidence_threshold normalization (v1 PII request) |
| `openmed/service/app.py` | 441 | model_name required when all=False in unload |

## Fix

Replace `assert` with explicit `if ... raise ValueError(...)` with descriptive error messages.

## Test Plan

- [x] Lint passes
- [ ] Verify service starts and validation works
