### PR TITLE
Add a HIPAA Safe Harbor attestation report generator

### DIFF
--- a/docs/compliance/hipaa-safe-harbor-attestation.md
+++ b/docs/compliance/hipaa-safe-harbor-attestation.md
@@ -30,6 +30,8 @@ openmed compliance safe-harbor run-audit.json \
 ```
 
 Omit `--output` to print the JSON artifact to standard output.
+Add `--json` to wrap stdout in OpenMed's uniform machine-readable command
+envelope; the attestation is returned in its `data` field.
 The command rejects an audit report whose reproducibility hash no longer
 matches its contents.
 

--- a/docs/compliance/hipaa-safe-harbor-attestation.md
+++ b/docs/compliance/hipaa-safe-harbor-attestation.md
@@ -1,0 +1,88 @@
+# HIPAA Safe Harbor Attestation
+
+OpenMed can turn a de-identification audit report into a PHI-safe evidence
+artifact covering all 18 HIPAA Safe Harbor identifier categories. The
+attestation records aggregate detection counts, observed actions, configured
+policy actions, and hashes. It does not copy source text, span offsets,
+surrogates, context, or detector evidence from the audit report.
+
+The artifact is evidence from one run. It is not a certification, legal
+sign-off, or substitute for the Safe Harbor “actual knowledge” assessment.
+
+## Generate an attestation offline
+
+First create an audit report during local de-identification:
+
+```bash
+openmed deid \
+  --input note.txt \
+  --output run-audit.json \
+  --policy hipaa_safe_harbor \
+  --audit
+```
+
+Then generate the attestation. Both commands run locally; the attestation
+command makes no network requests:
+
+```bash
+openmed compliance safe-harbor run-audit.json \
+  --output safe-harbor-attestation.json
+```
+
+Omit `--output` to print the JSON artifact to standard output.
+The command rejects an audit report whose reproducibility hash no longer
+matches its contents.
+
+## Report contents
+
+The report contains:
+
+- `source_report_hash`, which ties the evidence to the source audit run;
+- `attestation_hash`, which makes the generated artifact independently
+  reproducible;
+- exactly 18 ordered category records;
+- the canonical OpenMed labels mapped to each category;
+- the configured policy action for every mapped label;
+- aggregate detection and applied-action counts from the run; and
+- explicit residual-risk flags and reasons requiring qualified expert review.
+
+The report never includes raw span text, offsets, context, replacement values,
+surrogates, or per-detector evidence. Store and handle the source audit report
+under the controls appropriate for your deployment even though OpenMed audit
+reports are designed to be PHI-safe.
+
+## Coverage mapping
+
+The mapping is derived from `openmed.core.labels.LABEL_TO_HIPAA`, so the report
+stays aligned with the canonical label policy spine.
+
+| Safe Harbor category | Canonical label coverage |
+|---|---|
+| Names | `PERSON`, `FIRST_NAME`, `LAST_NAME`, `MIDDLE_NAME`, `PREFIX` |
+| Geographic subdivisions | `LOCATION`, `STREET_ADDRESS`, `BUILDING_NUMBER`, `ZIPCODE`, `GPS_COORDINATES`, `ORDINAL_DIRECTION` |
+| Date elements and ages over 89 | `DATE`, `DATE_OF_BIRTH`, `TIME`, `AGE` |
+| Telephone numbers | `PHONE` |
+| Fax numbers | No dedicated canonical mapping |
+| Email addresses | `EMAIL` |
+| Social Security numbers | `SSN` |
+| Medical record numbers | No dedicated canonical mapping |
+| Health plan beneficiary numbers | No dedicated canonical mapping |
+| Account numbers | Account and financial-identifier labels mapped by the canonical cross-map |
+| Certificate and license numbers | No dedicated canonical mapping |
+| Vehicle identifiers and serial numbers | `VIN`, `VEHICLE_REGISTRATION` |
+| Device identifiers and serial numbers | `MAC_ADDRESS`, `IMEI` |
+| Web URLs | `URL` |
+| IP addresses | `IP_ADDRESS` |
+| Biometric identifiers | No dedicated canonical mapping |
+| Full-face photographs and comparable images | No dedicated canonical mapping |
+| Other unique identifying numbers or codes | Remaining labels mapped to `UNIQUE_IDENTIFIER` by the canonical cross-map |
+
+Categories without a canonical mapping are always flagged as residual-risk
+items requiring qualified expert review. Specialized span producers can supply
+a valid `hipaa_safe_harbor_class` / `safe_harbor_class` tag or a Safe Harbor
+class in `regulatory_tags` to attribute a detection count more precisely. Such
+a tag does not turn an otherwise uncovered category into canonical detector
+coverage, so its residual-risk flag remains visible.
+
+The report also flags a covered category when any observed detection used the
+`keep` action.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - spaCy Pipeline Component: spacy-component.md
       - HL7 v2 De-identification: hl7v2-deidentification.md
       - Compliance Posture: compliance.md
+      - HIPAA Safe Harbor Attestation: compliance/hipaa-safe-harbor-attestation.md
       - Breach Notification Runbook: compliance/breach-notification-runbook.md
       - Breach Report Template: compliance/templates/breach-report-template.md
       - FHIR Interop Helpers: fhir-interop.md

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -1801,16 +1801,33 @@ def _handle_compliance_safe_harbor(args: argparse.Namespace) -> int:
     try:
         report = _load_audit_report(args.report)
         attestation = generate_safe_harbor_attestation(report)
-        rendered = f"{attestation.to_json()}\n"
-        if args.output is None:
-            sys.stdout.write(rendered)
-        else:
-            args.output.write_text(rendered, encoding="utf-8")
-            sys.stdout.write(f"Safe Harbor attestation written to: {args.output}\n")
     except (OSError, TypeError, ValueError) as exc:
-        sys.stderr.write(f"Failed to generate Safe Harbor attestation: {exc}\n")
-        return 1
-    return 0
+        raise CliError(
+            "Failed to generate Safe Harbor attestation.",
+            code="attestation_failed",
+            exit_code=EXIT_ERROR,
+        ) from exc
+
+    payload = attestation.to_dict()
+    if args.output is None:
+        return emit(args, payload, human=attestation.to_json())
+
+    try:
+        args.output.write_text(f"{attestation.to_json()}\n", encoding="utf-8")
+    except OSError as exc:
+        raise CliError(
+            "Failed to write Safe Harbor attestation.",
+            code="write_failed",
+            exit_code=EXIT_ERROR,
+        ) from exc
+    return emit(
+        args,
+        {
+            "output": str(args.output),
+            "attestation_hash": attestation.attestation_hash,
+        },
+        human=f"Safe Harbor attestation written to: {args.output}",
+    )
 
 
 def _load_audit_report(path: Path):

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -194,6 +194,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_redact_dataset_command(subparsers)
     _add_pii_command(subparsers)
     _add_audit_command(subparsers)
+    _add_compliance_command(subparsers)
     _add_risk_command(subparsers)
     _add_policy_command(subparsers)
     _add_fhir_command(subparsers)
@@ -750,6 +751,32 @@ def _add_audit_command(subparsers: argparse._SubParsersAction) -> None:
         help="Path to an audit report JSON file.",
     )
     show_parser.set_defaults(handler=_handle_audit_show)
+
+
+def _add_compliance_command(subparsers: argparse._SubParsersAction) -> None:
+    compliance_parser = subparsers.add_parser(
+        "compliance",
+        help="Generate local compliance evidence from OpenMed run artifacts.",
+    )
+    compliance_sub = compliance_parser.add_subparsers(dest="compliance_command")
+
+    safe_harbor_parser = compliance_sub.add_parser(
+        "safe-harbor",
+        help="Generate a HIPAA Safe Harbor attestation from an audit report.",
+    )
+    safe_harbor_parser.add_argument(
+        "report",
+        type=Path,
+        help="Path to a de-identification audit report JSON file.",
+    )
+    safe_harbor_parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="Optional path for the attestation JSON. Defaults to stdout.",
+    )
+    safe_harbor_parser.set_defaults(handler=_handle_compliance_safe_harbor)
 
 
 def _add_risk_command(subparsers: argparse._SubParsersAction) -> None:
@@ -1766,6 +1793,24 @@ def _audit_summary_payload(report: Any) -> dict[str, Any]:
         "action_counts": dict(sorted(action_counts.items())),
         "residual_risk": dict(report.residual_risk) if report.residual_risk else {},
     }
+
+
+def _handle_compliance_safe_harbor(args: argparse.Namespace) -> int:
+    from ..compliance.safe_harbor import generate_safe_harbor_attestation
+
+    try:
+        report = _load_audit_report(args.report)
+        attestation = generate_safe_harbor_attestation(report)
+        rendered = f"{attestation.to_json()}\n"
+        if args.output is None:
+            sys.stdout.write(rendered)
+        else:
+            args.output.write_text(rendered, encoding="utf-8")
+            sys.stdout.write(f"Safe Harbor attestation written to: {args.output}\n")
+    except (OSError, TypeError, ValueError) as exc:
+        sys.stderr.write(f"Failed to generate Safe Harbor attestation: {exc}\n")
+        return 1
+    return 0
 
 
 def _load_audit_report(path: Path):

--- a/openmed/compliance/__init__.py
+++ b/openmed/compliance/__init__.py
@@ -1,7 +1,8 @@
-"""GDPR compliance helpers (subject-access export, erasure companion).
+"""Local-first compliance reporting and subject-access helpers.
 
 This package hosts local-first, access-logged compliance workflows built on the
-surrogate vault and a tamper-evident audit chain.
+surrogate vault, de-identification audit reports, and a tamper-evident audit
+chain.
 """
 
 from .audit_chain import (
@@ -21,6 +22,16 @@ from .dsar import (
     plan_erasure,
     render_dsar_summary,
 )
+from .safe_harbor import (
+    SAFE_HARBOR_ATTESTATION_NOTICE,
+    SAFE_HARBOR_ATTESTATION_SCHEMA_VERSION,
+    SAFE_HARBOR_CATEGORY_LABELS,
+    SAFE_HARBOR_CATEGORY_ORDER,
+    SAFE_HARBOR_POLICY,
+    SafeHarborAttestation,
+    SafeHarborCategoryAttestation,
+    generate_safe_harbor_attestation,
+)
 
 __all__ = [
     "AuditRecord",
@@ -36,4 +47,12 @@ __all__ = [
     "assemble_dsar_package",
     "render_dsar_summary",
     "plan_erasure",
+    "SAFE_HARBOR_ATTESTATION_NOTICE",
+    "SAFE_HARBOR_ATTESTATION_SCHEMA_VERSION",
+    "SAFE_HARBOR_CATEGORY_LABELS",
+    "SAFE_HARBOR_CATEGORY_ORDER",
+    "SAFE_HARBOR_POLICY",
+    "SafeHarborAttestation",
+    "SafeHarborCategoryAttestation",
+    "generate_safe_harbor_attestation",
 ]

--- a/openmed/compliance/safe_harbor.py
+++ b/openmed/compliance/safe_harbor.py
@@ -1,0 +1,390 @@
+"""PHI-safe HIPAA Safe Harbor attestation reports.
+
+The generator in this module summarizes an existing de-identification audit
+report. It deliberately emits only canonical category metadata, aggregate
+counts, policy actions, and hashes. Source text, span offsets, context,
+surrogates, and detector evidence are never copied into the attestation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final
+
+from openmed.core.audit import stable_hash
+from openmed.core.labels import (
+    HIPAA_SAFE_HARBOR_CLASSES,
+    LABEL_TO_HIPAA,
+    normalize_label,
+)
+from openmed.core.policy import PolicyProfile, load_policy
+from openmed.core.schemas.span import ACTION_VALUES
+
+SAFE_HARBOR_POLICY: Final = "hipaa_safe_harbor"
+SAFE_HARBOR_ATTESTATION_SCHEMA_VERSION: Final = 1
+SAFE_HARBOR_ATTESTATION_NOTICE: Final = (
+    "This report is evidence from one OpenMed run, not a certification or legal "
+    "sign-off. Residual-risk items require qualified expert review."
+)
+
+# The regulatory order is meaningful and must not depend on frozenset ordering.
+SAFE_HARBOR_CATEGORY_ORDER: Final[tuple[str, ...]] = (
+    "NAME",
+    "GEOGRAPHIC_SUBDIVISION",
+    "DATE_ELEMENT",
+    "TELEPHONE_NUMBER",
+    "FAX_NUMBER",
+    "EMAIL_ADDRESS",
+    "SOCIAL_SECURITY_NUMBER",
+    "MEDICAL_RECORD_NUMBER",
+    "HEALTH_PLAN_BENEFICIARY_NUMBER",
+    "ACCOUNT_NUMBER",
+    "CERTIFICATE_LICENSE_NUMBER",
+    "VEHICLE_IDENTIFIER",
+    "DEVICE_IDENTIFIER",
+    "URL",
+    "IP_ADDRESS",
+    "BIOMETRIC_IDENTIFIER",
+    "FULL_FACE_PHOTO",
+    "UNIQUE_IDENTIFIER",
+)
+
+_CATEGORY_NAMES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "NAME": "Names",
+        "GEOGRAPHIC_SUBDIVISION": "Geographic subdivisions",
+        "DATE_ELEMENT": "Date elements and ages over 89",
+        "TELEPHONE_NUMBER": "Telephone numbers",
+        "FAX_NUMBER": "Fax numbers",
+        "EMAIL_ADDRESS": "Email addresses",
+        "SOCIAL_SECURITY_NUMBER": "Social Security numbers",
+        "MEDICAL_RECORD_NUMBER": "Medical record numbers",
+        "HEALTH_PLAN_BENEFICIARY_NUMBER": "Health plan beneficiary numbers",
+        "ACCOUNT_NUMBER": "Account numbers",
+        "CERTIFICATE_LICENSE_NUMBER": "Certificate and license numbers",
+        "VEHICLE_IDENTIFIER": "Vehicle identifiers and serial numbers",
+        "DEVICE_IDENTIFIER": "Device identifiers and serial numbers",
+        "URL": "Web URLs",
+        "IP_ADDRESS": "IP addresses",
+        "BIOMETRIC_IDENTIFIER": "Biometric identifiers",
+        "FULL_FACE_PHOTO": "Full-face photographs and comparable images",
+        "UNIQUE_IDENTIFIER": "Other unique identifying numbers or codes",
+    }
+)
+
+_labels_by_category: dict[str, tuple[str, ...]] = {
+    category: tuple(
+        sorted(
+            label
+            for label, mapped_category in LABEL_TO_HIPAA.items()
+            if mapped_category == category
+        )
+    )
+    for category in SAFE_HARBOR_CATEGORY_ORDER
+}
+SAFE_HARBOR_CATEGORY_LABELS: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType(
+    _labels_by_category
+)
+
+_SHA256_RE: Final = re.compile(r"^sha256:[0-9a-f]{64}$")
+_EXPLICIT_CATEGORY_KEYS: Final[tuple[str, ...]] = (
+    "hipaa_safe_harbor_class",
+    "safe_harbor_class",
+)
+
+
+def _validate_category_table() -> None:
+    categories = set(SAFE_HARBOR_CATEGORY_ORDER)
+    if len(SAFE_HARBOR_CATEGORY_ORDER) != 18:
+        raise RuntimeError("Safe Harbor attestation must enumerate 18 categories")
+    if categories != set(HIPAA_SAFE_HARBOR_CLASSES):
+        raise RuntimeError("Safe Harbor attestation categories differ from core labels")
+    if categories != set(_CATEGORY_NAMES):
+        raise RuntimeError("Safe Harbor category names are incomplete")
+
+
+_validate_category_table()
+
+
+@dataclass(frozen=True)
+class SafeHarborCategoryAttestation:
+    """Aggregate evidence for one of the 18 Safe Harbor categories."""
+
+    ordinal: int
+    category: str
+    name: str
+    mapped_labels: tuple[str, ...]
+    policy_actions: Mapping[str, str]
+    detection_count: int
+    applied_action_counts: Mapping[str, int]
+    residual_risk: bool
+    residual_risk_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-compatible category record."""
+
+        return {
+            "ordinal": self.ordinal,
+            "category": self.category,
+            "name": self.name,
+            "mapped_labels": list(self.mapped_labels),
+            "policy_actions": dict(sorted(self.policy_actions.items())),
+            "detection_count": self.detection_count,
+            "applied_action_counts": dict(sorted(self.applied_action_counts.items())),
+            "residual_risk": self.residual_risk,
+            "residual_risk_reason": self.residual_risk_reason,
+        }
+
+
+@dataclass(frozen=True)
+class SafeHarborAttestation:
+    """A PHI-safe aggregate attestation for one de-identification run."""
+
+    source_report_hash: str
+    policy: str
+    categories: tuple[SafeHarborCategoryAttestation, ...]
+    schema_version: int = SAFE_HARBOR_ATTESTATION_SCHEMA_VERSION
+    report_type: str = "hipaa_safe_harbor_attestation"
+    notice: str = SAFE_HARBOR_ATTESTATION_NOTICE
+
+    @property
+    def total_detection_count(self) -> int:
+        """Return the number of detections summarized across all categories."""
+
+        return sum(category.detection_count for category in self.categories)
+
+    @property
+    def residual_risk_categories(self) -> tuple[str, ...]:
+        """Return categories that require expert review."""
+
+        return tuple(
+            category.category for category in self.categories if category.residual_risk
+        )
+
+    @property
+    def requires_expert_determination(self) -> bool:
+        """Whether one or more category records carry residual risk."""
+
+        return bool(self.residual_risk_categories)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "report_type": self.report_type,
+            "source_report_hash": self.source_report_hash,
+            "policy": self.policy,
+            "summary": {
+                "category_count": len(self.categories),
+                "detection_count": self.total_detection_count,
+                "residual_risk_category_count": len(self.residual_risk_categories),
+                "requires_expert_determination": (self.requires_expert_determination),
+            },
+            "categories": [category.to_dict() for category in self.categories],
+            "notice": self.notice,
+        }
+
+    @property
+    def attestation_hash(self) -> str:
+        """Return the stable hash of the attestation payload."""
+
+        return stable_hash(self._payload())
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-compatible attestation."""
+
+        return {**self._payload(), "attestation_hash": self.attestation_hash}
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        """Serialize the attestation without exposing source span content."""
+
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=indent,
+            sort_keys=True,
+        )
+
+
+def generate_safe_harbor_attestation(
+    audit_report: Any,
+) -> SafeHarborAttestation:
+    """Generate an attestation from an audit report or compatible mapping.
+
+    The input must expose ``spans`` and may expose ``policy`` and
+    ``repro_hash`` either as mapping keys or object attributes. Every span must
+    contain a canonical/source label. Observed ``action`` values are counted;
+    a missing action falls back to the selected policy's configured action.
+
+    A span can override the canonical label-to-category fallback with a valid
+    ``hipaa_safe_harbor_class`` or ``safe_harbor_class`` in its top-level
+    fields, ``evidence``, or ``metadata``. ``regulatory_tags`` are also
+    supported. This lets specialized detectors distinguish categories such as
+    fax numbers while preserving the canonical ``PHONE`` label.
+    """
+
+    payload = _report_payload(audit_report)
+    integrity_check = getattr(audit_report, "repro_hash_matches", None)
+    if callable(integrity_check) and not integrity_check():
+        raise ValueError("audit report reproducibility hash does not match")
+    spans = _report_value(audit_report, "spans")
+    if isinstance(spans, (str, bytes)) or not isinstance(spans, Iterable):
+        raise TypeError("audit report spans must be an iterable of span records")
+
+    policy_name = str(_report_value(audit_report, "policy", "") or "")
+    if not policy_name:
+        raise ValueError("audit report must identify its de-identification policy")
+    profile = load_policy(policy_name)
+    if profile.name != SAFE_HARBOR_POLICY:
+        raise ValueError(
+            "Safe Harbor attestations require the hipaa_safe_harbor policy"
+        )
+
+    source_report_hash = _source_report_hash(audit_report, payload)
+    detection_counts: Counter[str] = Counter()
+    action_counts: dict[str, Counter[str]] = {
+        category: Counter() for category in SAFE_HARBOR_CATEGORY_ORDER
+    }
+
+    for span in spans:
+        canonical_label = _canonical_span_label(span)
+        category = _explicit_span_category(span) or LABEL_TO_HIPAA[canonical_label]
+        action = str(_span_value(span, "action", "") or "")
+        if not action:
+            action = profile.action_for(canonical_label)
+        if action not in ACTION_VALUES:
+            raise ValueError(f"unsupported audit span action: {action!r}")
+        detection_counts[category] += 1
+        action_counts[category][action] += 1
+
+    categories = tuple(
+        _category_attestation(
+            ordinal=ordinal,
+            category=category,
+            profile=profile,
+            detection_count=detection_counts[category],
+            action_counts=action_counts[category],
+        )
+        for ordinal, category in enumerate(SAFE_HARBOR_CATEGORY_ORDER, start=1)
+    )
+    return SafeHarborAttestation(
+        source_report_hash=source_report_hash,
+        policy=profile.name,
+        categories=categories,
+    )
+
+
+def _category_attestation(
+    *,
+    ordinal: int,
+    category: str,
+    profile: PolicyProfile,
+    detection_count: int,
+    action_counts: Mapping[str, int],
+) -> SafeHarborCategoryAttestation:
+    labels = SAFE_HARBOR_CATEGORY_LABELS[category]
+    policy_actions = {label: profile.action_for(label) for label in labels}
+    reasons: list[str] = []
+    if not labels:
+        reasons.append(
+            "No canonical OpenMed labels map to this category; qualified "
+            "expert review is required."
+        )
+    if action_counts.get("keep", 0):
+        reasons.append(
+            "One or more detections used the keep action; qualified expert "
+            "review is required."
+        )
+    return SafeHarborCategoryAttestation(
+        ordinal=ordinal,
+        category=category,
+        name=_CATEGORY_NAMES[category],
+        mapped_labels=labels,
+        policy_actions=policy_actions,
+        detection_count=detection_count,
+        applied_action_counts=dict(action_counts),
+        residual_risk=bool(reasons),
+        residual_risk_reason=" ".join(reasons) or None,
+    )
+
+
+def _report_payload(report: Any) -> Mapping[str, Any]:
+    if isinstance(report, Mapping):
+        return report
+    to_dict = getattr(report, "to_dict", None)
+    if callable(to_dict):
+        payload = to_dict()
+        if isinstance(payload, Mapping):
+            return payload
+    raise TypeError("audit report must be a mapping or expose to_dict()")
+
+
+def _report_value(report: Any, name: str, default: Any = None) -> Any:
+    if isinstance(report, Mapping):
+        return report.get(name, default)
+    return getattr(report, name, default)
+
+
+def _span_value(span: Any, name: str, default: Any = None) -> Any:
+    if isinstance(span, Mapping):
+        return span.get(name, default)
+    return getattr(span, name, default)
+
+
+def _canonical_span_label(span: Any) -> str:
+    value = _span_value(span, "canonical_label") or _span_value(span, "label")
+    if not value:
+        raise ValueError("audit span must include canonical_label or label")
+    try:
+        return normalize_label(str(value))
+    except (KeyError, ValueError) as exc:
+        raise ValueError(f"unsupported audit span label: {value!r}") from exc
+
+
+def _explicit_span_category(span: Any) -> str | None:
+    for container in (
+        span,
+        _span_value(span, "evidence", {}),
+        _span_value(span, "metadata", {}),
+    ):
+        if not isinstance(container, Mapping):
+            continue
+        for key in _EXPLICIT_CATEGORY_KEYS:
+            if key not in container:
+                continue
+            category = str(container[key])
+            if category not in HIPAA_SAFE_HARBOR_CLASSES:
+                raise ValueError(f"unknown HIPAA Safe Harbor category: {category!r}")
+            return category
+
+    tags = _span_value(span, "regulatory_tags", ())
+    if isinstance(tags, Sequence) and not isinstance(tags, (str, bytes)):
+        for tag in tags:
+            category = str(tag)
+            if category in HIPAA_SAFE_HARBOR_CLASSES:
+                return category
+    return None
+
+
+def _source_report_hash(report: Any, payload: Mapping[str, Any]) -> str:
+    candidate = str(_report_value(report, "repro_hash", "") or "")
+    if _SHA256_RE.fullmatch(candidate):
+        return candidate
+    return stable_hash(payload)
+
+
+__all__ = [
+    "SAFE_HARBOR_ATTESTATION_NOTICE",
+    "SAFE_HARBOR_ATTESTATION_SCHEMA_VERSION",
+    "SAFE_HARBOR_CATEGORY_LABELS",
+    "SAFE_HARBOR_CATEGORY_ORDER",
+    "SAFE_HARBOR_POLICY",
+    "SafeHarborAttestation",
+    "SafeHarborCategoryAttestation",
+    "generate_safe_harbor_attestation",
+]

--- a/openmed/compliance/safe_harbor.py
+++ b/openmed/compliance/safe_harbor.py
@@ -16,8 +16,9 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, Final
 
-from openmed.core.audit import stable_hash
+from openmed.core.audit import stable_hash, verify_repro_hash
 from openmed.core.labels import (
+    CANONICAL_LABELS,
     HIPAA_SAFE_HARBOR_CLASSES,
     LABEL_TO_HIPAA,
     normalize_label,
@@ -229,9 +230,6 @@ def generate_safe_harbor_attestation(
     """
 
     payload = _report_payload(audit_report)
-    integrity_check = getattr(audit_report, "repro_hash_matches", None)
-    if callable(integrity_check) and not integrity_check():
-        raise ValueError("audit report reproducibility hash does not match")
     spans = _report_value(audit_report, "spans")
     if isinstance(spans, (str, bytes)) or not isinstance(spans, Iterable):
         raise TypeError("audit report spans must be an iterable of span records")
@@ -258,7 +256,7 @@ def generate_safe_harbor_attestation(
         if not action:
             action = profile.action_for(canonical_label)
         if action not in ACTION_VALUES:
-            raise ValueError(f"unsupported audit span action: {action!r}")
+            raise ValueError("audit span contains an unsupported action")
         detection_counts[category] += 1
         action_counts[category][action] += 1
 
@@ -337,13 +335,17 @@ def _span_value(span: Any, name: str, default: Any = None) -> Any:
 
 
 def _canonical_span_label(span: Any) -> str:
-    value = _span_value(span, "canonical_label") or _span_value(span, "label")
+    canonical_value = _span_value(span, "canonical_label")
+    if canonical_value:
+        canonical_label = str(canonical_value)
+        if canonical_label not in CANONICAL_LABELS:
+            raise ValueError("audit span contains an unsupported label")
+        return canonical_label
+
+    value = _span_value(span, "label")
     if not value:
         raise ValueError("audit span must include canonical_label or label")
-    try:
-        return normalize_label(str(value))
-    except (KeyError, ValueError) as exc:
-        raise ValueError(f"unsupported audit span label: {value!r}") from exc
+    return normalize_label(str(value))
 
 
 def _explicit_span_category(span: Any) -> str | None:
@@ -359,7 +361,7 @@ def _explicit_span_category(span: Any) -> str | None:
                 continue
             category = str(container[key])
             if category not in HIPAA_SAFE_HARBOR_CLASSES:
-                raise ValueError(f"unknown HIPAA Safe Harbor category: {category!r}")
+                raise ValueError("audit span contains an unknown Safe Harbor category")
             return category
 
     tags = _span_value(span, "regulatory_tags", ())
@@ -373,9 +375,22 @@ def _explicit_span_category(span: Any) -> str | None:
 
 def _source_report_hash(report: Any, payload: Mapping[str, Any]) -> str:
     candidate = str(_report_value(report, "repro_hash", "") or "")
-    if _SHA256_RE.fullmatch(candidate):
-        return candidate
-    return stable_hash(payload)
+    if not candidate:
+        return stable_hash(payload)
+    if not _SHA256_RE.fullmatch(candidate):
+        raise ValueError("audit report reproducibility hash is invalid")
+
+    integrity_check = getattr(report, "repro_hash_matches", None)
+    if callable(integrity_check):
+        integrity_ok = bool(integrity_check())
+    else:
+        try:
+            integrity_ok = verify_repro_hash(payload)
+        except (TypeError, ValueError):
+            integrity_ok = False
+    if not integrity_ok:
+        raise ValueError("audit report reproducibility hash does not match")
+    return candidate
 
 
 __all__ = [

--- a/tests/unit/compliance/test_safe_harbor.py
+++ b/tests/unit/compliance/test_safe_harbor.py
@@ -147,18 +147,49 @@ def test_attestation_serialization_contains_no_raw_phi() -> None:
 
 
 def test_attestation_rejects_untrusted_action_text() -> None:
-    with pytest.raises(ValueError, match="unsupported audit span action"):
+    untrusted = "raw synthetic patient value"
+    with pytest.raises(ValueError, match="unsupported action") as error:
         generate_safe_harbor_attestation(
             {
                 "policy": "hipaa_safe_harbor",
                 "spans": [
                     {
                         "canonical_label": "EMAIL",
-                        "action": "raw synthetic patient value",
+                        "action": untrusted,
                     }
                 ],
             }
         )
+    assert untrusted not in str(error.value)
+
+
+@pytest.mark.parametrize(
+    ("span", "message"),
+    [
+        (
+            {"canonical_label": "synthetic patient value", "action": "mask"},
+            "unsupported label",
+        ),
+        (
+            {
+                "canonical_label": "EMAIL",
+                "action": "mask",
+                "safe_harbor_class": "synthetic patient value",
+            },
+            "unknown Safe Harbor category",
+        ),
+    ],
+)
+def test_attestation_errors_do_not_echo_untrusted_fields(
+    span: dict[str, str],
+    message: str,
+) -> None:
+    untrusted = "synthetic patient value"
+    with pytest.raises(ValueError, match=message) as error:
+        generate_safe_harbor_attestation(
+            {"policy": "hipaa_safe_harbor", "spans": [span]}
+        )
+    assert untrusted not in str(error.value)
 
 
 def test_attestation_rejects_tampered_audit_report() -> None:
@@ -167,6 +198,19 @@ def test_attestation_rejects_tampered_audit_report() -> None:
 
     with pytest.raises(ValueError, match="reproducibility hash does not match"):
         generate_safe_harbor_attestation(audit_report)
+
+
+def test_attestation_rejects_forged_mapping_repro_hash() -> None:
+    forged_hash = hash_text("unrelated audit payload")
+
+    with pytest.raises(ValueError, match="reproducibility hash does not match"):
+        generate_safe_harbor_attestation(
+            {
+                "policy": "hipaa_safe_harbor",
+                "spans": [],
+                "repro_hash": forged_hash,
+            }
+        )
 
 
 def test_keep_action_adds_residual_risk_to_a_covered_category() -> None:
@@ -208,6 +252,42 @@ def test_cli_emits_attestation_offline(
     assert SYNTHETIC_NAME not in json.dumps(payload)
 
 
+def test_cli_stdout_uses_json_envelope_when_requested(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    audit_path = tmp_path / "audit.json"
+    audit_path.write_text(_audit_report().to_json() + "\n", encoding="utf-8")
+
+    result = main_module.main(["compliance", "safe-harbor", str(audit_path), "--json"])
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["command"] == "compliance safe-harbor"
+    assert payload["data"]["report_type"] == "hipaa_safe_harbor_attestation"
+
+
+def test_cli_failure_does_not_echo_untrusted_audit_fields(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    untrusted = "synthetic patient value"
+    audit = _audit_report().to_dict()
+    audit["spans"][0]["action"] = untrusted
+    audit_path = tmp_path / "audit.json"
+    audit_path.write_text(json.dumps(audit), encoding="utf-8")
+
+    result = main_module.main(["compliance", "safe-harbor", str(audit_path), "--json"])
+
+    assert result == 1
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "attestation_failed"
+    assert untrusted not in output
+
+
 def test_cli_rejects_invalid_audit_input(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -218,4 +298,4 @@ def test_cli_rejects_invalid_audit_input(
     result = main_module.main(["compliance", "safe-harbor", str(audit_path)])
 
     assert result == 1
-    assert "Failed to generate Safe Harbor attestation" in capsys.readouterr().err
+    assert "Failed to generate Safe Harbor attestation." in capsys.readouterr().err

--- a/tests/unit/compliance/test_safe_harbor.py
+++ b/tests/unit/compliance/test_safe_harbor.py
@@ -1,0 +1,221 @@
+"""Tests for HIPAA Safe Harbor attestation reporting."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.cli import main_module
+from openmed.compliance import (
+    SAFE_HARBOR_CATEGORY_LABELS,
+    SAFE_HARBOR_CATEGORY_ORDER,
+    SafeHarborAttestation,
+    generate_safe_harbor_attestation,
+)
+from openmed.core.audit import AuditReport, AuditSpan, hash_text
+from openmed.core.labels import HIPAA_SAFE_HARBOR_CLASSES, LABEL_TO_HIPAA
+
+SYNTHETIC_NAME = "Alex Rivers"
+SYNTHETIC_FAX = "555-010-7788"
+
+
+def _span(
+    *,
+    start: int,
+    surface: str,
+    label: str,
+    action: str = "mask",
+    safe_harbor_class: str | None = None,
+) -> AuditSpan:
+    evidence = {"synthetic": True}
+    if safe_harbor_class is not None:
+        evidence["hipaa_safe_harbor_class"] = safe_harbor_class
+    return AuditSpan(
+        start=start,
+        end=start + len(surface),
+        label=label,
+        canonical_label=label,
+        sources=["synthetic"],
+        confidence=1.0,
+        threshold=0.7,
+        action=action,
+        surrogate=f"[{label}]",
+        text_hash=hash_text(surface),
+        evidence=evidence,
+    )
+
+
+def _audit_report() -> AuditReport:
+    spans = [
+        _span(start=0, surface=SYNTHETIC_NAME, label="PERSON"),
+        _span(start=20, surface="Jordan Lake", label="PERSON"),
+        _span(
+            start=40,
+            surface=SYNTHETIC_FAX,
+            label="PHONE",
+            safe_harbor_class="FAX_NUMBER",
+        ),
+        _span(start=60, surface="123-45-6789", label="SSN", action="hash"),
+    ]
+    return AuditReport(
+        policy="hipaa_safe_harbor",
+        resolved_profile={"method": "mask"},
+        detectors=[],
+        safety_sweep={},
+        spans=spans,
+        thresholds={},
+        residual_risk={},
+        openmed_version="test",
+        manifest_hash=hash_text("synthetic-manifest"),
+        document_length=100,
+        input_hash=hash_text("synthetic-input"),
+        deidentified_text_hash=hash_text("synthetic-output"),
+    )
+
+
+def _categories(report: SafeHarborAttestation) -> dict[str, object]:
+    return {category.category: category for category in report.categories}
+
+
+def test_category_mapping_enumerates_all_18_core_classes() -> None:
+    assert len(SAFE_HARBOR_CATEGORY_ORDER) == 18
+    assert set(SAFE_HARBOR_CATEGORY_ORDER) == HIPAA_SAFE_HARBOR_CLASSES
+    assert set(SAFE_HARBOR_CATEGORY_LABELS) == HIPAA_SAFE_HARBOR_CLASSES
+
+    reverse_pairs = {
+        (label, category)
+        for category, labels in SAFE_HARBOR_CATEGORY_LABELS.items()
+        for label in labels
+    }
+    assert reverse_pairs == set(LABEL_TO_HIPAA.items())
+
+
+def test_attestation_reports_counts_actions_and_policy_mapping() -> None:
+    report = generate_safe_harbor_attestation(_audit_report())
+    categories = _categories(report)
+
+    assert isinstance(report, SafeHarborAttestation)
+    assert len(report.categories) == 18
+    assert report.total_detection_count == 4
+
+    names = categories["NAME"]
+    assert names.detection_count == 2
+    assert names.applied_action_counts == {"mask": 2}
+    assert names.policy_actions["PERSON"] == "mask"
+
+    fax = categories["FAX_NUMBER"]
+    assert fax.detection_count == 1
+    assert fax.applied_action_counts == {"mask": 1}
+
+    ssn = categories["SOCIAL_SECURITY_NUMBER"]
+    assert ssn.detection_count == 1
+    assert ssn.applied_action_counts == {"hash": 1}
+
+
+def test_uncovered_categories_are_residual_risk_items() -> None:
+    report = generate_safe_harbor_attestation(_audit_report())
+    categories = _categories(report)
+    uncovered = {
+        category
+        for category, labels in SAFE_HARBOR_CATEGORY_LABELS.items()
+        if not labels
+    }
+
+    assert uncovered
+    assert report.requires_expert_determination is True
+    assert set(report.residual_risk_categories) == uncovered
+    for category in uncovered:
+        item = categories[category]
+        assert item.residual_risk is True
+        assert "expert review" in item.residual_risk_reason
+
+
+def test_attestation_serialization_contains_no_raw_phi() -> None:
+    report = generate_safe_harbor_attestation(_audit_report())
+    rendered = report.to_json()
+    payload = json.loads(rendered)
+
+    assert SYNTHETIC_NAME not in rendered
+    assert SYNTHETIC_FAX not in rendered
+    assert "surrogate" not in rendered
+    assert "context" not in rendered
+    assert payload["source_report_hash"].startswith("sha256:")
+    assert payload["attestation_hash"].startswith("sha256:")
+    assert payload["summary"]["category_count"] == 18
+
+
+def test_attestation_rejects_untrusted_action_text() -> None:
+    with pytest.raises(ValueError, match="unsupported audit span action"):
+        generate_safe_harbor_attestation(
+            {
+                "policy": "hipaa_safe_harbor",
+                "spans": [
+                    {
+                        "canonical_label": "EMAIL",
+                        "action": "raw synthetic patient value",
+                    }
+                ],
+            }
+        )
+
+
+def test_attestation_rejects_tampered_audit_report() -> None:
+    audit_report = _audit_report()
+    audit_report.repro_hash = hash_text("stale-audit-payload")
+
+    with pytest.raises(ValueError, match="reproducibility hash does not match"):
+        generate_safe_harbor_attestation(audit_report)
+
+
+def test_keep_action_adds_residual_risk_to_a_covered_category() -> None:
+    report = generate_safe_harbor_attestation(
+        {
+            "policy": "hipaa_safe_harbor",
+            "spans": [{"canonical_label": "EMAIL", "action": "keep"}],
+        }
+    )
+    email = _categories(report)["EMAIL_ADDRESS"]
+
+    assert email.residual_risk is True
+    assert "keep action" in email.residual_risk_reason
+
+
+def test_cli_emits_attestation_offline(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    audit_path = tmp_path / "audit.json"
+    output_path = tmp_path / "safe-harbor-attestation.json"
+    audit_path.write_text(_audit_report().to_json() + "\n", encoding="utf-8")
+
+    result = main_module.main(
+        [
+            "compliance",
+            "safe-harbor",
+            str(audit_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert result == 0
+    assert str(output_path) in capsys.readouterr().out
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["report_type"] == "hipaa_safe_harbor_attestation"
+    assert payload["summary"]["category_count"] == 18
+    assert SYNTHETIC_NAME not in json.dumps(payload)
+
+
+def test_cli_rejects_invalid_audit_input(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    audit_path = tmp_path / "invalid.json"
+    audit_path.write_text("{}", encoding="utf-8")
+
+    result = main_module.main(["compliance", "safe-harbor", str(audit_path)])
+
+    assert result == 1
+    assert "Failed to generate Safe Harbor attestation" in capsys.readouterr().err


### PR DESCRIPTION
## Description
Adds a local HIPAA Safe Harbor attestation generator over PHI-safe de-identification audit reports. The artifact enumerates all 18 identifier categories, maps canonical labels and policy actions, aggregates detections and applied actions, flags uncovered or kept categories for expert review, and binds the result to verified source and attestation hashes without exposing span content.

## Type of Change
- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made
- Added the Safe Harbor category mapping and deterministic attestation schema.
- Added `openmed compliance safe-harbor` for offline JSON generation, including the uniform `--json` command envelope.
- Rejects forged audit-report hashes and keeps untrusted audit fields out of user-facing errors.
- Added privacy, integrity, residual-risk, mapping, and CLI coverage.
- Added usage and coverage documentation to the docs navigation.

## Testing
- [x] `.venv/bin/python -m pytest tests/ -q` — 6111 passed, 48 skipped
- [x] Focused audit/compliance/CLI suite — 41 passed
- [x] `make format`
- [x] `make lint`
- [x] `make format-check`
- [x] `make type-check`
- [x] `make docs-build`
- [x] `python3 -m build`
- [x] Scoped pre-commit validation for all PR files

## Documentation
- [x] Added the HIPAA Safe Harbor attestation guide.
- [x] Added Google-style docstrings for the public API.
- [x] No changelog update required for this focused feature PR.

## Dependencies
- [x] No new dependencies.

## Related Issues
Closes #872

## Screenshots/Examples
The documentation includes offline CLI examples and the emitted JSON contract.
