### PR TITLE
OM-801: Shared input-normalization and validation gateway for REST, MCP, and library

### DIFF
--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -539,12 +539,12 @@ def _strip_accents(text: str) -> str:
 
 def _resolve_effective_pii_model(model_name: str, lang: str) -> str:
     """Validate language and resolve language-specific default PII model."""
+    from ..utils.gateway import validate_language
     from .pii_i18n import DEFAULT_PII_MODELS, SUPPORTED_LANGUAGES
 
-    if lang not in SUPPORTED_LANGUAGES:
-        raise ValueError(
-            f"Unsupported language '{lang}'. Supported: {sorted(SUPPORTED_LANGUAGES)}"
-        )
+    # Guard the language through the shared input gateway so the library PII
+    # path enforces the same language allow-list as the REST and MCP surfaces.
+    lang = validate_language(lang, supported=SUPPORTED_LANGUAGES)
 
     if model_name == _DEFAULT_EN_MODEL and lang != "en":
         return DEFAULT_PII_MODELS[lang]

--- a/openmed/mcp/server.py
+++ b/openmed/mcp/server.py
@@ -23,6 +23,7 @@ from openmed.mcp.tool_registry import (
 )
 from openmed.mcp.workflow import WorkflowRunner, builtin_workflow_step_executors
 from openmed.service.runtime import ServiceRuntime
+from openmed.utils.gateway import normalize_text, validate_language
 from openmed.utils.validation import validate_model_name
 
 RuntimeProvider = Callable[[], ServiceRuntime]
@@ -111,6 +112,10 @@ def openmed_analyze_text(
     """Run OpenMed named-entity recognition and return a JSON-ready result."""
     from openmed.service.schemas import AnalyzeRequest
 
+    # Validate through the shared gateway so the MCP surface applies the same
+    # length/size/encoding guardrails as the library and REST entry points.
+    text = normalize_text(text)
+
     payload = AnalyzeRequest(
         text=text,
         model_name=model_name,
@@ -165,6 +170,11 @@ def openmed_extract_pii(
     """Extract PII/PHI entities and return a JSON-ready result."""
     from openmed.service.schemas import PIIExtractRequest
 
+    # Shared gateway: normalize text and guard the language before dispatch so
+    # the MCP surface rejects the same bad inputs as the REST and library paths.
+    text = normalize_text(text)
+    lang = validate_language(lang)
+
     payload = PIIExtractRequest(
         text=text,
         model_name=model_name,
@@ -216,6 +226,11 @@ def openmed_deidentify(
 ) -> Dict[str, Any]:
     """De-identify text by masking, removing, replacing, hashing, or shifting PII."""
     from openmed.service.schemas import PIIDeidentifyRequest
+
+    # Shared gateway: normalize text and guard the language before dispatch so
+    # the MCP surface rejects the same bad inputs as the REST and library paths.
+    text = normalize_text(text)
+    lang = validate_language(lang)
 
     payload = PIIDeidentifyRequest(
         text=text,

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -6,13 +6,13 @@ from collections.abc import Sequence
 from typing import Any, Literal, Optional, Union
 
 from openmed.core.policy import canonical_policy_name
+from openmed.utils.gateway import get_default_limits, normalize_text
 from openmed.utils.validation import (
     validate_confidence_threshold,
     validate_model_name,
 )
 
 from .keep_alive import parse_keep_alive
-from .limits import get_max_text_length
 
 try:
     from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -60,20 +60,11 @@ PIILanguage = Literal[
 
 
 def _normalize_text(value: Any) -> str:
-    if value is None:
-        raise ValueError("Text is required")
-    if not isinstance(value, str):
-        value = str(value)
-
-    normalized = value.strip()
-    if not normalized:
-        raise ValueError("Text must not be blank")
-    max_text_length = get_max_text_length()
-    if len(normalized) > max_text_length:
-        raise ValueError(
-            f"Text exceeds the maximum length of {max_text_length} characters"
-        )
-    return normalized
+    # Route through the shared gateway so REST requests validate text identically
+    # to the library and MCP surfaces: same character cap (still driven by
+    # ``OPENMED_SERVICE_MAX_TEXT_LENGTH``), plus byte-size, UTF-8 encoding, and
+    # control-character guardrails. Errors never echo the (possibly PHI) text.
+    return normalize_text(value, limits=get_default_limits())
 
 
 def _normalize_model_name(value: str) -> str:

--- a/openmed/utils/__init__.py
+++ b/openmed/utils/__init__.py
@@ -1,5 +1,15 @@
 """Utility functions for OpenMed."""
 
+from .gateway import (
+    GatewayLimits,
+    InputValidationError,
+    NormalizedInput,
+    ensure_valid_encoding,
+    get_default_limits,
+    normalize_input,
+    normalize_text,
+    validate_language,
+)
 from .logging import get_logger, setup_logging
 from .profiling import (
     BatchMetrics,
@@ -22,6 +32,15 @@ __all__ = [
     "get_logger",
     "validate_input",
     "validate_model_name",
+    # Shared input gateway
+    "InputValidationError",
+    "GatewayLimits",
+    "NormalizedInput",
+    "ensure_valid_encoding",
+    "get_default_limits",
+    "normalize_text",
+    "validate_language",
+    "normalize_input",
     # Profiling utilities
     "Profiler",
     "ProfileReport",

--- a/openmed/utils/gateway.py
+++ b/openmed/utils/gateway.py
@@ -1,0 +1,377 @@
+"""Shared input-normalization and validation gateway.
+
+OpenMed exposes the same clinical NLP and PII capabilities through three
+surfaces: the Python library, the REST service (``openmed/service/``), and the
+MCP server (``openmed/mcp/``). Historically each surface validated request text
+and parameters with slightly different ad-hoc rules, so an input accepted by one
+entry point could be rejected (or silently mishandled) by another.
+
+This module centralises that logic. All three surfaces call the same functions
+here, so length/size limits, encoding validation, and language guardrails behave
+identically everywhere, and every failure raises the same typed error.
+
+Privacy note:
+    Validation errors NEVER embed the raw input text (or any excerpt of it).
+    Inputs may contain PHI, and error messages can end up in logs, HTTP
+    responses, or MCP transcripts. Messages describe *what* was wrong (a limit,
+    a type, an encoding fault) using only non-sensitive metadata such as sizes
+    and configured caps.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+__all__ = [
+    "InputValidationError",
+    "GatewayLimits",
+    "NormalizedInput",
+    "DEFAULT_MAX_TEXT_CHARS",
+    "DEFAULT_MAX_TEXT_BYTES",
+    "MAX_TEXT_BYTES_ENV_VAR",
+    "get_default_limits",
+    "ensure_valid_encoding",
+    "normalize_text",
+    "validate_language",
+    "normalize_input",
+]
+
+# Character cap. Mirrors ``openmed.service.limits.DEFAULT_MAX_TEXT_LENGTH`` so
+# the library and MCP surfaces default to the same bound the REST service uses.
+DEFAULT_MAX_TEXT_CHARS = 1_000_000
+
+# Byte cap on the UTF-8 encoding of the text. Guards against payloads that are
+# modest in character count but huge on the wire (e.g. multi-byte scripts).
+DEFAULT_MAX_TEXT_BYTES = 4_000_000
+
+MAX_TEXT_BYTES_ENV_VAR = "OPENMED_MAX_TEXT_BYTES"
+
+# Control characters that must never appear in text input. Common whitespace
+# (tab, newline, carriage return) is intentionally excluded so legitimate
+# multi-line clinical notes pass. This mirrors the historical suspicious-content
+# check in ``openmed.utils.validation`` but is applied uniformly across surfaces.
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+# Long control-character runs indicate binary or encoded payloads.
+_CONTROL_RUN_RE = re.compile(r"[\x00-\x08\x0e-\x1f\x7f]{10,}")
+
+# Extremely long single-character runs indicate abusive or malformed input.
+_LONG_REPEAT_RE = re.compile(r"(.)\1{100,}")
+
+
+class InputValidationError(ValueError):
+    """Raised when input fails shared normalization or validation.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers on
+    every surface keep working while callers that want to distinguish gateway
+    rejections can catch this type directly.
+
+    The message never contains the raw input text. Attributes carry only
+    non-sensitive metadata (a stable ``code`` plus optional sizes/limits) so
+    callers can build structured responses without touching PHI.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        limit: Optional[int] = None,
+        actual: Optional[int] = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.limit = limit
+        self.actual = actual
+
+
+@dataclass(frozen=True)
+class GatewayLimits:
+    """Bounds applied by the shared gateway.
+
+    Attributes:
+        max_chars: Maximum number of characters after stripping. ``None``
+            disables the character cap.
+        max_bytes: Maximum size of the UTF-8 encoding in bytes. ``None``
+            disables the byte cap.
+    """
+
+    max_chars: Optional[int] = DEFAULT_MAX_TEXT_CHARS
+    max_bytes: Optional[int] = DEFAULT_MAX_TEXT_BYTES
+
+
+@dataclass(frozen=True)
+class NormalizedInput:
+    """Result of :func:`normalize_input`.
+
+    Attributes:
+        text: The normalized, validated text.
+        language: The validated language code, or ``None`` when not requested.
+    """
+
+    text: str
+    language: Optional[str] = None
+
+
+def _parse_positive_int_env(env_var: str, default: int) -> int:
+    """Return a positive int from ``env_var`` or ``default`` on any problem."""
+    raw = os.getenv(env_var)
+    if raw is None:
+        return default
+    raw = raw.strip()
+    if not raw:
+        return default
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return default
+    if parsed <= 0:
+        return default
+    return parsed
+
+
+def get_default_limits() -> GatewayLimits:
+    """Return the effective gateway limits from the environment.
+
+    The character cap is sourced from the same environment variable the REST
+    service already honours (``OPENMED_SERVICE_MAX_TEXT_LENGTH``) so all three
+    surfaces agree. The byte cap is read from :data:`MAX_TEXT_BYTES_ENV_VAR`.
+    Invalid or non-positive values fall back to the module defaults.
+    """
+    # Imported lazily to avoid a package import cycle (service imports utils).
+    from openmed.service.limits import get_max_text_length
+
+    return GatewayLimits(
+        max_chars=get_max_text_length(),
+        max_bytes=_parse_positive_int_env(
+            MAX_TEXT_BYTES_ENV_VAR, DEFAULT_MAX_TEXT_BYTES
+        ),
+    )
+
+
+def _coerce_to_text(value: Any) -> str:
+    """Coerce ``value`` to ``str`` while rejecting undecodable bytes.
+
+    Raises:
+        InputValidationError: If ``value`` is ``None`` or bytes that are not
+            valid UTF-8.
+    """
+    if value is None:
+        raise InputValidationError("Input text is required.", code="text_required")
+
+    if isinstance(value, str):
+        # ``str`` can still hold lone surrogates (e.g. from ``surrogateescape``
+        # decoding of invalid bytes). Those cannot be encoded as UTF-8 and would
+        # blow up deep in tokenization, so reject them here with a clear error.
+        try:
+            value.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise InputValidationError(
+                "Input text is not valid UTF-8 (contains unpaired surrogates).",
+                code="invalid_encoding",
+            ) from exc
+        return value
+
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            return bytes(value).decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise InputValidationError(
+                "Input text is not valid UTF-8.",
+                code="invalid_encoding",
+            ) from exc
+
+    return str(value)
+
+
+def ensure_valid_encoding(value: Any) -> str:
+    """Coerce ``value`` to text, rejecting undecodable bytes or lone surrogates.
+
+    Public shim over the shared encoding check so surfaces that keep their own
+    length/empty rules (notably :func:`openmed.utils.validation.validate_input`)
+    still reject invalid UTF-8 the same way the full gateway does.
+
+    Args:
+        value: ``None``, ``str``, ``bytes``, or any object with a ``str()``.
+
+    Returns:
+        The value as ``str``.
+
+    Raises:
+        InputValidationError: If ``value`` is ``None`` or not valid UTF-8. The
+            message never contains the input text.
+    """
+    return _coerce_to_text(value)
+
+
+def _reject_suspicious_content(text: str) -> None:
+    """Reject binary/control payloads without echoing the text.
+
+    Raises:
+        InputValidationError: If control characters or abusive runs are found.
+    """
+    if _CONTROL_RUN_RE.search(text):
+        raise InputValidationError(
+            "Input text contains a run of control characters.",
+            code="control_characters",
+        )
+    if _CONTROL_CHAR_RE.search(text):
+        raise InputValidationError(
+            "Input text contains disallowed control characters.",
+            code="control_characters",
+        )
+    if _LONG_REPEAT_RE.search(text):
+        raise InputValidationError(
+            "Input text contains an abusive repeated-character run.",
+            code="repeated_characters",
+        )
+
+
+def normalize_text(
+    text: Any,
+    *,
+    limits: Optional[GatewayLimits] = None,
+    allow_empty: bool = False,
+    strip: bool = True,
+) -> str:
+    """Normalize and validate free-text input for any OpenMed surface.
+
+    The single normalization path used by the library, REST, and MCP entry
+    points. It performs, in order: encoding validation (reject invalid UTF-8 and
+    unpaired surrogates), optional whitespace stripping, empty/blank checks,
+    control-character rejection, and character/byte length caps.
+
+    Args:
+        text: The raw input. ``None``, ``str``, ``bytes``, or any object with a
+            useful ``str()`` representation.
+        limits: Length/size bounds. Defaults to :func:`get_default_limits`.
+        allow_empty: When ``True``, empty/blank input yields ``""`` instead of
+            raising.
+        strip: When ``True`` (default), leading/trailing whitespace is removed
+            before validation.
+
+    Returns:
+        The normalized text.
+
+    Raises:
+        InputValidationError: If the input is missing, malformed, mis-encoded,
+            or exceeds the configured limits. The message never contains the
+            input text.
+    """
+    if limits is None:
+        limits = get_default_limits()
+
+    decoded = _coerce_to_text(text)
+    normalized = decoded.strip() if strip else decoded
+
+    if not normalized:
+        if allow_empty:
+            return ""
+        raise InputValidationError("Input text must not be empty.", code="empty_text")
+
+    _reject_suspicious_content(normalized)
+
+    if limits.max_chars is not None and len(normalized) > limits.max_chars:
+        raise InputValidationError(
+            f"Input text exceeds the maximum length of {limits.max_chars} characters.",
+            code="max_chars",
+            limit=limits.max_chars,
+            actual=len(normalized),
+        )
+
+    if limits.max_bytes is not None:
+        byte_length = len(normalized.encode("utf-8"))
+        if byte_length > limits.max_bytes:
+            raise InputValidationError(
+                f"Input text exceeds the maximum size of {limits.max_bytes} bytes.",
+                code="max_bytes",
+                limit=limits.max_bytes,
+                actual=byte_length,
+            )
+
+    return normalized
+
+
+def validate_language(
+    lang: Any,
+    *,
+    supported: Optional[Iterable[str]] = None,
+) -> str:
+    """Validate a language code against the supported set.
+
+    Args:
+        lang: The requested ISO 639-1 language code.
+        supported: Iterable of allowed codes. Defaults to
+            :data:`openmed.core.pii_i18n.SUPPORTED_LANGUAGES`.
+
+    Returns:
+        The validated language code (lower-cased, stripped).
+
+    Raises:
+        InputValidationError: If the code is missing, the wrong type, or not in
+            the supported set.
+    """
+    if lang is None:
+        raise InputValidationError(
+            "Language code is required.", code="language_required"
+        )
+    if not isinstance(lang, str):
+        raise InputValidationError(
+            "Language code must be a string.", code="language_type"
+        )
+
+    normalized = lang.strip().lower()
+    if not normalized:
+        raise InputValidationError(
+            "Language code must not be blank.", code="language_required"
+        )
+
+    if supported is None:
+        from openmed.core.pii_i18n import SUPPORTED_LANGUAGES
+
+        supported = SUPPORTED_LANGUAGES
+
+    allowed = set(supported)
+    if normalized not in allowed:
+        raise InputValidationError(
+            f"Unsupported language '{normalized}'. Supported: {sorted(allowed)}",
+            code="unsupported_language",
+        )
+    return normalized
+
+
+def normalize_input(
+    text: Any,
+    *,
+    lang: Any = None,
+    limits: Optional[GatewayLimits] = None,
+    allow_empty: bool = False,
+    supported_languages: Optional[Iterable[str]] = None,
+) -> NormalizedInput:
+    """Normalize text and (optionally) validate a language in one call.
+
+    Convenience wrapper the surfaces use when they need both the normalized text
+    and a validated language code.
+
+    Args:
+        text: Raw input text (see :func:`normalize_text`).
+        lang: Optional language code. When ``None``, no language validation runs
+            and :attr:`NormalizedInput.language` is ``None``.
+        limits: Optional length/size bounds.
+        allow_empty: Whether empty text is allowed.
+        supported_languages: Optional override for the allowed language set.
+
+    Returns:
+        A :class:`NormalizedInput` with the validated text and language.
+
+    Raises:
+        InputValidationError: On any text or language validation failure.
+    """
+    normalized_text = normalize_text(text, limits=limits, allow_empty=allow_empty)
+    normalized_lang = (
+        None if lang is None else validate_language(lang, supported=supported_languages)
+    )
+    return NormalizedInput(text=normalized_text, language=normalized_lang)

--- a/openmed/utils/validation.py
+++ b/openmed/utils/validation.py
@@ -4,6 +4,8 @@ import re
 from pathlib import Path
 from typing import Any, Optional
 
+from .gateway import ensure_valid_encoding
+
 
 def validate_input(
     text: Any,
@@ -12,6 +14,12 @@ def validate_input(
     allow_empty: bool = False,
 ) -> str:
     """Validate and clean input text.
+
+    This is the library entry point into the shared input gateway. Encoding
+    validation is delegated to :func:`openmed.utils.gateway.ensure_valid_encoding`
+    so the library rejects invalid UTF-8 (including unpaired surrogates)
+    identically to the REST and MCP surfaces; the length, empty, and
+    suspicious-content rules below round out the shared contract.
 
     Args:
         text: Input text to validate.
@@ -30,9 +38,10 @@ def validate_input(
             return ""
         raise ValueError("Input text cannot be None")
 
-    # Convert to string if not already
-    if not isinstance(text, str):
-        text = str(text)
+    # Convert to string if not already, rejecting undecodable bytes / lone
+    # surrogates through the shared gateway so all three surfaces agree on what
+    # counts as valid UTF-8.
+    text = ensure_valid_encoding(text)
 
     # Basic cleaning
     text = text.strip()

--- a/tests/unit/utils/test_gateway.py
+++ b/tests/unit/utils/test_gateway.py
@@ -1,0 +1,216 @@
+"""Tests for the shared input-normalization and validation gateway.
+
+These cover the gateway in isolation (valid/invalid text, encoding, length,
+byte, and language guardrails) and confirm that all three surfaces — the Python
+library, the REST schemas, and the MCP server — route through it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.utils import gateway
+from openmed.utils.gateway import (
+    GatewayLimits,
+    InputValidationError,
+    NormalizedInput,
+    ensure_valid_encoding,
+    normalize_input,
+    normalize_text,
+    validate_language,
+)
+
+
+class TestNormalizeText:
+    def test_valid_text_is_stripped(self):
+        assert normalize_text("  Patient has asthma.  ") == "Patient has asthma."
+
+    def test_none_is_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text(None)
+        assert exc.value.code == "text_required"
+
+    def test_empty_is_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text("")
+        assert exc.value.code == "empty_text"
+
+    def test_blank_is_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text("   \n\t ")
+        assert exc.value.code == "empty_text"
+
+    def test_allow_empty_returns_empty_string(self):
+        assert normalize_text("", allow_empty=True) == ""
+        assert normalize_text("   ", allow_empty=True) == ""
+
+    def test_bytes_input_is_decoded(self):
+        assert normalize_text("café".encode("utf-8")) == "café"
+
+    def test_invalid_utf8_bytes_are_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text(b"\xff\xfe not utf-8")
+        assert exc.value.code == "invalid_encoding"
+
+    def test_lone_surrogate_is_rejected(self):
+        # A lone surrogate cannot be encoded to UTF-8.
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text("bad\ud800surrogate")
+        assert exc.value.code == "invalid_encoding"
+
+    def test_multilingual_text_is_accepted(self):
+        # CJK / Arabic / Devanagari runs must not be treated as suspicious.
+        for sample in ("患者は喘息です。", "المريض مصاب بالربو", "रोगी को अस्थमा है"):
+            assert normalize_text(sample) == sample
+
+    def test_char_limit_is_enforced(self):
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text("a" * 11, limits=GatewayLimits(max_chars=10))
+        assert exc.value.code == "max_chars"
+        assert exc.value.limit == 10
+        assert exc.value.actual == 11
+
+    def test_byte_limit_is_enforced(self):
+        # Four two-byte characters == 8 bytes but only 4 chars, so this trips the
+        # byte cap while staying under a generous char cap.
+        text = "é" * 4
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text(text, limits=GatewayLimits(max_chars=100, max_bytes=4))
+        assert exc.value.code == "max_bytes"
+        assert exc.value.limit == 4
+
+    def test_control_character_run_is_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text("ok" + "\x00" * 12)
+        assert exc.value.code == "control_characters"
+
+    def test_single_control_character_is_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text("hello\x07world")
+        assert exc.value.code == "control_characters"
+
+    def test_common_whitespace_is_allowed(self):
+        text = "line one\nline two\tindented"
+        assert normalize_text(text) == text
+
+    def test_abusive_repeated_run_is_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text("a" * 200)
+        assert exc.value.code == "repeated_characters"
+
+    def test_error_message_never_contains_input_text(self):
+        secret = "SSN 123-45-6789 belongs to Jane Q Patient"
+        # Force a limit failure while keeping the (sensitive) text in the input.
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text(secret, limits=GatewayLimits(max_chars=5))
+        assert secret not in str(exc.value)
+        assert "123-45-6789" not in str(exc.value)
+
+
+class TestEnsureValidEncoding:
+    def test_passes_valid_text(self):
+        assert ensure_valid_encoding("hello") == "hello"
+
+    def test_decodes_bytes(self):
+        assert ensure_valid_encoding("café".encode("utf-8")) == "café"
+
+    def test_rejects_none(self):
+        with pytest.raises(InputValidationError):
+            ensure_valid_encoding(None)
+
+    def test_rejects_invalid_bytes(self):
+        with pytest.raises(InputValidationError) as exc:
+            ensure_valid_encoding(b"\xff\xfe")
+        assert exc.value.code == "invalid_encoding"
+
+
+class TestValidateLanguage:
+    def test_valid_language(self):
+        assert validate_language("en") == "en"
+
+    def test_normalizes_case_and_whitespace(self):
+        assert validate_language("  FR ") == "fr"
+
+    def test_unsupported_language_raises(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_language("xx")
+        assert exc.value.code == "unsupported_language"
+        # The canonical library message contract is preserved.
+        assert "Unsupported language" in str(exc.value)
+
+    def test_none_language_raises(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_language(None)
+        assert exc.value.code == "language_required"
+
+    def test_non_string_language_raises(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_language(123)
+        assert exc.value.code == "language_type"
+
+    def test_custom_supported_set(self):
+        assert validate_language("zz", supported={"zz"}) == "zz"
+        with pytest.raises(InputValidationError):
+            validate_language("en", supported={"zz"})
+
+    def test_defaults_to_pii_supported_languages(self):
+        from openmed.core.pii_i18n import SUPPORTED_LANGUAGES
+
+        for code in SUPPORTED_LANGUAGES:
+            assert validate_language(code) == code
+
+
+class TestNormalizeInput:
+    def test_returns_normalized_text_and_language(self):
+        result = normalize_input("  hello  ", lang="EN")
+        assert isinstance(result, NormalizedInput)
+        assert result.text == "hello"
+        assert result.language == "en"
+
+    def test_language_optional(self):
+        result = normalize_input("hello")
+        assert result.language is None
+
+    def test_propagates_text_failure(self):
+        with pytest.raises(InputValidationError):
+            normalize_input("", lang="en")
+
+    def test_propagates_language_failure(self):
+        with pytest.raises(InputValidationError):
+            normalize_input("hello", lang="xx")
+
+
+class TestDefaultLimits:
+    def test_char_cap_follows_service_env(self, monkeypatch):
+        monkeypatch.setenv("OPENMED_SERVICE_MAX_TEXT_LENGTH", "5")
+        limits = gateway.get_default_limits()
+        assert limits.max_chars == 5
+
+    def test_byte_cap_follows_env(self, monkeypatch):
+        monkeypatch.setenv(gateway.MAX_TEXT_BYTES_ENV_VAR, "123")
+        limits = gateway.get_default_limits()
+        assert limits.max_bytes == 123
+
+    def test_invalid_byte_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(gateway.MAX_TEXT_BYTES_ENV_VAR, "not-an-int")
+        limits = gateway.get_default_limits()
+        assert limits.max_bytes == gateway.DEFAULT_MAX_TEXT_BYTES
+
+    def test_default_char_cap_used_by_normalize_text(self, monkeypatch):
+        monkeypatch.setenv("OPENMED_SERVICE_MAX_TEXT_LENGTH", "3")
+        with pytest.raises(InputValidationError) as exc:
+            normalize_text("abcd")
+        assert exc.value.code == "max_chars"
+
+
+class TestTypedError:
+    def test_is_value_error_subclass(self):
+        # Existing ``except ValueError`` handlers on every surface must still
+        # catch gateway rejections.
+        assert issubclass(InputValidationError, ValueError)
+
+    def test_carries_structured_metadata(self):
+        err = InputValidationError("boom", code="max_chars", limit=10, actual=20)
+        assert err.code == "max_chars"
+        assert err.limit == 10
+        assert err.actual == 20

--- a/tests/unit/utils/test_gateway_surface_integration.py
+++ b/tests/unit/utils/test_gateway_surface_integration.py
@@ -1,0 +1,198 @@
+"""Confirm the library, REST, and MCP surfaces all route through the gateway.
+
+The gateway (``openmed.utils.gateway``) is the single input-normalization and
+validation path. These tests assert that each of the three entry points rejects
+the same malformed inputs by delegating to it, rather than re-validating
+ad-hoc.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.utils.gateway import InputValidationError
+
+
+# ---------------------------------------------------------------------------
+# Library surface
+# ---------------------------------------------------------------------------
+class TestLibrarySurface:
+    def test_validate_input_rejects_invalid_utf8_bytes(self):
+        from openmed.utils.validation import validate_input
+
+        # The library entry point delegates encoding validation to the gateway.
+        with pytest.raises(ValueError):
+            validate_input(b"\xff\xfe not utf-8")
+
+    def test_validate_input_rejects_lone_surrogate(self):
+        from openmed.utils.validation import validate_input
+
+        with pytest.raises(ValueError):
+            validate_input("bad\ud800surrogate")
+
+    def test_validate_input_still_strips_and_accepts_clean_text(self):
+        from openmed.utils.validation import validate_input
+
+        assert validate_input("  hello  ") == "hello"
+
+    def test_extract_pii_language_guardrail_uses_gateway(self):
+        from openmed.core.pii import extract_pii
+
+        # ``_resolve_effective_pii_model`` now validates the language through the
+        # shared gateway, preserving the canonical "Unsupported language" error.
+        with pytest.raises(ValueError, match="Unsupported language"):
+            extract_pii("test", lang="ko")
+
+    def test_resolve_effective_pii_model_uses_gateway(self, monkeypatch):
+        import openmed.utils.gateway as gateway
+        from openmed.core.pii import _resolve_effective_pii_model
+
+        called = {}
+        real = gateway.validate_language
+
+        def spy(lang, **kwargs):
+            called["lang"] = lang
+            return real(lang, **kwargs)
+
+        # The function imports ``validate_language`` from the gateway module at
+        # call time, so patching the source module is picked up.
+        monkeypatch.setattr(gateway, "validate_language", spy)
+
+        result = _resolve_effective_pii_model("some/model", "en")
+        assert result == "some/model"
+        assert called["lang"] == "en"
+
+
+# ---------------------------------------------------------------------------
+# REST surface
+# ---------------------------------------------------------------------------
+class TestRestSurface:
+    def test_schemas_normalize_text_delegates_to_gateway(self, monkeypatch):
+        from openmed.service import schemas
+
+        sentinel = object()
+        captured = {}
+
+        def fake_normalize_text(value, **kwargs):
+            captured["value"] = value
+            return "NORMALIZED"
+
+        monkeypatch.setattr(schemas, "normalize_text", fake_normalize_text)
+        assert schemas._normalize_text(sentinel) == "NORMALIZED"
+        assert captured["value"] is sentinel
+
+    def test_analyze_request_rejects_blank_text(self):
+        from openmed.service.schemas import AnalyzeRequest
+
+        with pytest.raises(ValueError):
+            AnalyzeRequest(text="   ")
+
+    def test_pii_extract_request_rejects_control_characters(self):
+        from openmed.service.schemas import PIIExtractRequest
+
+        with pytest.raises(ValueError):
+            PIIExtractRequest(
+                text="clinical note\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            )
+
+    def test_pii_extract_request_rejects_invalid_utf8_bytes(self):
+        from openmed.service.schemas import PIIExtractRequest
+
+        with pytest.raises(ValueError):
+            PIIExtractRequest(text=b"\xff\xfe")
+
+    def test_analyze_request_accepts_clean_text(self):
+        from openmed.service.schemas import AnalyzeRequest
+
+        req = AnalyzeRequest(text="  Patient has asthma.  ")
+        assert req.text == "Patient has asthma."
+
+    def test_char_cap_honours_service_env(self, monkeypatch):
+        monkeypatch.setenv("OPENMED_SERVICE_MAX_TEXT_LENGTH", "5")
+        from openmed.service.schemas import AnalyzeRequest
+
+        with pytest.raises(ValueError):
+            AnalyzeRequest(text="x" * 6)
+
+
+# ---------------------------------------------------------------------------
+# MCP surface
+# ---------------------------------------------------------------------------
+def _exploding_runtime_provider():
+    """A runtime provider that fails if the gateway did not short-circuit."""
+
+    def _provider():
+        raise AssertionError(
+            "runtime must not be reached; gateway should reject input first"
+        )
+
+    return _provider
+
+
+class TestMcpSurface:
+    def test_analyze_rejects_blank_text_before_runtime(self):
+        from openmed.mcp.server import openmed_analyze_text
+
+        with pytest.raises(InputValidationError):
+            openmed_analyze_text(
+                "   ",
+                runtime_provider=_exploding_runtime_provider(),
+            )
+
+    def test_analyze_rejects_invalid_utf8_before_runtime(self):
+        from openmed.mcp.server import openmed_analyze_text
+
+        with pytest.raises(InputValidationError):
+            openmed_analyze_text(
+                b"\xff\xfe",
+                runtime_provider=_exploding_runtime_provider(),
+            )
+
+    def test_extract_pii_rejects_blank_text_before_runtime(self):
+        from openmed.mcp.server import openmed_extract_pii
+
+        with pytest.raises(InputValidationError):
+            openmed_extract_pii(
+                "   ",
+                runtime_provider=_exploding_runtime_provider(),
+            )
+
+    def test_extract_pii_rejects_unsupported_language_before_runtime(self):
+        from openmed.mcp.server import openmed_extract_pii
+
+        with pytest.raises(InputValidationError):
+            openmed_extract_pii(
+                "Patient John Doe",
+                lang="xx",
+                runtime_provider=_exploding_runtime_provider(),
+            )
+
+    def test_deidentify_rejects_blank_text_before_runtime(self):
+        from openmed.mcp.server import openmed_deidentify
+
+        with pytest.raises(InputValidationError):
+            openmed_deidentify(
+                "   ",
+                runtime_provider=_exploding_runtime_provider(),
+            )
+
+    def test_deidentify_rejects_unsupported_language_before_runtime(self):
+        from openmed.mcp.server import openmed_deidentify
+
+        with pytest.raises(InputValidationError):
+            openmed_deidentify(
+                "Patient John Doe",
+                lang="xx",
+                runtime_provider=_exploding_runtime_provider(),
+            )
+
+    def test_error_from_mcp_does_not_leak_input_text(self):
+        from openmed.mcp.server import openmed_extract_pii
+
+        secret = "SSN 123-45-6789 " + "x" * 10_000_000
+        with pytest.raises(InputValidationError) as exc:
+            openmed_extract_pii(
+                secret,
+                runtime_provider=_exploding_runtime_provider(),
+            )
+        assert "123-45-6789" not in str(exc.value)


### PR DESCRIPTION
## Description

Adds a single, small, importable **input-normalization and validation gateway** (`openmed/utils/gateway.py`) that the library, REST service (`openmed/service/`), and MCP server (`openmed/mcp/`) all call, so the three surfaces validate input identically instead of with ad-hoc, drifting rules.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring

## Changes Made
- New `openmed/utils/gateway.py` providing:
  - Character and UTF-8 byte-size caps (the char cap still honors `OPENMED_SERVICE_MAX_TEXT_LENGTH`, plus a new `OPENMED_MAX_TEXT_BYTES`).
  - Encoding validation that rejects invalid UTF-8 bytes and unpaired surrogates before they reach tokenization.
  - A `validate_language` guardrail checked against `SUPPORTED_LANGUAGES` as the single source of truth.
  - A typed `InputValidationError` (subclass of `ValueError` for backward compatibility) carrying a stable machine-readable `code` and non-sensitive size/limit metadata.
- Wired the gateway into all three surfaces (extend-in-place):
  - **Library** — `openmed.utils.validation.validate_input` delegates encoding checks to the gateway; `_resolve_effective_pii_model` validates language through it.
  - **REST** — `openmed/service/schemas.py` text validation routes through the gateway.
  - **MCP** — the `analyze` / `extract_pii` / `deidentify` handlers in `openmed/mcp/server.py` normalize text and guard language before dispatch.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- New tests under `tests/unit/utils/` cover valid/invalid inputs across the gateway (empty, blank, invalid UTF-8, lone surrogates, char/byte caps, control characters, language guardrails) and confirm the REST schemas and MCP handlers route through it, including that validation errors never leak the raw input text.
- Full suite: `.venv/bin/python -m pytest tests/ -q` → **3961 passed, 37 skipped**.

## Documentation
- [x] I have added docstrings to new functions/classes

## Privacy / Safety
- Validation errors never embed the raw (possibly PHI-bearing) input text; messages describe only what was wrong using sizes, limits, and a stable error `code`.

## Dependencies
- [x] I have not added any new dependencies

## Related Issues
Closes #1371
