### PR TITLE
Add Maven Central (Central Portal) AAR publishing workflow with signing and guarded release

### DIFF
--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -1,0 +1,176 @@
+# Tags matching v* build and publish the OpenMedKit Android AAR to Maven Central.
+# Required repository secrets:
+# - ANDROID_SIGNING_KEY: ASCII-armored GPG private key for Maven artifact signing.
+# - ANDROID_SIGNING_KEY_PASSWORD: passphrase for ANDROID_SIGNING_KEY.
+# - SONATYPE_USERNAME: Central Portal user-token username.
+# - SONATYPE_PASSWORD: Central Portal user-token password.
+name: Android Publish (OpenMedKit)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version to publish, without a leading v.
+        required: true
+      confirm_upload:
+        description: Type upload to confirm Central Portal upload.
+        required: true
+        default: "no"
+
+permissions:
+  contents: read
+  checks: read
+
+jobs:
+  guard:
+    name: Verify Android release guards
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: release
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ inputs.version }}"
+            if [ "${{ inputs.confirm_upload }}" != "upload" ]; then
+              echo "::error title=Manual confirmation required::Set confirm_upload to upload."
+              exit 1
+            fi
+          fi
+
+          if [ -z "$VERSION" ]; then
+            echo "::error title=Missing version::Release version is required."
+            exit 1
+          fi
+          if [[ "$VERSION" == *SNAPSHOT* ]]; then
+            echo "::error title=Invalid version::SNAPSHOT versions cannot be published."
+            exit 1
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9][A-Za-z0-9.-]*)?$ ]]; then
+            echo "::error title=Invalid version::Expected a version like 1.8.0 or 1.8.0-rc.1."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Require successful Android checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs" \
+            --paginate \
+            --jq '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv' \
+            > check-runs.tsv
+
+          required_checks=(
+            "Build & Test Android OpenMedKit"
+            "Android AAR size and cold-start gate"
+          )
+
+          for check_name in "${required_checks[@]}"; do
+            line=$(awk -F '\t' -v name="$check_name" '$1 == name { found=$0 } END { print found }' check-runs.tsv)
+            if [ -z "$line" ]; then
+              echo "::error title=Missing required check::$check_name has not run on ${GITHUB_SHA}."
+              exit 1
+            fi
+
+            status=$(printf '%s\n' "$line" | cut -f2)
+            conclusion=$(printf '%s\n' "$line" | cut -f3)
+            if [ "$status" != "completed" ] || [ "$conclusion" != "success" ]; then
+              echo "::error title=Required check did not pass::$check_name is $status/$conclusion."
+              exit 1
+            fi
+          done
+
+  build:
+    name: Build signed Central Portal bundle
+    needs: guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: gradle
+          cache-dependency-path: |
+            android/*.gradle*
+            android/gradle.properties
+            android/gradle/libs.versions.toml
+            android/gradle/wrapper/gradle-wrapper.properties
+            android/**/build.gradle*
+
+      - name: Run Android CI commands
+        working-directory: android
+        run: |
+          ./gradlew :openmedkit:assembleDebug :openmedkit:testDebugUnitTest --stacktrace
+
+      - name: Build signed Maven Central bundle
+        working-directory: android
+        env:
+          ORG_GRADLE_PROJECT_openmedAndroidVersion: ${{ needs.guard.outputs.version }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ANDROID_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
+        run: |
+          ./gradlew :openmedkit:bundleCentralPortalPublication --stacktrace
+
+      - name: Upload Central Portal bundle artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: openmedkit-central-portal-bundle
+          path: android/openmedkit/build/central-portal/openmedkit-${{ needs.guard.outputs.version }}.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Upload to Central Portal
+    needs: [guard, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: maven-central
+      url: https://central.sonatype.com/publishing
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download Central Portal bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: openmedkit-central-portal-bundle
+          path: dist/
+
+      - name: Upload deployment bundle
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          RELEASE_VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          if [ -z "$SONATYPE_USERNAME" ] || [ -z "$SONATYPE_PASSWORD" ]; then
+            echo "::error title=Missing Central Portal credentials::Configure SONATYPE_USERNAME and SONATYPE_PASSWORD."
+            exit 1
+          fi
+
+          token=$(printf '%s:%s' "$SONATYPE_USERNAME" "$SONATYPE_PASSWORD" | base64 | tr -d '\n')
+          deployment_id=$(curl --fail --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer ${token}" \
+            --form "bundle=@dist/openmedkit-${RELEASE_VERSION}.zip;type=application/octet-stream" \
+            "https://central.sonatype.com/api/v1/publisher/upload?name=openmedkit-${RELEASE_VERSION}&publishingType=AUTOMATIC")
+
+          echo "Central Portal deployment ${deployment_id} accepted for OpenMedKit ${RELEASE_VERSION}."

--- a/android/README.md
+++ b/android/README.md
@@ -21,3 +21,21 @@ The library currently targets SDK 33 and sets `minSdk` to 26. Android 8.0 is the
 baseline for on-device inference work because it preserves broad device support
 while keeping runtime, storage, and execution APIs modern enough for the planned
 local-first pipeline.
+
+## Maven Central Publishing
+
+OpenMedKit publishes from `.github/workflows/android-publish.yml` on `v*` tags or
+manual dispatch only. The workflow builds a signed Central Portal bundle from the
+Gradle `release` Maven publication and uploads it to Sonatype after the required
+Android checks have passed.
+
+The release commit must already have successful check runs named
+`Build & Test Android OpenMedKit` and `Android AAR size and cold-start gate`.
+Missing or failing checks block the upload.
+
+Required repository secrets:
+
+- `ANDROID_SIGNING_KEY`: ASCII-armored GPG private key for artifact signing.
+- `ANDROID_SIGNING_KEY_PASSWORD`: passphrase for the signing key.
+- `SONATYPE_USERNAME`: Central Portal user-token username.
+- `SONATYPE_PASSWORD`: Central Portal user-token password.

--- a/android/openmedkit/build.gradle.kts
+++ b/android/openmedkit/build.gradle.kts
@@ -1,16 +1,31 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    `maven-publish`
+    signing
 }
+
+group = "org.openmed"
+version = providers.gradleProperty("openmedAndroidVersion")
+    .orElse(providers.environmentVariable("OPENMED_ANDROID_VERSION"))
+    .orElse("0.0.0-SNAPSHOT")
+    .get()
 
 val repoRoot = rootProject.projectDir.parentFile
 val generatedCatalogAssetsDir = layout.buildDirectory.dir("generated/assets/openmedCatalog")
 val generatedCatalogAsset = generatedCatalogAssetsDir.map {
     it.file("openmed_model_catalog.jsonl")
 }
+val centralStagingRepository = layout.buildDirectory.dir("central-staging")
+val centralPortalBundle = layout.buildDirectory.dir("central-portal")
 val pythonExecutable = providers.gradleProperty("openmedPython")
     .orElse(providers.environmentVariable("PYTHON"))
     .orElse("python3")
+val releaseVersionPattern = Regex("""\d+\.\d+\.\d+([.-][A-Za-z0-9][A-Za-z0-9.-]*)?""")
+
+fun isSnapshotVersion(): Boolean {
+    return version.toString().contains("SNAPSHOT", ignoreCase = true)
+}
 
 val generateAndroidModelCatalog by tasks.registering(Exec::class) {
     val manifestFile = repoRoot.resolve("models.jsonl")
@@ -63,6 +78,13 @@ android {
             assets.srcDir(generatedCatalogAssetsDir)
         }
     }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 kotlin {
@@ -75,6 +97,112 @@ tasks.matching { it.name.endsWith("Assets") }.configureEach {
 
 tasks.matching { it.name.startsWith("test") }.configureEach {
     dependsOn(generateAndroidModelCatalog)
+}
+
+val verifyReleasePublicationVersion by tasks.registering {
+    group = "publishing"
+    description = "Fails when the OpenMedKit publication version is a SNAPSHOT or malformed."
+
+    doLast {
+        val releaseVersion = version.toString()
+        if (isSnapshotVersion()) {
+            throw GradleException("OpenMedKit release publication version cannot be a SNAPSHOT.")
+        }
+        if (!releaseVersionPattern.matches(releaseVersion)) {
+            throw GradleException(
+                "OpenMedKit release publication version must look like 1.2.3 or 1.2.3-rc.1.",
+            )
+        }
+    }
+}
+
+val cleanCentralStagingRepository by tasks.registering(Delete::class) {
+    group = "publishing"
+    delete(centralStagingRepository)
+}
+
+val bundleCentralPortalPublication by tasks.registering(Zip::class) {
+    group = "publishing"
+    description = "Bundles the signed Maven publication in Central Portal upload layout."
+    dependsOn("publishReleasePublicationToCentralStagingRepository")
+
+    archiveFileName.set("openmedkit-${project.version}.zip")
+    destinationDirectory.set(centralPortalBundle)
+    from(centralStagingRepository)
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+
+                groupId = "org.openmed"
+                artifactId = "openmedkit"
+                version = project.version.toString()
+
+                pom {
+                    name.set("OpenMedKit Android")
+                    description.set(
+                        "Local-first Android library for OpenMed clinical AI workflows.",
+                    )
+                    url.set("https://github.com/maziyarpanahi/openmed")
+
+                    licenses {
+                        license {
+                            name.set("Apache License, Version 2.0")
+                            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                            distribution.set("repo")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id.set("maziyarpanahi")
+                            name.set("Maziyar Panahi")
+                            url.set("https://github.com/maziyarpanahi")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git:https://github.com/maziyarpanahi/openmed.git")
+                        developerConnection.set(
+                            "scm:git:ssh://git@github.com/maziyarpanahi/openmed.git",
+                        )
+                        url.set("https://github.com/maziyarpanahi/openmed")
+                    }
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                name = "centralStaging"
+                url = centralStagingRepository.get().asFile.toURI()
+            }
+        }
+    }
+
+    tasks.named("publishReleasePublicationToCentralStagingRepository") {
+        dependsOn(cleanCentralStagingRepository)
+        dependsOn(verifyReleasePublicationVersion)
+    }
+
+    signing {
+        val signingKey = providers.gradleProperty("signingInMemoryKey")
+            .orElse(providers.environmentVariable("ANDROID_SIGNING_KEY"))
+        val signingPassword = providers.gradleProperty("signingInMemoryKeyPassword")
+            .orElse(providers.environmentVariable("ANDROID_SIGNING_KEY_PASSWORD"))
+
+        setRequired {
+            gradle.taskGraph.allTasks.any {
+                it.name.startsWith("publish") || it.name == "bundleCentralPortalPublication"
+            } && !isSnapshotVersion()
+        }
+
+        if (signingKey.isPresent && signingPassword.isPresent) {
+            useInMemoryPgpKeys(signingKey.get(), signingPassword.get())
+        }
+        sign(publishing.publications["release"])
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Closes #594.

## Summary
- Configure the OpenMedKit Android release Maven publication with sources and javadoc jars, Apache-2.0 POM metadata, in-memory GPG signing, and a Central Portal bundle task.
- Add a tag/manual Android publish workflow that validates non-SNAPSHOT versions, requires Android CI plus the Android size/cold-start gate check, builds a signed bundle, and uploads it to Central Portal from repository secrets.
- Document the required signing and Sonatype secret names for Android publishing.

## Tests
- `./gradlew :openmedkit:tasks --all`
- `./gradlew :openmedkit:generatePomFileForReleasePublication :openmedkit:assembleRelease :openmedkit:testDebugUnitTest --stacktrace`
- Temporary-key signed bundle verification with `./gradlew :openmedkit:bundleCentralPortalPublication --stacktrace`
- `actionlint .github/workflows/android-publish.yml`
- `python scripts/release/check_github_actions_refs.py`
- `python scripts/release/check_repo_policy.py`
- `./gradlew test`
- `.venv/bin/python -m pytest tests/ -q`
