### PR TITLE
feat: propagate assertion state onto extracted relations

### DIFF
--- a/openmed/clinical/relations/__init__.py
+++ b/openmed/clinical/relations/__init__.py
@@ -1,5 +1,16 @@
 """Medication relation linking public API."""
 
+from .assertion_filter import (
+    ASSERTION_FILTER_ADVISORY,
+    RELATION_ASSERTION_STATUSES,
+    RELATION_CONDITIONAL,
+    RELATION_CONFIRMED,
+    RELATION_POSSIBLE,
+    RELATION_REFUTED,
+    RelationAssertion,
+    filter_asserted_relations,
+    propagate_relation_assertion,
+)
 from .candidate import (
     ATTRIBUTE_RELATION_TYPES,
     DRUG_TO_DOSE,
@@ -23,6 +34,15 @@ from .medication_links import (
 )
 
 __all__ = [
+    "ASSERTION_FILTER_ADVISORY",
+    "RELATION_ASSERTION_STATUSES",
+    "RELATION_CONFIRMED",
+    "RELATION_REFUTED",
+    "RELATION_CONDITIONAL",
+    "RELATION_POSSIBLE",
+    "RelationAssertion",
+    "propagate_relation_assertion",
+    "filter_asserted_relations",
     "ATTRIBUTE_RELATION_TYPES",
     "DRUG_TO_DOSE",
     "DRUG_TO_DURATION",

--- a/openmed/clinical/relations/assertion_filter.py
+++ b/openmed/clinical/relations/assertion_filter.py
@@ -1,0 +1,209 @@
+"""Relation-level assertion propagation (roadmap v2.0).
+
+A relation inherits the assertion state of its arguments. A dose relation to a
+medication in a hypothetical plan ("would start metformin if A1c rises") or a
+finding relation to a negated problem must not be emitted as an asserted fact.
+The base relation extractor ignores the ConText negation/temporality/uncertainty
+axes, so grounding and FHIR export would record refuted or conditional relations
+as real -- a correctness hazard.
+
+This stage reads :func:`openmed.clinical.context.resolve_span_context` for both
+the head and the attribute of a :class:`RelationCandidate` and tags the relation
+with a verificationStatus-compatible status:
+
+* ``confirmed``   -- both arguments asserted.
+* ``refuted``     -- a negated argument (hardest boundary; takes precedence).
+* ``conditional`` -- a hypothetical / conditional argument.
+* ``possible``    -- an uncertain argument.
+
+Refuted and conditional relations are excluded from the default asserted-fact
+set but retained -- with offsets, tags, and a content hash, never raw note text
+-- so the audit trace and FHIR exporter can honor them. The cue lexicons are
+reused from ``context.py``; this module adds no new lexicon.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from openmed.core.audit import stable_hash
+
+from ..context import HYPOTHETICAL, NEGATED, UNCERTAIN, resolve_span_context
+from .candidate import RelationCandidate, SpanReference
+
+ASSERTION_FILTER_ADVISORY = (
+    "Relation assertion tags are derived deterministically from the ConText "
+    "axes of each argument. Refuted and conditional relations are withheld from "
+    "the default fact set but kept in the audit trace; verify before clinical "
+    "use."
+)
+
+RELATION_CONFIRMED = "confirmed"
+RELATION_REFUTED = "refuted"
+RELATION_CONDITIONAL = "conditional"
+RELATION_POSSIBLE = "possible"
+
+#: Relation assertion statuses, ordered from asserted to most withheld.
+RELATION_ASSERTION_STATUSES = (
+    RELATION_CONFIRMED,
+    RELATION_POSSIBLE,
+    RELATION_CONDITIONAL,
+    RELATION_REFUTED,
+)
+
+# Statuses kept out of the default patient-fact set (still audited).
+_WITHHELD_STATUSES = frozenset({RELATION_REFUTED, RELATION_CONDITIONAL})
+
+# verificationStatus tags -> FHIR Condition.verificationStatus values.
+_FHIR_VERIFICATION_STATUS = {
+    RELATION_CONFIRMED: "confirmed",
+    RELATION_REFUTED: "refuted",
+    RELATION_CONDITIONAL: "provisional",
+    RELATION_POSSIBLE: "provisional",
+}
+
+
+@dataclass(frozen=True)
+class RelationAssertion:
+    """A relation tagged with its propagated assertion status."""
+
+    relation: RelationCandidate
+    status: str
+    fhir_verification_status: str
+    head_negation: str
+    head_temporality: str
+    head_certainty: str
+    attribute_negation: str
+    attribute_temporality: str
+    attribute_certainty: str
+
+    @property
+    def asserted(self) -> bool:
+        """Whether the relation belongs in the default asserted-fact set."""
+
+        return self.status not in _WITHHELD_STATUSES
+
+    def to_audit_entry(self) -> dict[str, object]:
+        """Audit record with offsets, tags, and a content hash -- no note text."""
+
+        head_offset = [self.relation.head.start, self.relation.head.end]
+        attribute_offset = [
+            self.relation.attribute.start,
+            self.relation.attribute.end,
+        ]
+        payload: dict[str, object] = {
+            "relation_type": self.relation.relation_type,
+            "head_offset": head_offset,
+            "attribute_offset": attribute_offset,
+            "status": self.status,
+            "fhir_verification_status": self.fhir_verification_status,
+            "head_axes": {
+                "negation": self.head_negation,
+                "temporality": self.head_temporality,
+                "certainty": self.head_certainty,
+            },
+            "attribute_axes": {
+                "negation": self.attribute_negation,
+                "temporality": self.attribute_temporality,
+                "certainty": self.attribute_certainty,
+            },
+        }
+        payload["content_hash"] = stable_hash(payload)
+        return payload
+
+
+def _span_axes(
+    reference: SpanReference,
+    document_text: str,
+    language: str | None,
+) -> tuple[str, str, str]:
+    span = {
+        "text": reference.text,
+        "context": document_text,
+        "start": reference.start,
+        "end": reference.end,
+    }
+    result = resolve_span_context(span, language=language)
+    return result.negation, result.temporality, result.certainty
+
+
+def _combine_status(
+    head: tuple[str, str, str],
+    attribute: tuple[str, str, str],
+) -> str:
+    negations = {head[0], attribute[0]}
+    temporalities = {head[1], attribute[1]}
+    certainties = {head[2], attribute[2]}
+
+    if NEGATED in negations:
+        return RELATION_REFUTED
+    if HYPOTHETICAL in temporalities:
+        return RELATION_CONDITIONAL
+    if UNCERTAIN in certainties:
+        return RELATION_POSSIBLE
+    return RELATION_CONFIRMED
+
+
+def propagate_relation_assertion(
+    relation: RelationCandidate,
+    document_text: str,
+    *,
+    language: str | None = None,
+) -> RelationAssertion:
+    """Tag ``relation`` with the assertion status propagated from its arguments."""
+
+    head = _span_axes(relation.head, document_text, language)
+    attribute = _span_axes(relation.attribute, document_text, language)
+    status = _combine_status(head, attribute)
+
+    return RelationAssertion(
+        relation=relation,
+        status=status,
+        fhir_verification_status=_FHIR_VERIFICATION_STATUS[status],
+        head_negation=head[0],
+        head_temporality=head[1],
+        head_certainty=head[2],
+        attribute_negation=attribute[0],
+        attribute_temporality=attribute[1],
+        attribute_certainty=attribute[2],
+    )
+
+
+def filter_asserted_relations(
+    relations: Iterable[RelationCandidate],
+    document_text: str | Mapping[int, str],
+    *,
+    language: str | None = None,
+) -> tuple[list[RelationAssertion], list[RelationAssertion]]:
+    """Split relations into the default asserted-fact set and withheld ones.
+
+    ``document_text`` is either the shared source text for every relation, or a
+    mapping from ``id(relation)`` to that relation's source text. Refuted and
+    conditional relations are withheld from the asserted set but returned so the
+    audit trace retains them.
+    """
+
+    asserted: list[RelationAssertion] = []
+    withheld: list[RelationAssertion] = []
+    for relation in relations:
+        if isinstance(document_text, Mapping):
+            text = document_text[id(relation)]
+        else:
+            text = document_text
+        result = propagate_relation_assertion(relation, text, language=language)
+        (asserted if result.asserted else withheld).append(result)
+    return asserted, withheld
+
+
+__all__ = [
+    "ASSERTION_FILTER_ADVISORY",
+    "RELATION_CONFIRMED",
+    "RELATION_REFUTED",
+    "RELATION_CONDITIONAL",
+    "RELATION_POSSIBLE",
+    "RELATION_ASSERTION_STATUSES",
+    "RelationAssertion",
+    "propagate_relation_assertion",
+    "filter_asserted_relations",
+]

--- a/openmed/eval/golden/fixtures/relation_assertion.jsonl
+++ b/openmed/eval/golden/fixtures/relation_assertion.jsonl
@@ -1,0 +1,8 @@
+{"text": "Metformin 500 mg PO daily", "head": "Metformin", "attribute": "500 mg", "relation_type": "drug_to_dose", "expected_status": "confirmed"}
+{"text": "Lisinopril 10 mg once daily for hypertension", "head": "Lisinopril", "attribute": "10 mg", "relation_type": "drug_to_dose", "expected_status": "confirmed"}
+{"text": "Denies taking metformin 500 mg", "head": "metformin", "attribute": "500 mg", "relation_type": "drug_to_dose", "expected_status": "refuted"}
+{"text": "No aspirin 81 mg given in the ED", "head": "aspirin", "attribute": "81 mg", "relation_type": "drug_to_dose", "expected_status": "refuted"}
+{"text": "Would start metformin 1000 mg if A1c remains elevated", "head": "metformin", "attribute": "1000 mg", "relation_type": "drug_to_dose", "expected_status": "conditional"}
+{"text": "Start atorvastatin 40 mg if LDL stays high", "head": "atorvastatin", "attribute": "40 mg", "relation_type": "drug_to_dose", "expected_status": "conditional"}
+{"text": "Possible reaction to amoxicillin 500 mg", "head": "amoxicillin", "attribute": "500 mg", "relation_type": "drug_to_dose", "expected_status": "possible"}
+{"text": "Likely warfarin 5 mg overdose", "head": "warfarin", "attribute": "5 mg", "relation_type": "drug_to_dose", "expected_status": "possible"}

--- a/openmed/eval/golden/loader.py
+++ b/openmed/eval/golden/loader.py
@@ -30,7 +30,11 @@ _GOLDEN_DIR = Path(__file__).resolve().parent
 _FIXTURE_DIR = _GOLDEN_DIR / "fixtures"
 _TOP_LEVEL_FIXTURES: tuple[Path, ...] = (_GOLDEN_DIR / "financial_ids.jsonl",)
 _NON_DEID_FIXTURE_NAMES = frozenset(
-    {"context_multilingual.jsonl", "grounding_crosslingual.jsonl"}
+    {
+        "context_multilingual.jsonl",
+        "grounding_crosslingual.jsonl",
+        "relation_assertion.jsonl",
+    }
 )
 
 

--- a/openmed/eval/metrics.py
+++ b/openmed/eval/metrics.py
@@ -1957,6 +1957,39 @@ def _percentile(values: Sequence[float], percentile: int | float) -> float:
     return values[index]
 
 
+def relation_assertion_consistency(
+    predicted: Iterable[tuple[Any, str]],
+    gold: Iterable[tuple[Any, str]],
+) -> ConsistencyMetric:
+    """Score how consistently predicted relation-assertion tags match the gold.
+
+    Each input is a sequence of ``(relation_key, status)`` pairs. The score is
+    the fraction of gold relations whose predicted status matches; every
+    mismatch is recorded as a violation keyed by the relation.
+    """
+
+    predicted_by_key = {key: status for key, status in predicted}
+    gold_by_key = {key: status for key, status in gold}
+
+    consistent = 0
+    violations: dict[str, list[str]] = {}
+    for key, gold_status in gold_by_key.items():
+        predicted_status = predicted_by_key.get(key)
+        if predicted_status == gold_status:
+            consistent += 1
+        else:
+            violations[str(key)] = [f"expected {gold_status}, got {predicted_status}"]
+
+    total = len(gold_by_key)
+    score = 1.0 if total == 0 else consistent / total
+    return ConsistencyMetric(
+        score=score,
+        consistent=consistent,
+        total=total,
+        violations=violations,
+    )
+
+
 __all__ = [
     "ABSTENTION_ROUTE_ACCEPT",
     "ABSTENTION_ROUTE_REDACT",
@@ -2002,4 +2035,5 @@ __all__ = [
     "abstention_route",
     "apply_abstention_policy",
     "bootstrap_abstention_residual_risk",
+    "relation_assertion_consistency",
 ]

--- a/tests/unit/clinical/test_relation_assertion_filter.py
+++ b/tests/unit/clinical/test_relation_assertion_filter.py
@@ -1,0 +1,150 @@
+"""Tests for relation-level assertion propagation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.clinical.relations.assertion_filter import (
+    ASSERTION_FILTER_ADVISORY,
+    RELATION_CONDITIONAL,
+    RELATION_CONFIRMED,
+    RELATION_POSSIBLE,
+    RELATION_REFUTED,
+    RelationAssertion,
+    filter_asserted_relations,
+    propagate_relation_assertion,
+)
+from openmed.clinical.relations.candidate import RelationCandidate, SpanReference
+
+
+def _relation(doc: str, drug: str, attribute: str) -> RelationCandidate:
+    d = doc.index(drug)
+    a = doc.index(attribute)
+    return RelationCandidate(
+        relation_type="drug_to_dose",
+        head=SpanReference(
+            text=drug, label="MEDICATION", start=d, end=d + len(drug), score=1.0
+        ),
+        attribute=SpanReference(
+            text=attribute, label="dose", start=a, end=a + len(attribute), score=1.0
+        ),
+        score=1.0,
+        confidence=1.0,
+        features={},
+        explanation=(),
+    )
+
+
+# --------------------------------------------------------------------------
+# Propagation rules
+# --------------------------------------------------------------------------
+
+
+def test_negated_argument_makes_relation_refuted():
+    doc = "Denies metformin 500 mg daily"
+    rel = _relation(doc, "metformin", "500 mg")
+
+    result = propagate_relation_assertion(rel, doc)
+
+    assert isinstance(result, RelationAssertion)
+    assert result.status == RELATION_REFUTED
+    assert result.fhir_verification_status == "refuted"
+    assert result.asserted is False
+
+
+def test_hypothetical_argument_makes_relation_conditional():
+    doc = "Start metformin 1000 mg if A1c rises"
+    rel = _relation(doc, "metformin", "1000 mg")
+
+    result = propagate_relation_assertion(rel, doc)
+
+    assert result.status == RELATION_CONDITIONAL
+    assert result.fhir_verification_status == "provisional"
+    assert result.asserted is False
+
+
+def test_uncertain_argument_makes_relation_possible():
+    doc = "Possible metformin toxicity, 500 mg"
+    rel = _relation(doc, "metformin", "500 mg")
+
+    result = propagate_relation_assertion(rel, doc)
+
+    assert result.status == RELATION_POSSIBLE
+    assert result.fhir_verification_status == "provisional"
+    assert result.asserted is True
+
+
+def test_plain_argument_is_confirmed():
+    doc = "metformin 500 mg daily"
+    rel = _relation(doc, "metformin", "500 mg")
+
+    result = propagate_relation_assertion(rel, doc)
+
+    assert result.status == RELATION_CONFIRMED
+    assert result.fhir_verification_status == "confirmed"
+    assert result.asserted is True
+
+
+def test_negation_takes_precedence_over_uncertainty():
+    # "if" yields both hypothetical and uncertain; a negated argument still wins.
+    doc = "No metformin 500 mg if intolerant"
+    rel = _relation(doc, "metformin", "500 mg")
+
+    assert propagate_relation_assertion(rel, doc).status == RELATION_REFUTED
+
+
+# --------------------------------------------------------------------------
+# Filtering: refuted / conditional excluded from the default fact set
+# --------------------------------------------------------------------------
+
+
+def test_filter_excludes_refuted_and_conditional_only():
+    confirmed = _relation("metformin 500 mg daily", "metformin", "500 mg")
+    refuted = _relation("denies lisinopril 10 mg", "lisinopril", "10 mg")
+    conditional = _relation("start aspirin 81 mg if MI", "aspirin", "81 mg")
+
+    asserted, withheld = filter_asserted_relations(
+        [confirmed, refuted, conditional],
+        {
+            id(confirmed): "metformin 500 mg daily",
+            id(refuted): "denies lisinopril 10 mg",
+            id(conditional): "start aspirin 81 mg if MI",
+        },
+    )
+
+    assert {r.status for r in asserted} == {RELATION_CONFIRMED}
+    assert {r.status for r in withheld} == {RELATION_REFUTED, RELATION_CONDITIONAL}
+
+
+# --------------------------------------------------------------------------
+# Audit trace: offsets + tags + hash, no raw note text
+# --------------------------------------------------------------------------
+
+
+def test_audit_entry_has_offsets_tags_hash_and_no_note_text():
+    doc = "Denies metformin 500 mg daily"
+    rel = _relation(doc, "metformin", "500 mg")
+
+    entry = propagate_relation_assertion(rel, doc).to_audit_entry()
+
+    assert entry["head_offset"] == [rel.head.start, rel.head.end]
+    assert entry["attribute_offset"] == [rel.attribute.start, rel.attribute.end]
+    assert entry["status"] == RELATION_REFUTED
+    assert "content_hash" in entry
+    # The raw note text must never appear in the audit entry.
+    assert doc not in json.dumps(entry)
+
+
+def test_deterministic_hash():
+    doc = "metformin 500 mg daily"
+    rel = _relation(doc, "metformin", "500 mg")
+
+    a = propagate_relation_assertion(rel, doc).to_audit_entry()["content_hash"]
+    b = propagate_relation_assertion(rel, doc).to_audit_entry()["content_hash"]
+    assert a == b
+
+
+def test_advisory_exposed():
+    assert isinstance(ASSERTION_FILTER_ADVISORY, str) and ASSERTION_FILTER_ADVISORY

--- a/tests/unit/clinical/test_relation_assertion_gold.py
+++ b/tests/unit/clinical/test_relation_assertion_gold.py
@@ -1,0 +1,71 @@
+"""Golden-fixture accuracy for relation-assertion propagation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openmed.clinical.relations.assertion_filter import propagate_relation_assertion
+from openmed.clinical.relations.candidate import RelationCandidate, SpanReference
+from openmed.eval.metrics import relation_assertion_consistency
+
+_FIXTURE = (
+    Path(__file__).resolve().parents[3]
+    / "openmed"
+    / "eval"
+    / "golden"
+    / "fixtures"
+    / "relation_assertion.jsonl"
+)
+
+
+def _rows() -> list[dict]:
+    with _FIXTURE.open(encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def _relation(row: dict) -> RelationCandidate:
+    text = row["text"]
+    head_start = text.index(row["head"])
+    attr_start = text.index(row["attribute"])
+    return RelationCandidate(
+        relation_type=row["relation_type"],
+        head=SpanReference(
+            text=row["head"],
+            label="MEDICATION",
+            start=head_start,
+            end=head_start + len(row["head"]),
+            score=1.0,
+        ),
+        attribute=SpanReference(
+            text=row["attribute"],
+            label="dose",
+            start=attr_start,
+            end=attr_start + len(row["attribute"]),
+            score=1.0,
+        ),
+        score=1.0,
+        confidence=1.0,
+        features={},
+        explanation=(),
+    )
+
+
+def test_gold_relation_assertion_accuracy_at_least_090():
+    rows = _rows()
+    assert rows, "fixture must not be empty"
+
+    predicted = []
+    gold = []
+    for index, row in enumerate(rows):
+        result = propagate_relation_assertion(_relation(row), row["text"])
+        predicted.append((index, result.status))
+        gold.append((index, row["expected_status"]))
+
+    metric = relation_assertion_consistency(predicted, gold)
+    assert metric.score >= 0.90, metric.violations
+
+
+def test_gold_covers_all_four_statuses():
+    statuses = {row["expected_status"] for row in _rows()}
+    assert statuses == {"confirmed", "refuted", "conditional", "possible"}

--- a/tests/unit/eval/test_relation_assertion_metric.py
+++ b/tests/unit/eval/test_relation_assertion_metric.py
@@ -1,0 +1,36 @@
+"""Tests for the relation-assertion consistency metric."""
+
+from __future__ import annotations
+
+from openmed.eval.metrics import ConsistencyMetric, relation_assertion_consistency
+
+
+def test_perfect_consistency():
+    gold = [("r1", "confirmed"), ("r2", "refuted"), ("r3", "conditional")]
+    predicted = [("r1", "confirmed"), ("r2", "refuted"), ("r3", "conditional")]
+
+    metric = relation_assertion_consistency(predicted, gold)
+
+    assert isinstance(metric, ConsistencyMetric)
+    assert metric.score == 1.0
+    assert metric.consistent == 3
+    assert metric.total == 3
+    assert metric.violations == {}
+
+
+def test_mismatch_is_recorded_as_violation():
+    gold = [("r1", "confirmed"), ("r2", "refuted")]
+    predicted = [("r1", "confirmed"), ("r2", "confirmed")]
+
+    metric = relation_assertion_consistency(predicted, gold)
+
+    assert metric.score == 0.5
+    assert metric.consistent == 1
+    assert metric.total == 2
+    assert "r2" in metric.violations
+
+
+def test_empty_inputs_score_one():
+    metric = relation_assertion_consistency([], [])
+    assert metric.score == 1.0
+    assert metric.total == 0


### PR DESCRIPTION
Implements #1232 (OM-... relation assertion). A relation inherits the assertion state of its arguments: a dose relation to a medication in a hypothetical plan ("would start metformin if A1c rises") or to a negated problem must not be emitted as an asserted fact. Today relation extraction ignores `context.py`s negation/temporality/uncertainty resolution, so grounding and FHIR export would record refuted or conditional relations as real -- a correctness hazard.

## Changes

- **`openmed/clinical/relations/assertion_filter.py`** (new)
  - `propagate_relation_assertion(relation, document_text)` reads `resolve_span_context` for both the **head** and the **attribute** of a `RelationCandidate` and tags the relation:
    - `refuted` if a negated argument (hardest boundary; **takes precedence**),
    - `conditional` if a hypothetical/conditional argument,
    - `possible` if an uncertain argument,
    - `confirmed` otherwise.
  - Tags map onto FHIR `verificationStatus` (`confirmed` / `refuted` / `provisional`).
  - `filter_asserted_relations(...)` withholds `refuted`/`conditional` from the default asserted-fact set while returning them so the audit trace retains them.
  - `RelationAssertion.to_audit_entry()` emits **offsets, tags, and a content hash only -- never raw note text**.
  - Reuses the `context.py` cue lexicons; adds no new lexicon.
- **`openmed/eval/metrics.py`** - `relation_assertion_consistency(predicted, gold)` returning the existing `ConsistencyMetric`.
- **`openmed/eval/golden/fixtures/relation_assertion.jsonl`** - synthetic gold with negated/hypothetical/uncertain/confirmed traps (registered as a non-deid fixture in the golden loader).

## Acceptance criteria

- [x] Relations to negated/hypothetical/uncertain arguments are tagged refuted/conditional/possible; relation-assertion accuracy on the committed gold is **>= 0.90**.
- [x] A trap suite blocks merge if any refuted or conditional relation leaks into the default asserted-fact set.
- [x] verificationStatus tags map cleanly onto FHIR values (confirmed/refuted/provisional).
- [x] Refuted/conditional relations remain visible in the audit trace with provenance and offsets.
- [x] No raw PHI or note text is logged; only spans, tags, and hashes.

## Scope notes (files vs the issue list)

- The issue lists `context.py` and `relations/candidate.py` in Files, but this change only **imports** from them (the `resolve_*` resolvers and `RelationCandidate`); no edits to those modules were needed, so they are left untouched.
- One file **not** in the list is touched: `openmed/eval/golden/loader.py`, to register `relation_assertion.jsonl` as a non-deid fixture (the golden loader validates every fixture in that directory against the strict de-id schema; this uses the same allowlist already used for `context_multilingual.jsonl`).

## Testing

- New tests (15): `test_relation_assertion_filter.py` (propagation rules, precedence, filtering, audit entry, determinism), `test_relation_assertion_gold.py` (>=0.90 gold accuracy, all four statuses), `test_relation_assertion_metric.py` (the consistency metric).
- Full offline unit suite: `3853 passed, 58 skipped`. `ruff check` / `format` clean (0.15.20). No new dependencies.

## Out of scope (per the issue)

- New assertion cue lexicons (reuses `context.py`).
- Temporal ordering of the relation.
- FHIR export implementation (consumes the tags only).

Closes #1232