### PR TITLE
Add React Native bridge for on-device de-identification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+node_modules/
 develop-eggs/
 dist/
 downloads/

--- a/examples/react-native/RedactScreen.tsx
+++ b/examples/react-native/RedactScreen.tsx
@@ -1,0 +1,151 @@
+import React, { useMemo, useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  deidentify,
+  loadModel,
+  type OpenMedBackendKind,
+  type OpenMedDeidentifyResult,
+} from "../../js/openmedkit-react-native/src";
+
+const SYNTHETIC_NOTE =
+  "Patient Maya Shah was born on 1984-02-14. Email maya@example.org.";
+
+export interface RedactScreenProps {
+  modelPath: string;
+  backend?: OpenMedBackendKind;
+  policy?: string;
+}
+
+export function RedactScreen({
+  modelPath,
+  backend = "mlx",
+  policy = "hipaa_safe_harbor",
+}: RedactScreenProps) {
+  const [result, setResult] = useState<OpenMedDeidentifyResult | null>(null);
+  const [status, setStatus] = useState<"idle" | "running" | "failed">("idle");
+  const redactedText = useMemo(
+    () => result?.deidentifiedText ?? SYNTHETIC_NOTE,
+    [result],
+  );
+
+  async function runRedaction() {
+    setStatus("running");
+    setResult(null);
+    try {
+      await loadModel({
+        modelPath,
+        backend,
+        cacheKey: `${backend}:${modelPath}`,
+      });
+      const nextResult = await deidentify(SYNTHETIC_NOTE, {
+        policy,
+        docId: "rn-example",
+        detector: "openmedkit-react-native",
+      });
+      setResult(nextResult);
+      setStatus("idle");
+    } catch {
+      setStatus("failed");
+    }
+  }
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.header}>
+        <Text style={styles.title}>OpenMedKit redaction</Text>
+        <Text style={styles.count}>{result?.spans.length ?? 0} spans</Text>
+      </View>
+      <View style={styles.panel}>
+        <Text style={styles.label}>Synthetic note</Text>
+        <Text style={styles.note}>{SYNTHETIC_NOTE}</Text>
+      </View>
+      <View style={styles.panel}>
+        <Text style={styles.label}>Redacted output</Text>
+        <Text style={styles.note}>{redactedText}</Text>
+      </View>
+      <Pressable
+        accessibilityRole="button"
+        disabled={status === "running"}
+        onPress={runRedaction}
+        style={({ pressed }) => [
+          styles.button,
+          pressed && status !== "running" ? styles.buttonPressed : null,
+          status === "running" ? styles.buttonDisabled : null,
+        ]}
+      >
+        <Text style={styles.buttonText}>
+          {status === "running" ? "Redacting" : "Run redaction"}
+        </Text>
+      </Pressable>
+      {status === "failed" ? (
+        <Text style={styles.error}>Native model configuration failed.</Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    gap: 16,
+    padding: 20,
+    backgroundColor: "#f7f8fa",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  title: {
+    color: "#111827",
+    fontSize: 22,
+    fontWeight: "700",
+  },
+  count: {
+    color: "#374151",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  panel: {
+    gap: 8,
+    padding: 14,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#d1d5db",
+    backgroundColor: "#ffffff",
+  },
+  label: {
+    color: "#4b5563",
+    fontSize: 12,
+    fontWeight: "700",
+    textTransform: "uppercase",
+  },
+  note: {
+    color: "#111827",
+    fontSize: 16,
+    lineHeight: 23,
+  },
+  button: {
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 48,
+    borderRadius: 8,
+    backgroundColor: "#0f766e",
+  },
+  buttonPressed: {
+    backgroundColor: "#115e59",
+  },
+  buttonDisabled: {
+    backgroundColor: "#6b7280",
+  },
+  buttonText: {
+    color: "#ffffff",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  error: {
+    color: "#b91c1c",
+    fontSize: 14,
+  },
+});

--- a/js/openmedkit-react-native/android/OpenMedKitRnModule.kt
+++ b/js/openmedkit-react-native/android/OpenMedKitRnModule.kt
@@ -1,0 +1,423 @@
+package com.openmed.openmedkit.reactnative
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.ViewManager
+import com.openmed.openmedkit.DeidentifiedSpanAction
+import com.openmed.openmedkit.EntityPrediction
+import com.openmed.openmedkit.OpenMedBackend
+import com.openmed.openmedkit.OpenMedKit
+import java.io.File
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+
+@ReactModule(name = OpenMedKitRnModule.NAME)
+class OpenMedKitRnModule(
+    reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var runtime: OpenMedKit? = null
+    private var loadedCacheKey: String? = null
+
+    override fun getName(): String = NAME
+
+    @ReactMethod
+    fun loadModel(
+        options: ReadableMap,
+        promise: Promise,
+    ) {
+        scope.launch {
+            try {
+                val modelPath = options.requiredString("modelPath")
+                val backendName = options.string("backend") ?: "onnx"
+                val cacheKey = options.string("cacheKey") ?: "$backendName:$modelPath"
+
+                if (loadedCacheKey == cacheKey && runtime != null) {
+                    promise.resolve(
+                        Arguments.createMap().apply {
+                            putString("cacheKey", cacheKey)
+                            putString("modelPath", modelPath)
+                            putString("backend", backendName)
+                            putString("platform", "android")
+                            putBoolean("loaded", false)
+                        },
+                    )
+                    return@launch
+                }
+
+                require(backendName == "onnx") {
+                    "unsupported OpenMedKit Android backend: $backendName"
+                }
+                runtime = OpenMedKit(
+                    OpenMedBackend(
+                        modelDirectory = File(modelPath),
+                        id2Label = readId2Label(options.string("id2LabelPath")),
+                    ),
+                )
+                loadedCacheKey = cacheKey
+                promise.resolve(
+                    Arguments.createMap().apply {
+                        putString("cacheKey", cacheKey)
+                        putString("modelPath", modelPath)
+                        putString("backend", backendName)
+                        putString("platform", "android")
+                        putBoolean("loaded", true)
+                    },
+                )
+            } catch (error: Throwable) {
+                promise.reject("openmedkit_load_failed", error.message, error)
+            }
+        }
+    }
+
+    @ReactMethod
+    fun analyzeText(
+        text: String,
+        options: ReadableMap?,
+        promise: Promise,
+    ) {
+        scope.launch {
+            try {
+                val bridgeOptions = BridgeOptions(options)
+                val entities = requireRuntime().analyzeText(
+                    text = text,
+                    confidenceThreshold = bridgeOptions.confidenceThreshold,
+                )
+                promise.resolve(
+                    entityArray(
+                        entities = entities,
+                        text = text,
+                        options = bridgeOptions,
+                        action = "keep",
+                        replacement = null,
+                    ),
+                )
+            } catch (error: Throwable) {
+                promise.reject("openmedkit_analyze_failed", error.message, error)
+            }
+        }
+    }
+
+    @ReactMethod
+    fun extractPii(
+        text: String,
+        options: ReadableMap?,
+        promise: Promise,
+    ) {
+        scope.launch {
+            try {
+                val bridgeOptions = BridgeOptions(options)
+                val entities = requireRuntime().extractPii(
+                    text = text,
+                    confidenceThreshold = bridgeOptions.confidenceThreshold,
+                    useSmartMerging = bridgeOptions.useSmartMerging,
+                )
+                promise.resolve(
+                    entityArray(
+                        entities = entities,
+                        text = text,
+                        options = bridgeOptions,
+                        action = "keep",
+                        replacement = null,
+                    ),
+                )
+            } catch (error: Throwable) {
+                promise.reject("openmedkit_extract_failed", error.message, error)
+            }
+        }
+    }
+
+    @ReactMethod
+    fun deidentify(
+        text: String,
+        options: ReadableMap?,
+        promise: Promise,
+    ) {
+        scope.launch {
+            try {
+                val bridgeOptions = BridgeOptions(options)
+                val result = requireRuntime().deidentify(
+                    text = text,
+                    policy = bridgeOptions.policy,
+                    confidenceThreshold = bridgeOptions.confidenceThreshold,
+                    useSmartMerging = bridgeOptions.useSmartMerging,
+                )
+                promise.resolve(
+                    Arguments.createMap().apply {
+                        putString("text", text)
+                        putString("deidentifiedText", result.redactedText)
+                        putArray(
+                            "spans",
+                            actionArray(
+                                actions = result.actions,
+                                text = text,
+                                options = bridgeOptions,
+                            ),
+                        )
+                    },
+                )
+            } catch (error: Throwable) {
+                promise.reject("openmedkit_deidentify_failed", error.message, error)
+            }
+        }
+    }
+
+    private fun requireRuntime(): OpenMedKit =
+        runtime ?: throw IllegalStateException("OpenMedKit model is not loaded")
+
+    private fun entityArray(
+        entities: List<EntityPrediction>,
+        text: String,
+        options: BridgeOptions,
+        action: String,
+        replacement: String?,
+    ) = Arguments.createArray().apply {
+        entities.forEach { entity ->
+            pushMap(
+                spanMap(
+                    label = entity.label,
+                    canonicalLabel = canonicalLabel(entity.label),
+                    start = entity.start,
+                    end = entity.end,
+                    confidence = entity.confidence,
+                    action = action,
+                    replacement = replacement,
+                    text = text,
+                    options = options,
+                ),
+            )
+        }
+    }
+
+    private fun actionArray(
+        actions: List<DeidentifiedSpanAction>,
+        text: String,
+        options: BridgeOptions,
+    ) = Arguments.createArray().apply {
+        actions.forEach { action ->
+            pushMap(
+                spanMap(
+                    label = action.label,
+                    canonicalLabel = action.canonicalLabel,
+                    start = action.start,
+                    end = action.end,
+                    confidence = action.confidence,
+                    action = action.action.wireName,
+                    replacement = action.replacement,
+                    text = text,
+                    options = options,
+                ),
+            )
+        }
+    }
+
+    private fun spanMap(
+        label: String,
+        canonicalLabel: String,
+        start: Int,
+        end: Int,
+        confidence: Float,
+        action: String,
+        replacement: String?,
+        text: String,
+        options: BridgeOptions,
+    ): WritableMap {
+        val lowerBound = start.coerceIn(0, text.length)
+        val upperBound = end.coerceIn(lowerBound, text.length)
+        val surface = text.substring(lowerBound, upperBound)
+        return Arguments.createMap().apply {
+            putInt("schema_version", 1)
+            putString("doc_id", options.docId)
+            putInt("start", start)
+            putInt("end", end)
+            putString("text_hash", hmacTextHash(surface, options.hashSecret))
+            putString("entity_type", label)
+            putString("canonical_label", canonicalLabel)
+            putString("policy_label", policyLabel(canonicalLabel))
+            putArray("regulatory_tags", Arguments.createArray())
+            putDouble("score", confidence.toDouble())
+            putString("detector", options.detector ?: "openmedkit-android")
+            putMap(
+                "evidence",
+                Arguments.createMap().apply {
+                    putString("bridge", "react-native")
+                    putString("runtime", "OpenMedKit")
+                },
+            )
+            putString("action", action)
+            if (replacement == null) {
+                putNull("replacement")
+            } else {
+                putString("replacement", replacement)
+            }
+            putNull("reversible_id")
+            putNull("section")
+            putMap("metadata", options.metadata)
+        }
+    }
+
+    private fun readId2Label(path: String?): Map<Int, String> {
+        if (path.isNullOrBlank()) {
+            return emptyMap()
+        }
+        val root = JSONObject(File(path).readText(Charsets.UTF_8))
+        return root.keys().asSequence().associate { key ->
+            key.toInt() to root.getString(key)
+        }
+    }
+
+    private fun hmacTextHash(surface: String, secret: String): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+        return "hmac-sha256:" + mac.doFinal(surface.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it.toInt() and 0xff) }
+    }
+
+    private fun canonicalLabel(label: String): String {
+        val key = label
+            .removePrefix("B-")
+            .removePrefix("I-")
+            .removePrefix("E-")
+            .removePrefix("S-")
+            .uppercase()
+            .replace("-", "_")
+            .replace(" ", "_")
+            .filter { it.isLetterOrDigit() || it == '_' }
+        return if (key in canonicalLabels) key else "OTHER"
+    }
+
+    private fun policyLabel(canonicalLabel: String): String = when (canonicalLabel) {
+        in clinicalConceptLabels -> "CLINICAL_CONCEPT"
+        in quasiIdentifierLabels -> "QUASI_IDENTIFIER"
+        else -> "DIRECT_IDENTIFIER"
+    }
+
+    private fun ReadableMap.requiredString(key: String): String =
+        requireNotNull(string(key)) { "missing required OpenMedKit bridge option: $key" }
+            .also { require(it.isNotBlank()) { "$key must not be blank" } }
+
+    private fun ReadableMap.string(key: String): String? =
+        if (hasKey(key) && !isNull(key)) getString(key) else null
+
+    companion object {
+        const val NAME = "OpenMedKitRN"
+
+        private val clinicalConceptLabels = setOf(
+            "MICROORGANISM",
+            "ANTIBIOTIC",
+            "SUSCEPTIBILITY",
+            "CONDITION",
+            "MEDICATION",
+            "LAB_TEST",
+            "PROCEDURE",
+            "BODY_SITE",
+            "DIET_TYPE",
+            "NUTRITION_TARGET",
+            "FEEDING_ROUTE",
+            "NUTRITIONAL_STATUS",
+            "OTHER",
+        )
+
+        private val quasiIdentifierLabels = setOf(
+            "LOCATION",
+            "ZIPCODE",
+            "ORDINAL_DIRECTION",
+            "DATE",
+            "TIME",
+            "AGE",
+            "CREDIT_CARD_ISSUER",
+            "AMOUNT",
+            "CURRENCY",
+            "GENDER",
+            "EYE_COLOR",
+            "HEIGHT",
+            "ORGANIZATION",
+            "JOB_TITLE",
+            "JOB_DEPARTMENT",
+            "OCCUPATION",
+        )
+
+        private val canonicalLabels = setOf(
+            "PERSON",
+            "FIRST_NAME",
+            "LAST_NAME",
+            "EMAIL",
+            "PHONE",
+            "DATE",
+            "DATE_OF_BIRTH",
+            "SSN",
+            "ID_NUM",
+            "LOCATION",
+            "STREET_ADDRESS",
+            "ZIPCODE",
+            "CONDITION",
+            "MEDICATION",
+            "LAB_TEST",
+            "PROCEDURE",
+            "OTHER",
+        )
+    }
+}
+
+class OpenMedKitRnPackage : ReactPackage {
+    override fun createNativeModules(
+        reactContext: ReactApplicationContext,
+    ): List<NativeModule> = listOf(OpenMedKitRnModule(reactContext))
+
+    override fun createViewManagers(
+        reactContext: ReactApplicationContext,
+    ): List<ViewManager<*, *>> = emptyList()
+}
+
+private class BridgeOptions(options: ReadableMap?) {
+    val confidenceThreshold: Float =
+        if (options?.hasKey("confidenceThreshold") == true && !options.isNull("confidenceThreshold")) {
+            options.getDouble("confidenceThreshold").toFloat()
+        } else {
+            0.5f
+        }
+    val useSmartMerging: Boolean =
+        if (options?.hasKey("useSmartMerging") == true && !options.isNull("useSmartMerging")) {
+            options.getBoolean("useSmartMerging")
+        } else {
+            true
+        }
+    val docId: String =
+        if (options?.hasKey("docId") == true && !options.isNull("docId")) {
+            options.getString("docId") ?: "document"
+        } else {
+            "document"
+        }
+    val hashSecret: String =
+        if (options?.hasKey("hashSecret") == true && !options.isNull("hashSecret")) {
+            options.getString("hashSecret") ?: "openmedkit-react-native"
+        } else {
+            "openmedkit-react-native"
+        }
+    val detector: String? =
+        if (options?.hasKey("detector") == true && !options.isNull("detector")) {
+            options.getString("detector")
+        } else {
+            null
+        }
+    val metadata: WritableMap = Arguments.createMap()
+    val policy: String =
+        if (options?.hasKey("policy") == true && !options.isNull("policy")) {
+            options.getString("policy") ?: "hipaa_safe_harbor"
+        } else {
+            "hipaa_safe_harbor"
+        }
+}

--- a/js/openmedkit-react-native/ios/OpenMedKitRN.swift
+++ b/js/openmedkit-react-native/ios/OpenMedKitRN.swift
@@ -1,0 +1,378 @@
+import CryptoKit
+import Foundation
+import OpenMedKit
+import React
+
+@objc(OpenMedKitRN)
+final class OpenMedKitRN: NSObject, RCTBridgeModule {
+    private let queue = DispatchQueue(label: "org.openmed.openmedkit.reactnative")
+    private var runtime: OpenMed?
+    private var loadedCacheKey: String?
+
+    @objc
+    static func moduleName() -> String! {
+        "OpenMedKitRN"
+    }
+
+    @objc
+    static func requiresMainQueueSetup() -> Bool {
+        false
+    }
+
+    @objc(loadModel:resolver:rejecter:)
+    func loadModel(
+        _ options: NSDictionary,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        queue.async {
+            do {
+                let modelPath = try Self.requiredString(options, "modelPath")
+                let backendName = Self.string(options, "backend") ?? "mlx"
+                let cacheKey = Self.string(options, "cacheKey") ?? "\(backendName):\(modelPath)"
+
+                if self.loadedCacheKey == cacheKey, self.runtime != nil {
+                    resolve([
+                        "cacheKey": cacheKey,
+                        "modelPath": modelPath,
+                        "backend": backendName,
+                        "platform": "ios",
+                        "loaded": false,
+                    ])
+                    return
+                }
+
+                self.runtime = try OpenMed(backend: Self.backend(from: options))
+                self.loadedCacheKey = cacheKey
+                resolve([
+                    "cacheKey": cacheKey,
+                    "modelPath": modelPath,
+                    "backend": backendName,
+                    "platform": "ios",
+                    "loaded": true,
+                ])
+            } catch {
+                reject("openmedkit_load_failed", error.localizedDescription, error)
+            }
+        }
+    }
+
+    @objc(analyzeText:options:resolver:rejecter:)
+    func analyzeText(
+        _ text: String,
+        options: NSDictionary?,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        queue.async {
+            do {
+                let runtime = try self.requireRuntime()
+                let bridgeOptions = BridgeOptions(options)
+                let entities = try runtime.analyzeText(
+                    text,
+                    confidenceThreshold: bridgeOptions.confidenceThreshold
+                )
+                resolve(entities.map {
+                    Self.spanDictionary(
+                        entity: $0,
+                        text: text,
+                        options: bridgeOptions,
+                        action: "keep",
+                        replacement: nil
+                    )
+                })
+            } catch {
+                reject("openmedkit_analyze_failed", error.localizedDescription, error)
+            }
+        }
+    }
+
+    @objc(extractPii:options:resolver:rejecter:)
+    func extractPii(
+        _ text: String,
+        options: NSDictionary?,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        queue.async {
+            do {
+                let runtime = try self.requireRuntime()
+                let bridgeOptions = BridgeOptions(options)
+                let entities = try runtime.extractPII(
+                    text,
+                    confidenceThreshold: bridgeOptions.confidenceThreshold,
+                    useSmartMerging: bridgeOptions.useSmartMerging
+                )
+                resolve(entities.map {
+                    Self.spanDictionary(
+                        entity: $0,
+                        text: text,
+                        options: bridgeOptions,
+                        action: "keep",
+                        replacement: nil
+                    )
+                })
+            } catch {
+                reject("openmedkit_extract_failed", error.localizedDescription, error)
+            }
+        }
+    }
+
+    @objc(deidentify:options:resolver:rejecter:)
+    func deidentify(
+        _ text: String,
+        options: NSDictionary?,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        queue.async {
+            do {
+                let runtime = try self.requireRuntime()
+                let bridgeOptions = BridgeOptions(options)
+                let result = try runtime.deidentify(
+                    text,
+                    policy: bridgeOptions.policy,
+                    confidenceThreshold: bridgeOptions.confidenceThreshold,
+                    useSmartMerging: bridgeOptions.useSmartMerging
+                )
+                resolve([
+                    "text": text,
+                    "deidentifiedText": result.redactedText,
+                    "spans": result.actions.map {
+                        Self.spanDictionary(
+                            action: $0,
+                            text: text,
+                            options: bridgeOptions
+                        )
+                    },
+                ])
+            } catch {
+                reject("openmedkit_deidentify_failed", error.localizedDescription, error)
+            }
+        }
+    }
+
+    private func requireRuntime() throws -> OpenMed {
+        guard let runtime else {
+            throw BridgeError.modelNotLoaded
+        }
+        return runtime
+    }
+
+    private static func backend(from options: NSDictionary) throws -> OpenMedBackend {
+        let modelPath = try requiredString(options, "modelPath")
+        let backendName = string(options, "backend") ?? "mlx"
+
+        switch backendName {
+        case "mlx":
+            return .mlx(modelDirectoryURL: URL(fileURLWithPath: modelPath))
+        case "coreml":
+            let id2LabelPath = try requiredString(options, "id2LabelPath")
+            let tokenizerName =
+                string(options, "tokenizerName")
+                ?? "OpenMed/OpenMed-PII-ClinicalE5-Small-33M-v1"
+            let tokenizerFolderPath = string(options, "tokenizerFolderPath")
+            return .coreML(
+                modelURL: URL(fileURLWithPath: modelPath),
+                id2labelURL: URL(fileURLWithPath: id2LabelPath),
+                tokenizerName: tokenizerName,
+                tokenizerFolderURL: tokenizerFolderPath.map(URL.init(fileURLWithPath:))
+            )
+        default:
+            throw BridgeError.unsupportedBackend(backendName)
+        }
+    }
+
+    private static func spanDictionary(
+        entity: EntityPrediction,
+        text: String,
+        options: BridgeOptions,
+        action: String,
+        replacement: String?
+    ) -> [String: Any] {
+        let canonicalLabel = Policy.canonicalLabel(for: entity.label)
+        return spanDictionary(
+            label: entity.label,
+            canonicalLabel: canonicalLabel,
+            start: entity.start,
+            end: entity.end,
+            confidence: entity.confidence,
+            action: action,
+            replacement: replacement,
+            text: text,
+            options: options
+        )
+    }
+
+    private static func spanDictionary(
+        action: DeidentifiedSpanAction,
+        text: String,
+        options: BridgeOptions
+    ) -> [String: Any] {
+        spanDictionary(
+            label: action.label,
+            canonicalLabel: action.canonicalLabel,
+            start: action.start,
+            end: action.end,
+            confidence: action.confidence,
+            action: action.action.rawValue,
+            replacement: action.replacement,
+            text: text,
+            options: options
+        )
+    }
+
+    private static func spanDictionary(
+        label: String,
+        canonicalLabel: String,
+        start: Int,
+        end: Int,
+        confidence: Float,
+        action: String,
+        replacement: String?,
+        text: String,
+        options: BridgeOptions
+    ) -> [String: Any] {
+        let surface = substring(text, start: start, end: end)
+        return [
+            "schema_version": 1,
+            "doc_id": options.docID,
+            "start": start,
+            "end": end,
+            "text_hash": hmacTextHash(surface, secret: options.hashSecret),
+            "entity_type": label,
+            "canonical_label": canonicalLabel,
+            "policy_label": policyLabel(for: canonicalLabel),
+            "regulatory_tags": [],
+            "score": confidence,
+            "detector": options.detector ?? "openmedkit-ios",
+            "evidence": [
+                "bridge": "react-native",
+                "runtime": "OpenMedKit",
+            ],
+            "action": action,
+            "replacement": replacement ?? NSNull(),
+            "reversible_id": NSNull(),
+            "section": NSNull(),
+            "metadata": options.metadata,
+        ]
+    }
+
+    private static func substring(_ text: String, start: Int, end: Int) -> String {
+        guard start >= 0, end > start, end <= text.count else {
+            return ""
+        }
+        let lowerBound = text.index(text.startIndex, offsetBy: start)
+        let upperBound = text.index(text.startIndex, offsetBy: end)
+        return String(text[lowerBound..<upperBound])
+    }
+
+    private static func hmacTextHash(_ surface: String, secret: String) -> String {
+        let key = SymmetricKey(data: Data(secret.utf8))
+        let signature = HMAC<SHA256>.authenticationCode(
+            for: Data(surface.utf8),
+            using: key
+        )
+        return "hmac-sha256:" + signature.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func policyLabel(for canonicalLabel: String) -> String {
+        if clinicalConceptLabels.contains(canonicalLabel) {
+            return "CLINICAL_CONCEPT"
+        }
+        if quasiIdentifierLabels.contains(canonicalLabel) {
+            return "QUASI_IDENTIFIER"
+        }
+        return "DIRECT_IDENTIFIER"
+    }
+
+    private static func requiredString(
+        _ options: NSDictionary,
+        _ key: String
+    ) throws -> String {
+        guard let value = string(options, key), !value.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ).isEmpty else {
+            throw BridgeError.missingOption(key)
+        }
+        return value
+    }
+
+    private static func string(_ options: NSDictionary, _ key: String) -> String? {
+        options[key] as? String
+    }
+
+    private static let clinicalConceptLabels: Set<String> = [
+        "MICROORGANISM",
+        "ANTIBIOTIC",
+        "SUSCEPTIBILITY",
+        "CONDITION",
+        "MEDICATION",
+        "LAB_TEST",
+        "PROCEDURE",
+        "BODY_SITE",
+        "DIET_TYPE",
+        "NUTRITION_TARGET",
+        "FEEDING_ROUTE",
+        "NUTRITIONAL_STATUS",
+        "OTHER",
+    ]
+
+    private static let quasiIdentifierLabels: Set<String> = [
+        "LOCATION",
+        "ZIPCODE",
+        "ORDINAL_DIRECTION",
+        "DATE",
+        "TIME",
+        "AGE",
+        "CREDIT_CARD_ISSUER",
+        "AMOUNT",
+        "CURRENCY",
+        "GENDER",
+        "EYE_COLOR",
+        "HEIGHT",
+        "ORGANIZATION",
+        "JOB_TITLE",
+        "JOB_DEPARTMENT",
+        "OCCUPATION",
+    ]
+}
+
+private struct BridgeOptions {
+    let confidenceThreshold: Float
+    let useSmartMerging: Bool
+    let docID: String
+    let hashSecret: String
+    let detector: String?
+    let metadata: [String: Any]
+    let policy: String
+
+    init(_ options: NSDictionary?) {
+        self.confidenceThreshold = options?["confidenceThreshold"] as? Float
+            ?? (options?["confidenceThreshold"] as? NSNumber)?.floatValue
+            ?? 0.5
+        self.useSmartMerging = options?["useSmartMerging"] as? Bool ?? true
+        self.docID = options?["docId"] as? String ?? "document"
+        self.hashSecret = options?["hashSecret"] as? String ?? "openmedkit-react-native"
+        self.detector = options?["detector"] as? String
+        self.metadata = options?["metadata"] as? [String: Any] ?? [:]
+        self.policy = options?["policy"] as? String ?? Policy.defaultName
+    }
+}
+
+private enum BridgeError: LocalizedError {
+    case missingOption(String)
+    case unsupportedBackend(String)
+    case modelNotLoaded
+
+    var errorDescription: String? {
+        switch self {
+        case .missingOption(let key):
+            return "missing required OpenMedKit bridge option: \(key)"
+        case .unsupportedBackend(let backend):
+            return "unsupported OpenMedKit iOS backend: \(backend)"
+        case .modelNotLoaded:
+            return "OpenMedKit model is not loaded"
+        }
+    }
+}

--- a/js/openmedkit-react-native/package-lock.json
+++ b/js/openmedkit-react-native/package-lock.json
@@ -1,0 +1,582 @@
+{
+  "name": "@openmed/openmedkit-react-native",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openmed/openmedkit-react-native",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-native": ">=0.74"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.5.tgz",
+      "integrity": "sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/js/openmedkit-react-native/package.json
+++ b/js/openmedkit-react-native/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@openmed/openmedkit-react-native",
+  "version": "0.1.0",
+  "description": "React Native bridge for OpenMedKit on-device de-identification.",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "react-native": "./src/index.ts",
+  "types": "./src/index.ts",
+  "files": [
+    "android",
+    "ios",
+    "src"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "npm run typecheck && npm run test:node",
+    "test:node": "tsx --test ../../tests/mobile/test_rn_bridge_parity.ts"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-native": ">=0.74"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-native": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "Apache-2.0"
+}

--- a/js/openmedkit-react-native/src/index.ts
+++ b/js/openmedkit-react-native/src/index.ts
@@ -1,0 +1,483 @@
+export const OPENMED_REACT_NATIVE_MODULE_NAME = "OpenMedKitRN" as const;
+export const OPENMED_SPAN_SCHEMA_VERSION = 1 as const;
+
+export type OpenMedPlatform = "ios" | "android";
+export type OpenMedBackendKind = "mlx" | "coreml" | "onnx";
+export type SpanAction =
+  | "keep"
+  | "redact"
+  | "replace"
+  | "mask"
+  | "remove"
+  | "hash";
+export type PolicyLabel =
+  | "DIRECT_IDENTIFIER"
+  | "QUASI_IDENTIFIER"
+  | "CLINICAL_CONCEPT";
+export type TextHash = `hmac-sha256:${string}` | `sha256:${string}`;
+
+export interface OpenMedModelSource {
+  modelPath: string;
+  backend?: OpenMedBackendKind;
+  id2LabelPath?: string;
+  tokenizerName?: string;
+  tokenizerFolderPath?: string;
+  cacheKey?: string;
+}
+
+export interface OpenMedModelLoadResult {
+  cacheKey: string;
+  modelPath: string;
+  backend: OpenMedBackendKind;
+  platform: OpenMedPlatform;
+  loaded: boolean;
+}
+
+export interface OpenMedBridgeOptions {
+  confidenceThreshold?: number;
+  useSmartMerging?: boolean;
+  docId?: string;
+  hashSecret?: string;
+  detector?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OpenMedDeidentifyOptions extends OpenMedBridgeOptions {
+  policy?: string;
+}
+
+export interface OpenMedSpan {
+  schema_version: typeof OPENMED_SPAN_SCHEMA_VERSION;
+  doc_id: string;
+  start: number;
+  end: number;
+  text_hash: TextHash;
+  entity_type: string;
+  canonical_label: string;
+  policy_label: PolicyLabel;
+  regulatory_tags: string[];
+  score: number | null;
+  detector: string | null;
+  evidence: Record<string, unknown>;
+  action: SpanAction;
+  replacement: string | null;
+  reversible_id: string | null;
+  section: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface OpenMedDeidentifyResult {
+  text: string;
+  deidentifiedText: string;
+  spans: OpenMedSpan[];
+}
+
+export interface OpenMedKitNativeModule {
+  loadModel(source: NativeModelSource): Promise<OpenMedModelLoadResult>;
+  analyzeText(
+    text: string,
+    options?: NativeBridgeOptions,
+  ): Promise<NativeSpanResponse>;
+  extractPii(
+    text: string,
+    options?: NativeBridgeOptions,
+  ): Promise<NativeSpanResponse>;
+  deidentify(
+    text: string,
+    options?: NativeDeidentifyOptions,
+  ): Promise<NativeDeidentifyResponse>;
+}
+
+interface NativeModelSource {
+  modelPath: string;
+  backend: OpenMedBackendKind;
+  cacheKey: string;
+  id2LabelPath?: string;
+  tokenizerName?: string;
+  tokenizerFolderPath?: string;
+}
+
+interface NativeBridgeOptions {
+  confidenceThreshold?: number;
+  useSmartMerging?: boolean;
+  docId?: string;
+  hashSecret?: string;
+  detector?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+interface NativeDeidentifyOptions extends NativeBridgeOptions {
+  policy: string;
+}
+
+type NativeSpan = Partial<OpenMedSpan> & Record<string, unknown>;
+type NativeSpanResponse = NativeSpan[] | { spans?: NativeSpan[] };
+type NativeDeidentifyResponse =
+  | Partial<OpenMedDeidentifyResult>
+  | {
+      text?: string;
+      originalText?: string;
+      deidentifiedText?: string;
+      redactedText?: string;
+      spans?: NativeSpan[];
+    };
+
+interface ReactNativeRuntime {
+  NativeModules?: Record<string, unknown>;
+  TurboModuleRegistry?: {
+    get<T = unknown>(name: string): T | null | undefined;
+  };
+  Platform?: {
+    OS?: string;
+  };
+}
+
+declare const require: undefined | ((moduleName: string) => unknown);
+
+let injectedNativeModule: OpenMedKitNativeModule | null = null;
+
+export function setOpenMedKitNativeModuleForTests(
+  module: OpenMedKitNativeModule | null,
+): void {
+  injectedNativeModule = module;
+}
+
+export async function loadModel(
+  source: OpenMedModelSource,
+): Promise<OpenMedModelLoadResult> {
+  const nativeSource = normalizeModelSource(source);
+  const result = await nativeModule().loadModel(nativeSource);
+  const resultRecord = asRecord(result);
+  return {
+    cacheKey: readString(resultRecord, "cacheKey", nativeSource.cacheKey),
+    modelPath: readString(resultRecord, "modelPath", nativeSource.modelPath),
+    backend: readBackend(result.backend, nativeSource.backend),
+    platform: readPlatform(result.platform, currentPlatform()),
+    loaded: result.loaded !== false,
+  };
+}
+
+export async function analyzeText(
+  text: string,
+  options: OpenMedBridgeOptions = {},
+): Promise<OpenMedSpan[]> {
+  const response = await nativeModule().analyzeText(text, normalizeOptions(options));
+  return normalizeSpans(response, options);
+}
+
+export async function extractPii(
+  text: string,
+  options: OpenMedBridgeOptions = {},
+): Promise<OpenMedSpan[]> {
+  const response = await nativeModule().extractPii(text, normalizeOptions(options));
+  return normalizeSpans(response, options);
+}
+
+export async function deidentify(
+  text: string,
+  options: OpenMedDeidentifyOptions = {},
+): Promise<OpenMedDeidentifyResult> {
+  const nativeOptions: NativeDeidentifyOptions = {
+    ...normalizeOptions(options),
+    policy: options.policy ?? "hipaa_safe_harbor",
+  };
+  const response = await nativeModule().deidentify(text, nativeOptions);
+  const responseRecord = asRecord(response);
+  const spans = normalizeSpans(
+    Array.isArray(responseRecord.spans)
+      ? (responseRecord.spans as NativeSpan[])
+      : [],
+    options,
+  );
+  return {
+    text: readString(responseRecord, "text", text),
+    deidentifiedText:
+      stringValue(responseRecord.deidentifiedText) ??
+      stringValue(responseRecord.redactedText) ??
+      text,
+    spans,
+  };
+}
+
+function nativeModule(): OpenMedKitNativeModule {
+  if (injectedNativeModule) {
+    return injectedNativeModule;
+  }
+
+  const runtime = loadReactNative();
+  const turboModule =
+    runtime?.TurboModuleRegistry?.get<OpenMedKitNativeModule>(
+      OPENMED_REACT_NATIVE_MODULE_NAME,
+    ) ?? null;
+  const bridgeModule = runtime?.NativeModules?.[OPENMED_REACT_NATIVE_MODULE_NAME];
+  const resolved = turboModule ?? bridgeModule;
+
+  if (isNativeModule(resolved)) {
+    return resolved;
+  }
+
+  throw new Error(
+    `${OPENMED_REACT_NATIVE_MODULE_NAME} is not installed in the React Native runtime`,
+  );
+}
+
+function loadReactNative(): ReactNativeRuntime | null {
+  if (typeof require !== "function") {
+    return null;
+  }
+  try {
+    return require("react-native") as ReactNativeRuntime;
+  } catch {
+    return null;
+  }
+}
+
+function isNativeModule(value: unknown): value is OpenMedKitNativeModule {
+  const candidate = asRecord(value);
+  return (
+    typeof candidate.loadModel === "function" &&
+    typeof candidate.analyzeText === "function" &&
+    typeof candidate.extractPii === "function" &&
+    typeof candidate.deidentify === "function"
+  );
+}
+
+function normalizeModelSource(source: OpenMedModelSource): NativeModelSource {
+  const modelPath = source.modelPath.trim();
+  if (!modelPath) {
+    throw new Error("OpenMedKit modelPath must not be blank");
+  }
+
+  const backend = source.backend ?? defaultBackendForPlatform();
+  const nativeSource: NativeModelSource = {
+    modelPath,
+    backend,
+    cacheKey: source.cacheKey ?? `${backend}:${modelPath}`,
+  };
+  if (source.id2LabelPath !== undefined) {
+    nativeSource.id2LabelPath = source.id2LabelPath;
+  }
+  if (source.tokenizerName !== undefined) {
+    nativeSource.tokenizerName = source.tokenizerName;
+  }
+  if (source.tokenizerFolderPath !== undefined) {
+    nativeSource.tokenizerFolderPath = source.tokenizerFolderPath;
+  }
+  return nativeSource;
+}
+
+function normalizeOptions(options: OpenMedBridgeOptions): NativeBridgeOptions {
+  const normalized: NativeBridgeOptions = {};
+  if (options.confidenceThreshold !== undefined) {
+    normalized.confidenceThreshold = options.confidenceThreshold;
+  }
+  if (options.useSmartMerging !== undefined) {
+    normalized.useSmartMerging = options.useSmartMerging;
+  }
+  if (options.docId !== undefined) {
+    normalized.docId = options.docId;
+  }
+  if (options.hashSecret !== undefined) {
+    normalized.hashSecret = options.hashSecret;
+  }
+  if (options.detector !== undefined) {
+    normalized.detector = options.detector;
+  }
+  if (options.metadata !== undefined) {
+    normalized.metadata = options.metadata;
+  }
+  return normalized;
+}
+
+function normalizeSpans(
+  response: NativeSpanResponse,
+  options: OpenMedBridgeOptions,
+): OpenMedSpan[] {
+  const rawSpans = Array.isArray(response)
+    ? response
+    : Array.isArray(response.spans)
+      ? response.spans
+      : [];
+
+  return rawSpans
+    .map((span) => normalizeSpan(span, options))
+    .sort((left, right) => left.start - right.start || left.end - right.end);
+}
+
+function normalizeSpan(
+  span: NativeSpan,
+  options: OpenMedBridgeOptions,
+): OpenMedSpan {
+  const record = asRecord(span);
+  const canonicalLabel =
+    stringValue(record.canonical_label) ??
+    stringValue(record.canonicalLabel) ??
+    stringValue(record.label) ??
+    stringValue(record.entity_type) ??
+    "OTHER";
+  const entityType =
+    stringValue(record.entity_type) ??
+    stringValue(record.entityType) ??
+    stringValue(record.label) ??
+    canonicalLabel;
+
+  return {
+    schema_version: OPENMED_SPAN_SCHEMA_VERSION,
+    doc_id: stringValue(record.doc_id) ?? stringValue(record.docId) ?? "document",
+    start: numberValue(record.start) ?? 0,
+    end: numberValue(record.end) ?? 0,
+    text_hash:
+      textHashValue(record.text_hash) ??
+      textHashValue(record.textHash) ??
+      "sha256:missing-native-text-hash",
+    entity_type: entityType,
+    canonical_label: canonicalLabel,
+    policy_label:
+      policyLabelValue(record.policy_label) ??
+      policyLabelValue(record.policyLabel) ??
+      policyLabelFor(canonicalLabel),
+    regulatory_tags: stringArrayValue(record.regulatory_tags) ?? [],
+    score: numberValue(record.score) ?? numberValue(record.confidence),
+    detector:
+      stringValue(record.detector) ??
+      options.detector ??
+      `${OPENMED_REACT_NATIVE_MODULE_NAME}:${currentPlatform()}`,
+    evidence: recordValue(record.evidence) ?? {},
+    action: spanActionValue(record.action) ?? "keep",
+    replacement: stringValue(record.replacement) ?? null,
+    reversible_id:
+      stringValue(record.reversible_id) ?? stringValue(record.reversibleId) ?? null,
+    section: stringValue(record.section) ?? null,
+    metadata: {
+      ...recordValue(record.metadata),
+      ...options.metadata,
+    },
+  };
+}
+
+function currentPlatform(): OpenMedPlatform {
+  const runtimePlatform = loadReactNative()?.Platform?.OS;
+  return runtimePlatform === "android" ? "android" : "ios";
+}
+
+function defaultBackendForPlatform(): OpenMedBackendKind {
+  return currentPlatform() === "android" ? "onnx" : "mlx";
+}
+
+function readString(
+  record: Record<string, unknown>,
+  key: string,
+  fallback: string,
+): string {
+  return stringValue(record[key]) ?? fallback;
+}
+
+function readBackend(
+  value: unknown,
+  fallback: OpenMedBackendKind,
+): OpenMedBackendKind {
+  return value === "mlx" || value === "coreml" || value === "onnx"
+    ? value
+    : fallback;
+}
+
+function readPlatform(value: unknown, fallback: OpenMedPlatform): OpenMedPlatform {
+  return value === "android" || value === "ios" ? value : fallback;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function stringArrayValue(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+    ? value
+    : undefined;
+}
+
+function textHashValue(value: unknown): TextHash | undefined {
+  return typeof value === "string" &&
+    (value.startsWith("hmac-sha256:") || value.startsWith("sha256:"))
+    ? (value as TextHash)
+    : undefined;
+}
+
+function spanActionValue(value: unknown): SpanAction | undefined {
+  return value === "keep" ||
+    value === "redact" ||
+    value === "replace" ||
+    value === "mask" ||
+    value === "remove" ||
+    value === "hash"
+    ? value
+    : undefined;
+}
+
+function policyLabelValue(value: unknown): PolicyLabel | undefined {
+  return value === "DIRECT_IDENTIFIER" ||
+    value === "QUASI_IDENTIFIER" ||
+    value === "CLINICAL_CONCEPT"
+    ? value
+    : undefined;
+}
+
+function policyLabelFor(canonicalLabel: string): PolicyLabel {
+  if (CLINICAL_CONCEPT_LABELS.has(canonicalLabel)) {
+    return "CLINICAL_CONCEPT";
+  }
+  if (QUASI_IDENTIFIER_LABELS.has(canonicalLabel)) {
+    return "QUASI_IDENTIFIER";
+  }
+  return "DIRECT_IDENTIFIER";
+}
+
+const CLINICAL_CONCEPT_LABELS = new Set([
+  "MICROORGANISM",
+  "ANTIBIOTIC",
+  "SUSCEPTIBILITY",
+  "CONDITION",
+  "MEDICATION",
+  "LAB_TEST",
+  "PROCEDURE",
+  "BODY_SITE",
+  "DIET_TYPE",
+  "NUTRITION_TARGET",
+  "FEEDING_ROUTE",
+  "NUTRITIONAL_STATUS",
+  "OTHER",
+]);
+
+const QUASI_IDENTIFIER_LABELS = new Set([
+  "LOCATION",
+  "ZIPCODE",
+  "ORDINAL_DIRECTION",
+  "DATE",
+  "TIME",
+  "AGE",
+  "CREDIT_CARD_ISSUER",
+  "AMOUNT",
+  "CURRENCY",
+  "GENDER",
+  "EYE_COLOR",
+  "HEIGHT",
+  "ORGANIZATION",
+  "JOB_TITLE",
+  "JOB_DEPARTMENT",
+  "OCCUPATION",
+]);

--- a/js/openmedkit-react-native/tsconfig.json
+++ b/js/openmedkit-react-native/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tests/mobile/__snapshots__/openmedkit-react-native-public-api.json
+++ b/tests/mobile/__snapshots__/openmedkit-react-native-public-api.json
@@ -1,0 +1,28 @@
+{
+  "exports": [
+    "OPENMED_REACT_NATIVE_MODULE_NAME",
+    "OPENMED_SPAN_SCHEMA_VERSION",
+    "analyzeText",
+    "deidentify",
+    "extractPii",
+    "loadModel",
+    "setOpenMedKitNativeModuleForTests"
+  ],
+  "packagePeerDependencies": {
+    "react": ">=18",
+    "react-native": ">=0.74"
+  },
+  "packagePeerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-native": {
+      "optional": true
+    }
+  },
+  "packageScripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "npm run typecheck && npm run test:node",
+    "test:node": "tsx --test ../../tests/mobile/test_rn_bridge_parity.ts"
+  }
+}

--- a/tests/mobile/test_rn_bridge_parity.py
+++ b/tests/mobile/test_rn_bridge_parity.py
@@ -1,0 +1,36 @@
+"""Pytest bridge for the OpenMedKit React Native package checks."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_DIR = ROOT / "js" / "openmedkit-react-native"
+
+
+def test_openmedkit_react_native_package_checks() -> None:
+    node = shutil.which("node")
+    npm = shutil.which("npm")
+    if node is None or npm is None:
+        pytest.skip("node and npm are required for OpenMedKit React Native checks")
+
+    _run([npm, "ci"])
+    _run([npm, "test"])
+
+
+def _run(command: list[str]) -> None:
+    completed = subprocess.run(
+        command,
+        cwd=PACKAGE_DIR,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert completed.returncode == 0, completed.stdout

--- a/tests/mobile/test_rn_bridge_parity.ts
+++ b/tests/mobile/test_rn_bridge_parity.ts
@@ -1,0 +1,266 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  analyzeText,
+  deidentify,
+  extractPii,
+  loadModel,
+  setOpenMedKitNativeModuleForTests,
+  type OpenMedKitNativeModule,
+  type OpenMedSpan,
+} from "../../js/openmedkit-react-native/src/index";
+
+const rootDir = fileURLToPath(new URL("../..", import.meta.url));
+const packageDir = join(rootDir, "js", "openmedkit-react-native");
+const publicSurfaceSnapshotPath = join(
+  rootDir,
+  "tests",
+  "mobile",
+  "__snapshots__",
+  "openmedkit-react-native-public-api.json",
+);
+
+const fixtureText =
+  "Patient Alice Nguyen was born on 1979-04-12. Email alice@example.org.";
+const piiFragments = ["Alice", "Nguyen", "1979-04-12", "alice@example.org"];
+
+test.afterEach(() => {
+  setOpenMedKitNativeModuleForTests(null);
+});
+
+test("public runtime surface is snapshot-tested", async () => {
+  const api = await import("../../js/openmedkit-react-native/src/index.ts");
+  const snapshot = JSON.parse(
+    await readFile(publicSurfaceSnapshotPath, "utf8"),
+  ) as {
+    exports: string[];
+    packagePeerDependencies: unknown;
+    packagePeerDependenciesMeta: unknown;
+    packageScripts: unknown;
+  };
+  const packageJson = JSON.parse(
+    await readFile(join(packageDir, "package.json"), "utf8"),
+  ) as {
+    peerDependencies: unknown;
+    peerDependenciesMeta: unknown;
+    scripts: unknown;
+  };
+
+  assert.deepEqual(Object.keys(api).sort(), snapshot.exports);
+  assert.deepEqual(
+    packageJson.peerDependencies,
+    snapshot.packagePeerDependencies,
+  );
+  assert.deepEqual(
+    packageJson.peerDependenciesMeta,
+    snapshot.packagePeerDependenciesMeta,
+  );
+  assert.deepEqual(packageJson.scripts, snapshot.packageScripts);
+});
+
+for (const platform of ["ios", "android"] as const) {
+  test(`${platform} bridge returns spans matching the shared native fixture`, async () => {
+    const native = createNativeFixture(platform);
+    setOpenMedKitNativeModuleForTests(native);
+
+    const backend = platform === "android" ? "onnx" : "mlx";
+    const loadResult = await loadModel({
+      modelPath: `/app/models/openmed-${platform}`,
+      backend,
+      cacheKey: `fixture-${platform}`,
+    });
+    const secondLoadResult = await loadModel({
+      modelPath: `/app/models/openmed-${platform}`,
+      backend,
+      cacheKey: `fixture-${platform}`,
+    });
+
+    assert.deepEqual(loadResult, {
+      cacheKey: `fixture-${platform}`,
+      modelPath: `/app/models/openmed-${platform}`,
+      backend,
+      platform,
+      loaded: true,
+    });
+    assert.equal(secondLoadResult.loaded, false);
+
+    const analyzeSpans = await analyzeText(fixtureText, fixtureOptions);
+    const extractSpans = await extractPii(fixtureText, fixtureOptions);
+
+    assert.deepEqual(analyzeSpans, sharedKeepSpans);
+    assert.deepEqual(extractSpans, sharedKeepSpans);
+    assertNoPhiInSpans(analyzeSpans);
+  });
+}
+
+test("deidentify returns redacted text and never logs raw PHI", async () => {
+  const native = createNativeFixture("ios");
+  const consoleCalls: string[] = [];
+  const originalConsole = {
+    error: console.error,
+    info: console.info,
+    log: console.log,
+    warn: console.warn,
+  };
+
+  console.error = (...args: unknown[]) => {
+    consoleCalls.push(args.join(" "));
+  };
+  console.info = (...args: unknown[]) => {
+    consoleCalls.push(args.join(" "));
+  };
+  console.log = (...args: unknown[]) => {
+    consoleCalls.push(args.join(" "));
+  };
+  console.warn = (...args: unknown[]) => {
+    consoleCalls.push(args.join(" "));
+  };
+
+  try {
+    setOpenMedKitNativeModuleForTests(native);
+    await loadModel({
+      modelPath: "/app/models/openmed-ios",
+      backend: "mlx",
+      cacheKey: "fixture-ios",
+    });
+
+    const result = await deidentify(fixtureText, {
+      ...fixtureOptions,
+      policy: "hipaa_safe_harbor",
+    });
+
+    assert.equal(
+      result.deidentifiedText,
+      "Patient [PERSON] was born on [DATE_OF_BIRTH]. Email [EMAIL].",
+    );
+    assert.deepEqual(result.spans, sharedRedactedSpans);
+    assertNoPhiInSpans(result.spans);
+    assert.equal(consoleCalls.length, 0);
+  } finally {
+    console.error = originalConsole.error;
+    console.info = originalConsole.info;
+    console.log = originalConsole.log;
+    console.warn = originalConsole.warn;
+  }
+});
+
+const fixtureOptions = {
+  docId: "rn-fixture",
+  hashSecret: "fixture-secret",
+  detector: "openmedkit-native-fixture",
+  metadata: { fixture: "simulator-parity" },
+};
+
+const sharedKeepSpans: OpenMedSpan[] = [
+  span({
+    start: 8,
+    end: 20,
+    text_hash:
+      "hmac-sha256:7f42b1f8ec1bbff19ef8cf25ef95dc45d9486182b94a0b3fb4f3ca930bbd5a59",
+    entity_type: "PERSON",
+    canonical_label: "PERSON",
+    score: 0.99,
+  }),
+  span({
+    start: 33,
+    end: 43,
+    text_hash:
+      "hmac-sha256:8c385628c5b09d88ab813bb27f305c793f37f3ef9a1b2c9f74ccb7e8479da24f",
+    entity_type: "DATE_OF_BIRTH",
+    canonical_label: "DATE_OF_BIRTH",
+    score: 0.98,
+  }),
+  span({
+    start: 51,
+    end: 68,
+    text_hash:
+      "hmac-sha256:bd72f3d754422ae0d14d40a7fd16b7200eb2e427f404915cb8d5c41bf96ded39",
+    entity_type: "EMAIL",
+    canonical_label: "EMAIL",
+    score: 0.97,
+  }),
+];
+
+const sharedRedactedSpans: OpenMedSpan[] = [
+  { ...sharedKeepSpans[0]!, action: "mask", replacement: "[PERSON]" },
+  {
+    ...sharedKeepSpans[1]!,
+    action: "mask",
+    replacement: "[DATE_OF_BIRTH]",
+  },
+  { ...sharedKeepSpans[2]!, action: "mask", replacement: "[EMAIL]" },
+];
+
+function createNativeFixture(platform: "ios" | "android"): OpenMedKitNativeModule {
+  let loadedCacheKey: string | null = null;
+  return {
+    async loadModel(source) {
+      const loaded = loadedCacheKey !== source.cacheKey;
+      loadedCacheKey = source.cacheKey;
+      return {
+        cacheKey: source.cacheKey,
+        modelPath: source.modelPath,
+        backend: source.backend,
+        platform,
+        loaded,
+      };
+    },
+    async analyzeText() {
+      assert.ok(loadedCacheKey);
+      return sharedKeepSpans;
+    },
+    async extractPii() {
+      assert.ok(loadedCacheKey);
+      return { spans: sharedKeepSpans };
+    },
+    async deidentify() {
+      assert.ok(loadedCacheKey);
+      return {
+        text: fixtureText,
+        deidentifiedText:
+          "Patient [PERSON] was born on [DATE_OF_BIRTH]. Email [EMAIL].",
+        spans: sharedRedactedSpans,
+      };
+    },
+  };
+}
+
+function span(input: {
+  start: number;
+  end: number;
+  text_hash: OpenMedSpan["text_hash"];
+  entity_type: string;
+  canonical_label: string;
+  score: number;
+}): OpenMedSpan {
+  return {
+    schema_version: 1,
+    doc_id: "rn-fixture",
+    start: input.start,
+    end: input.end,
+    text_hash: input.text_hash,
+    entity_type: input.entity_type,
+    canonical_label: input.canonical_label,
+    policy_label: "DIRECT_IDENTIFIER",
+    regulatory_tags: [],
+    score: input.score,
+    detector: "openmedkit-native-fixture",
+    evidence: {},
+    action: "keep",
+    replacement: null,
+    reversible_id: null,
+    section: null,
+    metadata: { fixture: "simulator-parity" },
+  };
+}
+
+function assertNoPhiInSpans(spans: OpenMedSpan[]) {
+  const encoded = JSON.stringify(spans);
+  for (const fragment of piiFragments) {
+    assert.equal(encoded.includes(fragment), false);
+  }
+}


### PR DESCRIPTION
Closes #796.

## Summary
- Adds a private React Native OpenMedKit bridge package with a strict TypeScript API for model loading, analyzeText, extractPii, and policy de-identification.
- Adds iOS Swift and Android Kotlin native modules that wrap local OpenMedKit runtimes, reuse loaded model cache keys, and return hashed OpenMedSpan records without raw span text.
- Adds a synthetic example screen and pytest-backed Node parity and snapshot checks.

## Tests
- npm test (js/openmedkit-react-native)
- .venv/bin/python -m pytest tests/ -q