### PR TITLE
Add resilient integrity-checked model downloads

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,14 +107,38 @@ print(result.deidentified_text)
 `shift_dates`) — see the [Anonymization quickstart](anonymization.md#quickstart-choosing-a-method)
 for a runnable example of each, plus how to reverse one with `reidentify()`.
 
-## 4. Copy code snippets from the docs
+## 4. Pull a model reliably for offline use
+
+Use the model pull command to warm the Hugging Face cache before working
+offline. Downloads resume after interrupted transfers, retry transient network
+failures, and verify every file against Hub metadata:
+
+```bash
+openmed models pull disease_detection_superclinical
+```
+
+On a metered or unstable connection, pin the revision, limit transfer speed,
+and tune the retry count explicitly:
+
+```bash
+openmed models pull disease_detection_superclinical \
+  --revision main \
+  --max-bandwidth 524288 \
+  --retries 5
+```
+
+Progress contains only repository filenames and byte/file totals. After the
+pull completes, set `OPENMED_OFFLINE=1`; the same command then performs a
+cache-only lookup and never attempts a network connection.
+
+## 5. Copy code snippets from the docs
 
 All code blocks ship with Material for MkDocs copy buttons. Invoking the command palette (`/` or `cmd/ctrl + K`) lets you
 search for “GLiNER,” “OpenMedConfig,” or “token classification,” then copy the snippet that appears in the preview pane.
 If you rely on AI copilots (ChatGPT, Copilot, etc.), point them at the published docs URL so they crawl the same
 structured Markdown and surface canonical answers.
 
-## 5. Optional: pin configuration
+## 6. Optional: pin configuration
 
 ```python
 from openmed.core import OpenMedConfig, ModelLoader

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -150,6 +150,13 @@ def _non_negative_int(value: str) -> int:
     return parsed
 
 
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be greater than 0")
+    return parsed
+
+
 def _policy_name_arg(value: str) -> str:
     try:
         return canonical_policy_name(value)
@@ -749,6 +756,34 @@ def _add_fhir_command(subparsers: argparse._SubParsersAction) -> None:
 def _add_models_command(subparsers: argparse._SubParsersAction) -> None:
     models_parser = subparsers.add_parser("models", help="Discover OpenMed models.")
     models_sub = models_parser.add_subparsers(dest="models_command")
+
+    models_pull = models_sub.add_parser(
+        "pull",
+        help="Download and integrity-check a model for offline use.",
+    )
+    models_pull.add_argument(
+        "model",
+        help="Registry alias, bare model name, or Hugging Face repository id.",
+    )
+    models_pull.add_argument(
+        "--revision",
+        default=None,
+        help="Optional branch, tag, or commit to download.",
+    )
+    models_pull.add_argument(
+        "--max-bandwidth",
+        type=_positive_int,
+        default=None,
+        metavar="BYTES_PER_SECOND",
+        help="Limit aggregate download bandwidth in bytes per second.",
+    )
+    models_pull.add_argument(
+        "--retries",
+        type=_non_negative_int,
+        default=5,
+        help="Retries for transient network failures (default: 5).",
+    )
+    models_pull.set_defaults(handler=_handle_models_pull)
 
     models_list = models_sub.add_parser("list", help="List available models.")
     models_list.add_argument(
@@ -2658,6 +2693,42 @@ def _handle_models_list(args: argparse.Namespace) -> int:
     model_names = [str(model) for model in models]
     payload = {"count": len(model_names), "models": model_names}
     return emit(args, payload, human="\n".join(model_names))
+
+
+def _handle_models_pull(args: argparse.Namespace) -> int:
+    from ..core.hf_hub import DownloadProgress, prefetch_model
+
+    config = _load_and_apply_config(args)
+    completed_files = 0
+
+    def report_progress(progress: DownloadProgress) -> None:
+        nonlocal completed_files
+        finished = progress.files_done > completed_files
+        completed_files = max(completed_files, progress.files_done)
+        line_end = "\n" if finished else "\r"
+        sys.stdout.write(
+            f"{progress.filename}: "
+            f"{progress.bytes_done}/{progress.bytes_total} bytes; "
+            f"{progress.files_done}/{progress.files_total} files"
+            f"{line_end}"
+        )
+        sys.stdout.flush()
+
+    try:
+        path = prefetch_model(
+            args.model,
+            revision=args.revision,
+            config=config,
+            retries=args.retries,
+            max_bandwidth=args.max_bandwidth,
+            progress_callback=report_progress,
+        )
+    except Exception as exc:  # pragma: no cover - exact failures tested in helper
+        sys.stderr.write(f"Failed to pull model: {exc}\n")
+        return 1
+
+    sys.stdout.write(f"Model ready: {path}\n")
+    return 0
 
 
 def _handle_models_info(args: argparse.Namespace) -> int:

--- a/openmed/core/hf_hub.py
+++ b/openmed/core/hf_hub.py
@@ -484,7 +484,15 @@ def _normalise_patterns(
 
 def _safe_repo_filename(filename: str) -> bool:
     path = PurePosixPath(filename)
-    return bool(filename) and not path.is_absolute() and ".." not in path.parts
+    return (
+        bool(filename)
+        and not path.is_absolute()
+        and ".." not in path.parts
+        and "\\" not in filename
+        and all(
+            ord(character) >= 32 and ord(character) != 127 for character in filename
+        )
+    )
 
 
 def _is_hex_digest(value: Any, length: int) -> bool:
@@ -509,24 +517,32 @@ def _with_retry(operation: Callable[[], Any], *, retries: int) -> Any:
 
 
 def _is_transient_error(error: Exception) -> bool:
-    status_code = _error_status_code(error)
-    if status_code is not None:
-        return status_code in {408, 429} or 500 <= status_code <= 599
-    if isinstance(error, (ConnectionError, TimeoutError)):
-        return True
-    error_type = type(error)
-    qualified_name = f"{error_type.__module__}.{error_type.__name__}".lower()
-    return any(
-        marker in qualified_name
-        for marker in (
-            "connecterror",
-            "connectionerror",
-            "networkerror",
-            "proxyerror",
-            "timeoutexception",
-            "timeouterror",
-        )
-    )
+    current: Exception | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        status_code = _error_status_code(current)
+        if status_code is not None:
+            return status_code in {408, 429} or 500 <= status_code <= 599
+        if isinstance(current, (ConnectionError, TimeoutError)):
+            return True
+        error_type = type(current)
+        qualified_name = f"{error_type.__module__}.{error_type.__name__}".lower()
+        if any(
+            marker in qualified_name
+            for marker in (
+                "connecterror",
+                "connectionerror",
+                "networkerror",
+                "proxyerror",
+                "timeoutexception",
+                "timeouterror",
+            )
+        ):
+            return True
+        cause = current.__cause__ or current.__context__
+        current = cause if isinstance(cause, Exception) else None
+    return False
 
 
 def _error_status_code(error: Exception) -> int | None:

--- a/openmed/core/hf_hub.py
+++ b/openmed/core/hf_hub.py
@@ -18,10 +18,14 @@ Design constraints (see ``AGENTS.md``):
 
 from __future__ import annotations
 
+import fnmatch
+import hashlib
+import random
 import shutil
+import time
 from dataclasses import dataclass
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Optional, Sequence
 
 from .model_registry import get_model_info
 from .offline import OfflineModeError, is_local_only
@@ -31,6 +35,8 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 __all__ = [
     "CachedModel",
+    "DownloadIntegrityError",
+    "DownloadProgress",
     "prefetch_model",
     "list_cached_models",
     "clear_cached_model",
@@ -38,6 +44,9 @@ __all__ = [
 ]
 
 DEFAULT_ORG = "OpenMed"
+DEFAULT_RETRIES = 5
+_BACKOFF_BASE_SECONDS = 1.0
+_BACKOFF_MAX_SECONDS = 30.0
 
 _HF_INSTALL_HINT = (
     "huggingface-hub is required to pull OpenMed models from the Hub. "
@@ -60,6 +69,55 @@ class CachedModel:
     size_on_disk: int
     last_accessed: Optional[float]
     path: Path
+
+
+@dataclass(frozen=True)
+class DownloadProgress:
+    """PHI-free progress for one model-repository file.
+
+    Attributes:
+        filename: Repository-relative model filename.
+        bytes_done: Bytes already present for the current file.
+        bytes_total: Expected size of the current file.
+        files_done: Fully downloaded and integrity-checked files.
+        files_total: Total number of files selected for the snapshot.
+    """
+
+    filename: str
+    bytes_done: int
+    bytes_total: int
+    files_done: int
+    files_total: int
+
+
+class DownloadIntegrityError(RuntimeError):
+    """Raised when a downloaded model file cannot be verified safely."""
+
+
+@dataclass(frozen=True)
+class _RemoteFile:
+    filename: str
+    size: int
+    algorithm: str
+    digest: str
+
+
+class _BandwidthLimiter:
+    """Simple process-local limiter shared by every file in one pull."""
+
+    def __init__(self, bytes_per_second: int) -> None:
+        self.bytes_per_second = bytes_per_second
+        self.started_at = time.monotonic()
+        self.transferred = 0
+
+    def consume(self, byte_count: int) -> None:
+        if byte_count <= 0:
+            return
+        self.transferred += byte_count
+        target_elapsed = self.transferred / self.bytes_per_second
+        delay = target_elapsed - (time.monotonic() - self.started_at)
+        if delay > 0:
+            time.sleep(delay)
 
 
 def resolve_repo_id(name_or_alias: str, *, org: str = DEFAULT_ORG) -> str:
@@ -103,6 +161,9 @@ def prefetch_model(
     cache_dir: Optional[str] = None,
     org: str = DEFAULT_ORG,
     config: "OpenMedConfig | None" = None,
+    retries: int = DEFAULT_RETRIES,
+    max_bandwidth: int | None = None,
+    progress_callback: Callable[[DownloadProgress], None] | None = None,
 ) -> str:
     """Pre-download an OpenMed model snapshot and return its local path.
 
@@ -127,6 +188,12 @@ def prefetch_model(
         org: Organization used to qualify a bare name.
         config: Optional :class:`~openmed.core.config.OpenMedConfig` used to
             detect ``local_only`` mode.
+        retries: Number of retries after the initial attempt for transient
+            network failures. Defaults to five. Permanent HTTP errors such as
+            401 and 404 are never retried.
+        max_bandwidth: Optional aggregate download cap in bytes per second.
+        progress_callback: Optional callback receiving repository-relative
+            filenames and byte/file totals. No file contents are exposed.
 
     Returns:
         Filesystem path to the downloaded snapshot directory.
@@ -134,11 +201,23 @@ def prefetch_model(
     Raises:
         ImportError: If the optional ``[hf]`` extra is not installed.
         OfflineModeError: If offline mode is active and the model is not cached.
+        DownloadIntegrityError: If Hub metadata is insufficient for verification
+            or a downloaded file remains corrupt after one forced re-fetch.
+        ValueError: If *retries* or *max_bandwidth* is invalid.
     """
 
     snapshot_download, local_entry_not_found = _import_snapshot_download()
     repo_id = resolve_repo_id(name_or_alias, org=org)
     local_only = is_local_only(config)
+
+    if isinstance(retries, bool) or not isinstance(retries, int) or retries < 0:
+        raise ValueError("retries must be a non-negative integer")
+    if max_bandwidth is not None and (
+        isinstance(max_bandwidth, bool)
+        or not isinstance(max_bandwidth, int)
+        or max_bandwidth <= 0
+    ):
+        raise ValueError("max_bandwidth must be a positive integer")
 
     download_kwargs: dict[str, Any] = {
         "repo_id": repo_id,
@@ -153,6 +232,17 @@ def prefetch_model(
     if cache_dir is not None:
         download_kwargs["cache_dir"] = cache_dir
 
+    if not local_only:
+        return _prefetch_online(
+            repo_id=repo_id,
+            revision=revision,
+            allow_patterns=allow_patterns,
+            cache_dir=cache_dir,
+            retries=retries,
+            max_bandwidth=max_bandwidth,
+            progress_callback=progress_callback,
+        )
+
     try:
         return snapshot_download(**download_kwargs)
     except local_entry_not_found as exc:
@@ -163,6 +253,379 @@ def prefetch_model(
                 "disabled, or point HF_HOME at a cache that already contains it."
             ) from exc
         raise
+
+
+def _prefetch_online(
+    *,
+    repo_id: str,
+    revision: str | None,
+    allow_patterns: str | Sequence[str] | None,
+    cache_dir: str | None,
+    retries: int,
+    max_bandwidth: int | None,
+    progress_callback: Callable[[DownloadProgress], None] | None,
+) -> str:
+    hf_api_type, hf_hub_download = _import_online_downloads()
+    api = hf_api_type()
+    repo_info = _with_retry(
+        lambda: api.model_info(
+            repo_id,
+            revision=revision,
+            files_metadata=True,
+        ),
+        retries=retries,
+    )
+    commit_hash = getattr(repo_info, "sha", None)
+    if not isinstance(commit_hash, str) or not commit_hash:
+        raise DownloadIntegrityError(
+            f"Cannot verify {repo_id}: the Hub did not report a commit hash."
+        )
+
+    remote_files = _remote_files_from_info(
+        repo_id=repo_id,
+        siblings=getattr(repo_info, "siblings", None),
+        allow_patterns=allow_patterns,
+    )
+    limiter = _BandwidthLimiter(max_bandwidth) if max_bandwidth else None
+    downloaded: list[tuple[_RemoteFile, Path]] = []
+    files_total = len(remote_files)
+
+    for files_done, remote_file in enumerate(remote_files):
+        local_path = _download_remote_file(
+            hf_hub_download=hf_hub_download,
+            repo_id=repo_id,
+            revision=commit_hash,
+            cache_dir=cache_dir,
+            remote_file=remote_file,
+            retries=retries,
+            limiter=limiter,
+            progress_callback=progress_callback,
+            files_done=files_done,
+            files_total=files_total,
+            force_download=False,
+        )
+        if not _file_matches_metadata(local_path, remote_file):
+            _unlink_corrupt_file(local_path, remote_file.filename)
+            local_path = _download_remote_file(
+                hf_hub_download=hf_hub_download,
+                repo_id=repo_id,
+                revision=commit_hash,
+                cache_dir=cache_dir,
+                remote_file=remote_file,
+                retries=retries,
+                limiter=limiter,
+                progress_callback=progress_callback,
+                files_done=files_done,
+                files_total=files_total,
+                force_download=True,
+            )
+            if not _file_matches_metadata(local_path, remote_file):
+                raise DownloadIntegrityError(
+                    f"Integrity verification failed for {remote_file.filename} "
+                    "after one forced re-fetch. Clear the model cache and retry."
+                )
+
+        downloaded.append((remote_file, local_path))
+        _emit_progress(
+            progress_callback,
+            remote_file=remote_file,
+            bytes_done=remote_file.size,
+            files_done=files_done + 1,
+            files_total=files_total,
+        )
+
+    first_file, first_path = downloaded[0]
+    return str(_snapshot_root(first_path, first_file.filename))
+
+
+def _download_remote_file(
+    *,
+    hf_hub_download: Any,
+    repo_id: str,
+    revision: str,
+    cache_dir: str | None,
+    remote_file: _RemoteFile,
+    retries: int,
+    limiter: _BandwidthLimiter | None,
+    progress_callback: Callable[[DownloadProgress], None] | None,
+    files_done: int,
+    files_total: int,
+    force_download: bool,
+) -> Path:
+    progress_class = _make_progress_class(
+        remote_file=remote_file,
+        limiter=limiter,
+        progress_callback=progress_callback,
+        files_done=files_done,
+        files_total=files_total,
+    )
+    kwargs: dict[str, Any] = {
+        "repo_id": repo_id,
+        "filename": remote_file.filename,
+        "repo_type": "model",
+        "revision": revision,
+        "force_download": force_download,
+        "local_files_only": False,
+        "tqdm_class": progress_class,
+    }
+    if cache_dir is not None:
+        kwargs["cache_dir"] = cache_dir
+
+    path = _with_retry(lambda: hf_hub_download(**kwargs), retries=retries)
+    return Path(path)
+
+
+def _remote_files_from_info(
+    *,
+    repo_id: str,
+    siblings: Any,
+    allow_patterns: str | Sequence[str] | None,
+) -> list[_RemoteFile]:
+    patterns = _normalise_patterns(allow_patterns)
+    remote_files: list[_RemoteFile] = []
+    for sibling in siblings or ():
+        filename = getattr(sibling, "rfilename", None)
+        if not isinstance(filename, str) or not _safe_repo_filename(filename):
+            raise DownloadIntegrityError(
+                f"Cannot verify {repo_id}: the Hub reported an invalid filename."
+            )
+        if patterns and not any(
+            fnmatch.fnmatchcase(filename, pattern) for pattern in patterns
+        ):
+            continue
+
+        size = getattr(sibling, "size", None)
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            raise DownloadIntegrityError(
+                f"Cannot verify {filename}: the Hub did not report its size."
+            )
+        algorithm, digest = _metadata_digest(sibling)
+        if algorithm is None or digest is None:
+            raise DownloadIntegrityError(
+                f"Cannot verify {filename}: the Hub did not report an ETag or "
+                "SHA-256 digest."
+            )
+        remote_files.append(
+            _RemoteFile(
+                filename=filename,
+                size=size,
+                algorithm=algorithm,
+                digest=digest,
+            )
+        )
+
+    if not remote_files:
+        pattern_hint = f" matching {patterns!r}" if patterns else ""
+        raise DownloadIntegrityError(
+            f"Cannot verify {repo_id}: the Hub reported no model files{pattern_hint}."
+        )
+    return remote_files
+
+
+def _metadata_digest(sibling: Any) -> tuple[str | None, str | None]:
+    lfs = getattr(sibling, "lfs", None)
+    if isinstance(lfs, Mapping):
+        lfs_sha256 = lfs.get("sha256")
+    else:
+        lfs_sha256 = getattr(lfs, "sha256", None)
+    if _is_hex_digest(lfs_sha256, 64):
+        return "sha256", str(lfs_sha256).lower()
+
+    blob_id = getattr(sibling, "blob_id", None)
+    if _is_hex_digest(blob_id, 40):
+        return "git-sha1", str(blob_id).lower()
+    if _is_hex_digest(blob_id, 64):
+        return "sha256", str(blob_id).lower()
+    return None, None
+
+
+def _file_matches_metadata(path: Path, remote_file: _RemoteFile) -> bool:
+    try:
+        if not path.is_file() or path.stat().st_size != remote_file.size:
+            return False
+        if remote_file.algorithm == "git-sha1":
+            digest = hashlib.sha1(usedforsecurity=False)
+            digest.update(f"blob {remote_file.size}\0".encode())
+        else:
+            digest = hashlib.sha256()
+        with path.open("rb") as downloaded_file:
+            for chunk in iter(lambda: downloaded_file.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return False
+    return digest.hexdigest() == remote_file.digest
+
+
+def _unlink_corrupt_file(path: Path, filename: str) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        raise DownloadIntegrityError(
+            f"Corrupt file {filename} could not be removed before re-fetch: {exc}"
+        ) from exc
+
+
+def _snapshot_root(path: Path, filename: str) -> Path:
+    root = path
+    for _ in PurePosixPath(filename).parts:
+        root = root.parent
+    return root
+
+
+def _normalise_patterns(
+    allow_patterns: str | Sequence[str] | None,
+) -> list[str]:
+    if allow_patterns is None:
+        return []
+    if isinstance(allow_patterns, str):
+        return [allow_patterns]
+    return list(allow_patterns)
+
+
+def _safe_repo_filename(filename: str) -> bool:
+    path = PurePosixPath(filename)
+    return bool(filename) and not path.is_absolute() and ".." not in path.parts
+
+
+def _is_hex_digest(value: Any, length: int) -> bool:
+    if not isinstance(value, str) or len(value) != length:
+        return False
+    return all(character in "0123456789abcdefABCDEF" for character in value)
+
+
+def _with_retry(operation: Callable[[], Any], *, retries: int) -> Any:
+    for attempt in range(retries + 1):
+        try:
+            return operation()
+        except Exception as exc:
+            if attempt >= retries or not _is_transient_error(exc):
+                raise
+            exponential = min(
+                _BACKOFF_BASE_SECONDS * (2**attempt),
+                _BACKOFF_MAX_SECONDS,
+            )
+            time.sleep(exponential + random.uniform(0.0, _BACKOFF_BASE_SECONDS))
+    raise AssertionError("retry loop must return or raise")
+
+
+def _is_transient_error(error: Exception) -> bool:
+    status_code = _error_status_code(error)
+    if status_code is not None:
+        return status_code in {408, 429} or 500 <= status_code <= 599
+    if isinstance(error, (ConnectionError, TimeoutError)):
+        return True
+    error_type = type(error)
+    qualified_name = f"{error_type.__module__}.{error_type.__name__}".lower()
+    return any(
+        marker in qualified_name
+        for marker in (
+            "connecterror",
+            "connectionerror",
+            "networkerror",
+            "proxyerror",
+            "timeoutexception",
+            "timeouterror",
+        )
+    )
+
+
+def _error_status_code(error: Exception) -> int | None:
+    response = getattr(error, "response", None)
+    value = getattr(response, "status_code", None)
+    if value is None:
+        value = getattr(error, "status_code", None)
+    return value if isinstance(value, int) else None
+
+
+def _make_progress_class(
+    *,
+    remote_file: _RemoteFile,
+    limiter: _BandwidthLimiter | None,
+    progress_callback: Callable[[DownloadProgress], None] | None,
+    files_done: int,
+    files_total: int,
+) -> type[Any]:
+    furthest_bytes = 0
+
+    class _DownloadProgressBar:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            del args
+            initial = kwargs.get("initial", 0)
+            self.n = int(initial or 0)
+            self.total = int(kwargs.get("total") or remote_file.size)
+            self._last_limited_update = 0
+            self._record_progress(self.n)
+
+        def _record_progress(self, bytes_done: int) -> None:
+            nonlocal furthest_bytes
+            furthest_bytes = max(furthest_bytes, min(bytes_done, remote_file.size))
+            _emit_progress(
+                progress_callback,
+                remote_file=remote_file,
+                bytes_done=furthest_bytes,
+                files_done=files_done,
+                files_total=files_total,
+            )
+
+        def update(self, byte_count: int | float | None = 1) -> bool:
+            count = int(byte_count or 0)
+            if limiter is not None and count > 0:
+                limiter.consume(count)
+                self._last_limited_update = count
+            self.n += count
+            self._record_progress(self.n)
+            return True
+
+        def update_transfer(self, byte_count: int | float | None = 1) -> None:
+            count = int(byte_count or 0)
+            if self._last_limited_update == count:
+                self._last_limited_update = 0
+            elif limiter is not None and count > 0:
+                limiter.consume(count)
+
+        def __enter__(self) -> "_DownloadProgressBar":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            self.close()
+
+        def close(self) -> None:
+            return None
+
+        def refresh(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+        def set_description(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+        def set_postfix_str(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+        def set_transfer_postfix_str(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+    return _DownloadProgressBar
+
+
+def _emit_progress(
+    callback: Callable[[DownloadProgress], None] | None,
+    *,
+    remote_file: _RemoteFile,
+    bytes_done: int,
+    files_done: int,
+    files_total: int,
+) -> None:
+    if callback is None:
+        return
+    callback(
+        DownloadProgress(
+            filename=remote_file.filename,
+            bytes_done=bytes_done,
+            bytes_total=remote_file.size,
+            files_done=files_done,
+            files_total=files_total,
+        )
+    )
 
 
 def list_cached_models(
@@ -268,6 +731,14 @@ def _import_snapshot_download() -> tuple[Any, type[Exception]]:
     except ImportError as exc:
         raise ImportError(_HF_INSTALL_HINT) from exc
     return snapshot_download, LocalEntryNotFoundError
+
+
+def _import_online_downloads() -> tuple[Any, Any]:
+    try:
+        from huggingface_hub import HfApi, hf_hub_download
+    except ImportError as exc:
+        raise ImportError(_HF_INSTALL_HINT) from exc
+    return HfApi, hf_hub_download
 
 
 def _import_scan_cache_dir() -> tuple[Any, type[Exception], Path]:

--- a/tests/unit/core/test_hf_hub.py
+++ b/tests/unit/core/test_hf_hub.py
@@ -427,6 +427,37 @@ def test_prefetch_model_retries_transient_failures_with_backoff(
     assert delays == [1.0, 2.0]
 
 
+def test_prefetch_model_retries_wrapped_transient_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    content = b"{}"
+    snapshot = tmp_path / "snapshot"
+    attempts = 0
+
+    def fake_hf_hub_download(**kwargs: Any) -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            try:
+                raise TimeoutError("temporary outage")
+            except TimeoutError as cause:
+                raise _FakeLocalEntryNotFoundError("cache miss") from cause
+        return str(_write_snapshot_file(snapshot, "config.json", content))
+
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("config.json", content),
+        hf_hub_download=fake_hf_hub_download,
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+    monkeypatch.setattr(hf_hub.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(hf_hub.random, "uniform", lambda start, end: 0.0)
+
+    assert prefetch_model(_ALIAS, retries=1) == str(snapshot)
+    assert attempts == 2
+
+
 def test_prefetch_model_default_retries_five_times(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -476,6 +507,35 @@ def test_prefetch_model_does_not_retry_permanent_http_errors(
 
     with pytest.raises(RuntimeError, match=f"HTTP {status_code}"):
         prefetch_model(_ALIAS)
+
+    assert attempts == 1
+
+
+def test_prefetch_model_does_not_retry_permanent_error_with_transient_cause(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def fake_hf_hub_download(**kwargs: Any) -> str:
+        nonlocal attempts
+        attempts += 1
+        try:
+            raise TimeoutError("earlier timeout")
+        except TimeoutError as cause:
+            error = RuntimeError("HTTP 404")
+            error.response = types.SimpleNamespace(status_code=404)  # type: ignore[attr-defined]
+            raise error from cause
+
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("config.json", b"{}"),
+        hf_hub_download=fake_hf_hub_download,
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+
+    with pytest.raises(RuntimeError, match="HTTP 404"):
+        prefetch_model(_ALIAS, retries=2)
 
     assert attempts == 1
 
@@ -546,6 +606,28 @@ def test_prefetch_model_fails_when_integrity_metadata_is_missing(
 
     with pytest.raises(DownloadIntegrityError, match="model.bin"):
         prefetch_model(_ALIAS)
+
+
+@pytest.mark.parametrize(
+    "invalid_filename",
+    ["../secret", "/absolute", "..\\secret", "bad\nname", "\x1b[31mred"],
+)
+def test_prefetch_model_rejects_unsafe_remote_filenames(
+    monkeypatch: pytest.MonkeyPatch, invalid_filename: str
+) -> None:
+    info = _model_info(invalid_filename, b"content")
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: info,
+        hf_hub_download=lambda **kwargs: "/unused",
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+
+    with pytest.raises(DownloadIntegrityError, match="invalid filename") as exc_info:
+        prefetch_model(_ALIAS)
+
+    assert invalid_filename not in str(exc_info.value)
 
 
 def test_prefetch_model_offline_attempts_no_socket_connection(

--- a/tests/unit/core/test_hf_hub.py
+++ b/tests/unit/core/test_hf_hub.py
@@ -6,6 +6,8 @@ runs here, so the suite stays offline-friendly (see ``AGENTS.md``).
 
 from __future__ import annotations
 
+import hashlib
+import socket
 import sys
 import types
 from pathlib import Path
@@ -16,12 +18,18 @@ import pytest
 from openmed.core import hf_hub
 from openmed.core.hf_hub import (
     CachedModel,
+    DownloadIntegrityError,
+    DownloadProgress,
     clear_cached_model,
     list_cached_models,
     prefetch_model,
     resolve_repo_id,
 )
-from openmed.core.offline import OfflineModeError
+from openmed.core.offline import (
+    HF_OFFLINE_ENV_VARS,
+    OfflineModeError,
+    network_blocked_if_offline,
+)
 
 # A stable legacy registry alias -> Hub repo id pair.
 _ALIAS = "disease_detection_superclinical"
@@ -67,6 +75,14 @@ def _install_fake_hub(
 
     module = types.ModuleType("huggingface_hub")
     module.CacheNotFound = _FakeCacheNotFound
+    model_info = attrs.pop("model_info", None)
+    if model_info is not None:
+
+        class _FakeHfApi:
+            def model_info(self, *args: Any, **kwargs: Any) -> Any:
+                return model_info(*args, **kwargs)
+
+        module.HfApi = _FakeHfApi
     for name, value in attrs.items():
         setattr(module, name, value)
     constants_module = types.ModuleType("huggingface_hub.constants")
@@ -77,6 +93,27 @@ def _install_fake_hub(
     monkeypatch.setitem(sys.modules, "huggingface_hub.constants", constants_module)
     monkeypatch.setitem(sys.modules, "huggingface_hub.errors", errors_module)
     return module
+
+
+def _model_info(filename: str, content: bytes, *, sha: str = "a" * 40) -> Any:
+    return types.SimpleNamespace(
+        sha=sha,
+        siblings=[
+            types.SimpleNamespace(
+                rfilename=filename,
+                size=len(content),
+                blob_id=None,
+                lfs=types.SimpleNamespace(sha256=hashlib.sha256(content).hexdigest()),
+            )
+        ],
+    )
+
+
+def _write_snapshot_file(root: Path, filename: str, content: bytes) -> Path:
+    path = root / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
 
 
 # --- resolve_repo_id -------------------------------------------------------
@@ -104,62 +141,92 @@ def test_resolve_repo_id_rejects_empty() -> None:
 
 
 def test_prefetch_model_resolves_alias_before_download(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     calls: List[dict[str, Any]] = []
+    content = b"synthetic weights"
+    snapshot = tmp_path / "snapshot"
 
-    def fake_snapshot_download(**kwargs: Any) -> str:
+    def fake_hf_hub_download(**kwargs: Any) -> str:
         calls.append(kwargs)
-        return "/cache/models--OpenMed--DiseaseDetect"
+        return str(_write_snapshot_file(snapshot, kwargs["filename"], content))
 
-    _install_fake_hub(monkeypatch, snapshot_download=fake_snapshot_download)
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("model.safetensors", content),
+        hf_hub_download=fake_hf_hub_download,
+    )
     monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
 
     path = prefetch_model(_ALIAS, allow_patterns=["*.safetensors"])
 
-    assert path == "/cache/models--OpenMed--DiseaseDetect"
+    assert path == str(snapshot)
     assert len(calls) == 1
     kwargs = calls[0]
-    # The friendly alias is resolved to the Hub repo id before download.
     assert kwargs["repo_id"] == _REPO_ID
     assert kwargs["repo_type"] == "model"
     assert kwargs["local_files_only"] is False
-    assert kwargs["allow_patterns"] == ["*.safetensors"]
+    assert kwargs["filename"] == "model.safetensors"
+    assert "endpoint" not in kwargs
 
 
 def test_prefetch_model_forwards_revision_and_cache_dir(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: List[dict[str, Any]] = []
+    api_calls: List[dict[str, Any]] = []
+    download_calls: List[dict[str, Any]] = []
+    content = b"{}"
+    snapshot = tmp_path / "snapshot"
 
-    def fake_snapshot_download(**kwargs: Any) -> str:
-        calls.append(kwargs)
-        return "/cache/snapshot"
+    def fake_model_info(*args: Any, **kwargs: Any) -> Any:
+        api_calls.append(kwargs)
+        return _model_info("config.json", content, sha="b" * 40)
 
-    _install_fake_hub(monkeypatch, snapshot_download=fake_snapshot_download)
+    def fake_hf_hub_download(**kwargs: Any) -> str:
+        download_calls.append(kwargs)
+        return str(_write_snapshot_file(snapshot, kwargs["filename"], content))
+
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=fake_model_info,
+        hf_hub_download=fake_hf_hub_download,
+    )
     monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
 
     prefetch_model(_ALIAS, revision="v2", cache_dir="/tmp/hf")
 
-    assert calls[0]["revision"] == "v2"
-    assert calls[0]["cache_dir"] == "/tmp/hf"
+    assert api_calls[0]["revision"] == "v2"
+    assert download_calls[0]["revision"] == "b" * 40
+    assert download_calls[0]["cache_dir"] == "/tmp/hf"
 
 
 def test_prefetch_model_preserves_single_allow_pattern(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     calls: List[dict[str, Any]] = []
+    weights = b"weights"
+    config = b"{}"
+    snapshot = tmp_path / "snapshot"
 
-    def fake_snapshot_download(**kwargs: Any) -> str:
+    def fake_hf_hub_download(**kwargs: Any) -> str:
         calls.append(kwargs)
-        return "/cache/snapshot"
+        return str(_write_snapshot_file(snapshot, kwargs["filename"], weights))
 
-    _install_fake_hub(monkeypatch, snapshot_download=fake_snapshot_download)
+    info = _model_info("model.safetensors", weights)
+    info.siblings.extend(_model_info("config.json", config).siblings)
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: info,
+        hf_hub_download=fake_hf_hub_download,
+    )
     monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
 
     prefetch_model(_ALIAS, allow_patterns="*.safetensors")
 
-    assert calls[0]["allow_patterns"] == "*.safetensors"
+    assert [call["filename"] for call in calls] == ["model.safetensors"]
 
 
 def test_prefetch_model_offline_passes_local_files_only_and_raises_when_uncached(
@@ -200,14 +267,311 @@ def test_prefetch_model_offline_returns_path_when_cached(
 def test_prefetch_model_online_error_is_not_swallowed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fake_snapshot_download(**kwargs: Any) -> str:
+    def fake_hf_hub_download(**kwargs: Any) -> str:
         raise RuntimeError("network exploded")
 
-    _install_fake_hub(monkeypatch, snapshot_download=fake_snapshot_download)
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("config.json", b"{}"),
+        hf_hub_download=fake_hf_hub_download,
+    )
     monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
 
     with pytest.raises(RuntimeError, match="network exploded"):
         prefetch_model(_ALIAS)
+
+
+def test_prefetch_model_resumes_partial_file_after_connection_drop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    content = b"x" * 100
+    snapshot = tmp_path / "snapshot"
+    path = snapshot / "model.bin"
+    fetched_per_attempt: List[int] = []
+    progress: List[DownloadProgress] = []
+
+    def fake_hf_hub_download(**kwargs: Any) -> str:
+        existing = path.read_bytes() if path.exists() else b""
+        progress_bar = kwargs["tqdm_class"](
+            total=len(content),
+            initial=len(existing),
+        )
+        if not existing:
+            chunk = content[: len(content) // 2]
+            _write_snapshot_file(snapshot, "model.bin", chunk)
+            progress_bar.update(len(chunk))
+            fetched_per_attempt.append(len(chunk))
+            raise TimeoutError("connection dropped at 50%")
+
+        remainder = content[len(existing) :]
+        path.write_bytes(existing + remainder)
+        progress_bar.update(len(remainder))
+        fetched_per_attempt.append(len(remainder))
+        return str(path)
+
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("model.bin", content),
+        hf_hub_download=fake_hf_hub_download,
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+    monkeypatch.setattr(hf_hub.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(hf_hub.random, "uniform", lambda start, end: 0.0)
+
+    result = prefetch_model(_ALIAS, retries=1, progress_callback=progress.append)
+
+    assert result == str(snapshot)
+    assert fetched_per_attempt == [50, 50]
+    assert fetched_per_attempt[1] <= len(content) // 2 + 1
+    assert path.read_bytes() == content
+    assert progress[-1] == DownloadProgress(
+        filename="model.bin",
+        bytes_done=100,
+        bytes_total=100,
+        files_done=1,
+        files_total=1,
+    )
+
+
+def test_prefetch_model_refetches_corrupt_cached_file_once(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    content = b"good"
+    snapshot = tmp_path / "snapshot"
+    path = _write_snapshot_file(snapshot, "model.bin", b"bad!")
+    calls: List[bool] = []
+
+    def fake_hf_hub_download(**kwargs: Any) -> str:
+        calls.append(kwargs["force_download"])
+        if kwargs["force_download"]:
+            _write_snapshot_file(snapshot, "model.bin", content)
+        return str(path)
+
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("model.bin", content),
+        hf_hub_download=fake_hf_hub_download,
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+
+    assert prefetch_model(_ALIAS) == str(snapshot)
+    assert calls == [False, True]
+    assert path.read_bytes() == content
+
+
+def test_models_pull_exits_nonzero_when_refetched_file_remains_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from openmed.cli import main_module
+
+    content = b"good"
+    snapshot = tmp_path / "snapshot"
+    path = _write_snapshot_file(snapshot, "model.bin", b"bad!")
+    calls: List[bool] = []
+
+    def fake_hf_hub_download(**kwargs: Any) -> str:
+        calls.append(kwargs["force_download"])
+        _write_snapshot_file(snapshot, "model.bin", b"bad!")
+        return str(path)
+
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("model.bin", content),
+        hf_hub_download=fake_hf_hub_download,
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+
+    result = main_module.main(["models", "pull", _ALIAS])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert calls == [False, True]
+    assert "model.bin" in captured.err
+    assert "forced re-fetch" in captured.err
+
+
+def test_prefetch_model_retries_transient_failures_with_backoff(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    content = b"{}"
+    snapshot = tmp_path / "snapshot"
+    attempts = 0
+    delays: List[float] = []
+
+    def fake_hf_hub_download(**kwargs: Any) -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise TimeoutError("temporary outage")
+        return str(_write_snapshot_file(snapshot, "config.json", content))
+
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("config.json", content),
+        hf_hub_download=fake_hf_hub_download,
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+    monkeypatch.setattr(hf_hub.time, "sleep", delays.append)
+    monkeypatch.setattr(hf_hub.random, "uniform", lambda start, end: 0.0)
+
+    prefetch_model(_ALIAS, retries=2)
+
+    assert attempts == 3
+    assert delays == [1.0, 2.0]
+
+
+def test_prefetch_model_default_retries_five_times(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def fake_hf_hub_download(**kwargs: Any) -> str:
+        nonlocal attempts
+        attempts += 1
+        raise TimeoutError("still offline")
+
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("config.json", b"{}"),
+        hf_hub_download=fake_hf_hub_download,
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+    monkeypatch.setattr(hf_hub.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(hf_hub.random, "uniform", lambda start, end: 0.0)
+
+    with pytest.raises(TimeoutError, match="still offline"):
+        prefetch_model(_ALIAS)
+
+    assert attempts == 6
+
+
+@pytest.mark.parametrize("status_code", [401, 404])
+def test_prefetch_model_does_not_retry_permanent_http_errors(
+    monkeypatch: pytest.MonkeyPatch, status_code: int
+) -> None:
+    attempts = 0
+
+    def fake_hf_hub_download(**kwargs: Any) -> str:
+        nonlocal attempts
+        attempts += 1
+        error = RuntimeError(f"HTTP {status_code}")
+        error.response = types.SimpleNamespace(status_code=status_code)  # type: ignore[attr-defined]
+        raise error
+
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("config.json", b"{}"),
+        hf_hub_download=fake_hf_hub_download,
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+
+    with pytest.raises(RuntimeError, match=f"HTTP {status_code}"):
+        prefetch_model(_ALIAS)
+
+    assert attempts == 1
+
+
+def test_models_pull_caps_bandwidth_and_prints_file_progress(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from openmed.cli import main_module
+
+    content = b"x" * 1_048_576
+    snapshot = tmp_path / "snapshot"
+    clock = [0.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    def fake_sleep(seconds: float) -> None:
+        clock[0] += seconds
+
+    def fake_hf_hub_download(**kwargs: Any) -> str:
+        progress_bar = kwargs["tqdm_class"](total=len(content), initial=0)
+        for _ in range(4):
+            progress_bar.update(len(content) // 4)
+        return str(_write_snapshot_file(snapshot, "model.bin", content))
+
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: _model_info("model.bin", content),
+        hf_hub_download=fake_hf_hub_download,
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+    monkeypatch.setattr(hf_hub.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(hf_hub.time, "sleep", fake_sleep)
+
+    result = main_module.main(["models", "pull", _ALIAS, "--max-bandwidth", "524288"])
+
+    output = capsys.readouterr().out
+    assert result == 0
+    assert len(content) / clock[0] <= 524_288
+    assert "model.bin: 1048576/1048576 bytes; 1/1 files" in output
+    assert f"Model ready: {snapshot}" in output
+
+
+def test_prefetch_model_fails_when_integrity_metadata_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    info = types.SimpleNamespace(
+        sha="a" * 40,
+        siblings=[
+            types.SimpleNamespace(
+                rfilename="model.bin",
+                size=4,
+                lfs=None,
+                blob_id=None,
+            )
+        ],
+    )
+    _install_fake_hub(
+        monkeypatch,
+        snapshot_download=lambda **kwargs: "/offline/cache",
+        model_info=lambda *args, **kwargs: info,
+        hf_hub_download=lambda **kwargs: "/unused",
+    )
+    monkeypatch.delenv("OPENMED_OFFLINE", raising=False)
+
+    with pytest.raises(DownloadIntegrityError, match="model.bin"):
+        prefetch_model(_ALIAS)
+
+
+def test_prefetch_model_offline_attempts_no_socket_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[dict[str, Any]] = []
+
+    def fake_snapshot_download(**kwargs: Any) -> str:
+        calls.append(kwargs)
+        if not kwargs["local_files_only"]:
+            socket.create_connection(("127.0.0.1", 9))
+        return "/cache/already-here"
+
+    _install_fake_hub(monkeypatch, snapshot_download=fake_snapshot_download)
+    monkeypatch.setenv("OPENMED_OFFLINE", "1")
+
+    try:
+        with network_blocked_if_offline(local_only=True):
+            result = prefetch_model(_ALIAS)
+    finally:
+        for env_var in HF_OFFLINE_ENV_VARS:
+            monkeypatch.delenv(env_var, raising=False)
+
+    assert result == "/cache/already-here"
+    assert len(calls) == 1
+    assert calls[0]["local_files_only"] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Adds resumable, integrity-checked model pulls for unreliable or metered connections. The existing helper delegated a whole snapshot without configurable recovery, verification, transfer pacing, or CLI progress; this change downloads revision-pinned files through the Hub client, retries transient failures with exponential backoff and jitter, verifies each file, and force-refetches corruption once.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Extend `prefetch_model` with configurable retries, resumable per-file downloads, SHA-256/Git-object integrity checks, a PHI-free progress callback, and an aggregate byte-rate cap.
- Add `openmed models pull <alias>` with `--revision`, `--max-bandwidth`, and `--retries`.
- Preserve cache-only offline behavior and user-configured mirror/cache environment.
- Retry transient network failures even when the Hub client wraps the underlying exception, while keeping permanent HTTP failures fail-fast.
- Reject traversal, backslash, and terminal-control characters in remote filenames before download or progress rendering.
- Document reliable model pulls and add a synthetic fake-Hub suite covering interruption, corruption, retry classification, pacing, CLI output, filename safety, and socket blocking.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:

- `.venv/bin/python -m pytest tests/ -q` — 5,641 passed, 47 skipped
- `.venv/bin/python -m pytest tests/unit/core/test_hf_hub.py -q` — 39 passed
- `make format`
- `make lint`
- `make format-check`
- `make type-check`
- `pre-commit run --files docs/getting-started.md openmed/cli/main.py openmed/core/hf_hub.py tests/unit/core/test_hf_hub.py`
- `make docs-build`
- `python3 -m build`

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #1430

## Screenshots/Examples

```text
openmed models pull disease_detection_superclinical --max-bandwidth 524288 --retries 5
model.safetensors: 434000000/434000000 bytes; 1/1 files
Model ready: <cache-path>
```
