### PR TITLE
fix: add explicit UTF-8 encoding to write_text in vulnerability_scan_gate (P1)

### DIFF
--- a/scripts/security/vulnerability_scan_gate.py
+++ b/scripts/security/vulnerability_scan_gate.py
@@ -287,7 +287,7 @@ def write_summary(path: Path, result: GateResult) -> None:
     """Write the gate result as a JSON artifact."""
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = asdict(result)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def print_blocking_findings(findings: list[Finding]) -> None:


### PR DESCRIPTION
## Problem

`Path.write_text()` without explicit encoding defaults to the system locale (`cp1252` on Windows), causing silent data corruption when writing UTF-8 JSON content.

PR #1391 fixed the `read_text()` calls in `pip_audit_gate.py`. This PR fixes the remaining `write_text()` call in `vulnerability_scan_gate.py`.

## Change

`scripts/security/vulnerability_scan_gate.py`:
- `path.write_text(json.dumps(...) + "\n")` → `path.write_text(json.dumps(...) + "\n", encoding="utf-8")`

The payload is JSON (RFC 8259 = UTF-8), so the encoding must be explicit.

## Testing

File passes `python3 -m py_compile`.

Fixes #1411