### PR TITLE
Add core plugin SDK protocols and registry

### DIFF
--- a/openmed/plugins/__init__.py
+++ b/openmed/plugins/__init__.py
@@ -1,0 +1,63 @@
+"""Third-party extension SDK for OpenMed plugin components."""
+
+from __future__ import annotations
+
+from .protocols import (
+    COMPONENT_ANONYMIZER_PROVIDER,
+    COMPONENT_EXPORTER,
+    COMPONENT_INTEROP_ADAPTER,
+    COMPONENT_LANGUAGE_PACK,
+    COMPONENT_RECOGNIZER,
+    PLUGIN_COMPONENT_KINDS,
+    PLUGIN_SDK_MAJOR,
+    PLUGIN_SDK_VERSION,
+    AnonymizerProviderPlugin,
+    ExporterPlugin,
+    InteropAdapterPlugin,
+    LanguagePackPlugin,
+    PluginComponent,
+    PluginComponentMetadata,
+    RecognizerPlugin,
+)
+from .registry import (
+    PERMISSIVE_LICENSES,
+    PLUGIN_ENTRY_POINT_GROUP,
+    PluginDiscoveryPolicy,
+    PluginDiscoveryResult,
+    PluginQuarantineRecord,
+    PluginRegistration,
+    PluginRegistry,
+    discover_plugins,
+    is_permissive_license,
+    iter_plugins,
+    quarantined_plugins,
+)
+
+__all__ = [
+    "COMPONENT_ANONYMIZER_PROVIDER",
+    "COMPONENT_EXPORTER",
+    "COMPONENT_INTEROP_ADAPTER",
+    "COMPONENT_LANGUAGE_PACK",
+    "COMPONENT_RECOGNIZER",
+    "PERMISSIVE_LICENSES",
+    "PLUGIN_COMPONENT_KINDS",
+    "PLUGIN_ENTRY_POINT_GROUP",
+    "PLUGIN_SDK_MAJOR",
+    "PLUGIN_SDK_VERSION",
+    "AnonymizerProviderPlugin",
+    "ExporterPlugin",
+    "InteropAdapterPlugin",
+    "LanguagePackPlugin",
+    "PluginComponent",
+    "PluginComponentMetadata",
+    "PluginDiscoveryPolicy",
+    "PluginDiscoveryResult",
+    "PluginQuarantineRecord",
+    "PluginRegistration",
+    "PluginRegistry",
+    "RecognizerPlugin",
+    "discover_plugins",
+    "is_permissive_license",
+    "iter_plugins",
+    "quarantined_plugins",
+]

--- a/openmed/plugins/protocols.py
+++ b/openmed/plugins/protocols.py
@@ -1,0 +1,205 @@
+"""Versioned contracts for third-party OpenMed plugin components."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from openmed.core.schemas.span import OpenMedSpan
+
+PLUGIN_SDK_VERSION = "1.0.0"
+PLUGIN_SDK_MAJOR = 1
+
+COMPONENT_RECOGNIZER = "recognizer"
+COMPONENT_ANONYMIZER_PROVIDER = "anonymizer_provider"
+COMPONENT_EXPORTER = "exporter"
+COMPONENT_INTEROP_ADAPTER = "interop_adapter"
+COMPONENT_LANGUAGE_PACK = "language_pack"
+
+PLUGIN_COMPONENT_KINDS = frozenset(
+    {
+        COMPONENT_RECOGNIZER,
+        COMPONENT_ANONYMIZER_PROVIDER,
+        COMPONENT_EXPORTER,
+        COMPONENT_INTEROP_ADAPTER,
+        COMPONENT_LANGUAGE_PACK,
+    }
+)
+
+
+@dataclass(frozen=True)
+class PluginComponentMetadata:
+    """Metadata every OpenMed plugin component declares for validation.
+
+    Args:
+        plugin_id: Stable package or distribution identifier.
+        component_id: Stable identifier unique within the plugin package.
+        kind: One of :data:`PLUGIN_COMPONENT_KINDS`.
+        sdk_version: Plugin SDK semantic version targeted by the component.
+        license: SPDX license expression for the package or component.
+        network_egress: Whether the component may make network calls.
+        labels: Canonical OpenMed labels emitted or handled by the component.
+        languages: Language codes covered by the component, or ``"*"``.
+        name: Human-readable display name.
+        description: Human-readable component summary.
+        metadata: Extra machine-readable metadata reserved for consumers.
+    """
+
+    plugin_id: str
+    component_id: str
+    kind: str
+    sdk_version: str = PLUGIN_SDK_VERSION
+    license: str = "Apache-2.0"
+    network_egress: bool = False
+    labels: Sequence[str] = field(default_factory=tuple)
+    languages: Sequence[str] = field(default_factory=lambda: ("*",))
+    name: str = ""
+    description: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "plugin_id", str(self.plugin_id).strip())
+        object.__setattr__(self, "component_id", str(self.component_id).strip())
+        object.__setattr__(self, "kind", str(self.kind).strip().lower())
+        object.__setattr__(self, "sdk_version", str(self.sdk_version).strip())
+        object.__setattr__(self, "license", str(self.license).strip())
+        object.__setattr__(self, "network_egress", bool(self.network_egress))
+        object.__setattr__(
+            self,
+            "labels",
+            tuple(str(label).strip() for label in self.labels if str(label).strip()),
+        )
+        object.__setattr__(
+            self,
+            "languages",
+            tuple(
+                str(language).strip().lower().replace("_", "-")
+                for language in self.languages
+                if str(language).strip()
+            )
+            or ("*",),
+        )
+        object.__setattr__(self, "name", str(self.name or "").strip())
+        object.__setattr__(
+            self,
+            "description",
+            str(self.description or "").strip(),
+        )
+        object.__setattr__(self, "metadata", dict(self.metadata or {}))
+
+    @property
+    def qualified_id(self) -> str:
+        """Return the stable plugin/component identifier."""
+
+        return f"{self.plugin_id}:{self.component_id}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-compatible metadata."""
+
+        return {
+            "plugin_id": self.plugin_id,
+            "component_id": self.component_id,
+            "qualified_id": self.qualified_id,
+            "kind": self.kind,
+            "sdk_version": self.sdk_version,
+            "license": self.license,
+            "network_egress": self.network_egress,
+            "labels": list(self.labels),
+            "languages": list(self.languages),
+            "name": self.name,
+            "description": self.description,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "PluginComponentMetadata":
+        """Build metadata from a mapping exposed by a plugin package."""
+
+        return cls(
+            plugin_id=str(payload.get("plugin_id") or payload.get("plugin") or ""),
+            component_id=str(payload.get("component_id") or payload.get("id") or ""),
+            kind=str(payload.get("kind") or ""),
+            sdk_version=str(payload.get("sdk_version") or PLUGIN_SDK_VERSION),
+            license=str(payload.get("license") or payload.get("license_id") or ""),
+            network_egress=bool(payload.get("network_egress", False)),
+            labels=tuple(payload.get("labels") or ()),
+            languages=tuple(payload.get("languages") or ("*",)),
+            name=str(payload.get("name") or ""),
+            description=str(payload.get("description") or ""),
+            metadata=dict(payload.get("metadata") or {}),
+        )
+
+
+class PluginComponent(Protocol):
+    """Base protocol shared by all OpenMed plugin components."""
+
+    metadata: PluginComponentMetadata | Mapping[str, Any]
+
+
+class RecognizerPlugin(PluginComponent, Protocol):
+    """Recognizer contract.
+
+    Implementations return :class:`OpenMedSpan` records with offsets into the
+    input text, canonical labels from ``openmed.core.labels.CANONICAL_LABELS``,
+    safe evidence/metadata, and no raw PHI persisted outside the source text.
+    """
+
+    def recognize(self, text: str, **kwargs: Any) -> Sequence[OpenMedSpan]:
+        """Return canonical OpenMed spans for *text*."""
+
+
+class AnonymizerProviderPlugin(PluginComponent, Protocol):
+    """Anonymizer provider contract for replacing one canonical span."""
+
+    def replacement_for(
+        self,
+        span: OpenMedSpan,
+        surface: str,
+        **kwargs: Any,
+    ) -> str:
+        """Return a replacement string for *span* without logging raw PHI."""
+
+
+class ExporterPlugin(PluginComponent, Protocol):
+    """Exporter contract for serializing canonical OpenMed spans."""
+
+    def export(
+        self,
+        spans: Sequence[OpenMedSpan],
+        **kwargs: Any,
+    ) -> str | bytes | Mapping[str, Any] | Sequence[Mapping[str, Any]]:
+        """Return a serialized representation of canonical *spans*."""
+
+
+class InteropAdapterPlugin(PluginComponent, Protocol):
+    """Interop adapter contract for translating external records."""
+
+    def adapt(self, payload: Any, **kwargs: Any) -> Any:
+        """Translate *payload* to or from OpenMed canonical structures."""
+
+
+class LanguagePackPlugin(PluginComponent, Protocol):
+    """Language-pack contract for local lexicons and label metadata."""
+
+    def language_code(self) -> str:
+        """Return the BCP-47-ish language code provided by this package."""
+
+
+__all__ = [
+    "COMPONENT_ANONYMIZER_PROVIDER",
+    "COMPONENT_EXPORTER",
+    "COMPONENT_INTEROP_ADAPTER",
+    "COMPONENT_LANGUAGE_PACK",
+    "COMPONENT_RECOGNIZER",
+    "PLUGIN_COMPONENT_KINDS",
+    "PLUGIN_SDK_MAJOR",
+    "PLUGIN_SDK_VERSION",
+    "AnonymizerProviderPlugin",
+    "ExporterPlugin",
+    "InteropAdapterPlugin",
+    "LanguagePackPlugin",
+    "PluginComponent",
+    "PluginComponentMetadata",
+    "RecognizerPlugin",
+]

--- a/openmed/plugins/registry.py
+++ b/openmed/plugins/registry.py
@@ -1,0 +1,531 @@
+"""Lazy entry-point registry for OpenMed plugin components."""
+
+from __future__ import annotations
+
+import importlib.metadata as importlib_metadata
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from threading import RLock
+from typing import Any
+
+from openmed.core.labels import CANONICAL_LABELS
+
+from .protocols import (
+    COMPONENT_RECOGNIZER,
+    PLUGIN_COMPONENT_KINDS,
+    PLUGIN_SDK_MAJOR,
+    PluginComponentMetadata,
+)
+
+PLUGIN_ENTRY_POINT_GROUP = "openmed.plugins"
+
+REASON_DUPLICATE_COMPONENT = "duplicate_component"
+REASON_ENTRY_POINT_ENUMERATION_FAILED = "entry_point_enumeration_failed"
+REASON_INVALID_LABEL = "invalid_label"
+REASON_INVALID_METADATA = "invalid_metadata"
+REASON_LOAD_ERROR = "load_error"
+REASON_MISSING_LABELS = "missing_labels"
+REASON_NETWORK_EGRESS_OPT_IN_REQUIRED = "network_egress_opt_in_required"
+REASON_NON_PERMISSIVE_LICENSE_OPT_IN_REQUIRED = "non_permissive_license_opt_in_required"
+REASON_PROTOCOL_VERSION_MISMATCH = "protocol_version_mismatch"
+REASON_UNKNOWN_COMPONENT_KIND = "unknown_component_kind"
+
+PERMISSIVE_LICENSES = frozenset(
+    {
+        "0BSD",
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "CC0-1.0",
+        "ISC",
+        "MIT",
+        "Unlicense",
+        "Zlib",
+    }
+)
+
+_LICENSE_TOKEN_RE = re.compile(r"[A-Za-z0-9.+-]+")
+
+
+@dataclass(frozen=True)
+class PluginDiscoveryPolicy:
+    """Policy gates applied while discovering plugin entry points.
+
+    Args:
+        allow_network_egress: Allow plugins that declare network egress.
+        allow_non_permissive_licenses: Allow plugins with restricted licenses.
+        opt_in_plugins: Plugin ids or qualified component ids explicitly
+            allowed through both policy gates.
+    """
+
+    allow_network_egress: bool = False
+    allow_non_permissive_licenses: bool = False
+    opt_in_plugins: Sequence[str] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "opt_in_plugins",
+            tuple(str(item).strip() for item in self.opt_in_plugins if str(item)),
+        )
+
+
+@dataclass(frozen=True)
+class PluginRegistration:
+    """A plugin component accepted by the registry."""
+
+    entry_point_name: str
+    metadata: PluginComponentMetadata
+    component: Any
+    loaded_by_policy_opt_in: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-compatible registration metadata."""
+
+        return {
+            "entry_point_name": self.entry_point_name,
+            "metadata": self.metadata.to_dict(),
+            "loaded_by_policy_opt_in": self.loaded_by_policy_opt_in,
+        }
+
+
+@dataclass(frozen=True)
+class PluginQuarantineRecord:
+    """Structured reason a plugin component was skipped."""
+
+    entry_point_name: str
+    reason: str
+    message: str
+    plugin_id: str = ""
+    component_id: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def qualified_id(self) -> str:
+        """Return ``plugin_id:component_id`` when both are known."""
+
+        if not self.plugin_id or not self.component_id:
+            return ""
+        return f"{self.plugin_id}:{self.component_id}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-compatible quarantine details."""
+
+        return {
+            "entry_point_name": self.entry_point_name,
+            "reason": self.reason,
+            "message": self.message,
+            "plugin_id": self.plugin_id,
+            "component_id": self.component_id,
+            "qualified_id": self.qualified_id,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class PluginDiscoveryResult:
+    """Snapshot returned after one discovery pass."""
+
+    registrations: tuple[PluginRegistration, ...]
+    quarantined: tuple[PluginQuarantineRecord, ...]
+
+    def registrations_for_kind(self, kind: str) -> tuple[PluginRegistration, ...]:
+        """Return registrations whose metadata kind matches *kind*."""
+
+        normalized = str(kind or "").strip().lower()
+        return tuple(
+            registration
+            for registration in self.registrations
+            if registration.metadata.kind == normalized
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-compatible discovery results."""
+
+        return {
+            "registrations": [
+                registration.to_dict() for registration in self.registrations
+            ],
+            "quarantined": [record.to_dict() for record in self.quarantined],
+        }
+
+
+class PluginRegistry:
+    """Lazy registry for third-party OpenMed plugin entry points."""
+
+    def __init__(
+        self,
+        *,
+        policy: PluginDiscoveryPolicy | None = None,
+    ) -> None:
+        self.policy = policy or PluginDiscoveryPolicy()
+        self._lock = RLock()
+        self._discovered = False
+        self._registrations: dict[str, PluginRegistration] = {}
+        self._quarantined: list[PluginQuarantineRecord] = []
+
+    def discover(self, *, force: bool = False) -> PluginDiscoveryResult:
+        """Discover entry points once and return the registry snapshot."""
+
+        with self._lock:
+            if self._discovered and not force:
+                return self.snapshot()
+            self._discovered = True
+            self._registrations.clear()
+            self._quarantined.clear()
+
+        try:
+            entry_points = _entry_points_for_group(PLUGIN_ENTRY_POINT_GROUP)
+        except Exception as exc:  # pragma: no cover - importlib defensive guard
+            self._quarantine(
+                entry_point_name=PLUGIN_ENTRY_POINT_GROUP,
+                reason=REASON_ENTRY_POINT_ENUMERATION_FAILED,
+                message=f"failed to enumerate entry points: {exc.__class__.__name__}",
+            )
+            return self.snapshot()
+
+        for entry_point in entry_points:
+            self._load_entry_point(entry_point)
+
+        return self.snapshot()
+
+    def registrations(
+        self,
+        *,
+        kind: str | None = None,
+    ) -> tuple[PluginRegistration, ...]:
+        """Return accepted registrations, optionally filtered by kind."""
+
+        result = self.discover()
+        if kind is None:
+            return result.registrations
+        return result.registrations_for_kind(kind)
+
+    def quarantined(self) -> tuple[PluginQuarantineRecord, ...]:
+        """Return structured records for skipped plugin components."""
+
+        return self.discover().quarantined
+
+    def snapshot(self) -> PluginDiscoveryResult:
+        """Return the current registry snapshot without triggering discovery."""
+
+        with self._lock:
+            return PluginDiscoveryResult(
+                registrations=tuple(
+                    sorted(
+                        self._registrations.values(),
+                        key=lambda item: item.metadata.qualified_id,
+                    )
+                ),
+                quarantined=tuple(self._quarantined),
+            )
+
+    def _load_entry_point(self, entry_point: Any) -> None:
+        entry_name = str(getattr(entry_point, "name", "<unknown>"))
+        try:
+            loaded = entry_point.load()
+        except Exception as exc:
+            self._quarantine(
+                entry_point_name=entry_name,
+                reason=REASON_LOAD_ERROR,
+                message=f"failed to load entry point: {exc.__class__.__name__}",
+            )
+            return
+
+        try:
+            components = _coerce_components(loaded)
+        except Exception as exc:
+            self._quarantine(
+                entry_point_name=entry_name,
+                reason=REASON_INVALID_METADATA,
+                message=str(exc),
+            )
+            return
+
+        for component in components:
+            self._register_component(entry_name, component)
+
+    def _register_component(self, entry_name: str, component: Any) -> None:
+        try:
+            metadata = _metadata_for_component(component)
+        except Exception as exc:
+            self._quarantine(
+                entry_point_name=entry_name,
+                reason=REASON_INVALID_METADATA,
+                message=str(exc),
+            )
+            return
+
+        rejection = _metadata_rejection(metadata, self.policy)
+        if rejection is not None:
+            reason, message = rejection
+            self._quarantine_metadata(entry_name, metadata, reason, message)
+            return
+
+        key = metadata.qualified_id
+        with self._lock:
+            if key in self._registrations:
+                self._quarantined.append(
+                    _record_for_metadata(
+                        entry_name,
+                        metadata,
+                        REASON_DUPLICATE_COMPONENT,
+                        f"duplicate plugin component {key!r}",
+                    )
+                )
+                return
+            self._registrations[key] = PluginRegistration(
+                entry_point_name=entry_name,
+                metadata=metadata,
+                component=component,
+                loaded_by_policy_opt_in=_has_policy_opt_in(metadata, self.policy),
+            )
+
+    def _quarantine_metadata(
+        self,
+        entry_point_name: str,
+        metadata: PluginComponentMetadata,
+        reason: str,
+        message: str,
+    ) -> None:
+        with self._lock:
+            self._quarantined.append(
+                _record_for_metadata(entry_point_name, metadata, reason, message)
+            )
+
+    def _quarantine(
+        self,
+        *,
+        entry_point_name: str,
+        reason: str,
+        message: str,
+    ) -> None:
+        with self._lock:
+            self._quarantined.append(
+                PluginQuarantineRecord(
+                    entry_point_name=entry_point_name,
+                    reason=reason,
+                    message=message,
+                )
+            )
+
+
+_DEFAULT_REGISTRY = PluginRegistry()
+
+
+def discover_plugins(
+    *,
+    allow_network_egress: bool = False,
+    allow_non_permissive_licenses: bool = False,
+    opt_in_plugins: Sequence[str] = (),
+    force: bool = False,
+) -> PluginDiscoveryResult:
+    """Discover third-party plugin components.
+
+    Default discovery is cached and excludes plugins that declare network
+    egress or non-permissive licenses. Passing any opt-in option uses a fresh
+    registry so callers must make that policy choice explicitly.
+    """
+
+    policy = PluginDiscoveryPolicy(
+        allow_network_egress=allow_network_egress,
+        allow_non_permissive_licenses=allow_non_permissive_licenses,
+        opt_in_plugins=opt_in_plugins,
+    )
+    if policy == PluginDiscoveryPolicy():
+        return _DEFAULT_REGISTRY.discover(force=force)
+    return PluginRegistry(policy=policy).discover(force=True)
+
+
+def iter_plugins(
+    kind: str | None = None,
+    *,
+    allow_network_egress: bool = False,
+    allow_non_permissive_licenses: bool = False,
+    opt_in_plugins: Sequence[str] = (),
+) -> tuple[PluginRegistration, ...]:
+    """Return accepted plugin registrations, optionally filtered by kind."""
+
+    result = discover_plugins(
+        allow_network_egress=allow_network_egress,
+        allow_non_permissive_licenses=allow_non_permissive_licenses,
+        opt_in_plugins=opt_in_plugins,
+    )
+    if kind is None:
+        return result.registrations
+    return result.registrations_for_kind(kind)
+
+
+def quarantined_plugins() -> tuple[PluginQuarantineRecord, ...]:
+    """Return quarantine records from default plugin discovery."""
+
+    return _DEFAULT_REGISTRY.quarantined()
+
+
+def is_permissive_license(license_expression: str) -> bool:
+    """Return whether *license_expression* is allowed for auto-load."""
+
+    tokens = tuple(_LICENSE_TOKEN_RE.findall(str(license_expression or "")))
+    if not tokens:
+        return False
+    license_tokens = [
+        token for token in tokens if token.upper() not in {"AND", "OR", "WITH"}
+    ]
+    return bool(license_tokens) and all(
+        token in PERMISSIVE_LICENSES for token in license_tokens
+    )
+
+
+def _entry_points_for_group(group: str) -> Sequence[Any]:
+    try:
+        return tuple(importlib_metadata.entry_points(group=group))
+    except TypeError:
+        entry_points = importlib_metadata.entry_points()
+        if hasattr(entry_points, "select"):
+            return tuple(entry_points.select(group=group))
+        return tuple(entry_points.get(group, ()))
+
+
+def _coerce_components(value: Any) -> tuple[Any, ...]:
+    if value is None:
+        return ()
+    if _looks_like_component(value):
+        return (value,)
+    if callable(value):
+        return _coerce_components(value())
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes, Mapping)):
+        components: list[Any] = []
+        for item in value:
+            components.extend(_coerce_components(item))
+        return tuple(components)
+    raise TypeError("openmed.plugins entry points must return components with metadata")
+
+
+def _looks_like_component(value: Any) -> bool:
+    return hasattr(value, "metadata")
+
+
+def _metadata_for_component(component: Any) -> PluginComponentMetadata:
+    raw_metadata = getattr(component, "metadata", None)
+    if callable(raw_metadata):
+        raw_metadata = raw_metadata()
+    if isinstance(raw_metadata, PluginComponentMetadata):
+        return raw_metadata
+    if isinstance(raw_metadata, Mapping):
+        return PluginComponentMetadata.from_mapping(raw_metadata)
+    raise TypeError("plugin component must expose PluginComponentMetadata metadata")
+
+
+def _metadata_rejection(
+    metadata: PluginComponentMetadata,
+    policy: PluginDiscoveryPolicy,
+) -> tuple[str, str] | None:
+    if not metadata.plugin_id:
+        return REASON_INVALID_METADATA, "plugin_id must be non-empty"
+    if not metadata.component_id:
+        return REASON_INVALID_METADATA, "component_id must be non-empty"
+    if metadata.kind not in PLUGIN_COMPONENT_KINDS:
+        return (
+            REASON_UNKNOWN_COMPONENT_KIND,
+            f"component kind must be one of {', '.join(sorted(PLUGIN_COMPONENT_KINDS))}",
+        )
+
+    major = _sdk_major(metadata.sdk_version)
+    if major != PLUGIN_SDK_MAJOR:
+        return (
+            REASON_PROTOCOL_VERSION_MISMATCH,
+            f"plugin targets SDK {metadata.sdk_version!r}; "
+            f"OpenMed supports major {PLUGIN_SDK_MAJOR}",
+        )
+
+    label_error = _label_rejection(metadata)
+    if label_error is not None:
+        return label_error
+
+    if metadata.network_egress and not (
+        policy.allow_network_egress or _has_policy_opt_in(metadata, policy)
+    ):
+        return (
+            REASON_NETWORK_EGRESS_OPT_IN_REQUIRED,
+            "plugin declares network egress and requires explicit opt-in",
+        )
+
+    if not is_permissive_license(metadata.license) and not (
+        policy.allow_non_permissive_licenses or _has_policy_opt_in(metadata, policy)
+    ):
+        return (
+            REASON_NON_PERMISSIVE_LICENSE_OPT_IN_REQUIRED,
+            "plugin license is not auto-loadable and requires explicit opt-in",
+        )
+
+    return None
+
+
+def _label_rejection(
+    metadata: PluginComponentMetadata,
+) -> tuple[str, str] | None:
+    if metadata.kind == COMPONENT_RECOGNIZER and not metadata.labels:
+        return (
+            REASON_MISSING_LABELS,
+            "recognizer plugins must declare at least one canonical label",
+        )
+    for label in metadata.labels:
+        if label not in CANONICAL_LABELS:
+            return (
+                REASON_INVALID_LABEL,
+                f"label {label!r} is not in the canonical OpenMed label schema",
+            )
+    return None
+
+
+def _sdk_major(version: str) -> int:
+    major_text = str(version or "").split(".", 1)[0]
+    if not major_text.isdigit():
+        return -1
+    return int(major_text)
+
+
+def _has_policy_opt_in(
+    metadata: PluginComponentMetadata,
+    policy: PluginDiscoveryPolicy,
+) -> bool:
+    opt_ins = set(policy.opt_in_plugins)
+    return metadata.plugin_id in opt_ins or metadata.qualified_id in opt_ins
+
+
+def _record_for_metadata(
+    entry_point_name: str,
+    metadata: PluginComponentMetadata,
+    reason: str,
+    message: str,
+) -> PluginQuarantineRecord:
+    return PluginQuarantineRecord(
+        entry_point_name=entry_point_name,
+        plugin_id=metadata.plugin_id,
+        component_id=metadata.component_id,
+        reason=reason,
+        message=message,
+        metadata=metadata.to_dict(),
+    )
+
+
+def _reset_plugin_registry_for_tests() -> None:
+    global _DEFAULT_REGISTRY
+
+    _DEFAULT_REGISTRY = PluginRegistry()
+
+
+__all__ = [
+    "PERMISSIVE_LICENSES",
+    "PLUGIN_ENTRY_POINT_GROUP",
+    "PluginDiscoveryPolicy",
+    "PluginDiscoveryResult",
+    "PluginQuarantineRecord",
+    "PluginRegistration",
+    "PluginRegistry",
+    "discover_plugins",
+    "is_permissive_license",
+    "iter_plugins",
+    "quarantined_plugins",
+]

--- a/tests/unit/interop/test_core_does_not_import_adapters.py
+++ b/tests/unit/interop/test_core_does_not_import_adapters.py
@@ -35,10 +35,14 @@ def _is_optional_adapter_module(name: str) -> bool:
 
 def test_import_openmed_does_not_import_optional_adapter_dependencies():
     _clear_optional_adapter_modules()
+    for name in list(sys.modules):
+        if name == "openmed.plugins" or name.startswith("openmed.plugins."):
+            sys.modules.pop(name, None)
 
     import openmed  # noqa: F401
 
     assert not any(_is_optional_adapter_module(name) for name in sys.modules)
+    assert "openmed.plugins" not in sys.modules
 
 
 def test_import_interop_registry_does_not_import_optional_adapter_dependencies():

--- a/tests/unit/plugins/test_registry.py
+++ b/tests/unit/plugins/test_registry.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import pytest
+
+from openmed.plugins import registry
+from openmed.plugins.protocols import (
+    COMPONENT_EXPORTER,
+    COMPONENT_RECOGNIZER,
+    PLUGIN_SDK_VERSION,
+    PluginComponentMetadata,
+)
+from openmed.plugins.registry import (
+    REASON_INVALID_LABEL,
+    REASON_INVALID_METADATA,
+    REASON_NETWORK_EGRESS_OPT_IN_REQUIRED,
+    REASON_NON_PERMISSIVE_LICENSE_OPT_IN_REQUIRED,
+    REASON_PROTOCOL_VERSION_MISMATCH,
+    discover_plugins,
+    is_permissive_license,
+    iter_plugins,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_registry():
+    registry._reset_plugin_registry_for_tests()
+    yield
+    registry._reset_plugin_registry_for_tests()
+
+
+class FakeEntryPoint:
+    def __init__(self, name, loaded):
+        self.name = name
+        self._loaded = loaded
+
+    def load(self):
+        if isinstance(self._loaded, BaseException):
+            raise self._loaded
+        return self._loaded
+
+
+class ToyRecognizer:
+    metadata = PluginComponentMetadata(
+        plugin_id="acme-openmed",
+        component_id="toy-person",
+        kind=COMPONENT_RECOGNIZER,
+        labels=("PERSON",),
+        languages=("en",),
+    )
+
+    def recognize(self, text: str, **kwargs):
+        return ()
+
+
+class ToyExporter:
+    metadata = PluginComponentMetadata(
+        plugin_id="acme-openmed",
+        component_id="toy-exporter",
+        kind=COMPONENT_EXPORTER,
+        labels=("PERSON",),
+    )
+
+    def export(self, spans, **kwargs):
+        return {"spans": [span.to_dict() for span in spans]}
+
+
+def _patch_entry_points(monkeypatch, *entry_points):
+    calls = 0
+
+    def fake_entry_points(*, group=None):
+        nonlocal calls
+        calls += 1
+        assert group == registry.PLUGIN_ENTRY_POINT_GROUP
+        return entry_points
+
+    monkeypatch.setattr(registry.importlib_metadata, "entry_points", fake_entry_points)
+    return lambda: calls
+
+
+def test_valid_entry_point_is_discovered_once(monkeypatch):
+    calls = _patch_entry_points(
+        monkeypatch,
+        FakeEntryPoint("toy", lambda: (ToyRecognizer(), ToyExporter())),
+    )
+
+    result = discover_plugins()
+    assert [item.metadata.qualified_id for item in result.registrations] == [
+        "acme-openmed:toy-exporter",
+        "acme-openmed:toy-person",
+    ]
+    assert result.quarantined == ()
+
+    recognizers = iter_plugins(COMPONENT_RECOGNIZER)
+    assert [item.metadata.component_id for item in recognizers] == ["toy-person"]
+    assert calls() == 1
+
+
+def test_protocol_version_mismatch_is_quarantined(monkeypatch):
+    class FuturePlugin:
+        metadata = PluginComponentMetadata(
+            plugin_id="acme-openmed",
+            component_id="future",
+            kind=COMPONENT_RECOGNIZER,
+            sdk_version="2.0.0",
+            labels=("PERSON",),
+        )
+
+    _patch_entry_points(monkeypatch, FakeEntryPoint("future", FuturePlugin()))
+
+    result = discover_plugins()
+
+    assert result.registrations == ()
+    assert result.quarantined[0].reason == REASON_PROTOCOL_VERSION_MISMATCH
+    assert result.quarantined[0].plugin_id == "acme-openmed"
+    assert "2.0.0" in result.quarantined[0].message
+
+
+def test_policy_restricted_plugins_require_explicit_opt_in(monkeypatch):
+    class NetworkPlugin:
+        metadata = PluginComponentMetadata(
+            plugin_id="remote-plugin",
+            component_id="network-person",
+            kind=COMPONENT_RECOGNIZER,
+            network_egress=True,
+            labels=("PERSON",),
+        )
+
+    class RestrictedLicensePlugin:
+        metadata = PluginComponentMetadata(
+            plugin_id="restricted-plugin",
+            component_id="person",
+            kind=COMPONENT_RECOGNIZER,
+            license="GPL-3.0-only",
+            labels=("PERSON",),
+        )
+
+    _patch_entry_points(
+        monkeypatch,
+        FakeEntryPoint("network", NetworkPlugin()),
+        FakeEntryPoint("restricted", RestrictedLicensePlugin()),
+    )
+
+    result = discover_plugins()
+    assert result.registrations == ()
+    assert [record.reason for record in result.quarantined] == [
+        REASON_NETWORK_EGRESS_OPT_IN_REQUIRED,
+        REASON_NON_PERMISSIVE_LICENSE_OPT_IN_REQUIRED,
+    ]
+
+    opted_in = discover_plugins(
+        allow_network_egress=True,
+        opt_in_plugins=("restricted-plugin:person",),
+    )
+    assert [item.metadata.qualified_id for item in opted_in.registrations] == [
+        "remote-plugin:network-person",
+        "restricted-plugin:person",
+    ]
+    assert opted_in.registrations[1].loaded_by_policy_opt_in is True
+
+
+def test_unsupported_recognizer_label_is_quarantined(monkeypatch):
+    class BadLabelPlugin:
+        metadata = {
+            "plugin_id": "bad-labels",
+            "component_id": "alien",
+            "kind": COMPONENT_RECOGNIZER,
+            "sdk_version": PLUGIN_SDK_VERSION,
+            "license": "Apache-2.0",
+            "labels": ("ALIEN",),
+        }
+
+    _patch_entry_points(monkeypatch, FakeEntryPoint("bad-label", BadLabelPlugin()))
+
+    result = discover_plugins()
+
+    assert result.registrations == ()
+    assert result.quarantined[0].reason == REASON_INVALID_LABEL
+    assert "ALIEN" in result.quarantined[0].message
+
+
+def test_malformed_plugin_fixture_is_quarantined_with_specific_reason(monkeypatch):
+    class MissingMetadata:
+        pass
+
+    _patch_entry_points(monkeypatch, FakeEntryPoint("malformed", MissingMetadata()))
+
+    result = discover_plugins()
+
+    assert result.registrations == ()
+    assert result.quarantined[0].reason == REASON_INVALID_METADATA
+    assert "metadata" in result.quarantined[0].message
+
+
+def test_license_policy_accepts_only_permissive_expressions():
+    assert is_permissive_license("Apache-2.0")
+    assert is_permissive_license("Apache-2.0 OR MIT")
+    assert not is_permissive_license("GPL-3.0-only")
+    assert not is_permissive_license("")


### PR DESCRIPTION
# Pull Request

## Description
Adds the first plugin SDK slice for child issue #1324: versioned component metadata/protocol contracts and a lazy entry-point registry that validates plugin declarations before runtime integration.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `openmed.plugins` with SDK metadata/protocols for recognizer, anonymizer provider, exporter, interop adapter, and language pack components.
- Added lazy `openmed.plugins.registry` discovery for `openmed.plugins` entry points with structured quarantine records.
- Enforced default policy gates for network egress and non-permissive licenses, with explicit opt-in paths.
- Added tests for discovery, protocol-version mismatch, malformed fixtures, label rejection, policy opt-in, and bare import behavior.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `.venv/bin/python -m pytest tests/ -q` (3892 passed, 39 skipped)
- `make lint`
- `make format-check`
- `make format`
- `git diff --check`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1324
Related to #1283

## Screenshots/Examples
Not applicable.
