### PR TITLE
Aadhaar recognizer hardening: Verhoeff validation, UIDAI masking rules, and checksum-valid surrogates

### DIFF
--- a/openmed/core/anonymizer/engine.py
+++ b/openmed/core/anonymizer/engine.py
@@ -31,12 +31,13 @@ from __future__ import annotations
 import hashlib
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from .. import labels as L
 from ..labels import normalize_label
 from ..name_order import CJK_LANGUAGES, normalize_person_span
 from .format_preserve import (
+    mask_aadhaar,
     preserve_date_format,
     preserve_email_pattern,
     preserve_id_pattern,
@@ -178,8 +179,12 @@ class Anonymizer:
             when no specific generator is registered.
         """
         effective_lang = lang or self.config.lang
-        effective_locale = resolve_locale(effective_lang, locale or self.config.locale)
         canonical = normalize_label(label, effective_lang)
+        effective_locale = resolve_locale(effective_lang, locale or self.config.locale)
+        if canonical == L.ID_NUM and _is_aadhaar_surrogate_source(original):
+            # Aadhaar stays checksum-valid even when an English/code-mixed
+            # note routes through the generic en_US locale.
+            effective_locale = "en_IN"
 
         # CJK PERSON spans: peel a trailing honorific (さん/様/씨/님/先生/…) so
         # the name is swapped while the honorific is re-attached verbatim.
@@ -220,6 +225,39 @@ class Anonymizer:
                 stacklevel=2,
             )
             return f"[{label}]{honorific_suffix}"
+
+    def anonymize_aadhaar(
+        self,
+        original: str,
+        *,
+        strategy: Literal["uidai_mask", "surrogate"] = "uidai_mask",
+    ) -> str:
+        """Apply a dedicated Aadhaar anonymization strategy.
+
+        Args:
+            original: A checksum-valid Aadhaar value.
+            strategy: ``"uidai_mask"`` preserves only the last four digits;
+                ``"surrogate"`` returns a checksum-valid synthetic Aadhaar.
+
+        Returns:
+            A UIDAI-masked value or a Verhoeff-valid synthetic Aadhaar.
+
+        Raises:
+            ValueError: If the source is invalid or the strategy is unknown.
+        """
+
+        if not _is_valid_aadhaar(original):
+            raise ValueError("Aadhaar must have a valid Verhoeff checksum")
+        if strategy == "uidai_mask":
+            return mask_aadhaar(original)
+        if strategy == "surrogate":
+            return self.surrogate(
+                original,
+                "aadhaar",
+                lang="en",
+                locale="en_IN",
+            )
+        raise ValueError("strategy must be 'uidai_mask' or 'surrogate'")
 
     def can_format_preserve(
         self,
@@ -339,6 +377,19 @@ def _non_identical_surrogate(original: str, generator: Any) -> str | None:
         if surrogate != original:
             return surrogate
     return None
+
+
+def _is_valid_aadhaar(value: str) -> bool:
+    from ..pii_i18n import validate_aadhaar
+
+    return validate_aadhaar(value)
+
+
+def _is_aadhaar_surrogate_source(value: str) -> bool:
+    if _is_valid_aadhaar(value):
+        return True
+    source, separator, attempt = value.rpartition("|")
+    return bool(separator and attempt.isdigit() and _is_valid_aadhaar(source))
 
 
 __all__ = ["Anonymizer", "AnonymizerConfig"]

--- a/openmed/core/anonymizer/format_preserve.py
+++ b/openmed/core/anonymizer/format_preserve.py
@@ -148,6 +148,46 @@ def preserve_id_pattern(original: str, *, rng: Optional[random.Random] = None) -
     return "".join(out)
 
 
+_MASKED_AADHAAR_RE = re.compile(
+    r"^(?:X{4}|\*{4})[ -]?(?:X{4}|\*{4})[ -]?(?P<last_four>[0-9]{4})$",
+    re.IGNORECASE,
+)
+_AADHAAR_RE = re.compile(r"^(?:[2-9][0-9]{11}|[2-9][0-9]{3} [0-9]{4} [0-9]{4})$")
+
+
+def mask_aadhaar(original: str) -> str:
+    """Render an Aadhaar value in UIDAI's masked ``XXXX XXXX NNNN`` form.
+
+    The first eight digits are never returned. Already-masked values are
+    normalized to the same canonical form, which keeps repeated masking
+    idempotent.
+
+    Args:
+        original: A 12-digit Aadhaar surface, optionally in 4-4-4 display
+            form, or an already-masked Aadhaar value.
+
+    Returns:
+        The canonical masked Aadhaar surface containing only the last four
+        digits.
+
+    Raises:
+        ValueError: If ``original`` is not a supported Aadhaar surface.
+    """
+
+    candidate = original.strip()
+    masked_match = _MASKED_AADHAAR_RE.fullmatch(candidate)
+    if masked_match is not None:
+        return f"XXXX XXXX {masked_match.group('last_four')}"
+    if _AADHAAR_RE.fullmatch(candidate) is None:
+        raise ValueError("Aadhaar must use 12 digits or 4-4-4 spacing")
+    from ..pii_i18n import validate_aadhaar
+
+    if not validate_aadhaar(candidate):
+        raise ValueError("Aadhaar must have a valid Verhoeff checksum")
+    digits = candidate.replace(" ", "")
+    return f"XXXX XXXX {digits[-4:]}"
+
+
 def _different_digit(original: str, *, rng: random.Random) -> str:
     candidate = str(rng.randint(0, 8))
     if candidate >= original:
@@ -173,4 +213,5 @@ __all__ = [
     "preserve_date_format",
     "preserve_email_pattern",
     "preserve_id_pattern",
+    "mask_aadhaar",
 ]

--- a/openmed/core/anonymizer/providers/clinical_ids.py
+++ b/openmed/core/anonymizer/providers/clinical_ids.py
@@ -567,15 +567,21 @@ def _verhoeff_checksum(digits: Sequence[int]) -> int:
     return _VERHOEFF_INV[c]
 
 
+def generate_aadhaar(*, rng: random.Random | None = None) -> str:
+    """Generate a 12-digit Aadhaar value with a valid Verhoeff checksum."""
+
+    source = rng or random.Random()
+    digits = [source.randint(2, 9)]
+    digits.extend(source.randint(0, 9) for _ in range(10))
+    digits.append(_verhoeff_checksum(digits))
+    return "".join(str(digit) for digit in digits)
+
+
 class AadhaarProvider(BaseProvider):
     """Generates 12-digit Aadhaar numbers with valid Verhoeff checksums."""
 
     def aadhaar(self) -> str:
-        # First digit cannot be 0 or 1 per UIDAI spec.
-        digits = [self.generator.random.randint(2, 9)]
-        digits.extend(self.generator.random.randint(0, 9) for _ in range(10))
-        digits.append(_verhoeff_checksum(digits))
-        return "".join(str(d) for d in digits)
+        return generate_aadhaar(rng=self.generator.random)
 
 
 # ---------------------------------------------------------------------------
@@ -2387,6 +2393,7 @@ __all__ = [
     "generate_australian_medicare",
     "generate_australian_tfn",
     "generate_abha_number",
+    "generate_aadhaar",
     "generate_bc_phn",
     "generate_bic",
     "generate_bulgarian_egn",

--- a/openmed/core/anonymizer/providers/registry_ids.py
+++ b/openmed/core/anonymizer/providers/registry_ids.py
@@ -340,7 +340,7 @@ def _register_builtin_specs() -> None:
         faker_method="ssn",
     )
     _register_aliases(
-        ("in", "hi", "te", "en_IN", "hi_IN"),
+        ("in", "india", "en", "hi", "te", "en_IN", "hi_IN", "te_IN"),
         id_type="aadhaar",
         validate=validate_aadhaar,
         faker_method="aadhaar",

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -64,6 +64,7 @@ from .result_cache import (
 # Type alias for de-identification methods
 DEIDENTIFICATION_METHODS = (
     "mask",
+    "aadhaar_mask",
     "remove",
     "replace",
     "hash",
@@ -72,6 +73,7 @@ DEIDENTIFICATION_METHODS = (
 )
 DeidentificationMethod = Literal[
     "mask",
+    "aadhaar_mask",
     "remove",
     "replace",
     "hash",
@@ -1925,6 +1927,8 @@ def deidentify(
     Implements multiple de-identification strategies for HIPAA compliance:
 
     - **mask**: Replace with placeholders like [NAME], [EMAIL], etc.
+    - **aadhaar_mask**: Render valid Aadhaar values as ``XXXX XXXX NNNN``;
+      use ordinary placeholders for every other entity
     - **remove**: Remove PII text entirely (empty string)
     - **replace**: Replace with fake but realistic data
     - **hash**: Replace with consistent hashed values for entity linking
@@ -1937,8 +1941,8 @@ def deidentify(
 
     Args:
         text: Input text to de-identify
-        method: De-identification method (mask, remove, replace, hash,
-            shift_dates, format_preserve)
+        method: De-identification method (mask, aadhaar_mask, remove, replace,
+            hash, shift_dates, format_preserve)
         model_name: PII detection model
         confidence_threshold: Minimum confidence for redaction (default 0.7 for safety)
         keep_year: For dates, keep the year unchanged
@@ -2145,6 +2149,16 @@ def _redact_entity(
     """
     if method == "mask":
         # Replace with placeholder
+        return _mask_placeholder(entity)
+
+    elif method == "aadhaar_mask":
+        original = entity.original_text or entity.text
+        from .pii_i18n import validate_aadhaar
+
+        if validate_aadhaar(original):
+            from .anonymizer.format_preserve import mask_aadhaar
+
+            return mask_aadhaar(original)
         return _mask_placeholder(entity)
 
     elif method == "remove":

--- a/openmed/core/pii_entity_merger.py
+++ b/openmed/core/pii_entity_merger.py
@@ -32,6 +32,8 @@ class PIIPattern:
     - base_score: Low confidence for pattern-only matches (like Presidio's 0.01-0.3)
     - context_words: Keywords that boost confidence when found nearby
     - validator: Optional checksum/validation function to confirm matches
+    - reject_on_validation_failure: Drop regex matches whose validator fails,
+      rather than retaining them with a reduced confidence score
     - safety_sweep_requires_context: Require nearby context before the
       deterministic safety sweep accepts this pattern
 
@@ -58,6 +60,7 @@ class PIIPattern:
         None  # Validation function (e.g., checksum)
     )
     safety_sweep_requires_context: bool = False
+    reject_on_validation_failure: bool = False
 
 
 # ============================================================================
@@ -628,6 +631,8 @@ def find_semantic_units(
             if pii_pattern.validator:
                 is_valid = pii_pattern.validator(matched_text)
                 if not is_valid:
+                    if pii_pattern.reject_on_validation_failure:
+                        continue
                     # Failed validation - significantly reduce score
                     score = score * 0.3  # Reduce to 30% confidence
                     validated = False

--- a/openmed/core/pii_i18n.py
+++ b/openmed/core/pii_i18n.py
@@ -569,19 +569,22 @@ def validate_aadhaar(text: str) -> bool:
     Verhoeff check digit.
 
     Args:
-        text: Aadhaar string (may contain spaces or separators)
+        text: Aadhaar string, either as 12 digits or in the UIDAI 4-4-4
+            display form.
 
     Returns:
         True if the Aadhaar passes the Verhoeff checksum
     """
-    digits = re.sub(r"[^0-9]", "", text)
-
-    if len(digits) != 12:
+    candidate = text.strip()
+    if (
+        re.fullmatch(
+            r"[2-9][0-9]{11}|[2-9][0-9]{3} [0-9]{4} [0-9]{4}",
+            candidate,
+        )
+        is None
+    ):
         return False
-
-    # First digit cannot be 0 or 1
-    if digits[0] in ("0", "1"):
-        return False
+    digits = candidate.replace(" ", "")
 
     # Verhoeff checksum
     c = 0
@@ -2660,6 +2663,36 @@ MRZ_PII_PATTERNS: List[PIIPattern] = [
     ),
 ]
 
+# Aadhaar is language-agnostic in Indian clinical notes: English labels and
+# Romanized code-mixed text are common alongside Devanagari or Telugu cues.
+# The strict validator gate prevents phone-like or random 12-digit values from
+# being promoted to a national identifier by this deterministic recognizer.
+AADHAAR_PII_PATTERNS: List[PIIPattern] = [
+    PIIPattern(
+        r"(?<![0-9])[2-9][0-9]{3}(?P<aadhaar_sep> ?)[0-9]{4}"
+        r"(?P=aadhaar_sep)[0-9]{4}(?![0-9])",
+        "national_id",
+        priority=12,
+        base_score=0.55,
+        context_words=[
+            "आधार",
+            "यूआईडीएआई",
+            "पहचान",
+            "aadhaar",
+            "aadhar",
+            "uid",
+            "uidai",
+            "unique identification",
+            "ఆధార్",
+            "గుర్తింపు",
+        ],
+        context_boost=0.4,
+        validator=validate_aadhaar,
+        reject_on_validation_failure=True,
+        safety_sweep_requires_context=True,
+    ),
+]
+
 _FRENCH_PII_PATTERNS: List[PIIPattern] = [
     # French dates DD/MM/YYYY
     PIIPattern(
@@ -3378,22 +3411,6 @@ _HINDI_PII_PATTERNS: List[PIIPattern] = [
         context_boost=0.5,
         safety_sweep_requires_context=True,
     ),
-    # Aadhaar (12 digits, possibly spaced as 4-4-4)
-    PIIPattern(
-        r"\b\d{4}\s?\d{4}\s?\d{4}\b",
-        "national_id",
-        priority=9,
-        base_score=0.4,
-        context_words=[
-            "\u0906\u0927\u093e\u0930",
-            "aadhaar",
-            "\u092f\u0942\u0906\u0908\u0921\u0940\u090f\u0906\u0908",
-            "uid",
-            "\u092a\u0939\u091a\u093e\u0928",
-        ],
-        context_boost=0.45,
-        validator=validate_aadhaar,
-    ),
 ]
 
 _TELUGU_PII_PATTERNS: List[PIIPattern] = [
@@ -3461,21 +3478,6 @@ _TELUGU_PII_PATTERNS: List[PIIPattern] = [
         ],
         context_boost=0.5,
         safety_sweep_requires_context=True,
-    ),
-    # Aadhaar (12 digits, possibly spaced as 4-4-4)
-    PIIPattern(
-        r"\b\d{4}\s?\d{4}\s?\d{4}\b",
-        "national_id",
-        priority=9,
-        base_score=0.4,
-        context_words=[
-            "\u0c06\u0c27\u0c3e\u0c30\u0c4d",
-            "aadhaar",
-            "uid",
-            "\u0c17\u0c41\u0c30\u0c4d\u0c24\u0c3f\u0c02\u0c2a\u0c41",
-        ],
-        context_boost=0.45,
-        validator=validate_aadhaar,
     ),
 ]
 
@@ -6011,8 +6013,10 @@ LANGUAGE_PII_PATTERNS: Dict[str, List[PIIPattern]] = {
     "es": _SPANISH_PII_PATTERNS,
     "pt": _PORTUGUESE_PII_PATTERNS,
     "nl": _DUTCH_PII_PATTERNS,
-    "hi": _HINDI_PII_PATTERNS,
-    "te": _TELUGU_PII_PATTERNS,
+    # Keep Aadhaar discoverable through the historical per-language mapping
+    # while get_patterns_for_language deduplicates the universal rule.
+    "hi": [*_HINDI_PII_PATTERNS, *AADHAAR_PII_PATTERNS],
+    "te": [*_TELUGU_PII_PATTERNS, *AADHAAR_PII_PATTERNS],
     "ar": _ARABIC_PII_PATTERNS,
     "he": _HEBREW_PII_PATTERNS,
     "ja": _JAPANESE_PII_PATTERNS,
@@ -6889,13 +6893,20 @@ def get_patterns_for_language(lang: str, locale: str | None = None) -> List[PIIP
 
     from .pii_entity_merger import PII_PATTERNS
 
-    # English patterns serve as universal base
-    # MRZ and USCC patterns are language-agnostic, so they join the universal base.
-    base = list(PII_PATTERNS) + MRZ_PII_PATTERNS + USCC_PII_PATTERNS
+    # English patterns serve as universal base. MRZ, USCC, and Aadhaar patterns
+    # are language-agnostic, so they join the universal base for every route.
+    base = (
+        list(PII_PATTERNS) + MRZ_PII_PATTERNS + USCC_PII_PATTERNS + AADHAAR_PII_PATTERNS
+    )
 
     combined = base
     if base_lang != "en":
-        combined = combined + LANGUAGE_PII_PATTERNS.get(base_lang, [])
+        language_patterns = LANGUAGE_PII_PATTERNS.get(base_lang, [])
+        combined = combined + [
+            pattern
+            for pattern in language_patterns
+            if not any(pattern is existing for existing in combined)
+        ]
 
     for locale_key in _locale_pattern_keys(lang, locale):
         combined = combined + LOCALE_PII_PATTERNS.get(locale_key, [])

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -23,6 +23,7 @@ from .schemas.span import ACTION_KEEP, OpenMedSpan, hmac_text_hash
 # which otherwise imports ``Pipeline`` only when ``deidentify`` is called.
 DeidentificationMethod = Literal[
     "mask",
+    "aadhaar_mask",
     "remove",
     "replace",
     "hash",

--- a/openmed/core/safety_sweep.py
+++ b/openmed/core/safety_sweep.py
@@ -51,7 +51,9 @@ def _overlaps(start: int, end: int, spans: Sequence[Any]) -> bool:
 
 def _patterns_for_language(lang: str, locale: str | None = None) -> list[PIIPattern]:
     if lang == "en" and locale is None:
-        return list(PII_PATTERNS)
+        from .pii_i18n import AADHAAR_PII_PATTERNS
+
+        return [*PII_PATTERNS, *AADHAAR_PII_PATTERNS]
 
     from .pii_i18n import get_patterns_for_language
 

--- a/openmed/eval/golden/fixtures/aadhaar.json
+++ b/openmed/eval/golden/fixtures/aadhaar.json
@@ -1,0 +1,85 @@
+{
+  "fixtures": [
+    {
+      "gold_spans": [
+        {
+          "end": 46,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "aadhaar"
+          },
+          "start": 32,
+          "text": "9664 8088 5109"
+        }
+      ],
+      "id": "golden-aadhaar-english-masking",
+      "language": "en",
+      "metadata": {
+        "category": "checksum_ids",
+        "expected_output": {
+          "method": "aadhaar_mask",
+          "text": "Synthetic English note: Aadhaar XXXX XXXX 5109; invalid UID 919876543210; masked copy XXXX XXXX 5109."
+        },
+        "hard_negatives": [
+          {
+            "end": 72,
+            "identifier_type": "aadhaar",
+            "reason": "fails_verhoeff",
+            "start": 60,
+            "text": "919876543210"
+          },
+          {
+            "end": 100,
+            "identifier_type": "masked_aadhaar",
+            "reason": "already_masked",
+            "start": 86,
+            "text": "XXXX XXXX 5109"
+          }
+        ],
+        "locale": "en_IN",
+        "synthetic": true
+      },
+      "text": "Synthetic English note: Aadhaar 9664 8088 5109; invalid UID 919876543210; masked copy XXXX XXXX 5109."
+    },
+    {
+      "gold_spans": [
+        {
+          "end": 57,
+          "label": "ID_NUM",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "aadhaar"
+          },
+          "start": 43,
+          "text": "4679 3014 1424"
+        }
+      ],
+      "id": "golden-aadhaar-code-mixed-masking",
+      "language": "en",
+      "metadata": {
+        "category": "checksum_ids",
+        "expected_output": {
+          "method": "aadhaar_mask",
+          "text": "Synthetic code-mixed note: मरीज का Aadhaar XXXX XXXX 1424 है; random 234567890123."
+        },
+        "hard_negatives": [
+          {
+            "end": 81,
+            "identifier_type": "aadhaar",
+            "reason": "fails_verhoeff",
+            "start": 69,
+            "text": "234567890123"
+          }
+        ],
+        "locale": "en_IN",
+        "synthetic": true
+      },
+      "text": "Synthetic code-mixed note: मरीज का Aadhaar 4679 3014 1424 है; random 234567890123."
+    }
+  ],
+  "notice": "Synthetic-only Aadhaar fixtures; no DUA data and no real PHI.",
+  "suite": "golden",
+  "synthetic": true,
+  "version": 1
+}

--- a/tests/unit/core/test_aadhaar.py
+++ b/tests/unit/core/test_aadhaar.py
@@ -1,0 +1,203 @@
+"""Aadhaar detection, masking, and surrogate hardening tests."""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+from pathlib import Path
+
+import pytest
+
+from openmed.core.anonymizer import Anonymizer
+from openmed.core.anonymizer.format_preserve import mask_aadhaar
+from openmed.core.anonymizer.providers.clinical_ids import generate_aadhaar
+from openmed.core.anonymizer.providers.registry_ids import get_national_id
+from openmed.core.pii_entity_merger import find_semantic_units
+from openmed.core.pii_i18n import get_patterns_for_language, validate_aadhaar
+from openmed.core.pipeline import Pipeline
+from openmed.core.safety_sweep import safety_sweep
+from openmed.core.surrogate_vault import HMAC_SCHEME, SurrogateVault
+from openmed.processing.outputs import PredictionResult
+
+FIXTURE_PATH = Path("openmed/eval/golden/fixtures/aadhaar.json")
+
+
+def _fixture_rows() -> list[dict[str, object]]:
+    payload = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    return payload["fixtures"]
+
+
+def _empty_detector(text: str, **_kwargs: object) -> PredictionResult:
+    return PredictionResult(
+        text=text,
+        entities=[],
+        model_name="synthetic-empty-detector",
+        timestamp="2026-01-01T00:00:00Z",
+    )
+
+
+def _pipeline(*, lang: str = "en") -> Pipeline:
+    return Pipeline(
+        lang=lang,
+        model_detector=_empty_detector,
+        use_smart_merging=True,
+        use_safety_sweep=True,
+    )
+
+
+def test_fixture_validators_and_invalid_corpus_agree() -> None:
+    invalid_values: list[str] = []
+    for row in _fixture_rows():
+        text = str(row["text"])
+        for span in row["gold_spans"]:
+            value = span["text"]
+            assert text[span["start"] : span["end"]] == value
+            assert validate_aadhaar(value)
+        for negative in row["metadata"]["hard_negatives"]:
+            value = negative["text"]
+            assert text[negative["start"] : negative["end"]] == value
+            if negative["reason"] == "fails_verhoeff":
+                invalid_values.append(value)
+
+    invalid_values.extend(
+        [
+            "681937567570",
+            "123456789012",
+            "081937567577",
+            "+91 6819375675",
+            "6819-3756-7577",
+        ]
+    )
+    assert invalid_values
+    assert not any(validate_aadhaar(value) for value in invalid_values)
+
+
+def test_generated_aadhaar_corpus_is_always_verhoeff_valid() -> None:
+    source = random.Random(666)
+    generated = [generate_aadhaar(rng=source) for _ in range(500)]
+
+    assert len(set(generated)) == len(generated)
+    assert all(value[0] not in "01" for value in generated)
+    assert all(validate_aadhaar(value) for value in generated)
+
+
+@pytest.mark.parametrize("alias", ["en", "hi", "in", "india", "en_IN", "hi_IN"])
+def test_aadhaar_registry_maps_english_hindi_and_india_aliases(alias: str) -> None:
+    spec = get_national_id(alias, "aadhaar")
+
+    assert spec is not None
+    assert spec.faker_method == "aadhaar"
+    assert spec.validate(generate_aadhaar(rng=random.Random(42)))
+
+
+@pytest.mark.parametrize("lang", ["en", "hi", "te"])
+def test_aadhaar_pattern_is_language_agnostic_and_strict(lang: str) -> None:
+    patterns = get_patterns_for_language(lang)
+    valid_text = "Aadhaar पहचान: 9664 8088 5109"
+    invalid_text = "UID: 919876543210"
+
+    valid_units = [
+        unit
+        for unit in find_semantic_units(valid_text, patterns)
+        if unit[2] == "national_id"
+    ]
+    invalid_units = [
+        unit
+        for unit in find_semantic_units(invalid_text, patterns)
+        if unit[2] == "national_id"
+    ]
+
+    assert len(valid_units) == 1
+    assert valid_text[valid_units[0][0] : valid_units[0][1]] == "9664 8088 5109"
+    assert valid_units[0][5] is True
+    assert invalid_units == []
+
+
+def test_safety_sweep_rejects_phone_like_random_and_masked_values() -> None:
+    text = (
+        "Aadhaar 966480885109; phone-like 919876543210; "
+        "random 234567890123; masked XXXX XXXX 5109."
+    )
+    entities = safety_sweep(text, [], lang="en")
+    national_ids = [entity for entity in entities if entity.label == "national_id"]
+
+    assert [entity.text for entity in national_ids] == ["966480885109"]
+
+
+def test_safety_sweep_requires_aadhaar_context_even_for_valid_checksum() -> None:
+    assert safety_sweep("Reference 966480885109", [], lang="en") == []
+
+
+def test_uidai_masking_is_exact_idempotent_and_never_returns_first_eight() -> None:
+    assert mask_aadhaar("966480885109") == "XXXX XXXX 5109"
+    assert mask_aadhaar("9664 8088 5109") == "XXXX XXXX 5109"
+    assert mask_aadhaar("xxxx-xxxx-5109") == "XXXX XXXX 5109"
+    assert "96648088" not in mask_aadhaar("966480885109")
+
+    with pytest.raises(ValueError, match="12 digits"):
+        mask_aadhaar("9198765432")
+    with pytest.raises(ValueError, match="Verhoeff"):
+        mask_aadhaar("919876543210")
+
+
+def test_anonymizer_exposes_mask_and_valid_surrogate_strategies() -> None:
+    anonymizer = Anonymizer(lang="en", consistent=True, seed=666)
+
+    masked = anonymizer.anonymize_aadhaar("9664 8088 5109")
+    surrogate = anonymizer.anonymize_aadhaar(
+        "9664 8088 5109",
+        strategy="surrogate",
+    )
+
+    assert masked == "XXXX XXXX 5109"
+    assert validate_aadhaar(surrogate)
+    assert surrogate != "966480885109"
+
+    with pytest.raises(ValueError, match="Verhoeff"):
+        anonymizer.anonymize_aadhaar("919876543210")
+
+
+@pytest.mark.parametrize("row", _fixture_rows(), ids=lambda row: row["id"])
+def test_pipeline_detects_and_uidai_masks_english_and_code_mixed_notes(
+    row: dict[str, object],
+) -> None:
+    text = str(row["text"])
+    result = _pipeline(lang=str(row["language"])).run(text, method="aadhaar_mask")
+    deidentified = result.deidentification_result
+
+    assert deidentified.deidentified_text == row["metadata"]["expected_output"]["text"]
+    for span in row["gold_spans"]:
+        assert span["text"] not in deidentified.deidentified_text
+    for negative in row["metadata"]["hard_negatives"]:
+        assert negative["text"] in deidentified.deidentified_text
+
+
+def test_english_replace_uses_valid_vault_stable_aadhaar_without_logging_source(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_aadhaar = "9664 8088 5109"
+    text = f"Aadhaar: {raw_aadhaar}"
+    vault = SurrogateVault.in_memory("synthetic-unit-test-secret")
+    pipeline = _pipeline()
+
+    with caplog.at_level(logging.DEBUG):
+        first = pipeline.run(
+            text,
+            method="replace",
+            surrogate_vault=vault,
+        ).deidentification_result
+        second = pipeline.run(
+            text,
+            method="replace",
+            surrogate_vault=vault,
+        ).deidentification_result
+
+    first_surrogate = first.pii_entities[0].surrogate
+    second_surrogate = second.pii_entities[0].surrogate
+    assert first_surrogate == second_surrogate
+    assert first_surrogate is not None and validate_aadhaar(first_surrogate)
+    assert raw_aadhaar not in first.deidentified_text
+    assert raw_aadhaar not in caplog.text
+    assert len(vault.entries()) == 1
+    assert vault.entries()[0].key.text_hash.startswith(f"{HMAC_SCHEME}:")

--- a/tests/unit/test_pii_i18n.py
+++ b/tests/unit/test_pii_i18n.py
@@ -28,6 +28,7 @@ from openmed.core.anonymizer.providers.clinical_ids import (
 )
 from openmed.core.pii_entity_merger import PII_PATTERNS, PIIPattern, find_semantic_units
 from openmed.core.pii_i18n import (
+    AADHAAR_PII_PATTERNS,
     DEFAULT_PII_MODELS,
     LANGUAGE_FAKE_DATA,
     LANGUAGE_MODEL_PREFIX,
@@ -2183,122 +2184,30 @@ class TestGetPatternsForLanguage:
     def test_english_returns_base_patterns(self):
         patterns = get_patterns_for_language("en")
         assert len(patterns) == (
-            len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
+            len(PII_PATTERNS)
+            + len(MRZ_PII_PATTERNS)
+            + len(USCC_PII_PATTERNS)
+            + len(AADHAAR_PII_PATTERNS)
         )
 
-    def test_french_includes_base_and_language(self):
-        fr_patterns = get_patterns_for_language("fr")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["fr"])
-        assert len(fr_patterns) == base_count + lang_count
-
-    def test_german_includes_base_and_language(self):
-        de_patterns = get_patterns_for_language("de")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["de"])
-        assert len(de_patterns) == base_count + lang_count
-
-    def test_italian_includes_base_and_language(self):
-        it_patterns = get_patterns_for_language("it")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["it"])
-        assert len(it_patterns) == base_count + lang_count
-
-    def test_spanish_includes_base_and_language(self):
-        es_patterns = get_patterns_for_language("es")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["es"])
-        assert len(es_patterns) == base_count + lang_count
-
-    def test_portuguese_includes_base_and_language(self):
-        pt_patterns = get_patterns_for_language("pt")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["pt"])
-        assert len(pt_patterns) == base_count + lang_count
-
-    def test_dutch_includes_base_and_language(self):
-        nl_patterns = get_patterns_for_language("nl")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["nl"])
-        assert len(nl_patterns) == base_count + lang_count
-
-    def test_hindi_includes_base_and_language(self):
-        hi_patterns = get_patterns_for_language("hi")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["hi"])
-        assert len(hi_patterns) == base_count + lang_count
-
-    def test_telugu_includes_base_and_language(self):
-        te_patterns = get_patterns_for_language("te")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["te"])
-        assert len(te_patterns) == base_count + lang_count
-
-    def test_arabic_includes_base_and_language(self):
-        ar_patterns = get_patterns_for_language("ar")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["ar"])
-        assert len(ar_patterns) == base_count + lang_count
-
-    def test_hebrew_includes_base_and_language(self):
-        he_patterns = get_patterns_for_language("he")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["he"])
-        assert len(he_patterns) == base_count + lang_count
-
-    def test_japanese_includes_base_and_language(self):
-        ja_patterns = get_patterns_for_language("ja")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["ja"])
-        assert len(ja_patterns) == base_count + lang_count
-
-    def test_turkish_includes_base_and_language(self):
-        tr_patterns = get_patterns_for_language("tr")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["tr"])
-        assert len(tr_patterns) == base_count + lang_count
-
-    def test_thai_includes_base_and_language(self):
-        th_patterns = get_patterns_for_language("th")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["th"])
-        assert len(th_patterns) == base_count + lang_count
-
-    def test_indonesian_includes_base_and_language(self):
-        id_patterns = get_patterns_for_language("id")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["id"])
-        assert len(id_patterns) == base_count + lang_count
-
-    def test_slovak_includes_base_and_language(self):
-        sk_patterns = get_patterns_for_language("sk")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["sk"])
-        assert len(sk_patterns) == base_count + lang_count
-
-    def test_malay_includes_base_and_language(self):
-        ms_patterns = get_patterns_for_language("ms")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["ms"])
-        assert len(ms_patterns) == base_count + lang_count
-
-    def test_tagalog_includes_base_and_language(self):
-        tl_patterns = get_patterns_for_language("tl")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["tl"])
-        assert len(tl_patterns) == base_count + lang_count
-
-    def test_danish_includes_base_and_language(self):
-        da_patterns = get_patterns_for_language("da")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["da"])
-        assert len(da_patterns) == base_count + lang_count
-
-    def test_korean_includes_base_and_language(self):
-        ko_patterns = get_patterns_for_language("ko")
-        base_count = len(PII_PATTERNS) + len(MRZ_PII_PATTERNS) + len(USCC_PII_PATTERNS)
-        lang_count = len(LANGUAGE_PII_PATTERNS["ko"])
-        assert len(ko_patterns) == base_count + lang_count
+    @pytest.mark.parametrize(
+        "lang",
+        sorted((SUPPORTED_LANGUAGES | NATIONAL_ID_ONLY_LANGUAGES) - {"en"}),
+    )
+    def test_language_includes_universal_base_and_language_patterns(self, lang):
+        patterns = get_patterns_for_language(lang)
+        base_count = (
+            len(PII_PATTERNS)
+            + len(MRZ_PII_PATTERNS)
+            + len(USCC_PII_PATTERNS)
+            + len(AADHAAR_PII_PATTERNS)
+        )
+        universal_patterns = MRZ_PII_PATTERNS + USCC_PII_PATTERNS + AADHAAR_PII_PATTERNS
+        language_count = sum(
+            not any(pattern is universal for universal in universal_patterns)
+            for pattern in LANGUAGE_PII_PATTERNS[lang]
+        )
+        assert len(patterns) == base_count + language_count
 
     def test_unsupported_language_raises(self):
         with pytest.raises(ValueError, match="Unsupported language"):


### PR DESCRIPTION
# Pull Request

## Description

Hardens Aadhaar de-identification by requiring a valid Verhoeff checksum before recognition, adding exact UIDAI-style masking, and ensuring deterministic replacement values remain checksum-valid. This closes detection gaps in English and code-mixed clinical notes while preventing checksum-invalid phone-like and random values from being mislabeled.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Adds a strict, language-agnostic Aadhaar recognizer with Romanized, Devanagari, and Telugu context cues.
- Adds exact `XXXX XXXX NNNN` masking and checksum-valid Aadhaar surrogate generation across English, Hindi, Telugu, and India locale aliases.
- Adds synthetic valid, invalid, and already-masked fixtures plus detector, leakage, vault determinism, and log-safety coverage.
- Requires Aadhaar/UID context in the deterministic safety sweep and preserves the existing ABDM-specific Aadhaar path after rebasing onto current `master`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

- Full required suite: 5,860 passed, 47 skipped.
- Focused Aadhaar, ABDM, multilingual-pattern, anonymizer, pipeline, safety-sweep, vault, and PII suites: 565 passed.
- Repository formatting, lint, format-check, scoped hooks, Bandit, secret scan, strict docs build, and package build pass.

## Documentation

- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

No user guide or changelog update is needed for this scoped implementation.

## Code Quality

- [x] I ran the repository formatting, lint, and format-check gates
- [ ] For Swift/OpenMedKit changes, I ran the Swift formatting and lint gates
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #1492

## Screenshots/Examples

Valid Aadhaar values are rendered exactly as `XXXX XXXX NNNN`; checksum-invalid 12-digit values remain untouched by the Aadhaar recognizer.
