### PR TITLE
fix: reject duplicate resource ids in FHIR Bundle assembler (#530)

### DIFF
--- a/openmed/clinical/exporters/fhir/bundle.py
+++ b/openmed/clinical/exporters/fhir/bundle.py
@@ -65,6 +65,15 @@ def to_bundle(
     -------
     dict
         A ``resourceType=Bundle`` mapping with one entry per resource.
+
+    Raises
+    ------
+    ValueError
+        If a resource lacks a ``resourceType``, or if two resources share the
+        same ``resourceType`` and ``id``. Duplicate ids would silently
+        overwrite one another in the internal reference map, corrupting
+        cross-references, so they are rejected explicitly. Resources without
+        an ``id`` remain valid (they are simply unreferenceable).
     """
 
     entries: list[dict[str, Any]] = []
@@ -83,7 +92,14 @@ def to_bundle(
     for urn, resource in zip(urns, resources):
         resource_id = resource.get("id")
         if resource_id is not None:
-            reference_map[f"{resource['resourceType']}/{resource_id}"] = urn
+            ref_key = f"{resource['resourceType']}/{resource_id}"
+            if ref_key in reference_map:
+                raise ValueError(
+                    f"duplicate resource id {ref_key!r}: two resources share "
+                    "the same resourceType and id, which would silently "
+                    "corrupt internal cross-references"
+                )
+            reference_map[ref_key] = urn
 
     emit_request = bundle_type in _REQUEST_BUNDLE_TYPES
     for urn, resource in zip(urns, resources):

--- a/tests/unit/clinical/test_fhir_bundle.py
+++ b/tests/unit/clinical/test_fhir_bundle.py
@@ -209,3 +209,56 @@ def test_rewrite_references_is_pure_helper():
     assert rewritten["result"][0]["reference"] == "urn:uuid:abc"
     # original untouched
     assert node["result"][0]["reference"] == "Observation/obs1"
+
+
+class TestDuplicateResourceIds:
+    """Regression tests for duplicate ``ResourceType/id`` detection (OM-340)."""
+
+    def test_duplicate_resource_id_raises(self):
+        # Two resources with the same resourceType and id would silently
+        # overwrite each other in the reference map, corrupting cross-
+        # references. The assembler must reject this explicitly.
+        resources = [
+            {"resourceType": "Observation", "id": "obs1", "status": "final"},
+            {"resourceType": "Observation", "id": "obs1", "status": "final"},
+        ]
+        with pytest.raises(ValueError, match="duplicate resource id"):
+            to_bundle(resources, doc_id="doc-1")
+
+    def test_duplicate_id_error_names_colliding_key(self):
+        resources = [
+            {"resourceType": "Patient", "id": "pat1"},
+            {"resourceType": "Patient", "id": "pat1"},
+        ]
+        with pytest.raises(ValueError, match=r"Patient/pat1"):
+            to_bundle(resources, doc_id="doc-1")
+
+    def test_resources_without_id_do_not_collide(self):
+        # Resources without an id are unreferenceable, which is valid; two
+        # id-less resources of the same type must not raise.
+        resources = [
+            {"resourceType": "Observation", "status": "final"},
+            {"resourceType": "Observation", "status": "final"},
+        ]
+        bundle = to_bundle(resources, doc_id="doc-1")
+        assert len(bundle["entry"]) == 2
+
+    def test_same_id_different_resource_type_is_allowed(self):
+        # "Observation/1" and "Patient/1" are distinct keys, so no collision.
+        resources = [
+            {"resourceType": "Observation", "id": "1", "status": "final"},
+            {"resourceType": "Patient", "id": "1"},
+        ]
+        bundle = to_bundle(resources, doc_id="doc-1")
+        assert len(bundle["entry"]) == 2
+
+    def test_duplicate_id_raises_before_any_entry_emitted(self):
+        # The error should surface regardless of where the duplicate appears
+        # in the input sequence.
+        resources = [
+            {"resourceType": "Condition", "id": "c1"},
+            {"resourceType": "Observation", "id": "obs1"},
+            {"resourceType": "Condition", "id": "c1"},
+        ]
+        with pytest.raises(ValueError, match=r"Condition/c1"):
+            to_bundle(resources, doc_id="doc-1")


### PR DESCRIPTION
## Summary
- Detect duplicate `ResourceType/id` keys while building `reference_map` and raise a clear `ValueError`.
- The error message explains that two resources share the same key.

Closes #530