### PR TITLE
fix(cli): forward date-shift options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `openmed deid` and `openmed pii deidentify` commands now accept
+  `--date-shift-days` for `shift_dates`; omitting the legacy `--shift-dates`
+  flag no longer conflicts with an explicitly selected `--method shift_dates`.
+
 ## [1.9.1] - 2026-07-14
 
 This patch completes the `1.9` distribution rollout without changing the

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -390,6 +390,12 @@ def _add_deid_command(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Keep year in dates.",
     )
+    deid_parser.add_argument(
+        "--date-shift-days",
+        type=int,
+        default=None,
+        help="Shift dates by this many days when using the shift_dates method.",
+    )
     deid_parser.set_defaults(handler=_handle_deid)
 
 
@@ -543,7 +549,14 @@ def _add_pii_command(subparsers: argparse._SubParsersAction) -> None:
     deid_parser.add_argument(
         "--shift-dates",
         action="store_true",
+        default=None,
         help="Shift dates by random offset.",
+    )
+    deid_parser.add_argument(
+        "--date-shift-days",
+        type=int,
+        default=None,
+        help="Shift dates by this many days when using the shift_dates method.",
     )
     deid_parser.add_argument(
         "--keep-mapping",
@@ -2898,6 +2911,7 @@ def _handle_deid(args: argparse.Namespace) -> int:
             confidence_threshold=args.confidence_threshold,
             keep_year=args.keep_year,
             keep_mapping=args.keep_mapping,
+            date_shift_days=args.date_shift_days,
             config=config,
             policy=args.policy,
             audit=args.audit,
@@ -2977,16 +2991,21 @@ def _handle_pii_deidentify(args: argparse.Namespace) -> int:
             sys.stderr.write(f"Input file not found: {args.input_file}\n")
             return 1
 
-    result = deidentify(
-        text,
-        method=args.method,
-        model_name=args.model,
-        confidence_threshold=args.confidence_threshold,
-        keep_year=args.keep_year,
-        shift_dates=args.shift_dates,
-        keep_mapping=args.keep_mapping,
-        config=config,
-    )
+    try:
+        result = deidentify(
+            text,
+            method=args.method,
+            model_name=args.model,
+            confidence_threshold=args.confidence_threshold,
+            keep_year=args.keep_year,
+            shift_dates=args.shift_dates,
+            date_shift_days=args.date_shift_days,
+            keep_mapping=args.keep_mapping,
+            config=config,
+        )
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
 
     if args.output:
         args.output.write_text(result.deidentified_text, encoding="utf-8")

--- a/tests/unit/cli/test_deid_cli.py
+++ b/tests/unit/cli/test_deid_cli.py
@@ -47,6 +47,109 @@ def test_deid_stdin_prints_deidentified_text_and_forwards_policy_method(
     assert calls["audit"] is False
 
 
+def test_deid_forwards_explicit_date_shift_days(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: dict[str, Any] = {}
+
+    def fake_deidentify(text: str, **kwargs: Any) -> SimpleNamespace:
+        calls["text"] = text
+        calls.update(kwargs)
+        return SimpleNamespace(deidentified_text="Visit on 2024-06-30", pii_entities=[])
+
+    monkeypatch.setattr(pii_module, "deidentify", fake_deidentify)
+    monkeypatch.setattr(main_module.sys, "stdin", io.StringIO("Visit on 2024-01-02"))
+
+    result = main_module.main(
+        ["deid", "--method", "shift_dates", "--date-shift-days", "180"]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.err == ""
+    assert calls["method"] == "shift_dates"
+    assert calls["date_shift_days"] == 180
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_method", "expected_shift_dates", "expected_date_shift_days"),
+    [
+        (["pii", "deidentify", "--method", "shift_dates"], "shift_dates", None, None),
+        (["pii", "deidentify", "--shift-dates"], "mask", True, None),
+        (
+            [
+                "pii",
+                "deidentify",
+                "--method",
+                "shift_dates",
+                "--date-shift-days",
+                "180",
+            ],
+            "shift_dates",
+            None,
+            180,
+        ),
+    ],
+)
+def test_pii_deidentify_forwards_date_shift_options(
+    argv: list[str],
+    expected_method: str,
+    expected_shift_dates: bool | None,
+    expected_date_shift_days: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: dict[str, Any] = {}
+
+    def fake_deidentify(text: str, **kwargs: Any) -> SimpleNamespace:
+        pii_module._resolve_deidentification_method(
+            kwargs["method"],
+            kwargs["shift_dates"],
+            kwargs["date_shift_days"],
+        )
+        calls["text"] = text
+        calls.update(kwargs)
+        return SimpleNamespace(deidentified_text="Visit on 2024-06-30", pii_entities=[])
+
+    monkeypatch.setattr(pii_module, "deidentify", fake_deidentify)
+
+    result = main_module.main([*argv, "--text", "Visit on 2024-01-02"])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.err == "\n[Redacted 0 entities]\n"
+    assert calls["method"] == expected_method
+    assert calls["shift_dates"] is expected_shift_dates
+    assert calls["date_shift_days"] == expected_date_shift_days
+
+
+def test_pii_deidentify_prints_date_shift_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_deidentify(text: str, **kwargs: Any) -> SimpleNamespace:
+        raise ValueError("date_shift_days requires method='shift_dates'")
+
+    monkeypatch.setattr(pii_module, "deidentify", fake_deidentify)
+
+    result = main_module.main(
+        [
+            "pii",
+            "deidentify",
+            "--text",
+            "Visit on 2024-01-02",
+            "--date-shift-days",
+            "180",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 2
+    assert captured.out == ""
+    assert captured.err == "date_shift_days requires method='shift_dates'\n"
+
+
 def test_deid_audit_writes_report_and_prints_path(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- add --date-shift-days to openmed deid and openmed pii deidentify
- forward explicit date-shift offsets to the existing de-identification API
- treat an omitted legacy --shift-dates flag as unspecified, preventing it from conflicting with --method shift_dates
- return a clean CLI validation error for invalid date-shift option combinations

## Why

The core API already supports explicit date-shift offsets, but neither CLI surface exposed that control. In addition, openmed pii deidentify --method shift_dates forwarded the absent legacy alias as False, causing a conflict before de-identification could run.

The legacy --shift-dates alias remains supported.

## Testing

- python -m pytest -q tests/unit/cli/test_deid_cli.py
- python -m ruff check openmed/cli/main.py tests/unit/cli/test_deid_cli.py
- python -m ruff format --check openmed/cli/main.py tests/unit/cli/test_deid_cli.py
- git diff --check

All focused checks pass.