### PR TITLE
fix: replace bare asserts with explicit exceptions in service layer

### DIFF
--- a/openmed/mcp/server.py
+++ b/openmed/mcp/server.py
@@ -27,6 +27,18 @@ from openmed.utils.validation import validate_model_name
 
 RuntimeProvider = Callable[[], ServiceRuntime]
 
+
+def _safe_int_env(name: str, default: int) -> int:
+    """Read an environment variable as an int, falling back to *default* on error."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 MCP_INSTRUCTIONS = (
     "OpenMed exposes local clinical NLP, PII extraction, and de-identification "
     "tools. Use synthetic examples for tests and docs. Only send real PHI to "
@@ -532,7 +544,7 @@ def create_mcp_server(
         instructions=MCP_INSTRUCTIONS,
         website_url="https://openmed.life/docs/",
         host=host or os.getenv("OPENMED_MCP_HOST", "127.0.0.1"),
-        port=port or int(os.getenv("OPENMED_MCP_PORT", "8081")),
+        port=port or _safe_int_env("OPENMED_MCP_PORT", 8081),
         streamable_http_path=streamable_http_path,
         stateless_http=True,
         json_response=True,
@@ -559,7 +571,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--port",
         type=int,
-        default=int(os.getenv("OPENMED_MCP_PORT", "8081")),
+        default=_safe_int_env("OPENMED_MCP_PORT", 8081),
         help="Port for streamable HTTP transport.",
     )
     parser.add_argument(

--- a/openmed/service/auth.py
+++ b/openmed/service/auth.py
@@ -744,7 +744,8 @@ def _validate_jwt_claims(
     now: float,
 ) -> None:
     exp = _numeric_claim(payload, "exp", required=True)
-    assert exp is not None
+    if exp is None:
+        raise invalid_credentials()
     if now > exp + config.jwt_leeway_seconds:
         raise invalid_credentials()
 

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -371,7 +371,8 @@ if PYDANTIC_V2:
         @classmethod
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold must not be None")
             return normalized
 
         @field_validator("policy", mode="before")
@@ -738,7 +739,8 @@ else:
         @validator("confidence_threshold", "detector_confidence_floor")
         def _validate_confidence_threshold(cls, value: float) -> float:
             normalized = _normalize_confidence_threshold(value)
-            assert normalized is not None
+            if normalized is None:
+                raise ValueError("confidence_threshold must not be None")
             return normalized
 
         @validator("policy", pre=True)


### PR DESCRIPTION
## Description

Replace `assert` statements in production code with explicit `if ... raise` checks so invariant guards survive `python -O` (which strips all `assert` statements).

**Fixes #1407**

## Change Type

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes

### `openmed/service/auth.py` — JWT expiry guard (security-critical)

`_validate_jwt_claims` used `assert exp is not None` to guard the JWT `exp` claim before checking token expiry. Under `python -O`, this assert is stripped entirely — meaning the `now > exp + leeway` comparison would receive `None` and crash with `TypeError`, or worse, the expiry check could be bypassed in edge cases.

**Fix:** `if exp is None: raise invalid_credentials()` — explicit, `-O`-safe, and semantically identical.

### `openmed/service/schemas.py` — Pydantic validators (2 instances)

Two `@field_validator` / `@validator` methods for `confidence_threshold` used `assert normalized is not None` after calling `_normalize_confidence_threshold()`. While the current code path makes `None` unlikely (input is typed `float`, not `Optional`), the assert serves only as a type-narrowing hint for mypy/pyright and vanishes under `-O`.

**Fix:** `if normalized is None: raise ValueError(...)` — explicit, `-O`-safe.

### `openmed/mcp/server.py` — unguarded `int(os.getenv())` (crash on malformed input)

Two call sites used `int(os.getenv("OPENMED_MCP_PORT", "8081"))` which crashes with `ValueError` if the env var contains non-numeric text (e.g. `OPENMED_MCP_PORT=abc`).

**Fix:** Add `_safe_int_env(name, default)` helper that catches `ValueError`/`TypeError` and falls back to the default.

## Tests Run

```
tests/unit/service/ — 191 passed (excluding pre-existing gRPC stubs failure)
tests/unit/mcp/ — included above
Full suite — 2574 passed, 45 skipped
```

## Linked Issue

Fixes #1407