### PR TITLE
Add Chinese sentence segmentation honoring CJK punctuation

### DIFF
--- a/openmed/core/script_detect.py
+++ b/openmed/core/script_detect.py
@@ -340,6 +340,12 @@ def detect_script(text: str) -> str:
     return max(counts, key=lambda script: (counts[script], -first_seen[script]))
 
 
+def is_han_dominant(text: str) -> bool:
+    """Return whether Han is the dominant supported script in ``text``."""
+
+    return detect_script(text) == "Han"
+
+
 def segment_by_script(text: str) -> Iterator[tuple[int, int, str]]:
     """Yield contiguous ``(start, end, script)`` runs covering ``text``.
 
@@ -634,6 +640,7 @@ __all__ = [
     "confusable_skeleton",
     "detect_mixed_script",
     "detect_script",
+    "is_han_dominant",
     "mixed_script_spans",
     "normalize_for_pii_detection",
     "segment_by_script",

--- a/openmed/core/script_detect.py
+++ b/openmed/core/script_detect.py
@@ -343,7 +343,11 @@ def detect_script(text: str) -> str:
 def is_han_dominant(text: str) -> bool:
     """Return whether Han is the dominant supported script in ``text``."""
 
-    return detect_script(text) == "Han"
+    counts = _script_counts(text)
+    han_count = counts.get("Han", 0)
+    return han_count > 0 and all(
+        han_count > count for script, count in counts.items() if script != "Han"
+    )
 
 
 def segment_by_script(text: str) -> Iterator[tuple[int, int, str]]:

--- a/openmed/processing/__init__.py
+++ b/openmed/processing/__init__.py
@@ -58,6 +58,7 @@ from .object_storage import (
 )
 from .outputs import OutputFormatter, format_predictions
 from .pulsar_connector import PulsarClientPair, create_pulsar_clients
+from .sentences import SentenceSpan, segment_chinese_text, segment_text
 from .text import (
     INDIC_SCRIPTS,
     IndicNormalization,
@@ -154,4 +155,7 @@ __all__ = [
     "deidentify_stream",
     "replay",
     "sentences",
+    "SentenceSpan",
+    "segment_chinese_text",
+    "segment_text",
 ]

--- a/openmed/processing/sentences.py
+++ b/openmed/processing/sentences.py
@@ -13,7 +13,7 @@ warnings.filterwarnings("ignore", category=SyntaxWarning, module="pysbd")
 
 _SEGMENTER_CACHE: Dict[Tuple[str, bool], Any] = {}
 
-_CHINESE_TERMINATORS = frozenset({"。", "！", "？", "；", "．", "｡"})
+_CHINESE_TERMINATORS = frozenset({"。", "！", "？", "；", "．", "｡", "!", "?", ";"})
 _CHINESE_OPEN_TO_CLOSE = {
     "「": "」",
     "『": "』",
@@ -21,7 +21,27 @@ _CHINESE_OPEN_TO_CLOSE = {
     "（": "）",
     "〔": "〕",
 }
+_CHINESE_QUOTE_OPENERS = frozenset({"「", "『"})
 _CHINESE_CLOSERS = frozenset(_CHINESE_OPEN_TO_CLOSE.values())
+_CHINESE_CONTINUATION_PUNCTUATION = frozenset({",", ":", "、", "，", "："})
+_COMMON_LATIN_ABBREVIATIONS = frozenset(
+    {
+        "dr",
+        "e.g",
+        "etc",
+        "fig",
+        "i.e",
+        "jr",
+        "mr",
+        "mrs",
+        "ms",
+        "no",
+        "prof",
+        "sr",
+        "st",
+        "vs",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -98,10 +118,30 @@ def _uses_chinese_segmenter(text: str, language: str) -> bool:
     )
 
 
-def _is_decimal_point(text: str, index: int) -> bool:
-    if text[index] != "．" or index == 0 or index + 1 >= len(text):
+def _is_non_boundary_fullwidth_period(text: str, index: int) -> bool:
+    if text[index] != "．" or index == 0:
         return False
-    return text[index - 1].isdigit() and text[index + 1].isdigit()
+
+    previous = text[index - 1]
+    following = text[index + 1] if index + 1 < len(text) else ""
+    if previous.isdigit() and following.isdigit():
+        return True
+    if (
+        previous.isascii()
+        and previous.isalpha()
+        and following.isascii()
+        and following.isalpha()
+    ):
+        return True
+
+    token_start = index - 1
+    while token_start >= 0:
+        char = text[token_start]
+        if not ((char.isascii() and char.isalpha()) or char in {".", "．"}):
+            break
+        token_start -= 1
+    token = text[token_start + 1 : index].replace("．", ".").casefold().strip(".")
+    return token in _COMMON_LATIN_ABBREVIATIONS
 
 
 def _continues_chinese_sentence(char: str) -> bool:
@@ -119,10 +159,13 @@ def _chinese_spans(text: str) -> List[SentenceSpan]:
         if deferred_boundary and stack and not _continues_chinese_sentence(char):
             deferred_boundary = False
 
-        if boundary_ready and not _continues_chinese_sentence(char):
-            spans.append(SentenceSpan(text[start:index], start, index))
-            start = index
-            boundary_ready = False
+        if boundary_ready:
+            if char in _CHINESE_CONTINUATION_PUNCTUATION:
+                boundary_ready = False
+            elif not _continues_chinese_sentence(char):
+                spans.append(SentenceSpan(text[start:index], start, index))
+                start = index
+                boundary_ready = False
 
         if char in _CHINESE_OPEN_TO_CLOSE:
             stack.append(char)
@@ -136,12 +179,15 @@ def _chinese_spans(text: str) -> List[SentenceSpan]:
                     deferred_boundary = False
             continue
 
-        if char not in _CHINESE_TERMINATORS or _is_decimal_point(text, index):
+        if char not in _CHINESE_TERMINATORS or _is_non_boundary_fullwidth_period(
+            text,
+            index,
+        ):
             continue
 
-        if stack:
+        if stack and stack[-1] in _CHINESE_QUOTE_OPENERS:
             deferred_boundary = True
-        else:
+        elif not stack:
             boundary_ready = True
 
     if start < len(text):
@@ -174,7 +220,7 @@ def segment_text(
     if not text:
         return []
 
-    if _uses_chinese_segmenter(text, language):
+    if segmenter is None and _uses_chinese_segmenter(text, language):
         return segment_chinese_text(text)
 
     seg = _get_segmenter(language=language, clean=clean, segmenter=segmenter)

--- a/openmed/processing/sentences.py
+++ b/openmed/processing/sentences.py
@@ -1,4 +1,4 @@
-"""Sentence segmentation utilities built on top of pySBD."""
+"""Language-aware sentence segmentation utilities."""
 
 from __future__ import annotations
 
@@ -6,10 +6,22 @@ import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+from ..core.script_detect import is_han_dominant
+
 # Python 3.12 emits SyntaxWarnings for old-style regex escapes in pysbd.
 warnings.filterwarnings("ignore", category=SyntaxWarning, module="pysbd")
 
 _SEGMENTER_CACHE: Dict[Tuple[str, bool], Any] = {}
+
+_CHINESE_TERMINATORS = frozenset({"。", "！", "？", "；", "．", "｡"})
+_CHINESE_OPEN_TO_CLOSE = {
+    "「": "」",
+    "『": "』",
+    "《": "》",
+    "（": "）",
+    "〔": "〕",
+}
+_CHINESE_CLOSERS = frozenset(_CHINESE_OPEN_TO_CLOSE.values())
 
 
 @dataclass(frozen=True)
@@ -77,6 +89,76 @@ def _fallback_spans(text: str, sentences: Iterable[str]) -> List[SentenceSpan]:
     return spans
 
 
+def _uses_chinese_segmenter(text: str, language: str) -> bool:
+    normalized_language = language.casefold().replace("_", "-")
+    return (
+        normalized_language == "zh"
+        or normalized_language.startswith("zh-")
+        or is_han_dominant(text)
+    )
+
+
+def _is_decimal_point(text: str, index: int) -> bool:
+    if text[index] != "．" or index == 0 or index + 1 >= len(text):
+        return False
+    return text[index - 1].isdigit() and text[index + 1].isdigit()
+
+
+def _continues_chinese_sentence(char: str) -> bool:
+    return char.isspace() or char in _CHINESE_TERMINATORS or char in _CHINESE_CLOSERS
+
+
+def _chinese_spans(text: str) -> List[SentenceSpan]:
+    spans: List[SentenceSpan] = []
+    stack: List[str] = []
+    start = 0
+    boundary_ready = False
+    deferred_boundary = False
+
+    for index, char in enumerate(text):
+        if deferred_boundary and stack and not _continues_chinese_sentence(char):
+            deferred_boundary = False
+
+        if boundary_ready and not _continues_chinese_sentence(char):
+            spans.append(SentenceSpan(text[start:index], start, index))
+            start = index
+            boundary_ready = False
+
+        if char in _CHINESE_OPEN_TO_CLOSE:
+            stack.append(char)
+            continue
+
+        if char in _CHINESE_CLOSERS:
+            if stack and _CHINESE_OPEN_TO_CLOSE[stack[-1]] == char:
+                stack.pop()
+                if deferred_boundary and not stack:
+                    boundary_ready = True
+                    deferred_boundary = False
+            continue
+
+        if char not in _CHINESE_TERMINATORS or _is_decimal_point(text, index):
+            continue
+
+        if stack:
+            deferred_boundary = True
+        else:
+            boundary_ready = True
+
+    if start < len(text):
+        spans.append(SentenceSpan(text[start:], start, len(text)))
+
+    if all(text[span.start : span.end] == span.text for span in spans):
+        return spans
+    return _fallback_spans(text, (span.text for span in spans))
+
+
+def segment_chinese_text(text: str) -> List[SentenceSpan]:
+    """Split Chinese text while preserving exact source-code-point offsets."""
+    if not text:
+        return []
+    return _chinese_spans(text)
+
+
 def segment_text(
     text: str,
     *,
@@ -84,9 +166,16 @@ def segment_text(
     clean: bool = False,
     segmenter: Optional[Any] = None,
 ) -> List[SentenceSpan]:
-    """Split ``text`` into sentences using pySBD and capture character spans."""
+    """Split ``text`` into sentences and capture exact character spans.
+
+    Chinese and Han-dominant text use the built-in CJK-aware path. Other
+    languages retain the existing pySBD behavior.
+    """
     if not text:
         return []
+
+    if _uses_chinese_segmenter(text, language):
+        return segment_chinese_text(text)
 
     seg = _get_segmenter(language=language, clean=clean, segmenter=segmenter)
     sentences = seg.segment(text)
@@ -111,4 +200,4 @@ def segment_text(
     return spans
 
 
-__all__ = ["SentenceSpan", "segment_text"]
+__all__ = ["SentenceSpan", "segment_chinese_text", "segment_text"]

--- a/tests/unit/core/test_script_detect.py
+++ b/tests/unit/core/test_script_detect.py
@@ -18,6 +18,7 @@ from openmed.core.script_detect import (
     confusable_skeleton,
     detect_mixed_script,
     detect_script,
+    is_han_dominant,
     mixed_script_spans,
     normalize_for_pii_detection,
     segment_by_script,
@@ -174,6 +175,11 @@ def test_han_script_routes_to_chinese_candidate_language():
 
     assert script == "Han"
     assert candidate_languages_for_script(script)[0] == "zh"
+
+
+def test_han_dominance_detection_supports_language_routing():
+    assert is_han_dominant("患者王芳因心房颤动入院")
+    assert not is_han_dominant("Patient John Smith")
 
 
 def test_normalize_for_pii_detection_folds_obfuscation_with_offset_map():

--- a/tests/unit/core/test_script_detect.py
+++ b/tests/unit/core/test_script_detect.py
@@ -179,6 +179,8 @@ def test_han_script_routes_to_chinese_candidate_language():
 
 def test_han_dominance_detection_supports_language_routing():
     assert is_han_dominant("患者王芳因心房颤动入院")
+    assert is_han_dominant("患者A")
+    assert not is_han_dominant("患者AB")
     assert not is_han_dominant("Patient John Smith")
 
 

--- a/tests/unit/processing/test_sentences.py
+++ b/tests/unit/processing/test_sentences.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from openmed.processing import SentenceSpan, segment_chinese_text, segment_text
+
+
+def _assert_exact_round_trip(text: str, spans: list[SentenceSpan]) -> None:
+    assert all(text[span.start : span.end] == span.text for span in spans)
+    assert "".join(text[span.start : span.end] for span in spans) == text
+    assert all(left.end == right.start for left, right in zip(spans, spans[1:]))
+
+
+def test_chinese_three_sentence_note_has_exact_offsets():
+    text = "患者发热。血压稳定！是否复诊？"
+
+    spans = segment_text(text, language="zh")
+
+    assert [span.text for span in spans] == ["患者发热。", "血压稳定！", "是否复诊？"]
+    _assert_exact_round_trip(text, spans)
+
+
+def test_chinese_nested_quotes_defer_boundary_until_outer_quote_closes():
+    text = "医生记录：「患者说『胸痛缓解！』，生命体征稳定。」次日复诊。"
+
+    spans = segment_chinese_text(text)
+
+    assert [span.text for span in spans] == [
+        "医生记录：「患者说『胸痛缓解！』，生命体征稳定。」",
+        "次日复诊。",
+    ]
+    _assert_exact_round_trip(text, spans)
+
+
+def test_chinese_book_title_period_does_not_split_sentence():
+    text = "依据《临床指南。第二版》调整用药。患者情况稳定！"
+
+    spans = segment_chinese_text(text)
+
+    assert [span.text for span in spans] == [
+        "依据《临床指南。第二版》调整用药。",
+        "患者情况稳定！",
+    ]
+    _assert_exact_round_trip(text, spans)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_first"),
+    [
+        ("医生说：「情况稳定。」患者可以出院。", "医生说：「情况稳定。」"),
+        ("医嘱（立即复诊！）患者知情。", "医嘱（立即复诊！）"),
+        ("记录〔血压正常；〕继续观察。", "记录〔血压正常；〕"),
+    ],
+)
+def test_chinese_closing_punctuation_stays_with_preceding_sentence(
+    text: str,
+    expected_first: str,
+):
+    spans = segment_chinese_text(text)
+
+    assert spans[0].text == expected_first
+    assert len(spans) == 2
+    _assert_exact_round_trip(text, spans)
+
+
+def test_chinese_fullwidth_decimal_does_not_split():
+    text = "剂量为1．5毫克。复诊安排！"
+
+    spans = segment_chinese_text(text)
+
+    assert [span.text for span in spans] == ["剂量为1．5毫克。", "复诊安排！"]
+    _assert_exact_round_trip(text, spans)
+
+
+def test_chinese_spans_preserve_inter_sentence_and_trailing_whitespace():
+    text = "患者稳定。  血压正常！\n"
+
+    spans = segment_chinese_text(text)
+
+    assert [span.text for span in spans] == ["患者稳定。  ", "血压正常！\n"]
+    _assert_exact_round_trip(text, spans)
+
+
+def test_han_dominant_text_uses_chinese_segmenter_automatically():
+    text = "患者稳定。次日复诊！"
+
+    with patch("openmed.processing.sentences._get_segmenter") as get_segmenter:
+        spans = segment_text(text)
+
+    get_segmenter.assert_not_called()
+    assert [span.text for span in spans] == ["患者稳定。", "次日复诊！"]
+
+
+def test_non_chinese_language_keeps_pysbd_path():
+    text = "Patient is stable. Follow up tomorrow."
+    sentence_objects = [
+        SimpleNamespace(sent="Patient is stable. ", start=0, end=19),
+        SimpleNamespace(sent="Follow up tomorrow.", start=19, end=len(text)),
+    ]
+    pysbd_segmenter = Mock()
+    pysbd_segmenter.segment.return_value = sentence_objects
+
+    spans = segment_text(text, language="en", segmenter=pysbd_segmenter)
+
+    pysbd_segmenter.segment.assert_called_once_with(text)
+    assert spans == [
+        SentenceSpan("Patient is stable. ", 0, 19),
+        SentenceSpan("Follow up tomorrow.", 19, len(text)),
+    ]

--- a/tests/unit/processing/test_sentences.py
+++ b/tests/unit/processing/test_sentences.py
@@ -45,22 +45,40 @@ def test_chinese_book_title_period_does_not_split_sentence():
     _assert_exact_round_trip(text, spans)
 
 
-@pytest.mark.parametrize(
-    ("text", "expected_first"),
-    [
-        ("医生说：「情况稳定。」患者可以出院。", "医生说：「情况稳定。」"),
-        ("医嘱（立即复诊！）患者知情。", "医嘱（立即复诊！）"),
-        ("记录〔血压正常；〕继续观察。", "记录〔血压正常；〕"),
-    ],
-)
-def test_chinese_closing_punctuation_stays_with_preceding_sentence(
-    text: str,
-    expected_first: str,
-):
+def test_chinese_closing_quote_stays_with_preceding_sentence():
+    text = "医生说：「情况稳定。」患者可以出院。"
+
     spans = segment_chinese_text(text)
 
-    assert spans[0].text == expected_first
+    assert spans[0].text == "医生说：「情况稳定。」"
     assert len(spans) == 2
+    _assert_exact_round_trip(text, spans)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "医嘱（立即复诊！）患者知情。",
+        "记录〔血压正常；〕继续观察。",
+        "依据《临床指南。》调整用药。",
+    ],
+)
+def test_non_quote_bracket_punctuation_does_not_end_outer_sentence(text: str):
+    spans = segment_chinese_text(text)
+
+    assert [span.text for span in spans] == [text]
+    _assert_exact_round_trip(text, spans)
+
+
+def test_closing_quote_followed_by_comma_continues_the_outer_sentence():
+    text = "医生说：「情况稳定！」，建议明日出院。患者知情。"
+
+    spans = segment_chinese_text(text)
+
+    assert [span.text for span in spans] == [
+        "医生说：「情况稳定！」，建议明日出院。",
+        "患者知情。",
+    ]
     _assert_exact_round_trip(text, spans)
 
 
@@ -70,6 +88,15 @@ def test_chinese_fullwidth_decimal_does_not_split():
     spans = segment_chinese_text(text)
 
     assert [span.text for span in spans] == ["剂量为1．5毫克。", "复诊安排！"]
+    _assert_exact_round_trip(text, spans)
+
+
+def test_chinese_fullwidth_abbreviation_and_ascii_terminator():
+    text = "Dr．Wang记录剂量。情况稳定!"
+
+    spans = segment_chinese_text(text)
+
+    assert [span.text for span in spans] == ["Dr．Wang记录剂量。", "情况稳定!"]
     _assert_exact_round_trip(text, spans)
 
 
@@ -108,3 +135,15 @@ def test_non_chinese_language_keeps_pysbd_path():
         SentenceSpan("Patient is stable. ", 0, 19),
         SentenceSpan("Follow up tomorrow.", 19, len(text)),
     ]
+
+
+def test_explicit_segmenter_override_is_preserved_for_han_text():
+    text = "患者稳定。次日复诊！"
+    sentence_object = SimpleNamespace(sent=text, start=0, end=len(text))
+    explicit_segmenter = Mock()
+    explicit_segmenter.segment.return_value = [sentence_object]
+
+    spans = segment_text(text, language="zh", segmenter=explicit_segmenter)
+
+    explicit_segmenter.segment.assert_called_once_with(text)
+    assert spans == [SentenceSpan(text, 0, len(text))]


### PR DESCRIPTION
# Pull Request

## Description

Adds exact-offset Chinese sentence segmentation for explicit `zh` language hints and strictly Han-dominant text. The built-in path recognizes CJK and mixed-width sentence terminators, respects nested quote and bracket pairs, keeps adjacent closers with the preceding sentence, preserves decimal and abbreviation punctuation, and leaves explicit segmenter overrides and non-Chinese routing unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add a CJK-aware sentence state machine with balanced-pair handling and exact `SentenceSpan` offsets.
- Defer quote boundaries until closing punctuation and cancel them when comma/colon punctuation continues the outer sentence.
- Keep punctuation inside titles, parentheses, and non-quote brackets from ending the outer sentence.
- Preserve full-width decimal and Latin abbreviation punctuation while supporting ASCII `!`, `?`, and `;` in Han text.
- Route explicit `zh` and strictly Han-dominant text to the built-in path while preserving caller-supplied segmenters.
- Export the public Chinese segmentation APIs from `openmed.processing`.

## Testing

- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different inputs

Validation performed on the rebased head:

- `.venv/bin/python -m pytest tests/unit/processing/ tests/unit/core/test_script_detect.py -q` — 156 passed
- `.venv/bin/python -m pytest tests/ -q` — 6,210 passed, 48 skipped
- `make format`
- `make lint`
- `make format-check`
- `make type-check`
- `pre-commit run --files openmed/core/script_detect.py openmed/processing/__init__.py openmed/processing/sentences.py tests/unit/core/test_script_detect.py tests/unit/processing/test_sentences.py`
- `make docs-build`
- `python3 -m build`

## Documentation

- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new public functions
- [ ] I have updated the CHANGELOG.md

No user-guide or changelog update is needed for this focused processing API extension.

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented code where needed
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have organized my commits appropriately

## Related Issues

Closes #1471

## Screenshots/Examples

`患者发热。血压稳定！是否复诊？` produces three contiguous, exact-offset sentence spans whose source slices reconstruct the input byte-for-byte at the Python string level.
