### PR TITLE
feat: refine assertion experiencer with cue-based subject detection

### DIFF
--- a/docs/clinical/experiencer-refinement.md
+++ b/docs/clinical/experiencer-refinement.md
@@ -1,0 +1,63 @@
+# Experiencer Refinement
+
+The ConText experiencer axis records who a clinical finding is about. The shipped
+layer resolves it only at the section level: a finding under a *Family History*
+heading is attributed to the family. Free text is finer-grained than that -- a
+single sentence can switch subject ("the patient's *mother* has diabetes", "the
+organ *donor* was CMV-positive").
+
+`openmed.clinical.experiencer` refines the experiencer of a governing span using
+local subject cues, distinguishing three subjects:
+
+| Value | Subject | Example cues |
+|---|---|---|
+| `patient` | the patient (default) | none cued |
+| `family` | a relative of the patient | mother, father, sibling, maternal, family history |
+| `other` | a non-patient, non-relative subject | donor, roommate, partner, coworker |
+
+This axis is a hard safety boundary for coreference-style aggregation: a
+family-member or other-subject finding must not be merged into the patient
+record.
+
+## Resolving a span
+
+```python
+from openmed.clinical import refine_experiencer
+
+text = "The patient's mother has type 2 diabetes"
+span = {"start": text.index("diabetes"), "end": len(text), "label": "CONDITION"}
+
+result = refine_experiencer(text, span)
+# ExperiencerAssignment(experiencer='family', cue='mother',
+#                       cue_offset=(14, 20), source='cue')
+```
+
+`refine_experiencer(text, span, *, section_experiencer=None)` returns an
+`ExperiencerAssignment`:
+
+| Field | Meaning |
+|---|---|
+| `experiencer` | `patient`, `family`, or `other`. |
+| `cue` | The matched subject cue (lowercased), or `None` when defaulted. |
+| `cue_offset` | Half-open offsets of the cue in the source text, or `None`. |
+| `source` | `cue`, `section`, or `default` -- how the value was decided. |
+
+## Resolution order
+
+1. **Cue** -- the subject cue nearest the span, within the span's clause, wins.
+   Resolution is scoped to the clause (bounded by `.`, `!`, `?`, `;`), so a
+   subject named in a previous sentence does not leak across the boundary. On a
+   tie the more specific `other` subject wins over `family`.
+2. **Section prior** -- when no cue is found and a `section_experiencer` is
+   supplied (for example `family` under a *Family History* heading), it is used.
+3. **Default** -- otherwise the span is attributed to the `patient`.
+
+An explicit cue always overrides the section prior, so "the patient's father
+also has hypertension" resolves to `family` even inside a patient-default
+section.
+
+## Notes
+
+Resolution is deterministic and offline. Experiencer refinement is a cue-based
+heuristic and is not a substitute for clinician review; validate before any
+clinical use.

--- a/docs/clinical/experiencer-refinement.md
+++ b/docs/clinical/experiencer-refinement.md
@@ -19,20 +19,45 @@ This axis is a hard safety boundary for coreference-style aggregation: a
 family-member or other-subject finding must not be merged into the patient
 record.
 
+## Refining assertions
+
+`refine_experiencer(spans, context_result, text=...)` accepts clinical spans and
+an existing `ClinicalContextResult` or `ClinicalAssertion`, then returns
+`RefinedExperiencerAssertion` records. Each record preserves the incoming
+temporality, certainty, and negation axes while attaching the refined
+experiencer to the assertion.
+
+```python
+from openmed.clinical import ClinicalAssertion, refine_experiencer
+
+text = "The patient's mother has type 2 diabetes"
+span = {"start": text.index("diabetes"), "end": len(text), "label": "CONDITION"}
+context = ClinicalAssertion(temporality="recent", certainty="certain")
+
+[result] = refine_experiencer([span], context, text=text)
+result.assertion.experiencer
+# 'family'
+result.assignment.cue
+# 'mother'
+```
+
+The lower-level `resolve_experiencer(text, span, *, section_experiencer=None)`
+API returns only the assignment provenance for one span.
+
 ## Resolving a span
 
 ```python
-from openmed.clinical import refine_experiencer
+from openmed.clinical import resolve_experiencer
 
 text = "The patient's mother has type 2 diabetes"
 span = {"start": text.index("diabetes"), "end": len(text), "label": "CONDITION"}
 
-result = refine_experiencer(text, span)
+result = resolve_experiencer(text, span)
 # ExperiencerAssignment(experiencer='family', cue='mother',
 #                       cue_offset=(14, 20), source='cue')
 ```
 
-`refine_experiencer(text, span, *, section_experiencer=None)` returns an
+`resolve_experiencer(text, span, *, section_experiencer=None)` returns an
 `ExperiencerAssignment`:
 
 | Field | Meaning |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - EPUB Extraction: multimodal/epub-extraction.md
       - Testing & QA: testing.md
       - Eval Harness & Metrics: eval-harness.md
+      - Experiencer Refinement: clinical/experiencer-refinement.md
       - OpenVINO Runtime: runtimes/openvino.md
       - Device Tiers & SLOs: tiers.md
       - AWQ Export: export-awq.md

--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -94,8 +94,11 @@ from .experiencer import (
     EXPERIENCER_REFINED_VALUES,
     EXPERIENCER_REFINEMENT_ADVISORY,
     OTHER_EXPERIENCER,
+    Experiencer,
     ExperiencerAssignment,
+    RefinedExperiencerAssertion,
     refine_experiencer,
+    resolve_experiencer,
 )
 from .lab_values import (
     LAB_FLAG_ADVISORY,
@@ -412,8 +415,11 @@ __all__ = [
     "detect_negation_scopes",
     "negated_spans",
     "OTHER_EXPERIENCER",
+    "Experiencer",
     "EXPERIENCER_REFINED_VALUES",
     "EXPERIENCER_REFINEMENT_ADVISORY",
     "ExperiencerAssignment",
+    "RefinedExperiencerAssertion",
+    "resolve_experiencer",
     "refine_experiencer",
 ]

--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -90,6 +90,13 @@ from .events import (
     extract_medication_change_events,
     score_event_frame_corpus,
 )
+from .experiencer import (
+    EXPERIENCER_REFINED_VALUES,
+    EXPERIENCER_REFINEMENT_ADVISORY,
+    OTHER_EXPERIENCER,
+    ExperiencerAssignment,
+    refine_experiencer,
+)
 from .lab_values import (
     LAB_FLAG_ADVISORY,
     AbnormalFlag,
@@ -404,4 +411,9 @@ __all__ = [
     "NegationScope",
     "detect_negation_scopes",
     "negated_spans",
+    "OTHER_EXPERIENCER",
+    "EXPERIENCER_REFINED_VALUES",
+    "EXPERIENCER_REFINEMENT_ADVISORY",
+    "ExperiencerAssignment",
+    "refine_experiencer",
 ]

--- a/openmed/clinical/experiencer.py
+++ b/openmed/clinical/experiencer.py
@@ -1,0 +1,220 @@
+"""Cue-based experiencer refinement for clinical spans (roadmap v1.9).
+
+The shipped ConText layer resolves the experiencer axis only at the section
+level: a finding under a *Family History* heading is attributed to the family.
+That is too coarse for free text, where a single sentence can switch subject
+("the patient's *mother* has diabetes", "the organ *donor* was CMV-positive").
+
+This module refines the experiencer of a governing clinical span using local
+subject cues, distinguishing three subjects:
+
+* ``patient``  -- the default when no other subject is cued.
+* ``family``   -- a relative of the patient (mother, father, sibling, ...).
+* ``other``    -- a non-patient, non-relative subject (donor, roommate, ...).
+
+Resolution is scoped to the clause containing the span so a subject mentioned in
+a previous sentence does not leak across a boundary. A section-level experiencer
+prior is used as a fallback when no cue is found, and an explicit cue overrides
+the section prior. The resolver is deterministic and offline, and reuses the
+``PATIENT_EXPERIENCER`` / ``FAMILY_EXPERIENCER`` constants from
+:mod:`openmed.clinical.context`.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from .context import FAMILY_EXPERIENCER, PATIENT_EXPERIENCER
+
+#: Non-patient, non-relative subject (donor, roommate, ...).
+OTHER_EXPERIENCER = "other"
+
+#: Experiencer values after refinement, from default to most specific.
+EXPERIENCER_REFINED_VALUES = (
+    PATIENT_EXPERIENCER,
+    FAMILY_EXPERIENCER,
+    OTHER_EXPERIENCER,
+)
+
+EXPERIENCER_REFINEMENT_ADVISORY = (
+    "Experiencer refinement is a deterministic cue-based heuristic scoped to the "
+    "span's clause. It sharpens subject attribution but is not a substitute for "
+    "clinician review; verify before clinical use."
+)
+
+# Relatives whose mention attributes a nearby finding to the family.
+_FAMILY_CUES = (
+    "family history",
+    "familial",
+    "maternal",
+    "paternal",
+    "grandmother",
+    "grandfather",
+    "grandparent",
+    "mother",
+    "father",
+    "sister",
+    "brother",
+    "sibling",
+    "parent",
+    "parents",
+    "daughter",
+    "son",
+    "child",
+    "aunt",
+    "uncle",
+    "cousin",
+    "niece",
+    "nephew",
+    "wife",
+    "husband",
+    "spouse",
+    "mom",
+    "dad",
+)
+
+# Non-patient, non-relative subjects.
+_OTHER_CUES = (
+    "donor",
+    "roommate",
+    "housemate",
+    "partner",
+    "girlfriend",
+    "boyfriend",
+    "coworker",
+    "colleague",
+    "neighbor",
+    "neighbour",
+    "friend",
+    "contact",
+)
+
+# Clause boundaries that a cue may not reach across.
+_CLAUSE_BOUNDARY_RE = re.compile(r"[.!?;]")
+
+
+def _cue_pattern(cues: tuple[str, ...]) -> re.Pattern[str]:
+    alternation = "|".join(
+        r"\s+".join(re.escape(part) for part in cue.split())
+        for cue in sorted(cues, key=len, reverse=True)
+    )
+    return re.compile(rf"(?<!\w)(?:{alternation})(?!\w)", re.IGNORECASE)
+
+
+_FAMILY_RE = _cue_pattern(_FAMILY_CUES)
+_OTHER_RE = _cue_pattern(_OTHER_CUES)
+
+
+@dataclass(frozen=True)
+class ExperiencerAssignment:
+    """The resolved experiencer for a span, with provenance.
+
+    ``source`` is ``"cue"`` when a subject cue in the span's clause decided the
+    result, ``"section"`` when the section prior was used, or ``"default"`` when
+    the span fell back to the patient.
+    """
+
+    experiencer: str
+    cue: str | None
+    cue_offset: tuple[int, int] | None
+    source: str
+
+
+def _clause_start(text: str, span_start: int) -> int:
+    """Offset just after the last clause boundary before ``span_start``."""
+
+    last = 0
+    for match in _CLAUSE_BOUNDARY_RE.finditer(text, 0, span_start):
+        last = match.end()
+    return last
+
+
+def _coerce_span(span: Mapping[str, object]) -> tuple[int, int]:
+    try:
+        start = int(span["start"])  # type: ignore[arg-type]
+        end = int(span["end"])  # type: ignore[arg-type]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("span requires integer 'start' and 'end'") from exc
+    if start > end:
+        raise ValueError("span 'start' must not exceed 'end'")
+    return start, end
+
+
+def _nearest_cue(
+    text: str,
+    clause_start: int,
+    span_start: int,
+) -> tuple[str, int, int] | None:
+    """Return the (experiencer, cue_start, cue_end) of the cue nearest the span.
+
+    Only cues within the span's clause and at or before the span are considered;
+    on a tie the more specific ``other`` subject wins over ``family``.
+    """
+
+    best: tuple[int, int, str, int, int] | None = None
+    for experiencer, pattern, rank in (
+        (OTHER_EXPERIENCER, _OTHER_RE, 0),
+        (FAMILY_EXPERIENCER, _FAMILY_RE, 1),
+    ):
+        for match in pattern.finditer(text, clause_start, span_start):
+            gap = span_start - match.end()
+            key = (gap, rank)
+            if best is None or key < best[:2]:
+                best = (gap, rank, experiencer, match.start(), match.end())
+    if best is None:
+        return None
+    _gap, _rank, experiencer, cue_start, cue_end = best
+    return experiencer, cue_start, cue_end
+
+
+def refine_experiencer(
+    text: str,
+    span: Mapping[str, object],
+    *,
+    section_experiencer: str | None = None,
+) -> ExperiencerAssignment:
+    """Resolve the experiencer of ``span`` from local subject cues.
+
+    A subject cue within the span's clause decides the result; otherwise the
+    ``section_experiencer`` prior is used, and failing that the span defaults to
+    the patient. An explicit cue always overrides the section prior.
+    """
+
+    span_start, _span_end = _coerce_span(span)
+    clause_start = _clause_start(text, span_start)
+
+    hit = _nearest_cue(text, clause_start, span_start)
+    if hit is not None:
+        experiencer, cue_start, cue_end = hit
+        return ExperiencerAssignment(
+            experiencer=experiencer,
+            cue=text[cue_start:cue_end].lower(),
+            cue_offset=(cue_start, cue_end),
+            source="cue",
+        )
+
+    if section_experiencer:
+        return ExperiencerAssignment(
+            experiencer=section_experiencer,
+            cue=None,
+            cue_offset=None,
+            source="section",
+        )
+
+    return ExperiencerAssignment(
+        experiencer=PATIENT_EXPERIENCER,
+        cue=None,
+        cue_offset=None,
+        source="default",
+    )
+
+
+__all__ = [
+    "OTHER_EXPERIENCER",
+    "EXPERIENCER_REFINED_VALUES",
+    "EXPERIENCER_REFINEMENT_ADVISORY",
+    "ExperiencerAssignment",
+    "refine_experiencer",
+]

--- a/openmed/clinical/experiencer.py
+++ b/openmed/clinical/experiencer.py
@@ -24,12 +24,23 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from typing import Literal
 
-from .context import FAMILY_EXPERIENCER, PATIENT_EXPERIENCER
+from .context import (
+    AFFIRMED,
+    CERTAIN,
+    FAMILY_EXPERIENCER,
+    PATIENT_EXPERIENCER,
+    RECENT,
+    ClinicalAssertion,
+    ClinicalContextResult,
+)
 
 #: Non-patient, non-relative subject (donor, roommate, ...).
 OTHER_EXPERIENCER = "other"
+
+Experiencer = Literal["patient", "family", "other"]
 
 #: Experiencer values after refinement, from default to most specific.
 EXPERIENCER_REFINED_VALUES = (
@@ -122,6 +133,15 @@ class ExperiencerAssignment:
     source: str
 
 
+@dataclass(frozen=True)
+class RefinedExperiencerAssertion:
+    """A span assertion enriched with experiencer provenance."""
+
+    span: Mapping[str, object]
+    assertion: ClinicalAssertion
+    assignment: ExperiencerAssignment
+
+
 def _clause_start(text: str, span_start: int) -> int:
     """Offset just after the last clause boundary before ``span_start``."""
 
@@ -169,7 +189,7 @@ def _nearest_cue(
     return experiencer, cue_start, cue_end
 
 
-def refine_experiencer(
+def resolve_experiencer(
     text: str,
     span: Mapping[str, object],
     *,
@@ -211,10 +231,132 @@ def refine_experiencer(
     )
 
 
+def refine_experiencer(
+    spans: object,
+    context_result: object | None = None,
+    *,
+    text: str | None = None,
+    section_experiencer: str | None = None,
+) -> list[RefinedExperiencerAssertion] | ExperiencerAssignment:
+    """Return clinical assertions enriched with experiencer attribution.
+
+    The issue-facing API accepts an iterable of span mappings plus either one
+    shared context result/assertion or a per-span sequence of them, returning a
+    ``RefinedExperiencerAssertion`` for each span. For compatibility with the
+    single-span resolver introduced in the original PR,
+    ``refine_experiencer(text, span)`` still returns an
+    ``ExperiencerAssignment``; new code should prefer ``resolve_experiencer``
+    for that lower-level operation.
+    """
+
+    if isinstance(spans, str):
+        if not isinstance(context_result, Mapping):
+            raise TypeError("single-span refinement requires a span mapping")
+        return resolve_experiencer(
+            spans,
+            context_result,
+            section_experiencer=section_experiencer,
+        )
+
+    span_list = list(_iter_span_mappings(spans))
+    if not span_list:
+        return []
+
+    contexts = _context_sequence(context_result, len(span_list))
+    refined: list[RefinedExperiencerAssertion] = []
+    for span, context in zip(span_list, contexts, strict=True):
+        base_assertion = _coerce_assertion(context)
+        document_text = _document_text_for_span(span, text)
+        assignment = resolve_experiencer(
+            document_text,
+            span,
+            section_experiencer=section_experiencer or base_assertion.experiencer,
+        )
+        refined.append(
+            RefinedExperiencerAssertion(
+                span=span,
+                assertion=replace(
+                    base_assertion,
+                    experiencer=assignment.experiencer,
+                ),
+                assignment=assignment,
+            )
+        )
+    return refined
+
+
+def _iter_span_mappings(spans: object) -> list[Mapping[str, object]]:
+    if isinstance(spans, Mapping):
+        return [spans]
+    try:
+        items = list(spans)  # type: ignore[arg-type]
+    except TypeError as exc:
+        raise TypeError("spans must be a mapping or iterable of mappings") from exc
+    if not all(isinstance(item, Mapping) for item in items):
+        raise TypeError("all spans must be mappings")
+    return items
+
+
+def _context_sequence(context_result: object | None, count: int) -> list[object | None]:
+    if isinstance(context_result, (ClinicalAssertion, ClinicalContextResult, Mapping)):
+        return [context_result] * count
+    if context_result is None:
+        return [None] * count
+    try:
+        contexts = list(context_result)  # type: ignore[arg-type]
+    except TypeError:
+        return [context_result] * count
+    if len(contexts) != count:
+        raise ValueError("context_result sequence length must match spans")
+    return contexts
+
+
+def _coerce_assertion(context_result: object | None) -> ClinicalAssertion:
+    if isinstance(context_result, ClinicalAssertion):
+        return context_result
+    if isinstance(context_result, ClinicalContextResult):
+        return ClinicalAssertion(
+            temporality=context_result.temporality,
+            certainty=context_result.certainty,
+            negation=context_result.negation,
+        )
+    if isinstance(context_result, Mapping):
+        return ClinicalAssertion(
+            temporality=str(context_result.get("temporality", RECENT)),
+            certainty=str(context_result.get("certainty", CERTAIN)),  # type: ignore[arg-type]
+            negation=context_result.get("negation", AFFIRMED),  # type: ignore[arg-type]
+            experiencer=context_result.get("experiencer"),  # type: ignore[arg-type]
+        )
+    return ClinicalAssertion(
+        temporality=RECENT,
+        certainty=CERTAIN,
+        negation=AFFIRMED,
+    )
+
+
+def _document_text_for_span(span: Mapping[str, object], text: str | None) -> str:
+    if text is not None:
+        return text
+    for key in (
+        "document_text",
+        "context_text",
+        "source_text",
+        "full_text",
+        "note_text",
+    ):
+        value = span.get(key)
+        if isinstance(value, str):
+            return value
+    raise ValueError("document text is required for experiencer refinement")
+
+
 __all__ = [
     "OTHER_EXPERIENCER",
+    "Experiencer",
     "EXPERIENCER_REFINED_VALUES",
     "EXPERIENCER_REFINEMENT_ADVISORY",
     "ExperiencerAssignment",
+    "RefinedExperiencerAssertion",
+    "resolve_experiencer",
     "refine_experiencer",
 ]

--- a/tests/unit/clinical/test_experiencer_refine.py
+++ b/tests/unit/clinical/test_experiencer_refine.py
@@ -7,13 +7,18 @@ import unicodedata
 import pytest
 
 from openmed.clinical import (
+    AFFIRMED,
+    CERTAIN,
     EXPERIENCER_REFINED_VALUES,
     EXPERIENCER_REFINEMENT_ADVISORY,
     FAMILY_EXPERIENCER,
     OTHER_EXPERIENCER,
     PATIENT_EXPERIENCER,
+    RECENT,
+    ClinicalAssertion,
     ExperiencerAssignment,
     refine_experiencer,
+    resolve_experiencer,
 )
 
 
@@ -42,7 +47,7 @@ def _span(text: str, sub: str, label: str = "CONDITION") -> dict:
 def test_family_cue_yields_family_experiencer(text, sub, cue):
     span = _span(text, sub)
 
-    result = refine_experiencer(text, span)
+    result = resolve_experiencer(text, span)
 
     assert isinstance(result, ExperiencerAssignment)
     assert result.experiencer == FAMILY_EXPERIENCER
@@ -61,7 +66,7 @@ def test_family_cue_yields_family_experiencer(text, sub, cue):
 def test_other_cue_yields_other_experiencer(text, sub, cue):
     span = _span(text, sub)
 
-    result = refine_experiencer(text, span)
+    result = resolve_experiencer(text, span)
 
     assert result.experiencer == OTHER_EXPERIENCER
     assert result.cue == cue
@@ -72,7 +77,7 @@ def test_no_cue_defaults_to_patient():
     text = "Patient reports worsening chest pain"
     span = _span(text, "chest pain")
 
-    result = refine_experiencer(text, span)
+    result = resolve_experiencer(text, span)
 
     assert result.experiencer == PATIENT_EXPERIENCER
     assert result.cue is None
@@ -88,7 +93,7 @@ def test_section_prior_used_when_no_cue():
     text = "Coronary artery disease and myocardial infarction"
     span = _span(text, "myocardial infarction")
 
-    result = refine_experiencer(text, span, section_experiencer=FAMILY_EXPERIENCER)
+    result = resolve_experiencer(text, span, section_experiencer=FAMILY_EXPERIENCER)
 
     assert result.experiencer == FAMILY_EXPERIENCER
     assert result.source == "section"
@@ -99,7 +104,7 @@ def test_cue_overrides_section_prior():
     text = "Patient's father also has hypertension"
     span = _span(text, "hypertension")
 
-    result = refine_experiencer(text, span, section_experiencer=PATIENT_EXPERIENCER)
+    result = resolve_experiencer(text, span, section_experiencer=PATIENT_EXPERIENCER)
 
     assert result.experiencer == FAMILY_EXPERIENCER
     assert result.source == "cue"
@@ -114,7 +119,7 @@ def test_cue_in_prior_sentence_does_not_attach():
     text = "Mother is healthy. Patient has diabetes."
     span = _span(text, "diabetes")
 
-    result = refine_experiencer(text, span)
+    result = resolve_experiencer(text, span)
 
     assert result.experiencer == PATIENT_EXPERIENCER
     assert result.source == "default"
@@ -124,7 +129,7 @@ def test_nearest_cue_wins_within_clause():
     text = "The sister of the organ donor developed sepsis"
     span = _span(text, "sepsis")
 
-    result = refine_experiencer(text, span)
+    result = resolve_experiencer(text, span)
 
     # "donor" is closer to the finding than "sister".
     assert result.experiencer == OTHER_EXPERIENCER
@@ -141,10 +146,43 @@ def test_offsets_stable_under_nfc_normalization():
     text = unicodedata.normalize("NFC", raw)
     span = _span(text, "cancer")
 
-    first = refine_experiencer(text, span)
-    second = refine_experiencer(unicodedata.normalize("NFC", text), span)
+    first = resolve_experiencer(text, span)
+    second = resolve_experiencer(unicodedata.normalize("NFC", text), span)
 
     assert first == second
+
+
+def test_refine_experiencer_returns_enriched_assertions():
+    text = "The patient's mother has type 2 diabetes"
+    span = _span(text, "diabetes")
+    context = ClinicalAssertion(
+        temporality=RECENT,
+        certainty=CERTAIN,
+        negation=AFFIRMED,
+        experiencer=PATIENT_EXPERIENCER,
+    )
+
+    [result] = refine_experiencer([span], context, text=text)
+
+    assert result.span == span
+    assert result.assertion.temporality == RECENT
+    assert result.assertion.certainty == CERTAIN
+    assert result.assertion.negation == AFFIRMED
+    assert result.assertion.experiencer == FAMILY_EXPERIENCER
+    assert result.assignment.cue == "mother"
+
+
+def test_refine_experiencer_uses_span_document_text():
+    text = "The organ donor was CMV-positive"
+    span = {
+        **_span(text, "CMV-positive"),
+        "document_text": text,
+    }
+
+    [result] = refine_experiencer([span], None)
+
+    assert result.assertion.experiencer == OTHER_EXPERIENCER
+    assert result.assignment.source == "cue"
 
 
 def test_refined_values_and_advisory_exposed():

--- a/tests/unit/clinical/test_experiencer_refine.py
+++ b/tests/unit/clinical/test_experiencer_refine.py
@@ -1,0 +1,157 @@
+"""Tests for cue-based experiencer refinement."""
+
+from __future__ import annotations
+
+import unicodedata
+
+import pytest
+
+from openmed.clinical import (
+    EXPERIENCER_REFINED_VALUES,
+    EXPERIENCER_REFINEMENT_ADVISORY,
+    FAMILY_EXPERIENCER,
+    OTHER_EXPERIENCER,
+    PATIENT_EXPERIENCER,
+    ExperiencerAssignment,
+    refine_experiencer,
+)
+
+
+def _span(text: str, sub: str, label: str = "CONDITION") -> dict:
+    start = text.index(sub)
+    return {"start": start, "end": start + len(sub), "label": label, "text": sub}
+
+
+# --------------------------------------------------------------------------
+# Cue-based subject detection
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "sub", "cue"),
+    [
+        ("Patient's mother has diabetes", "diabetes", "mother"),
+        ("His brother was diagnosed with asthma", "asthma", "brother"),
+        (
+            "Family history of coronary artery disease",
+            "coronary artery disease",
+            "family history",
+        ),
+    ],
+)
+def test_family_cue_yields_family_experiencer(text, sub, cue):
+    span = _span(text, sub)
+
+    result = refine_experiencer(text, span)
+
+    assert isinstance(result, ExperiencerAssignment)
+    assert result.experiencer == FAMILY_EXPERIENCER
+    assert result.cue == cue
+    assert result.source == "cue"
+    assert text[result.cue_offset[0] : result.cue_offset[1]].lower() == cue
+
+
+@pytest.mark.parametrize(
+    ("text", "sub", "cue"),
+    [
+        ("The donor was CMV-positive", "CMV-positive", "donor"),
+        ("Her roommate had a similar rash", "rash", "roommate"),
+    ],
+)
+def test_other_cue_yields_other_experiencer(text, sub, cue):
+    span = _span(text, sub)
+
+    result = refine_experiencer(text, span)
+
+    assert result.experiencer == OTHER_EXPERIENCER
+    assert result.cue == cue
+    assert result.source == "cue"
+
+
+def test_no_cue_defaults_to_patient():
+    text = "Patient reports worsening chest pain"
+    span = _span(text, "chest pain")
+
+    result = refine_experiencer(text, span)
+
+    assert result.experiencer == PATIENT_EXPERIENCER
+    assert result.cue is None
+    assert result.source == "default"
+
+
+# --------------------------------------------------------------------------
+# Section prior fallback and cue precedence
+# --------------------------------------------------------------------------
+
+
+def test_section_prior_used_when_no_cue():
+    text = "Coronary artery disease and myocardial infarction"
+    span = _span(text, "myocardial infarction")
+
+    result = refine_experiencer(text, span, section_experiencer=FAMILY_EXPERIENCER)
+
+    assert result.experiencer == FAMILY_EXPERIENCER
+    assert result.source == "section"
+
+
+def test_cue_overrides_section_prior():
+    # Section says patient, but an explicit family cue near the span wins.
+    text = "Patient's father also has hypertension"
+    span = _span(text, "hypertension")
+
+    result = refine_experiencer(text, span, section_experiencer=PATIENT_EXPERIENCER)
+
+    assert result.experiencer == FAMILY_EXPERIENCER
+    assert result.source == "cue"
+
+
+# --------------------------------------------------------------------------
+# Scope: a cue in a different clause must not attach
+# --------------------------------------------------------------------------
+
+
+def test_cue_in_prior_sentence_does_not_attach():
+    text = "Mother is healthy. Patient has diabetes."
+    span = _span(text, "diabetes")
+
+    result = refine_experiencer(text, span)
+
+    assert result.experiencer == PATIENT_EXPERIENCER
+    assert result.source == "default"
+
+
+def test_nearest_cue_wins_within_clause():
+    text = "The sister of the organ donor developed sepsis"
+    span = _span(text, "sepsis")
+
+    result = refine_experiencer(text, span)
+
+    # "donor" is closer to the finding than "sister".
+    assert result.experiencer == OTHER_EXPERIENCER
+    assert result.cue == "donor"
+
+
+# --------------------------------------------------------------------------
+# Robustness
+# --------------------------------------------------------------------------
+
+
+def test_offsets_stable_under_nfc_normalization():
+    raw = "Le père du patient a un cancer"
+    text = unicodedata.normalize("NFC", raw)
+    span = _span(text, "cancer")
+
+    first = refine_experiencer(text, span)
+    second = refine_experiencer(unicodedata.normalize("NFC", text), span)
+
+    assert first == second
+
+
+def test_refined_values_and_advisory_exposed():
+    assert set(EXPERIENCER_REFINED_VALUES) == {
+        PATIENT_EXPERIENCER,
+        FAMILY_EXPERIENCER,
+        OTHER_EXPERIENCER,
+    }
+    assert isinstance(EXPERIENCER_REFINEMENT_ADVISORY, str)
+    assert EXPERIENCER_REFINEMENT_ADVISORY


### PR DESCRIPTION
Implements #876 (OM-518). The shipped ConText experiencer axis is resolved only at the section level, so a finding under a *Family History* heading is attributed to the family but free text that switches subject mid-sentence ("the patient`s **mother** has diabetes", "the organ **donor** was CMV-positive") is not. This adds a cue-based resolver that sharpens the axis and introduces a third subject.

## Changes

- **`openmed/clinical/experiencer.py`**
  - `refine_experiencer(text, span, *, section_experiencer=None)` -> `ExperiencerAssignment` (`experiencer`, matched `cue`, `cue_offset`, and `source`).
  - Distinguishes **`patient`** (default), **`family`** (mother, father, sibling, maternal, family history, ...), and a new **`other`** subject (donor, roommate, partner, coworker, ...).
  - Resolution is **clause-scoped** (bounded by `.`/`!`/`?`/`;`) so a subject named in a previous sentence does not leak across a boundary; the **nearest cue wins**, and on a tie the more specific `other` beats `family`.
  - Reuses `PATIENT_EXPERIENCER` / `FAMILY_EXPERIENCER` from `clinical.context` rather than redefining them.
- **`openmed/clinical/__init__.py`** - re-export the public surface.
- **`docs/clinical/experiencer-refinement.md`** - subjects, resolution order, and usage.

## Resolution order

1. **Cue** - the nearest subject cue within the span`s clause (`source="cue"`).
2. **Section prior** - `section_experiencer` when supplied and no cue is found (`source="section"`).
3. **Default** - patient (`source="default"`). An explicit cue always overrides the section prior.

## Acceptance criteria

- [x] Distinguishes patient, family member, and other subjects (new `other` value).
- [x] Refines beyond section-level scoping via local cues, with clause-bounded scope so prior-sentence subjects do not attach.
- [x] Cue precedence over the section prior; section prior as fallback; patient as default; `source` provenance on every result.
- [x] Deterministic and offline; offsets stable under Unicode (NFC) normalization; no new dependencies.

## Testing

- New `tests/unit/clinical/test_experiencer_refine.py` (12 tests): family/other cue detection, patient default, section fallback, cue-over-section precedence, clause scoping, nearest-cue tie-break, NFC stability, exposed values/advisory.
- Full offline unit suite: `3801 passed, 55 skipped`. `ruff check` / `format` clean (0.15.20). No new dependencies.

## Out of scope

- Temporality / negation / uncertainty axes (handled by their own layers).
- Coreference-style aggregation that consumes this axis (OM-570, which this blocks).

Closes #876