### PR TITLE
fix: add subprocess timeout to CI/release scripts (P1)

### DIFF
--- a/scripts/release/changelog.py
+++ b/scripts/release/changelog.py
@@ -210,6 +210,7 @@ def run_git(repo: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
+        timeout=60,
     )
 
 

--- a/scripts/release/check_release_version.py
+++ b/scripts/release/check_release_version.py
@@ -42,6 +42,7 @@ def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
+        timeout=60,
     )
 
 

--- a/scripts/release/check_repo_policy.py
+++ b/scripts/release/check_repo_policy.py
@@ -20,6 +20,7 @@ def git_ls_files(pattern: str) -> list[str]:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
+        timeout=60,
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -37,6 +38,7 @@ def git_tracked_ignored_files() -> list[str]:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
+        timeout=60,
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "git ls-files ignored check failed")
@@ -57,6 +59,7 @@ def git_deleted_files(pattern: str) -> set[str]:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=False,
+            timeout=60,
         )
         if result.returncode != 0:
             raise RuntimeError(

--- a/scripts/security/generate_sbom.py
+++ b/scripts/security/generate_sbom.py
@@ -76,6 +76,7 @@ def main() -> int:
             str(OUTFILE),
         ],
         check=True,
+        timeout=300,
     )
 
     bom = json.loads(OUTFILE.read_text(encoding="utf-8"))

--- a/scripts/security/pip_audit_gate.py
+++ b/scripts/security/pip_audit_gate.py
@@ -120,6 +120,7 @@ def run_pip_audit(report_path: Path) -> dict[str, Any]:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
+        timeout=300,
     )
 
     if result.stdout:


### PR DESCRIPTION
## Problem

All `subprocess.run()` calls in `scripts/` lacked a `timeout` parameter. If a child process (git, pip-audit, cyclonedx-py) hangs or blocks on stdin, the CI pipeline hangs indefinitely with no recovery.

Affected files:
- `scripts/security/pip_audit_gate.py` — 1 call
- `scripts/security/generate_sbom.py` — 1 call
- `scripts/release/changelog.py` — 1 call
- `scripts/release/check_release_version.py` — 1 call
- `scripts/release/check_repo_policy.py` — 3 calls

Note: `scripts/release/check_github_actions_refs.py` already had `timeout=30` — no change needed.

## Fix

Added `timeout` to every `subprocess.run()` call:
- `timeout=60` for git commands (fast, local)
- `timeout=300` for security audit tools (pip-audit, cyclonedx-py — may need to download data)

This matches the pattern already used in core code (`openmed/core/repro_hash.py`, `openmed/eval/release_gates.py`).

## Testing

Verified with `git diff --stat`: 5 files changed, 7 insertions(+). No logic changes — only adds the safety net.

Fixes #1410