### PR TITLE
vCard and iCalendar PHI redaction

### DIFF
--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 # stdlib-only, so the public multimodal import path remains free of heavy deps.
 from openmed.interop import cda as _cda
 
+from . import contacts_calendar as _contacts_calendar
 from . import dicom as _dicom
 
 # Importing the Markdown/AsciiDoc adapter registers lightweight text-markup
@@ -35,6 +36,7 @@ from .chatlog_jsonl import (
     redact_chatlog_jsonl,
     write_redacted_chatlog_jsonl,
 )
+from .contacts_calendar import redact_contacts_calendar
 from .dicom import (
     DicomHeaderAction,
     DicomHeaderDeidPolicy,
@@ -123,6 +125,7 @@ __all__ = [
     "iter_redacted_chatlog_jsonl",
     "redact_chatlog_jsonl",
     "write_redacted_chatlog_jsonl",
+    "redact_contacts_calendar",
     "DicomHeaderAction",
     "DicomHeaderDeidPolicy",
     "DicomHeaderDeidResult",

--- a/openmed/multimodal/contacts_calendar.py
+++ b/openmed/multimodal/contacts_calendar.py
@@ -247,7 +247,9 @@ def _redact_value(
 
     action = _action_for(property_name, label, ACTION_MASK, options)
     if property_name in _STRUCTURED_PROPERTIES:
-        return _redact_structured_value(value, label=label, action=action, options=options)
+        return _redact_structured_value(
+            value, label=label, action=action, options=options
+        )
     if _is_uri_valued(property_name, prefix, value):
         return _redact_uri_value(
             property_name,
@@ -257,7 +259,9 @@ def _redact_value(
             options=options,
         )
     if property_name in _CALENDAR_ADDRESS_PROPERTIES:
-        return _redact_calendar_address(value, label=label, action=action, options=options)
+        return _redact_calendar_address(
+            value, label=label, action=action, options=options
+        )
     return _apply_action(value, label=label, action=action, options=options)
 
 
@@ -417,8 +421,7 @@ def _action_for(
             action = str(override).lower()
             if action not in SUPPORTED_ACTIONS:
                 raise ValueError(
-                    "unsupported contacts/calendar redaction action: "
-                    f"{override!r}"
+                    f"unsupported contacts/calendar redaction action: {override!r}"
                 )
             return action
     return default
@@ -515,11 +518,7 @@ def _split_unquoted(text: str, delimiter: str, *, maxsplit: int = -1) -> list[st
         if char == '"':
             quoted = not quoted
             continue
-        if (
-            char == delimiter
-            and not quoted
-            and (maxsplit < 0 or splits < maxsplit)
-        ):
+        if char == delimiter and not quoted and (maxsplit < 0 or splits < maxsplit):
             parts.append(text[start:index])
             start = index + 1
             splits += 1

--- a/openmed/multimodal/contacts_calendar.py
+++ b/openmed/multimodal/contacts_calendar.py
@@ -1,0 +1,583 @@
+"""vCard and iCalendar PHI redaction.
+
+The parser handles the shared RFC content-line shape used by ``.vcf`` and
+``.ics`` files: unfold continuation lines, redact selected properties, then
+fold output lines back to a standard client-friendly width.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openmed.core.labels import (
+    EMAIL,
+    LOCATION,
+    ORGANIZATION,
+    PERSON,
+    PHONE,
+    STREET_ADDRESS,
+)
+
+from .base import ExtractedDocument, register_handler
+
+ACTION_MASK = "mask"
+ACTION_HASH = "hash"
+ACTION_REMOVE = "remove"
+ACTION_KEEP = "keep"
+ACTION_FREE_TEXT_REDACT = "free_text_redact"
+
+SUPPORTED_ACTIONS = frozenset(
+    {
+        ACTION_MASK,
+        ACTION_HASH,
+        ACTION_REMOVE,
+        ACTION_KEEP,
+        ACTION_FREE_TEXT_REDACT,
+    }
+)
+
+TextRedactor = Callable[[str], str]
+
+_DIRECT_PROPERTY_LABELS = {
+    "FN": PERSON,
+    "N": PERSON,
+    "TEL": PHONE,
+    "EMAIL": EMAIL,
+    "ATTENDEE": EMAIL,
+    "ORGANIZER": EMAIL,
+    "ADR": STREET_ADDRESS,
+    "ORG": ORGANIZATION,
+    "LOCATION": LOCATION,
+}
+_FREE_TEXT_PROPERTIES = frozenset({"NOTE", "SUMMARY", "DESCRIPTION"})
+_STRUCTURED_PROPERTIES = frozenset({"N", "ADR"})
+_CALENDAR_ADDRESS_PROPERTIES = frozenset({"ATTENDEE", "ORGANIZER"})
+_CALENDAR_CN_PROPERTIES = frozenset({"ATTENDEE", "ORGANIZER"})
+_URI_VALUE_PROPERTIES = frozenset({"EMAIL", "TEL", "ATTENDEE", "ORGANIZER"})
+_PROPERTY_NAME_RE = re.compile(r"^[A-Za-z0-9-]+$")
+
+
+@dataclass(frozen=True)
+class _RedactionOptions:
+    action_overrides: Mapping[str, str]
+    text_redactor: TextRedactor
+    lang: str
+
+
+def redact_contacts_calendar(
+    source: str | os.PathLike[str] | Any,
+    *,
+    policy: Any | None = None,
+    models: Any | None = None,
+    lang: str = "en",
+) -> ExtractedDocument:
+    """Redact PHI-bearing vCard and iCalendar properties.
+
+    Args:
+        source: A filesystem path, raw text string, or text file-like object.
+        policy: Optional string de-identification policy, or mapping with
+            ``action_overrides`` and ``deidentify_policy`` keys.
+        models: Optional callable, mapping, or object supplying a text redactor.
+        lang: OpenMed PII language code for free-text redaction.
+
+    Returns:
+        Redacted text in an :class:`ExtractedDocument`.
+    """
+    text, path = _read_source(source)
+    newline = _detect_newline(text)
+    had_final_newline = text.endswith(("\n", "\r"))
+    options = _redaction_options(policy=policy, models=models, lang=lang)
+
+    logical_lines = _unfold_lines(text)
+    redacted_lines = [_redact_content_line(line, options) for line in logical_lines]
+    folded = newline.join(_fold_line(line, newline=newline) for line in redacted_lines)
+    if had_final_newline:
+        folded += newline
+
+    return ExtractedDocument(
+        text=folded,
+        metadata={
+            "format": _format_name(text, path),
+            "line_count": len(logical_lines),
+        },
+    )
+
+
+def _contacts_calendar_handler(
+    path: str | os.PathLike[str],
+    *,
+    policy: Any = None,
+    models: Any = None,
+    lang: str | None = None,
+) -> ExtractedDocument:
+    return redact_contacts_calendar(
+        path,
+        policy=policy,
+        models=models,
+        lang=lang or "en",
+    )
+
+
+def _read_source(source: str | os.PathLike[str] | Any) -> tuple[str, str | None]:
+    if hasattr(source, "read"):
+        return str(source.read()), None
+    if isinstance(source, os.PathLike):
+        path = Path(source)
+        return path.read_text(encoding="utf-8"), str(path)
+    if isinstance(source, str):
+        if "\n" in source or "\r" in source:
+            return source, None
+        path = Path(source)
+        if path.exists():
+            return path.read_text(encoding="utf-8"), str(path)
+        return source, None
+    raise TypeError("source must be a path, text content, or text file-like object")
+
+
+def _detect_newline(text: str) -> str:
+    if "\r\n" in text:
+        return "\r\n"
+    if "\r" in text:
+        return "\r"
+    return "\n"
+
+
+def _unfold_lines(text: str) -> list[str]:
+    logical_lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith((" ", "\t")) and logical_lines:
+            logical_lines[-1] += line[1:]
+        else:
+            logical_lines.append(line)
+    return logical_lines
+
+
+def _fold_line(line: str, *, newline: str) -> str:
+    chunks: list[str] = []
+    current: list[str] = []
+    current_bytes = 0
+    limit = 75
+
+    for char in line:
+        char_bytes = len(char.encode("utf-8"))
+        if current and current_bytes + char_bytes > limit:
+            chunks.append("".join(current))
+            current = [char]
+            current_bytes = char_bytes
+            limit = 74
+        else:
+            current.append(char)
+            current_bytes += char_bytes
+
+    chunks.append("".join(current))
+    if len(chunks) == 1:
+        return chunks[0]
+    return chunks[0] + "".join(f"{newline} {chunk}" for chunk in chunks[1:])
+
+
+def _redact_content_line(line: str, options: _RedactionOptions) -> str:
+    separator = _find_unquoted(line, ":")
+    if separator is None:
+        return line
+
+    prefix = line[:separator]
+    value = line[separator + 1 :]
+    property_name = _property_name(prefix)
+    if property_name is None:
+        return line
+
+    redacted_prefix = _redact_parameters(prefix, property_name, options)
+    redacted_value = _redact_value(property_name, prefix, value, options)
+    return f"{redacted_prefix}:{redacted_value}"
+
+
+def _property_name(prefix: str) -> str | None:
+    property_token = _split_unquoted(prefix, ";", maxsplit=1)[0]
+    name = property_token.rsplit(".", 1)[-1]
+    if not name or _PROPERTY_NAME_RE.fullmatch(name) is None:
+        return None
+    return name.upper()
+
+
+def _redact_parameters(
+    prefix: str,
+    property_name: str,
+    options: _RedactionOptions,
+) -> str:
+    if property_name not in _CALENDAR_CN_PROPERTIES:
+        return prefix
+
+    tokens = _split_unquoted(prefix, ";")
+    redacted = [tokens[0]]
+    for token in tokens[1:]:
+        key, separator, value = token.partition("=")
+        if separator and key.upper() == "CN":
+            action = _action_for("CN", PERSON, ACTION_MASK, options)
+            value = _redact_parameter_value(
+                value,
+                label=PERSON,
+                action=action,
+                options=options,
+            )
+            redacted.append(f"{key}={value}")
+        else:
+            redacted.append(token)
+    return ";".join(redacted)
+
+
+def _redact_value(
+    property_name: str,
+    prefix: str,
+    value: str,
+    options: _RedactionOptions,
+) -> str:
+    if property_name in _FREE_TEXT_PROPERTIES:
+        action = _action_for(property_name, None, ACTION_FREE_TEXT_REDACT, options)
+        return _apply_action(value, label=None, action=action, options=options)
+
+    label = _DIRECT_PROPERTY_LABELS.get(property_name)
+    if label is None:
+        return value
+
+    action = _action_for(property_name, label, ACTION_MASK, options)
+    if property_name in _STRUCTURED_PROPERTIES:
+        return _redact_structured_value(value, label=label, action=action, options=options)
+    if _is_uri_valued(property_name, prefix, value):
+        return _redact_uri_value(
+            property_name,
+            value,
+            label=label,
+            action=action,
+            options=options,
+        )
+    if property_name in _CALENDAR_ADDRESS_PROPERTIES:
+        return _redact_calendar_address(value, label=label, action=action, options=options)
+    return _apply_action(value, label=label, action=action, options=options)
+
+
+def _redact_structured_value(
+    value: str,
+    *,
+    label: str,
+    action: str,
+    options: _RedactionOptions,
+) -> str:
+    parts = _split_escaped_value(value, ";")
+    return ";".join(
+        _apply_action(part, label=label, action=action, options=options)
+        if part
+        else part
+        for part in parts
+    )
+
+
+def _redact_calendar_address(
+    value: str,
+    *,
+    label: str,
+    action: str,
+    options: _RedactionOptions,
+) -> str:
+    if value.lower().startswith("mailto:") and action != ACTION_REMOVE:
+        return value[:7] + _apply_action(
+            value[7:],
+            label=label,
+            action=action,
+            options=options,
+        )
+    return _apply_action(value, label=label, action=action, options=options)
+
+
+def _is_uri_valued(property_name: str, prefix: str, value: str) -> bool:
+    if property_name not in _URI_VALUE_PROPERTIES:
+        return False
+
+    lower_value = value.lower()
+    if property_name in _CALENDAR_ADDRESS_PROPERTIES:
+        return lower_value.startswith("mailto:")
+    if property_name == "EMAIL" and lower_value.startswith("mailto:"):
+        return True
+    if property_name == "TEL" and lower_value.startswith("tel:"):
+        return True
+
+    parameter = _parameter_value(prefix, "VALUE")
+    return parameter is not None and parameter.lower() == "uri"
+
+
+def _parameter_value(prefix: str, name: str) -> str | None:
+    for token in _split_unquoted(prefix, ";")[1:]:
+        key, separator, value = token.partition("=")
+        if separator and key.upper() == name.upper():
+            return _unquote_parameter_value(value)
+    return None
+
+
+def _unquote_parameter_value(value: str) -> str:
+    if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    return value
+
+
+def _redact_uri_value(
+    property_name: str,
+    value: str,
+    *,
+    label: str,
+    action: str,
+    options: _RedactionOptions,
+) -> str:
+    if action == ACTION_KEEP or not value:
+        return value
+    if action == ACTION_REMOVE:
+        return ""
+    if action == ACTION_MASK:
+        return _masked_uri_value(property_name)
+    if action == ACTION_HASH:
+        return _hashed_uri_value(property_name, value)
+    return _apply_action(value, label=label, action=action, options=options)
+
+
+def _masked_uri_value(property_name: str) -> str:
+    if property_name == "TEL":
+        return "tel:+10000000000"
+    return "mailto:redacted@example.invalid"
+
+
+def _hashed_uri_value(property_name: str, value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    if property_name == "TEL":
+        digits = str(int(digest[:12], 16) % 10_000_000_000).zfill(10)
+        return f"tel:+1{digits}"
+    return f"mailto:email-{digest[:8]}@example.invalid"
+
+
+def _redact_parameter_value(
+    value: str,
+    *,
+    label: str,
+    action: str,
+    options: _RedactionOptions,
+) -> str:
+    if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+        inner = value[1:-1]
+        redacted = _apply_action(inner, label=label, action=action, options=options)
+        return f'"{redacted}"'
+    return _apply_action(value, label=label, action=action, options=options)
+
+
+def _apply_action(
+    value: str,
+    *,
+    label: str | None,
+    action: str,
+    options: _RedactionOptions,
+) -> str:
+    if action == ACTION_KEEP or not value:
+        return value
+    if action == ACTION_FREE_TEXT_REDACT:
+        return str(options.text_redactor(value))
+    if action == ACTION_REMOVE:
+        return ""
+    if label is None:
+        return value
+
+    from openmed.core.pii import PIIEntity, _redact_entity
+
+    entity = PIIEntity(
+        text=value,
+        label=label,
+        entity_type=label,
+        start=0,
+        end=len(value),
+        confidence=1.0,
+        original_text=value,
+    )
+    return _redact_entity(entity, action, lang=options.lang)
+
+
+def _action_for(
+    property_name: str,
+    label: str | None,
+    default: str,
+    options: _RedactionOptions,
+) -> str:
+    candidates = [property_name.upper()]
+    if label is not None:
+        candidates.append(label.upper())
+
+    for candidate in candidates:
+        override = options.action_overrides.get(candidate)
+        if override is not None:
+            action = str(override).lower()
+            if action not in SUPPORTED_ACTIONS:
+                raise ValueError(
+                    "unsupported contacts/calendar redaction action: "
+                    f"{override!r}"
+                )
+            return action
+    return default
+
+
+def _redaction_options(
+    *,
+    policy: Any | None,
+    models: Any | None,
+    lang: str,
+) -> _RedactionOptions:
+    action_overrides: dict[str, str] = {}
+    deidentify_policy = policy if isinstance(policy, str) else None
+
+    if isinstance(policy, Mapping):
+        raw_overrides = policy.get("action_overrides")
+        if isinstance(raw_overrides, Mapping):
+            action_overrides = {
+                str(key).upper(): str(value) for key, value in raw_overrides.items()
+            }
+        raw_deidentify_policy = policy.get("deidentify_policy")
+        if raw_deidentify_policy is not None:
+            deidentify_policy = str(raw_deidentify_policy)
+
+    text_redactor = _text_redactor_from_models(models) or _default_text_redactor(
+        policy=deidentify_policy,
+        lang=lang,
+    )
+    return _RedactionOptions(
+        action_overrides=action_overrides,
+        text_redactor=text_redactor,
+        lang=lang,
+    )
+
+
+def _text_redactor_from_models(models: Any | None) -> TextRedactor | None:
+    if callable(models):
+        return lambda text: str(models(text))
+    if isinstance(models, Mapping):
+        for key in ("text_redactor", "deidentifier", "redactor"):
+            candidate = models.get(key)
+            if callable(candidate):
+                return lambda text: str(candidate(text))
+    for attribute in ("text_redactor", "deidentifier", "redactor"):
+        candidate = getattr(models, attribute, None)
+        if callable(candidate):
+            return lambda text: str(candidate(text))
+    return None
+
+
+def _default_text_redactor(*, policy: str | None, lang: str) -> TextRedactor:
+    def redactor(text: str) -> str:
+        from openmed.core.pii import deidentify
+
+        result = deidentify(text, method=ACTION_MASK, lang=lang, policy=policy)
+        if hasattr(result, "deidentified_text"):
+            return str(result.deidentified_text)
+        return str(result)
+
+    return redactor
+
+
+def _find_unquoted(text: str, needle: str) -> int | None:
+    quoted = False
+    escaped = False
+    for index, char in enumerate(text):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == '"':
+            quoted = not quoted
+            continue
+        if char == needle and not quoted:
+            return index
+    return None
+
+
+def _split_unquoted(text: str, delimiter: str, *, maxsplit: int = -1) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    splits = 0
+    quoted = False
+    escaped = False
+    for index, char in enumerate(text):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == '"':
+            quoted = not quoted
+            continue
+        if (
+            char == delimiter
+            and not quoted
+            and (maxsplit < 0 or splits < maxsplit)
+        ):
+            parts.append(text[start:index])
+            start = index + 1
+            splits += 1
+    parts.append(text[start:])
+    return parts
+
+
+def _split_escaped_value(text: str, delimiter: str) -> list[str]:
+    parts: list[str] = []
+    current: list[str] = []
+    escaped = False
+    for char in text:
+        if escaped:
+            current.extend(("\\", char))
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == delimiter:
+            parts.append("".join(current))
+            current = []
+            continue
+        current.append(char)
+    if escaped:
+        current.append("\\")
+    parts.append("".join(current))
+    return parts
+
+
+def _format_name(text: str, path: str | None) -> str:
+    suffix = Path(path).suffix.lower() if path is not None else ""
+    if suffix == ".vcf":
+        return "vcard"
+    if suffix == ".ics":
+        return "icalendar"
+
+    upper = text.upper()
+    if "BEGIN:VCARD" in upper:
+        return "vcard"
+    if "BEGIN:VCALENDAR" in upper:
+        return "icalendar"
+    return "contacts_calendar"
+
+
+register_handler(
+    (".vcf", ".ics"),
+    _contacts_calendar_handler,
+    requires_multimodal=False,
+)
+
+
+__all__ = [
+    "ACTION_FREE_TEXT_REDACT",
+    "ACTION_HASH",
+    "ACTION_KEEP",
+    "ACTION_MASK",
+    "ACTION_REMOVE",
+    "SUPPORTED_ACTIONS",
+    "redact_contacts_calendar",
+]

--- a/tests/unit/multimodal/fixtures/synthetic_phi.ics
+++ b/tests/unit/multimodal/fixtures/synthetic_phi.ics
@@ -1,0 +1,14 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//OpenMed//Synthetic Calendar//EN
+BEGIN:VEVENT
+UID:appointment-safe-001
+DTSTART:20260401T090000Z
+SUMMARY:Visit for Jane Roe
+DESCRIPTION:Jane Roe reported symptoms and asked that the reminder include jane.roe@
+ example.com before the visit. This folded description should be unfolded before redaction.
+LOCATION:123 Main St\, Boston MA
+ATTENDEE;CN=Jane Roe;ROLE=REQ-PARTICIPANT:mailto:jane.roe@example.com
+ORGANIZER;CN="Dr Alice Smith":mailto:alice.smith@clinic.example
+END:VEVENT
+END:VCALENDAR

--- a/tests/unit/multimodal/fixtures/synthetic_phi.vcf
+++ b/tests/unit/multimodal/fixtures/synthetic_phi.vcf
@@ -1,0 +1,12 @@
+BEGIN:VCARD
+VERSION:3.0
+UID:contact-safe-001
+FN:John Doe
+N:Doe;John;;Dr.;
+TEL;TYPE=CELL:555-0101
+EMAIL;TYPE=HOME:john.doe@example.com
+ADR;TYPE=HOME:;;123 Main St;Boston;MA;02108;USA
+ORG:Open Clinic
+NOTE:Patient John Doe can be reached at 555-
+ 0101 for lab follow-up. The reminder includes john.doe@example.com and a safe phrase that should remain after redaction.
+END:VCARD

--- a/tests/unit/multimodal/test_contacts_calendar.py
+++ b/tests/unit/multimodal/test_contacts_calendar.py
@@ -1,0 +1,237 @@
+"""Tests for vCard and iCalendar PHI redaction."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+from openmed.multimodal import (
+    ExtractedDocument,
+    redact_contacts_calendar,
+    redact_document,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+MAILTO_URI_RE = re.compile(r"^mailto:[^@\s\[\]]+@[^@\s\[\]]+$", re.IGNORECASE)
+TEL_URI_RE = re.compile(r"^tel:\+?[0-9][0-9(). -]*$", re.IGNORECASE)
+
+
+def _fake_redactor(text: str) -> str:
+    replacements = {
+        "John Doe": "[PERSON]",
+        "Jane Roe": "[PERSON]",
+        "555-0101": "[PHONE]",
+        "john.doe@example.com": "[EMAIL]",
+        "jane.roe@example.com": "[EMAIL]",
+    }
+    redacted = text
+    for source, replacement in replacements.items():
+        redacted = redacted.replace(source, replacement)
+    return redacted
+
+
+def _unfold(text: str) -> str:
+    logical_lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith((" ", "\t")) and logical_lines:
+            logical_lines[-1] += line[1:]
+        else:
+            logical_lines.append(line)
+    return "\n".join(logical_lines)
+
+
+def _assert_folded_width(text: str) -> None:
+    for line in text.splitlines():
+        assert len(line.encode("utf-8")) <= 75
+
+
+def _parameter_value(prefix: str, name: str) -> str | None:
+    for token in prefix.split(";")[1:]:
+        key, separator, value = token.partition("=")
+        if separator and key.upper() == name.upper():
+            if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+                return value[1:-1]
+            return value
+    return None
+
+
+def _assert_content_lines_are_valid(text: str) -> None:
+    for line in _unfold(text).splitlines():
+        assert ":" in line
+        prefix, value = line.split(":", 1)
+        value_type = _parameter_value(prefix, "VALUE")
+        if value_type is not None and value_type.lower() == "uri":
+            assert URI_SCHEME_RE.match(value)
+        if value.lower().startswith("mailto:"):
+            assert MAILTO_URI_RE.match(value)
+        if value.lower().startswith("tel:"):
+            assert TEL_URI_RE.match(value)
+
+
+def test_vcard_redacts_direct_properties_and_free_text_note():
+    result = redact_contacts_calendar(
+        FIXTURES / "synthetic_phi.vcf",
+        models={"text_redactor": _fake_redactor},
+    )
+
+    text = _unfold(result.text)
+
+    assert result.metadata["format"] == "vcard"
+    assert "VERSION:3.0" in text
+    assert "UID:contact-safe-001" in text
+    assert "FN:[PERSON]" in text
+    assert "N:[PERSON];[PERSON];;[PERSON];" in text
+    assert "TEL;TYPE=CELL:[PHONE]" in text
+    assert "EMAIL;TYPE=HOME:[EMAIL]" in text
+    assert (
+        "ADR;TYPE=HOME:;;[STREET_ADDRESS];[STREET_ADDRESS];"
+        "[STREET_ADDRESS];[STREET_ADDRESS];[STREET_ADDRESS]"
+    ) in text
+    assert "ORG:[ORGANIZATION]" in text
+    assert "NOTE:Patient [PERSON] can be reached at [PHONE]" in text
+    assert "john.doe@example.com" not in text
+    assert "John Doe" not in text
+    assert "555-0101" not in text
+    _assert_folded_width(result.text)
+    assert any(line.startswith(" ") for line in result.text.splitlines())
+
+
+def test_vcard_uri_values_keep_valid_uri_shape():
+    source = (
+        "BEGIN:VCARD\n"
+        "VERSION:4.0\n"
+        "TEL;VALUE=uri:tel:+1-555-0101\n"
+        "EMAIL;VALUE=uri:mailto:john.doe@example.com\n"
+        "END:VCARD\n"
+    )
+
+    result = redact_contacts_calendar(source)
+    text = _unfold(result.text)
+
+    assert "TEL;VALUE=uri:tel:+10000000000" in text
+    assert "EMAIL;VALUE=uri:mailto:redacted@example.invalid" in text
+    assert "+1-555-0101" not in text
+    assert "john.doe@example.com" not in text
+    _assert_content_lines_are_valid(result.text)
+
+    hashed = redact_contacts_calendar(
+        source,
+        policy={"action_overrides": {"TEL": "hash", "EMAIL": "hash"}},
+    )
+    hashed_text = _unfold(hashed.text)
+
+    assert re.search(r"TEL;VALUE=uri:tel:\+1\d{10}", hashed_text)
+    assert re.search(
+        r"EMAIL;VALUE=uri:mailto:email-[0-9a-f]{8}@example\.invalid",
+        hashed_text,
+    )
+    assert "+1-555-0101" not in hashed_text
+    assert "john.doe@example.com" not in hashed_text
+    _assert_content_lines_are_valid(hashed.text)
+
+
+def test_icalendar_redacts_event_fields_values_and_cn_parameters():
+    result = redact_contacts_calendar(
+        FIXTURES / "synthetic_phi.ics",
+        models={"text_redactor": _fake_redactor},
+    )
+
+    text = _unfold(result.text)
+
+    assert result.metadata["format"] == "icalendar"
+    assert "VERSION:2.0" in text
+    assert "PRODID:-//OpenMed//Synthetic Calendar//EN" in text
+    assert "UID:appointment-safe-001" in text
+    assert "DTSTART:20260401T090000Z" in text
+    assert "SUMMARY:Visit for [PERSON]" in text
+    assert "DESCRIPTION:[PERSON] reported symptoms" in text
+    assert "LOCATION:[LOCATION]" in text
+    assert (
+        "ATTENDEE;CN=[PERSON];ROLE=REQ-PARTICIPANT:"
+        "mailto:redacted@example.invalid"
+    ) in text
+    assert 'ORGANIZER;CN="[PERSON]":mailto:redacted@example.invalid' in text
+    assert "Jane Roe" not in text
+    assert "jane.roe@example.com" not in text
+    assert "Dr Alice Smith" not in text
+    assert "alice.smith@clinic.example" not in text
+    _assert_folded_width(result.text)
+    assert any(line.startswith(" ") for line in result.text.splitlines())
+
+
+def test_redacted_output_keeps_valid_content_lines():
+    vcard = redact_contacts_calendar(
+        (
+            "BEGIN:VCARD\n"
+            "VERSION:4.0\n"
+            "TEL;VALUE=uri:tel:+1-555-0101\n"
+            "EMAIL;VALUE=uri:mailto:john.doe@example.com\n"
+            "END:VCARD\n"
+        )
+    )
+    calendar = redact_contacts_calendar(
+        FIXTURES / "synthetic_phi.ics",
+        models={"text_redactor": _fake_redactor},
+    )
+
+    _assert_content_lines_are_valid(vcard.text)
+    _assert_content_lines_are_valid(calendar.text)
+
+
+def test_default_free_text_redactor_calls_openmed_pii(monkeypatch):
+    calls = []
+
+    def fake_deidentify(text: str, **kwargs):
+        calls.append((text, kwargs))
+        return SimpleNamespace(deidentified_text=text.replace("John Doe", "[PERSON]"))
+
+    monkeypatch.setattr("openmed.core.pii.deidentify", fake_deidentify)
+
+    result = redact_contacts_calendar(
+        "BEGIN:VCALENDAR\nSUMMARY:Visit John Doe\nEND:VCALENDAR\n",
+        policy={"deidentify_policy": "hipaa_safe_harbor"},
+        lang="fr",
+    )
+
+    assert "SUMMARY:Visit [PERSON]" in result.text
+    assert calls == [
+        (
+            "Visit John Doe",
+            {
+                "method": "mask",
+                "lang": "fr",
+                "policy": "hipaa_safe_harbor",
+            },
+        )
+    ]
+
+
+def test_action_overrides_can_keep_selected_properties():
+    result = redact_contacts_calendar(
+        "BEGIN:VCARD\nFN:John Doe\nNOTE:John Doe\nEND:VCARD\n",
+        policy={"action_overrides": {"FN": "keep", "NOTE": "keep"}},
+        models={"text_redactor": _fake_redactor},
+    )
+
+    assert "FN:John Doe" in result.text
+    assert "NOTE:John Doe" in result.text
+
+
+def test_redact_document_dispatches_vcard_and_icalendar_handlers():
+    vcard = redact_document(
+        str(FIXTURES / "synthetic_phi.vcf"),
+        models={"text_redactor": _fake_redactor},
+    )
+    calendar = redact_document(
+        str(FIXTURES / "synthetic_phi.ics"),
+        models={"text_redactor": _fake_redactor},
+    )
+
+    assert isinstance(vcard, ExtractedDocument)
+    assert isinstance(calendar, ExtractedDocument)
+    assert vcard.metadata["format"] == "vcard"
+    assert calendar.metadata["format"] == "icalendar"
+    assert "FN:[PERSON]" in _unfold(vcard.text)
+    assert "SUMMARY:Visit for [PERSON]" in _unfold(calendar.text)

--- a/tests/unit/multimodal/test_contacts_calendar.py
+++ b/tests/unit/multimodal/test_contacts_calendar.py
@@ -149,8 +149,7 @@ def test_icalendar_redacts_event_fields_values_and_cn_parameters():
     assert "DESCRIPTION:[PERSON] reported symptoms" in text
     assert "LOCATION:[LOCATION]" in text
     assert (
-        "ATTENDEE;CN=[PERSON];ROLE=REQ-PARTICIPANT:"
-        "mailto:redacted@example.invalid"
+        "ATTENDEE;CN=[PERSON];ROLE=REQ-PARTICIPANT:mailto:redacted@example.invalid"
     ) in text
     assert 'ORGANIZER;CN="[PERSON]":mailto:redacted@example.invalid' in text
     assert "Jane Roe" not in text


### PR DESCRIPTION
# Pull Request

## Description
Adds vCard (`.vcf`) and iCalendar (`.ics`) PHI redaction support to the multimodal ingestion surface. The new redactor unfolds RFC-style content lines, redacts common contact and calendar PHI fields, preserves valid URI-valued email/phone shapes, folds output lines back to client-friendly width, and registers the handler with `redact_document`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added `openmed.multimodal.redact_contacts_calendar` for `.vcf` and `.ics` sources, including path/raw text/file-like input handling, content-line unfolding/folding, format metadata, and policy action overrides.
- Registered `.vcf` and `.ics` multimodal handlers and exported `redact_contacts_calendar` from `openmed.multimodal`.
- Redacts direct contact/calendar PHI properties such as `FN`, `N`, `TEL`, `EMAIL`, `ADR`, `ORG`, `LOCATION`, `ATTENDEE`, and `ORGANIZER`, plus calendar `CN` parameters and free-text `NOTE`, `SUMMARY`, and `DESCRIPTION` values.
- Added synthetic vCard/iCalendar fixtures and unit coverage for property redaction, URI validity, folded lines, default free-text redaction delegation, action overrides, and dispatcher routing.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Targeted validation run:

```bash
.venv/bin/python -m pytest tests/unit/multimodal/test_contacts_calendar.py -q
# 7 passed in 0.07s

.venv/bin/python -m ruff check openmed/multimodal/contacts_calendar.py tests/unit/multimodal/test_contacts_calendar.py
# All checks passed!
```

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [ ] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Related to #470

## Screenshots/Examples
Not applicable; this is a Python API and handler-registration change.