### PR TITLE
Add openEHR composition export

### DIFF
--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -178,6 +178,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_audit_command(subparsers)
     _add_risk_command(subparsers)
     _add_policy_command(subparsers)
+    _add_export_command(subparsers)
     _add_fhir_command(subparsers)
     _add_benchmark_command(subparsers)
     _add_eval_command(subparsers)
@@ -688,6 +689,73 @@ def _add_fhir_command(subparsers: argparse._SubParsersAction) -> None:
         help="Path to write the FHIR Bundle JSON.",
     )
     bundle_parser.set_defaults(handler=_handle_fhir_bundle)
+
+
+def _add_export_command(subparsers: argparse._SubParsersAction) -> None:
+    """Add clinical export commands."""
+
+    export_parser = subparsers.add_parser("export", help="Clinical export utilities.")
+    export_sub = export_parser.add_subparsers(dest="export_command")
+
+    openehr_parser = export_sub.add_parser(
+        "openehr",
+        help="Serialize grounded clinical entities into openEHR flat JSON.",
+    )
+    openehr_parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="JSON result file containing grounded clinical entities.",
+    )
+    openehr_parser.add_argument(
+        "--template",
+        type=Path,
+        required=True,
+        help="EHRbase WebTemplate JSON or allowed-path template manifest.",
+    )
+    openehr_parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Path to write the openEHR flat COMPOSITION JSON.",
+    )
+    openehr_parser.add_argument(
+        "--doc-id",
+        default=None,
+        help="Stable source document id; defaults to the input payload id.",
+    )
+    openehr_parser.add_argument(
+        "--source-text-file",
+        type=Path,
+        default=None,
+        help="Optional de-identified note text file for offset validation.",
+    )
+    openehr_parser.add_argument(
+        "--composer",
+        default="OpenMed",
+        help="Composer name for openEHR context.",
+    )
+    openehr_parser.add_argument(
+        "--language",
+        default="en",
+        help="ISO language code for openEHR context.",
+    )
+    openehr_parser.add_argument(
+        "--territory",
+        default="US",
+        help="ISO territory code for openEHR context.",
+    )
+    openehr_parser.add_argument(
+        "--time",
+        default=None,
+        help="Composition timestamp; defaults to the current UTC time.",
+    )
+    openehr_parser.add_argument(
+        "--vocabulary-key",
+        default=None,
+        help="Enable caller-supplied terminology codings when present.",
+    )
+    openehr_parser.set_defaults(handler=_handle_export_openehr)
 
 
 def _add_models_command(subparsers: argparse._SubParsersAction) -> None:
@@ -1563,6 +1631,115 @@ def _handle_fhir_bundle(args: argparse.Namespace) -> int:
 
     sys.stdout.write(f"FHIR Bundle written to: {args.output}\n")
     return 0
+
+
+def _handle_export_openehr(args: argparse.Namespace) -> int:
+    try:
+        payload = json.loads(args.input.read_text(encoding="utf-8"))
+        entities = _extract_clinical_entities(payload)
+        source_text = _extract_openehr_source_text(payload)
+        if args.source_text_file is not None:
+            source_text = args.source_text_file.read_text(encoding="utf-8")
+        doc_id = args.doc_id or _extract_doc_id(payload)
+
+        from ..clinical.exporters.openehr import to_openehr_composition
+
+        composition = to_openehr_composition(
+            entities,
+            operational_template=args.template,
+            doc_id=doc_id,
+            source_text=source_text,
+            composer_name=args.composer,
+            language=args.language,
+            territory=args.territory,
+            time=args.time,
+            vocabulary_key=args.vocabulary_key,
+        )
+        args.output.write_text(
+            json.dumps(composition, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except FileNotFoundError as exc:
+        sys.stderr.write(f"Input file not found: {exc.filename}\n")
+        return 1
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(
+            f"Invalid JSON in {args.input}: {exc.msg} "
+            f"at line {exc.lineno} column {exc.colno}\n"
+        )
+        return 1
+    except OSError as exc:
+        sys.stderr.write(f"Failed to read or write openEHR COMPOSITION: {exc}\n")
+        return 1
+    except (TypeError, ValueError) as exc:
+        sys.stderr.write(f"Failed to assemble openEHR COMPOSITION: {exc}\n")
+        return 1
+
+    sys.stdout.write(f"openEHR COMPOSITION written to: {args.output}\n")
+    return 0
+
+
+def _extract_doc_id(payload: Any) -> str:
+    """Return the stable source document id carried by a result payload."""
+
+    if isinstance(payload, MappingABC):
+        for key in ("doc_id", "document_id", "id"):
+            value = payload.get(key)
+            if isinstance(value, (str, int)) and str(value):
+                return str(value)
+    return "openmed-document"
+
+
+def _extract_clinical_entities(payload: Any) -> list[Any]:
+    entities = _find_clinical_entities_payload(payload)
+    if not isinstance(entities, list):
+        raise ValueError("clinical entities must be a JSON array")
+    normalized: list[Any] = []
+    for index, entity in enumerate(entities):
+        if not isinstance(entity, MappingABC):
+            raise ValueError(f"clinical entity at index {index} must be a JSON object")
+        normalized.append(dict(entity))
+    return normalized
+
+
+def _find_clinical_entities_payload(payload: Any) -> Any:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, MappingABC):
+        raise ValueError(
+            "openEHR input must be a JSON array of clinical entities or a result object"
+        )
+
+    for key in ("entities", "clinical_entities", "clinicalEntities"):
+        if key in payload:
+            return payload[key]
+
+    result_payload = payload.get("result")
+    if isinstance(result_payload, MappingABC):
+        for key in ("entities", "clinical_entities", "clinicalEntities"):
+            if key in result_payload:
+                return result_payload[key]
+
+    raise ValueError(
+        "openEHR input must contain grounded clinical entities under "
+        "'entities' or 'clinical_entities'"
+    )
+
+
+def _extract_openehr_source_text(payload: Any) -> str | None:
+    if not isinstance(payload, MappingABC):
+        return None
+    for key in ("source_text", "text", "note", "narrative"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    result_payload = payload.get("result")
+    if isinstance(result_payload, MappingABC):
+        for key in ("source_text", "text", "note", "narrative"):
+            value = result_payload.get(key)
+            if isinstance(value, str):
+                return value
+    return None
 
 
 def _extract_fhir_doc_id(payload: Any) -> str:

--- a/openmed/clinical/exporters/__init__.py
+++ b/openmed/clinical/exporters/__init__.py
@@ -26,6 +26,16 @@ from .flat_table import (
     to_csv,
     to_dataframe,
 )
+from .openehr import (
+    DEFAULT_OPENEHR_BINDINGS,
+    OpenEHRBinding,
+    OpenEHRTemplate,
+    OpenEHRValidationResult,
+    extract_round_trip_coded_values,
+    parse_operational_template,
+    to_openehr_composition,
+    validate_openehr_composition,
+)
 
 __all__ = [
     "CODE_SYSTEM_VERSION_SOURCE_EXTENSION_URL",
@@ -33,15 +43,23 @@ __all__ = [
     "CodeableConceptFinding",
     "CodeableConceptFindingCode",
     "FLAT_TABLE_COLUMNS",
+    "DEFAULT_OPENEHR_BINDINGS",
     "SYSTEM_URI",
     "GroundedSpan",
+    "OpenEHRBinding",
+    "OpenEHRTemplate",
+    "OpenEHRValidationResult",
     "build_reverse_index",
     "check_codeable_concept",
     "codeable_concept_from_ranked_candidates",
+    "extract_round_trip_coded_values",
     "flatten_clinical_entities",
     "flatten_entities",
+    "parse_operational_template",
     "stamp_coding_provenance",
     "to_codeable_concept",
     "to_csv",
     "to_dataframe",
+    "to_openehr_composition",
+    "validate_openehr_composition",
 ]

--- a/openmed/clinical/exporters/openehr/__init__.py
+++ b/openmed/clinical/exporters/openehr/__init__.py
@@ -1,0 +1,27 @@
+"""openEHR flat-JSON export helpers for clinical resources."""
+
+from __future__ import annotations
+
+from .binding import DEFAULT_OPENEHR_BINDINGS, OpenEHRBinding, binding_for_entity_kind
+from .composition import (
+    OpenEHRCoding,
+    OpenEHRTemplate,
+    OpenEHRValidationResult,
+    extract_round_trip_coded_values,
+    parse_operational_template,
+    to_openehr_composition,
+    validate_openehr_composition,
+)
+
+__all__ = [
+    "DEFAULT_OPENEHR_BINDINGS",
+    "OpenEHRCoding",
+    "OpenEHRBinding",
+    "OpenEHRTemplate",
+    "OpenEHRValidationResult",
+    "binding_for_entity_kind",
+    "extract_round_trip_coded_values",
+    "parse_operational_template",
+    "to_openehr_composition",
+    "validate_openehr_composition",
+]

--- a/openmed/clinical/exporters/openehr/binding.py
+++ b/openmed/clinical/exporters/openehr/binding.py
@@ -1,0 +1,133 @@
+"""Declarative openEHR archetype bindings for grounded clinical entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Sequence
+
+__all__ = [
+    "OpenEHRBinding",
+    "DEFAULT_OPENEHR_BINDINGS",
+    "binding_for_entity_kind",
+]
+
+
+@dataclass(frozen=True)
+class OpenEHRBinding:
+    """Map one OpenMed entity kind family to openEHR flat paths.
+
+    Paths are relative to the WebTemplate root id. ``{index}`` is replaced with
+    the zero-based occurrence index for the binding family so repeated entities
+    remain EHRbase-flat-compatible.
+    """
+
+    kind: str
+    aliases: tuple[str, ...]
+    archetype_id: str
+    archetype_label: str
+    text_path: str
+    code_path: str | None = None
+    quantity_path: str | None = None
+    preferred_code_systems: tuple[str, ...] = ()
+
+    def flat_text_path(self, template_id: str, index: int) -> str:
+        """Return the indexed flat path for the entity text element."""
+
+        return _join_template_path(template_id, self.text_path, index)
+
+    def flat_code_path(self, template_id: str, index: int) -> str | None:
+        """Return the indexed flat path for the optional coded element."""
+
+        if self.code_path is None:
+            return None
+        return _join_template_path(template_id, self.code_path, index)
+
+    def flat_quantity_path(self, template_id: str, index: int) -> str | None:
+        """Return the indexed flat path for the optional quantity element."""
+
+        if self.quantity_path is None:
+            return None
+        return _join_template_path(template_id, self.quantity_path, index)
+
+
+DEFAULT_OPENEHR_BINDINGS: Final[tuple[OpenEHRBinding, ...]] = (
+    OpenEHRBinding(
+        kind="problem",
+        aliases=("condition", "diagnosis", "problem", "problem_diagnosis"),
+        archetype_id="openEHR-EHR-EVALUATION.problem_diagnosis.v1",
+        archetype_label="Problem/Diagnosis",
+        text_path="problems/problem_diagnosis:{index}/problem_name",
+        code_path="problems/problem_diagnosis:{index}/problem_code",
+        preferred_code_systems=("SNOMED", "SNOMED-CT", "ICD10CM"),
+    ),
+    OpenEHRBinding(
+        kind="medication",
+        aliases=("medication", "drug", "medication_order", "medicine"),
+        archetype_id="openEHR-EHR-INSTRUCTION.medication_order.v1",
+        archetype_label="Medication order",
+        text_path="medications/medication_order:{index}/medication_name",
+        code_path="medications/medication_order:{index}/medication_code",
+        preferred_code_systems=("RXNORM", "SNOMED", "SNOMED-CT"),
+    ),
+    OpenEHRBinding(
+        kind="laboratory",
+        aliases=(
+            "lab",
+            "lab_result",
+            "laboratory",
+            "laboratory_result",
+            "measurement",
+            "test_result",
+        ),
+        archetype_id="openEHR-EHR-OBSERVATION.laboratory_test_result.v1",
+        archetype_label="Laboratory test result",
+        text_path=(
+            "laboratory/laboratory_test_result:{index}/"
+            "laboratory_analyte_result/analyte_name"
+        ),
+        code_path=(
+            "laboratory/laboratory_test_result:{index}/"
+            "laboratory_analyte_result/analyte_code"
+        ),
+        quantity_path=(
+            "laboratory/laboratory_test_result:{index}/"
+            "laboratory_analyte_result/analyte_value"
+        ),
+        preferred_code_systems=("LOINC", "SNOMED", "SNOMED-CT"),
+    ),
+    OpenEHRBinding(
+        kind="vital_sign",
+        aliases=("vital", "vital_sign", "vital_signs"),
+        archetype_id="openEHR-EHR-OBSERVATION.vital_signs.v1",
+        archetype_label="Vital signs",
+        text_path="vitals/vital_sign:{index}/vital_sign_name",
+        code_path="vitals/vital_sign:{index}/vital_sign_code",
+        quantity_path="vitals/vital_sign:{index}/value",
+        preferred_code_systems=("LOINC", "SNOMED", "SNOMED-CT"),
+    ),
+)
+
+
+def binding_for_entity_kind(
+    entity_kind: str,
+    bindings: Sequence[OpenEHRBinding] = DEFAULT_OPENEHR_BINDINGS,
+) -> OpenEHRBinding:
+    """Return the configured openEHR binding for a canonical entity label."""
+
+    normalized = _normalize_kind(entity_kind)
+    for binding in bindings:
+        if normalized == binding.kind or normalized in binding.aliases:
+            return binding
+    known = sorted({alias for binding in bindings for alias in binding.aliases})
+    raise ValueError(
+        f"No openEHR binding for entity kind {entity_kind!r}. "
+        f"Known kinds: {', '.join(known)}."
+    )
+
+
+def _join_template_path(template_id: str, relative_path: str, index: int) -> str:
+    return f"{template_id}/{relative_path.format(index=index)}"
+
+
+def _normalize_kind(value: str) -> str:
+    return value.strip().lower().replace("-", "_").replace(" ", "_")

--- a/openmed/clinical/exporters/openehr/composition.py
+++ b/openmed/clinical/exporters/openehr/composition.py
@@ -1,0 +1,686 @@
+"""openEHR flat-JSON COMPOSITION export for grounded clinical spans."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from openmed.clinical.exporters.flat_table import flatten_entities
+
+from .binding import DEFAULT_OPENEHR_BINDINGS, OpenEHRBinding, binding_for_entity_kind
+
+__all__ = [
+    "OpenEHRCoding",
+    "OpenEHRTemplate",
+    "OpenEHRValidationResult",
+    "extract_round_trip_coded_values",
+    "parse_operational_template",
+    "to_openehr_composition",
+    "validate_openehr_composition",
+]
+
+_MISSING = object()
+_INDEX_RE = re.compile(r":\d+(?=/|\|)")
+_SPAN_POINTER_RE = re.compile(r"^(?P<doc_id>.*):(?P<start>\d+)-(?P<end>\d+)$")
+
+_CONTEXT_PATHS = frozenset(
+    {
+        "ctx/language",
+        "ctx/territory",
+        "ctx/time",
+        "ctx/composer_name",
+        "ctx/composer_self",
+    }
+)
+_FEEDER_SUFFIXES = frozenset(
+    {
+        "originating_system_audit|system_id",
+        "originating_system_audit|version_id",
+        "originating_system_item_id:0|id",
+        "originating_system_item_id:0|issuer",
+        "originating_system_item_id:0|assigner",
+        "originating_system_item_id:0|type",
+    }
+)
+_TEXT_FIELDS = ("normalized_text", "text", "entity_text", "word", "surface")
+_VALUE_FIELDS = (
+    "value",
+    "magnitude",
+    "quantity_value",
+    "measurement_value",
+    "result_value",
+)
+_UNIT_FIELDS = ("unit", "units", "value_unit", "result_unit")
+_CANDIDATE_FIELDS = ("candidates", "grounding_candidates", "ranked_candidates")
+_SYSTEM_TERMINOLOGY = {
+    "HTTP://SNOMED.INFO/SCT": "SNOMED-CT",
+    "SNOMED": "SNOMED-CT",
+    "SNOMED-CT": "SNOMED-CT",
+    "HTTP://LOINC.ORG": "LOINC",
+    "LOINC": "LOINC",
+    "HTTP://WWW.NLM.NIH.GOV/RESEARCH/UMLS/RXNORM": "RxNorm",
+    "RXNORM": "RxNorm",
+    "HTTP://HL7.ORG/FHIR/SID/ICD-10-CM": "ICD-10-CM",
+    "ICD10CM": "ICD-10-CM",
+    "ICD-10-CM": "ICD-10-CM",
+}
+
+
+@dataclass(frozen=True)
+class OpenEHRCoding:
+    """Terminology coding emitted into an openEHR coded-text flat element."""
+
+    system: str
+    code: str
+    display: str
+    terminology: str
+
+
+@dataclass(frozen=True)
+class _EntitySpan:
+    kind: str
+    text: str
+    start: int
+    end: int
+    coding: OpenEHRCoding | None
+    value: int | float | None
+    unit: str
+
+
+@dataclass(frozen=True)
+class OpenEHRTemplate:
+    """Allowed flat paths parsed from an EHRbase WebTemplate."""
+
+    template_id: str
+    allowed_paths: frozenset[str]
+    element_paths: frozenset[str]
+    source: str = "webtemplate"
+
+    def allows_path(self, path: str) -> bool:
+        """Return whether ``path`` is valid for this flat COMPOSITION."""
+
+        if path in _CONTEXT_PATHS:
+            return True
+        feeder = _split_feeder_audit_path(path)
+        if feeder is not None:
+            base_path, feeder_suffix = feeder
+            return (
+                _normalize_flat_path(base_path) in self.element_paths
+                and feeder_suffix in _FEEDER_SUFFIXES
+            )
+        return _normalize_flat_path(path) in self.allowed_paths
+
+
+@dataclass(frozen=True)
+class OpenEHRValidationResult:
+    """Conformance and provenance findings for a flat COMPOSITION."""
+
+    out_of_template_paths: tuple[str, ...] = ()
+    missing_feeder_audit_paths: tuple[str, ...] = ()
+    unresolved_feeder_audit_paths: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        """Return ``True`` when the COMPOSITION satisfies all local gates."""
+
+        return not (
+            self.out_of_template_paths
+            or self.missing_feeder_audit_paths
+            or self.unresolved_feeder_audit_paths
+        )
+
+    def require_ok(self) -> None:
+        """Raise ``ValueError`` if any validation finding is present."""
+
+        if self.ok:
+            return
+        raise ValueError(self.message())
+
+    def message(self) -> str:
+        """Return a concise validation error summary."""
+
+        parts: list[str] = []
+        if self.out_of_template_paths:
+            parts.append(
+                "out-of-template paths: "
+                + ", ".join(sorted(self.out_of_template_paths))
+            )
+        if self.missing_feeder_audit_paths:
+            parts.append(
+                "missing FEEDER_AUDIT pointers: "
+                + ", ".join(sorted(self.missing_feeder_audit_paths))
+            )
+        if self.unresolved_feeder_audit_paths:
+            parts.append(
+                "unresolved FEEDER_AUDIT pointers: "
+                + ", ".join(sorted(self.unresolved_feeder_audit_paths))
+            )
+        return "; ".join(parts)
+
+
+def parse_operational_template(
+    template: OpenEHRTemplate | Mapping[str, Any] | str | os.PathLike[str],
+) -> OpenEHRTemplate:
+    """Parse a caller-supplied OPT/WebTemplate into allowed flat paths.
+
+    EHRbase flat JSON is driven by the WebTemplate representation generated
+    from an Operational Template. For tests and embedded deployments, callers
+    may also provide a mapping with ``templateId`` and explicit
+    ``allowed_paths``.
+    """
+
+    if isinstance(template, OpenEHRTemplate):
+        return template
+    if isinstance(template, Mapping):
+        return _template_from_mapping(template)
+
+    text, source = _read_template_text(template)
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        if text.lstrip().startswith("<"):
+            raise ValueError(
+                "openEHR flat export requires an EHRbase WebTemplate JSON "
+                "or a mapping with allowed_paths; XML OPT files do not carry "
+                "the simplified flat paths needed for local validation."
+            ) from exc
+        raise ValueError(f"Invalid openEHR template JSON in {source}: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"openEHR template in {source} must be a JSON object")
+    return _template_from_mapping(payload, source=source)
+
+
+def to_openehr_composition(
+    entities: Iterable[Any],
+    *,
+    operational_template: OpenEHRTemplate | Mapping[str, Any] | str | os.PathLike[str],
+    doc_id: str = "openmed-document",
+    source_text: str | None = None,
+    composer_name: str = "OpenMed",
+    language: str = "en",
+    territory: str = "US",
+    time: str | datetime | None = None,
+    vocabulary_key: str | None = None,
+    bindings: Sequence[OpenEHRBinding] = DEFAULT_OPENEHR_BINDINGS,
+    validate: bool = True,
+) -> dict[str, Any]:
+    """Serialize grounded entities into an EHRbase-compatible flat COMPOSITION.
+
+    ``vocabulary_key`` is an explicit caller opt-in gate. When omitted, the
+    exporter emits text and quantity values only, even if entity objects already
+    carry terminology candidates.
+    """
+
+    template = parse_operational_template(operational_template)
+    composition: dict[str, Any] = {
+        "ctx/language": language,
+        "ctx/territory": territory,
+        "ctx/time": _format_time(time),
+        "ctx/composer_name": composer_name,
+    }
+    counters: dict[str, int] = {}
+
+    for entity in entities:
+        span = _normalize_entity(
+            entity, vocabulary_key=vocabulary_key, bindings=bindings
+        )
+        binding = binding_for_entity_kind(span.kind, bindings)
+        index = counters.get(binding.kind, 0)
+        counters[binding.kind] = index + 1
+
+        text_path = binding.flat_text_path(template.template_id, index)
+        composition[text_path] = span.text
+        _add_feeder_audit(composition, text_path, doc_id=doc_id, span=span)
+
+        if span.coding is not None:
+            code_path = binding.flat_code_path(template.template_id, index)
+            if code_path is not None:
+                composition[f"{code_path}|code"] = span.coding.code
+                composition[f"{code_path}|value"] = span.coding.display
+                composition[f"{code_path}|terminology"] = span.coding.terminology
+                _add_feeder_audit(composition, code_path, doc_id=doc_id, span=span)
+
+        quantity_path = binding.flat_quantity_path(template.template_id, index)
+        if span.value is not None and quantity_path is not None:
+            if not span.unit:
+                raise ValueError(
+                    f"Entity {span.text!r} has a quantity value but no unit"
+                )
+            composition[f"{quantity_path}|magnitude"] = span.value
+            composition[f"{quantity_path}|unit"] = span.unit
+            _add_feeder_audit(composition, quantity_path, doc_id=doc_id, span=span)
+
+    if validate:
+        validate_openehr_composition(
+            composition,
+            template,
+            source_text=source_text,
+        ).require_ok()
+    return composition
+
+
+def validate_openehr_composition(
+    composition: Mapping[str, Any],
+    operational_template: OpenEHRTemplate | Mapping[str, Any] | str | os.PathLike[str],
+    *,
+    source_text: str | None = None,
+) -> OpenEHRValidationResult:
+    """Validate template conformance and source-offset FEEDER_AUDIT coverage."""
+
+    template = parse_operational_template(operational_template)
+    out_of_template = tuple(
+        path for path in composition if not template.allows_path(path)
+    )
+
+    element_bases = _non_empty_element_bases(composition)
+    missing: list[str] = []
+    unresolved: list[str] = []
+    for base_path in element_bases:
+        pointer_path = f"{base_path}/_feeder_audit/originating_system_item_id:0|id"
+        pointer = composition.get(pointer_path)
+        if not isinstance(pointer, str) or not pointer:
+            missing.append(base_path)
+            continue
+        if not _pointer_resolves(pointer, source_text):
+            unresolved.append(pointer_path)
+
+    return OpenEHRValidationResult(
+        out_of_template_paths=tuple(sorted(out_of_template)),
+        missing_feeder_audit_paths=tuple(sorted(missing)),
+        unresolved_feeder_audit_paths=tuple(sorted(unresolved)),
+    )
+
+
+def extract_round_trip_coded_values(
+    composition: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Extract coded-text and quantity values in deterministic flat-path order."""
+
+    bases = sorted(
+        {
+            path[: -len("|code")]
+            for path in composition
+            if path.endswith("|code")
+            and f"{path[: -len('|code')]}|value" in composition
+        }
+    )
+    values: list[dict[str, Any]] = []
+    for base in bases:
+        values.append(
+            {
+                "path": base,
+                "code": composition[f"{base}|code"],
+                "value": composition[f"{base}|value"],
+                "terminology": composition.get(f"{base}|terminology", ""),
+            }
+        )
+
+    quantity_bases = sorted(
+        {
+            path[: -len("|magnitude")]
+            for path in composition
+            if path.endswith("|magnitude")
+            and f"{path[: -len('|magnitude')]}|unit" in composition
+        }
+    )
+    for base in quantity_bases:
+        values.append(
+            {
+                "path": base,
+                "magnitude": composition[f"{base}|magnitude"],
+                "unit": composition[f"{base}|unit"],
+            }
+        )
+    return values
+
+
+def _template_from_mapping(
+    payload: Mapping[str, Any],
+    *,
+    source: str = "mapping",
+) -> OpenEHRTemplate:
+    template_id = _template_id(payload)
+    explicit_paths = payload.get("allowed_paths")
+    if explicit_paths is not None:
+        if not isinstance(explicit_paths, Sequence) or isinstance(
+            explicit_paths, (str, bytes)
+        ):
+            raise ValueError("openEHR allowed_paths must be a sequence")
+        allowed = {_normalize_flat_path(str(path)) for path in explicit_paths}
+        element_paths = {
+            _normalize_flat_path(path.split("|", 1)[0])
+            for path in allowed
+            if not path.startswith("ctx/")
+        }
+        return OpenEHRTemplate(
+            template_id=template_id,
+            allowed_paths=frozenset(allowed | _CONTEXT_PATHS),
+            element_paths=frozenset(element_paths),
+            source=source,
+        )
+
+    tree = payload.get("tree")
+    if not isinstance(tree, Mapping):
+        raise ValueError(
+            "openEHR template must contain a WebTemplate 'tree' or allowed_paths"
+        )
+
+    allowed, element_paths = _allowed_paths_from_webtemplate(tree)
+    return OpenEHRTemplate(
+        template_id=template_id,
+        allowed_paths=frozenset(allowed | _CONTEXT_PATHS),
+        element_paths=frozenset(element_paths),
+        source=source,
+    )
+
+
+def _template_id(payload: Mapping[str, Any]) -> str:
+    for key in ("templateId", "template_id", "id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    tree = payload.get("tree")
+    if isinstance(tree, Mapping):
+        value = tree.get("id")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise ValueError("openEHR template is missing templateId")
+
+
+def _allowed_paths_from_webtemplate(
+    root: Mapping[str, Any],
+) -> tuple[set[str], set[str]]:
+    allowed: set[str] = set()
+    element_paths: set[str] = set()
+
+    def walk(node: Mapping[str, Any], prefix: str | None) -> None:
+        node_id = node.get("id")
+        if not isinstance(node_id, str) or not node_id:
+            return
+        path = node_id if prefix is None else f"{prefix}/{node_id}"
+        children = node.get("children")
+        if not isinstance(children, Sequence) or isinstance(children, (str, bytes)):
+            children = ()
+        inputs = node.get("inputs")
+        if isinstance(inputs, Sequence) and not isinstance(inputs, (str, bytes)):
+            for item in inputs:
+                if not isinstance(item, Mapping):
+                    continue
+                suffix = item.get("suffix")
+                if isinstance(suffix, str) and suffix:
+                    allowed.add(_normalize_flat_path(f"{path}|{suffix}"))
+                else:
+                    allowed.add(_normalize_flat_path(path))
+                element_paths.add(_normalize_flat_path(path))
+        elif not children and prefix is not None:
+            allowed.add(_normalize_flat_path(path))
+            element_paths.add(_normalize_flat_path(path))
+
+        for child in children:
+            if isinstance(child, Mapping):
+                walk(child, path)
+
+    walk(root, None)
+    return allowed, element_paths
+
+
+def _read_template_text(template: str | os.PathLike[str]) -> tuple[str, str]:
+    if isinstance(template, os.PathLike):
+        path = Path(template)
+        return path.read_text(encoding="utf-8"), str(path)
+
+    if template.lstrip().startswith(("{", "[", "<")):
+        return template, "inline template"
+
+    candidate = Path(template)
+    if "\n" not in template and candidate.exists():
+        return candidate.read_text(encoding="utf-8"), str(candidate)
+    return template, "inline template"
+
+
+def _normalize_entity(
+    entity: Any,
+    *,
+    vocabulary_key: str | None,
+    bindings: Sequence[OpenEHRBinding],
+) -> _EntitySpan:
+    row = flatten_entities([entity])[0]
+    kind = str(row["entity_label"] or _first_scalar(_sources(entity), ("kind",)))
+    if not kind:
+        raise ValueError("openEHR export requires each entity to carry a label")
+    binding = binding_for_entity_kind(kind, bindings)
+    text = str(row["normalized_text"] or row["display"] or _first_text(entity))
+    if not text:
+        raise ValueError(f"Entity {kind!r} is missing text")
+    start = _required_offset(row.get("start"), "start", text)
+    end = _required_offset(row.get("end"), "end", text)
+    if start > end:
+        raise ValueError(f"Entity {text!r} has start offset after end offset")
+
+    return _EntitySpan(
+        kind=kind,
+        text=text,
+        start=start,
+        end=end,
+        coding=_coding_for_entity(entity, row, binding, vocabulary_key=vocabulary_key),
+        value=_number_value(entity),
+        unit=_first_scalar(_sources(entity), _UNIT_FIELDS),
+    )
+
+
+def _coding_for_entity(
+    entity: Any,
+    row: Mapping[str, Any],
+    binding: OpenEHRBinding,
+    *,
+    vocabulary_key: str | None,
+) -> OpenEHRCoding | None:
+    if not vocabulary_key:
+        return None
+
+    system = str(row.get("system") or "")
+    code = str(row.get("code") or "")
+    display = str(row.get("display") or row.get("normalized_text") or "")
+    if system and code:
+        return OpenEHRCoding(
+            system=system,
+            code=code,
+            display=display or code,
+            terminology=_terminology_for(system),
+        )
+
+    candidates = _candidate_codings(entity)
+    if not candidates:
+        return None
+    return _select_preferred_coding(candidates, binding.preferred_code_systems)
+
+
+def _candidate_codings(entity: Any) -> list[OpenEHRCoding]:
+    candidates: list[OpenEHRCoding] = []
+    for source in _sources(entity):
+        for field in _CANDIDATE_FIELDS:
+            value = _value(source, field)
+            if value is _MISSING or value is None or isinstance(value, (str, bytes)):
+                continue
+            for item in value:
+                system = _first_scalar((item,), ("system", "code_system"))
+                code = _first_scalar((item,), ("code", "code_value"))
+                display = _first_scalar((item,), ("display", "label", "text"))
+                if system and code:
+                    candidates.append(
+                        OpenEHRCoding(
+                            system=system,
+                            code=code,
+                            display=display or code,
+                            terminology=_terminology_for(system),
+                        )
+                    )
+    return candidates
+
+
+def _select_preferred_coding(
+    candidates: Sequence[OpenEHRCoding],
+    preferred_systems: Sequence[str],
+) -> OpenEHRCoding:
+    ranks = {
+        _terminology_for(system).upper(): index
+        for index, system in enumerate(preferred_systems)
+    }
+    return sorted(
+        candidates,
+        key=lambda coding: (
+            ranks.get(coding.terminology.upper(), len(ranks)),
+            coding.terminology,
+            coding.code,
+        ),
+    )[0]
+
+
+def _terminology_for(system: str) -> str:
+    normalized = system.strip().upper()
+    return _SYSTEM_TERMINOLOGY.get(normalized, system.strip() or "local")
+
+
+def _first_text(entity: Any) -> str:
+    return _first_scalar(_sources(entity), _TEXT_FIELDS)
+
+
+def _number_value(entity: Any) -> int | float | None:
+    value = _first_value(_sources(entity), _VALUE_FIELDS)
+    if value is _MISSING or value == "":
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError:
+            return None
+        if parsed.is_integer():
+            return int(parsed)
+        return parsed
+    return None
+
+
+def _required_offset(value: Any, name: str, text: str) -> int:
+    if value == "" or value is None:
+        raise ValueError(
+            f"Entity {text!r} is missing {name} offset required for FEEDER_AUDIT"
+        )
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Entity {text!r} has invalid {name} offset {value!r}"
+        ) from exc
+    if parsed < 0:
+        raise ValueError(f"Entity {text!r} has negative {name} offset")
+    return parsed
+
+
+def _add_feeder_audit(
+    composition: dict[str, Any],
+    base_path: str,
+    *,
+    doc_id: str,
+    span: _EntitySpan,
+) -> None:
+    pointer = f"{doc_id}:{span.start}-{span.end}"
+    audit_base = f"{base_path}/_feeder_audit"
+    composition[f"{audit_base}/originating_system_audit|system_id"] = "openmed"
+    composition[f"{audit_base}/originating_system_audit|version_id"] = (
+        "source-offsets-v1"
+    )
+    composition[f"{audit_base}/originating_system_item_id:0|id"] = pointer
+    composition[f"{audit_base}/originating_system_item_id:0|issuer"] = "openmed"
+    composition[f"{audit_base}/originating_system_item_id:0|assigner"] = doc_id
+    composition[f"{audit_base}/originating_system_item_id:0|type"] = "SOURCE_SPAN"
+
+
+def _non_empty_element_bases(composition: Mapping[str, Any]) -> tuple[str, ...]:
+    bases: set[str] = set()
+    for path, value in composition.items():
+        if value in (None, "") or path.startswith("ctx/") or "/_feeder_audit/" in path:
+            continue
+        bases.add(_element_base(path))
+    return tuple(sorted(bases))
+
+
+def _pointer_resolves(pointer: str, source_text: str | None) -> bool:
+    match = _SPAN_POINTER_RE.match(pointer)
+    if match is None:
+        return False
+    start = int(match.group("start"))
+    end = int(match.group("end"))
+    if start > end:
+        return False
+    return source_text is None or end <= len(source_text)
+
+
+def _split_feeder_audit_path(path: str) -> tuple[str, str] | None:
+    marker = "/_feeder_audit/"
+    if marker not in path:
+        return None
+    base_path, feeder_suffix = path.split(marker, 1)
+    return base_path, feeder_suffix
+
+
+def _element_base(path: str) -> str:
+    return path.split("|", 1)[0]
+
+
+def _normalize_flat_path(path: str) -> str:
+    return _INDEX_RE.sub("", path)
+
+
+def _format_time(value: str | datetime | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat()
+    return str(value)
+
+
+def _sources(entity: Any) -> tuple[Any, ...]:
+    sources: list[Any] = [entity]
+    for name in ("metadata", "meta", "context", "clinical_context"):
+        nested = _value(entity, name)
+        if nested is not _MISSING and nested is not None:
+            sources.append(nested)
+    return tuple(sources)
+
+
+def _first_scalar(sources: Iterable[Any], fields: Sequence[str]) -> str:
+    value = _first_value(sources, fields)
+    if value is _MISSING or value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float | str):
+        return str(value)
+    return ""
+
+
+def _first_value(sources: Iterable[Any], fields: Sequence[str]) -> Any:
+    for source in sources:
+        for field in fields:
+            value = _value(source, field)
+            if value is not _MISSING:
+                return value
+    return _MISSING
+
+
+def _value(source: Any, field: str) -> Any:
+    if isinstance(source, Mapping):
+        return source.get(field, _MISSING)
+    return getattr(source, field, _MISSING)

--- a/tests/fixtures/openehr/grounded_entities.json
+++ b/tests/fixtures/openehr/grounded_entities.json
@@ -1,0 +1,66 @@
+{
+  "doc_id": "synthetic-note-001",
+  "source_text": "Assessment: type 2 diabetes. Plan: metformin. Labs: glucose 145 mg/dL. Vitals: heart rate 88 /min.",
+  "entities": [
+    {
+      "label": "condition",
+      "text": "type 2 diabetes",
+      "start": 12,
+      "end": 27,
+      "candidates": [
+        {
+          "system": "SNOMED",
+          "code": "44054006",
+          "display": "Diabetes mellitus type 2",
+          "score": 0.98
+        }
+      ]
+    },
+    {
+      "label": "medication",
+      "text": "metformin",
+      "start": 35,
+      "end": 44,
+      "candidates": [
+        {
+          "system": "RXNORM",
+          "code": "6809",
+          "display": "metformin",
+          "score": 0.99
+        }
+      ]
+    },
+    {
+      "label": "lab_result",
+      "text": "glucose",
+      "start": 52,
+      "end": 59,
+      "value": 145,
+      "unit": "mg/dL",
+      "candidates": [
+        {
+          "system": "LOINC",
+          "code": "2345-7",
+          "display": "Glucose [Mass/volume] in Serum or Plasma",
+          "score": 0.97
+        }
+      ]
+    },
+    {
+      "label": "vital_sign",
+      "text": "heart rate",
+      "start": 80,
+      "end": 90,
+      "value": 88,
+      "unit": "/min",
+      "candidates": [
+        {
+          "system": "LOINC",
+          "code": "8867-4",
+          "display": "Heart rate",
+          "score": 0.96
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/openehr/openmed_grounded_sample_webtemplate.json
+++ b/tests/fixtures/openehr/openmed_grounded_sample_webtemplate.json
@@ -1,0 +1,197 @@
+{
+  "templateId": "openmed_grounded_clinical_data",
+  "semVer": "1.0.0",
+  "version": "1.0.0",
+  "defaultLanguage": "en",
+  "languages": ["en"],
+  "tree": {
+    "id": "openmed_grounded_clinical_data",
+    "name": "OpenMed grounded clinical data",
+    "rmType": "COMPOSITION",
+    "nodeId": "openEHR-EHR-COMPOSITION.report.v1",
+    "min": 1,
+    "max": 1,
+    "children": [
+      {
+        "id": "problems",
+        "name": "Problems",
+        "rmType": "SECTION",
+        "nodeId": "openEHR-EHR-SECTION.problem_list.v1",
+        "min": 0,
+        "max": 1,
+        "children": [
+          {
+            "id": "problem_diagnosis",
+            "name": "Problem diagnosis",
+            "rmType": "EVALUATION",
+            "nodeId": "openEHR-EHR-EVALUATION.problem_diagnosis.v1",
+            "min": 0,
+            "max": -1,
+            "children": [
+              {
+                "id": "problem_name",
+                "name": "Problem name",
+                "rmType": "DV_TEXT",
+                "nodeId": "at0002",
+                "inputs": [{"type": "TEXT"}]
+              },
+              {
+                "id": "problem_code",
+                "name": "Problem code",
+                "rmType": "DV_CODED_TEXT",
+                "nodeId": "at0.1",
+                "inputs": [
+                  {"suffix": "code", "type": "CODED_TEXT"},
+                  {"suffix": "value", "type": "CODED_TEXT"},
+                  {"suffix": "terminology", "type": "CODED_TEXT"}
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medications",
+        "name": "Medications",
+        "rmType": "SECTION",
+        "nodeId": "openEHR-EHR-SECTION.medications.v1",
+        "min": 0,
+        "max": 1,
+        "children": [
+          {
+            "id": "medication_order",
+            "name": "Medication order",
+            "rmType": "INSTRUCTION",
+            "nodeId": "openEHR-EHR-INSTRUCTION.medication_order.v1",
+            "min": 0,
+            "max": -1,
+            "children": [
+              {
+                "id": "medication_name",
+                "name": "Medication name",
+                "rmType": "DV_TEXT",
+                "nodeId": "at0002",
+                "inputs": [{"type": "TEXT"}]
+              },
+              {
+                "id": "medication_code",
+                "name": "Medication code",
+                "rmType": "DV_CODED_TEXT",
+                "nodeId": "at0.1",
+                "inputs": [
+                  {"suffix": "code", "type": "CODED_TEXT"},
+                  {"suffix": "value", "type": "CODED_TEXT"},
+                  {"suffix": "terminology", "type": "CODED_TEXT"}
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "laboratory",
+        "name": "Laboratory",
+        "rmType": "SECTION",
+        "nodeId": "openEHR-EHR-SECTION.laboratory.v1",
+        "min": 0,
+        "max": 1,
+        "children": [
+          {
+            "id": "laboratory_test_result",
+            "name": "Laboratory test result",
+            "rmType": "OBSERVATION",
+            "nodeId": "openEHR-EHR-OBSERVATION.laboratory_test_result.v1",
+            "min": 0,
+            "max": -1,
+            "children": [
+              {
+                "id": "laboratory_analyte_result",
+                "name": "Laboratory analyte result",
+                "rmType": "CLUSTER",
+                "nodeId": "openEHR-EHR-CLUSTER.laboratory_test_analyte.v1",
+                "children": [
+                  {
+                    "id": "analyte_name",
+                    "name": "Analyte name",
+                    "rmType": "DV_TEXT",
+                    "nodeId": "at0001",
+                    "inputs": [{"type": "TEXT"}]
+                  },
+                  {
+                    "id": "analyte_code",
+                    "name": "Analyte code",
+                    "rmType": "DV_CODED_TEXT",
+                    "nodeId": "at0.1",
+                    "inputs": [
+                      {"suffix": "code", "type": "CODED_TEXT"},
+                      {"suffix": "value", "type": "CODED_TEXT"},
+                      {"suffix": "terminology", "type": "CODED_TEXT"}
+                    ]
+                  },
+                  {
+                    "id": "analyte_value",
+                    "name": "Analyte value",
+                    "rmType": "DV_QUANTITY",
+                    "nodeId": "at0002",
+                    "inputs": [
+                      {"suffix": "magnitude", "type": "DECIMAL"},
+                      {"suffix": "unit", "type": "CODED_TEXT"}
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "vitals",
+        "name": "Vitals",
+        "rmType": "SECTION",
+        "nodeId": "openEHR-EHR-SECTION.vital_signs.v1",
+        "min": 0,
+        "max": 1,
+        "children": [
+          {
+            "id": "vital_sign",
+            "name": "Vital sign",
+            "rmType": "OBSERVATION",
+            "nodeId": "openEHR-EHR-OBSERVATION.vital_signs.v1",
+            "min": 0,
+            "max": -1,
+            "children": [
+              {
+                "id": "vital_sign_name",
+                "name": "Vital sign name",
+                "rmType": "DV_TEXT",
+                "nodeId": "at0001",
+                "inputs": [{"type": "TEXT"}]
+              },
+              {
+                "id": "vital_sign_code",
+                "name": "Vital sign code",
+                "rmType": "DV_CODED_TEXT",
+                "nodeId": "at0.1",
+                "inputs": [
+                  {"suffix": "code", "type": "CODED_TEXT"},
+                  {"suffix": "value", "type": "CODED_TEXT"},
+                  {"suffix": "terminology", "type": "CODED_TEXT"}
+                ]
+              },
+              {
+                "id": "value",
+                "name": "Value",
+                "rmType": "DV_QUANTITY",
+                "nodeId": "at0002",
+                "inputs": [
+                  {"suffix": "magnitude", "type": "DECIMAL"},
+                  {"suffix": "unit", "type": "CODED_TEXT"}
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/unit/cli/test_openehr_cli.py
+++ b/tests/unit/cli/test_openehr_cli.py
@@ -1,0 +1,76 @@
+"""Tests for the ``openmed export openehr`` CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.cli import main_module
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "fixtures" / "openehr"
+TEMPLATE = FIXTURES / "openmed_grounded_sample_webtemplate.json"
+ENTITIES = FIXTURES / "grounded_entities.json"
+
+
+def test_export_openehr_cli_writes_valid_flat_composition(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "composition.json"
+
+    exit_code = main_module.main(
+        [
+            "export",
+            "openehr",
+            "--input",
+            str(ENTITIES),
+            "--template",
+            str(TEMPLATE),
+            "--output",
+            str(output),
+            "--vocabulary-key",
+            "local-user-vocab",
+            "--time",
+            "2026-01-01T00:00:00+00:00",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert f"openEHR COMPOSITION written to: {output}" in captured.out
+    assert captured.err == ""
+
+    composition = json.loads(output.read_text(encoding="utf-8"))
+    assert composition["ctx/time"] == "2026-01-01T00:00:00+00:00"
+    assert any(path.endswith("|code") for path in composition)
+
+
+def test_export_openehr_cli_reports_invalid_payload(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result_file = tmp_path / "result.json"
+    result_file.write_text(json.dumps({"resources": []}), encoding="utf-8")
+    output = tmp_path / "composition.json"
+
+    exit_code = main_module.main(
+        [
+            "export",
+            "openehr",
+            "--input",
+            str(result_file),
+            "--template",
+            str(TEMPLATE),
+            "--output",
+            str(output),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "clinical entities" in captured.err
+    assert captured.out == ""
+    assert not output.exists()

--- a/tests/unit/clinical/exporters/test_openehr_composition.py
+++ b/tests/unit/clinical/exporters/test_openehr_composition.py
@@ -1,0 +1,163 @@
+"""Tests for openEHR flat-JSON COMPOSITION export."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.clinical.exporters.openehr import (
+    extract_round_trip_coded_values,
+    parse_operational_template,
+    to_openehr_composition,
+    validate_openehr_composition,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+FIXTURES = ROOT / "fixtures" / "openehr"
+TEMPLATE = FIXTURES / "openmed_grounded_sample_webtemplate.json"
+ENTITIES = FIXTURES / "grounded_entities.json"
+
+
+def _fixture_payload() -> dict:
+    return json.loads(ENTITIES.read_text(encoding="utf-8"))
+
+
+def test_openehr_export_validates_against_sample_webtemplate() -> None:
+    payload = _fixture_payload()
+
+    composition = to_openehr_composition(
+        payload["entities"],
+        operational_template=TEMPLATE,
+        doc_id=payload["doc_id"],
+        source_text=payload["source_text"],
+        time="2026-01-01T00:00:00+00:00",
+        vocabulary_key="local-user-vocab",
+    )
+    result = validate_openehr_composition(
+        composition,
+        TEMPLATE,
+        source_text=payload["source_text"],
+    )
+
+    assert result.ok
+    assert result.out_of_template_paths == ()
+    assert all(
+        path.startswith(("ctx/", "openmed_grounded_clinical_data/"))
+        for path in composition
+    )
+
+
+def test_every_non_empty_element_has_feeder_audit_source_span() -> None:
+    payload = _fixture_payload()
+
+    composition = to_openehr_composition(
+        payload["entities"],
+        operational_template=TEMPLATE,
+        doc_id=payload["doc_id"],
+        source_text=payload["source_text"],
+        vocabulary_key="local-user-vocab",
+    )
+    element_bases = {
+        path.split("|", 1)[0]
+        for path, value in composition.items()
+        if value not in ("", None)
+        and not path.startswith("ctx/")
+        and "/_feeder_audit/" not in path
+    }
+
+    assert element_bases
+    for base in element_bases:
+        pointer = composition[f"{base}/_feeder_audit/originating_system_item_id:0|id"]
+        _, offsets = pointer.rsplit(":", 1)
+        start, end = [int(part) for part in offsets.split("-", 1)]
+        assert payload["source_text"][start:end]
+
+
+def test_grounding_codes_require_user_vocabulary_key() -> None:
+    payload = _fixture_payload()
+
+    text_only = to_openehr_composition(
+        payload["entities"],
+        operational_template=TEMPLATE,
+        doc_id=payload["doc_id"],
+        source_text=payload["source_text"],
+    )
+    coded = to_openehr_composition(
+        payload["entities"],
+        operational_template=TEMPLATE,
+        doc_id=payload["doc_id"],
+        source_text=payload["source_text"],
+        vocabulary_key="local-user-vocab",
+    )
+
+    assert not any(path.endswith("|code") for path in text_only)
+    assert "type 2 diabetes" in text_only.values()
+    assert any(path.endswith("|code") for path in coded)
+    assert (
+        coded[
+            "openmed_grounded_clinical_data/problems/problem_diagnosis:0/"
+            "problem_code|code"
+        ]
+        == "44054006"
+    )
+
+
+def test_round_trip_flat_validator_preserves_codes_and_units() -> None:
+    payload = _fixture_payload()
+
+    composition = to_openehr_composition(
+        payload["entities"],
+        operational_template=TEMPLATE,
+        doc_id=payload["doc_id"],
+        source_text=payload["source_text"],
+        vocabulary_key="local-user-vocab",
+    )
+    values = extract_round_trip_coded_values(composition)
+
+    assert {
+        (item.get("code"), item.get("terminology")) for item in values if "code" in item
+    } == {
+        ("44054006", "SNOMED-CT"),
+        ("6809", "RxNorm"),
+        ("2345-7", "LOINC"),
+        ("8867-4", "LOINC"),
+    }
+    assert {
+        (item.get("magnitude"), item.get("unit"))
+        for item in values
+        if "magnitude" in item
+    } == {(145, "mg/dL"), (88, "/min")}
+    assert values == extract_round_trip_coded_values(
+        dict(reversed(composition.items()))
+    )
+
+
+def test_validator_rejects_out_of_template_paths() -> None:
+    payload = _fixture_payload()
+    composition = to_openehr_composition(
+        payload["entities"][:1],
+        operational_template=TEMPLATE,
+        doc_id=payload["doc_id"],
+        source_text=payload["source_text"],
+    )
+    composition["openmed_grounded_clinical_data/problems/forbidden/path"] = (
+        "not allowed"
+    )
+
+    result = validate_openehr_composition(
+        composition,
+        TEMPLATE,
+        source_text=payload["source_text"],
+    )
+
+    assert not result.ok
+    assert result.out_of_template_paths == (
+        "openmed_grounded_clinical_data/problems/forbidden/path",
+    )
+
+
+def test_parse_operational_template_rejects_xml_without_flat_paths() -> None:
+    with pytest.raises(ValueError, match="WebTemplate JSON"):
+        parse_operational_template("<template></template>")


### PR DESCRIPTION
## Description
Adds a local-first openEHR flat-JSON COMPOSITION export path for grounded clinical entities. The exporter uses caller-supplied WebTemplate constraints, declarative archetype bindings, terminology opt-in, and hashed source-span provenance.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test addition/improvement

## Changes Made
- Added declarative bindings for problem, medication, laboratory, and vital-sign entities.
- Added template path and archetype-lineage validation with FEEDER_AUDIT coverage checks.
- Added coding opt-in, stable code/unit round trips, hashed document provenance, and canonical ClinicalEntity support.
- Added the `openmed export openehr` command with structured success and error output.
- Added synthetic grounded-entity and WebTemplate fixtures.

## Testing
- [x] Fourteen focused exporter and CLI tests pass.
- [x] Changed-file lint checks pass.
- [x] Changed-file format checks pass.

## Documentation
- [x] Public APIs include usage and validation docstrings.
- [x] No changelog entry is required for this scoped feature branch.

## Code Quality
- [x] The implementation was reviewed against current master.
- [x] The diff contains no unrelated formatting churn.
- [x] The changes generate no new warnings in focused validation.

## Dependencies
- [x] No new dependencies were added.

## Checklist
- [x] The commits are focused and use the repository owner identity.
- [x] The branch is current with master.
- [x] The fixtures contain synthetic offline data only.

## Related Issues
Closes #1280

## Screenshots/Examples
Not applicable; this change has no UI surface.