### PR TITLE
Add request correlation IDs and structured no-PHI JSON logging to the REST service

### DIFF
--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -21,6 +21,12 @@ from openmed.utils.validation import validate_model_name
 
 from .batcher import BatchResult, DynamicBatcher
 from .coalesce import RequestCoalescer, coalescing_key
+from .logging import (
+    CorrelationIdMiddleware,
+    current_request_id,
+    service_log_config_from_env,
+    set_access_log_model_name,
+)
 from .metrics import (
     PROMETHEUS_CONTENT_TYPE,
     PrometheusMetricsRegistry,
@@ -91,15 +97,17 @@ def _error_response(
     details: Optional[Any] = None,
 ) -> JSONResponse:
     """Return a standardized API error response."""
+    error = {
+        "code": code,
+        "message": message,
+        "details": details,
+    }
+    request_id = current_request_id()
+    if request_id is not None:
+        error["request_id"] = request_id
     return JSONResponse(
         status_code=status_code,
-        content={
-            "error": {
-                "code": code,
-                "message": message,
-                "details": details,
-            }
-        },
+        content={"error": error},
     )
 
 
@@ -436,6 +444,7 @@ def create_app() -> FastAPI:
         request: Request,
     ) -> Dict[str, Any]:
         runtime = _get_service_runtime(request)
+        set_access_log_model_name(request, payload.model_name)
         if payload.all:
             return runtime.unload_all_models()
         if payload.model_name is None:
@@ -448,6 +457,7 @@ def create_app() -> FastAPI:
 
     @app.post("/analyze")
     async def analyze(payload: AnalyzeRequest, request: Request) -> Dict[str, Any]:
+        set_access_log_model_name(request, payload.model_name)
         runtime = _get_service_runtime(request)
 
         async def _operation() -> Dict[str, Any]:
@@ -472,6 +482,7 @@ def create_app() -> FastAPI:
     async def pii_extract(
         payload: PIIExtractRequest, request: Request
     ) -> Dict[str, Any]:
+        set_access_log_model_name(request, payload.model_name)
         runtime = _get_service_runtime(request)
 
         async def _operation() -> Dict[str, Any]:
@@ -504,6 +515,7 @@ def create_app() -> FastAPI:
         payload: PIIDeidentifyRequest,
         request: Request,
     ) -> Dict[str, Any]:
+        set_access_log_model_name(request, payload.model_name)
         runtime = _get_service_runtime(request)
 
         async def _operation() -> Dict[str, Any]:
@@ -523,6 +535,10 @@ def create_app() -> FastAPI:
             _operation,
         )
 
+    app.add_middleware(
+        CorrelationIdMiddleware,
+        log_config=service_log_config_from_env(),
+    )
     return app
 
 

--- a/openmed/service/logging.py
+++ b/openmed/service/logging.py
@@ -1,0 +1,217 @@
+"""Request correlation and structured access logging for the REST service."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+ACCESS_LOGGER_NAME = "openmed.service.access"
+REQUEST_ID_HEADER = "X-Request-ID"
+SERVICE_LOG_LEVEL_ENV_VAR = "OPENMED_SERVICE_LOG_LEVEL"
+SERVICE_LOG_FORMAT_ENV_VAR = "OPENMED_SERVICE_LOG_FORMAT"
+_MODEL_NAME_SCOPE_KEY = "openmed.access_log_model_name"
+
+_REQUEST_ID: ContextVar[Optional[str]] = ContextVar(
+    "openmed_service_request_id",
+    default=None,
+)
+
+
+@dataclass(frozen=True)
+class ServiceLogConfig:
+    """Access-log rendering and severity settings."""
+
+    level: int
+    fmt: str = "json"
+
+    @property
+    def enabled(self) -> bool:
+        return self.level <= logging.CRITICAL
+
+
+class StructuredJsonLogFormatter(logging.Formatter):
+    """Render OpenMed log records as single-line JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        access_log = getattr(record, "openmed_access_log", None)
+        if isinstance(access_log, Mapping):
+            return _json_dumps(access_log)
+        return _json_dumps(
+            {
+                "level": record.levelname,
+                "logger": record.name,
+                "message": record.getMessage(),
+            }
+        )
+
+
+def service_log_config_from_env() -> ServiceLogConfig:
+    """Return service logging settings from environment variables."""
+    return ServiceLogConfig(
+        level=_parse_log_level(os.getenv(SERVICE_LOG_LEVEL_ENV_VAR)),
+        fmt=_parse_log_format(os.getenv(SERVICE_LOG_FORMAT_ENV_VAR)),
+    )
+
+
+def current_request_id() -> Optional[str]:
+    """Return the request ID active in the current context, if any."""
+    return _REQUEST_ID.get()
+
+
+def set_access_log_model_name(request: Any, model_name: Optional[str]) -> None:
+    """Attach the parsed model name to the current request scope for logging."""
+    if model_name:
+        request.scope[_MODEL_NAME_SCOPE_KEY] = str(model_name)
+
+
+class CorrelationIdMiddleware:
+    """Add request IDs and emit PHI-free structured access logs."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        log_config: Optional[ServiceLogConfig] = None,
+    ) -> None:
+        self.app = app
+        self.log_config = log_config or service_log_config_from_env()
+        self.logger = logging.getLogger(ACCESS_LOGGER_NAME)
+        self.logger.setLevel(self.log_config.level)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = _request_id_from_scope(scope)
+        request_token = _REQUEST_ID.set(request_id)
+        start_time = time.perf_counter()
+        status_code = 500
+
+        async def send_with_request_id(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = int(message["status"])
+                MutableHeaders(scope=message)[REQUEST_ID_HEADER] = request_id
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        finally:
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            try:
+                emit_access_log(
+                    self.logger,
+                    self.log_config,
+                    {
+                        "method": str(scope.get("method", "")),
+                        "route": _route_template(scope),
+                        "status_code": status_code,
+                        "duration_ms": round(duration_ms, 3),
+                        "model_name": scope.get(_MODEL_NAME_SCOPE_KEY),
+                        "request_id": request_id,
+                    },
+                )
+            finally:
+                _REQUEST_ID.reset(request_token)
+
+
+def emit_access_log(
+    logger: logging.Logger,
+    config: ServiceLogConfig,
+    payload: Mapping[str, Any],
+) -> None:
+    """Emit one access-log record, suppressing logging failures."""
+    if not config.enabled:
+        return
+    try:
+        logger.log(
+            config.level,
+            _format_access_log(payload, config),
+            extra={"openmed_access_log": dict(payload)},
+        )
+    except Exception:
+        return
+
+
+def _request_id_from_scope(scope: Scope) -> str:
+    inbound = Headers(scope=scope).get(REQUEST_ID_HEADER)
+    if inbound:
+        return inbound
+    return str(uuid.uuid4())
+
+
+def _route_template(scope: Scope) -> str:
+    route = scope.get("route")
+    route_path = getattr(route, "path", None)
+    if isinstance(route_path, str) and route_path:
+        return route_path
+    return "unknown"
+
+
+def _format_access_log(payload: Mapping[str, Any], config: ServiceLogConfig) -> str:
+    if config.fmt == "plain":
+        return (
+            f"{payload.get('method', '')} {payload.get('route', 'unknown')} "
+            f"{payload.get('status_code', 0)} "
+            f"{payload.get('duration_ms', 0)}ms "
+            f"request_id={payload.get('request_id', '')} "
+            f"model_name={payload.get('model_name') or '-'}"
+        )
+    return _json_dumps(payload)
+
+
+def _json_dumps(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def _parse_log_level(raw_value: Optional[str]) -> int:
+    if raw_value is None:
+        return logging.INFO
+    value = raw_value.strip().upper()
+    if value in {"", "INFO"}:
+        return logging.INFO
+    if value in {"OFF", "NONE", "DISABLED"}:
+        return logging.CRITICAL + 1
+    parsed = logging.getLevelName(value)
+    if isinstance(parsed, int):
+        return parsed
+    try:
+        numeric = int(value)
+    except ValueError:
+        return logging.INFO
+    if numeric < 0:
+        return logging.INFO
+    return numeric
+
+
+def _parse_log_format(raw_value: Optional[str]) -> str:
+    if raw_value is None:
+        return "json"
+    value = raw_value.strip().lower()
+    if value in {"plain", "text"}:
+        return "plain"
+    return "json"
+
+
+__all__ = [
+    "ACCESS_LOGGER_NAME",
+    "REQUEST_ID_HEADER",
+    "SERVICE_LOG_FORMAT_ENV_VAR",
+    "SERVICE_LOG_LEVEL_ENV_VAR",
+    "CorrelationIdMiddleware",
+    "ServiceLogConfig",
+    "StructuredJsonLogFormatter",
+    "current_request_id",
+    "service_log_config_from_env",
+    "set_access_log_model_name",
+]

--- a/tests/unit/service/test_request_logging.py
+++ b/tests/unit/service/test_request_logging.py
@@ -1,0 +1,210 @@
+"""Tests for REST request correlation IDs and no-PHI access logs."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import openmed
+from openmed.service import runtime as service_runtime
+from openmed.service.app import create_app
+from openmed.service.logging import (
+    ACCESS_LOGGER_NAME,
+    REQUEST_ID_HEADER,
+    SERVICE_LOG_FORMAT_ENV_VAR,
+    SERVICE_LOG_LEVEL_ENV_VAR,
+)
+
+LOOPBACK_BASE_URL = "http://127.0.0.1"
+PHI_TEXT = (
+    "Patient Juniper Solstice, MRN JS-1188, DOB 02/03/1979, "
+    "SSN 111-22-3333, phone 425-555-0199."
+)
+PHI_SUBSTRINGS = (
+    "Juniper Solstice",
+    "JS-1188",
+    "02/03/1979",
+    "111-22-3333",
+    "425-555-0199",
+)
+
+
+class FakeLoader:
+    """Minimal loader double for request logging tests."""
+
+    def __init__(self, config: Any):
+        self.config = config
+
+    def resolve_model_name(self, model_name: str) -> str:
+        return model_name
+
+    def create_pipeline(self, model_name: str, **_: Any) -> object:
+        del model_name
+        return object()
+
+    def loaded_models(self) -> dict[str, dict[str, int]]:
+        return {}
+
+    def unload_model(self, model_name: str) -> dict[str, Any]:
+        return {
+            "model_name": model_name,
+            "models": 0,
+            "tokenizers": 0,
+            "pipelines": 0,
+        }
+
+    def unload_all_models(self) -> dict[str, int]:
+        return {"models": 0, "tokenizers": 0, "pipelines": 0}
+
+
+@pytest.fixture(autouse=True)
+def service_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service_runtime, "ModelLoader", FakeLoader)
+    monkeypatch.setenv("OPENMED_PROFILE", "test")
+    monkeypatch.delenv("OPENMED_SERVICE_PRELOAD_MODELS", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_KEEP_ALIVE", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_MAX_RESIDENT_MODELS", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_MAX_TEXT_LENGTH", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_BATCHING_ENABLED", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_BATCH_MAX_SIZE", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_BATCH_MAX_WAIT_MS", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_TRUSTED_HOSTS", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_COALESCING_ENABLED", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_RATE_LIMIT_RPS", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_RATE_LIMIT_BURST", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_RATE_LIMIT_MAX_CONCURRENCY", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_THROTTLE_KEY", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_CONCURRENCY_WAIT_SECONDS", raising=False)
+    monkeypatch.delenv(SERVICE_LOG_FORMAT_ENV_VAR, raising=False)
+    monkeypatch.delenv(SERVICE_LOG_LEVEL_ENV_VAR, raising=False)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = create_app()
+    with TestClient(
+        app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as test_client:
+        yield test_client
+
+
+def _access_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [record for record in caplog.records if record.name == ACCESS_LOGGER_NAME]
+
+
+def test_every_response_gets_generated_request_id(client: TestClient) -> None:
+    response = client.get("/health")
+
+    request_id = response.headers[REQUEST_ID_HEADER]
+    uuid.UUID(request_id)
+    assert response.status_code == 200
+
+
+def test_inbound_request_id_is_preserved_and_echoed(client: TestClient) -> None:
+    response = client.get("/health", headers={REQUEST_ID_HEADER: "req-inbound-123"})
+
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER] == "req-inbound-123"
+
+
+def test_access_log_record_is_single_line_json_with_required_fields(
+    client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_analyze(text: str, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "text": text,
+            "model_name": kwargs["model_name"],
+            "entities": [],
+        }
+
+    monkeypatch.setattr(openmed, "analyze_text", fake_analyze)
+    caplog.set_level(logging.INFO, logger=ACCESS_LOGGER_NAME)
+
+    response = client.post(
+        "/analyze",
+        headers={REQUEST_ID_HEADER: "req-log-json"},
+        json={"text": "sample", "model_name": "disease_detection_superclinical"},
+    )
+
+    assert response.status_code == 200
+    records = _access_records(caplog)
+    assert len(records) == 1
+    payload = json.loads(records[0].getMessage())
+    assert payload["method"] == "POST"
+    assert payload["route"] == "/analyze"
+    assert payload["status_code"] == 200
+    assert payload["model_name"] == "disease_detection_superclinical"
+    assert payload["request_id"] == "req-log-json"
+    assert payload["duration_ms"] >= 0
+
+
+def test_phi_bearing_request_does_not_leak_phi_substrings_to_access_log(
+    client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_extract_pii(text: str, **kwargs: Any) -> dict[str, Any]:
+        del text
+        return {"entities": [], "model_name": kwargs["model_name"]}
+
+    monkeypatch.setattr(openmed, "extract_pii", fake_extract_pii)
+    caplog.set_level(logging.INFO, logger=ACCESS_LOGGER_NAME)
+
+    response = client.post(
+        "/pii/extract",
+        json={"text": PHI_TEXT, "model_name": "test-pii-model"},
+    )
+
+    assert response.status_code == 200
+    rendered_logs = "\n".join(record.getMessage() for record in _access_records(caplog))
+    leaked = [substring for substring in PHI_SUBSTRINGS if substring in rendered_logs]
+    assert leaked == []
+
+
+def test_error_envelope_includes_request_id(client: TestClient) -> None:
+    response = client.post(
+        "/analyze",
+        headers={REQUEST_ID_HEADER: "req-validation-error"},
+        json={"text": "   "},
+    )
+
+    payload = response.json()
+    assert response.status_code == 422
+    assert response.headers[REQUEST_ID_HEADER] == "req-validation-error"
+    assert payload["error"]["request_id"] == "req-validation-error"
+    assert payload["error"]["details"][0]["field"] == "body.text"
+
+
+def test_access_log_format_can_be_plain(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(SERVICE_LOG_FORMAT_ENV_VAR, "plain")
+    app = create_app()
+    caplog.set_level(logging.INFO, logger=ACCESS_LOGGER_NAME)
+
+    with TestClient(
+        app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as test_client:
+        response = test_client.get(
+            "/health",
+            headers={REQUEST_ID_HEADER: "req-plain-log"},
+        )
+
+    assert response.status_code == 200
+    records = _access_records(caplog)
+    assert len(records) == 1
+    assert records[0].getMessage().startswith("GET /health 200 ")
+    assert "request_id=req-plain-log" in records[0].getMessage()


### PR DESCRIPTION
Closes #653.

Adds request correlation middleware that generates or preserves X-Request-ID, echoes it on responses, and includes it in service error envelopes. It emits one no-PHI access log record per request with method, route, status, duration, model_name, and request_id, with JSON default and plain-format env support; tests cover propagation, JSON logging, PHI substring absence, and error correlation.

Tests:
- .venv/bin/python -m pytest tests/ -q