### PR TITLE
Add Android model download and offline cache manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,10 @@ cache/
 *.cache/
 huggingface_cache/
 transformers_cache/
+!android/openmedkit/src/main/kotlin/com/openmed/openmedkit/cache/
+!android/openmedkit/src/main/kotlin/com/openmed/openmedkit/cache/**
+!android/openmedkit/src/test/kotlin/com/openmed/openmedkit/cache/
+!android/openmedkit/src/test/kotlin/com/openmed/openmedkit/cache/**
 
 # API keys and credentials
 *.key

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/cache/ModelCache.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/cache/ModelCache.kt
@@ -1,0 +1,319 @@
+package com.openmed.openmedkit.cache
+
+import android.content.Context
+import com.openmed.openmedkit.catalog.ModelCatalogEntry
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+import java.io.File
+import java.security.MessageDigest
+import java.util.UUID
+
+/**
+ * Offline-first app-private cache for downloaded OpenMed model artifacts.
+ */
+class ModelCache(
+    private val rootDirectory: File,
+    private val cacheBudgetBytes: Long = DEFAULT_CACHE_BUDGET_BYTES,
+    private val clock: ModelCacheClock = SystemModelCacheClock,
+) {
+    constructor(
+        context: Context,
+        cacheBudgetBytes: Long = DEFAULT_CACHE_BUDGET_BYTES,
+        clock: ModelCacheClock = SystemModelCacheClock,
+    ) : this(
+        File(context.noBackupFilesDir, CACHE_DIRECTORY_NAME),
+        cacheBudgetBytes,
+        clock,
+    )
+
+    init {
+        require(cacheBudgetBytes >= 0) { "cacheBudgetBytes must be non-negative" }
+        rootDirectory.mkdirs()
+    }
+
+    @Synchronized
+    fun isAvailable(repoId: String): Boolean =
+        isAvailable(repoId, expectedIntegrityHash = null)
+
+    @Synchronized
+    fun isAvailable(entry: ModelCatalogEntry): Boolean =
+        isAvailable(entry.repoId, entry.reproducibilityHash)
+
+    @Synchronized
+    fun totalSizeBytes(): Long =
+        readyModelDirectories().sumOf { payloadSizeBytes(it.directory) }
+
+    @Synchronized
+    fun sizeBytes(repoId: String): Long {
+        val directory = modelDirectory(repoId)
+        return if (isReadyDirectory(directory, expectedIntegrityHash = null)) {
+            payloadSizeBytes(directory)
+        } else {
+            0L
+        }
+    }
+
+    @Synchronized
+    fun evict(repoId: String): Boolean {
+        val directory = modelDirectory(repoId)
+        val existed = directory.exists()
+        if (existed) {
+            directory.deleteRecursively()
+        }
+        return existed
+    }
+
+    fun modelDirectory(repoId: String): File =
+        File(rootDirectory, cacheKey(repoId))
+
+    @Synchronized
+    internal fun createStagingDirectory(repoId: String): File {
+        rootDirectory.mkdirs()
+        val stagingRoot = File(rootDirectory, STAGING_DIRECTORY_NAME)
+        stagingRoot.mkdirs()
+        return File(
+            stagingRoot,
+            "${cacheKey(repoId)}-${clock.nowEpochMillis()}-${UUID.randomUUID()}",
+        ).also { it.mkdirs() }
+    }
+
+    @Synchronized
+    internal fun storeReadyModel(
+        repoId: String,
+        sourceDirectory: File,
+        expectedIntegrityHash: String,
+        actualIntegrityHash: String,
+        revisionSha: String?,
+    ): File {
+        val destination = modelDirectory(repoId)
+        if (destination.exists()) {
+            destination.deleteRecursively()
+        }
+        destination.parentFile?.mkdirs()
+
+        if (!sourceDirectory.renameTo(destination)) {
+            sourceDirectory.copyRecursively(destination, overwrite = true)
+            sourceDirectory.deleteRecursively()
+        }
+
+        val totalSizeBytes = payloadSizeBytes(destination)
+        writeMetadata(
+            destination,
+            CacheMetadata(
+                repoId = repoId,
+                status = STATUS_READY,
+                expectedIntegrityHash = expectedIntegrityHash,
+                actualIntegrityHash = actualIntegrityHash,
+                revisionSha = revisionSha,
+                totalSizeBytes = totalSizeBytes,
+                createdAtEpochMillis = clock.nowEpochMillis(),
+                lastAccessedEpochMillis = clock.nowEpochMillis(),
+            ),
+        )
+        trimToBudget(protectedRepoId = repoId)
+        return destination
+    }
+
+    private fun isAvailable(
+        repoId: String,
+        expectedIntegrityHash: String?,
+    ): Boolean {
+        val directory = modelDirectory(repoId)
+        val metadata = readyMetadata(directory, expectedIntegrityHash) ?: return false
+        writeMetadata(
+            directory,
+            metadata.copy(
+                totalSizeBytes = payloadSizeBytes(directory),
+                lastAccessedEpochMillis = clock.nowEpochMillis(),
+            ),
+        )
+        return true
+    }
+
+    private fun isReadyDirectory(
+        directory: File,
+        expectedIntegrityHash: String?,
+    ): Boolean =
+        readyMetadata(directory, expectedIntegrityHash) != null
+
+    private fun readyMetadata(
+        directory: File,
+        expectedIntegrityHash: String?,
+    ): CacheMetadata? {
+        if (!directory.isDirectory) {
+            return null
+        }
+        val metadata = readMetadata(directory) ?: return null
+        if (metadata.status != STATUS_READY) {
+            return null
+        }
+        if (metadata.repoId.isBlank()) {
+            return null
+        }
+        if (expectedIntegrityHash != null &&
+            metadata.expectedIntegrityHash != expectedIntegrityHash
+        ) {
+            return null
+        }
+        if (metadata.actualIntegrityHash != metadata.expectedIntegrityHash) {
+            return null
+        }
+        val actualSizeBytes = payloadSizeBytes(directory)
+        if (actualSizeBytes <= 0 || actualSizeBytes != metadata.totalSizeBytes) {
+            return null
+        }
+        return metadata
+    }
+
+    private fun readyModelDirectories(): List<ReadyDirectory> =
+        rootDirectory.listFiles()
+            ?.asSequence()
+            ?.filter { it.isDirectory && it.name != STAGING_DIRECTORY_NAME }
+            ?.mapNotNull { directory ->
+                val metadata = readyMetadata(directory, expectedIntegrityHash = null)
+                metadata?.let { ReadyDirectory(directory, it) }
+            }
+            ?.toList()
+            ?: emptyList()
+
+    private fun trimToBudget(protectedRepoId: String?) {
+        var totalSizeBytes = totalSizeBytes()
+        if (totalSizeBytes <= cacheBudgetBytes) {
+            return
+        }
+
+        for (readyDirectory in readyModelDirectories().sortedBy {
+            it.metadata.lastAccessedEpochMillis
+        }) {
+            if (totalSizeBytes <= cacheBudgetBytes) {
+                return
+            }
+            if (readyDirectory.metadata.repoId == protectedRepoId) {
+                continue
+            }
+            val directorySizeBytes = payloadSizeBytes(readyDirectory.directory)
+            readyDirectory.directory.deleteRecursively()
+            totalSizeBytes -= directorySizeBytes
+        }
+    }
+
+    private fun payloadSizeBytes(directory: File): Long {
+        if (!directory.exists()) {
+            return 0L
+        }
+        return directory.walkTopDown()
+            .filter { it.isFile && it.name != METADATA_FILE_NAME }
+            .sumOf { it.length() }
+    }
+
+    private fun readMetadata(directory: File): CacheMetadata? {
+        val metadataFile = File(directory, METADATA_FILE_NAME)
+        if (!metadataFile.isFile) {
+            return null
+        }
+        return try {
+            val jsonObject = json.parseToJsonElement(metadataFile.readText()).jsonObject
+            CacheMetadata(
+                repoId = jsonObject.stringValue("repo_id") ?: return null,
+                status = jsonObject.stringValue("status") ?: return null,
+                expectedIntegrityHash =
+                    jsonObject.stringValue("expected_integrity_hash") ?: return null,
+                actualIntegrityHash =
+                    jsonObject.stringValue("actual_integrity_hash") ?: return null,
+                revisionSha = jsonObject.stringValue("revision_sha"),
+                totalSizeBytes = jsonObject.longValue("total_size_bytes") ?: return null,
+                createdAtEpochMillis =
+                    jsonObject.longValue("created_at_epoch_millis") ?: return null,
+                lastAccessedEpochMillis =
+                    jsonObject.longValue("last_accessed_epoch_millis") ?: return null,
+            )
+        } catch (_: RuntimeException) {
+            null
+        }
+    }
+
+    private fun writeMetadata(directory: File, metadata: CacheMetadata) {
+        directory.mkdirs()
+        val metadataFile = File(directory, METADATA_FILE_NAME)
+        val payload = buildJsonObject {
+            put("repo_id", metadata.repoId)
+            put("status", metadata.status)
+            put("expected_integrity_hash", metadata.expectedIntegrityHash)
+            put("actual_integrity_hash", metadata.actualIntegrityHash)
+            put("revision_sha", metadata.revisionSha)
+            put("total_size_bytes", metadata.totalSizeBytes)
+            put("created_at_epoch_millis", metadata.createdAtEpochMillis)
+            put("last_accessed_epoch_millis", metadata.lastAccessedEpochMillis)
+        }
+        metadataFile.writeText(payload.toString())
+    }
+
+    private fun JsonObject.stringValue(key: String): String? =
+        this[key]?.jsonPrimitive?.contentOrNull
+
+    private fun JsonObject.longValue(key: String): Long? =
+        this[key]?.jsonPrimitive?.longOrNull
+
+    private fun cacheKey(repoId: String): String {
+        val safePrefix = repoId
+            .map { character ->
+                if (character.isLetterOrDigit() || character == '.' || character == '-') {
+                    character
+                } else {
+                    '_'
+                }
+            }
+            .joinToString("")
+            .trim('_')
+            .ifBlank { "model" }
+            .take(80)
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(repoId.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+            .take(16)
+        return "$safePrefix-$digest"
+    }
+
+    private data class ReadyDirectory(
+        val directory: File,
+        val metadata: CacheMetadata,
+    )
+
+    private data class CacheMetadata(
+        val repoId: String,
+        val status: String,
+        val expectedIntegrityHash: String,
+        val actualIntegrityHash: String,
+        val revisionSha: String?,
+        val totalSizeBytes: Long,
+        val createdAtEpochMillis: Long,
+        val lastAccessedEpochMillis: Long,
+    )
+
+    companion object {
+        const val DEFAULT_CACHE_BUDGET_BYTES = 2L * 1024L * 1024L * 1024L
+
+        private const val CACHE_DIRECTORY_NAME = "openmed-model-cache"
+        private const val METADATA_FILE_NAME = "metadata.json"
+        private const val STAGING_DIRECTORY_NAME = ".tmp"
+        private const val STATUS_READY = "ready"
+
+        private val json = Json {
+            ignoreUnknownKeys = true
+        }
+    }
+}
+
+fun interface ModelCacheClock {
+    fun nowEpochMillis(): Long
+}
+
+object SystemModelCacheClock : ModelCacheClock {
+    override fun nowEpochMillis(): Long = System.currentTimeMillis()
+}

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/catalog/ModelCatalog.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/catalog/ModelCatalog.kt
@@ -21,6 +21,7 @@ data class ModelCatalogEntry(
     val paramCount: Long?,
     val languages: List<String>,
     val license: String?,
+    val reproducibilityHash: String,
 )
 
 /**
@@ -91,6 +92,10 @@ class ModelCatalog private constructor(
                 paramCount = jsonObject.longValue("param_count"),
                 languages = jsonObject.stringList("languages"),
                 license = jsonObject.stringValue("license"),
+                reproducibilityHash = jsonObject.stringValue("reproducibility_hash")
+                    ?: throw IllegalArgumentException(
+                        "Catalog entry missing reproducibility_hash on line $lineNumber",
+                    ),
             )
         }
 

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/download/ModelDownloader.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/download/ModelDownloader.kt
@@ -1,0 +1,477 @@
+package com.openmed.openmedkit.download
+
+import android.content.Context
+import com.openmed.openmedkit.cache.ModelCache
+import com.openmed.openmedkit.catalog.ModelCatalogEntry
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import java.security.MessageDigest
+
+/**
+ * Downloads Hugging Face model artifacts and marks them ready only after
+ * manifest and file integrity checks pass.
+ */
+class ModelDownloader(
+    private val cache: ModelCache,
+    private val client: HuggingFaceModelClient = HttpHuggingFaceModelClient(),
+    private val logger: ModelDownloadLogger = ModelDownloadLogger.NONE,
+) {
+    constructor(
+        context: Context,
+        cacheBudgetBytes: Long = ModelCache.DEFAULT_CACHE_BUDGET_BYTES,
+        client: HuggingFaceModelClient = HttpHuggingFaceModelClient(),
+        logger: ModelDownloadLogger = ModelDownloadLogger.NONE,
+    ) : this(
+        ModelCache(context, cacheBudgetBytes),
+        client,
+        logger,
+    )
+
+    fun download(
+        entry: ModelCatalogEntry,
+        revision: String? = null,
+    ): ModelDownloadResult {
+        if (cache.isAvailable(entry)) {
+            val sizeBytes = cache.sizeBytes(entry.repoId)
+            logger.log(
+                ModelDownloadLogEvent(
+                    repoId = entry.repoId,
+                    status = ModelDownloadStatus.CACHE_HIT,
+                    sizeBytes = sizeBytes,
+                ),
+            )
+            return ModelDownloadResult(
+                repoId = entry.repoId,
+                directory = cache.modelDirectory(entry.repoId),
+                totalSizeBytes = sizeBytes,
+                filesDownloaded = 0,
+                fromCache = true,
+                integrityHash = entry.reproducibilityHash,
+            )
+        }
+
+        logger.log(
+            ModelDownloadLogEvent(
+                repoId = entry.repoId,
+                status = ModelDownloadStatus.DOWNLOAD_STARTED,
+                sizeBytes = 0L,
+            ),
+        )
+
+        val modelInfo = client.fetchModelInfo(entry.repoId, revision)
+        val actualIntegrityHash = ModelIntegrity.reproducibilityHash(
+            repoId = entry.repoId,
+            revisionSha = modelInfo.revisionSha,
+            released = modelInfo.released,
+            siblings = modelInfo.files.map { it.path },
+        )
+        if (actualIntegrityHash != entry.reproducibilityHash) {
+            throw ModelIntegrityException(
+                "Manifest integrity mismatch for ${entry.repoId}",
+            )
+        }
+
+        val filesToDownload = requiredAndroidFiles(entry, modelInfo.files)
+        if (filesToDownload.isEmpty()) {
+            throw ModelDownloadException(
+                "No Android-runnable files found for ${entry.repoId}",
+            )
+        }
+
+        val stagingDirectory = cache.createStagingDirectory(entry.repoId)
+        var completed = false
+        try {
+            val downloadRevision = revision ?: modelInfo.revisionSha ?: DEFAULT_REVISION
+            filesToDownload.forEach { remoteFile ->
+                val destination = resolveSafePath(stagingDirectory, remoteFile.path)
+                destination.parentFile?.mkdirs()
+                client.downloadFile(
+                    repoId = entry.repoId,
+                    path = remoteFile.path,
+                    revision = downloadRevision,
+                    destination = destination,
+                )
+                verifyDownloadedFile(entry.repoId, remoteFile, destination)
+            }
+
+            val readyDirectory = cache.storeReadyModel(
+                repoId = entry.repoId,
+                sourceDirectory = stagingDirectory,
+                expectedIntegrityHash = entry.reproducibilityHash,
+                actualIntegrityHash = actualIntegrityHash,
+                revisionSha = modelInfo.revisionSha,
+            )
+            val sizeBytes = cache.sizeBytes(entry.repoId)
+            completed = true
+            logger.log(
+                ModelDownloadLogEvent(
+                    repoId = entry.repoId,
+                    status = ModelDownloadStatus.DOWNLOAD_COMPLETE,
+                    sizeBytes = sizeBytes,
+                ),
+            )
+            return ModelDownloadResult(
+                repoId = entry.repoId,
+                directory = readyDirectory,
+                totalSizeBytes = sizeBytes,
+                filesDownloaded = filesToDownload.size,
+                fromCache = false,
+                integrityHash = actualIntegrityHash,
+            )
+        } finally {
+            if (!completed) {
+                stagingDirectory.deleteRecursively()
+            }
+        }
+    }
+
+    private fun verifyDownloadedFile(
+        repoId: String,
+        remoteFile: HuggingFaceModelFile,
+        destination: File,
+    ) {
+        if (!destination.isFile) {
+            throw ModelIntegrityException("Downloaded file missing for $repoId")
+        }
+        remoteFile.sizeBytes?.let { expectedSizeBytes ->
+            if (destination.length() != expectedSizeBytes) {
+                throw ModelIntegrityException("Downloaded file size mismatch for $repoId")
+            }
+        }
+        remoteFile.sha256?.let { expectedSha256 ->
+            if (sha256(destination) != expectedSha256.lowercase()) {
+                throw ModelIntegrityException("Downloaded file checksum mismatch for $repoId")
+            }
+        }
+    }
+
+    private fun requiredAndroidFiles(
+        entry: ModelCatalogEntry,
+        files: List<HuggingFaceModelFile>,
+    ): List<HuggingFaceModelFile> =
+        files
+            .filter { file -> isRequiredAndroidFile(file.path, entry.formats) }
+            .sortedBy { it.path }
+
+    private fun isRequiredAndroidFile(path: String, formats: List<String>): Boolean {
+        val normalizedPath = path.lowercase()
+        val fileName = normalizedPath.substringAfterLast("/")
+        if (fileName == ".gitattributes" ||
+            fileName == "readme.md" ||
+            fileName.startsWith("license")
+        ) {
+            return false
+        }
+
+        val wantsOnnx = formats.any { it.lowercase().startsWith("onnx") }
+        val wantsTflite = formats.any { it.lowercase().startsWith("tflite") }
+        if (wantsOnnx && (
+                normalizedPath.endsWith(".onnx") ||
+                    normalizedPath.endsWith(".ort") ||
+                    normalizedPath.endsWith(".onnx_data") ||
+                    normalizedPath.endsWith(".onnx.data")
+                )
+        ) {
+            return true
+        }
+        if (wantsTflite && normalizedPath.endsWith(".tflite")) {
+            return true
+        }
+
+        return fileName in REQUIRED_SIDECAR_FILES ||
+            (fileName.endsWith(".json") && REQUIRED_JSON_HINTS.any { fileName.contains(it) })
+    }
+
+    private fun resolveSafePath(root: File, relativePath: String): File {
+        val segments = relativePath.split("/")
+        require(segments.isNotEmpty()) { "empty model file path" }
+        var current = root
+        segments.forEach { segment ->
+            require(segment.isNotBlank()) { "blank model file path segment" }
+            require(segment != "." && segment != "..") {
+                "unsafe model file path segment"
+            }
+            require(!segment.contains('\\')) { "unsafe model file path segment" }
+            current = File(current, segment)
+        }
+        val canonicalRoot = root.canonicalFile
+        val canonicalFile = current.canonicalFile
+        require(canonicalFile.path.startsWith(canonicalRoot.path + File.separator)) {
+            "model file path escapes cache directory"
+        }
+        return current
+    }
+
+    private fun sha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read == -1) {
+                    break
+                }
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private companion object {
+        const val DEFAULT_REVISION = "main"
+
+        val REQUIRED_SIDECAR_FILES = setOf(
+            "added_tokens.json",
+            "config.json",
+            "generation_config.json",
+            "merges.txt",
+            "preprocessor_config.json",
+            "sentencepiece.bpe.model",
+            "special_tokens_map.json",
+            "spiece.model",
+            "tokenizer.json",
+            "tokenizer.model",
+            "tokenizer_config.json",
+            "vocab.json",
+            "vocab.txt",
+        )
+
+        val REQUIRED_JSON_HINTS = listOf(
+            "config",
+            "preprocessor",
+            "special_tokens",
+            "tokenizer",
+        )
+    }
+}
+
+data class ModelDownloadResult(
+    val repoId: String,
+    val directory: File,
+    val totalSizeBytes: Long,
+    val filesDownloaded: Int,
+    val fromCache: Boolean,
+    val integrityHash: String,
+)
+
+fun interface ModelDownloadLogger {
+    fun log(event: ModelDownloadLogEvent)
+
+    companion object {
+        val NONE = ModelDownloadLogger {}
+    }
+}
+
+data class ModelDownloadLogEvent(
+    val repoId: String,
+    val status: ModelDownloadStatus,
+    val sizeBytes: Long?,
+)
+
+enum class ModelDownloadStatus {
+    CACHE_HIT,
+    DOWNLOAD_STARTED,
+    DOWNLOAD_COMPLETE,
+}
+
+interface HuggingFaceModelClient {
+    fun fetchModelInfo(repoId: String, revision: String? = null): HuggingFaceModelInfo
+
+    fun downloadFile(
+        repoId: String,
+        path: String,
+        revision: String,
+        destination: File,
+    )
+}
+
+data class HuggingFaceModelInfo(
+    val repoId: String,
+    val revisionSha: String?,
+    val released: String?,
+    val files: List<HuggingFaceModelFile>,
+)
+
+data class HuggingFaceModelFile(
+    val path: String,
+    val sizeBytes: Long? = null,
+    val sha256: String? = null,
+)
+
+class ModelDownloadException(message: String) : RuntimeException(message)
+
+class ModelIntegrityException(message: String) : RuntimeException(message)
+
+class HttpHuggingFaceModelClient(
+    private val modelApiBaseUrl: String = "https://huggingface.co/api/models",
+    private val resolveBaseUrl: String = "https://huggingface.co",
+    private val connectTimeoutMillis: Int = 15_000,
+    private val readTimeoutMillis: Int = 60_000,
+) : HuggingFaceModelClient {
+    override fun fetchModelInfo(
+        repoId: String,
+        revision: String?,
+    ): HuggingFaceModelInfo {
+        val suffix = revision?.let { "/revision/${encodePathSegment(it)}" }.orEmpty()
+        val url = URL("$modelApiBaseUrl/${encodeRepoId(repoId)}$suffix?blobs=true")
+        val payload = openConnection(url).useJsonResponse()
+        val jsonObject = json.parseToJsonElement(payload).jsonObject
+        val files = jsonObject["siblings"]
+            ?.jsonArray
+            ?.mapNotNull { sibling ->
+                val siblingObject = sibling.jsonObject
+                val path = siblingObject.stringValue("rfilename") ?: return@mapNotNull null
+                val lfsObject = siblingObject["lfs"]?.jsonObject
+                HuggingFaceModelFile(
+                    path = path,
+                    sizeBytes = lfsObject?.longValue("size") ?: siblingObject.longValue("size"),
+                    sha256 = lfsObject?.stringValue("sha256")
+                        ?: lfsObject?.stringValue("oid")
+                        ?: siblingObject.stringValue("sha256"),
+                )
+            }
+            ?: emptyList()
+        return HuggingFaceModelInfo(
+            repoId = repoId,
+            revisionSha = jsonObject.stringValue("sha"),
+            released = normalizeDate(
+                jsonObject.stringValue("lastModified")
+                    ?: jsonObject.stringValue("createdAt"),
+            ),
+            files = files,
+        )
+    }
+
+    override fun downloadFile(
+        repoId: String,
+        path: String,
+        revision: String,
+        destination: File,
+    ) {
+        val url = URL(
+            "$resolveBaseUrl/${encodeRepoId(repoId)}/resolve/" +
+                "${encodePathSegment(revision)}/${encodeFilePath(path)}?download=true",
+        )
+        openConnection(url).useBinaryResponse { input ->
+            destination.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+    }
+
+    private fun openConnection(url: URL): HttpURLConnection =
+        (url.openConnection() as HttpURLConnection).apply {
+            connectTimeout = connectTimeoutMillis
+            readTimeout = readTimeoutMillis
+            requestMethod = "GET"
+            instanceFollowRedirects = true
+        }
+
+    private fun HttpURLConnection.useJsonResponse(): String =
+        useBinaryResponse { input ->
+            input.reader(Charsets.UTF_8).readText()
+        }
+
+    private fun <T> HttpURLConnection.useBinaryResponse(block: (java.io.InputStream) -> T): T {
+        try {
+            val statusCode = responseCode
+            if (statusCode !in 200..299) {
+                throw ModelDownloadException(
+                    "Hugging Face request failed with status $statusCode",
+                )
+            }
+            return inputStream.use(block)
+        } finally {
+            disconnect()
+        }
+    }
+
+    private fun JsonObject.stringValue(key: String): String? =
+        this[key]?.jsonPrimitive?.contentOrNull
+
+    private fun JsonObject.longValue(key: String): Long? =
+        this[key]?.jsonPrimitive?.longOrNull
+
+    private fun encodeRepoId(repoId: String): String =
+        repoId.split("/").joinToString("/") { encodePathSegment(it) }
+
+    private fun encodeFilePath(path: String): String =
+        path.split("/").joinToString("/") { encodePathSegment(it) }
+
+    private fun encodePathSegment(segment: String): String =
+        URLEncoder.encode(segment, Charsets.UTF_8.name()).replace("+", "%20")
+
+    private companion object {
+        val json = Json {
+            ignoreUnknownKeys = true
+        }
+    }
+}
+
+object ModelIntegrity {
+    fun reproducibilityHash(
+        repoId: String,
+        revisionSha: String?,
+        released: String?,
+        siblings: List<String>,
+    ): String {
+        val payload = buildString {
+            append("{")
+            append("\"released\":")
+            appendJsonStringOrNull(normalizeDate(released))
+            append(",\"repo_id\":")
+            appendJsonString(repoId)
+            append(",\"sha\":")
+            appendJsonStringOrNull(revisionSha)
+            append(",\"siblings\":[")
+            siblings.sorted().forEachIndexed { index, sibling ->
+                if (index > 0) {
+                    append(",")
+                }
+                appendJsonString(sibling)
+            }
+            append("]}")
+        }
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(payload.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+        return "sha256:$digest"
+    }
+
+    private fun StringBuilder.appendJsonStringOrNull(value: String?) {
+        if (value == null) {
+            append("null")
+        } else {
+            appendJsonString(value)
+        }
+    }
+
+    private fun StringBuilder.appendJsonString(value: String) {
+        append("\"")
+        value.forEach { character ->
+            when (character) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\b' -> append("\\b")
+                '\u000C' -> append("\\f")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> append(character)
+            }
+        }
+        append("\"")
+    }
+}
+
+private fun normalizeDate(value: String?): String? =
+    value?.take(10)?.ifBlank { null }

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/cache/ModelCacheTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/cache/ModelCacheTest.kt
@@ -1,0 +1,117 @@
+package com.openmed.openmedkit.cache
+
+import com.openmed.openmedkit.catalog.ModelCatalogEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ModelCacheTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun tracksAvailabilitySizeAndEviction() {
+        val cache = ModelCache(temporaryFolder.newFolder("cache"))
+        val entry = catalogEntry("OpenMed/tiny-onnx")
+
+        cache.storeReadyModel(
+            repoId = entry.repoId,
+            sourceDirectory = stagedModel("first", "model.onnx" to "weights"),
+            expectedIntegrityHash = entry.reproducibilityHash,
+            actualIntegrityHash = entry.reproducibilityHash,
+            revisionSha = "abc123",
+        )
+
+        assertTrue(cache.isAvailable(entry))
+        assertTrue(cache.isAvailable(entry.repoId))
+        assertEquals(7L, cache.totalSizeBytes())
+        assertEquals(7L, cache.sizeBytes(entry.repoId))
+
+        assertTrue(cache.evict(entry.repoId))
+        assertFalse(cache.isAvailable(entry))
+        assertEquals(0L, cache.totalSizeBytes())
+    }
+
+    @Test
+    fun evictsLeastRecentlyUsedModelWhenBudgetIsExceeded() {
+        val clock = MutableClock()
+        val cache = ModelCache(
+            rootDirectory = temporaryFolder.newFolder("cache"),
+            cacheBudgetBytes = 12L,
+            clock = clock,
+        )
+        val first = catalogEntry("OpenMed/first")
+        val second = catalogEntry("OpenMed/second")
+        val third = catalogEntry("OpenMed/third")
+
+        cache.storeReadyModel(
+            repoId = first.repoId,
+            sourceDirectory = stagedModel("first", "model.onnx" to "12345"),
+            expectedIntegrityHash = first.reproducibilityHash,
+            actualIntegrityHash = first.reproducibilityHash,
+            revisionSha = "aaa",
+        )
+        clock.advance()
+        cache.storeReadyModel(
+            repoId = second.repoId,
+            sourceDirectory = stagedModel("second", "model.onnx" to "12345"),
+            expectedIntegrityHash = second.reproducibilityHash,
+            actualIntegrityHash = second.reproducibilityHash,
+            revisionSha = "bbb",
+        )
+        clock.advance()
+        assertTrue(cache.isAvailable(first))
+        clock.advance()
+        cache.storeReadyModel(
+            repoId = third.repoId,
+            sourceDirectory = stagedModel("third", "model.onnx" to "12345"),
+            expectedIntegrityHash = third.reproducibilityHash,
+            actualIntegrityHash = third.reproducibilityHash,
+            revisionSha = "ccc",
+        )
+
+        assertTrue(cache.isAvailable(first))
+        assertFalse(cache.isAvailable(second))
+        assertTrue(cache.isAvailable(third))
+        assertEquals(10L, cache.totalSizeBytes())
+    }
+
+    private fun catalogEntry(repoId: String): ModelCatalogEntry =
+        ModelCatalogEntry(
+            repoId = repoId,
+            formats = listOf("onnx"),
+            tier = "tiny",
+            paramCount = 1,
+            languages = listOf("en"),
+            license = "apache-2.0",
+            reproducibilityHash =
+                "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        )
+
+    private fun stagedModel(
+        name: String,
+        vararg files: Pair<String, String>,
+    ): File {
+        val directory = temporaryFolder.newFolder("staged-$name")
+        files.forEach { (path, content) ->
+            val file = File(directory, path)
+            file.parentFile?.mkdirs()
+            file.writeText(content)
+        }
+        return directory
+    }
+
+    private class MutableClock : ModelCacheClock {
+        private var current = 1_000L
+
+        override fun nowEpochMillis(): Long = current
+
+        fun advance() {
+            current += 1_000L
+        }
+    }
+}

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/catalog/ModelCatalogTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/catalog/ModelCatalogTest.kt
@@ -25,6 +25,8 @@ class ModelCatalogTest {
                 paramCount = 33_000_000,
                 languages = listOf("en", "es"),
                 license = "apache-2.0",
+                reproducibilityHash =
+                    "sha256:1111111111111111111111111111111111111111111111111111111111111111",
             ),
             catalog.byRepoId("OpenMed/tiny-onnx"),
         )
@@ -82,9 +84,9 @@ class ModelCatalogTest {
 
     private companion object {
         private val SAMPLE_CATALOG = """
-            {"repo_id":"OpenMed/tiny-onnx","formats":["onnx","onnx-int8"],"tier":"tiny","param_count":33000000,"languages":["en","es"],"license":"apache-2.0"}
-            {"repo_id":"OpenMed/base-tflite","formats":["tflite-int8"],"tier":"base","param_count":125000000,"languages":["fr"],"license":"mit"}
-            {"repo_id":"OpenMed/untiered-onnx","formats":["onnx"],"tier":null,"param_count":null,"languages":[],"license":"bsd-3-clause"}
+            {"repo_id":"OpenMed/tiny-onnx","formats":["onnx","onnx-int8"],"tier":"tiny","param_count":33000000,"languages":["en","es"],"license":"apache-2.0","reproducibility_hash":"sha256:1111111111111111111111111111111111111111111111111111111111111111"}
+            {"repo_id":"OpenMed/base-tflite","formats":["tflite-int8"],"tier":"base","param_count":125000000,"languages":["fr"],"license":"mit","reproducibility_hash":"sha256:2222222222222222222222222222222222222222222222222222222222222222"}
+            {"repo_id":"OpenMed/untiered-onnx","formats":["onnx"],"tier":null,"param_count":null,"languages":[],"license":"bsd-3-clause","reproducibility_hash":"sha256:3333333333333333333333333333333333333333333333333333333333333333"}
         """.trimIndent()
     }
 }

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/download/ModelDownloaderTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/download/ModelDownloaderTest.kt
@@ -1,0 +1,192 @@
+package com.openmed.openmedkit.download
+
+import com.openmed.openmedkit.cache.ModelCache
+import com.openmed.openmedkit.catalog.ModelCatalogEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.security.MessageDigest
+
+class ModelDownloaderTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun downloadsFilesAndMarksModelReadyAfterIntegrityChecks() {
+        val repoId = "OpenMed/tiny-onnx"
+        val files = mapOf(
+            "model.onnx" to "weights",
+            "config.json" to "{\"hidden_size\":1}",
+            "README.md" to "not required",
+        )
+        val entry = catalogEntry(repoId, integrityHash(repoId, files.keys.toList()))
+        val client = FakeHuggingFaceModelClient(repoId, files)
+        val cache = ModelCache(temporaryFolder.newFolder("cache"))
+
+        val result = ModelDownloader(cache, client).download(entry)
+
+        assertFalse(result.fromCache)
+        assertEquals(2, result.filesDownloaded)
+        assertEquals(entry.reproducibilityHash, result.integrityHash)
+        assertTrue(cache.isAvailable(entry))
+        assertEquals(1, client.modelInfoCalls)
+        assertEquals(listOf("config.json", "model.onnx"), client.downloadedPaths.sorted())
+    }
+
+    @Test
+    fun rejectsChecksumFailuresWithoutMarkingTheModelReady() {
+        val repoId = "OpenMed/tiny-onnx"
+        val files = mapOf("model.onnx" to "weights")
+        val entry = catalogEntry(repoId, integrityHash(repoId, files.keys.toList()))
+        val client = FakeHuggingFaceModelClient(
+            repoId = repoId,
+            files = files,
+            sha256Overrides = mapOf("model.onnx" to "0".repeat(64)),
+        )
+        val cache = ModelCache(temporaryFolder.newFolder("cache"))
+
+        try {
+            ModelDownloader(cache, client).download(entry)
+        } catch (_: ModelIntegrityException) {
+            assertFalse(cache.isAvailable(entry))
+            return
+        }
+
+        throw AssertionError("Expected checksum failure")
+    }
+
+    @Test
+    fun servesOfflineCacheHitWithoutNetworkCalls() {
+        val repoId = "OpenMed/tiny-onnx"
+        val files = mapOf("model.onnx" to "weights")
+        val entry = catalogEntry(repoId, integrityHash(repoId, files.keys.toList()))
+        val cache = ModelCache(temporaryFolder.newFolder("cache"))
+        val firstClient = FakeHuggingFaceModelClient(repoId, files)
+
+        ModelDownloader(cache, firstClient).download(entry)
+        val offlineClient = object : HuggingFaceModelClient {
+            override fun fetchModelInfo(
+                repoId: String,
+                revision: String?,
+            ): HuggingFaceModelInfo =
+                throw AssertionError("network should not be used for cache hits")
+
+            override fun downloadFile(
+                repoId: String,
+                path: String,
+                revision: String,
+                destination: File,
+            ) {
+                throw AssertionError("network should not be used for cache hits")
+            }
+        }
+
+        val result = ModelDownloader(cache, offlineClient).download(entry)
+
+        assertTrue(result.fromCache)
+        assertEquals(0, result.filesDownloaded)
+        assertTrue(cache.isAvailable(entry))
+    }
+
+    @Test
+    fun keepsLogsAndMetadataFreeOfModelContent() {
+        val repoId = "OpenMed/tiny-onnx"
+        val modelContent = "patient Jane Doe phone 555-0100"
+        val files = mapOf("model.onnx" to modelContent)
+        val entry = catalogEntry(repoId, integrityHash(repoId, files.keys.toList()))
+        val events = mutableListOf<ModelDownloadLogEvent>()
+        val cache = ModelCache(temporaryFolder.newFolder("cache"))
+
+        ModelDownloader(
+            cache = cache,
+            client = FakeHuggingFaceModelClient(repoId, files),
+            logger = ModelDownloadLogger { event -> events += event },
+        ).download(entry)
+
+        val metadata = File(cache.modelDirectory(repoId), "metadata.json").readText()
+        val logs = events.joinToString("\n")
+        assertFalse(metadata.contains("Jane Doe"))
+        assertFalse(metadata.contains("555-0100"))
+        assertFalse(logs.contains("Jane Doe"))
+        assertFalse(logs.contains("555-0100"))
+        assertTrue(metadata.contains(repoId))
+        assertTrue(events.all { it.repoId == repoId })
+    }
+
+    private fun catalogEntry(
+        repoId: String,
+        reproducibilityHash: String,
+    ): ModelCatalogEntry =
+        ModelCatalogEntry(
+            repoId = repoId,
+            formats = listOf("onnx"),
+            tier = "tiny",
+            paramCount = 1,
+            languages = listOf("en"),
+            license = "apache-2.0",
+            reproducibilityHash = reproducibilityHash,
+        )
+
+    private fun integrityHash(repoId: String, siblings: List<String>): String =
+        ModelIntegrity.reproducibilityHash(
+            repoId = repoId,
+            revisionSha = FakeHuggingFaceModelClient.REVISION_SHA,
+            released = FakeHuggingFaceModelClient.RELEASED,
+            siblings = siblings,
+        )
+
+    private class FakeHuggingFaceModelClient(
+        private val repoId: String,
+        private val files: Map<String, String>,
+        private val sha256Overrides: Map<String, String> = emptyMap(),
+    ) : HuggingFaceModelClient {
+        var modelInfoCalls = 0
+        val downloadedPaths = mutableListOf<String>()
+
+        override fun fetchModelInfo(
+            repoId: String,
+            revision: String?,
+        ): HuggingFaceModelInfo {
+            check(repoId == this.repoId)
+            modelInfoCalls += 1
+            return HuggingFaceModelInfo(
+                repoId = repoId,
+                revisionSha = REVISION_SHA,
+                released = RELEASED,
+                files = files.map { (path, content) ->
+                    HuggingFaceModelFile(
+                        path = path,
+                        sizeBytes = content.toByteArray().size.toLong(),
+                        sha256 = sha256Overrides[path] ?: sha256(content),
+                    )
+                },
+            )
+        }
+
+        override fun downloadFile(
+            repoId: String,
+            path: String,
+            revision: String,
+            destination: File,
+        ) {
+            check(repoId == this.repoId)
+            check(revision == REVISION_SHA)
+            downloadedPaths += path
+            destination.writeText(files.getValue(path))
+        }
+
+        private fun sha256(content: String): String =
+            MessageDigest.getInstance("SHA-256")
+                .digest(content.toByteArray())
+                .joinToString("") { "%02x".format(it) }
+
+        companion object {
+            const val REVISION_SHA = "abc123"
+            const val RELEASED = "2026-01-01"
+        }
+    }
+}

--- a/scripts/android/build_android_catalog.py
+++ b/scripts/android/build_android_catalog.py
@@ -19,6 +19,7 @@ ANDROID_CATALOG_FIELDS = (
     "param_count",
     "languages",
     "license",
+    "reproducibility_hash",
 )
 
 PERMISSIVE_LICENSES = {
@@ -99,6 +100,7 @@ def build_catalog_rows(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]
                 "param_count": row.get("param_count"),
                 "languages": [str(language) for language in row.get("languages") or []],
                 "license": str(license_name),
+                "reproducibility_hash": row.get("reproducibility_hash"),
             }
         )
 

--- a/tests/unit/android/test_android_catalog_subset.py
+++ b/tests/unit/android/test_android_catalog_subset.py
@@ -22,6 +22,7 @@ def test_build_catalog_rows_filters_to_permissive_android_formats() -> None:
             "param_count": 1,
             "languages": ["en"],
             "license": "apache-2.0",
+            "reproducibility_hash": "sha256:" + "0" * 64,
         },
         {
             "repo_id": "OpenMed/onnx",
@@ -30,6 +31,7 @@ def test_build_catalog_rows_filters_to_permissive_android_formats() -> None:
             "param_count": 33_000_000,
             "languages": ["en", "es"],
             "license": "apache-2.0",
+            "reproducibility_hash": "sha256:" + "1" * 64,
         },
         {
             "repo_id": "OpenMed/tflite",
@@ -38,6 +40,7 @@ def test_build_catalog_rows_filters_to_permissive_android_formats() -> None:
             "param_count": 125_000_000,
             "languages": ["fr"],
             "license": "MIT",
+            "reproducibility_hash": "sha256:" + "2" * 64,
         },
         {
             "repo_id": "OpenMed/restricted",
@@ -46,6 +49,7 @@ def test_build_catalog_rows_filters_to_permissive_android_formats() -> None:
             "param_count": 125_000_000,
             "languages": ["en"],
             "license": "gpl-3.0",
+            "reproducibility_hash": "sha256:" + "3" * 64,
         },
         {
             "repo_id": "OpenMed/mlx-quantized",
@@ -54,6 +58,7 @@ def test_build_catalog_rows_filters_to_permissive_android_formats() -> None:
             "param_count": 125_000_000,
             "languages": ["en"],
             "license": "apache-2.0",
+            "reproducibility_hash": "sha256:" + "4" * 64,
         },
     ]
 
@@ -67,6 +72,7 @@ def test_build_catalog_rows_filters_to_permissive_android_formats() -> None:
             "param_count": 33_000_000,
             "languages": ["en", "es"],
             "license": "apache-2.0",
+            "reproducibility_hash": "sha256:" + "1" * 64,
         },
         {
             "repo_id": "OpenMed/tflite",
@@ -75,6 +81,7 @@ def test_build_catalog_rows_filters_to_permissive_android_formats() -> None:
             "param_count": 125_000_000,
             "languages": ["fr"],
             "license": "MIT",
+            "reproducibility_hash": "sha256:" + "2" * 64,
         },
     ]
 
@@ -88,6 +95,7 @@ def test_write_catalog_emits_compact_jsonl(tmp_path: Path) -> None:
         "param_count": None,
         "languages": ["en"],
         "license": "apache-2.0",
+        "reproducibility_hash": "sha256:" + "1" * 64,
         "ignored": "not written",
     }
 
@@ -108,6 +116,7 @@ def test_committed_manifest_derives_only_safe_android_rows() -> None:
     for row in catalog_rows:
         assert is_permissive_license(row["license"])
         assert row["repo_id"]
+        assert row["reproducibility_hash"].startswith("sha256:")
         assert set(row) == set(ANDROID_CATALOG_FIELDS)
         assert row["formats"]
         assert all(


### PR DESCRIPTION
Closes #593.

Adds an Android model downloader and app-private offline cache manager that verifies catalog integrity before marking downloads ready, serves valid cached models without network access, supports cache sizing and LRU eviction, and keeps logs and metadata limited to safe ids, sizes, and statuses.

Validation:
- cd android && ./gradlew test
- .venv/bin/python -m pytest tests/ -q