### PR TITLE
Complete l-diversity metric selection for tabular risk reports

### DIFF
--- a/openmed/risk/kanon.py
+++ b/openmed/risk/kanon.py
@@ -22,6 +22,7 @@ from .reid import _coerce_records, _normalize_qi_value, _profile_record
 
 __all__ = ["kanon_report"]
 
+_SUPPORTED_L_METRICS = ("distinct", "entropy")
 _SUPPORTED_T_DISTANCES = ("variational",)
 
 
@@ -53,6 +54,11 @@ def kanon_report(
         k (min class size), per-class l-diversity and t-closeness, and the
         worst-case (overall) l-diversity and t-closeness.
     """
+    if l_metric not in _SUPPORTED_L_METRICS:
+        raise ValueError(
+            f"Unsupported l_metric {l_metric!r}; "
+            f"supported: {', '.join(_SUPPORTED_L_METRICS)}."
+        )
     if t_distance not in _SUPPORTED_T_DISTANCES:
         raise ValueError(
             f"Unsupported t_distance {t_distance!r}; "
@@ -60,7 +66,7 @@ def kanon_report(
         )
 
     coerced = _coerce_records(records, source="deidentified")
-    sensitive = list(sensitive_attributes or [])
+    sensitive = sorted(dict.fromkeys(sensitive_attributes or []))
 
     members: defaultdict[Any, list[int]] = defaultdict(list)
     json_keys: dict[Any, list[Any]] = {}
@@ -140,6 +146,7 @@ def kanon_report(
         "class_count": len(classes),
         "class_size_distribution": _size_distribution(sizes),
         "equivalence_classes": classes,
+        "l": _headline_l_diversity(overall_l, l_metric),
         "l_diversity": overall_l,
         "t_closeness": overall_t,
         "l_metric": l_metric,
@@ -201,6 +208,14 @@ def _variational_distance(
 def _size_distribution(sizes: Sequence[int]) -> list[list[int]]:
     counts = Counter(sizes)
     return [[size, counts[size]] for size in sorted(counts)]
+
+
+def _headline_l_diversity(
+    overall_l: Mapping[str, Mapping[str, int | float]],
+    l_metric: str,
+) -> dict[str, int | float]:
+    field = "min_distinct" if l_metric == "distinct" else "min_entropy"
+    return {attr: metrics[field] for attr, metrics in overall_l.items()}
 
 
 def _reported_quasi_identifiers(

--- a/tests/unit/risk/test_kanon.py
+++ b/tests/unit/risk/test_kanon.py
@@ -58,6 +58,7 @@ class TestLDiversity:
         for cls in report["equivalence_classes"]:
             assert cls["l_diversity"]["disease"]["distinct"] == 1
             assert cls["l_diversity"]["disease"]["entropy"] == 0.0
+        assert report["l"]["disease"] == 1
         assert report["l_diversity"]["disease"]["min_distinct"] == 1
 
     def test_distinct_counts_multiple_sensitive_values(self):
@@ -71,6 +72,20 @@ class TestLDiversity:
         cls = report["equivalence_classes"][0]
         assert cls["l_diversity"]["disease"]["distinct"] == 2
         assert cls["l_diversity"]["disease"]["entropy"] == pytest.approx(1.0)
+
+    def test_entropy_metric_selects_overall_entropy(self):
+        records = [
+            {"g": "A", "disease": "flu"},
+            {"g": "A", "disease": "cold"},
+        ]
+        report = kanon_report(
+            records,
+            quasi_identifiers=["g"],
+            sensitive_attributes=["disease"],
+            l_metric="entropy",
+        )
+        assert report["l"]["disease"] == pytest.approx(1.0)
+        assert report["l_diversity"]["disease"]["min_entropy"] == pytest.approx(1.0)
 
 
 class TestTCloseness:
@@ -127,6 +142,7 @@ class TestContract:
     def test_no_sensitive_attributes_reports_k_only(self):
         report = kanon_report(self.RECORDS, quasi_identifiers=["age", "zip"])
         assert report["k"] == 1
+        assert report["l"] == {}
         assert report["l_diversity"] == {}
         assert report["t_closeness"] == {}
 
@@ -139,3 +155,7 @@ class TestContract:
         report = kanon_report(records, sensitive_attributes=None)
         assert report["k"] >= 1
         assert json.loads(json.dumps(report)) == report
+
+    def test_unsupported_l_metric_is_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported l_metric"):
+            kanon_report(self.RECORDS, quasi_identifiers=["age"], l_metric="ratio")


### PR DESCRIPTION
Closes #500.

This follow-up completes the OM-307 measurement API by making l_metric select a headline l-diversity value, validating unsupported l_metric values, and keeping the detailed per-class distinct and entropy metrics JSON-stable for audit and risk reports.

Validation:
- .venv/bin/python -m pytest tests/unit/risk/test_kanon.py tests/unit/risk/test_risk_dashboard.py -q
- .venv/bin/python -m pytest tests/ -q
- uv run ruff check openmed/risk/kanon.py tests/unit/risk/test_kanon.py
- uv run ruff format --check openmed/risk/kanon.py tests/unit/risk/test_kanon.py