### PR TITLE
fix: add explicit UTF-8 encoding to Path.read_text() in security scripts (P1)

### DIFF
--- a/scripts/security/pip_audit_gate.py
+++ b/scripts/security/pip_audit_gate.py
@@ -60,7 +60,7 @@ def load_ignores(path: Path, today: dt.date) -> set[str]:
     if not path.exists():
         raise FileNotFoundError(f"ignore file not found: {path}")
 
-    data = tomllib.loads(path.read_text())
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
     entries = data.get("ignore", [])
     if not isinstance(entries, list):
         raise ValueError("'ignore' must be a TOML array")
@@ -132,7 +132,7 @@ def run_pip_audit(report_path: Path) -> dict[str, Any]:
         raise RuntimeError(f"pip-audit exited with status {result.returncode}")
 
     try:
-        return json.loads(report_path.read_text())
+        return json.loads(report_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"pip-audit wrote invalid JSON: {exc}") from exc
 


### PR DESCRIPTION
## Summary

Add explicit `encoding="utf-8"` to `Path.read_text()` calls in security scripts.

## Problem

`Path.read_text()` without encoding defaults to system locale (cp1252 on Windows), causing silent data corruption when reading UTF-8 content like JSON and TOML config files.

## Changes

`scripts/security/pip_audit_gate.py`:
- `path.read_text()` -> `path.read_text(encoding="utf-8")` (2 instances)
- Both read JSON/TOML files which are UTF-8 by spec (RFC 8259 / TOML spec)

## Testing

File passes `python3 -m py_compile`.

Fixes #1409