### PR TITLE
Render a public auto-published benchmark leaderboard from archived eval reports

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["master"]
     tags: ["v*"]
-    tags: ["v*"]
   workflow_dispatch:
 
 permissions:
@@ -45,8 +44,8 @@ jobs:
           python -m openmed.eval.leaderboard \
             --reports-dir docs/benchmarks \
             --output-dir docs/eval/benchmark-leaderboard \
-             --manifest models.jsonl \
-             --release-tag "$release_tag"
+            --manifest models.jsonl \
+            --release-tag "$release_tag"
       - name: Build MkDocs site and verify LLM feeds
         run: |
           mkdocs build --strict

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Deploy Docs to GitHub Pages
 on:
   push:
     branches: ["master"]
+    tags: ["v*"]
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions:
@@ -31,6 +33,20 @@ jobs:
           python-version: "3.11"
       - name: Install documentation tooling
         run: pip install ".[docs]"
+      - name: Render public benchmark leaderboard
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="$GITHUB_REF_NAME"
+          if [ "$GITHUB_REF_TYPE" != "tag" ]; then
+            version="$(python -c 'from openmed.__about__ import __version__; print(__version__)')"
+            release_tag="v${version}"
+          fi
+          python -m openmed.eval.leaderboard \
+            --reports-dir docs/benchmarks \
+            --output-dir docs/eval/benchmark-leaderboard \
+             --manifest models.jsonl \
+             --release-tag "$release_tag"
       - name: Build MkDocs site and verify LLM feeds
         run: |
           mkdocs build --strict

--- a/docs/benchmarks/golden.report.json
+++ b/docs/benchmarks/golden.report.json
@@ -3,7 +3,8 @@
   "fixture_count": 1,
   "generated_at": "2026-06-14T00:00:00Z",
   "metadata": {
-    "source": "committed benchmark report"
+    "source": "committed benchmark report",
+    "synthetic": true
   },
   "metrics": {
     "exact_span_f1": {

--- a/docs/eval/benchmark-leaderboard/index.html
+++ b/docs/eval/benchmark-leaderboard/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenMed Public Benchmark Leaderboard</title>
+  <style>
+    :root{color-scheme:light dark;font-family:system-ui,sans-serif}
+    body{margin:0 auto;max-width:96rem;padding:2rem;line-height:1.5}
+    header{display:flex;gap:1rem;align-items:start;justify-content:space-between;flex-wrap:wrap}
+    .tabs{display:flex;gap:.5rem;flex-wrap:wrap;margin:1.5rem 0}
+    .tab{border:1px solid #64748b;border-radius:.4rem;padding:.55rem .9rem;background:transparent;cursor:pointer}
+    .tab[aria-selected="true"]{background:#2563eb;color:#fff;border-color:#2563eb}
+    .table-wrap{overflow-x:auto;margin-bottom:2rem}
+    table{border-collapse:collapse;width:100%;font-variant-numeric:tabular-nums}
+    th,td{border-bottom:1px solid #94a3b8;padding:.6rem;text-align:left;vertical-align:top}
+    th.numeric,td.numeric{text-align:right}
+    code{overflow-wrap:anywhere}
+    .metric-note{color:#64748b}
+  </style>
+</head>
+<body>
+<header><div><h1>OpenMed Public Benchmark Leaderboard</h1><p class="metric-note">Ranked leakage ascending, then recall descending. Every row links to its archived synthetic report.</p></div><a href="leaderboard.json" download>Download leaderboard.json</a></header>
+<div class="tabs" role="tablist" aria-label="Benchmark suites"><button class="tab" role="tab" id="suite-0-tab" aria-controls="suite-0" aria-selected="true" data-target="suite-0">golden</button></div>
+<section class="suite-panel" id="suite-0" role="tabpanel" aria-labelledby="suite-0-tab"><h2>PII</h2><div class="table-wrap"><table><thead><tr><th class="numeric">Rank</th><th>Model</th><th>Device</th><th class="numeric">Leakage</th><th class="numeric">Recall</th><th class="numeric">F1</th><th>Release</th><th>Run date</th><th>Reproducibility hash</th><th>Report</th></tr></thead><tbody><tr><td class="numeric">1</td><td>OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1-mlx</td><td>mlx-fp</td><td class="numeric">0.0000%</td><td class="numeric">100.0000%</td><td class="numeric">100.0000%</td><td><code>v1.9.1</code></td><td><time datetime="2026-06-14">2026-06-14</time></td><td><code>sha256:4818bdef580eb406f5cc665cc0892aefab1fd90c8743822d843dd48f135bde34</code></td><td><a href="reports/golden.report.json" download>Download JSON</a></td></tr></tbody></table></div></section>
+<script>
+  const tabs = document.querySelectorAll('[role="tab"]');
+  tabs.forEach((tab) => tab.addEventListener('click', () => {
+    tabs.forEach((item) => item.setAttribute('aria-selected', String(item === tab)));
+    document.querySelectorAll('[role="tabpanel"]').forEach((panel) => {
+      panel.hidden = panel.id !== tab.dataset.target;
+    });
+  }));
+</script>
+</body>
+</html>

--- a/docs/eval/benchmark-leaderboard/leaderboard.json
+++ b/docs/eval/benchmark-leaderboard/leaderboard.json
@@ -1,0 +1,50 @@
+{
+  "row_count": 1,
+  "rows": [
+    {
+      "device": "mlx-fp",
+      "f1": 1.0,
+      "leakage": 0.0,
+      "model_family": "PII",
+      "model_name": "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1-mlx",
+      "recall": 1.0,
+      "release_tag": "v1.9.1",
+      "report_path": "golden.report.json",
+      "report_url": "reports/golden.report.json",
+      "reproducibility_hash": "sha256:4818bdef580eb406f5cc665cc0892aefab1fd90c8743822d843dd48f135bde34",
+      "run_date": "2026-06-14",
+      "suite": "golden"
+    }
+  ],
+  "schema_version": 1,
+  "sort": [
+    "leakage:asc",
+    "recall:desc"
+  ],
+  "suites": [
+    {
+      "families": [
+        {
+          "name": "PII",
+          "rows": [
+            {
+              "device": "mlx-fp",
+              "f1": 1.0,
+              "leakage": 0.0,
+              "model_family": "PII",
+              "model_name": "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1-mlx",
+              "recall": 1.0,
+              "release_tag": "v1.9.1",
+              "report_path": "golden.report.json",
+              "report_url": "reports/golden.report.json",
+              "reproducibility_hash": "sha256:4818bdef580eb406f5cc665cc0892aefab1fd90c8743822d843dd48f135bde34",
+              "run_date": "2026-06-14",
+              "suite": "golden"
+            }
+          ]
+        }
+      ],
+      "name": "golden"
+    }
+  ]
+}

--- a/docs/eval/benchmark-leaderboard/reports/golden.report.json
+++ b/docs/eval/benchmark-leaderboard/reports/golden.report.json
@@ -1,0 +1,25 @@
+{
+  "device": "mlx-fp",
+  "fixture_count": 1,
+  "generated_at": "2026-06-14T00:00:00Z",
+  "metadata": {
+    "source": "committed benchmark report"
+  },
+  "metrics": {
+    "exact_span_f1": {
+      "f1": 1.0,
+      "false_negatives": 0,
+      "false_positives": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "true_positives": 1
+    },
+    "leakage": {
+      "leaked_chars": 0,
+      "overall": 0.0,
+      "total_chars": 4
+    }
+  },
+  "model_name": "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1-mlx",
+  "suite": "golden"
+}

--- a/docs/eval/benchmark-leaderboard/reports/golden.report.json
+++ b/docs/eval/benchmark-leaderboard/reports/golden.report.json
@@ -3,7 +3,8 @@
   "fixture_count": 1,
   "generated_at": "2026-06-14T00:00:00Z",
   "metadata": {
-    "source": "committed benchmark report"
+    "source": "committed benchmark report",
+    "synthetic": true
   },
   "metrics": {
     "exact_span_f1": {

--- a/docs/eval/leaderboard.md
+++ b/docs/eval/leaderboard.md
@@ -1,0 +1,68 @@
+# Public Benchmark Leaderboard
+
+The [public benchmark leaderboard](https://openmed.life/docs/eval/benchmark-leaderboard/)
+is a static, versioned view of OpenMed's archived synthetic evaluation reports.
+It is rebuilt without network access whenever the documentation site publishes
+from `master` and whenever a `v*` release tag publishes the site.
+
+The renderer ranks every row by leakage ascending and then recall descending.
+F1 and recall remain visible as secondary metrics, but a higher F1 can never
+outrank a report with lower leakage. Tabs separate benchmark suites, and model
+family headings keep comparisons within the same model class legible.
+
+## Public artifacts
+
+The stable publication path is
+`https://openmed.life/docs/eval/benchmark-leaderboard/`. Each render contains:
+
+- `index.html`, the browsable leaderboard with per-suite tabs;
+- `leaderboard.json`, the same rows in a versioned machine-readable schema;
+- `reports/`, canonical JSON copies of the archived reports linked from every
+  row.
+
+Every row records the release tag, benchmark run date, and a
+`sha256:<64 lower hex>` reproducibility hash. Older reports may obtain model
+family and reproducibility metadata from the matching `models.jsonl` entry,
+but missing ranking evidence fails the render instead of publishing an
+unverifiable row.
+
+## Source and refresh flow
+
+Only committed synthetic `BenchmarkReport` JSON under `docs/benchmarks/` is
+published. Non-synthetic, private, DUA-restricted, or raw clinical data must
+never be added to this archive.
+
+To reproduce the release artifact locally:
+
+```bash
+.venv/bin/python -m openmed.eval.leaderboard \
+  --reports-dir docs/benchmarks \
+  --output-dir docs/eval/benchmark-leaderboard \
+  --manifest models.jsonl \
+  --release-tag vX.Y.Z
+```
+
+The renderer sorts input paths and JSON keys, derives no wall-clock timestamp,
+and writes canonical report copies. Re-running it with the same inputs is
+therefore byte-identical and does not require a network connection.
+
+## Machine-readable contract
+
+`leaderboard.json` uses schema version `1`. Its top-level `rows` array is the
+canonical global ranking and declares the sort keys as `leakage:asc` and
+`recall:desc`. The `suites` view repeats those rows under deterministic suite
+and model-family groups for consumers that mirror the HTML navigation.
+
+Each row includes:
+
+| Field | Meaning |
+|---|---|
+| `suite` | Benchmark suite shown as a tab. |
+| `model_family` | Manifest or report model family. |
+| `model_name` / `device` | Evaluated model and runtime. |
+| `leakage` | Primary lower-is-better ranking metric in `[0, 1]`. |
+| `recall` / `f1` | Secondary higher-is-better metrics in `[0, 1]`. |
+| `release_tag` | Release that published or originally stamped the report. |
+| `run_date` | ISO `YYYY-MM-DD` date derived from the report timestamp. |
+| `reproducibility_hash` | Validated SHA-256 reproducibility identifier. |
+| `report_url` | Relative download URL for the underlying report JSON. |

--- a/docs/eval/leaderboard.md
+++ b/docs/eval/leaderboard.md
@@ -28,9 +28,12 @@ unverifiable row.
 
 ## Source and refresh flow
 
-Only committed synthetic `BenchmarkReport` JSON under `docs/benchmarks/` is
-published. Non-synthetic, private, DUA-restricted, or raw clinical data must
-never be added to this archive.
+Only committed `BenchmarkReport` JSON under `docs/benchmarks/` with
+`metadata.synthetic` set to `true` is published. Auxiliary JSON that has no
+BenchmarkReport fields is ignored, while malformed report candidates and
+reports without the explicit synthetic marker fail closed. Non-synthetic,
+private, DUA-restricted, or raw clinical data must never be added to this
+archive.
 
 To reproduce the release artifact locally:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - EPUB Extraction: multimodal/epub-extraction.md
       - Testing & QA: testing.md
       - Eval Harness & Metrics: eval-harness.md
+      - Public Benchmark Leaderboard: eval/leaderboard.md
       - Experiencer Refinement: clinical/experiencer-refinement.md
       - OpenVINO Runtime: runtimes/openvino.md
       - Device Tiers & SLOs: tiers.md

--- a/openmed/eval/leaderboard.py
+++ b/openmed/eval/leaderboard.py
@@ -1,0 +1,579 @@
+"""Deterministic public leaderboard rendering for archived benchmark reports."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import re
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+from urllib.parse import quote
+
+from openmed.core.model_registry import MANIFEST_PATH, load_manifest_rows
+from openmed.eval.report import BenchmarkReport
+
+LEADERBOARD_SCHEMA_VERSION = 1
+DEFAULT_REPORTS_DIR = Path("docs/benchmarks")
+DEFAULT_OUTPUT_DIR = Path("docs/eval/benchmark-leaderboard")
+
+_SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}")
+_LEAKAGE_METRICS = (
+    "leakage.overall",
+    "leakage_rate.overall",
+    "leakage_rate",
+    "critical_leakage_rate",
+)
+_RECALL_METRICS = (
+    "exact_span_f1.recall",
+    "span.recall",
+    "micro.recall",
+    "recall",
+)
+_F1_METRICS = (
+    "exact_span_f1.f1",
+    "span.f1",
+    "micro.f1",
+    "micro_f1",
+    "f1",
+)
+
+
+class LeaderboardError(ValueError):
+    """Raised when archived reports cannot form a trustworthy leaderboard."""
+
+
+@dataclass(frozen=True)
+class LeaderboardRow:
+    """One public leaderboard row derived from an archived report."""
+
+    suite: str
+    model_family: str
+    model_name: str
+    device: str
+    leakage: float
+    recall: float
+    f1: float
+    release_tag: str
+    run_date: str
+    reproducibility_hash: str
+    report_path: str
+    report_url: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable machine-readable row representation."""
+
+        return {
+            "device": self.device,
+            "f1": self.f1,
+            "leakage": self.leakage,
+            "model_family": self.model_family,
+            "model_name": self.model_name,
+            "recall": self.recall,
+            "release_tag": self.release_tag,
+            "report_path": self.report_path,
+            "report_url": self.report_url,
+            "reproducibility_hash": self.reproducibility_hash,
+            "run_date": self.run_date,
+            "suite": self.suite,
+        }
+
+
+@dataclass(frozen=True)
+class LeaderboardArtifacts:
+    """Paths written for one public leaderboard render."""
+
+    html_path: Path
+    json_path: Path
+    report_paths: tuple[Path, ...]
+
+
+@dataclass(frozen=True)
+class _ArchivedReport:
+    path: Path
+    relative_path: Path
+    payload: Mapping[str, Any]
+    report: BenchmarkReport
+
+
+def load_leaderboard_rows(
+    reports_dir: str | Path,
+    *,
+    manifest_rows: Iterable[Mapping[str, Any]] = (),
+    release_tag: str | None = None,
+) -> list[LeaderboardRow]:
+    """Load and rank archived reports for public rendering.
+
+    Args:
+        reports_dir: Directory recursively containing archived report JSON.
+        manifest_rows: Optional model manifest rows used to fill family and
+            reproducibility metadata absent from older reports.
+        release_tag: Fallback release tag for reports that predate that field.
+
+    Returns:
+        Rows sorted by leakage ascending, recall descending, then stable
+        identity fields.
+
+    Raises:
+        LeaderboardError: If the archive is empty or a required field is
+            missing or invalid.
+    """
+
+    archives = _load_archived_reports(reports_dir)
+    manifests = {
+        str(row.get("repo_id")): row
+        for row in manifest_rows
+        if row.get("repo_id") is not None
+    }
+    rows = [
+        _row_from_archive(
+            archive,
+            manifest_row=manifests.get(archive.report.model_name),
+            release_tag=release_tag,
+        )
+        for archive in archives
+    ]
+    return sorted(rows, key=_row_sort_key)
+
+
+def render_leaderboard_json(rows: Iterable[LeaderboardRow]) -> str:
+    """Render deterministic machine-readable leaderboard JSON."""
+
+    ranked_rows = sorted(rows, key=_row_sort_key)
+    payload = {
+        "row_count": len(ranked_rows),
+        "rows": [row.to_dict() for row in ranked_rows],
+        "schema_version": LEADERBOARD_SCHEMA_VERSION,
+        "sort": ["leakage:asc", "recall:desc"],
+        "suites": _suite_payload(ranked_rows),
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def render_leaderboard_html(rows: Iterable[LeaderboardRow]) -> str:
+    """Render deterministic, self-contained leaderboard HTML."""
+
+    ranked_rows = sorted(rows, key=_row_sort_key)
+    suites = _group_rows(ranked_rows)
+    tab_buttons: list[str] = []
+    panels: list[str] = []
+
+    for suite_index, (suite, families) in enumerate(suites.items()):
+        tab_id = f"suite-{suite_index}"
+        selected = suite_index == 0
+        tab_buttons.append(
+            '<button class="tab" role="tab" '
+            f'id="{tab_id}-tab" aria-controls="{tab_id}" '
+            f'aria-selected="{"true" if selected else "false"}" '
+            f'data-target="{tab_id}">{html.escape(suite)}</button>'
+        )
+        family_sections = [
+            _render_family_table(family, family_rows)
+            for family, family_rows in families.items()
+        ]
+        panels.append(
+            f'<section class="suite-panel" id="{tab_id}" '
+            f'role="tabpanel" aria-labelledby="{tab_id}-tab"'
+            f"{' hidden' if not selected else ''}>"
+            f"{''.join(family_sections)}</section>"
+        )
+
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '  <meta charset="utf-8">\n'
+        '  <meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "  <title>OpenMed Public Benchmark Leaderboard</title>\n"
+        "  <style>\n"
+        "    :root{color-scheme:light dark;font-family:system-ui,sans-serif}\n"
+        "    body{margin:0 auto;max-width:96rem;padding:2rem;line-height:1.5}\n"
+        "    header{display:flex;gap:1rem;align-items:start;justify-content:space-between;flex-wrap:wrap}\n"
+        "    .tabs{display:flex;gap:.5rem;flex-wrap:wrap;margin:1.5rem 0}\n"
+        "    .tab{border:1px solid #64748b;border-radius:.4rem;padding:.55rem .9rem;background:transparent;cursor:pointer}\n"
+        '    .tab[aria-selected="true"]{background:#2563eb;color:#fff;border-color:#2563eb}\n'
+        "    .table-wrap{overflow-x:auto;margin-bottom:2rem}\n"
+        "    table{border-collapse:collapse;width:100%;font-variant-numeric:tabular-nums}\n"
+        "    th,td{border-bottom:1px solid #94a3b8;padding:.6rem;text-align:left;vertical-align:top}\n"
+        "    th.numeric,td.numeric{text-align:right}\n"
+        "    code{overflow-wrap:anywhere}\n"
+        "    .metric-note{color:#64748b}\n"
+        "  </style>\n"
+        "</head>\n"
+        "<body>\n"
+        "<header><div><h1>OpenMed Public Benchmark Leaderboard</h1>"
+        '<p class="metric-note">Ranked leakage ascending, then recall descending. '
+        "Every row links to its archived synthetic report.</p></div>"
+        '<a href="leaderboard.json" download>Download leaderboard.json</a></header>\n'
+        f'<div class="tabs" role="tablist" aria-label="Benchmark suites">{"".join(tab_buttons)}</div>\n'
+        f"{''.join(panels)}\n"
+        "<script>\n"
+        "  const tabs = document.querySelectorAll('[role=\"tab\"]');\n"
+        "  tabs.forEach((tab) => tab.addEventListener('click', () => {\n"
+        "    tabs.forEach((item) => item.setAttribute('aria-selected', String(item === tab)));\n"
+        "    document.querySelectorAll('[role=\"tabpanel\"]').forEach((panel) => {\n"
+        "      panel.hidden = panel.id !== tab.dataset.target;\n"
+        "    });\n"
+        "  }));\n"
+        "</script>\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def write_leaderboard(
+    reports_dir: str | Path,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    *,
+    manifest_rows: Iterable[Mapping[str, Any]] = (),
+    release_tag: str | None = None,
+) -> LeaderboardArtifacts:
+    """Render HTML, JSON, and downloadable reports into *output_dir*.
+
+    Args:
+        reports_dir: Directory recursively containing archived report JSON.
+        output_dir: Destination below the documentation tree.
+        manifest_rows: Optional model manifest rows used for metadata fallback.
+        release_tag: Fallback release tag for legacy reports.
+
+    Returns:
+        Paths of the generated HTML, JSON, and report copies.
+    """
+
+    archives = _load_archived_reports(reports_dir)
+    manifests = {
+        str(row.get("repo_id")): row
+        for row in manifest_rows
+        if row.get("repo_id") is not None
+    }
+    rows = sorted(
+        (
+            _row_from_archive(
+                archive,
+                manifest_row=manifests.get(archive.report.model_name),
+                release_tag=release_tag,
+            )
+            for archive in archives
+        ),
+        key=_row_sort_key,
+    )
+
+    destination = Path(output_dir)
+    destination.mkdir(parents=True, exist_ok=True)
+    reports_output = destination / "reports"
+    _clear_generated_reports(reports_output)
+
+    copied_reports: list[Path] = []
+    for archive in archives:
+        report_output = reports_output / archive.relative_path
+        report_output.parent.mkdir(parents=True, exist_ok=True)
+        report_output.write_text(_json_text(archive.payload), encoding="utf-8")
+        copied_reports.append(report_output)
+
+    html_path = destination / "index.html"
+    json_path = destination / "leaderboard.json"
+    html_path.write_text(render_leaderboard_html(rows), encoding="utf-8")
+    json_path.write_text(render_leaderboard_json(rows), encoding="utf-8")
+    return LeaderboardArtifacts(
+        html_path=html_path,
+        json_path=json_path,
+        report_paths=tuple(copied_reports),
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the public leaderboard command-line parser."""
+
+    parser = argparse.ArgumentParser(
+        description="Render a deterministic public leaderboard from archived reports."
+    )
+    parser.add_argument("--reports-dir", type=Path, default=DEFAULT_REPORTS_DIR)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--manifest", type=Path, default=MANIFEST_PATH)
+    parser.add_argument(
+        "--release-tag",
+        help="Fallback release tag for archived reports that do not contain one.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Render the public leaderboard from command-line arguments."""
+
+    args = build_arg_parser().parse_args(argv)
+    manifest_rows = load_manifest_rows(args.manifest) if args.manifest.is_file() else []
+    artifacts = write_leaderboard(
+        args.reports_dir,
+        args.output_dir,
+        manifest_rows=manifest_rows,
+        release_tag=args.release_tag,
+    )
+    print(artifacts.html_path)
+    print(artifacts.json_path)
+    return 0
+
+
+def _load_archived_reports(reports_dir: str | Path) -> list[_ArchivedReport]:
+    root = Path(reports_dir)
+    if not root.is_dir():
+        raise LeaderboardError(f"Archived report directory does not exist: {root}")
+
+    paths = sorted(
+        (
+            path
+            for path in root.rglob("*.json")
+            if path.name != "leaderboard.json" and not path.is_symlink()
+        ),
+        key=lambda path: path.relative_to(root).as_posix(),
+    )
+    if not paths:
+        raise LeaderboardError(f"No archived report JSON found in {root}")
+
+    archives: list[_ArchivedReport] = []
+    for path in paths:
+        relative_path = path.relative_to(root)
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise LeaderboardError(
+                f"Could not read archived report {path}: {exc}"
+            ) from exc
+        if not isinstance(payload, Mapping):
+            raise LeaderboardError(f"Archived report must be a JSON object: {path}")
+        try:
+            report = BenchmarkReport.from_dict(payload)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise LeaderboardError(f"Invalid BenchmarkReport {path}: {exc}") from exc
+        archives.append(
+            _ArchivedReport(
+                path=path,
+                relative_path=relative_path,
+                payload=payload,
+                report=report,
+            )
+        )
+    return archives
+
+
+def _row_from_archive(
+    archive: _ArchivedReport,
+    *,
+    manifest_row: Mapping[str, Any] | None,
+    release_tag: str | None,
+) -> LeaderboardRow:
+    report = archive.report
+    source = archive.relative_path.as_posix()
+    metadata = report.metadata
+    family = metadata.get("model_family") or metadata.get("family")
+    if family is None and manifest_row is not None:
+        family = manifest_row.get("family")
+    if family is None or not str(family).strip():
+        raise LeaderboardError(f"Report {source} has no model family metadata")
+
+    row_release = metadata.get("release_tag") or metadata.get("release") or release_tag
+    if row_release is None or not str(row_release).strip():
+        raise LeaderboardError(f"Report {source} has no release tag")
+
+    run_date = metadata.get("run_date") or report.generated_at
+    normalized_run_date = _normalize_run_date(run_date, source=source)
+
+    repro_hash = metadata.get("reproducibility_hash") or metadata.get("repro_hash")
+    if repro_hash is None and manifest_row is not None:
+        repro_hash = manifest_row.get("reproducibility_hash")
+    if not isinstance(repro_hash, str) or not _SHA256_RE.fullmatch(repro_hash):
+        raise LeaderboardError(
+            f"Report {source} has no valid sha256 reproducibility hash"
+        )
+
+    return LeaderboardRow(
+        suite=_required_text(report.suite, field="suite", source=source),
+        model_family=str(family).strip(),
+        model_name=_required_text(
+            report.model_name,
+            field="model_name",
+            source=source,
+        ),
+        device=_required_text(report.device, field="device", source=source),
+        leakage=_metric(report.metrics, _LEAKAGE_METRICS, "leakage", source),
+        recall=_metric(report.metrics, _RECALL_METRICS, "recall", source),
+        f1=_metric(report.metrics, _F1_METRICS, "F1", source),
+        release_tag=str(row_release).strip(),
+        run_date=normalized_run_date,
+        reproducibility_hash=repro_hash,
+        report_path=source,
+        report_url=f"reports/{quote(source)}",
+    )
+
+
+def _metric(
+    metrics: Mapping[str, Any],
+    candidates: Sequence[str],
+    label: str,
+    source: str,
+) -> float:
+    for key in candidates:
+        value = _nested_get(metrics, key)
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise LeaderboardError(f"Report {source} has non-numeric {label}: {key}")
+        number = float(value)
+        if not math.isfinite(number) or not 0.0 <= number <= 1.0:
+            raise LeaderboardError(
+                f"Report {source} has {label} outside [0, 1]: {key}={value!r}"
+            )
+        return number
+    raise LeaderboardError(
+        f"Report {source} is missing {label}; expected one of {', '.join(candidates)}"
+    )
+
+
+def _nested_get(mapping: Mapping[str, Any], dotted_key: str) -> Any:
+    current: Any = mapping
+    for part in dotted_key.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _normalize_run_date(value: Any, *, source: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise LeaderboardError(f"Report {source} has no run date")
+    candidate = value.strip()[:10]
+    try:
+        return date.fromisoformat(candidate).isoformat()
+    except ValueError as exc:
+        raise LeaderboardError(
+            f"Report {source} has invalid run date: {value!r}"
+        ) from exc
+
+
+def _required_text(value: Any, *, field: str, source: str) -> str:
+    text = str(value).strip()
+    if not text:
+        raise LeaderboardError(f"Report {source} has empty {field}")
+    return text
+
+
+def _row_sort_key(row: LeaderboardRow) -> tuple[Any, ...]:
+    return (
+        row.leakage,
+        -row.recall,
+        row.suite.casefold(),
+        row.model_family.casefold(),
+        row.model_name.casefold(),
+        row.device.casefold(),
+        row.release_tag.casefold(),
+        row.report_path,
+    )
+
+
+def _group_rows(
+    rows: Iterable[LeaderboardRow],
+) -> dict[str, dict[str, list[LeaderboardRow]]]:
+    grouped: dict[str, dict[str, list[LeaderboardRow]]] = {}
+    for row in rows:
+        grouped.setdefault(row.suite, {}).setdefault(row.model_family, []).append(row)
+    return {
+        suite: {
+            family: sorted(family_rows, key=_row_sort_key)
+            for family, family_rows in sorted(
+                families.items(), key=lambda item: item[0].casefold()
+            )
+        }
+        for suite, families in sorted(
+            grouped.items(), key=lambda item: item[0].casefold()
+        )
+    }
+
+
+def _suite_payload(rows: Iterable[LeaderboardRow]) -> list[dict[str, Any]]:
+    return [
+        {
+            "families": [
+                {
+                    "name": family,
+                    "rows": [row.to_dict() for row in family_rows],
+                }
+                for family, family_rows in families.items()
+            ],
+            "name": suite,
+        }
+        for suite, families in _group_rows(rows).items()
+    ]
+
+
+def _render_family_table(family: str, rows: Sequence[LeaderboardRow]) -> str:
+    body: list[str] = []
+    for rank, row in enumerate(rows, start=1):
+        body.append(
+            "<tr>"
+            f'<td class="numeric">{rank}</td>'
+            f"<td>{html.escape(row.model_name)}</td>"
+            f"<td>{html.escape(row.device)}</td>"
+            f'<td class="numeric">{_format_percent(row.leakage)}</td>'
+            f'<td class="numeric">{_format_percent(row.recall)}</td>'
+            f'<td class="numeric">{_format_percent(row.f1)}</td>'
+            f"<td><code>{html.escape(row.release_tag)}</code></td>"
+            f'<td><time datetime="{html.escape(row.run_date)}">'
+            f"{html.escape(row.run_date)}</time></td>"
+            f"<td><code>{html.escape(row.reproducibility_hash)}</code></td>"
+            f'<td><a href="{html.escape(row.report_url)}" download>Download JSON</a></td>'
+            "</tr>"
+        )
+    return (
+        f"<h2>{html.escape(family)}</h2>"
+        '<div class="table-wrap"><table>'
+        '<thead><tr><th class="numeric">Rank</th><th>Model</th><th>Device</th>'
+        '<th class="numeric">Leakage</th><th class="numeric">Recall</th>'
+        '<th class="numeric">F1</th><th>Release</th><th>Run date</th>'
+        "<th>Reproducibility hash</th><th>Report</th></tr></thead>"
+        f"<tbody>{''.join(body)}</tbody></table></div>"
+    )
+
+
+def _format_percent(value: float) -> str:
+    return f"{value:.4%}"
+
+
+def _json_text(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _clear_generated_reports(reports_dir: Path) -> None:
+    if not reports_dir.exists():
+        return
+    if not reports_dir.is_dir() or reports_dir.is_symlink():
+        raise LeaderboardError(
+            f"Generated reports path is not a directory: {reports_dir}"
+        )
+    paths = sorted(
+        reports_dir.rglob("*"), key=lambda path: len(path.parts), reverse=True
+    )
+    for path in paths:
+        if path.is_file() or path.is_symlink():
+            path.unlink()
+        elif path.is_dir():
+            path.rmdir()
+
+
+__all__ = [
+    "DEFAULT_OUTPUT_DIR",
+    "DEFAULT_REPORTS_DIR",
+    "LEADERBOARD_SCHEMA_VERSION",
+    "LeaderboardArtifacts",
+    "LeaderboardError",
+    "LeaderboardRow",
+    "load_leaderboard_rows",
+    "render_leaderboard_html",
+    "render_leaderboard_json",
+    "write_leaderboard",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openmed/eval/leaderboard.py
+++ b/openmed/eval/leaderboard.py
@@ -8,7 +8,7 @@ import json
 import math
 import re
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 from urllib.parse import quote
@@ -21,6 +21,7 @@ DEFAULT_REPORTS_DIR = Path("docs/benchmarks")
 DEFAULT_OUTPUT_DIR = Path("docs/eval/benchmark-leaderboard")
 
 _SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}")
+_REPORT_DISCRIMINATORS = frozenset({"suite", "model_name", "fixture_count", "metrics"})
 _LEAKAGE_METRICS = (
     "leakage.overall",
     "leakage_rate.overall",
@@ -341,8 +342,15 @@ def _load_archived_reports(reports_dir: str | Path) -> list[_ArchivedReport]:
             raise LeaderboardError(
                 f"Could not read archived report {path}: {exc}"
             ) from exc
+        is_named_report = path.name.endswith(".report.json")
         if not isinstance(payload, Mapping):
-            raise LeaderboardError(f"Archived report must be a JSON object: {path}")
+            if is_named_report:
+                raise LeaderboardError(f"Archived report must be a JSON object: {path}")
+            continue
+        if not is_named_report and not _REPORT_DISCRIMINATORS.intersection(payload):
+            continue
+        source = relative_path.as_posix()
+        _validate_report_payload(payload, source=source)
         try:
             report = BenchmarkReport.from_dict(payload)
         except (KeyError, TypeError, ValueError) as exc:
@@ -355,7 +363,32 @@ def _load_archived_reports(reports_dir: str | Path) -> list[_ArchivedReport]:
                 report=report,
             )
         )
+    if not archives:
+        raise LeaderboardError(f"No archived BenchmarkReport JSON found in {root}")
     return archives
+
+
+def _validate_report_payload(payload: Mapping[str, Any], *, source: str) -> None:
+    for field in ("suite", "model_name", "device"):
+        _required_text(payload.get(field), field=field, source=source)
+
+    fixture_count = payload.get("fixture_count")
+    if (
+        isinstance(fixture_count, bool)
+        or not isinstance(fixture_count, int)
+        or fixture_count <= 0
+    ):
+        raise LeaderboardError(
+            f"Report {source} requires a positive integer fixture_count"
+        )
+    if not isinstance(payload.get("metrics"), Mapping):
+        raise LeaderboardError(f"Report {source} requires a metrics object")
+    metadata = payload.get("metadata", {})
+    if not isinstance(metadata, Mapping):
+        raise LeaderboardError(f"Report {source} requires a metadata object")
+    generated_at = payload.get("generated_at")
+    if generated_at is not None and not isinstance(generated_at, str):
+        raise LeaderboardError(f"Report {source} has a non-string generated_at")
 
 
 def _row_from_archive(
@@ -367,15 +400,23 @@ def _row_from_archive(
     report = archive.report
     source = archive.relative_path.as_posix()
     metadata = report.metadata
+    if metadata.get("synthetic") is not True:
+        raise LeaderboardError(f"Report {source} is not explicitly marked as synthetic")
     family = metadata.get("model_family") or metadata.get("family")
     if family is None and manifest_row is not None:
         family = manifest_row.get("family")
-    if family is None or not str(family).strip():
-        raise LeaderboardError(f"Report {source} has no model family metadata")
+    family_text = _required_text(
+        family,
+        field="model family metadata",
+        source=source,
+    )
 
     row_release = metadata.get("release_tag") or metadata.get("release") or release_tag
-    if row_release is None or not str(row_release).strip():
-        raise LeaderboardError(f"Report {source} has no release tag")
+    release_text = _required_text(
+        row_release,
+        field="release tag",
+        source=source,
+    )
 
     run_date = metadata.get("run_date") or report.generated_at
     normalized_run_date = _normalize_run_date(run_date, source=source)
@@ -390,7 +431,7 @@ def _row_from_archive(
 
     return LeaderboardRow(
         suite=_required_text(report.suite, field="suite", source=source),
-        model_family=str(family).strip(),
+        model_family=family_text,
         model_name=_required_text(
             report.model_name,
             field="model_name",
@@ -400,7 +441,7 @@ def _row_from_archive(
         leakage=_metric(report.metrics, _LEAKAGE_METRICS, "leakage", source),
         recall=_metric(report.metrics, _RECALL_METRICS, "recall", source),
         f1=_metric(report.metrics, _F1_METRICS, "F1", source),
-        release_tag=str(row_release).strip(),
+        release_tag=release_text,
         run_date=normalized_run_date,
         reproducibility_hash=repro_hash,
         report_path=source,
@@ -443,9 +484,12 @@ def _nested_get(mapping: Mapping[str, Any], dotted_key: str) -> Any:
 def _normalize_run_date(value: Any, *, source: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise LeaderboardError(f"Report {source} has no run date")
-    candidate = value.strip()[:10]
+    candidate = value.strip()
     try:
-        return date.fromisoformat(candidate).isoformat()
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", candidate):
+            return date.fromisoformat(candidate).isoformat()
+        normalized = f"{candidate[:-1]}+00:00" if candidate.endswith("Z") else candidate
+        return datetime.fromisoformat(normalized).date().isoformat()
     except ValueError as exc:
         raise LeaderboardError(
             f"Report {source} has invalid run date: {value!r}"
@@ -453,10 +497,9 @@ def _normalize_run_date(value: Any, *, source: str) -> str:
 
 
 def _required_text(value: Any, *, field: str, source: str) -> str:
-    text = str(value).strip()
-    if not text:
-        raise LeaderboardError(f"Report {source} has empty {field}")
-    return text
+    if not isinstance(value, str) or not value.strip():
+        raise LeaderboardError(f"Report {source} has no valid {field}")
+    return value.strip()
 
 
 def _row_sort_key(row: LeaderboardRow) -> tuple[Any, ...]:

--- a/tests/unit/eval/test_leaderboard.py
+++ b/tests/unit/eval/test_leaderboard.py
@@ -1,0 +1,277 @@
+"""Tests for the archived-report public leaderboard."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from openmed.__about__ import __version__
+from openmed.core.model_registry import load_manifest_rows
+from openmed.eval.leaderboard import (
+    LeaderboardError,
+    load_leaderboard_rows,
+    write_leaderboard,
+)
+from openmed.eval.report import BenchmarkReport
+
+ROOT = Path(__file__).resolve().parents[3]
+PUBLIC_LEADERBOARD = ROOT / "docs" / "eval" / "benchmark-leaderboard"
+PAGES_WORKFLOW = ROOT / ".github" / "workflows" / "pages.yml"
+
+
+def _write_report(
+    path: Path,
+    *,
+    model_name: str,
+    suite: str = "privacy",
+    family: str = "PII",
+    leakage: float = 0.0,
+    recall: float = 1.0,
+    f1: float = 1.0,
+    release_tag: str = "v2.0.0",
+    run_date: str = "2026-07-17T12:00:00Z",
+    repro_character: str = "a",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    BenchmarkReport(
+        suite=suite,
+        model_name=model_name,
+        device="cpu",
+        fixture_count=3,
+        generated_at=run_date,
+        metrics={
+            "exact_span_f1": {"f1": f1, "recall": recall},
+            "leakage": {"overall": leakage},
+        },
+        metadata={
+            "family": family,
+            "release_tag": release_tag,
+            "reproducibility_hash": "sha256:" + repro_character * 64,
+        },
+    ).write_json(path)
+
+
+def _snapshot(directory: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(directory).as_posix(): path.read_bytes()
+        for path in sorted(item for item in directory.rglob("*") if item.is_file())
+    }
+
+
+def test_renderer_sorts_leakage_first_then_recall(tmp_path: Path) -> None:
+    reports = tmp_path / "reports"
+    _write_report(
+        reports / "high-f1.json",
+        model_name="high-f1",
+        leakage=0.2,
+        recall=0.99,
+        f1=0.99,
+    )
+    _write_report(
+        reports / "low-recall.json",
+        model_name="low-recall",
+        leakage=0.1,
+        recall=0.8,
+        f1=0.95,
+        repro_character="b",
+    )
+    _write_report(
+        reports / "high-recall.json",
+        model_name="high-recall",
+        leakage=0.1,
+        recall=0.9,
+        f1=0.4,
+        repro_character="c",
+    )
+
+    rows = load_leaderboard_rows(reports)
+
+    assert [row.model_name for row in rows] == [
+        "high-recall",
+        "low-recall",
+        "high-f1",
+    ]
+    assert [(row.leakage, row.recall) for row in rows] == [
+        (0.1, 0.9),
+        (0.1, 0.8),
+        (0.2, 0.99),
+    ]
+
+
+def test_renderer_emits_grouped_html_json_and_downloads(tmp_path: Path) -> None:
+    reports = tmp_path / "reports"
+    _write_report(
+        reports / "nested" / "privacy.json",
+        model_name="privacy-model",
+        suite="privacy",
+        family="PII",
+    )
+    _write_report(
+        reports / "utility.json",
+        model_name="utility-model",
+        suite="utility",
+        family="NER",
+        leakage=0.02,
+        recall=0.91,
+        f1=0.9,
+        release_tag="v2.0.1",
+        run_date="2026-07-18T08:30:00Z",
+        repro_character="d",
+    )
+
+    output = tmp_path / "output"
+    artifacts = write_leaderboard(reports, output)
+    payload = json.loads(artifacts.json_path.read_text(encoding="utf-8"))
+    rendered = artifacts.html_path.read_text(encoding="utf-8")
+
+    assert payload["schema_version"] == 1
+    assert payload["sort"] == ["leakage:asc", "recall:desc"]
+    assert [suite["name"] for suite in payload["suites"]] == [
+        "privacy",
+        "utility",
+    ]
+    assert payload["rows"][0]["release_tag"] == "v2.0.0"
+    assert payload["rows"][0]["run_date"] == "2026-07-17"
+    assert payload["rows"][0]["reproducibility_hash"] == "sha256:" + "a" * 64
+    assert 'role="tab"' in rendered
+    assert ">PII</h2>" in rendered
+    assert ">NER</h2>" in rendered
+    assert 'href="reports/nested/privacy.json" download' in rendered
+    assert 'href="leaderboard.json" download' in rendered
+    assert (output / "reports" / "nested" / "privacy.json").is_file()
+    assert (output / "reports" / "utility.json").is_file()
+
+
+def test_rerendering_same_archive_is_byte_identical(tmp_path: Path) -> None:
+    reports = tmp_path / "reports"
+    _write_report(
+        reports / "z.json",
+        model_name="z-model",
+        leakage=0.03,
+        recall=0.9,
+        f1=0.88,
+    )
+    _write_report(
+        reports / "a.json",
+        model_name="a-model",
+        leakage=0.01,
+        recall=0.92,
+        f1=0.9,
+        repro_character="b",
+    )
+    output = tmp_path / "output"
+
+    write_leaderboard(reports, output)
+    first = _snapshot(output)
+    write_leaderboard(reports, output)
+    second = _snapshot(output)
+
+    assert first == second
+
+
+def test_manifest_and_release_fallback_stamp_legacy_report(tmp_path: Path) -> None:
+    report_path = tmp_path / "reports" / "legacy.json"
+    report_path.parent.mkdir()
+    BenchmarkReport(
+        suite="privacy",
+        model_name="OpenMed/legacy",
+        device="cpu",
+        fixture_count=1,
+        generated_at="2026-07-17T01:02:03Z",
+        metrics={
+            "exact_span_f1": {"f1": 0.9, "recall": 0.92},
+            "leakage": {"overall": 0.01},
+        },
+    ).write_json(report_path)
+    manifest = [
+        {
+            "repo_id": "OpenMed/legacy",
+            "family": "PII",
+            "reproducibility_hash": "sha256:" + "e" * 64,
+        }
+    ]
+
+    rows = load_leaderboard_rows(
+        report_path.parent,
+        manifest_rows=manifest,
+        release_tag="v2.0.0",
+    )
+
+    assert rows[0].model_family == "PII"
+    assert rows[0].release_tag == "v2.0.0"
+    assert rows[0].run_date == "2026-07-17"
+    assert rows[0].reproducibility_hash == "sha256:" + "e" * 64
+
+
+def test_renderer_fails_closed_when_ranking_evidence_is_missing(
+    tmp_path: Path,
+) -> None:
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    BenchmarkReport(
+        suite="privacy",
+        model_name="incomplete",
+        device="cpu",
+        fixture_count=1,
+        generated_at="2026-07-17T00:00:00Z",
+        metrics={"exact_span_f1": {"f1": 0.9, "recall": 0.9}},
+        metadata={
+            "family": "PII",
+            "release_tag": "v2.0.0",
+            "reproducibility_hash": "sha256:" + "a" * 64,
+        },
+    ).write_json(reports / "incomplete.json")
+
+    with pytest.raises(LeaderboardError, match="missing leakage"):
+        load_leaderboard_rows(reports)
+
+
+def test_renderer_escapes_report_metadata_in_html(tmp_path: Path) -> None:
+    reports = tmp_path / "reports"
+    _write_report(
+        reports / "unsafe.json",
+        model_name="<script>alert(1)</script>",
+        family="PII & NER",
+    )
+
+    artifacts = write_leaderboard(reports, tmp_path / "output")
+    rendered = artifacts.html_path.read_text(encoding="utf-8")
+
+    assert "<script>alert(1)</script>" not in rendered
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in rendered
+    assert "PII &amp; NER" in rendered
+
+
+def test_committed_public_leaderboard_does_not_drift(tmp_path: Path) -> None:
+    generated = tmp_path / "generated"
+    write_leaderboard(
+        ROOT / "docs" / "benchmarks",
+        generated,
+        manifest_rows=load_manifest_rows(ROOT / "models.jsonl"),
+        release_tag=f"v{__version__}",
+    )
+
+    assert _snapshot(generated) == _snapshot(PUBLIC_LEADERBOARD)
+
+
+def test_pages_workflow_renders_on_master_and_release_tags() -> None:
+    workflow = yaml.load(
+        PAGES_WORKFLOW.read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    push = workflow["on"]["push"]
+    steps = workflow["jobs"]["deploy"]["steps"]
+    render_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Render public benchmark leaderboard"
+    )
+
+    assert push["branches"] == ["master"]
+    assert push["tags"] == ["v*"]
+    assert "python -m openmed.eval.leaderboard" in render_step["run"]
+    assert "docs/eval/benchmark-leaderboard" in render_step["run"]
+    assert 'release_tag="$GITHUB_REF_NAME"' in render_step["run"]

--- a/tests/unit/eval/test_leaderboard.py
+++ b/tests/unit/eval/test_leaderboard.py
@@ -50,6 +50,7 @@ def _write_report(
             "family": family,
             "release_tag": release_tag,
             "reproducibility_hash": "sha256:" + repro_character * 64,
+            "synthetic": True,
         },
     ).write_json(path)
 
@@ -99,6 +100,19 @@ def test_renderer_sorts_leakage_first_then_recall(tmp_path: Path) -> None:
         (0.1, 0.8),
         (0.2, 0.99),
     ]
+
+
+def test_renderer_ignores_non_report_json_in_mixed_archive(tmp_path: Path) -> None:
+    reports = tmp_path / "reports"
+    _write_report(reports / "valid.report.json", model_name="valid")
+    (reports / "baseline.json").write_text(
+        '{"schema_version": 1, "throughput": 12.5}\n',
+        encoding="utf-8",
+    )
+
+    rows = load_leaderboard_rows(reports)
+
+    assert [row.model_name for row in rows] == ["valid"]
 
 
 def test_renderer_emits_grouped_html_json_and_downloads(tmp_path: Path) -> None:
@@ -185,6 +199,7 @@ def test_manifest_and_release_fallback_stamp_legacy_report(tmp_path: Path) -> No
             "exact_span_f1": {"f1": 0.9, "recall": 0.92},
             "leakage": {"overall": 0.01},
         },
+        metadata={"synthetic": True},
     ).write_json(report_path)
     manifest = [
         {
@@ -222,10 +237,45 @@ def test_renderer_fails_closed_when_ranking_evidence_is_missing(
             "family": "PII",
             "release_tag": "v2.0.0",
             "reproducibility_hash": "sha256:" + "a" * 64,
+            "synthetic": True,
         },
     ).write_json(reports / "incomplete.json")
 
     with pytest.raises(LeaderboardError, match="missing leakage"):
+        load_leaderboard_rows(reports)
+
+
+def test_renderer_rejects_report_without_explicit_synthetic_provenance(
+    tmp_path: Path,
+) -> None:
+    reports = tmp_path / "reports"
+    _write_report(reports / "unmarked.json", model_name="unmarked")
+    payload = json.loads((reports / "unmarked.json").read_text(encoding="utf-8"))
+    del payload["metadata"]["synthetic"]
+    (reports / "unmarked.json").write_text(
+        json.dumps(payload),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(LeaderboardError, match="explicitly marked as synthetic"):
+        load_leaderboard_rows(reports)
+
+
+@pytest.mark.parametrize(
+    "run_date",
+    ["2026-07-17 trailing text", "2026-13-01", 20260717],
+)
+def test_renderer_rejects_invalid_run_dates(tmp_path: Path, run_date: object) -> None:
+    reports = tmp_path / "reports"
+    _write_report(reports / "invalid-date.json", model_name="invalid-date")
+    payload = json.loads((reports / "invalid-date.json").read_text(encoding="utf-8"))
+    payload["generated_at"] = run_date
+    (reports / "invalid-date.json").write_text(
+        json.dumps(payload),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(LeaderboardError, match="generated_at|run date"):
         load_leaderboard_rows(reports)
 
 
@@ -258,8 +308,9 @@ def test_committed_public_leaderboard_does_not_drift(tmp_path: Path) -> None:
 
 
 def test_pages_workflow_renders_on_master_and_release_tags() -> None:
+    workflow_text = PAGES_WORKFLOW.read_text(encoding="utf-8")
     workflow = yaml.load(
-        PAGES_WORKFLOW.read_text(encoding="utf-8"),
+        workflow_text,
         Loader=yaml.BaseLoader,
     )
     push = workflow["on"]["push"]
@@ -272,6 +323,9 @@ def test_pages_workflow_renders_on_master_and_release_tags() -> None:
 
     assert push["branches"] == ["master"]
     assert push["tags"] == ["v*"]
+    assert workflow_text.count('tags: ["v*"]') == 1
     assert "python -m openmed.eval.leaderboard" in render_step["run"]
     assert "docs/eval/benchmark-leaderboard" in render_step["run"]
     assert 'release_tag="$GITHUB_REF_NAME"' in render_step["run"]
+    assert "test -s site/docs/llms.txt" in workflow_text
+    assert "test -s site/docs/llms-full.txt" in workflow_text


### PR DESCRIPTION
## Description

Adds an offline, deterministic renderer for archived synthetic benchmark reports. It publishes a browsable HTML leaderboard and machine-readable JSON at a stable documentation path, ranks leakage before recall, groups rows by suite and model family, and preserves downloadable report evidence with release, run-date, and reproducibility stamps.

Closes #880.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Add archived-report validation, deterministic leakage-first ranking, HTML suite tabs, grouped JSON, and canonical report downloads.
- Publish the rendered artifact from `master` and `v*` release tags at `docs/eval/benchmark-leaderboard/`.
- Preserve release tag, run date, and reproducibility-hash provenance on every row.
- Ignore unrelated auxiliary JSON in the mixed benchmark directory while failing closed on malformed report candidates.
- Require explicit `metadata.synthetic: true` provenance before any report can enter the public artifact.
- Preserve the existing Pages action pins and LLM documentation-feed checks after rebasing.

## Testing

- [x] I have added tests that prove the feature works
- [x] Focused leaderboard suite: 13 passed
- [x] Leaderboard, status, publication, workflow-reference, and repository-policy tests: 27 passed
- [x] Full suite: 6,160 passed, 48 skipped
- [x] Package wheel and sdist build successfully

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] Strict documentation build passes, including both LLM feeds

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I ran the scoped type-check gate
- [x] Scoped pre-commit checks pass for all nine PR files
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] The renderer is deterministic and offline
- [x] Public input is restricted to explicitly synthetic reports

## Related Issues

Closes #880

## Screenshots/Examples

The committed artifact is under `docs/eval/benchmark-leaderboard/`, with `index.html`, `leaderboard.json`, and canonical synthetic report downloads.
