### PR TITLE
Add tamper-evident audit chains for de-identification runs

### DIFF
--- a/docs/security/tamper-evident-audit-log.md
+++ b/docs/security/tamper-evident-audit-log.md
@@ -1,0 +1,96 @@
+# Tamper-evident audit log
+
+OpenMed can link de-identification audit reports into an ordered, append-only
+chain. Each entry commits to the preceding entry hash, its sequence number, the
+report reproducibility hash, the input and de-identified output hashes, and a
+minimal span summary. The retained entry count and head hash also make a
+truncated tail detectable when the chain document is verified.
+
+The chain is designed for local compliance evidence. Creation and verification
+do not make network calls.
+
+## Create and append
+
+Generate an `AuditReport` with `deidentify(..., audit=True)`, then append it to
+a chain file:
+
+```python
+from openmed import deidentify
+from openmed.core.audit_chain import append_to_chain_file
+
+report = deidentify(
+    clinical_text,
+    method="mask",
+    policy="hipaa_safe_harbor",
+    audit=True,
+)
+entry = append_to_chain_file("audit-chain.json", report)
+print(entry.sequence, entry.entry_hash)
+```
+
+`append_to_chain_file` loads and verifies an existing chain before adding an
+entry. It refuses to append a report whose reproducibility hash no longer
+matches the report contents, then atomically replaces the chain document.
+
+For in-memory workflows, use `AuditChain.append()` and `AuditChain.write()`:
+
+```python
+from openmed.core.audit_chain import AuditChain
+
+chain = AuditChain()
+chain.append(first_report)
+chain.append(second_report)
+assert chain.verify().valid
+chain.write("audit-chain.json")
+```
+
+## Verify from the CLI
+
+The existing audit verifier recognizes both individual reports and chain
+documents:
+
+```console
+openmed audit verify audit-chain.json
+```
+
+Use `verify-chain` to verify a chain and confirm that a particular signed report
+is one of its entries:
+
+```console
+openmed audit verify-chain audit-chain.json \
+  --report audit-report.json \
+  --key "$OPENMED_AUDIT_KEY"
+```
+
+For signed reports, omit `--key` to read `OPENMED_AUDIT_KEY`. Verification fails
+when the report signature or reproducibility hash is invalid, the report is not
+committed to the chain, or the chain shows insertion, deletion, reordering, or
+mutation. Failure output identifies the detected condition and affected entry
+when one can be identified.
+
+## What is stored
+
+The chain format is deliberately narrower than an `AuditReport`. An entry
+contains only:
+
+- the sequence number and previous-entry hash;
+- the report, input, and de-identified output hashes;
+- span start/end offsets, canonical labels, and text hashes; and
+- the entry hash.
+
+It does not serialize source or de-identified text, surrogates, context,
+detector evidence, mappings, free-form metadata, or residual-risk notes.
+Unknown fields are rejected when a chain is loaded so uncommitted data cannot
+be hidden alongside the verified payload.
+
+## Security boundary
+
+A valid chain proves that its contents still match its retained count, head,
+and links. It does not identify who created the chain and is not a replacement
+for access controls, backups, or the HMAC signature on an individual audit
+report. Keep the chain document read-only for normal consumers, retain its head
+hash with release or compliance records, and verify both the signed report and
+its chain membership when authenticity matters.
+
+Distributed consensus and external timestamp authorities are outside this
+feature's scope.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - Per-Language De-identification: languages.md
       - Smart Entity Merging: pii-smart-merging.md
       - No-Raw-PHI Logging: security/no-raw-phi-logging.md
+      - Tamper-evident Audit Log: security/tamper-evident-audit-log.md
       - LangChain Redaction Wrapper: integrations-langchain.md
       - Columnar Redactor: integrations/columnar-redactor.md
       - Lakehouse Table Redaction: integrations/lakehouse-redaction.md

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -704,12 +704,12 @@ def _add_audit_command(subparsers: argparse._SubParsersAction) -> None:
 
     verify_parser = audit_sub.add_parser(
         "verify",
-        help="Verify an audit report's reproducibility hash and signature.",
+        help="Verify an audit report or tamper-evident audit chain.",
     )
     verify_parser.add_argument(
         "report",
         type=Path,
-        help="Path to a signed audit report JSON file.",
+        help="Path to an audit report or audit-chain JSON file.",
     )
     verify_parser.add_argument(
         "--key",
@@ -717,6 +717,28 @@ def _add_audit_command(subparsers: argparse._SubParsersAction) -> None:
         help=f"HMAC key for signed reports. Defaults to {_AUDIT_KEY_ENV}.",
     )
     verify_parser.set_defaults(handler=_handle_audit_verify)
+
+    chain_parser = audit_sub.add_parser(
+        "verify-chain",
+        help="Verify an audit chain and optionally a report committed to it.",
+    )
+    chain_parser.add_argument(
+        "chain",
+        type=Path,
+        help="Path to a tamper-evident audit-chain JSON file.",
+    )
+    chain_parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Also verify this audit report and confirm chain membership.",
+    )
+    chain_parser.add_argument(
+        "--key",
+        default=None,
+        help=f"HMAC key for signed reports. Defaults to {_AUDIT_KEY_ENV}.",
+    )
+    chain_parser.set_defaults(handler=_handle_audit_chain_verify)
 
     show_parser = audit_sub.add_parser(
         "show",
@@ -1587,20 +1609,34 @@ def _handle_redact_dataset(args: argparse.Namespace) -> int:
 
 def _handle_audit_verify(args: argparse.Namespace) -> int:
     try:
-        report = _load_audit_report(args.report)
-    except (OSError, TypeError, ValueError) as exc:
+        artifact = _load_audit_artifact(args.report)
+    except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
         raise CliError(
-            f"Failed to load audit report: {exc}",
+            f"Failed to load audit artifact: {exc}",
             code="load_failed",
             exit_code=EXIT_ERROR,
         )
 
+    from ..core.audit_chain import AuditChain
+
+    if isinstance(artifact, AuditChain):
+        payload, human = _audit_chain_verification(artifact)
+    else:
+        payload, human = _audit_report_verification(artifact, args.key)
+    emit(args, payload, human=human)
+    return 0 if payload["verified"] else 1
+
+
+def _audit_report_verification(
+    report: Any,
+    key_override: str | None,
+) -> tuple[dict[str, Any], str]:
     repro_ok = report.repro_hash_matches()
     signature_status = "SKIPPED (report is unsigned)"
     signature_ok = True
 
     if report.signature is not None:
-        key = args.key or os.environ.get(_AUDIT_KEY_ENV)
+        key = key_override or os.environ.get(_AUDIT_KEY_ENV)
         if not key:
             signature_status = f"FAIL (set --key or {_AUDIT_KEY_ENV})"
             signature_ok = False
@@ -1625,8 +1661,77 @@ def _handle_audit_verify(args: argparse.Namespace) -> int:
         f"Reproducibility hash: {_pass_fail(repro_ok)}\n"
         f"HMAC signature: {signature_status}"
     )
-    emit(args, payload, human=human)
-    return 0 if verified else 1
+    return payload, human
+
+
+def _audit_chain_verification(chain: Any) -> tuple[dict[str, Any], str]:
+    result = chain.verify()
+    payload = {
+        "verified": result.valid,
+        "entries_checked": result.checked_entries,
+        "reason": result.reason,
+    }
+    lines = [
+        f"Audit chain verification: {_pass_fail(result.valid)}",
+        f"Entries checked: {result.checked_entries}",
+    ]
+    if not result.valid:
+        lines.append(f"Reason: {result.reason}")
+    return payload, "\n".join(lines)
+
+
+def _handle_audit_chain_verify(args: argparse.Namespace) -> int:
+    from ..core.audit_chain import AuditChain
+
+    try:
+        chain = AuditChain.load(args.chain)
+    except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+        raise CliError(
+            f"Failed to load audit chain: {exc}",
+            code="load_failed",
+            exit_code=EXIT_ERROR,
+        )
+
+    chain_payload, chain_human = _audit_chain_verification(chain)
+    payload: dict[str, Any] = {
+        "verified": chain_payload["verified"],
+        "chain": chain_payload,
+    }
+    human_parts = [chain_human]
+    if args.report is None:
+        emit(args, payload, human="\n".join(human_parts))
+        return 0 if payload["verified"] else 1
+
+    try:
+        report = _load_audit_report(args.report)
+    except (OSError, TypeError, ValueError) as exc:
+        raise CliError(
+            f"Failed to load audit report: {exc}",
+            code="load_failed",
+            exit_code=EXIT_ERROR,
+        )
+
+    report_payload, report_human = _audit_report_verification(report, args.key)
+    membership_ok = chain.contains_report(report)
+    payload.update(
+        {
+            "verified": bool(
+                chain_payload["verified"]
+                and report_payload["verified"]
+                and membership_ok
+            ),
+            "report": report_payload,
+            "report_membership": membership_ok,
+        }
+    )
+    human_parts.extend(
+        [
+            report_human,
+            f"Audit report chain membership: {_pass_fail(membership_ok)}",
+        ]
+    )
+    emit(args, payload, human="\n".join(human_parts))
+    return 0 if payload["verified"] else 1
 
 
 def _handle_audit_show(args: argparse.Namespace) -> int:
@@ -1667,6 +1772,18 @@ def _load_audit_report(path: Path):
     from ..core.audit import AuditReport
 
     return AuditReport.from_json(path.read_text(encoding="utf-8"))
+
+
+def _load_audit_artifact(path: Path):
+    from ..core.audit import AuditReport
+    from ..core.audit_chain import CHAIN_FORMAT, AuditChain
+
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, MappingABC):
+        raise ValueError("audit artifact JSON must contain an object")
+    if parsed.get("format") == CHAIN_FORMAT or "entries" in parsed:
+        return AuditChain.from_dict(parsed)
+    return AuditReport.from_dict(parsed)
 
 
 def _format_audit_summary(report: Any) -> str:

--- a/openmed/core/__init__.py
+++ b/openmed/core/__init__.py
@@ -1,6 +1,14 @@
 """Core functionality for OpenMed package."""
 
 from .audit import AuditReport, AuditSignature, AuditSpan, DetectorInfo
+from .audit_chain import (
+    AuditChain,
+    AuditChainEntry,
+    AuditChainSpan,
+    ChainVerificationResult,
+    append_to_chain_file,
+    verify_chain,
+)
 from .config import (
     PROFILE_PRESETS,
     OpenMedConfig,
@@ -93,6 +101,12 @@ __all__ = [
     "AuditSignature",
     "AuditSpan",
     "DetectorInfo",
+    "AuditChain",
+    "AuditChainEntry",
+    "AuditChainSpan",
+    "ChainVerificationResult",
+    "append_to_chain_file",
+    "verify_chain",
     "redaction_preview",
     "render_redaction_preview",
     "BIDI_CONTROL_CHARS",

--- a/openmed/core/audit_chain.py
+++ b/openmed/core/audit_chain.py
@@ -1,0 +1,503 @@
+"""Tamper-evident audit chains for de-identification runs.
+
+The chain stores only canonical labels, offsets, and cryptographic hashes from
+an :class:`~openmed.core.audit.AuditReport`. It deliberately excludes source
+text, replacements, detector evidence, context, and reversible mappings.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .audit import AuditReport, AuditSpan, stable_hash
+from .labels import CANONICAL_LABELS, normalize_label
+
+CHAIN_FORMAT = "openmed.audit-chain"
+CHAIN_VERSION = 1
+GENESIS_HASH = stable_hash(
+    {"format": CHAIN_FORMAT, "version": CHAIN_VERSION, "sequence": -1}
+)
+
+_CHAIN_FIELDS = {
+    "format",
+    "version",
+    "genesis_hash",
+    "entry_count",
+    "head_hash",
+    "entries",
+}
+_ENTRY_FIELDS = {
+    "sequence",
+    "previous_hash",
+    "report_hash",
+    "input_hash",
+    "deidentified_text_hash",
+    "spans",
+    "entry_hash",
+}
+_SPAN_FIELDS = {"start", "end", "label", "text_hash"}
+
+
+def _canonical_json(data: Any) -> str:
+    return json.dumps(
+        data,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _is_sha256_hash(value: Any) -> bool:
+    if not isinstance(value, str) or not value.startswith("sha256:"):
+        return False
+    digest = value.removeprefix("sha256:")
+    return len(digest) == 64 and all(char in "0123456789abcdef" for char in digest)
+
+
+def _require_sha256_hash(value: Any, field_name: str) -> str:
+    if not _is_sha256_hash(value):
+        raise ValueError(f"{field_name} must be a sha256:<hex> hash")
+    return value
+
+
+def _reject_unknown_fields(
+    data: Mapping[str, Any],
+    allowed: set[str],
+    object_name: str,
+) -> None:
+    if any(key not in allowed for key in data):
+        raise ValueError(f"{object_name} contains unsupported fields")
+
+
+@dataclass(frozen=True)
+class AuditChainSpan:
+    """PHI-safe span material committed to an audit-chain entry."""
+
+    start: int
+    end: int
+    label: str
+    text_hash: str
+
+    def __post_init__(self) -> None:
+        if type(self.start) is not int or self.start < 0:
+            raise ValueError("audit chain span start must be a non-negative integer")
+        if type(self.end) is not int or self.end < self.start:
+            raise ValueError("audit chain span end must be at or after start")
+        if not isinstance(self.label, str) or self.label not in CANONICAL_LABELS:
+            raise ValueError("audit chain span label must be canonical")
+        _require_sha256_hash(self.text_hash, "audit chain span text_hash")
+
+    @classmethod
+    def from_audit_span(cls, span: AuditSpan) -> "AuditChainSpan":
+        """Reduce an audit span to canonical label, offsets, and text hash."""
+        return cls(
+            start=span.start,
+            end=span.end,
+            label=normalize_label(span.canonical_label or span.label),
+            text_hash=span.text_hash,
+        )
+
+    def to_dict(self) -> dict[str, int | str]:
+        """Return the JSON-compatible safe span payload."""
+        return {
+            "start": self.start,
+            "end": self.end,
+            "label": self.label,
+            "text_hash": self.text_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AuditChainSpan":
+        """Load a safe span while rejecting fields that could hide raw PHI."""
+        _reject_unknown_fields(data, _SPAN_FIELDS, "audit chain span")
+        return cls(
+            start=data.get("start"),  # type: ignore[arg-type]
+            end=data.get("end"),  # type: ignore[arg-type]
+            label=data.get("label"),  # type: ignore[arg-type]
+            text_hash=data.get("text_hash"),  # type: ignore[arg-type]
+        )
+
+
+@dataclass(frozen=True)
+class AuditChainEntry:
+    """One de-identification run committed to the preceding entry hash."""
+
+    sequence: int
+    previous_hash: str
+    report_hash: str
+    input_hash: str
+    deidentified_text_hash: str
+    spans: tuple[AuditChainSpan, ...]
+    entry_hash: str
+
+    def __post_init__(self) -> None:
+        if type(self.sequence) is not int or self.sequence < 0:
+            raise ValueError("audit chain sequence must be a non-negative integer")
+        _require_sha256_hash(self.previous_hash, "audit chain previous_hash")
+        _require_sha256_hash(self.report_hash, "audit chain report_hash")
+        _require_sha256_hash(self.input_hash, "audit chain input_hash")
+        _require_sha256_hash(
+            self.deidentified_text_hash,
+            "audit chain deidentified_text_hash",
+        )
+        _require_sha256_hash(self.entry_hash, "audit chain entry_hash")
+        if not all(isinstance(span, AuditChainSpan) for span in self.spans):
+            raise TypeError("audit chain spans must contain AuditChainSpan values")
+
+    def _hash_payload(self) -> dict[str, Any]:
+        return {
+            "sequence": self.sequence,
+            "previous_hash": self.previous_hash,
+            "report_hash": self.report_hash,
+            "input_hash": self.input_hash,
+            "deidentified_text_hash": self.deidentified_text_hash,
+            "spans": [span.to_dict() for span in self.spans],
+        }
+
+    def compute_hash(self) -> str:
+        """Return the deterministic hash this entry should carry."""
+        return stable_hash(self._hash_payload())
+
+    def matches_report(self, report: AuditReport) -> bool:
+        """Return whether this entry commits to the supplied audit report."""
+        try:
+            expected = _entry_from_report(
+                report,
+                sequence=self.sequence,
+                previous_hash=self.previous_hash,
+            )
+        except (TypeError, ValueError):
+            return False
+        return self._hash_payload() == expected._hash_payload()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the complete JSON-compatible entry payload."""
+        return {**self._hash_payload(), "entry_hash": self.entry_hash}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AuditChainEntry":
+        """Load an entry while rejecting uncommitted or PHI-bearing fields."""
+        _reject_unknown_fields(data, _ENTRY_FIELDS, "audit chain entry")
+        spans = data.get("spans")
+        if not isinstance(spans, Sequence) or isinstance(spans, (str, bytes)):
+            raise TypeError("audit chain entry spans must be a list")
+        loaded_spans: list[AuditChainSpan] = []
+        for span in spans:
+            if not isinstance(span, Mapping):
+                raise TypeError("audit chain spans must contain objects")
+            loaded_spans.append(AuditChainSpan.from_dict(span))
+        return cls(
+            sequence=data.get("sequence"),  # type: ignore[arg-type]
+            previous_hash=data.get("previous_hash"),  # type: ignore[arg-type]
+            report_hash=data.get("report_hash"),  # type: ignore[arg-type]
+            input_hash=data.get("input_hash"),  # type: ignore[arg-type]
+            deidentified_text_hash=data.get(  # type: ignore[arg-type]
+                "deidentified_text_hash"
+            ),
+            spans=tuple(loaded_spans),
+            entry_hash=data.get("entry_hash"),  # type: ignore[arg-type]
+        )
+
+
+@dataclass(frozen=True)
+class ChainVerificationResult:
+    """Detailed result of an offline audit-chain verification."""
+
+    valid: bool
+    checked_entries: int
+    reason: str
+    entry_index: int | None = None
+
+    def __bool__(self) -> bool:
+        return self.valid
+
+    @property
+    def is_valid(self) -> bool:
+        """Compatibility alias for callers that prefer an ``is_valid`` field."""
+        return self.valid
+
+    @property
+    def error(self) -> str | None:
+        """Return the failure reason, or ``None`` for a valid chain."""
+        return None if self.valid else self.reason
+
+
+def _entry_from_report(
+    report: AuditReport,
+    *,
+    sequence: int,
+    previous_hash: str,
+) -> AuditChainEntry:
+    if not isinstance(report, AuditReport):
+        raise TypeError("audit chain entries require an AuditReport")
+    if not report.repro_hash_matches():
+        raise ValueError("cannot append an audit report with an invalid repro_hash")
+
+    safe_spans = tuple(
+        sorted(
+            (AuditChainSpan.from_audit_span(span) for span in report.spans),
+            key=lambda span: (
+                span.start,
+                span.end,
+                span.label,
+                span.text_hash,
+            ),
+        )
+    )
+    material = {
+        "sequence": sequence,
+        "previous_hash": _require_sha256_hash(
+            previous_hash, "audit chain previous_hash"
+        ),
+        "report_hash": _require_sha256_hash(
+            report.repro_hash, "audit chain report_hash"
+        ),
+        "input_hash": _require_sha256_hash(report.input_hash, "audit chain input_hash"),
+        "deidentified_text_hash": _require_sha256_hash(
+            report.deidentified_text_hash,
+            "audit chain deidentified_text_hash",
+        ),
+        "spans": [span.to_dict() for span in safe_spans],
+    }
+    return AuditChainEntry(
+        sequence=sequence,
+        previous_hash=previous_hash,
+        report_hash=report.repro_hash,
+        input_hash=report.input_hash,
+        deidentified_text_hash=report.deidentified_text_hash,
+        spans=safe_spans,
+        entry_hash=stable_hash(material),
+    )
+
+
+class AuditChain:
+    """Append-only sequence of PHI-safe de-identification audit entries."""
+
+    GENESIS_HASH = GENESIS_HASH
+
+    def __init__(
+        self,
+        entries: Sequence[AuditChainEntry] | None = None,
+        *,
+        declared_entry_count: int | None = None,
+        declared_head_hash: str | None = None,
+    ) -> None:
+        self._entries = list(entries or ())
+        self._declared_entry_count = (
+            len(self._entries) if declared_entry_count is None else declared_entry_count
+        )
+        current_head = (
+            self._entries[-1].entry_hash if self._entries else self.GENESIS_HASH
+        )
+        self._declared_head_hash = (
+            current_head if declared_head_hash is None else declared_head_hash
+        )
+
+    @property
+    def entries(self) -> tuple[AuditChainEntry, ...]:
+        """Return the entries in insertion order as an immutable tuple."""
+        return tuple(self._entries)
+
+    @property
+    def head_hash(self) -> str:
+        """Return the retained head hash that anchors the serialized chain."""
+        return self._declared_head_hash
+
+    def append(self, report: AuditReport) -> AuditChainEntry:
+        """Verify and append one audit report without retaining raw PHI fields."""
+        current = self.verify()
+        if not current.valid:
+            raise ValueError(
+                f"cannot append to an invalid audit chain: {current.reason}"
+            )
+        previous_hash = (
+            self._entries[-1].entry_hash if self._entries else self.GENESIS_HASH
+        )
+        entry = _entry_from_report(
+            report,
+            sequence=len(self._entries),
+            previous_hash=previous_hash,
+        )
+        self._entries.append(entry)
+        self._declared_entry_count = len(self._entries)
+        self._declared_head_hash = entry.entry_hash
+        return entry
+
+    append_report = append
+
+    def verify(self) -> ChainVerificationResult:
+        """Verify count, order, links, entry hashes, and retained head offline."""
+        actual_count = len(self._entries)
+        if actual_count > self._declared_entry_count:
+            return ChainVerificationResult(
+                False,
+                0,
+                "insertion detected: chain contains more entries than declared",
+            )
+        if actual_count < self._declared_entry_count:
+            return ChainVerificationResult(
+                False,
+                0,
+                "deletion detected: chain contains fewer entries than declared",
+            )
+
+        sequences = [entry.sequence for entry in self._entries]
+        expected_sequences = list(range(actual_count))
+        if sequences != expected_sequences:
+            if sorted(sequences) == expected_sequences:
+                reason = "reordering detected: entry sequence is out of order"
+            else:
+                reason = (
+                    "insertion or deletion detected: entry sequence is not contiguous"
+                )
+            return ChainVerificationResult(False, 0, reason)
+
+        previous_hash = self.GENESIS_HASH
+        for index, entry in enumerate(self._entries):
+            if entry.previous_hash != previous_hash:
+                return ChainVerificationResult(
+                    False,
+                    index,
+                    f"reordering or mutation detected: broken link at entry {index}",
+                    index,
+                )
+            if entry.entry_hash != entry.compute_hash():
+                return ChainVerificationResult(
+                    False,
+                    index,
+                    f"mutation detected: hash mismatch at entry {index}",
+                    index,
+                )
+            previous_hash = entry.entry_hash
+
+        if self._declared_head_hash != previous_hash:
+            return ChainVerificationResult(
+                False,
+                actual_count,
+                "deletion or mutation detected: retained head hash does not match",
+            )
+        return ChainVerificationResult(
+            True,
+            actual_count,
+            "chain is valid",
+        )
+
+    def contains_report(self, report: AuditReport) -> bool:
+        """Return whether a valid chain contains the supplied audit report."""
+        return bool(self.verify()) and any(
+            entry.matches_report(report) for entry in self._entries
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the versioned chain envelope and retained head anchor."""
+        return {
+            "format": CHAIN_FORMAT,
+            "version": CHAIN_VERSION,
+            "genesis_hash": self.GENESIS_HASH,
+            "entry_count": self._declared_entry_count,
+            "head_hash": self._declared_head_hash,
+            "entries": [entry.to_dict() for entry in self._entries],
+        }
+
+    def to_json(self) -> str:
+        """Serialize the chain deterministically."""
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AuditChain":
+        """Load a versioned audit chain from a mapping."""
+        _reject_unknown_fields(data, _CHAIN_FIELDS, "audit chain")
+        if data.get("format") != CHAIN_FORMAT:
+            raise ValueError(f"audit chain format must be {CHAIN_FORMAT!r}")
+        if data.get("version") != CHAIN_VERSION:
+            raise ValueError("unsupported audit chain version")
+        if data.get("genesis_hash") != GENESIS_HASH:
+            raise ValueError("audit chain genesis_hash does not match this format")
+        declared_count = data.get("entry_count")
+        if type(declared_count) is not int or declared_count < 0:
+            raise ValueError("audit chain entry_count must be a non-negative integer")
+        declared_head = _require_sha256_hash(
+            data.get("head_hash"), "audit chain head_hash"
+        )
+        entries = data.get("entries")
+        if not isinstance(entries, Sequence) or isinstance(entries, (str, bytes)):
+            raise TypeError("audit chain entries must be a list")
+        loaded_entries: list[AuditChainEntry] = []
+        for entry in entries:
+            if not isinstance(entry, Mapping):
+                raise TypeError("audit chain entries must contain objects")
+            loaded_entries.append(AuditChainEntry.from_dict(entry))
+        return cls(
+            loaded_entries,
+            declared_entry_count=declared_count,
+            declared_head_hash=declared_head,
+        )
+
+    @classmethod
+    def from_json(cls, data: str | bytes) -> "AuditChain":
+        """Load an audit chain from JSON."""
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSON for AuditChain: {exc}") from exc
+        if not isinstance(parsed, Mapping):
+            raise ValueError("AuditChain JSON must contain an object")
+        return cls.from_dict(parsed)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "AuditChain":
+        """Load a UTF-8 audit-chain document from disk."""
+        return cls.from_json(Path(path).read_text(encoding="utf-8"))
+
+    def write(self, path: str | Path) -> Path:
+        """Atomically persist the complete chain document."""
+        destination = Path(path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            "w",
+            delete=False,
+            dir=destination.parent,
+            encoding="utf-8",
+            prefix=f".{destination.name}.",
+        ) as handle:
+            handle.write(self.to_json())
+            handle.write("\n")
+            temporary = Path(handle.name)
+        os.replace(temporary, destination)
+        return destination
+
+
+def verify_chain(chain: AuditChain | Mapping[str, Any]) -> ChainVerificationResult:
+    """Verify an audit chain supplied as an object or decoded JSON mapping."""
+    if not isinstance(chain, AuditChain):
+        chain = AuditChain.from_dict(chain)
+    return chain.verify()
+
+
+def append_to_chain_file(path: str | Path, report: AuditReport) -> AuditChainEntry:
+    """Append one report to a new or existing chain file and persist atomically."""
+    destination = Path(path)
+    chain = AuditChain.load(destination) if destination.exists() else AuditChain()
+    entry = chain.append(report)
+    chain.write(destination)
+    return entry
+
+
+__all__ = [
+    "AuditChain",
+    "AuditChainEntry",
+    "AuditChainSpan",
+    "CHAIN_FORMAT",
+    "CHAIN_VERSION",
+    "ChainVerificationResult",
+    "GENESIS_HASH",
+    "append_to_chain_file",
+    "verify_chain",
+]

--- a/tests/unit/cli/test_audit_risk_cli.py
+++ b/tests/unit/cli/test_audit_risk_cli.py
@@ -9,6 +9,7 @@ import pytest
 
 from openmed.cli import main_module
 from openmed.core.audit import AuditReport, AuditSpan, DetectorInfo, hash_text
+from openmed.core.audit_chain import AuditChain
 
 
 def _audit_report() -> AuditReport:
@@ -140,6 +141,93 @@ def test_audit_verify_fails_for_tampered_report(
     assert "Audit report verification: FAIL" in output
     assert "Reproducibility hash: FAIL" in output
     assert "HMAC signature: FAIL" in output
+
+
+def test_audit_verify_auto_detects_a_valid_chain(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    chain_path = tmp_path / "audit-chain.json"
+    chain = AuditChain()
+    chain.append(_audit_report())
+    chain.write(chain_path)
+
+    result = main_module.main(["audit", "verify", str(chain_path)])
+
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "Audit chain verification: PASS" in output
+    assert "Entries checked: 1" in output
+
+
+def test_audit_verify_chain_checks_signed_report_membership(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    report = _audit_report().sign("release-key", key_id="unit")
+    report_path = tmp_path / "audit.json"
+    chain_path = tmp_path / "audit-chain.json"
+    _write_report(report_path, report)
+    chain = AuditChain()
+    chain.append(report)
+    chain.write(chain_path)
+
+    result = main_module.main(
+        [
+            "audit",
+            "verify-chain",
+            str(chain_path),
+            "--report",
+            str(report_path),
+            "--key",
+            "release-key",
+        ]
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "Audit chain verification: PASS" in output
+    assert "Audit report verification: PASS" in output
+    assert "Audit report chain membership: PASS" in output
+
+
+def test_audit_verify_chain_reports_tampering_reason(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    chain = AuditChain()
+    chain.append(_audit_report())
+    payload = chain.to_dict()
+    payload["head_hash"] = hash_text("wrong head")
+    chain_path = tmp_path / "audit-chain.json"
+    chain_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = main_module.main(["audit", "verify-chain", str(chain_path)])
+
+    assert result == 1
+    output = capsys.readouterr().out
+    assert "Audit chain verification: FAIL" in output
+    assert "Reason:" in output
+    assert "retained head hash" in output
+
+
+def test_audit_verify_chain_json_uses_one_success_envelope(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    chain_path = tmp_path / "audit-chain.json"
+    chain = AuditChain()
+    chain.append(_audit_report())
+    chain.write(chain_path)
+
+    result = main_module.main(["audit", "verify-chain", str(chain_path), "--json"])
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["command"] == "audit verify-chain"
+    assert payload["data"]["verified"] is True
+    assert payload["data"]["chain"]["entries_checked"] == 1
 
 
 def test_audit_show_prints_phi_safe_summary(

--- a/tests/unit/core/test_audit_chain.py
+++ b/tests/unit/core/test_audit_chain.py
@@ -1,0 +1,267 @@
+"""Tests for PHI-safe, tamper-evident de-identification audit chains."""
+
+from __future__ import annotations
+
+import copy
+import json
+import socket
+from pathlib import Path
+
+import pytest
+
+from openmed.core.audit import AuditReport, AuditSpan, DetectorInfo, hash_text
+from openmed.core.audit_chain import (
+    AuditChain,
+    append_to_chain_file,
+    verify_chain,
+)
+
+
+def _report(name: str, phone: str) -> AuditReport:
+    original = f"Patient {name} called {phone} from North Clinic."
+    deidentified = "Patient [PERSON] called [PHONE] from [ORGANIZATION]."
+    name_start = original.index(name)
+    phone_start = original.index(phone)
+    return AuditReport(
+        policy="hipaa_safe_harbor",
+        resolved_profile={"method": "mask", "language": "en"},
+        detectors=[
+            DetectorInfo(
+                source="ml",
+                model_id="local-unit-model",
+                model_format="transformers",
+                metadata={"operator_note": f"reviewed {name}"},
+            )
+        ],
+        safety_sweep={"spans_added": 0},
+        spans=[
+            AuditSpan(
+                start=name_start,
+                end=name_start + len(name),
+                label="NAME",
+                canonical_label="PERSON",
+                sources=["ml"],
+                confidence=0.98,
+                threshold=0.7,
+                action="replace",
+                surrogate=f"Replacement for {name}",
+                text_hash=hash_text(name),
+                evidence={"matched_text": name, "clinic": "North Clinic"},
+                context={"before": "Patient ", "after": f" called {phone}"},
+            ),
+            AuditSpan(
+                start=phone_start,
+                end=phone_start + len(phone),
+                label="PHONE",
+                canonical_label="PHONE",
+                sources=["regex"],
+                confidence=1.0,
+                threshold=0.7,
+                action="mask",
+                surrogate="[PHONE]",
+                text_hash=hash_text(phone),
+            ),
+        ],
+        thresholds={"PERSON": 0.7, "PHONE": 0.7},
+        residual_risk={"review_note": f"No remaining reference to {name}"},
+        openmed_version="1.9.1",
+        manifest_hash=hash_text("unit manifest"),
+        document_length=len(original),
+        input_hash=hash_text(original),
+        deidentified_text_hash=hash_text(deidentified),
+    )
+
+
+def _three_entry_chain() -> AuditChain:
+    chain = AuditChain()
+    chain.append(_report("Alice Rivera", "555-0101"))
+    chain.append(_report("Benoit Martin", "555-0102"))
+    chain.append(_report("Chandra Patel", "555-0103"))
+    return chain
+
+
+def test_append_produces_a_verifiable_linked_chain() -> None:
+    first_report = _report("Alice Rivera", "555-0101")
+    second_report = _report("Benoit Martin", "555-0102")
+    chain = AuditChain()
+
+    first = chain.append(first_report)
+    second = chain.append(second_report)
+
+    assert first.sequence == 0
+    assert first.previous_hash == AuditChain.GENESIS_HASH
+    assert second.sequence == 1
+    assert second.previous_hash == first.entry_hash
+    assert second.matches_report(second_report)
+    assert chain.contains_report(first_report)
+    result = chain.verify()
+    assert result.valid
+    assert result.checked_entries == 2
+    assert result.reason == "chain is valid"
+    assert verify_chain(chain).is_valid
+
+
+def test_chain_round_trips_through_json_and_disk(tmp_path: Path) -> None:
+    chain = _three_entry_chain()
+    restored = AuditChain.from_json(chain.to_json())
+
+    assert restored.to_dict() == chain.to_dict()
+    assert restored.verify().valid
+
+    path = tmp_path / "audit-chain.json"
+    chain.write(path)
+    assert AuditChain.load(path).verify().valid
+
+
+def test_append_to_chain_file_preserves_existing_entries(tmp_path: Path) -> None:
+    path = tmp_path / "audit-chain.json"
+
+    first = append_to_chain_file(path, _report("Alice Rivera", "555-0101"))
+    second = append_to_chain_file(path, _report("Benoit Martin", "555-0102"))
+
+    restored = AuditChain.load(path)
+    assert first.sequence == 0
+    assert second.sequence == 1
+    assert len(restored.entries) == 2
+    assert restored.verify().valid
+
+
+def test_mutated_entry_fails_with_a_clear_reason() -> None:
+    payload = json.loads(_three_entry_chain().to_json())
+    payload["entries"][1]["spans"][0]["label"] = "PHONE"
+
+    result = AuditChain.from_dict(payload).verify()
+
+    assert not result.valid
+    assert result.entry_index == 1
+    assert "mutation detected" in result.reason
+    assert "hash mismatch" in result.reason
+
+
+def test_inserted_entry_fails_with_a_clear_reason() -> None:
+    payload = json.loads(_three_entry_chain().to_json())
+    payload["entries"].insert(1, copy.deepcopy(payload["entries"][0]))
+
+    result = AuditChain.from_dict(payload).verify()
+
+    assert not result.valid
+    assert "insertion detected" in result.reason
+
+
+def test_deleted_entry_fails_with_a_clear_reason() -> None:
+    payload = json.loads(_three_entry_chain().to_json())
+    payload["entries"].pop(1)
+
+    result = AuditChain.from_dict(payload).verify()
+
+    assert not result.valid
+    assert "deletion detected" in result.reason
+
+
+def test_reordered_entries_fail_with_a_clear_reason() -> None:
+    payload = json.loads(_three_entry_chain().to_json())
+    payload["entries"][0], payload["entries"][1] = (
+        payload["entries"][1],
+        payload["entries"][0],
+    )
+
+    result = AuditChain.from_dict(payload).verify()
+
+    assert not result.valid
+    assert "reordering detected" in result.reason
+
+
+def test_retained_head_detects_tail_deletion() -> None:
+    payload = json.loads(_three_entry_chain().to_json())
+    payload["entries"].pop()
+
+    result = AuditChain.from_dict(payload).verify()
+
+    assert not result.valid
+    assert "deletion detected" in result.reason
+
+
+def test_explicit_invalid_head_is_not_replaced_by_the_computed_head() -> None:
+    chain = _three_entry_chain()
+    restored = AuditChain(chain.entries, declared_head_hash="")
+
+    result = restored.verify()
+
+    assert not result.valid
+    assert "retained head hash" in result.reason
+
+
+def test_chain_serialization_excludes_raw_phi_and_unsafe_report_fields() -> None:
+    report = _report("Alice Rivera", "555-0101")
+    chain = AuditChain()
+    chain.append(report)
+
+    serialized = chain.to_json()
+
+    for plaintext in (
+        "Alice Rivera",
+        "555-0101",
+        "North Clinic",
+        "Replacement for",
+        "matched_text",
+        "operator_note",
+        "review_note",
+        "Patient ",
+    ):
+        assert plaintext not in serialized
+    assert set(chain.to_dict()["entries"][0]) == {
+        "sequence",
+        "previous_hash",
+        "report_hash",
+        "input_hash",
+        "deidentified_text_hash",
+        "spans",
+        "entry_hash",
+    }
+    assert set(chain.to_dict()["entries"][0]["spans"][0]) == {
+        "start",
+        "end",
+        "label",
+        "text_hash",
+    }
+
+
+def test_loading_rejects_unknown_fields_without_echoing_phi() -> None:
+    payload = json.loads(_three_entry_chain().to_json())
+    phi_field = "Alice Rivera"
+    payload["entries"][0][phi_field] = "unsafe"
+
+    with pytest.raises(ValueError, match="unsupported fields") as exc_info:
+        AuditChain.from_dict(payload)
+
+    assert phi_field not in str(exc_info.value)
+
+
+def test_loading_rejects_unknown_version_without_echoing_phi() -> None:
+    payload = json.loads(_three_entry_chain().to_json())
+    phi_version = "Alice Rivera"
+    payload["version"] = phi_version
+
+    with pytest.raises(ValueError, match="unsupported audit chain version") as exc_info:
+        AuditChain.from_dict(payload)
+
+    assert phi_version not in str(exc_info.value)
+
+
+def test_append_rejects_a_report_with_a_tampered_repro_hash() -> None:
+    report = _report("Alice Rivera", "555-0101")
+    report.policy = "tampered"
+
+    with pytest.raises(ValueError, match="invalid repro_hash"):
+        AuditChain().append(report)
+
+
+def test_verification_is_fully_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    chain = AuditChain.from_json(_three_entry_chain().to_json())
+
+    def deny_network(*args: object, **kwargs: object) -> None:
+        raise AssertionError("network access is forbidden during chain verification")
+
+    monkeypatch.setattr(socket, "socket", deny_network)
+
+    assert chain.verify().valid


### PR DESCRIPTION
## Description

Adds a PHI-safe, tamper-evident hash chain for ordered de-identification audit reports. Each entry commits to the previous entry, retained count and head anchors detect truncation, and the existing audit verifier can validate chain documents fully offline.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing behavior)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add a versioned audit-chain format with PHI-safe entries, atomic persistence, report membership checks, and clear insertion, deletion, reordering, and mutation failures.
- Extend audit verification with automatic chain detection and an explicit `verify-chain` command.
- Preserve the current CLI text and machine-readable output contracts after rebasing.
- Prevent malformed chain errors from reflecting attacker-controlled field names or version values that could contain PHI.
- Document the storage and security boundaries and add offline, tamper, raw-PHI guard, persistence, and CLI coverage.

## Testing

- [x] Added tests proving the feature and privacy guards work.
- [x] Full repository suite passes locally: 6,095 passed and 48 skipped.
- [x] Broader audit and CLI scope passes: 85 passed.
- [x] Strict documentation, formatting, lint, type checks, pre-commit, package builds, and wheel-content verification pass.

## Documentation

- [x] Added a security guide covering creation, CLI verification, stored fields, and the trust boundary.
- [x] Added docstrings to new public functions and classes.
- [ ] The changelog is unchanged; release notes can include this feature when it ships.

## Code Quality

- [x] Repository formatting, lint, and format verification gates pass.
- [x] Performed a self-review of the complete diff.
- [x] Preserved one success/error envelope for scriptable CLI output.
- [x] Added no dependencies and no raw-PHI fields.

## Dependencies

- [x] No new package dependencies were added.
- [x] The OM-011 signed-audit prerequisite is complete in #85/#90.

## Checklist

- [x] Read the contributing guidelines.
- [x] Used a clear, focused commit.
- [x] Kept the branch scoped to OM-513.

## Related Issues

Closes #871

## Screenshots/Examples

Not applicable; this change adds a library and CLI integrity-verification surface.
