### PR TITLE
Add token- and document-level language routing

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -24,6 +24,35 @@ For the redaction methods (`mask`, `remove`, `replace`, `hash`, `shift_dates`),
 locale resolution, determinism, and cross-document surrogate vaults, see
 [PII Anonymization](anonymization.md).
 
+## Automatic language and script routing
+
+The staged privacy pipeline can choose a document pack automatically while
+preserving exact language decisions for every script run:
+
+```python
+from openmed.core.pipeline import Pipeline
+
+route = Pipeline(lang="auto").stage2_language_script(
+    "Patient stable. 患者发热。 रोगी स्थिर है।"
+)
+print(route.lang, route.model_name)
+print(route.metadata["runs"])
+```
+
+The core fallback is deterministic and dependency-free. It combines Unicode
+script runs with each `LanguagePack`'s candidate priority and context hints;
+for example, adjacent kana selects Japanese for Han runs, while standalone Han
+prefers Chinese and Devanagari currently prefers Hindi. Install
+`openmed[lid]` to enable the lazy, on-device `pycld2` adapter for ambiguous
+runs. The adapter and its CLD2 implementation are Apache-2.0, import only when
+routing is first requested, and do not download or bundle model weights.
+
+!!! warning "Language-ID license boundary"
+    This router deliberately excludes CLD3, which is outside this roadmap
+    task's approved dependency scope. Non-commercial language-ID assets remain
+    prohibited; only permissively licensed implementations may be bundled or
+    referenced by the router.
+
 !!! note "Kept in sync with the code"
     The table below lists **every** code in `SUPPORTED_LANGUAGES` together with
     its `DEFAULT_PII_MODELS` entry and its `LANG_TO_LOCALE` mapping.

--- a/openmed/core/__init__.py
+++ b/openmed/core/__init__.py
@@ -32,6 +32,14 @@ from .language_pack_coherence import (
     pack_coherence_report,
     require_language_pack_coherence,
 )
+from .language_router import (
+    DocumentLanguageDecision,
+    LanguageIdentifier,
+    LanguagePrediction,
+    LanguageRouter,
+    LanguageRun,
+    PyCLD2LanguageIdentifier,
+)
 from .model_search import ModelQuery, ModelSearchResult, search_models
 from .models import ModelLoader, load_model
 from .offline import OfflineModeError
@@ -136,4 +144,10 @@ __all__ = [
     "incoherent_packs",
     "pack_coherence_report",
     "require_language_pack_coherence",
+    "LanguageIdentifier",
+    "LanguagePrediction",
+    "LanguageRun",
+    "DocumentLanguageDecision",
+    "LanguageRouter",
+    "PyCLD2LanguageIdentifier",
 ]

--- a/openmed/core/language_pack.py
+++ b/openmed/core/language_pack.py
@@ -36,6 +36,19 @@ def _freeze_names(value: Iterable[str], field_name: str) -> tuple[str, ...]:
     return names
 
 
+def _freeze_optional_names(
+    value: Iterable[str],
+    field_name: str,
+) -> tuple[str, ...]:
+    if isinstance(value, str):
+        raise TypeError(f"{field_name} must be an iterable of strings, not a string")
+
+    names = tuple(_require_text(item, field_name) for item in value)
+    if len(set(names)) != len(names):
+        raise ValueError(f"{field_name} must not contain duplicate values")
+    return names
+
+
 def _freeze_text_mapping(
     value: Mapping[str, str],
     field_name: str,
@@ -68,6 +81,23 @@ def _freeze_recall_floors(
     return MappingProxyType(frozen)
 
 
+def _freeze_candidate_priorities(
+    value: Mapping[str, int],
+    scripts: tuple[str, ...],
+) -> Mapping[str, int]:
+    frozen: dict[str, int] = {}
+    for key, item in value.items():
+        script = _require_text(key, "candidate_priority key")
+        if script not in scripts:
+            raise ValueError(
+                f"candidate priority script {script!r} is not declared by the pack"
+            )
+        if isinstance(item, bool) or not isinstance(item, int):
+            raise TypeError("candidate priorities must be integers")
+        frozen[script] = item
+    return MappingProxyType(frozen)
+
+
 @dataclass(frozen=True, slots=True)
 class LanguagePack:
     """Describe one language's model, routing, surrogate, and safety hooks.
@@ -83,6 +113,9 @@ class LanguagePack:
             the locales that supply them.
         policy_overrides: Mapping of policy keys to pack-specific values.
         recall_floor_overrides: Mapping of canonical labels to probabilities.
+        candidate_priority: Per-script deterministic routing priorities. Higher
+            values win when a script maps to more than one registered pack.
+        context_scripts: Neighboring scripts that strongly identify this pack.
 
     Collection inputs are copied into immutable tuples or read-only mappings,
     so callers cannot mutate a registered pack through an object they retained.
@@ -97,6 +130,8 @@ class LanguagePack:
     national_id_providers: Mapping[str, str] = field(default_factory=dict)
     policy_overrides: Mapping[str, str] = field(default_factory=dict)
     recall_floor_overrides: Mapping[str, float] = field(default_factory=dict)
+    candidate_priority: Mapping[str, int] = field(default_factory=dict)
+    context_scripts: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         """Validate and freeze the complete pack declaration."""
@@ -144,6 +179,21 @@ class LanguagePack:
             "recall_floor_overrides",
             _freeze_recall_floors(self.recall_floor_overrides),
         )
+        object.__setattr__(
+            self,
+            "candidate_priority",
+            _freeze_candidate_priorities(self.candidate_priority, self.scripts),
+        )
+        object.__setattr__(
+            self,
+            "context_scripts",
+            _freeze_optional_names(self.context_scripts, "context_scripts"),
+        )
+
+    def priority_for(self, script: str) -> int:
+        """Return the pack's deterministic routing priority for ``script``."""
+
+        return self.candidate_priority.get(script, 0)
 
 
 class LanguagePackRegistry:
@@ -235,6 +285,13 @@ class LanguagePackRegistry:
         with self._lock:
             codes = tuple(sorted(self._packs))
         return iter(codes)
+
+    def iter_packs(self) -> Iterator[LanguagePack]:
+        """Iterate over a stable, code-sorted snapshot of registered packs."""
+
+        with self._lock:
+            packs = tuple(self._packs[code] for code in sorted(self._packs))
+        return iter(packs)
 
 
 LANGUAGE_PACK_REGISTRY = LanguagePackRegistry()

--- a/openmed/core/language_pack_catalog.py
+++ b/openmed/core/language_pack_catalog.py
@@ -40,6 +40,7 @@ def _pack(
     scripts: Sequence[str],
     *,
     national_id_provider: tuple[str, str] | None = None,
+    context_scripts: Sequence[str] = (),
 ) -> LanguagePack:
     providers: dict[str, str] = {}
     if national_id_provider is not None:
@@ -53,6 +54,7 @@ def _pack(
         recognizers=("builtin-patterns", "model"),
         surrogate_locale=locale,
         national_id_providers=providers,
+        context_scripts=tuple(context_scripts),
     )
 
 
@@ -138,6 +140,7 @@ BUILTIN_LANGUAGE_PACKS: tuple[LanguagePack, ...] = (
         "OpenMed/OpenMed-PII-Japanese-BigMed-Large-560M-v1",
         "ja_JP",
         ("Han", "Hiragana/Katakana"),
+        context_scripts=("Hiragana/Katakana",),
     ),
     LanguagePack(
         code="zh",

--- a/openmed/core/language_router.py
+++ b/openmed/core/language_router.py
@@ -1,0 +1,330 @@
+"""Token- and document-level language and script routing.
+
+The default path is stdlib-only and deterministic.  An optional ``pycld2``
+adapter supplies Apache-2.0 CLD2 language identification when installed and is
+imported only on the first routing call. OpenMed does not bundle language-ID
+weights. CLD3 is outside this router's approved dependency scope, and
+non-commercial language-ID assets must not be added.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from .language_pack import LanguagePack
+from .language_pack_catalog import LANGUAGE_PACK_ADAPTERS
+from .script_detect import (
+    UNKNOWN_SCRIPT,
+    candidate_languages_for_script,
+    segment_by_script,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LanguagePrediction:
+    """One language-ID backend prediction."""
+
+    language: str
+    confidence: float
+
+    def __post_init__(self) -> None:
+        """Validate the prediction probability."""
+
+        if not self.language:
+            raise ValueError("language must be non-empty")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+
+
+@runtime_checkable
+class LanguageIdentifier(Protocol):
+    """Interface implemented by optional on-device language-ID backends."""
+
+    name: str
+
+    def identify(
+        self,
+        text: str,
+        candidates: Sequence[str],
+    ) -> LanguagePrediction | None:
+        """Return the best candidate language for ``text``, if available."""
+
+
+class PyCLD2LanguageIdentifier:
+    """Lazy adapter for the Apache-2.0 ``pycld2`` package.
+
+    Missing optional dependencies are represented by ``None`` so callers can
+    continue through the deterministic fallback without an import failure.
+    """
+
+    name = "pycld2"
+
+    def __init__(self) -> None:
+        """Create an unloaded adapter."""
+
+        self._module: object | None = None
+        self._load_attempted = False
+
+    def _load(self) -> object | None:
+        if not self._load_attempted:
+            self._load_attempted = True
+            try:
+                self._module = importlib.import_module("pycld2")
+            except ImportError:
+                self._module = None
+        return self._module
+
+    def identify(
+        self,
+        text: str,
+        candidates: Sequence[str],
+    ) -> LanguagePrediction | None:
+        """Identify ``text`` using CLD2 and restrict output to ``candidates``."""
+
+        module = self._load()
+        if module is None or not text.strip():
+            return None
+
+        try:
+            _reliable, _text_bytes, details = module.detect(  # type: ignore[attr-defined]
+                text,
+                bestEffort=True,
+            )
+        except Exception:
+            # Optional LID must never prevent the deterministic router from
+            # handling an input that CLD2 rejects or cannot classify.
+            return None
+        candidate_set = set(candidates)
+        ranked: list[tuple[float, str]] = []
+        for _name, raw_code, percent, _score in details:
+            code = str(raw_code).lower().split("-", maxsplit=1)[0]
+            if code in candidate_set:
+                ranked.append((max(0.0, min(float(percent) / 100.0, 1.0)), code))
+        if not ranked:
+            return None
+        confidence, language = max(ranked)
+        return LanguagePrediction(language=language, confidence=confidence)
+
+
+@dataclass(frozen=True, slots=True)
+class LanguageRun:
+    """Exact-offset routing decision for one contiguous script run."""
+
+    start: int
+    end: int
+    script: str
+    language: str
+    confidence: float
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentLanguageDecision:
+    """Dominant document pack plus every per-run routing override."""
+
+    dominant_pack: LanguagePack
+    dominant_script: str
+    confidence: float
+    runs: tuple[LanguageRun, ...]
+    overrides: tuple[LanguageRun, ...]
+    lid_backend: str | None
+
+    @property
+    def language(self) -> str:
+        """Return the dominant pack's language code."""
+
+        return self.dominant_pack.code
+
+
+class LanguageRouter:
+    """Route exact script runs to language packs without mandatory dependencies."""
+
+    def __init__(
+        self,
+        *,
+        packs: Sequence[LanguagePack] | None = None,
+        language_identifier: LanguageIdentifier | None = None,
+        use_optional_lid: bool = True,
+    ) -> None:
+        """Create a router.
+
+        Args:
+            packs: Candidate packs. Built-in packs are used when omitted.
+            language_identifier: Injected local LID backend. When omitted and
+                ``use_optional_lid`` is true, the lazy CLD2 adapter is used.
+            use_optional_lid: Try the optional CLD2 adapter when no backend was
+                injected. Set false to force the stdlib-only path.
+        """
+
+        self.packs = tuple(
+            LANGUAGE_PACK_ADAPTERS.registry.iter_packs() if packs is None else packs
+        )
+        if not self.packs:
+            raise ValueError("packs must contain at least one LanguagePack")
+        if len({pack.code for pack in self.packs}) != len(self.packs):
+            raise ValueError("packs must not contain duplicate language codes")
+        if language_identifier is not None and not isinstance(
+            language_identifier,
+            LanguageIdentifier,
+        ):
+            raise TypeError("language_identifier must implement LanguageIdentifier")
+
+        self.language_identifier = language_identifier
+        if language_identifier is None and use_optional_lid:
+            self.language_identifier = PyCLD2LanguageIdentifier()
+        self._packs_by_code = {pack.code: pack for pack in self.packs}
+        self._packs_by_script = {
+            script: tuple(
+                sorted(
+                    (pack for pack in self.packs if script in pack.scripts),
+                    key=lambda pack: self._candidate_sort_key(pack, script),
+                )
+            )
+            for script in {script for pack in self.packs for script in pack.scripts}
+        }
+
+    @staticmethod
+    def _candidate_sort_key(pack: LanguagePack, script: str) -> tuple[int, int, str]:
+        hints = candidate_languages_for_script(script)
+        hint_order = {code: index for index, code in enumerate(hints)}
+        return (
+            -pack.priority_for(script),
+            hint_order.get(pack.code, len(hint_order)),
+            pack.code,
+        )
+
+    def route_runs(self, text: str) -> tuple[LanguageRun, ...]:
+        """Return exact-offset language decisions that tile ``text``."""
+
+        script_runs = tuple(segment_by_script(text))
+        routed: list[LanguageRun] = []
+        for index, (start, end, script) in enumerate(script_runs):
+            neighboring_scripts = {
+                script_runs[neighbor][2]
+                for neighbor in (index - 1, index + 1)
+                if 0 <= neighbor < len(script_runs)
+            }
+            pack, confidence, source = self._select_pack(
+                text[start:end],
+                script,
+                neighboring_scripts,
+            )
+            routed.append(
+                LanguageRun(
+                    start=start,
+                    end=end,
+                    script=script,
+                    language=pack.code,
+                    confidence=confidence,
+                    source=source,
+                )
+            )
+
+        self._validate_tiling(routed, len(text))
+        return tuple(routed)
+
+    def route(self, text: str) -> DocumentLanguageDecision:
+        """Return a document-level pack and all per-run decisions."""
+
+        runs = self.route_runs(text)
+        fallback_pack = self._packs_by_code.get("en", self.packs[0])
+        if not runs:
+            return DocumentLanguageDecision(
+                dominant_pack=fallback_pack,
+                dominant_script=UNKNOWN_SCRIPT,
+                confidence=0.0,
+                runs=(),
+                overrides=(),
+                lid_backend=self._lid_name,
+            )
+
+        totals: dict[str, int] = {}
+        first_seen: dict[str, int] = {}
+        for index, run in enumerate(runs):
+            totals[run.language] = totals.get(run.language, 0) + run.end - run.start
+            first_seen.setdefault(run.language, index)
+        language = max(
+            totals,
+            key=lambda code: (totals[code], -first_seen[code]),
+        )
+        dominant_pack = self._packs_by_code[language]
+        dominant_runs = [run for run in runs if run.language == language]
+        dominant_script = max(
+            dominant_runs,
+            key=lambda run: (run.end - run.start, -run.start),
+        ).script
+        total_length = sum(run.end - run.start for run in runs)
+        confidence = sum(run.confidence * (run.end - run.start) for run in runs) / max(
+            total_length, 1
+        )
+        overrides = tuple(run for run in runs if run.language != language)
+        return DocumentLanguageDecision(
+            dominant_pack=dominant_pack,
+            dominant_script=dominant_script,
+            confidence=confidence,
+            runs=runs,
+            overrides=overrides,
+            lid_backend=self._lid_name,
+        )
+
+    @property
+    def _lid_name(self) -> str | None:
+        backend = self.language_identifier
+        return str(backend.name) if backend is not None else None
+
+    def _select_pack(
+        self,
+        text: str,
+        script: str,
+        neighboring_scripts: set[str],
+    ) -> tuple[LanguagePack, float, str]:
+        candidates = self._packs_by_script.get(script, ())
+        if not candidates:
+            fallback = self._packs_by_code.get("en", self.packs[0])
+            return fallback, 0.5, "stdlib:unknown-script"
+
+        context_matches = tuple(
+            pack
+            for pack in candidates
+            if neighboring_scripts.intersection(pack.context_scripts)
+        )
+        if context_matches:
+            return context_matches[0], 0.99, "stdlib:context-script"
+
+        if len(candidates) == 1:
+            return candidates[0], 0.99, "stdlib:script"
+
+        backend = self.language_identifier
+        if backend is not None:
+            prediction = backend.identify(text, [pack.code for pack in candidates])
+            if prediction is not None:
+                selected = self._packs_by_code.get(prediction.language)
+                if selected in candidates:
+                    return selected, prediction.confidence, backend.name
+
+        return candidates[0], 0.8, "stdlib:pack-priority"
+
+    @staticmethod
+    def _validate_tiling(runs: Sequence[LanguageRun], text_length: int) -> None:
+        cursor = 0
+        for run in runs:
+            if run.start != cursor or run.end <= run.start:
+                raise RuntimeError(
+                    "language runs must tile text without gaps or overlaps"
+                )
+            cursor = run.end
+        if cursor != text_length:
+            raise RuntimeError("language runs must cover the entire input")
+
+
+__all__ = [
+    "DocumentLanguageDecision",
+    "LanguageIdentifier",
+    "LanguagePrediction",
+    "LanguageRouter",
+    "LanguageRun",
+    "PyCLD2LanguageIdentifier",
+]

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Iterator, Literal, Mapping, Optional, Sequence
 
 from .custom_recognizer import CUSTOM_DENY_DETECTOR, coerce_custom_recognizer
 from .labels import hipaa_class_for, normalize_label, policy_label_for
+from .language_router import DocumentLanguageDecision, LanguageRouter
 from .pii_entity_merger import PII_PATTERNS, PIIPattern
 from .schemas.span import ACTION_KEEP, OpenMedSpan, hmac_text_hash
 
@@ -129,6 +130,7 @@ class LanguageRoute:
     script: str
     model_name: str
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    decision: DocumentLanguageDecision | None = None
 
 
 @dataclass(frozen=True)
@@ -245,6 +247,7 @@ class Pipeline:
         model_detector: ModelDetector | None = None,
         clinical_model_detector: ModelDetector | None = None,
         cascade_router: Any = None,
+        language_router: LanguageRouter | None = None,
         arbitration: SpanHook | None = None,
         arbitration_mode: str | None = None,
         strict_no_leak: bool = False,
@@ -286,6 +289,9 @@ class Pipeline:
         self.model_detector = model_detector
         self.clinical_model_detector = clinical_model_detector
         self.cascade_router = cascade_router
+        self.language_router = language_router
+        if self.language_router is None and lang == "auto":
+            self.language_router = LanguageRouter()
         self.arbitration = arbitration
         self.arbitration_mode = arbitration_mode
         self.strict_no_leak = strict_no_leak
@@ -812,9 +818,33 @@ class Pipeline:
     def stage2_language_script(self, text: str) -> LanguageRoute:
         from . import pii
         from .pii_i18n import DEFAULT_PII_MODELS, SUPPORTED_LANGUAGES
+        from .script_detect import detect_script
 
-        script = _detect_script(text)
-        lang = _lang_from_script(script) if self.lang == "auto" else self.lang
+        if self.lang == "auto":
+            router = self.language_router or LanguageRouter()
+            decision = router.route(text)
+            lang = decision.language
+            script = decision.dominant_script
+            model_name = pii._resolve_effective_pii_model(self.model_name, lang)
+            return LanguageRoute(
+                lang=lang,
+                script=script,
+                model_name=model_name,
+                decision=decision,
+                metadata={
+                    "available_default_model": decision.dominant_pack.default_model,
+                    "dominant_pack": decision.dominant_pack.code,
+                    "routing_confidence": decision.confidence,
+                    "lid_backend": decision.lid_backend,
+                    "runs": [_language_run_metadata(run) for run in decision.runs],
+                    "run_overrides": [
+                        _language_run_metadata(run) for run in decision.overrides
+                    ],
+                },
+            )
+
+        script = detect_script(text)
+        lang = self.lang
         if lang not in SUPPORTED_LANGUAGES:
             raise ValueError(
                 f"Unsupported language '{lang}'. "
@@ -916,7 +946,7 @@ class Pipeline:
 
         return pii.extract_pii(
             text,
-            self.model_name,
+            route.model_name,
             self.confidence_threshold,
             self.config,
             self.use_smart_merging,
@@ -1528,27 +1558,17 @@ def _remap_section_to_normalized(section: Any, offset_map: OffsetMap) -> Any:
     return data
 
 
-def _detect_script(text: str) -> str:
-    for char in text:
-        codepoint = ord(char)
-        if 0x0600 <= codepoint <= 0x06FF:
-            return "arabic"
-        if 0x3040 <= codepoint <= 0x30FF or 0x4E00 <= codepoint <= 0x9FFF:
-            return "japanese"
-        if 0x0900 <= codepoint <= 0x097F:
-            return "devanagari"
-        if 0x0C00 <= codepoint <= 0x0C7F:
-            return "telugu"
-    return "latin"
+def _language_run_metadata(run: Any) -> dict[str, object]:
+    """Return PHI-free, offset-only metadata for one language run."""
 
-
-def _lang_from_script(script: str) -> str:
     return {
-        "arabic": "ar",
-        "japanese": "ja",
-        "devanagari": "hi",
-        "telugu": "te",
-    }.get(script, "en")
+        "start": run.start,
+        "end": run.end,
+        "script": run.script,
+        "language": run.language,
+        "confidence": run.confidence,
+        "source": run.source,
+    }
 
 
 def _deterministic_patterns(lang: str) -> list[PIIPattern]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,10 @@ mcp = [
   "mcp>=1.9",
 ]
 
+lid = [
+  "pycld2>=0.41,<1",
+]
+
 presidio = [
   "presidio-analyzer>=2.2.354,<3",
 ]

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -108,6 +108,7 @@ REVIEWED_LICENSES = {
     "prefect": "Apache-2.0",
     "presidio-analyzer": "MIT",
     "pyarrow": "Apache-2.0",
+    "pycld2": "Apache-2.0",
     "protobuf": "BSD-3-Clause",
     "pydicom": "MIT",
     "pydeid": "MIT",

--- a/tests/unit/core/test_language_router.py
+++ b/tests/unit/core/test_language_router.py
@@ -1,0 +1,230 @@
+"""Acceptance coverage for exact-offset language and script routing."""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from types import MappingProxyType
+
+import pytest
+
+from openmed.core.language_pack import LanguagePack
+from openmed.core.language_router import (
+    LanguagePrediction,
+    LanguageRouter,
+    PyCLD2LanguageIdentifier,
+)
+
+
+class _SyntheticLanguageIdentifier:
+    name = "synthetic-lid"
+
+    def identify(self, text, candidates):
+        if any("\u0900" <= char <= "\u097f" for char in text):
+            language = "hi"
+        elif any("\u3040" <= char <= "\u30ff" for char in text):
+            language = "ja"
+        elif any("\u3400" <= char <= "\u9fff" for char in text):
+            language = "zh"
+        else:
+            language = "en"
+        if language not in candidates:
+            return None
+        return LanguagePrediction(language=language, confidence=0.99)
+
+
+_ROUTING_CORPUS = (
+    ("Patient reports fever and cough.", "en"),
+    ("Nurse recorded stable blood pressure.", "en"),
+    ("患者发热并伴有咳嗽。", "zh"),
+    ("医生记录血压稳定。", "zh"),
+    ("患者は発熱があります。", "ja"),
+    ("医師が血圧を記録した。", "ja"),
+    ("रोगी को बुखार है।", "hi"),
+    ("चिकित्सक ने रक्तचाप दर्ज किया।", "hi"),
+)
+
+
+def _pack(
+    code: str,
+    scripts: tuple[str, ...],
+    model: str,
+    *,
+    candidate_priority: dict[str, int] | None = None,
+) -> LanguagePack:
+    return LanguagePack(
+        code=code,
+        scripts=scripts,
+        default_model=model,
+        segmenter_id="unicode-sentence",
+        recognizers=("builtin-patterns", "model"),
+        surrogate_locale="en_US",
+        candidate_priority=candidate_priority or {},
+    )
+
+
+def _routing_accuracy(router: LanguageRouter) -> float:
+    correct = 0
+    total = 0
+    for text, expected_language in _ROUTING_CORPUS:
+        for run in router.route_runs(text):
+            correct += run.language == expected_language
+            total += 1
+    return correct / total
+
+
+def test_runs_tile_mixed_script_input_without_gaps_or_overlaps():
+    text = "Patient stable. 患者は安定。 रोगी स्थिर है।"
+    runs = LanguageRouter(use_optional_lid=False).route_runs(text)
+
+    cursor = 0
+    for run in runs:
+        assert run.start == cursor
+        assert run.start < run.end
+        cursor = run.end
+    assert cursor == len(text)
+    assert "".join(text[run.start : run.end] for run in runs) == text
+
+
+def test_cross_script_accuracy_gates_for_lid_and_stdlib_paths():
+    lid_accuracy = _routing_accuracy(
+        LanguageRouter(language_identifier=_SyntheticLanguageIdentifier())
+    )
+    fallback_accuracy = _routing_accuracy(LanguageRouter(use_optional_lid=False))
+
+    assert lid_accuracy >= 0.95
+    assert fallback_accuracy >= 0.90
+
+
+def test_han_uses_kana_context_for_japanese_and_priority_for_chinese():
+    router = LanguageRouter(use_optional_lid=False)
+
+    chinese = router.route("患者发热并伴有咳嗽。")
+    japanese = router.route("患者は発熱です。")
+
+    assert chinese.language == "zh"
+    assert {run.language for run in chinese.runs} == {"zh"}
+    assert japanese.language == "ja"
+    assert {run.language for run in japanese.runs} == {"ja"}
+    assert any(run.source == "stdlib:context-script" for run in japanese.runs)
+
+
+def test_devanagari_uses_pack_declared_candidate_priority():
+    lower = _pack(
+        "hi",
+        ("Devanagari",),
+        "OpenMed/hindi",
+        candidate_priority={"Devanagari": 10},
+    )
+    higher = _pack(
+        "mr",
+        ("Devanagari",),
+        "OpenMed/marathi",
+        candidate_priority={"Devanagari": 20},
+    )
+
+    decision = LanguageRouter(
+        packs=(lower, higher),
+        use_optional_lid=False,
+    ).route("रुग्ण स्थिर आहे।")
+
+    assert decision.language == "mr"
+    assert decision.runs[0].source == "stdlib:pack-priority"
+
+
+def test_language_pack_freezes_routing_configuration():
+    priorities = {"Han": 10}
+    pack = _pack(
+        "zh",
+        ("Han",),
+        "OpenMed/chinese",
+        candidate_priority=priorities,
+    )
+    priorities["Han"] = 1
+
+    assert pack.candidate_priority == {"Han": 10}
+    assert isinstance(pack.candidate_priority, MappingProxyType)
+    with pytest.raises(TypeError):
+        pack.candidate_priority["Han"] = 2
+
+
+def test_optional_lid_is_lazy_and_missing_package_falls_back(monkeypatch):
+    calls = []
+    original_import_module = importlib.import_module
+
+    def missing_pycld2(name, package=None):
+        calls.append(name)
+        if name == "pycld2":
+            raise ModuleNotFoundError("pycld2 is not installed")
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", missing_pycld2)
+    router = LanguageRouter()
+    assert calls == []
+
+    decision = router.route("患者发热。")
+
+    assert calls == ["pycld2"]
+    assert decision.language == "zh"
+    assert decision.runs[0].source == "stdlib:pack-priority"
+
+
+def test_core_module_imports_when_optional_lid_is_uninstalled():
+    program = """
+import builtins
+original_import = builtins.__import__
+def guarded_import(name, *args, **kwargs):
+    if name == 'pycld2' or name.startswith('pycld2.'):
+        raise ModuleNotFoundError('pycld2 unavailable')
+    return original_import(name, *args, **kwargs)
+builtins.__import__ = guarded_import
+import openmed.core.language_router
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", program],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_pycld2_adapter_filters_predictions_to_pack_candidates(monkeypatch):
+    class FakeCLD2:
+        @staticmethod
+        def detect(text, bestEffort):
+            assert text == "患者发热。"
+            assert bestEffort is True
+            return (
+                True,
+                len(text.encode()),
+                (
+                    ("Chinese", "zh", 98, 1000.0),
+                    ("Unknown", "un", 2, 0.0),
+                ),
+            )
+
+    monkeypatch.setattr(importlib, "import_module", lambda name: FakeCLD2())
+    router = LanguageRouter(
+        language_identifier=PyCLD2LanguageIdentifier(),
+    )
+
+    run = router.route_runs("患者发热。")[0]
+
+    assert run.language == "zh"
+    assert run.confidence == pytest.approx(0.98)
+    assert run.source == "pycld2"
+
+
+def test_document_decision_exposes_only_non_dominant_run_overrides():
+    decision = LanguageRouter(use_optional_lid=False).route(
+        "Patient stable. 患者发热。"
+    )
+
+    assert decision.language == "en"
+    assert decision.dominant_pack.code == "en"
+    assert decision.overrides
+    assert {run.language for run in decision.overrides} == {"zh"}

--- a/tests/unit/core/test_pipeline_language_router.py
+++ b/tests/unit/core/test_pipeline_language_router.py
@@ -1,0 +1,67 @@
+"""End-to-end pipeline model selection from automatic language routing."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from openmed.core.pii_i18n import DEFAULT_PII_MODELS
+from openmed.core.pipeline import LanguageRoute, Pipeline
+from openmed.processing.outputs import PredictionResult
+
+
+def test_language_route_preserves_existing_positional_metadata_contract():
+    route = LanguageRoute("en", "Latin", "local-model", {"existing": True})
+
+    assert route.metadata == {"existing": True}
+    assert route.decision is None
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_language", "expected_model"),
+    (
+        (
+            "患者王芳因发热入院。",
+            "zh",
+            "OpenMed/privacy-filter-multilingual",
+        ),
+        (
+            "रोगी अनिता बुखार के कारण भर्ती हुई।",
+            "hi",
+            DEFAULT_PII_MODELS["hi"],
+        ),
+    ),
+)
+def test_pipeline_auto_route_selects_document_language_pack_and_model(
+    text,
+    expected_language,
+    expected_model,
+):
+    detector_calls = []
+
+    def detector(routed_text, **kwargs):
+        detector_calls.append((routed_text, kwargs))
+        return PredictionResult(
+            text=routed_text,
+            entities=[],
+            model_name=kwargs["model_name"],
+            timestamp=datetime.now().isoformat(),
+        )
+
+    result = Pipeline(
+        lang="auto",
+        model_detector=detector,
+        use_safety_sweep=False,
+    ).run(text)
+
+    assert result.route.lang == expected_language
+    assert result.route.model_name == expected_model
+    assert result.route.decision is not None
+    assert result.route.decision.dominant_pack.code == expected_language
+    assert detector_calls[0][1]["lang"] == expected_language
+    assert detector_calls[0][1]["model_name"] == expected_model
+    assert result.stage("language_script").metadata["dominant_pack"] == (
+        expected_language
+    )
+    assert result.stage("language_script").metadata["runs"]

--- a/uv.lock
+++ b/uv.lock
@@ -4987,6 +4987,9 @@ kafka = [
 langchain = [
     { name = "langchain-core" },
 ]
+lid = [
+    { name = "pycld2" },
+]
 llamaindex = [
     { name = "llama-index-core" },
 ]
@@ -5163,6 +5166,7 @@ requires-dist = [
     { name = "protobuf", marker = "extra == 'dev'", specifier = ">=5.26,<7" },
     { name = "protobuf", marker = "extra == 'service'", specifier = ">=5.26,<7" },
     { name = "pyarrow", marker = "extra == 'columnar'", specifier = ">=16" },
+    { name = "pycld2", marker = "extra == 'lid'", specifier = ">=0.41,<1" },
     { name = "pydeid", marker = "extra == 'pydeid'", specifier = ">=0.0.1" },
     { name = "pydicom", marker = "extra == 'multimodal'", specifier = ">=3.0" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.8" },
@@ -5197,7 +5201,7 @@ requires-dist = [
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'service'", specifier = ">=0.29" },
 ]
-provides-extras = ["agents", "awq", "cli", "cloud", "columnar", "coreml", "dask", "dev", "docs", "duckdb", "gliner", "gptq", "grounding", "hf", "kafka", "langchain", "llamaindex", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "onnx-runtime", "openvino", "pandas", "philter", "polars", "prefect", "presidio", "pydeid", "service", "spacy", "spark", "zh-hanlp", "zh-pkuseg"]
+provides-extras = ["agents", "awq", "cli", "cloud", "columnar", "coreml", "dask", "dev", "docs", "duckdb", "gliner", "gptq", "grounding", "hf", "kafka", "langchain", "lid", "llamaindex", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "onnx-runtime", "openvino", "pandas", "philter", "polars", "prefect", "presidio", "pydeid", "service", "spacy", "spark", "zh-hanlp", "zh-pkuseg"]
 
 [[package]]
 name = "opentelemetry-api"
@@ -6396,6 +6400,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycld2"
+version = "0.42"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/81/d4d348e224ac0994234992c6d5fb3a78cc9b660337d5bd17c67fac1baf6a/pycld2-0.42.tar.gz", hash = "sha256:5188084c97f99e896cf464057c64f6b0f91f68d111182dceb5bcfe487d7f4c0f", size = 41372203, upload-time = "2025-03-28T06:47:10.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/f2/7f9b04717a9f2592b180d5e34b94e29b5e176ffca60effaa058b34d503af/pycld2-0.42-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0770612afeeab2e5ca72889553e8e7850b865f9b3ca7b2a783e2a43fb1792a26", size = 4825692, upload-time = "2025-03-28T06:45:20.001Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/0a245c375b41ad3533e6b6110d9459124d7e7432dc8dcd4a29fdf8e284c8/pycld2-0.42-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce384bb927415a60ef69ff07781491e5305b80d4ae995a1948d396b3b22f564c", size = 9876867, upload-time = "2025-03-28T06:45:22.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/87/12150b7d7c668e7b77252cb0cb5d891b43951f40215394e608a40b96ccd4/pycld2-0.42-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f6e3460474f1de15932facc444dc2ba9d391fb97b11c0b48eeab15e58488b152", size = 9842102, upload-time = "2025-03-28T06:45:24.971Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/7a/06f9ba1976fc0a7b398fafbb590b399d60fe6d643fc9d10c6170135ed02e/pycld2-0.42-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:7073d0fe8803045286e96de2c48553f1de32c85ca765108eb379ab871bd4d6e2", size = 10985055, upload-time = "2025-03-28T06:45:27.376Z" },
+    { url = "https://files.pythonhosted.org/packages/56/da/a28226f6eb0cfd5368619469f62f3909f8b41f7ba43f78c5112f7319d860/pycld2-0.42-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:13f3dc267e02710dc8bf4a87a547e24768982a8f415921b54936a2925d45a31d", size = 10909331, upload-time = "2025-03-28T06:45:29.761Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/0196b4e40fe1a8ff4129828370d500b66ea6f8e5cb7982553120a41382b0/pycld2-0.42-cp310-cp310-win32.whl", hash = "sha256:67b71c0448a0ce48ac60b5c2c1646afbada573f46f027a61bb399e56c1ad18d9", size = 4749125, upload-time = "2025-03-28T06:45:32.013Z" },
+    { url = "https://files.pythonhosted.org/packages/14/71/a02a2d57f169e80247fec316cf441915f2fde9d33a5972e33e65ae74e001/pycld2-0.42-cp310-cp310-win_amd64.whl", hash = "sha256:8880f0495845e2646546f369cc2a6897f8c2d0974d4a9639d500fa10f7f28020", size = 4755325, upload-time = "2025-03-28T06:45:34.111Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d6/4ac8074a366ac355fc24242a0b2821c299f7c533f79cceb7c7855afdae26/pycld2-0.42-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a58b864bca55bc5c751ba5f2520aa1812d0f137b955cb8c057d72e1bff18eaa4", size = 4825702, upload-time = "2025-03-28T06:45:35.515Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2e/dcd5d53ee6dcb7e25e05195b11cd37255eca9d73cc31fb733a5c6ae2a88b/pycld2-0.42-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7092c00df1aa822b5acf2258330ecbe7cdc2ce3e8a4474ee8f23483462ebe83c", size = 9889584, upload-time = "2025-03-28T06:45:37.673Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/1df66b13974e8d72ab4b1b3ec8a7ec6908b1de933d802d990a120e48d218/pycld2-0.42-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f0964ae7a022698bf7a282f77fda9523ff354c0deaed9e586fbda3bf88d218d", size = 9851247, upload-time = "2025-03-28T06:45:39.698Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c7/e16dba31e731267c0e8573593ebc08b75c8bd08be8ccc404423f7273f841/pycld2-0.42-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4afd47e2bc0f4a17962dcf1422dd9b8549637bb3f6d133fb6fea2b127e64e451", size = 10997723, upload-time = "2025-03-28T06:45:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/67/61/0a4395a3eaa5aaf44cb14db5864067e1cd5533aef81209e008074c88b031/pycld2-0.42-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1e3b63ad5fafaa79f64cdf7078e9022b5184a98995a1b9c4533d27f41b3ecdb6", size = 10923986, upload-time = "2025-03-28T06:45:44.319Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1d/b93d4a3dac5c796bf537a880347a3c7307841a43138e2ea781ca956ce7cb/pycld2-0.42-cp311-cp311-win32.whl", hash = "sha256:bb8fa132026b08fc4a24b2b964ec318842b966c54d6ad8da84b30fccd5d694ec", size = 4749136, upload-time = "2025-03-28T06:45:47.119Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/4a/975427adf00d5d04e11571d7a84b7b1c0b2d27ed77585b7a1796eba52e9b/pycld2-0.42-cp311-cp311-win_amd64.whl", hash = "sha256:dac35607cd16281a64a51b916d219063dd31361ab1e8cb4203b922d535442b22", size = 4755329, upload-time = "2025-03-28T06:45:48.534Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/11/8f8a1f46e95c67b553bf90abd67dc676faf1d94478dc1bd78195ad8689e6/pycld2-0.42-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e09f7fd7d3543f08b8f5b1e22af7272bf19415ac9f1647ed805e16257a06ce77", size = 4825747, upload-time = "2025-03-28T06:45:50.031Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a6/afd36659a679c41deabbd2493712ed7a15486c944410fa5d1e3de255fb72/pycld2-0.42-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dc9bb56e2c44b3c55857442b3975cca0398c0c31b6ad9138c6f6ab7a2a36f49", size = 9889407, upload-time = "2025-03-28T06:45:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ac/b81bd376c56a3626eec59610b4fe79e5d599e6baf4f67b1ea05b87e098df/pycld2-0.42-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f4acb5e8873dd7c5985a7dd16c95a0096bb82adfac9303f92580f4b0cf5053f9", size = 9851119, upload-time = "2025-03-28T06:45:53.913Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/71/9404ff796950c066042e0056f478870fc5fbbcef9e467431298910231cd1/pycld2-0.42-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6f397d70aa46ad13d89db6912fbf3324afe0dc1685cd51db152f2613d7f76b9d", size = 10997687, upload-time = "2025-03-28T06:45:55.946Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/17/4ad5c060829d959588d0c921a1a94779d611c0ed46017c2b2935ad72bc5f/pycld2-0.42-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1e607ba47efd5d81a8ad3a2e5d31dfef35be73c0adfca1cc7f4f2fb795f3209d", size = 10922649, upload-time = "2025-03-28T06:45:57.968Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/aa/f123c1ab28147d9ad45cbe7b6a450d0237d340f77d006ce513cfc4071bcb/pycld2-0.42-cp312-cp312-win32.whl", hash = "sha256:81592540410a185c1b01cc10bc200bbe686fa3d868f6f61aa76a93daa3c54d8f", size = 4749126, upload-time = "2025-03-28T06:46:00.272Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/71/cb20195b034bff0361677d1b8d95c923272dd361e8c41238640272f936de/pycld2-0.42-cp312-cp312-win_amd64.whl", hash = "sha256:ea73aa77c5f1aa122bb9cfbc568699ca8a2182e0f49bc68c527ca78c62407841", size = 4755339, upload-time = "2025-03-28T06:46:01.887Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a9/eb235acf4233d0f448b644dc58e955c304ae35fb646dee06b11a54375177/pycld2-0.42-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:94b84050081c85f0038369ee4db1bdddc5c8178773809aa55fb4e78b94a3a1c5", size = 4825743, upload-time = "2025-03-28T06:46:03.848Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2d/649713e978b89407d60a88f5406e98bb347b572fefcb917b29a866e24af2/pycld2-0.42-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f939bfa74347ff931d2bfa7e19b06e1b21ecfcc93769e0ed2db2f36fc4252735", size = 9889420, upload-time = "2025-03-28T06:46:05.394Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9e/90598c4d66e300d760666d93fa17af7946cc612d5ee64a828bb1ae636ecd/pycld2-0.42-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a3676d4c9e258a74fdb6c94e7577c02a99974e41c8641e045a980ade64b818a", size = 9851117, upload-time = "2025-03-28T06:46:07.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/22/2583dff682a54366857dfee5d6f4478bedc03265cf0fff8ea610d17baece/pycld2-0.42-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f8d6dedca968b3b64a0bb1e693f67cfed7fe7bd207ab13d4c5b9fd1a27ce9600", size = 10997561, upload-time = "2025-03-28T06:46:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/34/de9d6a785c45b0679da5dd545df2f0b95e2011588eb74b08d819bb01c420/pycld2-0.42-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:593465e6f79ddb3a4be0c43dda8f0400015124a0f3bfe5cd3741d8d2c371412d", size = 10922625, upload-time = "2025-03-28T06:46:12.369Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/9a/67e29dab3665ea7925d5d9160b8560c97a588c980c336e402957a06333e8/pycld2-0.42-cp313-cp313-win32.whl", hash = "sha256:9820d363886177de1cc0886db9cd40629d61261d2896f755d682c71539b5ed5e", size = 4749125, upload-time = "2025-03-28T06:46:14.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/80/48e21c1c93cd375c61d3ac41737b166152cd105e653b042c401cbbb2ee91/pycld2-0.42-cp313-cp313-win_amd64.whl", hash = "sha256:3570a6c2d9487fad4c7ac9d36e1537caca9456fccfd23ec1b87d0c7e6a544e5c", size = 4755335, upload-time = "2025-03-28T06:46:15.906Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Closes #1506.

Adds exact-offset token- and document-level language routing so mixed-script clinical notes select a dominant registered language pack while retaining per-run overrides. The router combines the current catalog-backed pack registry, script segmentation, pack-declared priorities, Japanese kana context, and a lazy optional CLD2 signal with a deterministic dependency-free fallback.

## Type of Change

- [x] New feature
- [x] Test addition/improvement
- [x] Documentation update

## Changes Made

- Extend the existing immutable `LanguagePack` contract with frozen candidate priorities and context-script hints instead of replacing the current registry architecture.
- Add exact-offset language runs, document decisions, and dominant-pack overrides for Chinese, Japanese, Hindi, English, and the existing registered languages.
- Integrate automatic routing with staged pipeline model selection while preserving the existing positional `LanguageRoute` metadata contract.
- Add a lazy Apache-2.0 `pycld2` extra with deterministic fallback when the optional package is not installed.
- Keep CLD3 outside this router's approved dependency scope without assigning it an incorrect upstream license classification.

## Testing

- [x] Full repository suite: 5,345 passed, 52 skipped, 6 existing warnings.
- [x] Focused router, pipeline, registry, coherence, and script tests: 79 passed.
- [x] LID-enabled routing accuracy gate is at least 0.95.
- [x] Stdlib fallback routing accuracy gate is at least 0.90.
- [x] Exact coverage, lazy optional import, Chinese pack, and Hindi pack tests pass.
- [x] `make format`, `make lint`, and `make format-check` pass.
- [x] Strict docs build, lockfile check, and license-policy check pass.
- [x] Wheel and sdist build successfully; the wheel contains `openmed/core/language_router.py`.

## Documentation

- [x] Updated the multilingual language guide with automatic routing and dependency/license behavior.
- [x] Added public API docstrings for the routing types.

## Dependencies

- [x] Added `pycld2>=0.41,<1` as an optional-only Apache-2.0 language-ID extra; core installations remain dependency-free for routing.
- [x] The resolved optional package is `pycld2==0.42` with a fully pinned lock entry.

## Checklist

- [x] The change is focused on issue #1506.
- [x] The rebased commit has a clear descriptive message.
- [x] No assignees or reviewers were added.

## Related Issues

Closes #1506

## Screenshots/Examples

Not applicable; this is a core routing API.
