### PR TITLE
fix: use timezone-aware datetime.now(timezone.utc) for timestamps

### DIFF
--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -29,7 +29,7 @@ import re
 import unicodedata
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Literal, NoReturn, Optional, Sequence
@@ -432,7 +432,7 @@ def _prediction_result_from_privacy_filter_raw(
         text=original_text if do_normalize else text,
         entities=entities,
         model_name=model_name,
-        timestamp=datetime.now().isoformat(),
+        timestamp=datetime.now(timezone.utc).isoformat(),
     )
 
 
@@ -1605,7 +1605,7 @@ def _build_deidentification_result(
         deidentified_text=deidentified,
         pii_entities=pii_entities,
         method=effective_method,
-        timestamp=datetime.now(),
+        timestamp=datetime.now(timezone.utc),
         mapping=mapping,
         metadata=_copy_metadata(getattr(pii_result, "metadata", None)),
         audit_report=audit_report,

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -1761,7 +1761,7 @@ def _prediction_result_from_spans(
     *,
     model_name: str,
 ) -> Any:
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     from ..processing.outputs import EntityPrediction, PredictionResult
 
@@ -1783,7 +1783,7 @@ def _prediction_result_from_spans(
             for span in spans
         ],
         model_name=model_name,
-        timestamp=datetime.now().isoformat(),
+        timestamp=datetime.now(timezone.utc).isoformat(),
     )
 
 

--- a/openmed/processing/batch.py
+++ b/openmed/processing/batch.py
@@ -538,11 +538,11 @@ class BatchProcessor:
         on_progress: Optional[BatchProgressCallback] = None,
     ) -> BatchResult:
         """Internal method to process batch items."""
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         batch_result = BatchResult(
             model_name=self.model_name,
-            started_at=datetime.now().isoformat(),
+            started_at=datetime.now(timezone.utc).isoformat(),
         )
 
         total = len(items)
@@ -562,7 +562,7 @@ class BatchProcessor:
                 )
 
         batch_result.total_processing_time = time.time() - batch_start
-        batch_result.completed_at = datetime.now().isoformat()
+        batch_result.completed_at = datetime.now(timezone.utc).isoformat()
 
         return batch_result
 

--- a/openmed/processing/outputs.py
+++ b/openmed/processing/outputs.py
@@ -5,7 +5,7 @@ import json
 import logging
 import unicodedata
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union
 
 logger = logging.getLogger(__name__)
@@ -219,7 +219,7 @@ class OutputFormatter:
             text=original_text,
             entities=entities,
             model_name=model_name,
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.now(timezone.utc).isoformat(),
             processing_time=kwargs.get("processing_time"),
             metadata=kwargs.get("metadata", {}),
         )


### PR DESCRIPTION
## Summary

Replace 6 instances of `datetime.now()` with `datetime.now(timezone.utc)` to produce timezone-aware timestamps.

## Problem

Naive `datetime.now()` creates timestamps without timezone information. This can cause:

1. **Comparison bugs** — mixing naive and aware datetimes raises `TypeError`
2. **Serialization inconsistencies** — `.isoformat()` output varies by system timezone
3. **Silent data corruption** — distributed deployments across timezones produce inconsistent timestamps

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| processing/outputs.py | 222 | `datetime.now().isoformat()` | `datetime.now(timezone.utc).isoformat()` |
| processing/batch.py | 545 | `datetime.now().isoformat()` | `datetime.now(timezone.utc).isoformat()` |
| processing/batch.py | 565 | `datetime.now().isoformat()` | `datetime.now(timezone.utc).isoformat()` |
| core/pii.py | 435 | `datetime.now().isoformat()` | `datetime.now(timezone.utc).isoformat()` |
| core/pii.py | 1608 | `datetime.now()` | `datetime.now(timezone.utc)` |
| core/pipeline.py | 1786 | `datetime.now().isoformat()` | `datetime.now(timezone.utc).isoformat()` |

## Notes

- All other `datetime.now()` calls in the codebase already use `timezone.utc`
- These 6 were the only remaining naive datetime calls in production code
- Import statements updated to include `timezone`
