### PR TITLE
fix: skip unchanged Android release artifacts

### DIFF
--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -80,7 +80,8 @@ jobs:
           fi
 
           if git diff --quiet "$PREVIOUS_TAG" "$GITHUB_SHA" -- \
-            android/ ':(exclude,glob)android/**/*.md'; then
+            android/ models.jsonl scripts/android/build_android_catalog.py \
+            ':(exclude,glob)android/**/*.md'; then
             echo "publish_android=false" >> "$GITHUB_OUTPUT"
             echo "No Android artifact changes since $PREVIOUS_TAG; skipping publication."
           else

--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -22,7 +22,6 @@ on:
 
 permissions:
   contents: read
-  checks: read
 
 jobs:
   guard:
@@ -30,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.release.outputs.version }}
+      publish_android: ${{ steps.android_changes.outputs.publish_android }}
 
     steps:
       - uses: actions/checkout@v7
@@ -64,38 +64,33 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Require successful Android checks
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Detect Android artifact changes
+        id: android_changes
+        shell: bash
         run: |
-          gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs" \
-            --paginate \
-            --jq '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv' \
-            > check-runs.tsv
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "publish_android=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          required_checks=(
-            "Build & Test Android OpenMedKit"
-            "Android AAR size and cold-start gate"
-          )
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 "${GITHUB_SHA}^" 2>/dev/null || true)
+          if [ -z "$PREVIOUS_TAG" ]; then
+            echo "publish_android=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          for check_name in "${required_checks[@]}"; do
-            line=$(awk -F '\t' -v name="$check_name" '$1 == name { found=$0 } END { print found }' check-runs.tsv)
-            if [ -z "$line" ]; then
-              echo "::error title=Missing required check::$check_name has not run on ${GITHUB_SHA}."
-              exit 1
-            fi
-
-            status=$(printf '%s\n' "$line" | cut -f2)
-            conclusion=$(printf '%s\n' "$line" | cut -f3)
-            if [ "$status" != "completed" ] || [ "$conclusion" != "success" ]; then
-              echo "::error title=Required check did not pass::$check_name is $status/$conclusion."
-              exit 1
-            fi
-          done
+          if git diff --quiet "$PREVIOUS_TAG" "$GITHUB_SHA" -- \
+            android/ ':(exclude,glob)android/**/*.md'; then
+            echo "publish_android=false" >> "$GITHUB_OUTPUT"
+            echo "No Android artifact changes since $PREVIOUS_TAG; skipping publication."
+          else
+            echo "publish_android=true" >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     name: Build signed Central Portal bundle
     needs: guard
+    if: needs.guard.outputs.publish_android == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -141,6 +136,7 @@ jobs:
   publish:
     name: Upload to Central Portal
     needs: [guard, build]
+    if: needs.guard.outputs.publish_android == 'true'
     runs-on: ubuntu-latest
     environment:
       name: maven-central

--- a/android/README.md
+++ b/android/README.md
@@ -25,13 +25,12 @@ local-first pipeline.
 ## Maven Central Publishing
 
 OpenMedKit publishes from `.github/workflows/android-publish.yml` on `v*` tags or
-manual dispatch only. The workflow builds a signed Central Portal bundle from the
-Gradle `release` Maven publication and uploads it to Sonatype after the required
-Android checks have passed.
-
-The release commit must already have successful check runs named
-`Build & Test Android OpenMedKit` and `Android AAR size and cold-start gate`.
-Missing or failing checks block the upload.
+manual dispatch only. Tag releases skip Android publication when the Android
+artifact inputs have not changed since the previous release. When publication is
+needed, the workflow assembles the library, runs its unit tests, builds a signed
+Central Portal bundle from the Gradle `release` Maven publication, and uploads it
+to Sonatype. Manual dispatch always runs the full validated publication path after
+the explicit upload confirmation.
 
 Required repository secrets:
 

--- a/tests/unit/test_publish_workflow_version.py
+++ b/tests/unit/test_publish_workflow_version.py
@@ -115,7 +115,8 @@ def test_android_publish_skips_unchanged_artifacts_and_runs_its_own_tests():
     assert "fetch-depth: 0" in workflow
     assert "Detect Android artifact changes" in workflow
     assert 'git describe --tags --abbrev=0 "${GITHUB_SHA}^"' in workflow
-    assert "android/ ':(exclude,glob)android/**/*.md'" in workflow
+    assert "android/ models.jsonl scripts/android/build_android_catalog.py" in workflow
+    assert "':(exclude,glob)android/**/*.md'" in workflow
     assert 'echo "publish_android=false"' in workflow
     assert workflow.count("if: needs.guard.outputs.publish_android == 'true'") == 2
     assert ":openmedkit:assembleDebug" in workflow

--- a/tests/unit/test_publish_workflow_version.py
+++ b/tests/unit/test_publish_workflow_version.py
@@ -10,6 +10,7 @@ WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
 PROVENANCE_WORKFLOW = ROOT / ".github" / "workflows" / "provenance.yml"
 IMAGE_SBOM_WORKFLOW = ROOT / ".github" / "workflows" / "sbom-image.yml"
+ANDROID_PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "android-publish.yml"
 ABOUT_FILE = ROOT / "openmed" / "__about__.py"
 
 
@@ -106,3 +107,18 @@ def test_image_sbom_release_path_attaches_artifact_and_labels_image():
     assert (
         "org.opencontainers.image.sbom.digest=${{ steps.sbom_digest.outputs.digest }}"
     ) in workflow
+
+
+def test_android_publish_skips_unchanged_artifacts_and_runs_its_own_tests():
+    workflow = ANDROID_PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "fetch-depth: 0" in workflow
+    assert "Detect Android artifact changes" in workflow
+    assert 'git describe --tags --abbrev=0 "${GITHUB_SHA}^"' in workflow
+    assert "android/ ':(exclude,glob)android/**/*.md'" in workflow
+    assert 'echo "publish_android=false"' in workflow
+    assert workflow.count("if: needs.guard.outputs.publish_android == 'true'") == 2
+    assert ":openmedkit:assembleDebug" in workflow
+    assert ":openmedkit:testDebugUnitTest" in workflow
+    assert "check-runs" not in workflow
+    assert "Android AAR size and cold-start gate" not in workflow


### PR DESCRIPTION
## Description

Fixes a tag-release blocker exposed by v1.8.0. The Android publish workflow required two pre-existing commit checks before it could build, but one named check does not exist and path-filtered Android CI is normally absent on Python-only hotfix commits. That made an otherwise valid release workflow fail before any Android validation ran.

Tag releases now compare Android artifact inputs with the previous version tag. A Python-only hotfix skips Android publication cleanly. Releases with Android artifact changes, plus explicitly confirmed manual runs, execute the existing assemble, unit-test, signed-bundle, and Central Portal upload path.

This branch remains rooted in v1.8.0 so the v1.8.1 provenance calculation stays a patch release. The attention fix itself is already integrated into master through #1545.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Detect Android library, build, and embedded model-catalog changes since the previous version tag.
- Skip Android build and upload jobs when the release contains no Android artifact changes.
- Keep manual publication explicit and fully validated.
- Remove the stale dependency on nonexistent or path-filtered external checks.
- Document the release behavior and add workflow regression coverage.

## Testing

- [x] I have added tests that prove the fix is effective
- [x] New and existing focused unit tests pass locally
- [x] I have validated both release metadata and workflow syntax

Validated locally:

- Release workflow tests and Android catalog regression coverage: 39 passed
- actionlint on android-publish.yml
- make lint and make format-check with the project environment active
- pre-commit on all changed files
- repository policy and frozen lockfile checks
- scripts/release/check_release_version.py --version 1.8.1
- scripts/release/changelog.py computes patch / 1.8.1

## Documentation

- [x] Updated android/README.md
- [x] Updated CHANGELOG.md earlier in the v1.8.1 hotfix

## Code Quality

- [x] Ran canonical Ruff formatting, lint, and format checks
- [x] Performed a self-review
- [x] No new dependencies

## Dependencies

- [x] No new dependencies

## Related Issues

Release follow-up to #1545. The release was explicitly requested and confirmed by the maintainer.

## Screenshots/Examples

Not applicable.
