### PR TITLE
Add clinical coreference resolution linking entity mentions and pronouns

### DIFF
--- a/docs/clinical/coreference.md
+++ b/docs/clinical/coreference.md
@@ -83,7 +83,9 @@ interfaces can recover a chain without storing a raw mention surface.
 Mentions are processed in document order, and a reference can link only to an
 earlier compatible mention. This antecedent-only rule rejects cataphora such as
 "It resolved before the rash was documented." A pronoun with no antecedent
-remains a singleton chain.
+remains a singleton chain and cannot act as the anchor for another unresolved
+pronoun. Overlapping spans are not treated as successive mentions, and mixed
+document ids are rejected because each resolution pass is single-document.
 
 For compatible antecedents, the resolver combines:
 

--- a/docs/clinical/coreference.md
+++ b/docs/clinical/coreference.md
@@ -1,0 +1,105 @@
+# Clinical Coreference Resolution
+
+`resolve_coreference()` groups `OpenMedSpan` mentions that refer to the same
+clinical entity in one document. It handles repeated named mentions, nominal
+references such as "the lesion" or "that medication", personal and neutral
+pronouns, and patient anchors such as "the patient".
+
+!!! warning "Assistive annotations only"
+    Coreference chains are deterministic heuristics for review and downstream
+    organization. They must not automatically trigger a diagnosis, treatment,
+    medication change, or other clinical decision.
+
+The resolver is rules-first and fully local. It uses section agreement,
+sentence distance, head-noun agreement, and entity-type compatibility. It does
+not call a model, an LLM, or a network service. Source surfaces are used only
+in memory to compare mentions; the returned index contains document ids and
+offsets, and the resolver does not log raw mention text.
+
+## Resolving Spans
+
+Pass the source text and its `OpenMedSpan` mentions. Pronoun or generic nominal
+mentions can use `canonical_label="OTHER"`; informative nouns such as
+"medication" and personal pronouns provide a conservative type hint.
+
+```python
+from openmed.clinical import resolve_coreference
+from openmed.core.schemas import OpenMedSpan, hmac_text_hash
+
+text = "A left lung lesion was found. The lesion is stable. It is unchanged."
+
+
+def span(surface: str, label: str, occurrence: int = 0) -> OpenMedSpan:
+    start = -1
+    cursor = 0
+    for _ in range(occurrence + 1):
+        start = text.index(surface, cursor)
+        cursor = start + len(surface)
+    return OpenMedSpan(
+        doc_id="example-note",
+        start=start,
+        end=start + len(surface),
+        text_hash=hmac_text_hash(surface, "application-owned-secret"),
+        entity_type=label.casefold(),
+        canonical_label=label,
+        section="Assessment",
+    )
+
+
+spans = [
+    span("left lung lesion", "CONDITION"),
+    span("The lesion", "CONDITION"),
+    span("It", "OTHER"),
+]
+
+chains, span_to_chain = resolve_coreference(spans, text)
+chain = chains[0]
+
+[(member.start, member.end) for member in chain.members]
+# [(2, 18), (30, 40), (52, 54)]
+
+chain.representative.start, chain.representative.end
+# (2, 18)
+
+span_to_chain[(spans[2].doc_id, (spans[2].start, spans[2].end))]
+# stable chain id
+```
+
+Each `CoreferenceChain` contains:
+
+| Field | Meaning |
+| --- | --- |
+| `chain_id` | Stable document-scoped id derived from member offsets and labels. |
+| `members` | Original `OpenMedSpan` objects in document order. |
+| `representative` | Most informative non-anaphoric member. |
+| `confidence` | Mean deterministic link confidence, from `0.0` to `1.0`. |
+| `advisory` | Clinical-review disclaimer. |
+
+The `span_to_chain` index maps `(doc_id, (start, end))` to `chain_id`, so review
+interfaces can recover a chain without storing a raw mention surface.
+
+## Resolution Rules
+
+Mentions are processed in document order, and a reference can link only to an
+earlier compatible mention. This antecedent-only rule rejects cataphora such as
+"It resolved before the rash was documented." A pronoun with no antecedent
+remains a singleton chain.
+
+For compatible antecedents, the resolver combines:
+
+1. head-noun or canonical lexical agreement;
+2. `canonical_label` and `entity_type` compatibility;
+3. matching clinical sections; and
+4. sentence and character distance.
+
+Pronouns are limited to nearby antecedents. Nominals such as "the medication"
+use their head noun to avoid linking to a nearer but incompatible condition.
+
+## Experiencer Boundary
+
+Patient, family, and other experiencers are hard boundaries: mentions with
+different experiencers never share a chain. The resolver reads explicit
+`metadata["experiencer"]` first, uses Family History as a section prior, and
+otherwise applies the local cue-based experiencer resolver. This keeps a
+relative's diabetes separate from a patient's diabetes even when the surface
+forms are identical.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
       - Advanced NER & Output Formatting: output-formatting.md
       - Clinical Context & Extraction Depth: clinical/context-and-extraction.md
       - Clinical Abbreviation Disambiguation: clinical/abbreviation-disambiguation.md
+      - Clinical Coreference Resolution: clinical/coreference.md
       - Medication Sig Parser: clinical/sig-parser.md
       - Medical Tokenizer: medical-tokenizer.md
       - Indic Unicode Normalization: indic-normalization.md

--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -84,6 +84,14 @@ from .coref import (
     link_mentions,
     score_mention_pair,
 )
+from .coreference import (
+    COREFERENCE_FEATURES,
+    COREFERENCE_RESOLUTION_ADVISORY,
+    DEFAULT_COREFERENCE_THRESHOLD,
+    CoreferenceChain,
+    SpanChainKey,
+    resolve_coreference,
+)
 from .events import (
     ASSISTIVE_EVENT_DISCLAIMER,
     CLINICAL_EVENT_LEXICON_VERSION,
@@ -336,6 +344,12 @@ __all__ = [
     "canonicalize_text",
     "link_mentions",
     "score_mention_pair",
+    "COREFERENCE_FEATURES",
+    "COREFERENCE_RESOLUTION_ADVISORY",
+    "DEFAULT_COREFERENCE_THRESHOLD",
+    "CoreferenceChain",
+    "SpanChainKey",
+    "resolve_coreference",
     "LabValueEventMention",
     "lab_value_event_mentions",
     "link_lab_value_attributes",

--- a/openmed/clinical/coreference.py
+++ b/openmed/clinical/coreference.py
@@ -1,0 +1,718 @@
+"""Deterministic span-native clinical coreference resolution.
+
+The resolver links already-detected :class:`~openmed.core.schemas.OpenMedSpan`
+mentions within one document.  It uses only local lexical and structural
+features: mention form, head noun, entity type, section, sentence distance, and
+experiencer.  It never performs network or model calls and does not log source
+text.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from openmed.core.labels import (
+    CONDITION,
+    MEDICATION,
+    OTHER,
+    PERSON,
+)
+from openmed.core.schemas import OpenMedSpan
+
+from .context import FAMILY_EXPERIENCER, PATIENT_EXPERIENCER
+from .coref import canonicalize_text
+from .experiencer import resolve_experiencer
+
+SpanChainKey = tuple[str, tuple[int, int]]
+
+COREFERENCE_RESOLUTION_ADVISORY = (
+    "Clinical coreference chains are deterministic assistive annotations. "
+    "Review them before clinical use."
+)
+
+COREFERENCE_FEATURES = (
+    "section",
+    "sentence_distance",
+    "head_noun",
+    "entity_type",
+)
+
+DEFAULT_COREFERENCE_THRESHOLD = 0.70
+
+_WORD_RE = re.compile(
+    r"[^\W_]+(?:['\N{RIGHT SINGLE QUOTATION MARK}-][^\W_]+)?", re.UNICODE
+)
+_SENTENCE_BOUNDARY_RE = re.compile(r"(?:[.!?]+(?=\s|$)|\n+)")
+_SPACE_RE = re.compile(r"\s+")
+
+_PRONOUNS = {
+    "he",
+    "her",
+    "hers",
+    "him",
+    "his",
+    "it",
+    "its",
+    "she",
+    "that",
+    "their",
+    "theirs",
+    "them",
+    "these",
+    "they",
+    "this",
+    "those",
+}
+_PERSON_PRONOUNS = {"he", "her", "hers", "him", "his", "she"}
+_NEUTRAL_PRONOUNS = {"it", "its", "that", "this"}
+_PATIENT_ANCHORS = {
+    "patient",
+    "the patient",
+    "this patient",
+}
+_DETERMINERS = {
+    "a",
+    "an",
+    "another",
+    "that",
+    "the",
+    "these",
+    "this",
+    "those",
+}
+_POSSESSIVES = {"her", "his", "its", "their"}
+
+_CONDITION_HEADS = {
+    "condition",
+    "diagnosis",
+    "disease",
+    "finding",
+    "lesion",
+    "problem",
+    "symptom",
+}
+_MEDICATION_HEADS = {
+    "agent",
+    "drug",
+    "medication",
+    "medicine",
+    "prescription",
+    "therapy",
+}
+_PERSON_HEADS = {"individual", "person", "patient"}
+_GENERIC_TYPE_HEADS = (_CONDITION_HEADS | _MEDICATION_HEADS | _PERSON_HEADS) - {
+    "lesion"
+}
+_FAMILY_ANCHORS = {
+    "aunt",
+    "brother",
+    "daughter",
+    "father",
+    "mother",
+    "parent",
+    "relative",
+    "sibling",
+    "sister",
+    "son",
+}
+
+_TYPE_ALIASES = {
+    "condition": CONDITION,
+    "diagnosis": CONDITION,
+    "disease": CONDITION,
+    "finding": CONDITION,
+    "lesion": CONDITION,
+    "problem": CONDITION,
+    "symptom": CONDITION,
+    "drug": MEDICATION,
+    "med": MEDICATION,
+    "medication": MEDICATION,
+    "medicine": MEDICATION,
+    "person": PERSON,
+    "patient": PERSON,
+}
+_UNINFORMATIVE_TYPES = {
+    "clinical entity",
+    "entity",
+    "mention",
+    "nominal",
+    "pronoun",
+    "unknown",
+}
+_CONDITION_LABELS = {
+    CONDITION,
+    "CKD_STAGE",
+    "CLINICAL_SIGNIFICANCE",
+    "DYSPNEA_GRADE",
+    "ENDOSCOPIC_FINDING",
+    "GI_SYMPTOM",
+    "POLYP_DESCRIPTOR",
+    "RESPIRATORY_FINDING",
+    "URINE_FINDING",
+}
+_MEDICATION_LABELS = {
+    MEDICATION,
+    "ANESTHETIC_AGENT",
+    "ANTIBIOTIC",
+    "INSULIN_REGIMEN",
+    "VACCINE_NAME",
+}
+_PERSON_LABELS = {
+    PERSON,
+    "FIRST_NAME",
+    "LAST_NAME",
+    "MIDDLE_NAME",
+}
+
+
+@dataclass(frozen=True)
+class CoreferenceChain:
+    """One resolved entity chain with source-span provenance.
+
+    ``members`` contains the original immutable spans in document order.
+    ``representative`` is the most informative non-anaphoric member when one is
+    available. ``confidence`` is the mean confidence of the deterministic links
+    that formed the chain; singleton chains have confidence ``1.0``.
+    """
+
+    chain_id: str
+    members: tuple[OpenMedSpan, ...]
+    representative: OpenMedSpan
+    confidence: float
+    advisory: str = COREFERENCE_RESOLUTION_ADVISORY
+
+    @property
+    def member_spans(self) -> tuple[OpenMedSpan, ...]:
+        """Return ``members`` under the explicit issue-facing field name."""
+
+        return self.members
+
+    @property
+    def representative_mention(self) -> OpenMedSpan:
+        """Return the representative source mention."""
+
+        return self.representative
+
+
+@dataclass(frozen=True)
+class _Mention:
+    span: OpenMedSpan
+    surface: str
+    canonical_text: str
+    head_noun: str
+    form: str
+    entity_class: str | None
+    section: str | None
+    sentence_index: int
+    experiencer: str
+
+    @property
+    def key(self) -> SpanChainKey:
+        return self.span.doc_id, (self.span.start, self.span.end)
+
+
+def resolve_coreference(
+    spans: Iterable[OpenMedSpan],
+    text: str,
+    *,
+    threshold: float = DEFAULT_COREFERENCE_THRESHOLD,
+) -> tuple[tuple[CoreferenceChain, ...], dict[SpanChainKey, str]]:
+    """Resolve clinical mention coreference within ``text``.
+
+    Args:
+        spans: ``OpenMedSpan`` mentions whose offsets index ``text``. Pronoun and
+            nominal spans may use ``canonical_label=OTHER``; the resolver infers
+            compatible antecedent types from their surface form when possible.
+        text: Source text for the single-document resolution pass.
+        threshold: Minimum deterministic compatibility score for a link.
+
+    Returns:
+        ``(chains, span_to_chain)``. The index maps
+        ``(doc_id, (start, end))`` to a stable chain id, keeping raw source text
+        out of the index and preserving offsets for review UIs.
+
+    Raises:
+        TypeError: If ``text`` or a span has the wrong type.
+        ValueError: If offsets are invalid, duplicate span keys are supplied,
+            or ``threshold`` is outside ``[0, 1]``.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    if not 0.0 <= threshold <= 1.0:
+        raise ValueError("coreference threshold must be between 0 and 1")
+
+    span_list = list(spans)
+    if not span_list:
+        return (), {}
+
+    sentence_starts = _sentence_starts(text)
+    mentions = tuple(
+        sorted(
+            (_build_mention(span, text, sentence_starts) for span in span_list),
+            key=lambda mention: (
+                mention.span.doc_id,
+                mention.span.start,
+                mention.span.end,
+                mention.span.canonical_label,
+                mention.span.entity_type,
+            ),
+        )
+    )
+    _validate_unique_keys(mentions)
+
+    parents = list(range(len(mentions)))
+    link_scores: dict[int, float] = {}
+    for current_index, current in enumerate(mentions):
+        candidate = _best_antecedent(
+            mentions,
+            parents,
+            current_index,
+            threshold,
+        )
+        if candidate is None:
+            continue
+        antecedent_index, score = candidate
+        parents[current_index] = _find(parents, antecedent_index)
+        link_scores[current_index] = score
+
+    chains = _build_chains(mentions, parents, link_scores)
+    span_to_chain = {
+        (span.doc_id, (span.start, span.end)): chain.chain_id
+        for chain in chains
+        for span in chain.members
+    }
+    return chains, span_to_chain
+
+
+def _build_mention(
+    span: OpenMedSpan,
+    text: str,
+    sentence_starts: tuple[int, ...],
+) -> _Mention:
+    if not isinstance(span, OpenMedSpan):
+        raise TypeError("spans must contain OpenMedSpan instances")
+    if span.start == span.end:
+        raise ValueError("coreference spans must not be empty")
+    if span.end > len(text):
+        raise ValueError("span offsets must be within text")
+
+    surface = text[span.start : span.end]
+    if not surface.strip():
+        raise ValueError("coreference spans must contain non-whitespace text")
+
+    words = _words(surface)
+    if not words:
+        raise ValueError("coreference spans must contain at least one word")
+    normalized_surface = " ".join(words)
+    form = _mention_form(normalized_surface, words)
+    lexical_words = tuple(
+        word
+        for index, word in enumerate(words)
+        if not (index == 0 and word in _DETERMINERS)
+        and not (index == 0 and word in _POSSESSIVES)
+    )
+    canonical_text = _canonical_text(lexical_words or words)
+    head_noun = canonical_text.split()[-1]
+    entity_class = _entity_class(span, form, normalized_surface, head_noun)
+    section = _section_for(span)
+    experiencer = _experiencer_for(
+        span,
+        text,
+        section,
+        form,
+        normalized_surface,
+    )
+
+    return _Mention(
+        span=span,
+        surface=surface,
+        canonical_text=canonical_text,
+        head_noun=head_noun,
+        form=form,
+        entity_class=entity_class,
+        section=section,
+        sentence_index=_sentence_index(sentence_starts, span.start),
+        experiencer=experiencer,
+    )
+
+
+def _best_antecedent(
+    mentions: tuple[_Mention, ...],
+    parents: list[int],
+    current_index: int,
+    threshold: float,
+) -> tuple[int, float] | None:
+    current = mentions[current_index]
+    candidates: list[tuple[float, int, int]] = []
+    members_by_root: dict[int, list[_Mention]] = {}
+    for index in range(current_index):
+        members_by_root.setdefault(_find(parents, index), []).append(mentions[index])
+    representatives = {
+        root: _representative_mention(tuple(members))
+        for root, members in members_by_root.items()
+    }
+    for antecedent_index in range(current_index):
+        antecedent = mentions[antecedent_index]
+        if antecedent.span.doc_id != current.span.doc_id:
+            continue
+        root = _find(parents, antecedent_index)
+        representative = representatives[root]
+        score = _link_score(antecedent, representative, current)
+        if score is not None and score >= threshold:
+            candidates.append((score, antecedent.span.end, antecedent_index))
+
+    if not candidates:
+        return None
+    score, _end, antecedent_index = max(candidates)
+    return antecedent_index, score
+
+
+def _link_score(
+    antecedent: _Mention,
+    representative: _Mention,
+    current: _Mention,
+) -> float | None:
+    if antecedent.experiencer != current.experiencer:
+        return None
+
+    sentence_distance = current.sentence_index - antecedent.sentence_index
+    if sentence_distance < 0:
+        return None
+    if current.form == "pronoun" and sentence_distance > 2:
+        return None
+    if current.form in {"nominal", "patient_anchor"} and sentence_distance > 3:
+        return None
+
+    candidate_class = representative.entity_class or antecedent.entity_class
+    if not _types_compatible(candidate_class, current.entity_class):
+        return None
+
+    lexical_score: float
+    if current.form == "lexical":
+        if current.canonical_text != representative.canonical_text:
+            return None
+        lexical_score = 0.62
+    elif current.form == "nominal":
+        if current.canonical_text == representative.canonical_text:
+            lexical_score = 0.62
+        elif current.head_noun == representative.head_noun:
+            lexical_score = 0.54
+        elif (
+            current.head_noun in _GENERIC_TYPE_HEADS
+            and current.entity_class
+            and current.entity_class == candidate_class
+        ):
+            lexical_score = 0.42
+        else:
+            return None
+    elif current.form == "patient_anchor":
+        if candidate_class != PERSON:
+            return None
+        lexical_score = 0.46
+    else:
+        if current.canonical_text in _PERSON_PRONOUNS and candidate_class != PERSON:
+            return None
+        if current.canonical_text in _NEUTRAL_PRONOUNS and candidate_class == PERSON:
+            return None
+        lexical_score = 0.50
+
+    type_score = (
+        0.18
+        if current.entity_class and current.entity_class == candidate_class
+        else 0.08
+    )
+    section_score = _section_score(antecedent.section, current.section)
+    distance_score = _sentence_distance_score(sentence_distance)
+    recency_score = _recency_score(antecedent, current)
+    return round(
+        min(
+            1.0,
+            lexical_score + type_score + section_score + distance_score + recency_score,
+        ),
+        6,
+    )
+
+
+def _types_compatible(left: str | None, right: str | None) -> bool:
+    return left is None or right is None or left == right
+
+
+def _section_score(left: str | None, right: str | None) -> float:
+    if left is None or right is None:
+        return 0.0
+    return 0.08 if left == right else -0.03
+
+
+def _sentence_distance_score(distance: int) -> float:
+    if distance == 0:
+        return 0.12
+    if distance == 1:
+        return 0.09
+    if distance == 2:
+        return 0.05
+    if distance == 3:
+        return 0.02
+    return 0.0
+
+
+def _recency_score(antecedent: _Mention, current: _Mention) -> float:
+    gap = max(0, current.span.start - antecedent.span.end)
+    if gap <= 40:
+        return 0.08
+    if gap <= 120:
+        return 0.06
+    if gap <= 300:
+        return 0.03
+    return 0.0
+
+
+def _build_chains(
+    mentions: tuple[_Mention, ...],
+    parents: list[int],
+    link_scores: Mapping[int, float],
+) -> tuple[CoreferenceChain, ...]:
+    grouped: dict[int, list[int]] = {}
+    for index in range(len(mentions)):
+        grouped.setdefault(_find(parents, index), []).append(index)
+
+    chains = []
+    for indexes in grouped.values():
+        chain_mentions = tuple(mentions[index] for index in indexes)
+        representative = _representative_mention(chain_mentions)
+        scores = [link_scores[index] for index in indexes if index in link_scores]
+        confidence = 1.0 if not scores else round(sum(scores) / len(scores), 6)
+        members = tuple(mention.span for mention in chain_mentions)
+        chains.append(
+            CoreferenceChain(
+                chain_id=_chain_id(chain_mentions),
+                members=members,
+                representative=representative.span,
+                confidence=confidence,
+            )
+        )
+
+    return tuple(
+        sorted(
+            chains,
+            key=lambda chain: (
+                chain.members[0].doc_id,
+                chain.members[0].start,
+                chain.members[0].end,
+            ),
+        )
+    )
+
+
+def _representative_mention(mentions: tuple[_Mention, ...]) -> _Mention:
+    return min(
+        mentions,
+        key=lambda mention: (
+            _form_rank(mention.form),
+            -len(mention.canonical_text.split()),
+            -len(mention.canonical_text),
+            mention.span.start,
+            mention.span.end,
+        ),
+    )
+
+
+def _form_rank(form: str) -> int:
+    return {
+        "lexical": 0,
+        "nominal": 1,
+        "patient_anchor": 2,
+        "pronoun": 3,
+    }[form]
+
+
+def _chain_id(mentions: tuple[_Mention, ...]) -> str:
+    digest = hashlib.sha256()
+    digest.update(mentions[0].span.doc_id.encode("utf-8"))
+    for mention in mentions:
+        digest.update(
+            (
+                f"|{mention.span.start}:{mention.span.end}:"
+                f"{mention.span.canonical_label}"
+            ).encode("utf-8")
+        )
+    return f"{mentions[0].span.doc_id}:coref:{digest.hexdigest()[:12]}"
+
+
+def _mention_form(normalized_surface: str, words: tuple[str, ...]) -> str:
+    if normalized_surface in _PATIENT_ANCHORS:
+        return "patient_anchor"
+    if normalized_surface in _PRONOUNS:
+        return "pronoun"
+    if len(words) > 1 and words[0] in _DETERMINERS:
+        return "nominal"
+    return "lexical"
+
+
+def _entity_class(
+    span: OpenMedSpan,
+    form: str,
+    normalized_surface: str,
+    head_noun: str,
+) -> str | None:
+    if form == "patient_anchor":
+        return PERSON
+    if normalized_surface in _PERSON_PRONOUNS:
+        return PERSON
+
+    head_type = _head_type(head_noun)
+    if form == "nominal" and head_type:
+        return head_type
+    if span.canonical_label != OTHER:
+        return _canonical_entity_class(span.canonical_label)
+
+    entity_type = _normalize_label(span.entity_type)
+    if entity_type in _UNINFORMATIVE_TYPES:
+        return head_type
+    return _TYPE_ALIASES.get(entity_type, head_type)
+
+
+def _canonical_entity_class(label: str) -> str:
+    if label in _CONDITION_LABELS:
+        return CONDITION
+    if label in _MEDICATION_LABELS:
+        return MEDICATION
+    if label in _PERSON_LABELS:
+        return PERSON
+    return label
+
+
+def _head_type(head_noun: str) -> str | None:
+    if head_noun in _CONDITION_HEADS:
+        return CONDITION
+    if head_noun in _MEDICATION_HEADS:
+        return MEDICATION
+    if head_noun in _PERSON_HEADS:
+        return PERSON
+    return None
+
+
+def _experiencer_for(
+    span: OpenMedSpan,
+    text: str,
+    section: str | None,
+    form: str,
+    normalized_surface: str,
+) -> str:
+    explicit = _metadata_value(span.metadata, "experiencer")
+    if explicit is not None:
+        return _normalize_experiencer(explicit)
+    if form == "patient_anchor":
+        return PATIENT_EXPERIENCER
+    if set(normalized_surface.split()) & _FAMILY_ANCHORS:
+        return FAMILY_EXPERIENCER
+
+    section_experiencer = (
+        FAMILY_EXPERIENCER if section is not None and "family" in section else None
+    )
+    assignment = resolve_experiencer(
+        text,
+        {"start": span.start, "end": span.end},
+        section_experiencer=section_experiencer,
+    )
+    return _normalize_experiencer(assignment.experiencer)
+
+
+def _metadata_value(metadata: Mapping[str, object], key: str) -> str | None:
+    value = metadata.get(key)
+    if isinstance(value, str) and value.strip():
+        return value
+    context = metadata.get("context")
+    if isinstance(context, Mapping):
+        nested = context.get(key)
+        if isinstance(nested, str) and nested.strip():
+            return nested
+    return None
+
+
+def _normalize_experiencer(value: str) -> str:
+    normalized = _normalize_label(value)
+    if normalized in {
+        "family member",
+        "father",
+        "mother",
+        "parent",
+        "relative",
+        "sibling",
+    }:
+        return FAMILY_EXPERIENCER
+    if normalized in {"self", "subject"}:
+        return PATIENT_EXPERIENCER
+    return normalized
+
+
+def _section_for(span: OpenMedSpan) -> str | None:
+    value = span.section
+    if value is None:
+        value = _metadata_value(span.metadata, "section")
+    return _normalize_label(value) if value else None
+
+
+def _canonical_text(words: tuple[str, ...]) -> str:
+    surface = " ".join(words)
+    try:
+        return canonicalize_text(surface)
+    except ValueError:
+        return surface
+
+
+def _words(surface: str) -> tuple[str, ...]:
+    return tuple(match.group(0).casefold() for match in _WORD_RE.finditer(surface))
+
+
+def _normalize_label(value: str) -> str:
+    return _SPACE_RE.sub(" ", value.strip().casefold().replace("_", " "))
+
+
+def _sentence_starts(text: str) -> tuple[int, ...]:
+    starts = [0]
+    for match in _SENTENCE_BOUNDARY_RE.finditer(text):
+        start = match.end()
+        while start < len(text) and text[start].isspace():
+            start += 1
+        if start < len(text) and start != starts[-1]:
+            starts.append(start)
+    return tuple(starts)
+
+
+def _sentence_index(starts: tuple[int, ...], position: int) -> int:
+    low = 0
+    high = len(starts)
+    while low < high:
+        middle = (low + high) // 2
+        if starts[middle] <= position:
+            low = middle + 1
+        else:
+            high = middle
+    return max(0, low - 1)
+
+
+def _validate_unique_keys(mentions: tuple[_Mention, ...]) -> None:
+    keys = [mention.key for mention in mentions]
+    if len(keys) != len(set(keys)):
+        raise ValueError("coreference spans must have unique document offsets")
+
+
+def _find(parents: list[int], item: int) -> int:
+    while parents[item] != item:
+        parents[item] = parents[parents[item]]
+        item = parents[item]
+    return item
+
+
+__all__ = [
+    "COREFERENCE_FEATURES",
+    "COREFERENCE_RESOLUTION_ADVISORY",
+    "DEFAULT_COREFERENCE_THRESHOLD",
+    "CoreferenceChain",
+    "SpanChainKey",
+    "resolve_coreference",
+]

--- a/openmed/clinical/coreference.py
+++ b/openmed/clinical/coreference.py
@@ -237,7 +237,8 @@ def resolve_coreference(
     Raises:
         TypeError: If ``text`` or a span has the wrong type.
         ValueError: If offsets are invalid, duplicate span keys are supplied,
-            or ``threshold`` is outside ``[0, 1]``.
+            spans refer to more than one document, or ``threshold`` is outside
+            ``[0, 1]``.
     """
 
     if not isinstance(text, str):
@@ -263,6 +264,7 @@ def resolve_coreference(
         )
     )
     _validate_unique_keys(mentions)
+    _validate_single_document(mentions)
 
     parents = list(range(len(mentions)))
     link_scores: dict[int, float] = {}
@@ -376,6 +378,10 @@ def _link_score(
     representative: _Mention,
     current: _Mention,
 ) -> float | None:
+    if antecedent.span.end > current.span.start:
+        return None
+    if representative.form == "pronoun":
+        return None
     if antecedent.experiencer != current.experiencer:
         return None
 
@@ -699,6 +705,11 @@ def _validate_unique_keys(mentions: tuple[_Mention, ...]) -> None:
     keys = [mention.key for mention in mentions]
     if len(keys) != len(set(keys)):
         raise ValueError("coreference spans must have unique document offsets")
+
+
+def _validate_single_document(mentions: tuple[_Mention, ...]) -> None:
+    if len({mention.span.doc_id for mention in mentions}) != 1:
+        raise ValueError("coreference spans must belong to one document")
 
 
 def _find(parents: list[int], item: int) -> int:

--- a/tests/fixtures/clinical/coreference_gold.json
+++ b/tests/fixtures/clinical/coreference_gold.json
@@ -1,0 +1,161 @@
+{
+  "cases": [
+    {
+      "id": "repeated_problem_and_pronoun",
+      "text": "Assessment: A left lung lesion was found. The lesion is stable. It is unchanged.",
+      "mentions": [
+        {
+          "surface": "left lung lesion",
+          "canonical_label": "CONDITION",
+          "section": "Assessment",
+          "gold_chain": "lesion"
+        },
+        {
+          "surface": "The lesion",
+          "canonical_label": "CONDITION",
+          "section": "Assessment",
+          "gold_chain": "lesion"
+        },
+        {
+          "surface": "It",
+          "canonical_label": "OTHER",
+          "entity_type": "pronoun",
+          "section": "Assessment",
+          "gold_chain": "lesion"
+        }
+      ],
+      "representative": "left lung lesion"
+    },
+    {
+      "id": "medication_nominal_beats_nearer_condition",
+      "text": "Aspirin was started for a rash. The medication was continued.",
+      "mentions": [
+        {
+          "surface": "Aspirin",
+          "canonical_label": "MEDICATION",
+          "section": "Plan",
+          "gold_chain": "aspirin"
+        },
+        {
+          "surface": "rash",
+          "canonical_label": "CONDITION",
+          "section": "Plan",
+          "gold_chain": "rash"
+        },
+        {
+          "surface": "The medication",
+          "canonical_label": "OTHER",
+          "entity_type": "nominal",
+          "section": "Plan",
+          "gold_chain": "aspirin"
+        }
+      ],
+      "representative": "Aspirin"
+    },
+    {
+      "id": "patient_anchor_and_person_pronoun",
+      "text": "John Doe arrived. The patient reported pain. He was stable.",
+      "mentions": [
+        {
+          "surface": "John Doe",
+          "canonical_label": "PERSON",
+          "section": "HPI",
+          "gold_chain": "patient"
+        },
+        {
+          "surface": "The patient",
+          "canonical_label": "OTHER",
+          "entity_type": "patient_anchor",
+          "section": "HPI",
+          "gold_chain": "patient"
+        },
+        {
+          "surface": "He",
+          "canonical_label": "OTHER",
+          "entity_type": "pronoun",
+          "section": "HPI",
+          "gold_chain": "patient"
+        }
+      ],
+      "representative": "John Doe"
+    },
+    {
+      "id": "cataphora_rejected",
+      "text": "It resolved before the rash was documented.",
+      "mentions": [
+        {
+          "surface": "It",
+          "canonical_label": "OTHER",
+          "entity_type": "pronoun",
+          "section": "Assessment",
+          "gold_chain": "unresolved-pronoun"
+        },
+        {
+          "surface": "rash",
+          "canonical_label": "CONDITION",
+          "section": "Assessment",
+          "gold_chain": "rash"
+        }
+      ]
+    },
+    {
+      "id": "specific_nominal_requires_head_match",
+      "text": "A rash appeared. The lesion was measured.",
+      "mentions": [
+        {
+          "surface": "rash",
+          "canonical_label": "CONDITION",
+          "section": "Assessment",
+          "gold_chain": "rash"
+        },
+        {
+          "surface": "The lesion",
+          "canonical_label": "CONDITION",
+          "section": "Assessment",
+          "gold_chain": "lesion"
+        }
+      ]
+    },
+    {
+      "id": "no_antecedent_rejected",
+      "text": "It improved overnight.",
+      "mentions": [
+        {
+          "surface": "It",
+          "canonical_label": "OTHER",
+          "entity_type": "pronoun",
+          "section": "HPI",
+          "gold_chain": "unresolved-pronoun"
+        }
+      ]
+    },
+    {
+      "id": "experiencer_boundary",
+      "text": "Family History:\nMother had diabetes.\nAssessment:\nThe patient has diabetes. It is controlled.",
+      "mentions": [
+        {
+          "surface": "diabetes",
+          "occurrence": 0,
+          "canonical_label": "CONDITION",
+          "section": "Family History",
+          "gold_chain": "family-diabetes"
+        },
+        {
+          "surface": "diabetes",
+          "occurrence": 1,
+          "canonical_label": "CONDITION",
+          "section": "Assessment",
+          "gold_chain": "patient-diabetes"
+        },
+        {
+          "surface": "It",
+          "canonical_label": "OTHER",
+          "entity_type": "pronoun",
+          "section": "Assessment",
+          "gold_chain": "patient-diabetes"
+        }
+      ],
+      "representative": "diabetes"
+    }
+  ]
+}

--- a/tests/fixtures/clinical/coreference_gold.json
+++ b/tests/fixtures/clinical/coreference_gold.json
@@ -53,6 +53,34 @@
       "representative": "Aspirin"
     },
     {
+      "id": "repeated_medication_and_pronoun",
+      "text": "Aspirin was started. Aspirin was continued. It was tolerated.",
+      "mentions": [
+        {
+          "surface": "Aspirin",
+          "occurrence": 0,
+          "canonical_label": "MEDICATION",
+          "section": "Plan",
+          "gold_chain": "aspirin"
+        },
+        {
+          "surface": "Aspirin",
+          "occurrence": 1,
+          "canonical_label": "MEDICATION",
+          "section": "Plan",
+          "gold_chain": "aspirin"
+        },
+        {
+          "surface": "It",
+          "canonical_label": "OTHER",
+          "entity_type": "pronoun",
+          "section": "Plan",
+          "gold_chain": "aspirin"
+        }
+      ],
+      "representative": "Aspirin"
+    },
+    {
       "id": "patient_anchor_and_person_pronoun",
       "text": "John Doe arrived. The patient reported pain. He was stable.",
       "mentions": [
@@ -126,6 +154,28 @@
           "entity_type": "pronoun",
           "section": "HPI",
           "gold_chain": "unresolved-pronoun"
+        }
+      ]
+    },
+    {
+      "id": "unresolved_pronouns_do_not_anchor_each_other",
+      "text": "It improved. It resolved.",
+      "mentions": [
+        {
+          "surface": "It",
+          "occurrence": 0,
+          "canonical_label": "OTHER",
+          "entity_type": "pronoun",
+          "section": "HPI",
+          "gold_chain": "unresolved-pronoun-1"
+        },
+        {
+          "surface": "It",
+          "occurrence": 1,
+          "canonical_label": "OTHER",
+          "entity_type": "pronoun",
+          "section": "HPI",
+          "gold_chain": "unresolved-pronoun-2"
         }
       ]
     },

--- a/tests/unit/clinical/test_coreference.py
+++ b/tests/unit/clinical/test_coreference.py
@@ -160,3 +160,41 @@ def test_invalid_offsets_duplicates_and_threshold_are_rejected() -> None:
         resolve_coreference([span, span], case["text"])
     with pytest.raises(ValueError, match="between 0 and 1"):
         resolve_coreference([span], case["text"], threshold=1.1)
+
+
+def test_mixed_document_ids_are_rejected() -> None:
+    case = _load_cases()[0]
+    first, second = _spans_for(case)[:2]
+    other_document = OpenMedSpan.from_dict(
+        {**second.to_dict(), "doc_id": "another-document"}
+    )
+
+    with pytest.raises(ValueError, match="one document"):
+        resolve_coreference([first, other_document], case["text"])
+
+
+def test_overlapping_spans_do_not_form_antecedent_links() -> None:
+    text = "rash."
+    spans = [
+        OpenMedSpan(
+            doc_id="overlap",
+            start=0,
+            end=4,
+            text_hash=hmac_text_hash("rash", "synthetic-fixture-secret"),
+            entity_type="condition",
+            canonical_label="CONDITION",
+        ),
+        OpenMedSpan(
+            doc_id="overlap",
+            start=0,
+            end=5,
+            text_hash=hmac_text_hash("rash.", "synthetic-fixture-secret"),
+            entity_type="condition",
+            canonical_label="CONDITION",
+        ),
+    ]
+
+    chains, index = resolve_coreference(spans, text)
+
+    assert len(chains) == 2
+    assert index[("overlap", (0, 4))] != index[("overlap", (0, 5))]

--- a/tests/unit/clinical/test_coreference.py
+++ b/tests/unit/clinical/test_coreference.py
@@ -1,0 +1,162 @@
+"""Golden and safety tests for span-native clinical coreference."""
+
+from __future__ import annotations
+
+import json
+import socket
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openmed.clinical import (
+    COREFERENCE_FEATURES,
+    COREFERENCE_RESOLUTION_ADVISORY,
+    CoreferenceChain,
+    resolve_coreference,
+)
+from openmed.core.schemas import OpenMedSpan, hmac_text_hash
+
+FIXTURE_PATH = Path(__file__).parents[2] / "fixtures/clinical/coreference_gold.json"
+
+
+def _load_cases() -> list[dict[str, Any]]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))["cases"]
+
+
+def _offset(text: str, surface: str, occurrence: int = 0) -> tuple[int, int]:
+    cursor = 0
+    for _ in range(occurrence + 1):
+        start = text.index(surface, cursor)
+        cursor = start + len(surface)
+    return start, start + len(surface)
+
+
+def _spans_for(case: Mapping[str, Any]) -> list[OpenMedSpan]:
+    text = str(case["text"])
+    spans = []
+    for mention in case["mentions"]:
+        surface = str(mention["surface"])
+        start, end = _offset(text, surface, int(mention.get("occurrence", 0)))
+        spans.append(
+            OpenMedSpan(
+                doc_id=str(case["id"]),
+                start=start,
+                end=end,
+                text_hash=hmac_text_hash(surface, "synthetic-fixture-secret"),
+                entity_type=str(mention.get("entity_type", mention["canonical_label"])),
+                canonical_label=str(mention["canonical_label"]),
+                section=mention.get("section"),
+                metadata=mention.get("metadata", {}),
+            )
+        )
+    return spans
+
+
+def _predicted_partition(
+    case: Mapping[str, Any],
+    spans: list[OpenMedSpan],
+) -> dict[int, str]:
+    _chains, index = resolve_coreference(spans, str(case["text"]))
+    return {
+        position: index[(span.doc_id, (span.start, span.end))]
+        for position, span in enumerate(spans)
+    }
+
+
+@pytest.mark.parametrize("case", _load_cases(), ids=lambda case: case["id"])
+def test_golden_accept_and_reject_cases(case: Mapping[str, Any]) -> None:
+    spans = _spans_for(case)
+
+    predicted = _predicted_partition(case, spans)
+    mentions = case["mentions"]
+
+    for left in range(len(spans)):
+        for right in range(len(spans)):
+            expected_same = (
+                mentions[left]["gold_chain"] == mentions[right]["gold_chain"]
+            )
+            assert (predicted[left] == predicted[right]) is expected_same
+
+
+def test_repeated_mentions_keep_original_offsets_and_representative() -> None:
+    case = _load_cases()[0]
+    spans = _spans_for(case)
+
+    chains, index = resolve_coreference(spans, case["text"])
+
+    assert len(chains) == 1
+    chain = chains[0]
+    assert isinstance(chain, CoreferenceChain)
+    assert chain.members == tuple(spans)
+    assert chain.member_spans == tuple(spans)
+    assert chain.representative == spans[0]
+    assert chain.representative_mention == spans[0]
+    assert 0.70 <= chain.confidence <= 1.0
+    assert chain.advisory == COREFERENCE_RESOLUTION_ADVISORY
+    assert set(index) == {(span.doc_id, (span.start, span.end)) for span in spans}
+
+
+def test_resolution_is_input_order_invariant() -> None:
+    case = _load_cases()[1]
+    spans = _spans_for(case)
+
+    chains, index = resolve_coreference(spans, case["text"])
+    reversed_chains, reversed_index = resolve_coreference(reversed(spans), case["text"])
+
+    assert reversed_chains == chains
+    assert reversed_index == index
+
+
+def test_experiencer_boundary_never_merges_patient_and_family() -> None:
+    case = next(item for item in _load_cases() if item["id"] == "experiencer_boundary")
+    spans = _spans_for(case)
+
+    chains, index = resolve_coreference(spans, case["text"])
+
+    family_key = (spans[0].doc_id, (spans[0].start, spans[0].end))
+    patient_key = (spans[1].doc_id, (spans[1].start, spans[1].end))
+    pronoun_key = (spans[2].doc_id, (spans[2].start, spans[2].end))
+    assert index[family_key] != index[patient_key]
+    assert index[patient_key] == index[pronoun_key]
+    assert sorted(len(chain.members) for chain in chains) == [1, 2]
+
+
+def test_resolver_is_offline_and_emits_no_raw_text_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    case = _load_cases()[0]
+    spans = _spans_for(case)
+
+    def fail_network(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("network access is forbidden")
+
+    monkeypatch.setattr(socket, "create_connection", fail_network)
+    resolve_coreference(spans, case["text"])
+
+    captured = caplog.text.casefold()
+    assert "left lung lesion" not in captured
+    assert "the lesion" not in captured
+
+
+def test_feature_contract_names_all_required_deterministic_signals() -> None:
+    assert COREFERENCE_FEATURES == (
+        "section",
+        "sentence_distance",
+        "head_noun",
+        "entity_type",
+    )
+
+
+def test_invalid_offsets_duplicates_and_threshold_are_rejected() -> None:
+    case = _load_cases()[0]
+    span = _spans_for(case)[0]
+
+    with pytest.raises(ValueError, match="within text"):
+        resolve_coreference([span], "short")
+    with pytest.raises(ValueError, match="unique document offsets"):
+        resolve_coreference([span, span], case["text"])
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        resolve_coreference([span], case["text"], threshold=1.1)


### PR DESCRIPTION
# Pull Request

## Description
Adds deterministic, offline coreference resolution over `OpenMedSpan` mentions. The resolver links repeated clinical entities, nominal mentions, pronouns, and patient anchors using section, distance, head-noun, entity-type, and experiencer signals while preserving source offsets and keeping raw mention text out of logs.

## Type of Change
- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made
- Added the `CoreferenceChain` record and `resolve_coreference()` public API with a stable span-to-chain index.
- Added deterministic antecedent scoring with strict patient/family experiencer boundaries and cataphora rejection.
- Prevents unresolved pronouns from anchoring one another and rejects overlap-based or cross-document links.
- Added synthetic golden accept/reject cases for repeated problems, repeated medications, pronouns, nominals, cataphora, no-antecedent traps, and experiencer boundaries.
- Added user documentation and navigation.

## Testing
- [x] `.venv/bin/python -m pytest tests/ -q` — 6128 passed, 48 skipped
- [x] Focused coreference/context suite — 50 passed
- [x] `make format`
- [x] `make lint`
- [x] `make format-check`
- [x] `make type-check`
- [x] `make docs-build`
- [x] `python3 -m build`
- [x] Scoped pre-commit validation for all PR files

## Documentation
- [x] Added the clinical coreference guide.
- [x] Added Google-style public API docstrings.
- [x] No changelog update required for this focused feature PR.

## Dependencies
- [x] No new dependencies.

## Related Issues
Closes #873

## Screenshots/Examples
Not applicable. The documentation includes a complete span-resolution example.
