### PR TITLE
OpenMRS adapter: de-identify REST and FHIR2 handoffs locally

### DIFF
--- a/docs/openmrs-adapter.md
+++ b/docs/openmrs-adapter.md
@@ -1,0 +1,189 @@
+# OpenMRS Adapter
+
+OpenMed can pull notes and observations from a facility-local OpenMRS server,
+de-identify free text on the facility box, and then write or export only the
+de-identified copies. The adapter supports both the legacy REST API and the
+OpenMRS FHIR2 R4 module.
+
+```text
+KenyaEMR / UgandaEMR
+        |
+        | facility LAN (REST or FHIR2)
+        v
+OpenMed on the facility box
+  pull -> de-identify -> verify manifest
+        |
+        | de-identified payloads only
+        v
+destination OpenMRS / FHIR transaction Bundle / NDJSON
+```
+
+Raw notes do not need to leave the facility network. OpenMed does not cache
+source payloads, write raw PHI to logs, or make a network request during module
+import. Keep the adapter and its output directory on a facility-controlled
+machine and restrict the OpenMRS account to the resources it needs.
+
+## Install
+
+The HTTP client is optional:
+
+```bash
+uv pip install "openmed[openmrs]"
+```
+
+Importing `openmed.interop` and listing `available_adapters()` remains lazy;
+neither the OpenMRS module nor the HTTP client is imported until requested.
+
+## Connect to KenyaEMR or UgandaEMR
+
+Include the OpenMRS application context in the base URL. Many deployments use
+`/openmrs`, but confirm the local installation path with the facility
+administrator.
+
+```python
+from openmed.interop.openmrs import OpenMRSAdapter, OpenMRSClient, OpenMRSConfig
+
+config = OpenMRSConfig(
+    base_url="https://kenyaemr.facility.local/openmrs",
+    username="openmed-adapter",
+    password="read-from-a-secret-store",
+    page_size=100,
+    max_retries=3,
+)
+
+with OpenMRSClient(config) as client:
+    adapter = OpenMRSAdapter(client)
+    observations = adapter.pull_rest("obs", params={"patient": "patient-uuid"})
+    encounters = adapter.pull_rest(
+        "encounter",
+        params={"patient": "patient-uuid"},
+    )
+```
+
+Legacy REST collection requests use `limit` and `startIndex` pagination. The
+adapter follows server-provided next links when available, retries transient
+failures, and rejects pagination links that leave the configured OpenMRS
+origin or application path.
+
+The low-level client can pull the REST `patient` endpoint for facility-local
+lookup, but the adapter does not write legacy Patient objects back. Their name
+and identifier structure is not safely represented by the narrow REST
+obs/comment walker. Use the FHIR2 Patient path when a de-identified Patient
+resource must be handed off.
+
+OpenMRS also accepts an existing servlet session token. Pass only one
+authentication mode:
+
+```python
+config = OpenMRSConfig(
+    base_url="https://ugandaemr.facility.local/openmrs",
+    session_token="token-returned-by-the-local-session-endpoint",
+)
+```
+
+The token is sent as the `JSESSIONID` cookie. Do not put credentials or tokens
+in a URL, source file, log line, or committed configuration.
+
+## What the REST walker changes
+
+The legacy REST model is not FHIR. Its walker transforms only string-valued
+`value`, comment, and encounter-note fields. It never changes UUIDs, coded
+concepts, references, dates, or numeric observation values. Every result
+includes an OperationOutcome-style manifest of the changed paths:
+
+```python
+for record in observations:
+    print(record.source_id, record.transformed_paths)
+```
+
+Use transformed paths for audit counts, not the original or transformed text.
+The manifest contains paths and informational diagnostics only.
+
+## FHIR2 pull and export
+
+The FHIR2 path uses OpenMed's existing FHIR de-identification operation. Pull
+Patient, Encounter, and Observation resources before assembling a Bundle so
+all internal references have a target:
+
+```python
+with OpenMRSClient(config) as client:
+    adapter = OpenMRSAdapter(client)
+    records = (
+        adapter.pull_fhir("Patient", params={"_id": "patient-uuid"})
+        + adapter.pull_fhir("Encounter", params={"patient": "patient-uuid"})
+        + adapter.pull_fhir("Observation", params={"patient": "patient-uuid"})
+    )
+
+    bundle = adapter.export_bundle(records, doc_id="facility-job-2026-07-17")
+    summary = adapter.export_ndjson(records, "out/openmrs-deidentified.ndjson")
+```
+
+`export_bundle` delegates to `openmed.clinical.exporters.fhir.to_bundle`. It
+produces a FHIR R4 transaction Bundle with deterministic `urn:uuid` full URLs,
+request blocks, and rewritten in-Bundle references. `export_ndjson` uses the
+existing streaming FHIR bulk path and returns its PHI-safe summary and output
+digest.
+
+Never use a patient name, phone number, national identifier, or other direct
+identifier as `doc_id`; the identifier seeds deterministic full URLs and may
+be retained in operational metadata.
+
+## Write-back and dry runs
+
+Set a separate destination when de-identified copies should go to another
+facility-controlled OpenMRS server:
+
+```python
+config = OpenMRSConfig(
+    base_url="https://kenyaemr.facility.local/openmrs",
+    destination_url="https://research-openmrs.facility.local/openmrs",
+    username="openmed-adapter",
+    password="read-from-a-secret-store",
+)
+
+with OpenMRSClient(config) as client:
+    adapter = OpenMRSAdapter(client)
+    records = adapter.pull_fhir("Observation", params={"patient": "patient-uuid"})
+
+    planned = adapter.write_back(records, dry_run=True)
+    assert all(result.dry_run for result in planned)
+
+    # Perform this only after the local manifest/no-leak review.
+    completed = adapter.write_back(records)
+```
+
+FHIR resources with an `id` use `PUT`; new FHIR resources use `POST`. Legacy
+REST resources follow OpenMRS conventions and use `POST` for both create and
+partial update (`POST /resource/{uuid}`).
+
+For a legacy obs workflow that stores the de-identified value in the original
+obs comment without replacing the full resource, use the explicit convention:
+
+```python
+adapter.write_back(observations, obs_comment=True, dry_run=True)
+```
+
+This mode requires an obs UUID and sends only `{"comment": "..."}`. It is
+available for REST obs records only.
+
+## Facility deployment checklist
+
+1. Use a least-privilege OpenMRS service account and facility-managed secret
+   storage.
+2. Keep TLS verification enabled; install the facility CA rather than setting
+   `verify_tls=False` in production.
+3. Start with `dry_run=True`, review only resource IDs and transformed paths,
+   and avoid printing payload bodies.
+4. Run the no-leak guard against seeded identifiers before egress.
+5. Store Bundle or NDJSON output on encrypted facility-controlled storage and
+   apply the site's retention policy.
+
+The unit suite uses synthetic recorded-shape fixtures under
+`tests/unit/interop/fixtures/openmrs/`; it never contacts a live OpenMRS
+installation.
+
+## OpenMRS references
+
+- [OpenMRS REST API client documentation](https://openmrs.atlassian.net/wiki/spaces/docs/pages/25469830/)
+- [OpenMRS REST resource reference](https://rest.openmrs.org/)
+- [OpenMRS API overview](https://openmrs.atlassian.net/wiki/spaces/docs/pages/25520547/)

--- a/examples/openmrs_deid_handoff.py
+++ b/examples/openmrs_deid_handoff.py
@@ -1,0 +1,64 @@
+"""Pull OpenMRS FHIR2 resources and prepare a local de-identified handoff."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from openmed.interop.openmrs import OpenMRSAdapter, OpenMRSClient, OpenMRSConfig
+
+
+def _config_from_environment() -> OpenMRSConfig:
+    base_url = os.environ["OPENMRS_BASE_URL"]
+    destination_url = os.environ.get("OPENMRS_DESTINATION_URL")
+    session_token = os.environ.get("OPENMRS_SESSION_TOKEN")
+    username = os.environ.get("OPENMRS_USERNAME")
+    password = os.environ.get("OPENMRS_PASSWORD")
+
+    if session_token:
+        return OpenMRSConfig(
+            base_url=base_url,
+            destination_url=destination_url,
+            session_token=session_token,
+        )
+    if not username or not password:
+        raise RuntimeError(
+            "set OPENMRS_SESSION_TOKEN or both OPENMRS_USERNAME and OPENMRS_PASSWORD"
+        )
+    return OpenMRSConfig(
+        base_url=base_url,
+        destination_url=destination_url,
+        username=username,
+        password=password,
+    )
+
+
+def main() -> None:
+    """Run a FHIR2 handoff without printing clinical payload content."""
+
+    patient_uuid = os.environ["OPENMRS_PATIENT_UUID"]
+    output_path = Path(
+        os.environ.get("OPENMRS_NDJSON_PATH", "openmrs-deidentified.ndjson")
+    )
+    allow_write = os.environ.get("OPENMRS_ALLOW_WRITE") == "1"
+
+    with OpenMRSClient(_config_from_environment()) as client:
+        adapter = OpenMRSAdapter(client)
+        records = (
+            adapter.pull_fhir("Patient", params={"_id": patient_uuid})
+            + adapter.pull_fhir("Encounter", params={"patient": patient_uuid})
+            + adapter.pull_fhir("Observation", params={"patient": patient_uuid})
+        )
+
+        summary = adapter.export_ndjson(records, output_path)
+        writes = adapter.write_back(records, dry_run=not allow_write)
+
+    transformed_path_count = sum(len(record.transformed_paths) for record in records)
+    print(f"resources prepared: {len(records)}")
+    print(f"transformed paths: {transformed_path_count}")
+    print(f"NDJSON resources: {summary.resources_deidentified}")
+    print(f"write requests completed: {sum(not result.dry_run for result in writes)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Breach Report Template: compliance/templates/breach-report-template.md
       - FHIR Interop Helpers: fhir-interop.md
       - De-identified DHIS2 Export: dhis2-export.md
+      - OpenMRS Adapter: openmrs-adapter.md
   - Apple Silicon & Mobile:
       - MLX Backend: mlx-backend.md
       - Torch MPS Performance: performance-mps.md

--- a/openmed/interop/__init__.py
+++ b/openmed/interop/__init__.py
@@ -131,6 +131,12 @@ _ADAPTERS: Final[dict[str, AdapterSpec]] = {
         extra="",
         description="OMOP CDM loader for grounded clinical note spans",
     ),
+    "openmrs": AdapterSpec(
+        name="openmrs",
+        module="openmed.interop.openmrs",
+        extra="openmrs",
+        description="Local-first OpenMRS REST and FHIR2 de-identification adapter",
+    ),
 }
 
 _GATEWAY_EXPORTS: Final[dict[str, str]] = {

--- a/openmed/interop/fhir_operations.py
+++ b/openmed/interop/fhir_operations.py
@@ -39,7 +39,9 @@ from ..clinical.exporters.fhir import OperationOutcomeIssue, to_operation_outcom
 
 __all__ = [
     "de_identify_resource",
+    "de_identify_resource_with_manifest",
     "de_identify_bundle",
+    "de_identify_bundle_with_manifest",
     "de_identify",
 ]
 
@@ -157,6 +159,38 @@ def de_identify_resource(
     return transformed
 
 
+def de_identify_resource_with_manifest(
+    resource: Any,
+    *,
+    policy: str = _DEFAULT_POLICY,
+    method: str = _DEFAULT_METHOD,
+    deidentifier: Optional[Deidentifier] = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return a de-identified FHIR resource and its ``OperationOutcome``.
+
+    The outcome contains one informational issue per transformed FHIRPath-like
+    element path. It is useful to adapters that need to hand a PHI-free change
+    manifest to downstream systems without running the privacy pipeline twice.
+
+    Args:
+        resource: A FHIR resource mapping carrying ``resourceType``.
+        policy: Privacy policy profile passed to the pipeline.
+        method: De-identification method.
+        deidentifier: Optional privacy pipeline override, mainly for tests.
+
+    Returns:
+        A ``(resource, outcome)`` pair. Both values are newly allocated.
+    """
+
+    transformed, changes = _de_identify_resource(
+        resource,
+        policy=policy,
+        method=method,
+        deidentifier=deidentifier,
+    )
+    return transformed, _outcome_from_changes(changes)
+
+
 def de_identify_bundle(
     bundle: Any,
     *,
@@ -191,6 +225,37 @@ def de_identify_bundle(
         deidentifier=deidentifier,
     )
     return transformed
+
+
+def de_identify_bundle_with_manifest(
+    bundle: Any,
+    *,
+    policy: str = _DEFAULT_POLICY,
+    method: str = _DEFAULT_METHOD,
+    deidentifier: Optional[Deidentifier] = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return a de-identified FHIR Bundle and its ``OperationOutcome``.
+
+    Bundle entry structure, request blocks, ``fullUrl`` values, and references
+    are preserved exactly; the manifest reports only transformed text paths.
+
+    Args:
+        bundle: A FHIR ``Bundle`` resource mapping.
+        policy: Privacy policy profile passed to the pipeline.
+        method: De-identification method.
+        deidentifier: Optional privacy pipeline override, mainly for tests.
+
+    Returns:
+        A ``(bundle, outcome)`` pair. Both values are newly allocated.
+    """
+
+    transformed, changes = _de_identify_bundle(
+        bundle,
+        policy=policy,
+        method=method,
+        deidentifier=deidentifier,
+    )
+    return transformed, _outcome_from_changes(changes)
 
 
 def de_identify(

--- a/openmed/interop/openmrs.py
+++ b/openmed/interop/openmrs.py
@@ -1,0 +1,1077 @@
+"""Local-first OpenMRS REST and FHIR2 de-identification adapter.
+
+The adapter pulls resources from a facility-local OpenMRS installation,
+de-identifies text on the same machine, and only then writes or exports the
+result. Importing this module does not import an HTTP client or load a privacy
+model; both are resolved when they are first used.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import time
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Final, Literal
+from urllib.parse import urljoin, urlsplit
+
+from openmed.clinical.exporters.fhir import (
+    OperationOutcomeIssue,
+    to_bundle,
+    to_operation_outcome,
+)
+from openmed.interop.fhir_bulk import NDJSONFileSummary, deidentify_ndjson_stream
+from openmed.interop.fhir_operations import (
+    Deidentifier,
+    de_identify_resource_with_manifest,
+)
+
+APIKind = Literal["rest", "fhir2"]
+Sleep = Callable[[float], None]
+
+_REST_RESOURCES: Final[frozenset[str]] = frozenset({"obs", "encounter", "patient"})
+_FHIR_RESOURCES: Final[dict[str, str]] = {
+    "observation": "Observation",
+    "encounter": "Encounter",
+    "patient": "Patient",
+}
+_REST_TEXT_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "value",
+        "comment",
+        "comments",
+        "note",
+        "notes",
+        "encounternote",
+        "encounternotes",
+    }
+)
+_REST_TEXT_CONTAINER_KEYS: Final[frozenset[str]] = _REST_TEXT_KEYS - {"value"}
+_RETRYABLE_STATUS_CODES: Final[frozenset[int]] = frozenset(
+    {408, 425, 429, 500, 502, 503, 504}
+)
+_DEFAULT_POLICY: Final = "hipaa_safe_harbor"
+_DEFAULT_METHOD: Final = "replace"
+
+
+@dataclass(frozen=True)
+class OpenMRSConfig:
+    """Connection and retry settings for one OpenMRS installation.
+
+    ``base_url`` should include the installation context path when present,
+    for example ``http://kenyaemr.local/openmrs``. ``destination_url`` can
+    point at a separate facility-controlled server; when omitted, write-back
+    targets the source installation.
+    """
+
+    base_url: str
+    destination_url: str | None = None
+    username: str | None = None
+    password: str | None = field(default=None, repr=False)
+    session_token: str | None = field(default=None, repr=False)
+    session_cookie_name: str = "JSESSIONID"
+    timeout: float = 30.0
+    page_size: int = 100
+    max_retries: int = 3
+    backoff_factor: float = 0.5
+    verify_tls: bool = True
+    headers: Mapping[str, str] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        _validate_base_url(self.base_url, name="base_url")
+        if self.destination_url is not None:
+            _validate_base_url(self.destination_url, name="destination_url")
+        if (self.username is None) != (self.password is None):
+            raise ValueError("username and password must be provided together")
+        if self.session_token and self.username:
+            raise ValueError("use either basic authentication or a session token")
+        if self.session_token and any(
+            character in self.session_token for character in "\r\n;"
+        ):
+            raise ValueError("session_token contains invalid cookie characters")
+        if not self.session_cookie_name or any(
+            character in self.session_cookie_name for character in "\r\n;="
+        ):
+            raise ValueError("session_cookie_name is invalid")
+        if self.timeout <= 0:
+            raise ValueError("timeout must be greater than zero")
+        if self.page_size <= 0:
+            raise ValueError("page_size must be greater than zero")
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be zero or greater")
+        if self.backoff_factor < 0:
+            raise ValueError("backoff_factor must be zero or greater")
+
+
+@dataclass(frozen=True)
+class DeidentifiedResource:
+    """One de-identified OpenMRS resource and its PHI-free change manifest."""
+
+    api: APIKind
+    resource_name: str
+    resource: dict[str, Any] = field(repr=False)
+    manifest: dict[str, Any]
+    source_id: str | None = None
+
+    @property
+    def transformed_paths(self) -> tuple[str, ...]:
+        """Return transformed element paths recorded by the manifest."""
+
+        return manifest_paths(self.manifest)
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    """Result of one OpenMRS write-back request or dry run."""
+
+    method: str
+    url: str
+    status_code: int | None
+    dry_run: bool
+    response: dict[str, Any] | None = field(default=None, repr=False)
+
+
+class OpenMRSClient:
+    """Synchronous OpenMRS REST/FHIR2 client with pagination and retries.
+
+    Args:
+        config: Source, destination, authentication, and retry settings.
+        client: Optional HTTPX-compatible client, primarily for offline tests.
+        sleep: Retry delay callable.
+    """
+
+    def __init__(
+        self,
+        config: OpenMRSConfig,
+        *,
+        client: Any | None = None,
+        sleep: Sleep = time.sleep,
+    ) -> None:
+        self.config = config
+        self._httpx = _import_httpx()
+        self._sleep = sleep
+        self._owns_client = client is None
+        self._client = client or self._httpx.Client(
+            timeout=config.timeout,
+            verify=config.verify_tls,
+        )
+        self._auth = None
+        if config.username is not None and config.password is not None:
+            self._auth = self._httpx.BasicAuth(config.username, config.password)
+
+    def close(self) -> None:
+        """Close the internally created HTTP client."""
+
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> OpenMRSClient:
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+    def iter_rest_resources(
+        self,
+        resource_name: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield all pages from an OpenMRS legacy REST collection.
+
+        Supported collections are ``obs``, ``encounter``, and ``patient``.
+        Pagination follows a response ``next`` link when present and otherwise
+        advances with OpenMRS's ``startIndex``/``limit`` convention.
+
+        Args:
+            resource_name: Legacy collection name.
+            params: Additional OpenMRS search parameters.
+
+        Yields:
+            Deep-copied JSON resources in server order.
+
+        Raises:
+            ValueError: If the resource name, page URL, or response is invalid.
+            RuntimeError: If the server repeats a page link.
+        """
+
+        name = _normalize_rest_resource(resource_name)
+        url = _join_base(self.config.base_url, f"ws/rest/v1/{name}")
+        query: dict[str, Any] | None = {
+            "v": "full",
+            "limit": self.config.page_size,
+            **dict(params or {}),
+        }
+        seen_pages: set[str] = set()
+
+        while True:
+            signature = _page_signature(url, query)
+            if signature in seen_pages:
+                raise RuntimeError("OpenMRS REST pagination repeated a page")
+            seen_pages.add(signature)
+
+            page = self._get_json(url, params=query, allowed_base=self.config.base_url)
+            results = page.get("results")
+            if not isinstance(results, list):
+                raise ValueError(
+                    "OpenMRS REST collection response lacks a results list"
+                )
+            for resource in results:
+                if not isinstance(resource, dict):
+                    raise ValueError("OpenMRS REST results must be JSON objects")
+                yield copy.deepcopy(resource)
+
+            next_link = _next_page_link(page, link_key="links")
+            if next_link:
+                url = _resolve_page_url(
+                    next_link,
+                    current_url=url,
+                    allowed_base=self.config.base_url,
+                )
+                query = None
+                continue
+
+            limit = _positive_int((query or {}).get("limit"))
+            if not results or limit is None or len(results) < limit:
+                break
+            start_index = _nonnegative_int((query or {}).get("startIndex")) or 0
+            query = dict(query or {})
+            query["startIndex"] = start_index + len(results)
+
+    def pull_rest(
+        self,
+        resource_name: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> tuple[dict[str, Any], ...]:
+        """Return a materialized legacy REST collection.
+
+        Args:
+            resource_name: Legacy collection name.
+            params: Additional OpenMRS search parameters.
+
+        Returns:
+            Resources in server order.
+        """
+
+        return tuple(self.iter_rest_resources(resource_name, params=params))
+
+    def iter_fhir_resources(
+        self,
+        resource_name: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield resources from all pages of a FHIR2 R4 search Bundle.
+
+        Args:
+            resource_name: FHIR2 resource type.
+            params: Additional FHIR search parameters.
+
+        Yields:
+            Deep-copied FHIR resources in server order.
+
+        Raises:
+            ValueError: If the resource name, page URL, or Bundle is invalid.
+            RuntimeError: If the server repeats a page link.
+        """
+
+        name = _normalize_fhir_resource(resource_name)
+        url = _join_base(self.config.base_url, f"ws/fhir2/R4/{name}")
+        query: dict[str, Any] | None = {
+            "_count": self.config.page_size,
+            **dict(params or {}),
+        }
+        seen_pages: set[str] = set()
+
+        while True:
+            signature = _page_signature(url, query)
+            if signature in seen_pages:
+                raise RuntimeError("OpenMRS FHIR2 pagination repeated a page")
+            seen_pages.add(signature)
+
+            bundle = self._get_json(
+                url,
+                params=query,
+                allowed_base=self.config.base_url,
+            )
+            if bundle.get("resourceType") != "Bundle":
+                raise ValueError("OpenMRS FHIR2 search response must be a Bundle")
+            entries = bundle.get("entry") or []
+            if not isinstance(entries, list):
+                raise ValueError("OpenMRS FHIR2 Bundle.entry must be a list")
+            for entry in entries:
+                resource = entry.get("resource") if isinstance(entry, dict) else None
+                if not isinstance(resource, dict):
+                    raise ValueError("OpenMRS FHIR2 entries must contain resources")
+                yield copy.deepcopy(resource)
+
+            next_link = _next_page_link(bundle, link_key="link")
+            if not next_link:
+                break
+            url = _resolve_page_url(
+                next_link,
+                current_url=url,
+                allowed_base=self.config.base_url,
+            )
+            query = None
+
+    def pull_fhir(
+        self,
+        resource_name: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> tuple[dict[str, Any], ...]:
+        """Return a materialized FHIR2 R4 search result.
+
+        Args:
+            resource_name: FHIR2 resource type.
+            params: Additional FHIR search parameters.
+
+        Returns:
+            Resources in server order.
+        """
+
+        return tuple(self.iter_fhir_resources(resource_name, params=params))
+
+    def write_rest_resource(
+        self,
+        resource_name: str,
+        resource: Mapping[str, Any],
+        *,
+        dry_run: bool = False,
+        obs_comment: bool = False,
+    ) -> WriteResult:
+        """POST a de-identified REST resource to the destination server.
+
+        OpenMRS legacy REST uses ``POST /resource`` for creates and
+        ``POST /resource/{uuid}`` for partial updates. With ``obs_comment``,
+        only the de-identified string ``value`` (or existing ``comment``) is
+        written to the source obs's comment field.
+
+        Args:
+            resource_name: Legacy resource type.
+            resource: De-identified resource mapping.
+            dry_run: Return the planned request without sending it.
+            obs_comment: Send only a de-identified obs comment.
+
+        Returns:
+            The completed or planned request summary.
+
+        Raises:
+            ValueError: If the resource or obs-comment request is invalid.
+        """
+
+        name = _normalize_rest_resource(resource_name)
+        payload = copy.deepcopy(dict(resource))
+        resource_id = _optional_string(payload.get("uuid"))
+        if obs_comment:
+            if name != "obs":
+                raise ValueError("obs_comment convention is only valid for obs")
+            if resource_id is None:
+                raise ValueError("obs_comment write-back requires an obs uuid")
+            comment = payload.get("value")
+            if not isinstance(comment, str):
+                comment = payload.get("comment")
+            if not isinstance(comment, str) or not comment.strip():
+                raise ValueError("obs_comment write-back requires string text")
+            payload = {"comment": comment}
+
+        path = f"ws/rest/v1/{name}"
+        if resource_id:
+            path = f"{path}/{resource_id}"
+        url = _join_base(self._destination_base, path)
+        return self._write("POST", url, payload, dry_run=dry_run)
+
+    def write_fhir_resource(
+        self,
+        resource: Mapping[str, Any],
+        *,
+        dry_run: bool = False,
+    ) -> WriteResult:
+        """PUT or POST one de-identified FHIR2 resource.
+
+        Args:
+            resource: De-identified Patient, Encounter, or Observation.
+            dry_run: Return the planned request without sending it.
+
+        Returns:
+            The completed or planned request summary.
+
+        Raises:
+            ValueError: If the resource type is unsupported.
+        """
+
+        payload = copy.deepcopy(dict(resource))
+        resource_name = _normalize_fhir_resource(str(payload.get("resourceType") or ""))
+        resource_id = _optional_string(payload.get("id"))
+        path = f"ws/fhir2/R4/{resource_name}"
+        method = "POST"
+        if resource_id:
+            path = f"{path}/{resource_id}"
+            method = "PUT"
+        url = _join_base(self._destination_base, path)
+        return self._write(method, url, payload, dry_run=dry_run)
+
+    @property
+    def _destination_base(self) -> str:
+        return self.config.destination_url or self.config.base_url
+
+    def _write(
+        self,
+        method: str,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        dry_run: bool,
+    ) -> WriteResult:
+        if dry_run:
+            return WriteResult(
+                method=method,
+                url=url,
+                status_code=None,
+                dry_run=True,
+            )
+        response = self._request(
+            method,
+            url,
+            json_payload=payload,
+            allowed_base=self._destination_base,
+        )
+        decoded = _decode_optional_json(response)
+        return WriteResult(
+            method=method,
+            url=url,
+            status_code=int(response.status_code),
+            dry_run=False,
+            response=decoded,
+        )
+
+    def _get_json(
+        self,
+        url: str,
+        *,
+        params: Mapping[str, Any] | None,
+        allowed_base: str,
+    ) -> dict[str, Any]:
+        response = self._request(
+            "GET",
+            url,
+            params=params,
+            allowed_base=allowed_base,
+        )
+        decoded = _decode_optional_json(response)
+        if decoded is None:
+            raise ValueError("OpenMRS response body must be a JSON object")
+        return decoded
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        json_payload: Mapping[str, Any] | None = None,
+        allowed_base: str,
+    ) -> Any:
+        _ensure_url_within_base(url, allowed_base=allowed_base)
+        headers = {
+            "Accept": "application/fhir+json, application/json",
+            **{str(key): str(value) for key, value in self.config.headers.items()},
+        }
+        if json_payload is not None:
+            headers["Content-Type"] = "application/json"
+        if self.config.session_token:
+            headers["Cookie"] = (
+                f"{self.config.session_cookie_name}={self.config.session_token}"
+            )
+
+        request_kwargs: dict[str, Any] = {"headers": headers}
+        if params is not None:
+            request_kwargs["params"] = dict(params)
+        if json_payload is not None:
+            request_kwargs["json"] = dict(json_payload)
+        if self._auth is not None:
+            request_kwargs["auth"] = self._auth
+
+        for attempt in range(self.config.max_retries + 1):
+            try:
+                response = self._client.request(method, url, **request_kwargs)
+            except self._httpx.RequestError:
+                if attempt >= self.config.max_retries:
+                    raise
+                self._sleep(self._backoff_seconds(attempt, None))
+                continue
+
+            if (
+                int(response.status_code) in _RETRYABLE_STATUS_CODES
+                and attempt < self.config.max_retries
+            ):
+                retry_after = response.headers.get("Retry-After")
+                response.close()
+                self._sleep(self._backoff_seconds(attempt, retry_after))
+                continue
+            response.raise_for_status()
+            return response
+
+        raise RuntimeError("OpenMRS request retry loop exited unexpectedly")
+
+    def _backoff_seconds(self, attempt: int, retry_after: str | None) -> float:
+        if retry_after:
+            try:
+                return min(max(float(retry_after), 0.0), 60.0)
+            except ValueError:
+                pass
+        return min(self.config.backoff_factor * (2**attempt), 60.0)
+
+
+class OpenMRSAdapter:
+    """Pull, de-identify, write back, and export OpenMRS resources.
+
+    Args:
+        client: Configured facility-local OpenMRS client.
+        policy: Privacy policy passed to the OpenMed pipeline.
+        method: De-identification method.
+        deidentifier: Optional pipeline override, mainly for offline tests.
+    """
+
+    def __init__(
+        self,
+        client: OpenMRSClient,
+        *,
+        policy: str = _DEFAULT_POLICY,
+        method: str = _DEFAULT_METHOD,
+        deidentifier: Deidentifier | None = None,
+    ) -> None:
+        self.client = client
+        self.policy = policy
+        self.method = method
+        self.deidentifier = deidentifier
+
+    def pull_rest(
+        self,
+        resource_name: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> tuple[DeidentifiedResource, ...]:
+        """Pull and de-identify one legacy REST resource collection.
+
+        Args:
+            resource_name: ``obs``, ``encounter``, or ``patient``.
+            params: Additional OpenMRS search parameters.
+
+        Returns:
+            De-identified records with OperationOutcome-style manifests.
+        """
+
+        name = _normalize_rest_resource(resource_name)
+        return tuple(
+            self._transform_rest(name, resource)
+            for resource in self.client.iter_rest_resources(name, params=params)
+        )
+
+    def pull_fhir(
+        self,
+        resource_name: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> tuple[DeidentifiedResource, ...]:
+        """Pull and de-identify one FHIR2 R4 resource collection.
+
+        Args:
+            resource_name: Patient, Encounter, or Observation.
+            params: Additional FHIR search parameters.
+
+        Returns:
+            De-identified records with OperationOutcome-style manifests.
+        """
+
+        name = _normalize_fhir_resource(resource_name)
+        records: list[DeidentifiedResource] = []
+        for resource in self.client.iter_fhir_resources(name, params=params):
+            transformed, manifest = de_identify_resource_with_manifest(
+                resource,
+                policy=self.policy,
+                method=self.method,
+                deidentifier=self.deidentifier,
+            )
+            records.append(
+                DeidentifiedResource(
+                    api="fhir2",
+                    resource_name=name,
+                    source_id=_optional_string(resource.get("id")),
+                    resource=transformed,
+                    manifest=manifest,
+                )
+            )
+        return tuple(records)
+
+    def write_back(
+        self,
+        records: Iterable[DeidentifiedResource],
+        *,
+        dry_run: bool = False,
+        obs_comment: bool = False,
+    ) -> tuple[WriteResult, ...]:
+        """Write de-identified records to the configured destination.
+
+        Args:
+            records: Records returned by this adapter.
+            dry_run: Plan requests without sending them.
+            obs_comment: Use the legacy REST obs-comment convention.
+
+        Returns:
+            One request summary per input record.
+
+        Raises:
+            ValueError: If a record cannot be safely written by this path.
+        """
+
+        results: list[WriteResult] = []
+        for record in records:
+            if record.api == "rest":
+                if record.resource_name == "patient":
+                    raise ValueError(
+                        "legacy REST Patient write-back is not supported; "
+                        "use the FHIR2 Patient path so identifiers are de-identified"
+                    )
+                results.append(
+                    self.client.write_rest_resource(
+                        record.resource_name,
+                        record.resource,
+                        dry_run=dry_run,
+                        obs_comment=obs_comment,
+                    )
+                )
+            elif record.api == "fhir2":
+                if obs_comment:
+                    raise ValueError(
+                        "obs_comment convention is only valid for REST obs"
+                    )
+                results.append(
+                    self.client.write_fhir_resource(
+                        record.resource,
+                        dry_run=dry_run,
+                    )
+                )
+            else:
+                raise ValueError(f"unsupported OpenMRS API kind: {record.api!r}")
+        return tuple(results)
+
+    def export_bundle(
+        self,
+        records: Iterable[DeidentifiedResource],
+        *,
+        doc_id: str = "openmrs-handoff",
+    ) -> dict[str, Any]:
+        """Emit de-identified FHIR2 records as a transaction Bundle.
+
+        Args:
+            records: De-identified FHIR2 records.
+            doc_id: Non-PHI stable seed for deterministic full URLs.
+
+        Returns:
+            A FHIR R4 transaction Bundle.
+
+        Raises:
+            ValueError: If a record is not FHIR2 or resource IDs collide.
+        """
+
+        resources = _fhir_resources(records)
+        return to_bundle(resources, doc_id=doc_id, bundle_type="transaction")
+
+    def export_ndjson(
+        self,
+        records: Iterable[DeidentifiedResource],
+        out_path: str | Path,
+    ) -> NDJSONFileSummary:
+        """Emit records through the existing FHIR bulk NDJSON path.
+
+        Args:
+            records: De-identified FHIR2 records.
+            out_path: Destination NDJSON file.
+
+        Returns:
+            The PHI-safe streaming export summary.
+
+        Raises:
+            ValueError: If a record is not a FHIR2 resource.
+        """
+
+        resources = _fhir_resources(records)
+        destination = Path(out_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        lines = (
+            json.dumps(resource, ensure_ascii=False, separators=(",", ":")) + "\n"
+            for resource in resources
+        )
+        with destination.open("w", encoding="utf-8") as output:
+            return deidentify_ndjson_stream(
+                lines,
+                output,
+                source="openmrs-fhir2-memory",
+                destination=destination,
+                deidentifier=_identity_deidentifier,
+            )
+
+    def _transform_rest(
+        self,
+        resource_name: str,
+        resource: dict[str, Any],
+    ) -> DeidentifiedResource:
+        transformed, manifest = de_identify_rest_resource_with_manifest(
+            resource,
+            resource_name=resource_name,
+            policy=self.policy,
+            method=self.method,
+            deidentifier=self.deidentifier,
+        )
+        return DeidentifiedResource(
+            api="rest",
+            resource_name=resource_name,
+            source_id=_optional_string(resource.get("uuid")),
+            resource=transformed,
+            manifest=manifest,
+        )
+
+
+def de_identify_rest_resource(
+    resource: Mapping[str, Any],
+    *,
+    resource_name: str = "resource",
+    policy: str = _DEFAULT_POLICY,
+    method: str = _DEFAULT_METHOD,
+    deidentifier: Deidentifier | None = None,
+) -> dict[str, Any]:
+    """Return a copy with only REST text value/comment/note fields changed.
+
+    Args:
+        resource: Legacy OpenMRS REST resource.
+        resource_name: Name used as the manifest path root.
+        policy: Privacy policy passed to the pipeline.
+        method: De-identification method.
+        deidentifier: Optional pipeline override, mainly for offline tests.
+
+    Returns:
+        A deep-copied resource with eligible text transformed.
+    """
+
+    transformed, _ = de_identify_rest_resource_with_manifest(
+        resource,
+        resource_name=resource_name,
+        policy=policy,
+        method=method,
+        deidentifier=deidentifier,
+    )
+    return transformed
+
+
+def de_identify_rest_resource_with_manifest(
+    resource: Mapping[str, Any],
+    *,
+    resource_name: str = "resource",
+    policy: str = _DEFAULT_POLICY,
+    method: str = _DEFAULT_METHOD,
+    deidentifier: Deidentifier | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return a de-identified REST resource and an ``OperationOutcome``.
+
+    Only string values under ``value``, comment, or note keys are transformed.
+    Coded concepts, UUIDs, references, dates, numeric observations, and every
+    other structural field are copied byte-for-byte.
+
+    Args:
+        resource: Legacy OpenMRS REST resource.
+        resource_name: Name used as the manifest path root.
+        policy: Privacy policy passed to the pipeline.
+        method: De-identification method.
+        deidentifier: Optional pipeline override, mainly for offline tests.
+
+    Returns:
+        A ``(resource, outcome)`` pair.
+    """
+
+    if not isinstance(resource, Mapping):
+        raise TypeError("resource must be an OpenMRS REST mapping")
+    transformed = copy.deepcopy(dict(resource))
+    changes: list[str] = []
+    deid = _bind_text_deidentifier(
+        deidentifier,
+        policy=policy,
+        method=method,
+    )
+    root = f"OpenMRS.{str(resource_name or 'resource').strip()}"
+    _walk_rest_text(transformed, root, changes, deid)
+    return transformed, _outcome_from_paths(changes)
+
+
+def manifest_paths(manifest: Mapping[str, Any]) -> tuple[str, ...]:
+    """Extract transformed element paths from an OperationOutcome manifest.
+
+    Args:
+        manifest: FHIR OperationOutcome-style mapping.
+
+    Returns:
+        Expressions in issue order.
+    """
+
+    paths: list[str] = []
+    issues = manifest.get("issue") or []
+    if not isinstance(issues, list):
+        return ()
+    for issue in issues:
+        expressions = issue.get("expression") if isinstance(issue, dict) else None
+        if not isinstance(expressions, list):
+            continue
+        paths.extend(
+            expression for expression in expressions if isinstance(expression, str)
+        )
+    return tuple(paths)
+
+
+def ensure_registered() -> None:
+    """Registry hook; the OpenMRS adapter has no eager side effects."""
+
+
+def _walk_rest_text(
+    node: Any,
+    path: str,
+    changes: list[str],
+    deid: Callable[[str], str],
+    *,
+    text_container: bool = False,
+) -> None:
+    if isinstance(node, dict):
+        for key, value in list(node.items()):
+            child_path = f"{path}.{key}"
+            normalized_key = str(key).casefold()
+            is_text = normalized_key in _REST_TEXT_KEYS
+            if isinstance(value, str):
+                is_nested_text = text_container and normalized_key == "text"
+                if (is_text or is_nested_text) and value.strip():
+                    transformed = deid(value)
+                    if transformed != value:
+                        node[key] = transformed
+                        changes.append(child_path)
+            elif isinstance(value, (dict, list)):
+                _walk_rest_text(
+                    value,
+                    child_path,
+                    changes,
+                    deid,
+                    text_container=(
+                        text_container or normalized_key in _REST_TEXT_CONTAINER_KEYS
+                    ),
+                )
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            child_path = f"{path}[{index}]"
+            if isinstance(value, str):
+                if text_container and value.strip():
+                    transformed = deid(value)
+                    if transformed != value:
+                        node[index] = transformed
+                        changes.append(child_path)
+            elif isinstance(value, (dict, list)):
+                _walk_rest_text(
+                    value,
+                    child_path,
+                    changes,
+                    deid,
+                    text_container=text_container,
+                )
+
+
+def _bind_text_deidentifier(
+    deidentifier: Deidentifier | None,
+    *,
+    policy: str,
+    method: str,
+) -> Callable[[str], str]:
+    if deidentifier is None:
+        from openmed.core.pii import deidentify as deidentifier
+
+    def transform(text: str) -> str:
+        kwargs: dict[str, Any] = {"method": method, "policy": policy}
+        if method == "replace":
+            kwargs["consistent"] = True
+        try:
+            result = deidentifier(text, **kwargs)
+        except TypeError:
+            kwargs.pop("consistent", None)
+            result = deidentifier(text, **kwargs)
+        transformed = getattr(result, "deidentified_text", None)
+        if not isinstance(transformed, str):
+            raise TypeError("deidentifier must return an object with deidentified_text")
+        return transformed
+
+    return transform
+
+
+def _outcome_from_paths(paths: Sequence[str]) -> dict[str, Any]:
+    return to_operation_outcome(
+        [
+            OperationOutcomeIssue(
+                severity="information",
+                code="informational",
+                diagnostics="De-identified element.",
+                expression=path,
+            )
+            for path in paths
+        ]
+    )
+
+
+def _fhir_resources(
+    records: Iterable[DeidentifiedResource],
+) -> list[dict[str, Any]]:
+    resources: list[dict[str, Any]] = []
+    for record in records:
+        if record.api != "fhir2":
+            raise ValueError("FHIR export accepts only FHIR2 resources")
+        resources.append(copy.deepcopy(record.resource))
+    return resources
+
+
+@dataclass(frozen=True)
+class _IdentityResult:
+    deidentified_text: str
+
+
+def _identity_deidentifier(text: str, **_: Any) -> _IdentityResult:
+    return _IdentityResult(deidentified_text=text)
+
+
+def _normalize_rest_resource(resource_name: str) -> str:
+    name = str(resource_name or "").strip().lower()
+    if name not in _REST_RESOURCES:
+        allowed = ", ".join(sorted(_REST_RESOURCES))
+        raise ValueError(
+            f"unsupported OpenMRS REST resource {resource_name!r}: {allowed}"
+        )
+    return name
+
+
+def _normalize_fhir_resource(resource_name: str) -> str:
+    key = str(resource_name or "").strip().lower()
+    try:
+        return _FHIR_RESOURCES[key]
+    except KeyError as exc:
+        allowed = ", ".join(_FHIR_RESOURCES.values())
+        raise ValueError(
+            f"unsupported OpenMRS FHIR2 resource {resource_name!r}: {allowed}"
+        ) from exc
+
+
+def _import_httpx() -> Any:
+    try:
+        import httpx
+    except ImportError as exc:
+        raise ImportError(
+            "OpenMRS HTTP support requires the 'openmrs' extra; "
+            "install with `pip install openmed[openmrs]`"
+        ) from exc
+    return httpx
+
+
+def _validate_base_url(value: str, *, name: str) -> None:
+    parsed = urlsplit(str(value or ""))
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"{name} must be an absolute http(s) URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError(f"{name} must not contain credentials, query, or fragment")
+
+
+def _join_base(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _ensure_url_within_base(url: str, *, allowed_base: str) -> None:
+    candidate = urlsplit(url)
+    allowed = urlsplit(allowed_base)
+    if (candidate.scheme.lower(), candidate.netloc.lower()) != (
+        allowed.scheme.lower(),
+        allowed.netloc.lower(),
+    ):
+        raise ValueError("OpenMRS pagination/write URL changed origin")
+    base_path = allowed.path.rstrip("/")
+    if base_path and not (
+        candidate.path == base_path or candidate.path.startswith(f"{base_path}/")
+    ):
+        raise ValueError("OpenMRS URL escaped the configured installation path")
+
+
+def _resolve_page_url(
+    next_link: str,
+    *,
+    current_url: str,
+    allowed_base: str,
+) -> str:
+    resolved = urljoin(current_url, next_link)
+    _ensure_url_within_base(resolved, allowed_base=allowed_base)
+    return resolved
+
+
+def _next_page_link(payload: Mapping[str, Any], *, link_key: str) -> str | None:
+    links = payload.get(link_key) or []
+    if not isinstance(links, list):
+        return None
+    for link in links:
+        if not isinstance(link, Mapping):
+            continue
+        relation = str(link.get("rel") or link.get("relation") or "").lower()
+        if relation != "next":
+            continue
+        target = link.get("url") or link.get("uri")
+        if isinstance(target, str) and target:
+            return target
+    return None
+
+
+def _decode_optional_json(response: Any) -> dict[str, Any] | None:
+    if not response.content:
+        return None
+    decoded = response.json()
+    if not isinstance(decoded, dict):
+        raise ValueError("OpenMRS response body must be a JSON object")
+    return decoded
+
+
+def _page_signature(url: str, params: Mapping[str, Any] | None) -> str:
+    query = json.dumps(dict(params or {}), sort_keys=True, default=str)
+    return f"{url}\n{query}"
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _nonnegative_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _optional_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+__all__ = [
+    "APIKind",
+    "DeidentifiedResource",
+    "OpenMRSAdapter",
+    "OpenMRSClient",
+    "OpenMRSConfig",
+    "WriteResult",
+    "de_identify_rest_resource",
+    "de_identify_rest_resource_with_manifest",
+    "manifest_paths",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,10 @@ lid = [
   "pycld2>=0.41,<1",
 ]
 
+openmrs = [
+  "httpx>=0.27",
+]
+
 presidio = [
   "presidio-analyzer>=2.2.354,<3",
 ]

--- a/tests/unit/interop/fixtures/openmrs/fhir_encounter_bundle.json
+++ b/tests/unit/interop/fixtures/openmrs/fhir_encounter_bundle.json
@@ -1,0 +1,43 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "entry": [
+    {
+      "fullUrl": "https://facility.test/openmrs/ws/fhir2/R4/Encounter/encounter-1",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "encounter-1",
+        "status": "finished",
+        "class": {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          "code": "AMB",
+          "display": "ambulatory"
+        },
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "https://facility.test/openmrs/encounter-type",
+                "code": "adult-return",
+                "display": "Adult return visit"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/patient-1"
+        },
+        "period": {
+          "start": "2026-07-01T09:30:00+03:00",
+          "end": "2026-07-01T10:00:00+03:00"
+        },
+        "note": [
+          {
+            "text": "Amina Wanjiku confirmed Kenya ID 12345678."
+          }
+        ]
+      }
+    }
+  ],
+  "link": []
+}

--- a/tests/unit/interop/fixtures/openmrs/fhir_observation_page1.json
+++ b/tests/unit/interop/fixtures/openmrs/fhir_observation_page1.json
@@ -1,0 +1,41 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "entry": [
+    {
+      "fullUrl": "https://facility.test/openmrs/ws/fhir2/R4/Observation/observation-1",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "observation-1",
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "34109-9",
+              "display": "Note"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/patient-1"
+        },
+        "encounter": {
+          "reference": "Encounter/encounter-1"
+        },
+        "valueString": "Amina Wanjiku can be reached at +254 712 345 678.",
+        "note": [
+          {
+            "text": "National identifier 12345678 was checked on the facility box."
+          }
+        ]
+      }
+    }
+  ],
+  "link": [
+    {
+      "relation": "next",
+      "url": "https://facility.test/openmrs/ws/fhir2/R4/Observation?_count=2&page=2"
+    }
+  ]
+}

--- a/tests/unit/interop/fixtures/openmrs/fhir_observation_page2.json
+++ b/tests/unit/interop/fixtures/openmrs/fhir_observation_page2.json
@@ -1,0 +1,36 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "entry": [
+    {
+      "fullUrl": "https://facility.test/openmrs/ws/fhir2/R4/Observation/observation-2",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "observation-2",
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "25836-8",
+              "display": "HIV 1 RNA"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/patient-1"
+        },
+        "encounter": {
+          "reference": "Encounter/encounter-1"
+        },
+        "valueQuantity": {
+          "value": 42,
+          "unit": "copies/mL",
+          "system": "http://unitsofmeasure.org",
+          "code": "{copies}/mL"
+        }
+      }
+    }
+  ],
+  "link": []
+}

--- a/tests/unit/interop/fixtures/openmrs/fhir_patient_bundle.json
+++ b/tests/unit/interop/fixtures/openmrs/fhir_patient_bundle.json
@@ -1,0 +1,38 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "entry": [
+    {
+      "fullUrl": "https://facility.test/openmrs/ws/fhir2/R4/Patient/patient-1",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "patient-1",
+        "identifier": [
+          {
+            "system": "https://facility.test/openmrs/id/kenya-national-id",
+            "value": "12345678"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "text": "Amina Wanjiku",
+            "family": "Wanjiku",
+            "given": [
+              "Amina"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+254 712 345 678",
+            "use": "mobile"
+          }
+        ],
+        "gender": "female"
+      }
+    }
+  ],
+  "link": []
+}

--- a/tests/unit/interop/fixtures/openmrs/rest_encounters.json
+++ b/tests/unit/interop/fixtures/openmrs/rest_encounters.json
@@ -1,0 +1,27 @@
+{
+  "results": [
+    {
+      "uuid": "22222222-2222-4222-8222-222222222222",
+      "display": "Outpatient encounter",
+      "patient": {
+        "uuid": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+      },
+      "encounterType": {
+        "uuid": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        "display": "Adult return visit"
+      },
+      "encounterDatetime": "2026-07-01T09:30:00.000+0300",
+      "encounterNotes": [
+        "Amina Wanjiku confirmed phone +254 712 345 678.",
+        "Kenya ID 12345678 verified locally."
+      ],
+      "obs": [
+        {
+          "uuid": "11111111-1111-4111-8111-111111111111",
+          "comment": "Discussed with Amina Wanjiku."
+        }
+      ]
+    }
+  ],
+  "links": []
+}

--- a/tests/unit/interop/fixtures/openmrs/rest_obs_page1.json
+++ b/tests/unit/interop/fixtures/openmrs/rest_obs_page1.json
@@ -1,0 +1,33 @@
+{
+  "results": [
+    {
+      "uuid": "11111111-1111-4111-8111-111111111111",
+      "display": "Clinical note observation",
+      "concept": {
+        "uuid": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "display": "Visit narrative",
+        "links": [
+          {
+            "rel": "self",
+            "uri": "https://facility.test/openmrs/ws/rest/v1/concept/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+          }
+        ]
+      },
+      "person": {
+        "uuid": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+      },
+      "encounter": {
+        "uuid": "22222222-2222-4222-8222-222222222222"
+      },
+      "obsDatetime": "2026-07-01T09:30:00.000+0300",
+      "value": "Amina Wanjiku called from +254 712 345 678; Kenya ID 12345678.",
+      "comment": "Follow up with Amina Wanjiku next week."
+    }
+  ],
+  "links": [
+    {
+      "rel": "next",
+      "uri": "https://facility.test/openmrs/ws/rest/v1/obs?startIndex=1&limit=2&v=full"
+    }
+  ]
+}

--- a/tests/unit/interop/fixtures/openmrs/rest_obs_page2.json
+++ b/tests/unit/interop/fixtures/openmrs/rest_obs_page2.json
@@ -1,0 +1,23 @@
+{
+  "results": [
+    {
+      "uuid": "33333333-3333-4333-8333-333333333333",
+      "display": "Coded viral load observation",
+      "concept": {
+        "uuid": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "display": "HIV viral load",
+        "datatype": "Numeric"
+      },
+      "person": {
+        "uuid": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+      },
+      "encounter": {
+        "uuid": "22222222-2222-4222-8222-222222222222"
+      },
+      "obsDatetime": "2026-07-01T09:31:00.000+0300",
+      "value": 42,
+      "comment": "Result reviewed with Amina Wanjiku."
+    }
+  ],
+  "links": []
+}

--- a/tests/unit/interop/fixtures/openmrs/rest_patients.json
+++ b/tests/unit/interop/fixtures/openmrs/rest_patients.json
@@ -1,0 +1,18 @@
+{
+  "results": [
+    {
+      "uuid": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "display": "Synthetic patient",
+      "identifiers": [
+        {
+          "uuid": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+          "identifierType": {
+            "uuid": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+            "display": "KenyaEMR patient number"
+          }
+        }
+      ]
+    }
+  ],
+  "links": []
+}

--- a/tests/unit/interop/test_core_does_not_import_adapters.py
+++ b/tests/unit/interop/test_core_does_not_import_adapters.py
@@ -62,6 +62,7 @@ def test_import_interop_registry_does_not_import_optional_adapter_dependencies()
         "langchain",
         "llamaindex",
         "omop",
+        "openmrs",
         "pandas",
         "philter",
         "polars",
@@ -80,6 +81,7 @@ def test_import_interop_registry_does_not_import_optional_adapter_dependencies()
     assert adapter_spec("langchain").extra == "langchain"
     assert adapter_spec("llamaindex").extra == "llamaindex"
     assert adapter_spec("omop").extra == ""
+    assert adapter_spec("openmrs").extra == "openmrs"
     assert adapter_spec("pandas").extra == "pandas"
     assert adapter_spec("presidio").extra == "presidio"
     assert adapter_spec("philter").extra == "philter"

--- a/tests/unit/interop/test_openmrs_adapter.py
+++ b/tests/unit/interop/test_openmrs_adapter.py
@@ -1,0 +1,463 @@
+"""Offline round-trip coverage for the OpenMRS REST/FHIR2 adapter."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from openmed.interop import assert_redacted
+from openmed.interop.openmrs import (
+    OpenMRSAdapter,
+    OpenMRSClient,
+    OpenMRSConfig,
+    de_identify_rest_resource,
+    de_identify_rest_resource_with_manifest,
+    manifest_paths,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "openmrs"
+SOURCE_BASE = "https://facility.test/openmrs"
+DESTINATION_BASE = "https://handoff.test/openmrs"
+
+_REPLACEMENTS = (
+    ("+254 712 345 678", "[PHONE]"),
+    ("Amina Wanjiku", "[NAME]"),
+    ("12345678", "[NATIONAL_ID]"),
+    ("Wanjiku", "[FAMILY]"),
+    ("Amina", "[GIVEN]"),
+)
+_SEEDED_IDENTIFIERS = {
+    "[NAME]": "Amina Wanjiku",
+    "[PHONE]": "+254 712 345 678",
+    "[NATIONAL_ID]": "12345678",
+}
+
+
+@dataclass(frozen=True)
+class _FakeResult:
+    deidentified_text: str
+
+
+def _fake_deidentify(text: str, **_: Any) -> _FakeResult:
+    transformed = text
+    for original, replacement in _REPLACEMENTS:
+        transformed = transformed.replace(original, replacement)
+    return _FakeResult(deidentified_text=transformed)
+
+
+def _load(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _assert_no_seeded_phi(payload: Any) -> None:
+    assert_redacted(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True),
+        _SEEDED_IDENTIFIERS,
+    )
+
+
+class _FixtureServer:
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+        self.writes: list[tuple[str, str, dict[str, Any]]] = []
+        self.rest_obs_failures = 1
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        path = request.url.path
+        query = request.url.params
+
+        if request.method in {"POST", "PUT"}:
+            payload = json.loads(request.content)
+            self.writes.append((request.method, path, payload))
+            return httpx.Response(200, json=payload)
+
+        if path.endswith("/ws/rest/v1/obs"):
+            if self.rest_obs_failures:
+                self.rest_obs_failures -= 1
+                return httpx.Response(503, headers={"Retry-After": "0"})
+            name = (
+                "rest_obs_page2.json"
+                if query.get("startIndex") == "1"
+                else "rest_obs_page1.json"
+            )
+            return httpx.Response(200, json=_load(name))
+        if path.endswith("/ws/rest/v1/encounter"):
+            return httpx.Response(200, json=_load("rest_encounters.json"))
+        if path.endswith("/ws/rest/v1/patient"):
+            return httpx.Response(200, json=_load("rest_patients.json"))
+
+        if path.endswith("/ws/fhir2/R4/Patient"):
+            return httpx.Response(200, json=_load("fhir_patient_bundle.json"))
+        if path.endswith("/ws/fhir2/R4/Encounter"):
+            return httpx.Response(200, json=_load("fhir_encounter_bundle.json"))
+        if path.endswith("/ws/fhir2/R4/Observation"):
+            name = (
+                "fhir_observation_page2.json"
+                if query.get("page") == "2"
+                else "fhir_observation_page1.json"
+            )
+            return httpx.Response(200, json=_load(name))
+
+        return httpx.Response(404)
+
+
+def _make_adapter(
+    server: _FixtureServer,
+    *,
+    session_token: str | None = None,
+    sleeps: list[float] | None = None,
+) -> tuple[OpenMRSClient, OpenMRSAdapter]:
+    auth: dict[str, str] = (
+        {"session_token": session_token}
+        if session_token
+        else {"username": "adapter-user", "password": "adapter-password"}
+    )
+    config = OpenMRSConfig(
+        base_url=SOURCE_BASE,
+        destination_url=DESTINATION_BASE,
+        page_size=2,
+        max_retries=2,
+        backoff_factor=0,
+        **auth,
+    )
+    http_client = httpx.Client(transport=httpx.MockTransport(server))
+    client = OpenMRSClient(
+        config,
+        client=http_client,
+        sleep=(sleeps.append if sleeps is not None else lambda _: None),
+    )
+    return client, OpenMRSAdapter(client, deidentifier=_fake_deidentify)
+
+
+def test_registry_is_lazy_and_does_not_import_openmrs_or_httpx() -> None:
+    script = """
+import sys
+import openmed.interop as interop
+assert 'openmed.interop.openmrs' not in sys.modules
+assert 'httpx' not in sys.modules
+assert 'openmrs' in interop.available_adapters()
+assert interop.adapter_spec('openmrs').extra == 'openmrs'
+module = interop.get_adapter('openmrs')
+assert module.__name__ == 'openmed.interop.openmrs'
+assert 'httpx' not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
+def test_rest_walker_changes_only_text_value_comment_and_note_fields() -> None:
+    resource = _load("rest_obs_page1.json")["results"][0]
+    original = copy.deepcopy(resource)
+
+    transformed, manifest = de_identify_rest_resource_with_manifest(
+        resource,
+        resource_name="obs",
+        deidentifier=_fake_deidentify,
+    )
+
+    assert resource == original
+    assert transformed["uuid"] == original["uuid"]
+    assert transformed["concept"] == original["concept"]
+    assert transformed["person"] == original["person"]
+    assert transformed["encounter"] == original["encounter"]
+    assert transformed["obsDatetime"] == original["obsDatetime"]
+    assert transformed["value"] == (
+        "[NAME] called from [PHONE]; Kenya ID [NATIONAL_ID]."
+    )
+    assert transformed["comment"] == "Follow up with [NAME] next week."
+    assert manifest_paths(manifest) == (
+        "OpenMRS.obs.value",
+        "OpenMRS.obs.comment",
+    )
+    _assert_no_seeded_phi(transformed)
+
+
+def test_rest_walker_handles_encounter_note_lists_and_preserves_numeric_obs() -> None:
+    encounter = _load("rest_encounters.json")["results"][0]
+    transformed = de_identify_rest_resource(
+        encounter,
+        resource_name="encounter",
+        deidentifier=_fake_deidentify,
+    )
+    numeric = _load("rest_obs_page2.json")["results"][0]
+    numeric_result = de_identify_rest_resource(
+        numeric,
+        resource_name="obs",
+        deidentifier=_fake_deidentify,
+    )
+
+    assert transformed["uuid"] == encounter["uuid"]
+    assert transformed["patient"] == encounter["patient"]
+    assert transformed["encounterType"] == encounter["encounterType"]
+    assert transformed["encounterNotes"] == [
+        "[NAME] confirmed phone [PHONE].",
+        "Kenya ID [NATIONAL_ID] verified locally.",
+    ]
+    assert numeric_result["value"] == 42
+    assert numeric_result["concept"] == numeric["concept"]
+    _assert_no_seeded_phi(transformed)
+    _assert_no_seeded_phi(numeric_result)
+
+
+def test_rest_walker_handles_structured_note_text_without_touching_author() -> None:
+    resource = {
+        "uuid": "note-resource-uuid",
+        "notes": [
+            {
+                "text": "Amina Wanjiku called +254 712 345 678.",
+                "author": {"uuid": "author-uuid", "display": "Clinical officer"},
+            }
+        ],
+    }
+
+    transformed = de_identify_rest_resource(
+        resource,
+        resource_name="encounter",
+        deidentifier=_fake_deidentify,
+    )
+
+    assert transformed["notes"][0]["text"] == "[NAME] called [PHONE]."
+    assert transformed["notes"][0]["author"] == resource["notes"][0]["author"]
+
+
+def test_rest_pull_paginates_retries_and_uses_basic_auth() -> None:
+    server = _FixtureServer()
+    sleeps: list[float] = []
+    client, adapter = _make_adapter(server, sleeps=sleeps)
+
+    records = adapter.pull_rest("obs")
+
+    assert len(records) == 2
+    assert sleeps == [0.0]
+    get_requests = [request for request in server.requests if request.method == "GET"]
+    assert len(get_requests) == 3
+    assert all(
+        request.headers["authorization"].startswith("Basic ")
+        for request in get_requests
+    )
+    assert get_requests[-1].url.params["startIndex"] == "1"
+    assert records[0].source_id == "11111111-1111-4111-8111-111111111111"
+    assert records[0].transformed_paths == (
+        "OpenMRS.obs.value",
+        "OpenMRS.obs.comment",
+    )
+    assert records[1].resource["value"] == 42
+    client.close()
+
+
+@pytest.mark.parametrize(
+    ("resource_name", "path_suffix"),
+    [
+        ("obs", "/ws/rest/v1/obs"),
+        ("encounter", "/ws/rest/v1/encounter"),
+        ("patient", "/ws/rest/v1/patient"),
+    ],
+)
+def test_legacy_client_targets_all_required_endpoints(
+    resource_name: str,
+    path_suffix: str,
+) -> None:
+    server = _FixtureServer()
+    server.rest_obs_failures = 0
+    client, _ = _make_adapter(server)
+
+    resources = client.pull_rest(resource_name)
+
+    assert resources
+    assert server.requests[0].url.path.endswith(path_suffix)
+    client.close()
+
+
+def test_session_token_uses_openmrs_session_cookie() -> None:
+    server = _FixtureServer()
+    server.rest_obs_failures = 0
+    client, _ = _make_adapter(server, session_token="facility-session-token")
+
+    client.pull_rest("patient")
+
+    assert server.requests[0].headers["cookie"] == ("JSESSIONID=facility-session-token")
+    assert "authorization" not in server.requests[0].headers
+    client.close()
+
+
+def test_fhir_round_trip_bundle_and_ndjson_are_valid_and_phi_free(
+    tmp_path: Path,
+) -> None:
+    server = _FixtureServer()
+    client, adapter = _make_adapter(server)
+
+    patients = adapter.pull_fhir("Patient")
+    encounters = adapter.pull_fhir("Encounter")
+    observations = adapter.pull_fhir("Observation")
+    records = patients + encounters + observations
+
+    assert len(records) == 4
+    assert records[0].resource["identifier"][0]["system"] == (
+        "https://facility.test/openmrs/id/kenya-national-id"
+    )
+    assert (
+        records[1].resource["type"][0]["coding"]
+        == (
+            _load("fhir_encounter_bundle.json")["entry"][0]["resource"]["type"][0][
+                "coding"
+            ]
+        )
+    )
+    assert (
+        records[2].resource["code"]["coding"]
+        == (
+            _load("fhir_observation_page1.json")["entry"][0]["resource"]["code"][
+                "coding"
+            ]
+        )
+    )
+    assert records[2].resource["subject"]["reference"] == "Patient/patient-1"
+    assert records[2].resource["encounter"]["reference"] == ("Encounter/encounter-1")
+    assert "Observation.valueString" in records[2].transformed_paths
+    for record in records:
+        _assert_no_seeded_phi(record.resource)
+
+    bundle = adapter.export_bundle(records, doc_id="synthetic-openmrs-roundtrip")
+    repeated = adapter.export_bundle(records, doc_id="synthetic-openmrs-roundtrip")
+    assert bundle == repeated
+    assert bundle["resourceType"] == "Bundle"
+    assert bundle["type"] == "transaction"
+    assert all(entry["fullUrl"].startswith("urn:uuid:") for entry in bundle["entry"])
+    assert all("request" in entry for entry in bundle["entry"])
+    full_urls = {entry["fullUrl"] for entry in bundle["entry"]}
+    references = _collect_references(bundle)
+    assert references
+    assert all(reference in full_urls for reference in references)
+    _assert_no_seeded_phi(bundle)
+
+    output = tmp_path / "openmrs-deidentified.ndjson"
+    summary = adapter.export_ndjson(records, output)
+    lines = [json.loads(line) for line in output.read_text().splitlines()]
+    assert summary.resources_deidentified == 4
+    assert summary.error_count == 0
+    assert lines == [record.resource for record in records]
+    _assert_no_seeded_phi(lines)
+    client.close()
+
+
+def test_write_back_preserves_resources_and_dry_run_sends_nothing() -> None:
+    server = _FixtureServer()
+    server.rest_obs_failures = 0
+    client, adapter = _make_adapter(server)
+    rest_records = adapter.pull_rest("obs") + adapter.pull_rest("encounter")
+    fhir_records = adapter.pull_fhir("Patient") + adapter.pull_fhir("Observation")
+    requests_before_dry_run = len(server.requests)
+
+    dry_results = adapter.write_back(rest_records, dry_run=True)
+
+    assert all(result.dry_run and result.status_code is None for result in dry_results)
+    assert len(server.requests) == requests_before_dry_run
+
+    rest_results = adapter.write_back(rest_records)
+    fhir_results = adapter.write_back(fhir_records)
+
+    assert all(result.status_code == 200 for result in rest_results + fhir_results)
+    assert any(
+        method == "POST"
+        and path.endswith("/ws/rest/v1/obs/11111111-1111-4111-8111-111111111111")
+        for method, path, _ in server.writes
+    )
+    assert any(
+        method == "PUT" and path.endswith("/ws/fhir2/R4/Patient/patient-1")
+        for method, path, _ in server.writes
+    )
+    for _, _, payload in server.writes:
+        _assert_no_seeded_phi(payload)
+
+    rest_payload = next(
+        payload
+        for method, path, payload in server.writes
+        if method == "POST" and path.endswith("11111111-1111-4111-8111-111111111111")
+    )
+    original_rest = _load("rest_obs_page1.json")["results"][0]
+    assert rest_payload["uuid"] == original_rest["uuid"]
+    assert rest_payload["concept"] == original_rest["concept"]
+    assert rest_payload["person"] == original_rest["person"]
+    client.close()
+
+
+def test_obs_comment_write_back_only_posts_deidentified_comment() -> None:
+    server = _FixtureServer()
+    server.rest_obs_failures = 0
+    client, adapter = _make_adapter(server)
+    record = adapter.pull_rest("obs")[0]
+
+    results = adapter.write_back([record], obs_comment=True)
+
+    assert results[0].method == "POST"
+    assert server.writes[-1][2] == {
+        "comment": "[NAME] called from [PHONE]; Kenya ID [NATIONAL_ID]."
+    }
+    client.close()
+
+
+def test_legacy_patient_write_back_is_blocked_in_favor_of_safe_fhir_path() -> None:
+    server = _FixtureServer()
+    client, adapter = _make_adapter(server)
+    patients = adapter.pull_rest("patient")
+
+    with pytest.raises(ValueError, match="FHIR2 Patient"):
+        adapter.write_back(patients)
+    assert not server.writes
+    client.close()
+
+
+def test_pagination_rejects_cross_origin_next_link() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        payload = _load("fhir_patient_bundle.json")
+        payload["link"] = [
+            {"relation": "next", "url": "https://outside.example/Patient?page=2"}
+        ]
+        return httpx.Response(200, json=payload)
+
+    config = OpenMRSConfig(base_url=SOURCE_BASE, max_retries=0)
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = OpenMRSClient(config, client=http_client)
+
+    with pytest.raises(ValueError, match="changed origin"):
+        client.pull_fhir("Patient")
+    client.close()
+
+
+def test_config_rejects_ambiguous_auth_and_hides_secrets() -> None:
+    with pytest.raises(ValueError, match="either basic authentication"):
+        OpenMRSConfig(
+            base_url=SOURCE_BASE,
+            username="user",
+            password="password",
+            session_token="token",
+        )
+
+    config = OpenMRSConfig(
+        base_url=SOURCE_BASE,
+        username="user",
+        password="not-in-repr",
+    )
+    assert "not-in-repr" not in repr(config)
+
+
+def _collect_references(node: Any) -> list[str]:
+    references: list[str] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "reference" and isinstance(value, str):
+                references.append(value)
+            else:
+                references.extend(_collect_references(value))
+    elif isinstance(node, list):
+        for value in node:
+            references.extend(_collect_references(value))
+    return references

--- a/tests/unit/test_no_telemetry.py
+++ b/tests/unit/test_no_telemetry.py
@@ -65,6 +65,7 @@ ALLOWED_NETWORK_MODULES: dict[str, str] = {
     "core/offline.py": "the offline network-block guard itself (OM-005)",
     "eval/datasets/drugprot.py": "opt-in evaluation dataset download",
     "eval/suites/shield.py": "opt-in evaluation dataset/rows fetch",
+    "interop/openmrs.py": "opt-in facility-local OpenMRS HTTP client",
     "service/client.py": "opt-in REST service HTTP client",
     "service/privacy_gateway.py": "opt-in privacy-gateway forwarding (user-configured)",
     "service/smart_backend.py": "opt-in smart-backend routing (user-configured)",

--- a/uv.lock
+++ b/uv.lock
@@ -2162,14 +2162,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/24/0e0c12cb6f7cb864779a9d2fefee9ca91838f6db402c8780c9d28a8d7ebe/gitpython-3.1.53.tar.gz", hash = "sha256:06ae8d9623b0ed0d67b8adeac5c7008d0a5a404b087a9e0d0c7163bdd3a6b497", size = 224597, upload-time = "2026-07-20T13:41:52.839Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a6/bff12b3238885eeef7d28ef908b24e0cba91c476c31cb876a00a0986ce2c/gitpython-3.1.53-py3-none-any.whl", hash = "sha256:187885556b64ab357bd4ea84e2c4cce2861a613a7f4268b3f7f7ba05f2ce4ab0", size = 216237, upload-time = "2026-07-20T13:41:51.473Z" },
 ]
 
 [[package]]
@@ -5076,6 +5076,9 @@ onnx-runtime = [
     { name = "onnxruntime" },
     { name = "tokenizers" },
 ]
+openmrs = [
+    { name = "httpx" },
+]
 openvino = [
     { name = "nncf" },
     { name = "onnxruntime" },
@@ -5158,6 +5161,7 @@ requires-dist = [
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.64" },
     { name = "hanlp", marker = "extra == 'zh-hanlp'", specifier = ">=2.1,<3" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
+    { name = "httpx", marker = "extra == 'openmrs'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'service'", specifier = ">=0.27" },
     { name = "huggingface-hub", marker = "extra == 'coreml'", specifier = ">=0.30" },
     { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=0.30" },
@@ -5256,7 +5260,7 @@ requires-dist = [
     { name = "typer", marker = "extra == 'dev'", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'service'", specifier = ">=0.29" },
 ]
-provides-extras = ["agents", "awq", "cli", "cloud", "columnar", "coreml", "dask", "dev", "docs", "duckdb", "gliner", "gptq", "grounding", "hf", "indic", "integrity", "kafka", "langchain", "lid", "llamaindex", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "onnx-runtime", "openvino", "pandas", "philter", "polars", "prefect", "presidio", "pydeid", "service", "spacy", "spark", "zh", "zh-hanlp", "zh-pkuseg"]
+provides-extras = ["agents", "awq", "cli", "cloud", "columnar", "coreml", "dask", "dev", "docs", "duckdb", "gliner", "gptq", "grounding", "hf", "indic", "integrity", "kafka", "langchain", "lid", "llamaindex", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "onnx-runtime", "openmrs", "openvino", "pandas", "philter", "polars", "prefect", "presidio", "pydeid", "service", "spacy", "spark", "zh", "zh-hanlp", "zh-pkuseg"]
 
 [[package]]
 name = "opentelemetry-api"
@@ -6438,11 +6442,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds a facility-local OpenMRS adapter that pulls legacy REST and FHIR2 R4 resources, de-identifies eligible text before egress, and hands back only de-identified payloads through destination write-back, deterministic transaction Bundles, or streaming NDJSON.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing behavior)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Register a lazy `openmrs` interop adapter and optional HTTP extra without importing the adapter or HTTP client from the core registry.
- Add legacy REST and FHIR2 clients with Basic/session authentication, pagination, transient retry, same-origin page validation, dry runs, destination write-back, and the REST obs-comment convention.
- Reuse the FHIR privacy/export paths, add OperationOutcome-style manifests, and provide deterministic transaction Bundle and streaming NDJSON exports.
- Add synthetic recorded-shape REST/FHIR fixtures, round-trip and no-leak gates, documentation, and a facility handoff example.
- Register the explicitly user-initiated OpenMRS client in the reviewed network-surface inventory.

## Testing

- [x] I have added tests that prove this feature works
- [x] New and existing tests pass locally with these changes
- [x] I have tested this change with different inputs

Validation performed:

- `.venv/bin/python -m pytest tests/ -q` — 6,021 passed, 47 skipped
- Focused OpenMRS and lazy-import tests — 18 passed
- Network-surface policy tests — 9 passed
- `make format`
- `make lint`
- `make format-check`
- `make type-check`
- `pre-commit run --files <changed files>`
- `uv lock --check`
- `make docs-build`
- `python3 -m build`

All tests use synthetic REST and FHIR2 fixtures and make no live-server request.

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [ ] I have not added any new dependencies
- [x] The adapter exposes the existing `httpx` dependency through an opt-in `openmrs` extra while keeping core installation and imports unchanged.

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] I have kept the commit focused

## Related Issues

Closes #1427

## Screenshots/Examples

Not applicable; this is a Python interoperability adapter and documentation change.
