### PR TITLE
fix: use timezone-aware datetime.now(timezone.utc) in _build_redacted_result (pii.py:1661)

### DIFF
--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -29,7 +29,7 @@ import re
 import unicodedata
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Literal, NoReturn, Optional, Sequence
@@ -1658,7 +1658,7 @@ def _build_deidentification_result(
         deidentified_text=deidentified,
         pii_entities=pii_entities,
         method=effective_method,
-        timestamp=datetime.now(),
+        timestamp=datetime.now(timezone.utc),
         mapping=mapping,
         metadata=_copy_metadata(getattr(pii_result, "metadata", None)),
         audit_report=audit_report,


### PR DESCRIPTION
## Summary

`openmed/core/pii.py:1661` uses `datetime.now()` without a timezone argument, returning a naive datetime. This is the same class of bug addressed by PR #1227, but that PR does not cover this call site (it covers line 454 in the same file and other modules).

## Change

- `from datetime import datetime, timedelta` → `from datetime import datetime, timedelta, timezone`
- `timestamp=datetime.now()` → `timestamp=datetime.now(timezone.utc)`

## Context

Line 454 (`timestamp=datetime.now().isoformat()`) is covered by PR #1227. Line 1661 (`timestamp=datetime.now()`) in `_build_redacted_result()` is a different call site that was missed.

This PR is intentionally scoped to just the one uncovered instance. If PR #1227 merges first, this PR adds the remaining fix; if this PR merges first, PR #1227 can be rebased to cover only line 454.