### PR TITLE
feat: add per-label reliability and calibration curves to the eval harness

### DIFF
--- a/openmed/eval/per_label_calibration.py
+++ b/openmed/eval/per_label_calibration.py
@@ -1,0 +1,120 @@
+"""Per-label reliability and Expected Calibration Error (ECE).
+
+Breaks calibration out per entity label so over- or under-confident labels are
+visible and can drive per-label threshold tuning. Measurement-only: it does not
+refit thresholds (OM-033) or duplicate the model-level reliability already in
+the calibration harness (OM-264). Reuses :class:`CalibrationSample` as the input
+type so scored predictions parse consistently.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Iterable, Mapping
+
+from openmed.eval.calibrate import CalibrationSample
+
+__all__ = ["per_label_calibration_report"]
+
+_DEFAULT_NUM_BINS = 10
+
+
+def per_label_calibration_report(
+    samples: Iterable[CalibrationSample | Mapping[str, Any]],
+    *,
+    num_bins: int = _DEFAULT_NUM_BINS,
+    ece_budget: float | None = None,
+) -> dict[str, Any]:
+    """Compute per-label reliability curves, ECE, and a budget flag.
+
+    Args:
+        samples: Scored predictions as :class:`CalibrationSample` instances or
+            mappings (parsed via ``CalibrationSample.from_mapping``); each
+            carries a canonical label, a confidence ``score``, a boolean
+            ``target``, and an optional ``weight``.
+        num_bins: Number of equal-width confidence bins in ``[0, 1]``.
+        ece_budget: Optional Expected-Calibration-Error budget; labels whose ECE
+            exceeds it are flagged.
+
+    Returns:
+        A deterministic, JSON-serializable mapping with per-label reliability
+        curves, ECE and over-budget flags, plus the sorted flagged-label list.
+        Contains only labels and numbers (no raw text).
+    """
+    if num_bins < 1:
+        raise ValueError("num_bins must be >= 1")
+
+    by_label: dict[str, list[CalibrationSample]] = defaultdict(list)
+    for item in samples:
+        sample = (
+            item
+            if isinstance(item, CalibrationSample)
+            else (CalibrationSample.from_mapping(item, default_model_id="model"))
+        )
+        by_label[sample.label].append(sample)
+
+    labels: dict[str, Any] = {}
+    flagged: list[str] = []
+    for label in sorted(by_label):
+        report = _label_report(by_label[label], num_bins)
+        over_budget = ece_budget is not None and report["ece"] > ece_budget
+        report["over_budget"] = over_budget
+        labels[label] = report
+        if over_budget:
+            flagged.append(label)
+
+    return {
+        "num_bins": num_bins,
+        "ece_budget": ece_budget,
+        "labels": labels,
+        "flagged_labels": flagged,
+    }
+
+
+def _bin_index(score: float, num_bins: int) -> int:
+    return min(max(int(score * num_bins), 0), num_bins - 1)
+
+
+def _label_report(samples: list[CalibrationSample], num_bins: int) -> dict[str, Any]:
+    weight = [0.0] * num_bins
+    weighted_score = [0.0] * num_bins
+    weighted_correct = [0.0] * num_bins
+    count = [0] * num_bins
+    total_weight = 0.0
+
+    for sample in samples:
+        index = _bin_index(sample.score, num_bins)
+        weight[index] += sample.weight
+        weighted_score[index] += sample.weight * sample.score
+        weighted_correct[index] += sample.weight * (1.0 if sample.target else 0.0)
+        count[index] += 1
+        total_weight += sample.weight
+
+    ece = 0.0
+    reliability: list[dict[str, Any]] = []
+    for index in range(num_bins):
+        if weight[index] > 0.0:
+            mean_confidence = weighted_score[index] / weight[index]
+            accuracy = weighted_correct[index] / weight[index]
+            if total_weight > 0.0:
+                ece += (weight[index] / total_weight) * abs(accuracy - mean_confidence)
+        else:
+            mean_confidence = 0.0
+            accuracy = 0.0
+        reliability.append(
+            {
+                "bin_lower": index / num_bins,
+                "bin_upper": (index + 1) / num_bins,
+                "count": count[index],
+                "weight": weight[index],
+                "mean_confidence": mean_confidence,
+                "accuracy": accuracy,
+            }
+        )
+
+    return {
+        "sample_count": len(samples),
+        "total_weight": total_weight,
+        "ece": ece,
+        "reliability": reliability,
+    }

--- a/tests/unit/eval/test_per_label_calibration.py
+++ b/tests/unit/eval/test_per_label_calibration.py
@@ -1,0 +1,97 @@
+"""Tests for per-label reliability and calibration curves (issue #935)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.eval.per_label_calibration import per_label_calibration_report
+
+
+def _sample(label, score, target):
+    return {"model_id": "m", "label": label, "score": score, "target": target}
+
+
+class TestPerLabelEce:
+    def test_ece_matches_reference_computation(self):
+        # One bin ([0.8,0.9)) with mean confidence 0.8 and accuracy 0.5.
+        samples = [
+            _sample("PERSON", 0.8, True),
+            _sample("PERSON", 0.8, False),
+        ]
+        report = per_label_calibration_report(samples)
+        assert report["labels"]["PERSON"]["ece"] == pytest.approx(0.3)
+        assert report["labels"]["PERSON"]["sample_count"] == 2
+
+    def test_perfectly_calibrated_is_near_zero(self):
+        samples = [_sample("EMAIL", 1.0, True) for _ in range(5)]
+        samples += [_sample("EMAIL", 0.0, False) for _ in range(5)]
+        report = per_label_calibration_report(samples)
+        assert report["labels"]["EMAIL"]["ece"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_labels_scored_independently(self):
+        samples = [
+            _sample("PERSON", 0.8, True),
+            _sample("PERSON", 0.8, False),
+            _sample("EMAIL", 1.0, True),
+            _sample("EMAIL", 0.0, False),
+        ]
+        report = per_label_calibration_report(samples)
+        assert set(report["labels"]) == {"PERSON", "EMAIL"}
+        assert report["labels"]["EMAIL"]["ece"] == pytest.approx(0.0, abs=1e-9)
+        assert report["labels"]["PERSON"]["ece"] == pytest.approx(0.3)
+
+
+class TestReliabilityCurve:
+    def test_bins_carry_confidence_and_accuracy(self):
+        samples = [
+            _sample("PERSON", 0.85, True),
+            _sample("PERSON", 0.85, False),
+        ]
+        report = per_label_calibration_report(samples, num_bins=10)
+        curve = report["labels"]["PERSON"]["reliability"]
+        assert len(curve) == 10
+        populated = [b for b in curve if b["count"] > 0]
+        assert len(populated) == 1
+        assert populated[0]["mean_confidence"] == pytest.approx(0.85)
+        assert populated[0]["accuracy"] == pytest.approx(0.5)
+
+
+class TestBudgetFlagging:
+    def test_labels_over_budget_are_flagged(self):
+        samples = [
+            _sample("PERSON", 0.8, True),
+            _sample("PERSON", 0.8, False),
+            _sample("EMAIL", 1.0, True),
+            _sample("EMAIL", 0.0, False),
+        ]
+        report = per_label_calibration_report(samples, ece_budget=0.1)
+        assert report["labels"]["PERSON"]["over_budget"] is True
+        assert report["labels"]["EMAIL"]["over_budget"] is False
+        assert report["flagged_labels"] == ["PERSON"]
+
+    def test_no_budget_flags_nothing(self):
+        report = per_label_calibration_report([_sample("PERSON", 0.8, True)])
+        assert report["flagged_labels"] == []
+        assert report["labels"]["PERSON"]["over_budget"] is False
+
+
+class TestContract:
+    def test_deterministic_and_json_serializable(self):
+        samples = [
+            _sample("PERSON", 0.8, True),
+            _sample("PERSON", 0.3, False),
+            _sample("EMAIL", 0.9, True),
+        ]
+        first = per_label_calibration_report(samples, ece_budget=0.2)
+        second = per_label_calibration_report(samples, ece_budget=0.2)
+        assert first == second
+        assert json.loads(json.dumps(first)) == first
+
+    def test_output_has_no_raw_text(self):
+        report = per_label_calibration_report([_sample("PERSON", 0.8, True)])
+        blob = json.dumps(report)
+        # Only labels and numbers are emitted; no free-text sample content.
+        assert "text" not in report
+        assert isinstance(blob, str)


### PR DESCRIPTION
Implements #935 (OM-578): breaks model calibration out **per label** so over- or under-confident entity types are visible and can drive per-label threshold tuning. Model-level reliability already exists (OM-264); this adds the per-label view.

## Changes

- **`openmed/eval/per_label_calibration.py`** — `per_label_calibration_report(samples, *, num_bins=10, ece_budget=None)`:
  - Groups scored predictions by canonical label and bins confidences per label.
  - Per bin: weighted **empirical accuracy** and **mean confidence**.
  - Per label: **Expected Calibration Error** `ECE = sum over bins of (w_b/W)*|acc_b - conf_b|`, a full **reliability curve**, and an **over-budget flag** when `ece_budget` is set.
  - Reuses the existing `CalibrationSample` as the input type (so scored predictions parse consistently via `from_mapping`).
  - Output is **deterministic**, **JSON-serializable**, and contains only labels and numbers (no raw text).

## Acceptance criteria

- [x] Given synthetic scored predictions, per-label ECE matches a hand-computed reference (e.g. one bin, confidence 0.8, accuracy 0.5 -> ECE 0.3).
- [x] Perfectly calibrated synthetic input yields near-zero ECE for every label.
- [x] Output is deterministic and contains no raw text.

## Out of scope

- Refitting thresholds (OM-033).
- Model-level reliability already in OM-264.

## Testing

- New `tests/unit/eval/test_per_label_calibration.py` (8 tests). Full unit suite passes (`.venv/bin/python -m pytest tests/ -q` -> 3066 passed, 33 skipped).
- The only 2 failures in the full run are the pre-existing network-gated integration tests (`tests/integration/test_sentence_detection_real.py`); identical on `master` offline, unrelated.
- `ruff check`/`format` clean. No new dependencies.

Closes #935