### PR TITLE
OM-820: Graceful degradation when an optional model or extra is missing

### DIFF
--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -17,6 +17,15 @@ from .core.anonymizer import (
     register_label_generator,
 )
 from .core.audit import AuditReport, AuditSignature, AuditSpan, DetectorInfo
+from .core.capabilities import (
+    BackendSpec,
+    BackendStatus,
+    MissingOptionalDependencyError,
+    available_backends,
+    backend_status,
+    is_backend_available,
+    require_backend,
+)
 from .core.custom_recognizer import CustomRecognizer
 from .core.explain import ExplainReport, explain
 from .core.labels import CANONICAL_LABELS, normalize_label
@@ -637,6 +646,13 @@ __all__ = [
     "ModelLoader",
     "load_model",
     "OpenMedConfig",
+    "BackendSpec",
+    "BackendStatus",
+    "MissingOptionalDependencyError",
+    "available_backends",
+    "backend_status",
+    "is_backend_available",
+    "require_backend",
     "TextProcessor",
     "preprocess_text",
     "postprocess_text",

--- a/openmed/core/backends.py
+++ b/openmed/core/backends.py
@@ -92,14 +92,14 @@ class MLXBackend:
         self._config = config
 
     def is_available(self) -> bool:
+        # MLX only runs on Apple Silicon; gate on the platform first, then defer
+        # the import check to the shared capability probe so every seam answers
+        # "is mlx installed?" the same importless way.
         if platform.system() != "Darwin":
             return False
-        try:
-            import mlx.core  # noqa: F401
+        from .capabilities import is_backend_available
 
-            return True
-        except ImportError:
-            return False
+        return is_backend_available("mlx")
 
     def create_pipeline(
         self,

--- a/openmed/core/capabilities.py
+++ b/openmed/core/capabilities.py
@@ -1,0 +1,465 @@
+"""Unified capability probe for OpenMed's optional backends and extras.
+
+OpenMed ships many optional integrations behind ``pip install openmed[...]``
+extras (``mlx``, ``coreml``, ``onnx``, ``gliner``, ``spacy``, ``presidio``,
+``hf``, ``multimodal``, ``service``, ``mcp``, ...). Historically each seam
+guarded its optional imports differently: some raised a bare :class:`ImportError`
+with an ad-hoc message, others raised one of several ``MissingDependencyError``
+variants, and there was no single, importless way to probe which backends are
+available before use.
+
+This module is that single source of truth. It is deliberately dependency-free
+(standard library only) so importing it never drags in heavy optional packages,
+and every probe uses :func:`importlib.util.find_spec` so checking availability
+never imports the backend either.
+
+Two complementary contracts are provided:
+
+* A **capability probe** -- :func:`available_backends`, :func:`backend_status`,
+  and :func:`is_backend_available` -- for code that wants to *branch* on whether
+  an optional seam is installed and degrade gracefully (skip-with-warning or
+  fall back) when it is not.
+* An **actionable requirement** -- :func:`require_backend` raising
+  :class:`MissingOptionalDependencyError` -- for code paths where a feature
+  genuinely *requires* a missing extra and should fail with one consistent
+  message naming the exact ``pip install`` command.
+
+Example:
+    >>> from openmed import available_backends
+    >>> report = available_backends()
+    >>> report["hf"].available  # doctest: +SKIP
+    False
+    >>> report["hf"].install_hint  # doctest: +SKIP
+    "Install with `pip install openmed[hf]` or `pip install transformers`."
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import warnings
+from dataclasses import dataclass
+from typing import Final, NoReturn
+
+
+class MissingOptionalDependencyError(ImportError):
+    """Raised when a requested optional capability needs an unavailable package.
+
+    This is the canonical, shared "missing extra" error for the whole package.
+    It subclasses :class:`ImportError` so existing ``except ImportError`` guards
+    keep working, and it carries structured ``feature``/``package``/``extra``
+    fields plus an actionable install message.
+    """
+
+    def __init__(
+        self,
+        *,
+        package: str,
+        feature: str,
+        extra: str | None = None,
+    ) -> None:
+        instruction = install_hint(package, extra)
+        super().__init__(
+            f"{feature} requires optional dependency '{package}'. {instruction}"
+        )
+        self.package = package
+        self.feature = feature
+        self.extra = extra
+
+
+@dataclass(frozen=True)
+class BackendSpec:
+    """Registry metadata for one optional backend/extra seam.
+
+    Attributes:
+        name: Stable capability key (e.g. ``"mlx"``, ``"hf"``).
+        extra: The ``pip install openmed[<extra>]`` extra that provides it.
+        modules: Import module names that must all be importable for the
+            capability to be considered available.
+        description: Human-readable description of what the backend enables.
+        install: Optional distribution name to suggest with a bare
+            ``pip install`` when the extra alias is not enough (defaults to the
+            first entry of ``modules``).
+    """
+
+    name: str
+    extra: str
+    modules: tuple[str, ...]
+    description: str
+    install: str | None = None
+
+    @property
+    def primary_package(self) -> str:
+        """Return the package name to name in a bare ``pip install`` hint."""
+
+        return self.install or self.modules[0]
+
+
+# Canonical extra names mirror ``[project.optional-dependencies]`` in
+# ``pyproject.toml``. Keep this registry in sync when adding an optional extra.
+_BACKENDS: Final[dict[str, BackendSpec]] = {
+    "hf": BackendSpec(
+        name="hf",
+        extra="hf",
+        modules=("transformers",),
+        description="HuggingFace Transformers token-classification inference",
+        install="transformers",
+    ),
+    "mlx": BackendSpec(
+        name="mlx",
+        extra="mlx",
+        modules=("mlx.core",),
+        description="Apple MLX hardware-accelerated inference (Apple Silicon)",
+        install="mlx",
+    ),
+    "coreml": BackendSpec(
+        name="coreml",
+        extra="coreml",
+        modules=("coremltools",),
+        description="CoreML export for iOS/macOS deployment",
+        install="coremltools",
+    ),
+    "onnx": BackendSpec(
+        name="onnx",
+        extra="onnx",
+        modules=("onnx", "onnxruntime"),
+        description="ONNX export and ONNX Runtime inference",
+        install="onnxruntime",
+    ),
+    "openvino": BackendSpec(
+        name="openvino",
+        extra="openvino",
+        modules=("openvino",),
+        description="OpenVINO IR export and inference",
+        install="openvino",
+    ),
+    "gliner": BackendSpec(
+        name="gliner",
+        extra="gliner",
+        modules=("gliner",),
+        description="GLiNER zero-shot entity recognition",
+        install="gliner",
+    ),
+    "spacy": BackendSpec(
+        name="spacy",
+        extra="spacy",
+        modules=("spacy",),
+        description="spaCy pipeline component for OpenMed PII spans",
+        install="spacy",
+    ),
+    "presidio": BackendSpec(
+        name="presidio",
+        extra="presidio",
+        modules=("presidio_analyzer",),
+        description="Presidio RecognizerResult interoperability",
+        install="presidio-analyzer",
+    ),
+    "philter": BackendSpec(
+        name="philter",
+        extra="philter",
+        modules=("philter",),
+        description="Philter PHI span interoperability",
+        install="philter-ucsf",
+    ),
+    "pydeid": BackendSpec(
+        name="pydeid",
+        extra="pydeid",
+        modules=("pyDeid",),
+        description="pyDeid PHI span interoperability",
+        install="pyDeid",
+    ),
+    "multimodal": BackendSpec(
+        name="multimodal",
+        extra="multimodal",
+        modules=("pdfplumber", "docx", "PIL"),
+        description="Multimodal document/image ingestion and redaction",
+        install="pdfplumber",
+    ),
+    "service": BackendSpec(
+        name="service",
+        extra="service",
+        modules=("fastapi", "uvicorn"),
+        description="FastAPI REST service surface",
+        install="fastapi",
+    ),
+    "mcp": BackendSpec(
+        name="mcp",
+        extra="mcp",
+        modules=("mcp",),
+        description="Model Context Protocol server integration",
+        install="mcp",
+    ),
+    "langchain": BackendSpec(
+        name="langchain",
+        extra="langchain",
+        modules=("langchain_core",),
+        description="LangChain redaction runnable adapter",
+        install="langchain-core",
+    ),
+    "llamaindex": BackendSpec(
+        name="llamaindex",
+        extra="llamaindex",
+        modules=("llama_index.core",),
+        description="LlamaIndex FunctionTool adapter",
+        install="llama-index-core",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class BackendStatus:
+    """Importless availability report for one optional backend/extra seam.
+
+    Attributes:
+        name: The capability key.
+        available: True when every required module is importable.
+        extra: The ``openmed[<extra>]`` extra that provides the backend.
+        description: Human-readable description of the backend.
+        missing: Module names that are not importable (empty when available).
+        install_hint: Actionable ``pip install`` instruction.
+    """
+
+    name: str
+    available: bool
+    extra: str
+    description: str
+    missing: tuple[str, ...]
+    install_hint: str
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable mapping of this status."""
+
+        return {
+            "name": self.name,
+            "available": self.available,
+            "extra": self.extra,
+            "description": self.description,
+            "missing": list(self.missing),
+            "install_hint": self.install_hint,
+        }
+
+
+def install_hint(package: str, extra: str | None = None) -> str:
+    """Return an actionable install instruction for a missing optional package.
+
+    Args:
+        package: The distribution name to suggest with a bare ``pip install``.
+        extra: The ``openmed[<extra>]`` extra that also provides it, if any.
+
+    Returns:
+        A short sentence naming the exact command(s) to install the dependency.
+    """
+
+    if extra:
+        return (
+            f"Install with `pip install openmed[{extra}]` or `pip install {package}`."
+        )
+    return f"Install with `pip install {package}`."
+
+
+def registered_backends() -> tuple[str, ...]:
+    """Return every registered capability key, sorted, without importing them."""
+
+    return tuple(sorted(_BACKENDS))
+
+
+def backend_spec(name: str) -> BackendSpec:
+    """Return the :class:`BackendSpec` for *name* without importing it.
+
+    Raises:
+        KeyError: If *name* is not a registered capability.
+    """
+
+    key = _normalize(name)
+    try:
+        return _BACKENDS[key]
+    except KeyError as exc:
+        known = ", ".join(registered_backends())
+        raise KeyError(f"unknown backend {name!r}; available: {known}") from exc
+
+
+def _missing_modules(spec: BackendSpec) -> tuple[str, ...]:
+    """Return required module names that are not importable, without importing."""
+
+    missing: list[str] = []
+    for module in spec.modules:
+        try:
+            found = importlib.util.find_spec(module) is not None
+        except (ImportError, ValueError):
+            # A parent package that itself fails to import, or a submodule of a
+            # namespace that cannot be resolved, is treated as unavailable.
+            found = False
+        if not found:
+            missing.append(module)
+    return tuple(missing)
+
+
+def backend_status(name: str) -> BackendStatus:
+    """Return an importless :class:`BackendStatus` for a single backend.
+
+    Args:
+        name: A registered capability key (case-insensitive; ``-`` and ``_``
+            are treated the same).
+
+    Returns:
+        The availability report, computed via :func:`importlib.util.find_spec`
+        so the backend itself is never imported.
+
+    Raises:
+        KeyError: If *name* is not a registered capability.
+    """
+
+    spec = backend_spec(name)
+    missing = _missing_modules(spec)
+    return BackendStatus(
+        name=spec.name,
+        available=not missing,
+        extra=spec.extra,
+        description=spec.description,
+        missing=missing,
+        install_hint=install_hint(spec.primary_package, spec.extra),
+    )
+
+
+def is_backend_available(name: str) -> bool:
+    """Return True when every module for *name* is importable, importlessly.
+
+    Args:
+        name: A registered capability key.
+
+    Returns:
+        True if the backend can be used, False otherwise. Never raises for an
+        unavailable backend; only raises :class:`KeyError` for an unknown key.
+    """
+
+    return backend_status(name).available
+
+
+def available_backends() -> dict[str, BackendStatus]:
+    """Return an importless availability report for every optional backend.
+
+    This is the top-level capability probe. It imports none of the optional
+    dependencies (each is checked with :func:`importlib.util.find_spec`), so it
+    is safe to call on a minimal, local-first install to decide which features
+    to enable.
+
+    Returns:
+        A mapping of capability key to its :class:`BackendStatus`, ordered by
+        capability key.
+    """
+
+    return {name: backend_status(name) for name in registered_backends()}
+
+
+def require_backend(name: str, *, feature: str | None = None) -> None:
+    """Ensure a required backend is importable, or raise an actionable error.
+
+    Use this on code paths where the feature genuinely *cannot* proceed without
+    the optional extra. For paths that can degrade gracefully, prefer
+    :func:`is_backend_available` (or :func:`warn_backend_unavailable`) instead.
+
+    Args:
+        name: A registered capability key.
+        feature: Human-readable description of the feature being attempted;
+            defaults to the backend's registry description.
+
+    Raises:
+        MissingOptionalDependencyError: If any required module is missing.
+        KeyError: If *name* is not a registered capability.
+    """
+
+    status = backend_status(name)
+    if status.available:
+        return
+    spec = backend_spec(name)
+    raise MissingOptionalDependencyError(
+        package=", ".join(status.missing) or spec.primary_package,
+        feature=feature or spec.description,
+        extra=spec.extra,
+    )
+
+
+def raise_missing_backend(
+    name: str,
+    *,
+    feature: str | None = None,
+    cause: BaseException | None = None,
+) -> NoReturn:
+    """Unconditionally raise the shared missing-extra error for *name*.
+
+    Helper for ``except ImportError`` blocks that have already discovered the
+    backend is unavailable and want to re-raise a consistent, actionable error
+    chained from the original import failure.
+
+    Args:
+        name: A registered capability key.
+        feature: Human-readable description of the feature being attempted.
+        cause: The original :class:`ImportError`, chained via ``from``.
+
+    Raises:
+        MissingOptionalDependencyError: Always.
+    """
+
+    spec = backend_spec(name)
+    status = backend_status(name)
+    error = MissingOptionalDependencyError(
+        package=", ".join(status.missing) or spec.primary_package,
+        feature=feature or spec.description,
+        extra=spec.extra,
+    )
+    raise error from cause
+
+
+def warn_backend_unavailable(
+    name: str,
+    *,
+    feature: str | None = None,
+    action: str = "skipping",
+) -> BackendStatus:
+    """Emit a clear one-line warning that an optional backend is unavailable.
+
+    For graceful-degradation paths: call this to inform the user that a feature
+    is being skipped or falling back because the extra is not installed, then
+    continue. Returns the status so callers can branch further.
+
+    Args:
+        name: A registered capability key.
+        feature: Human-readable description of the affected feature; defaults to
+            the backend's registry description.
+        action: What the caller is doing instead (e.g. ``"skipping"`` or
+            ``"falling back"``).
+
+    Returns:
+        The :class:`BackendStatus` for *name*.
+    """
+
+    status = backend_status(name)
+    if not status.available:
+        warnings.warn(
+            f"OpenMed: {feature or status.description} is unavailable "
+            f"({action}) because optional dependency "
+            f"{', '.join(status.missing) or status.name} is not installed. "
+            f"{status.install_hint}",
+            UserWarning,
+            stacklevel=2,
+        )
+    return status
+
+
+def _normalize(name: str) -> str:
+    return str(name or "").strip().lower().replace("-", "_")
+
+
+__all__ = [
+    "BackendSpec",
+    "BackendStatus",
+    "MissingOptionalDependencyError",
+    "available_backends",
+    "backend_spec",
+    "backend_status",
+    "install_hint",
+    "is_backend_available",
+    "raise_missing_backend",
+    "registered_backends",
+    "require_backend",
+    "warn_backend_unavailable",
+]

--- a/openmed/core/models.py
+++ b/openmed/core/models.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from .config import OpenMedConfig
 
 from ..processing.tokenizer_cache import get_tokenizer_with_loader
+from .capabilities import require_backend
 from .config import get_config
 from .model_registry import (
     ModelInfo as RegistryModelInfo,
@@ -45,6 +46,23 @@ from .model_registry import (
     get_models_by_category,
 )
 from .offline import configure_offline_mode, is_local_only
+
+
+def is_hf_available() -> bool:
+    """Return True when HuggingFace Transformers is importable.
+
+    Mirrors the module-level ``HF_AVAILABLE`` flag so callers can branch on the
+    ``hf`` backend using the same convention as the other optional seams.
+    """
+
+    return bool(HF_AVAILABLE)
+
+
+def ensure_hf_available() -> None:
+    """Raise an actionable error when the ``hf`` extra is not installed."""
+
+    if not HF_AVAILABLE:
+        require_backend("hf", feature="HuggingFace Transformers inference")
 
 
 class ModelLoader:

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -35,6 +35,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Literal, NoReturn, Optional, Sequence
 
 from ..processing.outputs import EntityPrediction, PredictionResult
+from .capabilities import MissingOptionalDependencyError
+from .capabilities import install_hint as _optional_dependency_install_instruction
 from .config import OpenMedConfig
 from .custom_recognizer import CUSTOM_DENY_DETECTOR, coerce_custom_recognizer
 from .date_shift import (
@@ -72,37 +74,6 @@ DeidentificationMethod = Literal[
     "shift_dates",
     "format_preserve",
 ]
-
-
-class MissingOptionalDependencyError(ImportError):
-    """Raised when a requested optional capability needs an unavailable package."""
-
-    def __init__(
-        self,
-        *,
-        package: str,
-        feature: str,
-        extra: str | None = None,
-    ) -> None:
-        instruction = _optional_dependency_install_instruction(package, extra)
-        super().__init__(
-            f"{feature} requires optional dependency '{package}'. {instruction}"
-        )
-        self.package = package
-        self.feature = feature
-        self.extra = extra
-
-
-def _optional_dependency_install_instruction(
-    package: str,
-    extra: str | None = None,
-) -> str:
-    if extra:
-        return (
-            f"Install it with `pip install openmed[{extra}]` "
-            f"or `pip install {package}`."
-        )
-    return f"Install it with `pip install {package}`."
 
 
 def _optional_dependency_status(

--- a/openmed/coreml/__init__.py
+++ b/openmed/coreml/__init__.py
@@ -5,3 +5,22 @@ for deployment on iOS and macOS.
 
 Install with: ``pip install openmed[coreml]``
 """
+
+from __future__ import annotations
+
+from openmed.core.capabilities import is_backend_available as _is_backend_available
+from openmed.core.capabilities import require_backend as _require_backend
+
+__all__ = ["ensure_coreml_available", "is_coreml_available"]
+
+
+def is_coreml_available() -> bool:
+    """Return True when the ``coreml`` extra is importable, without importing it."""
+
+    return _is_backend_available("coreml")
+
+
+def ensure_coreml_available() -> None:
+    """Raise an actionable error when the ``coreml`` extra is not installed."""
+
+    _require_backend("coreml", feature="CoreML export")

--- a/openmed/coreml/convert.py
+++ b/openmed/coreml/convert.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Optional, Sequence
 
+from openmed.core.capabilities import raise_missing_backend
 from openmed.core.decoding import build_label_info, labels_to_token_spans
 from openmed.core.hf_publish import publish_artifact
 from openmed.eval.metrics import compute_recall_slices, normalize_eval_spans
@@ -240,9 +241,7 @@ def convert(
             AutoTokenizer,
         )
     except ImportError as e:
-        raise ImportError(
-            f"Missing dependency: {e}. Install with: pip install openmed[coreml]"
-        ) from e
+        raise_missing_backend("coreml", feature="CoreML model conversion", cause=e)
 
     source_config = AutoConfig.from_pretrained(model_id, cache_dir=cache_dir)
     model_type = resolve_supported_model_type(source_config)
@@ -1160,10 +1159,9 @@ def _hf_token_classification_runner(
                     pipeline,
                 )
             except ImportError as exc:
-                raise ImportError(
-                    "transformers is required to certify CoreML parity. "
-                    "Install with: pip install transformers"
-                ) from exc
+                raise_missing_backend(
+                    "hf", feature="Certifying CoreML parity", cause=exc
+                )
 
             tokenizer = get_tokenizer_with_loader(
                 model_id,
@@ -1203,10 +1201,11 @@ def _coreml_artifact_runner(
                 import numpy as np
                 from transformers import AutoTokenizer
             except ImportError as exc:
-                raise ImportError(
-                    "coremltools, numpy, and transformers are required to run "
-                    "CoreML parity fixtures."
-                ) from exc
+                raise_missing_backend(
+                    "coreml",
+                    feature="Running CoreML parity fixtures",
+                    cause=exc,
+                )
 
             id2label = _load_id2label_for_package(model_path)
             pipeline_state["np"] = np

--- a/openmed/interop/gliner_biomed.py
+++ b/openmed/interop/gliner_biomed.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from importlib import import_module as _import_module
 from typing import Any, Iterable, Mapping, Sequence
 
+from openmed.core.capabilities import raise_missing_backend
 from openmed.core.labels import normalize_label
 from openmed.core.pii import PIIEntity
 from openmed.core.pii_entity_merger import merge_entities_with_semantic_units
@@ -145,10 +146,7 @@ def _load_gliner_model(model_id: str) -> Any:
     try:
         module = _import_module("gliner")
     except ImportError as exc:
-        raise ImportError(
-            "GLiNER-BioMed support requires the 'gliner' extra. "
-            "Install with `pip install openmed[gliner]`."
-        ) from exc
+        raise_missing_backend("gliner", feature="GLiNER-BioMed support", cause=exc)
     return module.GLiNER.from_pretrained(model_id)
 
 

--- a/openmed/interop/langchain.py
+++ b/openmed/interop/langchain.py
@@ -9,6 +9,7 @@ from importlib import import_module as _import_module
 from pathlib import Path
 from typing import Any
 
+from openmed.core.capabilities import raise_missing_backend
 from openmed.interop.function_tools import (
     RuntimeProvider,
     create_tool_callable,
@@ -264,10 +265,7 @@ def _load_structured_tool() -> Any:
     try:
         module = _import_module("langchain_core.tools")
     except ImportError as exc:
-        raise ImportError(
-            "LangChain tools require the 'langchain' extra. "
-            "Install with `pip install openmed[langchain]`."
-        ) from exc
+        raise_missing_backend("langchain", feature="LangChain tools", cause=exc)
 
     try:
         return module.StructuredTool
@@ -281,10 +279,7 @@ def _load_runnable_lambda() -> Any:
     try:
         module = _import_module("langchain_core.runnables")
     except ImportError as exc:
-        raise ImportError(
-            "LangChain support requires the 'langchain' extra. "
-            "Install with `pip install openmed[langchain]`."
-        ) from exc
+        raise_missing_backend("langchain", feature="LangChain support", cause=exc)
 
     try:
         return module.RunnableLambda

--- a/openmed/interop/llamaindex.py
+++ b/openmed/interop/llamaindex.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from importlib import import_module as _import_module
 from typing import Any
 
+from openmed.core.capabilities import raise_missing_backend
 from openmed.interop.function_tools import (
     RuntimeProvider,
     create_tool_callable,
@@ -57,10 +58,7 @@ def _load_function_tool() -> Any:
     try:
         module = _import_module("llama_index.core.tools")
     except ImportError as exc:
-        raise ImportError(
-            "LlamaIndex tools require the 'llamaindex' extra. "
-            "Install with `pip install openmed[llamaindex]`."
-        ) from exc
+        raise_missing_backend("llamaindex", feature="LlamaIndex tools", cause=exc)
 
     try:
         return module.FunctionTool

--- a/openmed/interop/presidio.py
+++ b/openmed/interop/presidio.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from importlib import import_module as _import_module
 from typing import Any, Iterable, Mapping, Sequence
 
+from openmed.core.capabilities import raise_missing_backend
 from openmed.core.labels import normalize_label
 from openmed.core.pii import PIIEntity
 from openmed.core.pii_entity_merger import merge_entities_with_semantic_units
@@ -134,10 +135,7 @@ def _load_presidio_result_cls() -> type[Any]:
     try:
         module = _import_module("presidio_analyzer")
     except ImportError as exc:
-        raise ImportError(
-            "Presidio support requires the 'presidio' extra. "
-            "Install with `pip install openmed[presidio]`."
-        ) from exc
+        raise_missing_backend("presidio", feature="Presidio support", cause=exc)
     return module.RecognizerResult
 
 

--- a/openmed/interop/spacy_component.py
+++ b/openmed/interop/spacy_component.py
@@ -7,15 +7,14 @@ from dataclasses import dataclass
 from inspect import Parameter, signature
 from typing import Any
 
+from openmed.core.capabilities import raise_missing_backend
+
 try:
     from spacy.language import Language
     from spacy.tokens import Doc, Span
     from spacy.util import filter_spans
 except ImportError as exc:  # pragma: no cover - exercised without the extra
-    raise ImportError(
-        "spaCy support requires the 'spacy' extra. "
-        "Install with `pip install openmed[spacy]`."
-    ) from exc
+    raise_missing_backend("spacy", feature="spaCy support", cause=exc)
 
 
 Extractor = Callable[..., Any]

--- a/openmed/mcp/__init__.py
+++ b/openmed/mcp/__init__.py
@@ -1,14 +1,44 @@
-"""Model Context Protocol integration for OpenMed."""
+"""Model Context Protocol integration for OpenMed.
+
+The MCP server depends on the optional ``mcp`` extra. Importing this package
+stays lightweight: :func:`create_mcp_server` and :func:`main` are resolved
+lazily, and :func:`is_mcp_available` / :func:`ensure_mcp_available` provide the
+same capability-probe convention as the other optional backends.
+
+Install with: ``pip install openmed[mcp]``.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["create_mcp_server", "main"]
+from openmed.core.capabilities import is_backend_available as _is_backend_available
+from openmed.core.capabilities import require_backend as _require_backend
+
+_LAZY_EXPORTS = ("create_mcp_server", "main")
+
+__all__ = [
+    "create_mcp_server",
+    "main",
+    "ensure_mcp_available",
+    "is_mcp_available",
+]
+
+
+def is_mcp_available() -> bool:
+    """Return True when the ``mcp`` extra is importable, without importing it."""
+
+    return _is_backend_available("mcp")
+
+
+def ensure_mcp_available() -> None:
+    """Raise an actionable error when the ``mcp`` extra is not installed."""
+
+    _require_backend("mcp", feature="The OpenMed MCP server")
 
 
 def __getattr__(name: str) -> Any:
-    if name in __all__:
+    if name in _LAZY_EXPORTS:
         from .server import create_mcp_server, main
 
         exports = {"create_mcp_server": create_mcp_server, "main": main}

--- a/openmed/mlx/__init__.py
+++ b/openmed/mlx/__init__.py
@@ -6,6 +6,8 @@ via Apple's MLX framework.
 Install with: ``pip install openmed[mlx]``
 """
 
+from openmed.core.capabilities import is_backend_available as _is_backend_available
+from openmed.core.capabilities import require_backend as _require_backend
 from openmed.mlx.inference import (
     GLiClassMLXPipeline,
     GLiNERMLXPipeline,
@@ -34,7 +36,22 @@ from openmed.mlx.lm import (
     tokenizers_are_aligned,
 )
 
+
+def is_mlx_available() -> bool:
+    """Return True when the ``mlx`` extra is importable, without importing it."""
+
+    return _is_backend_available("mlx")
+
+
+def ensure_mlx_available() -> None:
+    """Raise an actionable error when the ``mlx`` extra is not installed."""
+
+    _require_backend("mlx", feature="MLX inference")
+
+
 __all__ = [
+    "ensure_mlx_available",
+    "is_mlx_available",
     "DEFAULT_SPECULATIVE_TOKENS",
     "LANEFORMER_DRAFT_MLX_MODEL",
     "LANEFORMER_MLX_MODEL",

--- a/openmed/mlx/convert.py
+++ b/openmed/mlx/convert.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Mapping, Tuple
 
+from openmed.core.capabilities import raise_missing_backend
 from openmed.core.hf_publish import publish_artifact
 from openmed.mlx.artifact import find_tokenizer_files, write_manifest
 from openmed.mlx.models import (
@@ -354,11 +355,8 @@ def convert_weights(
     """Load HF token-classification weights and config, then remap for MLX."""
     try:
         from transformers import AutoConfig, AutoModelForTokenClassification
-    except ImportError:
-        raise ImportError(
-            "transformers is required for model conversion. "
-            "Install with: pip install transformers"
-        )
+    except ImportError as exc:
+        raise_missing_backend("hf", feature="MLX model conversion", cause=exc)
 
     logger.info("Loading Hugging Face token-classification model %s ...", model_id)
     config = AutoConfig.from_pretrained(model_id, cache_dir=cache_dir)
@@ -411,8 +409,8 @@ def save_mlx_model(
         import mlx.core as mx
         import mlx.nn as nn
         from mlx.utils import tree_flatten
-    except ImportError:
-        raise ImportError("MLX is required. Install with: pip install openmed[mlx]")
+    except ImportError as exc:
+        raise_missing_backend("mlx", feature="Saving an MLX model artifact", cause=exc)
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -688,10 +686,11 @@ def _hf_token_classification_runner(
                     pipeline,
                 )
             except ImportError as exc:
-                raise ImportError(
-                    "transformers is required to certify MLX quantization. "
-                    "Install with: pip install transformers"
-                ) from exc
+                raise_missing_backend(
+                    "hf",
+                    feature="Certifying MLX quantization recall",
+                    cause=exc,
+                )
 
             tokenizer = get_tokenizer_with_loader(
                 model_id,

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -23,6 +23,7 @@ from .base import (
     ExtractedDocument,
     SourceSpan,
     ensure_multimodal_available,
+    is_multimodal_available,
     redact_document,
     register_handler,
 )
@@ -114,6 +115,7 @@ __all__ = [
     "redact_document",
     "register_handler",
     "ensure_multimodal_available",
+    "is_multimodal_available",
     "MissingDependencyError",
     "UnsupportedDocumentError",
     "ChatLogRedactionSummary",

--- a/openmed/multimodal/base.py
+++ b/openmed/multimodal/base.py
@@ -41,6 +41,15 @@ def _missing_multimodal_dependencies() -> list[str]:
     ]
 
 
+def is_multimodal_available() -> bool:
+    """Return True when the ``multimodal`` extra is fully importable.
+
+    Uses :func:`importlib.util.find_spec` under the hood so probing never
+    imports the heavy ingestion dependencies.
+    """
+    return not _missing_multimodal_dependencies()
+
+
 def ensure_multimodal_available() -> None:
     """Raise a clear error if the ``multimodal`` extra is not installed."""
     missing = _missing_multimodal_dependencies()

--- a/openmed/multimodal/exceptions.py
+++ b/openmed/multimodal/exceptions.py
@@ -1,22 +1,38 @@
 """Exceptions for the multimodal ingest/redact subsystem.
 
 Kept dependency-free so importing it never drags in heavy ingestion packages.
+The shared :class:`~openmed.core.capabilities.MissingOptionalDependencyError`
+it builds on is standard-library only, so this stays lightweight.
 """
 
 from __future__ import annotations
 
+from openmed.core.capabilities import MissingOptionalDependencyError
 
-class MissingDependencyError(ImportError):
-    """Raised when the multimodal extra is required but not installed."""
+
+class MissingDependencyError(MissingOptionalDependencyError):
+    """Raised when the multimodal extra is required but not installed.
+
+    Subclasses the shared :class:`MissingOptionalDependencyError` so a single
+    ``except MissingOptionalDependencyError`` guard catches every optional-extra
+    failure across OpenMed, while keeping the historical
+    ``(dependency, instruction)`` constructor and message for callers that rely
+    on it.
+    """
 
     def __init__(self, dependency: str, instruction: str) -> None:
         message = (
             f"Optional dependency '{dependency}' is required for this operation. "
             f"{instruction}"
         )
-        super().__init__(message)
+        # Bypass the parent's keyword-only constructor to preserve the legacy
+        # message/attributes while remaining part of the shared error family.
+        ImportError.__init__(self, message)
         self.dependency = dependency
         self.instruction = instruction
+        self.package = dependency
+        self.feature = "This operation"
+        self.extra = None
 
 
 class UnsupportedDocumentError(ValueError):

--- a/openmed/ner/exceptions.py
+++ b/openmed/ner/exceptions.py
@@ -2,15 +2,29 @@
 
 from __future__ import annotations
 
+from openmed.core.capabilities import MissingOptionalDependencyError
 
-class MissingDependencyError(ImportError):
-    """Raised when an optional dependency is required but unavailable."""
+
+class MissingDependencyError(MissingOptionalDependencyError):
+    """Raised when an optional NER dependency is required but unavailable.
+
+    Subclasses the shared :class:`MissingOptionalDependencyError` so a single
+    ``except MissingOptionalDependencyError`` guard catches every optional-extra
+    failure across OpenMed, while keeping the historical
+    ``(dependency, instruction)`` constructor and message for callers that rely
+    on it.
+    """
 
     def __init__(self, dependency: str, instruction: str) -> None:
         message = (
             f"Optional dependency '{dependency}' is required for this operation. "
             f"{instruction}"
         )
-        super().__init__(message)
+        # Bypass the parent's keyword-only constructor to preserve the legacy
+        # message/attributes while remaining part of the shared error family.
+        ImportError.__init__(self, message)
         self.dependency = dependency
         self.instruction = instruction
+        self.package = dependency
+        self.feature = "This operation"
+        self.extra = None

--- a/openmed/onnx/__init__.py
+++ b/openmed/onnx/__init__.py
@@ -5,7 +5,39 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any
 
+from openmed.core.capabilities import is_backend_available as _is_backend_available
+from openmed.core.capabilities import require_backend as _require_backend
+
+
+def is_onnx_available() -> bool:
+    """Return True when the ``onnx`` extra is importable, without importing it."""
+
+    return _is_backend_available("onnx")
+
+
+def ensure_onnx_available() -> None:
+    """Raise an actionable error when the ``onnx`` extra is not installed."""
+
+    _require_backend("onnx", feature="ONNX export and inference")
+
+
+def is_openvino_available() -> bool:
+    """Return True when the ``openvino`` extra is importable, without importing."""
+
+    return _is_backend_available("openvino")
+
+
+def ensure_openvino_available() -> None:
+    """Raise an actionable error when the ``openvino`` extra is not installed."""
+
+    _require_backend("openvino", feature="OpenVINO export and inference")
+
+
 __all__ = [
+    "ensure_onnx_available",
+    "ensure_openvino_available",
+    "is_onnx_available",
+    "is_openvino_available",
     "ANDROID_ONNX_FORMAT",
     "ANDROID_ONNX_OPSET",
     "ANDROID_PROFILE_NAME",

--- a/openmed/onnx/convert.py
+++ b/openmed/onnx/convert.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from openmed.core.capabilities import raise_missing_backend
 from openmed.core.hf_publish import publish_artifact
 from openmed.eval.quant_delta import evaluate_onnx_logit_parity
 from openmed.mlx.artifact import find_tokenizer_files
@@ -215,10 +216,7 @@ def export_onnx(
         import torch
         from transformers import AutoModelForTokenClassification, AutoTokenizer
     except ImportError as exc:
-        raise ImportError(
-            "torch and transformers are required for ONNX export. "
-            "Install with: pip install openmed[onnx]"
-        ) from exc
+        raise_missing_backend("onnx", feature="ONNX export", cause=exc)
 
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -311,10 +309,7 @@ def export_webgpu(
         import onnx
         from onnxruntime.transformers.float16 import convert_float_to_float16
     except ImportError as exc:
-        raise ImportError(
-            "onnx and onnxruntime are required for WebGPU export. "
-            "Install with: pip install openmed[onnx]"
-        ) from exc
+        raise_missing_backend("onnx", feature="WebGPU export", cause=exc)
 
     onnx_path = Path(onnx_path)
     output_path = Path(output_path)
@@ -635,10 +630,7 @@ def save_source_assets(
     try:
         from transformers import AutoConfig, AutoTokenizer
     except ImportError as exc:
-        raise ImportError(
-            "transformers is required for ONNX export metadata. "
-            "Install with: pip install openmed[onnx]"
-        ) from exc
+        raise_missing_backend("onnx", feature="ONNX export metadata", cause=exc)
 
     output_dir = Path(output_dir)
     config = AutoConfig.from_pretrained(model_id, cache_dir=cache_dir).to_dict()
@@ -798,10 +790,7 @@ def validate_optimized_onnx_export(
         import onnxruntime as ort
         from transformers import AutoTokenizer
     except ImportError as exc:
-        raise ImportError(
-            "numpy, onnxruntime, and transformers are required for optimized "
-            "ONNX validation. Install with: pip install openmed[onnx]"
-        ) from exc
+        raise_missing_backend("onnx", feature="Optimized ONNX validation", cause=exc)
 
     shape_bucket_config = shape_bucket_config or ShapeBucketConfig()
     optimization_config = _normalise_optimization_config(optimization_config)
@@ -1020,10 +1009,9 @@ def _optimize_with_ort_session(
     try:
         import onnxruntime as ort
     except ImportError as exc:
-        raise ImportError(
-            "onnxruntime is required for post-export graph optimization. "
-            "Install with: pip install openmed[onnx]"
-        ) from exc
+        raise_missing_backend(
+            "onnx", feature="Post-export graph optimization", cause=exc
+        )
 
     session_options = ort.SessionOptions()
     session_options.graph_optimization_level = _graph_optimization_level(ort, config)
@@ -1270,10 +1258,9 @@ def _check_onnx_model(path: Path) -> None:
     try:
         import onnx
     except ImportError as exc:
-        raise ImportError(
-            "onnx is required to validate exported artifacts. "
-            "Install with: pip install openmed[onnx]"
-        ) from exc
+        raise_missing_backend(
+            "onnx", feature="Validating exported ONNX artifacts", cause=exc
+        )
     model = onnx.load(str(path))
     onnx.checker.check_model(model)
 
@@ -1324,10 +1311,9 @@ def _transformers_tokenizer_loader(*, cache_dir: str | None) -> Any:
     try:
         from transformers import AutoTokenizer
     except ImportError as exc:
-        raise ImportError(
-            "transformers is required for OpenVINO export verification. "
-            "Install with: pip install openmed[openvino]"
-        ) from exc
+        raise_missing_backend(
+            "openvino", feature="OpenVINO export verification", cause=exc
+        )
 
     def load_tokenizer(model_id: str, **kwargs: Any) -> Any:
         options = dict(kwargs)

--- a/openmed/service/__init__.py
+++ b/openmed/service/__init__.py
@@ -1,5 +1,42 @@
-"""OpenMed REST service package."""
+"""OpenMed REST service package.
 
-from .app import app, create_app
+The REST surface depends on the optional ``service`` extra (FastAPI, uvicorn,
+...). Importing this package stays lightweight and never crashes when the extra
+is absent: ``app`` and ``create_app`` are resolved lazily, and touching them
+without the extra raises a single actionable
+:class:`~openmed.core.capabilities.MissingOptionalDependencyError`.
 
-__all__ = ["app", "create_app"]
+Install with: ``pip install openmed[service]``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openmed.core.capabilities import (
+    is_backend_available,
+    require_backend,
+)
+
+__all__ = ["app", "create_app", "ensure_service_available", "is_service_available"]
+
+
+def is_service_available() -> bool:
+    """Return True when the ``service`` extra (FastAPI/uvicorn) is importable."""
+
+    return is_backend_available("service")
+
+
+def ensure_service_available() -> None:
+    """Raise an actionable error when the ``service`` extra is not installed."""
+
+    require_backend("service", feature="The OpenMed REST service")
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"app", "create_app"}:
+        ensure_service_available()
+        from .app import app, create_app
+
+        return {"app": app, "create_app": create_app}[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/unit/core/test_capabilities.py
+++ b/tests/unit/core/test_capabilities.py
@@ -1,0 +1,230 @@
+"""Tests for the unified optional-backend capability probe.
+
+These tests simulate missing optional extras (by forcing
+``importlib.util.find_spec`` to report modules as absent) and assert that the
+capability layer degrades gracefully: the probe stays importless and never
+crashes, and required-but-missing features raise one shared, actionable error.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from openmed.core import capabilities
+from openmed.core.capabilities import (
+    BackendStatus,
+    MissingOptionalDependencyError,
+    available_backends,
+    backend_spec,
+    backend_status,
+    install_hint,
+    is_backend_available,
+    raise_missing_backend,
+    registered_backends,
+    require_backend,
+    warn_backend_unavailable,
+)
+
+
+@pytest.fixture
+def force_missing(monkeypatch):
+    """Return a helper that forces the named modules to look uninstalled.
+
+    Every other module keeps its real availability, so a probe that is
+    genuinely installed in the test environment is not accidentally reported
+    as present when the test wants it absent.
+    """
+
+    real_find_spec = importlib.util.find_spec
+
+    def _apply(*missing_modules: str) -> None:
+        missing = set(missing_modules)
+
+        def fake_find_spec(name, package=None):
+            if name in missing:
+                return None
+            return real_find_spec(name, package)
+
+        monkeypatch.setattr(capabilities.importlib.util, "find_spec", fake_find_spec)
+
+    return _apply
+
+
+@pytest.fixture
+def force_present(monkeypatch):
+    """Force the named modules to look installed regardless of the env."""
+
+    real_find_spec = importlib.util.find_spec
+
+    def _apply(*present_modules: str) -> None:
+        present = set(present_modules)
+
+        def fake_find_spec(name, package=None):
+            if name in present:
+                return object()
+            return real_find_spec(name, package)
+
+        monkeypatch.setattr(capabilities.importlib.util, "find_spec", fake_find_spec)
+
+    return _apply
+
+
+def test_registered_backends_cover_every_optional_seam():
+    names = set(registered_backends())
+    # The seams called out in OM-820 must all be probeable.
+    for seam in (
+        "mlx",
+        "coreml",
+        "onnx",
+        "openvino",
+        "gliner",
+        "spacy",
+        "presidio",
+        "hf",
+        "multimodal",
+        "service",
+        "mcp",
+    ):
+        assert seam in names, f"missing capability seam: {seam}"
+
+
+def test_available_backends_reports_every_seam_importlessly(force_missing):
+    force_missing("transformers")
+    report = available_backends()
+    assert set(report) == set(registered_backends())
+    assert all(isinstance(status, BackendStatus) for status in report.values())
+    # Nothing here imports transformers; the probe only inspects specs.
+    assert report["hf"].available is False
+    assert report["hf"].missing == ("transformers",)
+
+
+def test_available_backends_never_imports_backend_modules(force_present):
+    # Even when every spec is reported present, the probe must not import them.
+    force_present(
+        "mlx.core",
+        "coremltools",
+        "onnx",
+        "onnxruntime",
+        "gliner",
+        "transformers",
+    )
+    report = available_backends()
+    assert report["mlx"].available is True
+    assert report["onnx"].available is True
+    assert report["hf"].available is True
+    # find_spec was stubbed, so no heavy module ended up imported by the probe.
+
+
+def test_is_backend_available_false_when_missing(force_missing):
+    force_missing("mlx.core")
+    assert is_backend_available("mlx") is False
+
+
+def test_is_backend_available_true_when_present(force_present):
+    force_present("gliner")
+    assert is_backend_available("gliner") is True
+
+
+def test_backend_status_lists_all_missing_modules(force_missing):
+    force_missing("onnx", "onnxruntime")
+    status = backend_status("onnx")
+    assert status.available is False
+    assert set(status.missing) == {"onnx", "onnxruntime"}
+    assert "openmed[onnx]" in status.install_hint
+
+
+def test_backend_status_available_when_partial_present(monkeypatch):
+    # onnx needs both onnx and onnxruntime; missing just one is unavailable.
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, package=None):
+        if name == "onnxruntime":
+            return None
+        if name == "onnx":
+            return object()
+        return real_find_spec(name, package)
+
+    monkeypatch.setattr(capabilities.importlib.util, "find_spec", fake_find_spec)
+    status = backend_status("onnx")
+    assert status.available is False
+    assert status.missing == ("onnxruntime",)
+
+
+def test_backend_status_name_is_normalized():
+    assert backend_status("MLX").name == "mlx"
+    assert backend_status("Multimodal").name == "multimodal"
+    # Case and surrounding whitespace are normalized to the canonical key.
+    assert backend_spec("  LlamaIndex  ").name == "llamaindex"
+
+
+def test_unknown_backend_raises_keyerror():
+    with pytest.raises(KeyError, match="unknown backend"):
+        backend_status("does-not-exist")
+    with pytest.raises(KeyError):
+        backend_spec("nope")
+
+
+def test_require_backend_returns_none_when_available(force_present):
+    force_present("presidio_analyzer")
+    assert require_backend("presidio") is None
+
+
+def test_require_backend_raises_actionable_error(force_missing):
+    force_missing("spacy")
+    with pytest.raises(MissingOptionalDependencyError) as excinfo:
+        require_backend("spacy", feature="spaCy pipeline component")
+
+    err = excinfo.value
+    assert isinstance(err, ImportError)  # backward-compatible with old guards
+    assert err.extra == "spacy"
+    message = str(err)
+    assert "spaCy pipeline component" in message
+    assert "pip install openmed[spacy]" in message
+
+
+def test_raise_missing_backend_chains_cause(force_missing):
+    force_missing("gliner")
+    original = ImportError("No module named 'gliner'")
+    with pytest.raises(MissingOptionalDependencyError) as excinfo:
+        raise_missing_backend("gliner", feature="GLiNER support", cause=original)
+    assert excinfo.value.__cause__ is original
+    assert "openmed[gliner]" in str(excinfo.value)
+
+
+def test_warn_backend_unavailable_emits_warning_and_returns_status(force_missing):
+    force_missing("transformers")
+    with pytest.warns(UserWarning, match="pip install openmed\\[hf\\]"):
+        status = warn_backend_unavailable(
+            "hf", feature="HF inference", action="skipping"
+        )
+    assert status.available is False
+
+
+def test_warn_backend_unavailable_silent_when_available(force_present, recwarn):
+    force_present("transformers")
+    status = warn_backend_unavailable("hf")
+    assert status.available is True
+    assert len(recwarn) == 0
+
+
+def test_install_hint_mentions_extra_and_package():
+    hint = install_hint("transformers", "hf")
+    assert "pip install openmed[hf]" in hint
+    assert "pip install transformers" in hint
+
+
+def test_install_hint_without_extra():
+    hint = install_hint("python-dateutil")
+    assert "openmed[" not in hint
+    assert "pip install python-dateutil" in hint
+
+
+def test_status_as_dict_is_serializable(force_missing):
+    force_missing("mlx.core")
+    data = backend_status("mlx").as_dict()
+    assert data["name"] == "mlx"
+    assert data["available"] is False
+    assert data["missing"] == ["mlx.core"]
+    assert "install_hint" in data

--- a/tests/unit/test_graceful_degradation.py
+++ b/tests/unit/test_graceful_degradation.py
@@ -1,0 +1,237 @@
+"""End-to-end graceful-degradation tests across the optional-extra seams.
+
+Each test simulates a missing optional extra (either by blocking the real
+import via ``sys.meta_path`` or by forcing the capability probe to report the
+module absent) and asserts that:
+
+* importing OpenMed and its optional subpackages never crashes, and
+* touching a feature that *requires* the missing extra raises the single shared
+  :class:`~openmed.core.capabilities.MissingOptionalDependencyError` with an
+  actionable ``pip install openmed[...]`` message.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+
+import pytest
+
+import openmed
+from openmed.core.capabilities import MissingOptionalDependencyError
+
+
+class _ImportBlocker:
+    """A ``sys.meta_path`` finder that makes selected top-level packages fail."""
+
+    def __init__(self, *blocked_prefixes: str) -> None:
+        self._blocked = blocked_prefixes
+
+    def find_spec(self, name, path=None, target=None):  # noqa: D401 - finder API
+        top = name.split(".")[0]
+        if top in self._blocked or name in self._blocked:
+            raise ImportError(f"blocked for test: {name}")
+        return None
+
+
+@pytest.fixture
+def block_imports(monkeypatch):
+    """Return a helper that blocks the given top-level packages from importing."""
+
+    def _apply(*blocked_prefixes: str):
+        blocker = _ImportBlocker(*blocked_prefixes)
+        monkeypatch.setattr("sys.meta_path", [blocker, *importlib.sys.meta_path])
+        for mod_name in list(importlib.sys.modules):
+            top = mod_name.split(".")[0]
+            if top in blocked_prefixes or mod_name in blocked_prefixes:
+                monkeypatch.delitem(importlib.sys.modules, mod_name, raising=False)
+        return blocker
+
+    return _apply
+
+
+def test_import_openmed_exposes_capability_probe():
+    # The top-level probe is part of the public API.
+    assert callable(openmed.available_backends)
+    assert callable(openmed.is_backend_available)
+    assert callable(openmed.require_backend)
+    assert openmed.MissingOptionalDependencyError is MissingOptionalDependencyError
+
+
+def test_available_backends_top_level_matches_module():
+    from openmed.core.capabilities import available_backends as module_probe
+
+    assert set(openmed.available_backends()) == set(module_probe())
+
+
+def test_service_package_imports_without_fastapi(block_imports):
+    block_imports("fastapi", "uvicorn", "starlette")
+    # Importing the package must not crash even though FastAPI is unavailable.
+    service = importlib.import_module("openmed.service")
+    importlib.reload(service)
+    assert service.is_service_available() is False
+
+
+def test_service_create_app_raises_actionable_error(block_imports):
+    block_imports("fastapi", "uvicorn", "starlette")
+    service = importlib.import_module("openmed.service")
+    importlib.reload(service)
+    with pytest.raises(MissingOptionalDependencyError) as excinfo:
+        service.ensure_service_available()
+    assert "pip install openmed[service]" in str(excinfo.value)
+
+
+def test_service_getattr_app_raises_actionable_error(block_imports):
+    block_imports("fastapi", "uvicorn", "starlette")
+    service = importlib.import_module("openmed.service")
+    importlib.reload(service)
+    with pytest.raises(MissingOptionalDependencyError):
+        _ = service.create_app
+
+
+def test_mlx_package_imports_without_mlx(block_imports):
+    block_imports("mlx")
+    mlx_pkg = importlib.import_module("openmed.mlx")
+    importlib.reload(mlx_pkg)
+    assert mlx_pkg.is_mlx_available() is False
+    with pytest.raises(MissingOptionalDependencyError) as excinfo:
+        mlx_pkg.ensure_mlx_available()
+    assert "pip install openmed[mlx]" in str(excinfo.value)
+
+
+def test_onnx_package_imports_without_onnx(block_imports):
+    block_imports("onnx", "onnxruntime")
+    onnx_pkg = importlib.import_module("openmed.onnx")
+    importlib.reload(onnx_pkg)
+    assert onnx_pkg.is_onnx_available() is False
+    with pytest.raises(MissingOptionalDependencyError) as excinfo:
+        onnx_pkg.ensure_onnx_available()
+    assert "pip install openmed[onnx]" in str(excinfo.value)
+
+
+def test_coreml_package_imports_without_coremltools(block_imports):
+    block_imports("coremltools")
+    coreml_pkg = importlib.import_module("openmed.coreml")
+    importlib.reload(coreml_pkg)
+    assert coreml_pkg.is_coreml_available() is False
+    with pytest.raises(MissingOptionalDependencyError):
+        coreml_pkg.ensure_coreml_available()
+
+
+def test_mcp_package_imports_without_mcp(block_imports):
+    block_imports("mcp")
+    mcp_pkg = importlib.import_module("openmed.mcp")
+    importlib.reload(mcp_pkg)
+    assert mcp_pkg.is_mcp_available() is False
+    with pytest.raises(MissingOptionalDependencyError):
+        mcp_pkg.ensure_mcp_available()
+
+
+def test_presidio_adapter_raises_shared_error_when_missing(block_imports):
+    block_imports("presidio_analyzer")
+    from openmed.interop import presidio
+
+    with pytest.raises(MissingOptionalDependencyError, match=r"openmed\[presidio\]"):
+        presidio._load_presidio_result_cls()
+
+
+def test_gliner_biomed_adapter_raises_shared_error_when_missing(block_imports):
+    block_imports("gliner")
+    from openmed.interop import gliner_biomed
+
+    with pytest.raises(MissingOptionalDependencyError, match=r"openmed\[gliner\]"):
+        gliner_biomed._load_gliner_model("does/not-matter")
+
+
+def test_langchain_adapter_raises_shared_error_when_missing(block_imports):
+    block_imports("langchain_core")
+    from openmed.interop import langchain
+
+    with pytest.raises(MissingOptionalDependencyError, match=r"openmed\[langchain\]"):
+        langchain._load_runnable_lambda()
+
+
+def test_llamaindex_adapter_raises_shared_error_when_missing(block_imports):
+    block_imports("llama_index")
+    from openmed.interop import llamaindex
+
+    with pytest.raises(MissingOptionalDependencyError, match=r"openmed\[llamaindex\]"):
+        llamaindex._load_function_tool()
+
+
+def test_multimodal_reports_unavailable_without_extra(monkeypatch):
+    from openmed import multimodal
+
+    # Force every multimodal dependency to look absent via the shared probe path.
+    monkeypatch.setattr(
+        multimodal.base,
+        "_missing_multimodal_dependencies",
+        lambda: ["pdfplumber", "python-docx"],
+    )
+    assert multimodal.is_multimodal_available() is False
+    with pytest.raises(MissingOptionalDependencyError, match=r"openmed\[multimodal\]"):
+        multimodal.ensure_multimodal_available()
+
+
+def test_shared_error_family_catches_every_seam(block_imports):
+    """A single ``except MissingOptionalDependencyError`` covers all seams."""
+
+    block_imports("gliner")
+    from openmed.interop import gliner_biomed
+    from openmed.multimodal.exceptions import MissingDependencyError as MmErr
+    from openmed.ner.exceptions import MissingDependencyError as NerErr
+
+    # Subclass relationships mean the shared guard catches the legacy errors.
+    assert issubclass(NerErr, MissingOptionalDependencyError)
+    assert issubclass(MmErr, MissingOptionalDependencyError)
+
+    caught = False
+    try:
+        gliner_biomed._load_gliner_model("x")
+    except MissingOptionalDependencyError:
+        caught = True
+    assert caught
+
+
+def test_hf_loader_degrades_when_transformers_missing(monkeypatch):
+    from openmed.core import models
+
+    monkeypatch.setattr(models, "HF_AVAILABLE", False)
+    assert models.is_hf_available() is False
+    with pytest.raises(MissingOptionalDependencyError, match=r"openmed\[hf\]"):
+        models.ensure_hf_available()
+
+
+def test_no_optional_extra_installed_still_imports_core(block_imports):
+    """Blocking every heavy optional extra must not break ``import openmed``."""
+
+    block_imports(
+        "transformers",
+        "torch",
+        "mlx",
+        "coremltools",
+        "onnx",
+        "onnxruntime",
+        "gliner",
+        "spacy",
+        "presidio_analyzer",
+    )
+    module = importlib.reload(importlib.import_module("openmed"))
+    report = module.available_backends()
+    assert report["hf"].available is False
+    assert report["mlx"].available is False
+
+
+def test_original_importerror_still_catchable_as_importerror(block_imports):
+    """Existing ``except ImportError`` guards keep working after unification."""
+
+    block_imports("presidio_analyzer")
+    from openmed.interop import presidio
+
+    with pytest.raises(ImportError):
+        presidio._load_presidio_result_cls()
+
+
+def test_builtins_import_not_globally_monkeypatched():
+    # Sanity: the real import machinery is intact between tests.
+    assert builtins.__import__ is builtins.__import__


### PR DESCRIPTION
# Pull Request

## Description

Unifies graceful degradation across OpenMed optional model, backend, and integration seams. Minimal installs can probe capabilities without importing heavy packages, optional paths can fall back, and required paths raise one shared actionable error naming the exact OpenMed extra to install.

## Type of Change

- [x] Code refactoring
- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made

- Add a standard-library-only capability registry and importless probes for MLX, CoreML, ONNX, OpenVINO, GLiNER, spaCy, Presidio, Philter, pyDeid, Hugging Face, multimodal ingestion, service, MCP, LangChain, and LlamaIndex seams.
- Expose `available_backends`, `backend_status`, `is_backend_available`, and `require_backend` through the lazy top-level API.
- Consolidate missing-extra failures under `MissingOptionalDependencyError` while preserving legacy NER and multimodal exception classes as compatible subclasses.
- Route backend conversion and adapter guards through the shared helper with actionable `pip install openmed[...]` guidance.
- Keep service and MCP exports lazy so their packages import cleanly without optional server dependencies.
- Preserve newer master behavior in ONNX external-data handling and top-level lazy imports while reconciling the original implementation onto current master.

## Testing

- [x] Added synthetic offline tests for missing extras, import isolation, fallback behavior, capability reports, and actionable shared errors.
- [x] Ran only explicit OM-820 test files and nearest individual regression cases: 74 passed.
- [x] Ran Ruff lint and format checks only on changed Python files.

## Documentation

- [x] Added public API docstrings and install guidance.

## Code Quality

- [x] Focused tests pass.
- [x] Changed files pass Ruff lint and format checks.
- [x] No new runtime dependencies were added.

## Related Issues

Related to #1366

