### PR TITLE
feat: add negation-scope boundary detector for clinical spans

### DIFF
--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -90,6 +90,15 @@ from .medication_sig import (
     normalize_frequency,
     normalize_medication_attribute,
 )
+from .negation_scope import (
+    BACKWARD,
+    FORWARD,
+    NEGATION_SCOPE_ADVISORY,
+    Direction,
+    NegationScope,
+    detect_negation_scopes,
+    negated_spans,
+)
 from .problem_list import (
     ACTIVE,
     INACTIVE,
@@ -266,4 +275,11 @@ __all__ = [
     "VITAL_SIGNS_ADVISORY",
     "empty_vital_sign_result",
     "structure_vital_sign",
+    "NEGATION_SCOPE_ADVISORY",
+    "FORWARD",
+    "BACKWARD",
+    "Direction",
+    "NegationScope",
+    "detect_negation_scopes",
+    "negated_spans",
 ]

--- a/openmed/clinical/negation_scope.py
+++ b/openmed/clinical/negation_scope.py
@@ -1,0 +1,206 @@
+"""Negation-scope boundary detection for clinical spans (roadmap v1.9).
+
+The shipped ConText negation layer (:mod:`openmed.clinical.context`) decides
+*whether* a negation cue is present, scoping it to the sentence. That is too
+coarse: in ``"no chest pain but has fever"`` a sentence-level scope wrongly
+negates ``fever``. This module computes the exact token region each negation
+cue governs, terminating the scope at conjunctions, clause breaks, and
+scope-terminating cue words, so an entity is negated only when it falls inside a
+cue's computed influence span.
+
+Forward cues (``no``, ``denies``, ``no evidence of`` ...) govern the text to
+their right; backward cues (``ruled out``, ``absent`` ...) govern the text to
+their left. Pseudo-negation phrases (``cannot be excluded``, ``not ruled out``)
+are masked first so they never open a scope. The detector is deterministic and
+offline, and reuses the authoritative cue lexicons from
+:mod:`openmed.clinical.context` so the two layers cannot drift apart.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+from .context import NEGATION_CUES, PSEUDO_NEGATION_CUES
+
+NEGATION_SCOPE_ADVISORY = (
+    "Negation scopes are computed deterministically from surface cues and "
+    "clause boundaries. They sharpen assertion accuracy but are not a "
+    "substitute for clinician review; verify before clinical use."
+)
+
+Direction = str  # "forward" | "backward"
+
+FORWARD: Direction = "forward"
+BACKWARD: Direction = "backward"
+
+# Post-coordinated cues that govern the text to their LEFT rather than their
+# right (kept in sync with the backward cues used by the ConText layer).
+_BACKWARD_CUES: frozenset[str] = frozenset(
+    {
+        "absent",
+        "not present",
+        "ruled out",
+        "resolved",
+    }
+)
+
+# A negation scope terminates at sentence punctuation, coordinating
+# conjunctions, and classic NegEx clause-break terminators. The punctuation and
+# ``and``/``or``/``but``/``however`` set mirror the shipped ConText
+# ``_SCOPE_TERMINATOR_RE``; the remaining NegEx terminators sharpen the boundary
+# beyond sentence-level scoping. Comma is intentionally not a terminator so
+# coordinated negation lists ("no fever, chills, or cough") stay in scope.
+_TERMINATOR_RE = re.compile(
+    r"(?:[.!?;]|(?<!\w)(?:"
+    r"and|but|however|or|although|though|nevertheless|yet|still|"
+    r"except|aside from|apart from|secondary to|which|who|because"
+    r")(?!\w))",
+    re.IGNORECASE,
+)
+
+
+def _cue_pattern(cues: Iterable[str]) -> re.Pattern[str]:
+    alternation = "|".join(
+        r"\s+".join(re.escape(part) for part in cue.split())
+        for cue in sorted(cues, key=len, reverse=True)
+    )
+    return re.compile(rf"(?<!\w)(?:{alternation})(?!\w)", re.IGNORECASE)
+
+
+_NEGATION_RE = _cue_pattern(NEGATION_CUES)
+_PSEUDO_NEGATION_RE = _cue_pattern(PSEUDO_NEGATION_CUES)
+
+
+@dataclass(frozen=True)
+class NegationScope:
+    """The region of text governed by one negation cue.
+
+    ``scope_start`` / ``scope_end`` are half-open character offsets into the
+    source text bounding the governed region (excluding the cue itself).
+    ``governed`` holds the ``(start, end)`` offsets of the input entity spans
+    that fall entirely inside that region.
+    """
+
+    cue: str
+    cue_start: int
+    cue_end: int
+    direction: Direction
+    scope_start: int
+    scope_end: int
+    governed: tuple[tuple[int, int], ...]
+
+
+def _mask_pseudo_negation(text: str) -> str:
+    """Blank out pseudo-negation phrases, preserving every character offset."""
+
+    return _PSEUDO_NEGATION_RE.sub(lambda match: " " * len(match.group(0)), text)
+
+
+def _normalize_cue(surface: str) -> str:
+    return " ".join(surface.casefold().split())
+
+
+def _forward_bound(text: str, start: int) -> int:
+    """First terminator at or after ``start``; end of text if none."""
+
+    match = _TERMINATOR_RE.search(text, start)
+    return match.start() if match else len(text)
+
+
+def _backward_bound(text: str, end: int) -> int:
+    """Offset just after the last terminator before ``end``; 0 if none."""
+
+    last = 0
+    for match in _TERMINATOR_RE.finditer(text, 0, end):
+        last = match.end()
+    return last
+
+
+def _coerce_span(span: Mapping[str, object]) -> tuple[int, int]:
+    try:
+        start = int(span["start"])  # type: ignore[arg-type]
+        end = int(span["end"])  # type: ignore[arg-type]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("entity spans require integer 'start' and 'end'") from exc
+    if start > end:
+        raise ValueError("entity span 'start' must not exceed 'end'")
+    return start, end
+
+
+def detect_negation_scopes(
+    text: str,
+    spans: Iterable[Mapping[str, object]] = (),
+) -> list[NegationScope]:
+    """Compute the governed scope of every negation cue in ``text``.
+
+    ``spans`` are optional entity mentions (mappings with integer ``start`` /
+    ``end``); each is attached to a scope's ``governed`` tuple when it lies
+    fully inside that scope. Pseudo-negation phrases are masked first and never
+    open a scope. Scopes are returned ordered by cue offset.
+    """
+
+    entities = [_coerce_span(span) for span in spans]
+    masked = _mask_pseudo_negation(text)
+
+    scopes: list[NegationScope] = []
+    for match in _NEGATION_RE.finditer(masked):
+        cue_start, cue_end = match.start(), match.end()
+        surface = text[cue_start:cue_end]
+        direction = BACKWARD if _normalize_cue(surface) in _BACKWARD_CUES else FORWARD
+        if direction == FORWARD:
+            scope_start, scope_end = cue_end, _forward_bound(text, cue_end)
+        else:
+            scope_start, scope_end = _backward_bound(text, cue_start), cue_start
+
+        governed = tuple(
+            (start, end)
+            for start, end in entities
+            if start >= scope_start and end <= scope_end
+        )
+        scopes.append(
+            NegationScope(
+                cue=surface,
+                cue_start=cue_start,
+                cue_end=cue_end,
+                direction=direction,
+                scope_start=scope_start,
+                scope_end=scope_end,
+                governed=governed,
+            )
+        )
+    return scopes
+
+
+def negated_spans(
+    text: str,
+    spans: Sequence[Mapping[str, object]],
+) -> tuple[tuple[int, int], ...]:
+    """Return the ``(start, end)`` offsets of spans that fall inside a scope.
+
+    A span is negated only when it lies within some negation cue's computed
+    scope, not merely the same sentence. Offsets are returned in first-seen
+    order without duplicates.
+    """
+
+    scopes = detect_negation_scopes(text, spans)
+    seen: set[tuple[int, int]] = set()
+    ordered: list[tuple[int, int]] = []
+    for scope in scopes:
+        for offset in scope.governed:
+            if offset not in seen:
+                seen.add(offset)
+                ordered.append(offset)
+    return tuple(ordered)
+
+
+__all__ = [
+    "NEGATION_SCOPE_ADVISORY",
+    "FORWARD",
+    "BACKWARD",
+    "Direction",
+    "NegationScope",
+    "detect_negation_scopes",
+    "negated_spans",
+]

--- a/tests/unit/clinical/test_negation_scope.py
+++ b/tests/unit/clinical/test_negation_scope.py
@@ -1,0 +1,179 @@
+"""Tests for the negation-scope boundary detector."""
+
+from __future__ import annotations
+
+import unicodedata
+
+import pytest
+
+from openmed.clinical import (
+    NEGATION_SCOPE_ADVISORY,
+    NegationScope,
+    detect_negation_scopes,
+    negated_spans,
+)
+
+
+def _span(text: str, sub: str, label: str = "CONDITION") -> dict:
+    start = text.index(sub)
+    return {"start": start, "end": start + len(sub), "label": label, "text": sub}
+
+
+# --------------------------------------------------------------------------
+# Scope boundary computation
+# --------------------------------------------------------------------------
+
+
+def test_forward_cue_scope_stops_at_conjunction():
+    text = "no chest pain but has fever"
+    chest_pain = _span(text, "chest pain")
+    fever = _span(text, "fever")
+
+    scopes = detect_negation_scopes(text, [chest_pain, fever])
+
+    assert len(scopes) == 1
+    scope = scopes[0]
+    assert isinstance(scope, NegationScope)
+    assert scope.cue == "no"
+    assert (scope.cue_start, scope.cue_end) == (0, 2)
+    assert scope.direction == "forward"
+    # Scope ends where "but" begins; fever sits past the terminator.
+    assert scope.scope_start >= scope.cue_end
+    assert scope.scope_end == text.index("but")
+    assert (chest_pain["start"], chest_pain["end"]) in scope.governed
+    assert (fever["start"], fever["end"]) not in scope.governed
+
+
+def test_forward_cue_scope_stops_at_sentence_break():
+    text = "no cough. Fever is present."
+    cough = _span(text, "cough")
+    fever = _span(text, "Fever")
+
+    scopes = detect_negation_scopes(text, [cough, fever])
+
+    assert len(scopes) == 1
+    assert scopes[0].governed == ((cough["start"], cough["end"]),)
+
+
+def test_backward_cue_scopes_to_the_left():
+    text = "Pneumonia was ruled out today"
+    pneumonia = _span(text, "Pneumonia")
+
+    scopes = detect_negation_scopes(text, [pneumonia])
+
+    assert len(scopes) == 1
+    scope = scopes[0]
+    assert scope.cue == "ruled out"
+    assert scope.direction == "backward"
+    assert scope.scope_end <= scope.cue_start
+    assert (pneumonia["start"], pneumonia["end"]) in scope.governed
+
+
+# --------------------------------------------------------------------------
+# Pseudo-negation must not create a scope
+# --------------------------------------------------------------------------
+
+
+def test_pseudo_negation_creates_no_scope():
+    text = "Pneumonia cannot be excluded"
+    pneumonia = _span(text, "Pneumonia")
+
+    scopes = detect_negation_scopes(text, [pneumonia])
+
+    assert scopes == []
+
+
+def test_pseudo_negation_not_ruled_out_is_masked():
+    text = "Fracture not ruled out on imaging"
+    fracture = _span(text, "Fracture")
+
+    scopes = detect_negation_scopes(text, [fracture])
+
+    assert scopes == []
+
+
+# --------------------------------------------------------------------------
+# Entity-level negation assignment (the core over/under-negation fix)
+# --------------------------------------------------------------------------
+
+
+def test_negated_spans_only_returns_in_scope_entities():
+    text = "no nausea but reports vomiting"
+    nausea = _span(text, "nausea")
+    vomiting = _span(text, "vomiting")
+
+    result = negated_spans(text, [nausea, vomiting])
+
+    assert (nausea["start"], nausea["end"]) in result
+    assert (vomiting["start"], vomiting["end"]) not in result
+
+
+def test_entity_after_scope_terminator_is_not_negated():
+    text = "denies fever and cough; reports chest pain"
+    fever = _span(text, "fever")
+    cough = _span(text, "cough")
+    chest_pain = _span(text, "chest pain")
+
+    result = negated_spans(text, [fever, cough, chest_pain])
+
+    # "and" terminates the scope, so only fever is negated.
+    assert result == ((fever["start"], fever["end"]),)
+
+
+# --------------------------------------------------------------------------
+# Offset exactness / determinism / Unicode stability
+# --------------------------------------------------------------------------
+
+
+def test_comma_separated_list_stays_in_scope():
+    text = "no fever, chills, or cough"
+    fever = _span(text, "fever")
+    chills = _span(text, "chills")
+    cough = _span(text, "cough")
+
+    result = negated_spans(text, [fever, chills, cough])
+
+    # Commas do not terminate: fever and chills are negated; "or" ends the run.
+    assert (fever["start"], fever["end"]) in result
+    assert (chills["start"], chills["end"]) in result
+    assert (cough["start"], cough["end"]) not in result
+
+
+def test_cue_offsets_index_back_to_the_cue_text():
+    text = "no evidence of metastatic disease"
+    disease = _span(text, "metastatic disease")
+
+    scope = detect_negation_scopes(text, [disease])[0]
+
+    assert text[scope.cue_start : scope.cue_end].lower() == "no evidence of"
+    assert (disease["start"], disease["end"]) in scope.governed
+
+
+def test_offsets_are_stable_under_nfc_normalization():
+    raw = "no diseña findings but café noted"
+    text = unicodedata.normalize("NFC", raw)
+    finding = _span(text, "diseña findings")
+
+    scopes_raw = detect_negation_scopes(text, [finding])
+    scopes_again = detect_negation_scopes(unicodedata.normalize("NFC", text), [finding])
+
+    assert scopes_raw == scopes_again
+    assert (finding["start"], finding["end"]) in scopes_raw[0].governed
+
+
+def test_detection_is_deterministic():
+    text = "no fever, no chills, but has cough"
+    spans = [_span(text, "fever"), _span(text, "chills"), _span(text, "cough")]
+
+    assert detect_negation_scopes(text, spans) == detect_negation_scopes(text, spans)
+
+
+def test_no_spans_returns_scopes_with_empty_governed():
+    text = "no acute distress"
+    scopes = detect_negation_scopes(text)
+    assert len(scopes) == 1
+    assert scopes[0].governed == ()
+
+
+def test_advisory_is_exposed():
+    assert isinstance(NEGATION_SCOPE_ADVISORY, str) and NEGATION_SCOPE_ADVISORY


### PR DESCRIPTION
Implements #928 (OM-571). The shipped ConText layer flags *whether* a negation cue is present but scopes it to the whole sentence, which over-negates: in `no chest pain but has fever` a sentence-level scope wrongly negates `fever`. This adds a dedicated detector that computes the exact token region each cue governs, so an entity is negated only when it falls inside a cue`s influence span.

## Changes

- **`openmed/clinical/negation_scope.py`**
  - `detect_negation_scopes(text, spans=())` -> ordered `NegationScope` records (cue span, `direction`, half-open `scope_start`/`scope_end`, and the `governed` entity offsets inside the scope).
  - `negated_spans(text, spans)` -> the `(start, end)` offsets that fall inside a scope (the over/under-negation fix in one call).
  - **Direction:** forward cues (`no`, `denies`, `no evidence of` ...) govern to the right; backward cues (`ruled out`, `absent`, `not present`, `resolved`) govern to the left.
  - **Termination:** scopes end at sentence punctuation and coordinating conjunctions (mirroring the shipped `_SCOPE_TERMINATOR_RE`), plus classic NegEx clause-break terminators (`however`, `although`, `though`, `except`, `secondary to` ...) to sharpen the boundary. Comma is deliberately **not** a terminator so coordinated lists (`no fever, chills, or cough`) stay in scope.
  - **Pseudo-negation** (`cannot be excluded`, `not ruled out`) is masked first and never opens a scope.
  - Reuses the authoritative `NEGATION_CUES` / `PSEUDO_NEGATION_CUES` lexicons from `clinical.context` so the base and boundary layers cannot drift.
- **`openmed/clinical/__init__.py`** - re-export the public surface.

## Acceptance criteria

- [x] Golden fixture of conjunction and scope-terminator traps assigns negation only to in-scope entities (`no ... but ...`, `denies ... and ...`, `... ; ...`).
- [x] Boundary offsets are exact and stable under Unicode (NFC) normalization; cue offsets index back to the cue text.
- [x] Reduces false negation on entities after a scope terminator versus sentence-level scoping (verified on `but` / `and` / `;` traps and backward `ruled out`).
- [x] Offline, deterministic, no PHI in output beyond offsets; no new dependencies.

## Design note (for review)

Coordinating conjunctions `and`/`or` terminate a scope, matching the existing `context.py` convention. This means `denies fever and cough` negates `fever` only. That is deterministic and consistent with the shipped layer; happy to extend `and`-within-a-negated-list handling in a follow-up if you would prefer coordinate lists to stay in scope.

## Testing

- New `tests/unit/clinical/test_negation_scope.py` (13 tests): forward/backward scoping, conjunction/sentence/comma boundaries, pseudo-negation masking, entity-level assignment, offset exactness, NFC stability, determinism.
- Full offline unit suite: `3273 passed, 37 skipped`. `ruff check` / `format` clean (0.15.20). No new dependencies.

## Out of scope (per the issue)

- The base negation axis and cross-sentence scope leak (already shipped).
- Temporality / uncertainty scope.

Closes #928