### PR TITLE
Add training provenance reproducibility gate

### DIFF
--- a/.github/workflows/repro-provenance.yml
+++ b/.github/workflows/repro-provenance.yml
@@ -1,0 +1,125 @@
+name: Reproducibility Provenance Gate
+
+on:
+  pull_request:
+    branches: [main, master, develop]
+    paths:
+      - ".github/workflows/repro-provenance.yml"
+      - ".github/workflows/reproducible-lock.yml"
+      - "openmed/core/repro_hash.py"
+      - "openmed/core/model_card.py"
+      - "openmed/core/manifest_schema.py"
+      - "openmed/eval/data_provenance.py"
+      - "scripts/release/verify_provenance.py"
+      - "models.jsonl"
+      - "**/training_provenance.json"
+  workflow_dispatch:
+    inputs:
+      checkpoint-dir:
+        description: "Checkpoint directory containing training_provenance.json"
+        required: false
+        type: string
+      provenance:
+        description: "Explicit training_provenance.json path"
+        required: false
+        type: string
+      manifest:
+        description: "models.jsonl path for manifest hash cross-checking"
+        required: false
+        default: "models.jsonl"
+        type: string
+      model-card:
+        description: "Rendered model card README.md path"
+        required: false
+        type: string
+      repo-id:
+        description: "Repo id to select from the manifest"
+        required: false
+        type: string
+
+jobs:
+  training-provenance:
+    name: Verify training provenance
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Install verifier dependencies
+        run: uv sync --frozen --extra dev --python 3.11
+
+      - name: Verify candidate provenance
+        env:
+          CHECKPOINT_DIR: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['checkpoint-dir'] || '' }}
+          PROVENANCE_PATH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.provenance || '' }}
+          MANIFEST_PATH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.manifest || 'models.jsonl' }}
+          MODEL_CARD_PATH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['model-card'] || '' }}
+          REPO_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['repo-id'] || '' }}
+        run: |
+          set -euo pipefail
+
+          verify_one() {
+            local provenance="$1"
+            local args=(scripts/release/verify_provenance.py --provenance "$provenance")
+            if [ -n "$MANIFEST_PATH" ]; then
+              args+=(--manifest "$MANIFEST_PATH")
+            fi
+            if [ -n "$MODEL_CARD_PATH" ]; then
+              args+=(--model-card "$MODEL_CARD_PATH")
+            fi
+            if [ -n "$REPO_ID" ]; then
+              args+=(--repo-id "$REPO_ID")
+            fi
+            uv run python "${args[@]}"
+          }
+
+          if [ -n "$CHECKPOINT_DIR" ] && [ -n "$PROVENANCE_PATH" ]; then
+            echo "::error title=Ambiguous candidate::Use checkpoint-dir or provenance, not both."
+            exit 1
+          fi
+
+          if [ -n "$CHECKPOINT_DIR" ]; then
+            args=(scripts/release/verify_provenance.py --checkpoint-dir "$CHECKPOINT_DIR")
+            if [ -n "$MANIFEST_PATH" ]; then
+              args+=(--manifest "$MANIFEST_PATH")
+            fi
+            if [ -n "$MODEL_CARD_PATH" ]; then
+              args+=(--model-card "$MODEL_CARD_PATH")
+            fi
+            if [ -n "$REPO_ID" ]; then
+              args+=(--repo-id "$REPO_ID")
+            fi
+            uv run python "${args[@]}"
+            exit 0
+          fi
+
+          if [ -n "$PROVENANCE_PATH" ]; then
+            verify_one "$PROVENANCE_PATH"
+            exit 0
+          fi
+
+          mapfile -t candidates < <(find . \
+            -path "./.git" -prune -o \
+            -name "training_provenance.json" -type f -print | sort)
+
+          if [ "${#candidates[@]}" -eq 0 ]; then
+            echo "No training provenance candidate found in this change."
+            exit 0
+          fi
+
+          for candidate in "${candidates[@]}"; do
+            verify_one "$candidate"
+          done

--- a/.github/workflows/reproducible-lock.yml
+++ b/.github/workflows/reproducible-lock.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.digest.outputs.digest }}
+      uv_lock_sha256: ${{ steps.digest.outputs.uv_lock_sha256 }}
 
     steps:
       - uses: actions/checkout@v7
@@ -159,6 +160,7 @@ jobs:
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as gh:
               gh.write(f"digest={digest}\n")
+              gh.write(f"uv_lock_sha256=sha256:{lock_hash}\n")
           PYEOF
 
       - name: Upload reproducibility digest artifact
@@ -256,6 +258,7 @@ jobs:
         run: |
           echo "Lock gate passed."
           echo "Reproducibility digest: ${{ needs.lock-integrity.outputs.digest }}"
+          echo "uv.lock sha256: ${{ needs.lock-integrity.outputs.uv_lock_sha256 }}"
           echo ""
           echo "This confirms:"
           echo "  - Every transitive dependency is pinned to an exact version."

--- a/openmed/core/manifest_schema.py
+++ b/openmed/core/manifest_schema.py
@@ -34,12 +34,36 @@ OPTIONAL_ENRICHMENT_FIELDS = frozenset(
         "latency_ms",
         "peak_ram_mb",
         "recommended_tier",
+        "training_provenance",
     }
 )
 MANIFEST_FIELDS = REQUIRED_FIELDS | OPTIONAL_ENRICHMENT_FIELDS
 BENCHMARK_FIELDS = frozenset({"dataset", "micro_f1", "recall"})
 BENCHMARK_SUITE_FIELDS = frozenset(
     {"suite", "dataset", "micro_f1", "recall", "leakage"}
+)
+TRAINING_PROVENANCE_REQUIRED_FIELDS = frozenset(
+    {
+        "base_model_revision",
+        "data_manifest_hash",
+        "env_lock_digest",
+        "git_sha",
+        "recipe_config_hash",
+        "reproducibility_hash",
+        "rng_seeds",
+    }
+)
+TRAINING_PROVENANCE_OPTIONAL_FIELDS = frozenset(
+    {
+        "base_model",
+        "checkpoint_id",
+        "path",
+        "repo_id",
+        "schema_version",
+    }
+)
+TRAINING_PROVENANCE_FIELDS = (
+    TRAINING_PROVENANCE_REQUIRED_FIELDS | TRAINING_PROVENANCE_OPTIONAL_FIELDS
 )
 
 ALLOWED_TIERS = ("Tiny", "Small", "Base", "Medium", "Large", "XLarge")
@@ -284,6 +308,14 @@ def validate_manifest_row(row: Any, line_number: int) -> list[ManifestViolation]
                 )
             )
 
+    if "training_provenance" in row:
+        _validate_training_provenance(
+            violations,
+            line_number,
+            row["training_provenance"],
+            row.get("reproducibility_hash"),
+        )
+
     return violations
 
 
@@ -457,6 +489,113 @@ def _validate_number_map(
                     f"{field}.{device} must be a non-negative number",
                 )
             )
+
+
+def _validate_training_provenance(
+    violations: list[ManifestViolation],
+    line_number: int,
+    value: Any,
+    row_reproducibility_hash: Any,
+) -> None:
+    if not isinstance(value, Mapping):
+        violations.append(
+            ManifestViolation(line_number, "training_provenance must be an object")
+        )
+        return
+
+    fields = set(value)
+    for field in sorted(TRAINING_PROVENANCE_REQUIRED_FIELDS - fields):
+        violations.append(
+            ManifestViolation(
+                line_number,
+                f"training_provenance missing required key: {field}",
+            )
+        )
+    for field in sorted(fields - TRAINING_PROVENANCE_FIELDS):
+        violations.append(
+            ManifestViolation(
+                line_number,
+                f"training_provenance unexpected key: {field}",
+            )
+        )
+
+    for field in (
+        "data_manifest_hash",
+        "env_lock_digest",
+        "recipe_config_hash",
+        "reproducibility_hash",
+    ):
+        if field not in value:
+            continue
+        digest = value[field]
+        if not isinstance(digest, str) or not REPRODUCIBILITY_HASH_RE.fullmatch(digest):
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    f"training_provenance.{field} must match "
+                    "sha256:<64 lowercase hex characters>",
+                )
+            )
+
+    for field in (
+        "base_model",
+        "base_model_revision",
+        "checkpoint_id",
+        "git_sha",
+        "path",
+        "repo_id",
+        "schema_version",
+    ):
+        if field in value and (
+            not isinstance(value[field], str) or not value[field].strip()
+        ):
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    f"training_provenance.{field} must be a non-empty string",
+                )
+            )
+
+    seeds = value.get("rng_seeds")
+    if "rng_seeds" in value:
+        if not isinstance(seeds, Mapping) or not seeds:
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    "training_provenance.rng_seeds must be a non-empty object",
+                )
+            )
+        else:
+            for key, seed in seeds.items():
+                if not isinstance(key, str) or not key:
+                    violations.append(
+                        ManifestViolation(
+                            line_number,
+                            "training_provenance.rng_seeds keys must be "
+                            "non-empty strings",
+                        )
+                    )
+                if isinstance(seed, bool) or not isinstance(seed, int):
+                    violations.append(
+                        ManifestViolation(
+                            line_number,
+                            f"training_provenance.rng_seeds.{key} must be an integer",
+                        )
+                    )
+
+    provenance_hash = value.get("reproducibility_hash")
+    if (
+        isinstance(provenance_hash, str)
+        and isinstance(row_reproducibility_hash, str)
+        and provenance_hash != row_reproducibility_hash
+    ):
+        violations.append(
+            ManifestViolation(
+                line_number,
+                "training_provenance.reproducibility_hash must match "
+                "reproducibility_hash",
+            )
+        )
 
 
 def _validate_metric(

--- a/openmed/core/model_card.py
+++ b/openmed/core/model_card.py
@@ -69,6 +69,9 @@ def render_model_card(row: dict[str, Any]) -> str:
     distillation_lines = _distillation_block(row)
     if distillation_lines:
         lines.extend(["", "## Distillation Evidence", "", *distillation_lines])
+    training_provenance_lines = _training_provenance_block(row)
+    if training_provenance_lines:
+        lines.extend(["", "## Training Provenance", "", *training_provenance_lines])
     return "\n".join(lines) + "\n"
 
 
@@ -214,6 +217,33 @@ def _distillation_payload(row: dict[str, Any]) -> dict[str, Any]:
     if isinstance(evidence, dict) and isinstance(evidence.get("distillation"), dict):
         return evidence["distillation"]
     return {}
+
+
+def _training_provenance_block(row: dict[str, Any]) -> list[str]:
+    payload = row.get("training_provenance")
+    if not isinstance(payload, dict):
+        return []
+
+    seeds = payload.get("rng_seeds")
+    seed_text = "Not reported"
+    if isinstance(seeds, dict) and seeds:
+        seed_text = ", ".join(
+            f"`{str(key)}`={value}" for key, value in sorted(seeds.items())
+        )
+
+    lines = [
+        "| Field | Value |",
+        "|---|---|",
+        f"| Provenance file | `{_string(payload.get('path'), 'training_provenance.json')}` |",
+        f"| Base model revision | `{_string(payload.get('base_model_revision'), 'Not reported')}` |",
+        f"| Git SHA | `{_string(payload.get('git_sha'), 'Not reported')}` |",
+        f"| RNG seeds | {seed_text} |",
+        f"| Data manifest hash | `{_string(payload.get('data_manifest_hash'), 'Not reported')}` |",
+        f"| Recipe config hash | `{_string(payload.get('recipe_config_hash'), 'Not reported')}` |",
+        f"| Environment lock digest | `{_string(payload.get('env_lock_digest'), 'Not reported')}` |",
+        f"| Provenance reproducibility hash | `{_string(payload.get('reproducibility_hash'), 'Not reported')}` |",
+    ]
+    return lines
 
 
 def _gate_status(value: Any) -> str:

--- a/openmed/core/repro_hash.py
+++ b/openmed/core/repro_hash.py
@@ -5,9 +5,34 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Any, Mapping
+
+TRAINING_PROVENANCE_FILENAME = "training_provenance.json"
+TRAINING_PROVENANCE_SCHEMA_VERSION = "openmed.training_provenance.v1"
+
+_SHA256_DIGEST_RE = re.compile(r"^(?:sha256:)?[0-9a-f]{64}$")
+_MODEL_CARD_REPRO_HASH_RE = re.compile(
+    r"^\|\s*Reproducibility hash\s*\|\s*`(?P<hash>sha256:[0-9a-f]{64})`\s*\|$",
+    re.MULTILINE,
+)
+_REQUIRED_TRAINING_PROVENANCE_FIELDS = (
+    "schema_version",
+    "rng_seeds",
+    "data_manifest_hash",
+    "recipe_config_hash",
+    "env_lock_digest",
+    "base_model",
+    "base_model_revision",
+    "git_sha",
+    "reproducibility_hash",
+)
+
+
+class ReproducibilityVerificationError(ValueError):
+    """Raised when a training provenance record cannot be verified."""
 
 
 def compute_reproducibility_hash(
@@ -16,8 +41,16 @@ def compute_reproducibility_hash(
     data_manifest: Any,
     base_model: Any,
     git_sha: str | None = None,
+    rng_seeds: Mapping[str, int] | None = None,
+    recipe_config_hash: str | None = None,
+    env_lock_digest: str | None = None,
 ) -> str:
-    """Return ``sha256(recipe + data manifest + base model + git SHA)``."""
+    """Return a deterministic ``sha256:`` hash for reproducible artifacts.
+
+    Existing release hashes cover recipe, data manifest, base model, and git SHA.
+    Training checkpoints can additionally fold in explicit RNG seeds, the recipe
+    config file digest, and the resolved environment lock digest.
+    """
 
     payload = {
         "base_model": _normalise_component(base_model),
@@ -25,6 +58,18 @@ def compute_reproducibility_hash(
         "git_sha": git_sha or resolve_git_sha(),
         "recipe": _normalise_component(recipe),
     }
+    if rng_seeds is not None:
+        payload["rng_seeds"] = _normalise_seed_set(rng_seeds)
+    if recipe_config_hash is not None:
+        payload["recipe_config_hash"] = _normalise_digest(
+            recipe_config_hash,
+            "recipe_config_hash",
+        )
+    if env_lock_digest is not None:
+        payload["env_lock_digest"] = _normalise_digest(
+            env_lock_digest,
+            "env_lock_digest",
+        )
     encoded = json.dumps(
         payload,
         ensure_ascii=False,
@@ -32,6 +77,165 @@ def compute_reproducibility_hash(
         separators=(",", ":"),
     ).encode("utf-8")
     return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def compute_file_digest(path: str | Path) -> str:
+    """Return ``sha256:<digest>`` for one file."""
+
+    return f"sha256:{_file_sha256(Path(path))}"
+
+
+def compute_environment_lock_digest(lock_path: str | Path = "uv.lock") -> str:
+    """Return the uv.lock digest used by the reproducible-lock gate."""
+
+    return compute_file_digest(lock_path)
+
+
+def compute_training_reproducibility_hash(
+    *,
+    rng_seeds: Mapping[str, int],
+    data_manifest_hash: str,
+    recipe_config_hash: str,
+    env_lock_digest: str,
+    base_model: str,
+    base_model_revision: str,
+    git_sha: str,
+) -> str:
+    """Return the checkpoint hash from pinned training provenance inputs."""
+
+    recipe_hash = _normalise_digest(recipe_config_hash, "recipe_config_hash")
+    data_hash = _normalise_digest(data_manifest_hash, "data_manifest_hash")
+    lock_digest = _normalise_digest(env_lock_digest, "env_lock_digest")
+    model = {
+        "id": _required_string(base_model, "base_model"),
+        "revision": _required_string(base_model_revision, "base_model_revision"),
+    }
+    return compute_reproducibility_hash(
+        recipe={"config_hash": recipe_hash},
+        data_manifest={"hash": data_hash},
+        base_model=model,
+        git_sha=_required_string(git_sha, "git_sha"),
+        rng_seeds=_normalise_seed_set(rng_seeds),
+        recipe_config_hash=recipe_hash,
+        env_lock_digest=lock_digest,
+    )
+
+
+def build_training_provenance(
+    *,
+    rng_seeds: Mapping[str, int],
+    data_manifest_hash: str,
+    recipe_config_hash: str,
+    env_lock_digest: str,
+    base_model: str,
+    base_model_revision: str,
+    git_sha: str | None = None,
+    repo_id: str | None = None,
+    checkpoint_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a complete ``training_provenance.json`` payload."""
+
+    resolved_git_sha = git_sha or resolve_git_sha()
+    seeds = _normalise_seed_set(rng_seeds)
+    data_hash = _normalise_digest(data_manifest_hash, "data_manifest_hash")
+    recipe_hash = _normalise_digest(recipe_config_hash, "recipe_config_hash")
+    lock_digest = _normalise_digest(env_lock_digest, "env_lock_digest")
+    payload: dict[str, Any] = {
+        "schema_version": TRAINING_PROVENANCE_SCHEMA_VERSION,
+        "base_model": _required_string(base_model, "base_model"),
+        "base_model_revision": _required_string(
+            base_model_revision,
+            "base_model_revision",
+        ),
+        "data_manifest_hash": data_hash,
+        "env_lock_digest": lock_digest,
+        "git_sha": _required_string(resolved_git_sha, "git_sha"),
+        "rng_seeds": seeds,
+        "recipe_config_hash": recipe_hash,
+    }
+    if repo_id is not None:
+        payload["repo_id"] = _required_string(repo_id, "repo_id")
+    if checkpoint_id is not None:
+        payload["checkpoint_id"] = _required_string(checkpoint_id, "checkpoint_id")
+    payload["reproducibility_hash"] = compute_training_reproducibility_hash(
+        rng_seeds=seeds,
+        data_manifest_hash=data_hash,
+        recipe_config_hash=recipe_hash,
+        env_lock_digest=lock_digest,
+        base_model=payload["base_model"],
+        base_model_revision=payload["base_model_revision"],
+        git_sha=payload["git_sha"],
+    )
+    return payload
+
+
+def write_training_provenance(
+    checkpoint_dir: str | Path,
+    provenance: Mapping[str, Any],
+    *,
+    filename: str = TRAINING_PROVENANCE_FILENAME,
+) -> Path:
+    """Write ``training_provenance.json`` into a checkpoint directory."""
+
+    verified = _normalise_training_provenance(provenance)
+    verify_reproducibility(verified)
+    output_dir = Path(checkpoint_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / filename
+    path.write_text(
+        json.dumps(
+            verified,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def load_training_provenance(path: str | Path) -> dict[str, Any]:
+    """Load and validate a training provenance JSON file."""
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ReproducibilityVerificationError("training provenance must be an object")
+    return _normalise_training_provenance(payload)
+
+
+def verify_reproducibility(
+    provenance: Mapping[str, Any] | str | Path,
+    *,
+    manifest_row: Mapping[str, Any] | None = None,
+    model_card_text: str | None = None,
+) -> str:
+    """Re-derive and verify the recorded training reproducibility hash."""
+
+    payload = (
+        load_training_provenance(provenance)
+        if isinstance(provenance, (str, Path))
+        else _normalise_training_provenance(provenance)
+    )
+    recorded = payload["reproducibility_hash"]
+    expected = compute_training_reproducibility_hash(
+        rng_seeds=payload["rng_seeds"],
+        data_manifest_hash=payload["data_manifest_hash"],
+        recipe_config_hash=payload["recipe_config_hash"],
+        env_lock_digest=payload["env_lock_digest"],
+        base_model=payload["base_model"],
+        base_model_revision=payload["base_model_revision"],
+        git_sha=payload["git_sha"],
+    )
+    if recorded != expected:
+        raise ReproducibilityVerificationError(
+            "recorded reproducibility_hash does not match pinned training inputs"
+        )
+    if manifest_row is not None:
+        _verify_manifest_row_hash(manifest_row, recorded)
+    if model_card_text is not None:
+        _verify_model_card_hash(model_card_text, recorded)
+    return recorded
 
 
 def resolve_git_sha(*, cwd: str | Path | None = None) -> str:
@@ -73,6 +277,108 @@ def _normalise_component(value: Any) -> Any:
     return value
 
 
+def _normalise_training_provenance(provenance: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(provenance)
+    missing = [
+        field
+        for field in _REQUIRED_TRAINING_PROVENANCE_FIELDS
+        if field not in payload or payload[field] in (None, "")
+    ]
+    if missing:
+        fields = ", ".join(missing)
+        raise ReproducibilityVerificationError(
+            f"missing required training provenance fields: {fields}"
+        )
+
+    if payload["schema_version"] != TRAINING_PROVENANCE_SCHEMA_VERSION:
+        raise ReproducibilityVerificationError(
+            "unsupported training provenance schema_version: "
+            f"{payload['schema_version']!r}"
+        )
+
+    normalised = dict(payload)
+    normalised["rng_seeds"] = _normalise_seed_set(payload["rng_seeds"])
+    for field in (
+        "data_manifest_hash",
+        "recipe_config_hash",
+        "env_lock_digest",
+        "reproducibility_hash",
+    ):
+        normalised[field] = _normalise_digest(str(payload[field]), field)
+    for field in ("base_model", "base_model_revision", "git_sha"):
+        normalised[field] = _required_string(payload[field], field)
+    if "repo_id" in normalised:
+        normalised["repo_id"] = _required_string(normalised["repo_id"], "repo_id")
+    if "checkpoint_id" in normalised:
+        normalised["checkpoint_id"] = _required_string(
+            normalised["checkpoint_id"],
+            "checkpoint_id",
+        )
+    return normalised
+
+
+def _normalise_seed_set(seeds: Mapping[str, Any]) -> dict[str, int]:
+    if not isinstance(seeds, Mapping) or not seeds:
+        raise ReproducibilityVerificationError("rng_seeds must be a non-empty object")
+
+    normalised: dict[str, int] = {}
+    for key, value in sorted(seeds.items(), key=lambda item: str(item[0])):
+        seed_name = _required_string(key, "rng_seeds key")
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ReproducibilityVerificationError(
+                f"rng_seeds.{seed_name} must be an integer"
+            )
+        normalised[seed_name] = int(value)
+    return normalised
+
+
+def _normalise_digest(value: str, field: str) -> str:
+    digest = value.strip()
+    if not _SHA256_DIGEST_RE.fullmatch(digest):
+        raise ReproducibilityVerificationError(
+            f"{field} must match sha256:<64 lowercase hex characters>"
+        )
+    if digest.startswith("sha256:"):
+        return digest
+    return f"sha256:{digest}"
+
+
+def _required_string(value: Any, field: str) -> str:
+    text = str(value).strip()
+    if not text:
+        raise ReproducibilityVerificationError(f"{field} must be a non-empty string")
+    return text
+
+
+def _verify_manifest_row_hash(row: Mapping[str, Any], recorded_hash: str) -> None:
+    manifest_hash = row.get("reproducibility_hash")
+    if manifest_hash != recorded_hash:
+        raise ReproducibilityVerificationError(
+            "manifest reproducibility_hash does not match training provenance"
+        )
+
+    training_provenance = row.get("training_provenance")
+    if isinstance(training_provenance, Mapping):
+        embedded_hash = training_provenance.get("reproducibility_hash")
+        if embedded_hash is not None and embedded_hash != recorded_hash:
+            raise ReproducibilityVerificationError(
+                "manifest training_provenance.reproducibility_hash does not "
+                "match training provenance"
+            )
+
+
+def _verify_model_card_hash(model_card_text: str, recorded_hash: str) -> None:
+    match = _MODEL_CARD_REPRO_HASH_RE.search(model_card_text)
+    if match is None:
+        raise ReproducibilityVerificationError(
+            "model card is missing a reproducibility hash row"
+        )
+    if match.group("hash") != recorded_hash:
+        raise ReproducibilityVerificationError(
+            "model card reproducibility hash does not match training provenance"
+        )
+
+
 def _path_component(path: Path) -> dict[str, Any]:
     if path.is_file():
         return {
@@ -102,4 +408,17 @@ def _file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-__all__ = ["compute_reproducibility_hash", "resolve_git_sha"]
+__all__ = [
+    "TRAINING_PROVENANCE_FILENAME",
+    "TRAINING_PROVENANCE_SCHEMA_VERSION",
+    "ReproducibilityVerificationError",
+    "build_training_provenance",
+    "compute_environment_lock_digest",
+    "compute_file_digest",
+    "compute_reproducibility_hash",
+    "compute_training_reproducibility_hash",
+    "load_training_provenance",
+    "resolve_git_sha",
+    "verify_reproducibility",
+    "write_training_provenance",
+]

--- a/openmed/eval/data_provenance.py
+++ b/openmed/eval/data_provenance.py
@@ -1,0 +1,205 @@
+"""PHI-safe training data provenance manifests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+TRAINING_DATA_MANIFEST_SCHEMA_VERSION = "openmed.training_data_manifest.v1"
+
+
+def build_training_data_manifest(
+    fixtures: Iterable[Any],
+    *,
+    dataset_id: str,
+    data_revision: str,
+    source: str | None = None,
+) -> dict[str, Any]:
+    """Build a content-addressed manifest without persisting raw text."""
+
+    entries = sorted(
+        (_fixture_manifest_entry(fixture) for fixture in fixtures),
+        key=lambda entry: entry["fixture_id"],
+    )
+    payload: dict[str, Any] = {
+        "schema_version": TRAINING_DATA_MANIFEST_SCHEMA_VERSION,
+        "data_revision": _required_string(data_revision, "data_revision"),
+        "dataset_id": _required_string(dataset_id, "dataset_id"),
+        "fixture_count": len(entries),
+        "fixtures": entries,
+    }
+    if source is not None:
+        payload["source"] = _required_string(source, "source")
+    payload["manifest_hash"] = compute_training_data_manifest_hash(payload)
+    return payload
+
+
+def compute_training_data_manifest_hash(manifest: Mapping[str, Any]) -> str:
+    """Return the content hash for a training data manifest."""
+
+    payload = dict(manifest)
+    payload.pop("manifest_hash", None)
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def write_training_data_manifest(
+    path: str | Path,
+    fixtures: Iterable[Any],
+    *,
+    dataset_id: str,
+    data_revision: str,
+    source: str | None = None,
+) -> Path:
+    """Write a PHI-safe training data manifest and return its path."""
+
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = build_training_data_manifest(
+        fixtures,
+        dataset_id=dataset_id,
+        data_revision=data_revision,
+        source=source,
+    )
+    output_path.write_text(
+        json.dumps(
+            manifest,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def _fixture_manifest_entry(fixture: Any) -> dict[str, Any]:
+    fixture_id = _fixture_id(fixture)
+    text = _fixture_text(fixture)
+    spans = tuple(
+        _normalise_span(span, source_text=text) for span in _fixture_spans(fixture)
+    )
+    payload: dict[str, Any] = {
+        "fixture_id": fixture_id,
+        "span_count": len(spans),
+        "spans": list(spans),
+        "text_length": len(text),
+        "text_sha256": _hash_text(text),
+    }
+    language = _fixture_language(fixture)
+    if language is not None:
+        payload["language"] = language
+
+    fixture_hash_payload = dict(payload)
+    payload["fixture_hash"] = _hash_json(fixture_hash_payload)
+    return payload
+
+
+def _fixture_id(fixture: Any) -> str:
+    if isinstance(fixture, Mapping):
+        return _required_string(
+            fixture.get("fixture_id") or fixture.get("id"),
+            "fixture_id",
+        )
+    return _required_string(getattr(fixture, "fixture_id", None), "fixture_id")
+
+
+def _fixture_text(fixture: Any) -> str:
+    if isinstance(fixture, Mapping):
+        text = fixture.get("text", "")
+    else:
+        text = getattr(fixture, "text", "")
+    return str(text)
+
+
+def _fixture_language(fixture: Any) -> str | None:
+    if isinstance(fixture, Mapping):
+        value = fixture.get("language") or fixture.get("lang")
+    else:
+        value = getattr(fixture, "language", None)
+    if value is None:
+        return None
+    return _required_string(value, "language")
+
+
+def _fixture_spans(fixture: Any) -> Iterable[Any]:
+    if isinstance(fixture, Mapping):
+        return (
+            fixture.get("gold_spans")
+            or fixture.get("spans")
+            or fixture.get("entities")
+            or []
+        )
+    return getattr(fixture, "gold_spans", ())
+
+
+def _normalise_span(span: Any, *, source_text: str) -> dict[str, Any]:
+    start = _span_int(span, "start")
+    end = _span_int(span, "end")
+    if start < 0 or end < start:
+        raise ValueError(f"invalid span offsets: {start}:{end}")
+    label = _required_string(_span_value(span, "label"), "label")
+    span_text = source_text[start:end] if end <= len(source_text) else _span_text(span)
+    return {
+        "end": end,
+        "label": label,
+        "length": end - start,
+        "start": start,
+        "text_sha256": _hash_text(span_text),
+    }
+
+
+def _span_int(span: Any, field: str) -> int:
+    value = _span_value(span, field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"span {field} must be an integer")
+    return int(value)
+
+
+def _span_value(span: Any, field: str) -> Any:
+    if isinstance(span, Mapping):
+        return span.get(field)
+    return getattr(span, field, None)
+
+
+def _span_text(span: Any) -> str:
+    value = _span_value(span, "text")
+    return "" if value is None else str(value)
+
+
+def _required_string(value: Any, field: str) -> str:
+    text = "" if value is None else str(value).strip()
+    if not text:
+        raise ValueError(f"{field} must be a non-empty string")
+    return text
+
+
+def _hash_text(value: str) -> str:
+    return f"sha256:{hashlib.sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def _hash_json(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+__all__ = [
+    "TRAINING_DATA_MANIFEST_SCHEMA_VERSION",
+    "build_training_data_manifest",
+    "compute_training_data_manifest_hash",
+    "write_training_data_manifest",
+]

--- a/scripts/release/verify_provenance.py
+++ b/scripts/release/verify_provenance.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Verify checkpoint training provenance against pinned inputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from openmed.core.repro_hash import (
+    TRAINING_PROVENANCE_FILENAME,
+    ReproducibilityVerificationError,
+    load_training_provenance,
+    verify_reproducibility,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the training provenance verifier."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--provenance",
+        type=Path,
+        help="Path to training_provenance.json.",
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
+        type=Path,
+        help=(f"Checkpoint directory containing {TRAINING_PROVENANCE_FILENAME}."),
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        help="Optional models.jsonl path for manifest hash cross-checking.",
+    )
+    parser.add_argument(
+        "--model-card",
+        type=Path,
+        help="Optional rendered README.md model card for hash cross-checking.",
+    )
+    parser.add_argument(
+        "--repo-id",
+        help="Repo id to select from --manifest; defaults to provenance repo_id.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        provenance_path = _resolve_provenance_path(args.provenance, args.checkpoint_dir)
+        provenance = load_training_provenance(provenance_path)
+        repo_id = args.repo_id or provenance.get("repo_id")
+        manifest_row = (
+            _load_manifest_row(args.manifest, repo_id) if args.manifest else None
+        )
+        model_card_text = (
+            args.model_card.read_text(encoding="utf-8") if args.model_card else None
+        )
+        verified_hash = verify_reproducibility(
+            provenance,
+            manifest_row=manifest_row,
+            model_card_text=model_card_text,
+        )
+    except (
+        FileNotFoundError,
+        json.JSONDecodeError,
+        ReproducibilityVerificationError,
+        ValueError,
+    ) as exc:
+        print(f"Training provenance quarantined: {exc}", file=sys.stderr)
+        return 1
+
+    print("Training provenance verified")
+    print(f"- provenance: {provenance_path}")
+    print(f"- reproducibility_hash: {verified_hash}")
+    return 0
+
+
+def _resolve_provenance_path(
+    provenance: Path | None,
+    checkpoint_dir: Path | None,
+) -> Path:
+    if provenance is not None and checkpoint_dir is not None:
+        raise ValueError("use either --provenance or --checkpoint-dir, not both")
+    if provenance is not None:
+        return provenance
+    if checkpoint_dir is None:
+        raise ValueError("one of --provenance or --checkpoint-dir is required")
+    path = checkpoint_dir / TRAINING_PROVENANCE_FILENAME
+    if not path.exists():
+        raise FileNotFoundError(
+            f"{TRAINING_PROVENANCE_FILENAME} is missing from {checkpoint_dir}"
+        )
+    return path
+
+
+def _load_manifest_row(path: Path, repo_id: Any) -> dict[str, Any]:
+    selected_repo_id = "" if repo_id is None else str(repo_id).strip()
+    if not selected_repo_id:
+        raise ValueError("--manifest requires --repo-id or provenance repo_id")
+
+    manifest_path = path if path.is_absolute() else ROOT / path
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if row.get("repo_id") == selected_repo_id:
+                return row
+
+    raise ValueError(f"repo_id {selected_repo_id!r} was not found in {manifest_path}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/core/test_manifest_schema.py
+++ b/tests/unit/core/test_manifest_schema.py
@@ -104,6 +104,45 @@ def test_manifest_schema_accepts_mlx_4bit_format():
     assert validate_manifest_row(row, line_number=1) == []
 
 
+def test_manifest_schema_accepts_complete_training_provenance():
+    reproducibility_hash = "sha256:" + "1" * 64
+    row = _manifest_row_fixture(
+        reproducibility_hash=reproducibility_hash,
+        training_provenance=_training_provenance_fixture(reproducibility_hash),
+    )
+
+    assert validate_manifest_row(row, line_number=1) == []
+
+
+def test_manifest_schema_rejects_training_provenance_hash_mismatch():
+    row = _manifest_row_fixture(
+        reproducibility_hash="sha256:" + "1" * 64,
+        training_provenance=_training_provenance_fixture("sha256:" + "2" * 64),
+    )
+
+    violations = validate_manifest_row(row, line_number=1)
+
+    assert [str(item) for item in violations] == [
+        "line 1: training_provenance.reproducibility_hash must match "
+        "reproducibility_hash"
+    ]
+
+
+def test_manifest_schema_rejects_incomplete_training_provenance():
+    training_provenance = _training_provenance_fixture("sha256:" + "1" * 64)
+    training_provenance.pop("rng_seeds")
+    row = _manifest_row_fixture(
+        reproducibility_hash="sha256:" + "1" * 64,
+        training_provenance=training_provenance,
+    )
+
+    violations = validate_manifest_row(row, line_number=1)
+
+    assert [
+        "line 1: training_provenance missing required key: rng_seeds",
+    ] == [str(item) for item in violations]
+
+
 def test_registry_model_ids_are_derived_from_manifest():
     manifest_ids = {row["repo_id"] for row in _rows()}
     registry_ids = {info.model_id for info in model_registry.OPENMED_MODELS.values()}
@@ -194,3 +233,16 @@ def _manifest_row_fixture(**overrides):
     }
     row.update(overrides)
     return row
+
+
+def _training_provenance_fixture(reproducibility_hash: str):
+    return {
+        "base_model_revision": "7b4f2ca",
+        "data_manifest_hash": "sha256:" + "a" * 64,
+        "env_lock_digest": "sha256:" + "b" * 64,
+        "git_sha": "abc123",
+        "path": "checkpoints/model/training_provenance.json",
+        "recipe_config_hash": "sha256:" + "c" * 64,
+        "reproducibility_hash": reproducibility_hash,
+        "rng_seeds": {"numpy": 21, "python": 13, "torch": 34},
+    }

--- a/tests/unit/core/test_model_card.py
+++ b/tests/unit/core/test_model_card.py
@@ -125,6 +125,31 @@ def test_render_model_card_includes_distillation_evidence_when_present():
     assert "| EMAIL | 0.9900 | 0.9700 | -0.0200 | yes |" in card
 
 
+def test_render_model_card_includes_training_provenance_when_present():
+    row = {
+        **_fixture_row(),
+        "training_provenance": {
+            "base_model_revision": "7b4f2ca",
+            "data_manifest_hash": "sha256:" + "a" * 64,
+            "env_lock_digest": "sha256:" + "b" * 64,
+            "git_sha": "abc123",
+            "path": "checkpoints/model/training_provenance.json",
+            "recipe_config_hash": "sha256:" + "c" * 64,
+            "reproducibility_hash": _fixture_row()["reproducibility_hash"],
+            "rng_seeds": {"numpy": 21, "python": 13, "torch": 34},
+        },
+    }
+
+    card = render_model_card(row)
+
+    assert "## Training Provenance" in card
+    assert "| Provenance file | `checkpoints/model/training_provenance.json` |" in card
+    assert "| Base model revision | `7b4f2ca` |" in card
+    assert "| RNG seeds | `numpy`=21, `python`=13, `torch`=34 |" in card
+    assert "| Data manifest hash | `sha256:" in card
+    assert "| Provenance reproducibility hash | `" in card
+
+
 def test_publish_model_card_uploads_rendered_readme():
     row = _fixture_row()
     captured: dict[str, object] = {}

--- a/tests/unit/core/test_repro_hash.py
+++ b/tests/unit/core/test_repro_hash.py
@@ -1,0 +1,117 @@
+"""Tests for training reproducibility provenance hashes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from openmed.core.repro_hash import (
+    ReproducibilityVerificationError,
+    build_training_provenance,
+    compute_environment_lock_digest,
+    compute_reproducibility_hash,
+    load_training_provenance,
+    verify_reproducibility,
+    write_training_provenance,
+)
+
+HASH_A = "sha256:" + "a" * 64
+HASH_B = "sha256:" + "b" * 64
+HASH_C = "sha256:" + "c" * 64
+
+
+def _provenance() -> dict[str, object]:
+    return build_training_provenance(
+        rng_seeds={"python": 13, "numpy": 21, "torch": 34},
+        data_manifest_hash=HASH_A,
+        recipe_config_hash=HASH_B,
+        env_lock_digest=HASH_C,
+        base_model="OpenMed/base-model",
+        base_model_revision="7b4f2ca",
+        git_sha="abc123",
+        repo_id="OpenMed/test-model",
+        checkpoint_id="checkpoint-001",
+    )
+
+
+def test_reproducibility_hash_folds_training_inputs() -> None:
+    base = compute_reproducibility_hash(
+        recipe={"config_hash": HASH_B},
+        data_manifest={"hash": HASH_A},
+        base_model={"id": "OpenMed/base-model", "revision": "7b4f2ca"},
+        git_sha="abc123",
+        rng_seeds={"python": 13, "numpy": 21},
+        recipe_config_hash=HASH_B,
+        env_lock_digest=HASH_C,
+    )
+    changed_seed = compute_reproducibility_hash(
+        recipe={"config_hash": HASH_B},
+        data_manifest={"hash": HASH_A},
+        base_model={"id": "OpenMed/base-model", "revision": "7b4f2ca"},
+        git_sha="abc123",
+        rng_seeds={"python": 13, "numpy": 22},
+        recipe_config_hash=HASH_B,
+        env_lock_digest=HASH_C,
+    )
+    changed_lock = compute_reproducibility_hash(
+        recipe={"config_hash": HASH_B},
+        data_manifest={"hash": HASH_A},
+        base_model={"id": "OpenMed/base-model", "revision": "7b4f2ca"},
+        git_sha="abc123",
+        rng_seeds={"python": 13, "numpy": 21},
+        recipe_config_hash=HASH_B,
+        env_lock_digest="sha256:" + "d" * 64,
+    )
+
+    assert base != changed_seed
+    assert base != changed_lock
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", base)
+
+
+def test_verify_reproducibility_rederives_recorded_hash_and_fails_drift() -> None:
+    provenance = _provenance()
+
+    assert verify_reproducibility(provenance) == provenance["reproducibility_hash"]
+
+    drifted = dict(provenance)
+    drifted["rng_seeds"] = {"python": 13, "numpy": 21, "torch": 35}
+    with pytest.raises(
+        ReproducibilityVerificationError,
+        match="does not match pinned training inputs",
+    ):
+        verify_reproducibility(drifted)
+
+
+@pytest.mark.parametrize(
+    "missing", ["rng_seeds", "data_manifest_hash", "env_lock_digest"]
+)
+def test_verify_reproducibility_fails_closed_when_required_fields_are_missing(
+    missing: str,
+) -> None:
+    provenance = _provenance()
+    provenance.pop(missing)
+
+    with pytest.raises(ReproducibilityVerificationError, match=missing):
+        verify_reproducibility(provenance)
+
+
+def test_write_training_provenance_persists_verified_json(tmp_path: Path) -> None:
+    provenance = _provenance()
+
+    path = write_training_provenance(tmp_path / "checkpoint", provenance)
+
+    assert path.name == "training_provenance.json"
+    assert load_training_provenance(path) == provenance
+    assert json.loads(path.read_text(encoding="utf-8")) == provenance
+
+
+def test_environment_lock_digest_matches_uv_lock_sha256(tmp_path: Path) -> None:
+    lock = tmp_path / "uv.lock"
+    lock.write_text('[[package]]\nname = "demo"\nversion = "1.0.0"\n')
+    expected = hashlib.sha256(lock.read_bytes()).hexdigest()
+
+    assert compute_environment_lock_digest(lock) == f"sha256:{expected}"

--- a/tests/unit/eval/test_data_provenance.py
+++ b/tests/unit/eval/test_data_provenance.py
@@ -1,0 +1,96 @@
+"""Tests for PHI-safe training data provenance manifests."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from openmed.eval.data_provenance import (
+    build_training_data_manifest,
+    compute_training_data_manifest_hash,
+    write_training_data_manifest,
+)
+
+
+def _fixture() -> dict[str, object]:
+    return {
+        "fixture_id": "doc-001",
+        "language": "en",
+        "text": "Patient Alice Smith lives in Paris.",
+        "gold_spans": [
+            {"start": 8, "end": 19, "label": "PERSON", "text": "Alice Smith"},
+            {"start": 29, "end": 34, "label": "LOCATION", "text": "Paris"},
+        ],
+    }
+
+
+def test_training_data_manifest_hashes_content_without_persisting_raw_text() -> None:
+    manifest = build_training_data_manifest(
+        [_fixture()],
+        dataset_id="synthetic-pii",
+        data_revision="git:abc123",
+    )
+    serialized = json.dumps(manifest, sort_keys=True)
+
+    assert "Alice" not in serialized
+    assert "Paris" not in serialized
+    assert "Patient" not in serialized
+    assert manifest["data_revision"] == "git:abc123"
+    assert manifest["fixture_count"] == 1
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", manifest["manifest_hash"])
+
+    fixture = manifest["fixtures"][0]
+    assert fixture["fixture_id"] == "doc-001"
+    assert fixture["text_length"] == len(_fixture()["text"])
+    assert fixture["spans"] == [
+        {
+            "end": 19,
+            "label": "PERSON",
+            "length": 11,
+            "start": 8,
+            "text_sha256": fixture["spans"][0]["text_sha256"],
+        },
+        {
+            "end": 34,
+            "label": "LOCATION",
+            "length": 5,
+            "start": 29,
+            "text_sha256": fixture["spans"][1]["text_sha256"],
+        },
+    ]
+    assert all(
+        re.fullmatch(r"sha256:[0-9a-f]{64}", span["text_sha256"])
+        for span in fixture["spans"]
+    )
+
+
+def test_training_data_manifest_hash_is_deterministic() -> None:
+    first = build_training_data_manifest(
+        [_fixture()],
+        dataset_id="synthetic-pii",
+        data_revision="git:abc123",
+    )
+    second = build_training_data_manifest(
+        [_fixture()],
+        data_revision="git:abc123",
+        dataset_id="synthetic-pii",
+    )
+
+    assert first == second
+    assert compute_training_data_manifest_hash(first) == first["manifest_hash"]
+
+
+def test_write_training_data_manifest_outputs_json(tmp_path: Path) -> None:
+    path = write_training_data_manifest(
+        tmp_path / "training-data-manifest.json",
+        [_fixture()],
+        dataset_id="synthetic-pii",
+        data_revision="git:abc123",
+    )
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert path.exists()
+    assert payload["dataset_id"] == "synthetic-pii"
+    assert payload["manifest_hash"] == compute_training_data_manifest_hash(payload)

--- a/tests/unit/release/test_repro_provenance_workflow.py
+++ b/tests/unit/release/test_repro_provenance_workflow.py
@@ -1,0 +1,119 @@
+"""Training provenance workflow and verifier tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from openmed.core.model_card import render_model_card
+from openmed.core.repro_hash import build_training_provenance
+from scripts.release import verify_provenance
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "repro-provenance.yml"
+
+
+def _provenance() -> dict[str, object]:
+    return build_training_provenance(
+        rng_seeds={"python": 13, "numpy": 21, "torch": 34},
+        data_manifest_hash="sha256:" + "a" * 64,
+        recipe_config_hash="sha256:" + "b" * 64,
+        env_lock_digest="sha256:" + "c" * 64,
+        base_model="OpenMed/base-model",
+        base_model_revision="7b4f2ca",
+        git_sha="abc123",
+        repo_id="OpenMed/test-model",
+        checkpoint_id="checkpoint-001",
+    )
+
+
+def _manifest_row(provenance: dict[str, object]) -> dict[str, object]:
+    return {
+        "repo_id": "OpenMed/test-model",
+        "family": "PII",
+        "task": "token-classification",
+        "languages": ["en"],
+        "tier": "Tiny",
+        "param_count": 65_000_000,
+        "architecture": "distilbert",
+        "base_model": "OpenMed/base-model",
+        "formats": ["pytorch"],
+        "canonical_labels": ["PERSON"],
+        "benchmark": {"dataset": None, "micro_f1": None, "recall": None},
+        "arxiv": None,
+        "license": "apache-2.0",
+        "reproducibility_hash": provenance["reproducibility_hash"],
+        "released": "2026-06-24",
+        "training_provenance": {
+            "base_model_revision": provenance["base_model_revision"],
+            "data_manifest_hash": provenance["data_manifest_hash"],
+            "env_lock_digest": provenance["env_lock_digest"],
+            "git_sha": provenance["git_sha"],
+            "path": "checkpoints/model/training_provenance.json",
+            "recipe_config_hash": provenance["recipe_config_hash"],
+            "reproducibility_hash": provenance["reproducibility_hash"],
+            "rng_seeds": provenance["rng_seeds"],
+        },
+    }
+
+
+def test_repro_provenance_workflow_runs_verifier_for_candidates() -> None:
+    workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    content = WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow["on"]["workflow_dispatch"]["inputs"]["checkpoint-dir"]
+    assert "training_provenance.json" in content
+    assert "scripts/release/verify_provenance.py" in content
+    assert "--checkpoint-dir" in content
+    assert "--manifest" in content
+
+
+def test_verify_provenance_cli_checks_hash_manifest_and_model_card(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    provenance = _provenance()
+    row = _manifest_row(provenance)
+    provenance_path = tmp_path / "training_provenance.json"
+    manifest_path = tmp_path / "models.jsonl"
+    model_card_path = tmp_path / "README.md"
+    provenance_path.write_text(
+        json.dumps(provenance, sort_keys=True),
+        encoding="utf-8",
+    )
+    manifest_path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+    model_card_path.write_text(render_model_card(row), encoding="utf-8")
+
+    exit_code = verify_provenance.main(
+        [
+            "--provenance",
+            str(provenance_path),
+            "--manifest",
+            str(manifest_path),
+            "--model-card",
+            str(model_card_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Training provenance verified" in captured.out
+
+
+def test_verify_provenance_cli_quarantines_missing_seeds(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    provenance = _provenance()
+    provenance.pop("rng_seeds")
+    path = tmp_path / "training_provenance.json"
+    path.write_text(json.dumps(provenance, sort_keys=True), encoding="utf-8")
+
+    exit_code = verify_provenance.main(["--provenance", str(path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Training provenance quarantined" in captured.err
+    assert "rng_seeds" in captured.err


### PR DESCRIPTION
# Pull Request

## Description
Adds reproducible training provenance support for checkpoints by pinning RNG seeds, recipe config hashes, data manifest hashes, environment lock digests, base model revisions, and git SHAs into a verifiable `training_provenance.json` contract.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Extends reproducibility hashing and adds training provenance build, write, load, and verify helpers.
- Adds a PHI-safe training data manifest builder that stores hashes, offsets, labels, and revisions without raw text.
- Surfaces training provenance in model cards and validates manifest/provenance hash agreement.
- Adds a release verifier script plus a reproducibility provenance workflow gate.
- Exposes the uv.lock SHA-256 digest from the existing reproducible lock workflow.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/unit/core/test_repro_hash.py tests/unit/eval/test_data_provenance.py tests/unit/core/test_model_card.py tests/unit/core/test_manifest_schema.py tests/unit/release/test_repro_provenance_workflow.py -q`
- `.venv/bin/python -m pytest tests/ -q`
- `uv lock --check`
- `uv run python scripts/release/check_github_actions_refs.py`
- `uv run python scripts/release/check_repo_policy.py`
- `actionlint .github/workflows/repro-provenance.yml .github/workflows/reproducible-lock.yml`
- `git diff --check`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1200

## Screenshots/Examples
Not applicable.
