### PR TITLE
Add Chinese numeral normalization for dates, IDs, and quantities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added opt-in Simplified/Traditional Chinese normalization through OpenCC,
   including Taiwan and Hong Kong conversion configs, mixed-variant detection,
   and offset-preserving span projection back to original text (#1467).
+- Added source-aligned Chinese numeral parsing for everyday and financial
+  forms, valid year/month/day normalization, and contextual Chinese date,
+  medical-record identifier, and clinical-quantity PII patterns (#1469).
 - Added a Swahili README and an African developer onboarding guide covering
   bandwidth-aware model sizing and offline setup, POPIA/NDPA policy pointers,
   OpenMRS FHIR and DHIS2 Tracker recipes, community links, and shared

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,26 @@ source phrase rather than guessing partial offsets. If OpenCC is absent, the
 pre-pass returns the input unchanged with identity alignment and emits one
 optional-dependency warning.
 
+Chinese numeral helpers do not require the optional script-conversion package.
+They parse everyday and financial forms, return exact source code-point spans,
+and recognize valid year/month/day expressions:
+
+```python
+from openmed.processing import (
+    find_chinese_numbers,
+    normalize_chinese_dates,
+    parse_chinese_numeral,
+)
+
+assert parse_chinese_numeral("一百零一") == 101
+numbers = find_chinese_numbers("剂量三千五百毫升")
+dates = normalize_chinese_dates("出生于一九八五年十二月三日")
+```
+
+When PII detection uses `lang="zh"`, contextual patterns also recognize valid
+Chinese-numeral dates, medical-record identifiers, and clinical quantities.
+Invalid unit sequences and impossible calendar dates are rejected.
+
 ## PyTorch attention backends
 
 `torch_attention_backend="auto"` is the default. In OpenMed 1.8.1 and later,

--- a/openmed/core/pii_i18n.py
+++ b/openmed/core/pii_i18n.py
@@ -7793,6 +7793,58 @@ _VIETNAMESE_PII_PATTERNS: List[PIIPattern] = [
 ]
 
 
+# Keep this character set aligned with processing.zh_normalize without making
+# the core pattern registry depend on the processing package at import time.
+_CHINESE_NUMERAL_CHARS = "〇零一二三四五六七八九十百千万亿壹贰叁肆伍陆柒捌玖拾佰仟萬億"
+_CHINESE_NUMERAL_RUN = rf"[{_CHINESE_NUMERAL_CHARS}]+"
+
+_CHINESE_NUMERAL_PII_PATTERNS: List[PIIPattern] = [
+    PIIPattern(
+        rf"(?<![{_CHINESE_NUMERAL_CHARS}]){_CHINESE_NUMERAL_RUN}\s*年\s*"
+        rf"{_CHINESE_NUMERAL_RUN}\s*月\s*{_CHINESE_NUMERAL_RUN}\s*日"
+        rf"(?![{_CHINESE_NUMERAL_CHARS}])",
+        "date",
+        priority=10,
+        base_score=0.65,
+        context_words=["出生", "生于", "出生日期", "出生年月日", "生日"],
+        context_boost=0.3,
+    ),
+    PIIPattern(
+        r"(?:(?<=病历号：)|(?<=病历号:)|(?<=病历号)|"
+        r"(?<=病历号码：)|(?<=病历号码:)|(?<=病历号码)|"
+        r"(?<=住院号：)|(?<=住院号:)|(?<=住院号)|"
+        r"(?<=住院号码：)|(?<=住院号码:)|(?<=住院号码)|"
+        r"(?<=患者编号：)|(?<=患者编号:)|(?<=患者编号))"
+        rf"[{_CHINESE_NUMERAL_CHARS}]{{3,24}}"
+        rf"(?![{_CHINESE_NUMERAL_CHARS}])",
+        "medical_record_number",
+        priority=9,
+        base_score=0.3,
+        context_words=["病历号", "病历号码", "住院号", "住院号码", "患者编号"],
+        context_boost=0.6,
+        safety_sweep_requires_context=True,
+    ),
+    PIIPattern(
+        rf"(?<![{_CHINESE_NUMERAL_CHARS}]){_CHINESE_NUMERAL_RUN}"
+        r"(?=\s*(?:毫升|毫克|微克|克|千克|公斤|单位|片|粒|支|袋|次))",
+        "quantity",
+        priority=7,
+        base_score=0.25,
+        context_words=[
+            "剂量",
+            "用量",
+            "容量",
+            "毫升",
+            "毫克",
+            "微克",
+            "千克",
+            "公斤",
+        ],
+        context_boost=0.45,
+        safety_sweep_requires_context=True,
+    ),
+]
+
 _TANZANIA_NIDA_PII_PATTERNS = [
     PIIPattern(
         r"(?<![A-Za-z0-9])(?:\d{20}|\d{8}-\d{5}-\d{5}-\d{2})(?![A-Za-z0-9])",
@@ -7869,7 +7921,6 @@ _ETHIOPIA_FAYDA_PII_PATTERNS = [
     ),
 ]
 
-
 LANGUAGE_PII_PATTERNS: Dict[str, List[PIIPattern]] = {
     "af": _NGUNI_PII_PATTERNS,
     "am": [*_AMHARIC_PII_PATTERNS, *_ETHIOPIA_FAYDA_PII_PATTERNS],
@@ -7893,6 +7944,7 @@ LANGUAGE_PII_PATTERNS: Dict[str, List[PIIPattern]] = {
         *_CHINESE_PII_PATTERNS,
         *_CHINESE_ADDRESS_PII_PATTERNS,
         *_CHINESE_IDENTIFIER_PII_PATTERNS,
+        *_CHINESE_NUMERAL_PII_PATTERNS,
     ],
     "tr": _TURKISH_PII_PATTERNS,
     "id": _INDONESIAN_PII_PATTERNS,
@@ -9169,7 +9221,8 @@ def get_patterns_for_language(lang: str, locale: str | None = None) -> List[PIIP
         lang: ISO 639-1 language code, optionally with a region suffix for
             pattern lookup. Model-backed languages are listed in
             :data:`SUPPORTED_LANGUAGES`; national-ID-only languages are listed
-            in :data:`NATIONAL_ID_ONLY_LANGUAGES`.
+            in :data:`NATIONAL_ID_ONLY_LANGUAGES`. Deterministic-only language
+            packs may also be exposed directly in :data:`LANGUAGE_PII_PATTERNS`.
         locale: Optional locale override (for example, ``"en_GB"``) whose
             locale-specific deterministic patterns should also be active.
 

--- a/openmed/core/pii_i18n.py
+++ b/openmed/core/pii_i18n.py
@@ -7798,6 +7798,33 @@ _VIETNAMESE_PII_PATTERNS: List[PIIPattern] = [
 _CHINESE_NUMERAL_CHARS = "〇零一二三四五六七八九十百千万亿壹贰叁肆伍陆柒捌玖拾佰仟萬億"
 _CHINESE_NUMERAL_RUN = rf"[{_CHINESE_NUMERAL_CHARS}]+"
 
+
+def _validate_chinese_numeral_surface(value: str) -> bool:
+    """Return whether ``value`` is a structurally valid Chinese numeral."""
+
+    # Keep the registry import-cycle-free while sharing the public parser at
+    # match time instead of maintaining a second unit-order implementation.
+    from openmed.processing.zh_normalize import parse_chinese_numeral
+
+    try:
+        parse_chinese_numeral(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _validate_chinese_date_surface(value: str) -> bool:
+    """Return whether ``value`` is one complete, valid Chinese calendar date."""
+
+    from openmed.processing.zh_normalize import normalize_chinese_dates
+
+    try:
+        matches = normalize_chinese_dates(value)
+    except TypeError:
+        return False
+    return len(matches) == 1 and matches[0].span == (0, len(value))
+
+
 _CHINESE_NUMERAL_PII_PATTERNS: List[PIIPattern] = [
     PIIPattern(
         rf"(?<![{_CHINESE_NUMERAL_CHARS}]){_CHINESE_NUMERAL_RUN}\s*年\s*"
@@ -7808,6 +7835,8 @@ _CHINESE_NUMERAL_PII_PATTERNS: List[PIIPattern] = [
         base_score=0.65,
         context_words=["出生", "生于", "出生日期", "出生年月日", "生日"],
         context_boost=0.3,
+        validator=_validate_chinese_date_surface,
+        reject_on_validation_failure=True,
     ),
     PIIPattern(
         r"(?:(?<=病历号：)|(?<=病历号:)|(?<=病历号)|"
@@ -7841,6 +7870,8 @@ _CHINESE_NUMERAL_PII_PATTERNS: List[PIIPattern] = [
             "公斤",
         ],
         context_boost=0.45,
+        validator=_validate_chinese_numeral_surface,
+        reject_on_validation_failure=True,
         safety_sweep_requires_context=True,
     ),
 ]

--- a/openmed/processing/__init__.py
+++ b/openmed/processing/__init__.py
@@ -79,13 +79,20 @@ from .transliteration import (
     transliteration_key,
 )
 from .zh_normalize import (
+    CHINESE_NUMERAL_CHARACTERS,
+    CHINESE_NUMERAL_PATTERN,
+    ChineseDateNormalization,
+    ChineseNumberSpan,
     ChineseTargetScript,
     OpenCCConfig,
     OpenCCUnavailableWarning,
     ScriptConversion,
     convert_script,
     detect_variant_normalized,
+    find_chinese_numbers,
+    normalize_chinese_dates,
     normalize_chinese_variants,
+    parse_chinese_numeral,
 )
 from .zh_segmentation import (
     ChineseSegmentationConfig,
@@ -190,4 +197,11 @@ __all__ = [
     "to_latin",
     "transliterate",
     "transliteration_key",
+    "CHINESE_NUMERAL_CHARACTERS",
+    "CHINESE_NUMERAL_PATTERN",
+    "ChineseDateNormalization",
+    "ChineseNumberSpan",
+    "parse_chinese_numeral",
+    "find_chinese_numbers",
+    "normalize_chinese_dates",
 ]

--- a/openmed/processing/zh_normalize.py
+++ b/openmed/processing/zh_normalize.py
@@ -515,6 +515,8 @@ def detect_variant_normalized(
         original_start, original_end = conversion.to_original_span(start, end)
         results.append((original_start, original_end, *tuple(item[2:])))
     return results
+
+
 def _parse_below_ten_thousand(numeral: str) -> int:
     if not numeral:
         return 0

--- a/openmed/processing/zh_normalize.py
+++ b/openmed/processing/zh_normalize.py
@@ -28,10 +28,12 @@ detected spans onto the original document before redaction.
 
 from __future__ import annotations
 
+import re
 import unicodedata
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
+from datetime import date
 from enum import Enum
 from functools import lru_cache
 from typing import Any
@@ -81,6 +83,110 @@ class OpenCCUnavailableWarning(RuntimeWarning):
 
 
 _OPENCC_NOTICE_EMITTED = False
+
+# Chinese numeral characters intentionally exclude colloquial variants such as
+# 两: the parser covers the everyday and financial forms in the public contract.
+CHINESE_NUMERAL_CHARACTERS = (
+    "〇零一二三四五六七八九十百千万亿壹贰叁肆伍陆柒捌玖拾佰仟萬億"
+)
+CHINESE_NUMERAL_PATTERN = rf"[{CHINESE_NUMERAL_CHARACTERS}]+"
+
+_DIGIT_VALUES = {
+    "〇": 0,
+    "零": 0,
+    "一": 1,
+    "壹": 1,
+    "二": 2,
+    "贰": 2,
+    "三": 3,
+    "叁": 3,
+    "四": 4,
+    "肆": 4,
+    "五": 5,
+    "伍": 5,
+    "六": 6,
+    "陆": 6,
+    "七": 7,
+    "柒": 7,
+    "八": 8,
+    "捌": 8,
+    "九": 9,
+    "玖": 9,
+}
+_SMALL_UNIT_VALUES = {
+    "十": 10,
+    "拾": 10,
+    "百": 100,
+    "佰": 100,
+    "千": 1000,
+    "仟": 1000,
+}
+_LARGE_UNIT_VALUES = {
+    "万": 10_000,
+    "萬": 10_000,
+    "亿": 100_000_000,
+    "億": 100_000_000,
+}
+_ALL_NUMERAL_VALUES = _DIGIT_VALUES | _SMALL_UNIT_VALUES | _LARGE_UNIT_VALUES
+_CHINESE_NUMERAL_RE = re.compile(CHINESE_NUMERAL_PATTERN)
+_CHINESE_DATE_RE = re.compile(
+    rf"(?P<year>{CHINESE_NUMERAL_PATTERN})\s*年\s*"
+    rf"(?P<month>{CHINESE_NUMERAL_PATTERN})\s*月\s*"
+    rf"(?P<day>{CHINESE_NUMERAL_PATTERN})\s*日"
+)
+
+
+@dataclass(frozen=True)
+class ChineseNumberSpan:
+    """A parsed Chinese numeral and its exact source code-point span."""
+
+    value: int
+    start: int
+    end: int
+    text: str
+
+    @property
+    def span(self) -> tuple[int, int]:
+        """Return the half-open ``(start, end)`` source span."""
+
+        return self.start, self.end
+
+    @property
+    def source_span(self) -> tuple[int, int]:
+        """Return the half-open source span as an explicit alias."""
+
+        return self.span
+
+
+@dataclass(frozen=True)
+class ChineseDateNormalization:
+    """A Chinese year/month/day expression with source-aligned number runs."""
+
+    year: int
+    month: int
+    day: int
+    start: int
+    end: int
+    text: str
+    number_spans: tuple[ChineseNumberSpan, ChineseNumberSpan, ChineseNumberSpan]
+
+    @property
+    def span(self) -> tuple[int, int]:
+        """Return the half-open span covering the complete source date."""
+
+        return self.start, self.end
+
+    @property
+    def source_span(self) -> tuple[int, int]:
+        """Return the complete source date span as an explicit alias."""
+
+        return self.span
+
+    @property
+    def normalized(self) -> str:
+        """Return the parsed date in ISO ``YYYY-MM-DD`` form."""
+
+        return f"{self.year:04d}-{self.month:02d}-{self.day:02d}"
 
 
 @dataclass(frozen=True)
@@ -409,6 +515,189 @@ def detect_variant_normalized(
         original_start, original_end = conversion.to_original_span(start, end)
         results.append((original_start, original_end, *tuple(item[2:])))
     return results
+def _parse_below_ten_thousand(numeral: str) -> int:
+    if not numeral:
+        return 0
+
+    if not any(char in _SMALL_UNIT_VALUES for char in numeral):
+        if not all(char in _DIGIT_VALUES for char in numeral):
+            raise ValueError(f"invalid Chinese numeral section: {numeral!r}")
+        value = 0
+        for char in numeral:
+            value = value * 10 + _DIGIT_VALUES[char]
+        return value
+
+    total = 0
+    pending_digit: int | None = None
+    last_unit = 10_000
+    zero_placeholder = False
+
+    for char in numeral:
+        if char in _DIGIT_VALUES:
+            digit = _DIGIT_VALUES[char]
+            if digit == 0:
+                pending_digit = None
+                zero_placeholder = True
+                continue
+            if pending_digit is not None:
+                raise ValueError(f"adjacent digits in unit numeral: {numeral!r}")
+            pending_digit = digit
+            zero_placeholder = False
+            continue
+
+        unit = _SMALL_UNIT_VALUES.get(char)
+        if unit is None or unit >= last_unit:
+            raise ValueError(f"invalid unit order in Chinese numeral: {numeral!r}")
+        if pending_digit is None and zero_placeholder:
+            raise ValueError(f"unit cannot follow a zero placeholder: {numeral!r}")
+
+        total += (pending_digit if pending_digit is not None else 1) * unit
+        pending_digit = None
+        zero_placeholder = False
+        last_unit = unit
+
+    if pending_digit is not None:
+        total += pending_digit
+    return total
+
+
+def _parse_below_hundred_million(numeral: str) -> int:
+    positions = [
+        index
+        for index, char in enumerate(numeral)
+        if _LARGE_UNIT_VALUES.get(char) == 10_000
+    ]
+    if len(positions) > 1:
+        raise ValueError(f"repeated ten-thousand unit in numeral: {numeral!r}")
+    if not positions:
+        return _parse_below_ten_thousand(numeral)
+
+    position = positions[0]
+    left = numeral[:position]
+    right = numeral[position + 1 :]
+    left_value = _parse_below_ten_thousand(left) if left else 1
+    return left_value * 10_000 + _parse_below_ten_thousand(right)
+
+
+def parse_chinese_numeral(numeral: str) -> int:
+    """Parse an everyday or financial-form Chinese numeral as an integer.
+
+    Digit-only forms such as ``二〇二四`` are read positionally. Unit forms use
+    descending ``十/百/千`` multipliers inside ``万/亿`` sections, so interior
+    zero placeholders do not contribute a digit of their own. A bare zero is
+    rejected because it is not a useful numeral span for PHI detection.
+
+    Args:
+        numeral: A non-empty run of supported Chinese numeral characters.
+
+    Returns:
+        The integer represented by ``numeral``.
+
+    Raises:
+        TypeError: If ``numeral`` is not a string.
+        ValueError: If the run is empty, unsupported, structurally invalid, or
+            consists only of zero characters.
+    """
+
+    if not isinstance(numeral, str):
+        raise TypeError("numeral must be a string")
+    if not numeral:
+        raise ValueError("numeral must not be empty")
+    unsupported = set(numeral) - _ALL_NUMERAL_VALUES.keys()
+    if unsupported:
+        raise ValueError(f"unsupported Chinese numeral characters: {unsupported!r}")
+    if not any(_ALL_NUMERAL_VALUES[char] > 0 for char in numeral):
+        raise ValueError("a standalone Chinese zero is not a numeral span")
+
+    hundred_million_positions = [
+        index
+        for index, char in enumerate(numeral)
+        if _LARGE_UNIT_VALUES.get(char) == 100_000_000
+    ]
+    if len(hundred_million_positions) > 1:
+        raise ValueError(f"repeated hundred-million unit in numeral: {numeral!r}")
+    if not hundred_million_positions:
+        return _parse_below_hundred_million(numeral)
+
+    position = hundred_million_positions[0]
+    left = numeral[:position]
+    right = numeral[position + 1 :]
+    left_value = _parse_below_hundred_million(left) if left else 1
+    return left_value * 100_000_000 + _parse_below_hundred_million(right)
+
+
+def find_chinese_numbers(text: str) -> list[ChineseNumberSpan]:
+    """Find valid Chinese numeral runs with values and source offsets.
+
+    Offsets are Python string indices and therefore exact Unicode code-point
+    offsets. Standalone ``〇`` or ``零`` runs and structurally invalid runs are
+    ignored rather than emitted as ambiguous numeric spans.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+
+    numbers: list[ChineseNumberSpan] = []
+    for match in _CHINESE_NUMERAL_RE.finditer(text):
+        try:
+            value = parse_chinese_numeral(match.group())
+        except ValueError:
+            continue
+        numbers.append(
+            ChineseNumberSpan(
+                value=value,
+                start=match.start(),
+                end=match.end(),
+                text=match.group(),
+            )
+        )
+    return numbers
+
+
+def normalize_chinese_dates(text: str) -> list[ChineseDateNormalization]:
+    """Recognize Chinese year/month/day dates without losing source offsets.
+
+    Each result contains the parsed ISO-compatible fields, the whole date span,
+    and three :class:`ChineseNumberSpan` records for the year, month, and day.
+    Invalid calendar dates are ignored.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+
+    dates: list[ChineseDateNormalization] = []
+    for match in _CHINESE_DATE_RE.finditer(text):
+        parts: list[ChineseNumberSpan] = []
+        values: list[int] = []
+        try:
+            for name in ("year", "month", "day"):
+                start, end = match.span(name)
+                value = parse_chinese_numeral(match.group(name))
+                values.append(value)
+                parts.append(
+                    ChineseNumberSpan(
+                        value=value,
+                        start=start,
+                        end=end,
+                        text=text[start:end],
+                    )
+                )
+            date(*values)
+        except ValueError:
+            continue
+
+        dates.append(
+            ChineseDateNormalization(
+                year=values[0],
+                month=values[1],
+                day=values[2],
+                start=match.start(),
+                end=match.end(),
+                text=match.group(),
+                number_spans=(parts[0], parts[1], parts[2]),
+            )
+        )
+    return dates
 
 
 def _convert_char(ch: str, convention: str, space_target: str) -> str:
@@ -494,6 +783,13 @@ __all__ = [
     "OpenCCConfig",
     "OpenCCUnavailableWarning",
     "ScriptConversion",
+    "CHINESE_NUMERAL_CHARACTERS",
+    "CHINESE_NUMERAL_PATTERN",
+    "ChineseNumberSpan",
+    "ChineseDateNormalization",
+    "parse_chinese_numeral",
+    "find_chinese_numbers",
+    "normalize_chinese_dates",
     "WidthNormalization",
     "convert_script",
     "detect_variant_normalized",

--- a/tests/unit/processing/test_zh_normalize.py
+++ b/tests/unit/processing/test_zh_normalize.py
@@ -30,8 +30,11 @@ from openmed.processing.zh_normalize import (
     convert_script,
     detect_variant_normalized,
     detect_width_normalized,
+    find_chinese_numbers,
+    normalize_chinese_dates,
     normalize_chinese_variants,
     normalize_width,
+    parse_chinese_numeral,
 )
 
 # --------------------------------------------------------------------------
@@ -471,3 +474,133 @@ def test_config_exposes_optional_chinese_target_script():
     assert config.to_dict()["chinese_target_script"] == "traditional"
     with pytest.raises(ValueError, match="chinese_target_script"):
         OpenMedConfig(chinese_target_script="mixed")
+
+
+# --------------------------------------------------------------------------
+# Chinese numeral parsing and exact source spans
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("surface", "expected"),
+    [
+        ("一", 1),
+        ("十", 10),
+        ("二十", 20),
+        ("十二", 12),
+        ("一百零一", 101),
+        ("三千五百", 3500),
+        ("三万五千", 35_000),
+        ("二〇二四", 2024),
+        ("壹仟贰佰叁拾肆", 1234),
+        ("壹萬零壹", 10_001),
+        ("一亿零三万零五", 100_030_005),
+        ("一万亿", 1_000_000_000_000),
+    ],
+)
+def test_parse_chinese_numeral_table(surface, expected):
+    assert parse_chinese_numeral(surface) == expected
+
+
+@pytest.mark.parametrize("surface", ["", "〇", "零", "一百十百", "一百A"])
+def test_parse_chinese_numeral_rejects_ambiguous_or_invalid_runs(surface):
+    with pytest.raises(ValueError):
+        parse_chinese_numeral(surface)
+
+
+def test_find_chinese_numbers_returns_exact_codepoint_spans_and_values():
+    text = "剂量三千五百毫升，编号贰零贰肆零零壹，标记〇。"
+
+    numbers = find_chinese_numbers(text)
+
+    assert [(item.text, item.value) for item in numbers] == [
+        ("三千五百", 3500),
+        ("贰零贰肆零零壹", 2_024_001),
+    ]
+    for item in numbers:
+        assert item.span == item.source_span == (item.start, item.end)
+        assert text[item.start : item.end] == item.text
+
+
+def test_normalize_chinese_date_maps_each_run_and_whole_date():
+    text = "患者出生于一九八五年十二月三日，记录已核对。"
+
+    matches = normalize_chinese_dates(text)
+
+    assert len(matches) == 1
+    normalized = matches[0]
+    assert normalized.normalized == "1985-12-03"
+    assert text[normalized.start : normalized.end] == "一九八五年十二月三日"
+    assert [part.text for part in normalized.number_spans] == [
+        "一九八五",
+        "十二",
+        "三",
+    ]
+    assert [part.value for part in normalized.number_spans] == [1985, 12, 3]
+    assert [text[part.start : part.end] for part in normalized.number_spans] == [
+        "一九八五",
+        "十二",
+        "三",
+    ]
+
+
+def test_normalize_chinese_dates_skips_invalid_calendar_date():
+    assert normalize_chinese_dates("出生于二〇二四年十三月三十二日") == []
+
+
+# --------------------------------------------------------------------------
+# Chinese contextual PHI patterns
+# --------------------------------------------------------------------------
+
+
+def test_chinese_birth_date_pattern_covers_complete_source_date():
+    text = "患者出生于一九八五年十二月三日。"
+    units = find_semantic_units(text, get_patterns_for_language("zh"))
+
+    dates = [unit for unit in units if unit[2] == "date"]
+    assert len(dates) == 1
+    start, end, _, score, *_ = dates[0]
+    assert text[start:end] == "一九八五年十二月三日"
+    assert score == pytest.approx(0.95)
+
+
+def test_chinese_financial_medical_record_id_has_exact_boosted_span():
+    text = "病历号：贰零贰肆零零壹"
+    units = find_semantic_units(text, get_patterns_for_language("zh"))
+
+    medical_ids = [unit for unit in units if unit[2] == "medical_record_number"]
+    assert len(medical_ids) == 1
+    start, end, _, score, pattern, *_ = medical_ids[0]
+    assert text[start:end] == "贰零贰肆零零壹"
+    assert (start, end) == (4, len(text))
+    assert score == pytest.approx(0.9)
+    assert pattern.safety_sweep_requires_context
+
+
+def test_chinese_unlabeled_numeral_run_is_not_treated_as_medical_record_id():
+    units = find_semantic_units("编号贰零贰肆零零壹", get_patterns_for_language("zh"))
+
+    assert not any(unit[2] == "medical_record_number" for unit in units)
+
+
+def test_chinese_quantity_pattern_covers_only_the_numeral_run():
+    text = "给药剂量三千五百毫升"
+    units = find_semantic_units(text, get_patterns_for_language("zh"))
+
+    quantities = [unit for unit in units if unit[2] == "quantity"]
+    assert len(quantities) == 1
+    start, end, _, score, *_ = quantities[0]
+    assert text[start:end] == "三千五百"
+    assert score == pytest.approx(0.7)
+
+
+def test_chinese_patterns_do_not_mutate_existing_language_pattern_lists():
+    from openmed.core.pii_i18n import LANGUAGE_PII_PATTERNS
+
+    counts = {lang: len(patterns) for lang, patterns in LANGUAGE_PII_PATTERNS.items()}
+    zh_patterns = get_patterns_for_language("zh")
+
+    assert len(zh_patterns) > len(LANGUAGE_PII_PATTERNS["zh"])
+    assert {
+        lang: len(patterns) for lang, patterns in LANGUAGE_PII_PATTERNS.items()
+    } == (counts)

--- a/tests/unit/processing/test_zh_normalize.py
+++ b/tests/unit/processing/test_zh_normalize.py
@@ -594,6 +594,46 @@ def test_chinese_quantity_pattern_covers_only_the_numeral_run():
     assert score == pytest.approx(0.7)
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        "出生于二〇二四年十三月三十二日",
+        "出生于一百十百年十二月三日",
+        "剂量〇毫升",
+        "剂量一百十百毫升",
+    ],
+)
+def test_chinese_patterns_reject_invalid_numeral_and_calendar_surfaces(text):
+    units = find_semantic_units(text, get_patterns_for_language("zh"))
+
+    assert not any(unit[2] in {"date", "quantity"} for unit in units)
+
+
+def test_chinese_numeral_patterns_preserve_existing_chinese_patterns():
+    patterns = get_patterns_for_language("zh")
+    text = "患者王伟今日复诊，病历号：贰零贰肆零零壹"
+
+    units = find_semantic_units(text, patterns)
+
+    assert any(
+        text[start:end] == "王伟" and kind == "person" for start, end, kind, *_ in units
+    )
+    assert any(
+        text[start:end] == "贰零贰肆零零壹" and kind == "medical_record_number"
+        for start, end, kind, *_ in units
+    )
+
+
+def test_chinese_numeral_helpers_are_exported_from_processing():
+    from openmed import processing
+
+    assert processing.parse_chinese_numeral("一百零一") == 101
+    assert processing.find_chinese_numbers("剂量三毫升")[0].span == (2, 3)
+    assert processing.normalize_chinese_dates("二〇二四年三月五日")[0].normalized == (
+        "2024-03-05"
+    )
+
+
 def test_chinese_patterns_do_not_mutate_existing_language_pattern_lists():
     from openmed.core.pii_i18n import LANGUAGE_PII_PATTERNS
 


### PR DESCRIPTION
Closes #1469.

## Description

Adds source-aligned Chinese numeral normalization for everyday and financial forms so dates, medical-record identifiers, and clinical quantities can be detected without losing original Unicode code-point offsets. The branch is rebased onto the merged Chinese script-normalization foundation.

## Changes Made

- Parses digit sequences and positional multiplier forms across ten, hundred, thousand, ten-thousand, and hundred-million sections.
- Returns exact source spans for numeral runs and validated Chinese year/month/day expressions.
- Adds contextual Chinese date, medical-record identifier, and quantity patterns without replacing the existing Chinese person, identifier, or address packs.
- Rejects structurally invalid numeral runs and impossible calendar dates from date and quantity detection.
- Exports the helpers through `openmed.processing` and documents the public API.

## Type of Change

- [x] New feature
- [x] Test addition/improvement
- [x] Documentation update

## Testing

- [x] `.venv/bin/python -m pytest tests/ -q` — 7,108 passed, 48 skipped
- [x] Focused Chinese normalization and PHI suite — 73 passed
- [x] Broader international PII and processing suite — 940 passed
- [x] `make format`
- [x] `make lint`
- [x] `make format-check`
- [x] `make type-check`
- [x] `make docs-build`
- [x] Scoped pre-commit hooks
- [x] Repository, license, and action-reference policy checks
- [x] Isolated dependency vulnerability audit
- [x] High/medium static-security gate
- [x] Wheel and source-distribution build

## Documentation

- [x] Added public API usage to the configuration guide
- [x] Added public function and result-type docstrings
- [x] Updated `CHANGELOG.md`

## Dependencies

- [x] No new dependencies
