### PR TITLE
Add secret scanning workflow and baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,76 +245,8 @@ jobs:
       run: |
         pytest tests/unit/interop/test_spacy_component.py -q
 
-  secret-scan:
-    needs: repo-policy
-    runs-on: ubuntu-latest
-    env:
-      GITLEAKS_VERSION: "8.30.1"
-      GITLEAKS_LINUX_X64_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
-
-    - name: Install gitleaks
-      run: |
-        archive="/tmp/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-        curl -sSfL \
-          "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-          -o "$archive"
-        echo "${GITLEAKS_LINUX_X64_SHA256}  $archive" | sha256sum -c -
-        tar -xzf "$archive" -C /tmp gitleaks
-        sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
-        gitleaks version
-
-    - name: Verify secret scanner canary
-      run: |
-        canary_dir="$(mktemp -d)"
-        cp tests/fixtures/secret_scan_canary.txt "$canary_dir/canary.txt"
-        set +e
-        gitleaks dir \
-          --config .gitleaks.toml \
-          --redact \
-          --no-banner \
-          --report-format json \
-          --report-path "$RUNNER_TEMP/gitleaks-canary.json" \
-          "$canary_dir"
-        canary_status=$?
-        set -e
-        if [ "$canary_status" -eq 0 ]; then
-          echo "::error title=Secret scanner canary was not detected::Expected the synthetic canary to fail outside its allowlisted fixture path"
-          exit 1
-        fi
-        if [ "$canary_status" -ne 1 ]; then
-          echo "::error title=Secret scanner canary failed unexpectedly::Scanner exited with status $canary_status"
-          exit "$canary_status"
-        fi
-
-    - name: Scan committed changes for secrets
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        PUSH_BEFORE_SHA: ${{ github.event.before }}
-      run: |
-        zero_sha="0000000000000000000000000000000000000000"
-        if [ "$EVENT_NAME" = "pull_request" ]; then
-          scan_range="${PR_BASE_SHA}..${PR_HEAD_SHA}"
-        elif [ -n "$PUSH_BEFORE_SHA" ] && [ "$PUSH_BEFORE_SHA" != "$zero_sha" ]; then
-          scan_range="${PUSH_BEFORE_SHA}..${GITHUB_SHA}"
-        else
-          scan_range="${GITHUB_SHA}^..${GITHUB_SHA}"
-        fi
-        gitleaks git \
-          --config .gitleaks.toml \
-          --redact \
-          --no-banner \
-          --verbose \
-          --log-opts "$scan_range" \
-          .
-
   build:
-    needs: [repo-policy, lint, test, security, secret-scan, spacy-integration]
+    needs: [repo-policy, lint, test, security, spacy-integration]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,79 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master, develop ]
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    env:
+      GITLEAKS_VERSION: "8.30.1"
+      GITLEAKS_LINUX_X64_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Install gitleaks
+      run: |
+        archive="/tmp/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+        curl -sSfL \
+          "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          -o "$archive"
+        echo "${GITLEAKS_LINUX_X64_SHA256}  $archive" | sha256sum -c -
+        tar -xzf "$archive" -C /tmp gitleaks
+        sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+        gitleaks version
+
+    - name: Verify secret scanner canary
+      run: |
+        canary_dir="$(mktemp -d)"
+        cp tests/fixtures/secret_scan_canary.txt "$canary_dir/canary.txt"
+        set +e
+        gitleaks dir \
+          --config .gitleaks.toml \
+          --redact \
+          --no-banner \
+          --report-format json \
+          --report-path "$RUNNER_TEMP/gitleaks-canary.json" \
+          "$canary_dir"
+        canary_status=$?
+        set -e
+        if [ "$canary_status" -eq 0 ]; then
+          echo "::error title=Secret scanner canary was not detected::Expected the synthetic canary to fail outside its allowlisted fixture path"
+          exit 1
+        fi
+        if [ "$canary_status" -ne 1 ]; then
+          echo "::error title=Secret scanner canary failed unexpectedly::Scanner exited with status $canary_status"
+          exit "$canary_status"
+        fi
+
+    - name: Scan committed changes for secrets
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PUSH_BEFORE_SHA: ${{ github.event.before }}
+      run: |
+        zero_sha="0000000000000000000000000000000000000000"
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          scan_range="${PR_BASE_SHA}..${PR_HEAD_SHA}"
+        elif [ -n "$PUSH_BEFORE_SHA" ] && [ "$PUSH_BEFORE_SHA" != "$zero_sha" ]; then
+          scan_range="${PUSH_BEFORE_SHA}..${GITHUB_SHA}"
+        else
+          scan_range="${GITHUB_SHA}^..${GITHUB_SHA}"
+        fi
+        gitleaks git \
+          --config .gitleaks.toml \
+          --baseline-path .secrets.baseline \
+          --redact \
+          --no-banner \
+          --verbose \
+          --log-opts "$scan_range" \
+          .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,4 @@ repos:
     rev: v8.30.1
     hooks:
       - id: gitleaks
-        args: [--config=.gitleaks.toml]
+        args: [--config=.gitleaks.toml, --baseline-path=.secrets.baseline]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,24 @@
+[
+ {
+  "RuleID": "openmed-secret-scan-canary",
+  "Description": "Synthetic canary used to verify the secret scanner gate",
+  "StartLine": 2,
+  "EndLine": 2,
+  "StartColumn": 2,
+  "EndColumn": 60,
+  "Match": "REDACTED",
+  "Secret": "REDACTED",
+  "File": "tests/fixtures/secret_scan_canary.txt",
+  "SymlinkFile": "",
+  "Commit": "",
+  "Entropy": 4.4548664,
+  "Author": "",
+  "Email": "",
+  "Date": "",
+  "Message": "",
+  "Tags": [
+   "secret-scanner-canary"
+  ],
+  "Fingerprint": "tests/fixtures/secret_scan_canary.txt:openmed-secret-scan-canary:2"
+ }
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,10 @@ uv pip install -e ".[dev]"      # editable install with test + lint deps
 pre-commit install              # auto-format staged files on commit
 ```
 
+The pre-commit hooks also run the Gitleaks secret scanner on staged changes.
+See [Secret Scanning](docs/security/secret-scanning.md) for local use, CI
+behavior, and baseline maintenance.
+
 ## Run the checks before opening a PR
 
 ```bash

--- a/docs/security/secret-handling.md
+++ b/docs/security/secret-handling.md
@@ -16,7 +16,9 @@ pre-commit install
 ```
 
 The secret-scanning hook is pinned in `.pre-commit-config.yaml` and uses the
-rules in `.gitleaks.toml`.
+rules in `.gitleaks.toml` plus the committed `.secrets.baseline`. See
+[Secret Scanning](secret-scanning.md) for local setup, CI behavior, and
+baseline maintenance.
 
 Run the staged-change secret scanner manually when changing auth, release, or
 CI files:
@@ -40,8 +42,9 @@ where the repository plan supports it.
 
 Prefer replacing realistic-looking examples with placeholders such as
 `<TOKEN>` or `<PYPI_TOKEN>`. If a false positive cannot be avoided, add the
-narrowest possible allowlist entry in `.gitleaks.toml`, scoped by path and
-pattern, and explain the reason in the pull request.
+narrowest possible allowlist entry in `.gitleaks.toml` or redacted baseline
+entry in `.secrets.baseline`, scoped by path and pattern, and explain the
+reason in the pull request.
 
 ## If A Secret Is Committed
 

--- a/docs/security/secret-scanning.md
+++ b/docs/security/secret-scanning.md
@@ -1,0 +1,60 @@
+# Secret Scanning
+
+OpenMed uses Gitleaks to catch committed credentials, private tokens, local
+credential files, and scanner canaries before they reach shared history. The
+same scanner configuration is used locally by pre-commit and in GitHub Actions.
+
+## Local Setup
+
+Install the repository hooks after setting up the development environment:
+
+```bash
+pre-commit install
+```
+
+The Gitleaks hook is pinned in `.pre-commit-config.yaml`. It scans staged
+changes with `.gitleaks.toml` and ignores only findings recorded in
+`.secrets.baseline`.
+
+Run the hook manually when changing authentication, release, deployment, or CI
+files:
+
+```bash
+pre-commit run gitleaks
+```
+
+Do not bypass the hook for real credentials. If a local example needs a token,
+use a placeholder such as `<TOKEN>` or keep the value in an untracked local
+file.
+
+## CI Gate
+
+The `Secret Scan` workflow installs the pinned Gitleaks release after verifying
+its checksum. It then runs two checks on every pull request and push:
+
+1. Copy `tests/fixtures/secret_scan_canary.txt` to a temporary,
+   non-allowlisted path and confirm Gitleaks fails on that synthetic secret.
+2. Scan the pull request or push commit range with `.gitleaks.toml` and
+   `.secrets.baseline`.
+
+If the canary is missed, CI fails because the scanner is not working. If a new
+non-baselined secret appears in the diff, CI fails and the value is redacted in
+scanner output. If branch protection uses selected required checks, require the
+`Secret Scan / secret-scan` check to make this gate merge-blocking.
+
+## Baseline Maintenance
+
+`.secrets.baseline` is a redacted Gitleaks JSON report for known synthetic
+findings. Keep baseline entries narrow and only for committed synthetic
+fixtures that are intentional.
+
+When maintaining the baseline:
+
+- Prefer changing examples to placeholders instead of adding baseline entries.
+- Keep `.gitleaks.toml` allowlists scoped by path and pattern.
+- Keep `.secrets.baseline` redacted; do not commit real secret values.
+- Explain every new baseline or allowlist entry in the pull request.
+
+If a scan reports a real credential, revoke or rotate it immediately, remove it
+from the branch before merging, and avoid posting the value in issues, pull
+requests, logs, or screenshots.

--- a/tests/unit/security/test_secret_scanning_gate.py
+++ b/tests/unit/security/test_secret_scanning_gate.py
@@ -1,16 +1,29 @@
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
 CONFIG = ROOT / ".gitleaks.toml"
+BASELINE = ROOT / ".secrets.baseline"
 CANARY = ROOT / "tests/fixtures/secret_scan_canary.txt"
-WORKFLOW = ROOT / ".github/workflows/ci.yml"
+PRE_COMMIT = ROOT / ".pre-commit-config.yaml"
+WORKFLOW = ROOT / ".github/workflows/secret-scan.yml"
 
 
 def _gitleaks_config_text() -> str:
     return CONFIG.read_text()
+
+
+def test_pre_commit_runs_baseline_aware_gitleaks_hook() -> None:
+    pre_commit = PRE_COMMIT.read_text()
+
+    assert "https://github.com/gitleaks/gitleaks" in pre_commit
+    assert "rev: v8.30.1" in pre_commit
+    assert "- id: gitleaks" in pre_commit
+    assert "--config=.gitleaks.toml" in pre_commit
+    assert "--baseline-path=.secrets.baseline" in pre_commit
 
 
 def test_canary_fixture_matches_project_specific_rule() -> None:
@@ -33,6 +46,27 @@ def test_canary_fixture_is_the_only_canary_allowlist_path() -> None:
     assert r"tests/fixtures/secret_scan_canary\.txt$" in config
 
 
+def test_canary_fixture_is_recorded_in_redacted_baseline() -> None:
+    baseline = json.loads(BASELINE.read_text())
+
+    assert [
+        (
+            finding["RuleID"],
+            finding["File"],
+            finding["Secret"],
+            finding["Fingerprint"],
+        )
+        for finding in baseline
+    ] == [
+        (
+            "openmed-secret-scan-canary",
+            "tests/fixtures/secret_scan_canary.txt",
+            "REDACTED",
+            "tests/fixtures/secret_scan_canary.txt:openmed-secret-scan-canary:2",
+        )
+    ]
+
+
 def test_local_credential_files_are_explicitly_flagged() -> None:
     config = _gitleaks_config_text()
 
@@ -51,4 +85,5 @@ def test_workflow_runs_canary_before_secret_scan() -> None:
     assert canary_step < scan_step
     assert "secret_scan_canary.txt" in workflow
     assert "gitleaks git" in workflow
+    assert "--baseline-path .secrets.baseline" in workflow
     assert "secret-scan" in workflow


### PR DESCRIPTION
# Pull Request

## Description
Adds baseline-aware secret scanning before credentials reach shared history. This PR wires Gitleaks into pre-commit for staged diffs, adds a standalone GitHub Actions secret-scan gate, commits a narrow redacted baseline for the synthetic canary fixture, and documents local setup plus baseline maintenance.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added a standalone `Secret Scan / secret-scan` workflow that installs pinned Gitleaks, verifies the synthetic canary is detected outside its allowlisted fixture path, and scans PR or push commit ranges with redacted output.
- Updated the pre-commit Gitleaks hook to use `.gitleaks.toml` with the committed `.secrets.baseline`.
- Added a redacted `.secrets.baseline` entry scoped to the synthetic canary fixture and tests that assert the hook, workflow, and baseline remain wired together.
- Documented local pre-commit usage, CI behavior, baseline maintenance, and the branch-protection requirement for making `Secret Scan / secret-scan` merge-blocking.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Targeted validation run:

```bash
.venv/bin/python -m pytest tests/unit/security/test_secret_scanning_gate.py -q
# 6 passed

.venv/bin/pre-commit run check-yaml --files .github/workflows/secret-scan.yml .pre-commit-config.yaml
# Passed

.venv/bin/pre-commit run gitleaks --all-files
# Passed

.venv/bin/python scripts/release/check_github_actions_refs.py
# Passed
```

Acceptance behavior was also checked in isolated throwaway repositories:

- A staged synthetic canary failed the pre-commit Gitleaks hook as expected.
- A clean `gitleaks git` commit range exited 0.
- A commit range introducing the synthetic canary exited 1 as expected.

Full test suite and model/input matrix were not run because this change only
touches repository secret-scanning configuration, CI workflow wiring, tests, and
docs.

## Documentation
- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

No new functions or classes were added. `CHANGELOG.md` was not updated because
this is repository security tooling and documentation rather than a user-facing
runtime feature.

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Broad formatting and lint targets were not run; targeted YAML, Gitleaks, unit,
and GitHub Actions reference checks passed. No Swift/OpenMedKit files were
changed. No code comments were added because the changed logic is workflow and
configuration oriented.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #863