### PR TITLE
feat: add GDPR DSAR subject-access export helper

### DIFF
--- a/docs/compliance/gdpr-dsar-export.md
+++ b/docs/compliance/gdpr-dsar-export.md
@@ -1,0 +1,101 @@
+# GDPR DSAR Subject-Access Export
+
+Under GDPR Article 15 a controller must produce all personal data held about a
+data subject. When OpenMed maintains a cross-document surrogate vault, the data
+held about a subject is the set of pseudonymous vault entries whose source
+surface hashes to one of that subject's known identifier values.
+
+`openmed.compliance.dsar` assembles that Article 15 package locally, logs the
+export to a tamper-evident audit chain, and offers a non-destructive Article 17
+erasure companion.
+
+OpenMed does not self-certify compliance. This helper does not verify the
+requester's identity and does not discover data outside OpenMed. Validate
+against your own data, jurisdiction, and counsel before releasing any export.
+
+## How subject matching works
+
+The surrogate vault is keyed by `(canonical_label, lang, text_hash)`, where
+`text_hash` is an HMAC of a single source surface. The vault has no subject
+grouping, so the helper takes the identifier surfaces the controller already
+holds for the subject (name, MRN, date of birth, ...), recomputes each
+`text_hash` through the existing vault configuration, and selects only the vault
+entries whose hash matches. The package therefore contains only data tied to the
+requested identifiers.
+
+Because the vault stores HMAC hashes and surrogates rather than raw values, the
+package and the audit log carry no raw PHI.
+
+## Assembling an access package
+
+```python
+from openmed.compliance import (
+    HashChainAuditLog,
+    SubjectIdentifier,
+    assemble_dsar_package,
+    render_dsar_summary,
+)
+from openmed.core.surrogate_vault import SurrogateVault
+
+vault = SurrogateVault.from_file("vault.json", hmac_secret=SECRET)
+audit = HashChainAuditLog()
+
+identifiers = [
+    SubjectIdentifier("John Smith", "first_name"),
+    SubjectIdentifier("MRN-12345", "id_num"),
+]
+
+package = assemble_dsar_package(
+    identifiers,
+    vault,
+    audit_sink=audit,
+    audit_references=["deid-run-2026-07-01"],
+)
+
+print(render_dsar_summary(package))
+assert audit.verify()
+```
+
+`assemble_dsar_package` returns a `DsarPackage`:
+
+| Field | Meaning |
+|---|---|
+| `subject_ref` | Stable, non-PHI reference derived from the identifier hashes. |
+| `entries` | The matching `DsarEntry` holdings (canonical label, lang, `text_hash`, surrogate). |
+| `categories` | The distinct canonical labels held for the subject. |
+| `audit_references` | Caller-supplied references to related audit artifacts. |
+| `audit_record` | The `AuditRecord` appended for this export, when an `audit_sink` is passed. |
+
+## Audit logging
+
+Export generation is recorded through an injected `AuditSink`. The default
+`HashChainAuditLog` is an append-only ledger where each record commits to its
+predecessor's hash, so tampering is detectable via `verify()`. The recorded
+payload holds the subject reference, counts, categories, and content hashes
+only, never raw PHI.
+
+The `AuditSink` protocol is deliberately small so the shared OpenMed audit chain
+can replace the default implementation without changing callers.
+
+## Article 17 erasure companion
+
+`plan_erasure` lists what an erasure would remove and is non-destructive by
+default: it returns the erasable holdings and leaves the vault untouched.
+
+```python
+from openmed.compliance import plan_erasure
+
+plan = plan_erasure(package, vault, audit_sink=audit)
+assert plan.executed is False
+for entry in plan.erasable:
+    print(entry.canonical_label, entry.text_hash)
+```
+
+The preview is logged as a non-destructive `dsar.erasure_preview` event. Actual
+deletion is a separate, deliberate operation the controller performs on the
+vault store under its own key-custody and governance controls.
+
+## Scope
+
+- Identity verification of the requester is out of scope.
+- Automated cross-system data discovery outside OpenMed is out of scope.

--- a/openmed/compliance/__init__.py
+++ b/openmed/compliance/__init__.py
@@ -1,0 +1,39 @@
+"""GDPR compliance helpers (subject-access export, erasure companion).
+
+This package hosts local-first, access-logged compliance workflows built on the
+surrogate vault and a tamper-evident audit chain.
+"""
+
+from .audit_chain import (
+    AuditRecord,
+    AuditSink,
+    HashChainAuditLog,
+)
+from .dsar import (
+    DSAR_ADVISORY,
+    ERASURE_PREVIEW_EVENT,
+    EXPORT_EVENT,
+    DsarEntry,
+    DsarPackage,
+    ErasurePlan,
+    SubjectIdentifier,
+    assemble_dsar_package,
+    plan_erasure,
+    render_dsar_summary,
+)
+
+__all__ = [
+    "AuditRecord",
+    "AuditSink",
+    "HashChainAuditLog",
+    "DSAR_ADVISORY",
+    "EXPORT_EVENT",
+    "ERASURE_PREVIEW_EVENT",
+    "SubjectIdentifier",
+    "DsarEntry",
+    "DsarPackage",
+    "ErasurePlan",
+    "assemble_dsar_package",
+    "render_dsar_summary",
+    "plan_erasure",
+]

--- a/openmed/compliance/audit_chain.py
+++ b/openmed/compliance/audit_chain.py
@@ -1,0 +1,140 @@
+"""Minimal hash-chained append-only audit log for compliance workflows.
+
+GDPR access and erasure workflows must record *that* an export or preview was
+generated without persisting the underlying personal data. This module provides
+a narrow :class:`AuditSink` protocol and a self-contained
+:class:`HashChainAuditLog` default implementation: an append-only ledger where
+each record commits to its predecessor's hash, so any later mutation is
+detectable via :meth:`HashChainAuditLog.verify`.
+
+The interface is deliberately small so it can be swapped for the shared,
+tamper-evident audit chain (OM-305) when that lands, without changing callers.
+Records hold event metadata, provenance, and content hashes only -- never raw
+PHI.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from openmed.core.audit import stable_hash
+
+
+@dataclass
+class AuditRecord:
+    """One entry in a hash-chained audit log.
+
+    ``payload`` carries export metadata / provenance / content hashes only; it
+    must not contain raw PHI. ``record_hash`` commits to the sequence, event
+    type, payload, and ``previous_hash`` so the chain is tamper-evident.
+    """
+
+    sequence: int
+    event_type: str
+    payload: Mapping[str, Any]
+    previous_hash: str
+    record_hash: str = field(default="")
+
+    def compute_hash(self) -> str:
+        """Return the deterministic hash this record should carry."""
+
+        return stable_hash(
+            {
+                "sequence": self.sequence,
+                "event_type": self.event_type,
+                "payload": self.payload,
+                "previous_hash": self.previous_hash,
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this record to JSON-compatible fields."""
+
+        return {
+            "sequence": self.sequence,
+            "event_type": self.event_type,
+            "payload": dict(self.payload),
+            "previous_hash": self.previous_hash,
+            "record_hash": self.record_hash,
+        }
+
+
+@runtime_checkable
+class AuditSink(Protocol):
+    """A narrow append-only audit sink.
+
+    Callers depend on this protocol, not the concrete log, so the eventual
+    shared audit chain can be injected in place of the default implementation.
+    """
+
+    def append(self, event_type: str, payload: Mapping[str, Any]) -> AuditRecord:
+        """Record an event and return the resulting audit record."""
+        ...
+
+
+class HashChainAuditLog:
+    """A self-contained, tamper-evident append-only audit log."""
+
+    #: Anchor that the first record's ``previous_hash`` links to.
+    GENESIS_HASH: str = stable_hash(
+        {"chain": "openmed.compliance.audit", "sequence": -1}
+    )
+
+    def __init__(self) -> None:
+        self._records: list[AuditRecord] = []
+
+    @property
+    def records(self) -> list[AuditRecord]:
+        """The append-only records in insertion order."""
+
+        return self._records
+
+    def append(self, event_type: str, payload: Mapping[str, Any]) -> AuditRecord:
+        """Append an event, linking it to the current chain head."""
+
+        if not isinstance(payload, Mapping):
+            raise TypeError("audit payload must be a mapping")
+
+        previous_hash = (
+            self._records[-1].record_hash if self._records else self.GENESIS_HASH
+        )
+        record = AuditRecord(
+            sequence=len(self._records),
+            event_type=str(event_type),
+            payload=dict(payload),
+            previous_hash=previous_hash,
+        )
+        record.record_hash = record.compute_hash()
+        self._records.append(record)
+        return record
+
+    def verify(self) -> bool:
+        """Return ``True`` when the chain is intact and untampered."""
+
+        previous_hash = self.GENESIS_HASH
+        for index, record in enumerate(self._records):
+            if record.sequence != index:
+                return False
+            if record.previous_hash != previous_hash:
+                return False
+            if record.record_hash != record.compute_hash():
+                return False
+            previous_hash = record.record_hash
+        return True
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize the whole chain, including the genesis anchor."""
+
+        return {
+            "genesis_hash": self.GENESIS_HASH,
+            "records": [record.to_dict() for record in self._records],
+        }
+
+
+__all__ = [
+    "AuditRecord",
+    "AuditSink",
+    "HashChainAuditLog",
+]

--- a/openmed/compliance/dsar.py
+++ b/openmed/compliance/dsar.py
@@ -22,7 +22,7 @@ non-destructive by default.
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from openmed.core.audit import stable_hash
 from openmed.core.surrogate_vault import SurrogateVault
@@ -94,7 +94,11 @@ def _matching_entries(
     identifiers: Sequence[SubjectIdentifier],
     vault: SurrogateVault,
 ) -> tuple[tuple[DsarEntry, ...], frozenset[str]]:
-    subject_hashes = {vault.text_hash(ident.surface) for ident in identifiers}
+    subject_keys = {
+        vault.key_for(ident.surface, label=ident.label, lang=ident.lang)
+        for ident in identifiers
+    }
+    subject_hashes = {key.text_hash for key in subject_keys}
     entries = tuple(
         DsarEntry(
             canonical_label=entry.key.canonical_label,
@@ -103,7 +107,7 @@ def _matching_entries(
             surrogate=entry.surrogate,
         )
         for entry in vault.entries()
-        if entry.key.text_hash in subject_hashes
+        if entry.key in subject_keys
     )
     return entries, frozenset(subject_hashes)
 

--- a/openmed/compliance/dsar.py
+++ b/openmed/compliance/dsar.py
@@ -1,0 +1,223 @@
+"""GDPR subject-access (Article 15) and erasure-companion (Article 17) export.
+
+Under Article 15 a controller must produce all personal data held about a data
+subject. When OpenMed maintains a cross-document surrogate vault, the data held
+about a subject is the set of pseudonymous vault entries whose source surface
+hashes to one of the subject's known identifier values.
+
+The surrogate vault is keyed by ``(canonical_label, lang, text_hash)`` where
+``text_hash`` is an HMAC of a single source surface; it has no subject grouping.
+So this helper takes the *caller-provided* known identifier surfaces for the
+subject (the values the controller already holds -- name, MRN, DOB, ...),
+recomputes each ``text_hash`` through the existing vault configuration, and
+selects only the vault entries whose hash matches. The package therefore
+contains only data tied to the requested identifiers.
+
+Export generation is recorded to an injected :class:`AuditSink`; the audit
+payload carries counts, the subject reference, and content hashes only -- never
+raw PHI. The Article 17 companion lists what *would* be erased and is
+non-destructive by default.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+
+from openmed.core.audit import stable_hash
+from openmed.core.surrogate_vault import SurrogateVault
+
+from .audit_chain import AuditRecord, AuditSink
+
+DSAR_ADVISORY = (
+    "This subject-access export is assembled from caller-provided identifiers "
+    "and the local surrogate vault. It does not verify the requester's identity "
+    "or discover data outside OpenMed; review before release."
+)
+
+EXPORT_EVENT = "dsar.export"
+ERASURE_PREVIEW_EVENT = "dsar.erasure_preview"
+
+
+@dataclass(frozen=True)
+class SubjectIdentifier:
+    """One known identifier value the controller holds for the data subject."""
+
+    surface: str
+    label: str
+    lang: str = "en"
+
+
+@dataclass(frozen=True)
+class DsarEntry:
+    """A pseudonymous vault holding tied to the subject.
+
+    Only the vault's privacy-safe fields are exposed: the canonical label, the
+    HMAC ``text_hash``, and the surrogate. The raw source surface is never
+    stored in the vault and never appears here.
+    """
+
+    canonical_label: str
+    lang: str
+    text_hash: str
+    surrogate: str
+
+
+@dataclass(frozen=True)
+class DsarPackage:
+    """A structured Article 15 subject-access package."""
+
+    subject_ref: str
+    entries: tuple[DsarEntry, ...]
+    categories: tuple[str, ...]
+    audit_references: tuple[str, ...] = ()
+    audit_record: AuditRecord | None = None
+
+
+@dataclass(frozen=True)
+class ErasurePlan:
+    """A non-destructive Article 17 erasure companion."""
+
+    subject_ref: str
+    erasable: tuple[DsarEntry, ...]
+    executed: bool = False
+    audit_record: AuditRecord | None = None
+
+
+def _subject_ref(text_hashes: Iterable[str]) -> str:
+    """A stable, non-PHI reference derived from the subject's identifier hashes."""
+
+    return stable_hash(sorted(set(text_hashes)))
+
+
+def _matching_entries(
+    identifiers: Sequence[SubjectIdentifier],
+    vault: SurrogateVault,
+) -> tuple[tuple[DsarEntry, ...], frozenset[str]]:
+    subject_hashes = {vault.text_hash(ident.surface) for ident in identifiers}
+    entries = tuple(
+        DsarEntry(
+            canonical_label=entry.key.canonical_label,
+            lang=entry.key.lang,
+            text_hash=entry.key.text_hash,
+            surrogate=entry.surrogate,
+        )
+        for entry in vault.entries()
+        if entry.key.text_hash in subject_hashes
+    )
+    return entries, frozenset(subject_hashes)
+
+
+def assemble_dsar_package(
+    identifiers: Iterable[SubjectIdentifier],
+    vault: SurrogateVault,
+    *,
+    audit_sink: AuditSink | None = None,
+    audit_references: Iterable[str] = (),
+) -> DsarPackage:
+    """Assemble the Article 15 package for the subject's known identifiers.
+
+    Only vault entries whose ``text_hash`` matches one of the recomputed
+    identifier hashes are included. When ``audit_sink`` is provided, the export
+    is recorded with counts / subject reference / hashes only (no raw PHI).
+    """
+
+    identifiers = list(identifiers)
+    references = tuple(str(ref) for ref in audit_references)
+    entries, subject_hashes = _matching_entries(identifiers, vault)
+    subject_ref = _subject_ref(subject_hashes)
+    categories = tuple(sorted({entry.canonical_label for entry in entries}))
+
+    record: AuditRecord | None = None
+    if audit_sink is not None:
+        record = audit_sink.append(
+            EXPORT_EVENT,
+            {
+                "subject_ref": subject_ref,
+                "identifier_count": len(identifiers),
+                "entry_count": len(entries),
+                "categories": list(categories),
+                "text_hashes": sorted(entry.text_hash for entry in entries),
+                "audit_references": list(references),
+            },
+        )
+
+    return DsarPackage(
+        subject_ref=subject_ref,
+        entries=entries,
+        categories=categories,
+        audit_references=references,
+        audit_record=record,
+    )
+
+
+def render_dsar_summary(package: DsarPackage) -> str:
+    """Render a deterministic human-readable summary of the package."""
+
+    lines = [
+        "GDPR Article 15 subject-access export",
+        f"Subject reference: {package.subject_ref}",
+        f"Records held: {len(package.entries)}",
+        f"Categories: {', '.join(package.categories) or '(none)'}",
+    ]
+    for entry in package.entries:
+        lines.append(
+            f"  - {entry.canonical_label} [{entry.lang}] -> surrogate "
+            f"{entry.surrogate!r} (hash {entry.text_hash})"
+        )
+    if package.audit_references:
+        lines.append(f"Audit references: {', '.join(package.audit_references)}")
+    lines.append(DSAR_ADVISORY)
+    return "\n".join(lines)
+
+
+def plan_erasure(
+    package: DsarPackage,
+    vault: SurrogateVault,
+    *,
+    audit_sink: AuditSink | None = None,
+) -> ErasurePlan:
+    """List what an Article 17 erasure would remove, without deleting anything.
+
+    The companion is non-destructive by default: it returns the erasable
+    holdings and leaves the vault untouched. ``vault`` is accepted so the plan
+    reflects the live vault contents at preview time.
+    """
+
+    live_hashes = {entry.key.text_hash for entry in vault.entries()}
+    erasable = tuple(
+        entry for entry in package.entries if entry.text_hash in live_hashes
+    )
+
+    record: AuditRecord | None = None
+    if audit_sink is not None:
+        record = audit_sink.append(
+            ERASURE_PREVIEW_EVENT,
+            {
+                "subject_ref": package.subject_ref,
+                "erasable_count": len(erasable),
+                "text_hashes": sorted(entry.text_hash for entry in erasable),
+                "destructive": False,
+            },
+        )
+
+    return ErasurePlan(
+        subject_ref=package.subject_ref,
+        erasable=erasable,
+        executed=False,
+        audit_record=record,
+    )
+
+
+__all__ = [
+    "DSAR_ADVISORY",
+    "EXPORT_EVENT",
+    "ERASURE_PREVIEW_EVENT",
+    "SubjectIdentifier",
+    "DsarEntry",
+    "DsarPackage",
+    "ErasurePlan",
+    "assemble_dsar_package",
+    "render_dsar_summary",
+    "plan_erasure",
+]

--- a/tests/unit/compliance/test_audit_chain.py
+++ b/tests/unit/compliance/test_audit_chain.py
@@ -1,0 +1,83 @@
+"""Tests for the minimal hash-chained append-only audit log."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.compliance import (
+    AuditRecord,
+    AuditSink,
+    HashChainAuditLog,
+)
+
+
+def test_append_returns_sequential_records():
+    log = HashChainAuditLog()
+
+    first = log.append("dsar.export", {"entries": 2})
+    second = log.append("dsar.export", {"entries": 5})
+
+    assert isinstance(first, AuditRecord)
+    assert (first.sequence, second.sequence) == (0, 1)
+    assert first.event_type == "dsar.export"
+    assert first.payload == {"entries": 2}
+
+
+def test_records_form_a_hash_chain():
+    log = HashChainAuditLog()
+    a = log.append("dsar.export", {"n": 1})
+    b = log.append("dsar.erasure_preview", {"n": 2})
+
+    # Genesis record links to a fixed empty-chain anchor; each subsequent record
+    # commits to its predecessor's hash.
+    assert a.previous_hash == HashChainAuditLog.GENESIS_HASH
+    assert b.previous_hash == a.record_hash
+    assert a.record_hash != b.record_hash
+
+
+def test_verify_detects_tampering():
+    log = HashChainAuditLog()
+    log.append("dsar.export", {"n": 1})
+    log.append("dsar.export", {"n": 2})
+
+    assert log.verify() is True
+
+    # Mutating a recorded payload must break the chain.
+    object.__setattr__(log.records[0], "payload", {"n": 999})
+    assert log.verify() is False
+
+
+def test_hashing_is_deterministic_across_logs():
+    log_a = HashChainAuditLog()
+    log_b = HashChainAuditLog()
+    for log in (log_a, log_b):
+        log.append("dsar.export", {"subject": "abc", "entries": 3})
+
+    assert log_a.records[0].record_hash == log_b.records[0].record_hash
+
+
+def test_append_rejects_non_mapping_payload():
+    log = HashChainAuditLog()
+    with pytest.raises(TypeError):
+        log.append("dsar.export", ["not", "a", "mapping"])  # type: ignore[arg-type]
+
+
+def test_hashchain_log_is_an_audit_sink():
+    # The concrete log satisfies the injected AuditSink protocol.
+    def use_sink(sink: AuditSink) -> AuditRecord:
+        return sink.append("dsar.export", {"ok": True})
+
+    record = use_sink(HashChainAuditLog())
+    assert record.sequence == 0
+
+
+def test_to_payload_round_trips_the_chain():
+    log = HashChainAuditLog()
+    log.append("dsar.export", {"n": 1})
+    log.append("dsar.export", {"n": 2})
+
+    payload = log.to_payload()
+    assert [r["sequence"] for r in payload["records"]] == [0, 1]
+    assert (
+        payload["records"][1]["previous_hash"] == payload["records"][0]["record_hash"]
+    )

--- a/tests/unit/compliance/test_dsar_export.py
+++ b/tests/unit/compliance/test_dsar_export.py
@@ -1,0 +1,178 @@
+"""Tests for the GDPR DSAR subject-access export helper."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.compliance import (
+    DsarPackage,
+    ErasurePlan,
+    HashChainAuditLog,
+    SubjectIdentifier,
+    assemble_dsar_package,
+    plan_erasure,
+    render_dsar_summary,
+)
+from openmed.core.surrogate_vault import SurrogateVault
+
+SECRET = "unit-test-secret"
+
+
+def _seed(vault: SurrogateVault, surface: str, label: str, surrogate: str) -> None:
+    key = vault.key_for(surface, label=label, lang="en")
+    vault.store.set(key, surrogate)
+
+
+def _subject_vault() -> SurrogateVault:
+    vault = SurrogateVault.in_memory(SECRET)
+    _seed(vault, "John Smith", "first_name", "Robert Jones")
+    _seed(vault, "MRN-12345", "id_num", "MRN-90001")
+    # An unrelated data subject that must never appear in the package.
+    _seed(vault, "Jane Doe", "first_name", "Alice Brown")
+    return vault
+
+
+def _subject_ids() -> list[SubjectIdentifier]:
+    return [
+        SubjectIdentifier("John Smith", "first_name"),
+        SubjectIdentifier("MRN-12345", "id_num"),
+    ]
+
+
+# --------------------------------------------------------------------------
+# Assembly: only the requested subject's data
+# --------------------------------------------------------------------------
+
+
+def test_package_gathers_only_the_requested_subject_entries():
+    vault = _subject_vault()
+
+    package = assemble_dsar_package(_subject_ids(), vault)
+
+    assert isinstance(package, DsarPackage)
+    surrogates = {entry.surrogate for entry in package.entries}
+    assert surrogates == {"Robert Jones", "MRN-90001"}
+    # The unrelated subject's surrogate is absent.
+    assert "Alice Brown" not in surrogates
+
+
+def test_package_reports_held_categories():
+    vault = _subject_vault()
+
+    package = assemble_dsar_package(_subject_ids(), vault)
+
+    # Categories are the canonical labels held for the subject.
+    assert set(package.categories) == {
+        entry.canonical_label for entry in package.entries
+    }
+    assert len(package.categories) == 2
+
+
+def test_unmatched_identifier_yields_empty_package():
+    vault = _subject_vault()
+
+    package = assemble_dsar_package(
+        [SubjectIdentifier("Nobody Here", "first_name")], vault
+    )
+
+    assert package.entries == ()
+    assert package.categories == ()
+
+
+def test_subject_ref_is_deterministic_and_not_raw_phi():
+    vault = _subject_vault()
+
+    first = assemble_dsar_package(_subject_ids(), vault)
+    second = assemble_dsar_package(_subject_ids(), vault)
+
+    assert first.subject_ref == second.subject_ref
+    assert "John Smith" not in first.subject_ref
+    assert "MRN-12345" not in first.subject_ref
+
+
+# --------------------------------------------------------------------------
+# Audit logging
+# --------------------------------------------------------------------------
+
+
+def test_export_is_logged_to_the_audit_sink():
+    vault = _subject_vault()
+    log = HashChainAuditLog()
+
+    package = assemble_dsar_package(_subject_ids(), vault, audit_sink=log)
+
+    assert len(log.records) == 1
+    record = log.records[0]
+    assert record.event_type == "dsar.export"
+    assert package.audit_record is record
+    assert log.verify() is True
+
+
+def test_audit_payload_carries_no_raw_phi():
+    vault = _subject_vault()
+    log = HashChainAuditLog()
+
+    assemble_dsar_package(_subject_ids(), vault, audit_sink=log)
+
+    blob = json.dumps(log.records[0].payload)
+    assert "John Smith" not in blob
+    assert "MRN-12345" not in blob
+    assert "Robert Jones" not in blob
+
+
+def test_audit_references_are_included():
+    vault = _subject_vault()
+
+    package = assemble_dsar_package(
+        _subject_ids(), vault, audit_references=["run-2026-07-01", "run-2026-07-02"]
+    )
+
+    assert package.audit_references == ("run-2026-07-01", "run-2026-07-02")
+
+
+# --------------------------------------------------------------------------
+# Human-readable summary
+# --------------------------------------------------------------------------
+
+
+def test_summary_is_readable_and_counts_holdings():
+    vault = _subject_vault()
+    package = assemble_dsar_package(_subject_ids(), vault)
+
+    summary = render_dsar_summary(package)
+
+    assert isinstance(summary, str)
+    assert "2" in summary  # two entries held
+    assert package.subject_ref in summary
+
+
+# --------------------------------------------------------------------------
+# Article 17 deletion companion (non-destructive)
+# --------------------------------------------------------------------------
+
+
+def test_erasure_plan_lists_erasable_records_without_deleting():
+    vault = _subject_vault()
+    package = assemble_dsar_package(_subject_ids(), vault)
+    before = len(vault.entries())
+
+    plan = plan_erasure(package, vault)
+
+    assert isinstance(plan, ErasurePlan)
+    assert plan.executed is False
+    assert {e.surrogate for e in plan.erasable} == {"Robert Jones", "MRN-90001"}
+    # The vault is untouched: this is a companion, not a deletion.
+    assert len(vault.entries()) == before
+
+
+def test_erasure_preview_is_audit_logged_non_destructively():
+    vault = _subject_vault()
+    log = HashChainAuditLog()
+    package = assemble_dsar_package(_subject_ids(), vault)
+
+    plan_erasure(package, vault, audit_sink=log)
+
+    assert log.records[0].event_type == "dsar.erasure_preview"
+    assert log.records[0].payload.get("destructive") is False

--- a/tests/unit/compliance/test_dsar_export.py
+++ b/tests/unit/compliance/test_dsar_export.py
@@ -20,8 +20,15 @@ from openmed.core.surrogate_vault import SurrogateVault
 SECRET = "unit-test-secret"
 
 
-def _seed(vault: SurrogateVault, surface: str, label: str, surrogate: str) -> None:
-    key = vault.key_for(surface, label=label, lang="en")
+def _seed(
+    vault: SurrogateVault,
+    surface: str,
+    label: str,
+    surrogate: str,
+    *,
+    lang: str = "en",
+) -> None:
+    key = vault.key_for(surface, label=label, lang=lang)
     vault.store.set(key, surrogate)
 
 
@@ -56,6 +63,19 @@ def test_package_gathers_only_the_requested_subject_entries():
     assert surrogates == {"Robert Jones", "MRN-90001"}
     # The unrelated subject's surrogate is absent.
     assert "Alice Brown" not in surrogates
+
+
+def test_package_matches_identifier_label_and_language():
+    vault = SurrogateVault.in_memory(SECRET)
+    _seed(vault, "12345", "id_num", "MRN-90001", lang="en")
+    _seed(vault, "12345", "phone", "555-0100", lang="en")
+    _seed(vault, "12345", "id_num", "MRN-FR-90001", lang="fr")
+
+    package = assemble_dsar_package(
+        [SubjectIdentifier("12345", "id_num", lang="en")], vault
+    )
+
+    assert {entry.surrogate for entry in package.entries} == {"MRN-90001"}
 
 
 def test_package_reports_held_categories():


### PR DESCRIPTION
Implements #921 (OM-564). Assembles a GDPR Article 15 subject-access export from the surrogate vault, logs it to a tamper-evident audit chain, and adds a non-destructive Article 17 erasure companion. Design confirmed with the maintainer in [the issue thread](https://github.com/maziyarpanahi/openmed/issues/921#issuecomment-4868632061).

## Subject matching (the confirmed interpretation)

The surrogate vault is keyed by `(canonical_label, lang, text_hash)` where `text_hash` is an HMAC of a single source surface; it has no subject grouping. Per the maintainer, this does **not** add subject grouping to the vault. Instead `assemble_dsar_package` accepts the caller-provided **known identifier surfaces** for the subject (name, MRN, DOB, ...), recomputes each `text_hash` through the existing vault configuration, and includes only the vault entries whose hash matches. The package therefore contains only data tied to the requested identifiers, and carries HMAC hashes + surrogates rather than raw PHI.

## Changes

- **`openmed/compliance/dsar.py`**
  - `assemble_dsar_package(identifiers, vault, *, audit_sink=None, audit_references=())` -> `DsarPackage` (subject reference, matching `DsarEntry` holdings, held categories, audit references, audit record).
  - `render_dsar_summary(package)` -> deterministic human-readable summary.
  - `plan_erasure(package, vault, *, audit_sink=None)` -> `ErasurePlan`; the Article 17 companion lists erasable holdings and is **non-destructive by default** (vault untouched).
- **`openmed/compliance/audit_chain.py`** (per the maintainer, option (a))
  - `AuditSink` `Protocol` + minimal `HashChainAuditLog`: append-only, each record commits to its predecessor`s hash, tamper detectable via `verify()`. Payloads carry counts / subject reference / content hashes only, never raw PHI. The interface is intentionally small so the shared OM-305 audit chain can replace it without changing callers.
- **`docs/compliance/gdpr-dsar-export.md`** - usage, matching model, audit logging, and the erasure companion.

## Acceptance criteria

- [x] Assembles a DSAR package for a synthetic subject key with vault and audit references.
- [x] Package contains only data tied to the requested subject (unrelated subjects excluded - asserted).
- [x] Export generation is logged to the audit chain; **audit payload carries no raw PHI** (asserted).
- [x] Deletion-companion lists erasable records without performing destructive changes by default (vault unchanged - asserted).

## Scope note (files beyond the issue list)

The issue listed `dsar.py` + test + docs. Per the maintainers option (a), this also adds `audit_chain.py` (+ `__init__.py` and `test_audit_chain.py`) for the injected audit-sink protocol and minimal hash-chained log under `openmed/compliance/`, so OM-564 can land independently of OM-305.

## Testing

- New `tests/unit/compliance/test_audit_chain.py` (7) + `test_dsar_export.py` (10) = 17 tests.
- Full offline unit suite: `3278 passed, 37 skipped`. `ruff check` / `format` clean (0.15.20). No new dependencies.

## Out of scope (per the issue)

- Identity verification of the requester.
- Automated cross-system data discovery outside OpenMed.

Closes #921