### PR TITLE
feat: add the HPO phenotype linker for clinical-finding spans

### DIFF
--- a/openmed/clinical/grounding/__init__.py
+++ b/openmed/clinical/grounding/__init__.py
@@ -1,0 +1,26 @@
+"""Clinical concept grounding: map clinical spans to coded vocabulary concepts.
+
+Provides the shared, reusable surface for the free-vocabulary linkers
+(RxNorm/ICD-10-CM/LOINC/HPO): the :class:`Candidate` type, a lightweight
+:func:`load_vocab` index loader, and a linker registry. Importing this package
+registers the bundled linkers by system key.
+"""
+
+from __future__ import annotations
+
+# Importing the linkers package registers them in the registry (e.g. "rxnorm").
+from . import linkers as _linkers  # noqa: F401  (import for registration side effect)
+from .registry import available_linkers, get_linker, register_linker
+from .types import Candidate
+from .vocab import VocabEntry, VocabIndex, load_vocab, normalize_term
+
+__all__ = [
+    "Candidate",
+    "VocabEntry",
+    "VocabIndex",
+    "load_vocab",
+    "normalize_term",
+    "register_linker",
+    "get_linker",
+    "available_linkers",
+]

--- a/openmed/clinical/grounding/linkers/__init__.py
+++ b/openmed/clinical/grounding/linkers/__init__.py
@@ -1,0 +1,7 @@
+"""Concept-grounding linkers. Importing a linker registers it by system key."""
+
+from __future__ import annotations
+
+from .rxnorm import RxNormLinker
+
+__all__ = ["RxNormLinker"]

--- a/openmed/clinical/grounding/linkers/__init__.py
+++ b/openmed/clinical/grounding/linkers/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
+from .hpo import HpoLinker
 from .icd10cm import Icd10cmLinker
 from .rxnorm import RxNormLinker
 
-__all__ = ["Icd10cmLinker", "RxNormLinker"]
+__all__ = ["HpoLinker", "Icd10cmLinker", "RxNormLinker"]

--- a/openmed/clinical/grounding/linkers/__init__.py
+++ b/openmed/clinical/grounding/linkers/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .icd10cm import Icd10cmLinker
 from .rxnorm import RxNormLinker
 
-__all__ = ["RxNormLinker"]
+__all__ = ["Icd10cmLinker", "RxNormLinker"]

--- a/openmed/clinical/grounding/linkers/base.py
+++ b/openmed/clinical/grounding/linkers/base.py
@@ -1,0 +1,108 @@
+"""Shared candidate-generation base for free-vocabulary linkers.
+
+Both the RxNorm and ICD-10-CM linkers share this two-stage matching (exact
+alias, then rapidfuzz approximate) so matching logic is implemented once.
+Subclasses set ``system``/``required_label`` and may override code formatting
+and ranking (e.g. ICD-10-CM dotted codes and leaf-over-category preference).
+Importing this module works without the optional ``grounding`` extra; the
+approximate stage is skipped when rapidfuzz is absent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openmed.core.labels import normalize_label
+
+from ..types import Candidate
+from ..vocab import VocabEntry, VocabIndex, normalize_term
+
+_DEFAULT_TOP_K = 5
+_DEFAULT_MIN_SCORE = 0.6
+
+
+class VocabLinker:
+    """Map span text to ranked ``Candidate`` codes over a vocabulary index."""
+
+    #: Vocabulary system emitted on candidates, e.g. ``"RXNORM"``.
+    system: str = ""
+    #: Registry key the linker registers under, e.g. ``"rxnorm"``.
+    key: str = ""
+    #: Canonical label the span must carry, e.g. ``MEDICATION`` (None = any).
+    required_label: str | None = None
+
+    def __init__(self, vocab: VocabIndex) -> None:
+        self._vocab = vocab
+
+    def link(
+        self,
+        text: str,
+        *,
+        top_k: int = _DEFAULT_TOP_K,
+        min_score: float = _DEFAULT_MIN_SCORE,
+        canonical_label: str | None = None,
+        fuzzy: bool = True,
+    ) -> list[Candidate]:
+        """Return ranked candidates for ``text``.
+
+        If ``canonical_label`` is given and does not normalize to
+        :attr:`required_label`, an empty list is returned.
+        """
+        if (
+            canonical_label is not None
+            and self.required_label is not None
+            and normalize_label(canonical_label) != self.required_label
+        ):
+            return []
+
+        query = normalize_term(text)
+        if not query:
+            return []
+
+        best: dict[str, Candidate] = {}
+        for entry in self._vocab.exact(query):
+            self._offer(best, entry, 1.0)
+        if fuzzy:
+            for entry, score in approximate_match(self._vocab, query):
+                if score >= min_score:
+                    self._offer(best, entry, score)
+
+        return sorted(best.values(), key=self._rank_key)[:top_k]
+
+    def _offer(
+        self, best: dict[str, Candidate], entry: VocabEntry, score: float
+    ) -> None:
+        candidate = self._candidate(entry, score)
+        existing = best.get(candidate.code)
+        if existing is None or score > existing.score:
+            best[candidate.code] = candidate
+
+    def _candidate(self, entry: VocabEntry, score: float) -> Candidate:
+        return Candidate(
+            self.system, self._format_code(entry.code), entry.display, float(score)
+        )
+
+    def _format_code(self, code: str) -> str:
+        """Hook for vocabulary-specific code formatting (default: unchanged)."""
+        return code
+
+    def _rank_key(self, candidate: Candidate) -> tuple[Any, ...]:
+        """Deterministic ranking: score desc, then code asc for ties."""
+        return (-candidate.score, candidate.code)
+
+
+def approximate_match(vocab: VocabIndex, query: str) -> list[tuple[VocabEntry, float]]:
+    """Best rapidfuzz similarity per entry; empty when rapidfuzz is absent."""
+    try:
+        from rapidfuzz import fuzz
+    except ImportError:  # pragma: no cover - exercised without the extra
+        return []
+
+    best_score: dict[str, float] = {}
+    best_entry: dict[str, VocabEntry] = {}
+    for alias, entry in vocab.iter_alias_entries():
+        score = fuzz.ratio(query, alias) / 100.0
+        if score > best_score.get(entry.code, 0.0):
+            best_score[entry.code] = score
+            best_entry[entry.code] = entry
+    return [(best_entry[code], score) for code, score in best_score.items()]

--- a/openmed/clinical/grounding/linkers/hpo.py
+++ b/openmed/clinical/grounding/linkers/hpo.py
@@ -1,0 +1,32 @@
+"""HPO phenotype linker for clinical-finding spans.
+
+Rounds out the free-vocabulary linker set (RxNorm/ICD-10-CM/LOINC/HPO) via the
+shared :mod:`.base` matching, normalizing codes to the ``HP:nnnnnnn`` format.
+"""
+
+from __future__ import annotations
+
+import re
+
+from openmed.core.labels import CONDITION
+
+from ..registry import register_linker
+from ..types import Candidate
+from .base import VocabLinker
+
+
+class HpoLinker(VocabLinker):
+    """Map phenotype/finding text to ranked HPO ``Candidate`` codes."""
+
+    system = "HPO"
+    key = "hpo"
+    required_label = CONDITION
+
+    def _format_code(self, code: str) -> str:
+        code = str(code).strip()
+        digits = re.sub(r"\D", "", code)
+        # HPO codes are seven zero-padded digits behind the ``HP:`` prefix.
+        return f"HP:{digits.zfill(7)}" if digits else code
+
+
+register_linker("hpo", HpoLinker)

--- a/openmed/clinical/grounding/linkers/icd10cm.py
+++ b/openmed/clinical/grounding/linkers/icd10cm.py
@@ -1,0 +1,38 @@
+"""ICD-10-CM diagnosis linker for condition spans.
+
+Follows the RxNorm linker pattern via the shared :mod:`.base` matching, adding
+ICD-10-CM specifics: dotted code formatting (``E119`` -> ``E11.9``) and a
+preference for billable leaf codes over their 3-character category.
+"""
+
+from __future__ import annotations
+
+from openmed.core.labels import CONDITION
+
+from ..registry import register_linker
+from ..types import Candidate
+from .base import VocabLinker
+
+
+class Icd10cmLinker(VocabLinker):
+    """Map diagnosis/condition text to ranked ICD-10-CM ``Candidate`` codes."""
+
+    system = "ICD10CM"
+    key = "icd10cm"
+    required_label = CONDITION
+
+    def _format_code(self, code: str) -> str:
+        code = str(code).strip().upper()
+        if "." in code or len(code) <= 3:
+            return code
+        # ICD-10-CM: 3-character category, then a dot, then the subcategory.
+        return f"{code[:3]}.{code[3:]}"
+
+    def _rank_key(self, candidate: Candidate) -> tuple[object, ...]:
+        # Score desc, then prefer billable leaf codes (longer/more specific),
+        # then code asc for a deterministic tie-break.
+        specificity = len(candidate.code.replace(".", ""))
+        return (-candidate.score, -specificity, candidate.code)
+
+
+register_linker("icd10cm", Icd10cmLinker)

--- a/openmed/clinical/grounding/linkers/rxnorm.py
+++ b/openmed/clinical/grounding/linkers/rxnorm.py
@@ -1,92 +1,23 @@
 """RxNorm approximate-match linker for medication spans.
 
-Reference implementation for the free-vocabulary linkers (ICD-10-CM, LOINC,
-HPO follow the same pattern). Candidate generation is two-stage: exact alias
-match first, then approximate match (rapidfuzz) over synonyms. Exact matching
-and importing this module work without the optional ``grounding`` extra; the
-approximate stage is skipped when rapidfuzz is not installed.
+Reference implementation for the free-vocabulary linkers; the shared
+candidate-generation lives in :mod:`.base`.
 """
 
 from __future__ import annotations
 
-from openmed.core.labels import MEDICATION, normalize_label
+from openmed.core.labels import MEDICATION
 
 from ..registry import register_linker
-from ..types import Candidate
-from ..vocab import VocabEntry, VocabIndex, normalize_term
-
-SYSTEM = "RXNORM"
-
-_DEFAULT_TOP_K = 5
-_DEFAULT_MIN_SCORE = 0.6
+from .base import VocabLinker
 
 
-class RxNormLinker:
+class RxNormLinker(VocabLinker):
     """Map medication text to ranked RxNorm ``Candidate`` codes."""
 
-    system = "rxnorm"
-
-    def __init__(self, vocab: VocabIndex) -> None:
-        self._vocab = vocab
-
-    def link(
-        self,
-        text: str,
-        *,
-        top_k: int = _DEFAULT_TOP_K,
-        min_score: float = _DEFAULT_MIN_SCORE,
-        canonical_label: str | None = None,
-        fuzzy: bool = True,
-    ) -> list[Candidate]:
-        """Return ranked RxNorm candidates for ``text``.
-
-        Only operates on medication spans: if ``canonical_label`` is given and
-        does not normalize to ``MEDICATION``, an empty list is returned.
-        """
-        if (
-            canonical_label is not None
-            and normalize_label(canonical_label) != MEDICATION
-        ):
-            return []
-
-        query = normalize_term(text)
-        if not query:
-            return []
-
-        best: dict[str, Candidate] = {}
-        for entry in self._vocab.exact(query):
-            best[entry.code] = Candidate(SYSTEM, entry.code, entry.display, 1.0)
-
-        if fuzzy:
-            for entry, score in self._approximate(query):
-                if score < min_score:
-                    continue
-                existing = best.get(entry.code)
-                if existing is None or score > existing.score:
-                    best[entry.code] = Candidate(
-                        SYSTEM, entry.code, entry.display, score
-                    )
-
-        # Deterministic ranking: score desc, then code asc for ties.
-        ranked = sorted(
-            best.values(), key=lambda candidate: (-candidate.score, candidate.code)
-        )
-        return ranked[:top_k]
-
-    def _approximate(self, query: str) -> list[tuple[VocabEntry, float]]:
-        try:
-            from rapidfuzz import fuzz
-        except ImportError:  # pragma: no cover - exercised without the extra
-            return []
-
-        best_score: dict[str, float] = {}
-        best_entry: dict[str, VocabEntry] = {}
-        for alias, entry in self._vocab.iter_alias_entries():
-            score = fuzz.ratio(query, alias) / 100.0
-            if score > best_score.get(entry.code, 0.0):
-                best_score[entry.code] = score
-                best_entry[entry.code] = entry
-        return [(best_entry[code], score) for code, score in best_score.items()]
+    system = "RXNORM"
+    key = "rxnorm"
+    required_label = MEDICATION
 
 
 register_linker("rxnorm", RxNormLinker)

--- a/openmed/clinical/grounding/linkers/rxnorm.py
+++ b/openmed/clinical/grounding/linkers/rxnorm.py
@@ -1,0 +1,92 @@
+"""RxNorm approximate-match linker for medication spans.
+
+Reference implementation for the free-vocabulary linkers (ICD-10-CM, LOINC,
+HPO follow the same pattern). Candidate generation is two-stage: exact alias
+match first, then approximate match (rapidfuzz) over synonyms. Exact matching
+and importing this module work without the optional ``grounding`` extra; the
+approximate stage is skipped when rapidfuzz is not installed.
+"""
+
+from __future__ import annotations
+
+from openmed.core.labels import MEDICATION, normalize_label
+
+from ..registry import register_linker
+from ..types import Candidate
+from ..vocab import VocabEntry, VocabIndex, normalize_term
+
+SYSTEM = "RXNORM"
+
+_DEFAULT_TOP_K = 5
+_DEFAULT_MIN_SCORE = 0.6
+
+
+class RxNormLinker:
+    """Map medication text to ranked RxNorm ``Candidate`` codes."""
+
+    system = "rxnorm"
+
+    def __init__(self, vocab: VocabIndex) -> None:
+        self._vocab = vocab
+
+    def link(
+        self,
+        text: str,
+        *,
+        top_k: int = _DEFAULT_TOP_K,
+        min_score: float = _DEFAULT_MIN_SCORE,
+        canonical_label: str | None = None,
+        fuzzy: bool = True,
+    ) -> list[Candidate]:
+        """Return ranked RxNorm candidates for ``text``.
+
+        Only operates on medication spans: if ``canonical_label`` is given and
+        does not normalize to ``MEDICATION``, an empty list is returned.
+        """
+        if (
+            canonical_label is not None
+            and normalize_label(canonical_label) != MEDICATION
+        ):
+            return []
+
+        query = normalize_term(text)
+        if not query:
+            return []
+
+        best: dict[str, Candidate] = {}
+        for entry in self._vocab.exact(query):
+            best[entry.code] = Candidate(SYSTEM, entry.code, entry.display, 1.0)
+
+        if fuzzy:
+            for entry, score in self._approximate(query):
+                if score < min_score:
+                    continue
+                existing = best.get(entry.code)
+                if existing is None or score > existing.score:
+                    best[entry.code] = Candidate(
+                        SYSTEM, entry.code, entry.display, score
+                    )
+
+        # Deterministic ranking: score desc, then code asc for ties.
+        ranked = sorted(
+            best.values(), key=lambda candidate: (-candidate.score, candidate.code)
+        )
+        return ranked[:top_k]
+
+    def _approximate(self, query: str) -> list[tuple[VocabEntry, float]]:
+        try:
+            from rapidfuzz import fuzz
+        except ImportError:  # pragma: no cover - exercised without the extra
+            return []
+
+        best_score: dict[str, float] = {}
+        best_entry: dict[str, VocabEntry] = {}
+        for alias, entry in self._vocab.iter_alias_entries():
+            score = fuzz.ratio(query, alias) / 100.0
+            if score > best_score.get(entry.code, 0.0):
+                best_score[entry.code] = score
+                best_entry[entry.code] = entry
+        return [(best_entry[code], score) for code, score in best_score.items()]
+
+
+register_linker("rxnorm", RxNormLinker)

--- a/openmed/clinical/grounding/registry.py
+++ b/openmed/clinical/grounding/registry.py
@@ -1,0 +1,29 @@
+"""Linker registry so ``ground(systems=[...])`` (a later task) can dispatch.
+
+Linkers register themselves under a vocabulary system key (e.g. ``"rxnorm"``).
+The registry stores a callable ``(vocab) -> linker`` factory so callers can
+build a linker with their own vocabulary data.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+LinkerFactory = Callable[..., Any]
+
+_LINKERS: dict[str, LinkerFactory] = {}
+
+
+def register_linker(system: str, factory: LinkerFactory) -> None:
+    """Register a linker factory under a vocabulary ``system`` key."""
+    _LINKERS[system] = factory
+
+
+def get_linker(system: str) -> LinkerFactory:
+    """Return the linker factory registered for ``system`` (raises KeyError)."""
+    return _LINKERS[system]
+
+
+def available_linkers() -> list[str]:
+    """Return the sorted list of registered linker system keys."""
+    return sorted(_LINKERS)

--- a/openmed/clinical/grounding/types.py
+++ b/openmed/clinical/grounding/types.py
@@ -1,0 +1,20 @@
+"""Shared types for clinical concept grounding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A ranked grounding candidate: a coded concept for a clinical span.
+
+    ``system`` is the vocabulary (e.g. ``"RXNORM"``), ``code`` its identifier
+    (e.g. an RxCUI), ``display`` a human-readable name, and ``score`` a
+    ``0.0``-``1.0`` match confidence (``1.0`` for an exact alias match).
+    """
+
+    system: str
+    code: str
+    display: str
+    score: float

--- a/openmed/clinical/grounding/vocab.py
+++ b/openmed/clinical/grounding/vocab.py
@@ -1,0 +1,103 @@
+"""Lightweight free-vocabulary index for concept-grounding linkers.
+
+The loader accepts either a JSONL file path or in-memory rows, so no full
+vocabulary is bundled: callers provide their own (open) vocabulary data at
+runtime, while tests use a small committed fixture. Each row carries a code, a
+display name, and synonyms/aliases; key names are matched leniently so the same
+loader serves RxNorm, ICD-10-CM, LOINC and HPO.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping, Sequence
+
+_CODE_KEYS = ("code", "rxcui", "cui", "id")
+_DISPLAY_KEYS = ("display", "name", "str", "label")
+_SYNONYM_KEYS = ("synonyms", "aliases", "terms")
+
+
+def normalize_term(term: Any) -> str:
+    """Casefold, trim and collapse whitespace for alias matching."""
+    return " ".join(str(term).strip().casefold().split())
+
+
+@dataclass(frozen=True)
+class VocabEntry:
+    """One vocabulary concept: a code, display name and its aliases."""
+
+    code: str
+    display: str
+    synonyms: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class VocabIndex:
+    """An indexed vocabulary with exact-alias lookup and alias iteration."""
+
+    entries: tuple[VocabEntry, ...]
+    alias_map: Mapping[str, tuple[VocabEntry, ...]]
+
+    def exact(self, term: str) -> list[VocabEntry]:
+        """Return entries whose alias exactly matches ``term`` (normalized)."""
+        return list(self.alias_map.get(normalize_term(term), ()))
+
+    def iter_alias_entries(self) -> Iterator[tuple[str, VocabEntry]]:
+        """Yield ``(normalized_alias, entry)`` for every alias in the index."""
+        for entry in self.entries:
+            for synonym in entry.synonyms:
+                yield normalize_term(synonym), entry
+
+
+def load_vocab(source: str | Path | Iterable[Mapping[str, Any]]) -> VocabIndex:
+    """Load a vocabulary from a JSONL path or an iterable of row mappings."""
+    entries = tuple(_entry_from_row(row) for row in _iter_rows(source))
+
+    alias_map: dict[str, list[VocabEntry]] = {}
+    for entry in entries:
+        aliases = entry.synonyms or (entry.display,)
+        for alias in aliases:
+            key = normalize_term(alias)
+            if not key:
+                continue
+            bucket = alias_map.setdefault(key, [])
+            if entry not in bucket:
+                bucket.append(entry)
+
+    return VocabIndex(
+        entries=entries,
+        alias_map={key: tuple(value) for key, value in alias_map.items()},
+    )
+
+
+def _iter_rows(
+    source: str | Path | Iterable[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    if isinstance(source, (str, Path)):
+        with open(source, encoding="utf-8") as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+    return [dict(row) for row in source]
+
+
+def _entry_from_row(row: Mapping[str, Any]) -> VocabEntry:
+    code = _first(row, _CODE_KEYS)
+    if code is None:
+        raise ValueError(f"vocabulary row is missing a code field: {row!r}")
+    display = _first(row, _DISPLAY_KEYS, default=code)
+    synonyms = _first(row, _SYNONYM_KEYS, default=None)
+    if isinstance(synonyms, Sequence) and not isinstance(synonyms, (str, bytes)):
+        synonym_tuple = tuple(str(item) for item in synonyms)
+    else:
+        synonym_tuple = (str(display),)
+    return VocabEntry(code=str(code), display=str(display), synonyms=synonym_tuple)
+
+
+def _first(
+    row: Mapping[str, Any], keys: tuple[str, ...], *, default: Any = None
+) -> Any:
+    for key in keys:
+        if key in row and row[key] is not None:
+            return row[key]
+    return default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
   "pandas>=2.0",
   "polars>=0.20",
   "python-dateutil>=2.8",
+  "rapidfuzz>=3",
   "ruff==0.15.20",
   "tomli>=2.0; python_version < '3.11'",
 ]
@@ -101,6 +102,10 @@ multimodal = [
 
 # PaddleOCR is a heavy, platform-sensitive backend (pulls in paddlepaddle), so
 # it is opt-in rather than bundled into the general multimodal extra.
+grounding = [
+  "rapidfuzz>=3",
+]
+
 ocr-paddle = [
   "paddleocr>=2.7",
 ]

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -99,6 +99,7 @@ REVIEWED_LICENSES = {
     "python-doctr": "Apache-2.0",
     "pytesseract": "Apache-2.0",
     "python-docx": "MIT",
+    "rapidfuzz": "MIT",
     "rich": "MIT",
     "safetensors": "Apache-2.0",
     "spacy": "MIT",

--- a/tests/fixtures/clinical/grounding/hpo_sample.jsonl
+++ b/tests/fixtures/clinical/grounding/hpo_sample.jsonl
@@ -1,0 +1,5 @@
+{"code": "1250", "display": "Seizure", "synonyms": ["seizure", "seizures", "epileptic seizure"]}
+{"code": "0002315", "display": "Headache", "synonyms": ["headache", "headaches", "cephalgia"]}
+{"code": "HP:0001945", "display": "Fever", "synonyms": ["fever", "pyrexia", "febrile"]}
+{"code": "1251", "display": "Ataxia", "synonyms": ["ataxia", "loss of coordination"]}
+{"code": "0012735", "display": "Cough", "synonyms": ["cough", "coughing"]}

--- a/tests/fixtures/clinical/grounding/icd10cm_sample.jsonl
+++ b/tests/fixtures/clinical/grounding/icd10cm_sample.jsonl
@@ -1,0 +1,5 @@
+{"code": "E119", "display": "Type 2 diabetes mellitus without complications", "synonyms": ["type 2 diabetes mellitus", "type 2 diabetes", "T2DM", "NIDDM"]}
+{"code": "E11", "display": "Type 2 diabetes mellitus", "synonyms": ["type 2 diabetes mellitus"]}
+{"code": "E1165", "display": "Type 2 diabetes mellitus with hyperglycemia", "synonyms": ["type 2 diabetes mellitus with hyperglycemia"]}
+{"code": "I10", "display": "Essential (primary) hypertension", "synonyms": ["hypertension", "high blood pressure", "essential hypertension"]}
+{"code": "J189", "display": "Pneumonia, unspecified organism", "synonyms": ["pneumonia"]}

--- a/tests/fixtures/clinical/grounding/rxnorm_sample.jsonl
+++ b/tests/fixtures/clinical/grounding/rxnorm_sample.jsonl
@@ -1,0 +1,5 @@
+{"code": "1191", "display": "aspirin", "synonyms": ["aspirin", "acetylsalicylic acid", "ASA"]}
+{"code": "161", "display": "acetaminophen", "synonyms": ["acetaminophen", "paracetamol", "Tylenol", "APAP"]}
+{"code": "6809", "display": "metformin", "synonyms": ["metformin", "Glucophage"]}
+{"code": "29046", "display": "lisinopril", "synonyms": ["lisinopril", "Prinivil", "Zestril"]}
+{"code": "5640", "display": "ibuprofen", "synonyms": ["ibuprofen", "Advil", "Motrin"]}

--- a/tests/unit/clinical/test_linker_hpo.py
+++ b/tests/unit/clinical/test_linker_hpo.py
@@ -1,0 +1,66 @@
+"""Tests for the HPO phenotype linker (issue #297)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openmed.clinical.grounding import (
+    Candidate,
+    available_linkers,
+    get_linker,
+    load_vocab,
+)
+from openmed.clinical.grounding.linkers.hpo import HpoLinker
+
+FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "clinical"
+    / "grounding"
+    / "hpo_sample.jsonl"
+)
+
+
+@pytest.fixture
+def linker() -> HpoLinker:
+    return HpoLinker(load_vocab(FIXTURE))
+
+
+class TestHpoLinker:
+    def test_phenotype_links_to_expected_hp_code(self, linker):
+        candidates = linker.link("seizure")
+        assert candidates
+        top = candidates[0]
+        assert isinstance(top, Candidate)
+        assert top.system == "HPO"
+        assert top.code == "HP:0001250"
+        assert top.score == pytest.approx(1.0)
+
+    def test_synonym_links_to_expected_code(self, linker):
+        assert linker.link("pyrexia")[0].code == "HP:0001945"
+
+    def test_hp_code_format_is_normalized(self, linker):
+        # Fixture stores bare/short/prefixed codes; output is always HP:nnnnnnn.
+        assert linker.link("headache")[0].code == "HP:0002315"
+        assert linker.link("ataxia")[0].code == "HP:0001251"
+        assert linker.link("fever")[0].code == "HP:0001945"
+
+    def test_deterministic_across_runs(self, linker):
+        assert linker.link("cough") == linker.link("cough")
+
+    def test_condition_gate(self, linker):
+        assert linker.link("seizure", canonical_label="DATE") == []
+        assert linker.link("seizure", canonical_label="finding")
+
+
+class TestRegistryAndReuse:
+    def test_registered_under_hpo(self):
+        assert "hpo" in available_linkers()
+        assert get_linker("hpo") is HpoLinker
+
+    def test_reuses_shared_matching_base(self):
+        from openmed.clinical.grounding.linkers.base import VocabLinker
+
+        assert issubclass(HpoLinker, VocabLinker)

--- a/tests/unit/clinical/test_linker_icd10cm.py
+++ b/tests/unit/clinical/test_linker_icd10cm.py
@@ -1,0 +1,67 @@
+"""Tests for the ICD-10-CM diagnosis linker (issue #268)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openmed.clinical.grounding import (
+    Candidate,
+    available_linkers,
+    get_linker,
+    load_vocab,
+)
+from openmed.clinical.grounding.linkers.icd10cm import Icd10cmLinker
+
+FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "clinical"
+    / "grounding"
+    / "icd10cm_sample.jsonl"
+)
+
+
+@pytest.fixture
+def linker() -> Icd10cmLinker:
+    return Icd10cmLinker(load_vocab(FIXTURE))
+
+
+class TestIcd10cmLinker:
+    def test_diagnosis_links_to_leaf_code_with_dotted_format(self, linker):
+        candidates = linker.link("type 2 diabetes mellitus")
+        assert candidates
+        top = candidates[0]
+        assert isinstance(top, Candidate)
+        assert top.system == "ICD10CM"
+        # Leaf (billable) code preferred over the E11 category, dotted formatting.
+        assert top.code == "E11.9"
+
+    def test_synonym_links_to_expected_code(self, linker):
+        assert linker.link("high blood pressure")[0].code == "I10"
+
+    def test_dotted_formatting_for_longer_codes(self, linker):
+        candidates = linker.link("type 2 diabetes mellitus with hyperglycemia")
+        assert candidates[0].code == "E11.65"
+
+    def test_deterministic_across_runs(self, linker):
+        assert linker.link("pneumonia") == linker.link("pneumonia")
+
+    def test_condition_gate_blocks_non_condition_label(self, linker):
+        assert linker.link("pneumonia", canonical_label="DATE") == []
+        assert linker.link("pneumonia", canonical_label="disease")
+
+
+class TestRegistryAndReuse:
+    def test_registered_under_icd10cm(self):
+        assert "icd10cm" in available_linkers()
+        assert get_linker("icd10cm") is Icd10cmLinker
+
+    def test_reuses_shared_matching_base(self):
+        from openmed.clinical.grounding.linkers.base import VocabLinker
+        from openmed.clinical.grounding.linkers.rxnorm import RxNormLinker
+
+        # Both linkers share the base implementation rather than duplicating it.
+        assert issubclass(Icd10cmLinker, VocabLinker)
+        assert issubclass(RxNormLinker, VocabLinker)

--- a/tests/unit/clinical/test_linker_rxnorm.py
+++ b/tests/unit/clinical/test_linker_rxnorm.py
@@ -1,0 +1,98 @@
+"""Tests for the RxNorm approximate-match linker and grounding scaffolding (#267)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openmed.clinical.grounding import (
+    Candidate,
+    available_linkers,
+    get_linker,
+    load_vocab,
+)
+from openmed.clinical.grounding.linkers.rxnorm import RxNormLinker
+
+FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "clinical"
+    / "grounding"
+    / "rxnorm_sample.jsonl"
+)
+
+
+@pytest.fixture
+def linker() -> RxNormLinker:
+    return RxNormLinker(load_vocab(FIXTURE))
+
+
+class TestVocabLoader:
+    def test_loads_from_path(self):
+        vocab = load_vocab(FIXTURE)
+        assert vocab.exact("aspirin")
+
+    def test_loads_from_in_memory_rows(self):
+        vocab = load_vocab(
+            [{"code": "1", "display": "widget", "synonyms": ["widget", "gadget"]}]
+        )
+        assert vocab.exact("gadget")
+
+
+class TestExactMatch:
+    def test_link_exact_returns_expected_rxcui_top1(self, linker):
+        candidates = linker.link("aspirin")
+        assert candidates
+        top = candidates[0]
+        assert isinstance(top, Candidate)
+        assert top.system == "RXNORM"
+        assert top.code == "1191"
+        assert top.display == "aspirin"
+        assert top.score == pytest.approx(1.0)
+
+    def test_link_matches_brand_synonym(self, linker):
+        candidates = linker.link("Tylenol")
+        assert candidates[0].code == "161"
+
+    def test_out_of_vocabulary_returns_empty_or_low_score(self, linker):
+        candidates = linker.link("qwertabcdrug")
+        assert candidates == [] or all(c.score < 0.5 for c in candidates)
+
+    def test_deterministic_across_runs(self, linker):
+        first = linker.link("acetaminophen")
+        second = linker.link("acetaminophen")
+        assert first == second
+
+
+class TestApproximateMatch:
+    def test_misspelling_links_within_threshold(self, linker):
+        pytest.importorskip("rapidfuzz")
+        candidates = linker.link("asprin")  # missing 'a'
+        assert candidates
+        assert candidates[0].code == "1191"
+        assert candidates[0].score < 1.0
+
+    def test_top_k_limits_results(self, linker):
+        pytest.importorskip("rapidfuzz")
+        candidates = linker.link("metformin", top_k=2)
+        assert len(candidates) <= 2
+
+
+class TestMedicationGate:
+    def test_gate_blocks_non_medication_label(self, linker):
+        assert linker.link("aspirin", canonical_label="DATE") == []
+
+    def test_gate_allows_drug_alias(self, linker):
+        # 'drug' normalizes to MEDICATION via the canonical label taxonomy.
+        assert linker.link("aspirin", canonical_label="drug")
+
+
+class TestRegistry:
+    def test_rxnorm_linker_is_discoverable(self):
+        assert "rxnorm" in available_linkers()
+        assert get_linker("rxnorm") is RxNormLinker
+
+    def test_unknown_system_raises(self):
+        with pytest.raises(KeyError):
+            get_linker("does-not-exist")

--- a/uv.lock
+++ b/uv.lock
@@ -3371,6 +3371,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "python-dateutil" },
+    { name = "rapidfuzz" },
     { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -3393,6 +3394,9 @@ gliner = [
 ]
 gptq = [
     { name = "auto-gptq" },
+]
+grounding = [
+    { name = "rapidfuzz" },
 ]
 hf = [
     { name = "accelerate" },
@@ -3525,6 +3529,8 @@ requires-dist = [
     { name = "python-doctr", marker = "extra == 'multimodal'", specifier = ">=1.0" },
     { name = "python-docx", marker = "extra == 'multimodal'", specifier = ">=1.1" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rapidfuzz", marker = "extra == 'dev'", specifier = ">=3" },
+    { name = "rapidfuzz", marker = "extra == 'grounding'", specifier = ">=3" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
     { name = "safetensors", marker = "extra == 'mlx'", specifier = ">=0.4" },
@@ -3543,7 +3549,7 @@ requires-dist = [
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'service'", specifier = ">=0.29" },
 ]
-provides-extras = ["awq", "cli", "coreml", "dev", "docs", "duckdb", "gliner", "gptq", "hf", "kafka", "langchain", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "pandas", "philter", "polars", "presidio", "pydeid", "service", "spacy"]
+provides-extras = ["awq", "cli", "coreml", "dev", "docs", "duckdb", "gliner", "gptq", "grounding", "hf", "kafka", "langchain", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "pandas", "philter", "polars", "presidio", "pydeid", "service", "spacy"]
 
 [[package]]
 name = "orjson"


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #1135 (#268) → #1134 (#267).** This reuses the shared `VocabLinker` base from #268 and the grounding scaffolding from #267. Until those merge, the diff below also shows their changes; I will rebase onto `master` as they land. Please review #1134 → #1135 first.

Implements #297 (OM-132): the HPO phenotype linker, completing the free-vocabulary linker set (RxNorm/ICD-10-CM/LOINC/HPO). Follows the established pattern via the shared matcher.

## Changes

- **`grounding/linkers/hpo.py`** — `HpoLinker` (`HPO` / gated on `CONDITION` clinical-finding spans) mapping phenotype/finding text to HPO terms over the shared exact + rapidfuzz-approximate matching, **normalizing codes to the `HP:nnnnnnn` format** (7 zero-padded digits). Registered under `"hpo"`.
- **`tests/fixtures/clinical/grounding/hpo_sample.jsonl`** — tiny curated fixture with mixed code formats (`1250`, `0002315`, `HP:0001945`) to exercise the normalization. Full HPO is not bundled.

## Acceptance criteria

- [x] `HpoLinker(vocab).link("seizure")` returns the fixture HP code as top-1 with `HP:0001250` formatting.
- [x] Registered under `"hpo"` and reuses the shared matching base (asserted `issubclass(HpoLinker, VocabLinker)`).
- [x] Code format preserved/normalized; determinism; CONDITION gate.

## Testing

- New `tests/unit/clinical/test_linker_hpo.py` (7 tests). Full unit suite passes (`.venv/bin/python -m pytest tests/ -q` -> 3067 passed, 28 skipped).
- The only 2 failures in the full run are the pre-existing network-gated integration tests; identical on `master` offline, unrelated.
- `ruff check`/`format` clean. No new dependencies (reuses the `grounding` extra).

## Out of scope

- Dense retrieval; FHIR/OMOP export; HPO-to-OMIM disease associations.

Closes #297