### PR TITLE
Add MCP clinical workflow contracts

### DIFF
--- a/openmed/interop/function_tools.py
+++ b/openmed/interop/function_tools.py
@@ -111,6 +111,14 @@ def _tool_handler(
             **kwargs,
             runtime_provider=runtime_provider,
         ),
+        "openmed_ground": lambda **kwargs: mcp_server.openmed_ground(**kwargs),
+        "openmed_export_fhir": lambda **kwargs: mcp_server.openmed_export_fhir(
+            **kwargs
+        ),
+        "openmed_risk_score": lambda **kwargs: mcp_server.openmed_risk_score(**kwargs),
+        "openmed_clinical_pipeline": (
+            lambda **kwargs: mcp_server.openmed_clinical_pipeline(**kwargs)
+        ),
     }
     try:
         return handlers[name]

--- a/openmed/mcp/server.py
+++ b/openmed/mcp/server.py
@@ -21,7 +21,11 @@ from openmed.mcp.tool_registry import (
     render_tool_registry_document,
     validate_registered_tool_output,
 )
-from openmed.mcp.workflow import WorkflowRunner, builtin_workflow_step_executors
+from openmed.mcp.workflow import (
+    WorkflowRunner,
+    builtin_workflow_step_executors,
+    plan_clinical_pipeline,
+)
 from openmed.service.runtime import ServiceRuntime
 from openmed.utils.validation import validate_model_name
 
@@ -357,6 +361,86 @@ def openmed_run_workflow(
     return validate_registered_tool_output("openmed_run_workflow", response)
 
 
+def openmed_ground(
+    spans: list[Dict[str, Any]],
+    vocabularies: Optional[list[str]] = None,
+    max_candidates: int = 5,
+    allow_external_llm: bool = False,
+) -> Dict[str, Any]:
+    """Return the registered grounding contract until runtime work lands."""
+    del vocabularies, max_candidates, allow_external_llm
+    response = {
+        "schema_version": "openmed.ground.v1",
+        "status": "unimplemented",
+        "spans": list(spans),
+        "grounded_concepts": [],
+        "error": _pending_contract_error("ground"),
+    }
+    return validate_registered_tool_output("openmed_ground", response)
+
+
+def openmed_export_fhir(
+    spans: list[Dict[str, Any]],
+    resources: Optional[list[Dict[str, Any]]] = None,
+    doc_id: str = "workflow",
+    bundle_type: str = "collection",
+) -> Dict[str, Any]:
+    """Return the registered FHIR export contract until runtime work lands."""
+    del spans, resources, doc_id, bundle_type
+    response = {
+        "schema_version": "openmed.export_fhir.v1",
+        "status": "unimplemented",
+        "bundle": {},
+        "resource_count": 0,
+        "error": _pending_contract_error("export"),
+    }
+    return validate_registered_tool_output("openmed_export_fhir", response)
+
+
+def openmed_risk_score(
+    spans: list[Dict[str, Any]],
+    deidentified_text: Optional[str] = None,
+    records: Optional[list[Dict[str, Any]]] = None,
+    quasi_identifiers: Optional[list[str]] = None,
+) -> Dict[str, Any]:
+    """Return the registered risk-score contract until runtime work lands."""
+    del spans, deidentified_text, records, quasi_identifiers
+    response = {
+        "schema_version": "openmed.risk_score.v1",
+        "status": "unimplemented",
+        "risk_report": {},
+        "error": _pending_contract_error("risk"),
+    }
+    return validate_registered_tool_output("openmed_risk_score", response)
+
+
+def openmed_clinical_pipeline(
+    stages: list[str],
+    text: Optional[str] = None,
+    spans: Optional[list[Dict[str, Any]]] = None,
+    options: Optional[Dict[str, Any]] = None,
+    allow_external_llm: bool = False,
+    session_id: Optional[str] = None,
+    workflow_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Plan and validate the registered clinical pipeline contract."""
+    del text, spans, options, allow_external_llm, session_id, workflow_id
+    response = plan_clinical_pipeline(stages)
+    return validate_registered_tool_output("openmed_clinical_pipeline", response)
+
+
+def _pending_contract_error(stage: str) -> Dict[str, Any]:
+    return {
+        "code": "handler_pending",
+        "message": (
+            "This MCP tool contract is registered; runtime execution is tracked "
+            "by the next OM-754 child issue."
+        ),
+        "stage": stage,
+        "details": {"implemented": False},
+    }
+
+
 def _workflow_step_executors(
     runtime_provider: Optional[RuntimeProvider],
 ) -> Dict[str, Callable[..., Any]]:
@@ -443,6 +527,12 @@ def _register_tools(
         "openmed_run_workflow": lambda **kwargs: openmed_run_workflow(
             **kwargs,
             runtime_provider=runtime_provider,
+        ),
+        "openmed_ground": lambda **kwargs: openmed_ground(**kwargs),
+        "openmed_export_fhir": lambda **kwargs: openmed_export_fhir(**kwargs),
+        "openmed_risk_score": lambda **kwargs: openmed_risk_score(**kwargs),
+        "openmed_clinical_pipeline": (
+            lambda **kwargs: openmed_clinical_pipeline(**kwargs)
         ),
     }
 

--- a/openmed/mcp/tool_registry.py
+++ b/openmed/mcp/tool_registry.py
@@ -19,6 +19,15 @@ _SEMVER_RE = re.compile(
     r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
 )
 _STABILITY_VALUES = frozenset({"experimental", "stable", "deprecated"})
+_CLINICAL_STAGE_VALUES = (
+    "detect",
+    "context",
+    "sections",
+    "relations",
+    "ground",
+    "export",
+    "risk",
+)
 
 
 class ToolSchemaValidationError(ValueError):
@@ -781,6 +790,134 @@ _WORKFLOW_RESULT_OUTPUT = _object(
         "trace",
     ),
 )
+_OPENMED_SPAN_OUTPUT = _object(
+    properties={
+        "schema_version": _schema("integer"),
+        "doc_id": _schema("string"),
+        "start": _schema("integer", minimum=0),
+        "end": _schema("integer", minimum=0),
+        "text_hash": _schema("string"),
+        "entity_type": _schema("string"),
+        "canonical_label": _schema("string"),
+        "policy_label": _schema("string"),
+        "regulatory_tags": _array(_schema("string")),
+        "score": _nullable("number", minimum=0.0, maximum=1.0),
+        "detector": _nullable("string"),
+        "evidence": _object(),
+        "action": _schema("string"),
+        "replacement": _nullable("string"),
+        "reversible_id": _nullable("string"),
+        "section": _nullable("string"),
+        "metadata": _object(),
+    },
+    required=(
+        "schema_version",
+        "doc_id",
+        "start",
+        "end",
+        "text_hash",
+        "entity_type",
+        "canonical_label",
+        "policy_label",
+        "regulatory_tags",
+        "score",
+        "detector",
+        "evidence",
+        "action",
+        "replacement",
+        "reversible_id",
+        "section",
+        "metadata",
+    ),
+    additional=False,
+)
+_STRUCTURED_ERROR_OUTPUT = _object(
+    properties={
+        "code": _schema("string"),
+        "message": _schema("string"),
+        "stage": _nullable("string"),
+        "details": _object(),
+    },
+    required=("code", "message", "stage", "details"),
+)
+_ERROR_OR_NULL = {"anyOf": [_STRUCTURED_ERROR_OUTPUT, _schema("null")]}
+_CLINICAL_TRACE_OUTPUT = _object(
+    properties={
+        "stage": _schema("string", enum=_CLINICAL_STAGE_VALUES),
+        "status": _schema("string"),
+        "duration_ms": _nullable("number"),
+    },
+    required=("stage", "status"),
+)
+_GROUND_OUTPUT = _object(
+    properties={
+        "schema_version": _schema("string", enum=["openmed.ground.v1"]),
+        "status": _schema("string", enum=["completed", "failed", "unimplemented"]),
+        "spans": _array(_OPENMED_SPAN_OUTPUT),
+        "grounded_concepts": _array(_object()),
+        "error": _ERROR_OR_NULL,
+    },
+    required=("schema_version", "status", "spans", "grounded_concepts", "error"),
+)
+_EXPORT_FHIR_OUTPUT = _object(
+    properties={
+        "schema_version": _schema("string", enum=["openmed.export_fhir.v1"]),
+        "status": _schema("string", enum=["completed", "failed", "unimplemented"]),
+        "bundle": _object(),
+        "resource_count": _schema("integer", minimum=0),
+        "error": _ERROR_OR_NULL,
+    },
+    required=("schema_version", "status", "bundle", "resource_count", "error"),
+)
+_RISK_SCORE_OUTPUT = _object(
+    properties={
+        "schema_version": _schema("string", enum=["openmed.risk_score.v1"]),
+        "status": _schema("string", enum=["completed", "failed", "unimplemented"]),
+        "risk_report": _object(),
+        "error": _ERROR_OR_NULL,
+    },
+    required=("schema_version", "status", "risk_report", "error"),
+)
+_CLINICAL_PIPELINE_OUTPUT = _object(
+    properties={
+        "schema_version": _schema("string", enum=["openmed.clinical_pipeline.v1"]),
+        "status": _schema(
+            "string", enum=["planned", "completed", "rejected", "failed"]
+        ),
+        "stages": _array(_schema("string", enum=_CLINICAL_STAGE_VALUES)),
+        "artifacts": _object(),
+        "final_output": {},
+        "error": _ERROR_OR_NULL,
+        "trace": _array(_CLINICAL_TRACE_OUTPUT),
+    },
+    required=(
+        "schema_version",
+        "status",
+        "stages",
+        "artifacts",
+        "final_output",
+        "error",
+        "trace",
+    ),
+)
+_SPAN_ARRAY_OR_NULL = {"anyOf": [_array(_OPENMED_SPAN_OUTPUT), _schema("null")]}
+_STRING_ARRAY_OR_NULL = {"anyOf": [_array(_schema("string")), _schema("null")]}
+_OBJECT_ARRAY_OR_NULL = {"anyOf": [_array(_object()), _schema("null")]}
+_CLINICAL_STAGES_PARAMETER = _parameter(
+    "stages",
+    _array(_schema("string", enum=_CLINICAL_STAGE_VALUES)),
+    list[str],
+    description=(
+        "Declared clinical workflow stages in canonical order: "
+        "detect, context, sections, relations, ground, export, risk."
+    ),
+)
+_CLINICAL_SPANS_PARAMETER = _parameter(
+    "spans",
+    _array(_OPENMED_SPAN_OUTPUT),
+    list[dict[str, Any]],
+    description="Canonical OpenMedSpan artifacts to process.",
+)
 
 
 def _tool_spec(
@@ -906,6 +1043,136 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
             _parameter("workflow_id", _nullable("string"), Optional[str], None),
         ),
         output_schema=_WORKFLOW_RESULT_OUTPUT,
+    ),
+    _tool_spec(
+        name="openmed_ground",
+        description=(
+            "Contract for grounding canonical OpenMedSpan artifacts to clinical "
+            "coding systems."
+        ),
+        parameters=(
+            _CLINICAL_SPANS_PARAMETER,
+            _parameter(
+                "vocabularies",
+                _STRING_ARRAY_OR_NULL,
+                Optional[list[str]],
+                None,
+                "Optional grounding vocabularies to constrain.",
+            ),
+            _parameter(
+                "max_candidates",
+                _schema("integer", minimum=1),
+                int,
+                5,
+                "Maximum grounding candidates per span.",
+            ),
+            _parameter(
+                "allow_external_llm",
+                _schema("boolean"),
+                bool,
+                False,
+                "Reserve external-LLM routing for privacy-gateway mediated flows.",
+            ),
+        ),
+        output_schema=_GROUND_OUTPUT,
+    ),
+    _tool_spec(
+        name="openmed_export_fhir",
+        description=(
+            "Contract for exporting canonical OpenMedSpan artifacts to a FHIR Bundle."
+        ),
+        parameters=(
+            _CLINICAL_SPANS_PARAMETER,
+            _parameter(
+                "resources",
+                _OBJECT_ARRAY_OR_NULL,
+                Optional[list[dict[str, Any]]],
+                None,
+                "Optional prebuilt standalone FHIR resources.",
+            ),
+            _parameter("doc_id", _schema("string"), str, "workflow"),
+            _parameter(
+                "bundle_type",
+                _schema("string", enum=["collection", "transaction", "batch"]),
+                str,
+                "collection",
+            ),
+        ),
+        output_schema=_EXPORT_FHIR_OUTPUT,
+    ),
+    _tool_spec(
+        name="openmed_risk_score",
+        description=(
+            "Contract for residual re-identification risk scoring over "
+            "de-identified clinical artifacts."
+        ),
+        parameters=(
+            _CLINICAL_SPANS_PARAMETER,
+            _parameter(
+                "deidentified_text",
+                _nullable("string"),
+                Optional[str],
+                None,
+                "Optional de-identified text for residual-risk scoring.",
+            ),
+            _parameter(
+                "records",
+                _OBJECT_ARRAY_OR_NULL,
+                Optional[list[dict[str, Any]]],
+                None,
+                "Optional tabular records for residual-risk scoring.",
+            ),
+            _parameter(
+                "quasi_identifiers",
+                _STRING_ARRAY_OR_NULL,
+                Optional[list[str]],
+                None,
+                "Optional quasi-identifier field names.",
+            ),
+        ),
+        output_schema=_RISK_SCORE_OUTPUT,
+    ),
+    _tool_spec(
+        name="openmed_clinical_pipeline",
+        description=(
+            "Plan and validate a composable clinical workflow over "
+            "de-identification, extraction, grounding, FHIR export, and risk "
+            "stages."
+        ),
+        parameters=(
+            _CLINICAL_STAGES_PARAMETER,
+            _parameter(
+                "text",
+                _nullable("string"),
+                Optional[str],
+                None,
+                "Optional raw clinical text for future pipeline execution.",
+            ),
+            _parameter(
+                "spans",
+                _SPAN_ARRAY_OR_NULL,
+                Optional[list[dict[str, Any]]],
+                None,
+                "Optional canonical OpenMedSpan artifacts.",
+            ),
+            _parameter(
+                "options",
+                _object(),
+                dict[str, Any],
+                {},
+                "Execution options reserved for later pipeline handlers.",
+            ),
+            _parameter(
+                "allow_external_llm",
+                _schema("boolean"),
+                bool,
+                False,
+                "Reserve external-LLM routing for privacy-gateway mediated flows.",
+            ),
+            _parameter("session_id", _nullable("string"), Optional[str], None),
+            _parameter("workflow_id", _nullable("string"), Optional[str], None),
+        ),
+        output_schema=_CLINICAL_PIPELINE_OUTPUT,
     ),
 )
 

--- a/openmed/mcp/workflow.py
+++ b/openmed/mcp/workflow.py
@@ -8,7 +8,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Callable, Mapping, MutableMapping, Optional
+from typing import Any, Callable, Mapping, MutableMapping, Optional, Sequence
 
 from openmed.clinical.exporters.codeable_concept_simple import (
     codeable_concept,
@@ -30,6 +30,166 @@ class WorkflowValidationError(WorkflowError):
 
 class TransientWorkflowError(WorkflowError):
     """Raised by step adapters to signal a retryable transient failure."""
+
+
+CLINICAL_PIPELINE_SCHEMA_VERSION = "openmed.clinical_pipeline.v1"
+CLINICAL_STAGE_ORDER = (
+    "detect",
+    "context",
+    "sections",
+    "relations",
+    "ground",
+    "export",
+    "risk",
+)
+_CLINICAL_STAGE_INDEX = {
+    stage: index for index, stage in enumerate(CLINICAL_STAGE_ORDER)
+}
+
+
+class ClinicalStageOrderError(WorkflowValidationError):
+    """Raised when a declared clinical workflow violates stage ordering."""
+
+    def __init__(
+        self,
+        *,
+        code: str,
+        message: str,
+        stages: Sequence[Any],
+        stage: str | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        merged_details: dict[str, Any] = {
+            "stages": [str(item) for item in stages],
+            "allowed_order": list(CLINICAL_STAGE_ORDER),
+        }
+        if details:
+            merged_details.update(dict(details))
+        self.error = {
+            "code": code,
+            "message": message,
+            "stage": stage,
+            "details": merged_details,
+        }
+
+
+def validate_clinical_stage_order(stages: Sequence[Any]) -> tuple[str, ...]:
+    """Return normalized clinical stages, or raise for unsafe order."""
+    if isinstance(stages, (str, bytes, bytearray)) or not isinstance(stages, Sequence):
+        raise ClinicalStageOrderError(
+            code="invalid_stage_list",
+            message="Clinical pipeline stages must be a non-empty list.",
+            stages=(),
+        )
+    if not stages:
+        raise ClinicalStageOrderError(
+            code="invalid_stage_list",
+            message="Clinical pipeline stages must be a non-empty list.",
+            stages=stages,
+        )
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    previous_stage: str | None = None
+    previous_index = -1
+    for raw_stage in stages:
+        stage = str(raw_stage).strip().lower()
+        if stage not in _CLINICAL_STAGE_INDEX:
+            raise ClinicalStageOrderError(
+                code="unknown_stage",
+                message=f"Unknown clinical pipeline stage: {raw_stage!r}.",
+                stages=stages,
+                stage=stage or None,
+            )
+        if stage in seen:
+            raise ClinicalStageOrderError(
+                code="duplicate_stage",
+                message=f"Duplicate clinical pipeline stage: {stage}.",
+                stages=stages,
+                stage=stage,
+            )
+
+        stage_index = _CLINICAL_STAGE_INDEX[stage]
+        if stage_index < previous_index:
+            raise ClinicalStageOrderError(
+                code="invalid_stage_order",
+                message=(
+                    f"Clinical pipeline stage {stage!r} cannot run after "
+                    f"{previous_stage!r}."
+                ),
+                stages=stages,
+                stage=stage,
+                details={"previous_stage": previous_stage},
+            )
+
+        normalized.append(stage)
+        seen.add(stage)
+        previous_stage = stage
+        previous_index = stage_index
+
+    return tuple(normalized)
+
+
+def plan_clinical_pipeline(
+    stages: Sequence[Any],
+    *,
+    stage_callbacks: Mapping[str, Callable[[], Any]] | None = None,
+) -> dict[str, Any]:
+    """Validate and optionally dry-run a clinical pipeline stage declaration."""
+    try:
+        normalized_stages = validate_clinical_stage_order(stages)
+    except ClinicalStageOrderError as exc:
+        response_stages: Sequence[Any]
+        if isinstance(stages, (str, bytes, bytearray)) or not isinstance(
+            stages, Sequence
+        ):
+            response_stages = ()
+        else:
+            response_stages = stages
+        return _clinical_pipeline_payload(
+            status="rejected",
+            stages=response_stages,
+            error=exc.error,
+        )
+
+    callbacks = dict(stage_callbacks or {})
+    artifacts: dict[str, Any] = {}
+    trace: list[dict[str, Any]] = []
+    for stage in normalized_stages:
+        callback = callbacks.get(stage)
+        if callback is None:
+            continue
+        artifacts[stage] = callback()
+        trace.append({"stage": stage, "status": "completed"})
+
+    return _clinical_pipeline_payload(
+        status="completed" if trace else "planned",
+        stages=normalized_stages,
+        artifacts=artifacts,
+        final_output=artifacts.get(normalized_stages[-1]) if artifacts else None,
+        trace=trace,
+    )
+
+
+def _clinical_pipeline_payload(
+    *,
+    status: str,
+    stages: Sequence[Any],
+    artifacts: Mapping[str, Any] | None = None,
+    final_output: Any = None,
+    error: Mapping[str, Any] | None = None,
+    trace: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    return {
+        "schema_version": CLINICAL_PIPELINE_SCHEMA_VERSION,
+        "status": status,
+        "stages": [str(stage).strip().lower() for stage in stages],
+        "artifacts": dict(artifacts or {}),
+        "final_output": copy.deepcopy(final_output),
+        "error": dict(error) if error is not None else None,
+        "trace": [dict(item) for item in trace],
+    }
 
 
 @dataclass

--- a/tests/unit/mcp/test_tool_registry.py
+++ b/tests/unit/mcp/test_tool_registry.py
@@ -84,6 +84,52 @@ def test_tool_registry_resource_is_generated_from_specs() -> None:
     assert all(tool["stability"] for tool in payload["tools"])
 
 
+def test_clinical_tool_contracts_are_registered_and_versioned() -> None:
+    expected = {
+        "openmed_ground",
+        "openmed_export_fhir",
+        "openmed_risk_score",
+        "openmed_clinical_pipeline",
+    }
+
+    for name in expected:
+        spec = TOOL_REGISTRY.get(name)
+        assert spec.version == "1.0.0"
+        assert spec.input_schema["type"] == "object"
+        assert spec.output_schema["type"] == "object"
+        assert "schema_version" in spec.output_schema["required"]
+
+    pipeline = TOOL_REGISTRY.get("openmed_clinical_pipeline")
+    assert pipeline.input_schema["required"] == ["stages"]
+    stages = pipeline.input_schema["properties"]["stages"]["items"]
+    assert list(stages["enum"]) == [
+        "detect",
+        "context",
+        "sections",
+        "relations",
+        "ground",
+        "export",
+        "risk",
+    ]
+
+
+def test_clinical_contract_handler_outputs_validate() -> None:
+    span = _sample_openmed_span()
+
+    assert mcp_server.openmed_ground([span])["status"] == "unimplemented"
+    assert mcp_server.openmed_export_fhir([span])["status"] == "unimplemented"
+    assert mcp_server.openmed_risk_score([span])["status"] == "unimplemented"
+    assert mcp_server.openmed_clinical_pipeline(["detect", "ground"]) == {
+        "schema_version": "openmed.clinical_pipeline.v1",
+        "status": "planned",
+        "stages": ["detect", "ground"],
+        "artifacts": {},
+        "final_output": None,
+        "error": None,
+        "trace": [],
+    }
+
+
 def test_adapter_tool_definitions_match_registry_schemas() -> None:
     langchain_defs = langchain.create_tool_definitions()
     presidio_defs = presidio.create_tool_definitions()
@@ -127,6 +173,23 @@ def test_breaking_schema_change_with_major_bump_passes() -> None:
     check_tool_registry_compatibility(previous, current)
 
 
+def test_breaking_new_clinical_tool_schema_change_is_caught() -> None:
+    previous = TOOL_REGISTRY.latest_specs()
+    target = TOOL_REGISTRY.get("openmed_clinical_pipeline")
+    output_schema = deepcopy(dict(target.output_schema))
+    output_schema["properties"] = deepcopy(dict(output_schema["properties"]))
+    output_schema["properties"]["status"] = {
+        "type": "string",
+        "enum": ["completed"],
+    }
+    broken = _replace_spec(target, output_schema=output_schema)
+
+    current = [broken if spec.name == broken.name else spec for spec in previous]
+
+    with pytest.raises(ToolCompatibilityError, match="openmed_clinical_pipeline"):
+        check_tool_registry_compatibility(previous, current)
+
+
 def test_registry_supports_multiple_versions_side_by_side() -> None:
     original = TOOL_REGISTRY.get("openmed_analyze_text")
     bumped = _replace_spec(original, version="2.0.0")
@@ -168,3 +231,29 @@ def _schema_projection(definitions: tuple[dict[str, Any], ...]) -> list[dict[str
         }
         for definition in definitions
     ]
+
+
+def _sample_openmed_span() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "doc_id": "fixture-note",
+        "start": 0,
+        "end": 8,
+        "text_hash": (
+            "hmac-sha256:"
+            "0123456789abcdef0123456789abcdef"
+            "0123456789abcdef0123456789abcdef"
+        ),
+        "entity_type": "clinical_problem",
+        "canonical_label": "OTHER",
+        "policy_label": "CLINICAL_CONCEPT",
+        "regulatory_tags": [],
+        "score": 0.99,
+        "detector": "fixture",
+        "evidence": {},
+        "action": "keep",
+        "replacement": None,
+        "reversible_id": None,
+        "section": None,
+        "metadata": {},
+    }

--- a/tests/unit/mcp/test_workflow.py
+++ b/tests/unit/mcp/test_workflow.py
@@ -19,6 +19,7 @@ from openmed.mcp.workflow import (
     WorkflowRunner,
     WorkflowStateStore,
     builtin_workflow_step_executors,
+    plan_clinical_pipeline,
 )
 
 PHI_NOTE = "Patient Jane Doe called 555-1212 about diabetes."
@@ -396,3 +397,53 @@ def test_workflow_tool_is_registered_and_schema_validated():
     _register_tools(fake_server, runtime_provider=None)
 
     assert "openmed_run_workflow" in fake_server.tools
+
+
+def test_clinical_pipeline_rejects_illegal_order_without_running_callbacks():
+    counters: Counter[str] = Counter()
+
+    result = plan_clinical_pipeline(
+        ["ground", "detect"],
+        stage_callbacks={
+            "ground": lambda: counters.update(["ground"]),
+            "detect": lambda: counters.update(["detect"]),
+        },
+    )
+
+    assert result["status"] == "rejected"
+    assert result["error"]["code"] == "invalid_stage_order"
+    assert result["error"]["stage"] == "detect"
+    assert counters == {}
+    assert (
+        validate_registered_tool_output("openmed_clinical_pipeline", result) == result
+    )
+
+
+def test_clinical_pipeline_accepts_ordered_stage_subsequence():
+    counters: Counter[str] = Counter()
+
+    def _stage(name: str) -> dict[str, str]:
+        counters.update([name])
+        return {"stage": name}
+
+    result = plan_clinical_pipeline(
+        ["detect", "ground", "risk"],
+        stage_callbacks={
+            "detect": lambda: _stage("detect"),
+            "ground": lambda: _stage("ground"),
+            "risk": lambda: _stage("risk"),
+        },
+    )
+
+    assert result["status"] == "completed"
+    assert result["stages"] == ["detect", "ground", "risk"]
+    assert result["final_output"] == {"stage": "risk"}
+    assert [item["stage"] for item in result["trace"]] == [
+        "detect",
+        "ground",
+        "risk",
+    ]
+    assert counters == {"detect": 1, "ground": 1, "risk": 1}
+    assert (
+        validate_registered_tool_output("openmed_clinical_pipeline", result) == result
+    )


### PR DESCRIPTION
## Description
Adds the first OM-754 child slice: versioned MCP contracts for clinical grounding, FHIR export, residual-risk scoring, and a declarative clinical pipeline stage planner. The pipeline contract validates the safe stage order before any stage callback can run.

Closes #1300.
Part of #1251.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Registered `openmed_ground`, `openmed_export_fhir`, `openmed_risk_score`, and `openmed_clinical_pipeline` tool contracts with versioned input and output schemas.
- Added clinical pipeline stage-order validation for `detect -> context -> sections -> relations -> ground -> export -> risk`.
- Added contract-only MCP and adapter handlers so all registry-rendered tools remain callable while runtime execution is handled by later child issues.
- Added tests for schema registration, compatibility checks, contract handler output validation, and invalid-order no-work behavior.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `.venv/bin/python -m pytest tests/ -q`
- `.venv/bin/python -m pytest tests/unit/interop/test_framework_adapters.py tests/unit/mcp/test_tool_registry.py tests/unit/mcp/test_workflow.py -q`
- `uv run ruff check openmed/interop/function_tools.py openmed/mcp/tool_registry.py openmed/mcp/server.py openmed/mcp/workflow.py tests/unit/mcp/test_tool_registry.py tests/unit/mcp/test_workflow.py tests/unit/interop/test_framework_adapters.py`
- `uv run ruff format --check openmed/interop/function_tools.py openmed/mcp/tool_registry.py openmed/mcp/server.py openmed/mcp/workflow.py tests/unit/mcp/test_tool_registry.py tests/unit/mcp/test_workflow.py tests/unit/interop/test_framework_adapters.py`
- `git diff --check`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1300
Related to #1251

## Screenshots/Examples
Not applicable.