### PR TITLE
Add consistent India transliterated-name surrogates

### DIFF
--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1406,7 +1406,9 @@ def _apply_safety_sweep_to_result(
 
 
 _AUDIT_TEXT_KEYS = {
+    "canonical_transliteration_key",
     "text",
+    "transliteration_key",
     "word",
     "value",
     "surface",
@@ -2344,9 +2346,10 @@ def deidentify(
             ``method="replace"`` and ``method="format_preserve"``. When
             ``None``, derived from ``lang``.
         surrogate_vault: Optional cross-document surrogate vault. When provided
-            with ``method="replace"``, OpenMed stores only HMAC source hashes
-            and reuses the same surrogate for the same label/language/source
-            identifier across calls.
+            with ``method="replace"``, OpenMed stores only HMAC source hashes.
+            Indian names in Devanagari, Tamil, or opted-in Romanization use one
+            HMAC of an in-memory phonetic fold and render the reused identity in
+            the input script; the fold itself is never persisted or audited.
         policy: Optional policy profile name controlling arbitration, action
             selection, mandatory safety sweep behavior, and reversible mapping.
         calibration_thresholds_path: Optional thresholds.json artifact path

--- a/openmed/core/script_detect.py
+++ b/openmed/core/script_detect.py
@@ -601,7 +601,12 @@ def canonical_indian_name(text: str) -> str:
             ignored_marks=frozenset(),
         )
     else:
-        transliterated = text
+        words = []
+        for word in text.split():
+            if word.endswith("a") and any(not char.isascii() for char in word):
+                word = word[:-1]
+            words.append(word)
+        transliterated = " ".join(words)
     return _fold_indian_romanization(transliterated)
 
 

--- a/openmed/core/script_detect.py
+++ b/openmed/core/script_detect.py
@@ -14,6 +14,7 @@ evasion defense are retained.
 
 from __future__ import annotations
 
+import re
 import unicodedata
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -116,6 +117,221 @@ _CONFUSABLE_FOLD: dict[str, str] = {
     "\u0456": "i",
     "\u3007": "O",
 }
+
+INDIAN_NAME_LANGUAGES = frozenset({"hi", "ta"})
+INDIAN_NAME_SCRIPTS = frozenset({"Devanagari", "Tamil"})
+
+_DEVANAGARI_CONSONANTS = {
+    "क": "k",
+    "ख": "kh",
+    "ग": "g",
+    "घ": "gh",
+    "ङ": "n",
+    "च": "ch",
+    "छ": "chh",
+    "ज": "j",
+    "झ": "jh",
+    "ञ": "n",
+    "ट": "t",
+    "ठ": "th",
+    "ड": "d",
+    "ढ": "dh",
+    "ण": "n",
+    "त": "t",
+    "थ": "th",
+    "द": "d",
+    "ध": "dh",
+    "न": "n",
+    "प": "p",
+    "फ": "ph",
+    "ब": "b",
+    "भ": "bh",
+    "म": "m",
+    "य": "y",
+    "र": "r",
+    "ल": "l",
+    "व": "v",
+    "श": "sh",
+    "ष": "sh",
+    "स": "s",
+    "ह": "h",
+    "क़": "k",
+    "ख़": "kh",
+    "ग़": "g",
+    "ज़": "j",
+    "ड़": "d",
+    "ढ़": "dh",
+    "फ़": "f",
+}
+_DEVANAGARI_VOWELS = {
+    "अ": "a",
+    "आ": "aa",
+    "इ": "i",
+    "ई": "ii",
+    "उ": "u",
+    "ऊ": "uu",
+    "ऋ": "r",
+    "ए": "e",
+    "ऐ": "ai",
+    "ओ": "o",
+    "औ": "au",
+}
+_DEVANAGARI_VOWEL_SIGNS = {
+    "ा": "aa",
+    "ि": "i",
+    "ी": "ii",
+    "ु": "u",
+    "ू": "uu",
+    "ृ": "r",
+    "े": "e",
+    "ै": "ai",
+    "ो": "o",
+    "ौ": "au",
+}
+
+_TAMIL_CONSONANTS = {
+    "க": "k",
+    "ங": "n",
+    "ச": "s",
+    "ஞ": "n",
+    "ட": "t",
+    "ண": "n",
+    "த": "t",
+    "ந": "n",
+    "ப": "p",
+    "ம": "m",
+    "ய": "y",
+    "ர": "r",
+    "ல": "l",
+    "வ": "v",
+    "ழ": "l",
+    "ள": "l",
+    "ற": "r",
+    "ன": "n",
+    "ஜ": "j",
+    "ஷ": "sh",
+    "ஸ": "s",
+    "ஹ": "h",
+}
+_TAMIL_VOWELS = {
+    "அ": "a",
+    "ஆ": "aa",
+    "இ": "i",
+    "ஈ": "ii",
+    "உ": "u",
+    "ஊ": "uu",
+    "எ": "e",
+    "ஏ": "e",
+    "ஐ": "ai",
+    "ஒ": "o",
+    "ஓ": "o",
+    "ஔ": "au",
+}
+_TAMIL_VOWEL_SIGNS = {
+    "ா": "aa",
+    "ி": "i",
+    "ீ": "ii",
+    "ு": "u",
+    "ூ": "uu",
+    "ெ": "e",
+    "ே": "e",
+    "ை": "ai",
+    "ொ": "o",
+    "ோ": "o",
+    "ௌ": "au",
+}
+
+_DEVANAGARI_RENDER_CONSONANTS = {
+    "kh": "ख",
+    "gh": "घ",
+    "ch": "च",
+    "jh": "झ",
+    "th": "थ",
+    "dh": "ध",
+    "ph": "फ",
+    "bh": "भ",
+    "sh": "श",
+    "k": "क",
+    "g": "ग",
+    "c": "च",
+    "j": "ज",
+    "t": "त",
+    "d": "द",
+    "n": "न",
+    "p": "प",
+    "b": "ब",
+    "m": "म",
+    "y": "य",
+    "r": "र",
+    "l": "ल",
+    "v": "व",
+    "w": "व",
+    "s": "स",
+    "h": "ह",
+    "f": "फ",
+    "q": "क",
+    "x": "क्स",
+    "z": "ज",
+}
+_DEVANAGARI_RENDER_VOWELS = {
+    "a": ("अ", ""),
+    "i": ("इ", "ि"),
+    "u": ("उ", "ु"),
+    "e": ("ए", "े"),
+    "o": ("ओ", "ो"),
+    "ai": ("ऐ", "ै"),
+    "au": ("औ", "ौ"),
+}
+
+_TAMIL_RENDER_CONSONANTS = {
+    "kh": "க",
+    "gh": "க",
+    "ch": "ச",
+    "jh": "ஜ",
+    "th": "த",
+    "dh": "த",
+    "ph": "ப",
+    "bh": "ப",
+    "sh": "ஷ",
+    "k": "க",
+    "g": "க",
+    "c": "ச",
+    "j": "ஜ",
+    "t": "த",
+    "d": "த",
+    "n": "ந",
+    "p": "ப",
+    "b": "ப",
+    "m": "ம",
+    "y": "ய",
+    "r": "ர",
+    "l": "ல",
+    "v": "வ",
+    "w": "வ",
+    "s": "ஸ",
+    "h": "ஹ",
+    "f": "ஃப",
+    "q": "க",
+    "x": "க்ஸ",
+    "z": "ஜ",
+}
+_TAMIL_RENDER_VOWELS = {
+    "a": ("அ", ""),
+    "i": ("இ", "ி"),
+    "u": ("உ", "ு"),
+    "e": ("எ", "ெ"),
+    "o": ("ஒ", "ொ"),
+    "ai": ("ஐ", "ை"),
+    "au": ("ஔ", "ௌ"),
+}
+
+_PHONETIC_VOWEL_FOLDS = (
+    ("ee", "i"),
+    ("ii", "i"),
+    ("oo", "u"),
+    ("uu", "u"),
+    ("aa", "a"),
+)
 
 
 @dataclass(frozen=True)
@@ -335,6 +551,188 @@ _SCRIPT_RANGES: tuple[tuple[str, tuple[tuple[int, int], ...]], ...] = (
     ),
     ("Thai", ((0x0E00, 0x0E7F),)),
 )
+
+
+def indian_name_script(text: str, lang: str = "hi") -> str | None:
+    """Return the rendering script for an Indian name surface, if in scope.
+
+    Native Devanagari and Tamil surfaces are unambiguous. Latin surfaces opt in
+    through a Hindi or Tamil language hint so unrelated Latin names retain their
+    existing exact vault key behavior.
+    """
+
+    script = detect_script(text)
+    if script in INDIAN_NAME_SCRIPTS:
+        return script
+    base_lang = str(lang or "").strip().replace("-", "_").split("_", 1)[0]
+    if script == "Latin" and base_lang.casefold() in INDIAN_NAME_LANGUAGES:
+        return script
+    return None
+
+
+def canonical_indian_name(text: str) -> str:
+    """Fold a Devanagari, Tamil, or Romanized name to one phonetic key.
+
+    This is a deterministic transliteration fold, not fuzzy entity resolution.
+    It handles common long-vowel Roman variants and Indic consonant spellings
+    while retaining the rest of each name, so similar but distinct names do not
+    merge merely because they share a prefix.
+    """
+
+    script = detect_script(text)
+    if script == "Devanagari":
+        transliterated = _indic_to_latin(
+            text,
+            consonants=_DEVANAGARI_CONSONANTS,
+            vowels=_DEVANAGARI_VOWELS,
+            vowel_signs=_DEVANAGARI_VOWEL_SIGNS,
+            virama="्",
+            nasal_marks=frozenset({"ं", "ँ"}),
+            ignored_marks=frozenset({"़"}),
+        )
+    elif script == "Tamil":
+        transliterated = _indic_to_latin(
+            text,
+            consonants=_TAMIL_CONSONANTS,
+            vowels=_TAMIL_VOWELS,
+            vowel_signs=_TAMIL_VOWEL_SIGNS,
+            virama="்",
+            nasal_marks=frozenset(),
+            ignored_marks=frozenset(),
+        )
+    else:
+        transliterated = text
+    return _fold_indian_romanization(transliterated)
+
+
+def render_indian_name(canonical_name: str, script: str) -> str:
+    """Render one canonical Indian surrogate identity in ``script``."""
+
+    if script == "Devanagari":
+        return _latin_to_indic(
+            canonical_name,
+            consonants=_DEVANAGARI_RENDER_CONSONANTS,
+            vowels=_DEVANAGARI_RENDER_VOWELS,
+            virama="्",
+        )
+    if script == "Tamil":
+        return _latin_to_indic(
+            canonical_name,
+            consonants=_TAMIL_RENDER_CONSONANTS,
+            vowels=_TAMIL_RENDER_VOWELS,
+            virama="்",
+        )
+    return " ".join(part.capitalize() for part in canonical_name.split())
+
+
+def _indic_to_latin(
+    text: str,
+    *,
+    consonants: dict[str, str],
+    vowels: dict[str, str],
+    vowel_signs: dict[str, str],
+    virama: str,
+    nasal_marks: frozenset[str],
+    ignored_marks: frozenset[str],
+) -> str:
+    output: list[str] = []
+    index = 0
+    while index < len(text):
+        char = text[index]
+        consonant = consonants.get(char)
+        if consonant is not None:
+            following = text[index + 1] if index + 1 < len(text) else ""
+            if following == virama:
+                output.append(consonant)
+                index += 2
+                continue
+            vowel_sign = vowel_signs.get(following)
+            if vowel_sign is not None:
+                output.append(consonant + vowel_sign)
+                index += 2
+                continue
+            output.append(consonant + "a")
+        elif char in vowels:
+            output.append(vowels[char])
+        elif char in nasal_marks:
+            output.append("n")
+        elif char in ignored_marks or char == virama:
+            pass
+        elif char.isascii() or char.isspace():
+            output.append(char)
+        index += 1
+
+    words = "".join(output).split()
+    return " ".join(word[:-1] if word.endswith("a") else word for word in words)
+
+
+def _fold_indian_romanization(text: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", text).casefold()
+    ascii_letters = "".join(
+        char
+        for char in decomposed
+        if not unicodedata.combining(char) and (char.isascii() or char.isspace())
+    )
+    folded = re.sub(r"[^a-z]+", " ", ascii_letters).strip()
+    folded = folded.replace("sh", "s")
+    for source, replacement in _PHONETIC_VOWEL_FOLDS:
+        folded = folded.replace(source, replacement)
+    return " ".join(folded.split())
+
+
+def _latin_to_indic(
+    text: str,
+    *,
+    consonants: dict[str, str],
+    vowels: dict[str, tuple[str, str]],
+    virama: str,
+) -> str:
+    consonant_tokens = sorted(consonants, key=len, reverse=True)
+    vowel_tokens = sorted(vowels, key=len, reverse=True)
+    output: list[str] = []
+    index = 0
+    previous_was_consonant = False
+
+    while index < len(text):
+        char = text[index]
+        if not char.isalpha():
+            if previous_was_consonant:
+                output.append(virama)
+            output.append(char)
+            previous_was_consonant = False
+            index += 1
+            continue
+
+        consonant = next(
+            (token for token in consonant_tokens if text.startswith(token, index)),
+            None,
+        )
+        if consonant is not None:
+            if previous_was_consonant:
+                output.append(virama)
+            output.append(consonants[consonant])
+            previous_was_consonant = True
+            index += len(consonant)
+            continue
+
+        vowel = next(
+            (token for token in vowel_tokens if text.startswith(token, index)),
+            None,
+        )
+        if vowel is not None:
+            independent, sign = vowels[vowel]
+            output.append(sign if previous_was_consonant else independent)
+            previous_was_consonant = False
+            index += len(vowel)
+            continue
+
+        output.append(char)
+        previous_was_consonant = False
+        index += 1
+
+    if previous_was_consonant:
+        output.append(virama)
+    return "".join(output)
 
 
 def detect_script(text: str) -> str:
@@ -743,19 +1141,24 @@ __all__ = [
     "CONFUSABLE_DATA_VERSION",
     "DetectionNormalization",
     "INDIC_SCRIPTS",
+    "INDIAN_NAME_LANGUAGES",
+    "INDIAN_NAME_SCRIPTS",
     "MixedScriptSpan",
     "ScriptDetectionWindow",
     "SCRIPT_LANGUAGE_HINTS",
     "SUPPORTED_SCRIPTS",
     "UNKNOWN_SCRIPT",
     "ZERO_WIDTH_CHARS",
+    "canonical_indian_name",
     "candidate_languages_for_script",
     "confusable_skeleton",
     "detect_mixed_script",
     "detect_script",
     "india_clinical_script_windows",
+    "indian_name_script",
     "is_han_dominant",
     "mixed_script_spans",
     "normalize_for_pii_detection",
+    "render_indian_name",
     "segment_by_script",
 ]

--- a/openmed/core/surrogate_vault.py
+++ b/openmed/core/surrogate_vault.py
@@ -2,7 +2,8 @@
 
 The vault stores mappings from ``(canonical_label, lang, text_hash)`` to the
 selected surrogate value. ``text_hash`` is an HMAC-SHA256 digest of the source
-surface; raw source identifiers are never stored. Persisted vault payloads
+surface, or of an in-memory canonical transliteration for opted-in Indian name
+surfaces; neither form is persisted as plaintext. Persisted vault payloads
 encrypt surrogate values under a versioned epoch key so the file at rest does
 not reveal replacement identifiers.
 """
@@ -24,6 +25,11 @@ from typing import AbstractSet, Any, Callable
 
 from .labels import normalize_label
 from .schemas.span import hmac_text_hash
+from .script_detect import (
+    canonical_indian_name,
+    indian_name_script,
+    render_indian_name,
+)
 
 LEGACY_SCHEMA_VERSION = 1
 SCHEMA_VERSION = 2
@@ -33,6 +39,8 @@ ENCRYPTION_SCHEME = "hmac-sha256-stream-xor+hmac-sha256"
 _EPOCH_PREFIX = "epoch"
 _KEY_ID_BYTES = 8
 _NONCE_BYTES = 16
+_INDIAN_NAME_KEY_LANG = "india"
+_INDIAN_NAME_LABELS = frozenset({"PERSON", "FIRST_NAME", "LAST_NAME"})
 
 
 @dataclass(frozen=True, order=True)
@@ -129,6 +137,14 @@ class SurrogateSource:
             raise ValueError("label must be non-empty")
         if not self.lang:
             object.__setattr__(self, "lang", "en")
+
+
+@dataclass(frozen=True)
+class _SourceIdentity:
+    canonical_label: str
+    key_lang: str
+    key_text: str = field(repr=False)
+    render_script: str | None = None
 
 
 @dataclass(frozen=True)
@@ -576,6 +592,12 @@ def _matches_required_script(candidate: str, required_script: str | None) -> boo
     )
 
 
+def _contains_indian_name(candidate: str, canonical_source: str) -> bool:
+    if candidate == canonical_source:
+        return True
+    return len(canonical_source) >= 4 and canonical_source in candidate
+
+
 class SurrogateVault:
     """Stable cross-document surrogate mapper.
 
@@ -689,11 +711,17 @@ class SurrogateVault:
         key = self._key_for_epoch(source, self._epoch_manager.current_key)
         existing = self.store.get(key)
         if existing is not None:
-            return existing
-        legacy_key = self._legacy_key_for_epoch(source, self._epoch_manager.current_key)
-        if legacy_key == key:
-            return None
-        return self.store.get(legacy_key)
+            return self._render_for_source(existing, source)
+        for legacy_key in self._legacy_keys_for_epoch(
+            source,
+            self._epoch_manager.current_key,
+        ):
+            if legacy_key == key:
+                continue
+            existing = self.store.get(legacy_key)
+            if existing is not None:
+                return self._render_for_source(existing, source)
+        return None
 
     def get_or_create(
         self,
@@ -707,35 +735,51 @@ class SurrogateVault:
         """Return a stable surrogate, optionally constrained to one script run."""
 
         source = _source(source_text=source_text, label=label, lang=lang)
+        identity = _source_identity(source)
         key = self._key_for_epoch(source, self._epoch_manager.current_key)
         existing = self.store.get(key)
         if existing is not None:
-            if not _matches_required_script(existing, required_script):
+            rendered = self._render_for_source(existing, source)
+            assert rendered is not None
+            if not _matches_required_script(rendered, required_script):
                 raise ValueError("existing surrogate does not satisfy required_script")
-            return existing
-        legacy_key = self._legacy_key_for_epoch(source, self._epoch_manager.current_key)
-        if legacy_key != key:
+            return rendered
+        for legacy_key in self._legacy_keys_for_epoch(
+            source,
+            self._epoch_manager.current_key,
+        ):
+            if legacy_key == key:
+                continue
             existing = self.store.get(legacy_key)
             if existing is not None:
-                if not _matches_required_script(existing, required_script):
+                stored_existing = (
+                    canonical_indian_name(existing)
+                    if identity.render_script is not None
+                    else existing
+                )
+                rendered = self._render_for_source(stored_existing, source)
+                assert rendered is not None
+                if not _matches_required_script(rendered, required_script):
                     raise ValueError(
                         "existing legacy surrogate does not satisfy required_script"
                     )
                 try:
-                    self.store.set(key, existing, key_id=self.current_key_id)
+                    self.store.set(key, stored_existing, key_id=self.current_key_id)
                 except ValueError:
                     normalized_existing = self.store.get(key)
                     if normalized_existing is None:
                         raise
-                    if not _matches_required_script(
+                    normalized_rendered = self._render_for_source(
                         normalized_existing,
-                        required_script,
-                    ):
+                        source,
+                    )
+                    assert normalized_rendered is not None
+                    if not _matches_required_script(normalized_rendered, required_script):
                         raise ValueError(
                             "existing surrogate does not satisfy required_script"
                         )
-                    return normalized_existing
-                return existing
+                    return normalized_rendered
+                return rendered
 
         used = self.store.used_surrogates(
             canonical_label=key.canonical_label,
@@ -746,10 +790,22 @@ class SurrogateVault:
             candidate = create_surrogate(attempt)
             if not candidate:
                 continue
+            if identity.render_script is not None:
+                candidate = canonical_indian_name(candidate)
+                if not candidate:
+                    continue
+                leaks_source = _contains_indian_name(candidate, identity.key_text)
+                rendered_candidate = render_indian_name(
+                    candidate,
+                    identity.render_script,
+                )
+            else:
+                leaks_source = _contains_source_surface(candidate, source_text)
+                rendered_candidate = candidate
             if (
-                _contains_source_surface(candidate, source_text)
+                leaks_source
                 or candidate in used
-                or not _matches_required_script(candidate, required_script)
+                or not _matches_required_script(rendered_candidate, required_script)
             ):
                 continue
             surrogate = candidate
@@ -758,18 +814,21 @@ class SurrogateVault:
         if not surrogate:
             suffix = key.text_hash.rsplit(":", 1)[-1][:8]
             base = create_surrogate(0) or key.canonical_label
-            if (
-                _contains_source_surface(base, source_text)
-                or base in used
-                or not _matches_required_script(base, required_script)
-            ):
-                base = key.canonical_label
+            if identity.render_script is not None:
+                base = canonical_indian_name(base) or key.canonical_label.casefold()
+                leaks_source = _contains_indian_name(base, identity.key_text)
+            else:
+                leaks_source = _contains_source_surface(base, source_text)
+            if leaks_source or base in used:
+                base = key.canonical_label.casefold()
             surrogate = f"{base}_{suffix}"
-            if not _matches_required_script(surrogate, required_script):
+            rendered_surrogate = self._render_for_source(surrogate, source)
+            assert rendered_surrogate is not None
+            if not _matches_required_script(rendered_surrogate, required_script):
                 raise ValueError("unable to create a surrogate in required_script")
 
         self.store.set(key, surrogate, key_id=self.current_key_id)
-        return surrogate
+        return self._render_for_source(surrogate, source)
 
     def entries(self) -> tuple[SurrogateEntry, ...]:
         """Return the current sorted vault entries."""
@@ -936,6 +995,16 @@ class SurrogateVault:
         save()
 
     def _key_for_epoch(self, source: SurrogateSource, epoch: _EpochKey) -> SurrogateKey:
+        identity = _source_identity(source)
+        return SurrogateKey(
+            canonical_label=identity.canonical_label,
+            lang=identity.key_lang,
+            text_hash=hmac_text_hash(identity.key_text, epoch.linkage_key),
+        )
+
+    def _normalized_legacy_key_for_epoch(
+        self, source: SurrogateSource, epoch: _EpochKey
+    ) -> SurrogateKey:
         effective_lang = str(source.lang or "en")
         canonical_label = normalize_label(str(source.label), effective_lang)
         source_text = _linkage_source_text(source.source_text, canonical_label)
@@ -956,15 +1025,34 @@ class SurrogateVault:
             text_hash=hmac_text_hash(source.source_text, epoch.linkage_key),
         )
 
+    def _legacy_keys_for_epoch(
+        self, source: SurrogateSource, epoch: _EpochKey
+    ) -> tuple[SurrogateKey, ...]:
+        candidates = (
+            self._normalized_legacy_key_for_epoch(source, epoch),
+            self._legacy_key_for_epoch(source, epoch),
+        )
+        return tuple(dict.fromkeys(candidates))
+
+    def _render_for_source(
+        self,
+        stored_surrogate: str | None,
+        source: SurrogateSource,
+    ) -> str | None:
+        if stored_surrogate is None:
+            return None
+        script = _source_identity(source).render_script
+        if script is None:
+            return stored_surrogate
+        return render_indian_name(stored_surrogate, script)
+
     def _source_proof(self, source: SurrogateSource) -> str:
-        effective_lang = str(source.lang or "en")
-        canonical_label = normalize_label(str(source.label), effective_lang)
-        source_text = _linkage_source_text(source.source_text, canonical_label)
+        identity = _source_identity(source)
         material = json.dumps(
             {
-                "canonical_label": canonical_label,
-                "lang": effective_lang,
-                "source_text": source_text,
+                "canonical_label": identity.canonical_label,
+                "lang": identity.key_lang,
+                "source_text": identity.key_text,
             },
             ensure_ascii=True,
             separators=(",", ":"),
@@ -996,9 +1084,8 @@ class SurrogateVault:
         source_by_key: dict[SurrogateKey, SurrogateSource] = {}
         for source in sources:
             source_by_key[self._key_for_epoch(source, from_key)] = source
-            source_by_key.setdefault(
-                self._legacy_key_for_epoch(source, from_key), source
-            )
+            for legacy_key in self._legacy_keys_for_epoch(source, from_key):
+                source_by_key.setdefault(legacy_key, source)
         remapped: dict[SurrogateKey, SurrogateEntry] = {}
         missing: list[str] = []
         for entry in entries:
@@ -1007,7 +1094,13 @@ class SurrogateVault:
                 missing.append(entry.key.text_hash)
                 continue
             next_key = self._key_for_epoch(matched_source, to_key)
-            next_entry = SurrogateEntry(next_key, entry.surrogate, to_key.key_id)
+            identity = _source_identity(matched_source)
+            next_surrogate = (
+                canonical_indian_name(entry.surrogate)
+                if identity.render_script is not None
+                else entry.surrogate
+            )
+            next_entry = SurrogateEntry(next_key, next_surrogate, to_key.key_id)
             current = remapped.get(next_key)
             if current is not None and current.surrogate != next_entry.surrogate:
                 raise ValueError("rotation would collapse two surrogates into one key")
@@ -1177,6 +1270,26 @@ def _linkage_source_text(source_text: str, canonical_label: str) -> str:
     if script not in {*INDIC_SCRIPTS, "Latin"}:
         return source_text
     return transliteration_key(source_text)
+
+
+def _source_identity(source: SurrogateSource) -> _SourceIdentity:
+    effective_lang = str(source.lang or "en")
+    canonical_label = normalize_label(str(source.label), effective_lang)
+    script = indian_name_script(source.source_text, effective_lang)
+    if canonical_label in _INDIAN_NAME_LABELS and script is not None:
+        canonical_name = canonical_indian_name(source.source_text)
+        if canonical_name:
+            return _SourceIdentity(
+                canonical_label=canonical_label,
+                key_lang=_INDIAN_NAME_KEY_LANG,
+                key_text=canonical_name,
+                render_script=script,
+            )
+    return _SourceIdentity(
+        canonical_label=canonical_label,
+        key_lang=effective_lang,
+        key_text=source.source_text,
+    )
 
 
 def _sources(

--- a/openmed/core/surrogate_vault.py
+++ b/openmed/core/surrogate_vault.py
@@ -774,7 +774,9 @@ class SurrogateVault:
                         source,
                     )
                     assert normalized_rendered is not None
-                    if not _matches_required_script(normalized_rendered, required_script):
+                    if not _matches_required_script(
+                        normalized_rendered, required_script
+                    ):
                         raise ValueError(
                             "existing surrogate does not satisfy required_script"
                         )

--- a/tests/fixtures/pii/india_transliterated_names.json
+++ b/tests/fixtures/pii/india_transliterated_names.json
@@ -1,0 +1,34 @@
+{
+  "canonical_name": "sunil sarma",
+  "documents": [
+    {
+      "id": "india-name-devanagari",
+      "language": "hi",
+      "script": "Devanagari",
+      "surface": "सुनील शर्मा",
+      "text": "रोगी सुनील शर्मा आज आए।"
+    },
+    {
+      "id": "india-name-tamil",
+      "language": "ta",
+      "script": "Tamil",
+      "surface": "சுனீல் சர்மா",
+      "text": "நோயாளி சுனீல் சர்மா இன்று வந்தார்."
+    },
+    {
+      "id": "india-name-latin-standard",
+      "language": "hi",
+      "script": "Latin",
+      "surface": "Sunil Sharma",
+      "text": "Patient Sunil Sharma returned today."
+    },
+    {
+      "id": "india-name-latin-variant",
+      "language": "ta",
+      "script": "Latin",
+      "surface": "Suneel Sarma",
+      "text": "Patient Suneel Sarma returned today."
+    }
+  ],
+  "negative_surface": "Sunita Sharma"
+}

--- a/tests/unit/core/test_hinglish_deidentification.py
+++ b/tests/unit/core/test_hinglish_deidentification.py
@@ -190,7 +190,7 @@ def test_surrogate_vault_script_constraint_rejects_non_latin_candidates() -> Non
 def test_surrogate_vault_script_constraint_rejects_non_latin_legacy() -> None:
     vault = SurrogateVault.in_memory("script-constraint-legacy-secret")
     source = SurrogateSource("Rahul", "NAME", "en")
-    legacy_key = vault._legacy_key_for_epoch(
+    legacy_key = vault._normalized_legacy_key_for_epoch(
         source,
         vault._epoch_manager.current_key,
     )

--- a/tests/unit/core/test_india_name_surrogate_vault.py
+++ b/tests/unit/core/test_india_name_surrogate_vault.py
@@ -1,0 +1,213 @@
+"""India multi-script name consistency and leakage regression tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openmed.core.pii import deidentify
+from openmed.core.script_detect import canonical_indian_name, detect_script
+from openmed.core.surrogate_vault import HMAC_SCHEME, SurrogateVault
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+_FIXTURE_PATH = Path("tests/fixtures/pii/india_transliterated_names.json")
+_SECRET = "india-name-unit-test-secret"
+
+
+def _fixture() -> dict[str, object]:
+    return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _prediction(
+    text: str,
+    surface: str,
+    *,
+    metadata: dict[str, str] | None = None,
+) -> PredictionResult:
+    start = text.index(surface)
+    return PredictionResult(
+        text=text,
+        entities=[
+            EntityPrediction(
+                text=surface,
+                label="NAME",
+                start=start,
+                end=start + len(surface),
+                confidence=0.99,
+                metadata=metadata,
+            )
+        ],
+        model_name="synthetic-india-name-fixture",
+        timestamp="now",
+    )
+
+
+def _fixture_documents() -> list[dict[str, str]]:
+    documents = _fixture()["documents"]
+    assert isinstance(documents, list)
+    return [dict(document) for document in documents]
+
+
+def test_multiscript_name_aliases_round_trip_through_one_vault_entry(tmp_path):
+    fixture = _fixture()
+    documents = _fixture_documents()
+    expected_canonical = str(fixture["canonical_name"])
+    path = tmp_path / "india-name-vault.json"
+    vault = SurrogateVault.from_file(path, hmac_secret=_SECRET)
+
+    keys = {
+        vault.key_for(
+            document["surface"],
+            label="PERSON",
+            lang=document["language"],
+        )
+        for document in documents
+    }
+    assert {canonical_indian_name(document["surface"]) for document in documents} == {
+        expected_canonical
+    }
+    assert len(keys) == 1
+
+    rendered = {}
+    for document in documents:
+        rendered[document["id"]] = vault.get_or_create(
+            document["surface"],
+            label="PERSON",
+            lang=document["language"],
+            create_surrogate=lambda attempt: "Aarav Mehta",
+        )
+
+    assert len(vault.entries()) == 1
+    assert vault.entries()[0].surrogate == canonical_indian_name("Aarav Mehta")
+    assert detect_script(rendered["india-name-devanagari"]) == "Devanagari"
+    assert detect_script(rendered["india-name-tamil"]) == "Tamil"
+    assert rendered["india-name-latin-standard"] == rendered["india-name-latin-variant"]
+    assert detect_script(rendered["india-name-latin-standard"]) == "Latin"
+
+    reloaded = SurrogateVault.from_file(path, hmac_secret=_SECRET)
+    for document in documents:
+        assert (
+            reloaded.get(
+                document["surface"],
+                label="PERSON",
+                lang=document["language"],
+            )
+            == rendered[document["id"]]
+        )
+
+
+def test_similar_romanized_people_do_not_collapse_to_one_identity():
+    fixture = _fixture()
+    first = "Sunil Sharma"
+    second = str(fixture["negative_surface"])
+    vault = SurrogateVault.in_memory(_SECRET)
+
+    assert canonical_indian_name(first) != canonical_indian_name(second)
+    assert vault.key_for(first, label="PERSON", lang="hi") != vault.key_for(
+        second,
+        label="PERSON",
+        lang="hi",
+    )
+    first_surrogate = vault.get_or_create(
+        first,
+        label="PERSON",
+        lang="hi",
+        create_surrogate=lambda attempt: "Aarav Mehta",
+    )
+    second_surrogate = vault.get_or_create(
+        second,
+        label="PERSON",
+        lang="hi",
+        create_surrogate=lambda attempt: "Kabir Rao",
+    )
+
+    assert first_surrogate != second_surrogate
+    assert len(vault.entries()) == 2
+
+
+def test_canonical_name_is_absent_from_vault_payload_and_audit(
+    monkeypatch,
+    tmp_path,
+):
+    fixture = _fixture()
+    documents = _fixture_documents()
+    canonical_name = str(fixture["canonical_name"])
+    surfaces = {document["surface"] for document in documents}
+
+    def fake_extract(text: str, *args, **kwargs) -> PredictionResult:
+        surface = next(surface for surface in surfaces if surface in text)
+        return _prediction(
+            text,
+            surface,
+            metadata={"canonical_transliteration_key": canonical_name},
+        )
+
+    monkeypatch.setattr("openmed.core.pii.extract_pii", fake_extract)
+    monkeypatch.setattr(
+        "openmed.core.anonymizer.Anonymizer.surrogate",
+        lambda self, original, label, **kwargs: "Aarav Mehta",
+    )
+    path = tmp_path / "india-name-vault.json"
+    vault = SurrogateVault.from_file(path, hmac_secret=_SECRET)
+
+    audit_payloads = []
+    for document in documents:
+        report = deidentify(
+            document["text"],
+            method="replace",
+            lang="hi",
+            surrogate_vault=vault,
+            use_safety_sweep=False,
+            audit=True,
+        )
+        audit_payloads.append(report.to_json())
+
+    raw_vault = path.read_text(encoding="utf-8")
+    assert canonical_name not in raw_vault
+    assert all(surface not in raw_vault for surface in surfaces)
+    assert all(canonical_name not in payload for payload in audit_payloads)
+    assert all(
+        surface not in payload for surface in surfaces for payload in audit_payloads
+    )
+    persisted = json.loads(raw_vault)
+    assert len(persisted["entries"]) == 1
+    assert persisted["entries"][0]["text_hash"].startswith(f"{HMAC_SCHEME}:")
+
+
+def test_multiscript_fixture_deidentification_has_no_name_leakage(monkeypatch):
+    documents = _fixture_documents()
+    surfaces = {document["surface"] for document in documents}
+
+    def fake_extract(text: str, *args, **kwargs) -> PredictionResult:
+        surface = next(surface for surface in surfaces if surface in text)
+        return _prediction(text, surface)
+
+    monkeypatch.setattr("openmed.core.pii.extract_pii", fake_extract)
+    monkeypatch.setattr(
+        "openmed.core.anonymizer.Anonymizer.surrogate",
+        lambda self, original, label, **kwargs: "Aarav Mehta",
+    )
+    vault = SurrogateVault.in_memory(_SECRET)
+
+    for document in documents:
+        result = deidentify(
+            document["text"],
+            method="replace",
+            lang="hi",
+            surrogate_vault=vault,
+            use_safety_sweep=False,
+        )
+        assert all(surface not in result.deidentified_text for surface in surfaces)
+        assert (
+            detect_script(result.pii_entities[0].surrogate or "") == document["script"]
+        )
+
+
+def test_non_india_name_keys_keep_exact_source_and_language_behavior():
+    vault = SurrogateVault.in_memory(_SECRET)
+    source = "Alice Zephyr"
+
+    key = vault.key_for(source, label="PERSON", lang="en")
+
+    assert key.lang == "en"
+    assert key.text_hash == vault.text_hash(source)

--- a/tests/unit/core/test_surrogate_vault.py
+++ b/tests/unit/core/test_surrogate_vault.py
@@ -10,6 +10,7 @@ import pytest
 from openmed.core import surrogate_vault as vault_module
 from openmed.core.pii import deidentify, reidentify
 from openmed.core.schemas.span import hmac_text_hash
+from openmed.core.script_detect import detect_script
 from openmed.core.surrogate_vault import (
     ENCRYPTION_SCHEME,
     HMAC_SCHEME,
@@ -78,8 +79,8 @@ def test_shared_vault_reuses_surrogates_across_deidentify_calls(monkeypatch):
     assert "Bruno Quill" not in third.deidentified_text
 
 
-def test_shared_vault_reuses_one_surrogate_across_indic_scripts(monkeypatch):
-    """ISO linkage keeps cross-script mentions consistent within a document."""
+def test_shared_vault_reuses_one_identity_across_indic_scripts(monkeypatch):
+    """Cross-script mentions share one identity with script-aware rendering."""
 
     text = "राम met ராம and rāma"
 
@@ -99,18 +100,23 @@ def test_shared_vault_reuses_one_surrogate_across_indic_scripts(monkeypatch):
     )
 
     assert len(result.pii_entities) == 3
-    assert len({entity.surrogate for entity in result.pii_entities}) == 1
+    assert {
+        detect_script(entity.surrogate or "") for entity in result.pii_entities
+    } == {"Devanagari", "Tamil", "Latin"}
     assert len(vault.entries()) == 1
     assert result.mapping is not None
     assert reidentify(result.deidentified_text, result.mapping) == text
 
 
-def test_vault_reads_pre_transliteration_person_keys():
-    """Existing raw-surface entries remain readable after key normalization."""
+def test_vault_reads_pre_india_person_keys():
+    """Existing normalized PERSON entries remain readable after India scoping."""
 
     source = SurrogateSource("Alice Zephyr", "NAME")
     vault = SurrogateVault.in_memory("unit-test-hmac-secret")
-    legacy_key = vault._legacy_key_for_epoch(source, vault._epoch_manager.current_key)
+    legacy_key = vault._normalized_legacy_key_for_epoch(
+        source,
+        vault._epoch_manager.current_key,
+    )
     vault.store.set(legacy_key, "Casey Example", key_id=vault.current_key_id)
 
     assert legacy_key != vault.key_for(source.source_text, label=source.label)
@@ -141,8 +147,17 @@ def test_legacy_person_key_migrates_for_cross_script_reuse():
         create_surrogate=lambda _attempt: "Different Value",
     )
 
-    assert first == second == "Casey Example"
-    assert vault.get("ராம", label="NAME", lang="hi") == "Casey Example"
+    assert detect_script(first) == "Devanagari"
+    assert detect_script(second) == "Tamil"
+    assert vault.key_for("राम", label="NAME", lang="hi") == vault.key_for(
+        "ராம",
+        label="NAME",
+        lang="hi",
+    )
+    assert vault.get("ராம", label="NAME", lang="hi") == second
+    assert vault.store.get(vault.key_for("राम", label="NAME", lang="hi")) == (
+        "casey example"
+    )
 
 
 def test_json_vault_persists_only_hmac_hashes_and_encrypted_surrogates(


### PR DESCRIPTION
## Description

Closes #1502.

Adds deterministic phonetic folding for Devanagari, Tamil, and opted-in Romanized Indian names so one encrypted vault entry preserves cross-document identity while each replacement is rendered in the source script. The canonical transliteration remains in memory only, and existing non-India vault key behavior is unchanged.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made

- Added script-routed Devanagari and Tamil transliteration plus conservative Roman spelling folds.
- Added one HMAC-keyed Indian name identity bucket with source-script rendering on vault reads.
- Preserved compatibility with normalized and raw legacy vault keys after rebasing onto the earlier India language work.
- Added synthetic multi-script fixtures and coverage for round trips, similar-name separation, audit privacy, leakage prevention, and legacy migration.

## Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different scripts and Romanized inputs

Maintainer validation after rebase:

- Full suite: 6,466 passed, 48 skipped.
- Focused vault and script regressions: 166 passed.
- Formatting, lint, type checks, scoped pre-commit hooks, and package build pass.

## Documentation

- [x] I have added docstrings to new functions/classes
- [ ] User documentation update not required; the public call shape is unchanged
- [ ] Changelog update deferred to release notes

## Code Quality

- [x] Canonical format, lint, and format-check gates pass
- [x] I have performed a self-review of my own code
- [x] I have commented the transliteration and privacy-sensitive behavior
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] The contributor commit remains intact, with one scoped maintainer compatibility follow-up

## Related Issues

Closes #1502

## Screenshots/Examples

Not applicable; this is a core privacy and consistency change.
