### PR TITLE
Add epub support

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -21,7 +21,7 @@ coverage, see
 | --- | --- | --- |
 | Multimodal document contract | `ExtractedDocument`, `SourceSpan`, lazy handler registration, source-offset mapping, and dispatcher-based redaction. | `openmed/multimodal/base.py`, `examples/v17_multimodal_browser_interop.py` |
 | OCR and scanned documents | Shared OCR result contract, fake test engine, Tesseract, PaddleOCR, EasyOCR, docTR, OCR language selection, and available-engine discovery. | `openmed/multimodal/ocr.py`, `tests/unit/multimodal/test_ocr_engines.py`, `examples/v17_multimodal_browser_interop.py` |
-| Markup and metadata | Markdown/AsciiDoc extraction, source text redaction, image/PDF/DOCX metadata scrubbing, and residual metadata verification. | `openmed/multimodal/documents_markdown.py`, `openmed/multimodal/metadata_scrub.py`, `examples/v17_multimodal_browser_interop.py` |
+| Markup and metadata | Markdown/AsciiDoc and EPUB extraction, source text redaction, image/PDF/DOCX metadata scrubbing, and residual metadata verification. | `openmed/multimodal/documents_markdown.py`, `openmed/multimodal/epub.py`, `openmed/multimodal/metadata_scrub.py`, `examples/v17_multimodal_browser_interop.py` |
 | Chat logs and tabular data | JSONL chat-log redaction with speaker pseudonymization, CSV/TSV PHI column classification, column actions, and PHI-safe manifests. | `openmed/multimodal/chatlog_jsonl.py`, `openmed/multimodal/tabular_csv.py`, `examples/v17_multimodal_browser_interop.py` |
 
 ## Health-data Interop

--- a/docs/multimodal/epub-extraction.md
+++ b/docs/multimodal/epub-extraction.md
@@ -1,0 +1,42 @@
+# EPUB Extraction
+
+OpenMed can extract text from EPUB books through the shared multimodal document
+contract. The EPUB ingester walks the package spine in reading order, reads each
+XHTML/HTML content document, strips markup, and returns an `ExtractedDocument`
+with offsets back to the source content item.
+
+```python
+from openmed.multimodal import extract_epub
+
+document = extract_epub("patient-education.epub")
+
+print(document.text)
+print(document.metadata["sections"])
+```
+
+Each `SourceSpan` maps a range in `document.text` to one XHTML source item:
+
+```python
+offset = document.text.index("Jane Roe")
+span = document.location_at(offset)
+
+print(span.metadata["section_href"])
+print(span.metadata["source_start"], span.metadata["source_end"])
+```
+
+The metadata is PHI-safe: it includes section identifiers, EPUB paths, document
+offsets, and source character ranges, but it does not store raw XHTML content.
+
+## Behavior
+
+- `.epub` files are discoverable through `redact_document`.
+- EPUB text is extracted from `application/xhtml+xml` and `text/html` spine
+  items.
+- `head`, `script`, and `style` content is ignored.
+- Character references such as `&amp;` are decoded in extracted text while the
+  source span still points back to the original reference range.
+- Section boundaries are available in `document.metadata["sections"]`.
+
+DRM-protected or encrypted EPUB entries are unsupported. Repackaging a redacted
+EPUB is also out of scope; callers can use source offsets to project findings
+back to XHTML content documents when they need custom write-back behavior.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
       - Performance Profiling: profiling.md
       - Zero-shot Toolkit: zero-shot-ner.md
       - Examples & Copy/Paste Recipes: examples.md
+      - EPUB Extraction: multimodal/epub-extraction.md
       - Testing & QA: testing.md
       - Eval Harness & Metrics: eval-harness.md
       - OpenVINO Runtime: runtimes/openvino.md

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -55,6 +55,7 @@ from .documents_docx import (
 )
 from .documents_markdown import extract_asciidoc, extract_markdown, redact_source_text
 from .documents_pdf import ProjectedRectangle, extract_pdf, project_text_spans
+from .epub import extract_epub
 from .exceptions import MissingDependencyError, UnsupportedDocumentError
 from .image import (
     ImageMetadataReport,
@@ -133,6 +134,7 @@ __all__ = [
     "extract_docx",
     "map_text_spans_to_docx_runs",
     "write_redacted_docx",
+    "extract_epub",
     "MetadataFinding",
     "ResidualMetadataReport",
     "MetadataScrubResult",

--- a/openmed/multimodal/epub.py
+++ b/openmed/multimodal/epub.py
@@ -1,0 +1,460 @@
+"""EPUB text extraction with source character offsets.
+
+The ingester uses only the Python standard library so EPUB dispatch remains
+available without pulling extra dependencies into the multimodal install path.
+It reads the EPUB package manifest and spine, extracts visible XHTML text in
+reading order, and records source offsets back into each content document.
+"""
+
+from __future__ import annotations
+
+import html as html_lib
+import posixpath
+import zipfile
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote
+from xml.etree import ElementTree as ET
+
+from .base import ExtractedDocument, SourceSpan, register_handler
+from .exceptions import UnsupportedDocumentError
+
+_CONTAINER_PATH = "META-INF/container.xml"
+_SUPPORTED_CONTENT_TYPES = frozenset({"application/xhtml+xml", "text/html"})
+_IGNORED_TAGS = frozenset({"head", "script", "style"})
+_BREAK_TAGS = frozenset({"br"})
+_BLOCK_TAGS = frozenset(
+    {
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "caption",
+        "dd",
+        "details",
+        "div",
+        "dl",
+        "dt",
+        "figcaption",
+        "figure",
+        "footer",
+        "form",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hr",
+        "li",
+        "main",
+        "nav",
+        "ol",
+        "p",
+        "pre",
+        "section",
+        "table",
+        "tbody",
+        "td",
+        "tfoot",
+        "th",
+        "thead",
+        "tr",
+        "ul",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _ManifestItem:
+    item_id: str
+    href: str
+    path: str
+    media_type: str
+
+
+@dataclass(frozen=True)
+class _ParsedPackage:
+    package_path: str
+    manifest: dict[str, _ManifestItem]
+    spine: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _ParsedXhtml:
+    text: str
+    spans: tuple[SourceSpan, ...]
+
+
+def extract_epub(path: str | Path) -> ExtractedDocument:
+    """Extract EPUB spine text and source-offset metadata.
+
+    Args:
+        path: EPUB file path.
+
+    Returns:
+        An :class:`ExtractedDocument` with normalized text in spine reading
+        order. Each mapped span carries source offsets into the XHTML content
+        document named by ``section_href``.
+
+    Raises:
+        UnsupportedDocumentError: If the file is not a readable EPUB, declares
+            encrypted content, or has no supported XHTML/HTML spine text.
+    """
+    source_path = Path(path)
+    try:
+        with zipfile.ZipFile(source_path) as archive:
+            _ensure_supported_archive(archive)
+            package = _read_package(archive)
+            return _extract_spine_text(archive, package, source_path)
+    except zipfile.BadZipFile as exc:
+        raise UnsupportedDocumentError("EPUB must be a valid ZIP archive") from exc
+
+
+def _ensure_supported_archive(archive: zipfile.ZipFile) -> None:
+    for info in archive.infolist():
+        if info.flag_bits & 0x1:
+            raise UnsupportedDocumentError(
+                "Encrypted EPUB ZIP entries are not supported"
+            )
+    if any(name.lower() == "meta-inf/encryption.xml" for name in archive.namelist()):
+        raise UnsupportedDocumentError("DRM-protected EPUB files are not supported")
+
+
+def _read_package(archive: zipfile.ZipFile) -> _ParsedPackage:
+    container = _parse_xml(
+        _read_required(archive, _CONTAINER_PATH),
+        "container",
+    )
+    package_path = _package_path(container)
+    package_root = _parse_xml(
+        _read_required(archive, package_path),
+        "package",
+    )
+    package_dir = posixpath.dirname(package_path)
+    manifest = _manifest_items(package_root, package_dir)
+    spine = _spine_itemrefs(package_root)
+    if not spine:
+        raise UnsupportedDocumentError("EPUB package does not define a spine")
+    return _ParsedPackage(
+        package_path=package_path,
+        manifest=manifest,
+        spine=spine,
+    )
+
+
+def _extract_spine_text(
+    archive: zipfile.ZipFile,
+    package: _ParsedPackage,
+    source_path: Path,
+) -> ExtractedDocument:
+    parts: list[str] = []
+    spans: list[SourceSpan] = []
+    sections: list[dict[str, Any]] = []
+    cursor = 0
+
+    for idref in package.spine:
+        item = package.manifest.get(idref)
+        if item is None or item.media_type not in _SUPPORTED_CONTENT_TYPES:
+            continue
+
+        section_source = _decode_text(_read_required(archive, item.path))
+        section = _parse_xhtml(section_source)
+        if not section.text:
+            continue
+
+        if parts:
+            parts.append("\n")
+            cursor += 1
+
+        section_index = len(sections)
+        section_start = cursor
+        parts.append(section.text)
+        cursor += len(section.text)
+        section_end = cursor
+
+        for span in section.spans:
+            metadata = dict(span.metadata)
+            metadata.update(
+                {
+                    "format": "epub",
+                    "section_index": section_index,
+                    "section_id": item.item_id,
+                    "section_href": item.path,
+                }
+            )
+            spans.append(
+                SourceSpan(
+                    start=section_start + span.start,
+                    end=section_start + span.end,
+                    metadata=metadata,
+                )
+            )
+
+        sections.append(
+            {
+                "index": section_index,
+                "id": item.item_id,
+                "href": item.path,
+                "start": section_start,
+                "end": section_end,
+            }
+        )
+
+    if not sections:
+        raise UnsupportedDocumentError(
+            "EPUB spine does not contain supported XHTML or HTML text"
+        )
+
+    return ExtractedDocument(
+        text="".join(parts),
+        spans=tuple(spans),
+        metadata={
+            "format": "epub",
+            "source_path": str(source_path),
+            "package_path": package.package_path,
+            "section_count": len(sections),
+            "sections": sections,
+        },
+    )
+
+
+def _package_path(container: ET.Element) -> str:
+    rootfiles = [
+        element
+        for element in container.iter()
+        if _local_name(element.tag) == "rootfile"
+    ]
+    for rootfile in rootfiles:
+        full_path = rootfile.get("full-path")
+        if full_path and rootfile.get("media-type") == "application/oebps-package+xml":
+            return _clean_zip_path(full_path)
+    for rootfile in rootfiles:
+        full_path = rootfile.get("full-path")
+        if full_path:
+            return _clean_zip_path(full_path)
+    raise UnsupportedDocumentError("EPUB container does not declare a package file")
+
+
+def _manifest_items(root: ET.Element, package_dir: str) -> dict[str, _ManifestItem]:
+    manifest = _required_child(root, "manifest")
+    items: dict[str, _ManifestItem] = {}
+    for element in _children(manifest, "item"):
+        item_id = element.get("id")
+        href = element.get("href")
+        media_type = (element.get("media-type") or "").lower()
+        if not item_id or not href:
+            continue
+        items[item_id] = _ManifestItem(
+            item_id=item_id,
+            href=href,
+            path=_resolve_href(package_dir, href),
+            media_type=media_type,
+        )
+    return items
+
+
+def _spine_itemrefs(root: ET.Element) -> tuple[str, ...]:
+    spine = _required_child(root, "spine")
+    itemrefs: list[str] = []
+    for element in _children(spine, "itemref"):
+        idref = element.get("idref")
+        if idref:
+            itemrefs.append(idref)
+    return tuple(itemrefs)
+
+
+def _parse_xhtml(source: str) -> _ParsedXhtml:
+    parser = _XhtmlTextParser(source)
+    parser.feed(source)
+    parser.close()
+    return parser.document()
+
+
+class _XhtmlTextParser(HTMLParser):
+    def __init__(self, source: str) -> None:
+        super().__init__(convert_charrefs=False)
+        self._source = source
+        self._line_offsets = _line_offsets(source)
+        self._parts: list[str] = []
+        self._spans: list[SourceSpan] = []
+        self._cursor = 0
+        self._ignore_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        normalized = tag.lower()
+        if normalized in _IGNORED_TAGS:
+            self._ignore_depth += 1
+            return
+        if self._ignore_depth:
+            return
+        if normalized in _BREAK_TAGS or normalized in _BLOCK_TAGS:
+            self._append_break()
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        normalized = tag.lower()
+        if self._ignore_depth or normalized in _IGNORED_TAGS:
+            return
+        if normalized in _BREAK_TAGS or normalized in _BLOCK_TAGS:
+            self._append_break()
+
+    def handle_endtag(self, tag: str) -> None:
+        normalized = tag.lower()
+        if normalized in _IGNORED_TAGS and self._ignore_depth:
+            self._ignore_depth -= 1
+            return
+        if self._ignore_depth:
+            return
+        if normalized in _BLOCK_TAGS:
+            self._append_break()
+
+    def handle_data(self, data: str) -> None:
+        if self._ignore_depth or not data or not data.strip():
+            return
+        source_start = self._source_offset()
+        self._append_mapped(data, source_start, source_start + len(data))
+
+    def handle_entityref(self, name: str) -> None:
+        if self._ignore_depth:
+            return
+        source_start = self._source_offset()
+        source_end = source_start + 1 + len(name)
+        if source_end < len(self._source) and self._source[source_end] == ";":
+            source_end += 1
+        self._append_mapped(
+            html_lib.unescape(self._source[source_start:source_end]),
+            source_start,
+            source_end,
+        )
+
+    def handle_charref(self, name: str) -> None:
+        if self._ignore_depth:
+            return
+        source_start = self._source_offset()
+        source_end = source_start + 2 + len(name)
+        if source_end < len(self._source) and self._source[source_end] == ";":
+            source_end += 1
+        self._append_mapped(
+            html_lib.unescape(self._source[source_start:source_end]),
+            source_start,
+            source_end,
+        )
+
+    def document(self) -> _ParsedXhtml:
+        while self._parts and self._parts[-1] == "\n":
+            self._parts.pop()
+            self._cursor -= 1
+        return _ParsedXhtml(text="".join(self._parts), spans=tuple(self._spans))
+
+    def _append_break(self) -> None:
+        if not self._parts or self._parts[-1].endswith("\n"):
+            return
+        self._parts.append("\n")
+        self._cursor += 1
+
+    def _append_mapped(self, text: str, source_start: int, source_end: int) -> None:
+        if not text:
+            return
+        start = self._cursor
+        self._parts.append(text)
+        self._cursor += len(text)
+        self._spans.append(
+            SourceSpan(
+                start=start,
+                end=self._cursor,
+                metadata={
+                    "source_start": source_start,
+                    "source_end": source_end,
+                },
+            )
+        )
+
+    def _source_offset(self) -> int:
+        line, column = self.getpos()
+        if line <= 0:
+            return min(max(column, 0), len(self._source))
+        index = line - 1
+        if index >= len(self._line_offsets):
+            return len(self._source)
+        return min(self._line_offsets[index] + column, len(self._source))
+
+
+def _line_offsets(text: str) -> tuple[int, ...]:
+    starts = [0]
+    for index, character in enumerate(text):
+        if character == "\n":
+            starts.append(index + 1)
+    return tuple(starts)
+
+
+def _read_required(archive: zipfile.ZipFile, path: str) -> bytes:
+    try:
+        return archive.read(path)
+    except KeyError as exc:
+        raise UnsupportedDocumentError(f"EPUB archive is missing {path}") from exc
+
+
+def _decode_text(data: bytes) -> str:
+    for encoding in ("utf-8-sig", "utf-16"):
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    raise UnsupportedDocumentError(
+        "EPUB content documents must be UTF-8 or UTF-16 encoded"
+    )
+
+
+def _parse_xml(data: bytes, name: str) -> ET.Element:
+    try:
+        return ET.fromstring(data)
+    except ET.ParseError as exc:
+        raise UnsupportedDocumentError(f"EPUB {name} XML is invalid") from exc
+
+
+def _required_child(element: ET.Element, name: str) -> ET.Element:
+    for child in element:
+        if _local_name(child.tag) == name:
+            return child
+    raise UnsupportedDocumentError(f"EPUB package is missing {name}")
+
+
+def _children(element: ET.Element, name: str) -> list[ET.Element]:
+    return [child for child in element if _local_name(child.tag) == name]
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _resolve_href(package_dir: str, href: str) -> str:
+    href_path = unquote(href.split("#", 1)[0])
+    if package_dir:
+        href_path = posixpath.join(package_dir, href_path)
+    return _clean_zip_path(href_path)
+
+
+def _clean_zip_path(path: str) -> str:
+    normalized = posixpath.normpath(unquote(path).lstrip("/"))
+    if normalized in {"", ".", ".."} or normalized.startswith("../"):
+        raise UnsupportedDocumentError("EPUB contains an invalid archive path")
+    return normalized
+
+
+def _epub_handler(
+    path: str | Path,
+    *,
+    policy: Any = None,
+    models: Any = None,
+    lang: str | None = None,
+) -> ExtractedDocument:
+    return extract_epub(path)
+
+
+register_handler(".epub", _epub_handler, requires_multimodal=False)
+
+
+__all__ = ["extract_epub"]

--- a/openmed/multimodal/epub.py
+++ b/openmed/multimodal/epub.py
@@ -312,9 +312,12 @@ class _XhtmlTextParser(HTMLParser):
             self._append_break()
 
     def handle_data(self, data: str) -> None:
-        if self._ignore_depth or not data or not data.strip():
+        if self._ignore_depth or not data:
             return
         source_start = self._source_offset()
+        if not data.strip():
+            self._append_whitespace(source_start, source_start + len(data))
+            return
         self._append_mapped(data, source_start, source_start + len(data))
 
     def handle_entityref(self, name: str) -> None:
@@ -354,6 +357,11 @@ class _XhtmlTextParser(HTMLParser):
             return
         self._parts.append("\n")
         self._cursor += 1
+
+    def _append_whitespace(self, source_start: int, source_end: int) -> None:
+        if not self._parts or self._parts[-1].endswith((" ", "\n")):
+            return
+        self._append_mapped(" ", source_start, source_end)
 
     def _append_mapped(self, text: str, source_start: int, source_end: int) -> None:
         if not text:

--- a/tests/unit/multimodal/test_epub_extract.py
+++ b/tests/unit/multimodal/test_epub_extract.py
@@ -1,0 +1,212 @@
+"""Tests for EPUB text extraction with source offset maps."""
+
+from __future__ import annotations
+
+import html
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from openmed.multimodal import ExtractedDocument, extract_epub, redact_document
+from openmed.multimodal.exceptions import UnsupportedDocumentError
+
+CHAPTER_ONE = (
+    '<html xmlns="http://www.w3.org/1999/xhtml">'
+    "<head>"
+    "<title>Ignore Jane Roe</title>"
+    "<style>.hidden { display: none; }</style>"
+    "</head>"
+    "<body>"
+    "<h1>First</h1>"
+    "<p>Patient <strong>Jane Roe</strong></p>"
+    "<script>MRN hidden</script>"
+    "</body>"
+    "</html>"
+)
+
+CHAPTER_TWO = (
+    '<html xmlns="http://www.w3.org/1999/xhtml">'
+    "<body>"
+    "<p>MRN <span>A123</span></p>"
+    "<p>Discharged &amp; stable</p>"
+    "</body>"
+    "</html>"
+)
+
+SECTION_SOURCES = {
+    "OEBPS/chapter1.xhtml": CHAPTER_ONE,
+    "OEBPS/chapter2.xhtml": CHAPTER_TWO,
+}
+
+
+def _write_synthetic_epub(path: Path) -> Path:
+    manifest_items = "\n".join(
+        [
+            (
+                '<item id="chapter-2" href="chapter2.xhtml" '
+                'media-type="application/xhtml+xml"/>'
+            ),
+            (
+                '<item id="chapter-1" href="chapter1.xhtml" '
+                'media-type="application/xhtml+xml"/>'
+            ),
+        ]
+    )
+    spine_items = "\n".join(
+        [
+            '<itemref idref="chapter-1"/>',
+            '<itemref idref="chapter-2"/>',
+        ]
+    )
+    package = f"""<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Synthetic PHI</dc:title>
+  </metadata>
+  <manifest>
+    {manifest_items}
+  </manifest>
+  <spine>
+    {spine_items}
+  </spine>
+</package>
+"""
+    container = """<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+  <rootfiles>
+    <rootfile full-path="OEBPS/package.opf"
+      media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+"""
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("mimetype", "application/epub+zip")
+        archive.writestr("META-INF/container.xml", container)
+        archive.writestr("OEBPS/package.opf", package)
+        archive.writestr("OEBPS/chapter1.xhtml", CHAPTER_ONE)
+        archive.writestr("OEBPS/chapter2.xhtml", CHAPTER_TWO)
+    return path
+
+
+def _raw_for_span(doc: ExtractedDocument, offset: int) -> str:
+    span = doc.location_at(offset)
+    assert span is not None
+    source = SECTION_SOURCES[span.metadata["section_href"]]
+    return source[span.metadata["source_start"] : span.metadata["source_end"]]
+
+
+def test_extract_epub_reads_spine_order_and_preserves_sections(tmp_path: Path):
+    path = _write_synthetic_epub(tmp_path / "synthetic_phi.epub")
+
+    doc = extract_epub(path)
+
+    expected_first = "First\nPatient Jane Roe"
+    expected_second = "MRN A123\nDischarged & stable"
+    assert doc.text == f"{expected_first}\n{expected_second}"
+    assert "<strong>" not in doc.text
+    assert "Ignore Jane Roe" not in doc.text
+    assert "MRN hidden" not in doc.text
+    assert doc.metadata["format"] == "epub"
+    assert doc.metadata["package_path"] == "OEBPS/package.opf"
+    assert doc.metadata["section_count"] == 2
+    assert "source_text" not in doc.metadata
+
+    sections = doc.metadata["sections"]
+    assert sections == [
+        {
+            "index": 0,
+            "id": "chapter-1",
+            "href": "OEBPS/chapter1.xhtml",
+            "start": 0,
+            "end": len(expected_first),
+        },
+        {
+            "index": 1,
+            "id": "chapter-2",
+            "href": "OEBPS/chapter2.xhtml",
+            "start": len(expected_first) + 1,
+            "end": len(doc.text),
+        },
+    ]
+
+
+def test_epub_source_spans_map_back_to_xhtml_ranges(tmp_path: Path):
+    path = _write_synthetic_epub(tmp_path / "synthetic_phi.epub")
+    doc = extract_epub(path)
+
+    jane = doc.location_at(doc.text.index("Jane Roe"))
+    assert jane is not None
+    assert jane.metadata["format"] == "epub"
+    assert jane.metadata["section_index"] == 0
+    assert jane.metadata["section_id"] == "chapter-1"
+    assert jane.metadata["section_href"] == "OEBPS/chapter1.xhtml"
+    assert _raw_for_span(doc, doc.text.index("Jane Roe")) == "Jane Roe"
+
+    for span in doc.spans:
+        source = SECTION_SOURCES[span.metadata["section_href"]]
+        raw = source[span.metadata["source_start"] : span.metadata["source_end"]]
+        assert html.unescape(raw) == doc.text_for(span)
+        assert doc.location_at(span.start) == span
+
+
+def test_epub_character_references_keep_source_ranges(tmp_path: Path):
+    path = _write_synthetic_epub(tmp_path / "synthetic_phi.epub")
+    doc = extract_epub(path)
+
+    ampersand = doc.location_at(doc.text.index("&"))
+
+    assert ampersand is not None
+    assert doc.text_for(ampersand) == "&"
+    assert _raw_for_span(doc, doc.text.index("&")) == "&amp;"
+
+
+def test_redact_document_dispatches_epub(tmp_path: Path):
+    path = _write_synthetic_epub(tmp_path / "synthetic_phi.epub")
+
+    doc = redact_document(path)
+
+    assert isinstance(doc, ExtractedDocument)
+    assert "Patient Jane Roe" in doc.text
+
+
+def test_epub_without_supported_spine_text_raises(tmp_path: Path):
+    path = tmp_path / "image_only.epub"
+    container = """<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+  <rootfiles>
+    <rootfile full-path="OEBPS/package.opf"
+      media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+"""
+    package = """<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <manifest>
+    <item id="cover" href="cover.png" media-type="image/png"/>
+  </manifest>
+  <spine>
+    <itemref idref="cover"/>
+  </spine>
+</package>
+"""
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("META-INF/container.xml", container)
+        archive.writestr("OEBPS/package.opf", package)
+        archive.writestr("OEBPS/cover.png", b"not an image")
+
+    with pytest.raises(UnsupportedDocumentError, match="supported XHTML or HTML"):
+        extract_epub(path)
+
+
+def test_encrypted_epub_entries_raise(tmp_path: Path):
+    path = _write_synthetic_epub(tmp_path / "encrypted.epub")
+    payload = bytearray(path.read_bytes())
+    for signature, flag_offset in ((b"PK\x03\x04", 6), (b"PK\x01\x02", 8)):
+        header = payload.find(signature)
+        assert header != -1
+        payload[header + flag_offset] |= 0x1
+    path.write_bytes(payload)
+
+    with pytest.raises(UnsupportedDocumentError, match="Encrypted EPUB"):
+        extract_epub(path)

--- a/tests/unit/multimodal/test_epub_extract.py
+++ b/tests/unit/multimodal/test_epub_extract.py
@@ -29,6 +29,7 @@ CHAPTER_TWO = (
     '<html xmlns="http://www.w3.org/1999/xhtml">'
     "<body>"
     "<p>MRN <span>A123</span></p>"
+    "<p><span>Alice</span> <span>Smith</span></p>"
     "<p>Discharged &amp; stable</p>"
     "</body>"
     "</html>"
@@ -102,7 +103,7 @@ def test_extract_epub_reads_spine_order_and_preserves_sections(tmp_path: Path):
     doc = extract_epub(path)
 
     expected_first = "First\nPatient Jane Roe"
-    expected_second = "MRN A123\nDischarged & stable"
+    expected_second = "MRN A123\nAlice Smith\nDischarged & stable"
     assert doc.text == f"{expected_first}\n{expected_second}"
     assert "<strong>" not in doc.text
     assert "Ignore Jane Roe" not in doc.text
@@ -159,6 +160,22 @@ def test_epub_character_references_keep_source_ranges(tmp_path: Path):
     assert ampersand is not None
     assert doc.text_for(ampersand) == "&"
     assert _raw_for_span(doc, doc.text.index("&")) == "&amp;"
+
+
+def test_epub_inline_whitespace_keeps_mapped_separator(tmp_path: Path):
+    path = _write_synthetic_epub(tmp_path / "synthetic_phi.epub")
+    doc = extract_epub(path)
+
+    name_start = doc.text.index("Alice Smith")
+    space_offset = name_start + len("Alice")
+    space = doc.location_at(space_offset)
+
+    assert "AliceSmith" not in doc.text
+    assert doc.text[space_offset] == " "
+    assert space is not None
+    assert doc.text_for(space) == " "
+    assert space.metadata["section_index"] == 1
+    assert _raw_for_span(doc, space_offset) == " "
 
 
 def test_redact_document_dispatches_epub(tmp_path: Path):


### PR DESCRIPTION
# Pull Request

## Description
Adds EPUB text extraction support to the multimodal document ingestion pipeline.
The new extractor reads EPUB spine content in order, extracts visible XHTML/HTML
text, preserves source span offsets, and exposes `.epub` files through the
existing `redact_document` dispatcher.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added a stdlib-only EPUB extractor with manifest/spine parsing, visible text extraction, section metadata, and source offset spans.
- Registered and exported `extract_epub` through `openmed.multimodal`, including `.epub` dispatch via `redact_document`.
- Added EPUB extraction documentation and MkDocs navigation.
- Added unit tests for spine ordering, span mapping, entity decoding, inline whitespace, dispatcher behavior, unsupported EPUBs, and encrypted entries.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Targeted test run:

```bash
.venv/bin/python -m pytest tests/unit/multimodal/test_epub_extract.py -q
```

Result:

```text
7 passed in 0.24s
```

Also checked:

```bash
git diff --check upstream/master...HEAD
```

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [ ] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Related to #858

## Screenshots/Examples
N/A. This is a Python ingestion feature covered by unit tests and documentation.