### PR TITLE
Add multilingual de-identification Space demo

### DIFF
--- a/examples/spaces/deid_demo/README.md
+++ b/examples/spaces/deid_demo/README.md
@@ -1,0 +1,54 @@
+---
+title: OpenMed Multilingual De-identification
+emoji: 🛡️
+colorFrom: blue
+colorTo: indigo
+sdk: gradio
+sdk_version: 6.20.0
+python_version: "3.11"
+app_file: app.py
+pinned: false
+license: apache-2.0
+models:
+  - OpenMed/OpenMed-PII-Chinese-BigMed-Large-278M-v1
+  - OpenMed/OpenMed-PII-Hindi-SuperClinical-Small-44M-v1
+  - OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1
+tags:
+  - de-identification
+  - healthcare
+  - multilingual
+---
+
+# OpenMed multilingual de-identification demo
+
+Try OpenMed de-identification with fabricated Simplified Chinese, Hindi, English,
+or Hinglish notes. Unicode script detection selects the matching checkpoint and
+language-aware pattern pack, and a manual override is available for mixed-script
+examples.
+
+> **Synthetic data only. Never paste real patient data or protected health
+> information (PHI).** The demo does not log input text, enable analytics, cache
+> de-identification results, or write notes to disk.
+
+The first request for a language downloads its model checkpoint. Later requests
+reuse the runtime's model cache; user text is never added to that cache.
+
+## Run locally
+
+From this directory:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+python app.py
+```
+
+Open the local URL printed by Gradio. The app starts with an English fabricated
+note; switch the UI language to preload the corresponding Chinese or Hindi sample.
+
+## Deploy as a Space
+
+Use the contents of this directory as the root of a Gradio Space repository. The
+YAML block above pins the SDK and points directly to `app.py`; no file changes are
+required.

--- a/examples/spaces/deid_demo/app.py
+++ b/examples/spaces/deid_demo/app.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Multilingual Gradio demo for synthetic OpenMed de-identification.
+
+The module is import-safe: it does not build the UI, load a model, access the
+network, or start a server until the corresponding function is called.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from openmed import deidentify
+
+try:
+    from .samples import SAMPLES
+except ImportError:  # Running ``python app.py`` from the Space directory.
+    from samples import SAMPLES
+
+
+GRADIO_INSTALL_HINT = (
+    "Gradio is required for this demo. Install the pinned requirements with: "
+    "pip install -r requirements.txt"
+)
+
+MODEL_IDS = {
+    "zh": "OpenMed/OpenMed-PII-Chinese-BigMed-Large-278M-v1",
+    "hi": "OpenMed/OpenMed-PII-Hindi-SuperClinical-Small-44M-v1",
+    "en": "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+}
+LANGUAGE_OVERRIDES = ("auto", "zh", "hi", "en")
+
+DISCLAIMERS = {
+    "en": (
+        "Synthetic data only. Never paste real patient data or protected "
+        "health information (PHI)."
+    ),
+    "zh": "仅限合成数据。切勿粘贴真实患者数据或受保护的健康信息（PHI）。",
+    "hi": (
+        "केवल कृत्रिम डेटा। कभी भी वास्तविक रोगी डेटा या संरक्षित स्वास्थ्य "
+        "जानकारी (PHI) न चिपकाएँ।"
+    ),
+}
+DISCLAIMER_MARKDOWN = "\n\n".join(
+    f"> **{language.upper()}** — {disclaimer}"
+    for language, disclaimer in DISCLAIMERS.items()
+)
+
+UI_STRINGS = {
+    "en": {
+        "title": "OpenMed multilingual de-identification",
+        "intro": "Try a fabricated note in Chinese, Hindi, English, or Hinglish.",
+        "input": "Synthetic input",
+        "override": "Input language",
+        "auto": "Auto-detect",
+        "zh": "Chinese",
+        "hi": "Hindi",
+        "en": "English / Hinglish",
+        "submit": "De-identify",
+        "output": "Masked output",
+        "route": "Detected route",
+        "empty": "Enter synthetic text to continue.",
+        "error": "The note could not be de-identified. Please try again.",
+    },
+    "zh": {
+        "title": "OpenMed 多语言去标识化",
+        "intro": "试用中文、印地语、英语或 Hinglish 的完全虚构病历。",
+        "input": "合成文本输入",
+        "override": "输入语言",
+        "auto": "自动检测",
+        "zh": "中文",
+        "hi": "印地语",
+        "en": "英语 / Hinglish",
+        "submit": "去标识化",
+        "output": "遮蔽后的输出",
+        "route": "检测到的路由",
+        "empty": "请输入合成文本后继续。",
+        "error": "无法完成去标识化，请重试。",
+    },
+    "hi": {
+        "title": "OpenMed बहुभाषी डी-आइडेंटिफिकेशन",
+        "intro": "चीनी, हिन्दी, अंग्रेज़ी या हिंग्लिश में काल्पनिक नोट आज़माएँ।",
+        "input": "कृत्रिम इनपुट",
+        "override": "इनपुट भाषा",
+        "auto": "स्वतः पहचानें",
+        "zh": "चीनी",
+        "hi": "हिन्दी",
+        "en": "अंग्रेज़ी / हिंग्लिश",
+        "submit": "पहचान हटाएँ",
+        "output": "मास्क किया गया आउटपुट",
+        "route": "चुना गया रूट",
+        "empty": "आगे बढ़ने के लिए कृत्रिम टेक्स्ट दर्ज करें।",
+        "error": "नोट से पहचान नहीं हटाई जा सकी। कृपया फिर प्रयास करें।",
+    },
+}
+
+
+@dataclass(frozen=True)
+class ModelRoute:
+    """Resolved input language and OpenMed model configuration."""
+
+    language: str
+    model_id: str
+    openmed_language: str
+
+
+@dataclass(frozen=True)
+class DemoResult:
+    """Safe UI output for one de-identification request."""
+
+    deidentified_text: str
+    route: ModelRoute
+
+
+Deidentifier = Callable[..., Any]
+
+
+def _is_han(character: str) -> bool:
+    codepoint = ord(character)
+    return (
+        0x3400 <= codepoint <= 0x4DBF
+        or 0x4E00 <= codepoint <= 0x9FFF
+        or 0xF900 <= codepoint <= 0xFAFF
+        or 0x20000 <= codepoint <= 0x2FA1F
+    )
+
+
+def _is_devanagari(character: str) -> bool:
+    codepoint = ord(character)
+    return 0x0900 <= codepoint <= 0x097F or 0xA8E0 <= codepoint <= 0xA8FF
+
+
+def detect_script(text: str) -> str:
+    """Detect the routing language from Unicode script ranges.
+
+    Han takes precedence for mixed-script text, followed by Devanagari.
+    Latin, Hinglish, digits, punctuation, and empty text use the English path.
+    """
+
+    if any(_is_han(character) for character in text):
+        return "zh"
+    if any(_is_devanagari(character) for character in text):
+        return "hi"
+    return "en"
+
+
+def resolve_model_route(text: str, language_override: str = "auto") -> ModelRoute:
+    """Resolve a model route, honoring an explicit language override."""
+
+    if language_override not in LANGUAGE_OVERRIDES:
+        raise ValueError(
+            f"Unsupported language override {language_override!r}; "
+            f"choose one of {LANGUAGE_OVERRIDES}."
+        )
+    language = detect_script(text) if language_override == "auto" else language_override
+    return ModelRoute(
+        language=language,
+        model_id=MODEL_IDS[language],
+        openmed_language=language,
+    )
+
+
+def _sample_recognizer(language: str) -> dict[str, Any]:
+    """Build deterministic rules for the fabricated sample identifiers."""
+
+    return {
+        "case_sensitive": False,
+        "deny": {
+            "terms": [
+                {"term": term, "label": label}
+                for term, label in SAMPLES[language].identifiers
+            ]
+        },
+    }
+
+
+def run_deidentification(
+    text: str,
+    language_override: str = "auto",
+    *,
+    deidentifier: Deidentifier = deidentify,
+) -> DemoResult:
+    """De-identify text without logging, analytics, caching, or persistence."""
+
+    if not text.strip():
+        raise ValueError("Synthetic input must not be empty.")
+    route = resolve_model_route(text, language_override)
+    result = deidentifier(
+        text,
+        method="mask",
+        model_name=route.model_id,
+        lang=route.openmed_language,
+        policy="strict_no_leak",
+        use_safety_sweep=True,
+        custom_recognizer=_sample_recognizer(route.language),
+        keep_mapping=False,
+        audit=False,
+        cache_results=False,
+    )
+    return DemoResult(deidentified_text=result.deidentified_text, route=route)
+
+
+def localized_strings(locale: str) -> dict[str, str]:
+    """Return UI copy for a supported display locale."""
+
+    if locale not in UI_STRINGS:
+        raise ValueError(f"Unsupported UI locale: {locale!r}")
+    return UI_STRINGS[locale]
+
+
+def language_choices(locale: str) -> list[tuple[str, str]]:
+    """Return localized language-override labels and stable values."""
+
+    strings = localized_strings(locale)
+    return [(strings[value], value) for value in LANGUAGE_OVERRIDES]
+
+
+def route_status(route: ModelRoute, locale: str) -> str:
+    """Format safe route metadata without including user input."""
+
+    strings = localized_strings(locale)
+    return f"**{strings['route']}:** {strings[route.language]} · `{route.model_id}`"
+
+
+def build_demo() -> Any:
+    """Build the localized Gradio UI without loading models or launching."""
+
+    try:
+        import gradio as gr
+    except ImportError as exc:  # pragma: no cover - exercised via import shim
+        raise SystemExit(GRADIO_INSTALL_HINT) from exc
+
+    initial = localized_strings("en")
+
+    def _on_locale_change(locale: str) -> tuple[Any, ...]:
+        strings = localized_strings(locale)
+        return (
+            gr.Markdown(value=f"# {strings['title']}\n\n{strings['intro']}"),
+            gr.Textbox(label=strings["input"], value=SAMPLES[locale].text, lines=8),
+            gr.Radio(
+                label=strings["override"],
+                choices=language_choices(locale),
+                value="auto",
+            ),
+            gr.Button(value=strings["submit"], variant="primary"),
+            gr.Textbox(label=strings["output"], lines=8, interactive=False),
+            gr.Markdown(value=f"**{strings['route']}:** —"),
+        )
+
+    def _on_submit(text: str, override: str, locale: str) -> tuple[str, str]:
+        strings = localized_strings(locale)
+        if not text.strip():
+            return strings["empty"], f"**{strings['route']}:** —"
+        try:
+            result = run_deidentification(text, override)
+        except Exception:  # Keep raw input and backend details out of logs/UI.
+            return strings["error"], f"**{strings['route']}:** —"
+        return result.deidentified_text, route_status(result.route, locale)
+
+    with gr.Blocks(
+        title="OpenMed multilingual de-identification",
+        analytics_enabled=False,
+    ) as demo:
+        intro = gr.Markdown(f"# {initial['title']}\n\n{initial['intro']}")
+        gr.Markdown(DISCLAIMER_MARKDOWN)
+        ui_locale = gr.Radio(
+            choices=[("English", "en"), ("简体中文", "zh"), ("हिन्दी", "hi")],
+            value="en",
+            label="UI language / 界面语言 / इंटरफ़ेस भाषा",
+        )
+        text_in = gr.Textbox(
+            label=initial["input"],
+            value=SAMPLES["en"].text,
+            lines=8,
+        )
+        override = gr.Radio(
+            label=initial["override"],
+            choices=language_choices("en"),
+            value="auto",
+        )
+        submit = gr.Button(initial["submit"], variant="primary")
+        text_out = gr.Textbox(
+            label=initial["output"],
+            lines=8,
+            interactive=False,
+        )
+        status = gr.Markdown(f"**{initial['route']}:** —")
+
+        ui_locale.change(
+            _on_locale_change,
+            inputs=ui_locale,
+            outputs=[intro, text_in, override, submit, text_out, status],
+        )
+        submit.click(
+            _on_submit,
+            inputs=[text_in, override, ui_locale],
+            outputs=[text_out, status],
+        )
+
+    return demo
+
+
+def main() -> None:
+    """Launch the app locally or in a Gradio Space."""
+
+    build_demo().launch(show_error=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/spaces/deid_demo/requirements.txt
+++ b/examples/spaces/deid_demo/requirements.txt
@@ -1,0 +1,3 @@
+gradio==6.20.0
+openmed[hf,zh]==1.9.1
+torch==2.13.0

--- a/examples/spaces/deid_demo/samples.py
+++ b/examples/spaces/deid_demo/samples.py
@@ -1,0 +1,73 @@
+"""Fabricated multilingual notes used by the de-identification demo.
+
+Every person, organization, address, and identifier in this module is synthetic.
+The values are deliberately reserved for examples and do not describe a real
+patient or clinician.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SyntheticSample:
+    """One fabricated note and the identifiers it contains."""
+
+    text: str
+    identifiers: tuple[tuple[str, str], ...]
+
+
+SAMPLES = {
+    "zh": SyntheticSample(
+        text=(
+            "【完全虚构的合成示例】患者李晓雯，病历号 ZH-709-0001，出生日期 "
+            "1990年2月3日。联系电话 +86 10 5555 0709，电子邮箱 "
+            "li.xiaowen@example.test，住址北京市海淀区示例路709号。陈志远医生"
+            "建议一周后复诊。"
+        ),
+        identifiers=(
+            ("李晓雯", "PERSON"),
+            ("陈志远", "PERSON"),
+            ("ZH-709-0001", "ID_NUM"),
+            ("1990年2月3日", "DATE"),
+            ("+86 10 5555 0709", "PHONE"),
+            ("li.xiaowen@example.test", "EMAIL"),
+            ("北京市海淀区示例路709号", "ADDRESS"),
+        ),
+    ),
+    "hi": SyntheticSample(
+        text=(
+            "【पूरी तरह काल्पनिक सिंथेटिक उदाहरण】रोगी अनन्या मेहता, मेडिकल रिकॉर्ड "
+            "HI-709-0001, जन्म तिथि 3 फ़रवरी 1990। फोन +91 98765 40709, ईमेल "
+            "ananya@example.test। डॉ. रोहन कपूर ने एक सप्ताह बाद जाँच की सलाह दी।"
+        ),
+        identifiers=(
+            ("अनन्या मेहता", "PERSON"),
+            ("डॉ. रोहन कपूर", "PERSON"),
+            ("HI-709-0001", "ID_NUM"),
+            ("3 फ़रवरी 1990", "DATE"),
+            ("+91 98765 40709", "PHONE"),
+            ("ananya@example.test", "EMAIL"),
+        ),
+    ),
+    "en": SyntheticSample(
+        text=(
+            "Synthetic-only example: patient Alex Example, medical record "
+            "EN-709-0001, was seen on February 3, 1990. Call +1 415 555 0709 "
+            "or email alex@example.test. Dr. Casey Sample requested follow-up "
+            "in one week."
+        ),
+        identifiers=(
+            ("Alex Example", "PERSON"),
+            ("Dr. Casey Sample", "PERSON"),
+            ("EN-709-0001", "ID_NUM"),
+            ("February 3, 1990", "DATE"),
+            ("+1 415 555 0709", "PHONE"),
+            ("alex@example.test", "EMAIL"),
+        ),
+    ),
+}
+
+
+__all__ = ["SAMPLES", "SyntheticSample"]

--- a/tests/unit/test_examples_smoke.py
+++ b/tests/unit/test_examples_smoke.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import ast
+import importlib
 import os
+import re
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import yaml
+from jsonschema import validate
 
 from examples import (
     clinical_ner_families,
@@ -19,6 +23,8 @@ from examples import (
     onboarding_china_mirrors,
     onboarding_india_dpdp,
 )
+
+deid_demo = importlib.import_module("examples.spaces.deid_demo.app")
 
 
 def test_clinical_ner_families_example_is_syntactically_valid():
@@ -518,3 +524,185 @@ def test_hindi_hinglish_deid_example_fails_closed_on_synthetic_leak(
             note_name,
             note,
         )
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_language"),
+    [
+        ("患者李晓雯今天复诊。", "zh"),
+        ("रोगी आज जाँच के लिए आए।", "hi"),
+        ("Patient Alex Example was seen today.", "en"),
+        ("Patient Ananya ka follow-up aaj hai.", "en"),
+        ("1234 / +1 555 0100", "en"),
+    ],
+)
+def test_deid_demo_detects_unicode_script(text, expected_language):
+    assert deid_demo.detect_script(text) == expected_language
+
+
+@pytest.mark.parametrize("override", ["zh", "hi", "en"])
+def test_deid_demo_manual_override_wins(override):
+    route = deid_demo.resolve_model_route("患者 हिन्दी Patient", override)
+
+    assert route.language == override
+    assert route.model_id == deid_demo.MODEL_IDS[override]
+
+
+@pytest.mark.parametrize(
+    ("sample_language", "openmed_language"),
+    [("zh", "zh"), ("hi", "hi"), ("en", "en")],
+)
+def test_deid_demo_routes_samples_without_network(
+    sample_language,
+    openmed_language,
+):
+    calls = []
+
+    def fake_deidentify(text, **kwargs):
+        calls.append((text, kwargs))
+        return SimpleNamespace(deidentified_text=f"[{sample_language.upper()} MASKED]")
+
+    sample = deid_demo.SAMPLES[sample_language]
+    result = deid_demo.run_deidentification(
+        sample.text,
+        deidentifier=fake_deidentify,
+    )
+
+    assert result.deidentified_text == f"[{sample_language.upper()} MASKED]"
+    assert result.route.language == sample_language
+    assert calls[0][0] == sample.text
+    assert calls[0][1] == {
+        "method": "mask",
+        "model_name": deid_demo.MODEL_IDS[sample_language],
+        "lang": openmed_language,
+        "policy": "strict_no_leak",
+        "use_safety_sweep": True,
+        "custom_recognizer": deid_demo._sample_recognizer(sample_language),
+        "keep_mapping": False,
+        "audit": False,
+        "cache_results": False,
+    }
+
+
+def test_deid_demo_models_are_registered():
+    from openmed.core.model_registry import get_model_info
+
+    assert all(
+        get_model_info(model_id) is not None
+        for model_id in deid_demo.MODEL_IDS.values()
+    )
+
+
+def test_deid_demo_samples_run_through_pipeline_without_network(monkeypatch):
+    from openmed.core import pii
+    from openmed.processing.outputs import PredictionResult
+
+    calls = []
+
+    def fake_extract_pii(text, model_name, *args, **kwargs):
+        calls.append((text, model_name, kwargs["lang"]))
+        return PredictionResult(
+            text=text,
+            entities=[],
+            model_name=model_name,
+            timestamp="2026-01-01T00:00:00",
+        )
+
+    monkeypatch.setattr(pii, "extract_pii", fake_extract_pii)
+
+    for language, sample in deid_demo.SAMPLES.items():
+        result = deid_demo.run_deidentification(sample.text, language)
+
+        assert all(
+            identifier not in result.deidentified_text
+            for identifier, _label in sample.identifiers
+        )
+
+    assert calls == [
+        (sample.text, deid_demo.MODEL_IDS[language], language)
+        for language, sample in deid_demo.SAMPLES.items()
+    ]
+
+
+def test_deid_demo_rejects_unknown_override():
+    with pytest.raises(ValueError, match="Unsupported language override"):
+        deid_demo.resolve_model_route("Synthetic note", "fr")
+
+
+def test_deid_demo_does_not_log_or_persist_input(caplog, monkeypatch, tmp_path):
+    raw_input = "Synthetic secret ZH-709-NEVER-LOG"
+    monkeypatch.chdir(tmp_path)
+
+    def fake_deidentify(text, **kwargs):
+        del text, kwargs
+        return SimpleNamespace(deidentified_text="Synthetic secret [ID_NUM]")
+
+    result = deid_demo.run_deidentification(
+        raw_input,
+        language_override="en",
+        deidentifier=fake_deidentify,
+    )
+
+    assert result.deidentified_text == "Synthetic secret [ID_NUM]"
+    assert raw_input not in caplog.text
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_deid_demo_disclaimer_contains_all_locales():
+    assert set(deid_demo.DISCLAIMERS) == {"zh", "hi", "en"}
+    assert all(
+        disclaimer in deid_demo.DISCLAIMER_MARKDOWN
+        for disclaimer in deid_demo.DISCLAIMERS.values()
+    )
+    assert "Never paste real patient data" in deid_demo.DISCLAIMERS["en"]
+    assert "真实患者数据" in deid_demo.DISCLAIMERS["zh"]
+    assert "वास्तविक रोगी डेटा" in deid_demo.DISCLAIMERS["hi"]
+
+
+def test_deid_demo_space_frontmatter_matches_schema():
+    readme = Path("examples/spaces/deid_demo/README.md").read_text(encoding="utf-8")
+    match = re.match(r"\A---\n(.*?)\n---\n", readme, flags=re.DOTALL)
+    assert match is not None
+    metadata = yaml.safe_load(match.group(1))
+    schema = {
+        "type": "object",
+        "required": ["title", "sdk", "sdk_version", "app_file", "models"],
+        "properties": {
+            "title": {"type": "string", "minLength": 1},
+            "sdk": {"const": "gradio"},
+            "sdk_version": {"type": "string", "pattern": r"^\d+\.\d+\.\d+$"},
+            "python_version": {"type": "string", "pattern": r"^3\.\d+(?:\.\d+)?$"},
+            "app_file": {"const": "app.py"},
+            "models": {
+                "type": "array",
+                "minItems": 3,
+                "items": {"type": "string", "pattern": r"^OpenMed/"},
+            },
+        },
+    }
+
+    validate(instance=metadata, schema=schema)
+    assert Path("examples/spaces/deid_demo", metadata["app_file"]).is_file()
+    assert metadata["sdk_version"] == "6.20.0"
+
+
+def test_deid_demo_requirements_are_pinned():
+    requirements = Path("examples/spaces/deid_demo/requirements.txt").read_text(
+        encoding="utf-8"
+    )
+    lines = [
+        line for line in requirements.splitlines() if line and not line.startswith("#")
+    ]
+
+    assert lines
+    assert all(
+        re.fullmatch(r"[A-Za-z0-9_.-]+(?:\[[A-Za-z0-9_,.-]+\])?==[^\s]+", line)
+        for line in lines
+    )
+
+
+def test_deid_demo_readme_has_local_run_instructions():
+    readme = Path("examples/spaces/deid_demo/README.md").read_text(encoding="utf-8")
+
+    assert "python -m pip install -r requirements.txt" in readme
+    assert "python app.py" in readme


### PR DESCRIPTION
# Pull Request

## Description

Adds a directly deployable multilingual de-identification demo for fabricated Chinese, Hindi, English, and Hinglish clinical notes. The app selects a language checkpoint and language-aware pattern pack from Unicode script ranges, supports a manual override, localizes the interface, and keeps a persistent synthetic-only warning visible in all three interface languages.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Added script detection, explicit zh/hi/en model and language-pack routing, manual language selection, and localized interface copy.
- Added one fabricated sample per language with deterministic sample-identifier coverage and no app-level input logging, analytics, result caching, or disk persistence.
- Added a directly deployable Space layout with pinned runtime requirements, validated frontmatter, and local run instructions.
- Added registry validation and a true no-network pipeline test for all three samples.

## Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Validation:

- `.venv/bin/python -m pytest tests/ -q` — 6553 passed, 47 skipped
- `.venv/bin/python -m pytest tests/unit/test_examples_smoke.py -q` — 48 passed
- `make format`, `make lint`, `make format-check`, and `make type-check`
- Scoped `pre-commit` hooks
- `make docs-build`
- `/usr/local/bin/python3 -m build`
- Exact folder requirements resolved successfully for Python 3.11
- Fabricated zh, hi, and en samples completed through their real checkpoints with no known sample identifiers remaining
- `python app.py` served on loopback with HTTP 200; the live UI config contained all three disclaimer translations and analytics was disabled

No hosted Space was created, deployed, operated, or reconfigured as part of validation.

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md (not required for this example addition)

## Code Quality

- [x] I ran the canonical format, lint, format-check, and type-check gates
- [x] Swift/OpenMedKit checks are not applicable to this Python-only change
- [x] I have performed a self-review of my own code
- [x] I have commented the routing decisions and privacy-sensitive behavior
- [x] My changes generate no new warnings

## Dependencies

- [ ] I have not added any new dependencies
- [x] The example adds pinned, folder-local dependencies required for the hosted interface and checkpoint execution; core package dependencies are unchanged

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] I have organized the change as one focused commit

## Related Issues

Closes #1535

## Screenshots/Examples

The local interface served successfully with the three-language warning and analytics disabled in its runtime configuration.
