### PR TITLE
Add cross-script Indic transliteration with ISO 15919

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   impression, and recommendation text with provenance spans, captures only
   explicitly stated BI-RADS or Lung-RADS categories, and includes synthetic
   offline accuracy gates (#1838).
+- Added a deterministic, offline ISO 15919 transliteration pivot for nine Indic
+  scripts, ITRANS and Harvard-Kyoto parsing, offset-preserving romanization,
+  and cross-script person-name linkage in surrogate vaults (#1483).
 - Added an offline Vietnamese (`vi`) PII language pack with context-gated CCCD
   and legacy CMND detection, Vietnamese dates, phone numbers, addresses and
   five-digit postal codes, plus `vi_VN` surrogates and a synthetic golden

--- a/docs/anonymization.md
+++ b/docs/anonymization.md
@@ -279,6 +279,38 @@ entries plus `schema_version` and `hmac_scheme`; it does not store raw source
 surfaces or the HMAC secret. Treat the file as sensitive pseudonymous linkage
 data anyway: it can connect records across documents even without plaintext.
 
+For person names, the vault derives that HMAC input from a deterministic ISO
+15919 pivot. Devanagari, Bengali, Gurmukhi, Gujarati, Odia, Tamil, Telugu,
+Kannada, Malayalam, and ISO 15919 inputs can therefore share one in-memory join
+key and one surrogate without storing the romanized name. The same engine can
+normalize explicit ITRANS and Harvard-Kyoto input before conversion:
+
+```python
+from openmed.processing import from_latin, to_latin, transliteration_key
+
+result = to_latin("राम ராம rāma")
+assert result.text == "rāma rāma rāma"
+assert result.remap_span(0, 4) == (0, 3)
+assert transliteration_key("राम") == transliteration_key("ராம")
+assert transliteration_key("rAma", "ITRANS") == transliteration_key("rāma")
+assert from_latin("lakShmI", "Devanagari", scheme="itrans") == "लक्ष्मी"
+```
+
+The default `schwa_policy="preserve"` and `anusvara_policy="marker"` form the
+round-trip-safe subset. `schwa_policy="source"` applies northern word-final
+schwa deletion, while `anusvara_policy="homorganic"` expands a nasal according
+to the following consonant; both are intentionally lossy. The public
+`LOSSY_CASES` tuple also lists nukta and extended letters, Tamil distinctions
+that its orthography does not encode, Gurmukhi addak, and Malayalam chillu
+letters. The stdlib-only tables are a clean-room Unicode/ISO implementation
+interoperable with the conventions of Aksharamukha (AGPL-3.0) and the Indic NLP
+Library (MIT). No code, data, copyleft component, neural weights, or third-party
+mapping bundle from either project is included.
+
+Perso-Arabic Urdu is intentionally an unsupported stub. The built-in API fails
+closed with `ValueError`; deployments that need it must supply a separately
+licensed, out-of-process adapter.
+
 ### Format preservation
 
 Phone numbers, dates, and emails preserve the structure of the original:

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -195,7 +195,9 @@ class DeidentificationResult:
         pii_entities: List of detected and redacted PII entities
         method: De-identification method used
         timestamp: When de-identification was performed
-        mapping: Optional mapping for re-identification (redacted -> original)
+        mapping: Optional mapping for re-identification. Colliding replacement
+            surfaces use private occurrence keys so separate source spellings
+            remain reversible without changing the de-identified text.
     """
 
     original_text: str
@@ -332,6 +334,7 @@ class DeidentificationResult:
 # For these, input is automatically stripped of accents before model
 # inference and entity positions are mapped back to the original text.
 _ACCENT_NORMALIZE_LANGS = frozenset({"es"})
+_OCCURRENCE_MAPPING_PREFIX = "__openmed_occurrence_v1__:"
 
 _DEFAULT_EN_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
 _DAY_FIRST_LANGS = frozenset(
@@ -1631,7 +1634,8 @@ def _build_deidentification_result(
         )
 
     deidentified = text
-    mapping = {} if keep_mapping else None
+    mapping: dict[str, str] | None = None
+    mapping_occurrences: dict[str, list[tuple[int, str]]] = {}
     source_surrogates: dict[tuple[str, str], str] = {}
     entity_occurrence_indexes: dict[int, int] = {}
     if keep_mapping:
@@ -1721,8 +1725,13 @@ def _build_deidentification_result(
             deidentified[: entity.start] + redacted + deidentified[entity.end :]
         )
 
-        if keep_mapping and mapping is not None:
-            mapping[redacted] = entity.original_text or entity.text
+        if keep_mapping:
+            mapping_occurrences.setdefault(redacted, []).append(
+                (entity.start, entity.original_text or entity.text)
+            )
+
+    if keep_mapping:
+        mapping = _build_reidentification_mapping(mapping_occurrences)
 
     audit_report = None
     if audit:
@@ -2861,7 +2870,8 @@ def reidentify(
 
     Args:
         deidentified_text: De-identified text
-        mapping: Mapping from redacted to original text
+        mapping: Mapping from redacted to original text, optionally including
+            occurrence-aware entries emitted for colliding replacement values.
 
     Returns:
         Re-identified text with original PII restored
@@ -2879,8 +2889,57 @@ def reidentify(
         Requires proper authorization and audit logging in production.
     """
     result = deidentified_text
-
+    regular_mapping: dict[str, str] = {}
+    occurrence_mapping: dict[str, list[tuple[int, str]]] = {}
     for redacted, original in mapping.items():
+        parsed = _parse_occurrence_mapping_key(redacted)
+        if parsed is None:
+            regular_mapping[redacted] = original
+            continue
+        ordinal, surface = parsed
+        occurrence_mapping.setdefault(surface, []).append((ordinal, original))
+
+    for redacted in sorted(occurrence_mapping, key=len, reverse=True):
+        originals = [original for _, original in sorted(occurrence_mapping[redacted])]
+        occurrence_index = 0
+
+        def restore_occurrence(match: re.Match[str]) -> str:
+            nonlocal occurrence_index
+            if occurrence_index >= len(originals):
+                return match.group(0)
+            original = originals[occurrence_index]
+            occurrence_index += 1
+            return original
+
+        result = re.sub(re.escape(redacted), restore_occurrence, result)
+
+    for redacted, original in regular_mapping.items():
         result = result.replace(redacted, original)
 
     return result
+
+
+def _build_reidentification_mapping(
+    occurrences: Mapping[str, list[tuple[int, str]]],
+) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for redacted, values in occurrences.items():
+        ordered = sorted(values)
+        originals = [original for _, original in ordered]
+        if len(set(originals)) == 1:
+            mapping[redacted] = originals[0]
+            continue
+        for ordinal, original in enumerate(originals, start=1):
+            key = f"{_OCCURRENCE_MAPPING_PREFIX}{ordinal:08d}:{redacted}"
+            mapping[key] = original
+    return mapping
+
+
+def _parse_occurrence_mapping_key(key: str) -> tuple[int, str] | None:
+    if not key.startswith(_OCCURRENCE_MAPPING_PREFIX):
+        return None
+    payload = key[len(_OCCURRENCE_MAPPING_PREFIX) :]
+    ordinal_text, separator, redacted = payload.partition(":")
+    if not separator or not ordinal_text.isdigit() or not redacted:
+        return None
+    return int(ordinal_text), redacted

--- a/openmed/core/surrogate_vault.py
+++ b/openmed/core/surrogate_vault.py
@@ -700,6 +700,13 @@ class SurrogateVault:
         if legacy_key != key:
             existing = self.store.get(legacy_key)
             if existing is not None:
+                try:
+                    self.store.set(key, existing, key_id=self.current_key_id)
+                except ValueError:
+                    normalized_existing = self.store.get(key)
+                    if normalized_existing is None:
+                        raise
+                    return normalized_existing
                 return existing
 
         used = self.store.used_surrogates(

--- a/openmed/core/surrogate_vault.py
+++ b/openmed/core/surrogate_vault.py
@@ -19,7 +19,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import RLock
-from typing import Any, Callable
+from typing import AbstractSet, Any, Callable
 
 from .labels import normalize_label
 from .schemas.span import hmac_text_hash
@@ -336,7 +336,7 @@ class InMemorySurrogateStore:
         with self._lock:
             return tuple(self._entries[key] for key in sorted(self._entries))
 
-    def used_surrogates(self, *, canonical_label: str, lang: str) -> set[str]:
+    def used_surrogates(self, *, canonical_label: str, lang: str) -> AbstractSet[str]:
         """Return surrogates already used for the label/language bucket."""
 
         with self._lock:
@@ -671,7 +671,15 @@ class SurrogateVault:
     ) -> str | None:
         """Return an existing surrogate for a source identifier."""
 
-        return self.store.get(self.key_for(source_text, label=label, lang=lang))
+        source = _source(source_text=source_text, label=label, lang=lang)
+        key = self._key_for_epoch(source, self._epoch_manager.current_key)
+        existing = self.store.get(key)
+        if existing is not None:
+            return existing
+        legacy_key = self._legacy_key_for_epoch(source, self._epoch_manager.current_key)
+        if legacy_key == key:
+            return None
+        return self.store.get(legacy_key)
 
     def get_or_create(
         self,
@@ -683,10 +691,16 @@ class SurrogateVault:
     ) -> str:
         """Return a stable surrogate, creating and storing it if needed."""
 
-        key = self.key_for(source_text, label=label, lang=lang)
+        source = _source(source_text=source_text, label=label, lang=lang)
+        key = self._key_for_epoch(source, self._epoch_manager.current_key)
         existing = self.store.get(key)
         if existing is not None:
             return existing
+        legacy_key = self._legacy_key_for_epoch(source, self._epoch_manager.current_key)
+        if legacy_key != key:
+            existing = self.store.get(legacy_key)
+            if existing is not None:
+                return existing
 
         used = self.store.used_surrogates(
             canonical_label=key.canonical_label,
@@ -879,6 +893,18 @@ class SurrogateVault:
     def _key_for_epoch(self, source: SurrogateSource, epoch: _EpochKey) -> SurrogateKey:
         effective_lang = str(source.lang or "en")
         canonical_label = normalize_label(str(source.label), effective_lang)
+        source_text = _linkage_source_text(source.source_text, canonical_label)
+        return SurrogateKey(
+            canonical_label=canonical_label,
+            lang=effective_lang,
+            text_hash=hmac_text_hash(source_text, epoch.linkage_key),
+        )
+
+    def _legacy_key_for_epoch(
+        self, source: SurrogateSource, epoch: _EpochKey
+    ) -> SurrogateKey:
+        effective_lang = str(source.lang or "en")
+        canonical_label = normalize_label(str(source.label), effective_lang)
         return SurrogateKey(
             canonical_label=canonical_label,
             lang=effective_lang,
@@ -888,11 +914,12 @@ class SurrogateVault:
     def _source_proof(self, source: SurrogateSource) -> str:
         effective_lang = str(source.lang or "en")
         canonical_label = normalize_label(str(source.label), effective_lang)
+        source_text = _linkage_source_text(source.source_text, canonical_label)
         material = json.dumps(
             {
                 "canonical_label": canonical_label,
                 "lang": effective_lang,
-                "source_text": source.source_text,
+                "source_text": source_text,
             },
             ensure_ascii=True,
             separators=(",", ":"),
@@ -921,17 +948,20 @@ class SurrogateVault:
         from_key: _EpochKey,
         to_key: _EpochKey,
     ) -> tuple[SurrogateEntry, ...]:
-        source_by_key = {
-            self._key_for_epoch(source, from_key): source for source in sources
-        }
+        source_by_key: dict[SurrogateKey, SurrogateSource] = {}
+        for source in sources:
+            source_by_key[self._key_for_epoch(source, from_key)] = source
+            source_by_key.setdefault(
+                self._legacy_key_for_epoch(source, from_key), source
+            )
         remapped: dict[SurrogateKey, SurrogateEntry] = {}
         missing: list[str] = []
         for entry in entries:
-            source = source_by_key.get(entry.key)
-            if source is None:
+            matched_source = source_by_key.get(entry.key)
+            if matched_source is None:
                 missing.append(entry.key.text_hash)
                 continue
-            next_key = self._key_for_epoch(source, to_key)
+            next_key = self._key_for_epoch(matched_source, to_key)
             next_entry = SurrogateEntry(next_key, entry.surrogate, to_key.key_id)
             current = remapped.get(next_key)
             if current is not None and current.surrogate != next_entry.surrogate:
@@ -1085,6 +1115,23 @@ def _source(*, source_text: str, label: str, lang: str = "en") -> SurrogateSourc
     return SurrogateSource(
         source_text=str(source_text), label=str(label), lang=str(lang or "en")
     )
+
+
+def _linkage_source_text(source_text: str, canonical_label: str) -> str:
+    """Return cross-script linkage material without persisting source text."""
+
+    if canonical_label != "PERSON":
+        return source_text
+
+    # Import lazily so the lightweight vault module does not initialize the
+    # broader processing package during module import.
+    from ..processing.transliteration import INDIC_SCRIPTS, transliteration_key
+    from .script_detect import detect_script
+
+    script = detect_script(source_text)
+    if script not in {*INDIC_SCRIPTS, "Latin"}:
+        return source_text
+    return transliteration_key(source_text)
 
 
 def _sources(

--- a/openmed/processing/__init__.py
+++ b/openmed/processing/__init__.py
@@ -69,6 +69,15 @@ from .text import (
 )
 from .tokenization import TokenizationHelper, infer_tokenizer_max_length
 from .tokenizer_cache import clear_tokenizer_cache, get_tokenizer
+from .transliteration import (
+    LOSSY_CASES,
+    TransliterationResult,
+    from_latin,
+    romanized_to_iso15919,
+    to_latin,
+    transliterate,
+    transliteration_key,
+)
 from .zh_segmentation import (
     ChineseSegmentationConfig,
     ChineseSegmenter,
@@ -158,4 +167,11 @@ __all__ = [
     "SentenceSpan",
     "segment_chinese_text",
     "segment_text",
+    "LOSSY_CASES",
+    "TransliterationResult",
+    "from_latin",
+    "romanized_to_iso15919",
+    "to_latin",
+    "transliterate",
+    "transliteration_key",
 ]

--- a/openmed/processing/transliteration.py
+++ b/openmed/processing/transliteration.py
@@ -779,11 +779,14 @@ def _romanized_pieces(text: str, source_start: int, *, scheme: str) -> list[_Pie
     normalized_scheme = _normalize_scheme(scheme)
     if normalized_scheme == "iso15919":
         pieces: list[_Piece] = []
-        for index, char in enumerate(text):
-            folded = char.casefold()
-            pieces.append(
-                _Piece(folded, source_start + index, source_start + index + 1)
-            )
+        index = 0
+        while index < len(text):
+            end = index + 1
+            while end < len(text) and unicodedata.combining(text[end]):
+                end += 1
+            folded = unicodedata.normalize("NFC", text[index:end].casefold())
+            pieces.append(_Piece(folded, source_start + index, source_start + end))
+            index = end
         return pieces
 
     mapping = _ITRANS_TO_ISO if normalized_scheme == "itrans" else _HK_TO_ISO

--- a/openmed/processing/transliteration.py
+++ b/openmed/processing/transliteration.py
@@ -1,0 +1,920 @@
+"""Deterministic transliteration for the major Brahmi-derived Indic scripts.
+
+The engine uses ISO 15919 as a common, NFC-normalized pivot for Devanagari,
+Bengali, Gurmukhi, Gujarati, Odia, Tamil, Telugu, Kannada, and Malayalam.  The
+tables are a clean-room Unicode/ISO implementation interoperable with mapping
+conventions used by Aksharamukha (AGPL-3.0) and the Indic NLP Library (MIT); no
+project code, data bundle, copyleft component, or model weights are copied or
+shipped. Neural or statistical transliterators remain user-supplied adapters.
+Perso-Arabic Urdu is an explicit unsupported stub: callers receive
+``ValueError`` and must provide an out-of-process adapter rather than silently
+using an Indic-script table.
+
+The default ``preserve`` schwa policy is orthographic and round-trip safe for
+the supported subset.  The documented lossy cases are exposed as
+``LOSSY_CASES``: script-specific letters without a one-to-one ISO pivot,
+nukta/extended letters, Tamil consonant voicing and aspiration, source-policy
+word-final schwa deletion, homorganic expansion of anusvara, and Malayalam
+chillu letters.  Callers that need exact reconstruction should keep the default
+schwa and anusvara policies and restrict input to ``LOSSY_CASES``-free text.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Literal, cast
+
+RomanizationScheme = Literal["iso15919", "itrans", "harvard-kyoto"]
+SchwaPolicy = Literal["preserve", "word-final", "source"]
+AnusvaraPolicy = Literal["marker", "homorganic"]
+
+INDIC_SCRIPTS = (
+    "Devanagari",
+    "Bengali",
+    "Gurmukhi",
+    "Gujarati",
+    "Odia",
+    "Tamil",
+    "Telugu",
+    "Kannada",
+    "Malayalam",
+)
+
+LOSSY_CASES = (
+    "nukta and script-specific extended consonants",
+    "Tamil voicing and aspiration distinctions",
+    "word-final schwa deletion with schwa_policy='word-final' or 'source'",
+    "anusvara expansion with anusvara_policy='homorganic'",
+    "Gurmukhi addak and Malayalam chillu letters",
+)
+
+_SCRIPT_BASES = {
+    "Devanagari": 0x0900,
+    "Bengali": 0x0980,
+    "Gurmukhi": 0x0A00,
+    "Gujarati": 0x0A80,
+    "Odia": 0x0B00,
+    "Tamil": 0x0B80,
+    "Telugu": 0x0C00,
+    "Kannada": 0x0C80,
+    "Malayalam": 0x0D00,
+}
+
+_NORTHERN_SCHWA_SCRIPTS = frozenset(
+    {"Devanagari", "Bengali", "Gurmukhi", "Gujarati", "Odia"}
+)
+
+_INDEPENDENT_VOWEL_OFFSETS = {
+    0x05: "a",
+    0x06: "ā",
+    0x07: "i",
+    0x08: "ī",
+    0x09: "u",
+    0x0A: "ū",
+    0x0B: "r̥",
+    0x0C: "l̥",
+    0x0E: "e",
+    0x0F: "ē",
+    0x10: "ai",
+    0x12: "o",
+    0x13: "ō",
+    0x14: "au",
+    0x60: "r̥̄",
+    0x61: "l̥̄",
+}
+
+_DEPENDENT_VOWEL_OFFSETS = {
+    0x3E: "ā",
+    0x3F: "i",
+    0x40: "ī",
+    0x41: "u",
+    0x42: "ū",
+    0x43: "r̥",
+    0x44: "r̥̄",
+    0x46: "e",
+    0x47: "ē",
+    0x48: "ai",
+    0x4A: "o",
+    0x4B: "ō",
+    0x4C: "au",
+    0x62: "l̥",
+    0x63: "l̥̄",
+}
+
+_CONSONANT_OFFSETS = {
+    0x15: "k",
+    0x16: "kh",
+    0x17: "g",
+    0x18: "gh",
+    0x19: "ṅ",
+    0x1A: "c",
+    0x1B: "ch",
+    0x1C: "j",
+    0x1D: "jh",
+    0x1E: "ñ",
+    0x1F: "ṭ",
+    0x20: "ṭh",
+    0x21: "ḍ",
+    0x22: "ḍh",
+    0x23: "ṇ",
+    0x24: "t",
+    0x25: "th",
+    0x26: "d",
+    0x27: "dh",
+    0x28: "n",
+    0x29: "ṉ",
+    0x2A: "p",
+    0x2B: "ph",
+    0x2C: "b",
+    0x2D: "bh",
+    0x2E: "m",
+    0x2F: "y",
+    0x30: "r",
+    0x31: "ṟ",
+    0x32: "l",
+    0x33: "ḷ",
+    0x34: "ḻ",
+    0x35: "v",
+    0x36: "ś",
+    0x37: "ṣ",
+    0x38: "s",
+    0x39: "h",
+}
+
+_MARK_OFFSETS = {
+    0x01: "m̐",
+    0x02: "ṁ",
+    0x03: "ḥ",
+}
+
+_ISO_VOWELS = frozenset(_INDEPENDENT_VOWEL_OFFSETS.values())
+_ISO_CONSONANTS = frozenset(_CONSONANT_OFFSETS.values()) | frozenset(
+    {"q", "x", "ġ", "z", "ṛ", "ṛh", "f", "ẏ"}
+)
+_ISO_MARKS = frozenset({"m̐", "ṁ", "ṃ", "ḥ"})
+_ISO_TOKENS = tuple(
+    sorted(_ISO_VOWELS | _ISO_CONSONANTS | _ISO_MARKS, key=len, reverse=True)
+)
+
+_ITRANS_TO_ISO = {
+    "RRI": "r̥̄",
+    "RRi": "r̥",
+    "R^I": "r̥̄",
+    "R^i": "r̥",
+    "LLI": "l̥̄",
+    "LLi": "l̥",
+    "L^I": "l̥̄",
+    "L^i": "l̥",
+    "Ch": "ch",
+    "chh": "ch",
+    "ch": "c",
+    "kh": "kh",
+    "gh": "gh",
+    "jh": "jh",
+    "Th": "ṭh",
+    "Dh": "ḍh",
+    "th": "th",
+    "dh": "dh",
+    "ph": "ph",
+    "bh": "bh",
+    "~N": "ṅ",
+    "~n": "ñ",
+    ".N": "m̐",
+    ".n": "ṁ",
+    "Sh": "ṣ",
+    "sh": "ś",
+    "aa": "ā",
+    "ii": "ī",
+    "uu": "ū",
+    "ai": "ai",
+    "au": "au",
+    "A": "ā",
+    "I": "ī",
+    "U": "ū",
+    "T": "ṭ",
+    "D": "ḍ",
+    "N": "ṇ",
+    "M": "ṁ",
+    "H": "ḥ",
+    "a": "a",
+    "i": "i",
+    "u": "u",
+    "e": "ē",
+    "o": "ō",
+    "k": "k",
+    "g": "g",
+    "c": "c",
+    "j": "j",
+    "t": "t",
+    "d": "d",
+    "n": "n",
+    "p": "p",
+    "b": "b",
+    "m": "m",
+    "y": "y",
+    "r": "r",
+    "l": "l",
+    "v": "v",
+    "w": "v",
+    "s": "s",
+    "h": "h",
+}
+
+_HK_TO_ISO = {
+    "lRR": "l̥̄",
+    "RR": "r̥̄",
+    "lR": "l̥",
+    "kh": "kh",
+    "gh": "gh",
+    "ch": "ch",
+    "jh": "jh",
+    "Th": "ṭh",
+    "Dh": "ḍh",
+    "th": "th",
+    "dh": "dh",
+    "ph": "ph",
+    "bh": "bh",
+    "ai": "ai",
+    "au": "au",
+    "A": "ā",
+    "I": "ī",
+    "U": "ū",
+    "R": "r̥",
+    "G": "ṅ",
+    "J": "ñ",
+    "T": "ṭ",
+    "D": "ḍ",
+    "N": "ṇ",
+    "z": "ś",
+    "S": "ṣ",
+    "M": "ṁ",
+    "H": "ḥ",
+    "a": "a",
+    "i": "i",
+    "u": "u",
+    "e": "ē",
+    "o": "ō",
+    "k": "k",
+    "g": "g",
+    "c": "c",
+    "j": "j",
+    "t": "t",
+    "d": "d",
+    "n": "n",
+    "p": "p",
+    "b": "b",
+    "m": "m",
+    "y": "y",
+    "r": "r",
+    "l": "l",
+    "v": "v",
+    "s": "s",
+    "h": "h",
+}
+
+_SCHEME_ALIASES = {
+    "iso": "iso15919",
+    "iso15919": "iso15919",
+    "iso-15919": "iso15919",
+    "itrans": "itrans",
+    "harvardkyoto": "harvard-kyoto",
+    "harvard-kyoto": "harvard-kyoto",
+    "hk": "harvard-kyoto",
+}
+
+_TARGET_CONSONANT_ALIASES = {
+    "Tamil": {
+        "kh": "k",
+        "g": "k",
+        "gh": "k",
+        "ch": "c",
+        "jh": "j",
+        "ṭh": "ṭ",
+        "ḍ": "ṭ",
+        "ḍh": "ṭ",
+        "th": "t",
+        "d": "t",
+        "dh": "t",
+        "ph": "p",
+        "b": "p",
+        "bh": "p",
+    }
+}
+
+_HOMORGANIC_NASAL = {
+    "k": "ṅ",
+    "kh": "ṅ",
+    "g": "ṅ",
+    "gh": "ṅ",
+    "c": "ñ",
+    "ch": "ñ",
+    "j": "ñ",
+    "jh": "ñ",
+    "ṭ": "ṇ",
+    "ṭh": "ṇ",
+    "ḍ": "ṇ",
+    "ḍh": "ṇ",
+    "t": "n",
+    "th": "n",
+    "d": "n",
+    "dh": "n",
+    "p": "m",
+    "ph": "m",
+    "b": "m",
+    "bh": "m",
+}
+
+
+@dataclass(frozen=True)
+class TransliterationResult:
+    """ISO 15919 text plus an explicit output-to-source offset map."""
+
+    text: str
+    source_length: int
+    offset_starts: tuple[int, ...]
+    offset_ends: tuple[int, ...]
+    source_scripts: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.text) != len(self.offset_starts) or len(self.text) != len(
+            self.offset_ends
+        ):
+            raise ValueError("offset map length must match transliterated text")
+
+    def remap_span(self, start: int, end: int) -> tuple[int, int]:
+        """Map a half-open ISO-output span back to its source-text span."""
+
+        safe_start = max(0, min(int(start), len(self.text)))
+        safe_end = max(safe_start, min(int(end), len(self.text)))
+        if safe_start == safe_end:
+            if safe_start >= len(self.offset_starts):
+                return self.source_length, self.source_length
+            origin = self.offset_starts[safe_start]
+            return origin, origin
+        return (
+            self.offset_starts[safe_start],
+            max(self.offset_ends[safe_start:safe_end]),
+        )
+
+
+@dataclass(frozen=True)
+class _Piece:
+    text: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class _ScriptTable:
+    script: str
+    base: int
+    independent_vowels: dict[str, str]
+    dependent_vowels: dict[str, str]
+    consonants: dict[str, str]
+    marks: dict[str, str]
+    virama: str
+    nukta: str | None
+    independent_by_iso: dict[str, str]
+    dependent_by_iso: dict[str, str]
+    consonant_by_iso: dict[str, str]
+    mark_by_iso: dict[str, str]
+
+
+def _assigned_mapping(base: int, offsets: dict[int, str]) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for offset, pivot in offsets.items():
+        char = chr(base + offset)
+        if unicodedata.category(char)[0] in {"L", "M"}:
+            mapping[char] = pivot
+    return mapping
+
+
+def _reverse_first(mapping: dict[str, str]) -> dict[str, str]:
+    reverse: dict[str, str] = {}
+    for char, pivot in mapping.items():
+        reverse.setdefault(pivot, char)
+    return reverse
+
+
+def _build_table(script: str, base: int) -> _ScriptTable:
+    independent = _assigned_mapping(base, _INDEPENDENT_VOWEL_OFFSETS)
+    dependent = _assigned_mapping(base, _DEPENDENT_VOWEL_OFFSETS)
+    consonants = _assigned_mapping(base, _CONSONANT_OFFSETS)
+    marks = _assigned_mapping(base, _MARK_OFFSETS)
+    if script == "Tamil":
+        marks[chr(base + 0x03)] = "ḵ"
+    return _ScriptTable(
+        script=script,
+        base=base,
+        independent_vowels=independent,
+        dependent_vowels=dependent,
+        consonants=consonants,
+        marks=marks,
+        virama=chr(base + 0x4D),
+        nukta=chr(base + 0x3C)
+        if unicodedata.category(chr(base + 0x3C)).startswith("M")
+        else None,
+        independent_by_iso=_reverse_first(independent),
+        dependent_by_iso=_reverse_first(dependent),
+        consonant_by_iso=_reverse_first(consonants),
+        mark_by_iso=_reverse_first(marks),
+    )
+
+
+_TABLES = {script: _build_table(script, base) for script, base in _SCRIPT_BASES.items()}
+
+
+def to_latin(
+    text: str,
+    script: str | None = None,
+    *,
+    scheme: str = "iso15919",
+    schwa_policy: SchwaPolicy = "preserve",
+    anusvara_policy: AnusvaraPolicy = "marker",
+) -> TransliterationResult:
+    """Transliterate Indic or romanized text to the ISO 15919 pivot.
+
+    Args:
+        text: Source text, including mixed Indic and Latin runs.
+        script: Optional source script. Indic script names, ``"Latin"``,
+            ``"ITRANS"``, and ``"Harvard-Kyoto"`` are accepted. When omitted,
+            each Indic run is detected independently.
+        scheme: Romanized input scheme for Latin runs.
+        schwa_policy: ``"preserve"`` for lossless orthographic output,
+            ``"word-final"`` to drop final inherent vowels, or ``"source"``
+            to apply word-final deletion only to northern scripts.
+        anusvara_policy: Keep anusvara as ``ṁ`` or expand it to the following
+            consonant's homorganic nasal.
+
+    Returns:
+        Transliteration text with an output-to-source offset map.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    if schwa_policy not in {"preserve", "word-final", "source"}:
+        raise ValueError("schwa_policy must be preserve, word-final, or source")
+    if anusvara_policy not in {"marker", "homorganic"}:
+        raise ValueError("anusvara_policy must be marker or homorganic")
+
+    source_script, source_scheme = _resolve_source(script, scheme)
+    pieces: list[_Piece] = []
+    scripts_seen: list[str] = []
+    index = 0
+    while index < len(text):
+        detected = _indic_script_for_char(text[index])
+        if source_script in _TABLES and detected is None:
+            detected = None
+        elif source_script in _TABLES:
+            detected = source_script
+
+        if detected is not None:
+            end = index + 1
+            while end < len(text):
+                next_script = _indic_script_for_char(text[end])
+                if source_script in _TABLES:
+                    if next_script != source_script:
+                        break
+                elif next_script != detected:
+                    break
+                end += 1
+            pieces.extend(
+                _romanize_indic_run(
+                    text[index:end],
+                    index,
+                    _TABLES[detected],
+                    schwa_policy=schwa_policy,
+                    anusvara_policy=anusvara_policy,
+                )
+            )
+            if detected not in scripts_seen:
+                scripts_seen.append(detected)
+            index = end
+            continue
+
+        if _is_latin_char(text[index]) or (
+            unicodedata.category(text[index]).startswith("M") and pieces
+        ):
+            end = index + 1
+            while end < len(text) and (
+                _is_latin_char(text[end])
+                or unicodedata.category(text[end]).startswith("M")
+            ):
+                end += 1
+            pieces.extend(
+                _romanized_pieces(text[index:end], index, scheme=source_scheme)
+            )
+            if "Latin" not in scripts_seen:
+                scripts_seen.append("Latin")
+            index = end
+            continue
+
+        pieces.append(_Piece(text[index], index, index + 1))
+        index += 1
+
+    output: list[str] = []
+    starts: list[int] = []
+    ends: list[int] = []
+    for piece in pieces:
+        normalized = unicodedata.normalize("NFC", piece.text)
+        output.append(normalized)
+        starts.extend([piece.start] * len(normalized))
+        ends.extend([piece.end] * len(normalized))
+    return TransliterationResult(
+        text="".join(output),
+        source_length=len(text),
+        offset_starts=tuple(starts),
+        offset_ends=tuple(ends),
+        source_scripts=tuple(scripts_seen),
+    )
+
+
+def from_latin(
+    text: str,
+    target_script: str,
+    *,
+    scheme: str = "iso15919",
+) -> str:
+    """Transliterate ISO 15919, ITRANS, or Harvard-Kyoto text to an Indic script.
+
+    Args:
+        text: Romanized source text.
+        target_script: One of :data:`INDIC_SCRIPTS`.
+        scheme: Input romanization scheme.
+
+    Returns:
+        NFC-normalized target-script text.
+    """
+
+    script = _normalize_indic_script(target_script)
+    iso_text = romanized_to_iso15919(text, scheme=scheme)
+    tokens = _tokenize_iso(iso_text)
+    table = _TABLES[script]
+    output: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in _ISO_CONSONANTS:
+            output.append(_target_consonant(token, table))
+            if index + 1 < len(tokens) and tokens[index + 1] in _ISO_VOWELS:
+                vowel = tokens[index + 1]
+                if vowel != "a":
+                    sign = table.dependent_by_iso.get(vowel)
+                    if sign is None:
+                        raise ValueError(
+                            f"{script} has no dependent vowel for ISO token {vowel!r}"
+                        )
+                    output.append(sign)
+                index += 2
+                continue
+            output.append(table.virama)
+            index += 1
+            continue
+        if token in _ISO_VOWELS:
+            independent_vowel = table.independent_by_iso.get(token)
+            if independent_vowel is None:
+                raise ValueError(
+                    f"{script} has no independent vowel for ISO token {token!r}"
+                )
+            output.append(independent_vowel)
+            index += 1
+            continue
+        if token in _ISO_MARKS:
+            mark = table.mark_by_iso.get("ṁ" if token == "ṃ" else token)
+            if mark is None:
+                raise ValueError(f"{script} has no mark for ISO token {token!r}")
+            output.append(mark)
+            index += 1
+            continue
+        output.append(token)
+        index += 1
+    return unicodedata.normalize("NFC", "".join(output))
+
+
+def transliterate(
+    text: str,
+    target_script: str,
+    *,
+    source_script: str | None = None,
+    scheme: str = "iso15919",
+    schwa_policy: SchwaPolicy = "preserve",
+    anusvara_policy: AnusvaraPolicy = "marker",
+) -> str:
+    """Transliterate text between supported scripts through ISO 15919.
+
+    Args:
+        text: Source text.
+        target_script: Indic script name or ``"Latin"``.
+        source_script: Optional explicit source script.
+        scheme: Romanized input scheme when the source is Latin.
+        schwa_policy: Inherent-vowel handling policy.
+        anusvara_policy: Anusvara handling policy.
+
+    Returns:
+        Transliterated text.
+    """
+
+    pivot = to_latin(
+        text,
+        source_script,
+        scheme=scheme,
+        schwa_policy=schwa_policy,
+        anusvara_policy=anusvara_policy,
+    ).text
+    if _normalized_name(target_script) in {"latin", "iso", "iso15919"}:
+        return pivot
+    return from_latin(pivot, target_script)
+
+
+def romanized_to_iso15919(text: str, *, scheme: str = "iso15919") -> str:
+    """Normalize ISO 15919, ITRANS, or Harvard-Kyoto input to ISO 15919.
+
+    Args:
+        text: Romanized text.
+        scheme: Source romanization scheme.
+
+    Returns:
+        NFC-normalized ISO 15919 text.
+    """
+
+    return unicodedata.normalize(
+        "NFC",
+        "".join(piece.text for piece in _romanized_pieces(text, 0, scheme=scheme)),
+    )
+
+
+def transliteration_key(
+    text: str,
+    script: str | None = None,
+    *,
+    scheme: str = "iso15919",
+) -> str:
+    """Return a deterministic cross-script join key for an in-memory surface.
+
+    The returned value contains normalized source-equivalent text and is not a
+    privacy-preserving digest. Persisted callers should HMAC it with a
+    deployment secret, as :class:`openmed.core.surrogate_vault.SurrogateVault`
+    does.
+
+    Args:
+        text: Indic or romanized source surface.
+        script: Optional source script or romanization scheme.
+        scheme: Romanized input scheme when ``script`` does not name one.
+
+    Returns:
+        An ``iso15919:``-prefixed canonical key.
+    """
+
+    pivot = to_latin(text, script, scheme=scheme).text
+    pivot = unicodedata.normalize("NFC", pivot).casefold()
+    pivot = pivot.replace("ṃ", "ṁ")
+    pivot = re.sub(r"[\u200b\u200c\u200d\u2060\ufeff]", "", pivot)
+    pivot = " ".join(pivot.split())
+    return f"iso15919:{pivot}"
+
+
+def _romanize_indic_run(
+    run: str,
+    source_start: int,
+    table: _ScriptTable,
+    *,
+    schwa_policy: SchwaPolicy,
+    anusvara_policy: AnusvaraPolicy,
+) -> list[_Piece]:
+    pieces: list[_Piece] = []
+    index = 0
+    while index < len(run):
+        char = run[index]
+        absolute = source_start + index
+        consonant = table.consonants.get(char)
+        if consonant is not None:
+            consumed_end = index + 1
+            if (
+                table.nukta is not None
+                and consumed_end < len(run)
+                and run[consumed_end] == table.nukta
+            ):
+                consonant += "̣"
+                consumed_end += 1
+            next_char = run[consumed_end] if consumed_end < len(run) else None
+            if next_char == table.virama:
+                pieces.append(
+                    _Piece(
+                        consonant,
+                        absolute,
+                        source_start + consumed_end + 1,
+                    )
+                )
+                index = consumed_end + 1
+                continue
+            pieces.append(_Piece(consonant, absolute, source_start + consumed_end))
+            if next_char in table.dependent_vowels:
+                pieces.append(
+                    _Piece(
+                        table.dependent_vowels[next_char],
+                        source_start + consumed_end,
+                        source_start + consumed_end + 1,
+                    )
+                )
+                index = consumed_end + 1
+                continue
+            if not _delete_inherent_vowel(
+                table.script, run, consumed_end, schwa_policy
+            ):
+                pieces.append(_Piece("a", absolute, source_start + consumed_end))
+            index = consumed_end
+            continue
+
+        independent = table.independent_vowels.get(char)
+        if independent is not None:
+            pieces.append(_Piece(independent, absolute, absolute + 1))
+            index += 1
+            continue
+
+        mark = table.marks.get(char)
+        if mark is not None:
+            if mark == "ṁ" and anusvara_policy == "homorganic":
+                following = _following_consonant(run, index + 1, table)
+                mark = _HOMORGANIC_NASAL.get(following or "", mark)
+            pieces.append(_Piece(mark, absolute, absolute + 1))
+            index += 1
+            continue
+
+        digit = ord(char) - (table.base + 0x66)
+        if 0 <= digit <= 9:
+            pieces.append(_Piece(str(digit), absolute, absolute + 1))
+        elif table.script == "Gurmukhi" and char == chr(table.base + 0x71):
+            following = _following_consonant(run, index + 1, table)
+            pieces.append(_Piece(following or "", absolute, absolute + 1))
+        elif char not in {table.virama, table.nukta}:
+            pieces.append(_Piece(char, absolute, absolute + 1))
+        index += 1
+    return pieces
+
+
+def _delete_inherent_vowel(
+    script: str,
+    run: str,
+    next_index: int,
+    policy: SchwaPolicy,
+) -> bool:
+    if any(unicodedata.category(char)[0] in {"L", "M"} for char in run[next_index:]):
+        return False
+    if policy == "word-final":
+        return True
+    return policy == "source" and script in _NORTHERN_SCHWA_SCRIPTS
+
+
+def _following_consonant(run: str, index: int, table: _ScriptTable) -> str | None:
+    while index < len(run) and run[index] in {table.virama, table.nukta}:
+        index += 1
+    if index >= len(run):
+        return None
+    return table.consonants.get(run[index])
+
+
+def _romanized_pieces(text: str, source_start: int, *, scheme: str) -> list[_Piece]:
+    normalized_scheme = _normalize_scheme(scheme)
+    if normalized_scheme == "iso15919":
+        pieces: list[_Piece] = []
+        for index, char in enumerate(text):
+            folded = char.casefold()
+            pieces.append(
+                _Piece(folded, source_start + index, source_start + index + 1)
+            )
+        return pieces
+
+    mapping = _ITRANS_TO_ISO if normalized_scheme == "itrans" else _HK_TO_ISO
+    source_tokens = tuple(sorted(mapping, key=len, reverse=True))
+    pieces = []
+    index = 0
+    while index < len(text):
+        token = next(
+            (
+                candidate
+                for candidate in source_tokens
+                if text.startswith(candidate, index)
+            ),
+            None,
+        )
+        if token is None:
+            pieces.append(
+                _Piece(
+                    text[index].casefold(),
+                    source_start + index,
+                    source_start + index + 1,
+                )
+            )
+            index += 1
+            continue
+        pieces.append(
+            _Piece(
+                mapping[token],
+                source_start + index,
+                source_start + index + len(token),
+            )
+        )
+        index += len(token)
+    return pieces
+
+
+def _tokenize_iso(text: str) -> list[str]:
+    normalized = unicodedata.normalize("NFC", text).casefold().replace("ṃ", "ṁ")
+    tokens: list[str] = []
+    index = 0
+    while index < len(normalized):
+        token = next(
+            (
+                candidate
+                for candidate in _ISO_TOKENS
+                if normalized.startswith(candidate, index)
+            ),
+            None,
+        )
+        if token is None:
+            tokens.append(normalized[index])
+            index += 1
+            continue
+        tokens.append(token)
+        index += len(token)
+    return tokens
+
+
+def _target_consonant(token: str, table: _ScriptTable) -> str:
+    consonant = table.consonant_by_iso.get(token)
+    if consonant is not None:
+        return consonant
+    alias = _TARGET_CONSONANT_ALIASES.get(table.script, {}).get(token)
+    if alias is not None and alias in table.consonant_by_iso:
+        return table.consonant_by_iso[alias]
+    raise ValueError(f"{table.script} has no consonant for ISO token {token!r}")
+
+
+def _indic_script_for_char(char: str) -> str | None:
+    codepoint = ord(char)
+    for script, base in _SCRIPT_BASES.items():
+        if base <= codepoint <= base + 0x7F:
+            return script
+    return None
+
+
+def _is_latin_char(char: str) -> bool:
+    return "LATIN" in unicodedata.name(char, "")
+
+
+def _resolve_source(script: str | None, scheme: str) -> tuple[str | None, str]:
+    normalized_scheme = _normalize_scheme(scheme)
+    if script is None:
+        return None, normalized_scheme
+    name = _normalized_name(script)
+    for indic_script in INDIC_SCRIPTS:
+        if name == _normalized_name(indic_script) or (
+            name == "oriya" and indic_script == "Odia"
+        ):
+            return indic_script, normalized_scheme
+    if name == "latin":
+        return "Latin", normalized_scheme
+    if name in _SCHEME_ALIASES:
+        return "Latin", _SCHEME_ALIASES[name]
+    raise ValueError(f"unsupported source script or scheme: {script!r}")
+
+
+def _normalize_indic_script(script: str) -> str:
+    name = _normalized_name(script)
+    for supported in INDIC_SCRIPTS:
+        if name == _normalized_name(supported) or (
+            name == "oriya" and supported == "Odia"
+        ):
+            return supported
+    raise ValueError(
+        f"unsupported target script {script!r}; expected one of {INDIC_SCRIPTS!r}"
+    )
+
+
+def _normalize_scheme(scheme: str) -> RomanizationScheme:
+    name = _normalized_name(scheme)
+    normalized = _SCHEME_ALIASES.get(name)
+    if normalized is None:
+        raise ValueError("scheme must be iso15919, itrans, or harvard-kyoto")
+    return cast(RomanizationScheme, normalized)
+
+
+def _normalized_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value).casefold())
+
+
+__all__ = [
+    "AnusvaraPolicy",
+    "INDIC_SCRIPTS",
+    "LOSSY_CASES",
+    "RomanizationScheme",
+    "SchwaPolicy",
+    "TransliterationResult",
+    "from_latin",
+    "romanized_to_iso15919",
+    "to_latin",
+    "transliterate",
+    "transliteration_key",
+]

--- a/tests/unit/core/test_surrogate_vault.py
+++ b/tests/unit/core/test_surrogate_vault.py
@@ -81,10 +81,10 @@ def test_shared_vault_reuses_surrogates_across_deidentify_calls(monkeypatch):
 def test_shared_vault_reuses_one_surrogate_across_indic_scripts(monkeypatch):
     """ISO linkage keeps cross-script mentions consistent within a document."""
 
-    text = "राम met ராம"
+    text = "राम met ராம and rāma"
 
     def fake_extract(text: str, *args, **kwargs) -> PredictionResult:
-        return _prediction_result(text, ["राम", "ராம"])
+        return _prediction_result(text, ["राम", "ராம", "rāma"])
 
     monkeypatch.setattr("openmed.core.pii.extract_pii", fake_extract)
     vault = SurrogateVault.in_memory("unit-test-hmac-secret")
@@ -98,8 +98,8 @@ def test_shared_vault_reuses_one_surrogate_across_indic_scripts(monkeypatch):
         use_safety_sweep=False,
     )
 
-    assert len(result.pii_entities) == 2
-    assert result.pii_entities[0].surrogate == result.pii_entities[1].surrogate
+    assert len(result.pii_entities) == 3
+    assert len({entity.surrogate for entity in result.pii_entities}) == 1
     assert len(vault.entries()) == 1
     assert result.mapping is not None
     assert reidentify(result.deidentified_text, result.mapping) == text
@@ -115,6 +115,34 @@ def test_vault_reads_pre_transliteration_person_keys():
 
     assert legacy_key != vault.key_for(source.source_text, label=source.label)
     assert vault.get(source.source_text, label=source.label) == "Casey Example"
+
+
+def test_legacy_person_key_migrates_for_cross_script_reuse():
+    """A legacy surface seeds the normalized key used by other scripts."""
+
+    devanagari = SurrogateSource("राम", "NAME", "hi")
+    vault = SurrogateVault.in_memory("unit-test-hmac-secret")
+    legacy_key = vault._legacy_key_for_epoch(
+        devanagari,
+        vault._epoch_manager.current_key,
+    )
+    vault.store.set(legacy_key, "Casey Example", key_id=vault.current_key_id)
+
+    first = vault.get_or_create(
+        devanagari.source_text,
+        label=devanagari.label,
+        lang=devanagari.lang,
+        create_surrogate=lambda _attempt: "Unused Value",
+    )
+    second = vault.get_or_create(
+        "ராம",
+        label="NAME",
+        lang="hi",
+        create_surrogate=lambda _attempt: "Different Value",
+    )
+
+    assert first == second == "Casey Example"
+    assert vault.get("ராம", label="NAME", lang="hi") == "Casey Example"
 
 
 def test_json_vault_persists_only_hmac_hashes_and_encrypted_surrogates(

--- a/tests/unit/core/test_surrogate_vault.py
+++ b/tests/unit/core/test_surrogate_vault.py
@@ -78,6 +78,45 @@ def test_shared_vault_reuses_surrogates_across_deidentify_calls(monkeypatch):
     assert "Bruno Quill" not in third.deidentified_text
 
 
+def test_shared_vault_reuses_one_surrogate_across_indic_scripts(monkeypatch):
+    """ISO linkage keeps cross-script mentions consistent within a document."""
+
+    text = "राम met ராம"
+
+    def fake_extract(text: str, *args, **kwargs) -> PredictionResult:
+        return _prediction_result(text, ["राम", "ராம"])
+
+    monkeypatch.setattr("openmed.core.pii.extract_pii", fake_extract)
+    vault = SurrogateVault.in_memory("unit-test-hmac-secret")
+
+    result = deidentify(
+        text,
+        method="replace",
+        lang="hi",
+        keep_mapping=True,
+        surrogate_vault=vault,
+        use_safety_sweep=False,
+    )
+
+    assert len(result.pii_entities) == 2
+    assert result.pii_entities[0].surrogate == result.pii_entities[1].surrogate
+    assert len(vault.entries()) == 1
+    assert result.mapping is not None
+    assert reidentify(result.deidentified_text, result.mapping) == text
+
+
+def test_vault_reads_pre_transliteration_person_keys():
+    """Existing raw-surface entries remain readable after key normalization."""
+
+    source = SurrogateSource("Alice Zephyr", "NAME")
+    vault = SurrogateVault.in_memory("unit-test-hmac-secret")
+    legacy_key = vault._legacy_key_for_epoch(source, vault._epoch_manager.current_key)
+    vault.store.set(legacy_key, "Casey Example", key_id=vault.current_key_id)
+
+    assert legacy_key != vault.key_for(source.source_text, label=source.label)
+    assert vault.get(source.source_text, label=source.label) == "Casey Example"
+
+
 def test_json_vault_persists_only_hmac_hashes_and_encrypted_surrogates(
     monkeypatch,
     tmp_path,

--- a/tests/unit/processing/test_transliteration.py
+++ b/tests/unit/processing/test_transliteration.py
@@ -1,0 +1,116 @@
+"""Tests for deterministic Indic transliteration."""
+
+from __future__ import annotations
+
+import unicodedata
+
+import pytest
+
+from openmed.processing.transliteration import (
+    INDIC_SCRIPTS,
+    LOSSY_CASES,
+    from_latin,
+    romanized_to_iso15919,
+    to_latin,
+    transliterate,
+    transliteration_key,
+)
+
+_RAMA_BY_SCRIPT = {
+    "Devanagari": "राम",
+    "Bengali": "রাম",
+    "Gurmukhi": "ਰਾਮ",
+    "Gujarati": "રામ",
+    "Odia": "ରାମ",
+    "Tamil": "ராம",
+    "Telugu": "రామ",
+    "Kannada": "ರಾಮ",
+    "Malayalam": "രാമ",
+}
+
+
+@pytest.mark.parametrize(
+    "name",
+    ("राम", "अनिता", "किरण", "लक्ष्मी", "अर्जुन", "सीता", "अक्का"),
+)
+def test_devanagari_lossless_subset_round_trips_through_iso15919(name):
+    pivot = to_latin(name, "Devanagari").text
+
+    assert from_latin(pivot, "Devanagari") == unicodedata.normalize("NFC", name)
+
+
+def test_all_nine_scripts_share_the_iso15919_pivot():
+    assert tuple(_RAMA_BY_SCRIPT) == INDIC_SCRIPTS
+
+    for script, source in _RAMA_BY_SCRIPT.items():
+        assert to_latin(source, script).text == "rāma"
+        assert from_latin("rāma", script) == source
+        assert transliterate("राम", script, source_script="Devanagari") == source
+
+
+def test_cross_script_and_romanized_names_share_one_key():
+    expected = transliteration_key("राम", "Devanagari")
+
+    assert transliteration_key("ராம", "Tamil") == expected
+    assert transliteration_key("RĀMA", "ISO 15919") == expected
+    assert transliteration_key("rAma", "ITRANS") == expected
+    assert transliteration_key("rAma", "Harvard-Kyoto") == expected
+
+
+@pytest.mark.parametrize(
+    ("itrans_source", "harvard_kyoto_source", "expected"),
+    (
+        ("rAma", "rAma", "rāma"),
+        ("lakShmI", "lakSmI", "lakṣmī"),
+        ("kR^iShNa", "kRSNa", "kr̥ṣṇa"),
+        ("chandra", "candra", "candra"),
+    ),
+)
+def test_itrans_and_harvard_kyoto_normalize_to_the_same_pivot(
+    itrans_source,
+    harvard_kyoto_source,
+    expected,
+):
+    itrans = romanized_to_iso15919(itrans_source, scheme="itrans")
+    harvard_kyoto = romanized_to_iso15919(harvard_kyoto_source, scheme="harvard-kyoto")
+
+    assert itrans == harvard_kyoto == expected
+
+
+def test_fixed_romanization_inputs_decode_to_the_same_devanagari_text():
+    assert from_latin("lakShmI", "Devanagari", scheme="itrans") == "लक्ष्मी"
+    assert from_latin("lakSmI", "Devanagari", scheme="harvard-kyoto") == "लक्ष्मी"
+
+
+def test_offset_map_and_iso_output_are_idempotent_for_mixed_script_text():
+    source = "राम ராம rāma"
+    first = to_latin(source)
+    second = to_latin(first.text)
+
+    assert first.text == second.text == "rāma rāma rāma"
+    assert first.remap_span(0, 4) == (0, 3)
+    assert first.remap_span(5, 9) == (4, 7)
+    assert first.remap_span(10, 14) == (8, 12)
+    assert len(first.offset_starts) == len(first.text)
+    assert len(first.offset_ends) == len(first.text)
+
+
+def test_explicit_schwa_and_anusvara_policies_document_lossiness():
+    assert to_latin("राम", schwa_policy="preserve").text == "rāma"
+    assert to_latin("राम", schwa_policy="source").text == "rām"
+    assert to_latin("राम।", schwa_policy="source").text == "rām।"
+    assert to_latin("அருண", schwa_policy="source").text == "aruṇa"
+    assert to_latin("अंक", anusvara_policy="marker").text == "aṁka"
+    assert to_latin("अंक", anusvara_policy="homorganic").text == "aṅka"
+    assert LOSSY_CASES
+    assert any("schwa" in case for case in LOSSY_CASES)
+    assert any("anusvara" in case for case in LOSSY_CASES)
+
+
+def test_invalid_scheme_and_script_fail_closed():
+    with pytest.raises(ValueError, match="scheme"):
+        romanized_to_iso15919("rAma", scheme="unknown")
+    with pytest.raises(ValueError, match="target script"):
+        from_latin("rāma", "Sinhala")
+    with pytest.raises(ValueError, match="target script"):
+        from_latin("rāma", "Urdu")

--- a/tests/unit/processing/test_transliteration.py
+++ b/tests/unit/processing/test_transliteration.py
@@ -95,6 +95,16 @@ def test_offset_map_and_iso_output_are_idempotent_for_mixed_script_text():
     assert len(first.offset_ends) == len(first.text)
 
 
+def test_decomposed_iso_input_is_nfc_with_source_offsets_preserved():
+    source = "ra\u0304ma"
+
+    result = to_latin(source)
+
+    assert result.text == "rāma"
+    assert unicodedata.is_normalized("NFC", result.text)
+    assert result.remap_span(1, 2) == (1, 3)
+
+
 def test_explicit_schwa_and_anusvara_policies_document_lossiness():
     assert to_latin("राम", schwa_policy="preserve").text == "rāma"
     assert to_latin("राम", schwa_policy="source").text == "rām"


### PR DESCRIPTION
## Description

Adds a deterministic, offline transliteration engine that uses ISO 15919 as a common pivot across nine Indic scripts. It normalizes ISO 15919, ITRANS, and Harvard-Kyoto input, preserves output-to-source offsets, and lets person-name variants across scripts reuse one surrogate-vault key while remaining occurrence-reversible within a document.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Adds clean-room Unicode mapping tables for Devanagari, Bengali, Gurmukhi, Gujarati, Odia, Tamil, Telugu, Kannada, and Malayalam with ISO 15919 conversion in both directions.
- Adds explicit schwa and anusvara policies, ITRANS and Harvard-Kyoto parsing, cross-script join keys, and output-to-source span remapping.
- Integrates person-name linkage with encrypted surrogate vaults, including legacy raw-surface lookup and migration to normalized cross-script keys.
- Keeps colliding replacement surfaces occurrence-aware so each original spelling remains reversible without changing the de-identified output.
- Normalizes decomposed ISO input to NFC while retaining conservative source offsets.
- Documents the lossless subset, lossy cases, unsupported Urdu stub, and third-party license boundaries; no third-party mapping bundle, component, or model weights are shipped.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Validation completed on the rebased branch:

- `.venv/bin/python -m pytest tests/ -q` — 6,266 passed, 48 skipped
- Focused transliteration, vault, script, and de-identification tests — 179 passed
- `make format`, `make lint`, `make format-check`, and `make type-check`
- `pre-commit run --files <changed files>`
- `make docs-build`
- `/usr/local/bin/python3 -m build`

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #1483

## Screenshots/Examples

Not applicable; this change adds a Python API and privacy linkage behavior with synthetic test coverage.
