### PR TITLE
Add crash-safe batch checkpoints and resume

### DIFF
--- a/docs/batch-processing.md
+++ b/docs/batch-processing.md
@@ -49,6 +49,103 @@ result = processor.process_directory(
 )
 ```
 
+## Crash-safe checkpoints and resume
+
+Long-running batches can durably commit progress every N items. A checkpoint
+contains only hashes, item indexes and statuses, committed-output byte offsets,
+and output hashes. It never stores raw input text, source paths, model output,
+or entity values.
+
+```python
+from pathlib import Path
+
+from openmed import BatchProcessor
+
+processor = BatchProcessor(
+    model_name="disease_detection_superclinical",
+    checkpoint_interval=25,
+)
+
+result = processor.process_texts(
+    texts,
+    output_path=Path("results.json"),
+    checkpoint_path=Path("results.checkpoint.json"),
+)
+```
+
+If the process or host stops, rerun the same batch with the same ordered input,
+model settings, output format, and paths:
+
+```python
+result = processor.process_texts(
+    texts,
+    output_path=Path("results.json"),
+    checkpoint_path=Path("results.checkpoint.json"),
+    resume_from_checkpoint=True,
+)
+```
+
+`BatchProcessor.resume_from_checkpoint()` is also available when the caller
+already has `BatchItem` objects. Resume verifies the input and configuration
+fingerprints, the committed journal prefix, and the final output when the
+checkpoint is complete. It refuses to continue if an output is missing,
+truncated, or has a different SHA-256 digest.
+
+Each checkpoint first writes and fsyncs a same-directory part file, atomically
+renames it, and then atomically commits the checkpoint that points to its valid
+byte prefix. If power fails between those commits, resume discards the
+uncommitted tail. At most `checkpoint_interval` items are processed again.
+Final result files also use temp-file, fsync, and atomic-rename semantics.
+
+The checkpoint JSON is PHI-free. For `process_texts`, `process_files`, and
+`process_directory`, `<checkpoint-path>.part` is the committed result journal
+and has the same sensitivity as the requested result file; protect it with the
+same permissions. The `openmed pii batch` journal is status-only, while each
+de-identified output file is hashed and verified separately.
+
+The general CLI enables checkpoints whenever `--output` is present:
+
+```bash
+openmed batch \
+  --input-dir /data/notes \
+  --output /data/results.json \
+  --output-format json \
+  --checkpoint-interval 25
+
+# After an interruption, repeat the same command and add --resume.
+openmed batch \
+  --input-dir /data/notes \
+  --output /data/results.json \
+  --output-format json \
+  --checkpoint-interval 25 \
+  --resume
+```
+
+Use `--checkpoint-path` to override the default
+`<output>.checkpoint.json`. `--resume` requires `--output` so the committed
+result can be verified.
+
+For atomic per-file de-identification:
+
+```bash
+openmed pii batch \
+  --input-dir /data/raw-notes \
+  --output-dir /data/deidentified \
+  --checkpoint-interval 25
+
+# Resume after a power failure.
+openmed pii batch \
+  --input-dir /data/raw-notes \
+  --output-dir /data/deidentified \
+  --checkpoint-interval 25 \
+  --resume
+```
+
+The PII command defaults to
+`<output-dir>/.openmed-batch.checkpoint.json`. On resume, every file recorded as
+complete must still match its committed size and hash; a changed output stops
+the run with a clear integrity error instead of silently mixing results.
+
 ## Operations
 
 `BatchProcessor` supports three operations:

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -393,6 +393,22 @@ def _add_batch_command(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Suppress progress output.",
     )
+    batch_parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from the checkpoint associated with --output.",
+    )
+    batch_parser.add_argument(
+        "--checkpoint-path",
+        type=Path,
+        help="Checkpoint path (default: <output>.checkpoint.json).",
+    )
+    batch_parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=10,
+        help="Commit progress after this many items (default: 10).",
+    )
     batch_parser.set_defaults(handler=_handle_batch)
 
 
@@ -654,6 +670,24 @@ def _add_pii_command(subparsers: argparse._SubParsersAction) -> None:
         type=float,
         default=0.7,
         help="Minimum confidence for redaction.",
+    )
+    batch_parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from the output directory checkpoint.",
+    )
+    batch_parser.add_argument(
+        "--checkpoint-path",
+        type=Path,
+        help=(
+            "Checkpoint path (default: <output-dir>/.openmed-batch.checkpoint.json)."
+        ),
+    )
+    batch_parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=10,
+        help="Commit progress after this many files (default: 10).",
     )
     batch_parser.set_defaults(handler=_handle_pii_batch)
 
@@ -1428,6 +1462,17 @@ def _handle_batch(args: argparse.Namespace) -> int:
 
     _, _, _, BatchProcessor = _lazy_api()
 
+    if args.checkpoint_interval < 1:
+        sys.stderr.write("--checkpoint-interval must be positive\n")
+        return 2
+    if (args.resume or args.checkpoint_path is not None) and args.output is None:
+        sys.stderr.write("--resume and --checkpoint-path require --output\n")
+        return 2
+
+    checkpoint_path = None
+    if args.output is not None:
+        checkpoint_path = args.checkpoint_path or Path(f"{args.output}.checkpoint.json")
+
     continue_on_error = not args.stop_on_error if args.stop_on_error else True
 
     processor = BatchProcessor(
@@ -1436,6 +1481,7 @@ def _handle_batch(args: argparse.Namespace) -> int:
         confidence_threshold=args.confidence_threshold or 0.0,
         group_entities=args.group_entities,
         continue_on_error=continue_on_error,
+        checkpoint_interval=args.checkpoint_interval,
     )
 
     def progress_callback(current: int, total: int, result: Any) -> None:
@@ -1451,11 +1497,19 @@ def _handle_batch(args: argparse.Namespace) -> int:
             result = processor.process_texts(
                 args.texts,
                 progress_callback=progress_callback if not args.quiet else None,
+                output_path=args.output,
+                checkpoint_path=checkpoint_path,
+                resume_from_checkpoint=args.resume,
+                output_format=args.output_format,
             )
         elif args.input_files:
             result = processor.process_files(
                 args.input_files,
                 progress_callback=progress_callback if not args.quiet else None,
+                output_path=args.output,
+                checkpoint_path=checkpoint_path,
+                resume_from_checkpoint=args.resume,
+                output_format=args.output_format,
             )
         elif args.input_dir:
             if not args.input_dir.is_dir():
@@ -1469,6 +1523,10 @@ def _handle_batch(args: argparse.Namespace) -> int:
                 pattern=args.pattern,
                 recursive=args.recursive,
                 progress_callback=progress_callback if not args.quiet else None,
+                output_path=args.output,
+                checkpoint_path=checkpoint_path,
+                resume_from_checkpoint=args.resume,
+                output_format=args.output_format,
             )
         else:
             raise CliError("No input provided.", code="no_input", exit_code=EXIT_USAGE)
@@ -1492,14 +1550,6 @@ def _handle_batch(args: argparse.Namespace) -> int:
         output = result.summary()
 
     if args.output:
-        try:
-            args.output.write_text(output, encoding="utf-8")
-        except OSError as exc:
-            raise CliError(
-                f"Failed to write output: {exc}",
-                code="write_failed",
-                exit_code=EXIT_ERROR,
-            )
         human = f"Results written to: {args.output}"
     else:
         human = output
@@ -3343,8 +3393,6 @@ def _handle_pii_deidentify(args: argparse.Namespace) -> int:
 
 def _handle_pii_batch(args: argparse.Namespace) -> int:
     """Handle batch PII de-identification command."""
-    from ..core.pii import deidentify
-
     config = _load_and_apply_config(args)
 
     if not args.input_dir.is_dir():
@@ -3353,15 +3401,19 @@ def _handle_pii_batch(args: argparse.Namespace) -> int:
             code="not_a_directory",
             exit_code=EXIT_ERROR,
         )
+    if args.checkpoint_interval < 1:
+        raise CliError(
+            "--checkpoint-interval must be positive",
+            code="invalid_argument",
+            exit_code=EXIT_USAGE,
+        )
 
-    # Create output directory
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Find files to process
     if args.recursive:
-        files = list(args.input_dir.rglob(args.pattern))
+        files = sorted(args.input_dir.rglob(args.pattern))
     else:
-        files = list(args.input_dir.glob(args.pattern))
+        files = sorted(args.input_dir.glob(args.pattern))
 
     if not files:
         raise CliError(
@@ -3370,61 +3422,62 @@ def _handle_pii_batch(args: argparse.Namespace) -> int:
             exit_code=EXIT_ERROR,
         )
 
-    # Process files
-    processed = 0
-    failed = 0
-    file_results: list[dict[str, Any]] = []
     json_mode = wants_json(args)
+    checkpoint_path = args.checkpoint_path or (
+        args.output_dir / ".openmed-batch.checkpoint.json"
+    )
+    _, _, _, BatchProcessor = _lazy_api()
+    processor = BatchProcessor(
+        model_name=args.model,
+        operation="deidentify",
+        config=config,
+        confidence_threshold=args.confidence_threshold,
+        checkpoint_interval=args.checkpoint_interval,
+        method=args.method,
+    )
 
-    for input_file in files:
-        try:
-            text = input_file.read_text(encoding="utf-8")
-
-            result = deidentify(
-                text,
-                method=args.method,
-                model_name=args.model,
-                confidence_threshold=args.confidence_threshold,
-                config=config,
+    def progress_callback(current: int, total: int, item_result: Any) -> None:
+        if json_mode:
+            return
+        if item_result and item_result.success:
+            result_value = item_result.result
+            if isinstance(result_value, MappingABC):
+                entities = result_value.get("pii_entities", [])
+            else:
+                entities = getattr(result_value, "pii_entities", [])
+            sys.stdout.write(
+                f"[{current}/{total}] {item_result.id}: "
+                f"{len(entities)} entities redacted\n"
             )
+        else:
+            item_id = item_result.id if item_result else "?"
+            sys.stderr.write(f"[{current}/{total}] {item_id}: failed\n")
 
-            # Preserve directory structure
-            relative_path = input_file.relative_to(args.input_dir)
-            output_file = args.output_dir / relative_path
-            output_file.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = processor.process_files_to_directory(
+            files,
+            input_root=args.input_dir,
+            output_dir=args.output_dir,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=args.resume,
+            progress_callback=progress_callback,
+        )
+    except Exception as exc:
+        raise CliError(
+            f"Batch processing failed: {exc}",
+            code="batch_failed",
+            exit_code=EXIT_ERROR,
+        )
 
-            output_file.write_text(result.deidentified_text, encoding="utf-8")
-
-            processed += 1
-            entities = len(result.pii_entities)
-            file_results.append(
-                {"file": str(input_file), "entities_redacted": entities, "ok": True}
-            )
-            if not json_mode:
-                sys.stdout.write(
-                    f"[{processed}/{len(files)}] {input_file.name}: "
-                    f"{entities} entities redacted\n"
-                )
-
-        except Exception as exc:
-            failed += 1
-            file_results.append(
-                {"file": str(input_file), "ok": False, "error": str(exc)}
-            )
-            sys.stderr.write(f"Failed to process {input_file}: {exc}\n")
-
-    payload = {
-        "processed": processed,
-        "failed": failed,
-        "output_dir": str(args.output_dir),
-        "files": file_results,
-    }
+    payload = result.to_dict()
+    payload["output_dir"] = str(args.output_dir)
     human = (
-        f"\nProcessed {processed} files, {failed} failed\n"
+        f"\nProcessed {result.successful_items} files, "
+        f"{result.failed_items} failed\n"
         f"Output directory: {args.output_dir}"
     )
     emit(args, payload, human=human)
-    return 0 if failed == 0 else 1
+    return 0 if result.failed_items == 0 else 1
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/openmed/processing/batch.py
+++ b/openmed/processing/batch.py
@@ -11,11 +11,15 @@ all other columns are copied through unchanged.
 from __future__ import annotations
 
 import csv
+import hashlib
 import json
 import logging
+import os
+import tempfile
 import time
 from collections import Counter
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import (
     Any,
@@ -36,6 +40,8 @@ BatchOperation = Literal["analyze_text", "extract_pii", "deidentify"]
 DatasetFormat = Literal["csv", "jsonl", "parquet"]
 _VALID_OPERATIONS = {"analyze_text", "extract_pii", "deidentify"}
 _DEFAULT_PII_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+_BATCH_CHECKPOINT_SCHEMA_VERSION = 1
+_DEFAULT_CHECKPOINT_INTERVAL = 10
 
 
 @dataclass
@@ -65,10 +71,16 @@ class BatchItemResult:
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary representation."""
+        if self.result is None:
+            serialized_result = None
+        elif hasattr(self.result, "to_dict"):
+            serialized_result = self.result.to_dict()
+        else:
+            serialized_result = self.result
         return {
             "id": self.id,
             "success": self.success,
-            "result": self.result.to_dict() if self.result else None,
+            "result": serialized_result,
             "error": self.error,
             "processing_time": self.processing_time,
             "source": self.source,
@@ -222,6 +234,493 @@ ProgressCallback = Callable[[int, int, Optional[BatchItemResult]], None]
 BatchProgressCallback = Callable[[BatchProgress], None]
 
 
+class BatchCheckpointError(ValueError):
+    """Raised when a durable batch checkpoint cannot be resumed safely."""
+
+
+@dataclass(frozen=True)
+class _OutputArtifact:
+    size: int
+    sha256: str
+
+
+AtomicWriteHook = Callable[[str, Path], None]
+ArtifactWriter = Callable[[int, BatchItem, BatchItemResult], Optional[_OutputArtifact]]
+ArtifactPathResolver = Callable[[int, BatchItem], Optional[Path]]
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _stable_hash(*values: Any) -> str:
+    """Hash potentially sensitive values without persisting their plaintext."""
+    digest = hashlib.sha256()
+    for value in values:
+        if isinstance(value, bytes):
+            encoded = value
+        elif isinstance(value, str):
+            encoded = value.encode("utf-8")
+        else:
+            encoded = json.dumps(
+                value,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+                default=repr,
+            ).encode("utf-8")
+        digest.update(str(len(encoded)).encode("ascii"))
+        digest.update(b":")
+        digest.update(encoded)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _fsync_directory(path: Path) -> None:
+    """Best-effort fsync of a directory after an atomic rename."""
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        directory_fd = os.open(path, flags)
+    except OSError:  # pragma: no cover - platform/filesystem dependent
+        return
+    try:
+        os.fsync(directory_fd)
+    except OSError:  # pragma: no cover - platform/filesystem dependent
+        pass
+    finally:
+        os.close(directory_fd)
+
+
+def _atomic_write_bytes(
+    path: Path,
+    payload: bytes,
+    *,
+    hook: Optional[AtomicWriteHook] = None,
+) -> None:
+    """Durably replace ``path`` with ``payload`` using a same-directory temp."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            if hook:
+                hook("after_write", path)
+            os.fsync(handle.fileno())
+            if hook:
+                hook("after_fsync", path)
+        if hook:
+            hook("before_replace", path)
+        os.replace(temporary_path, path)
+        if hook:
+            hook("after_replace", path)
+        _fsync_directory(path.parent)
+        if hook:
+            hook("after_directory_fsync", path)
+    except BaseException:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _serialize_result_record(result: BatchItemResult) -> bytes:
+    return (
+        json.dumps(
+            result.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _restore_result_record(record: Mapping[str, Any]) -> BatchItemResult:
+    return BatchItemResult(
+        id=str(record.get("id", "")),
+        result=record.get("result"),
+        error=(str(record["error"]) if record.get("error") is not None else None),
+        processing_time=float(record.get("processing_time", 0.0)),
+        source=(str(record["source"]) if record.get("source") is not None else None),
+    )
+
+
+class _BatchCheckpointSession:
+    """Coordinate a PHI-free checkpoint with a durable result journal."""
+
+    def __init__(
+        self,
+        *,
+        items: Sequence[BatchItem],
+        checkpoint_path: Path,
+        checkpoint_interval: int,
+        model_name: str,
+        operation: BatchOperation,
+        configuration: Mapping[str, Any],
+        final_output_path: Optional[Path],
+        output_format: str,
+        store_full_results: bool,
+        artifact_path_resolver: Optional[ArtifactPathResolver],
+        atomic_write_hook: Optional[AtomicWriteHook],
+    ) -> None:
+        self.items = list(items)
+        self.checkpoint_path = checkpoint_path
+        self.state_path = Path(f"{checkpoint_path}.part")
+        self.checkpoint_interval = checkpoint_interval
+        self.model_name = model_name
+        self.operation = operation
+        self.configuration_hash = _stable_hash(configuration)
+        self.final_output_path = final_output_path
+        self.store_full_results = store_full_results
+        self.output_format = output_format
+        self.artifact_path_resolver = artifact_path_resolver
+        self.atomic_write_hook = atomic_write_hook
+        self.input_hash = _stable_hash(
+            [
+                {
+                    "id": item.id,
+                    "source": item.source,
+                    "text": item.text,
+                    "metadata": item.metadata,
+                }
+                for item in self.items
+            ]
+        )
+        self.started_at = datetime.now().isoformat()
+        self.completed_at = ""
+        self.is_complete = False
+        self.artifacts: Dict[int, _OutputArtifact] = {}
+
+    def start(self) -> None:
+        """Create an empty durable journal and initial checkpoint."""
+        _atomic_write_bytes(
+            self.state_path,
+            b"",
+            hook=self.atomic_write_hook,
+        )
+        self._write_checkpoint([], status="in_progress")
+
+    def resume(self) -> List[BatchItemResult]:
+        """Load, validate, and return the checkpointed result prefix."""
+        try:
+            payload = json.loads(self.checkpoint_path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise BatchCheckpointError(
+                f"Checkpoint not found: {self.checkpoint_path}"
+            ) from exc
+        except (OSError, json.JSONDecodeError) as exc:
+            raise BatchCheckpointError(
+                f"Checkpoint is not readable: {self.checkpoint_path}"
+            ) from exc
+
+        self._validate_checkpoint(payload)
+        self.checkpoint_interval = int(payload["checkpoint_interval"])
+        self.started_at = str(payload.get("started_at") or self.started_at)
+        self.completed_at = str(payload.get("completed_at") or "")
+        self.is_complete = payload.get("status") == "complete"
+        committed_count = int(payload["committed_count"])
+        committed_output = payload["committed_output"]
+        committed_offset = int(committed_output["offset"])
+        expected_hash = str(committed_output["sha256"])
+
+        try:
+            durable_bytes = self.state_path.read_bytes()
+        except OSError as exc:
+            raise BatchCheckpointError(
+                f"Committed batch output is not readable: {self.state_path}"
+            ) from exc
+        if len(durable_bytes) < committed_offset:
+            raise BatchCheckpointError(
+                "Committed batch output is shorter than the checkpoint offset"
+            )
+
+        committed_bytes = durable_bytes[:committed_offset]
+        if _sha256_bytes(committed_bytes) != expected_hash:
+            raise BatchCheckpointError(
+                "Committed batch output does not match the checkpoint hash"
+            )
+
+        if len(durable_bytes) > committed_offset:
+            _atomic_write_bytes(
+                self.state_path,
+                committed_bytes,
+                hook=self.atomic_write_hook,
+            )
+
+        serialized_records: List[Mapping[str, Any]] = []
+        try:
+            for line in committed_bytes.splitlines():
+                parsed = json.loads(line)
+                if not isinstance(parsed, Mapping):
+                    raise TypeError("result record is not an object")
+                serialized_records.append(parsed)
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise BatchCheckpointError(
+                "Committed batch output contains an invalid result record"
+            ) from exc
+
+        if len(serialized_records) != committed_count:
+            raise BatchCheckpointError(
+                "Committed result count does not match the checkpoint"
+            )
+
+        checkpointed_items = payload.get("items", [])
+        if not isinstance(checkpointed_items, list) or len(checkpointed_items) != len(
+            serialized_records
+        ):
+            raise BatchCheckpointError("Checkpoint item metadata is incomplete")
+
+        records: List[BatchItemResult] = []
+        for index, (item, serialized_record, metadata) in enumerate(
+            zip(self.items, serialized_records, checkpointed_items)
+        ):
+            if not isinstance(metadata, Mapping):
+                raise BatchCheckpointError("Checkpoint item metadata is invalid")
+            if int(metadata.get("index", -1)) != index:
+                raise BatchCheckpointError("Checkpoint item order does not match input")
+            if str(metadata.get("item_id_sha256", "")) != _stable_hash(item.id):
+                raise BatchCheckpointError("Checkpoint item id does not match input")
+            if self.store_full_results:
+                record = _restore_result_record(serialized_record)
+            else:
+                record_succeeded = serialized_record.get("status") == "success"
+                record = BatchItemResult(
+                    id=item.id,
+                    result={"checkpointed": True} if record_succeeded else None,
+                    error=None if record_succeeded else "Previously failed",
+                    source=item.source,
+                )
+            expected_status = "success" if record.success else "failed"
+            if metadata.get("status") != expected_status:
+                raise BatchCheckpointError("Checkpoint item status is inconsistent")
+            self._restore_and_verify_artifact(index, item, metadata)
+            records.append(record)
+
+        if payload.get("status") == "complete" and self.final_output_path is not None:
+            self._verify_final_output(payload)
+
+        return records
+
+    def commit(
+        self,
+        results: Sequence[BatchItemResult],
+        *,
+        status: str,
+        completed_at: str = "",
+        final_output: Optional[_OutputArtifact] = None,
+    ) -> None:
+        """Atomically publish a new result journal, then its checkpoint."""
+        journal = b"".join(
+            self._serialize_journal_record(index, result)
+            for index, result in enumerate(results)
+        )
+        _atomic_write_bytes(
+            self.state_path,
+            journal,
+            hook=self.atomic_write_hook,
+        )
+        self._write_checkpoint(
+            results,
+            status=status,
+            completed_at=completed_at,
+            final_output=final_output,
+        )
+
+    def record_artifact(self, index: int, artifact: _OutputArtifact) -> None:
+        self.artifacts[index] = artifact
+
+    def _write_checkpoint(
+        self,
+        results: Sequence[BatchItemResult],
+        *,
+        status: str,
+        completed_at: str = "",
+        final_output: Optional[_OutputArtifact] = None,
+    ) -> None:
+        serialized_records = [
+            self._serialize_journal_record(index, result)
+            for index, result in enumerate(results)
+        ]
+        journal = b"".join(serialized_records)
+        offsets: List[int] = []
+        offset = 0
+        for serialized_record in serialized_records:
+            offset += len(serialized_record)
+            offsets.append(offset)
+
+        item_metadata = []
+        for index, (item, result, output_offset) in enumerate(
+            zip(self.items, results, offsets)
+        ):
+            metadata: Dict[str, Any] = {
+                "index": index,
+                "item_id_sha256": _stable_hash(item.id),
+                "status": "success" if result.success else "failed",
+                "committed_output_offset": output_offset,
+            }
+            artifact = self.artifacts.get(index)
+            if artifact is not None:
+                metadata["artifact_size"] = artifact.size
+                metadata["artifact_sha256"] = artifact.sha256
+            item_metadata.append(metadata)
+
+        payload: Dict[str, Any] = {
+            "schema_version": _BATCH_CHECKPOINT_SCHEMA_VERSION,
+            "status": status,
+            "operation": self.operation,
+            "model_sha256": _stable_hash(self.model_name),
+            "configuration_sha256": self.configuration_hash,
+            "input_sha256": self.input_hash,
+            "total_items": len(self.items),
+            "committed_count": len(results),
+            "checkpoint_interval": self.checkpoint_interval,
+            "journal_format": (
+                "full_result" if self.store_full_results else "status_only"
+            ),
+            "output_format": self.output_format,
+            "committed_output": {
+                "offset": len(journal),
+                "sha256": _sha256_bytes(journal),
+            },
+            "items": item_metadata,
+            "started_at": self.started_at,
+            "completed_at": completed_at,
+            "contains_raw_input": False,
+            "contains_raw_output": False,
+        }
+        if final_output is not None:
+            payload["final_output"] = {
+                "size": final_output.size,
+                "sha256": final_output.sha256,
+                "format": self.output_format,
+            }
+        checkpoint_bytes = (
+            json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+        ).encode("utf-8")
+        _atomic_write_bytes(
+            self.checkpoint_path,
+            checkpoint_bytes,
+            hook=self.atomic_write_hook,
+        )
+
+    def _serialize_journal_record(
+        self,
+        index: int,
+        result: BatchItemResult,
+    ) -> bytes:
+        if self.store_full_results:
+            return _serialize_result_record(result)
+        payload = {
+            "index": index,
+            "status": "success" if result.success else "failed",
+        }
+        return (
+            json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+        ).encode("utf-8")
+
+    def _validate_checkpoint(self, payload: Any) -> None:
+        if not isinstance(payload, Mapping):
+            raise BatchCheckpointError("Checkpoint must contain a JSON object")
+        if int(payload.get("schema_version", 0)) != _BATCH_CHECKPOINT_SCHEMA_VERSION:
+            raise BatchCheckpointError("Unsupported batch checkpoint schema version")
+        if payload.get("status") not in {"in_progress", "complete"}:
+            raise BatchCheckpointError("Checkpoint status is invalid")
+        if payload.get("operation") != self.operation:
+            raise BatchCheckpointError("Checkpoint operation does not match this batch")
+        if payload.get("model_sha256") != _stable_hash(self.model_name):
+            raise BatchCheckpointError("Checkpoint model does not match this batch")
+        if payload.get("configuration_sha256") != self.configuration_hash:
+            raise BatchCheckpointError(
+                "Checkpoint configuration does not match this batch"
+            )
+        if payload.get("input_sha256") != self.input_hash:
+            raise BatchCheckpointError("Checkpoint input does not match this batch")
+        if int(payload.get("total_items", -1)) != len(self.items):
+            raise BatchCheckpointError("Checkpoint item count does not match input")
+        committed_count = int(payload.get("committed_count", -1))
+        if committed_count < 0 or committed_count > len(self.items):
+            raise BatchCheckpointError("Checkpoint committed count is invalid")
+        if int(payload.get("checkpoint_interval", 0)) < 1:
+            raise BatchCheckpointError("Checkpoint interval is invalid")
+        expected_journal_format = (
+            "full_result" if self.store_full_results else "status_only"
+        )
+        if payload.get("journal_format") != expected_journal_format:
+            raise BatchCheckpointError(
+                "Checkpoint output mode does not match this batch"
+            )
+        if payload.get("output_format") != self.output_format:
+            raise BatchCheckpointError(
+                "Checkpoint output format does not match this batch"
+            )
+        if not isinstance(payload.get("committed_output"), Mapping):
+            raise BatchCheckpointError("Checkpoint output metadata is missing")
+
+    def _restore_and_verify_artifact(
+        self,
+        index: int,
+        item: BatchItem,
+        metadata: Mapping[str, Any],
+    ) -> None:
+        size_value = metadata.get("artifact_size")
+        hash_value = metadata.get("artifact_sha256")
+        if size_value is None and hash_value is None:
+            return
+        if size_value is None or hash_value is None:
+            raise BatchCheckpointError("Checkpoint artifact metadata is incomplete")
+        if self.artifact_path_resolver is None:
+            raise BatchCheckpointError("Checkpoint artifact cannot be resolved")
+        artifact_path = self.artifact_path_resolver(index, item)
+        if artifact_path is None:
+            raise BatchCheckpointError("Checkpoint artifact path is unavailable")
+        try:
+            contents = artifact_path.read_bytes()
+        except OSError as exc:
+            raise BatchCheckpointError(
+                "Committed output artifact is missing or unreadable"
+            ) from exc
+        artifact = _OutputArtifact(size=len(contents), sha256=_sha256_bytes(contents))
+        if artifact.size != int(size_value) or artifact.sha256 != str(hash_value):
+            raise BatchCheckpointError(
+                "Committed output artifact does not match the checkpoint hash"
+            )
+        self.artifacts[index] = artifact
+
+    def _verify_final_output(self, payload: Mapping[str, Any]) -> None:
+        metadata = payload.get("final_output")
+        if not isinstance(metadata, Mapping):
+            raise BatchCheckpointError("Completed checkpoint has no final output hash")
+        try:
+            contents = self.final_output_path.read_bytes()
+        except OSError as exc:
+            raise BatchCheckpointError(
+                "Final batch output is missing or unreadable"
+            ) from exc
+        if len(contents) != int(metadata.get("size", -1)) or _sha256_bytes(
+            contents
+        ) != str(metadata.get("sha256", "")):
+            raise BatchCheckpointError(
+                "Final batch output does not match the checkpoint hash"
+            )
+
+
+def _serialize_batch_output(batch_result: BatchResult, output_format: str) -> bytes:
+    if output_format == "json":
+        rendered = json.dumps(batch_result.to_dict(), indent=2)
+    elif output_format == "summary":
+        rendered = batch_result.summary()
+    else:
+        raise ValueError("output_format must be 'json' or 'summary'")
+    return rendered.encode("utf-8")
+
+
 class BatchProcessor:
     """Process multiple texts efficiently with progress tracking.
 
@@ -244,6 +743,8 @@ class BatchProcessor:
         confidence_threshold: Optional[float] = None,
         group_entities: bool = False,
         continue_on_error: bool = True,
+        checkpoint_interval: int = _DEFAULT_CHECKPOINT_INTERVAL,
+        _atomic_write_hook: Optional[AtomicWriteHook] = None,
         **analyze_kwargs: Any,
     ):
         """Initialize batch processor.
@@ -266,6 +767,8 @@ class BatchProcessor:
             group_entities: Whether to group adjacent entities
                 (``analyze_text`` operation only).
             continue_on_error: Continue processing on individual item errors.
+            checkpoint_interval: Maximum number of items processed between
+                durable checkpoints.
             **analyze_kwargs: Additional arguments passed to the selected function.
         """
         if operation not in _VALID_OPERATIONS:
@@ -289,6 +792,10 @@ class BatchProcessor:
         )
         self.group_entities = group_entities
         self.continue_on_error = continue_on_error
+        if isinstance(checkpoint_interval, bool) or checkpoint_interval < 1:
+            raise ValueError("Checkpoint interval must be positive")
+        self.checkpoint_interval = int(checkpoint_interval)
+        self._atomic_write_hook = _atomic_write_hook
         self.analyze_kwargs = analyze_kwargs
 
         self._analyze_text = None
@@ -394,6 +901,11 @@ class BatchProcessor:
         progress_callback: Optional[ProgressCallback] = None,
         *,
         on_progress: Optional[BatchProgressCallback] = None,
+        output_path: Optional[Union[str, Path]] = None,
+        checkpoint_path: Optional[Union[str, Path]] = None,
+        resume_from_checkpoint: bool = False,
+        checkpoint_interval: Optional[int] = None,
+        output_format: str = "json",
     ) -> BatchResult:
         """Process multiple texts.
 
@@ -404,6 +916,12 @@ class BatchProcessor:
                 Signature: callback(completed_count, total_count, result)
             on_progress: Optional PHI-safe callback that receives a
                 BatchProgress record after each completed item.
+            output_path: Optional atomically written final result file.
+            checkpoint_path: Optional PHI-free durable checkpoint file.
+            resume_from_checkpoint: Resume the committed result prefix instead
+                of starting a new checkpoint.
+            checkpoint_interval: Per-run override for checkpoint frequency.
+            output_format: ``"json"`` or ``"summary"`` for ``output_path``.
 
         Returns:
             BatchResult with all processing results.
@@ -413,6 +931,11 @@ class BatchProcessor:
             items,
             progress_callback=progress_callback,
             on_progress=on_progress,
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=resume_from_checkpoint,
+            checkpoint_interval=checkpoint_interval,
+            output_format=output_format,
         )
 
     def process_files(
@@ -422,6 +945,11 @@ class BatchProcessor:
         progress_callback: Optional[ProgressCallback] = None,
         *,
         on_progress: Optional[BatchProgressCallback] = None,
+        output_path: Optional[Union[str, Path]] = None,
+        checkpoint_path: Optional[Union[str, Path]] = None,
+        resume_from_checkpoint: bool = False,
+        checkpoint_interval: Optional[int] = None,
+        output_format: str = "json",
     ) -> BatchResult:
         """Process multiple files.
 
@@ -431,6 +959,11 @@ class BatchProcessor:
             progress_callback: Optional callback for progress updates.
             on_progress: Optional PHI-safe callback that receives a
                 BatchProgress record after each completed item.
+            output_path: Optional atomically written final result file.
+            checkpoint_path: Optional PHI-free durable checkpoint file.
+            resume_from_checkpoint: Resume the committed result prefix.
+            checkpoint_interval: Per-run override for checkpoint frequency.
+            output_format: ``"json"`` or ``"summary"`` for ``output_path``.
 
         Returns:
             BatchResult with all processing results.
@@ -466,6 +999,11 @@ class BatchProcessor:
             items,
             progress_callback=progress_callback,
             on_progress=on_progress,
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=resume_from_checkpoint,
+            checkpoint_interval=checkpoint_interval,
+            output_format=output_format,
         )
 
     def process_directory(
@@ -477,6 +1015,11 @@ class BatchProcessor:
         progress_callback: Optional[ProgressCallback] = None,
         *,
         on_progress: Optional[BatchProgressCallback] = None,
+        output_path: Optional[Union[str, Path]] = None,
+        checkpoint_path: Optional[Union[str, Path]] = None,
+        resume_from_checkpoint: bool = False,
+        checkpoint_interval: Optional[int] = None,
+        output_format: str = "json",
     ) -> BatchResult:
         """Process all matching files in a directory.
 
@@ -488,6 +1031,11 @@ class BatchProcessor:
             progress_callback: Optional callback for progress updates.
             on_progress: Optional PHI-safe callback that receives a
                 BatchProgress record after each completed item.
+            output_path: Optional atomically written final result file.
+            checkpoint_path: Optional PHI-free durable checkpoint file.
+            resume_from_checkpoint: Resume the committed result prefix.
+            checkpoint_interval: Per-run override for checkpoint frequency.
+            output_format: ``"json"`` or ``"summary"`` for ``output_path``.
 
         Returns:
             BatchResult with all processing results.
@@ -504,6 +1052,11 @@ class BatchProcessor:
             encoding=encoding,
             progress_callback=progress_callback,
             on_progress=on_progress,
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=resume_from_checkpoint,
+            checkpoint_interval=checkpoint_interval,
+            output_format=output_format,
         )
 
     def process_items(
@@ -512,6 +1065,11 @@ class BatchProcessor:
         progress_callback: Optional[ProgressCallback] = None,
         *,
         on_progress: Optional[BatchProgressCallback] = None,
+        output_path: Optional[Union[str, Path]] = None,
+        checkpoint_path: Optional[Union[str, Path]] = None,
+        resume_from_checkpoint: bool = False,
+        checkpoint_interval: Optional[int] = None,
+        output_format: str = "json",
     ) -> BatchResult:
         """Process a sequence of BatchItem objects.
 
@@ -520,6 +1078,11 @@ class BatchProcessor:
             progress_callback: Optional callback for progress updates.
             on_progress: Optional PHI-safe callback that receives a
                 BatchProgress record after each completed item.
+            output_path: Optional atomically written final result file.
+            checkpoint_path: Optional PHI-free durable checkpoint file.
+            resume_from_checkpoint: Resume the committed result prefix.
+            checkpoint_interval: Per-run override for checkpoint frequency.
+            output_format: ``"json"`` or ``"summary"`` for ``output_path``.
 
         Returns:
             BatchResult with all processing results.
@@ -528,6 +1091,133 @@ class BatchProcessor:
             list(items),
             progress_callback=progress_callback,
             on_progress=on_progress,
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=resume_from_checkpoint,
+            checkpoint_interval=checkpoint_interval,
+            output_format=output_format,
+        )
+
+    def resume_from_checkpoint(
+        self,
+        items: Sequence[BatchItem],
+        *,
+        checkpoint_path: Union[str, Path],
+        output_path: Optional[Union[str, Path]] = None,
+        progress_callback: Optional[ProgressCallback] = None,
+        on_progress: Optional[BatchProgressCallback] = None,
+        output_format: str = "json",
+    ) -> BatchResult:
+        """Resume ``items`` from a previously committed batch checkpoint."""
+        return self.process_items(
+            items,
+            progress_callback=progress_callback,
+            on_progress=on_progress,
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=True,
+            output_format=output_format,
+        )
+
+    def process_files_to_directory(
+        self,
+        file_paths: Sequence[Union[str, Path]],
+        *,
+        input_root: Union[str, Path],
+        output_dir: Union[str, Path],
+        encoding: str = "utf-8",
+        checkpoint_path: Optional[Union[str, Path]] = None,
+        resume_from_checkpoint: bool = False,
+        checkpoint_interval: Optional[int] = None,
+        progress_callback: Optional[ProgressCallback] = None,
+        on_progress: Optional[BatchProgressCallback] = None,
+    ) -> BatchResult:
+        """De-identify files into an atomic, checkpointed output directory.
+
+        Output paths preserve each input's location relative to ``input_root``.
+        Committed files are hashed in the PHI-free checkpoint and verified
+        before a resumed run skips them.
+        """
+        if self.operation != "deidentify":
+            raise ValueError(
+                "process_files_to_directory requires operation='deidentify'"
+            )
+
+        resolved_input_root = Path(input_root).resolve()
+        resolved_output_dir = Path(output_dir)
+        resolved_output_dir.mkdir(parents=True, exist_ok=True)
+        items: List[BatchItem] = []
+        destinations: List[Path] = []
+
+        for raw_path in file_paths:
+            path = Path(raw_path)
+            relative_path = path.resolve().relative_to(resolved_input_root)
+            destinations.append(resolved_output_dir / relative_path)
+            try:
+                text = path.read_text(encoding=encoding)
+                items.append(
+                    BatchItem(id=str(relative_path), text=text, source=str(path))
+                )
+            except (OSError, IOError) as exc:
+                logger.warning(
+                    "Failed to read batch input file: error_type=%s",
+                    type(exc).__name__,
+                )
+                if not self.continue_on_error:
+                    raise
+                items.append(
+                    BatchItem(
+                        id=str(relative_path),
+                        text="",
+                        source=str(path),
+                        metadata={"read_error": str(exc)},
+                    )
+                )
+
+        def artifact_path_resolver(index: int, item: BatchItem) -> Path:
+            del item
+            return destinations[index]
+
+        def artifact_writer(
+            index: int,
+            item: BatchItem,
+            item_result: BatchItemResult,
+        ) -> Optional[_OutputArtifact]:
+            del item
+            if not item_result.success:
+                return None
+            if isinstance(item_result.result, Mapping):
+                deidentified_text = item_result.result.get("deidentified_text")
+            else:
+                deidentified_text = getattr(
+                    item_result.result,
+                    "deidentified_text",
+                    None,
+                )
+            if not isinstance(deidentified_text, str):
+                raise ValueError(
+                    "de-identification result does not contain deidentified_text"
+                )
+            output_bytes = deidentified_text.encode(encoding)
+            _atomic_write_bytes(
+                destinations[index],
+                output_bytes,
+                hook=self._atomic_write_hook,
+            )
+            return _OutputArtifact(
+                size=len(output_bytes),
+                sha256=_sha256_bytes(output_bytes),
+            )
+
+        return self._process_items(
+            items,
+            progress_callback=progress_callback,
+            on_progress=on_progress,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=resume_from_checkpoint,
+            checkpoint_interval=checkpoint_interval,
+            artifact_writer=artifact_writer,
+            artifact_path_resolver=artifact_path_resolver,
         )
 
     def _process_items(
@@ -536,21 +1226,94 @@ class BatchProcessor:
         progress_callback: Optional[ProgressCallback] = None,
         *,
         on_progress: Optional[BatchProgressCallback] = None,
+        output_path: Optional[Union[str, Path]] = None,
+        checkpoint_path: Optional[Union[str, Path]] = None,
+        resume_from_checkpoint: bool = False,
+        checkpoint_interval: Optional[int] = None,
+        output_format: str = "json",
+        artifact_writer: Optional[ArtifactWriter] = None,
+        artifact_path_resolver: Optional[ArtifactPathResolver] = None,
     ) -> BatchResult:
         """Internal method to process batch items."""
-        from datetime import datetime
+        if output_format not in {"json", "summary"}:
+            raise ValueError("output_format must be 'json' or 'summary'")
+        if resume_from_checkpoint and checkpoint_path is None:
+            raise ValueError("resume_from_checkpoint requires checkpoint_path")
+        resolved_interval = (
+            self.checkpoint_interval
+            if checkpoint_interval is None
+            else checkpoint_interval
+        )
+        if isinstance(resolved_interval, bool) or resolved_interval < 1:
+            raise ValueError("Checkpoint interval must be positive")
+
+        session: Optional[_BatchCheckpointSession] = None
+        restored_results: List[BatchItemResult] = []
+        if checkpoint_path is not None:
+            session = _BatchCheckpointSession(
+                items=items,
+                checkpoint_path=Path(checkpoint_path),
+                checkpoint_interval=int(resolved_interval),
+                model_name=self.model_name,
+                operation=self.operation,
+                configuration={
+                    "aggregation_strategy": self.aggregation_strategy,
+                    "confidence_threshold": self.confidence_threshold,
+                    "group_entities": self.group_entities,
+                    "continue_on_error": self.continue_on_error,
+                    "analyze_kwargs": self.analyze_kwargs,
+                },
+                final_output_path=(
+                    Path(output_path) if output_path is not None else None
+                ),
+                output_format=output_format,
+                store_full_results=artifact_writer is None,
+                artifact_path_resolver=artifact_path_resolver,
+                atomic_write_hook=self._atomic_write_hook,
+            )
+            if resume_from_checkpoint:
+                restored_results = session.resume()
+                resolved_interval = session.checkpoint_interval
+            else:
+                session.start()
 
         batch_result = BatchResult(
+            items=list(restored_results),
             model_name=self.model_name,
-            started_at=datetime.now().isoformat(),
+            started_at=(session.started_at if session else datetime.now().isoformat()),
         )
+
+        if session is not None and session.is_complete:
+            batch_result.completed_at = session.completed_at
+            batch_result.total_processing_time = sum(
+                item.processing_time for item in batch_result.items
+            )
+            return batch_result
 
         total = len(items)
         batch_start = time.time()
 
-        for chunk in self._iter_chunks(items):
+        next_index = len(batch_result.items)
+        while next_index < total:
+            if session is not None:
+                until_checkpoint = int(resolved_interval) - (
+                    len(batch_result.items) % int(resolved_interval)
+                )
+                chunk_size = min(self.batch_size, until_checkpoint, total - next_index)
+            else:
+                chunk_size = min(self.batch_size, total - next_index)
+            chunk = items[next_index : next_index + chunk_size]
             chunk_results = self._process_batch_chunk(chunk)
             for item_result in chunk_results:
+                item_index = len(batch_result.items)
+                if artifact_writer is not None:
+                    artifact = artifact_writer(
+                        item_index,
+                        items[item_index],
+                        item_result,
+                    )
+                    if artifact is not None and session is not None:
+                        session.record_artifact(item_index, artifact)
                 batch_result.items.append(item_result)
                 self._emit_progress(
                     completed=len(batch_result.items),
@@ -560,9 +1323,38 @@ class BatchProcessor:
                     progress_callback=progress_callback,
                     on_progress=on_progress,
                 )
+                if session is not None and (
+                    len(batch_result.items) % int(resolved_interval) == 0
+                ):
+                    session.commit(batch_result.items, status="in_progress")
+            next_index += len(chunk)
 
         batch_result.total_processing_time = time.time() - batch_start
         batch_result.completed_at = datetime.now().isoformat()
+
+        if session is not None:
+            session.commit(batch_result.items, status="in_progress")
+
+        final_output: Optional[_OutputArtifact] = None
+        if output_path is not None:
+            output_bytes = _serialize_batch_output(batch_result, output_format)
+            _atomic_write_bytes(
+                Path(output_path),
+                output_bytes,
+                hook=self._atomic_write_hook,
+            )
+            final_output = _OutputArtifact(
+                size=len(output_bytes),
+                sha256=_sha256_bytes(output_bytes),
+            )
+
+        if session is not None:
+            session.commit(
+                batch_result.items,
+                status="complete",
+                completed_at=batch_result.completed_at,
+                final_output=final_output,
+            )
 
         return batch_result
 

--- a/openmed/processing/batch.py
+++ b/openmed/processing/batch.py
@@ -276,6 +276,13 @@ def _stable_hash(*values: Any) -> str:
     return digest.hexdigest()
 
 
+def _checkpoint_integer(value: Any, field_name: str, *, minimum: int = 0) -> int:
+    """Return a strictly typed checkpoint integer or raise a safe error."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise BatchCheckpointError(f"Checkpoint {field_name} is invalid")
+    return value
+
+
 def _fsync_directory(path: Path) -> None:
     """Best-effort fsync of a directory after an atomic rename."""
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
@@ -421,13 +428,23 @@ class _BatchCheckpointSession:
             ) from exc
 
         self._validate_checkpoint(payload)
-        self.checkpoint_interval = int(payload["checkpoint_interval"])
+        self.checkpoint_interval = _checkpoint_integer(
+            payload.get("checkpoint_interval"),
+            "interval",
+            minimum=1,
+        )
         self.started_at = str(payload.get("started_at") or self.started_at)
         self.completed_at = str(payload.get("completed_at") or "")
         self.is_complete = payload.get("status") == "complete"
-        committed_count = int(payload["committed_count"])
+        committed_count = _checkpoint_integer(
+            payload.get("committed_count"),
+            "committed count",
+        )
         committed_output = payload["committed_output"]
-        committed_offset = int(committed_output["offset"])
+        committed_offset = _checkpoint_integer(
+            committed_output.get("offset"),
+            "committed output offset",
+        )
         expected_hash = str(committed_output["sha256"])
 
         try:
@@ -455,12 +472,16 @@ class _BatchCheckpointSession:
             )
 
         serialized_records: List[Mapping[str, Any]] = []
+        record_offsets: List[int] = []
+        record_offset = 0
         try:
-            for line in committed_bytes.splitlines():
+            for line in committed_bytes.splitlines(keepends=True):
                 parsed = json.loads(line)
                 if not isinstance(parsed, Mapping):
                     raise TypeError("result record is not an object")
                 serialized_records.append(parsed)
+                record_offset += len(line)
+                record_offsets.append(record_offset)
         except (TypeError, ValueError, json.JSONDecodeError) as exc:
             raise BatchCheckpointError(
                 "Committed batch output contains an invalid result record"
@@ -478,19 +499,49 @@ class _BatchCheckpointSession:
             raise BatchCheckpointError("Checkpoint item metadata is incomplete")
 
         records: List[BatchItemResult] = []
-        for index, (item, serialized_record, metadata) in enumerate(
-            zip(self.items, serialized_records, checkpointed_items)
+        for index, (item, serialized_record, metadata, output_offset) in enumerate(
+            zip(self.items, serialized_records, checkpointed_items, record_offsets)
         ):
             if not isinstance(metadata, Mapping):
                 raise BatchCheckpointError("Checkpoint item metadata is invalid")
-            if int(metadata.get("index", -1)) != index:
+            if _checkpoint_integer(metadata.get("index"), "item index") != index:
                 raise BatchCheckpointError("Checkpoint item order does not match input")
             if str(metadata.get("item_id_sha256", "")) != _stable_hash(item.id):
                 raise BatchCheckpointError("Checkpoint item id does not match input")
+            if (
+                _checkpoint_integer(
+                    metadata.get("committed_output_offset"),
+                    "item output offset",
+                )
+                != output_offset
+            ):
+                raise BatchCheckpointError(
+                    "Checkpoint item output offset does not match the journal"
+                )
             if self.store_full_results:
-                record = _restore_result_record(serialized_record)
+                try:
+                    record = _restore_result_record(serialized_record)
+                except (TypeError, ValueError) as exc:
+                    raise BatchCheckpointError(
+                        "Committed batch output contains an invalid result record"
+                    ) from exc
             else:
-                record_succeeded = serialized_record.get("status") == "success"
+                if (
+                    _checkpoint_integer(
+                        serialized_record.get("index"),
+                        "journal item index",
+                    )
+                    != index
+                ):
+                    raise BatchCheckpointError(
+                        "Committed journal item order does not match input"
+                    )
+                journal_status = serialized_record.get("status")
+                if journal_status not in {"success", "failed"}:
+                    raise BatchCheckpointError(
+                        "Committed journal item status is invalid"
+                    )
+                record_succeeded = journal_status == "success"
                 record = BatchItemResult(
                     id=item.id,
                     result={"checkpointed": True} if record_succeeded else None,
@@ -628,7 +679,10 @@ class _BatchCheckpointSession:
     def _validate_checkpoint(self, payload: Any) -> None:
         if not isinstance(payload, Mapping):
             raise BatchCheckpointError("Checkpoint must contain a JSON object")
-        if int(payload.get("schema_version", 0)) != _BATCH_CHECKPOINT_SCHEMA_VERSION:
+        if (
+            _checkpoint_integer(payload.get("schema_version"), "schema version")
+            != _BATCH_CHECKPOINT_SCHEMA_VERSION
+        ):
             raise BatchCheckpointError("Unsupported batch checkpoint schema version")
         if payload.get("status") not in {"in_progress", "complete"}:
             raise BatchCheckpointError("Checkpoint status is invalid")
@@ -642,13 +696,21 @@ class _BatchCheckpointSession:
             )
         if payload.get("input_sha256") != self.input_hash:
             raise BatchCheckpointError("Checkpoint input does not match this batch")
-        if int(payload.get("total_items", -1)) != len(self.items):
+        if _checkpoint_integer(payload.get("total_items"), "item count") != len(
+            self.items
+        ):
             raise BatchCheckpointError("Checkpoint item count does not match input")
-        committed_count = int(payload.get("committed_count", -1))
-        if committed_count < 0 or committed_count > len(self.items):
+        committed_count = _checkpoint_integer(
+            payload.get("committed_count"),
+            "committed count",
+        )
+        if committed_count > len(self.items):
             raise BatchCheckpointError("Checkpoint committed count is invalid")
-        if int(payload.get("checkpoint_interval", 0)) < 1:
-            raise BatchCheckpointError("Checkpoint interval is invalid")
+        _checkpoint_integer(
+            payload.get("checkpoint_interval"),
+            "interval",
+            minimum=1,
+        )
         expected_journal_format = (
             "full_result" if self.store_full_results else "status_only"
         )
@@ -660,8 +722,16 @@ class _BatchCheckpointSession:
             raise BatchCheckpointError(
                 "Checkpoint output format does not match this batch"
             )
-        if not isinstance(payload.get("committed_output"), Mapping):
+        committed_output = payload.get("committed_output")
+        if not isinstance(committed_output, Mapping):
             raise BatchCheckpointError("Checkpoint output metadata is missing")
+        _checkpoint_integer(
+            committed_output.get("offset"),
+            "committed output offset",
+        )
+        committed_hash = committed_output.get("sha256")
+        if not isinstance(committed_hash, str) or len(committed_hash) != 64:
+            raise BatchCheckpointError("Checkpoint committed output hash is invalid")
 
     def _restore_and_verify_artifact(
         self,
@@ -672,6 +742,8 @@ class _BatchCheckpointSession:
         size_value = metadata.get("artifact_size")
         hash_value = metadata.get("artifact_sha256")
         if size_value is None and hash_value is None:
+            if not self.store_full_results and metadata.get("status") == "success":
+                raise BatchCheckpointError("Checkpoint artifact metadata is incomplete")
             return
         if size_value is None or hash_value is None:
             raise BatchCheckpointError("Checkpoint artifact metadata is incomplete")
@@ -687,7 +759,8 @@ class _BatchCheckpointSession:
                 "Committed output artifact is missing or unreadable"
             ) from exc
         artifact = _OutputArtifact(size=len(contents), sha256=_sha256_bytes(contents))
-        if artifact.size != int(size_value) or artifact.sha256 != str(hash_value):
+        expected_size = _checkpoint_integer(size_value, "artifact size")
+        if artifact.size != expected_size or artifact.sha256 != str(hash_value):
             raise BatchCheckpointError(
                 "Committed output artifact does not match the checkpoint hash"
             )
@@ -703,9 +776,13 @@ class _BatchCheckpointSession:
             raise BatchCheckpointError(
                 "Final batch output is missing or unreadable"
             ) from exc
-        if len(contents) != int(metadata.get("size", -1)) or _sha256_bytes(
-            contents
-        ) != str(metadata.get("sha256", "")):
+        expected_size = _checkpoint_integer(
+            metadata.get("size"),
+            "final output size",
+        )
+        if len(contents) != expected_size or _sha256_bytes(contents) != str(
+            metadata.get("sha256", "")
+        ):
             raise BatchCheckpointError(
                 "Final batch output does not match the checkpoint hash"
             )
@@ -1261,6 +1338,11 @@ class BatchProcessor:
                     "confidence_threshold": self.confidence_threshold,
                     "group_entities": self.group_entities,
                     "continue_on_error": self.continue_on_error,
+                    "config": (
+                        self.config.to_dict()
+                        if callable(getattr(self.config, "to_dict", None))
+                        else self.config
+                    ),
                     "analyze_kwargs": self.analyze_kwargs,
                 },
                 final_output_path=(

--- a/tests/unit/processing/test_batch_checkpoint.py
+++ b/tests/unit/processing/test_batch_checkpoint.py
@@ -271,6 +271,123 @@ def test_resume_refuses_mismatched_committed_journal(tmp_path: Path) -> None:
         )
 
 
+def test_resume_refuses_mismatched_configuration(tmp_path: Path) -> None:
+    output_path = tmp_path / "results.json"
+    checkpoint_path = tmp_path / "results.checkpoint.json"
+    processor = _SyntheticProcessor()
+    processor.config = {"profile": "first"}
+    processor.process_texts(
+        ["Patient Alice Example"],
+        output_path=output_path,
+        checkpoint_path=checkpoint_path,
+    )
+
+    resumed_processor = _SyntheticProcessor()
+    resumed_processor.config = {"profile": "second"}
+    with pytest.raises(
+        BatchCheckpointError,
+        match="Checkpoint configuration does not match this batch",
+    ):
+        resumed_processor.process_texts(
+            ["Patient Alice Example"],
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        ("schema_version", {}),
+        ("total_items", "1"),
+        ("committed_count", 1.0),
+        ("checkpoint_interval", False),
+    ],
+)
+def test_resume_rejects_malformed_checkpoint_integers(
+    tmp_path: Path,
+    field: str,
+    invalid_value: object,
+) -> None:
+    output_path = tmp_path / "results.json"
+    checkpoint_path = tmp_path / "results.checkpoint.json"
+    processor = _SyntheticProcessor()
+    processor.process_texts(
+        ["Patient Alice Example"],
+        output_path=output_path,
+        checkpoint_path=checkpoint_path,
+    )
+    checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    checkpoint[field] = invalid_value
+    checkpoint_path.write_text(json.dumps(checkpoint), encoding="utf-8")
+
+    with pytest.raises(BatchCheckpointError, match="Checkpoint .* is invalid"):
+        processor.process_texts(
+            ["Patient Alice Example"],
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=True,
+        )
+
+
+def test_resume_refuses_mismatched_item_output_offset(tmp_path: Path) -> None:
+    output_path = tmp_path / "results.json"
+    checkpoint_path = tmp_path / "results.checkpoint.json"
+    processor = _SyntheticProcessor()
+    processor.process_texts(
+        ["Patient Alice Example"],
+        output_path=output_path,
+        checkpoint_path=checkpoint_path,
+    )
+    checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    checkpoint["items"][0]["committed_output_offset"] += 1
+    checkpoint_path.write_text(json.dumps(checkpoint), encoding="utf-8")
+
+    with pytest.raises(
+        BatchCheckpointError,
+        match="Checkpoint item output offset does not match the journal",
+    ):
+        processor.process_texts(
+            ["Patient Alice Example"],
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=True,
+        )
+
+
+def test_resume_requires_hash_for_every_successful_file(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    source = input_dir / "note.txt"
+    source.write_text("Patient Alice Example", encoding="utf-8")
+    checkpoint_path = output_dir / "checkpoint.json"
+    processor = _SyntheticProcessor()
+    processor.process_files_to_directory(
+        [source],
+        input_root=input_dir,
+        output_dir=output_dir,
+        checkpoint_path=checkpoint_path,
+    )
+    checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    del checkpoint["items"][0]["artifact_size"]
+    del checkpoint["items"][0]["artifact_sha256"]
+    checkpoint_path.write_text(json.dumps(checkpoint), encoding="utf-8")
+
+    with pytest.raises(
+        BatchCheckpointError,
+        match="Checkpoint artifact metadata is incomplete",
+    ):
+        processor.process_files_to_directory(
+            [source],
+            input_root=input_dir,
+            output_dir=output_dir,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=True,
+        )
+
+
 @pytest.mark.parametrize("target_name", ["checkpoint.json", "checkpoint.json.part"])
 @pytest.mark.parametrize(
     "crash_phase",
@@ -448,3 +565,59 @@ def test_pii_batch_cli_checkpoint_is_phi_free_and_resume_skips_completed_files(
     assert main_module.main([*arguments, "--resume"]) == 0
     assert calls == []
     assert "Processed 1 files, 0 failed" in capsys.readouterr().out
+
+
+def test_pii_batch_cli_json_mode_emits_only_envelope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    (input_dir / "note.txt").write_text(
+        "Patient Alice Example called 555-0100.",
+        encoding="utf-8",
+    )
+
+    def deidentify_batch(
+        texts: list[str],
+        **kwargs: object,
+    ) -> list[DeidentificationResult]:
+        return [
+            DeidentificationResult(
+                original_text=text,
+                deidentified_text="Patient [NAME] called [PHONE].",
+                pii_entities=[],
+                method=str(kwargs["method"]),
+                timestamp=datetime(2026, 1, 1),
+            )
+            for text in texts
+        ]
+
+    monkeypatch.setattr("openmed.core.pii._deidentify_batch", deidentify_batch)
+    monkeypatch.setattr(BatchProcessor, "_get_shared_loader", lambda self: None)
+
+    assert (
+        main_module.main(
+            [
+                "pii",
+                "batch",
+                "--model",
+                "synthetic-model",
+                "--input-dir",
+                str(input_dir),
+                "--output-dir",
+                str(output_dir),
+                "--json",
+            ]
+        )
+        == 0
+    )
+    captured = capsys.readouterr()
+    envelope = json.loads(captured.out)
+    assert envelope["ok"] is True
+    assert envelope["command"] == "pii batch"
+    assert envelope["data"]["successful_items"] == 1
+    assert envelope["data"]["output_dir"] == str(output_dir)
+    assert captured.err == ""

--- a/tests/unit/processing/test_batch_checkpoint.py
+++ b/tests/unit/processing/test_batch_checkpoint.py
@@ -1,0 +1,450 @@
+"""Crash-safety tests for durable batch checkpoints and atomic output."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import signal
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from openmed.cli import main_module
+from openmed.core.pii import DeidentificationResult
+from openmed.processing.batch import (
+    BatchCheckpointError,
+    BatchItem,
+    BatchItemResult,
+    BatchProcessor,
+    _atomic_write_bytes,
+)
+from openmed.processing.outputs import PredictionResult
+
+
+@dataclass
+class _SyntheticDeidentification:
+    original_text: str
+    deidentified_text: str
+    pii_entities: list[dict[str, str]]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "original_text": self.original_text,
+            "deidentified_text": self.deidentified_text,
+            "pii_entities": self.pii_entities,
+        }
+
+
+class _SyntheticProcessor(BatchProcessor):
+    def __init__(self, *, event_log: Path | None = None, delay: float = 0.0) -> None:
+        super().__init__(
+            model_name="synthetic-model",
+            operation="deidentify",
+            batch_size=1,
+            checkpoint_interval=2,
+            method="mask",
+        )
+        self.event_log = event_log
+        self.delay = delay
+
+    def _process_batch_chunk(
+        self,
+        items: list[BatchItem],
+    ) -> list[BatchItemResult]:
+        results = []
+        for item in items:
+            if self.event_log is not None:
+                with self.event_log.open("a", encoding="utf-8") as handle:
+                    handle.write(f"{item.id}\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+            if self.delay:
+                time.sleep(self.delay)
+            results.append(
+                BatchItemResult(
+                    id=item.id,
+                    result=_SyntheticDeidentification(
+                        original_text=item.text,
+                        deidentified_text=f"redacted::{item.id}",
+                        pii_entities=[{"label": "NAME"}],
+                    ),
+                    processing_time=0.0,
+                    source=item.source,
+                )
+            )
+        return results
+
+
+def _run_checkpoint_worker(
+    input_dir: str,
+    output_dir: str,
+    checkpoint_path: str,
+    event_log: str,
+) -> None:
+    files = sorted(Path(input_dir).glob("*.txt"))
+    _SyntheticProcessor(
+        event_log=Path(event_log), delay=0.2
+    ).process_files_to_directory(
+        files,
+        input_root=input_dir,
+        output_dir=output_dir,
+        checkpoint_path=checkpoint_path,
+    )
+
+
+def _wait_for_uncommitted_interval(
+    checkpoint_path: Path,
+    event_log: Path,
+    *,
+    timeout: float = 10.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            checkpoint = {}
+        events = (
+            event_log.read_text(encoding="utf-8").splitlines()
+            if event_log.exists()
+            else []
+        )
+        if checkpoint.get("committed_count") == 2 and len(events) >= 4:
+            return
+        time.sleep(0.01)
+    raise AssertionError("worker did not reach the expected checkpoint boundary")
+
+
+@pytest.mark.skipif(
+    not hasattr(signal, "SIGKILL")
+    or "fork" not in multiprocessing.get_all_start_methods(),
+    reason="requires POSIX SIGKILL and fork",
+)
+def test_sigkill_resume_is_byte_identical_and_rework_is_bounded(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    interrupted_output = tmp_path / "interrupted"
+    uninterrupted_output = tmp_path / "uninterrupted"
+    input_dir.mkdir()
+    raw_inputs = [
+        "Patient Alice Example called 555-0100.",
+        "Patient Bob Example called 555-0101.",
+        "Patient Carol Example called 555-0102.",
+        "Patient David Example called 555-0103.",
+        "Patient Erin Example called 555-0104.",
+        "Patient Frank Example called 555-0105.",
+    ]
+    for index, text in enumerate(raw_inputs):
+        (input_dir / f"note-{index}.txt").write_text(text, encoding="utf-8")
+
+    files = sorted(input_dir.glob("*.txt"))
+    _SyntheticProcessor().process_files_to_directory(
+        files,
+        input_root=input_dir,
+        output_dir=uninterrupted_output,
+        checkpoint_path=uninterrupted_output / "checkpoint.json",
+    )
+
+    interrupted_output.mkdir()
+    checkpoint_path = interrupted_output / "checkpoint.json"
+    event_log = tmp_path / "processed.log"
+    context = multiprocessing.get_context("fork")
+    worker = context.Process(
+        target=_run_checkpoint_worker,
+        args=(
+            str(input_dir),
+            str(interrupted_output),
+            str(checkpoint_path),
+            str(event_log),
+        ),
+    )
+    worker.start()
+    _wait_for_uncommitted_interval(checkpoint_path, event_log)
+    os.kill(worker.pid, signal.SIGKILL)
+    worker.join(timeout=5)
+    assert worker.exitcode == -signal.SIGKILL
+
+    _SyntheticProcessor(event_log=event_log).process_files_to_directory(
+        files,
+        input_root=input_dir,
+        output_dir=interrupted_output,
+        checkpoint_path=checkpoint_path,
+        resume_from_checkpoint=True,
+    )
+
+    for input_file in files:
+        relative_path = input_file.relative_to(input_dir)
+        assert (interrupted_output / relative_path).read_bytes() == (
+            uninterrupted_output / relative_path
+        ).read_bytes()
+
+    process_events = event_log.read_text(encoding="utf-8").splitlines()
+    assert len(process_events) - len(files) <= 2
+    checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    assert checkpoint["status"] == "complete"
+    checkpoint_text = checkpoint_path.read_text(encoding="utf-8") + Path(
+        f"{checkpoint_path}.part"
+    ).read_text(encoding="utf-8")
+    for raw_input in raw_inputs:
+        assert raw_input not in checkpoint_text
+        for phi_value in raw_input.removesuffix(".").split()[1:]:
+            assert phi_value not in checkpoint_text
+
+
+def test_resume_refuses_mismatched_committed_output_artifact(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    source = input_dir / "note.txt"
+    source.write_text("Patient Alice Example called 555-0100.", encoding="utf-8")
+    checkpoint_path = output_dir / "checkpoint.json"
+    processor = _SyntheticProcessor()
+    processor.process_files_to_directory(
+        [source],
+        input_root=input_dir,
+        output_dir=output_dir,
+        checkpoint_path=checkpoint_path,
+    )
+
+    (output_dir / "note.txt").write_text("tampered", encoding="utf-8")
+
+    with pytest.raises(
+        BatchCheckpointError,
+        match="output artifact does not match the checkpoint hash",
+    ):
+        processor.process_files_to_directory(
+            [source],
+            input_root=input_dir,
+            output_dir=output_dir,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=True,
+        )
+
+
+def test_resume_refuses_mismatched_final_output(tmp_path: Path) -> None:
+    output_path = tmp_path / "results.json"
+    checkpoint_path = tmp_path / "results.checkpoint.json"
+    processor = _SyntheticProcessor()
+    processor.process_texts(
+        ["Patient Alice Example"],
+        output_path=output_path,
+        checkpoint_path=checkpoint_path,
+    )
+    output_path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(
+        BatchCheckpointError,
+        match="Final batch output does not match the checkpoint hash",
+    ):
+        processor.process_texts(
+            ["Patient Alice Example"],
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=True,
+        )
+
+
+def test_resume_refuses_mismatched_committed_journal(tmp_path: Path) -> None:
+    output_path = tmp_path / "results.json"
+    checkpoint_path = tmp_path / "results.checkpoint.json"
+    processor = _SyntheticProcessor()
+    processor.process_texts(
+        ["Patient Alice Example"],
+        output_path=output_path,
+        checkpoint_path=checkpoint_path,
+    )
+    journal_path = Path(f"{checkpoint_path}.part")
+    journal_path.write_bytes(b"tampered\n" + journal_path.read_bytes())
+
+    with pytest.raises(
+        BatchCheckpointError,
+        match="Committed batch output does not match the checkpoint hash",
+    ):
+        processor.process_texts(
+            ["Patient Alice Example"],
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            resume_from_checkpoint=True,
+        )
+
+
+@pytest.mark.parametrize("target_name", ["checkpoint.json", "checkpoint.json.part"])
+@pytest.mark.parametrize(
+    "crash_phase",
+    [
+        "after_write",
+        "after_fsync",
+        "before_replace",
+        "after_replace",
+        "after_directory_fsync",
+    ],
+)
+def test_atomic_checkpoint_and_output_survive_every_crash_point(
+    tmp_path: Path,
+    target_name: str,
+    crash_phase: str,
+) -> None:
+    target = tmp_path / target_name
+    previous = b'{"generation":1}\n'
+    candidate = b'{"generation":2}\n'
+    target.write_bytes(previous)
+
+    def crash_hook(phase: str, path: Path) -> None:
+        assert path == target
+        if phase == crash_phase:
+            raise RuntimeError("simulated power loss")
+
+    with pytest.raises(RuntimeError, match="simulated power loss"):
+        _atomic_write_bytes(target, candidate, hook=crash_hook)
+
+    persisted = target.read_bytes()
+    assert persisted in {previous, candidate}
+    assert json.loads(persisted)["generation"] in {1, 2}
+    assert not list(tmp_path.glob(f".{target.name}.*.tmp"))
+
+
+def test_cli_parses_resume_and_checkpoint_interval_flags() -> None:
+    parser = main_module.build_parser()
+    batch_args = parser.parse_args(
+        [
+            "batch",
+            "--texts",
+            "synthetic",
+            "--output",
+            "results.json",
+            "--resume",
+            "--checkpoint-interval",
+            "3",
+        ]
+    )
+    pii_args = parser.parse_args(
+        [
+            "pii",
+            "batch",
+            "--input-dir",
+            "input",
+            "--output-dir",
+            "output",
+            "--resume",
+            "--checkpoint-interval",
+            "4",
+        ]
+    )
+
+    assert batch_args.resume is True
+    assert batch_args.checkpoint_interval == 3
+    assert pii_args.resume is True
+    assert pii_args.checkpoint_interval == 4
+
+
+def test_batch_cli_writes_and_resumes_atomic_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[str] = []
+
+    def analyze(text: str, **kwargs: object) -> PredictionResult:
+        del kwargs
+        calls.append(text)
+        return PredictionResult(
+            text=text,
+            entities=[],
+            model_name="synthetic-model",
+            timestamp="2026-01-01T00:00:00",
+            processing_time=0.0,
+        )
+
+    monkeypatch.setattr(BatchProcessor, "_get_analyze_text", lambda self: analyze)
+    output_path = tmp_path / "results.json"
+    arguments = [
+        "batch",
+        "--model",
+        "synthetic-model",
+        "--texts",
+        "Patient Alice Example",
+        "Patient Bob Example",
+        "--output",
+        str(output_path),
+        "--output-format",
+        "json",
+        "--quiet",
+        "--checkpoint-interval",
+        "1",
+    ]
+
+    assert main_module.main(arguments) == 0
+    assert calls == ["Patient Alice Example", "Patient Bob Example"]
+    assert json.loads(output_path.read_text(encoding="utf-8"))["total_items"] == 2
+    calls.clear()
+    capsys.readouterr()
+
+    assert main_module.main([*arguments, "--resume"]) == 0
+    assert calls == []
+    assert "Results written to" in capsys.readouterr().out
+
+
+def test_pii_batch_cli_checkpoint_is_phi_free_and_resume_skips_completed_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    raw_text = "Patient Alice Example called 555-0100."
+    (input_dir / "note.txt").write_text(raw_text, encoding="utf-8")
+    calls: list[str] = []
+
+    def deidentify_batch(
+        texts: list[str],
+        **kwargs: object,
+    ) -> list[DeidentificationResult]:
+        calls.extend(texts)
+        return [
+            DeidentificationResult(
+                original_text=text,
+                deidentified_text="Patient [NAME] called [PHONE].",
+                pii_entities=[],
+                method=str(kwargs["method"]),
+                timestamp=datetime(2026, 1, 1),
+            )
+            for text in texts
+        ]
+
+    monkeypatch.setattr("openmed.core.pii._deidentify_batch", deidentify_batch)
+    monkeypatch.setattr(BatchProcessor, "_get_shared_loader", lambda self: None)
+    arguments = [
+        "pii",
+        "batch",
+        "--model",
+        "synthetic-model",
+        "--input-dir",
+        str(input_dir),
+        "--output-dir",
+        str(output_dir),
+        "--checkpoint-interval",
+        "1",
+    ]
+
+    assert main_module.main(arguments) == 0
+    assert calls == [raw_text]
+    assert (output_dir / "note.txt").read_text(encoding="utf-8") == (
+        "Patient [NAME] called [PHONE]."
+    )
+    checkpoint_path = output_dir / ".openmed-batch.checkpoint.json"
+    checkpoint_material = checkpoint_path.read_text(encoding="utf-8") + Path(
+        f"{checkpoint_path}.part"
+    ).read_text(encoding="utf-8")
+    assert raw_text not in checkpoint_material
+    assert "Alice Example" not in checkpoint_material
+    assert "555-0100" not in checkpoint_material
+    calls.clear()
+    capsys.readouterr()
+
+    assert main_module.main([*arguments, "--resume"]) == 0
+    assert calls == []
+    assert "Processed 1 files, 0 failed" in capsys.readouterr().out


### PR DESCRIPTION
## Description

Adds power-failure-resilient batch processing with PHI-free checkpoints, atomic output commits, integrity-checked resume, and bounded reprocessing. Interrupted jobs can now continue from their last committed interval without trusting truncated or modified output.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing behavior)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add atomic result journals and PHI-free checkpoints with item status, byte offsets, and SHA-256 integrity metadata.
- Add checkpoint-aware resume to `BatchProcessor`, `openmed batch`, and `openmed pii batch`, including atomic per-file de-identification output.
- Add real SIGKILL recovery, rework-bound, PHI exclusion, integrity mismatch, CLI, and atomic crash-point coverage.
- Verify committed per-item offsets and every successful per-file output hash during resume, reject malformed checkpoint field types, and include the effective runtime configuration in the integrity fingerprint.
- Preserve the CLI's single-envelope JSON contract for checkpointed PII batches.
- Document checkpoint configuration, recovery commands, sidecar sensitivity, and mismatch behavior.

## Testing

- [x] `.venv/bin/python -m pytest tests/ -q` (`5772 passed, 47 skipped`)
- [x] Focused batch, checkpoint, progress, and CLI coverage (`135 passed`)
- [x] Crash and resume tests cover interrupted and uninterrupted byte-for-byte output equality.
- [x] Checkpoint tests cover raw-value exclusion, interval-bounded rework, malformed metadata, committed offsets, missing artifact hashes, configuration mismatches, and output hash mismatches.
- [x] Atomic-write tests inject failures before and after every commit phase.
- [x] `make format`, `make lint`, and `make format-check`
- [x] Scoped pre-commit hooks, including Bandit and secret detection
- [x] `make docs-build`
- [x] `/usr/local/bin/python3 -m build`

## Documentation

- [x] Updated `docs/batch-processing.md` with API and CLI recovery workflows.
- [x] Added docstrings for the new public batch methods and checkpoint error.
- [ ] Updated the changelog (not required for this issue-scoped feature PR).

## Code Quality

- [x] Performed a maintainer review of crash consistency, durable commit ordering, checkpoint parsing, artifact verification, and resume state transitions.
- [x] No new dependencies.

## Related Issues

Closes #1433

## Screenshots/Examples

Not applicable; this change affects the Python API and command-line batch workflows.
