### PR TITLE
Add a k-anonymity engine for tabular outputs

### DIFF
--- a/openmed/risk/__init__.py
+++ b/openmed/risk/__init__.py
@@ -22,6 +22,15 @@ from .budget import (
     evaluate_budget,
 )
 from .dashboard import render_risk_dashboard, write_risk_dashboard
+from .k_anonymity import (
+    EquivalenceClass,
+    KAnonymityEngine,
+    KAnonymityReport,
+    SuppressionProposal,
+    analyze_k_anonymity,
+    apply_suppression,
+    propose_suppression,
+)
 from .kanon import build_generalization_hierarchies, enforce_kanon, kanon_report
 from .reid import (
     LongitudinalCorpus,
@@ -46,6 +55,9 @@ __all__ = [
     "DPSurrogateSensitivity",
     "DPSurrogateSensitivityRegistry",
     "DPSurrogateSpend",
+    "EquivalenceClass",
+    "KAnonymityEngine",
+    "KAnonymityReport",
     "RiskBudget",
     "RiskBudgetExceeded",
     "RiskBudgetVerdict",
@@ -55,6 +67,9 @@ __all__ = [
     "LongitudinalNote",
     "LongitudinalPatient",
     "SurrogateDrawKind",
+    "SuppressionProposal",
+    "analyze_k_anonymity",
+    "apply_suppression",
     "budget_for_policy",
     "build_longitudinal_corpus",
     "evaluate_budget",
@@ -64,6 +79,7 @@ __all__ = [
     "build_generalization_hierarchies",
     "enforce_kanon",
     "kanon_report",
+    "propose_suppression",
     "diff_audit_reports",
     "AuditDiff",
     "render_risk_dashboard",

--- a/openmed/risk/k_anonymity.py
+++ b/openmed/risk/k_anonymity.py
@@ -90,6 +90,7 @@ class SuppressionProposal:
     """
 
     target_k: int
+    quasi_identifiers: tuple[str, ...]
     source_record_count: int
     row_indices: tuple[int, ...]
     retained_count: int
@@ -122,6 +123,7 @@ class SuppressionProposal:
         return {
             "strategy": "minimal_whole_row_suppression",
             "target_k": int(self.target_k),
+            "quasi_identifiers": list(self.quasi_identifiers),
             "source_record_count": int(self.source_record_count),
             "row_indices": list(self.row_indices),
             "suppressed_count": self.suppressed_count,
@@ -178,6 +180,7 @@ class KAnonymityEngine:
         after = _analyze_rows(retained, self.quasi_identifiers, self.target_k)
         return SuppressionProposal(
             target_k=self.target_k,
+            quasi_identifiers=self.quasi_identifiers,
             source_record_count=len(rows),
             row_indices=before.violating_rows,
             retained_count=len(retained),
@@ -235,18 +238,31 @@ def apply_suppression(
                 "Target k cannot be reached by row suppression without removing "
                 "every record."
             )
+        _validate_columns(rows, proposal.quasi_identifiers)
+        current = _analyze_rows(
+            rows,
+            proposal.quasi_identifiers,
+            proposal.target_k,
+        )
+        if current.violating_rows != proposal.row_indices:
+            raise ValueError(
+                "Suppression proposal does not match the supplied table's "
+                "equivalence classes."
+            )
+        if len(current.violating_rows) == len(rows):
+            raise ValueError(
+                "Target k cannot be reached by row suppression without removing "
+                "every record."
+            )
         row_indices = proposal.row_indices
     else:
         row_indices = tuple(proposal)
 
-    invalid = sorted(
-        {
-            index
-            for index in row_indices
-            if type(index) is not int or index < 0 or index >= len(rows)
-        },
-        key=str,
-    )
+    invalid = [
+        index
+        for index in row_indices
+        if type(index) is not int or index < 0 or index >= len(rows)
+    ]
     if invalid:
         raise ValueError(f"Suppression row indices are out of range: {invalid!r}")
 
@@ -260,18 +276,26 @@ def _analyze_rows(
     target_k: int,
 ) -> KAnonymityReport:
     measurement = kanon_report(rows, quasi_identifiers=quasi_identifiers)
+    class_rows = []
+    for equivalence_class in measurement["equivalence_classes"]:
+        row_indices = tuple(
+            sorted(int(index) for index in equivalence_class["members"])
+        )
+        class_rows.append(
+            EquivalenceClass(
+                class_hash=stable_hash(
+                    {
+                        "kind": "k-anonymity-equivalence-class",
+                        "row_indices": row_indices,
+                    }
+                ),
+                size=int(equivalence_class["size"]),
+                row_indices=row_indices,
+            )
+        )
     classes = tuple(
         sorted(
-            (
-                EquivalenceClass(
-                    class_hash=stable_hash(equivalence_class["key"]),
-                    size=int(equivalence_class["size"]),
-                    row_indices=tuple(
-                        sorted(int(index) for index in equivalence_class["members"])
-                    ),
-                )
-                for equivalence_class in measurement["equivalence_classes"]
-            ),
+            class_rows,
             key=lambda equivalence_class: (
                 equivalence_class.row_indices[0],
                 equivalence_class.class_hash,
@@ -327,9 +351,30 @@ def _validate_columns(
     if not rows:
         return
     available = {str(field) for row in rows for field in row}
-    missing = sorted(set(quasi_identifiers) - available)
+    unknown = sorted(set(quasi_identifiers) - available)
+    if unknown:
+        raise ValueError(f"Unknown quasi-identifier columns: {unknown!r}")
+
+    missing: dict[str, list[int]] = {}
+    unsupported: dict[str, list[int]] = {}
+    for row_index, row in enumerate(rows):
+        fields = {str(field): value for field, value in row.items()}
+        for quasi_identifier in quasi_identifiers:
+            if quasi_identifier not in fields:
+                missing.setdefault(quasi_identifier, []).append(row_index)
+                continue
+            value = fields[quasi_identifier]
+            if value is not None and not isinstance(value, (str, int, float, bool)):
+                unsupported.setdefault(quasi_identifier, []).append(row_index)
     if missing:
-        raise ValueError(f"Unknown quasi-identifier columns: {missing!r}")
+        raise ValueError(
+            f"Declared quasi-identifier columns are missing from rows: {missing!r}"
+        )
+    if unsupported:
+        raise TypeError(
+            "Declared quasi-identifiers require scalar values; unsupported rows: "
+            f"{unsupported!r}"
+        )
 
 
 def _materialize_rows(records: Any) -> list[dict[str, Any]]:

--- a/openmed/risk/k_anonymity.py
+++ b/openmed/risk/k_anonymity.py
@@ -1,0 +1,373 @@
+"""Targeted k-anonymity analysis and minimal row suppression.
+
+This module builds on :func:`openmed.risk.kanon_report` to add the policy
+operations needed by tabular anonymization workflows: identify rows that do
+not meet a declared ``k`` and propose the smallest row-suppression set that
+removes those violations. It intentionally does not search a generalization
+lattice; callers that need full-domain generalization can use
+:func:`openmed.risk.enforce_kanon`.
+
+Reports contain row offsets, sizes, and hashes only. Raw quasi-identifier
+values are used in-process to form equivalence classes but are not returned.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from openmed.core.audit import stable_hash
+
+from .kanon import kanon_report
+
+__all__ = [
+    "EquivalenceClass",
+    "KAnonymityEngine",
+    "KAnonymityReport",
+    "SuppressionProposal",
+    "analyze_k_anonymity",
+    "apply_suppression",
+    "propose_suppression",
+]
+
+
+@dataclass(frozen=True)
+class EquivalenceClass:
+    """Privacy-safe description of one quasi-identifier equivalence class."""
+
+    class_hash: str
+    size: int
+    row_indices: tuple[int, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic, JSON-serializable representation."""
+        return {
+            "class_hash": self.class_hash,
+            "size": int(self.size),
+            "row_indices": list(self.row_indices),
+        }
+
+
+@dataclass(frozen=True)
+class KAnonymityReport:
+    """Equivalence-class analysis against a target k-anonymity policy."""
+
+    record_count: int
+    quasi_identifiers: tuple[str, ...]
+    target_k: int
+    achieved_k: int
+    smallest_class_size: int
+    equivalence_classes: tuple[EquivalenceClass, ...]
+    violating_rows: tuple[int, ...]
+    meets_target: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic, JSON-serializable representation."""
+        return {
+            "record_count": int(self.record_count),
+            "quasi_identifiers": list(self.quasi_identifiers),
+            "target_k": int(self.target_k),
+            "achieved_k": int(self.achieved_k),
+            "smallest_class_size": int(self.smallest_class_size),
+            "class_count": len(self.equivalence_classes),
+            "equivalence_classes": [
+                equivalence_class.to_dict()
+                for equivalence_class in self.equivalence_classes
+            ],
+            "violating_rows": list(self.violating_rows),
+            "meets_target": bool(self.meets_target),
+        }
+
+
+@dataclass(frozen=True)
+class SuppressionProposal:
+    """Minimal whole-row suppression proposal for a target k.
+
+    ``feasible`` is false when row suppression would remove every record. In
+    that case the proposal remains useful as a diagnostic, but :meth:`apply`
+    refuses to emit an empty table as if it satisfied k-anonymity.
+    """
+
+    target_k: int
+    source_record_count: int
+    row_indices: tuple[int, ...]
+    retained_count: int
+    achieved_k_after_suppression: int
+    feasible: bool
+
+    @property
+    def suppressed_count(self) -> int:
+        """Return the number of rows selected for suppression."""
+        return len(self.row_indices)
+
+    @property
+    def suppression_rate(self) -> float:
+        """Return the proposed fraction of source rows to suppress."""
+        if not self.source_record_count:
+            return 0.0
+        return self.suppressed_count / self.source_record_count
+
+    def apply(self, records: Any) -> list[dict[str, Any]]:
+        """Apply this proposal while preserving all fields in retained rows."""
+        if not self.feasible:
+            raise ValueError(
+                "Target k cannot be reached by row suppression without removing "
+                "every record."
+            )
+        return apply_suppression(records, self)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic, JSON-serializable representation."""
+        return {
+            "strategy": "minimal_whole_row_suppression",
+            "target_k": int(self.target_k),
+            "source_record_count": int(self.source_record_count),
+            "row_indices": list(self.row_indices),
+            "suppressed_count": self.suppressed_count,
+            "retained_count": int(self.retained_count),
+            "suppression_rate": float(self.suppression_rate),
+            "achieved_k_after_suppression": int(self.achieved_k_after_suppression),
+            "feasible": bool(self.feasible),
+        }
+
+
+@dataclass(frozen=True, init=False)
+class KAnonymityEngine:
+    """Analyze and suppress tabular rows against a declared target k.
+
+    Args:
+        quasi_identifiers: Column names that form each equivalence-class key.
+        target_k: Required minimum equivalence-class size.
+    """
+
+    quasi_identifiers: tuple[str, ...]
+    target_k: int
+
+    def __init__(
+        self,
+        quasi_identifiers: Sequence[str],
+        target_k: int = 2,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "quasi_identifiers",
+            _validate_quasi_identifiers(quasi_identifiers),
+        )
+        object.__setattr__(self, "target_k", _validate_target_k(target_k))
+
+    def analyze(self, records: Any) -> KAnonymityReport:
+        """Compute equivalence classes and rows that violate ``target_k``."""
+        rows = _materialize_rows(records)
+        _validate_columns(rows, self.quasi_identifiers)
+        return _analyze_rows(rows, self.quasi_identifiers, self.target_k)
+
+    def propose_suppression(self, records: Any) -> SuppressionProposal:
+        """Propose the minimal whole-row suppression set for ``target_k``.
+
+        Every row in an undersized equivalence class must be suppressed: if
+        any row in that class remained, its class could only stay the same size
+        or shrink, and would still violate ``target_k``. Removing precisely all
+        such classes is therefore the unique minimal whole-row suppression set.
+        """
+        rows = _materialize_rows(records)
+        _validate_columns(rows, self.quasi_identifiers)
+        before = _analyze_rows(rows, self.quasi_identifiers, self.target_k)
+        suppressed = frozenset(before.violating_rows)
+        retained = [row for index, row in enumerate(rows) if index not in suppressed]
+        after = _analyze_rows(retained, self.quasi_identifiers, self.target_k)
+        return SuppressionProposal(
+            target_k=self.target_k,
+            source_record_count=len(rows),
+            row_indices=before.violating_rows,
+            retained_count=len(retained),
+            achieved_k_after_suppression=after.achieved_k,
+            feasible=after.meets_target,
+        )
+
+    def suppress(self, records: Any) -> list[dict[str, Any]]:
+        """Propose and apply minimal suppression in one operation."""
+        proposal = self.propose_suppression(records)
+        return proposal.apply(records)
+
+
+def analyze_k_anonymity(
+    records: Any,
+    quasi_identifiers: Sequence[str],
+    *,
+    target_k: int = 2,
+) -> KAnonymityReport:
+    """Analyze equivalence classes against ``target_k`` fully in-process."""
+    return KAnonymityEngine(quasi_identifiers, target_k).analyze(records)
+
+
+def propose_suppression(
+    records: Any,
+    quasi_identifiers: Sequence[str],
+    *,
+    target_k: int = 2,
+) -> SuppressionProposal:
+    """Return the minimal whole-row suppression proposal for ``target_k``."""
+    return KAnonymityEngine(quasi_identifiers, target_k).propose_suppression(records)
+
+
+def apply_suppression(
+    records: Any,
+    proposal: SuppressionProposal | Sequence[int],
+) -> list[dict[str, Any]]:
+    """Return copies of rows not selected by a suppression proposal.
+
+    Args:
+        records: A sequence of row mappings or a DataFrame-like object.
+        proposal: A :class:`SuppressionProposal` or positional row indices.
+
+    Returns:
+        Materialized copies of the retained rows in their original order.
+    """
+    rows = _materialize_rows(records)
+    if isinstance(proposal, SuppressionProposal):
+        if len(rows) != proposal.source_record_count:
+            raise ValueError(
+                "Suppression proposal record count does not match the supplied table."
+            )
+        if not proposal.feasible:
+            raise ValueError(
+                "Target k cannot be reached by row suppression without removing "
+                "every record."
+            )
+        row_indices = proposal.row_indices
+    else:
+        row_indices = tuple(proposal)
+
+    invalid = sorted(
+        {
+            index
+            for index in row_indices
+            if type(index) is not int or index < 0 or index >= len(rows)
+        },
+        key=str,
+    )
+    if invalid:
+        raise ValueError(f"Suppression row indices are out of range: {invalid!r}")
+
+    suppressed = frozenset(row_indices)
+    return [dict(row) for index, row in enumerate(rows) if index not in suppressed]
+
+
+def _analyze_rows(
+    rows: Sequence[Mapping[str, Any]],
+    quasi_identifiers: tuple[str, ...],
+    target_k: int,
+) -> KAnonymityReport:
+    measurement = kanon_report(rows, quasi_identifiers=quasi_identifiers)
+    classes = tuple(
+        sorted(
+            (
+                EquivalenceClass(
+                    class_hash=stable_hash(equivalence_class["key"]),
+                    size=int(equivalence_class["size"]),
+                    row_indices=tuple(
+                        sorted(int(index) for index in equivalence_class["members"])
+                    ),
+                )
+                for equivalence_class in measurement["equivalence_classes"]
+            ),
+            key=lambda equivalence_class: (
+                equivalence_class.row_indices[0],
+                equivalence_class.class_hash,
+            ),
+        )
+    )
+    violating_rows = tuple(
+        sorted(
+            index
+            for equivalence_class in classes
+            if equivalence_class.size < target_k
+            for index in equivalence_class.row_indices
+        )
+    )
+    achieved_k = int(measurement["k"])
+    return KAnonymityReport(
+        record_count=len(rows),
+        quasi_identifiers=quasi_identifiers,
+        target_k=target_k,
+        achieved_k=achieved_k,
+        smallest_class_size=achieved_k,
+        equivalence_classes=classes,
+        violating_rows=violating_rows,
+        meets_target=bool(rows) and not violating_rows,
+    )
+
+
+def _validate_quasi_identifiers(
+    quasi_identifiers: Sequence[str],
+) -> tuple[str, ...]:
+    if isinstance(quasi_identifiers, (str, bytes, bytearray)):
+        raise TypeError("quasi_identifiers must be a sequence of column names")
+    normalized: list[str] = []
+    for field in quasi_identifiers:
+        if not isinstance(field, str) or not field.strip():
+            raise ValueError("quasi_identifiers must contain non-empty column names")
+        normalized.append(field.strip())
+    if not normalized:
+        raise ValueError("At least one quasi-identifier must be declared")
+    return tuple(sorted(dict.fromkeys(normalized)))
+
+
+def _validate_target_k(target_k: int) -> int:
+    if type(target_k) is not int or target_k < 1:
+        raise ValueError("target_k must be an integer >= 1")
+    return target_k
+
+
+def _validate_columns(
+    rows: Sequence[Mapping[str, Any]],
+    quasi_identifiers: Sequence[str],
+) -> None:
+    if not rows:
+        return
+    available = {str(field) for row in rows for field in row}
+    missing = sorted(set(quasi_identifiers) - available)
+    if missing:
+        raise ValueError(f"Unknown quasi-identifier columns: {missing!r}")
+
+
+def _materialize_rows(records: Any) -> list[dict[str, Any]]:
+    if records is None:
+        return []
+
+    to_dicts = getattr(records, "to_dicts", None)
+    if callable(to_dicts):
+        records = to_dicts()
+    else:
+        to_dict = getattr(records, "to_dict", None)
+        if callable(to_dict) and not isinstance(records, Mapping):
+            try:
+                records = to_dict("records")
+            except TypeError as error:
+                raise TypeError(
+                    "DataFrame-like records must support to_dict('records')."
+                ) from error
+
+    if isinstance(records, Mapping):
+        container = next(
+            (
+                records[name]
+                for name in ("records", "rows", "items")
+                if name in records and _is_row_sequence(records[name])
+            ),
+            None,
+        )
+        records = container if container is not None else [records]
+
+    if not _is_row_sequence(records):
+        raise TypeError("records must be a sequence of row mappings")
+    return [dict(row) for row in records]
+
+
+def _is_row_sequence(value: Any) -> bool:
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes, bytearray))
+        and all(isinstance(row, Mapping) for row in value)
+    )

--- a/tests/unit/risk/test_k_anonymity.py
+++ b/tests/unit/risk/test_k_anonymity.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from openmed.core.audit import stable_hash
 from openmed.risk import (
     KAnonymityEngine,
     analyze_k_anonymity,
@@ -97,6 +98,9 @@ def test_report_is_deterministic_json_safe_and_does_not_emit_raw_qi_values() -> 
         item["class_hash"].startswith("sha256:")
         for item in first["equivalence_classes"]
     )
+    assert stable_hash([["age", "30"], ["zip", "10001"]]) not in {
+        item["class_hash"] for item in first["equivalence_classes"]
+    }
 
 
 def test_infeasible_suppression_does_not_claim_an_empty_table_meets_target() -> None:
@@ -109,6 +113,16 @@ def test_infeasible_suppression_does_not_claim_an_empty_table_meets_target() -> 
     assert proposal.feasible is False
     with pytest.raises(ValueError, match="without removing every record"):
         proposal.apply(rows)
+
+
+def test_empty_table_reports_zero_k_without_claiming_success() -> None:
+    report = analyze_k_anonymity([], ["age"], target_k=2)
+    proposal = propose_suppression([], ["age"], target_k=2)
+
+    assert report.achieved_k == 0
+    assert report.smallest_class_size == 0
+    assert report.meets_target is False
+    assert proposal.feasible is False
 
 
 class _FrameLike:
@@ -126,6 +140,28 @@ def test_operates_in_process_on_dataframe_like_input() -> None:
     report = KAnonymityEngine(["age", "zip"], target_k=2).analyze(frame)
 
     assert report.violating_rows == (5,)
+
+
+def test_proposal_cannot_be_applied_to_a_different_same_length_table() -> None:
+    proposal = propose_suppression(
+        [{"age": 1}, {"age": 2}, {"age": 2}],
+        ["age"],
+        target_k=2,
+    )
+    different_rows = [{"age": 1}, {"age": 1}, {"age": 2}]
+
+    with pytest.raises(ValueError, match="does not match"):
+        proposal.apply(different_rows)
+
+
+def test_every_row_must_contain_scalar_quasi_identifiers() -> None:
+    with pytest.raises(ValueError, match=r"'zip': \[1\]"):
+        analyze_k_anonymity(
+            [{"age": 30, "zip": "10001"}, {"age": 30}],
+            ["age", "zip"],
+        )
+    with pytest.raises(TypeError, match=r"'age': \[0\]"):
+        analyze_k_anonymity([{"age": [30]}], ["age"])
 
 
 @pytest.mark.parametrize("target_k", [0, -1, 1.5, True])

--- a/tests/unit/risk/test_k_anonymity.py
+++ b/tests/unit/risk/test_k_anonymity.py
@@ -1,0 +1,154 @@
+"""Tests for targeted k-anonymity analysis and suppression (issue #882)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.risk import (
+    KAnonymityEngine,
+    analyze_k_anonymity,
+    apply_suppression,
+    propose_suppression,
+)
+
+
+def _synthetic_rows() -> list[dict[str, object]]:
+    return [
+        {"age": 30, "zip": "10001", "diagnosis": "flu"},
+        {"age": 30, "zip": "10001", "diagnosis": "cold"},
+        {"age": 40, "zip": "20001", "diagnosis": "flu"},
+        {"age": 40, "zip": "20001", "diagnosis": "cold"},
+        {"age": 40, "zip": "20001", "diagnosis": "asthma"},
+        {"age": 91, "zip": "99999", "diagnosis": "rare"},
+    ]
+
+
+def test_reports_equivalence_classes_achieved_k_and_violating_rows() -> None:
+    report = analyze_k_anonymity(
+        _synthetic_rows(),
+        quasi_identifiers=["age", "zip"],
+        target_k=2,
+    )
+
+    assert sorted(item.size for item in report.equivalence_classes) == [1, 2, 3]
+    assert report.achieved_k == 1
+    assert report.smallest_class_size == 1
+    assert report.violating_rows == (5,)
+    assert report.meets_target is False
+
+
+def test_minimal_suppression_reaches_target_and_preserves_retained_rows() -> None:
+    rows = _synthetic_rows()
+    engine = KAnonymityEngine(["age", "zip"], target_k=2)
+
+    proposal = engine.propose_suppression(rows)
+    retained = proposal.apply(rows)
+    after = engine.analyze(retained)
+
+    assert proposal.row_indices == (5,)
+    assert proposal.suppressed_count == 1
+    assert proposal.retained_count == 5
+    assert proposal.achieved_k_after_suppression == 2
+    assert proposal.feasible is True
+    assert retained == rows[:5]
+    assert after.meets_target is True
+    assert after.achieved_k == 2
+
+
+def test_all_rows_in_every_undersized_class_are_minimally_suppressed() -> None:
+    rows = [
+        {"age": 30, "zip": "10001"},
+        {"age": 30, "zip": "10001"},
+        {"age": 30, "zip": "10001"},
+        {"age": 40, "zip": "20001"},
+        {"age": 40, "zip": "20001"},
+        {"age": 50, "zip": "30001"},
+    ]
+
+    proposal = propose_suppression(
+        rows,
+        quasi_identifiers=["age", "zip"],
+        target_k=3,
+    )
+    retained = apply_suppression(rows, proposal)
+
+    assert proposal.row_indices == (3, 4, 5)
+    assert analyze_k_anonymity(
+        retained,
+        quasi_identifiers=["age", "zip"],
+        target_k=3,
+    ).meets_target
+
+
+def test_report_is_deterministic_json_safe_and_does_not_emit_raw_qi_values() -> None:
+    engine = KAnonymityEngine(["zip", "age"], target_k=2)
+
+    first = engine.analyze(_synthetic_rows()).to_dict()
+    second = engine.analyze(_synthetic_rows()).to_dict()
+    serialized = json.dumps(first, sort_keys=True)
+
+    assert first == second
+    assert json.loads(serialized) == first
+    assert "10001" not in serialized
+    assert "99999" not in serialized
+    assert all(
+        item["class_hash"].startswith("sha256:")
+        for item in first["equivalence_classes"]
+    )
+
+
+def test_infeasible_suppression_does_not_claim_an_empty_table_meets_target() -> None:
+    rows = [{"age": 30}, {"age": 40}]
+    proposal = propose_suppression(rows, ["age"], target_k=2)
+
+    assert proposal.row_indices == (0, 1)
+    assert proposal.retained_count == 0
+    assert proposal.achieved_k_after_suppression == 0
+    assert proposal.feasible is False
+    with pytest.raises(ValueError, match="without removing every record"):
+        proposal.apply(rows)
+
+
+class _FrameLike:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self.rows = rows
+
+    def to_dict(self, orient: str) -> list[dict[str, object]]:
+        assert orient == "records"
+        return self.rows
+
+
+def test_operates_in_process_on_dataframe_like_input() -> None:
+    frame = _FrameLike(_synthetic_rows())
+
+    report = KAnonymityEngine(["age", "zip"], target_k=2).analyze(frame)
+
+    assert report.violating_rows == (5,)
+
+
+@pytest.mark.parametrize("target_k", [0, -1, 1.5, True])
+def test_rejects_invalid_target_k(target_k: object) -> None:
+    with pytest.raises(ValueError, match="integer >= 1"):
+        KAnonymityEngine(["age"], target_k=target_k)  # type: ignore[arg-type]
+
+
+def test_rejects_missing_or_unknown_quasi_identifier_columns() -> None:
+    with pytest.raises(ValueError, match="At least one"):
+        KAnonymityEngine([])
+    with pytest.raises(ValueError, match="Unknown quasi-identifier"):
+        KAnonymityEngine(["missing"]).analyze(_synthetic_rows())
+
+
+def test_public_api_is_exported() -> None:
+    import openmed.risk as risk
+
+    expected = {
+        "KAnonymityEngine",
+        "analyze_k_anonymity",
+        "apply_suppression",
+        "propose_suppression",
+    }
+    assert expected <= set(risk.__all__)
+    assert all(hasattr(risk, name) for name in expected)


### PR DESCRIPTION
## Description

Adds a lightweight, offline k-anonymity engine for declared tabular quasi-identifiers. It layers target evaluation and minimal whole-row suppression over the existing measurement semantics while keeping raw quasi-identifier values out of reports.

Closes #882.

## Type of Change

- [x] New feature
- [x] Test addition/improvement

## Changes Made

- Add deterministic equivalence-class analysis with achieved k, smallest-class size, and violating row offsets.
- Add privacy-safe minimal suppression proposals, feasibility reporting, and retained-row application.
- Require every row to carry scalar values for every declared quasi-identifier.
- Bind proposals to the source table's QI class structure so they cannot be misapplied to a different same-length table.
- Derive public class hashes from already-reported membership offsets instead of low-entropy QI values.
- Export the public API and cover synthetic, invalid, infeasible, deterministic, empty, and DataFrame-like cases.

## Testing

- [x] I have added tests that prove the feature works
- [x] Focused k-anonymity tests: 15 passed
- [x] Complete risk package: 72 passed
- [x] Full suite: 6,175 passed, 48 skipped
- [x] Package wheel and sdist build successfully

## Documentation

- [x] I have added Google-style docstrings to the new public functions and classes
- [x] Strict documentation build passes

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I ran the scoped type-check gate
- [x] Scoped pre-commit checks pass for all three PR files
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] The engine operates fully in-process and offline
- [x] Reports contain offsets, sizes, and non-reversible class identifiers rather than raw QI values

## Related Issues

Closes #882

## Screenshots/Examples

Not applicable; this change adds a Python API with synthetic unit-test examples.
