### PR TITLE
Add clinical abbreviation and acronym sense disambiguation

### DIFF
--- a/docs/clinical/abbreviation-disambiguation.md
+++ b/docs/clinical/abbreviation-disambiguation.md
@@ -1,0 +1,136 @@
+# Clinical Abbreviation Disambiguation
+
+Clinical short forms are often ambiguous. `MS`, for example, can refer to
+multiple sclerosis, mitral stenosis, or morphine sulfate. OpenMed provides a
+small offline sense inventory and a deterministic resolver that ranks meanings
+from three kinds of local evidence:
+
+- the clinical section containing the abbreviation;
+- semantic types of nearby entities; and
+- literal cue words or phrases in the surrounding text.
+
+This feature is assistive support. Review ambiguous or low-evidence resolutions
+before clinical use.
+
+## Resolve one abbreviation
+
+```python
+from openmed.clinical import disambiguate_abbreviation
+
+sense = disambiguate_abbreviation(
+    "PT",
+    "PT was prolonged at 18 seconds with an INR of 1.8.",
+    section="coagulation",
+    entity_types=("laboratory_test", "lab_value"),
+)
+
+assert sense is not None
+assert sense.long_form == "prothrombin time"
+print(sense.score)
+print([alternative.long_form for alternative in sense.alternatives])
+```
+
+The winning `AbbreviationSense` includes its long form, semantic type, source,
+normalized score, matched features, and every non-winning candidate in ranked
+`alternatives`. The winner and alternative scores sum to approximately `1.0`.
+An unknown short form returns `None` without making a network request or raising
+an error.
+
+## Annotate detected spans
+
+`expand_abbreviations()` accepts mappings or objects with `start` and `end`
+offsets. Span-level `section` metadata and nearby labelled spans contribute
+context:
+
+```python
+from openmed.clinical import expand_abbreviations
+
+text = "Laboratory: PT was prolonged at 18 seconds with INR 1.8."
+pt_start = text.index("PT")
+value_start = text.index("18")
+
+annotations = expand_abbreviations(
+    text,
+    [
+        {
+            "start": pt_start,
+            "end": pt_start + 2,
+            "label": "ACRONYM",
+            "section": "laboratory",
+        },
+        {
+            "start": value_start,
+            "end": value_start + 2,
+            "label": "LAB_VALUE",
+        },
+    ],
+)
+
+assert annotations[0].sense is not None
+assert annotations[0].sense.long_form == "prothrombin time"
+```
+
+Known inventory entries are recognized even when their spans have no label.
+Unknown spans explicitly labelled `ABBREVIATION` or `ACRONYM` are retained with
+`sense=None`. Invalid or out-of-range offsets raise `ValueError` rather than
+being silently moved.
+
+## Supply a local inventory
+
+The bundled file is a manually authored synthetic starter set under `CC0-1.0`.
+It is not derived from UMLS LRABR or another restricted vocabulary. No network
+or external terminology service is used.
+
+A local JSON inventory uses this schema:
+
+```json
+{
+  "schema_version": 1,
+  "provenance": {
+    "source": "my local synthetic inventory"
+  },
+  "senses": {
+    "HCM": [
+      {
+        "long_form": "hypertrophic cardiomyopathy",
+        "semantic_type": "condition",
+        "source": "local-clinical-team",
+        "sections": ["cardiology"],
+        "entity_types": ["condition"],
+        "cue_words": ["septal hypertrophy"],
+        "prior": 0.2
+      }
+    ]
+  }
+}
+```
+
+Load it and pass the result to either API:
+
+```python
+from openmed.clinical import disambiguate_abbreviation, load_sense_inventory
+
+inventory = load_sense_inventory("clinic-abbreviations.json")
+sense = disambiguate_abbreviation(
+    "HCM",
+    "Septal hypertrophy supports HCM.",
+    section="cardiology",
+    inventory=inventory,
+)
+```
+
+Local candidates with the same short form and long form replace their starter
+definition. New long forms extend an existing short form, and new short forms
+extend the registry. Use `include_starter=False` to load only the local file.
+
+Inventory authors are responsible for the licensing and permitted use of any
+user-supplied terminology data. Restricted resources must remain outside the
+OpenMed package and repository.
+
+## Scoring behavior
+
+Scoring is deterministic and uses fixed evidence weights. A matching section
+adds `3.0`, each matching nearby entity type adds `2.0`, and each matching cue
+adds `1.5`, on top of the candidate's `prior`. Raw candidate scores are divided
+by their sum to expose review-friendly normalized scores. Inventory order is
+the stable tie-breaker when evidence is equal.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - Tokenizer Script Coverage: model-tokenizer-script-coverage.md
       - Advanced NER & Output Formatting: output-formatting.md
       - Clinical Context & Extraction Depth: clinical/context-and-extraction.md
+      - Clinical Abbreviation Disambiguation: clinical/abbreviation-disambiguation.md
       - Medication Sig Parser: clinical/sig-parser.md
       - Medical Tokenizer: medical-tokenizer.md
       - Indic Unicode Normalization: indic-normalization.md

--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -4,6 +4,20 @@ Intended contents include sections.py, context.py, grounding.py, relations.py,
 sdoh.py, and FHIR/OMOP exporters.
 """
 
+from .abbreviation import (
+    ABBREVIATION_DISAMBIGUATION_ADVISORY,
+    DEFAULT_SENSE_INVENTORY_RESOURCE,
+    AbbreviationAnnotation,
+    AbbreviationDisambiguator,
+    AbbreviationSense,
+    SenseAlternative,
+    SenseDefinition,
+    SenseInventory,
+    disambiguate_abbreviation,
+    expand_abbreviations,
+    load_abbreviation_inventory,
+    load_sense_inventory,
+)
 from .assertion_graph import (
     ASSERTION_GRAPH_ADVISORY,
     ASSERTION_GRAPH_AXES,
@@ -243,6 +257,18 @@ from .vital_signs import (
 )
 
 __all__ = [
+    "ABBREVIATION_DISAMBIGUATION_ADVISORY",
+    "DEFAULT_SENSE_INVENTORY_RESOURCE",
+    "AbbreviationAnnotation",
+    "AbbreviationDisambiguator",
+    "AbbreviationSense",
+    "SenseAlternative",
+    "SenseDefinition",
+    "SenseInventory",
+    "disambiguate_abbreviation",
+    "expand_abbreviations",
+    "load_abbreviation_inventory",
+    "load_sense_inventory",
     "AFFIRMED",
     "NEGATED",
     "NEGATION_VALUES",

--- a/openmed/clinical/abbreviation.py
+++ b/openmed/clinical/abbreviation.py
@@ -1,0 +1,699 @@
+"""Deterministic clinical abbreviation sense disambiguation.
+
+The bundled sense inventory is deliberately small, synthetic, and permissively
+licensed.  It is not derived from UMLS LRABR or another restricted vocabulary.
+Callers can extend or override it with a local JSON inventory while keeping the
+resolver offline and deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SENSE_INVENTORY_RESOURCE = "data/abbreviation_senses_starter.json"
+ABBREVIATION_DISAMBIGUATION_ADVISORY = (
+    "Abbreviation expansion is deterministic assistive support based on a small "
+    "sense inventory and local context. Ambiguous or low-evidence resolutions "
+    "require review before clinical use."
+)
+
+_INVENTORY_PACKAGE = "openmed.clinical"
+_ABBREVIATION_LABELS = {"abbreviation", "acronym", "short_form", "shortform"}
+_LABEL_KEYS = ("label", "entity_type", "canonical_label", "semantic_type", "type")
+_SECTION_KEYS = ("section", "section_label", "section_name")
+_DIRECT_ENTITY_TYPE_KEYS = (
+    "cooccurring_entity_types",
+    "context_entity_types",
+    "entity_types",
+)
+
+
+@dataclass(frozen=True)
+class SenseDefinition:
+    """One candidate meaning stored in a :class:`SenseInventory`."""
+
+    long_form: str
+    semantic_type: str
+    source: str
+    sections: tuple[str, ...] = ()
+    entity_types: tuple[str, ...] = ()
+    cue_words: tuple[str, ...] = ()
+    prior: float = 0.1
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation of this definition."""
+
+        return {
+            "long_form": self.long_form,
+            "semantic_type": self.semantic_type,
+            "source": self.source,
+            "sections": list(self.sections),
+            "entity_types": list(self.entity_types),
+            "cue_words": list(self.cue_words),
+            "prior": self.prior,
+        }
+
+
+@dataclass(frozen=True)
+class SenseAlternative:
+    """A non-winning candidate retained for review and downstream routing."""
+
+    long_form: str
+    semantic_type: str
+    source: str
+    score: float
+    matched_features: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-compatible representation."""
+
+        return {
+            "long_form": self.long_form,
+            "semantic_type": self.semantic_type,
+            "source": self.source,
+            "score": self.score,
+            "matched_features": list(self.matched_features),
+        }
+
+
+@dataclass(frozen=True)
+class AbbreviationSense:
+    """Resolved meaning for one clinical abbreviation occurrence."""
+
+    short_form: str
+    long_form: str
+    semantic_type: str
+    source: str
+    score: float
+    alternatives: tuple[SenseAlternative, ...] = ()
+    matched_features: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-compatible representation."""
+
+        return {
+            "short_form": self.short_form,
+            "long_form": self.long_form,
+            "semantic_type": self.semantic_type,
+            "source": self.source,
+            "score": self.score,
+            "alternatives": [item.to_dict() for item in self.alternatives],
+            "matched_features": list(self.matched_features),
+        }
+
+
+@dataclass(frozen=True)
+class AbbreviationAnnotation:
+    """A short-form span annotated with its resolved sense, if available."""
+
+    start: int
+    end: int
+    short_form: str
+    sense: AbbreviationSense | None
+    section: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-compatible representation."""
+
+        return {
+            "start": self.start,
+            "end": self.end,
+            "short_form": self.short_form,
+            "section": self.section,
+            "sense": self.sense.to_dict() if self.sense is not None else None,
+        }
+
+
+class SenseInventory(Mapping[str, tuple[SenseDefinition, ...]]):
+    """Read-only mapping from normalized short form to candidate senses."""
+
+    def __init__(self, senses: Mapping[str, Sequence[SenseDefinition]]) -> None:
+        normalized: dict[str, tuple[SenseDefinition, ...]] = {}
+        for short_form, definitions in senses.items():
+            key = _normalize_short_form(short_form)
+            if not key:
+                raise ValueError("sense inventory short forms must be non-empty")
+            candidates = tuple(definitions)
+            if not candidates:
+                raise ValueError(f"sense inventory entry {key!r} has no candidates")
+            if not all(isinstance(item, SenseDefinition) for item in candidates):
+                raise TypeError(
+                    f"sense inventory entry {key!r} must contain SenseDefinition values"
+                )
+            normalized[key] = candidates
+        self._senses = normalized
+
+    def __getitem__(self, short_form: str) -> tuple[SenseDefinition, ...]:
+        return self._senses[_normalize_short_form(short_form)]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._senses)
+
+    def __len__(self) -> int:
+        return len(self._senses)
+
+    def candidates(self, short_form: object) -> tuple[SenseDefinition, ...]:
+        """Return candidates for ``short_form`` or an empty tuple when unknown."""
+
+        return self._senses.get(_normalize_short_form(short_form), ())
+
+    def to_dict(self) -> dict[str, list[dict[str, Any]]]:
+        """Return the registry as a deterministic JSON-compatible mapping."""
+
+        return {
+            short_form: [candidate.to_dict() for candidate in candidates]
+            for short_form, candidates in self._senses.items()
+        }
+
+
+class AbbreviationDisambiguator:
+    """Score abbreviation candidates from section, entity, and cue evidence."""
+
+    def __init__(self, inventory: SenseInventory | None = None) -> None:
+        self.inventory = inventory or load_sense_inventory()
+
+    def disambiguate(
+        self,
+        short_form: object,
+        context: object = "",
+        *,
+        section: str | None = None,
+        entity_types: Iterable[object] = (),
+    ) -> AbbreviationSense | None:
+        """Resolve one short form against local, non-network context.
+
+        Args:
+            short_form: Abbreviation surface form, matched case-insensitively.
+            context: Local sentence or character window around the occurrence.
+            section: Optional clinical section name for the occurrence.
+            entity_types: Semantic types of nearby entity spans.
+
+        Returns:
+            The top-scoring :class:`AbbreviationSense` with ranked alternatives,
+            or ``None`` when ``short_form`` is absent from the inventory.
+        """
+
+        normalized_short_form = _normalize_short_form(short_form)
+        candidates = self.inventory.candidates(normalized_short_form)
+        if not candidates:
+            return None
+
+        normalized_context = _normalize_text(context)
+        normalized_section = _normalize_label(section)
+        normalized_entity_types = {
+            normalized
+            for value in entity_types
+            if (normalized := _normalize_label(value))
+        }
+        scored = [
+            _score_candidate(
+                candidate,
+                index=index,
+                context=normalized_context,
+                section=normalized_section,
+                entity_types=normalized_entity_types,
+            )
+            for index, candidate in enumerate(candidates)
+        ]
+        scored.sort(key=lambda item: (-item.raw_score, item.index))
+
+        total = sum(item.raw_score for item in scored)
+        if total <= 0.0:
+            normalized_scores = [1.0 / len(scored)] * len(scored)
+        else:
+            normalized_scores = [item.raw_score / total for item in scored]
+
+        winner = scored[0]
+        return AbbreviationSense(
+            short_form=normalized_short_form,
+            long_form=winner.definition.long_form,
+            semantic_type=winner.definition.semantic_type,
+            source=winner.definition.source,
+            score=round(normalized_scores[0], 6),
+            alternatives=tuple(
+                SenseAlternative(
+                    long_form=item.definition.long_form,
+                    semantic_type=item.definition.semantic_type,
+                    source=item.definition.source,
+                    score=round(score, 6),
+                    matched_features=item.matched_features,
+                )
+                for item, score in zip(scored[1:], normalized_scores[1:])
+            ),
+            matched_features=winner.matched_features,
+        )
+
+
+@dataclass(frozen=True)
+class _ScoredCandidate:
+    definition: SenseDefinition
+    index: int
+    raw_score: float
+    matched_features: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _SpanRecord:
+    original: object
+    start: int
+    end: int
+    label: str | None
+    section: str | None
+    direct_entity_types: tuple[str, ...]
+
+
+def load_sense_inventory(
+    path: str | Path | None = None,
+    *,
+    include_starter: bool = True,
+) -> SenseInventory:
+    """Load the starter inventory and optionally merge a local JSON file.
+
+    A user entry with the same short form and long form replaces the starter
+    definition. New long forms and new short forms extend the registry. Set
+    ``include_starter=False`` to load only the supplied inventory.
+
+    Args:
+        path: Optional path to a user-supplied JSON sense inventory.
+        include_starter: Whether to start with the bundled permissive inventory.
+
+    Returns:
+        A validated, read-only :class:`SenseInventory`.
+    """
+
+    merged: dict[str, list[SenseDefinition]] = {}
+    if include_starter:
+        merged = {
+            short_form: list(candidates)
+            for short_form, candidates in _starter_inventory().items()
+        }
+
+    if path is not None:
+        custom_path = Path(path)
+        with custom_path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        custom = _inventory_from_payload(payload, require_permissive=False)
+        _merge_inventory(merged, custom)
+    elif not include_starter:
+        raise ValueError("path is required when include_starter is False")
+
+    return SenseInventory(merged)
+
+
+def load_abbreviation_inventory(
+    path: str | Path | None = None,
+    *,
+    include_starter: bool = True,
+) -> SenseInventory:
+    """Alias for :func:`load_sense_inventory` with an explicit domain name."""
+
+    return load_sense_inventory(path, include_starter=include_starter)
+
+
+def disambiguate_abbreviation(
+    short_form: object,
+    context: object = "",
+    *,
+    section: str | None = None,
+    entity_types: Iterable[object] = (),
+    inventory: SenseInventory | None = None,
+) -> AbbreviationSense | None:
+    """Resolve one abbreviation with the default or supplied inventory."""
+
+    return AbbreviationDisambiguator(inventory).disambiguate(
+        short_form,
+        context,
+        section=section,
+        entity_types=entity_types,
+    )
+
+
+def expand_abbreviations(
+    text: str,
+    spans: Iterable[object],
+    *,
+    inventory: SenseInventory | None = None,
+    section: str | None = None,
+    section_by_span: Mapping[tuple[int, int], str] | None = None,
+    entity_types: Iterable[object] = (),
+    context_window: int = 160,
+) -> tuple[AbbreviationAnnotation, ...]:
+    """Annotate detected short-form spans with resolved senses.
+
+    Span mappings or objects must expose integer ``start`` and ``end`` values.
+    A span is treated as a short-form target when its source slice exists in the
+    inventory, its label is ``ABBREVIATION``/``ACRONYM``, or it has no label.
+    Other labelled spans inside ``context_window`` supply co-occurring entity
+    types. A target span may also provide ``section`` and an ``entity_types``
+    sequence directly.
+
+    Unknown labelled abbreviations are retained with ``sense=None``. Invalid
+    offsets raise ``ValueError`` instead of being silently shifted.
+
+    Args:
+        text: Original document text.
+        spans: Detected abbreviation spans and optional nearby entity spans.
+        inventory: Optional loaded sense inventory.
+        section: Fallback section for targets without span-level section data.
+        section_by_span: Optional section lookup keyed by ``(start, end)``.
+        entity_types: Additional document- or caller-level semantic types.
+        context_window: Characters retained on each side of a target span.
+
+    Returns:
+        Offset-ordered abbreviation annotations.
+    """
+
+    if context_window < 0:
+        raise ValueError("context_window must be non-negative")
+
+    active_inventory = inventory or load_sense_inventory()
+    disambiguator = AbbreviationDisambiguator(active_inventory)
+    records = tuple(_coerce_span(text, span) for span in spans)
+    section_lookup = section_by_span or {}
+    shared_entity_types = tuple(entity_types)
+    annotations: list[AbbreviationAnnotation] = []
+
+    for record in records:
+        short_form = text[record.start : record.end]
+        known = bool(active_inventory.candidates(short_form))
+        if not (known or record.label in _ABBREVIATION_LABELS or record.label is None):
+            continue
+
+        context_start = max(0, record.start - context_window)
+        context_end = min(len(text), record.end + context_window)
+        nearby_types = set(record.direct_entity_types)
+        for other in records:
+            if other is record or other.label is None:
+                continue
+            if other.label in _ABBREVIATION_LABELS:
+                continue
+            if other.end >= context_start and other.start <= context_end:
+                nearby_types.add(other.label)
+        nearby_types.update(
+            normalized
+            for item in shared_entity_types
+            if (normalized := _normalize_label(item))
+        )
+
+        span_section = (
+            record.section or section_lookup.get((record.start, record.end)) or section
+        )
+        sense = disambiguator.disambiguate(
+            short_form,
+            text[context_start:context_end],
+            section=span_section,
+            entity_types=nearby_types,
+        )
+        annotations.append(
+            AbbreviationAnnotation(
+                start=record.start,
+                end=record.end,
+                short_form=short_form,
+                sense=sense,
+                section=span_section,
+            )
+        )
+
+    return tuple(sorted(annotations, key=lambda item: (item.start, item.end)))
+
+
+@lru_cache(maxsize=1)
+def _starter_inventory() -> SenseInventory:
+    resource = resources.files(_INVENTORY_PACKAGE).joinpath(
+        DEFAULT_SENSE_INVENTORY_RESOURCE
+    )
+    with resource.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return _inventory_from_payload(payload, require_permissive=True)
+
+
+def _inventory_from_payload(
+    payload: object,
+    *,
+    require_permissive: bool,
+) -> SenseInventory:
+    if not isinstance(payload, Mapping):
+        raise ValueError("sense inventory must be a JSON object")
+    if payload.get("schema_version") != 1:
+        raise ValueError("sense inventory schema_version must be 1")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise ValueError("sense inventory requires provenance metadata")
+    if not _required_text(provenance.get("source")):
+        raise ValueError("sense inventory provenance.source must be non-empty")
+    if require_permissive:
+        if provenance.get("restricted_data") is not False:
+            raise ValueError(
+                "starter sense inventory must declare restricted_data=false"
+            )
+        if not _required_text(provenance.get("license")):
+            raise ValueError("starter sense inventory must declare a license")
+
+    raw_senses = payload.get("senses")
+    if not isinstance(raw_senses, Mapping) or not raw_senses:
+        raise ValueError("sense inventory requires a non-empty senses mapping")
+
+    senses: dict[str, tuple[SenseDefinition, ...]] = {}
+    for raw_short_form, raw_definitions in raw_senses.items():
+        short_form = _normalize_short_form(raw_short_form)
+        if not short_form:
+            raise ValueError("sense inventory short forms must be non-empty")
+        if not _is_nonstring_sequence(raw_definitions) or not raw_definitions:
+            raise ValueError(f"sense inventory entry {short_form!r} needs candidates")
+        senses[short_form] = tuple(
+            _definition_from_payload(short_form, item) for item in raw_definitions
+        )
+    return SenseInventory(senses)
+
+
+def _definition_from_payload(short_form: str, payload: object) -> SenseDefinition:
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"candidate for {short_form!r} must be an object")
+    for key in ("long_form", "semantic_type", "source"):
+        if not _required_text(payload.get(key)):
+            raise ValueError(f"candidate for {short_form!r} requires {key}")
+
+    prior = payload.get("prior", 0.1)
+    if isinstance(prior, bool) or not isinstance(prior, (int, float)):
+        raise ValueError(f"candidate prior for {short_form!r} must be numeric")
+    if not 0.0 <= float(prior) <= 1.0:
+        raise ValueError(f"candidate prior for {short_form!r} must be between 0 and 1")
+
+    return SenseDefinition(
+        long_form=str(payload["long_form"]).strip(),
+        semantic_type=_normalize_label(payload["semantic_type"]),
+        source=str(payload["source"]).strip(),
+        sections=_string_tuple(short_form, "sections", payload.get("sections", ())),
+        entity_types=_string_tuple(
+            short_form,
+            "entity_types",
+            payload.get("entity_types", ()),
+            normalize_labels=True,
+        ),
+        cue_words=_string_tuple(short_form, "cue_words", payload.get("cue_words", ())),
+        prior=float(prior),
+    )
+
+
+def _merge_inventory(
+    merged: dict[str, list[SenseDefinition]],
+    custom: SenseInventory,
+) -> None:
+    for short_form, custom_candidates in custom.items():
+        current = merged.setdefault(short_form, [])
+        positions = {
+            candidate.long_form.casefold(): index
+            for index, candidate in enumerate(current)
+        }
+        for candidate in custom_candidates:
+            key = candidate.long_form.casefold()
+            if key in positions:
+                current[positions[key]] = candidate
+            else:
+                positions[key] = len(current)
+                current.append(candidate)
+
+
+def _score_candidate(
+    definition: SenseDefinition,
+    *,
+    index: int,
+    context: str,
+    section: str,
+    entity_types: set[str],
+) -> _ScoredCandidate:
+    score = definition.prior
+    features: list[str] = []
+
+    normalized_sections = {_normalize_label(value) for value in definition.sections}
+    if section and section in normalized_sections:
+        score += 3.0
+        features.append(f"section:{section}")
+
+    matched_entity_types = sorted(entity_types & set(definition.entity_types))
+    for entity_type in matched_entity_types:
+        score += 2.0
+        features.append(f"entity_type:{entity_type}")
+
+    for cue in definition.cue_words:
+        normalized_cue = _normalize_text(cue)
+        if normalized_cue and _phrase_in_text(normalized_cue, context):
+            score += 1.5
+            features.append(f"cue:{normalized_cue}")
+
+    return _ScoredCandidate(
+        definition=definition,
+        index=index,
+        raw_score=score,
+        matched_features=tuple(features),
+    )
+
+
+def _coerce_span(text: str, span: object) -> _SpanRecord:
+    start = _field_value(span, "start")
+    end = _field_value(span, "end")
+    if (
+        isinstance(start, bool)
+        or not isinstance(start, int)
+        or isinstance(end, bool)
+        or not isinstance(end, int)
+    ):
+        raise ValueError("abbreviation spans require integer start and end")
+    normalized_start = start
+    normalized_end = end
+    if (
+        normalized_start < 0
+        or normalized_end < normalized_start
+        or normalized_end > len(text)
+    ):
+        raise ValueError("abbreviation span offsets must fall within text")
+
+    raw_label = next(
+        (
+            value
+            for key in _LABEL_KEYS
+            if (value := _field_value(span, key)) is not None
+        ),
+        None,
+    )
+    raw_section = next(
+        (
+            value
+            for key in _SECTION_KEYS
+            if (value := _field_value(span, key)) is not None
+        ),
+        None,
+    )
+    direct_entity_types: list[str] = []
+    for key in _DIRECT_ENTITY_TYPE_KEYS:
+        value = _field_value(span, key)
+        if value is None:
+            continue
+        if isinstance(value, str):
+            values: Iterable[object] = (value,)
+        elif _is_nonstring_sequence(value):
+            values = value
+        else:
+            raise ValueError(f"span {key} must be a string sequence")
+        direct_entity_types.extend(
+            normalized for item in values if (normalized := _normalize_label(item))
+        )
+
+    return _SpanRecord(
+        original=span,
+        start=normalized_start,
+        end=normalized_end,
+        label=_normalize_label(raw_label) or None,
+        section=str(raw_section).strip() if raw_section is not None else None,
+        direct_entity_types=tuple(dict.fromkeys(direct_entity_types)),
+    )
+
+
+def _field_value(item: object, name: str) -> object | None:
+    if isinstance(item, Mapping):
+        return item.get(name)
+    return getattr(item, name, None)
+
+
+def _normalize_short_form(value: object) -> str:
+    if value is None:
+        return ""
+    return unicodedata.normalize("NFKC", str(value)).strip().upper()
+
+
+def _normalize_text(value: object) -> str:
+    if value is None:
+        return ""
+    text = unicodedata.normalize("NFKC", str(value)).casefold()
+    text = re.sub(r"[\u2010-\u2015\u2212]", "-", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _normalize_label(value: object) -> str:
+    normalized = _normalize_text(value)
+    return re.sub(r"[\s-]+", "_", normalized)
+
+
+@lru_cache(maxsize=1024)
+def _phrase_pattern(phrase: str) -> re.Pattern[str]:
+    escaped = re.escape(phrase).replace(r"\ ", r"\s+")
+    return re.compile(r"(?<!\w)" + escaped + r"(?!\w)")
+
+
+def _phrase_in_text(phrase: str, text: str) -> bool:
+    return _phrase_pattern(phrase).search(text) is not None
+
+
+def _required_text(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _is_nonstring_sequence(value: object) -> bool:
+    return isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    )
+
+
+def _string_tuple(
+    short_form: str,
+    field_name: str,
+    value: object,
+    *,
+    normalize_labels: bool = False,
+) -> tuple[str, ...]:
+    if not _is_nonstring_sequence(value):
+        raise ValueError(f"candidate {field_name} for {short_form!r} must be a list")
+    items: list[str] = []
+    for item in value:
+        if not _required_text(item):
+            raise ValueError(
+                f"candidate {field_name} for {short_form!r} must contain strings"
+            )
+        normalized = _normalize_label(item) if normalize_labels else str(item).strip()
+        items.append(normalized)
+    return tuple(dict.fromkeys(items))
+
+
+__all__ = [
+    "ABBREVIATION_DISAMBIGUATION_ADVISORY",
+    "DEFAULT_SENSE_INVENTORY_RESOURCE",
+    "AbbreviationAnnotation",
+    "AbbreviationDisambiguator",
+    "AbbreviationSense",
+    "SenseAlternative",
+    "SenseDefinition",
+    "SenseInventory",
+    "disambiguate_abbreviation",
+    "expand_abbreviations",
+    "load_abbreviation_inventory",
+    "load_sense_inventory",
+]

--- a/openmed/clinical/data/abbreviation_senses_starter.json
+++ b/openmed/clinical/data/abbreviation_senses_starter.json
@@ -1,0 +1,155 @@
+{
+  "schema_version": 1,
+  "provenance": {
+    "source": "OpenMed manually authored synthetic starter inventory",
+    "license": "CC0-1.0",
+    "restricted_data": false,
+    "note": "Synthetic examples only; not derived from UMLS LRABR or another restricted vocabulary."
+  },
+  "senses": {
+    "MS": [
+      {
+        "long_form": "multiple sclerosis",
+        "semantic_type": "condition",
+        "source": "openmed-synthetic-1",
+        "sections": ["assessment", "neurology", "problem list", "history"],
+        "entity_types": ["condition", "finding"],
+        "cue_words": [
+          "demyelinating",
+          "neurology",
+          "relapsing",
+          "remitting",
+          "white matter lesions"
+        ],
+        "prior": 0.1
+      },
+      {
+        "long_form": "mitral stenosis",
+        "semantic_type": "condition",
+        "source": "openmed-synthetic-1",
+        "sections": ["cardiology", "assessment", "echocardiography"],
+        "entity_types": ["condition", "cardiac_finding"],
+        "cue_words": [
+          "diastolic murmur",
+          "echocardiogram",
+          "mitral valve",
+          "valve area"
+        ],
+        "prior": 0.1
+      },
+      {
+        "long_form": "morphine sulfate",
+        "semantic_type": "medication",
+        "source": "openmed-synthetic-1",
+        "sections": ["medications", "medication administration", "orders"],
+        "entity_types": ["medication", "dose", "route"],
+        "cue_words": ["analgesia", "intravenous", "iv", "mg", "pain control"],
+        "prior": 0.1
+      }
+    ],
+    "PT": [
+      {
+        "long_form": "physical therapy",
+        "semantic_type": "procedure",
+        "source": "openmed-synthetic-1",
+        "sections": ["plan", "rehabilitation", "therapy"],
+        "entity_types": ["procedure", "service"],
+        "cue_words": [
+          "ambulation",
+          "gait training",
+          "rehabilitation",
+          "strengthening",
+          "therapist"
+        ],
+        "prior": 0.1
+      },
+      {
+        "long_form": "prothrombin time",
+        "semantic_type": "laboratory_test",
+        "source": "openmed-synthetic-1",
+        "sections": ["laboratory", "coagulation", "results"],
+        "entity_types": ["laboratory_test", "lab_value"],
+        "cue_words": ["coagulation", "inr", "prolonged", "seconds", "warfarin"],
+        "prior": 0.1
+      },
+      {
+        "long_form": "patient",
+        "semantic_type": "person",
+        "source": "openmed-synthetic-1",
+        "sections": ["history", "subjective", "note"],
+        "entity_types": ["person"],
+        "cue_words": ["denies", "reports", "states", "was advised"],
+        "prior": 0.1
+      }
+    ],
+    "RA": [
+      {
+        "long_form": "rheumatoid arthritis",
+        "semantic_type": "condition",
+        "source": "openmed-synthetic-1",
+        "sections": ["rheumatology", "assessment", "problem list"],
+        "entity_types": ["condition", "finding"],
+        "cue_words": [
+          "anti-ccp",
+          "joint swelling",
+          "rheumatoid factor",
+          "synovitis",
+          "symmetric"
+        ],
+        "prior": 0.1
+      },
+      {
+        "long_form": "right atrium",
+        "semantic_type": "anatomy",
+        "source": "openmed-synthetic-1",
+        "sections": ["cardiology", "echocardiography", "imaging"],
+        "entity_types": ["anatomy", "cardiac_finding"],
+        "cue_words": [
+          "atrial",
+          "echocardiogram",
+          "enlargement",
+          "right ventricle"
+        ],
+        "prior": 0.1
+      },
+      {
+        "long_form": "room air",
+        "semantic_type": "oxygen_support",
+        "source": "openmed-synthetic-1",
+        "sections": ["vital signs", "respiratory", "observations"],
+        "entity_types": ["vital_sign", "oxygen_saturation"],
+        "cue_words": ["oxygen saturation", "spo2", "saturation", "without oxygen"],
+        "prior": 0.1
+      }
+    ],
+    "CA": [
+      {
+        "long_form": "cancer",
+        "semantic_type": "condition",
+        "source": "openmed-synthetic-1",
+        "sections": ["oncology", "assessment", "problem list"],
+        "entity_types": ["condition", "finding"],
+        "cue_words": ["biopsy", "chemotherapy", "malignancy", "metastatic", "tumor"],
+        "prior": 0.1
+      },
+      {
+        "long_form": "calcium",
+        "semantic_type": "laboratory_test",
+        "source": "openmed-synthetic-1",
+        "sections": ["laboratory", "chemistry", "results"],
+        "entity_types": ["laboratory_test", "lab_value"],
+        "cue_words": ["albumin", "chemistry panel", "mg/dl", "mmol/l", "serum"],
+        "prior": 0.1
+      },
+      {
+        "long_form": "cardiac arrest",
+        "semantic_type": "condition",
+        "source": "openmed-synthetic-1",
+        "sections": ["emergency", "resuscitation", "assessment"],
+        "entity_types": ["condition", "procedure"],
+        "cue_words": ["cpr", "defibrillation", "resuscitation", "return of circulation"],
+        "prior": 0.1
+      }
+    ]
+  }
+}

--- a/tests/fixtures/clinical/abbreviation_senses_gold.json
+++ b/tests/fixtures/clinical/abbreviation_senses_gold.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ms_multiple_sclerosis",
+    "text": "Neurology assessment: relapsing MS with demyelinating lesions remains stable.",
+    "short_form": "MS",
+    "section": "neurology",
+    "entity_types": ["condition"],
+    "expected_long_form": "multiple sclerosis"
+  },
+  {
+    "id": "ms_mitral_stenosis",
+    "text": "The echocardiogram shows severe MS with a diastolic murmur.",
+    "short_form": "MS",
+    "section": "cardiology",
+    "entity_types": ["cardiac_finding"],
+    "expected_long_form": "mitral stenosis"
+  },
+  {
+    "id": "ms_morphine_sulfate",
+    "text": "Give MS 2 mg IV for pain control.",
+    "short_form": "MS",
+    "section": "medications",
+    "entity_types": ["medication", "dose", "route"],
+    "expected_long_form": "morphine sulfate"
+  },
+  {
+    "id": "pt_physical_therapy",
+    "text": "Continue PT for gait training and strengthening before discharge.",
+    "short_form": "PT",
+    "section": "rehabilitation",
+    "entity_types": ["procedure"],
+    "expected_long_form": "physical therapy"
+  },
+  {
+    "id": "pt_prothrombin_time",
+    "text": "PT was prolonged at 18 seconds with an INR of 1.8.",
+    "short_form": "PT",
+    "section": "coagulation",
+    "entity_types": ["laboratory_test", "lab_value"],
+    "expected_long_form": "prothrombin time"
+  },
+  {
+    "id": "pt_patient",
+    "text": "PT reports nausea but denies vomiting today.",
+    "short_form": "PT",
+    "section": "subjective",
+    "entity_types": ["person"],
+    "expected_long_form": "patient"
+  },
+  {
+    "id": "ra_rheumatoid_arthritis",
+    "text": "RA flare includes symmetric joint swelling and synovitis.",
+    "short_form": "RA",
+    "section": "rheumatology",
+    "entity_types": ["condition"],
+    "expected_long_form": "rheumatoid arthritis"
+  },
+  {
+    "id": "ra_right_atrium",
+    "text": "The echocardiogram demonstrates RA enlargement and right ventricle dilation.",
+    "short_form": "RA",
+    "section": "echocardiography",
+    "entity_types": ["anatomy", "cardiac_finding"],
+    "expected_long_form": "right atrium"
+  },
+  {
+    "id": "ra_room_air",
+    "text": "Oxygen saturation is 97% on RA without supplemental oxygen.",
+    "short_form": "RA",
+    "section": "vital signs",
+    "entity_types": ["oxygen_saturation"],
+    "expected_long_form": "room air"
+  },
+  {
+    "id": "ca_cancer",
+    "text": "The biopsy confirmed metastatic CA and chemotherapy was discussed.",
+    "short_form": "CA",
+    "section": "oncology",
+    "entity_types": ["condition"],
+    "expected_long_form": "cancer"
+  },
+  {
+    "id": "ca_calcium",
+    "text": "Serum CA is 11.2 mg/dL on the chemistry panel.",
+    "short_form": "CA",
+    "section": "laboratory",
+    "entity_types": ["laboratory_test", "lab_value"],
+    "expected_long_form": "calcium"
+  },
+  {
+    "id": "ca_cardiac_arrest",
+    "text": "Witnessed CA prompted immediate CPR and defibrillation.",
+    "short_form": "CA",
+    "section": "emergency",
+    "entity_types": ["condition", "procedure"],
+    "expected_long_form": "cardiac arrest"
+  }
+]

--- a/tests/unit/clinical/test_abbreviation.py
+++ b/tests/unit/clinical/test_abbreviation.py
@@ -1,0 +1,215 @@
+"""Tests for deterministic clinical abbreviation disambiguation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import openmed.clinical.abbreviation as abbreviation_module
+from openmed.clinical import (
+    ABBREVIATION_DISAMBIGUATION_ADVISORY,
+    AbbreviationDisambiguator,
+    SenseInventory,
+    disambiguate_abbreviation,
+    expand_abbreviations,
+    load_sense_inventory,
+)
+
+FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "clinical"
+    / "abbreviation_senses_gold.json"
+)
+STARTER = (
+    Path(__file__).resolve().parents[3]
+    / "openmed"
+    / "clinical"
+    / "data"
+    / "abbreviation_senses_starter.json"
+)
+
+
+@pytest.mark.parametrize("case", json.loads(FIXTURE.read_text(encoding="utf-8")))
+def test_golden_contexts_resolve_ambiguous_senses(case: dict) -> None:
+    sense = disambiguate_abbreviation(
+        case["short_form"],
+        case["text"],
+        section=case["section"],
+        entity_types=case["entity_types"],
+    )
+
+    assert sense is not None, case["id"]
+    assert sense.long_form == case["expected_long_form"], case["id"]
+    assert 0.0 < sense.score <= 1.0
+    assert sense.alternatives
+    assert sense.matched_features
+
+
+def test_scores_and_alternatives_are_deterministic_and_normalized() -> None:
+    disambiguator = AbbreviationDisambiguator()
+    results = [
+        disambiguator.disambiguate(
+            "PT",
+            "PT is prolonged and the INR is elevated.",
+            section="coagulation",
+            entity_types=("lab_value",),
+        )
+        for _ in range(20)
+    ]
+
+    assert all(result == results[0] for result in results)
+    sense = results[0]
+    assert sense is not None
+    assert sense.long_form == "prothrombin time"
+    assert sum(
+        [sense.score, *(item.score for item in sense.alternatives)]
+    ) == pytest.approx(
+        1.0,
+        abs=2e-6,
+    )
+
+
+def test_unknown_short_form_returns_no_sense_without_error() -> None:
+    assert disambiguate_abbreviation("XYZ", "XYZ noted in the source") is None
+
+    text = "Unknown XYZ was copied from a legacy note."
+    start = text.index("XYZ")
+    annotations = expand_abbreviations(
+        text,
+        [{"start": start, "end": start + 3, "label": "ACRONYM"}],
+    )
+
+    assert len(annotations) == 1
+    assert annotations[0].short_form == "XYZ"
+    assert annotations[0].sense is None
+
+
+def test_user_inventory_overrides_and_extends_starter(tmp_path: Path) -> None:
+    custom_path = tmp_path / "custom-senses.json"
+    custom_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "provenance": {"source": "local synthetic test inventory"},
+                "senses": {
+                    "MS": [
+                        {
+                            "long_form": "multiple sclerosis",
+                            "semantic_type": "custom_condition",
+                            "source": "local-override",
+                            "sections": ["neuroimmunology"],
+                            "entity_types": ["custom_condition"],
+                            "cue_words": ["optic neuritis"],
+                            "prior": 0.9,
+                        }
+                    ],
+                    "HCM": [
+                        {
+                            "long_form": "hypertrophic cardiomyopathy",
+                            "semantic_type": "condition",
+                            "source": "local-extension",
+                            "sections": ["cardiology"],
+                            "entity_types": ["condition"],
+                            "cue_words": ["septal hypertrophy"],
+                            "prior": 0.2,
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    inventory = load_sense_inventory(custom_path)
+
+    assert isinstance(inventory, SenseInventory)
+    assert set(inventory) >= {"MS", "PT", "RA", "CA", "HCM"}
+    assert len(inventory["MS"]) == 3
+    assert inventory["MS"][0].source == "local-override"
+    hcm = disambiguate_abbreviation(
+        "hcm",
+        "Septal hypertrophy supports HCM.",
+        section="cardiology",
+        inventory=inventory,
+    )
+    assert hcm is not None
+    assert hcm.long_form == "hypertrophic cardiomyopathy"
+
+
+def test_user_inventory_can_be_loaded_without_starter(tmp_path: Path) -> None:
+    custom_path = tmp_path / "only-local.json"
+    custom_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "provenance": {"source": "local synthetic test inventory"},
+                "senses": {
+                    "ZZ": [
+                        {
+                            "long_form": "synthetic zeta zone",
+                            "semantic_type": "synthetic_type",
+                            "source": "local-only",
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    inventory = load_sense_inventory(custom_path, include_starter=False)
+
+    assert tuple(inventory) == ("ZZ",)
+
+
+def test_expand_abbreviations_uses_section_and_nearby_entity_types() -> None:
+    text = "Laboratory: PT was prolonged at 18 seconds with INR 1.8."
+    pt_start = text.index("PT")
+    value_start = text.index("18")
+    spans = [
+        {
+            "start": pt_start,
+            "end": pt_start + 2,
+            "label": "ACRONYM",
+            "section": "laboratory",
+        },
+        {
+            "start": value_start,
+            "end": value_start + 2,
+            "label": "LAB_VALUE",
+        },
+    ]
+
+    annotations = expand_abbreviations(text, spans)
+
+    assert len(annotations) == 1
+    annotation = annotations[0]
+    assert (annotation.start, annotation.end) == (pt_start, pt_start + 2)
+    assert annotation.section == "laboratory"
+    assert annotation.sense is not None
+    assert annotation.sense.long_form == "prothrombin time"
+    assert "entity_type:lab_value" in annotation.sense.matched_features
+    assert annotation.to_dict()["sense"]["long_form"] == "prothrombin time"
+
+
+def test_invalid_span_offsets_fail_closed() -> None:
+    with pytest.raises(ValueError, match="offsets must fall within text"):
+        expand_abbreviations("MS", [{"start": 0, "end": 3}])
+
+
+def test_starter_inventory_is_explicitly_synthetic_and_permissive() -> None:
+    payload = json.loads(STARTER.read_text(encoding="utf-8"))
+    provenance = payload["provenance"]
+
+    assert provenance["restricted_data"] is False
+    assert provenance["license"] == "CC0-1.0"
+    assert "synthetic" in provenance["source"].casefold()
+    assert "UMLS LRABR" in provenance["note"]
+    assert "restricted vocabulary" in (abbreviation_module.__doc__ or "")
+
+
+def test_public_advisory_requires_review() -> None:
+    assert "review" in ABBREVIATION_DISAMBIGUATION_ADVISORY.casefold()


### PR DESCRIPTION
## Description

Adds deterministic, offline clinical abbreviation sense disambiguation so ambiguous short forms can be resolved from local section, nearby entity types, and cue words before downstream grounding. The bundled starter inventory is manually authored synthetic data under a permissive license, and local JSON inventories can override or extend it.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Added a validated sense-inventory registry, local inventory loader, deterministic scorer, ranked alternatives, and span annotation helper.
- Added a synthetic starter inventory for ambiguous MS, PT, RA, and CA senses with explicit provenance and licensing metadata.
- Added a golden clinical fixture, public API exports, and a guide covering scoring, span annotation, and local inventory extension.

## Testing

- [x] Added tests covering the golden cases, deterministic scoring, unknown short forms, inventory overrides/extensions, span annotation, and invalid offsets.
- [x] Full repository suite passes locally: 6,065 passed and 48 skipped.
- [x] Complete clinical unit scope passes: 705 passed and 2 skipped.
- [x] Strict documentation, formatting, lint, type checks, pre-commit, build, and distribution-resource verification pass.

## Documentation

- [x] Updated the clinical guide navigation and added an abbreviation-disambiguation guide.
- [x] Added docstrings to the public functions and classes.
- [ ] The changelog is unchanged; release notes can include this feature when it ships.

## Code Quality

- [x] Repository formatting, lint, and format verification gates pass.
- [x] Performed a self-review of the complete diff.
- [x] Added comments and documentation around scoring, inventory merging, provenance, and fail-closed offset handling.
- [x] The changes introduce no new warnings.

## Dependencies

- [x] No new dependencies were added.

## Checklist

- [x] Read the contributing guidelines.
- [x] Used a clear, focused commit.
- [x] Kept the branch scoped to OM-509.

## Related Issues

Closes #867

## Screenshots/Examples

A coagulation-section `PT` mention near an INR or lab-value span resolves to `prothrombin time`, while rehabilitation cues resolve the same short form to `physical therapy`. Unknown short forms return no sense without error.
