### PR TITLE
refactor: replace len(x) == 0 / len(x) > 0 with idiomatic Python (P2)

### DIFF
--- a/openmed/clinical/units/ucum.py
+++ b/openmed/clinical/units/ucum.py
@@ -520,7 +520,7 @@ def parse_unit(unit: object) -> ParsedUnit:
 def is_dimensionless(dimension: Dimension) -> bool:
     """Return whether ``dimension`` has no base dimensions."""
 
-    return len(dimension) == 0
+    return not dimension
 
 
 def canonical_unit_for_dimension(dimension: Dimension) -> str:

--- a/openmed/core/quality_gates.py
+++ b/openmed/core/quality_gates.py
@@ -320,7 +320,7 @@ def validate_entity_spans(
             warnings.warn(msg, SpanValidationWarning, stacklevel=2)
 
         # Tag metadata so downstream code can inspect validity.
-        _set_span_valid(entity, len(problems) == 0)
+        _set_span_valid(entity, not problems)
 
     return entities
 

--- a/openmed/multimodal/metadata_scrub.py
+++ b/openmed/multimodal/metadata_scrub.py
@@ -816,7 +816,7 @@ def _has_value(value: Any) -> bool:
     if value is None:
         return False
     if isinstance(value, (bytes, str)):
-        return len(value) > 0
+        return value
     if isinstance(value, Mapping):
         return bool(value)
     if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):

--- a/openmed/utils/validation.py
+++ b/openmed/utils/validation.py
@@ -43,7 +43,7 @@ def validate_input(
 
     # Check length constraints
     if len(text) < min_length:
-        if allow_empty and len(text) == 0:
+        if allow_empty and not text:
             return text
         raise ValueError(f"Input text too short. Minimum length: {min_length}")
 


### PR DESCRIPTION
## Summary

Replace explicit `len()` comparisons with idiomatic Python truthiness checks.

## Changes

4 files, 4 instances:
- `openmed/clinical/units/ucum.py`: `len(x) == 0` -> `not x`
- `openmed/core/quality_gates.py`: `len(x) == 0` -> `not x`
- `openmed/multimodal/metadata_scrub.py`: `len(x) > 0` -> `x`
- `openmed/utils/validation.py`: `len(x) == 0` -> `not x`

## Testing

All 4 files pass `python3 -m py_compile`.
