### PR TITLE
fix: keep Pages deployments from cancelling

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,7 +12,9 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  # Pages deployments should finish once started; cancelling them can leave
+  # the final deploy-pages handoff in a failed state during merge bursts.
+  cancel-in-progress: false
 
 jobs:
   deploy:


### PR DESCRIPTION
## Description
Fixes the intermittent `Deploy Docs to GitHub Pages` failure seen on master at https://github.com/maziyarpanahi/openmed/actions/runs/28715979515/job/85157353727. The MkDocs build and artifact upload succeeded there; the failure happened during the final `actions/deploy-pages@v5` handoff with `Deployment failed, try again later.`

The workflow was cancelling in-progress Pages deployments during merge bursts. GitHub Pages starter workflows use `cancel-in-progress: false` for this deployment group so production deploys can finish once started. This PR aligns OpenMed with that behavior and leaves the docs build/deploy actions unchanged.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Changes Made
- Change Pages workflow concurrency from `cancel-in-progress: true` to `false`.
- Add a short workflow comment explaining why Pages deployments should be allowed to finish.

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Validation run:
- `actionlint .github/workflows/pages.yml`
- `uv run python scripts/release/check_github_actions_refs.py`
- `uv run --extra docs mkdocs build --strict`

## Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

Not applicable; this is a workflow-only fix.

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Related to failing master Pages job: https://github.com/maziyarpanahi/openmed/actions/runs/28715979515/job/85157353727

## Screenshots/Examples
Not applicable.