### PR TITLE
test: cover help for every CLI command

### DIFF
--- a/tests/unit/cli/test_cli_help_coverage.py
+++ b/tests/unit/cli/test_cli_help_coverage.py
@@ -1,0 +1,71 @@
+"""Coherence checks for the argparse command help surface."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from openmed.cli.main import build_parser
+
+
+def _command_paths(
+    parser: argparse.ArgumentParser,
+    prefix: tuple[str, ...] = (),
+) -> list[tuple[tuple[str, ...], str]]:
+    paths: list[tuple[tuple[str, ...], str]] = []
+
+    for action in parser._actions:
+        if not isinstance(action, argparse._SubParsersAction):
+            continue
+
+        help_by_name = {choice.dest: choice.help for choice in action._choices_actions}
+        for name, child_parser in action.choices.items():
+            path = (*prefix, name)
+            paths.append((path, help_by_name.get(name, "")))
+            paths.extend(_command_paths(child_parser, path))
+
+    return paths
+
+
+def test_every_subcommand_has_help_text() -> None:
+    command_paths = _command_paths(build_parser())
+
+    assert command_paths
+    missing = [" ".join(path) for path, help_text in command_paths if not help_text]
+    assert not missing, f"Subcommands without help text: {missing}"
+
+
+@pytest.mark.parametrize(
+    "command_path",
+    [path for path, _ in _command_paths(build_parser())],
+    ids=lambda path: " ".join(path),
+)
+def test_every_command_path_prints_help(
+    command_path: tuple[str, ...],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    parser = build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([*command_path, "--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert output.strip()
+    assert output.startswith(f"usage: openmed {' '.join(command_path)}")
+
+
+def test_top_level_help_lists_every_subcommand() -> None:
+    parser = build_parser()
+    help_text = parser.format_help()
+    normalized_help = " ".join(help_text.split())
+
+    top_level_commands = [
+        (path[0], description)
+        for path, description in _command_paths(parser)
+        if len(path) == 1
+    ]
+    for name, description in top_level_commands:
+        assert name in normalized_help
+        assert " ".join(description.split()) in normalized_help


### PR DESCRIPTION
## Description

Add a recursive coherence test for the argparse CLI help surface. The test discovers every nested command path from `build_parser()`, requires each registered subcommand to have non-empty help text, invokes `--help` for every path, and verifies the top-level help lists all commands and descriptions.

## Type of Change

- [x] Test addition/improvement

## Changes Made

- recursively discover all 53 current CLI command paths
- fail when a subcommand is registered without help text
- verify every command path exits successfully and prints usage output
- verify top-level help includes every command description

## Testing

- [x] I have added tests that prove the help coverage guard works
- [x] New and existing CLI unit tests pass locally: `63 passed`
- [x] Ruff check and format check pass for the new test

Full-suite note: `pytest tests/ -q` reached 205 passed and 7 skipped before an unrelated React Native parity test ran `npm ci`. That test could not complete because the local Node.js version is 18 while the package requires 20+, and npm registry access was unavailable in the test sandbox.

## Documentation

Not applicable; this PR only adds regression coverage for the existing CLI help text.

## Code Quality

- [x] Ruff lint and format checks pass for the changed file
- [x] I have performed a self-review of the change
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] The PR contains one focused commit

## Related Issues

Closes #485

## Screenshots/Examples

Not applicable for a test-only change.