### PR TITLE
docs: add document adapter provenance guide

### DIFF
--- a/docs/document-adapter-provenance.md
+++ b/docs/document-adapter-provenance.md
@@ -1,0 +1,58 @@
+# Document Adapter Provenance, Disclaimers, and Offline Packaging
+
+## Overview
+
+Document adapters provide a standardized way to package, validate, and distribute document-processing capabilities while maintaining reproducibility and traceability.
+
+## Adapter Metadata
+
+Each document adapter should include:
+
+- Adapter name
+- Supported document families
+- Version
+- Source repository or artifact
+- Build timestamp
+- Validation status
+
+## Provenance
+
+Record the provenance of every packaged adapter, including:
+
+- Source commit or release tag
+- Build environment
+- Packaging process
+- Validation results
+
+This information should remain available for auditing and reproducibility.
+
+## Clinical Disclaimer
+
+Document adapters assist document processing and information extraction only. They do not replace professional clinical judgment, diagnosis, or treatment decisions.
+
+## Permissive License Constraints
+
+Only adapters and model artifacts that are distributed under compatible permissive licenses should be packaged by default. When a model has additional licensing requirements, document those requirements clearly and require users to obtain the model separately instead of bundling it into offline packages.
+
+## Offline Packaging
+
+Offline packages should:
+
+- Include all required model artifacts.
+- Avoid external network dependencies during inference.
+- Preserve metadata and provenance information.
+- Be validated before release.
+
+## Release Checklist
+
+Before publishing a new adapter:
+
+- Verify metadata completeness.
+- Validate adapter behavior.
+- Confirm provenance records.
+- Verify offline packaging.
+- Update related documentation.
+
+## Related Epic
+
+Parent Epic:#1285

--- a/docs/document-adapter-provenance.md
+++ b/docs/document-adapter-provenance.md
@@ -1,58 +1,86 @@
-# Document Adapter Provenance, Disclaimers, and Offline Packaging
+# Document Adapter Provenance
 
-## Overview
+Document adapters package document-family handling for PDFs, images, OCR output,
+and structured clinical documents while preserving reproducibility, licensing
+boundaries, and offline operation. Each adapter release should make it clear what
+was packaged, how it was validated, and what happens when the preferred adapter
+or artifact is unavailable.
 
-Document adapters provide a standardized way to package, validate, and distribute document-processing capabilities while maintaining reproducibility and traceability.
+This guide is child work for [#1285](https://github.com/maziyarpanahi/openmed/issues/1285)
+and does not close the parent epic.
 
 ## Adapter Metadata
 
-Each document adapter should include:
+Every packaged adapter should declare:
 
-- Adapter name
-- Supported document families
-- Version
-- Source repository or artifact
-- Build timestamp
-- Validation status
+- Adapter name and version.
+- Supported document families, MIME types, and file extensions.
+- Source repository, release tag, or source commit.
+- Build environment, build timestamp, and package digest.
+- Runtime requirements, optional extras, and offline artifact locations.
+- Validation fixture set, validation date, and validation result summary.
+- License identifiers for adapter code and any packaged artifacts.
 
-## Provenance
+## Provenance Records
 
-Record the provenance of every packaged adapter, including:
+Keep provenance records with the packaged adapter rather than only in release
+notes. At minimum, record the source revision, build command, build environment,
+input artifacts, package hash, and validation results. Validation summaries
+should reference synthetic or permissively licensed fixtures only; do not include
+raw PHI or restricted datasets in release artifacts.
 
-- Source commit or release tag
-- Build environment
-- Packaging process
-- Validation results
+When a packaged adapter depends on model weights, record the exact artifact name,
+version, digest, and license. If the weights are not bundled, document the
+expected local path or user-supplied download step without adding a mandatory
+network call to inference.
 
-This information should remain available for auditing and reproducibility.
+## Fallback Behavior
+
+Adapters must fail predictably when the preferred engine, model, or optional
+dependency is unavailable. Document the fallback order and user-visible behavior:
+
+- Use a packaged local artifact when it is available and license-compatible.
+- Fall back to a deterministic local parser or metadata-only extraction when the
+  model artifact is absent.
+- Surface an actionable error when no safe local fallback exists.
+- Preserve source offsets and provenance fields when falling back.
+- Never send documents to a remote service as an implicit fallback.
+
+Fallback behavior should be covered by release validation so an offline package
+does not appear healthy only because a developer machine had extra dependencies
+or cached models.
 
 ## Clinical Disclaimer
 
-Document adapters assist document processing and information extraction only. They do not replace professional clinical judgment, diagnosis, or treatment decisions.
+Document adapters assist document processing, extraction, and de-identification
+workflows. They are not diagnostic systems and must not be presented as a
+replacement for clinical judgment, treatment decisions, or medical-device
+approval. Any adapter documentation that mentions clinical use should preserve
+this boundary.
 
-## Permissive License Constraints
+## Licensing And Offline Packaging
 
-Only adapters and model artifacts that are distributed under compatible permissive licenses should be packaged by default. When a model has additional licensing requirements, document those requirements clearly and require users to obtain the model separately instead of bundling it into offline packages.
+Only adapter code and artifacts with compatible permissive licenses may be
+bundled by default. Model weights are not bundled unless they are explicitly
+packaged as permissive local artifacts with recorded provenance and hashes.
 
-## Offline Packaging
+If a model has restricted, source-available, proprietary, GPL-incompatible, DUA,
+UMLS, SNOMED CT, CPT, MIMIC, i2b2, or n2c2 constraints, do not bundle it in an
+OpenMed offline package. Document the requirement and require users to provide
+the artifact out of band.
 
-Offline packages should:
-
-- Include all required model artifacts.
-- Avoid external network dependencies during inference.
-- Preserve metadata and provenance information.
-- Be validated before release.
+Offline packages should avoid external network dependencies during inference,
+preserve provenance metadata, validate the packaged fallback path, and include
+only synthetic or permissively licensed validation data.
 
 ## Release Checklist
 
-Before publishing a new adapter:
+Before publishing a document adapter:
 
-- Verify metadata completeness.
-- Validate adapter behavior.
-- Confirm provenance records.
-- Verify offline packaging.
-- Update related documentation.
-
-## Related Epic
-
-Parent Epic:#1285
+- Verify required metadata fields and provenance records are complete.
+- Confirm packaged code and artifacts have compatible licenses.
+- Validate preferred and fallback behavior in an offline environment.
+- Confirm model weights are either permissive packaged artifacts or documented
+  as user-supplied external inputs.
+- Confirm fixtures are synthetic or permissively licensed.
+- Update release notes and related documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - Zero-shot NER How-to: zero-shot-howto.md
       - Zero-shot Toolkit: zero-shot-ner.md
       - Examples & Copy/Paste Recipes: examples.md
+      - Document Adapter Provenance: document-adapter-provenance.md
       - EPUB Extraction: multimodal/epub-extraction.md
       - Testing & QA: testing.md
       - Eval Harness & Metrics: eval-harness.md


### PR DESCRIPTION
## Summary
•⁠  ⁠Add documentation for document adapter provenance.
•⁠  ⁠Document adapter metadata and validation guidance.
•⁠  ⁠Add clinical-use disclaimer.
•⁠  ⁠Document offline packaging recommendations.
•⁠  ⁠Add release checklist.
•⁠  ⁠Reference parent epic #1285.

Closes #1333