### PR TITLE
No-PHI OpenTelemetry tracing and metrics for pipeline stages

### DIFF
--- a/openmed/core/__init__.py
+++ b/openmed/core/__init__.py
@@ -37,6 +37,12 @@ from .surrogate_vault import (
     VaultConsistencyReport,
     VaultRotationResult,
 )
+from .telemetry import (
+    PipelineTelemetry,
+    StageMetrics,
+    otel_available,
+    telemetry_enabled_from_env,
+)
 
 __all__ = [
     "ModelLoader",
@@ -77,4 +83,8 @@ __all__ = [
     "normalize_for_pii_detection",
     "segment_by_script",
     "OfflineModeError",
+    "PipelineTelemetry",
+    "StageMetrics",
+    "otel_available",
+    "telemetry_enabled_from_env",
 ]

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -200,6 +200,7 @@ class Pipeline:
         section_detector: Callable[..., Mapping[str, Any]] | None = None,
         custom_recognizer: Any = None,
         hmac_secret: str | bytes = DEFAULT_HASH_SECRET,
+        telemetry: Any = None,
     ) -> None:
         from . import pii
         from .policy import load_policy
@@ -242,6 +243,14 @@ class Pipeline:
         self.section_detector = section_detector
         self.custom_recognizer = coerce_custom_recognizer(custom_recognizer)
         self.hmac_secret = hmac_secret
+        # Optional, no-PHI observability. Off by default and opt-in via the
+        # ``OPENMED_TELEMETRY_ENABLED`` env var (or by passing a telemetry
+        # instance). When OpenTelemetry is not installed this is a no-op.
+        if telemetry is None:
+            from .telemetry import PipelineTelemetry
+
+            telemetry = PipelineTelemetry.from_env()
+        self.telemetry = telemetry
         from .clinical_protect import protection_options_from_config
 
         self.clinical_protect_options = protection_options_from_config(config)
@@ -277,13 +286,23 @@ class Pipeline:
             date_shift_secret=date_shift_secret,
         )
         original_text = text.strip()
-        normalized = self.stage1_normalize(original_text)
-        route = self.stage2_language_script(normalized.normalized_text)
+        telemetry = self.telemetry
+        telemetry.start_pipeline()
+        with telemetry.stage_span(1, STAGE_NAMES[0]) as _stage1:
+            normalized = self.stage1_normalize(original_text)
+            _stage1.set_input_length(len(normalized.normalized_text))
+        with telemetry.stage_span(2, STAGE_NAMES[1]):
+            route = self.stage2_language_script(normalized.normalized_text)
+        telemetry.set_run_context(language=route.lang, script=route.script)
         resolved_doc_id = doc_id or hmac_text_hash(
             normalized.normalized_text,
             self.hmac_secret,
         )
-        section_metadata = self.stage3_doc_type_section(normalized.normalized_text)
+        telemetry.set_run_context(
+            doc_id_hash=hmac_text_hash(resolved_doc_id, self.hmac_secret)
+        )
+        with telemetry.stage_span(3, STAGE_NAMES[2]):
+            section_metadata = self.stage3_doc_type_section(normalized.normalized_text)
         context = PipelineContext(
             doc_id=resolved_doc_id,
             original_text=normalized.original_text,
@@ -318,52 +337,54 @@ class Pipeline:
 
         cascade_driven = self.cascade_router is not None
         if cascade_driven:
-            cascade_result = self.cascade_router.run(
-                normalized.normalized_text,
-                context=context,
-                strict_no_leak=self.strict_no_leak,
-                language=route.lang,
-                policy_profile=self.policy_profile,
-            )
-            deterministic_spans = _cascade_stage_spans(cascade_result, {"R0"})
-            model_spans = _cascade_stage_spans(cascade_result, {"R1", "R2"})
-            clinical_spans = _cascade_stage_spans(cascade_result, {"R3", "R4"})
-            deterministic_spans = (
-                *deterministic_spans,
-                *self._registered_detector_spans(
+            with telemetry.stage_span(4, STAGE_NAMES[3]) as _stage4:
+                cascade_result = self.cascade_router.run(
                     normalized.normalized_text,
-                    context,
-                    pipeline_stage=STAGE_NAMES[3],
-                ),
-            )
-            model_spans = (
-                *model_spans,
-                *self._registered_detector_spans(
-                    normalized.normalized_text,
-                    context,
-                    pipeline_stage=STAGE_NAMES[4],
-                ),
-            )
-            clinical_spans = (
-                *clinical_spans,
-                *self._registered_detector_spans(
-                    normalized.normalized_text,
-                    context,
-                    pipeline_stage=STAGE_NAMES[5],
-                ),
-            )
-            deterministic_spans = _stamp_span_sections(
-                deterministic_spans,
-                context.section_metadata,
-            )
-            model_spans = _stamp_span_sections(
-                model_spans,
-                context.section_metadata,
-            )
-            clinical_spans = _stamp_span_sections(
-                clinical_spans,
-                context.section_metadata,
-            )
+                    context=context,
+                    strict_no_leak=self.strict_no_leak,
+                    language=route.lang,
+                    policy_profile=self.policy_profile,
+                )
+                deterministic_spans = _cascade_stage_spans(cascade_result, {"R0"})
+                model_spans = _cascade_stage_spans(cascade_result, {"R1", "R2"})
+                clinical_spans = _cascade_stage_spans(cascade_result, {"R3", "R4"})
+                deterministic_spans = (
+                    *deterministic_spans,
+                    *self._registered_detector_spans(
+                        normalized.normalized_text,
+                        context,
+                        pipeline_stage=STAGE_NAMES[3],
+                    ),
+                )
+                model_spans = (
+                    *model_spans,
+                    *self._registered_detector_spans(
+                        normalized.normalized_text,
+                        context,
+                        pipeline_stage=STAGE_NAMES[4],
+                    ),
+                )
+                clinical_spans = (
+                    *clinical_spans,
+                    *self._registered_detector_spans(
+                        normalized.normalized_text,
+                        context,
+                        pipeline_stage=STAGE_NAMES[5],
+                    ),
+                )
+                deterministic_spans = _stamp_span_sections(
+                    deterministic_spans,
+                    context.section_metadata,
+                )
+                model_spans = _stamp_span_sections(
+                    model_spans,
+                    context.section_metadata,
+                )
+                clinical_spans = _stamp_span_sections(
+                    clinical_spans,
+                    context.section_metadata,
+                )
+                _stage4.set_span_count(len(deterministic_spans))
             pii_result = _prediction_result_from_spans(
                 normalized.normalized_text,
                 cascade_result.spans,
@@ -389,91 +410,113 @@ class Pipeline:
                     metadata=cascade_metadata,
                 )
             )
+            with telemetry.stage_span(5, STAGE_NAMES[4]) as _stage5:
+                _stage5.set_span_count(len(model_spans))
             stage_results.append(
                 PipelineStageResult(5, STAGE_NAMES[4], spans=model_spans)
             )
+            with telemetry.stage_span(6, STAGE_NAMES[5]) as _stage6:
+                _stage6.set_span_count(len(clinical_spans))
             stage_results.append(
                 PipelineStageResult(6, STAGE_NAMES[5], spans=clinical_spans)
             )
         else:
-            deterministic_spans = self.stage4_deterministic_detectors(
-                normalized.normalized_text,
-                context,
-            )
-            deterministic_spans = _stamp_span_sections(
-                deterministic_spans,
-                context.section_metadata,
-            )
+            with telemetry.stage_span(4, STAGE_NAMES[3]) as _stage4:
+                deterministic_spans = self.stage4_deterministic_detectors(
+                    normalized.normalized_text,
+                    context,
+                )
+                deterministic_spans = _stamp_span_sections(
+                    deterministic_spans,
+                    context.section_metadata,
+                )
+                _stage4.set_span_count(len(deterministic_spans))
             stage_results.append(
                 PipelineStageResult(4, STAGE_NAMES[3], spans=deterministic_spans)
             )
 
-            pii_result = self.stage5_fast_pii_model(normalized.normalized_text, route)
-            self._apply_calibration_thresholds(pii_result, route)
-            model_spans = self._entities_to_spans(
-                getattr(pii_result, "entities", ()),
-                normalized.normalized_text,
-                context,
-                default_detector=(
-                    f"model:{getattr(pii_result, 'model_name', route.model_name)}"
-                ),
-                stage=STAGE_NAMES[4],
-            )
-            model_spans = (
-                *model_spans,
-                *self._registered_detector_spans(
+            with telemetry.stage_span(5, STAGE_NAMES[4]) as _stage5:
+                pii_result = self.stage5_fast_pii_model(
+                    normalized.normalized_text, route
+                )
+                self._apply_calibration_thresholds(pii_result, route)
+                model_spans = self._entities_to_spans(
+                    getattr(pii_result, "entities", ()),
                     normalized.normalized_text,
                     context,
-                    pipeline_stage=STAGE_NAMES[4],
-                ),
-            )
-            model_spans = _stamp_span_sections(model_spans, context.section_metadata)
+                    default_detector=(
+                        f"model:{getattr(pii_result, 'model_name', route.model_name)}"
+                    ),
+                    stage=STAGE_NAMES[4],
+                )
+                model_spans = (
+                    *model_spans,
+                    *self._registered_detector_spans(
+                        normalized.normalized_text,
+                        context,
+                        pipeline_stage=STAGE_NAMES[4],
+                    ),
+                )
+                model_spans = _stamp_span_sections(
+                    model_spans, context.section_metadata
+                )
+                _stage5.set_span_count(len(model_spans))
+                _stage5.set_labels(_span_labels(model_spans))
             stage_results.append(
                 PipelineStageResult(5, STAGE_NAMES[4], spans=model_spans)
             )
 
-            clinical_spans = self.stage6_clinical_phi_model(
-                normalized.normalized_text,
-                context,
-            )
-            clinical_spans = _stamp_span_sections(
-                clinical_spans,
-                context.section_metadata,
-            )
+            with telemetry.stage_span(6, STAGE_NAMES[5]) as _stage6:
+                clinical_spans = self.stage6_clinical_phi_model(
+                    normalized.normalized_text,
+                    context,
+                )
+                clinical_spans = _stamp_span_sections(
+                    clinical_spans,
+                    context.section_metadata,
+                )
+                _stage6.set_span_count(len(clinical_spans))
             stage_results.append(
                 PipelineStageResult(6, STAGE_NAMES[5], spans=clinical_spans)
             )
 
         arbitration_candidates = (*deterministic_spans, *model_spans, *clinical_spans)
-        merged_spans = self.stage7_arbitration(
-            arbitration_candidates,
-            context,
-        )
-        arbitration_trace_metadata = (
-            _arbitration_trace_metadata(
+        with telemetry.stage_span(
+            7,
+            STAGE_NAMES[6],
+            span_count_baseline=len(arbitration_candidates),
+        ) as _stage7:
+            merged_spans = self.stage7_arbitration(
                 arbitration_candidates,
-                merged_spans,
-                mode=self.arbitration_mode,
-                strict_no_leak=self.strict_no_leak,
-                language=route.lang,
-                policy_profile=self.policy_profile,
-                label_floors=self.arbitration_label_floors,
-                high_recall_label_floors=self.high_recall_label_floors,
-                threshold_matrix=self.threshold_matrix,
+                context,
             )
-            if explain and self.arbitration is None
-            else None
-        )
-        merged_spans, allow_metadata = self._suppress_custom_allowed_spans(
-            normalized.normalized_text,
-            merged_spans,
-        )
-        merged_spans, clinical_protection_metadata = self._protect_clinical_spans(
-            normalized.normalized_text,
-            merged_spans,
-            context,
-        )
-        merged_spans = _stamp_span_sections(merged_spans, context.section_metadata)
+            arbitration_trace_metadata = (
+                _arbitration_trace_metadata(
+                    arbitration_candidates,
+                    merged_spans,
+                    mode=self.arbitration_mode,
+                    strict_no_leak=self.strict_no_leak,
+                    language=route.lang,
+                    policy_profile=self.policy_profile,
+                    label_floors=self.arbitration_label_floors,
+                    high_recall_label_floors=self.high_recall_label_floors,
+                    threshold_matrix=self.threshold_matrix,
+                )
+                if explain and self.arbitration is None
+                else None
+            )
+            merged_spans, allow_metadata = self._suppress_custom_allowed_spans(
+                normalized.normalized_text,
+                merged_spans,
+            )
+            merged_spans, clinical_protection_metadata = self._protect_clinical_spans(
+                normalized.normalized_text,
+                merged_spans,
+                context,
+            )
+            merged_spans = _stamp_span_sections(merged_spans, context.section_metadata)
+            _stage7.set_span_count(len(merged_spans))
+            _stage7.set_labels(_span_labels(merged_spans))
         arbitration_metadata = {
             **dict(allow_metadata),
             **dict(clinical_protection_metadata),
@@ -502,12 +545,14 @@ class Pipeline:
             )
         )
 
-        policy_spans = self.stage8_policy_actions(
-            merged_spans,
-            context,
-            explain=explain,
-        )
-        policy_spans = _stamp_span_sections(policy_spans, context.section_metadata)
+        with telemetry.stage_span(8, STAGE_NAMES[7]) as _stage8:
+            policy_spans = self.stage8_policy_actions(
+                merged_spans,
+                context,
+                explain=explain,
+            )
+            policy_spans = _stamp_span_sections(policy_spans, context.section_metadata)
+            _stage8.set_span_count(len(policy_spans))
         stage_results.append(PipelineStageResult(8, STAGE_NAMES[7], spans=policy_spans))
 
         if self.policy is not None:
@@ -541,11 +586,13 @@ class Pipeline:
                 ],
             )
 
-        sweep_spans, sweep_metadata = self.stage9_safety_sweep(
-            normalized.normalized_text,
-            pii_result,
-            context,
-        )
+        with telemetry.stage_span(9, STAGE_NAMES[8]) as _stage9:
+            sweep_spans, sweep_metadata = self.stage9_safety_sweep(
+                normalized.normalized_text,
+                pii_result,
+                context,
+            )
+            _stage9.set_span_count(len(sweep_spans))
         stage_results.append(
             PipelineStageResult(
                 9,
@@ -558,45 +605,54 @@ class Pipeline:
         effective_keep_mapping = keep_mapping or bool(
             self.policy is not None and self.policy.keep_mapping
         )
-        emission_pii_result = _remap_pii_result_to_original(
-            pii_result,
-            normalized,
-            self.hmac_secret,
-        )
-        deidentified = self.stage10_emit(
-            normalized.original_text,
-            emission_pii_result,
-            effective_method=effective_method,
-            keep_year=keep_year,
-            date_shift_days=date_shift_days,
-            patient_key=patient_key,
-            date_shift_max_days=date_shift_max_days,
-            date_shift_secret=date_shift_secret,
-            keep_mapping=effective_keep_mapping,
-            lang=route.lang,
-            consistent=consistent,
-            seed=seed,
-            locale=locale,
-            surrogate_vault=surrogate_vault,
-            model_name=route.model_name,
-            confidence_threshold=self.confidence_threshold,
-            normalize_accents=self.normalize_accents,
-            use_smart_merging=self.use_smart_merging,
-            use_safety_sweep=self.use_safety_sweep,
-            reversible_ids=bool(self.policy is not None and self.policy.reversible_id),
-            policy_name=self.policy.name if self.policy is not None else None,
-            policy=self.policy.name if self.policy is not None else "hipaa_safe_harbor",
-            audit=audit,
-        )
-        final_spans = (
-            sweep_spans if self.policy is not None else (sweep_spans or policy_spans)
-        )
-        final_spans = _stamp_span_sections(final_spans, context.section_metadata)
-        emission_spans = _remap_spans_to_original(
-            final_spans,
-            normalized,
-            self.hmac_secret,
-        )
+        with telemetry.stage_span(10, STAGE_NAMES[9]) as _stage10:
+            emission_pii_result = _remap_pii_result_to_original(
+                pii_result,
+                normalized,
+                self.hmac_secret,
+            )
+            deidentified = self.stage10_emit(
+                normalized.original_text,
+                emission_pii_result,
+                effective_method=effective_method,
+                keep_year=keep_year,
+                date_shift_days=date_shift_days,
+                patient_key=patient_key,
+                date_shift_max_days=date_shift_max_days,
+                date_shift_secret=date_shift_secret,
+                keep_mapping=effective_keep_mapping,
+                lang=route.lang,
+                consistent=consistent,
+                seed=seed,
+                locale=locale,
+                surrogate_vault=surrogate_vault,
+                model_name=route.model_name,
+                confidence_threshold=self.confidence_threshold,
+                normalize_accents=self.normalize_accents,
+                use_smart_merging=self.use_smart_merging,
+                use_safety_sweep=self.use_safety_sweep,
+                reversible_ids=bool(
+                    self.policy is not None and self.policy.reversible_id
+                ),
+                policy_name=self.policy.name if self.policy is not None else None,
+                policy=(
+                    self.policy.name if self.policy is not None else "hipaa_safe_harbor"
+                ),
+                audit=audit,
+            )
+            final_spans = (
+                sweep_spans
+                if self.policy is not None
+                else (sweep_spans or policy_spans)
+            )
+            final_spans = _stamp_span_sections(final_spans, context.section_metadata)
+            emission_spans = _remap_spans_to_original(
+                final_spans,
+                normalized,
+                self.hmac_secret,
+            )
+            _stage10.set_span_count(len(emission_spans))
+            _stage10.set_redacted_length(len(deidentified.deidentified_text))
         stage_results.append(
             PipelineStageResult(
                 10,
@@ -1743,6 +1799,20 @@ def _span_trace_ref(span: OpenMedSpan) -> Mapping[str, Any]:
         "detector": span.detector,
         "score": span.score,
     }
+
+
+def _span_labels(spans: Sequence[OpenMedSpan]) -> tuple[str, ...]:
+    """Return the set of canonical labels for telemetry (no raw surface text).
+
+    Canonical labels are non-PHI category names (e.g. ``NAME``, ``PHONE``), so
+    they are safe to emit as span attributes.
+    """
+    labels = {
+        str(span.canonical_label)
+        for span in spans
+        if getattr(span, "canonical_label", None)
+    }
+    return tuple(sorted(labels))
 
 
 def _cascade_stage_spans(

--- a/openmed/core/telemetry.py
+++ b/openmed/core/telemetry.py
@@ -1,0 +1,455 @@
+"""Optional, no-PHI observability for the core de-identification pipeline.
+
+This module adds developer opt-in tracing and lightweight metrics for the
+staged privacy pipeline (:mod:`openmed.core.pipeline`). It is designed to
+preserve OpenMed's local-first, no-telemetry-by-default guarantees:
+
+- **Off by default.** Nothing is recorded unless the caller explicitly opts in,
+  either by constructing :class:`PipelineTelemetry` with ``enabled=True`` or by
+  setting the ``OPENMED_TELEMETRY_ENABLED`` environment variable to a truthy
+  value.
+- **OpenTelemetry is optional.** The OTel packages are imported lazily behind a
+  guard. When they are not installed, a no-op backend is used so importing and
+  using this module never raises and core stays dependency-free.
+- **Local-first.** No network exporter is ever configured here. Callers wire
+  their own span processors/exporters onto their OTel ``TracerProvider`` if and
+  when they want to ship spans somewhere.
+- **No raw PHI.** Only aggregate, non-reversible signals are ever emitted:
+  stage names, span/entity counts, character offsets and lengths, label *sets*,
+  hashes, and durations. Raw text and detected identifiers are never recorded.
+  Attribute keys are constrained to an explicit allowlist and values are scrubbed
+  by :func:`safe_stage_attributes`.
+
+Example:
+    >>> from openmed.core.telemetry import PipelineTelemetry
+    >>> telemetry = PipelineTelemetry(enabled=False)  # no-op backend
+    >>> with telemetry.stage_span(3, "deterministic_detectors") as stage:
+    ...     stage.set_span_count(2)
+    >>> telemetry.enabled
+    False
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Iterator, Mapping, Optional, Sequence
+
+try:  # pragma: no cover - exercised when the optional otel extra is absent.
+    from opentelemetry import trace as _otel_trace
+    from opentelemetry.trace import SpanKind as _OTelSpanKind
+    from opentelemetry.trace import Status as _OTelStatus
+    from opentelemetry.trace import StatusCode as _OTelStatusCode
+except ImportError as exc:  # pragma: no cover - depends on install extras.
+    _otel_trace = None  # type: ignore[assignment]
+    _OTelSpanKind = None  # type: ignore[assignment]
+    _OTelStatus = None  # type: ignore[assignment]
+    _OTelStatusCode = None  # type: ignore[assignment]
+    _OTEL_IMPORT_ERROR: Optional[ImportError] = exc
+else:
+    _OTEL_IMPORT_ERROR = None
+
+TELEMETRY_ENABLED_ENV_VAR = "OPENMED_TELEMETRY_ENABLED"
+TRACER_NAME = "openmed.pipeline"
+SPAN_NAME_PREFIX = "openmed.pipeline"
+
+_ENABLED_VALUES = frozenset({"1", "true", "yes", "on", "enabled"})
+_DISABLED_VALUES = frozenset({"0", "false", "no", "off", "disabled"})
+_SAFE_LABEL_PATTERN = re.compile(r"^[A-Za-z0-9_.:/ -]{1,128}$")
+
+# Only these no-PHI attribute keys may ever reach a span. Anything else — and in
+# particular any key carrying raw surface text — is dropped by
+# ``safe_stage_attributes``. This mirrors the allowlist used by the REST
+# service tracer (``openmed.service.tracing``) so the two stay consistent.
+_ALLOWED_ATTRIBUTE_KEYS = frozenset(
+    {
+        "openmed.pipeline.doc_id_hash",
+        "openmed.pipeline.language",
+        "openmed.pipeline.script",
+        "openmed.pipeline.stage_count",
+        "openmed.stage",
+        "openmed.stage.index",
+        "openmed.stage.span_count",
+        "openmed.stage.span_delta",
+        "openmed.stage.entity_count",
+        "openmed.stage.labels",
+        "openmed.stage.input_length",
+        "openmed.stage.redacted_length",
+        "openmed.stage.duration_ms",
+        "openmed.error.type",
+    }
+)
+
+
+def parse_telemetry_enabled(raw_value: Optional[str]) -> bool:
+    """Parse the telemetry opt-in flag.
+
+    Args:
+        raw_value: Raw environment-variable value (or ``None`` when unset).
+
+    Returns:
+        ``True`` only when the value is an explicit truthy token. Absent,
+        empty, or falsy values keep telemetry disabled — the safe default.
+
+    Raises:
+        ValueError: If the value is a non-empty, unrecognized token.
+    """
+    if raw_value is None:
+        return False
+    normalized = raw_value.strip().lower()
+    if not normalized:
+        return False
+    if normalized in _ENABLED_VALUES:
+        return True
+    if normalized in _DISABLED_VALUES:
+        return False
+    raise ValueError(
+        f"{TELEMETRY_ENABLED_ENV_VAR} must be a boolean value like 'true' or 'false'"
+    )
+
+
+def telemetry_enabled_from_env() -> bool:
+    """Return whether telemetry is opted in via the environment (default off)."""
+    return parse_telemetry_enabled(os.getenv(TELEMETRY_ENABLED_ENV_VAR))
+
+
+def otel_available() -> bool:
+    """Return whether the optional OpenTelemetry API is importable."""
+    return _OTEL_IMPORT_ERROR is None
+
+
+def _safe_scalar(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return value
+    if isinstance(value, str):
+        return value[:256]
+    return None
+
+
+def _safe_label(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if _SAFE_LABEL_PATTERN.fullmatch(normalized):
+        return normalized
+    return None
+
+
+def _as_sequence(value: Any) -> Sequence[Any]:
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return list(value)
+    return [value]
+
+
+def safe_stage_attributes(attributes: Mapping[str, Any]) -> dict[str, Any]:
+    """Return only approved, no-PHI scalar or scalar-list attributes.
+
+    Keys outside :data:`_ALLOWED_ATTRIBUTE_KEYS` are dropped, so no raw surface
+    text can ever reach a span even if a caller passes it in by mistake. Label
+    lists are additionally constrained to a conservative character allowlist.
+
+    Args:
+        attributes: Candidate attribute mapping.
+
+    Returns:
+        A new dict containing only safe, allowlisted attributes.
+    """
+    safe: dict[str, Any] = {}
+    for key, value in attributes.items():
+        if key not in _ALLOWED_ATTRIBUTE_KEYS or value is None:
+            continue
+        if key == "openmed.stage.labels":
+            labels = sorted(
+                {
+                    label
+                    for raw in _as_sequence(value)
+                    if (label := _safe_label(raw)) is not None
+                }
+            )
+            if labels:
+                safe[key] = tuple(labels)
+            continue
+        normalized = _safe_scalar(value)
+        if normalized is not None:
+            safe[key] = normalized
+    return safe
+
+
+@dataclass
+class StageMetrics:
+    """No-PHI metrics collected for one pipeline stage.
+
+    Only aggregate signals are stored; no raw text is ever kept here.
+    """
+
+    index: int
+    name: str
+    span_count: int = 0
+    entity_count: int = 0
+    labels: tuple[str, ...] = ()
+    input_length: Optional[int] = None
+    redacted_length: Optional[int] = None
+    duration_ms: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly, no-PHI summary of this stage."""
+        payload: dict[str, Any] = {
+            "index": self.index,
+            "name": self.name,
+            "span_count": self.span_count,
+            "entity_count": self.entity_count,
+            "labels": list(self.labels),
+            "duration_ms": round(self.duration_ms, 3),
+        }
+        if self.input_length is not None:
+            payload["input_length"] = self.input_length
+        if self.redacted_length is not None:
+            payload["redacted_length"] = self.redacted_length
+        return payload
+
+
+class StageRecorder:
+    """Collect no-PHI signals for one stage and mirror them onto a span.
+
+    Instances are yielded by :meth:`PipelineTelemetry.stage_span`. Every setter
+    routes values through :func:`safe_stage_attributes` before touching the
+    active span, so it is impossible to attach a raw-text attribute here.
+    """
+
+    def __init__(
+        self,
+        metrics: StageMetrics,
+        span: Any,
+        *,
+        span_count_baseline: int = 0,
+    ) -> None:
+        self._metrics = metrics
+        self._span = span
+        self._baseline = span_count_baseline
+
+    @property
+    def metrics(self) -> StageMetrics:
+        """Return the underlying :class:`StageMetrics` accumulator."""
+        return self._metrics
+
+    def _set_attributes(self, attributes: Mapping[str, Any]) -> None:
+        if self._span is None:
+            return
+        safe = safe_stage_attributes(attributes)
+        setter = getattr(self._span, "set_attributes", None)
+        if safe and callable(setter):
+            setter(safe)
+
+    def set_span_count(self, count: int) -> None:
+        """Record the number of spans this stage produced."""
+        value = int(count)
+        self._metrics.span_count = value
+        self._set_attributes(
+            {
+                "openmed.stage.span_count": value,
+                "openmed.stage.span_delta": value - self._baseline,
+            }
+        )
+
+    def set_entity_count(self, count: int) -> None:
+        """Record the number of entities associated with this stage."""
+        value = int(count)
+        self._metrics.entity_count = value
+        self._set_attributes({"openmed.stage.entity_count": value})
+
+    def set_labels(self, labels: Sequence[str]) -> None:
+        """Record the *set* of canonical labels seen in this stage (no text)."""
+        safe_labels = tuple(
+            sorted({label for raw in labels if (label := _safe_label(raw)) is not None})
+        )
+        self._metrics.labels = safe_labels
+        if safe_labels:
+            self._set_attributes({"openmed.stage.labels": safe_labels})
+
+    def set_input_length(self, length: int) -> None:
+        """Record the input character length processed by this stage."""
+        value = int(length)
+        self._metrics.input_length = value
+        self._set_attributes({"openmed.stage.input_length": value})
+
+    def set_redacted_length(self, length: int) -> None:
+        """Record the redacted-output character length for this stage."""
+        value = int(length)
+        self._metrics.redacted_length = value
+        self._set_attributes({"openmed.stage.redacted_length": value})
+
+
+class _NullStageRecorder(StageRecorder):
+    """Recorder used when telemetry is disabled: accumulates nothing extra."""
+
+    def __init__(self, metrics: StageMetrics) -> None:
+        super().__init__(metrics, span=None)
+
+
+@dataclass
+class PipelineTelemetry:
+    """Opt-in, no-PHI telemetry for the staged de-identification pipeline.
+
+    When ``enabled`` is ``False`` (the default) every method is a cheap no-op and
+    no OpenTelemetry objects are touched. When ``enabled`` is ``True`` but the
+    OpenTelemetry API is not installed, a no-op backend is used instead of
+    raising, so callers can safely request telemetry without hard-depending on
+    the optional extra.
+
+    Attributes:
+        enabled: Whether span/metric recording is active.
+        tracer: Optional OpenTelemetry tracer. When ``None`` and ``enabled`` is
+            ``True``, the module-global tracer is used if OTel is available.
+        service_name: Logical component name; kept for parity with the REST
+            tracer.
+    """
+
+    enabled: bool = False
+    tracer: Any = None
+    service_name: str = "openmed-pipeline"
+    stage_metrics: list[StageMetrics] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.enabled and self.tracer is None and otel_available():
+            self.tracer = _otel_trace.get_tracer(TRACER_NAME)
+        # Keep ``enabled`` an honest predicate: it is only ``True`` when a span
+        # will actually be created. If the caller opted in but no backend is
+        # usable, degrade to the no-op path instead of raising.
+        if self.enabled and self.tracer is None:
+            self.enabled = False
+        self._run_context: dict[str, Any] = {}
+
+    @classmethod
+    def from_env(cls, *, tracer: Any = None) -> "PipelineTelemetry":
+        """Build telemetry honoring the ``OPENMED_TELEMETRY_ENABLED`` flag."""
+        return cls(enabled=telemetry_enabled_from_env(), tracer=tracer)
+
+    @classmethod
+    def disabled(cls) -> "PipelineTelemetry":
+        """Return an explicitly disabled, no-op telemetry instance."""
+        return cls(enabled=False)
+
+    def start_pipeline(self) -> None:
+        """Reset per-run accumulators for a new pipeline invocation."""
+        self.stage_metrics = []
+        self._run_context = {}
+
+    def set_run_context(
+        self,
+        *,
+        language: Optional[str] = None,
+        script: Optional[str] = None,
+        doc_id_hash: Optional[str] = None,
+    ) -> None:
+        """Attach no-PHI run context applied to subsequent stage spans.
+
+        Only non-reversible signals are retained: the language, script, and an
+        already-hashed document id. Never a raw document id or text.
+        """
+        if language is not None:
+            self._run_context["openmed.pipeline.language"] = _safe_label(language)
+        if script is not None:
+            self._run_context["openmed.pipeline.script"] = _safe_label(script)
+        if doc_id_hash is not None and isinstance(doc_id_hash, str):
+            self._run_context["openmed.pipeline.doc_id_hash"] = doc_id_hash
+
+    @contextmanager
+    def stage_span(
+        self,
+        index: int,
+        name: str,
+        *,
+        span_count_baseline: int = 0,
+    ) -> Iterator[StageRecorder]:
+        """Trace one pipeline stage, timing it and recording no-PHI signals.
+
+        Args:
+            index: 1-based stage index.
+            name: Stage name (one of :data:`openmed.core.pipeline.STAGE_NAMES`).
+            span_count_baseline: Prior cumulative span count, so the stage can
+                report its net contribution as ``openmed.stage.span_delta``.
+
+        Yields:
+            A :class:`StageRecorder` for attaching aggregate stage metrics.
+        """
+        metrics = StageMetrics(index=index, name=name)
+        self.stage_metrics.append(metrics)
+
+        if not self.enabled or self.tracer is None:
+            recorder = _NullStageRecorder(metrics)
+            start = time.perf_counter()
+            try:
+                yield recorder
+            finally:
+                metrics.duration_ms = (time.perf_counter() - start) * 1000
+            return
+
+        base_attributes = safe_stage_attributes(
+            {
+                "openmed.stage": name,
+                "openmed.stage.index": index,
+                **{
+                    key: value
+                    for key, value in self._run_context.items()
+                    if value is not None
+                },
+            }
+        )
+        start = time.perf_counter()
+        with self.tracer.start_as_current_span(
+            f"{SPAN_NAME_PREFIX}.{name}",
+            kind=_OTelSpanKind.INTERNAL,
+            attributes=base_attributes,
+        ) as span:
+            recorder = StageRecorder(
+                metrics,
+                span,
+                span_count_baseline=span_count_baseline,
+            )
+            try:
+                yield recorder
+            except Exception as exc:
+                span.record_exception(exc)
+                span.set_status(_OTelStatus(_OTelStatusCode.ERROR))
+                span.set_attributes(
+                    safe_stage_attributes({"openmed.error.type": type(exc).__name__})
+                )
+                raise
+            finally:
+                metrics.duration_ms = (time.perf_counter() - start) * 1000
+                span.set_attributes(
+                    safe_stage_attributes(
+                        {"openmed.stage.duration_ms": round(metrics.duration_ms, 3)}
+                    )
+                )
+
+    def summary(self) -> dict[str, Any]:
+        """Return an aggregate, no-PHI summary of the most recent run."""
+        return {
+            "enabled": self.enabled,
+            "stage_count": len(self.stage_metrics),
+            "total_duration_ms": round(
+                sum(metric.duration_ms for metric in self.stage_metrics), 3
+            ),
+            "stages": [metric.to_dict() for metric in self.stage_metrics],
+        }
+
+
+__all__ = [
+    "PipelineTelemetry",
+    "StageMetrics",
+    "StageRecorder",
+    "TELEMETRY_ENABLED_ENV_VAR",
+    "TRACER_NAME",
+    "otel_available",
+    "parse_telemetry_enabled",
+    "safe_stage_attributes",
+    "telemetry_enabled_from_env",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,15 @@ service = [
   "uvicorn[standard]>=0.29",
 ]
 
+# Opt-in, no-PHI observability for the core de-identification pipeline
+# (openmed.core.telemetry). Local-first: no network exporter is installed here.
+# The OTLP exporter lives in the heavier ``service`` extra for users who want to
+# ship spans off-box.
+otel = [
+  "opentelemetry-api>=1.26,<2",
+  "opentelemetry-sdk>=1.26,<2",
+]
+
 gliner = [
   "gliner[tokenizers]>=0.2.0",
   "torch>=2.0"

--- a/tests/unit/core/test_pipeline_telemetry.py
+++ b/tests/unit/core/test_pipeline_telemetry.py
@@ -1,0 +1,322 @@
+"""Tests for the optional, no-PHI core pipeline telemetry layer.
+
+These cover the OM-821 invariants:
+
+- Telemetry is OFF by default and only records when explicitly opted in.
+- OpenTelemetry is an optional, lazily-imported dependency; a no-op backend is
+  used when it is absent so importing/using the module never raises.
+- Every pipeline stage is traced with no-PHI attributes only.
+- Feeding synthetic PHI through the pipeline never leaks raw text or detected
+  identifiers into any emitted span attribute.
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openmed.core import telemetry as telemetry_module
+from openmed.core.pipeline import STAGE_NAMES, Pipeline
+from openmed.core.telemetry import (
+    TELEMETRY_ENABLED_ENV_VAR,
+    PipelineTelemetry,
+    otel_available,
+    parse_telemetry_enabled,
+    safe_stage_attributes,
+    telemetry_enabled_from_env,
+)
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+# Synthetic PHI only — never a real person. These substrings must never appear
+# in any span attribute or metric label emitted by the pipeline.
+PHI_TEXT = (
+    "Patient Juniper Solstice, MRN 1234567890123, "
+    "DOB 02/03/1979, phone 425-555-0199, email jsolstice@example.com."
+)
+PHI_SUBSTRINGS = (
+    "Juniper Solstice",
+    "Juniper",
+    "Solstice",
+    "1234567890123",
+    "02/03/1979",
+    "425-555-0199",
+    "jsolstice@example.com",
+)
+
+
+def _pii_detector(text: str, **_: Any) -> PredictionResult:
+    """Return a fixture PII result that flags the synthetic name span."""
+    entities = []
+    index = text.find("Juniper Solstice")
+    if index >= 0:
+        entities.append(
+            EntityPrediction(
+                text="Juniper Solstice",
+                label="NAME",
+                start=index,
+                end=index + len("Juniper Solstice"),
+                confidence=0.99,
+            )
+        )
+    return PredictionResult(
+        text=text,
+        entities=entities,
+        model_name="fixture-pii-model",
+        timestamp=datetime.now().isoformat(),
+    )
+
+
+@pytest.fixture
+def span_exporter() -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return exporter
+
+
+@pytest.fixture
+def enabled_telemetry(span_exporter: InMemorySpanExporter) -> PipelineTelemetry:
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    tracer = provider.get_tracer("openmed.pipeline.test")
+    return PipelineTelemetry(enabled=True, tracer=tracer)
+
+
+# ---------------------------------------------------------------------------
+# Opt-in / default-off behavior
+# ---------------------------------------------------------------------------
+
+
+def test_telemetry_is_disabled_by_default() -> None:
+    telemetry = PipelineTelemetry()
+    assert telemetry.enabled is False
+
+
+def test_pipeline_defaults_to_disabled_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(TELEMETRY_ENABLED_ENV_VAR, raising=False)
+    pipeline = Pipeline(model_detector=_pii_detector)
+    assert pipeline.telemetry.enabled is False
+
+
+def test_env_flag_opts_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TELEMETRY_ENABLED_ENV_VAR, "true")
+    assert telemetry_enabled_from_env() is True
+    monkeypatch.setenv(TELEMETRY_ENABLED_ENV_VAR, "false")
+    assert telemetry_enabled_from_env() is False
+    monkeypatch.delenv(TELEMETRY_ENABLED_ENV_VAR, raising=False)
+    assert telemetry_enabled_from_env() is False
+
+
+def test_parse_telemetry_enabled_rejects_garbage() -> None:
+    assert parse_telemetry_enabled(None) is False
+    assert parse_telemetry_enabled("") is False
+    assert parse_telemetry_enabled("1") is True
+    assert parse_telemetry_enabled("off") is False
+    with pytest.raises(ValueError):
+        parse_telemetry_enabled("maybe")
+
+
+def test_disabled_telemetry_records_nothing_to_a_span(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    telemetry = PipelineTelemetry(enabled=False)
+    telemetry.start_pipeline()
+    with telemetry.stage_span(1, STAGE_NAMES[0]) as stage:
+        stage.set_span_count(5)
+        stage.set_labels(["NAME"])
+    # No spans exported, but stage timing metrics are still collected locally.
+    assert span_exporter.get_finished_spans() == ()
+    summary = telemetry.summary()
+    assert summary["enabled"] is False
+    assert summary["stage_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Optional / lazy OpenTelemetry dependency
+# ---------------------------------------------------------------------------
+
+
+def test_otel_available_reports_installed_backend() -> None:
+    # The dev/test environment installs OTel, so this should be True here.
+    assert otel_available() is True
+
+
+def test_opt_in_without_otel_degrades_to_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Simulate the optional dependency being absent.
+    monkeypatch.setattr(telemetry_module, "_OTEL_IMPORT_ERROR", ImportError("no otel"))
+    monkeypatch.setattr(telemetry_module, "_otel_trace", None)
+
+    telemetry = PipelineTelemetry(enabled=True)
+    # Requesting telemetry without a backend must not raise and must fall back
+    # to the no-op path (enabled becomes False because no span can be created).
+    assert telemetry.enabled is False
+    telemetry.start_pipeline()
+    with telemetry.stage_span(1, STAGE_NAMES[0]) as stage:
+        stage.set_span_count(3)
+    assert telemetry.summary()["stage_count"] == 1
+
+
+def test_pipeline_runs_without_otel_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(telemetry_module, "_OTEL_IMPORT_ERROR", ImportError("no otel"))
+    monkeypatch.setattr(telemetry_module, "_otel_trace", None)
+
+    telemetry = PipelineTelemetry(enabled=True)
+    pipeline = Pipeline(model_detector=_pii_detector, telemetry=telemetry)
+    result = pipeline.run(PHI_TEXT, method="mask")
+
+    assert "Juniper Solstice" not in result.redacted_text
+    # Local stage metrics still collected even though no spans are exported.
+    assert len(telemetry.stage_metrics) == len(STAGE_NAMES)
+
+
+# ---------------------------------------------------------------------------
+# Stage tracing
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_traces_every_stage(
+    span_exporter: InMemorySpanExporter,
+    enabled_telemetry: PipelineTelemetry,
+) -> None:
+    pipeline = Pipeline(model_detector=_pii_detector, telemetry=enabled_telemetry)
+    pipeline.run(PHI_TEXT, method="mask")
+
+    spans = list(span_exporter.get_finished_spans())
+    traced_stages = {span.name.removeprefix("openmed.pipeline.") for span in spans}
+    assert set(STAGE_NAMES) <= traced_stages
+    assert len(spans) == len(STAGE_NAMES)
+
+    for span in spans:
+        assert "openmed.stage.duration_ms" in span.attributes
+        assert span.attributes["openmed.stage"] in STAGE_NAMES
+
+
+def test_stage_spans_carry_only_aggregate_signals(
+    span_exporter: InMemorySpanExporter,
+    enabled_telemetry: PipelineTelemetry,
+) -> None:
+    pipeline = Pipeline(model_detector=_pii_detector, telemetry=enabled_telemetry)
+    pipeline.run(PHI_TEXT, method="mask")
+
+    spans = list(span_exporter.get_finished_spans())
+    emit_span = next(
+        span for span in spans if span.attributes["openmed.stage"] == "emit"
+    )
+    # Emit stage reports offsets/counts/hashes/durations — never text.
+    assert emit_span.attributes["openmed.stage.span_count"] >= 1
+    assert emit_span.attributes["openmed.stage.redacted_length"] > 0
+    assert emit_span.attributes["openmed.pipeline.language"] == "en"
+    assert emit_span.attributes["openmed.pipeline.doc_id_hash"].startswith(
+        "hmac-sha256:"
+    )
+
+
+def test_labels_are_category_names_not_raw_text(
+    span_exporter: InMemorySpanExporter,
+    enabled_telemetry: PipelineTelemetry,
+) -> None:
+    pipeline = Pipeline(model_detector=_pii_detector, telemetry=enabled_telemetry)
+    pipeline.run(PHI_TEXT, method="mask")
+
+    spans = list(span_exporter.get_finished_spans())
+    labelled = [span for span in spans if "openmed.stage.labels" in span.attributes]
+    assert labelled, "at least one stage should report a label set"
+    for span in labelled:
+        for label in span.attributes["openmed.stage.labels"]:
+            # Labels are canonical categories; none of them is the raw surface.
+            assert label not in PHI_SUBSTRINGS
+
+
+def test_telemetry_summary_shape(
+    enabled_telemetry: PipelineTelemetry,
+) -> None:
+    pipeline = Pipeline(model_detector=_pii_detector, telemetry=enabled_telemetry)
+    pipeline.run(PHI_TEXT, method="mask")
+
+    summary = enabled_telemetry.summary()
+    assert summary["enabled"] is True
+    assert summary["stage_count"] == len(STAGE_NAMES)
+    assert summary["total_duration_ms"] >= 0.0
+    assert [stage["name"] for stage in summary["stages"]] == list(STAGE_NAMES)
+
+
+# ---------------------------------------------------------------------------
+# The key invariant: NO raw PHI in any emitted attribute
+# ---------------------------------------------------------------------------
+
+
+def test_no_raw_phi_in_any_span_attribute(
+    span_exporter: InMemorySpanExporter,
+    enabled_telemetry: PipelineTelemetry,
+) -> None:
+    pipeline = Pipeline(model_detector=_pii_detector, telemetry=enabled_telemetry)
+    result = pipeline.run(PHI_TEXT, method="mask")
+
+    # Sanity: the pipeline actually detected and redacted the synthetic name,
+    # so this test would catch a real leak rather than passing vacuously.
+    assert "Juniper Solstice" not in result.redacted_text
+
+    spans = list(span_exporter.get_finished_spans())
+    assert spans, "telemetry should have exported spans"
+
+    rendered = []
+    for span in spans:
+        rendered.append(span.name)
+        for key, value in span.attributes.items():
+            rendered.append(str(key))
+            rendered.append(str(value))
+        for event in span.events:
+            rendered.append(event.name)
+            for key, value in event.attributes.items():
+                rendered.append(str(key))
+                rendered.append(str(value))
+    haystack = "\n".join(rendered)
+
+    leaked = [substring for substring in PHI_SUBSTRINGS if substring in haystack]
+    assert leaked == [], f"raw PHI leaked into spans: {leaked}"
+
+
+def test_safe_stage_attributes_drops_unapproved_and_text_keys() -> None:
+    attributes = safe_stage_attributes(
+        {
+            "openmed.stage": "emit",
+            "openmed.stage.span_count": 3,
+            "openmed.stage.labels": ["NAME", "PHONE"],
+            # Unapproved keys carrying raw text must be dropped entirely.
+            "openmed.stage.text": "Juniper Solstice",
+            "openmed.input.raw": "MRN 1234567890123",
+            "openmed.stage.surface": "425-555-0199",
+        }
+    )
+    assert attributes == {
+        "openmed.stage": "emit",
+        "openmed.stage.span_count": 3,
+        "openmed.stage.labels": ("NAME", "PHONE"),
+    }
+
+
+def test_safe_stage_attributes_scrubs_unsafe_label_values() -> None:
+    attributes = safe_stage_attributes(
+        {"openmed.stage.labels": ["NAME", "Juniper Solstice, MRN 123"]}
+    )
+    # The free-text value with commas fails the conservative label pattern and
+    # is dropped; the clean category name survives.
+    assert attributes["openmed.stage.labels"] == ("NAME",)
+
+
+def test_module_reimport_is_safe() -> None:
+    # Re-importing must not raise even if OTel state was monkeypatched elsewhere.
+    reloaded = importlib.reload(telemetry_module)
+    assert hasattr(reloaded, "PipelineTelemetry")


### PR DESCRIPTION
## Description
Adds an optional, no-PHI observability layer for the staged de-identification / PII-extraction pipeline. It emits OpenTelemetry spans and per-stage timings for all ten `Pipeline` stages, carrying only aggregate, non-reversible signals — stage names, span/entity counts, offsets, label *sets*, hashes, and durations. Raw text and detected identifiers are never recorded.

Telemetry is developer opt-in and OFF by default, local-first (no network exporter is configured by default), and OpenTelemetry is an optional, lazily-imported dependency: when it is not installed the layer degrades to a no-op backend so core stays dependency-free.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made
- `openmed/core/telemetry.py` (new): `PipelineTelemetry` with a guarded OpenTelemetry backend that falls back to a no-op when otel is absent. Off by default; opt-in via `OPENMED_TELEMETRY_ENABLED`. An attribute allowlist (`safe_stage_attributes`) guarantees raw surface text can never reach a span, even if a caller passes it in. Reuses `time.perf_counter` timing consistent with the existing `Timer`/`Profiler` utilities rather than duplicating them.
- `openmed/core/pipeline.py`: instrument all ten stages (`normalize` … `emit`) via `stage_span`, recording aggregate span counts, label sets, and input/redacted lengths. Document ids are hashed before being attached as `openmed.pipeline.doc_id_hash`.
- `openmed/core/__init__.py`: export `PipelineTelemetry`, `StageMetrics`, `otel_available`, `telemetry_enabled_from_env`.
- `pyproject.toml`: add an optional `otel` extra (api + sdk only; the OTLP exporter stays in the heavier `service` extra to keep local-first defaults).
- `tests/unit/core/test_pipeline_telemetry.py` (new): in-memory span exporter asserts every stage is traced; the no-op path works without otel; and — the key invariant — synthetic PHI fed through the pipeline never leaks into any emitted span attribute, event, or label.

## Testing
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

```
.venv/bin/python -m pytest tests/unit -q
# 3894 passed, 36 skipped

.venv/bin/python -m pytest tests/unit -q -k "telemetry or otel or trace or metric"
# 83 passed, 2 skipped
```

## Documentation
- [x] I have added docstrings to new functions/classes

## Code Quality
- [x] I ran the canonical Ruff formatter and linter on the touched files (`ruff format`, `ruff check` — all checks pass)
- [x] I have performed a self-review of my own code

## Dependencies
- [x] No new *required* dependencies. OpenTelemetry remains optional and lazily imported; a new opt-in `otel` extra is added for users who want spans, but core stays dependency-free.

## Related Issues
Closes #1351
