### PR TITLE
Add DICOM burned-in pixel-text OCR redaction

### DIFF
--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -38,7 +38,12 @@ from .dicom import (
     DicomHeaderAction,
     DicomHeaderDeidPolicy,
     DicomHeaderDeidResult,
+    DicomPixelFinding,
+    DicomPixelRedactionPolicy,
+    DicomPixelRedactionResult,
+    DicomResidualTextReport,
     deidentify_dicom_headers,
+    redact_dicom_pixels,
 )
 from .documents_markdown import extract_asciidoc, extract_markdown, redact_source_text
 from .documents_pdf import ProjectedRectangle, extract_pdf, project_text_spans
@@ -95,7 +100,12 @@ __all__ = [
     "DicomHeaderAction",
     "DicomHeaderDeidPolicy",
     "DicomHeaderDeidResult",
+    "DicomPixelFinding",
+    "DicomPixelRedactionPolicy",
+    "DicomPixelRedactionResult",
+    "DicomResidualTextReport",
     "deidentify_dicom_headers",
+    "redact_dicom_pixels",
     "ProjectedRectangle",
     "extract_pdf",
     "project_text_spans",

--- a/openmed/multimodal/dicom.py
+++ b/openmed/multimodal/dicom.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import math
 import re
 import uuid
 from collections import Counter
@@ -16,7 +17,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 from .base import ExtractedDocument, register_handler
 from .exceptions import MissingDependencyError
@@ -106,6 +107,116 @@ class DicomHeaderDeidResult:
             "uid_remap_count": self.uid_remap_count,
             "private_tag_removed_count": self.private_tag_removed_count,
             "actions": [action.to_dict() for action in self.actions],
+        }
+
+
+@dataclass(frozen=True)
+class DicomPixelRedactionPolicy:
+    """Policy knobs for DICOM burned-in pixel-text redaction."""
+
+    output_path: str | Path | None = None
+    ocr_engine: Any = None
+    model_name: str | None = None
+    confidence_threshold: float = 0.5
+    bbox_padding: int = 1
+    verify_residual: bool = True
+    fail_on_residual: bool = True
+    custom_recognizer: Any = None
+
+
+@dataclass(frozen=True)
+class DicomPixelFinding:
+    """Audit-safe description of one OCR-projected pixel redaction."""
+
+    frame_index: int
+    bbox: tuple[int, int, int, int]
+    label: str
+    confidence: float
+    text_sha256: str
+    text_length: int
+    sources: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return an audit-safe finding summary without raw OCR text."""
+
+        payload: dict[str, Any] = {
+            "frame_index": self.frame_index,
+            "bbox": list(self.bbox),
+            "label": self.label,
+            "confidence": self.confidence,
+            "text_sha256": self.text_sha256,
+            "text_length": self.text_length,
+        }
+        if self.sources:
+            payload["sources"] = list(self.sources)
+        return payload
+
+
+@dataclass(frozen=True)
+class DicomResidualTextReport:
+    """Residual OCR PHI verification report for redacted DICOM pixels."""
+
+    frame_count: int
+    residuals: tuple[DicomPixelFinding, ...] = ()
+
+    @property
+    def residual_entity_count(self) -> int:
+        """Number of residual OCR-projected PHI findings."""
+
+        return len(self.residuals)
+
+    @property
+    def passed(self) -> bool:
+        """Whether residual OCR found zero PHI."""
+
+        return self.residual_entity_count == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable residual report."""
+
+        return {
+            "frame_count": self.frame_count,
+            "passed": self.passed,
+            "residual_entity_count": self.residual_entity_count,
+            "residuals": [finding.to_dict() for finding in self.residuals],
+        }
+
+
+@dataclass(frozen=True)
+class DicomPixelRedactionResult:
+    """Result returned by :func:`redact_dicom_pixels`."""
+
+    source_path: Path
+    output_path: Path
+    frames_processed: int
+    findings: tuple[DicomPixelFinding, ...]
+    residual_report: DicomResidualTextReport
+
+    @property
+    def redaction_count(self) -> int:
+        """Number of projected pixel boxes blacked out."""
+
+        return len(self.findings)
+
+    def to_audit_report(self) -> dict[str, Any]:
+        """Return an audit-safe provenance summary."""
+
+        label_counts = Counter(finding.label for finding in self.findings)
+        frame_counts = Counter(finding.frame_index for finding in self.findings)
+        return {
+            "type": "dicom_pixel_ocr_redaction",
+            "source_path_sha256": _hash_value(str(self.source_path)),
+            "output_path_sha256": _hash_value(str(self.output_path)),
+            "source_suffix": self.source_path.suffix.lower(),
+            "output_suffix": self.output_path.suffix.lower(),
+            "frames_processed": self.frames_processed,
+            "redaction_count": self.redaction_count,
+            "redaction_counts_by_label": dict(sorted(label_counts.items())),
+            "redaction_counts_by_frame": {
+                str(frame): count for frame, count in sorted(frame_counts.items())
+            },
+            "findings": [finding.to_dict() for finding in self.findings],
+            "residual_report": self.residual_report.to_dict(),
         }
 
 
@@ -268,6 +379,109 @@ def deidentify_dicom_headers(
     )
 
 
+def redact_dicom_pixels(
+    path: str | Path,
+    *,
+    policy: Any | None = None,
+    output_path: str | Path | None = None,
+    ocr_engine: Any = None,
+    models: Any = None,
+    model_name: str | None = None,
+    confidence_threshold: float | None = None,
+    bbox_padding: int | None = None,
+    verify_residual: bool | None = None,
+    fail_on_residual: bool | None = None,
+    custom_recognizer: Any = None,
+    lang: str | None = None,
+) -> DicomPixelRedactionResult:
+    """Redact burned-in PHI text from DICOM pixels using OCR bboxes.
+
+    Header values from the source DICOM seed a per-image custom recognizer
+    before header de-identification clears them. Returned reports intentionally
+    exclude raw OCR/header text and carry hashes, labels, bboxes, and counts.
+    """
+
+    pydicom = _import_pydicom()
+    source = Path(path)
+    resolved_policy = _override_pixel_policy(
+        _coerce_pixel_policy(policy),
+        output_path=output_path,
+        ocr_engine=ocr_engine,
+        model_name=model_name,
+        confidence_threshold=confidence_threshold,
+        bbox_padding=bbox_padding,
+        verify_residual=verify_residual,
+        fail_on_residual=fail_on_residual,
+        custom_recognizer=custom_recognizer,
+    )
+    destination = (
+        Path(resolved_policy.output_path)
+        if resolved_policy.output_path is not None
+        else source
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    dataset = pydicom.dcmread(source, force=True)
+    header_recognizer = _header_seed_recognizer(dataset)
+    model = _resolve_pixel_model_name(models, resolved_policy.model_name)
+
+    if "PixelData" not in dataset:
+        _save_dataset(dataset, destination)
+        residual_report = DicomResidualTextReport(frame_count=0)
+        return DicomPixelRedactionResult(
+            source_path=source,
+            output_path=destination,
+            frames_processed=0,
+            findings=(),
+            residual_report=residual_report,
+        )
+
+    pixel_array = _copy_pixel_array(dataset)
+    frame_views = tuple(_iter_pixel_frames(pixel_array, dataset))
+    findings: list[DicomPixelFinding] = []
+
+    for frame_index, frame in enumerate(frame_views):
+        frame_findings = _detect_frame_pixel_findings(
+            frame,
+            dataset=dataset,
+            frame_index=frame_index,
+            policy=resolved_policy,
+            model_name=model,
+            header_recognizer=header_recognizer,
+            lang=lang,
+        )
+        for finding in frame_findings:
+            _blackout_bbox(frame, finding.bbox, dataset)
+        findings.extend(frame_findings)
+
+    dataset.PixelData = _pixel_bytes(pixel_array)
+    _save_dataset(dataset, destination)
+
+    residual_report = DicomResidualTextReport(frame_count=len(frame_views))
+    if resolved_policy.verify_residual:
+        residual_report = _residual_text_report(
+            frame_views,
+            dataset=dataset,
+            policy=resolved_policy,
+            model_name=model,
+            header_recognizer=header_recognizer,
+            lang=lang,
+        )
+        if resolved_policy.fail_on_residual and not residual_report.passed:
+            raise ValueError(
+                "DICOM residual OCR PHI verification failed: "
+                f"{residual_report.residual_entity_count} residual findings"
+            )
+
+    return DicomPixelRedactionResult(
+        source_path=source,
+        output_path=destination,
+        frames_processed=len(frame_views),
+        findings=tuple(findings),
+        residual_report=residual_report,
+    )
+
+
 def _import_pydicom() -> Any:
     try:
         return importlib.import_module("pydicom")
@@ -275,6 +489,101 @@ def _import_pydicom() -> Any:
         raise MissingDependencyError(
             dependency="pydicom", instruction=_DICOM_INSTALL_HINT
         ) from exc
+
+
+def _import_numpy() -> Any:
+    try:
+        return importlib.import_module("numpy")
+    except ImportError as exc:  # pragma: no cover - exercised without extra.
+        raise MissingDependencyError(
+            dependency="numpy", instruction=_DICOM_INSTALL_HINT
+        ) from exc
+
+
+def _coerce_pixel_policy(policy: Any | None) -> DicomPixelRedactionPolicy:
+    if policy is None:
+        return DicomPixelRedactionPolicy()
+    if isinstance(policy, DicomPixelRedactionPolicy):
+        return policy
+    if isinstance(policy, Mapping):
+        return DicomPixelRedactionPolicy(
+            output_path=policy.get("pixel_output_path", policy.get("output_path")),
+            ocr_engine=policy.get("ocr_engine"),
+            model_name=(
+                policy.get("pii_model_name")
+                or policy.get("pii_model")
+                or policy.get("model_name")
+            ),
+            confidence_threshold=_optional_float(
+                policy.get("confidence_threshold"), default=0.5
+            ),
+            bbox_padding=_optional_int(policy.get("bbox_padding")) or 1,
+            verify_residual=bool(policy.get("verify_residual", True)),
+            fail_on_residual=bool(policy.get("fail_on_residual", True)),
+            custom_recognizer=policy.get("custom_recognizer"),
+        )
+    return DicomPixelRedactionPolicy(
+        output_path=getattr(
+            policy,
+            "pixel_output_path",
+            getattr(policy, "output_path", None),
+        ),
+        ocr_engine=getattr(policy, "ocr_engine", None),
+        model_name=(
+            getattr(policy, "pii_model_name", None)
+            or getattr(policy, "pii_model", None)
+            or getattr(policy, "model_name", None)
+        ),
+        confidence_threshold=_optional_float(
+            getattr(policy, "confidence_threshold", None), default=0.5
+        ),
+        bbox_padding=_optional_int(getattr(policy, "bbox_padding", None)) or 1,
+        verify_residual=bool(getattr(policy, "verify_residual", True)),
+        fail_on_residual=bool(getattr(policy, "fail_on_residual", True)),
+        custom_recognizer=getattr(policy, "custom_recognizer", None),
+    )
+
+
+def _override_pixel_policy(
+    policy: DicomPixelRedactionPolicy,
+    *,
+    output_path: str | Path | None,
+    ocr_engine: Any,
+    model_name: str | None,
+    confidence_threshold: float | None,
+    bbox_padding: int | None,
+    verify_residual: bool | None,
+    fail_on_residual: bool | None,
+    custom_recognizer: Any,
+) -> DicomPixelRedactionPolicy:
+    return DicomPixelRedactionPolicy(
+        output_path=output_path if output_path is not None else policy.output_path,
+        ocr_engine=ocr_engine if ocr_engine is not None else policy.ocr_engine,
+        model_name=model_name if model_name is not None else policy.model_name,
+        confidence_threshold=(
+            float(confidence_threshold)
+            if confidence_threshold is not None
+            else policy.confidence_threshold
+        ),
+        bbox_padding=(
+            int(bbox_padding) if bbox_padding is not None else policy.bbox_padding
+        ),
+        verify_residual=(
+            bool(verify_residual)
+            if verify_residual is not None
+            else policy.verify_residual
+        ),
+        fail_on_residual=(
+            bool(fail_on_residual)
+            if fail_on_residual is not None
+            else policy.fail_on_residual
+        ),
+        custom_recognizer=(
+            custom_recognizer
+            if custom_recognizer is not None
+            else policy.custom_recognizer
+        ),
+    )
 
 
 def _coerce_policy(policy: Any | None) -> DicomHeaderDeidPolicy:
@@ -309,6 +618,12 @@ def _optional_int(value: Any | None) -> int | None:
     return int(value)
 
 
+def _optional_float(value: Any | None, *, default: float) -> float:
+    if value is None:
+        return default
+    return float(value)
+
+
 def _resolve_shift_days(policy: DicomHeaderDeidPolicy) -> int:
     from openmed.core.pii import _resolve_date_shift_days
 
@@ -321,6 +636,451 @@ def _resolve_shift_days(policy: DicomHeaderDeidPolicy) -> int:
     if shift_days == 0:
         raise ValueError("date_shift_days must be non-zero for DICOM de-id")
     return shift_days
+
+
+def _resolve_pixel_model_name(models: Any, policy_model_name: str | None) -> str | None:
+    if policy_model_name:
+        return str(policy_model_name)
+    if models is None:
+        return None
+    if isinstance(models, str):
+        return models
+    if isinstance(models, Mapping):
+        for key in ("pii_model_name", "pii_model", "model_name", "pii"):
+            value = models.get(key)
+            if value:
+                return str(value)
+        return None
+    for attr in ("pii_model_name", "pii_model", "model_name"):
+        value = getattr(models, attr, None)
+        if value:
+            return str(value)
+    return None
+
+
+def _copy_pixel_array(dataset: Any) -> Any:
+    numpy = _import_numpy()
+    return numpy.array(dataset.pixel_array, copy=True)
+
+
+def _iter_pixel_frames(pixel_array: Any, dataset: Any) -> Sequence[Any]:
+    number_of_frames = int(getattr(dataset, "NumberOfFrames", 1) or 1)
+    if number_of_frames > 1 and getattr(pixel_array, "ndim", 0) >= 3:
+        frame_count = min(number_of_frames, int(pixel_array.shape[0]))
+        return tuple(pixel_array[index] for index in range(frame_count))
+    return (pixel_array,)
+
+
+def _pixel_bytes(pixel_array: Any) -> bytes:
+    numpy = _import_numpy()
+    return numpy.ascontiguousarray(pixel_array).tobytes()
+
+
+def _detect_frame_pixel_findings(
+    frame: Any,
+    *,
+    dataset: Any,
+    frame_index: int,
+    policy: DicomPixelRedactionPolicy,
+    model_name: str | None,
+    header_recognizer: Any,
+    lang: str | None,
+) -> tuple[DicomPixelFinding, ...]:
+    from . import ocr as ocr_mod
+
+    languages = [lang] if lang else None
+    ocr_result = ocr_mod.ocr(
+        _frame_for_ocr(frame, dataset),
+        engine=policy.ocr_engine,
+        languages=languages,
+    )
+    document = ocr_result.to_document()
+    entities = _detect_pixel_entities(
+        document.text,
+        model_name=model_name,
+        confidence_threshold=policy.confidence_threshold,
+        lang=lang,
+        header_recognizer=header_recognizer,
+        custom_recognizer=policy.custom_recognizer,
+    )
+    return _project_entities_to_findings(
+        document,
+        entities,
+        frame_index=frame_index,
+        frame_shape=frame.shape,
+        padding=policy.bbox_padding,
+    )
+
+
+def _detect_pixel_entities(
+    text: str,
+    *,
+    model_name: str | None,
+    confidence_threshold: float,
+    lang: str | None,
+    header_recognizer: Any,
+    custom_recognizer: Any,
+) -> tuple[Any, ...]:
+    if not text.strip():
+        return ()
+
+    result = _extract_dicom_pixel_phi(
+        text,
+        model_name=model_name,
+        confidence_threshold=confidence_threshold,
+        lang=lang,
+        custom_recognizer=custom_recognizer,
+    )
+    entities = list(getattr(result, "entities", ()) or ())
+    if header_recognizer is not None:
+        entities.extend(header_recognizer.detect_entities(text))
+    return _dedupe_entities(text, entities)
+
+
+def _extract_dicom_pixel_phi(
+    text: str,
+    *,
+    model_name: str | None,
+    confidence_threshold: float,
+    lang: str | None,
+    custom_recognizer: Any,
+) -> Any:
+    from openmed.core.pii import extract_pii
+
+    kwargs: dict[str, Any] = {
+        "confidence_threshold": confidence_threshold,
+        "lang": lang or "en",
+        "custom_recognizer": custom_recognizer,
+    }
+    if model_name is not None:
+        kwargs["model_name"] = model_name
+    return extract_pii(text, **kwargs)
+
+
+def _dedupe_entities(text: str, entities: Sequence[Any]) -> tuple[Any, ...]:
+    deduped: list[Any] = []
+    seen: set[tuple[int, int, str]] = set()
+    for entity in entities:
+        bounds = _entity_bounds(entity, text)
+        if bounds is None:
+            continue
+        label = _entity_label(entity)
+        key = (bounds[0], bounds[1], label)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(entity)
+    return tuple(deduped)
+
+
+def _project_entities_to_findings(
+    document: ExtractedDocument,
+    entities: Sequence[Any],
+    *,
+    frame_index: int,
+    frame_shape: Sequence[int],
+    padding: int,
+) -> tuple[DicomPixelFinding, ...]:
+    height, width = int(frame_shape[0]), int(frame_shape[1])
+    findings: list[DicomPixelFinding] = []
+    seen_bboxes: set[tuple[int, int, int, int]] = set()
+    for entity in entities:
+        bounds = _entity_bounds(entity, document.text)
+        if bounds is None:
+            continue
+        surface = document.text[bounds[0] : bounds[1]]
+        for span in document.spans:
+            if span.bbox is None or not _intervals_overlap(
+                span.start, span.end, bounds[0], bounds[1]
+            ):
+                continue
+            bbox = _clamp_bbox(span.bbox, width=width, height=height, padding=padding)
+            if bbox is None or bbox in seen_bboxes:
+                continue
+            seen_bboxes.add(bbox)
+            findings.append(
+                DicomPixelFinding(
+                    frame_index=frame_index,
+                    bbox=bbox,
+                    label=_entity_label(entity),
+                    confidence=_entity_confidence(entity),
+                    text_sha256=_hash_value(surface),
+                    text_length=len(surface),
+                    sources=_entity_sources(entity),
+                )
+            )
+    return tuple(findings)
+
+
+def _residual_text_report(
+    frame_views: Sequence[Any],
+    *,
+    dataset: Any,
+    policy: DicomPixelRedactionPolicy,
+    model_name: str | None,
+    header_recognizer: Any,
+    lang: str | None,
+) -> DicomResidualTextReport:
+    residuals: list[DicomPixelFinding] = []
+    for frame_index, frame in enumerate(frame_views):
+        residuals.extend(
+            _detect_frame_pixel_findings(
+                frame,
+                dataset=dataset,
+                frame_index=frame_index,
+                policy=policy,
+                model_name=model_name,
+                header_recognizer=header_recognizer,
+                lang=lang,
+            )
+        )
+    return DicomResidualTextReport(
+        frame_count=len(frame_views),
+        residuals=tuple(residuals),
+    )
+
+
+def _frame_for_ocr(frame: Any, dataset: Any) -> Any:
+    numpy = _import_numpy()
+    array = numpy.asarray(frame)
+    if _is_color_frame(array, dataset):
+        return _normalize_color_frame(array)
+
+    image = _normalize_uint8(array)
+    if str(getattr(dataset, "PhotometricInterpretation", "")).upper() == "MONOCHROME1":
+        image = 255 - image
+    return image
+
+
+def _is_color_frame(frame: Any, dataset: Any) -> bool:
+    samples = int(getattr(dataset, "SamplesPerPixel", 1) or 1)
+    photometric = str(getattr(dataset, "PhotometricInterpretation", "")).upper()
+    return samples > 1 or photometric in {"RGB", "YBR_FULL", "YBR_FULL_422"}
+
+
+def _normalize_color_frame(frame: Any) -> Any:
+    numpy = _import_numpy()
+    array = numpy.asarray(frame)
+    if array.dtype == numpy.uint8:
+        return numpy.array(array, copy=True)
+    return _normalize_uint8(array)
+
+
+def _normalize_uint8(array: Any) -> Any:
+    numpy = _import_numpy()
+    values = numpy.asarray(array)
+    if values.dtype == numpy.uint8:
+        return numpy.array(values, copy=True)
+    values = values.astype("float32", copy=False)
+    minimum = float(numpy.nanmin(values))
+    maximum = float(numpy.nanmax(values))
+    if not math.isfinite(minimum) or not math.isfinite(maximum) or minimum == maximum:
+        return numpy.zeros(values.shape, dtype=numpy.uint8)
+    scaled = (values - minimum) * (255.0 / (maximum - minimum))
+    return numpy.clip(scaled, 0, 255).astype(numpy.uint8)
+
+
+def _blackout_bbox(
+    frame: Any,
+    bbox: tuple[int, int, int, int],
+    dataset: Any,
+) -> None:
+    x0, y0, x1, y1 = bbox
+    value = _pixel_black_value(frame, dataset)
+    if getattr(frame, "ndim", 0) >= 3:
+        frame[y0:y1, x0:x1, ...] = value
+    else:
+        frame[y0:y1, x0:x1] = value
+
+
+def _pixel_black_value(frame: Any, dataset: Any) -> int:
+    if str(getattr(dataset, "PhotometricInterpretation", "")).upper() != "MONOCHROME1":
+        return 0
+    bits_stored = int(
+        getattr(dataset, "BitsStored", getattr(dataset, "BitsAllocated", 8)) or 8
+    )
+    return int((2**bits_stored) - 1)
+
+
+def _clamp_bbox(
+    bbox: Sequence[float],
+    *,
+    width: int,
+    height: int,
+    padding: int,
+) -> tuple[int, int, int, int] | None:
+    if len(bbox) != 4:
+        return None
+    x0 = max(0, math.floor(float(bbox[0])) - padding)
+    y0 = max(0, math.floor(float(bbox[1])) - padding)
+    x1 = min(width, math.ceil(float(bbox[2])) + padding)
+    y1 = min(height, math.ceil(float(bbox[3])) + padding)
+    if x0 >= x1 or y0 >= y1:
+        return None
+    return (x0, y0, x1, y1)
+
+
+def _intervals_overlap(
+    start: int,
+    end: int,
+    other_start: int,
+    other_end: int,
+) -> bool:
+    return start < other_end and end > other_start
+
+
+def _entity_bounds(entity: Any, text: str) -> tuple[int, int] | None:
+    start = getattr(entity, "start", None)
+    end = getattr(entity, "end", None)
+    if (
+        isinstance(start, int)
+        and isinstance(end, int)
+        and 0 <= start < end <= len(text)
+    ):
+        return start, end
+
+    surface = str(getattr(entity, "text", "") or "")
+    if not surface:
+        return None
+    found = text.find(surface)
+    if found < 0:
+        return None
+    return found, found + len(surface)
+
+
+def _entity_label(entity: Any) -> str:
+    return str(
+        getattr(entity, "canonical_label", None)
+        or getattr(entity, "entity_type", None)
+        or getattr(entity, "label", None)
+        or "UNKNOWN"
+    )
+
+
+def _entity_confidence(entity: Any) -> float:
+    try:
+        return float(getattr(entity, "confidence", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _entity_sources(entity: Any) -> tuple[str, ...]:
+    sources = getattr(entity, "sources", None)
+    if sources:
+        return tuple(str(source) for source in sources)
+    metadata = getattr(entity, "metadata", None) or {}
+    if isinstance(metadata, Mapping):
+        source = metadata.get("detector") or metadata.get("source")
+        if source:
+            return (str(source),)
+        custom = metadata.get("custom_recognizer")
+        if isinstance(custom, Mapping) and custom.get("detector"):
+            return (str(custom["detector"]),)
+    return ("model",)
+
+
+def _header_seed_recognizer(dataset: Any) -> Any:
+    terms = _header_seed_terms(dataset)
+    if not terms:
+        return None
+    from openmed.core.custom_recognizer import CustomRecognizer
+
+    return CustomRecognizer.from_config(
+        {
+            "case_sensitive": False,
+            "deny_terms": [
+                {
+                    "term": term,
+                    "label": label,
+                    "confidence": 1.0,
+                    "id": _header_seed_rule_id(keyword, term),
+                }
+                for keyword, label, term in terms
+            ],
+        }
+    )
+
+
+def _header_seed_terms(dataset: Any) -> tuple[tuple[str, str, str], ...]:
+    specs = (
+        ("PatientName", "NAME"),
+        ("OtherPatientNames", "NAME"),
+        ("PatientBirthName", "NAME"),
+        ("PatientMothersBirthName", "NAME"),
+        ("PatientID", "ID_NUM"),
+        ("OtherPatientIDs", "ID_NUM"),
+        ("AccessionNumber", "ID_NUM"),
+        ("AdmissionID", "ID_NUM"),
+        ("StudyID", "ID_NUM"),
+        ("PatientBirthDate", "DATE"),
+        ("StudyDate", "DATE"),
+        ("SeriesDate", "DATE"),
+        ("ContentDate", "DATE"),
+        ("AcquisitionDate", "DATE"),
+    )
+    terms: list[tuple[str, str, str]] = []
+    seen: set[str] = set()
+    for keyword, label in specs:
+        value = getattr(dataset, keyword, None)
+        for raw in _dicom_value_strings(value):
+            for term in _header_value_variants(raw, keyword=keyword):
+                normalized = " ".join(term.split())
+                if not normalized:
+                    continue
+                dedupe_key = normalized.casefold()
+                if dedupe_key in seen:
+                    continue
+                seen.add(dedupe_key)
+                terms.append((keyword, label, normalized))
+    return tuple(terms)
+
+
+def _dicom_value_strings(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, bytes):
+        return (value.decode("utf-8", errors="ignore"),)
+    if isinstance(value, list | tuple):
+        return tuple(item for child in value for item in _dicom_value_strings(child))
+    return (str(value),)
+
+
+def _header_value_variants(value: str, *, keyword: str) -> tuple[str, ...]:
+    text = value.strip()
+    if not text:
+        return ()
+
+    variants = [text]
+    if "^" in text:
+        parts = [part.strip() for part in text.split("^") if part.strip()]
+        if parts:
+            variants.append(" ".join(parts))
+        if len(parts) >= 2:
+            variants.append(f"{parts[1]} {parts[0]}")
+            variants.append(f"{parts[0]} {parts[1]}")
+
+    if keyword.lower().endswith("date"):
+        variants.extend(_date_variants(text))
+    return tuple(variants)
+
+
+def _date_variants(value: str) -> tuple[str, ...]:
+    text = value.strip()
+    if not re.fullmatch(r"\d{8}", text):
+        return ()
+    year, month, day = text[:4], text[4:6], text[6:8]
+    return (
+        f"{year}-{month}-{day}",
+        f"{month}/{day}/{year}",
+        f"{day}/{month}/{year}",
+    )
+
+
+def _header_seed_rule_id(keyword: str, term: str) -> str:
+    digest = _hash_value(f"{keyword}:{term}")[:12]
+    return f"dicom_header_{keyword}_{digest}"
 
 
 def _deidentify_dataset(dataset: Any, context: _Context, *, location: str) -> None:
@@ -606,13 +1366,24 @@ def _dicom_handler(
     models: Any = None,
     lang: str | None = None,
 ) -> ExtractedDocument:
-    del models, lang
-    result = deidentify_dicom_headers(path, policy=policy)
+    pixel_result = redact_dicom_pixels(path, policy=policy, models=models, lang=lang)
+    header_policy = _coerce_policy(policy)
+    header_policy = DicomHeaderDeidPolicy(
+        output_path=pixel_result.output_path,
+        date_shift_days=header_policy.date_shift_days,
+        patient_key=header_policy.patient_key,
+        date_shift_max_days=header_policy.date_shift_max_days,
+        date_shift_secret=header_policy.date_shift_secret,
+        uid_salt=header_policy.uid_salt,
+        keep_year=header_policy.keep_year,
+    )
+    result = deidentify_dicom_headers(pixel_result.output_path, policy=header_policy)
     return ExtractedDocument(
         text="",
         metadata={
             "format": "dicom",
             "dicom_header_deid": result.to_audit_report(),
+            "dicom_pixel_redaction": pixel_result.to_audit_report(),
         },
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ spacy = [
 ]
 
 multimodal = [
+  "numpy>=1.26",
   "pdfplumber>=0.11",
   "python-docx>=1.1",
   "Pillow>=10.0",

--- a/tests/unit/multimodal/test_dicom_pixels.py
+++ b/tests/unit/multimodal/test_dicom_pixels.py
@@ -1,0 +1,204 @@
+"""Tests for DICOM burned-in pixel-text OCR redaction."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+import openmed.multimodal.dicom as dicom_mod
+from openmed.multimodal import (
+    OcrResult,
+    OcrWord,
+    redact_dicom_pixels,
+    redact_document,
+)
+from openmed.processing.outputs import PredictionResult
+
+pydicom = pytest.importorskip("pydicom")
+np = pytest.importorskip("numpy")
+from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import CTImageStorage, ExplicitVRLittleEndian, generate_uid
+
+
+def test_redact_dicom_pixels_redacts_burned_in_phi_and_residual_is_clean(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _generic_model_misses(monkeypatch)
+    source = _write_pixel_dicom(tmp_path / "phi.dcm", _single_frame_pixels())
+    output = tmp_path / "redacted.dcm"
+
+    result = redact_dicom_pixels(
+        source,
+        output_path=output,
+        ocr_engine=_BurnedInOcrEngine(_name_words()),
+        model_name="stub",
+    )
+
+    redacted = pydicom.dcmread(output).pixel_array
+    assert redacted[7:21, 7:59].max() == 0
+    assert result.frames_processed == 1
+    assert result.redaction_count == 2
+    assert result.residual_report.passed
+    assert result.residual_report.residual_entity_count == 0
+
+    serialized = json.dumps(result.to_audit_report(), sort_keys=True)
+    assert "Jane" not in serialized
+    assert "Doe" not in serialized
+    assert "MRN-12345" not in serialized
+
+
+def test_header_seeded_recognizer_recovers_name_generic_model_misses(
+    monkeypatch,
+    tmp_path: Path,
+):
+    calls: list[str] = []
+
+    def fake_model(text: str, **_kwargs):
+        calls.append(text)
+        return PredictionResult(
+            text=text,
+            entities=[],
+            model_name="stub",
+            timestamp=datetime.now().isoformat(),
+        )
+
+    monkeypatch.setattr(dicom_mod, "_extract_dicom_pixel_phi", fake_model)
+    source = _write_pixel_dicom(tmp_path / "phi.dcm", _single_frame_pixels())
+
+    result = redact_dicom_pixels(
+        source,
+        output_path=tmp_path / "redacted.dcm",
+        ocr_engine=_BurnedInOcrEngine(_name_words()),
+        model_name="stub",
+    )
+
+    assert calls == ["Jane Doe"]
+    assert result.redaction_count == 2
+    assert {finding.sources for finding in result.findings} == {
+        ("custom:deny",),
+    }
+
+
+def test_redact_dicom_pixels_redacts_every_frame(monkeypatch, tmp_path: Path):
+    _generic_model_misses(monkeypatch)
+    pixels = np.zeros((2, 32, 96), dtype=np.uint8)
+    pixels[:, 8:20, 8:58] = 255
+    source = _write_pixel_dicom(tmp_path / "multi.dcm", pixels)
+    output = tmp_path / "multi-redacted.dcm"
+
+    result = redact_dicom_pixels(
+        source,
+        output_path=output,
+        ocr_engine=_BurnedInOcrEngine(_name_words()),
+        model_name="stub",
+    )
+
+    redacted = pydicom.dcmread(output).pixel_array
+    assert redacted[0, 7:21, 7:59].max() == 0
+    assert redacted[1, 7:21, 7:59].max() == 0
+    assert result.frames_processed == 2
+    assert result.redaction_count == 4
+    assert result.residual_report.passed
+
+
+def test_redact_document_runs_header_and_pixel_pass(monkeypatch, tmp_path: Path):
+    _generic_model_misses(monkeypatch)
+    source = _write_pixel_dicom(tmp_path / "phi.dcm", _single_frame_pixels())
+    output = tmp_path / "document-redacted.dcm"
+
+    document = redact_document(
+        source,
+        policy={
+            "output_path": output,
+            "date_shift_days": 5,
+            "ocr_engine": _BurnedInOcrEngine(_name_words()),
+            "model_name": "stub",
+        },
+    )
+
+    redacted = pydicom.dcmread(output)
+    assert str(redacted.PatientName) == ""
+    assert redacted.PatientID == ""
+    assert redacted.pixel_array[7:21, 7:59].max() == 0
+    assert document.metadata["format"] == "dicom"
+    assert document.metadata["dicom_header_deid"]["action_count"] > 0
+    assert document.metadata["dicom_pixel_redaction"]["residual_report"]["passed"]
+
+
+class _BurnedInOcrEngine:
+    name = "burned-in-test"
+
+    def __init__(self, words: tuple[OcrWord, ...]) -> None:
+        self._words = words
+
+    def recognize(self, image, *, languages=None):
+        del languages
+        array = np.asarray(image)
+        words = []
+        for word in self._words:
+            x0, y0, x1, y1 = (int(value) for value in word.bbox)
+            if array[y0:y1, x0:x1].max(initial=0) > 0:
+                words.append(word)
+        return OcrResult(words=tuple(words), metadata={"engine": self.name})
+
+
+def _generic_model_misses(monkeypatch) -> None:
+    def fake_model(text: str, **_kwargs):
+        return PredictionResult(
+            text=text,
+            entities=[],
+            model_name="stub",
+            timestamp=datetime.now().isoformat(),
+        )
+
+    monkeypatch.setattr(dicom_mod, "_extract_dicom_pixel_phi", fake_model)
+
+
+def _name_words() -> tuple[OcrWord, ...]:
+    return (
+        OcrWord("Jane", (8.0, 8.0, 30.0, 20.0), 0.99),
+        OcrWord("Doe", (31.0, 8.0, 58.0, 20.0), 0.99),
+    )
+
+
+def _single_frame_pixels():
+    pixels = np.zeros((32, 96), dtype=np.uint8)
+    pixels[8:20, 8:58] = 255
+    return pixels
+
+
+def _write_pixel_dicom(path: Path, pixels) -> Path:
+    file_meta = FileMetaDataset()
+    file_meta.MediaStorageSOPClassUID = CTImageStorage
+    file_meta.MediaStorageSOPInstanceUID = generate_uid()
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    file_meta.ImplementationClassUID = generate_uid()
+
+    dataset = FileDataset(str(path), {}, file_meta=file_meta, preamble=b"\0" * 128)
+    dataset.SOPClassUID = CTImageStorage
+    dataset.SOPInstanceUID = str(file_meta.MediaStorageSOPInstanceUID)
+    dataset.StudyInstanceUID = generate_uid()
+    dataset.SeriesInstanceUID = generate_uid()
+    dataset.PatientName = "DOE^Jane"
+    dataset.PatientID = "MRN-12345"
+    dataset.PatientBirthDate = "19800102"
+    dataset.StudyDate = "20200101"
+    dataset.SeriesDate = "20200102"
+    dataset.ContentDate = "20200103"
+    dataset.Rows = int(pixels.shape[-2])
+    dataset.Columns = int(pixels.shape[-1])
+    dataset.SamplesPerPixel = 1
+    dataset.PhotometricInterpretation = "MONOCHROME2"
+    dataset.BitsAllocated = 8
+    dataset.BitsStored = 8
+    dataset.HighBit = 7
+    dataset.PixelRepresentation = 0
+    if pixels.ndim == 3:
+        dataset.NumberOfFrames = int(pixels.shape[0])
+    dataset.PixelData = np.ascontiguousarray(pixels).tobytes()
+    dataset.save_as(path, enforce_file_format=True)
+    return path

--- a/uv.lock
+++ b/uv.lock
@@ -3421,6 +3421,7 @@ mlx = [
 multimodal = [
     { name = "easyocr" },
     { name = "markdown-it-py" },
+    { name = "numpy" },
     { name = "pdfplumber" },
     { name = "piexif" },
     { name = "pikepdf" },
@@ -3499,6 +3500,7 @@ requires-dist = [
     { name = "mlx-lm", marker = "extra == 'mlx'", specifier = ">=0.31" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.26" },
     { name = "numpy", marker = "extra == 'duckdb'", specifier = ">=1.26" },
+    { name = "numpy", marker = "extra == 'multimodal'", specifier = ">=1.26" },
     { name = "onnx", marker = "extra == 'onnx'", specifier = ">=1.14" },
     { name = "onnxruntime", marker = "extra == 'onnx'", specifier = ">=1.16" },
     { name = "onnxscript", marker = "extra == 'onnx'", specifier = ">=0.1.0" },


### PR DESCRIPTION
## Description
Adds DICOM burned-in pixel-text redaction that renders pixel frames, runs OCR, detects projected PHI spans through OpenMed PII detection plus header-seeded deny terms, blacks out matching pixel boxes, and returns an audit-safe residual OCR report. The DICOM document handler now composes pixel redaction with the existing PS3.15 header de-identification pass.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `redact_dicom_pixels()` with frame-wise OCR, header-seeded recognizer boosting, bbox blackouts, and residual verification.
- Registered the DICOM handler to run pixel redaction and header de-identification together for `.dcm` files.
- Added synthetic single-frame, header-seeded recall, multi-frame, and `redact_document()` DICOM pixel tests.
- Added `numpy` to the `multimodal` extra because pixel-array redaction requires NumPy-backed DICOM frame manipulation.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `.venv/bin/python -m pytest tests/ -q` (`3148 passed, 29 skipped`)
- `make format`
- `make lint`
- `make format-check`
- `uv lock --check`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [ ] I have not added any new dependencies
- [x] OR I have added new dependencies and they are justified because: DICOM pixel redaction needs NumPy arrays for pydicom pixel frame manipulation, and the `multimodal` extra should install the runtime dependency required by this feature.

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #240

## Screenshots/Examples
Not applicable.