### PR TITLE
Build a shared free-vocabulary lexical matcher engine and loader registry

### DIFF
--- a/openmed/clinical/grounding/__init__.py
+++ b/openmed/clinical/grounding/__init__.py
@@ -1,7 +1,21 @@
 """Vocabulary loading and linker helpers for clinical concept grounding."""
 
 from . import linkers as _linkers  # noqa: F401
-from .registry import available_linkers, get_linker, register_linker
+from .matcher import ConceptMatch, LexicalConcept, LexicalMatcher, normalize_term
+from .registry import (
+    InvalidVocabularyLoaderError,
+    RestrictedVocabularyLoaderError,
+    VocabularyLoader,
+    VocabularyLoaderRegistry,
+    VocabularyRegistryError,
+    available_linkers,
+    available_loaders,
+    get_linker,
+    get_loader,
+    register_linker,
+    register_loader,
+    validate_vocabulary_loader,
+)
 from .types import Candidate
 from .vocab import (
     FREE_VOCAB_SYSTEMS,
@@ -20,19 +34,32 @@ from .vocab import (
 
 __all__ = [
     "Candidate",
+    "ConceptMatch",
     "FREE_VOCAB_SYSTEMS",
+    "InvalidVocabularyLoaderError",
+    "LexicalConcept",
+    "LexicalMatcher",
     "RESTRICTED_VOCAB_SYSTEMS",
     "RestrictedVocabularyError",
+    "RestrictedVocabularyLoaderError",
     "VocabConcept",
     "VocabLoader",
     "VocabLoaderError",
     "VocabSource",
     "VocabularyChecksumError",
     "VocabularyIndex",
+    "VocabularyLoader",
+    "VocabularyLoaderRegistry",
     "VocabularyNotFoundError",
+    "VocabularyRegistryError",
     "available_linkers",
+    "available_loaders",
     "get_index",
     "get_linker",
+    "get_loader",
     "normalize_language",
+    "normalize_term",
     "register_linker",
+    "register_loader",
+    "validate_vocabulary_loader",
 ]

--- a/openmed/clinical/grounding/matcher.py
+++ b/openmed/clinical/grounding/matcher.py
@@ -1,0 +1,457 @@
+"""Deterministic offline lexical matching for clinical vocabularies.
+
+The matcher indexes caller-supplied term-to-concept mappings.  It does not
+download or bundle terminology data, which keeps the lookup path fully local
+and lets vocabulary-specific loaders control how their snapshots are parsed.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import unicodedata
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Literal, TypeAlias
+
+__all__ = [
+    "AbbreviationMap",
+    "ConceptInput",
+    "ConceptMatch",
+    "LexicalConcept",
+    "LexicalMatcher",
+    "MatchType",
+    "VocabularyTerms",
+    "normalize_term",
+]
+
+
+MatchType: TypeAlias = Literal["exact", "normalized", "abbreviation"]
+AbbreviationMap: TypeAlias = Mapping[str, str | Sequence[str]]
+_URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+_MATCH_SCORES: Mapping[MatchType, float] = {
+    "exact": 1.0,
+    "normalized": 0.95,
+    "abbreviation": 0.90,
+}
+
+
+@dataclass(frozen=True)
+class LexicalConcept:
+    """One coded concept stored in a :class:`LexicalMatcher`.
+
+    Args:
+        system_uri: Canonical URI identifying the vocabulary.
+        code: Identifier within the vocabulary.
+        display: Human-readable preferred term.
+        metadata: Vocabulary-specific, non-PHI fields such as a term type or
+            hierarchy flag.
+    """
+
+    system_uri: str
+    code: str
+    display: str
+    metadata: Mapping[str, object] = field(default_factory=dict, hash=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "system_uri", _validate_system_uri(self.system_uri))
+        object.__setattr__(self, "code", _nonempty_text(self.code, "code"))
+        object.__setattr__(self, "display", _nonempty_text(self.display, "display"))
+        if not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """Return the stable vocabulary URI and code identity."""
+
+        return (self.system_uri, self.code)
+
+
+ConceptInput: TypeAlias = LexicalConcept | str | Mapping[str, object]
+VocabularyTerms: TypeAlias = Mapping[str, ConceptInput | Sequence[ConceptInput]]
+
+
+@dataclass(frozen=True)
+class ConceptMatch:
+    """A ranked lexical match returned for a query.
+
+    ``match_type`` records whether the original term matched exactly, only
+    after normalization, or through an abbreviation.  ``matched_term`` is the
+    vocabulary term, not the caller's query, so match results do not duplicate
+    arbitrary source text.
+    """
+
+    system_uri: str
+    code: str
+    display: str
+    score: float
+    match_type: MatchType
+    matched_term: str
+    metadata: Mapping[str, object] = field(default_factory=dict, hash=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "system_uri", _validate_system_uri(self.system_uri))
+        object.__setattr__(self, "code", _nonempty_text(self.code, "code"))
+        object.__setattr__(self, "display", _nonempty_text(self.display, "display"))
+        object.__setattr__(
+            self, "matched_term", _nonempty_text(self.matched_term, "matched_term")
+        )
+        if self.match_type not in _MATCH_SCORES:
+            raise ValueError(
+                "match_type must be 'exact', 'normalized', or 'abbreviation'"
+            )
+        score = float(self.score)
+        if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+            raise ValueError("score must be finite and between 0.0 and 1.0")
+        object.__setattr__(self, "score", score)
+        if not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """Return the stable vocabulary URI and code identity."""
+
+        return (self.system_uri, self.code)
+
+
+@dataclass(frozen=True)
+class _IndexedConcept:
+    concept: LexicalConcept
+    term: str
+    order: int
+
+
+class LexicalMatcher:
+    """Index arbitrary vocabulary terms for deterministic lexical lookup.
+
+    Values in ``terms`` may be :class:`LexicalConcept` objects, concept
+    mappings, code strings, or sequences of those values.  ``system_uri`` is
+    used as the default for mappings and is required for bare code strings.
+
+    Args:
+        terms: Vocabulary term to one-or-more-concepts mapping.
+        system_uri: Default canonical vocabulary URI.
+        abbreviations: Optional abbreviation-to-expanded-term mapping.  Common
+            initialisms such as ``"cbc"`` for ``"complete blood count"`` are
+            also indexed automatically.
+    """
+
+    def __init__(
+        self,
+        terms: VocabularyTerms,
+        *,
+        system_uri: str | None = None,
+        abbreviations: AbbreviationMap | None = None,
+    ) -> None:
+        if not isinstance(terms, Mapping):
+            raise TypeError("terms must be a term-to-concept mapping")
+        self.system_uri = (
+            _validate_system_uri(system_uri) if system_uri is not None else None
+        )
+        exact: dict[str, list[_IndexedConcept]] = defaultdict(list)
+        normalized: dict[str, list[_IndexedConcept]] = defaultdict(list)
+        exact_keys: dict[str, set[tuple[str, str]]] = defaultdict(set)
+        normalized_keys: dict[str, set[tuple[str, str]]] = defaultdict(set)
+        concept_keys: set[tuple[str, str]] = set()
+        order = 0
+
+        for raw_term, raw_concepts in terms.items():
+            term = _nonempty_text(raw_term, "term")
+            normalized_term = normalize_term(term)
+            if not normalized_term:
+                raise ValueError(f"term {term!r} has no indexable characters")
+            for raw_concept in _concept_values(raw_concepts):
+                concept = _coerce_concept(
+                    raw_concept,
+                    term=term,
+                    default_system_uri=self.system_uri,
+                )
+                entry = _IndexedConcept(concept=concept, term=term, order=order)
+                order += 1
+                if concept.key not in exact_keys[term]:
+                    exact[term].append(entry)
+                    exact_keys[term].add(concept.key)
+                if concept.key not in normalized_keys[normalized_term]:
+                    normalized[normalized_term].append(entry)
+                    normalized_keys[normalized_term].add(concept.key)
+                concept_keys.add(concept.key)
+
+        self._exact_index = _freeze_index(exact)
+        self._normalized_index = _freeze_index(normalized)
+        self._abbreviation_index = self._build_abbreviation_index(abbreviations or {})
+        self._concept_count = len(concept_keys)
+
+    @property
+    def term_count(self) -> int:
+        """Number of distinct source terms in the index."""
+
+        return len(self._exact_index)
+
+    @property
+    def concept_count(self) -> int:
+        """Number of distinct ``(system_uri, code)`` concepts in the index."""
+
+        return self._concept_count
+
+    def lookup(
+        self, query: str, *, limit: int | None = None
+    ) -> tuple[ConceptMatch, ...]:
+        """Return deterministically ranked concepts for ``query``.
+
+        Exact matches rank ahead of normalized matches, which rank ahead of
+        abbreviation matches.  A concept reachable through multiple terms is
+        returned once at its best score.
+        """
+
+        if not isinstance(query, str):
+            raise TypeError("query must be a string")
+        if limit is not None and (
+            not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0
+        ):
+            raise ValueError("limit must be a positive integer or None")
+        normalized_query = normalize_term(query)
+        if not normalized_query:
+            return ()
+
+        best: dict[tuple[str, str], ConceptMatch] = {}
+        order_by_key: dict[tuple[str, str], int] = {}
+        self._offer_matches(
+            best,
+            order_by_key,
+            self._exact_index.get(query, ()),
+            "exact",
+        )
+        self._offer_matches(
+            best,
+            order_by_key,
+            self._normalized_index.get(normalized_query, ()),
+            "normalized",
+        )
+        self._offer_matches(
+            best,
+            order_by_key,
+            self._abbreviation_index.get(normalized_query, ()),
+            "abbreviation",
+        )
+
+        matches = sorted(
+            best.values(),
+            key=lambda match: (
+                -match.score,
+                match.system_uri,
+                match.code,
+                match.display,
+                order_by_key[match.key],
+            ),
+        )
+        if limit is not None:
+            matches = matches[:limit]
+        return tuple(matches)
+
+    def match(
+        self, query: str, *, limit: int | None = None
+    ) -> tuple[ConceptMatch, ...]:
+        """Alias for :meth:`lookup`."""
+
+        return self.lookup(query, limit=limit)
+
+    def _build_abbreviation_index(
+        self, abbreviations: AbbreviationMap
+    ) -> dict[str, tuple[_IndexedConcept, ...]]:
+        abbreviation_index: dict[str, list[_IndexedConcept]] = defaultdict(list)
+        abbreviation_keys: dict[str, set[tuple[tuple[str, str], str]]] = defaultdict(
+            set
+        )
+        for normalized_term, entries in self._normalized_index.items():
+            acronym = _acronym(normalized_term)
+            if acronym:
+                _extend_unique(
+                    abbreviation_index[acronym],
+                    abbreviation_keys[acronym],
+                    entries,
+                )
+
+        for raw_abbreviation, raw_expansions in abbreviations.items():
+            abbreviation = normalize_term(
+                _nonempty_text(raw_abbreviation, "abbreviation")
+            )
+            expansions = (
+                (raw_expansions,)
+                if isinstance(raw_expansions, str)
+                else tuple(raw_expansions)
+            )
+            if not expansions:
+                raise ValueError(
+                    f"abbreviation {raw_abbreviation!r} must have an expansion"
+                )
+            for raw_expansion in expansions:
+                expansion = normalize_term(
+                    _nonempty_text(raw_expansion, "abbreviation expansion")
+                )
+                expansion_entries = self._normalized_index.get(expansion)
+                if expansion_entries is None:
+                    raise ValueError(
+                        f"abbreviation expansion {raw_expansion!r} does not match "
+                        "an indexed vocabulary term"
+                    )
+                _extend_unique(
+                    abbreviation_index[abbreviation],
+                    abbreviation_keys[abbreviation],
+                    expansion_entries,
+                )
+        return _freeze_index(abbreviation_index)
+
+    @staticmethod
+    def _offer_matches(
+        best: dict[tuple[str, str], ConceptMatch],
+        order_by_key: dict[tuple[str, str], int],
+        entries: Sequence[_IndexedConcept],
+        match_type: MatchType,
+    ) -> None:
+        score = _MATCH_SCORES[match_type]
+        for entry in entries:
+            key = entry.concept.key
+            candidate = ConceptMatch(
+                system_uri=entry.concept.system_uri,
+                code=entry.concept.code,
+                display=entry.concept.display,
+                score=score,
+                match_type=match_type,
+                matched_term=entry.term,
+                metadata=entry.concept.metadata,
+            )
+            existing = best.get(key)
+            if existing is None or candidate.score > existing.score:
+                best[key] = candidate
+                order_by_key[key] = entry.order
+
+
+def normalize_term(value: str) -> str:
+    """Normalize a lexical surface without consulting external resources.
+
+    Unicode compatibility normalization and case-folding are followed by
+    punctuation/symbol folding and whitespace collapse.  Letters and numbers
+    from every script are retained.
+    """
+
+    if not isinstance(value, str):
+        raise TypeError("value must be a string")
+    folded = unicodedata.normalize("NFKC", value).casefold()
+    characters = (
+        character if _is_term_character(character) else " " for character in folded
+    )
+    return " ".join("".join(characters).split())
+
+
+def _concept_values(
+    value: ConceptInput | Sequence[ConceptInput],
+) -> tuple[ConceptInput, ...]:
+    if isinstance(value, (LexicalConcept, str, Mapping)):
+        return (value,)
+    if not isinstance(value, Sequence):
+        raise TypeError(
+            "concept values must be a concept, mapping, code string, or sequence"
+        )
+    concepts = tuple(value)
+    if not concepts:
+        raise ValueError("concept sequences must not be empty")
+    return concepts
+
+
+def _coerce_concept(
+    value: ConceptInput,
+    *,
+    term: str,
+    default_system_uri: str | None,
+) -> LexicalConcept:
+    if isinstance(value, LexicalConcept):
+        return value
+    if isinstance(value, str):
+        if default_system_uri is None:
+            raise ValueError("system_uri is required when concept values are codes")
+        return LexicalConcept(default_system_uri, value, term)
+    if not isinstance(value, Mapping):
+        raise TypeError(
+            "each concept must be a LexicalConcept, mapping, or code string"
+        )
+
+    raw_system_uri = (
+        value.get("system_uri") or default_system_uri or value.get("system")
+    )
+    raw_code = value.get("code") or value.get("id")
+    raw_display = value.get("display") or value.get("preferred_term") or term
+    if raw_system_uri is None:
+        raise ValueError("concept mappings require system_uri or a matcher default")
+    if raw_code is None:
+        raise ValueError("concept mappings require a code")
+    raw_metadata = value.get("metadata", {})
+    if not isinstance(raw_metadata, Mapping):
+        raise TypeError("concept metadata must be a mapping")
+    metadata = dict(raw_metadata)
+    reserved = {
+        "system_uri",
+        "system",
+        "code",
+        "id",
+        "display",
+        "preferred_term",
+        "metadata",
+    }
+    for key, item in value.items():
+        if key not in reserved:
+            metadata.setdefault(str(key), item)
+    return LexicalConcept(
+        system_uri=str(raw_system_uri),
+        code=str(raw_code),
+        display=str(raw_display),
+        metadata=metadata,
+    )
+
+
+def _acronym(normalized_term: str) -> str:
+    tokens = normalized_term.split()
+    if len(tokens) < 2:
+        return ""
+    acronym = "".join(token[0] for token in tokens if token)
+    return acronym if len(acronym) >= 2 else ""
+
+
+def _is_term_character(character: str) -> bool:
+    return character.isalnum() or unicodedata.category(character).startswith("M")
+
+
+def _extend_unique(
+    target: list[_IndexedConcept],
+    existing: set[tuple[tuple[str, str], str]],
+    entries: Sequence[_IndexedConcept],
+) -> None:
+    for entry in entries:
+        identity = (entry.concept.key, entry.term)
+        if identity not in existing:
+            target.append(entry)
+            existing.add(identity)
+
+
+def _freeze_index(
+    index: Mapping[str, Sequence[_IndexedConcept]],
+) -> dict[str, tuple[_IndexedConcept, ...]]:
+    return {key: tuple(entries) for key, entries in index.items()}
+
+
+def _validate_system_uri(value: object) -> str:
+    text = _nonempty_text(value, "system_uri")
+    if not _URI_SCHEME_RE.match(text) or any(character.isspace() for character in text):
+        raise ValueError("system_uri must be an absolute URI with no whitespace")
+    return text
+
+
+def _nonempty_text(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    text = value.strip()
+    if not text:
+        raise ValueError(f"{field_name} must not be empty")
+    return text

--- a/openmed/clinical/grounding/registry.py
+++ b/openmed/clinical/grounding/registry.py
@@ -1,15 +1,35 @@
-"""Linker registry so ``ground(systems=[...])`` (a later task) can dispatch.
+"""Registries for grounding linkers and free-vocabulary loaders.
 
-Linkers register themselves under a vocabulary system key (e.g. ``"rxnorm"``).
-The registry stores a callable ``(vocab) -> linker`` factory so callers can
-build a linker with their own vocabulary data.
+Linker factories keep their established short system keys.  Vocabulary loaders
+use canonical system URIs and are accepted only when they explicitly declare
+that their source is redistributable.
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable
+import re
+from collections.abc import Mapping
+from typing import Any, Callable, Protocol, cast, runtime_checkable
+
+from .matcher import AbbreviationMap, LexicalMatcher, VocabularyTerms
+
+__all__ = [
+    "InvalidVocabularyLoaderError",
+    "RestrictedVocabularyLoaderError",
+    "VocabularyLoader",
+    "VocabularyLoaderRegistry",
+    "VocabularyRegistryError",
+    "available_linkers",
+    "available_loaders",
+    "get_linker",
+    "get_loader",
+    "register_linker",
+    "register_loader",
+    "validate_vocabulary_loader",
+]
 
 LinkerFactory = Callable[..., Any]
+_URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
 
 _LINKERS: dict[str, LinkerFactory] = {}
 
@@ -27,3 +47,180 @@ def get_linker(system: str) -> LinkerFactory:
 def available_linkers() -> list[str]:
     """Return the sorted list of registered linker system keys."""
     return sorted(_LINKERS)
+
+
+class VocabularyRegistryError(ValueError):
+    """Base error raised by the free-vocabulary loader registry."""
+
+
+class InvalidVocabularyLoaderError(TypeError, VocabularyRegistryError):
+    """Raised when an object does not satisfy the loader contract."""
+
+
+class RestrictedVocabularyLoaderError(VocabularyRegistryError):
+    """Raised when a restricted-license loader is registered in-process."""
+
+
+@runtime_checkable
+class VocabularyLoader(Protocol):
+    """Contract implemented by loaders for redistributable vocabularies.
+
+    Implementations parse a caller-supplied or freely redistributable snapshot
+    into terms consumed by :class:`~openmed.clinical.grounding.LexicalMatcher`.
+    Registration never calls :meth:`load`, so configuring a loader has no I/O
+    or network side effects.
+    """
+
+    system_uri: str
+    redistributable: bool
+
+    def load(self) -> VocabularyTerms:
+        """Load local vocabulary terms keyed by lexical surface."""
+        ...
+
+
+class VocabularyLoaderRegistry:
+    """Registry of redistributable vocabulary loaders keyed by system URI."""
+
+    def __init__(self) -> None:
+        self._loaders: dict[str, VocabularyLoader] = {}
+
+    def register(self, loader: VocabularyLoader, *, replace: bool = False) -> None:
+        """Register ``loader`` after validating its license declaration.
+
+        Args:
+            loader: Object implementing :class:`VocabularyLoader`.
+            replace: Replace an existing loader for the same URI when true.
+
+        Raises:
+            InvalidVocabularyLoaderError: If the loader contract is incomplete.
+            RestrictedVocabularyLoaderError: If ``redistributable`` is false.
+            VocabularyRegistryError: If the URI is already registered.
+        """
+
+        validated = validate_vocabulary_loader(loader)
+        system_uri = validated.system_uri.strip()
+        if not replace and system_uri in self._loaders:
+            raise VocabularyRegistryError(
+                f"A vocabulary loader is already registered for {system_uri!r}."
+            )
+        self._loaders[system_uri] = validated
+
+    def get(self, system_uri: str) -> VocabularyLoader:
+        """Return the loader registered for ``system_uri``."""
+
+        normalized = _validate_registry_system_uri(system_uri)
+        try:
+            return self._loaders[normalized]
+        except KeyError:
+            raise KeyError(
+                f"No vocabulary loader is registered for {normalized!r}."
+            ) from None
+
+    def available(self) -> tuple[str, ...]:
+        """Return registered system URIs in deterministic order."""
+
+        return tuple(sorted(self._loaders))
+
+    def matcher(
+        self,
+        system_uri: str,
+        *,
+        abbreviations: AbbreviationMap | None = None,
+    ) -> LexicalMatcher:
+        """Load ``system_uri`` and build its offline lexical matcher."""
+
+        loader = self.get(system_uri)
+        terms = loader.load()
+        if not isinstance(terms, Mapping):
+            raise InvalidVocabularyLoaderError(
+                f"Vocabulary loader for {loader.system_uri!r} must return a mapping."
+            )
+        return LexicalMatcher(
+            terms,
+            system_uri=loader.system_uri,
+            abbreviations=abbreviations,
+        )
+
+    def __contains__(self, system_uri: object) -> bool:
+        return isinstance(system_uri, str) and system_uri.strip() in self._loaders
+
+    def __len__(self) -> int:
+        return len(self._loaders)
+
+
+def validate_vocabulary_loader(loader: object) -> VocabularyLoader:
+    """Validate and return an object implementing :class:`VocabularyLoader`."""
+
+    system_uri = getattr(loader, "system_uri", None)
+    redistributable = getattr(loader, "redistributable", None)
+    restricted_license = getattr(loader, "restricted_license", False)
+    load = getattr(loader, "load", None)
+    if not isinstance(system_uri, str):
+        raise InvalidVocabularyLoaderError(
+            "Vocabulary loaders must declare a string system_uri."
+        )
+    _validate_registry_system_uri(system_uri)
+    if not isinstance(restricted_license, bool):
+        raise InvalidVocabularyLoaderError(
+            f"Vocabulary loader for {system_uri!r} must declare "
+            "restricted_license as a boolean when provided."
+        )
+    if restricted_license:
+        raise RestrictedVocabularyLoaderError(
+            f"Refusing to register vocabulary loader for {system_uri!r}: it is "
+            "flagged as restricted-license and must remain user-controlled and "
+            "out of process."
+        )
+    if not isinstance(redistributable, bool):
+        raise InvalidVocabularyLoaderError(
+            f"Vocabulary loader for {system_uri!r} must declare a boolean "
+            "redistributable flag."
+        )
+    if not callable(load):
+        raise InvalidVocabularyLoaderError(
+            f"Vocabulary loader for {system_uri!r} must define load()."
+        )
+    if not redistributable:
+        raise RestrictedVocabularyLoaderError(
+            f"Refusing to register vocabulary loader for {system_uri!r}: "
+            "redistributable must be true. Restricted-license vocabularies "
+            "must remain user-controlled and out of process."
+        )
+    return cast(VocabularyLoader, loader)
+
+
+_VOCABULARY_LOADERS = VocabularyLoaderRegistry()
+
+
+def register_loader(loader: VocabularyLoader, *, replace: bool = False) -> None:
+    """Register a loader in the process-wide free-vocabulary registry."""
+
+    _VOCABULARY_LOADERS.register(loader, replace=replace)
+
+
+def get_loader(system_uri: str) -> VocabularyLoader:
+    """Return a loader from the process-wide free-vocabulary registry."""
+
+    return _VOCABULARY_LOADERS.get(system_uri)
+
+
+def available_loaders() -> list[str]:
+    """Return system URIs in the process-wide loader registry."""
+
+    return list(_VOCABULARY_LOADERS.available())
+
+
+def _validate_registry_system_uri(system_uri: object) -> str:
+    if not isinstance(system_uri, str):
+        raise InvalidVocabularyLoaderError("system_uri must be a string")
+    normalized = system_uri.strip()
+    if (
+        not normalized
+        or not _URI_SCHEME_RE.match(normalized)
+        or any(character.isspace() for character in normalized)
+    ):
+        raise InvalidVocabularyLoaderError(
+            "system_uri must be an absolute URI with no whitespace"
+        )
+    return normalized

--- a/tests/unit/clinical/grounding/test_matcher.py
+++ b/tests/unit/clinical/grounding/test_matcher.py
@@ -1,0 +1,144 @@
+"""Tests for the shared offline lexical matcher."""
+
+from __future__ import annotations
+
+import json
+import socket
+from dataclasses import asdict
+
+import pytest
+
+from openmed.clinical.grounding.matcher import (
+    ConceptMatch,
+    LexicalConcept,
+    LexicalMatcher,
+    normalize_term,
+)
+
+SYSTEM_URI = "https://example.org/fhir/CodeSystem/synthetic-free"
+
+
+def _matcher() -> LexicalMatcher:
+    aspirin = LexicalConcept(
+        system_uri=SYSTEM_URI,
+        code="MED-001",
+        display="Aspirin",
+        metadata={"kind": "ingredient"},
+    )
+    return LexicalMatcher(
+        {
+            "Aspirin": aspirin,
+            "acetylsalicylic acid": aspirin,
+            "Complete blood count": {
+                "code": "LAB-001",
+                "display": "Complete blood count",
+                "kind": "laboratory-test",
+            },
+            "type-2 diabetes": {
+                "code": "DX-001",
+                "display": "Type 2 diabetes mellitus",
+            },
+        },
+        system_uri=SYSTEM_URI,
+        abbreviations={"ASA": "acetylsalicylic acid"},
+    )
+
+
+def test_exact_and_normalized_queries_return_ranked_concept_matches():
+    matcher = _matcher()
+
+    exact = matcher.lookup("Aspirin")
+    normalized = matcher.lookup("  ASPIRIN  ")
+    punctuation_normalized = matcher.lookup("Type 2 diabetes")
+
+    assert exact == (
+        ConceptMatch(
+            system_uri=SYSTEM_URI,
+            code="MED-001",
+            display="Aspirin",
+            score=1.0,
+            match_type="exact",
+            matched_term="Aspirin",
+            metadata={"kind": "ingredient"},
+        ),
+    )
+    assert normalized[0].code == "MED-001"
+    assert normalized[0].match_type == "normalized"
+    assert normalized[0].score < exact[0].score
+    assert punctuation_normalized[0].code == "DX-001"
+    assert punctuation_normalized[0].match_type == "normalized"
+
+
+def test_configured_and_automatic_abbreviations_resolve_offline():
+    matcher = _matcher()
+
+    configured = matcher.lookup("asa")
+    automatic = matcher.lookup("CBC")
+
+    assert configured[0].code == "MED-001"
+    assert configured[0].matched_term == "acetylsalicylic acid"
+    assert configured[0].match_type == "abbreviation"
+    assert automatic[0].code == "LAB-001"
+    assert automatic[0].match_type == "abbreviation"
+    assert automatic[0].metadata["kind"] == "laboratory-test"
+    assert json.loads(json.dumps(asdict(automatic[0])))["code"] == "LAB-001"
+
+
+def test_matcher_ranks_match_kinds_and_deduplicates_concepts():
+    matcher = LexicalMatcher(
+        {
+            "ASA": {"code": "OTHER", "display": "A synthetic exact term"},
+            "acetylsalicylic acid": [
+                {"code": "ASPIRIN", "display": "Aspirin"},
+                {"code": "SECOND", "display": "Second candidate"},
+            ],
+            "Acetylsalicylic-acid": {
+                "code": "ASPIRIN",
+                "display": "Aspirin",
+            },
+        },
+        system_uri=SYSTEM_URI,
+        abbreviations={"ASA": "acetylsalicylic acid"},
+    )
+
+    matches = matcher.lookup("ASA")
+
+    assert [match.code for match in matches] == ["OTHER", "ASPIRIN", "SECOND"]
+    assert [match.score for match in matches] == [1.0, 0.9, 0.9]
+    assert sum(match.code == "ASPIRIN" for match in matches) == 1
+    assert matcher.lookup("ASA", limit=2) == matches[:2]
+
+
+def test_bare_code_dictionary_uses_matcher_system_uri():
+    matcher = LexicalMatcher({"synthetic term": "CODE-1"}, system_uri=SYSTEM_URI)
+
+    assert matcher.lookup("synthetic term")[0].key == (SYSTEM_URI, "CODE-1")
+    assert matcher.term_count == 1
+    assert matcher.concept_count == 1
+
+
+def test_lookup_path_never_opens_a_network_connection(monkeypatch):
+    matcher = _matcher()
+
+    def fail_connection(*args, **kwargs):
+        raise AssertionError("lexical lookup attempted a network connection")
+
+    monkeypatch.setattr(socket, "create_connection", fail_connection)
+
+    assert matcher.lookup("CBC")[0].code == "LAB-001"
+
+
+def test_normalization_is_unicode_aware_and_input_validation_is_clear():
+    assert normalize_term("  β-Blocker\u2014Dose  ") == "β blocker dose"
+    assert normalize_term("తెలుగు") == "తెలుగు"
+
+    with pytest.raises(ValueError, match="positive integer"):
+        _matcher().lookup("aspirin", limit=0)
+    with pytest.raises(ValueError, match="does not match an indexed"):
+        LexicalMatcher(
+            {"known term": "CODE-1"},
+            system_uri=SYSTEM_URI,
+            abbreviations={"KT": "missing expansion"},
+        )
+    with pytest.raises(ValueError, match="must not be empty"):
+        LexicalMatcher({"known term": []}, system_uri=SYSTEM_URI)

--- a/tests/unit/clinical/grounding/test_registry.py
+++ b/tests/unit/clinical/grounding/test_registry.py
@@ -1,0 +1,104 @@
+"""Tests for the redistributable vocabulary loader registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.clinical.grounding import (
+    RestrictedVocabularyLoaderError,
+    VocabularyLoader,
+    VocabularyLoaderRegistry,
+    VocabularyRegistryError,
+    validate_vocabulary_loader,
+)
+from openmed.clinical.grounding.matcher import VocabularyTerms
+from openmed.clinical.grounding.registry import InvalidVocabularyLoaderError
+
+SYSTEM_URI = "https://example.org/fhir/CodeSystem/fake-free"
+
+
+class FakeFreeVocabularyLoader:
+    """Minimal conforming loader over a synthetic in-memory snapshot."""
+
+    system_uri = SYSTEM_URI
+    redistributable = True
+
+    def load(self) -> VocabularyTerms:
+        return {
+            "Synthetic finding": {
+                "code": "SYN-001",
+                "display": "Synthetic finding",
+                "provenance": "synthetic-permissive",
+            }
+        }
+
+
+class FakeRestrictedVocabularyLoader(FakeFreeVocabularyLoader):
+    system_uri = "http://restricted.example/CodeSystem/private"
+    redistributable = False
+
+
+def test_fake_free_loader_conforms_and_builds_matcher():
+    loader = FakeFreeVocabularyLoader()
+    registry = VocabularyLoaderRegistry()
+
+    assert isinstance(loader, VocabularyLoader)
+    assert validate_vocabulary_loader(loader) is loader
+
+    registry.register(loader)
+    matcher = registry.matcher(SYSTEM_URI)
+    matches = matcher.lookup(" synthetic-finding ")
+
+    assert registry.get(SYSTEM_URI) is loader
+    assert registry.available() == (SYSTEM_URI,)
+    assert matches[0].code == "SYN-001"
+    assert matches[0].metadata["provenance"] == "synthetic-permissive"
+
+
+def test_registry_refuses_restricted_license_loader_with_clear_error():
+    registry = VocabularyLoaderRegistry()
+
+    with pytest.raises(
+        RestrictedVocabularyLoaderError,
+        match="redistributable must be true.*out of process",
+    ):
+        registry.register(FakeRestrictedVocabularyLoader())
+
+    assert len(registry) == 0
+
+
+def test_registry_refuses_explicit_restricted_license_flag():
+    class FlaggedRestrictedLoader(FakeFreeVocabularyLoader):
+        restricted_license = True
+
+    with pytest.raises(
+        RestrictedVocabularyLoaderError,
+        match="flagged as restricted-license.*out of process",
+    ):
+        VocabularyLoaderRegistry().register(FlaggedRestrictedLoader())
+
+
+def test_registry_requires_explicit_boolean_license_declaration():
+    class MissingLicenseFlag:
+        system_uri = SYSTEM_URI
+
+        def load(self):
+            return {}
+
+    with pytest.raises(InvalidVocabularyLoaderError, match="boolean redistributable"):
+        VocabularyLoaderRegistry().register(MissingLicenseFlag())
+
+
+def test_registry_is_keyed_by_system_uri_and_rejects_accidental_replacement():
+    registry = VocabularyLoaderRegistry()
+    first = FakeFreeVocabularyLoader()
+    second = FakeFreeVocabularyLoader()
+
+    registry.register(first)
+
+    assert SYSTEM_URI in registry
+    with pytest.raises(VocabularyRegistryError, match="already registered"):
+        registry.register(second)
+
+    registry.register(second, replace=True)
+    assert registry.get(SYSTEM_URI) is second


### PR DESCRIPTION
## Description

Closes #868.

Adds a shared, fully offline lexical matcher over caller-supplied terminology snapshots and a canonical-system-URI loader registry. The matcher ranks exact, normalized, and abbreviation-aware `ConceptMatch` results, while the loader contract and registry enforce explicit redistributable licensing before in-process registration.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add a Unicode-aware inverted index for arbitrary term-to-concept mappings with deterministic exact, normalized, and abbreviation ranking.
- Add serializable `ConceptMatch` and `LexicalConcept` records with vocabulary-specific metadata support and no network activity in lookup.
- Extend the existing grounding registry with a runtime-checkable `VocabularyLoader` contract, URI-keyed registries, and restricted-license rejection.
- Export the new public grounding APIs while preserving existing linker registration behavior.
- Add synthetic matcher and loader conformance tests, including offline lookup and restricted-license gates.

## Testing

- [x] Added tests for exact, normalized, and abbreviation ranking; deterministic deduplication; offline lookup; loader conformance; and restricted-license rejection.
- [x] Full repository suite passes locally: 6,076 passed and 48 skipped.
- [x] Focused grounding tests pass: 11 passed.
- [x] Formatting, lint, format verification, scoped type checks, pre-commit, package builds, and wheel-content verification pass.

## Documentation

- [ ] User-facing documentation is unchanged; this is an internal grounding foundation.
- [x] Added docstrings to new public functions and classes.
- [ ] The changelog is unchanged; release notes can include this feature when it ships.

## Code Quality

- [x] Repository formatting, lint, and format verification gates pass.
- [x] Performed a self-review of the complete diff.
- [x] Preserved the existing linker registry behavior.
- [x] Added no dependencies or bundled vocabulary data.

## Dependencies

- [x] No new package dependencies were added.
- [x] The OM-059 grounding prerequisite is already complete in #224.

## Checklist

- [x] Read the contributing guidelines.
- [x] Used a clear, focused commit.
- [x] Kept the branch scoped to OM-510.

## Related Issues

Closes #868

## Screenshots/Examples

Not applicable; this is an offline Python grounding API.
