### PR TITLE
docs: add China mirror and offline-cache onboarding

### DIFF
--- a/docs/onboarding-china.md
+++ b/docs/onboarding-china.md
@@ -1,0 +1,204 @@
+# OpenMed onboarding for users in China
+
+[简体中文版](onboarding-china.zh.md)
+
+This guide keeps the first OpenMed install and model download practical on
+networks where the default PyPI and Hugging Face endpoints are slow or
+unreachable. It covers package mirrors, a Hugging Face model mirror, a
+transferable local cache, and the bundled PIPL-oriented policy profile.
+
+The mirrors below are independent third-party services, not OpenMed-operated
+or endorsed infrastructure. Check your organization's supply-chain policy,
+pin package and model versions, and validate downloaded artifacts before
+production use.
+
+## Install OpenMed from a PyPI mirror
+
+For a one-time install through the Tsinghua TUNA mirror:
+
+```bash
+python -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple openmed
+```
+
+Install the optional Hugging Face dependencies when this machine will download
+or inspect model snapshots:
+
+```bash
+python -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple "openmed[hf]"
+```
+
+The `simple` path segment is required. TUNA's
+[PyPI mirror instructions](https://mirrors.tuna.tsinghua.edu.cn/help/pypi/)
+also document the equivalent long service URL.
+
+As an alternative, the Aliyun public mirror supports the same pip interface:
+
+```bash
+python -m pip install -i https://mirrors.aliyun.com/pypi/simple/ openmed
+```
+
+See the [Aliyun PyPI mirror page](https://developer.aliyun.com/mirror/pypi/)
+for its public and ECS-specific endpoints.
+
+### Pin the mirror in `pip.conf`
+
+To make TUNA the default for the current user, let pip update the user-level
+configuration rather than editing an unknown system file:
+
+```bash
+python -m pip config --user set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+python -m pip config --user get global.index-url
+```
+
+Run `python -m pip config debug` to see the active `pip.conf` location. The
+equivalent file content is:
+
+```ini
+[global]
+index-url = https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+Replace the URL with `https://mirrors.aliyun.com/pypi/simple/` to make Aliyun
+the default instead. A mirror can lag the canonical index, so pin exact package
+versions and investigate unexpected version differences before falling back to
+another index.
+
+## Download models through HF-Mirror
+
+Install `openmed[hf]`, then set the mirror endpoint **before** importing
+`huggingface_hub`, Transformers, or OpenMed in that process:
+
+=== "Linux and macOS"
+
+    ```bash
+    export HF_ENDPOINT=https://hf-mirror.com
+    ```
+
+=== "Windows PowerShell"
+
+    ```powershell
+    $env:HF_ENDPOINT = "https://hf-mirror.com"
+    ```
+
+This is the environment-variable method documented by
+[HF-Mirror](https://hf-mirror.com/). It changes where compatible Hugging Face
+clients fetch model files; it does not route OpenMed inference to a hosted API.
+
+## Pre-download once, then run from the local cache
+
+The standard Hugging Face cache lives under `~/.cache/huggingface` unless
+`HF_HOME` or `HF_HUB_CACHE` selects another location. Use a dedicated `HF_HOME`
+when the cache must be archived or copied to an isolated machine.
+
+### 1. Warm the cache on a connected machine
+
+From an OpenMed source checkout, the example downloads only after an explicit
+opt-in:
+
+```bash
+export HF_HOME="$PWD/openmed-hf-cache"
+OPENMED_EXAMPLE_ALLOW_DOWNLOAD=1 \
+  python examples/onboarding_china_mirrors.py
+```
+
+The example sets `HF_ENDPOINT=https://hf-mirror.com` before lazily importing
+the Hub client and caches the default 44M PII model. To pre-download directly
+from an installed environment instead:
+
+```bash
+export HF_HOME="$PWD/openmed-hf-cache"
+export HF_ENDPOINT=https://hf-mirror.com
+python -c 'from huggingface_hub import snapshot_download; print(snapshot_download("OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"))'
+```
+
+Archive or copy the entire `openmed-hf-cache` directory to the offline host,
+preserving its directory structure and symlinks.
+
+### 2. Resolve the cache with all Hub traffic disabled
+
+On the offline host, point `HF_HOME` at the transferred directory and enable
+offline mode before starting Python:
+
+```bash
+export HF_HOME="$PWD/openmed-hf-cache"
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+python examples/onboarding_china_mirrors.py
+```
+
+The example also passes `local_files_only=True`. If the snapshot is absent, it
+reports a cache miss instead of attempting a network request. The same flags
+can wrap an application after its models are cached:
+
+```bash
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python your_openmed_app.py
+```
+
+See the Hugging Face Hub documentation for the
+[`HF_HOME`, `HF_HUB_CACHE`, and `HF_HUB_OFFLINE` behavior](https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables).
+
+## PIPL-oriented policy quickstart
+
+PIPL compliance depends on purpose, consent or another lawful basis, data
+classification, retention, cross-border transfer, access controls, and human
+governance. A software policy profile is only one technical control; this
+section is not legal advice or a claim of PIPL compliance.
+
+OpenMed ships a `china_pipl` technical profile for sensitive personal
+information. It uses the high-recall `strict_no_leak` threshold profile,
+requires a safety sweep, replaces direct identifiers, and masks
+quasi-identifiers and clinical concepts:
+
+```python
+from openmed.core.policy import list_policies, load_policy
+
+policy_name = "china_pipl"
+assert policy_name in list_policies()
+
+policy = load_policy(policy_name)
+assert policy.name == "china_pipl"
+assert policy.threshold_profile == "strict_no_leak"
+assert policy.safety_sweep_mandatory
+assert policy.default_action == "replace"
+assert policy.keep_mapping is True
+assert policy.reversible_id is True
+
+print(policy.name, policy.default_action)
+```
+
+This snippet runs entirely from the installed package and loads
+`openmed/core/policies/china_pipl.json`; it does not need a model or network
+connection. Pass the same `policy_name` to the normal runtime call as
+`deidentify(synthetic_text, policy=policy_name)`. The profile intentionally
+keeps a reversible mapping for replacement workflows, so its output remains
+personal information under PIPL; only irreversible anonymization can remove
+data from PIPL scope. Reassess the policy and your legal controls before
+production processing of personal information or protected health information
+(PHI).
+
+## Privacy and network boundary
+
+!!! important
+    **Mirrors affect package and model downloads only. OpenMed inference stays
+    fully local, and the OpenMed library sends no telemetry.** After required
+    artifacts are cached, `HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1`
+    provide an explicit cache-only boundary for compatible Hub and Transformers
+    loaders.
+
+Package installers and model-download clients are third-party tools with their
+own configuration and policies. Keep real personally identifiable information
+(PII) and PHI out of install commands, model repository names, logs, and mirror
+requests. Use only synthetic data while verifying this setup.
+
+## Troubleshooting
+
+- `No matching distribution found`: confirm the mirror has synchronized the
+  requested OpenMed version, then compare it with the canonical PyPI release.
+- `LocalEntryNotFoundError` in offline mode: the selected model or revision is
+  missing from the transferred cache. Warm that exact snapshot while connected.
+- A request still leaves the machine: ensure all environment variables are set
+  before Python starts, and audit any additional application dependencies that
+  have their own network clients.
+- A gated or private model fails through the mirror: follow the model owner's
+  access terms and your organization's credential policy; do not place tokens
+  in shell history, source files, or documentation.

--- a/docs/onboarding-china.zh.md
+++ b/docs/onboarding-china.zh.md
@@ -1,0 +1,182 @@
+# 中国用户 OpenMed 上手指南
+
+[English](onboarding-china.md)
+
+在默认 PyPI 或 Hugging Face 端点速度较慢、无法稳定访问的网络环境中，
+本指南帮助你完成首次 OpenMed 安装和模型下载。内容包括 Python 软件包镜像、
+Hugging Face 模型镜像、可迁移的本地缓存，以及内置的 PIPL 技术策略。
+
+以下镜像均为独立的第三方服务，并非 OpenMed 运营或背书的基础设施。投入生产前，
+请遵守组织的软件供应链要求，固定软件包和模型版本，并校验下载的产物。
+
+## 通过 PyPI 镜像安装 OpenMed
+
+临时使用清华大学 TUNA 镜像安装：
+
+```bash
+python -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple openmed
+```
+
+如果当前机器需要下载或检查 Hugging Face 模型快照，请安装可选依赖：
+
+```bash
+python -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple "openmed[hf]"
+```
+
+地址中的 `simple` 路径不可省略。TUNA 的
+[PyPI 镜像帮助](https://mirrors.tuna.tsinghua.edu.cn/help/pypi/)
+还提供了等价的完整服务地址。
+
+也可以使用阿里云公共镜像：
+
+```bash
+python -m pip install -i https://mirrors.aliyun.com/pypi/simple/ openmed
+```
+
+[阿里云 PyPI 镜像页面](https://developer.aliyun.com/mirror/pypi/)
+列出了公共网络和 ECS 专用端点。
+
+### 在 `pip.conf` 中固定镜像
+
+让 pip 修改当前用户的配置，可以避免误改未知的系统级文件：
+
+```bash
+python -m pip config --user set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+python -m pip config --user get global.index-url
+```
+
+运行 `python -m pip config debug` 可查看实际生效的 `pip.conf` 位置。等价的文件内容为：
+
+```ini
+[global]
+index-url = https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+如需默认使用阿里云，请将 URL 替换为
+`https://mirrors.aliyun.com/pypi/simple/`。镜像同步可能滞后于官方索引，
+因此应固定准确版本；遇到意外的版本差异时，先核查原因，再决定是否切换索引。
+
+## 通过 HF-Mirror 下载模型
+
+安装 `openmed[hf]` 后，必须在当前进程导入 `huggingface_hub`、Transformers
+或 OpenMed **之前**设置模型镜像端点：
+
+=== "Linux 和 macOS"
+
+    ```bash
+    export HF_ENDPOINT=https://hf-mirror.com
+    ```
+
+=== "Windows PowerShell"
+
+    ```powershell
+    $env:HF_ENDPOINT = "https://hf-mirror.com"
+    ```
+
+这是 [HF-Mirror](https://hf-mirror.com/) 文档提供的环境变量用法。
+它只改变兼容的 Hugging Face 客户端获取模型文件的位置，不会把 OpenMed 推理转发到托管 API。
+
+## 预下载一次，随后只使用本地缓存
+
+除非通过 `HF_HOME` 或 `HF_HUB_CACHE` 指定其他位置，Hugging Face 标准缓存位于
+`~/.cache/huggingface`。如果需要把缓存打包或复制到隔离网络中的机器，建议使用独立的
+`HF_HOME` 目录。
+
+### 1. 在联网机器上预热缓存
+
+在 OpenMed 源代码检出目录中，示例脚本只有在明确允许后才会下载：
+
+```bash
+export HF_HOME="$PWD/openmed-hf-cache"
+OPENMED_EXAMPLE_ALLOW_DOWNLOAD=1 \
+  python examples/onboarding_china_mirrors.py
+```
+
+示例会先设置 `HF_ENDPOINT=https://hf-mirror.com`，再延迟导入 Hub 客户端，
+并缓存默认的 44M PII 模型。如果只安装了软件包，也可以直接预下载：
+
+```bash
+export HF_HOME="$PWD/openmed-hf-cache"
+export HF_ENDPOINT=https://hf-mirror.com
+python -c 'from huggingface_hub import snapshot_download; print(snapshot_download("OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"))'
+```
+
+将整个 `openmed-hf-cache` 目录打包或复制到离线机器，并保留目录结构和符号链接。
+
+### 2. 禁止所有 Hub 网络流量，只解析缓存
+
+在离线机器上，让 `HF_HOME` 指向已传输的目录，并在启动 Python 前启用离线模式：
+
+```bash
+export HF_HOME="$PWD/openmed-hf-cache"
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+python examples/onboarding_china_mirrors.py
+```
+
+示例还会传入 `local_files_only=True`。如果快照不存在，它只报告缓存未命中，
+不会尝试网络请求。模型缓存完成后，同样的变量可以包裹实际应用：
+
+```bash
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python your_openmed_app.py
+```
+
+关于 `HF_HOME`、`HF_HUB_CACHE` 和 `HF_HUB_OFFLINE` 的准确行为，请参阅
+[Hugging Face Hub 环境变量文档](https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables)。
+
+## 面向《个人信息保护法》的策略快速入门
+
+《个人信息保护法》（PIPL）合规取决于处理目的、同意或其他合法性基础、数据分类、
+保存期限、跨境传输、访问控制和人工治理。软件策略配置只是其中一项技术控制；
+本节不是法律意见，也不表示使用某个配置即可实现 PIPL 合规。
+
+OpenMed 已提供面向敏感个人信息的 `china_pipl` 技术策略。该策略使用高召回率的
+`strict_no_leak` 阈值配置，强制执行安全扫描，替换直接标识符，并遮蔽准标识符和
+临床概念：
+
+```python
+from openmed.core.policy import list_policies, load_policy
+
+policy_name = "china_pipl"
+assert policy_name in list_policies()
+
+policy = load_policy(policy_name)
+assert policy.name == "china_pipl"
+assert policy.threshold_profile == "strict_no_leak"
+assert policy.safety_sweep_mandatory
+assert policy.default_action == "replace"
+assert policy.keep_mapping is True
+assert policy.reversible_id is True
+
+print(policy.name, policy.default_action)
+```
+
+这段代码完全从已安装的软件包中加载
+`openmed/core/policies/china_pipl.json`，不依赖模型或网络。
+在常规去标识化调用中，可以把同一个 `policy_name` 传给
+`deidentify(synthetic_text, policy=policy_name)`。该策略会为替换流程保留可逆映射，
+因此其输出在 PIPL 下仍属于个人信息；只有不可逆匿名化才可能使数据脱离 PIPL 的适用范围。
+在生产环境处理个人信息或受保护健康信息 (PHI) 前，请重新评估技术策略和法律治理措施。
+
+## 隐私与网络边界
+
+!!! important
+    **镜像只影响软件包和模型下载。OpenMed 推理始终完全在本地运行，OpenMed
+    库不会发送遥测数据。** 所需产物缓存完成后，`HF_HUB_OFFLINE=1` 和
+    `TRANSFORMERS_OFFLINE=1` 会为兼容的 Hub 和 Transformers 加载器建立明确的
+    仅缓存边界。
+
+软件包安装器和模型下载客户端属于第三方工具，有各自的配置与政策。请勿在安装命令、
+模型仓库名称、日志或镜像请求中放入真实的个人身份信息 (PII) 或受保护健康信息 (PHI)。
+验证配置时只使用合成数据。
+
+## 故障排查
+
+- `No matching distribution found`：确认镜像已同步所需的 OpenMed 版本，
+  再与 PyPI 官方发布版本比较。
+- 离线模式出现 `LocalEntryNotFoundError`：传输的缓存中缺少所选模型或修订版本，
+  需要在联网机器上预热该准确快照。
+- 机器仍产生出站请求：确保所有环境变量都在 Python 启动前设置，并审计应用中的
+  其他依赖是否自带网络客户端。
+- 受限或私有模型无法通过镜像获取：遵守模型所有者的访问条款和组织的凭据政策；
+  不要把令牌写入 shell 历史、源代码或文档。

--- a/examples/onboarding_china_mirrors.py
+++ b/examples/onboarding_china_mirrors.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Use a Hugging Face mirror to warm a cache, then resolve it offline.
+
+The example is cache-only by default. Set
+``OPENMED_EXAMPLE_ALLOW_DOWNLOAD=1`` on a connected machine to pre-download
+the model through the configured mirror. A normal run sets the Hugging Face
+offline flags and never attempts a network request.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+
+HF_MIRROR_ENDPOINT = "https://hf-mirror.com"
+DEFAULT_MODEL_ID = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+ALLOW_DOWNLOAD_ENV = "OPENMED_EXAMPLE_ALLOW_DOWNLOAD"
+
+SnapshotLoader = Callable[..., str]
+
+
+@contextmanager
+def hub_environment(*, offline: bool) -> Iterator[None]:
+    """Temporarily configure the mirror and cache-only environment flags."""
+    updates: Mapping[str, str | None] = {
+        "HF_ENDPOINT": HF_MIRROR_ENDPOINT,
+        "HF_HUB_OFFLINE": "1" if offline else None,
+        "TRANSFORMERS_OFFLINE": "1" if offline else None,
+    }
+    previous = {name: os.environ.get(name) for name in updates}
+    for name, value in updates.items():
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+    try:
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _snapshot_loader() -> SnapshotLoader:
+    """Import the Hub client only after its environment is configured."""
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:  # pragma: no cover - depends on optional extra
+        raise ImportError(
+            'Install the Hub client with: pip install "openmed[hf]"'
+        ) from exc
+    return snapshot_download
+
+
+def predownload_model(
+    model_id: str = DEFAULT_MODEL_ID,
+    *,
+    loader: SnapshotLoader | None = None,
+) -> Path:
+    """Download *model_id* through the mirror into the standard local cache."""
+    with hub_environment(offline=False):
+        snapshot_path = (loader or _snapshot_loader())(
+            repo_id=model_id,
+            repo_type="model",
+            local_files_only=False,
+        )
+    return Path(snapshot_path)
+
+
+def load_cached_model(
+    model_id: str = DEFAULT_MODEL_ID,
+    *,
+    loader: SnapshotLoader | None = None,
+) -> Path:
+    """Resolve *model_id* from the local cache without any network access."""
+    with hub_environment(offline=True):
+        snapshot_path = (loader or _snapshot_loader())(
+            repo_id=model_id,
+            repo_type="model",
+            local_files_only=True,
+        )
+    return Path(snapshot_path)
+
+
+def run(
+    model_id: str = DEFAULT_MODEL_ID,
+    *,
+    loader: SnapshotLoader | None = None,
+) -> Path | None:
+    """Warm the cache when opted in; otherwise perform cache-only resolution."""
+    if os.getenv(ALLOW_DOWNLOAD_ENV) == "1":
+        path = predownload_model(model_id, loader=loader)
+        print(f"Cached {model_id} at {path}")
+        return path
+
+    print("Offline cache-only mode (HF_HUB_OFFLINE=1)")
+    try:
+        path = load_cached_model(model_id, loader=loader)
+    except Exception as exc:
+        print(f"Model is not available in the local cache: {exc}")
+        print(
+            "On a connected machine, set "
+            f"{ALLOW_DOWNLOAD_ENV}=1 and run this example once."
+        )
+        return None
+
+    print(f"Resolved cached model at {path}")
+    return path
+
+
+def main() -> None:
+    """Run the mirror-to-offline-cache example."""
+    run()
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,8 @@ nav:
       - v1.6-v1.7 Feature Coverage: release/v1.6-v1.7-feature-coverage.md
       - Quick Start: getting-started.md
       - Persona Quickstarts: quickstarts.md
+      - China Onboarding: onboarding-china.md
+      - 中国用户上手指南: onboarding-china.zh.md
   - Core Guides:
       - Analyze Text Helper: analyze-text.md
       - REST Service (MVP): rest-service.md

--- a/tests/unit/test_examples_smoke.py
+++ b/tests/unit/test_examples_smoke.py
@@ -10,7 +10,12 @@ from types import SimpleNamespace
 
 import pytest
 
-from examples import clinical_ner_families, datasets_walkthrough, gradio_deid_app
+from examples import (
+    clinical_ner_families,
+    datasets_walkthrough,
+    gradio_deid_app,
+    onboarding_china_mirrors,
+)
 
 
 def test_clinical_ner_families_example_is_syntactically_valid():
@@ -181,3 +186,84 @@ def test_datasets_walkthrough_reports_offline_unavailable(capsys, monkeypatch):
     captured = capsys.readouterr().out
     assert "Synthetic data: yes" in captured
     assert "model unavailable offline" in captured
+
+
+def test_onboarding_china_mirrors_example_is_syntactically_valid():
+    source = Path("examples/onboarding_china_mirrors.py").read_text(encoding="utf-8")
+
+    ast.parse(source)
+
+
+def test_onboarding_china_mirrors_configures_download_endpoint(monkeypatch):
+    calls = []
+
+    def fake_snapshot_download(**kwargs):
+        assert os.environ["HF_ENDPOINT"] == "https://hf-mirror.com"
+        assert "HF_HUB_OFFLINE" not in os.environ
+        assert "TRANSFORMERS_OFFLINE" not in os.environ
+        calls.append(kwargs)
+        return "/cache/downloaded-snapshot"
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+
+    path = onboarding_china_mirrors.predownload_model(loader=fake_snapshot_download)
+
+    assert path == Path("/cache/downloaded-snapshot")
+    assert calls == [
+        {
+            "repo_id": onboarding_china_mirrors.DEFAULT_MODEL_ID,
+            "repo_type": "model",
+            "local_files_only": False,
+        }
+    ]
+    assert os.environ["HF_HUB_OFFLINE"] == "1"
+    assert os.environ["TRANSFORMERS_OFFLINE"] == "1"
+
+
+def test_onboarding_china_mirrors_loads_cache_without_network(monkeypatch):
+    calls = []
+
+    def fake_snapshot_download(**kwargs):
+        assert os.environ["HF_ENDPOINT"] == "https://hf-mirror.com"
+        assert os.environ["HF_HUB_OFFLINE"] == "1"
+        assert os.environ["TRANSFORMERS_OFFLINE"] == "1"
+        calls.append(kwargs)
+        return "/cache/offline-snapshot"
+
+    monkeypatch.delenv("HF_ENDPOINT", raising=False)
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+
+    path = onboarding_china_mirrors.load_cached_model(loader=fake_snapshot_download)
+
+    assert path == Path("/cache/offline-snapshot")
+    assert calls == [
+        {
+            "repo_id": onboarding_china_mirrors.DEFAULT_MODEL_ID,
+            "repo_type": "model",
+            "local_files_only": True,
+        }
+    ]
+    assert "HF_ENDPOINT" not in os.environ
+    assert "HF_HUB_OFFLINE" not in os.environ
+    assert "TRANSFORMERS_OFFLINE" not in os.environ
+
+
+def test_onboarding_china_mirrors_run_defaults_to_offline_cache(
+    capsys,
+    monkeypatch,
+):
+    def fake_snapshot_download(**kwargs):
+        assert kwargs["local_files_only"] is True
+        assert os.environ["HF_HUB_OFFLINE"] == "1"
+        return "/cache/offline-snapshot"
+
+    monkeypatch.delenv(onboarding_china_mirrors.ALLOW_DOWNLOAD_ENV, raising=False)
+
+    path = onboarding_china_mirrors.run(loader=fake_snapshot_download)
+
+    assert path == Path("/cache/offline-snapshot")
+    captured = capsys.readouterr().out
+    assert "Offline cache-only mode" in captured
+    assert "Resolved cached model" in captured


### PR DESCRIPTION
## Description

Adds English and Simplified Chinese onboarding for reliable package and model acquisition in China, transferable offline caches, and a PIPL-oriented quickstart using the policy profile now shipped by OpenMed.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Documents TUNA and Aliyun package-mirror installation, persistent pip configuration, and environment-based model-mirror setup in English and Simplified Chinese.
- Adds an offline-by-default example for explicit cache warming and cache-only model resolution.
- Registers both guides in the documentation navigation and adds network-free smoke coverage for the example.
- Uses the shipped `china_pipl` policy directly, including its reversible-mapping boundary and legal disclaimer.
- Preserves the existing dataset walkthrough smoke coverage while reconciling the rebased test file.

## Testing

- [x] Full local suite passed: 6,517 passed, 48 skipped.
- [x] Focused example and policy tests passed: 61 passed.
- [x] Strict docs build, canonical formatting, lint, type checks, scoped hooks, and package build passed.
- [x] The example ran in cache-only mode without a network request.
- [x] Mirror and offline syntax was checked against current TUNA, HF-Mirror, pip, and Hub documentation.

## Documentation

- [x] English and Simplified Chinese onboarding guides added to navigation.
- [ ] Changelog update is not required for this documentation and example change.

## Dependencies

- [x] No new dependencies.

Closes #1532
