### PR TITLE
Add a warehouse transformation package with a redaction model and macro

### DIFF
--- a/examples/dbt-deidentify/README.md
+++ b/examples/dbt-deidentify/README.md
@@ -1,0 +1,90 @@
+# OpenMed de-identification for dbt
+
+A small [dbt](https://www.getdbt.com/) package that expresses PHI redaction as a
+reusable **macro** and a **staging model**, so analytics-engineering teams can
+de-identify free-text columns declaratively instead of writing ad-hoc SQL.
+
+The macros wrap a warehouse **de-identification UDF** — `openmed_deidentify(text,
+policy)` — that must be registered on your warehouse connection. This package
+generates SQL only; the redaction runs in-warehouse inside the UDF, so PHI never
+leaves the database.
+
+## Layout
+
+```
+dbt-deidentify/
+├── dbt_project.yml
+├── macros/redact.sql            # redact() / redact_columns()
+├── models/stg_redacted.sql      # applies redact() to configured columns
+├── models/schema.yml            # documents the model and its columns
+└── seeds/synthetic_patients.csv # fully synthetic sample data (no real PHI)
+```
+
+## Macro signature
+
+```sql
+{{ redact(column, policy='hipaa_safe_harbor') }}
+-- renders: openmed_deidentify(<column>, '<policy>')
+
+{{ redact_columns(['notes', 'reason_for_visit'], policy='gdpr_pseudonymization') }}
+-- renders one redacted, aliased column per input column
+```
+
+`policy` accepts any bundled OpenMed policy profile (for example
+`hipaa_safe_harbor`, `gdpr_pseudonymization`, `strict_no_leak`).
+
+## Prerequisite: register the UDF
+
+The model fails with a clear "function `openmed_deidentify` does not exist" error
+until the UDF is registered on the connection. Register it once per session.
+
+**DuckDB (local dev / `dbt-duckdb`):**
+
+```python
+import duckdb
+from openmed.interop.duckdb_udf import register_openmed_udfs
+
+con = duckdb.connect("dev.duckdb")
+register_openmed_udfs(con)  # exposes openmed_deidentify(text, policy)
+```
+
+With `dbt-duckdb`, register the UDF through its Python
+[plugin hook](https://github.com/duckdb/dbt-duckdb#using-local-python-modules) so
+every model run has the function available.
+
+**Snowflake / BigQuery:** register the equivalent remote-function / UDF for
+`openmed_deidentify(text, policy)` (see the warehouse UDF tasks) and point this
+package's profile at that warehouse — the models are unchanged.
+
+## Run it locally
+
+dbt reads connection settings from a `profiles.yml` (by default `~/.dbt/profiles.yml`).
+Add a DuckDB profile named to match this project:
+
+```yaml
+# ~/.dbt/profiles.yml
+openmed_deidentify:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: dev.duckdb
+```
+
+Then, with the `openmed_deidentify` UDF registered on that DuckDB file:
+
+```bash
+pip install "openmed[duckdb]" dbt-duckdb
+cd examples/dbt-deidentify
+dbt seed && dbt run          # UDF must be registered on the connection first
+```
+
+`stg_redacted` materializes with every configured text column replaced by its
+de-identified value; `patient_id` and other structured columns pass through.
+
+## Testing
+
+`tests/unit/integrations/test_dbt_package.py` compiles the macro and executes the
+generated SQL against DuckDB (the local adapter's engine) with a stubbed UDF,
+asserting the configured columns are redacted, PHI is absent from the output, and
+a missing UDF raises a clear error. It needs no warehouse and no network.

--- a/examples/dbt-deidentify/dbt_project.yml
+++ b/examples/dbt-deidentify/dbt_project.yml
@@ -1,0 +1,18 @@
+name: 'openmed_deidentify'
+version: '1.0.0'
+config-version: 2
+
+# This example uses the DuckDB adapter for a fully local, no-warehouse run.
+profile: 'openmed_deidentify'
+
+model-paths: ["models"]
+macro-paths: ["macros"]
+seed-paths: ["seeds"]
+target-path: "target"
+clean-targets:
+  - "target"
+  - "dbt_packages"
+
+models:
+  openmed_deidentify:
+    +materialized: view

--- a/examples/dbt-deidentify/macros/redact.sql
+++ b/examples/dbt-deidentify/macros/redact.sql
@@ -1,0 +1,25 @@
+{#
+    OpenMed de-identification macros for warehouse transformations.
+
+    `redact(column, policy)` emits a call to the OpenMed warehouse
+    de-identification UDF, `openmed_deidentify(text, policy)`. The UDF must be
+    registered on the target warehouse/connection before the model runs (see the
+    package README). These macros only generate SQL — they never see PHI
+    themselves; redaction happens in-warehouse inside the UDF.
+
+    `column` is rendered as a bare SQL identifier and `policy` as a single-quoted
+    literal, so both are trusted, developer-controlled compile-time inputs: pass a
+    real column name and a bundled OpenMed policy profile (e.g. hipaa_safe_harbor,
+    gdpr_pseudonymization, strict_no_leak), never row data or untrusted strings.
+#}
+
+{% macro redact(column, policy='hipaa_safe_harbor') -%}
+openmed_deidentify({{ column }}, '{{ policy }}')
+{%- endmacro %}
+
+
+{% macro redact_columns(columns, policy='hipaa_safe_harbor') -%}
+{%- for column in columns -%}
+{{ redact(column, policy) }} as {{ column }}{{ ", " if not loop.last }}
+{%- endfor -%}
+{%- endmacro %}

--- a/examples/dbt-deidentify/models/schema.yml
+++ b/examples/dbt-deidentify/models/schema.yml
@@ -1,0 +1,19 @@
+version: 2
+
+models:
+  - name: stg_redacted
+    description: >
+      Staging model that applies OpenMed de-identification to the configured
+      free-text columns via the `openmed_deidentify(text, policy)` warehouse UDF.
+      Structured columns pass through unchanged.
+    columns:
+      - name: patient_id
+        description: Structured identifier, passed through unchanged.
+      - name: notes
+        description: Free-text clinical note, de-identified by the redact() macro.
+      - name: reason_for_visit
+        description: Free-text visit reason, de-identified by the redact() macro.
+
+seeds:
+  - name: synthetic_patients
+    description: Fully synthetic sample rows (no real PHI) for local runs.

--- a/examples/dbt-deidentify/models/stg_redacted.sql
+++ b/examples/dbt-deidentify/models/stg_redacted.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='view') }}
+
+-- Staging model: apply OpenMed de-identification to the configured free-text
+-- columns. Requires the `openmed_deidentify(text, policy)` UDF to be registered
+-- on the warehouse connection (see the package README). Structured columns pass
+-- through unchanged; only the listed text columns are redacted.
+
+with source as (
+    select * from {{ ref('synthetic_patients') }}
+)
+
+select
+    patient_id,
+    {{ redact('notes') }} as notes,
+    {{ redact('reason_for_visit') }} as reason_for_visit
+from source

--- a/examples/dbt-deidentify/seeds/synthetic_patients.csv
+++ b/examples/dbt-deidentify/seeds/synthetic_patients.csv
@@ -1,0 +1,4 @@
+patient_id,notes,reason_for_visit
+1,"John Doe reports chest pain; MRN 12345","Follow-up with Dr. Smith"
+2,"Jane Roe seen on 2024-03-02; phone 617-555-0134","Medication review"
+3,"A. Nonymous, SSN 000-00-0000, DOB 1980-01-01","Annual physical"

--- a/tests/unit/integrations/test_dbt_package.py
+++ b/tests/unit/integrations/test_dbt_package.py
@@ -1,0 +1,102 @@
+"""Tests for the dbt de-identification package (examples/dbt-deidentify).
+
+The package expresses PHI redaction as a dbt macro wrapping the
+``openmed_deidentify(text, policy)`` warehouse UDF. These tests compile the
+macro with Jinja and execute the generated SQL against DuckDB (the local
+adapter's engine) with a stubbed UDF, so they need no warehouse and no network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_PACKAGE = Path(__file__).resolve().parents[3] / "examples" / "dbt-deidentify"
+
+
+def _render(call: str) -> str:
+    """Render a call to a package macro, returning the generated SQL."""
+    jinja2 = pytest.importorskip("jinja2")
+    source = (_PACKAGE / "macros" / "redact.sql").read_text(encoding="utf-8")
+    template = jinja2.Environment().from_string(source + "{{ " + call + " }}")
+    return template.render().strip()
+
+
+def _seed_connection():
+    duckdb = pytest.importorskip("duckdb")
+    con = duckdb.connect()
+    con.execute(
+        "CREATE TABLE patients AS SELECT * FROM (VALUES "
+        "(1, 'John Doe reports chest pain; MRN 12345'), "
+        "(2, 'Jane Roe seen on 2024-03-02; phone 617-555-0134')) "
+        "AS t(patient_id, notes)"
+    )
+    return con
+
+
+def _stub_deidentifier():
+    def _deidentify(text, **kwargs):  # noqa: ARG001 - policy/kwargs unused in the stub
+        return SimpleNamespace(deidentified_text="[REDACTED]")
+
+    return _deidentify
+
+
+def test_redact_macro_renders_udf_call():
+    assert (
+        _render("redact('notes')") == "openmed_deidentify(notes, 'hipaa_safe_harbor')"
+    )
+    assert (
+        _render("redact('reason', 'gdpr_pseudonymization')")
+        == "openmed_deidentify(reason, 'gdpr_pseudonymization')"
+    )
+
+
+def test_redact_columns_lists_every_configured_column():
+    sql = _render("redact_columns(['notes', 'reason_for_visit'])")
+    assert "openmed_deidentify(notes, 'hipaa_safe_harbor') as notes" in sql
+    assert (
+        "openmed_deidentify(reason_for_visit, 'hipaa_safe_harbor') as reason_for_visit"
+        in sql
+    )
+
+
+def test_generated_sql_redacts_columns_and_removes_phi():
+    from openmed.interop.duckdb_udf import register_openmed_udfs
+
+    con = _seed_connection()
+    register_openmed_udfs(con, deidentifier=_stub_deidentifier())
+
+    redacted = _render("redact('notes')")
+    rows = con.execute(
+        f"SELECT patient_id, {redacted} AS notes FROM patients ORDER BY patient_id"
+    ).fetchall()
+
+    # The stub UDF stands in for the real de-identifier (which is out of scope
+    # here and covered by test_duckdb_udf.py): this proves the macro-generated
+    # SQL routes each configured column through openmed_deidentify and replaces
+    # its value, so no source text survives in the materialized output.
+    assert [row[1] for row in rows] == ["[REDACTED]", "[REDACTED]"]
+    materialized = " ".join(str(row) for row in rows)
+    for leaked in ("John", "Jane", "12345", "617-555"):
+        assert leaked not in materialized
+
+
+def test_macro_errors_clearly_when_udf_not_registered():
+    con = _seed_connection()  # UDF intentionally not registered
+    redacted = _render("redact('notes')")
+
+    with pytest.raises(Exception) as excinfo:  # noqa: PT011 - DuckDB error type varies
+        con.execute(f"SELECT {redacted} AS notes FROM patients").fetchall()
+
+    assert "openmed_deidentify" in str(excinfo.value)
+
+
+def test_seed_and_docs_are_present_and_synthetic():
+    seed = (_PACKAGE / "seeds" / "synthetic_patients.csv").read_text(encoding="utf-8")
+    assert seed.splitlines()[0] == "patient_id,notes,reason_for_visit"
+    readme = (_PACKAGE / "README.md").read_text(encoding="utf-8").lower()
+    assert "synthetic" in readme
+    assert (_PACKAGE / "models" / "stg_redacted.sql").exists()
+    assert (_PACKAGE / "dbt_project.yml").exists()


### PR DESCRIPTION
Closes #797.

Analytics-engineering teams build warehouse transformations declaratively and want PHI redaction expressed as a reusable model and macro rather than ad-hoc SQL. This adds a small dbt package for that.

## What
- `examples/dbt-deidentify/` — a dbt package with a `redact(column, policy)` macro (and `redact_columns`) that generate a call to the in-warehouse `openmed_deidentify(text, policy)` UDF, plus a `stg_redacted` staging model applying it to configured free-text columns. Structured columns pass through unchanged.
- A fully synthetic seed, project/model config, and a README documenting installation, the macro signature, and the UDF dependency (registered locally via `openmed.interop.duckdb_udf.register_openmed_udfs`, or the warehouse remote-function/UDF for Snowflake/BigQuery).

## Tests
`tests/unit/integrations/test_dbt_package.py` compiles the macro with Jinja and executes the generated SQL against DuckDB (the local adapter's engine) with a stubbed UDF — no warehouse, no network. It asserts the configured columns are redacted, PHI is absent from the materialized output, and that a missing UDF raises a clear error naming `openmed_deidentify`. Seed data is fully synthetic. Full suite green.

Implementing the warehouse UDF itself and publishing to a package hub are out of scope.