### PR TITLE
docs: add Android quickstart covering setup, model load, and redaction

### DIFF
--- a/docs/android-quickstart.md
+++ b/docs/android-quickstart.md
@@ -1,0 +1,142 @@
+# Android Quickstart (OpenMedKit)
+
+OpenMedKit Android is the on-device counterpart to the
+[Swift Package (OpenMedKit)](swift-openmedkit.md). It loads a de-identification
+model from the on-device model catalog and redacts clinical text entirely on the
+handset — no network access and no cloud fallback for PHI.
+
+This page walks through the first-run path: add the Gradle dependency, load a
+model from the catalog, and redact a synthetic clinical note.
+
+## Requirements
+
+| Requirement | Value |
+| --- | --- |
+| Minimum Android API | 26 (Android 8.0) |
+| Compile / target SDK | 33 |
+| Build JDK | 11 |
+| Language | Kotlin (coroutines) |
+
+The library performs inference on device via ONNX Runtime Mobile. See
+[Android ONNX Export](export-onnx-android.md) for producing a compatible model
+artifact and [Android Span Parity](android-parity.md) for the cross-platform
+span guarantees.
+
+## Install
+
+OpenMedKit Android is published from immutable OpenMed release tags through
+JitPack. Add the scoped repository in the consumer application's
+`settings.gradle.kts`:
+
+```kotlin
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url = uri("https://jitpack.io")
+            content { includeGroup("com.github.maziyarpanahi") }
+        }
+    }
+}
+```
+
+Then add the release coordinate in the module `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("com.github.maziyarpanahi:openmed:v1.9.1")
+}
+```
+
+JitPack resolves the immutable `v1.9.1` tag and publishes the `openmedkit`
+Android release component as an AAR. Public consumers do not need GitHub
+credentials.
+
+## Quick Start: Kotlin
+
+The snippet below discovers a model in the on-device catalog, resolves its
+cached directory, constructs an `OpenMedKit` facade, and de-identifies a
+synthetic, non-PHI clinical note. `deidentify` is a `suspend` function, so call
+it from a coroutine.
+
+```kotlin
+import android.content.Context
+import com.openmed.openmedkit.OpenMedBackend
+import com.openmed.openmedkit.OpenMedKit
+import com.openmed.openmedkit.cache.ModelCache
+import com.openmed.openmedkit.catalog.ModelCatalog
+import java.io.File
+
+suspend fun redactSyntheticNote(context: Context): String {
+    // 1. Load the bundled on-device model catalog and pick an entry.
+    val catalog = ModelCatalog.load(context)
+    val entry = catalog.entries.first()
+
+    // 2. Resolve the model's on-device directory from the local cache.
+    val cache = ModelCache(rootDirectory = File(context.filesDir, "openmed-models"))
+    require(cache.isAvailable(entry.repoId)) {
+        "Model ${entry.repoId} is not present on device yet."
+    }
+    val modelDirectory = cache.modelDirectory(entry.repoId)
+
+    // 3. Build the local-first backend and facade.
+    val backend = OpenMedBackend(modelDirectory = modelDirectory)
+
+    // 4. De-identify a synthetic (fictional, non-PHI) clinical note.
+    val syntheticNote =
+        "Patient: Jane Roe (synthetic). MRN 000-00-0000. " +
+            "Seen on 2024-01-02 for routine follow-up; contact 555-0100."
+
+    return OpenMedKit(backend).use { kit ->
+        val result = kit.deidentify(syntheticNote)
+        result.redactedText
+    }
+}
+```
+
+By default `deidentify` applies the bundled `hipaa_safe_harbor` policy profile;
+pass `policy = "..."` to select another bundled profile. The returned
+`PolicyDeidentificationResult` exposes `redactedText`, the applied `policyName`,
+and the per-span `actions`.
+
+## Public API
+
+| Symbol | Purpose |
+| --- | --- |
+| `OpenMedBackend` | Local-first configuration pointing at an on-device model directory and tokenizer assets. Performs no network access. |
+| `OpenMedKit` | `Closeable` facade. `deidentify(text, policy, …)` redacts under a bundled policy; `extractPii(text, …)` and `extractPiiChunked(text, …)` return detected `EntityPrediction` spans. |
+| `ModelCatalog` | Reads the bundled `openmed_model_catalog.jsonl` asset into `ModelCatalogEntry` rows (`repoId`, `formats`, `languages`, …). |
+| `ModelCache` | Resolves and manages on-device model directories keyed by `repoId`. |
+
+## Local-First Guarantees
+
+OpenMedKit Android is deliberately local-first:
+
+- **On-device only.** All tokenization, inference, and de-identification run on
+  the handset. `OpenMedBackend` reads model and tokenizer assets from a local
+  directory and performs no network access.
+- **No cloud fallback for PHI.** There is no remote inference path; clinical text
+  is never transmitted off the device for processing.
+- **No PHI in logs.** The library does not log input text, detected spans, or
+  redacted output. Do not add application logging that echoes clinical text.
+- **Not a clinical decision.** Output is an assistive redaction aid, not medical
+  advice or a clinical decision. De-identification is best-effort and must be
+  reviewed before any downstream use; it does not guarantee removal of every
+  identifier.
+
+## Demo Apps
+
+Two runnable Android demos exercise the on-device path end to end:
+
+- [`android/OpenMedDemo`](https://github.com/maziyarpanahi/openmed/tree/master/android/OpenMedDemo)
+  — Compose de-identification demo over a synthetic note.
+- [`android/OpenMedScanDemo`](https://github.com/maziyarpanahi/openmed/tree/master/android/OpenMedScanDemo)
+  — on-device capture-and-redact demo.
+
+## See Also
+
+- [Swift Package (OpenMedKit)](swift-openmedkit.md) — the Apple-platform counterpart.
+- [Swift-Kotlin API Parity](swift-kotlin-parity.md) — cross-platform API alignment.
+- [Android ONNX Export](export-onnx-android.md) — producing a compatible on-device model.
+- [Model Manifest](model-manifest.md) — the model catalog and reproducibility metadata.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - MLX Quantized Export: export-mlx-quant.md
       - Transformers.js Export: export-transformersjs.md
       - ONNX Runtime Web Loader: runtimes/onnxruntime-web.md
+      - Android Quickstart: android-quickstart.md
       - Android ONNX Export: export-onnx-android.md
       - Android Span Parity: android-parity.md
       - CoreML Packaging: coreml-export.md


### PR DESCRIPTION
## Summary

Implements #586: adds `docs/android-quickstart.md`, the on-device Android counterpart to the existing `docs/swift-openmedkit.md` page. Until now there was no single page showing an Android developer how to add the dependency, load a model, and redact text, so the first-run experience was undocumented.

The page mirrors the Swift page's structure and covers:

- **Install** — the JitPack `settings.gradle.kts` repository block and the release coordinate `implementation("com.github.maziyarpanahi:openmed:v1.9.1")`.
- **Requirements** — minimum Android API 26 (Android 8.0), compile/target SDK 33, JDK 11.
- **Quick Start: Kotlin** — a runnable snippet that loads a model from the on-device catalog (`ModelCatalog.load` → `ModelCache.modelDirectory` → `OpenMedBackend`) and calls `OpenMedKit.deidentify` on a synthetic, non-PHI clinical note, returning `redactedText`.
- **Public API** — brief table of `OpenMedBackend`, `OpenMedKit`, `ModelCatalog`, `ModelCache`.
- **Local-first guarantees** — on-device only, no cloud fallback for PHI, no PHI in logs, and the medical-device disclaimer that output is not a clinical decision.
- **Cross-links** — the two Android demo apps, the Swift counterpart, the ONNX export and span-parity pages, and the model manifest.

## Accuracy

Every API symbol, Gradle coordinate, and SDK level in the doc was read from the current source (`android/openmedkit/`, `android/README.md`, `build.gradle.kts`) rather than invented — including the `suspend deidentify` signature, the `hipaa_safe_harbor` default policy, and the `ModelCatalog`/`ModelCache` load path. The clinical note in the snippet is fictional/synthetic.

## Scope notes

- **2 files**, matching the issue: `docs/android-quickstart.md` (new) and one nav line in `mkdocs.yml`.
- Added under the existing **Apple Silicon & Mobile** nav section, grouped with the other Android entries. I did not rename the section — it already reads "& Mobile", and renaming would touch unrelated nav.
- I did not add a reciprocal cross-link from the Swift page (the issue allows but does not require it); happy to add it if preferred.

## Verification

- `mkdocs build --strict`: passes (exit 0, no warnings-as-errors); the new page renders.
- Out of scope, as stated in the issue: no Android library code changes, no model-catalog API reference (covered by the manifest/integration docs), no screenshots.

Closes #586