### PR TITLE
fix(service): replace bare asserts with proper error handling in validators

### DIFF
--- a/openmed/service/auth.py
+++ b/openmed/service/auth.py
@@ -744,7 +744,10 @@ def _validate_jwt_claims(
     now: float,
 ) -> None:
     exp = _numeric_claim(payload, "exp", required=True)
-    assert exp is not None
+    # _numeric_claim with required=True raises invalid_credentials() when
+    # the claim is missing, so exp is guaranteed non-None here.
+    if exp is None:
+        raise invalid_credentials()
     if now > exp + config.jwt_leeway_seconds:
         raise invalid_credentials()
 

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -371,7 +371,8 @@ if PYDANTIC_V2:
         @classmethod
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold must be a valid number")
             return normalized
 
         @field_validator("policy", mode="before")
@@ -738,7 +739,8 @@ else:
         @validator("confidence_threshold", "detector_confidence_floor")
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold must be a valid number")
             return normalized
 
         @validator("policy", pre=True)


### PR DESCRIPTION
## Summary

Replace 3 bare `assert` statements in production service code with explicit error raises. Bare asserts are silently stripped when Python runs with `-O` (optimize) flag, causing validation bypass without any error.

## Affected Files

- `openmed/service/schemas.py` (lines 374, 741) — 2 confidence_threshold validators
- `openmed/service/auth.py` (line 747) — JWT exp claim guard

## Root Cause

Three validators use `assert normalized is not None` instead of the `raise ValueError(...)` pattern used by the same validators at lines 268 and 324 in the same file. This inconsistency means:

1. Running with `python -O` strips the asserts entirely
2. A `None` return from `_normalize_confidence_threshold` passes through silently
3. The Pydantic model accepts invalid confidence values without error

## Fix

| Location | Before | After |
|----------|--------|-------|
| schemas.py:374 | `assert normalized is not None` | `if normalized is None: raise ValueError(...)` |
| schemas.py:741 | `assert normalized is not None` | `if normalized is None: raise ValueError(...)` |
| auth.py:747 | `assert exp is not None` | `if exp is None: raise invalid_credentials()` |

The fix is consistent with the existing pattern at schemas.py:268 and schemas.py:324 which already use `raise ValueError`.
