### PR TITLE
docs: add per-language PII de-identification guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,9 @@ These are the model-backed PII language allow-list.
 OpenMed also includes validator-backed national-ID coverage for additional
 ID-only locales such as Polish, Latvian, Slovak, Malay, Filipino, and Danish.
 
+See the [per-language guide](docs/languages.md) for each code's default PII
+model, Faker locale, and a before/after de-identification example.
+
 ```bash
 python -c "from openmed import extract_pii; print([(e.label, e.text) for e in extract_pii('Dr. Pedro Almeida, CPF: 123.456.789-09, email: pedro@hospital.pt', lang='pt').entities])"
 ```

--- a/docs/anonymization.md
+++ b/docs/anonymization.md
@@ -229,6 +229,10 @@ locale via `LANG_TO_LOCALE`:
 Pass `locale=` explicitly to override per call (e.g. `pt_BR` to generate
 CPF/CNPJ surrogates instead of Portuguese NIF/VAT).
 
+For the full per-language table — every `SUPPORTED_LANGUAGES` code with its
+default PII model, Faker locale, and a before/after example — see
+[Per-Language De-identification](languages.md).
+
 ### Determinism
 
 Three modes:

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,0 +1,223 @@
+# Per-Language PII De-identification
+
+OpenMed's PII detection and de-identification are multilingual. The list of
+model-backed language codes is the single source of truth in
+[`openmed.core.pii_i18n.SUPPORTED_LANGUAGES`](https://github.com/maziyarpanahi/openmed/blob/master/openmed/core/pii_i18n.py),
+and each code wires up:
+
+- a **default PII model** from `DEFAULT_PII_MODELS`, used when you pass `lang=`
+  without an explicit `model_name=`, and
+- a **Faker locale** from `LANG_TO_LOCALE`
+  ([`openmed/core/anonymizer/locales.py`](https://github.com/maziyarpanahi/openmed/blob/master/openmed/core/anonymizer/locales.py)),
+  used by `method="replace"` to generate locale-aware surrogates.
+
+Pick a language by passing its ISO 639-1 code to `extract_pii()` or
+`deidentify()`:
+
+```python
+from openmed import deidentify
+
+deidentify("Paciente Pedro Almeida, CPF 123.456.789-09", lang="pt", method="mask")
+```
+
+For the redaction methods (`mask`, `remove`, `replace`, `hash`, `shift_dates`),
+locale resolution, determinism, and cross-document surrogate vaults, see
+[PII Anonymization](anonymization.md).
+
+!!! note "Kept in sync with the code"
+    The table below lists **every** code in `SUPPORTED_LANGUAGES` together with
+    its `DEFAULT_PII_MODELS` entry and its `LANG_TO_LOCALE` mapping.
+    `tests/unit/test_docs_language_coherence.py` asserts this page matches the
+    constants exactly, so a newly wired language fails the suite until it is
+    documented here.
+
+## Supported languages
+
+| Code   | Language   | Default PII model                                          | Faker locale | Notes                                                        |
+| ------ | ---------- | ---------------------------------------------------------- | ------------ | ----------------------------------------------------------- |
+| `ar`   | Arabic     | `OpenMed/OpenMed-PII-Arabic-SnowflakeMed-Large-568M-v1`    | `ar_EG`      | Egypt is the most-populous Arabic locale; override per call. |
+| `de`   | German     | `OpenMed/OpenMed-PII-German-SuperClinical-Small-44M-v1`    | `de_DE`      | Steuer-ID surrogates via `GermanSteuerIdProvider`.           |
+| `en`   | English    | `OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1`           | `en_US`      | Default model splits names into `first_name`/`last_name`.    |
+| `es`   | Spanish    | `OpenMed/OpenMed-PII-Spanish-SuperClinical-Small-44M-v1`   | `es_ES`      | DNI/NIE checksum-aware surrogates.                           |
+| `fr`   | French     | `OpenMed/OpenMed-PII-French-SuperClinical-Small-44M-v1`    | `fr_FR`      | NIR / INSEE surrogates via `fr_FR.ssn`.                      |
+| `he`   | Hebrew     | `OpenMed/privacy-filter-multilingual`                      | `he_IL`      | Served by the multilingual privacy filter.                   |
+| `hi`   | Hindi      | `OpenMed/OpenMed-PII-Hindi-SuperClinical-Large-434M-v1`    | `hi_IN`      | Aadhaar (Verhoeff) surrogates.                               |
+| `id`   | Indonesian | `OpenMed/privacy-filter-multilingual`                      | `id_ID`      | Served by the multilingual privacy filter; NIK-aware.        |
+| `it`   | Italian    | `OpenMed/OpenMed-PII-Italian-SuperClinical-Small-44M-v1`   | `it_IT`      | Codice Fiscale surrogates via `it_IT.ssn`.                   |
+| `ja`   | Japanese   | `OpenMed/OpenMed-PII-Japanese-BigMed-Large-560M-v1`        | `ja_JP`      | Family-name-first `PERSON` spans.                            |
+| `ko`   | Korean     | `OpenMed/OpenMed-PII-Korean-NomicMed-Large-395M-v1`        | `ko_KR`      | Resident Registration Number (RRN) surrogates.               |
+| `nl`   | Dutch      | `OpenMed/OpenMed-PII-Dutch-SuperClinical-Large-434M-v1`    | `nl_NL`      | BSN (Elfproef) surrogates via `nl_NL.ssn`.                   |
+| `pt`   | Portuguese | `OpenMed/OpenMed-PII-Portuguese-SnowflakeMed-Large-568M-v1` | `pt_PT`     | Pass `locale="pt_BR"` for CPF/CNPJ surrogates.               |
+| `ro`   | Romanian   | `OpenMed/privacy-filter-multilingual`                      | `ro_RO`      | Served by the multilingual privacy filter; CNP-aware.        |
+| `te`   | Telugu     | `OpenMed/OpenMed-PII-Telugu-SuperClinical-Large-434M-v1`   | `en_IN`      | No Faker Telugu locale — `en_IN` approximation (warns once). |
+| `th`   | Thai       | `OpenMed/privacy-filter-multilingual`                      | `th_TH`      | Served by the multilingual privacy filter; Thai NID-aware.   |
+| `tr`   | Turkish    | `OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1`   | `tr_TR`      | TCKN surrogates.                                             |
+
+Codes outside this list (for example `zh`, `pl`, `lv`, `sk`, `ms`, `tl`, `da`)
+are **not** model-backed PII languages. Several of them still have
+validator-backed national-ID coverage
+(`openmed.core.pii_i18n.NATIONAL_ID_ONLY_LANGUAGES`); see
+[PII Anonymization](anonymization.md#clinical-id-checksums) for the ID providers.
+
+## Worked examples
+
+Each example de-identifies synthetic, non-PHI text with `method="mask"`. The
+exact placeholder tokens come from the chosen model's own entity labels, so
+they can vary by model (see
+[choosing a method](anonymization.md#quickstart-choosing-a-method)); the
+canonical labels below are illustrative.
+
+### Arabic — `ar`
+
+- Model: `OpenMed/OpenMed-PII-Arabic-SnowflakeMed-Large-568M-v1` · locale `ar_EG`
+
+```text
+Before: المريضة ليلى حسن، الهاتف +20 10 1234 5678
+After:  المريضة [NAME]، الهاتف [PHONE]
+```
+
+### German — `de`
+
+- Model: `OpenMed/OpenMed-PII-German-SuperClinical-Small-44M-v1` · locale `de_DE`
+
+```text
+Before: Patientin Anna Müller, Steuer-ID 86095742719
+After:  Patientin [NAME], Steuer-ID [ID]
+```
+
+### English — `en`
+
+- Model: `OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1` · locale `en_US`
+
+```text
+Before: Patient John Doe was seen on 03/14/2025; call 555-0142
+After:  Patient [NAME] was seen on [DATE]; call [PHONE]
+```
+
+### Spanish — `es`
+
+- Model: `OpenMed/OpenMed-PII-Spanish-SuperClinical-Small-44M-v1` · locale `es_ES`
+
+```text
+Before: Paciente Maria Garcia, DNI 12345678Z
+After:  Paciente [NAME], DNI [ID]
+```
+
+### French — `fr`
+
+- Model: `OpenMed/OpenMed-PII-French-SuperClinical-Small-44M-v1` · locale `fr_FR`
+
+```text
+Before: Patient Jean Dupont, NIR 1 84 12 76 451 089 46
+After:  Patient [NAME], NIR [ID]
+```
+
+### Hebrew — `he`
+
+- Model: `OpenMed/privacy-filter-multilingual` · locale `he_IL`
+
+```text
+Before: מטופל דוד לוי, טלפון 054-1234567
+After:  מטופל [NAME], טלפון [PHONE]
+```
+
+### Hindi — `hi`
+
+- Model: `OpenMed/OpenMed-PII-Hindi-SuperClinical-Large-434M-v1` · locale `hi_IN`
+
+```text
+Before: रोगी अनीता शर्मा, फोन +91 9876543210
+After:  रोगी [NAME], फोन [PHONE]
+```
+
+### Indonesian — `id`
+
+- Model: `OpenMed/privacy-filter-multilingual` · locale `id_ID`
+
+```text
+Before: Pasien Budi Santoso, NIK 3201234567890123
+After:  Pasien [NAME], NIK [ID]
+```
+
+### Italian — `it`
+
+- Model: `OpenMed/OpenMed-PII-Italian-SuperClinical-Small-44M-v1` · locale `it_IT`
+
+```text
+Before: Paziente Marco Rossi, codice fiscale RSSMRC80A01H501U
+After:  Paziente [NAME], codice fiscale [ID]
+```
+
+### Japanese — `ja`
+
+- Model: `OpenMed/OpenMed-PII-Japanese-BigMed-Large-560M-v1` · locale `ja_JP`
+
+```text
+Before: 患者 佐藤 花子、電話 +81 90 1234 5678
+After:  患者 [NAME]、電話 [PHONE]
+```
+
+### Korean — `ko`
+
+- Model: `OpenMed/OpenMed-PII-Korean-NomicMed-Large-395M-v1` · locale `ko_KR`
+
+```text
+Before: 환자 김민수, 전화 010-1234-5678
+After:  환자 [NAME], 전화 [PHONE]
+```
+
+### Dutch — `nl`
+
+- Model: `OpenMed/OpenMed-PII-Dutch-SuperClinical-Large-434M-v1` · locale `nl_NL`
+
+```text
+Before: Patiënt Eva de Vries, BSN 123456782
+After:  Patiënt [NAME], BSN [ID]
+```
+
+### Portuguese — `pt`
+
+- Model: `OpenMed/OpenMed-PII-Portuguese-SnowflakeMed-Large-568M-v1` · locale `pt_PT`
+  (pass `locale="pt_BR"` for Brazilian CPF/CNPJ surrogates)
+
+```text
+Before: Paciente Pedro Almeida, CPF 123.456.789-09
+After:  Paciente [NAME], CPF [ID]
+```
+
+### Romanian — `ro`
+
+- Model: `OpenMed/privacy-filter-multilingual` · locale `ro_RO`
+
+```text
+Before: Pacient Ion Popescu, CNP 1960101221144
+After:  Pacient [NAME], CNP [ID]
+```
+
+### Telugu — `te`
+
+- Model: `OpenMed/OpenMed-PII-Telugu-SuperClinical-Large-434M-v1` · locale `en_IN`
+  (Faker has no Telugu locale — `en_IN` is a documented approximation)
+
+```text
+Before: రోగి రమేష్ కుమార్, ఫోన్ +91 9876543210
+After:  రోగి [NAME], ఫోన్ [PHONE]
+```
+
+### Thai — `th`
+
+- Model: `OpenMed/privacy-filter-multilingual` · locale `th_TH`
+
+```text
+Before: ผู้ป่วย สมชาย ใจดี โทร 081-234-5678
+After:  ผู้ป่วย [NAME] โทร [PHONE]
+```
+
+### Turkish — `tr`
+
+- Model: `OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1` · locale `tr_TR`
+
+```text
+Before: Hasta Ayşe Yılmaz, TCKN 10000000146
+After:  Hasta [NAME], TCKN [ID]
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
   - PII & De-identification:
       - De-identification API: api/deidentification.md
       - PII Anonymization: anonymization.md
+      - Per-Language De-identification: languages.md
       - Smart Entity Merging: pii-smart-merging.md
       - No-Raw-PHI Logging: security/no-raw-phi-logging.md
       - LangChain Redaction Wrapper: integrations-langchain.md

--- a/tests/unit/test_docs_language_coherence.py
+++ b/tests/unit/test_docs_language_coherence.py
@@ -1,0 +1,79 @@
+"""Source-of-truth guards for the per-language de-identification guide.
+
+``docs/languages.md`` must document exactly the languages wired in
+``openmed.core.pii_i18n.SUPPORTED_LANGUAGES``, and for each one it must list the
+default PII model (``DEFAULT_PII_MODELS``), the Faker locale
+(``LANG_TO_LOCALE``), and a per-language worked example. These assertions fail
+loudly when a new language is wired in code but not documented here (or vice
+versa), keeping the page coherent with the constants.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from openmed.core.anonymizer.locales import LANG_TO_LOCALE
+from openmed.core.pii_i18n import (
+    DEFAULT_PII_MODELS,
+    LANGUAGE_NAMES,
+    SUPPORTED_LANGUAGES,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "languages.md"
+ANONYMIZATION = ROOT / "docs" / "anonymization.md"
+README = ROOT / "README.md"
+MKDOCS = ROOT / "mkdocs.yml"
+
+# Matches a summary-table row: | `xx` | Language | `model` | `locale` | ... |
+_TABLE_ROW = re.compile(
+    r"^\|\s*`([a-z]{2})`\s*\|\s*([^|]+?)\s*\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|"
+)
+# Matches a per-language subsection heading: ### Language — `xx`
+_HEADING = re.compile(r"^###\s+.*`([a-z]{2})`")
+
+
+def _table_rows(text: str) -> dict[str, tuple[str, str, str]]:
+    rows: dict[str, tuple[str, str, str]] = {}
+    for line in text.splitlines():
+        match = _TABLE_ROW.match(line)
+        if match:
+            code, name, model, locale = match.groups()
+            rows[code] = (name.strip(), model.strip(), locale.strip())
+    return rows
+
+
+def _heading_codes(text: str) -> set[str]:
+    return {match.group(1) for line in text.splitlines() if (match := _HEADING.match(line))}
+
+
+def test_languages_doc_table_matches_supported_languages() -> None:
+    rows = _table_rows(DOC.read_text(encoding="utf-8"))
+
+    assert set(rows) == SUPPORTED_LANGUAGES
+
+    for lang in SUPPORTED_LANGUAGES:
+        name, model, locale = rows[lang]
+        assert name == LANGUAGE_NAMES[lang], lang
+        assert model == DEFAULT_PII_MODELS[lang], lang
+        assert locale == LANG_TO_LOCALE[lang], lang
+
+
+def test_languages_doc_has_a_worked_example_per_language() -> None:
+    text = DOC.read_text(encoding="utf-8")
+
+    assert _heading_codes(text) == SUPPORTED_LANGUAGES
+    # Each worked example shows a before/after de-identification.
+    assert text.count("Before:") >= len(SUPPORTED_LANGUAGES)
+    assert text.count("After:") >= len(SUPPORTED_LANGUAGES)
+
+
+def test_languages_doc_is_in_nav_and_cross_linked() -> None:
+    nav = MKDOCS.read_text(encoding="utf-8")
+    anonymization = ANONYMIZATION.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+
+    assert "languages.md" in nav
+    assert "languages.md" in anonymization
+    assert "docs/languages.md" in readme

--- a/tests/unit/test_docs_language_coherence.py
+++ b/tests/unit/test_docs_language_coherence.py
@@ -45,7 +45,9 @@ def _table_rows(text: str) -> dict[str, tuple[str, str, str]]:
 
 
 def _heading_codes(text: str) -> set[str]:
-    return {match.group(1) for line in text.splitlines() if (match := _HEADING.match(line))}
+    return {
+        match.group(1) for line in text.splitlines() if (match := _HEADING.match(line))
+    }
 
 
 def test_languages_doc_table_matches_supported_languages() -> None:


### PR DESCRIPTION
Closes #287.

## Description

Adds `docs/languages.md`, a per-language guide for the model-backed PII languages. For each code in `SUPPORTED_LANGUAGES` it gives the default model from `DEFAULT_PII_MODELS`, the Faker locale from `LANG_TO_LOCALE`, and a short mask example, plus a note on which codes are validator-backed ID-only rather than model-backed.

The issue says 12 languages, but `SUPPORTED_LANGUAGES` is up to 17 now, so I documented all of them.

## Changes Made

- `docs/languages.md` (new): summary table of every supported code with model + locale + notes, and a before/after example per language.
- `tests/unit/test_docs_language_coherence.py` (new): asserts the page documents exactly the codes in `SUPPORTED_LANGUAGES`, with the right `DEFAULT_PII_MODELS` and `LANG_TO_LOCALE` values and an example section each. Wire a new language in code without documenting it and the suite fails.
- `mkdocs.yml`: page added under PII & De-identification.
- `README.md`, `docs/anonymization.md`: links to the new page.

The before/after blocks are illustrative, not captured output. Placeholder tokens come from each model's own labels so they vary, and the page says so.

## Testing

Ran the docs tests, 29 passed. `mkdocs build` is clean apart from the pre-existing not-in-nav warnings.

Docs only, no code or dependency changes.