### PR TITLE
docs: decide and document the on-device Android tokenization strategy

### DIFF
--- a/docs/android-tokenization.md
+++ b/docs/android-tokenization.md
@@ -1,0 +1,114 @@
+# Android Tokenization Strategy (Decision)
+
+Android token-classification inference needs WordPiece/BPE tokenization on
+device, with token-to-character offset mapping so detected tokens can be mapped
+back to character spans and turned into OpenMedSpan records. This page records
+the decision on how OpenMedKit Android tokenizes, the options considered, and
+the rationale.
+
+**Status:** Accepted. The decision below is embodied in the shipping
+`android/openmedkit` module.
+
+## Constraints
+
+Tokenization on Android must satisfy the same local-first guarantees as the
+rest of OpenMedKit:
+
+- **On-device only.** Tokenization runs entirely on the handset. No network
+  access is performed after the model and its tokenizer assets are downloaded;
+  there is no remote tokenization path.
+- **No PHI in logs.** The tokenizer must not log raw input text, token strings,
+  or character offsets. De-identification input is clinical text and must never
+  reach application or dependency logs.
+- **Permissive license only.** The tokenizer dependency must be permissively
+  licensed (Apache-2.0/MIT-style). No GPL/LGPL or proprietary tokenizer.
+- **Span-offset fidelity.** Char-level offset mapping must be faithful enough to
+  recover exact character spans for every detected entity.
+- **Python parity.** On-device tokenization must match OpenMed's Python
+  tokenization so span offsets and labels agree across platforms.
+
+## Options Considered
+
+Three realistic approaches were evaluated.
+
+| Criterion | DJL HuggingFace tokenizers AAR | Pure-Kotlin WordPiece | ORT-Extensions in-graph BertTokenizer |
+| --- | --- | --- | --- |
+| License | Apache-2.0 (DJL wrapper and the Rust `tokenizers` crate) | Project code (permissive) | MIT (`onnxruntime-extensions`) |
+| Offset mapping | Native char offsets from the Rust tokenizer `Encoding` — high fidelity | Must be re-implemented by hand; correctness is the author's burden | Limited; in-graph tokenizers do not cleanly expose char offsets for span recovery |
+| Binary / asset size | Adds a native `.so` per ABI to the APK; tokenizer asset is `tokenizer.json` | Smallest — no native library; tokenizer asset is `tokenizer.json`/`vocab.txt` | Tokenization baked into the `.ort` graph; no separate tokenizer runtime, larger graph |
+| Min SDK | 26 (matches the OpenMedKit module) | Unconstrained | Tied to the ONNX Runtime + Extensions build |
+| Python parity | Exact — consumes the same `tokenizer.json` as OpenMed's Python fast tokenizer | Approximate — must replicate normalization, pre-tokenization, and offsets | WordPiece/BERT only; no BPE; graph-encoded rules can drift from Python |
+
+### DJL HuggingFace tokenizers AAR
+
+`ai.djl.huggingface:tokenizers` wraps the same Rust `tokenizers` library that
+backs Hugging Face's Python fast tokenizers. It loads a `tokenizer.json` and
+returns an `Encoding` whose char-offset table maps every token back to the
+source string. Because it consumes the identical `tokenizer.json` that OpenMed's
+Python pipeline uses, WordPiece/BPE behavior, normalization, and offsets match
+by construction — the strongest possible parity guarantee. The cost is a native
+library per ABI in the APK and a minimum SDK of 26.
+
+### Pure-Kotlin WordPiece
+
+A hand-written WordPiece tokenizer has the smallest footprint and no native or
+copyleft dependency. The trade-off is implementation burden and parity risk: the
+normalization, pre-tokenization, and offset-mapping rules must be re-implemented
+to match the Python fast tokenizer exactly, and any drift silently corrupts span
+recovery. It also does not cover BPE-based checkpoints without additional work.
+
+### ORT-Extensions in-graph BertTokenizer
+
+ONNX Runtime Extensions can bake a `BertTokenizer` into the `.ort` graph, so the
+model accepts raw strings and no separate tokenizer runtime is shipped. However,
+in-graph tokenizers do not cleanly surface char-level offsets, which are required
+for span recovery; the approach is WordPiece/BERT-only (no BPE); and encoding
+rules frozen into the graph can drift from the Python tokenizer.
+
+## Decision
+
+- **Primary strategy: the DJL HuggingFace tokenizers AAR.** It is Apache-2.0
+  (permissive, no GPL), provides native high-fidelity char offsets for span
+  recovery, targets min SDK 26 (the module's floor), and gives exact parity with
+  OpenMed's Python tokenization because both consume the same `tokenizer.json`.
+  Span-offset fidelity and Python parity are the decisive factors, and they
+  outweigh the per-ABI native-library footprint. This is what the
+  `android/openmedkit` module ships today (`ai.djl.huggingface:tokenizers` with
+  `HuggingFaceTokenizer.newInstance(...)` and encoding offset mapping in
+  `Runtime.kt`).
+- **Fallback strategy: pure-Kotlin WordPiece.** If the AAR's native footprint
+  becomes unacceptable for a target deployment, a pure-Kotlin WordPiece
+  implementation is the fallback: it removes the native dependency at the cost of
+  significant implementation work and a parity-verification burden against the
+  Python tokenizer. Implementing it is a separate Android-module task.
+
+ORT-Extensions in-graph tokenization is **not** adopted, primarily because its
+weak char-offset support is incompatible with the span-recovery requirement.
+
+## Tokenizer Assets To Bundle
+
+The primary strategy consumes the exported Hugging Face fast-tokenizer assets
+from the model directory:
+
+- `tokenizer.json` — the fast-tokenizer definition (vocabulary, merges,
+  normalization, and pre-tokenization rules). Required by the DJL tokenizer.
+- `tokenizer_config.json` — special-token and configuration metadata.
+- `id2label.json` — the label map used to decode token-classification logits
+  into entity labels.
+
+These are emitted alongside the ONNX graph by the Android export task
+(`openmed/onnx/convert.py`; see [Android ONNX Export](export-onnx-android.md)),
+which writes the repository's tokenizer and label assets next to the exported
+model. Bundling the assets into the app or downloading them with the model is a
+separate task.
+
+## References
+
+- [Android ONNX Export](export-onnx-android.md) — the export matrix and the task
+  that emits the tokenizer and label assets.
+- [Android Span Parity](android-parity.md) — the cross-platform span guarantees
+  that offset fidelity must preserve.
+- [Swift-Kotlin API Parity](swift-kotlin-parity.md) — cross-platform API
+  alignment.
+- [Model Manifest](model-manifest.md) — model catalog and reproducibility
+  metadata.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - Transformers.js Export: export-transformersjs.md
       - ONNX Runtime Web Loader: runtimes/onnxruntime-web.md
       - Android ONNX Export: export-onnx-android.md
+      - Android Tokenization: android-tokenization.md
       - Android Span Parity: android-parity.md
       - CoreML Packaging: coreml-export.md
       - Swift Package (OpenMedKit): swift-openmedkit.md


### PR DESCRIPTION
## Summary

Implements #571: adds `docs/android-tokenization.md`, an accepted decision record for how OpenMedKit Android tokenizes on device. A documented decision is the prerequisite the issue calls out for the Android module and asset-bundling tasks.

The doc compares the three realistic approaches — the **DJL HuggingFace tokenizers AAR**, a **pure-Kotlin WordPiece** implementation, and **ORT-Extensions in-graph BertTokenizer** — across license, offset-mapping fidelity, binary/asset size, min SDK, and parity with OpenMed's Python tokenization.

## The decision is grounded in shipping code, not speculation

Rather than propose an open-ended choice, the doc documents and justifies the strategy the `android/openmedkit` module already embodies:
- `gradle/libs.versions.toml` depends on `ai.djl.huggingface:tokenizers` + `ai.djl.android:tokenizer-native`
- `Runtime.kt` uses `HuggingFaceTokenizer.newInstance(...)` and maps the Rust tokenizer's `Encoding` char offsets back to spans
- the module's `minSdk` is 26 — the DJL floor

**Primary: DJL HuggingFace tokenizers AAR** — Apache-2.0 (permissive, no GPL), native high-fidelity char offsets for span recovery, min SDK 26, and exact Python parity because both consume the same `tokenizer.json`. **Fallback: pure-Kotlin WordPiece** — smallest footprint and no native/copyleft dependency, at the cost of implementation work and a parity-verification burden. ORT-Extensions in-graph is compared but not adopted (weak char-offset support conflicts with span recovery).

## Coverage of the acceptance criteria

- Compares all three options on license, offset mapping, size, and min SDK (table + prose).
- Names one primary and one fallback strategy with rationale tied to span-offset fidelity and footprint.
- Records the on-device-only (no network after download) and no-PHI-in-logs constraints.
- Lists the tokenizer assets to bundle (`tokenizer.json`, `tokenizer_config.json`, `id2label.json`) and the Android ONNX export task (`openmed/onnx/convert.py`) that emits them.
- Registered in the mkdocs "Apple Silicon & Mobile" nav; a stable **Decision** heading lets the export-matrix doc and Android module task cite it.

## Scope notes

- **2 files**, matching the issue: `docs/android-tokenization.md` (new) and one nav line in `mkdocs.yml`.
- Cross-links only pages that exist on master (`export-onnx-android.md`, `android-parity.md`, `swift-kotlin-parity.md`, `model-manifest.md`) so all internal links resolve under `--strict`. (The Android quickstart page from #1606 is deliberately not linked yet to keep this PR independent; a reciprocal link is a natural follow-up once both land.)
- Out of scope, per the issue: implementing the tokenizer in Kotlin, bundling the assets, and any Python export changes.

## Verification

- `mkdocs build --strict`: passes (exit 0, no warnings-as-errors); the new page renders and all internal links resolve.

Closes #571