### PR TITLE
test(security): add telemetry-off-by-default enforcement guard (OM-099)

### DIFF
--- a/docs/security/no-telemetry.md
+++ b/docs/security/no-telemetry.md
@@ -1,0 +1,79 @@
+# No-Telemetry Guarantee
+
+OpenMed collects no telemetry and phones no data home. The library ships no
+analytics or usage-tracking client, and the core inference path makes no
+outbound network calls at runtime. This restates the roadmap non-goal S8.8 #4 —
+*"no telemetry-by-default, no license server, no mandatory network calls
+post-download"* — and the project's public promise of *"no telemetry, no
+outbound calls at runtime"*.
+
+This guarantee complements the OM-005 offline mode
+([`OPENMED_OFFLINE`](../configuration.md)) and the OM-004 no-raw-PHI logging
+policy ([`no-raw-phi-logging.md`](no-raw-phi-logging.md)).
+
+## What is prohibited
+
+- Analytics / product-telemetry / error-reporting SDKs (Segment, PostHog,
+  Sentry, Mixpanel, Amplitude, Datadog, Bugsnag, Rollbar, New Relic, and the
+  like) anywhere in the `openmed` package.
+- Outbound calls to analytics or phone-home hosts.
+- Telemetry that is on by default. An *opt-OUT* switch is itself prohibited,
+  because it implies collection is enabled until the user disables it.
+
+## What outbound traffic is allowed
+
+Networking is confined to legitimate, explicitly user-initiated actions. The
+only reviewed reasons a module in `openmed` may open a connection are:
+
+- **Model downloads** — Hugging Face model/weight fetches via
+  `huggingface_hub` (e.g. `core/hf_hub.py`, `onnx/inference.py`). These honour
+  `HF_HOME`/`HF_HUB_CACHE`/`HF_ENDPOINT` and are skipped entirely in offline
+  mode.
+- **Opt-in evaluation dataset downloads** — `eval/` dataset and suite loaders.
+- **Opt-in clinical vocabulary downloads** — `clinical/grounding/vocab.py`,
+  offline-gated.
+- **The opt-in REST service** — the HTTP client, smart-backend routing, privacy
+  gateway, and user-configured webhooks under `service/`.
+- **Opt-in distributed training** — rendezvous sockets under `training/`.
+- **The offline guard itself** — `core/offline.py`, which blocks sockets when
+  `OPENMED_OFFLINE`/`local_only` is set.
+
+None of these run on the default de-identification path, and none contact an
+OpenMed-operated or analytics endpoint.
+
+### Distributed tracing (opt-in, off by default)
+
+The REST service integrates OpenTelemetry in `service/tracing.py` for operators
+who want request tracing in **their own** infrastructure. It is off by default
+(`enabled = False`), enabled only via `OPENMED_SERVICE_TRACING_ENABLED`, and
+exports to a user-supplied `OPENMED_SERVICE_OTLP_ENDPOINT`. Because it is opt-in
+and points only at the operator's own collector, it does not constitute
+telemetry-by-default or a phone-home.
+
+## How the guarantee is enforced
+
+[`tests/unit/test_no_telemetry.py`](https://github.com/maziyarpanahi/openmed/blob/master/tests/unit/test_no_telemetry.py)
+enforces the guarantee on every test run:
+
+- A **static scan** of `openmed/**/*.py` fails if a telemetry/analytics SDK is
+  imported, a known phone-home host literal appears, or a telemetry opt-OUT
+  environment variable is read.
+- A **network-surface inventory** pins the exact set of modules allowed to
+  import a raw-network library. A new module that opens the network fails the
+  test until it is reviewed and added to the allowlist — this is how outbound
+  additions are caught.
+- A **self-test** plants synthetic violations to prove each detector fires.
+- A **runtime check** reuses the OM-005 socket-blocking pattern to assert a
+  representative `extract_pii` + `deidentify` path opens no socket.
+
+Run the guard directly:
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_no_telemetry.py -q
+```
+
+The full suite must also pass before release or pull request review:
+
+```bash
+.venv/bin/python -m pytest tests/ -q
+```

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -188,6 +188,7 @@ OpenMed version instead of re-exporting the legacy artifact.
 | Overlap resolution + span quality gates | **OM-012** | [`quality_gates.py`](https://github.com/maziyarpanahi/openmed/blob/master/openmed/core/quality_gates.py) |
 | Adversarial re-identification eval / harness | **OM-034** | [`eval/attacks/reid.py`](https://github.com/maziyarpanahi/openmed/blob/master/openmed/eval/attacks/reid.py), [`risk/reid.py`](https://github.com/maziyarpanahi/openmed/blob/master/openmed/risk/reid.py) |
 | No-raw-PHI logging / artifact hygiene | **OM-004** | [`no-raw-phi-logging.md`](no-raw-phi-logging.md) |
+| No-telemetry / no phone-home enforcement | **OM-099** | [`no-telemetry.md`](no-telemetry.md) |
 | Adversarial-Unicode normalization | this task / de-id path | [`script_detect.py`](https://github.com/maziyarpanahi/openmed/blob/master/openmed/core/script_detect.py) |
 
 ### 6.2 Open gaps (no complete mitigation today)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Reproducible Dependencies: contributing/reproducible-dependencies.md
       - Security & Disclosure: security/disclosure-policy.md
       - Redactor Threat Model: security/threat-model.md
+      - No-Telemetry Guarantee: security/no-telemetry.md
       - HF Write Token Policy: security/hf-token-policy.md
       - Supply Chain Controls: security/supply-chain.md
       - Vulnerability Scanning: supply-chain/vulnerability-scanning.md

--- a/tests/unit/test_no_telemetry.py
+++ b/tests/unit/test_no_telemetry.py
@@ -1,0 +1,460 @@
+"""Guard that the openmed package ships no telemetry, analytics, or phone-home.
+
+Roadmap non-goal S8.8 #4 promises "no telemetry-by-default, no license server,
+no mandatory network calls post-download", and the marketing site repeats "no
+telemetry, no outbound calls at runtime". OM-004 guards raw-PHI logging and
+OM-005 guards offline mode; this OM-099 guard asserts the library introduces no
+analytics/telemetry client and no non-allowlisted outbound call.
+
+The guard has two layers:
+
+* A static scan of ``openmed/**/*.py`` that fails when a telemetry/analytics SDK
+  is imported, a known phone-home host literal appears, a telemetry opt-OUT
+  environment variable is read (an opt-out implies telemetry-on-by-default), or a
+  brand-new module starts importing a raw-network library without being added to
+  the reviewed ``ALLOWED_NETWORK_MODULES`` inventory.
+* A runtime check that a representative de-identification path opens no socket,
+  reusing the OM-005 socket-blocking pattern from ``test_offline_mode.py``.
+
+Every fixture value below is synthetic.
+"""
+
+from __future__ import annotations
+
+import ast
+import socket
+from pathlib import Path
+
+from openmed.core.config import OpenMedConfig
+from openmed.core.offline import OFFLINE_ENV_VAR
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "openmed"
+
+# ---------------------------------------------------------------------------
+# Static-scan denylists / allowlist inventory
+# ---------------------------------------------------------------------------
+
+# Raw-network modules whose import marks a file as touching the network. Model
+# downloads via ``huggingface_hub`` do not appear here because they delegate the
+# transport to that library rather than importing a socket/HTTP module directly.
+NETWORK_IMPORT_MODULES = frozenset(
+    {
+        "socket",
+        "ssl",
+        "requests",
+        "httpx",
+        "aiohttp",
+        "websocket",
+        "websockets",
+        "http.client",
+        "urllib.request",
+        "urllib3",
+        "ftplib",
+        "smtplib",
+        "telnetlib",
+    }
+)
+
+# The reviewed set of openmed modules allowed to touch the network today, each
+# for a legitimate, explicitly user-initiated reason (model/dataset download,
+# opt-in REST service, opt-in training rendezvous, or the offline guard itself).
+# A new module importing a raw-network library must be added here on review --
+# that is the "fails on additions" enforcement for outbound calls.
+ALLOWED_NETWORK_MODULES: dict[str, str] = {
+    "clinical/grounding/vocab.py": "opt-in clinical vocabulary download (offline-gated)",
+    "core/offline.py": "the offline network-block guard itself (OM-005)",
+    "eval/datasets/drugprot.py": "opt-in evaluation dataset download",
+    "eval/suites/shield.py": "opt-in evaluation dataset/rows fetch",
+    "service/client.py": "opt-in REST service HTTP client",
+    "service/privacy_gateway.py": "opt-in privacy-gateway forwarding (user-configured)",
+    "service/smart_backend.py": "opt-in smart-backend routing (user-configured)",
+    "service/webhooks.py": "opt-in user-configured webhooks",
+    "training/recipe.py": "opt-in training distributed rendezvous",
+}
+
+# Import roots of known analytics/telemetry/error-reporting SDKs. Matched against
+# the top-level package of every import; none may appear in openmed/.
+TELEMETRY_IMPORT_ROOTS = frozenset(
+    {
+        "segment",
+        "posthog",
+        "sentry_sdk",
+        "sentry",
+        "mixpanel",
+        "amplitude",
+        "amplitude_analytics",
+        "statsd",
+        "datadog",
+        "ddtrace",
+        "bugsnag",
+        "rollbar",
+        "newrelic",
+        "opentelemetry",
+        "elasticapm",
+        "elastic_apm",
+        "appdynamics",
+        "libhoney",
+        "scarf",
+        "ga4mp",
+    }
+)
+
+# Known phone-home / analytics-collector hostnames. Matched (casefolded) against
+# string literals in the package.
+TELEMETRY_HOST_LITERALS = frozenset(
+    {
+        "segment.io",
+        "sentry.io",
+        "google-analytics.com",
+        "analytics.google.com",
+        "mixpanel.com",
+        "amplitude.com",
+        "datadoghq.com",
+        "bugsnag.com",
+        "rollbar.com",
+        "newrelic.com",
+        "posthog.com",
+        "scarf.sh",
+        "doubleclick.net",
+    }
+)
+
+# Environment-variable name fragments that imply a telemetry opt-OUT switch. The
+# existence of an opt-out is itself a violation: it means telemetry is on by
+# default. Matched (upper-cased) against environment-variable names the package
+# actually reads.
+TELEMETRY_ENV_FRAGMENTS = (
+    "TELEMETRY",
+    "ANALYTICS",
+    "OPT_OUT",
+    "OPTOUT",
+    "DO_NOT_TRACK",
+    "PHONE_HOME",
+    "PHONEHOME",
+    "SEND_STATS",
+    "USAGE_STATS",
+)
+
+# Reviewed exceptions where a telemetry-tooling import is permitted because it is
+# opt-in, off by default, and exports only to a user-configured endpoint (not a
+# vendor phone-home). Maps ``relative/path.py`` -> allowed import root. The
+# permitted properties are additionally pinned by
+# ``test_service_tracing_is_opt_in_and_off_by_default``.
+TELEMETRY_SDK_ALLOWLIST: dict[str, str] = {
+    "service/tracing.py": "opentelemetry",
+}
+
+# Attribute chains that read an environment variable by name in ``arg`` 0.
+_ENV_READ_ATTRS = {"getenv", "get", "setdefault", "pop"}
+
+
+# ---------------------------------------------------------------------------
+# Pure detectors (operate on source text so the self-tests can plant violations)
+# ---------------------------------------------------------------------------
+
+
+def _iter_import_roots(tree: ast.AST):
+    """Yield (top_level_package, dotted_name) for every import in ``tree``."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name.split(".")[0], alias.name
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import, never a third-party SDK
+                continue
+            if node.module:
+                yield node.module.split(".")[0], node.module
+
+
+def _network_modules(source: str) -> set[str]:
+    """Return the raw-network modules imported by ``source``."""
+    tree = ast.parse(source)
+    found: set[str] = set()
+    for _root, dotted in _iter_import_roots(tree):
+        if dotted in NETWORK_IMPORT_MODULES:
+            found.add(dotted)
+    return found
+
+
+def _env_var_names(tree: ast.AST) -> set[str]:
+    """Return environment-variable names the source reads by string literal."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        # os.environ["NAME"] / os.environ.get("NAME") style subscripts
+        if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Constant):
+            if _is_environ(node.value) and isinstance(node.slice.value, str):
+                names.add(node.slice.value)
+        # os.getenv("NAME"), os.environ.get("NAME"), environ.setdefault("NAME")
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in _ENV_READ_ATTRS and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    if node.func.attr == "getenv" or _is_environ(node.func.value):
+                        names.add(first.value)
+    return names
+
+
+def _is_environ(node: ast.AST) -> bool:
+    """True when ``node`` denotes ``os.environ`` (or a bare ``environ``)."""
+    if isinstance(node, ast.Attribute):
+        return node.attr == "environ"
+    return isinstance(node, ast.Name) and node.id == "environ"
+
+
+def _string_literals(tree: ast.AST):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield node.value
+
+
+def _telemetry_sdk_imports(source: str) -> list[str]:
+    """Return dotted names of telemetry/analytics SDKs imported by ``source``."""
+    tree = ast.parse(source)
+    return [
+        dotted
+        for root, dotted in _iter_import_roots(tree)
+        if root in TELEMETRY_IMPORT_ROOTS
+    ]
+
+
+def _telemetry_host_hits(source: str) -> list[str]:
+    """Return known phone-home host literals appearing in ``source``."""
+    hits: list[str] = []
+    for literal in _string_literals(ast.parse(source)):
+        lowered = literal.casefold()
+        hits.extend(host for host in TELEMETRY_HOST_LITERALS if host in lowered)
+    return hits
+
+
+def _telemetry_optout_envs(source: str) -> list[str]:
+    """Return environment variables read by ``source`` that look like opt-outs."""
+    hits: list[str] = []
+    for env_name in _env_var_names(ast.parse(source)):
+        upper = env_name.upper()
+        if any(fragment in upper for fragment in TELEMETRY_ENV_FRAGMENTS):
+            hits.append(env_name)
+    return hits
+
+
+def _telemetry_violations(
+    source: str, *, allowed_sdk_root: str | None = None
+) -> list[str]:
+    """Return human-readable telemetry indicators found in ``source``.
+
+    ``allowed_sdk_root`` suppresses SDK-import findings for a single reviewed
+    import root (e.g. opt-in OpenTelemetry in ``service/tracing.py``); every
+    other indicator, including any other SDK, still fails.
+    """
+    violations: list[str] = []
+    for dotted in _telemetry_sdk_imports(source):
+        if allowed_sdk_root and (
+            dotted == allowed_sdk_root or dotted.startswith(f"{allowed_sdk_root}.")
+        ):
+            continue
+        violations.append(f"telemetry SDK import: {dotted}")
+    violations.extend(
+        f"telemetry host literal: {host}" for host in _telemetry_host_hits(source)
+    )
+    violations.extend(
+        f"telemetry opt-out env var: {name}" for name in _telemetry_optout_envs(source)
+    )
+    return violations
+
+
+def _package_files() -> list[Path]:
+    return sorted(PACKAGE_ROOT.rglob("*.py"))
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(PACKAGE_ROOT).as_posix()
+
+
+# ---------------------------------------------------------------------------
+# Static guard: the real package must be clean
+# ---------------------------------------------------------------------------
+
+
+def test_openmed_package_has_no_telemetry_indicators():
+    offenders: dict[str, list[str]] = {}
+    for path in _package_files():
+        rel = _rel(path)
+        violations = _telemetry_violations(
+            path.read_text(encoding="utf-8"),
+            allowed_sdk_root=TELEMETRY_SDK_ALLOWLIST.get(rel),
+        )
+        if violations:
+            offenders[rel] = violations
+
+    assert offenders == {}, f"telemetry/analytics indicators found: {offenders!r}"
+
+
+def test_service_tracing_is_opt_in_and_off_by_default():
+    """The one reviewed telemetry-tooling exception must stay opt-in and safe."""
+    tracing = PACKAGE_ROOT / "service" / "tracing.py"
+    source = tracing.read_text(encoding="utf-8")
+
+    # OpenTelemetry usage is confined to this single reviewed module.
+    users = [
+        _rel(path)
+        for path in _package_files()
+        if any(
+            root.startswith("opentelemetry")
+            for root, _ in _iter_import_roots(
+                ast.parse(path.read_text(encoding="utf-8"))
+            )
+        )
+    ]
+    assert users == ["service/tracing.py"], (
+        f"opentelemetry imported outside the reviewed carve-out: {users!r}"
+    )
+
+    # Off by default and opt-in via an explicit enable flag (never an opt-out).
+    assert "enabled: bool = False" in source
+    assert 'TRACING_ENABLED_ENV_VAR = "OPENMED_SERVICE_TRACING_ENABLED"' in source
+
+    # The export endpoint is user-supplied; no hardcoded vendor phone-home host.
+    assert _telemetry_host_hits(source) == []
+    assert _telemetry_optout_envs(source) == []
+
+
+def test_network_surface_matches_reviewed_allowlist():
+    discovered: dict[str, set[str]] = {}
+    for path in _package_files():
+        modules = _network_modules(path.read_text(encoding="utf-8"))
+        if modules:
+            discovered[_rel(path)] = modules
+
+    unlisted = sorted(set(discovered) - set(ALLOWED_NETWORK_MODULES))
+    assert unlisted == [], (
+        "new module(s) import a raw-network library without a reviewed entry in "
+        f"ALLOWED_NETWORK_MODULES: {unlisted!r}"
+    )
+
+    stale = sorted(set(ALLOWED_NETWORK_MODULES) - set(discovered))
+    assert stale == [], (
+        "ALLOWED_NETWORK_MODULES lists module(s) that no longer touch the "
+        f"network -- prune them: {stale!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Self-tests: the detectors must actually fire on planted violations
+# ---------------------------------------------------------------------------
+
+
+def test_guard_detects_planted_telemetry_sdk():
+    source = "import sentry_sdk\nsentry_sdk.init('https://example.test')\n"
+    assert any("telemetry SDK import" in v for v in _telemetry_violations(source))
+
+
+def test_guard_detects_planted_phone_home_host():
+    source = 'URL = "https://api.segment.io/v1/track"\n'
+    assert any("telemetry host literal" in v for v in _telemetry_violations(source))
+
+
+def test_guard_detects_planted_optout_env_var():
+    source = 'import os\nflag = os.getenv("OPENMED_DISABLE_TELEMETRY")\n'
+    assert any("telemetry opt-out env var" in v for v in _telemetry_violations(source))
+
+
+def test_guard_detects_planted_unlisted_network_module():
+    source = "import requests\nrequests.post('https://collector.example.test')\n"
+    assert _network_modules(source) == {"requests"}
+
+
+def test_guard_ignores_urllib_parse_and_offline_mentions():
+    # urllib.parse is not a network transport; a docstring mentioning telemetry
+    # must not be flagged as a telemetry indicator.
+    source = (
+        '"""Local-first module: no telemetry and no mandatory network access."""\n'
+        "from urllib.parse import urljoin\n"
+        "value = urljoin('a', 'b')\n"
+    )
+    assert _network_modules(source) == set()
+    assert _telemetry_violations(source) == []
+
+
+# ---------------------------------------------------------------------------
+# Runtime guard: a representative deidentify path opens no socket (OM-005 reuse)
+# ---------------------------------------------------------------------------
+
+
+class _FakeLocalPiiPipeline:
+    tokenizer = None
+
+    @staticmethod
+    def _entities(text: str):
+        return [
+            {
+                "entity_group": "NAME",
+                "score": 0.99,
+                "word": "John Doe",
+                "start": text.index("John Doe"),
+                "end": text.index("John Doe") + len("John Doe"),
+            },
+            {
+                "entity_group": "PHONE",
+                "score": 0.98,
+                "word": "555-1234",
+                "start": text.index("555-1234"),
+                "end": text.index("555-1234") + len("555-1234"),
+            },
+        ]
+
+    def __call__(self, text, **kwargs):
+        if isinstance(text, list):
+            return [self._entities(item) for item in text]
+        return self._entities(text)
+
+
+class _FakeLocalLoader:
+    def __init__(self, config: OpenMedConfig):
+        self.config = config
+        self.pipeline = _FakeLocalPiiPipeline()
+
+    def create_pipeline(self, *args, **kwargs):
+        return self.pipeline
+
+    def get_max_sequence_length(self, *args, **kwargs):
+        return None
+
+
+def test_representative_deidentify_path_opens_no_socket(monkeypatch):
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+    blocked_attempts: list[tuple] = []
+
+    def fail_socket(*args, **kwargs):
+        blocked_attempts.append((args, kwargs))
+        raise AssertionError("network egress attempted from deidentify path")
+
+    monkeypatch.setattr(socket.socket, "connect", fail_socket)
+    monkeypatch.setattr(socket.socket, "connect_ex", fail_socket)
+    monkeypatch.setattr(socket, "create_connection", fail_socket)
+
+    from openmed.core.pii import deidentify, extract_pii
+
+    text = "Patient John Doe called 555-1234."
+    config = OpenMedConfig(use_medical_tokenizer=False)
+    loader = _FakeLocalLoader(config)
+
+    pii_result = extract_pii(
+        text,
+        model_name="local-pii",
+        config=config,
+        loader=loader,
+        use_smart_merging=False,
+    )
+    assert [(e.label, e.text) for e in pii_result.entities] == [
+        ("NAME", "John Doe"),
+        ("PHONE", "555-1234"),
+    ]
+
+    deid_result = deidentify(
+        text,
+        model_name="local-pii",
+        config=config,
+        loader=loader,
+        use_smart_merging=False,
+    )
+    assert deid_result.deidentified_text == "Patient [NAME] called [PHONE]."
+    assert blocked_attempts == []


### PR DESCRIPTION
## Summary

Adds the OM-099 telemetry-off-by-default enforcement guard promised by roadmap
non-goal S8.8 #4 ("no telemetry-by-default, no license server, no mandatory
network calls post-download") and the marketing site ("no telemetry, no
outbound calls at runtime"). OM-004 guards raw-PHI logging and OM-005 guards
offline mode; there was no guard asserting the library makes no
analytics/telemetry/phone-home calls, so the promise could silently regress.

Scope items from the issue:

- **Static guard** that scans `openmed/**/*.py` and fails on telemetry/analytics
  indicators: imports of known analytics/error-reporting SDKs (Segment, PostHog,
  Sentry, Mixpanel, Amplitude, Datadog, Bugsnag, Rollbar, New Relic, …), known
  phone-home host literals, and telemetry opt-OUT environment variables (an
  opt-out implies telemetry-on-by-default).
- **Runtime guard** asserting a representative `extract_pii` + `deidentify` path
  opens no socket, reusing the OM-005 socket-blocking pattern from
  `test_offline_mode.py`.
- **Docs** at `docs/security/no-telemetry.md` documenting the guarantee, the
  allowed-outbound surface, and how the guard enforces it.
- **Allowlist kept limited** to legitimate, explicitly user-initiated traffic
  (model/dataset downloads, opt-in REST service, opt-in training, offline guard).

## Deviations from the issue's letter

The issue named two files; the guard as designed touches four. Each extra is
justified below with evidence.

- **`openmed/` already makes legitimate outbound calls today**, so a naive "ban
  all `requests`/`httpx`/`urllib`" scan would fail on day one. Real network
  users found by AST scan: `service/{client,webhooks,smart_backend,privacy_gateway}.py`
  (httpx), `eval/suites/shield.py` + `eval/datasets/drugprot.py` (urlopen),
  `clinical/grounding/vocab.py` (urllib, offline-gated), `training/recipe.py` +
  `core/offline.py` (socket). The guard therefore targets **telemetry
  specifically** and pins a reviewed inventory (`ALLOWED_NETWORK_MODULES`) of
  the modules allowed to touch the network — a new outbound call site fails the
  guard until reviewed. This is the "fails on additions" enforcement.

- **OpenTelemetry carve-out.** The scan surfaced `openmed/service/tracing.py`,
  which imports `opentelemetry`. It is off by default (`enabled = False`),
  opt-in via `OPENMED_SERVICE_TRACING_ENABLED`, and exports only to a
  user-configured `OPENMED_SERVICE_OTLP_ENDPOINT` (no hardcoded vendor host) —
  i.e. compatible with "no telemetry *by default*". Rather than silently
  ignore it, the guard keeps detecting `opentelemetry` and adds an explicit
  reviewed exception plus `test_service_tracing_is_opt_in_and_off_by_default`,
  which pins those safety properties so the exception cannot regress to
  default-on or a hardcoded endpoint.

- **`mkdocs.yml`** — added a nav entry under the security cluster, mirroring how
  the OM-004 `no-raw-phi-logging.md` doc is registered. Not gate-forced; for
  discoverability/consistency.

- **`docs/security/threat-model.md`** — added an OM-099 row to the §6.1
  mitigation ownership map, mirroring the OM-004 row. Not gate-forced; for
  consistency with the existing map.

## Data provenance

All fixture values are synthetic and algorithmically constructed (planted
sample source strings for the detector self-tests, a fake local pipeline for the
runtime test). No real hosts, keys, or PHI.

## Verification

- `.venv/bin/python -m pytest tests/unit/test_no_telemetry.py -q` → 9 passed.
- `.venv/bin/python -m pytest tests/ -q` → 4867 passed, 43 skipped, 0 failures
  (on the tree rebased onto `maziyarpanahi/openmed@master`).
- `pre-commit run --files <the four changed files>` → all hooks pass.
- Rebased onto upstream `master`; `git rev-list --count HEAD..upstream/master`
  is 0.

Closes #264
