### PR TITLE
African French and Portuguese locale surrogate providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surrogates; bare `ar` still defaults to `ar_EG`. Locales missing from the
   installed Faker fall back to `ar_EG` with a one-time warning, and
   `list_regional_locales('ar')` enumerates the supported tags (#483).
+- Added curated conceptual surrogate locales for Senegal, Côte d’Ivoire,
+  Cameroon, Mozambique, and Angola (`fr_SN`, `fr_CI`, `fr_CM`, `pt_MZ`, and
+  `pt_AO`), including in-country names, addresses, cities, phone formats, and
+  context-only Senegal CNI and Angola BI detection. Arabic regional overrides
+  now also document `ar-DZ` and `ar-MA`; unavailable Faker backends retain the
+  existing one-time-warning fallback to `ar_EG` (#1443).
 - Added a release evidence job that keylessly signs each wheel and source
   distribution with Sigstore and attaches the SLSA provenance bundle, the
   release artifact digest manifest, and the Sigstore bundles to the tagged

--- a/docs/anonymization.md
+++ b/docs/anonymization.md
@@ -229,6 +229,16 @@ locale via `LANG_TO_LOCALE`:
 Pass `locale=` explicitly to override per call (e.g. `pt_BR` to generate
 CPF/CNPJ surrogates instead of Portuguese NIF/VAT).
 
+Country-aware African French and Portuguese surrogates are available through
+conceptual locale overrides. `fr_SN`, `fr_CI`, and `fr_CM` use curated names,
+cities, addresses, and country-code phone formats while keeping the French PII
+model; `pt_MZ` and `pt_AO` do the same with the Portuguese model. Unsupported
+Faker methods delegate to `fr_FR` or `pt_PT`, so these overrides do not alter
+the default `fr` and `pt` output. Arabic also accepts `ar-DZ` and `ar-MA`; if
+the installed Faker release lacks the requested regional backend, OpenMed
+falls back to `ar_EG` and emits the same one-time warning used by the other
+Arabic regional overrides.
+
 For the full per-language table — every `SUPPORTED_LANGUAGES` code with its
 default PII model, Faker locale, and a before/after example — see
 [Per-Language De-identification](languages.md).

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -74,7 +74,7 @@ routing is first requested, and do not download or bundle model weights.
 | `de`   | German     | `OpenMed/OpenMed-PII-German-SuperClinical-Small-44M-v1`    | `de_DE`      | Steuer-ID surrogates via `GermanSteuerIdProvider`.           |
 | `en`   | English    | `OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1`           | `en_US`      | Default model splits names into `first_name`/`last_name`.    |
 | `es`   | Spanish    | `OpenMed/OpenMed-PII-Spanish-SuperClinical-Small-44M-v1`   | `es_ES`      | DNI/NIE checksum-aware surrogates.                           |
-| `fr`   | French     | `OpenMed/OpenMed-PII-French-SuperClinical-Small-44M-v1`    | `fr_FR`      | NIR / INSEE surrogates via `fr_FR.ssn`.                      |
+| `fr`   | French     | `OpenMed/OpenMed-PII-French-SuperClinical-Small-44M-v1`    | `fr_FR`      | NIR / INSEE; `fr_SN`, `fr_CI`, and `fr_CM` locale overlays.  |
 | `gu`   | Gujarati   | `env:OPENMED_INDIC_NER_MODEL`                               | `gu_IN`      | Optional Indic NER weights.                                  |
 | `he`   | Hebrew     | `OpenMed/privacy-filter-multilingual`                      | `he_IL`      | Served by the multilingual privacy filter.                   |
 | `hi`   | Hindi      | `OpenMed/OpenMed-PII-Hindi-SuperClinical-Large-434M-v1`    | `hi_IN`      | Aadhaar (Verhoeff) surrogates.                               |
@@ -88,7 +88,7 @@ routing is first requested, and do not download or bundle model weights.
 | `nl`   | Dutch      | `OpenMed/OpenMed-PII-Dutch-SuperClinical-Large-434M-v1`    | `nl_NL`      | BSN (Elfproef) surrogates via `nl_NL.ssn`.                   |
 | `or`   | Odia       | `env:OPENMED_INDIC_NER_MODEL`                               | `or_IN`      | Optional Indic NER weights.                                  |
 | `pa`   | Punjabi    | `env:OPENMED_INDIC_NER_MODEL`                               | `pa_IN`      | Optional Indic NER weights; Indian Faker fallback.           |
-| `pt`   | Portuguese | `OpenMed/OpenMed-PII-Portuguese-SnowflakeMed-Large-568M-v1` | `pt_PT`     | Pass `locale="pt_BR"` for CPF/CNPJ surrogates.               |
+| `pt`   | Portuguese | `OpenMed/OpenMed-PII-Portuguese-SnowflakeMed-Large-568M-v1` | `pt_PT`     | `pt_BR` IDs; `pt_MZ` and `pt_AO` locale overlays.            |
 | `ro`   | Romanian   | `OpenMed/privacy-filter-multilingual`                      | `ro_RO`      | Served by the multilingual privacy filter; CNP-aware.        |
 | `sw`   | Swahili    | `OpenMed/privacy-filter-multilingual`                      | `sw`         | Bilingual patterns with Kenya ID and Maisha-aware surrogates. |
 | `ta`   | Tamil      | `env:OPENMED_INDIC_NER_MODEL`                               | `ta_IN`      | Optional Indic NER weights.                                  |

--- a/openmed/core/anonymizer/locales.py
+++ b/openmed/core/anonymizer/locales.py
@@ -13,6 +13,12 @@ Notes:
   available through the language pack.
 - Portuguese defaults to ``pt_PT``; pass ``locale="pt_BR"`` explicitly to
   generate Brazilian-Portuguese surrogates (matters for CPF/CNPJ context).
+- African French and Portuguese conceptual locales (``fr_SN``, ``fr_CI``,
+  ``fr_CM``, ``pt_MZ``, and ``pt_AO``) use curated in-country surrogate data
+  while delegating unsupported Faker methods to ``fr_FR`` or ``pt_PT``.
+- Arabic defaults to ``ar_EG``. Region tags ``ar-DZ`` and ``ar-MA`` select an
+  installed regional Faker backend, or fall back to ``ar_EG`` with a one-time
+  warning when that backend is unavailable.
 - Chinese resolves to ``zh_CN`` so PERSON/FIRST_NAME/LAST_NAME dispatch uses
   the surname-aware, Han-only surrogate generators rather than a Latin fallback.
 
@@ -62,6 +68,18 @@ _APPROXIMATE_LOCALES: Final = frozenset(
 )
 
 
+# Conceptual locale -> OpenMed model language. These locales deliberately do
+# not become new language packs: they select country-aware surrogate and
+# deterministic-pattern overlays for the existing French and Portuguese packs.
+CONCEPTUAL_LOCALE_LANGUAGES: Final[Mapping[str, str]] = {
+    "fr_SN": "fr",
+    "fr_CI": "fr",
+    "fr_CM": "fr",
+    "pt_MZ": "pt",
+    "pt_AO": "pt",
+}
+
+
 # Conceptual locale -> installed Faker locale. This keeps national-ID dispatch
 # keyed by the target country while allowing generic names/addresses to use a
 # nearby installed Faker backend.
@@ -76,11 +94,16 @@ FAKER_BACKEND_LOCALE: Final[Mapping[str, str]] = {
     "en_ZA": "zu_ZA",
     "en_GH": "tw_GH",
     "fr_MA": "fr_FR",
+    "fr_SN": "fr_FR",
+    "fr_CI": "fr_FR",
+    "fr_CM": "fr_FR",
     "kn_IN": "en_IN",
     "ml_IN": "en_IN",
     "mr_IN": "hi_IN",
     "ms_MY": "id_ID",
     "pa_IN": "en_IN",
+    "pt_MZ": "pt_PT",
+    "pt_AO": "pt_PT",
     "rw_RW": "en_US",
     "sr_RS": "hr_HR",
     "sw_TZ": "sw",
@@ -90,10 +113,12 @@ FAKER_BACKEND_LOCALE: Final[Mapping[str, str]] = {
 
 
 # Region-qualified Arabic codes -> Faker locale. Bare ``ar`` stays ``ar_EG``
-# (see LANG_TO_LOCALE); these let callers request a Gulf/Levant flavour so
-# surrogate names, phones and addresses read in-region (OM-285).
+# (see LANG_TO_LOCALE); these let callers request a Maghreb/Gulf/Levant flavour
+# so surrogate names, phones and addresses read in-region (OM-285, OM-866).
 AR_REGION_LOCALES: Final[Mapping[str, str]] = {
     "ar-EG": "ar_EG",  # Egypt (the bare-"ar" default, exposed explicitly too)
+    "ar-DZ": "ar_DZ",  # Algeria / Maghrebi Arabic
+    "ar-MA": "ar_MA",  # Morocco when shipped; otherwise documented fallback
     "ar-SA": "ar_SA",  # Saudi Arabia
     "ar-AE": "ar_AE",  # United Arab Emirates
     "ar-JO": "ar_JO",  # Jordan
@@ -149,8 +174,9 @@ def resolve_locale(
 
     Args:
         lang: ISO 639-1 language code (``en``, ``fr``, ``de``, ...).
-        locale_override: Caller-supplied Faker locale (e.g. ``pt_BR``) or
-            documented region tag (e.g. ``ar-SA``); takes precedence.
+        locale_override: Caller-supplied Faker or conceptual locale (for
+            example, ``pt_BR``, ``fr_SN``, or ``pt_MZ``), or a documented
+            Arabic region tag such as ``ar-DZ`` or ``ar-MA``; takes precedence.
         warn_approximation: Emit the documented one-time warning when the
             resolved Faker locale approximates ``lang``. Script-specific
             providers set this false because they do not use Faker's name data.
@@ -211,14 +237,13 @@ def resolve_faker_backend_locale(locale: str) -> str:
 
 
 def locale_coherence_report() -> list[dict[str, object]]:
-    """Return one locale-coherence row per supported or ID-only language.
+    """Return locale-coherence rows for defaults and conceptual overrides.
 
     Each row is a plain JSON-friendly ``dict`` (so the status/leaderboard work
     can reuse it) with:
 
       - ``language``: the OpenMed ISO 639-1 code.
-      - ``locale``: the default Faker locale it resolves to (no warning side
-        effect — read straight from :data:`LANG_TO_LOCALE`).
+      - ``locale``: the default or conceptual locale.
       - ``approximate``: ``True`` when that default locale is a documented
         approximation rather than a native match.
       - ``id_providers``: national-ID Faker method names whose surrogates
@@ -257,11 +282,26 @@ def locale_coherence_report() -> list[dict[str, object]]:
                 "id_locale": id_locale,
             }
         )
+
+    for locale, lang in sorted(CONCEPTUAL_LOCALE_LANGUAGES.items()):
+        rows.append(
+            {
+                "language": lang,
+                "locale": locale,
+                "approximate": False,
+                # Senegal CNI and Angola BI coverage is contextual rather than
+                # checksum-backed, so no provider or validator is claimed.
+                "id_providers": [],
+                "id_types": [],
+                "id_locale": None,
+            }
+        )
     return rows
 
 
 __all__ = [
     "AR_REGION_LOCALES",
+    "CONCEPTUAL_LOCALE_LANGUAGES",
     "LANG_TO_LOCALE",
     "FAKER_BACKEND_LOCALE",
     "NATIONAL_ID_PROVIDERS",

--- a/openmed/core/anonymizer/registry.py
+++ b/openmed/core/anonymizer/registry.py
@@ -62,6 +62,18 @@ def _draw_distinct(faker, original: str, method: str) -> str:
     return candidate
 
 
+def _locale_fake_value(faker, locale: str, key: str, original: str):
+    """Draw a curated value for an OpenMed conceptual locale, if present."""
+
+    from ..pii_i18n import LOCALE_FAKE_DATA
+
+    values = LOCALE_FAKE_DATA.get(locale, {}).get(key, ())
+    if not values:
+        return None
+    alternatives = tuple(value for value in values if value != original)
+    return faker.random_element(alternatives or tuple(values))
+
+
 # ---------------------------------------------------------------------------
 # Names
 # ---------------------------------------------------------------------------
@@ -143,7 +155,7 @@ def _gen_zh_person(faker, original: str) -> str:
 def _gen_person(faker, original, *, locale):
     if _is_zh_cn(locale):
         return _gen_zh_person(faker, original)
-    return faker.name()
+    return _locale_fake_value(faker, locale, "NAME", original) or faker.name()
 
 
 def _gen_first_name(faker, original, *, locale):
@@ -154,7 +166,9 @@ def _gen_first_name(faker, original, *, locale):
             length=max(1, min(len(source) or 1, 2)),
             forbidden=set(source),
         )
-    return faker.first_name()
+    return (
+        _locale_fake_value(faker, locale, "FIRST_NAME", original) or faker.first_name()
+    )
 
 
 def _gen_last_name(faker, original, *, locale):
@@ -165,7 +179,7 @@ def _gen_last_name(faker, original, *, locale):
             compound=len(source) >= 2,
             forbidden=set(source),
         )
-    return faker.last_name()
+    return _locale_fake_value(faker, locale, "LAST_NAME", original) or faker.last_name()
 
 
 def _gen_middle_name(faker, original, *, locale):
@@ -215,6 +229,9 @@ def _gen_email(faker, original, *, locale):
 
 
 def _gen_phone(faker, original, *, locale):
+    curated = _locale_fake_value(faker, locale, "PHONE", original)
+    if curated is not None:
+        return curated
     if _is_zh_cn(locale):
         from openmed.core.pii_i18n import validate_chinese_mobile_number
 
@@ -333,7 +350,7 @@ def _gen_location(faker, original, *, locale):
     if _is_zh_address_locale(locale):
         return "".join(_pick_zh_division(faker, original))
     # Prefer city-level granularity since most "LOCATION" detections are cities
-    return faker.city()
+    return _locale_fake_value(faker, locale, "LOCATION", original) or faker.city()
 
 
 def _gen_street_address(faker, original, *, locale):
@@ -350,7 +367,10 @@ def _gen_street_address(faker, original, *, locale):
             return f"{street}{building}号，邮编{postcode}"
         province, city, district = _pick_zh_division(faker, original)
         return f"{province}{city}{district}{street}{building}号，邮编{postcode}"
-    return faker.street_address()
+    return (
+        _locale_fake_value(faker, locale, "STREET_ADDRESS", original)
+        or faker.street_address()
+    )
 
 
 def _gen_india_street_address(faker, original, *, locale):

--- a/openmed/core/pii_i18n.py
+++ b/openmed/core/pii_i18n.py
@@ -7914,6 +7914,126 @@ LANGUAGE_PII_PATTERNS: Dict[str, List[PIIPattern]] = {
     "ur": _URDU_PII_PATTERNS,
 }
 
+
+AFRICAN_FR_PT_PHONE_PREFIXES: Dict[str, str] = {
+    "fr_sn": "+221",
+    "fr_ci": "+225",
+    "fr_cm": "+237",
+    "pt_mz": "+258",
+    "pt_ao": "+244",
+}
+
+_AFRICAN_FR_PT_PHONE_CONTEXT = [
+    "téléphone",
+    "telephone",
+    "tél",
+    "tel",
+    "portable",
+    "contact",
+    "telefone",
+    "telemóvel",
+    "telemovel",
+    "contacto",
+]
+
+_AFRICAN_FR_PT_PHONE_PII_PATTERNS: Dict[str, PIIPattern] = {
+    # International and 00-prefix renderings are intentionally required. The
+    # existing fr/pt language patterns retain responsibility for national-only
+    # numbers, while these country overlays make the calling code unambiguous.
+    "fr_sn": PIIPattern(
+        r"(?<![A-Za-z0-9])(?:\+|00)221[\s.-]?[378](?:[\s.-]?[0-9]){8}"
+        r"(?![A-Za-z0-9])",
+        "phone_number",
+        priority=11,
+        base_score=0.65,
+        context_words=_AFRICAN_FR_PT_PHONE_CONTEXT,
+        context_boost=0.3,
+        flags=re.IGNORECASE,
+    ),
+    "fr_ci": PIIPattern(
+        r"(?<![A-Za-z0-9])(?:\+|00)225[\s.-]?(?:0[157]|2[157])"
+        r"(?:[\s.-]?[0-9]){8}(?![A-Za-z0-9])",
+        "phone_number",
+        priority=11,
+        base_score=0.65,
+        context_words=_AFRICAN_FR_PT_PHONE_CONTEXT,
+        context_boost=0.3,
+        flags=re.IGNORECASE,
+    ),
+    "fr_cm": PIIPattern(
+        r"(?<![A-Za-z0-9])(?:\+|00)237[\s.-]?[26](?:[\s.-]?[0-9]){8}"
+        r"(?![A-Za-z0-9])",
+        "phone_number",
+        priority=11,
+        base_score=0.65,
+        context_words=_AFRICAN_FR_PT_PHONE_CONTEXT,
+        context_boost=0.3,
+        flags=re.IGNORECASE,
+    ),
+    "pt_mz": PIIPattern(
+        r"(?<![A-Za-z0-9])(?:\+|00)258[\s.-]?(?:2[1-9]|8[234567])"
+        r"(?:[\s.-]?[0-9]){7}(?![A-Za-z0-9])",
+        "phone_number",
+        priority=11,
+        base_score=0.65,
+        context_words=_AFRICAN_FR_PT_PHONE_CONTEXT,
+        context_boost=0.3,
+        flags=re.IGNORECASE,
+    ),
+    "pt_ao": PIIPattern(
+        r"(?<![A-Za-z0-9])(?:\+|00)244[\s.-]?[29](?:[\s.-]?[0-9]){8}"
+        r"(?![A-Za-z0-9])",
+        "phone_number",
+        priority=11,
+        base_score=0.65,
+        context_words=_AFRICAN_FR_PT_PHONE_CONTEXT,
+        context_boost=0.3,
+        flags=re.IGNORECASE,
+    ),
+}
+
+_SENEGAL_CNI_PII_PATTERN = PIIPattern(
+    # ECOWAS CNI NIN: sex digit + 3-digit civil centre + 4-digit birth year +
+    # 5-digit register sequence. No public checksum is claimed.
+    r"(?<![0-9])[12][0-9]{3}(?:19|20)[0-9]{2}[0-9]{5}(?![0-9])",
+    "national_id",
+    priority=12,
+    base_score=0.35,
+    context_words=[
+        "cni",
+        "carte nationale d'identité",
+        "carte nationale d’identite",
+        "numéro d'identification national",
+        "numéro d’identification national",
+        "nin",
+    ],
+    context_boost=0.6,
+    safety_sweep_requires_context=True,
+    flags=re.IGNORECASE,
+)
+
+_ANGOLA_BI_PII_PATTERN = PIIPattern(
+    # Current BI/NIF examples use nine digits, a two-letter issuing series,
+    # and three trailing digits. No public checksum is claimed.
+    r"(?<![A-Za-z0-9])0[0-9]{8}[A-Z]{2}[0-9]{3}(?![A-Za-z0-9])",
+    "national_id",
+    priority=12,
+    base_score=0.35,
+    context_words=[
+        "bilhete de identidade",
+        "número do bilhete",
+        "numero do bilhete",
+        "número de identificação civil",
+        "numero de identificacao civil",
+        "nº do bi",
+        "n.º do bi",
+        "bi:",
+    ],
+    context_boost=0.6,
+    safety_sweep_requires_context=True,
+    flags=re.IGNORECASE,
+)
+
 LOCALE_PII_PATTERNS: Dict[str, List[PIIPattern]] = {
     "am": _ETHIOPIA_FAYDA_PII_PATTERNS,
     "zh_cn": _CHINESE_IDENTIFIER_PII_PATTERNS,
@@ -7940,6 +8060,17 @@ LOCALE_PII_PATTERNS: Dict[str, List[PIIPattern]] = {
     "en_au": _AU_ENGLISH_PII_PATTERNS,
     "en_ca": _CANADIAN_ENGLISH_PII_PATTERNS,
     "fr_ca": _CANADIAN_ENGLISH_PII_PATTERNS,
+    "fr_sn": [
+        _AFRICAN_FR_PT_PHONE_PII_PATTERNS["fr_sn"],
+        _SENEGAL_CNI_PII_PATTERN,
+    ],
+    "fr_ci": [_AFRICAN_FR_PT_PHONE_PII_PATTERNS["fr_ci"]],
+    "fr_cm": [_AFRICAN_FR_PT_PHONE_PII_PATTERNS["fr_cm"]],
+    "pt_mz": [_AFRICAN_FR_PT_PHONE_PII_PATTERNS["pt_mz"]],
+    "pt_ao": [
+        _AFRICAN_FR_PT_PHONE_PII_PATTERNS["pt_ao"],
+        _ANGOLA_BI_PII_PATTERN,
+    ],
 }
 
 for _country, _plan in AFRICAN_MOBILE_PLANS.items():
@@ -7980,6 +8111,104 @@ if _NIGERIA_HEALTH_FACILITY_PII_PATTERNS[0] not in _NIGERIAN_PII_PATTERNS:
 # ---------------------------------------------------------------------------
 # Language-specific fake data
 # ---------------------------------------------------------------------------
+
+# Curated supplements for conceptual locales that Faker does not ship. These
+# values cover only the culturally sensitive methods; every other generator is
+# delegated to the installed backend in ``FAKER_BACKEND_LOCALE``. Keeping this
+# separate from ``LANGUAGE_FAKE_DATA`` ensures the default ``fr`` and ``pt``
+# code paths remain unchanged unless the caller explicitly passes ``locale=``.
+LOCALE_FAKE_DATA: Dict[str, Dict[str, List[str]]] = {
+    "fr_SN": {
+        "NAME": ["Awa Ndiaye", "Mamadou Diop", "Fatou Sarr", "Ibrahima Fall"],
+        "FIRST_NAME": ["Awa", "Mamadou", "Fatou", "Ibrahima"],
+        "LAST_NAME": ["Ndiaye", "Diop", "Sarr", "Fall"],
+        "PHONE": [
+            "+221 77 642 18 35",
+            "+221 76 315 42 87",
+            "+221 70 824 53 16",
+        ],
+        "STREET_ADDRESS": [
+            "12 avenue Cheikh Anta Diop, Dakar",
+            "48 rue Carnot, Saint-Louis",
+            "7 avenue Léopold Sédar Senghor, Thiès",
+        ],
+        "LOCATION": ["Dakar", "Thiès", "Saint-Louis", "Kaolack"],
+    },
+    "fr_CI": {
+        "NAME": ["Aïcha Koné", "Kouadio Yao", "Aminata Traoré", "Koffi N'Guessan"],
+        "FIRST_NAME": ["Aïcha", "Kouadio", "Aminata", "Koffi"],
+        "LAST_NAME": ["Koné", "Yao", "Traoré", "N'Guessan"],
+        "PHONE": [
+            "+225 07 48 26 15 39",
+            "+225 05 31 74 82 60",
+            "+225 01 62 93 47 18",
+        ],
+        "STREET_ADDRESS": [
+            "17 boulevard Latrille, Abidjan",
+            "8 rue des Jardins, Bouaké",
+            "23 avenue Houphouët-Boigny, Yamoussoukro",
+        ],
+        "LOCATION": ["Abidjan", "Bouaké", "Yamoussoukro", "San-Pédro"],
+    },
+    "fr_CM": {
+        "NAME": ["Mireille Ngono", "Alain Njoya", "Chantal Mbarga", "Samuel Tchinda"],
+        "FIRST_NAME": ["Mireille", "Alain", "Chantal", "Samuel"],
+        "LAST_NAME": ["Ngono", "Njoya", "Mbarga", "Tchinda"],
+        "PHONE": [
+            "+237 6 71 24 83 59",
+            "+237 6 96 35 72 18",
+            "+237 6 52 81 46 30",
+        ],
+        "STREET_ADDRESS": [
+            "25 avenue Kennedy, Yaoundé",
+            "10 rue Joss, Douala",
+            "6 avenue des Banques, Bafoussam",
+        ],
+        "LOCATION": ["Yaoundé", "Douala", "Bafoussam", "Garoua"],
+    },
+    "pt_MZ": {
+        "NAME": [
+            "Amélia Mucavele",
+            "Ernesto Mondlane",
+            "Celina Nhantumbo",
+            "Luís Mabote",
+        ],
+        "FIRST_NAME": ["Amélia", "Ernesto", "Celina", "Luís"],
+        "LAST_NAME": ["Mucavele", "Mondlane", "Nhantumbo", "Mabote"],
+        "PHONE": [
+            "+258 84 362 7185",
+            "+258 82 715 4369",
+            "+258 87 246 5913",
+        ],
+        "STREET_ADDRESS": [
+            "24 Avenida Julius Nyerere, Maputo",
+            "16 Avenida Eduardo Mondlane, Beira",
+            "9 Rua dos Continuadores, Nampula",
+        ],
+        "LOCATION": ["Maputo", "Beira", "Nampula", "Quelimane"],
+    },
+    "pt_AO": {
+        "NAME": [
+            "Ana Domingos",
+            "Manuel Mateus",
+            "Teresa Chissola",
+            "Paulo Cassoma",
+        ],
+        "FIRST_NAME": ["Ana", "Manuel", "Teresa", "Paulo"],
+        "LAST_NAME": ["Domingos", "Mateus", "Chissola", "Cassoma"],
+        "PHONE": [
+            "+244 923 461 785",
+            "+244 934 725 816",
+            "+244 951 284 639",
+        ],
+        "STREET_ADDRESS": [
+            "31 Rua Rainha Ginga, Luanda",
+            "14 Avenida da Independência, Benguela",
+            "8 Rua do Comércio, Huambo",
+        ],
+        "LOCATION": ["Luanda", "Benguela", "Huambo", "Lubango"],
+    },
+}
 
 LANGUAGE_FAKE_DATA: Dict[str, Dict[str, List[str]]] = {
     "en": {

--- a/tests/fuzz/test_date_shift_fuzz.py
+++ b/tests/fuzz/test_date_shift_fuzz.py
@@ -30,7 +30,7 @@ import calendar
 from datetime import date, datetime, timedelta
 
 import pytest
-from hypothesis import assume, given
+from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 from openmed.core.pii import _replace_year_safe, _shift_date
@@ -54,6 +54,7 @@ _leap_years = st.sampled_from(
 
 
 @given(d=_dates, shift=_offsets, keep_year=st.booleans())
+@settings(deadline=1000)
 def test_shift_date_iso_never_crashes_and_stays_valid(d, shift, keep_year):
     """ISO dates shift without crashing and always yield a valid calendar date."""
     iso = d.isoformat()  # YYYY-MM-DD

--- a/tests/unit/core/test_locale_coherence.py
+++ b/tests/unit/core/test_locale_coherence.py
@@ -25,10 +25,12 @@ from faker.config import AVAILABLE_LOCALES
 from openmed.core.anonymizer import Anonymizer
 from openmed.core.anonymizer import locales as L
 from openmed.core.anonymizer.locales import (
+    CONCEPTUAL_LOCALE_LANGUAGES,
     FAKER_BACKEND_LOCALE,
     LANG_TO_LOCALE,
     NATIONAL_ID_PROVIDERS,
     locale_coherence_report,
+    resolve_faker_backend_locale,
     resolve_locale,
 )
 from openmed.core.anonymizer.registry import _LOCALE_ID_METHODS
@@ -37,6 +39,7 @@ from openmed.core.pii_entity_merger import PII_PATTERNS
 from openmed.core.pii_i18n import (
     INDIC_NER_LANGUAGES,
     LANGUAGE_PII_PATTERNS,
+    LOCALE_FAKE_DATA,
     NATIONAL_ID_ONLY_LANGUAGES,
     SUPPORTED_LANGUAGES,
 )
@@ -71,6 +74,14 @@ SAMPLE_SIZE = 40
 REPORT_LANGUAGES = (
     SUPPORTED_LANGUAGES | NATIONAL_ID_ONLY_LANGUAGES | INDIC_NER_LANGUAGES
 )
+
+CONCEPTUAL_BACKENDS = {
+    "fr_SN": "fr_FR",
+    "fr_CI": "fr_FR",
+    "fr_CM": "fr_FR",
+    "pt_MZ": "pt_PT",
+    "pt_AO": "pt_PT",
+}
 
 
 def _languages_with_national_id_validator():
@@ -131,6 +142,14 @@ class TestLocaleResolution:
         assert locale in AVAILABLE_LOCALES
         assert not caught
         assert "sw" not in L._APPROXIMATE_LOCALES
+
+    @pytest.mark.parametrize("locale", sorted(CONCEPTUAL_BACKENDS))
+    def test_conceptual_locale_resolves_to_installed_backend(self, locale):
+        language = CONCEPTUAL_LOCALE_LANGUAGES[locale]
+
+        assert resolve_locale(language, locale) == locale
+        assert resolve_faker_backend_locale(locale) == CONCEPTUAL_BACKENDS[locale]
+        assert CONCEPTUAL_BACKENDS[locale] in AVAILABLE_LOCALES
 
 
 class TestNationalIdRoundTrip:
@@ -227,11 +246,17 @@ class TestApproximateLocaleWarnings:
 class TestLocaleCoherenceReport:
     def test_one_row_per_supported_language(self):
         rows = locale_coherence_report()
-        assert len(rows) == len(REPORT_LANGUAGES)
-        assert {r["language"] for r in rows} == REPORT_LANGUAGES
+        default_rows = [row for row in rows if row["locale"] not in CONCEPTUAL_BACKENDS]
+
+        assert len(default_rows) == len(REPORT_LANGUAGES)
+        assert {r["language"] for r in default_rows} == REPORT_LANGUAGES
 
     def test_row_shape_and_values(self):
-        rows = {r["language"]: r for r in locale_coherence_report()}
+        rows = {
+            r["language"]: r
+            for r in locale_coherence_report()
+            if r["locale"] not in CONCEPTUAL_BACKENDS
+        }
         for lang, row in rows.items():
             assert set(row) == {
                 "language",
@@ -257,6 +282,161 @@ class TestLocaleCoherenceReport:
                 assert row["id_types"] == []
                 assert row["id_locale"] is None
 
+    def test_conceptual_rows_include_all_backends(self):
+        rows = {
+            row["locale"]: row
+            for row in locale_coherence_report()
+            if row["locale"] in CONCEPTUAL_BACKENDS
+        }
+
+        assert set(rows) == set(CONCEPTUAL_BACKENDS)
+        for locale, backend in CONCEPTUAL_BACKENDS.items():
+            row = rows[locale]
+            assert set(row) == {
+                "language",
+                "locale",
+                "approximate",
+                "id_providers",
+                "id_types",
+                "id_locale",
+            }
+            assert row["language"] == CONCEPTUAL_LOCALE_LANGUAGES[locale]
+            assert FAKER_BACKEND_LOCALE[locale] == backend
+            assert row["approximate"] is False
+            assert row["id_providers"] == []
+            assert row["id_types"] == []
+            assert row["id_locale"] is None
+
     def test_report_is_json_serializable(self):
         # The status/leaderboard work serializes this; keep it JSON-friendly.
         json.dumps(locale_coherence_report())
+
+
+class TestAfricanFrenchPortugueseSurrogates:
+    @pytest.mark.parametrize("locale", sorted(CONCEPTUAL_BACKENDS))
+    def test_curated_name_location_address_and_phone_surrogates(self, locale):
+        lang = CONCEPTUAL_LOCALE_LANGUAGES[locale]
+        anonymizer = Anonymizer(lang=lang, locale=locale, consistent=True, seed=866)
+
+        for label, key in (
+            ("NAME", "NAME"),
+            ("LOCATION", "LOCATION"),
+            ("STREET_ADDRESS", "STREET_ADDRESS"),
+            ("PHONE", "PHONE"),
+        ):
+            surrogate = anonymizer.surrogate(f"source-{key}", label)
+            assert surrogate in LOCALE_FAKE_DATA[locale][key]
+
+    def test_default_french_and_portuguese_outputs_are_unchanged(self):
+        expected = {
+            "fr": {
+                "NAME": "Vincent Da Silva",
+                "LOCATION": "Vaillant",
+                "STREET_ADDRESS": "35, chemin Ruiz",
+                "PHONE": "0558229502",
+            },
+            "pt": {
+                "NAME": "Samuel Amorim",
+                "LOCATION": "Vila Real",
+                "STREET_ADDRESS": "R. de Amorim, 64",
+                "PHONE": "(351) 929962295",
+            },
+        }
+        originals = {
+            "NAME": "Patient Exemple",
+            "LOCATION": "Ville Exemple",
+            "STREET_ADDRESS": "Adresse Exemple",
+            "PHONE": "contact",
+        }
+
+        for lang, values in expected.items():
+            anonymizer = Anonymizer(lang=lang, consistent=True, seed=866)
+            assert {
+                label: anonymizer.surrogate(originals[label], label) for label in values
+            } == values
+
+    @pytest.mark.parametrize(
+        ("lang", "locale", "text", "model_entities", "sweep_values"),
+        [
+            (
+                "fr",
+                "fr_SN",
+                "Patiente Aïssatou Ba, domiciliée au 9 rue de Rufisque, Dakar. "
+                "Téléphone: +221 77 123 45 67. CNI: 1002199012345.",
+                (
+                    ("Aïssatou Ba", "NAME"),
+                    ("9 rue de Rufisque, Dakar", "STREET_ADDRESS"),
+                ),
+                ("+221 77 123 45 67", "1002199012345"),
+            ),
+            (
+                "pt",
+                "pt_MZ",
+                "Paciente Lúcia Matola, residente na 7 Avenida Samora Machel, "
+                "Maputo. Telefone: +258 84 123 4567.",
+                (
+                    ("Lúcia Matola", "NAME"),
+                    ("7 Avenida Samora Machel, Maputo", "STREET_ADDRESS"),
+                ),
+                ("+258 84 123 4567",),
+            ),
+        ],
+    )
+    def test_synthetic_clinical_fixtures_have_zero_leakage(
+        self,
+        lang,
+        locale,
+        text,
+        model_entities,
+        sweep_values,
+    ):
+        from openmed.core.pii import (
+            _apply_safety_sweep_to_result,
+            _build_deidentification_result,
+        )
+        from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+        entities = []
+        for surface, label in model_entities:
+            start = text.index(surface)
+            entities.append(
+                EntityPrediction(
+                    text=surface,
+                    label=label,
+                    start=start,
+                    end=start + len(surface),
+                    confidence=0.99,
+                )
+            )
+        prediction = PredictionResult(
+            text=text,
+            entities=entities,
+            model_name="synthetic-fixture",
+            timestamp="2026-07-18T00:00:00Z",
+            metadata={"synthetic": True},
+        )
+
+        swept, added_count = _apply_safety_sweep_to_result(
+            text,
+            prediction,
+            lang=lang,
+            locale=locale,
+        )
+        result = _build_deidentification_result(
+            text,
+            swept,
+            effective_method="replace",
+            keep_year=False,
+            date_shift_days=None,
+            keep_mapping=False,
+            lang=lang,
+            consistent=True,
+            seed=866,
+            locale=locale,
+            use_safety_sweep=True,
+        )
+
+        protected_values = [surface for surface, _label in model_entities]
+        protected_values.extend(sweep_values)
+        assert added_count == len(sweep_values)
+        assert all(value not in result.deidentified_text for value in protected_values)

--- a/tests/unit/core/test_locale_formats.py
+++ b/tests/unit/core/test_locale_formats.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from openmed.core.locale_formats import (
@@ -13,7 +15,13 @@ from openmed.core.locale_formats import (
     normalize_number,
     parse_date,
 )
-from openmed.core.pii_i18n import NATIONAL_ID_ONLY_LANGUAGES, SUPPORTED_LANGUAGES
+from openmed.core.pii_i18n import (
+    AFRICAN_FR_PT_PHONE_PREFIXES,
+    LOCALE_PII_PATTERNS,
+    NATIONAL_ID_ONLY_LANGUAGES,
+    SUPPORTED_LANGUAGES,
+)
+from openmed.core.safety_sweep import safety_sweep
 
 
 def test_parse_date_respects_german_day_month_order() -> None:
@@ -102,3 +110,58 @@ def test_format_hint_returns_date_order_and_separators(lang: str) -> None:
     assert hint.date_order in {"dmy", "mdy", "ymd"}
     assert hint.decimal_separator
     assert hint.number.decimal_separators
+
+
+@pytest.mark.parametrize(
+    ("locale", "phone"),
+    [
+        ("fr_sn", "+221 77 642 18 35"),
+        ("fr_ci", "+225 07 48 26 15 39"),
+        ("fr_cm", "+237 6 71 24 83 59"),
+        ("pt_mz", "+258 84 362 7185"),
+        ("pt_ao", "+244 923 461 785"),
+    ],
+)
+def test_african_fr_pt_phone_formats_match_country_prefix(locale, phone) -> None:
+    phone_patterns = [
+        pattern
+        for pattern in LOCALE_PII_PATTERNS[locale]
+        if pattern.entity_type == "phone_number"
+    ]
+
+    assert phone.startswith(AFRICAN_FR_PT_PHONE_PREFIXES[locale])
+    assert any(
+        re.fullmatch(pattern.pattern, phone, pattern.flags)
+        for pattern in phone_patterns
+    )
+
+
+@pytest.mark.parametrize(
+    ("lang", "locale", "contextual_text", "bare_value"),
+    [
+        ("fr", "fr_SN", "CNI: 1002199012345", "1002199012345"),
+        ("pt", "pt_AO", "Bilhete de Identidade: 009523666HO041", "009523666HO041"),
+    ],
+)
+def test_context_only_national_id_formats_do_not_claim_a_validator(
+    lang,
+    locale,
+    contextual_text,
+    bare_value,
+) -> None:
+    detected = safety_sweep(contextual_text, [], lang=lang, locale=locale)
+    without_context = safety_sweep(bare_value, [], lang=lang, locale=locale)
+    matching_patterns = [
+        pattern
+        for pattern in LOCALE_PII_PATTERNS[locale.casefold()]
+        if pattern.entity_type == "national_id"
+        and re.fullmatch(pattern.pattern, bare_value, pattern.flags)
+    ]
+
+    assert [(span.text, span.label) for span in detected] == [
+        (bare_value, "national_id")
+    ]
+    assert without_context == []
+    assert matching_patterns
+    assert all(pattern.validator is None for pattern in matching_patterns)
+    assert all(pattern.safety_sweep_requires_context for pattern in matching_patterns)


### PR DESCRIPTION
## Description

Adds five conceptual African French and Portuguese locales backed by the existing French and Portuguese Faker providers, with curated in-country names, cities, street addresses, and phone surrogates. The locale overlays also recognize the five country calling codes plus context-gated Senegal CNI and Angola BI formats without claiming unavailable checksum validation.

Closes #1443.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement
- [x] Documentation

## Changes Made

- Registered `fr_SN`, `fr_CI`, `fr_CM`, `pt_MZ`, and `pt_AO` with `fr_FR` or `pt_PT` backends and exposed them in locale coherence reporting.
- Added curated surrogate supplements for names, locations, addresses, and phones while preserving the existing default French and Portuguese outputs.
- Added locale-specific +221, +225, +237, +258, and +244 phone recognition plus context-only Senegal CNI and Angola BI recognition.
- Added Maghrebi Arabic `ar-DZ` and `ar-MA` override behavior alongside the existing `ar_EG` default and documented fallback behavior for unavailable backends.
- Added backend, format, default-output, and zero-leakage regression coverage.
- Aligned the ISO date-shift fuzz property's timing allowance with the existing nightly profile after a Windows runner exceeded the tighter default deadline.

## Testing

- [x] `.venv/bin/python -m pytest tests/ -q` — 6,870 passed, 47 skipped
- [x] Focused locale suite — 277 passed
- [x] Date-shift fuzz suite under default and nightly profiles — 7 passed each
- [x] `make format`
- [x] `make lint`
- [x] `make format-check`
- [x] `make type-check`
- [x] `make docs-build`
- [x] Scoped pre-commit hooks
- [x] `git diff --check`

## Documentation

- [x] Updated public locale-resolution and coherence-report docstrings
- [x] Updated the anonymization and language guides
- [x] Added a changelog entry

## Dependencies

- [x] No new dependencies

## Related Issues

Closes #1443
