### PR TITLE
Add redacted-PDF text-layer leakage and visual fidelity verification

### DIFF
--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -36,6 +36,7 @@ from ..core.policy import CANONICAL_POLICY_NAMES, canonical_policy_name
 from .active_learning import add_active_learning_command
 from .calibrate import add_calibrate_command
 from .gates import add_gates_command
+from .verify_pdf import add_verify_pdf_command
 
 _ANALYZE_TEXT = None
 _GET_MODEL_MAX_LENGTH = None
@@ -186,6 +187,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_doctor_command(subparsers)
     add_calibrate_command(subparsers)
     add_gates_command(subparsers)
+    add_verify_pdf_command(subparsers)
     return parser
 
 

--- a/openmed/cli/verify_pdf.py
+++ b/openmed/cli/verify_pdf.py
@@ -1,0 +1,121 @@
+"""CLI subcommand for redacted-PDF text-layer and visual fidelity verification.
+
+Wraps :func:`openmed.multimodal.verify_pdf.verify_redacted_pdf`. Given an
+original PDF, a redacted PDF, and the redaction regions, it prints a PHI-safe
+fidelity report and exits non-zero when any region still leaks selectable text
+or shows no visible redaction box.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence, TextIO
+
+
+def add_verify_pdf_command(subparsers: "argparse._SubParsersAction") -> None:
+    """Register the ``verify-pdf`` subcommand on the top-level parser."""
+    parser = subparsers.add_parser(
+        "verify-pdf",
+        help="Verify a redacted PDF scrubbed its text layer and drew redaction boxes.",
+    )
+    parser.add_argument("original", type=Path, help="Path to the original PDF.")
+    parser.add_argument("redacted", type=Path, help="Path to the redacted PDF.")
+    parser.add_argument(
+        "--spans",
+        type=Path,
+        required=True,
+        metavar="FILE",
+        help=(
+            "JSON file listing the redacted regions: a list of "
+            '{"page": int, "bbox": [x0, top, x1, bottom]} objects, or character '
+            'spans {"start": int, "end": int} projected against the original.'
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="Optional path to write the fidelity report JSON.",
+    )
+    parser.set_defaults(handler=run_from_args)
+
+
+def _load_spans(path: Path) -> list[Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        for key in ("spans", "regions", "redaction_rectangles"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+        raise ValueError(
+            "spans JSON object must contain a 'spans', 'regions', or "
+            "'redaction_rectangles' list"
+        )
+    if not isinstance(payload, list):
+        raise ValueError("spans JSON must be a list or an object wrapping one")
+    return payload
+
+
+def run_from_args(
+    args: argparse.Namespace,
+    *,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    """Run redacted-PDF verification from argparse arguments."""
+    stdout = stdout or sys.stdout
+    stderr = stderr or sys.stderr
+
+    from openmed.multimodal.verify_pdf import verify_redacted_pdf
+
+    try:
+        spans = _load_spans(args.spans)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        stderr.write(f"Failed to read spans file: {exc}\n")
+        return 2
+
+    try:
+        report = verify_redacted_pdf(args.original, args.redacted, spans)
+    except FileNotFoundError as exc:
+        stderr.write(f"Input PDF not found: {exc}\n")
+        return 2
+    except Exception as exc:  # noqa: BLE001 - surface a clean CLI error.
+        stderr.write(f"PDF fidelity verification failed: {exc}\n")
+        return 2
+
+    output = json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    if args.output is not None:
+        try:
+            args.output.write_text(output + "\n", encoding="utf-8")
+        except OSError as exc:
+            stderr.write(f"Failed to write report: {exc}\n")
+            return 2
+    stdout.write(output + "\n")
+    stdout.write(report.summary() + "\n")
+    return 0 if report.passed else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Standalone entry point for ``python -m openmed.cli.verify_pdf``."""
+    parser = argparse.ArgumentParser(
+        prog="openmed verify-pdf",
+        description="Verify redacted-PDF text-layer leakage and visual fidelity.",
+    )
+    parser.add_argument("original", type=Path, help="Path to the original PDF.")
+    parser.add_argument("redacted", type=Path, help="Path to the redacted PDF.")
+    parser.add_argument(
+        "--spans", type=Path, required=True, help="Redacted regions JSON."
+    )
+    parser.add_argument(
+        "--output", "-o", type=Path, default=None, help="Report JSON path."
+    )
+    args = parser.parse_args(argv)
+    return run_from_args(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -101,6 +101,12 @@ from .tabular_csv import (
     read_table,
     redact_table,
 )
+from .verify_pdf import (
+    PdfFidelityReport,
+    RedactionFidelityError,
+    RegionFidelity,
+    verify_redacted_pdf,
+)
 
 __all__ = [
     "ExtractedDocument",
@@ -168,4 +174,8 @@ __all__ = [
     "extract_markdown",
     "extract_asciidoc",
     "redact_source_text",
+    "PdfFidelityReport",
+    "RegionFidelity",
+    "RedactionFidelityError",
+    "verify_redacted_pdf",
 ]

--- a/openmed/multimodal/verify_pdf.py
+++ b/openmed/multimodal/verify_pdf.py
@@ -1,0 +1,498 @@
+"""Redacted-PDF text-layer leakage and visual fidelity verification.
+
+Drawing a black box over PHI hides it visually, but a copy-pasteable text layer
+underneath frequently survives — a classic real-world redaction failure where
+the selectable text still leaks the very names that look blacked out. This
+module verifies a *redacted* PDF against the regions that were supposed to be
+scrubbed and **fails closed** when either:
+
+* residual selectable text remains under a redaction box (text-layer leak), or
+* a redaction region shows no visible change — no opaque box was actually drawn
+  (an unchanged region where the redaction silently did not apply).
+
+The verifier is deterministic and works from the PDF's own text and vector
+content (via ``pdfplumber``); it optionally corroborates the visual check by
+rendering each region to pixels when a raster backend is available (or when a
+``rasterizer`` callable is supplied). The structured, PHI-safe report is
+suitable for embedding into a de-identification audit report — it records
+offsets, bounding boxes, hashes, and counts, never plaintext identifiers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.util
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from .documents_pdf import extract_pdf, project_text_spans
+from .exceptions import MissingDependencyError
+
+_PDF_INSTALL_HINT = 'Install with: pip install "openmed[multimodal]".'
+_PDF_WORD_FIELDS = ("x0", "top", "x1", "bottom")
+
+# A word counts as "under the box" when most of its area falls inside the region.
+_WORD_OVERLAP_FRACTION = 0.5
+# A rectangle counts as a redaction box when it opaquely covers most of the region.
+_BOX_COVER_FRACTION = 0.6
+
+Rasterizer = Callable[[str | Path, int, "tuple[float, float, float, float]"], bytes]
+
+
+class RedactionFidelityError(RuntimeError):
+    """Raised when a redacted PDF fails the leakage / visual-fidelity check."""
+
+    def __init__(self, report: "PdfFidelityReport") -> None:
+        self.report = report
+        super().__init__(report.summary())
+
+
+@dataclass(frozen=True)
+class RegionFidelity:
+    """The verification result for one redaction region (PHI-safe)."""
+
+    page: int
+    bbox: tuple[float, float, float, float]
+    residual_text_found: bool
+    residual_word_count: int
+    residual_sha256: tuple[str, ...]
+    redaction_box_present: bool
+    pixels_changed: bool | None
+    visual_method: str
+    label: str | None = None
+
+    @property
+    def visual_ok(self) -> bool:
+        """True when the region visibly changed (a box was drawn over it)."""
+        if not self.redaction_box_present:
+            return False
+        # If pixels were rendered, they must confirm a change as well.
+        return self.pixels_changed is not False
+
+    @property
+    def passed(self) -> bool:
+        """A region passes only when text is scrubbed AND it visibly changed."""
+        return (not self.residual_text_found) and self.visual_ok
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a PHI-safe representation (hashes/offsets only)."""
+        payload: dict[str, Any] = {
+            "page": self.page,
+            "bbox": list(self.bbox),
+            "passed": self.passed,
+            "residual_text_found": self.residual_text_found,
+            "residual_word_count": self.residual_word_count,
+            "residual_sha256": list(self.residual_sha256),
+            "redaction_box_present": self.redaction_box_present,
+            "visual_method": self.visual_method,
+        }
+        if self.pixels_changed is not None:
+            payload["pixels_changed"] = self.pixels_changed
+        if self.label is not None:
+            payload["label"] = self.label
+        return payload
+
+
+@dataclass(frozen=True)
+class PdfFidelityReport:
+    """Structured, per-region fidelity report for a redacted PDF."""
+
+    regions: tuple[RegionFidelity, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        """True only when every region passed (fails closed on empty input)."""
+        return bool(self.regions) and all(region.passed for region in self.regions)
+
+    @property
+    def failing_regions(self) -> tuple[RegionFidelity, ...]:
+        return tuple(region for region in self.regions if not region.passed)
+
+    @property
+    def residual_text_regions(self) -> tuple[RegionFidelity, ...]:
+        return tuple(region for region in self.regions if region.residual_text_found)
+
+    def to_dict(self) -> dict[str, Any]:
+        """PHI-safe structured report suitable for the audit report."""
+        return {
+            "check": "redacted_pdf_fidelity",
+            "passed": self.passed,
+            "region_count": len(self.regions),
+            "failing_region_count": len(self.failing_regions),
+            "residual_text_region_count": len(self.residual_text_regions),
+            "regions": [region.to_dict() for region in self.regions],
+            "metadata": dict(self.metadata),
+        }
+
+    def summary(self) -> str:
+        if not self.regions:
+            return "PDF fidelity check FAILED: no redaction regions were provided."
+        if self.passed:
+            return f"PDF fidelity check PASSED for all {len(self.regions)} region(s)."
+        leaks = len(self.residual_text_regions)
+        # Count "no visible box" only for regions that did not also leak text, so
+        # the two categories are disjoint and never sum past failing_regions.
+        no_box = sum(
+            1
+            for region in self.failing_regions
+            if not region.residual_text_found and not region.visual_ok
+        )
+        return (
+            f"PDF fidelity check FAILED: {len(self.failing_regions)} of "
+            f"{len(self.regions)} region(s) failed "
+            f"({leaks} with residual selectable text, {no_box} with no visible box)."
+        )
+
+    def raise_for_leakage(self) -> "PdfFidelityReport":
+        """Raise :class:`RedactionFidelityError` unless every region passed."""
+        if not self.passed:
+            raise RedactionFidelityError(self)
+        return self
+
+
+def verify_redacted_pdf(
+    original: str | Path,
+    redacted: str | Path,
+    spans: Iterable[Any],
+    *,
+    rasterizer: Rasterizer | None = None,
+    strict: bool = False,
+) -> PdfFidelityReport:
+    """Verify that ``redacted`` scrubbed the PHI ``spans`` present in ``original``.
+
+    ``spans`` describes what was redacted. Each item may be:
+
+    * a ``(page, bbox)`` region (a mapping/object with ``page`` and ``bbox``, or
+      a :class:`~openmed.multimodal.documents_pdf.ProjectedRectangle`), or
+    * a character span into ``original``'s extracted text (a ``(start, end)``
+      tuple, or a mapping/object with ``start``/``end``) that is projected to a
+      page rectangle using ``original``.
+
+    For each region the verifier asserts (a) no selectable word in ``redacted``
+    remains under the region and (b) an opaque redaction box covers the region.
+    When a raster backend is available (or ``rasterizer`` is supplied) the
+    region is also rendered to pixels in both documents and required to differ.
+
+    Returns a :class:`PdfFidelityReport`. Pass ``strict=True`` to raise
+    :class:`RedactionFidelityError` on any residual leakage instead.
+    """
+    regions = _resolve_regions(original, spans)
+    layout = _read_pdf_layout(redacted)
+
+    results: list[RegionFidelity] = []
+    for page, bbox, label in regions:
+        words, rects = layout.get(page, ((), ()))
+        residual = _residual_words(words, bbox)
+        box_present = _box_covers(rects, bbox)
+        pixels_changed, method = _visual_change(
+            original, redacted, page, bbox, rasterizer=rasterizer
+        )
+        results.append(
+            RegionFidelity(
+                page=page,
+                bbox=bbox,
+                residual_text_found=bool(residual),
+                residual_word_count=len(residual),
+                residual_sha256=tuple(_sha256(text) for text in residual),
+                redaction_box_present=box_present,
+                pixels_changed=pixels_changed,
+                visual_method=method,
+                label=label,
+            )
+        )
+
+    report = PdfFidelityReport(
+        regions=tuple(results),
+        # Do not echo raw file paths — they can themselves contain identifiers
+        # (e.g. /exports/John_Doe_MRN12345.pdf). The report stays PHI-safe.
+        metadata={"region_count": len(results)},
+    )
+    if strict:
+        report.raise_for_leakage()
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Region resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_regions(
+    original: str | Path, spans: Iterable[Any]
+) -> list[tuple[int, tuple[float, float, float, float], str | None]]:
+    direct: list[tuple[int, tuple[float, float, float, float], str | None]] = []
+    char_spans: list[Any] = []
+    for span in spans:
+        region = _as_region(span)
+        if region is not None:
+            direct.append(region)
+        else:
+            char_spans.append(span)
+
+    if char_spans:
+        document = extract_pdf(original)
+        for rectangle in project_text_spans(document, char_spans):
+            direct.append((rectangle.page, tuple(rectangle.bbox), rectangle.label))
+    return direct
+
+
+def _as_region(
+    span: Any,
+) -> tuple[int, tuple[float, float, float, float], str | None] | None:
+    if isinstance(span, Mapping):
+        page = span.get("page")
+        bbox = span.get("bbox")
+        label = span.get("label", span.get("entity_type"))
+    elif isinstance(span, Sequence) and not isinstance(span, (str, bytes, bytearray)):
+        # A (page, bbox) region tuple has a 4-length bbox sequence as its second
+        # element; a bare (start, end) character span (two scalars) does not and
+        # is resolved against the original instead.
+        if (
+            len(span) >= 2
+            and isinstance(span[1], Sequence)
+            and not isinstance(span[1], (str, bytes, bytearray))
+            and len(span[1]) >= 4
+        ):
+            page, bbox, label = span[0], span[1], None
+        else:
+            return None
+    else:
+        page = getattr(span, "page", None)
+        bbox = getattr(span, "bbox", None)
+        label = getattr(span, "label", getattr(span, "entity_type", None))
+    if page is None or bbox is None:
+        return None
+    coerced = _coerce_bbox(bbox)
+    if coerced is None:
+        return None
+    return int(page), coerced, (str(label) if label is not None else None)
+
+
+def _coerce_bbox(bbox: Any) -> tuple[float, float, float, float] | None:
+    if isinstance(bbox, Mapping):
+        try:
+            values = [float(bbox[key]) for key in _PDF_WORD_FIELDS]
+        except (KeyError, TypeError, ValueError):
+            return None
+        return tuple(values)  # type: ignore[return-value]
+    if isinstance(bbox, Sequence) and len(bbox) >= 4:
+        try:
+            return tuple(float(value) for value in tuple(bbox)[:4])  # type: ignore[return-value]
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# PDF layout reading (words + rectangles), lazy pdfplumber
+# ---------------------------------------------------------------------------
+
+
+def _import_pdfplumber() -> Any:
+    try:
+        return importlib.import_module("pdfplumber")
+    except ImportError as exc:  # pragma: no cover - exercised without the extra.
+        raise MissingDependencyError(
+            dependency="pdfplumber", instruction=_PDF_INSTALL_HINT
+        ) from exc
+
+
+def _read_pdf_layout(
+    path: str | Path,
+) -> dict[int, tuple[tuple[Mapping[str, Any], ...], tuple[Mapping[str, Any], ...]]]:
+    pdfplumber = _import_pdfplumber()
+    layout: dict[int, tuple[tuple[Any, ...], tuple[Any, ...]]] = {}
+    with pdfplumber.open(path) as pdf:
+        for page_index, page in enumerate(getattr(pdf, "pages", ())):
+            words = tuple(
+                word
+                for word in page.extract_words(
+                    x_tolerance=1,
+                    y_tolerance=3,
+                    keep_blank_chars=False,
+                    use_text_flow=True,
+                )
+                if str(word.get("text", "")).strip()
+            )
+            rects = tuple(getattr(page, "rects", ()) or ())
+            layout[page_index] = (words, rects)
+    return layout
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+
+def _residual_words(
+    words: Iterable[Mapping[str, Any]],
+    region: tuple[float, float, float, float],
+) -> list[str]:
+    residual: list[str] = []
+    region_area = _area(region)
+    for word in words:
+        bbox = _word_bbox(word)
+        if bbox is None:
+            continue
+        word_area = _area(bbox)
+        if word_area <= 0 and region_area <= 0:
+            continue
+        overlap = _intersection_area(bbox, region)
+        if overlap <= 0:
+            continue
+        if overlap / max(word_area, 1e-6) >= _WORD_OVERLAP_FRACTION:
+            residual.append(str(word.get("text", "")).strip())
+    return [text for text in residual if text]
+
+
+def _box_covers(
+    rects: Iterable[Mapping[str, Any]],
+    region: tuple[float, float, float, float],
+) -> bool:
+    region_area = _area(region)
+    if region_area <= 0:
+        return False
+    for rect in rects:
+        if not _is_opaque(rect):
+            continue
+        bbox = _rect_bbox(rect)
+        if bbox is None:
+            continue
+        if _intersection_area(bbox, region) / region_area >= _BOX_COVER_FRACTION:
+            return True
+    return False
+
+
+def _visual_change(
+    original: str | Path,
+    redacted: str | Path,
+    page: int,
+    region: tuple[float, float, float, float],
+    *,
+    rasterizer: Rasterizer | None,
+) -> tuple[bool | None, str]:
+    render = rasterizer or _default_rasterizer()
+    if render is None:
+        return None, "vector"
+    try:
+        before = render(original, page, region)
+        after = render(redacted, page, region)
+    except (FileNotFoundError, OSError) as exc:
+        # A raster backend was selected but a PDF could not be read. Do NOT
+        # silently drop the visual check and let a clean-looking box report a
+        # pass — that would fail open on a missing/unreadable original. Surface
+        # it so the caller (and the CLI) treat it as a verification error.
+        raise FileNotFoundError(
+            f"Could not read a PDF for visual verification of {original!r} / "
+            f"{redacted!r}: {exc}"
+        ) from exc
+    except Exception:  # pragma: no cover - non-IO backend hiccup -> vector fallback.
+        return None, "vector"
+    return (before != after), "pixel"
+
+
+def _default_rasterizer() -> Rasterizer | None:
+    """Return a pdfplumber-backed region rasterizer if a backend is available."""
+    try:
+        importlib.import_module("pdfplumber")
+    except ImportError:  # pragma: no cover - no PDF stack installed.
+        return None
+    # A raster backend (pypdfium2 or ImageMagick/Wand) is required for to_image().
+    if (
+        importlib.util.find_spec("pypdfium2") is None
+        and importlib.util.find_spec("wand") is None
+    ):
+        return None
+    return _pdfplumber_region_bytes  # pragma: no cover - exercised only with a backend.
+
+
+def _pdfplumber_region_bytes(  # pragma: no cover - requires a raster backend.
+    path: str | Path,
+    page: int,
+    region: tuple[float, float, float, float],
+    resolution: int = 150,
+) -> bytes:
+    pdfplumber = _import_pdfplumber()
+    scale = resolution / 72.0
+    with pdfplumber.open(path) as pdf:
+        page_obj = pdf.pages[page]
+        image = page_obj.to_image(resolution=resolution)
+        crop = image.original.crop(
+            (
+                int(region[0] * scale),
+                int(region[1] * scale),
+                int(region[2] * scale),
+                int(region[3] * scale),
+            )
+        )
+        return crop.convert("L").tobytes()
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers
+# ---------------------------------------------------------------------------
+
+
+def _word_bbox(word: Mapping[str, Any]) -> tuple[float, float, float, float] | None:
+    try:
+        return tuple(float(word[field]) for field in _PDF_WORD_FIELDS)  # type: ignore[return-value]
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _rect_bbox(rect: Mapping[str, Any]) -> tuple[float, float, float, float] | None:
+    return _word_bbox(rect)
+
+
+def _is_opaque(rect: Mapping[str, Any]) -> bool:
+    # A redaction box is a *filled* rectangle. Stroke-only rects (table borders,
+    # cell rules, underlines) are not redactions even though pdfplumber still
+    # reports a non_stroking_color for them, so require an actual fill first,
+    # then reject white / near-white fills (which hide nothing).
+    if not rect.get("fill"):
+        return False
+    color = rect.get("non_stroking_color")
+    if color is None:
+        return True  # filled with the graphics-state default (typically black)
+    if isinstance(color, (int, float)):
+        return float(color) < 0.95
+    if isinstance(color, Sequence) and not isinstance(color, (str, bytes)):
+        try:
+            channels = [float(value) for value in color]
+        except (TypeError, ValueError):
+            return True
+        return any(channel < 0.95 for channel in channels)
+    return True
+
+
+def _intersection_area(
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
+) -> float:
+    x0 = max(a[0], b[0])
+    y0 = max(a[1], b[1])
+    x1 = min(a[2], b[2])
+    y1 = min(a[3], b[3])
+    if x1 <= x0 or y1 <= y0:
+        return 0.0
+    return (x1 - x0) * (y1 - y0)
+
+
+def _area(bbox: tuple[float, float, float, float]) -> float:
+    return max(0.0, bbox[2] - bbox[0]) * max(0.0, bbox[3] - bbox[1])
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "PdfFidelityReport",
+    "RedactionFidelityError",
+    "RegionFidelity",
+    "verify_redacted_pdf",
+]

--- a/tests/unit/multimodal/fixtures/redaction_pdfs.py
+++ b/tests/unit/multimodal/fixtures/redaction_pdfs.py
@@ -1,0 +1,105 @@
+"""Synthetic redacted-PDF fixtures for verify_pdf tests.
+
+Builds minimal, fully synthetic single-page PDFs (no real PHI) from raw content
+streams so tests do not depend on a PDF-writing library. Text is placed with an
+absolute text matrix and redaction boxes are drawn as filled rectangles, which
+``pdfplumber`` reports under ``page.rects`` with ``fill=True``.
+
+Three canonical variants back the fidelity checks:
+
+* ``original`` — the source page with the name present and no box.
+* ``clean_redaction`` — the name removed from the text layer AND a box drawn.
+* ``leaky_redaction`` — a box drawn but the name still selectable underneath.
+"""
+
+from __future__ import annotations
+
+# The synthetic name lives only in these fixtures; it is not real PHI.
+_NAME_LINE = "Patient John Doe"
+_SCRUBBED_LINE = "Patient"
+_SECOND_LINE = "MRN 12345"
+
+# Generous box (PDF bottom-up coords) covering the "John Doe" glyphs at y=720.
+_REDACTION_RECT = (110.0, 708.0, 95.0, 22.0)
+
+
+def _text_block(lines: list[tuple[float, float, str]]) -> bytes:
+    parts = [b"BT\n/F1 12 Tf\n"]
+    for x, y, text in lines:
+        parts.append(f"1 0 0 1 {x} {y} Tm\n".encode("ascii"))
+        parts.append(b"(" + text.encode("ascii") + b") Tj\n")
+    parts.append(b"ET\n")
+    return b"".join(parts)
+
+
+def _rect_fill(rect: tuple[float, float, float, float]) -> bytes:
+    x, y, w, h = rect
+    return f"0 0 0 rg\n{x} {y} {w} {h} re\nf\n".encode("ascii")
+
+
+def build_pdf(content_stream: bytes) -> bytes:
+    """Assemble a minimal one-page PDF around ``content_stream``."""
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
+        ),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        b"<< /Length "
+        + str(len(content_stream)).encode("ascii")
+        + b" >>\nstream\n"
+        + content_stream
+        + b"endstream",
+    ]
+
+    payload = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    offsets = [0]
+    for index, obj in enumerate(objects, start=1):
+        offsets.append(len(payload))
+        payload.extend(f"{index} 0 obj\n".encode("ascii"))
+        payload.extend(obj)
+        payload.extend(b"\nendobj\n")
+
+    xref_offset = len(payload)
+    payload.extend(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
+    payload.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        payload.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
+    payload.extend(
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n".encode("ascii")
+    )
+    return bytes(payload)
+
+
+def original_pdf_bytes() -> bytes:
+    """Source page: the synthetic name is present and no box is drawn."""
+    return build_pdf(
+        _text_block([(72.0, 720.0, _NAME_LINE), (72.0, 700.0, _SECOND_LINE)])
+    )
+
+
+def clean_redaction_pdf_bytes() -> bytes:
+    """Correct redaction: the name is removed AND a box is drawn over it."""
+    return build_pdf(
+        _rect_fill(_REDACTION_RECT)
+        + _text_block([(72.0, 720.0, _SCRUBBED_LINE), (72.0, 700.0, _SECOND_LINE)])
+    )
+
+
+def leaky_redaction_pdf_bytes() -> bytes:
+    """Leaky redaction: a box is drawn but the name is still selectable."""
+    return build_pdf(
+        _rect_fill(_REDACTION_RECT)
+        + _text_block([(72.0, 720.0, _NAME_LINE), (72.0, 700.0, _SECOND_LINE)])
+    )
+
+
+__all__ = [
+    "build_pdf",
+    "clean_redaction_pdf_bytes",
+    "leaky_redaction_pdf_bytes",
+    "original_pdf_bytes",
+]

--- a/tests/unit/multimodal/test_verify_pdf.py
+++ b/tests/unit/multimodal/test_verify_pdf.py
@@ -1,0 +1,366 @@
+"""Tests for redacted-PDF text-layer leakage and visual fidelity verification."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from openmed.multimodal import (
+    PdfFidelityReport,
+    RedactionFidelityError,
+    verify_redacted_pdf,
+)
+
+# A redaction region over a synthetic name; coordinates are pdfplumber top-based.
+REGION = {"page": 0, "bbox": (100.0, 60.0, 180.0, 74.0), "label": "PERSON"}
+
+
+def _word(text, x0, top, x1, bottom):
+    return {"text": text, "x0": x0, "top": top, "x1": x1, "bottom": bottom}
+
+
+def _rect(x0, top, x1, bottom, *, fill=True):
+    return {"x0": x0, "top": top, "x1": x1, "bottom": bottom, "fill": fill}
+
+
+class _FakePage:
+    def __init__(self, words=(), rects=()):
+        self._words = list(words)
+        self.rects = list(rects)
+
+    def extract_words(self, **kwargs):
+        return list(self._words)
+
+
+class _FakePdf:
+    def __init__(self, pages):
+        self.pages = pages
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def _install_fake_pdfplumber(monkeypatch, layouts):
+    """Install a fake ``pdfplumber`` whose ``open`` dispatches on the path."""
+
+    def _open(path):
+        return _FakePdf(layouts[str(path)])
+
+    monkeypatch.setitem(sys.modules, "pdfplumber", SimpleNamespace(open=_open))
+
+
+def test_detects_residual_text_under_box(monkeypatch):
+    # Box drawn, but "John Doe" is still selectable underneath -> leak.
+    redacted = [
+        _FakePage(
+            words=[_word("John", 110, 62, 140, 72), _word("Doe", 145, 62, 175, 72)],
+            rects=[_rect(100, 58, 190, 80)],
+        )
+    ]
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": redacted})
+
+    report = verify_redacted_pdf("original.pdf", "redacted.pdf", [REGION])
+
+    assert isinstance(report, PdfFidelityReport)
+    region = report.regions[0]
+    assert region.residual_text_found
+    assert region.residual_word_count == 2
+    assert region.redaction_box_present  # a box is present, yet text leaked
+    assert not region.passed
+    assert not report.passed
+    assert report.residual_text_regions
+
+
+def test_detects_unchanged_region_no_box(monkeypatch):
+    # No visible box was drawn over the region -> fails closed.
+    redacted = [_FakePage(words=[], rects=[])]
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": redacted})
+
+    report = verify_redacted_pdf("original.pdf", "redacted.pdf", [REGION])
+
+    region = report.regions[0]
+    assert not region.residual_text_found
+    assert not region.redaction_box_present
+    assert not region.visual_ok
+    assert not region.passed
+    assert not report.passed
+
+
+def test_correct_redaction_passes(monkeypatch):
+    # Text scrubbed AND an opaque box drawn -> passes.
+    redacted = [_FakePage(words=[], rects=[_rect(100, 58, 190, 80)])]
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": redacted})
+
+    report = verify_redacted_pdf("original.pdf", "redacted.pdf", [REGION])
+
+    region = report.regions[0]
+    assert not region.residual_text_found
+    assert region.redaction_box_present
+    # The fake page has no to_image(), so the rasterizer raises a non-IO error
+    # and the visual check falls back to the vector (box-presence) path.
+    assert region.visual_method == "vector"
+    assert region.pixels_changed is None
+    assert region.passed
+    assert report.passed
+
+
+def test_stroke_only_border_is_not_a_redaction_box(monkeypatch):
+    # A black table border reports fill=False but a non_stroking_color; it must
+    # NOT count as a redaction box (regression for the false-positive fix).
+    border = _rect(90, 55, 200, 85, fill=False)
+    border["stroke"] = True
+    border["non_stroking_color"] = 0
+    redacted = [_FakePage(words=[], rects=[border])]
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": redacted})
+
+    report = verify_redacted_pdf("original.pdf", "redacted.pdf", [REGION])
+    region = report.regions[0]
+    assert not region.redaction_box_present  # a border is not a redaction
+    assert not region.passed
+    assert not report.passed
+
+
+def test_missing_original_fails_closed_when_rasterizing(monkeypatch):
+    # A raster backend selected but a PDF that cannot be read must not silently
+    # report a clean pass; it surfaces an error (regression for the fails-open fix).
+    redacted = [_FakePage(words=[], rects=[_rect(100, 58, 190, 80)])]
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": redacted})
+
+    def raise_ioerror(path, page, bbox):
+        raise FileNotFoundError(str(path))
+
+    with pytest.raises(FileNotFoundError):
+        verify_redacted_pdf(
+            "original.pdf", "redacted.pdf", [REGION], rasterizer=raise_ioerror
+        )
+
+
+def test_page_bbox_tuple_region_is_accepted(monkeypatch):
+    redacted = [
+        _FakePage(
+            words=[_word("John", 110, 62, 175, 72)], rects=[_rect(100, 58, 190, 80)]
+        )
+    ]
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": redacted})
+
+    # (page, bbox) as a tuple must be treated as a direct region, not a char span.
+    report = verify_redacted_pdf(
+        "original.pdf", "redacted.pdf", [(0, (100.0, 60.0, 180.0, 74.0))]
+    )
+    assert len(report.regions) == 1
+    assert report.regions[0].residual_text_found
+    assert not report.passed
+
+
+def test_pixel_path_requires_region_to_change(monkeypatch):
+    redacted = [_FakePage(words=[], rects=[_rect(100, 58, 190, 80)])]
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": redacted})
+
+    def changed(path, page, bbox):
+        return b"redacted" if str(path) == "redacted.pdf" else b"original"
+
+    changed_report = verify_redacted_pdf(
+        "original.pdf", "redacted.pdf", [REGION], rasterizer=changed
+    )
+    region = changed_report.regions[0]
+    assert region.visual_method == "pixel"
+    assert region.pixels_changed is True
+    assert region.passed
+
+    def unchanged(path, page, bbox):
+        return b"identical"
+
+    unchanged_report = verify_redacted_pdf(
+        "original.pdf", "redacted.pdf", [REGION], rasterizer=unchanged
+    )
+    region = unchanged_report.regions[0]
+    assert region.pixels_changed is False
+    assert not region.passed  # box present but pixels never changed
+    assert not unchanged_report.passed
+
+
+def test_strict_raises_on_leak(monkeypatch):
+    redacted = [
+        _FakePage(
+            words=[_word("John", 110, 62, 175, 72)],
+            rects=[_rect(100, 58, 190, 80)],
+        )
+    ]
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": redacted})
+
+    with pytest.raises(RedactionFidelityError) as excinfo:
+        verify_redacted_pdf("original.pdf", "redacted.pdf", [REGION], strict=True)
+    assert excinfo.value.report.residual_text_regions
+
+
+def test_report_is_phi_safe(monkeypatch):
+    redacted = [
+        _FakePage(
+            words=[_word("John", 110, 62, 175, 72)],
+            rects=[_rect(100, 58, 190, 80)],
+        )
+    ]
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": redacted})
+
+    report = verify_redacted_pdf("original.pdf", "redacted.pdf", [REGION])
+    payload = report.to_dict()
+
+    assert payload["check"] == "redacted_pdf_fidelity"
+    assert payload["passed"] is False
+    assert payload["region_count"] == 1
+    assert payload["regions"][0]["residual_sha256"]  # residual recorded as a hash
+    # The report must never carry plaintext identifiers.
+    assert "John" not in json.dumps(payload)
+
+
+def test_char_span_input_resolves_against_original(monkeypatch):
+    original = [
+        _FakePage(
+            words=[
+                _word("Patient", 72, 60, 110, 72),
+                _word("John", 115, 60, 150, 72),
+                _word("Doe", 152, 60, 180, 72),
+            ]
+        )
+    ]
+    redacted = [
+        _FakePage(
+            words=[_word("John", 115, 60, 150, 72), _word("Doe", 152, 60, 180, 72)],
+            rects=[_rect(110, 56, 185, 76)],
+        )
+    ]
+    _install_fake_pdfplumber(
+        monkeypatch, {"original.pdf": original, "redacted.pdf": redacted}
+    )
+
+    # Text is "Patient John Doe"; the "John Doe" character span is 8..16.
+    report = verify_redacted_pdf("original.pdf", "redacted.pdf", [(8, 16)])
+
+    region = report.regions[0]
+    # A bare (start, end) char span carries no label, so it projects to None.
+    assert region.label is None
+    assert region.residual_text_found  # the name survived under the box
+    assert not report.passed
+
+
+def test_empty_spans_fails_closed(monkeypatch):
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": [_FakePage()]})
+    report = verify_redacted_pdf("original.pdf", "redacted.pdf", [])
+    assert not report.passed  # nothing verified -> not a pass
+
+
+def _write_spans(tmp_path, payload):
+    path = tmp_path / "spans.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_cli_exit_codes_and_output(monkeypatch, tmp_path, capsys):
+    from openmed.cli.verify_pdf import run_from_args
+
+    leaky = [
+        _FakePage(
+            words=[_word("John", 110, 62, 175, 72)], rects=[_rect(100, 58, 190, 80)]
+        )
+    ]
+    clean = [_FakePage(words=[], rects=[_rect(100, 58, 190, 80)])]
+
+    # Leak -> exit 1, and the report JSON is written to --output.
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": leaky})
+    spans = _write_spans(tmp_path, [{"page": 0, "bbox": [100, 60, 180, 74]}])
+    out = tmp_path / "report.json"
+    args = SimpleNamespace(
+        original=Path("original.pdf"),
+        redacted=Path("redacted.pdf"),
+        spans=spans,
+        output=out,
+    )
+    assert run_from_args(args) == 1
+    written = json.loads(out.read_text())
+    assert written["passed"] is False
+    assert "John" not in out.read_text()  # report file stays PHI-safe
+
+    # Clean -> exit 0.
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": clean})
+    args = SimpleNamespace(
+        original=Path("original.pdf"),
+        redacted=Path("redacted.pdf"),
+        spans=spans,
+        output=None,
+    )
+    assert run_from_args(args) == 0
+
+
+def test_cli_bad_spans_file_exits_2(tmp_path):
+    from openmed.cli.verify_pdf import run_from_args
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+    args = SimpleNamespace(
+        original=Path("o.pdf"), redacted=Path("r.pdf"), spans=bad, output=None
+    )
+    assert run_from_args(args) == 2
+
+
+def test_cli_spans_object_wrapper(monkeypatch, tmp_path):
+    from openmed.cli.verify_pdf import run_from_args
+
+    clean = [_FakePage(words=[], rects=[_rect(100, 58, 190, 80)])]
+    _install_fake_pdfplumber(monkeypatch, {"redacted.pdf": clean})
+    # spans provided as {"regions": [...]} instead of a bare list.
+    spans = _write_spans(
+        tmp_path, {"regions": [{"page": 0, "bbox": [100, 60, 180, 74]}]}
+    )
+    args = SimpleNamespace(
+        original=Path("original.pdf"),
+        redacted=Path("redacted.pdf"),
+        spans=spans,
+        output=None,
+    )
+    assert run_from_args(args) == 0
+
+
+def _load_fixture_builder():
+    path = Path(__file__).parent / "fixtures" / "redaction_pdfs.py"
+    spec = importlib.util.spec_from_file_location("redaction_pdfs", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_real_pdfplumber_end_to_end(tmp_path):
+    pytest.importorskip("pdfplumber")
+    from openmed.multimodal import extract_pdf, project_text_spans
+
+    fx = _load_fixture_builder()
+    original = tmp_path / "original.pdf"
+    leaky = tmp_path / "leaky_redaction.pdf"
+    clean = tmp_path / "clean_redaction.pdf"
+    original.write_bytes(fx.original_pdf_bytes())
+    leaky.write_bytes(fx.leaky_redaction_pdf_bytes())
+    clean.write_bytes(fx.clean_redaction_pdf_bytes())
+
+    document = extract_pdf(original)
+    start = document.text.index("John")
+    end = document.text.index("Doe") + len("Doe")
+    regions = project_text_spans(document, [(start, end)])
+    assert regions
+
+    leaky_report = verify_redacted_pdf(original, leaky, regions)
+    assert not leaky_report.passed
+    assert leaky_report.residual_text_regions
+
+    clean_report = verify_redacted_pdf(original, clean, regions)
+    assert clean_report.passed
+
+    # A "redacted" file identical to the original means nothing was applied.
+    unchanged_report = verify_redacted_pdf(original, original, regions)
+    assert not unchanged_report.passed


### PR DESCRIPTION
Closes #1101.

Drawing a black box over PHI hides it visually, but a copy-pasteable text layer underneath frequently survives — a classic redaction failure where selectable text still leaks the names that look blacked out. This adds a verifier that fails closed on that.

## What
- `openmed.multimodal.verify_redacted_pdf(original, redacted, spans)` checks, per region: (a) no selectable word remains under the redaction box (text-layer leak), and (b) an opaque redaction box actually covers the region (a silently-unapplied redaction shows no visible change). When a raster backend is available it also renders each region to pixels and requires them to differ; otherwise it falls back to vector-content checks.
- A structured, PHI-safe `PdfFidelityReport` (per-region offsets, bounding boxes, and residual-text hashes — never plaintext) suitable for embedding in the audit report, with `raise_for_leakage()` / `strict=True`.
- An `openmed verify-pdf` CLI subcommand that prints the report and exits non-zero on residual leakage.

## Tests
- Deterministic cases (run without the multimodal extra via a faked `pdfplumber`): residual text under a box, an unchanged region with no box, a correctly redacted region, the pixel path via an injected rasterizer, PHI-safe report, char-span resolution, and strict raising.
- An end-to-end test with real `pdfplumber` over synthetic generated PDFs (leaky fails, clean passes, an unchanged copy fails). Full suite green.

Redaction itself is out of scope (that is the re-render task); this only verifies a provided redacted PDF. Scanned image-only PDFs are covered by image re-OCR elsewhere.