### PR TITLE
Add Africa data-residency deployment guide and attestation reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added PHI-free, hash-verifiable Africa data-residency attestations for audited
+  local de-identification runs, with data-driven jurisdiction wording, exact
+  policy and model provenance, conservative captured offline evidence, a public
+  JSON Schema, and an offline deployment and review guide (#1446).
 - Added an Igbo (`ig`) PII pack for Nigerian clinical text with NFC, NFD, and
   unmarked context support, native `ig_NG` surrogates, shared Nigerian NIN and
   phone patterns, and grapheme-safe replacement of dot-below names (#1441).

--- a/docs/compliance/africa-data-residency-guide.md
+++ b/docs/compliance/africa-data-residency-guide.md
@@ -1,0 +1,224 @@
+# Africa Data-Residency Deployment Guide
+
+This guide is decision-support material, not legal advice, a regulator filing,
+or a certification of compliance. Data-residency outcomes depend on the entire
+system: intake, backups, logs, model delivery, support tooling, exports, and
+operator access—not only the OpenMed process. Confirm the current rules and the
+deployment design with local counsel and the responsible privacy authority.
+
+OpenMed de-identification runs in the application process. The attestation API
+records PHI-free evidence about that run: policy name and posture, local model
+artifact paths and content checksums, captured offline flags, host-local
+execution wording, counts, timestamps, and hashes. It never copies source text,
+de-identified text, detected identifiers, surrogates, or reversible mappings.
+
+## Choose a deployment pattern
+
+### Air-gapped host
+
+Use a host with no physical or logical route to an external network. Transfer
+the OpenMed wheel, its locked dependencies, model artifacts, policy files, and
+checksums through an approved removable-media process. Store the original
+checksums outside the air gap and compare them after transfer. Keep input,
+output, audit, and attestation artifacts on storage governed by the same local
+retention and access controls.
+
+This is the strongest no-egress pattern, but the OpenMed assertion is only one
+piece of evidence. Network diagrams, firewall configuration, removable-media
+logs, backup destinations, and access records remain necessary.
+
+### Network-isolated clinical subnet
+
+Place processing hosts and local model storage in a subnet with deny-by-default
+egress. Permit only explicitly reviewed internal routes, such as a local package
+mirror or records system, and document whether those routes cross a national
+boundary. Preload models before the production window, then remove temporary
+download access. Test DNS, proxy, IPv4, IPv6, and direct-IP paths at the network
+control layer.
+
+### Managed on-device application
+
+Bundle or provision model artifacts to a managed workstation or mobile device,
+enable OpenMed local-only mode, and use device-management controls to block
+unapproved data sharing, cloud backup, diagnostics, and support collection.
+Record the model checksum and app release with each attestation. Treat OS crash
+reports, keyboard services, clipboard synchronization, and third-party SDKs as
+separate potential transfer paths.
+
+## Verify no-network operation
+
+1. Pre-download every model and dependency into an approved local path. Record
+   each model artifact checksum before the production run.
+2. Set `OPENMED_OFFLINE=1`. OpenMed also enables `HF_HUB_OFFLINE`,
+   `TRANSFORMERS_OFFLINE`, and `HF_DATASETS_OFFLINE` for cache-only dependency
+   behavior.
+3. Construct `OpenMedConfig(local_only=True)` for an explicit application-level
+   assertion. OpenMed requests its outbound socket guard during guarded model
+   operations when local-only mode is active.
+4. Enforce no egress outside the Python process as well: firewall or sandbox the
+   host, disable unapproved proxies and DNS, and monitor attempted connections.
+5. Run a synthetic canary with the network controls enabled. Confirm the model
+   loads from the approved local path and a forced remote model reference fails
+   closed.
+6. Generate the attestation immediately after the audited run. Require
+   `execution.offline_assertion.asserted` to be `true`; if it is `false`, keep
+   the artifact as host-local evidence but do not describe it as verified
+   no-egress evidence.
+7. Validate the attestation against OpenMed's bundled `attestation` JSON Schema
+   and retain both the JSON and Markdown forms with the firewall, image, and
+   deployment evidence.
+
+The offline assertion proves only that OpenMed local-only mode and the bundled
+dependency flags were captured together. It does not prove firewall state,
+physical location, absence of other processes, or the behavior of the wider
+application.
+
+## Generate an attestation through Python
+
+The feature extends the audit-report API; it does not add a CLI subcommand.
+
+```python
+from datetime import datetime, timezone
+from pathlib import Path
+
+from openmed import OpenMedConfig, deidentify
+
+config = OpenMedConfig(local_only=True)
+audit = deidentify(
+    "Synthetic patient Example Person, record TEST-0001.",
+    policy="strict_no_leak",
+    config=config,
+    audit=True,
+)
+attestation = audit.attest(
+    "rwanda-law-058-2021",
+    model_artifacts={"pii-model": "/opt/openmed/models/pii"},
+    generated_at=datetime.now(timezone.utc),
+)
+
+Path("attestation.json").write_text(attestation.to_json(indent=2), encoding="utf-8")
+Path("attestation.md").write_text(attestation.to_markdown(), encoding="utf-8")
+assert attestation.repro_hash_matches()
+assert attestation.integrity_hash_matches()
+```
+
+The jurisdiction profile requires the audit's `strict_no_leak` policy. The
+generator loads that bundled policy and records its exact canonical name,
+posture, schema version, and default action. A missing policy, an invalid policy,
+or a policy that does not match the jurisdiction profile fails with a clear
+error. Model paths must exist; files and directory contents are hashed locally.
+
+The `repro_hash` is stable for the same audit, template, offline evidence, and
+model contents, even when `generated_at` changes. The `integrity_hash` covers the
+full JSON payload, including the timestamp. These are SHA-256 integrity hashes,
+not digital signatures or regulator-issued seals.
+
+## Rwanda
+
+- Attestation profile: `rwanda-law-058-2021`
+- Policy profile: `strict_no_leak`
+- Template field: `residency_statement`
+
+[Rwanda Law No. 058/2021](https://dpo.gov.rw/fileadmin/DPO/Law_relating_to_the_protection_of_personal_data_and_privacy.pdf)
+addresses transfers outside Rwanda in Articles 48-49. Article 50 provides for
+storage in Rwanda and a registration-certificate route for storage outside the
+country. A host-local, offline deployment can reduce transfer and offshore
+storage paths, but the attestation does not establish where backups, upstream
+systems, or downstream exports reside.
+
+Decision questions:
+
+- Are the processing host, input store, output store, logs, and backups all in
+  Rwanda?
+- Does any operator, support tool, model fetch, or synchronization service make
+  the data available outside Rwanda?
+- If any offshore storage remains, has the organization obtained and retained
+  the required authorization evidence?
+
+## Ethiopia
+
+- Attestation profile: `ethiopia-proclamation-1321-2024`
+- Policy profile: `strict_no_leak`
+- Template field: `residency_statement`
+
+[Ethiopia's Personal Data Protection Proclamation No. 1321/2024](https://pdp.eca.et/files/pdfs/pdp-proclamation/pdp_personal_data_protection_proclamation_No_1321_2024.pdf)
+sets cross-border transfer conditions in Articles 18-21. Article 22 requires
+personal data collected or obtained locally to be stored on a server or in a
+data center located in Ethiopia, permits the Authority to designate critical
+personal-data categories for local-only processing, and requires prior Authority
+approval for cross-border transfer of sensitive personal data; the definition
+of sensitive data includes physical or mental health information. The
+attestation can support a finding that a particular de-identification run stayed
+host-local, but it is not Authority approval.
+
+Decision questions:
+
+- Does the workflow handle health, biometric, genetic, or other sensitive
+  personal data before de-identification?
+- Has the Authority designated this processing category for an Ethiopia-located
+  server or data center?
+- Is any cross-border access or transfer proposed, and if so, is prior approval
+  required and documented?
+
+## Kenya
+
+- Attestation profile: `kenya-dpa-2019`
+- Policy profile: `strict_no_leak`
+- Template field: `residency_statement`
+
+[Kenya's Data Protection Act No. 24 of 2019](https://new.kenyalaw.org/akn/ke/act/2019/24/eng@2022-12-31)
+sets transfer conditions and safeguard duties in sections 48-49. Section 49
+addresses consent and appropriate safeguards for sensitive personal data, while
+section 50 allows prescribed processing categories to be limited to a server or
+data center in Kenya. Regulation 26 of the
+[Data Protection (General) Regulations, 2021](https://new.kenyalaw.org/akn/ke/act/ln/2021/263/eng@2022-01-14)
+applies that local-processing or serving-copy rule to specified state interests,
+including primary or secondary health care. Host-local operation is useful
+evidence, but the organization must still determine whether a transfer occurs
+and which category or condition applies.
+
+Decision questions:
+
+- Can the organization prove appropriate safeguards for every transfer path?
+- Is valid data-subject consent and confirmation of safeguards required for the
+  sensitive-data flow?
+- Has a section 50 prescription or sector-specific rule made local processing
+  mandatory for this workload?
+
+## Egypt
+
+- Attestation profile: `egypt-pdpl-151-2020`
+- Policy profile: `strict_no_leak`
+- Template field: `residency_statement`
+
+Egypt enacted [Personal Data Protection Law No. 151 of 2020][egypt-pdpl].
+An [English reference translation](https://eg.andersen.com/wp-content/uploads/2025/06/Law-No.-151-OF-2020.pdf)
+describes licensing or authorization conditions for cross-border transfer,
+storage, sharing, or processing in Articles 14-16. A local deployment can avoid
+those paths for the recorded run, but the attestation is not a licence, permit,
+adequacy decision, or substitute for checking current implementing regulations.
+
+[egypt-pdpl]: https://sis.gov.eg/ar/%D8%A7%D9%84%D8%B1%D8%A6%D8%A7%D8%B3%D8%A9/%D8%B4%D8%A6%D9%88%D9%86-%D8%AF%D8%A7%D8%AE%D9%84%D9%8A%D8%A9/%D8%A7%D9%84%D9%82%D8%B1%D8%A7%D8%B1%D8%A7%D8%AA-%D8%A7%D9%84%D8%B1%D8%A6%D8%A7%D8%B3%D9%8A%D8%A9/%D8%A7%D9%84%D8%B1%D8%A6%D9%8A%D8%B3-%D8%A7%D9%84%D8%B3%D9%8A%D8%B3%D9%89%D9%8A-%D9%8A-%D8%B5%D8%AF-%D9%82-%D8%B9%D9%84%D9%89-%D9%82%D8%A7%D9%86%D9%88%D9%86-%D8%AD%D9%85%D8%A7%D9%8A%D8%A9-%D8%A7%D9%84%D8%A8%D9%8A%D8%A7%D9%86%D8%A7%D8%AA-%D8%A7%D9%84%D8%B4%D8%AE%D8%B5%D9%8A%D8%A9/
+
+Decision questions:
+
+- Do model delivery, backups, support, analytics, or remote administration make
+  personal data available outside Egypt?
+- Does the workflow require a processing, sensitive-data, or cross-border
+  licence or authorization even if the core inference is local?
+- Have current executive regulations and Personal Data Protection Center
+  procedures been checked for this deployment?
+
+## Review and retention checklist
+
+- Validate the JSON against the bundled attestation schema.
+- Verify `repro_hash_matches()` and `integrity_hash_matches()` after copying or
+  archiving the artifact.
+- Compare model checksums with the approved deployment manifest.
+- Confirm the exact policy name and posture match the approved privacy design.
+- Attach firewall, network, device-management, physical-location, backup, and
+  access-control evidence; the attestation does not replace them.
+- Keep raw documents and reversible mappings out of the attestation package.
+- Record counsel or privacy-officer review separately using the
+  [attestation review template](templates/africa-data-residency-attestation.md).
+- Reassess after model, policy, template, network, storage, or legal changes.

--- a/docs/compliance/templates/africa-data-residency-attestation.json
+++ b/docs/compliance/templates/africa-data-residency-attestation.json
@@ -1,0 +1,63 @@
+{
+  "template_version": 1,
+  "template_id": "africa-data-residency",
+  "disclaimer": "Decision-support evidence only; this attestation is not legal advice, a regulator filing, or a certification of compliance.",
+  "profiles": [
+    {
+      "id": "rwanda-law-058-2021",
+      "jurisdiction": "Rwanda",
+      "country_code": "RW",
+      "legal_reference": "Law No. 058/2021, Articles 48-50",
+      "source_url": "https://dpo.gov.rw/fileadmin/DPO/Law_relating_to_the_protection_of_personal_data_and_privacy.pdf",
+      "policy_profile": "strict_no_leak",
+      "attestation_title": "Rwanda host-local processing attestation",
+      "residency_statement": "This artifact records host-local de-identification evidence that an organization can use when assessing Rwanda's rules for transfers and storage outside Rwanda. It does not establish whether every system in the organization's wider data flow stores personal data in Rwanda.",
+      "host_local_statement": "OpenMed reports that the de-identification computation ran in-process on the host. The attestation does not name the host and contains no source document content.",
+      "offline_enabled_statement": "The captured run evidence records OpenMed local-only mode and all bundled dependency offline flags as enabled. Confirm operating-system and network controls separately.",
+      "offline_disabled_statement": "The captured run evidence does not contain a complete OpenMed offline assertion. Treat the artifact as host-local processing evidence, not proof of an air-gapped or no-egress deployment.",
+      "guide_field": "residency_statement"
+    },
+    {
+      "id": "ethiopia-proclamation-1321-2024",
+      "jurisdiction": "Ethiopia",
+      "country_code": "ET",
+      "legal_reference": "Personal Data Protection Proclamation No. 1321/2024, Articles 18-22",
+      "source_url": "https://pdp.eca.et/files/pdfs/pdp-proclamation/pdp_personal_data_protection_proclamation_No_1321_2024.pdf",
+      "policy_profile": "strict_no_leak",
+      "attestation_title": "Ethiopia host-local processing attestation",
+      "residency_statement": "This artifact records host-local de-identification evidence that an organization can use when assessing Ethiopia's local-storage and cross-border transfer rules, including the local-server requirement for personal data collected or obtained locally and prior approval for cross-border transfer of sensitive personal data. It does not replace an Authority determination or approval.",
+      "host_local_statement": "OpenMed reports that the de-identification computation ran in-process on the host. The attestation does not name the host and contains no source document content.",
+      "offline_enabled_statement": "The captured run evidence records OpenMed local-only mode and all bundled dependency offline flags as enabled. Confirm operating-system and network controls separately.",
+      "offline_disabled_statement": "The captured run evidence does not contain a complete OpenMed offline assertion. Treat the artifact as host-local processing evidence, not proof of an air-gapped or no-egress deployment.",
+      "guide_field": "residency_statement"
+    },
+    {
+      "id": "kenya-dpa-2019",
+      "jurisdiction": "Kenya",
+      "country_code": "KE",
+      "legal_reference": "Data Protection Act No. 24 of 2019, sections 48-50",
+      "source_url": "https://new.kenyalaw.org/akn/ke/act/2019/24/eng@2022-12-31",
+      "policy_profile": "strict_no_leak",
+      "attestation_title": "Kenya host-local processing attestation",
+      "residency_statement": "This artifact records host-local de-identification evidence that an organization can use when assessing Kenya's safeguards, consent, and prescribed-local-processing requirements for transfers outside Kenya. It does not determine whether a transfer exception or prescribed category applies.",
+      "host_local_statement": "OpenMed reports that the de-identification computation ran in-process on the host. The attestation does not name the host and contains no source document content.",
+      "offline_enabled_statement": "The captured run evidence records OpenMed local-only mode and all bundled dependency offline flags as enabled. Confirm operating-system and network controls separately.",
+      "offline_disabled_statement": "The captured run evidence does not contain a complete OpenMed offline assertion. Treat the artifact as host-local processing evidence, not proof of an air-gapped or no-egress deployment.",
+      "guide_field": "residency_statement"
+    },
+    {
+      "id": "egypt-pdpl-151-2020",
+      "jurisdiction": "Egypt",
+      "country_code": "EG",
+      "legal_reference": "Personal Data Protection Law No. 151 of 2020, Articles 14-16",
+      "source_url": "https://sis.gov.eg/ar/%D8%A7%D9%84%D8%B1%D8%A6%D8%A7%D8%B3%D8%A9/%D8%B4%D8%A6%D9%88%D9%86-%D8%AF%D8%A7%D8%AE%D9%84%D9%8A%D8%A9/%D8%A7%D9%84%D9%82%D8%B1%D8%A7%D8%B1%D8%A7%D8%AA-%D8%A7%D9%84%D8%B1%D8%A6%D8%A7%D8%B3%D9%8A%D8%A9/%D8%A7%D9%84%D8%B1%D8%A6%D9%8A%D8%B3-%D8%A7%D9%84%D8%B3%D9%8A%D8%B3%D9%89%D9%8A-%D9%8A-%D8%B5%D8%AF-%D9%82-%D8%B9%D9%84%D9%89-%D9%82%D8%A7%D9%86%D9%88%D9%86-%D8%AD%D9%85%D8%A7%D9%8A%D8%A9-%D8%A7%D9%84%D8%A8%D9%8A%D8%A7%D9%86%D8%A7%D8%AA-%D8%A7%D9%84%D8%B4%D8%AE%D8%B5%D9%8A%D8%A9/",
+      "policy_profile": "strict_no_leak",
+      "attestation_title": "Egypt host-local processing attestation",
+      "residency_statement": "This artifact records host-local de-identification evidence that an organization can use when assessing Egypt's licensing or authorization rules for cross-border transfer, storage, sharing, or processing. It is not a licence, permit, or adequacy decision from the Personal Data Protection Center.",
+      "host_local_statement": "OpenMed reports that the de-identification computation ran in-process on the host. The attestation does not name the host and contains no source document content.",
+      "offline_enabled_statement": "The captured run evidence records OpenMed local-only mode and all bundled dependency offline flags as enabled. Confirm operating-system and network controls separately.",
+      "offline_disabled_statement": "The captured run evidence does not contain a complete OpenMed offline assertion. Treat the artifact as host-local processing evidence, not proof of an air-gapped or no-egress deployment.",
+      "guide_field": "residency_statement"
+    }
+  ]
+}

--- a/docs/compliance/templates/africa-data-residency-attestation.md
+++ b/docs/compliance/templates/africa-data-residency-attestation.md
@@ -1,0 +1,60 @@
+# Africa Data-Residency Attestation Review Template
+
+This template is decision-support material, not legal advice, a regulator
+filing, or a certification of compliance. Do not paste raw PHI, PII, source
+document text, de-identified document text, identifiers, surrogates, or
+reversible mappings into this record. Use hashes, counts, controlled-system
+references, and synthetic examples.
+
+The runtime wording source is the checked-in
+`africa-data-residency-attestation.json` data template. Keep any approved local
+wording override as a controlled JSON file and record its checksum below.
+
+## Artifact record
+
+- Review ID:
+- Jurisdiction:
+- Attestation profile:
+- JSON artifact controlled-system reference:
+- Markdown artifact controlled-system reference:
+- Attestation template ID, version, and hash:
+- Attestation repro hash:
+- Attestation integrity hash:
+- Audit repro hash:
+- Generated timestamp and time zone:
+- Reviewer:
+- Privacy officer or counsel:
+- Review date:
+
+## Deployment evidence
+
+- Processing-device physical location:
+- Model artifact paths and approved checksums:
+- OpenMed policy name and posture:
+- OpenMed offline assertion result:
+- Firewall or sandbox evidence reference:
+- DNS, proxy, IPv4, IPv6, and direct-IP test evidence:
+- Backup destination evidence:
+- Remote administration and support path evidence:
+- Device-management policy evidence:
+- Package and model transfer log:
+
+## Decision-support assessment
+
+- Applicable law and sections reviewed:
+- Current regulations or authority guidance reviewed:
+- Whether any cross-border transfer, storage, access, or disclosure occurs:
+- Whether authorization, consent, safeguards, a licence, or a permit is needed:
+- Evidence supporting that conclusion:
+- Known gaps or assumptions:
+- Required remediation:
+- Approval owner:
+- Reassessment trigger and date:
+
+## Sign-off
+
+- Technical reviewer decision:
+- Privacy or legal decision:
+- Conditions or limitations:
+- Approval reference:
+- Retention location and period:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,8 @@ nav:
       - HL7 v2 De-identification: hl7v2-deidentification.md
       - Compliance Posture: compliance.md
       - Egypt PDPL & Morocco Law 09-08: compliance/north-africa-pdpl-0908-checklist.md
+      - Africa Data-Residency Guide: compliance/africa-data-residency-guide.md
+      - Africa Attestation Review Template: compliance/templates/africa-data-residency-attestation.md
       - HIPAA Safe Harbor Attestation: compliance/hipaa-safe-harbor-attestation.md
       - Breach Notification Runbook: compliance/breach-notification-runbook.md
       - Breach Report Template: compliance/templates/breach-report-template.md

--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -17,6 +17,13 @@ from .core.anonymizer import (
     register_clinical_provider,
     register_label_generator,
 )
+from .core.attestation import (
+    AttestationReport,
+    AttestationTemplateError,
+    generate_attestation,
+    list_attestation_profiles,
+    load_attestation_template,
+)
 from .core.audit import AuditReport, AuditSignature, AuditSpan, DetectorInfo
 from .core.custom_recognizer import CustomRecognizer
 from .core.explain import ExplainReport, explain
@@ -731,6 +738,11 @@ __all__ = [
     "reidentify",
     "PIIEntity",
     "DeidentificationResult",
+    "AttestationReport",
+    "AttestationTemplateError",
+    "generate_attestation",
+    "list_attestation_profiles",
+    "load_attestation_template",
     "CustomRecognizer",
     "StreamingBufferError",
     "StreamingDeidentificationEvent",

--- a/openmed/core/attestation.py
+++ b/openmed/core/attestation.py
@@ -1,0 +1,521 @@
+"""PHI-free, template-driven data-residency attestations."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from .audit import AuditReport, stable_hash
+from .offline import (
+    HF_OFFLINE_ENV_VARS,
+    OFFLINE_ENV_VAR,
+)
+from .policy import load_policy
+
+ATTESTATION_SCHEMA_VERSION = 1
+DEFAULT_ATTESTATION_TEMPLATE = "africa-data-residency.json"
+_TEMPLATE_PACKAGE = "openmed.core.attestation_templates"
+_TEMPLATE_FIELDS = (
+    "id",
+    "jurisdiction",
+    "country_code",
+    "legal_reference",
+    "source_url",
+    "policy_profile",
+    "attestation_title",
+    "residency_statement",
+    "host_local_statement",
+    "offline_enabled_statement",
+    "offline_disabled_statement",
+    "guide_field",
+)
+
+
+class AttestationTemplateError(ValueError):
+    """Raised when an attestation wording template is invalid."""
+
+
+@dataclass(frozen=True)
+class AttestationReport:
+    """Machine-readable attestation with a human-readable Markdown renderer."""
+
+    _data: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "_data", copy.deepcopy(dict(self._data)))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return an isolated JSON-compatible attestation payload."""
+
+        return copy.deepcopy(dict(self._data))
+
+    def to_json(self, *, indent: int | None = None) -> str:
+        """Serialize the attestation as deterministic JSON."""
+
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=indent,
+            separators=(",", ":") if indent is None else None,
+            sort_keys=True,
+        )
+
+    def to_markdown(self) -> str:
+        """Render the attestation as PHI-free Markdown."""
+
+        payload = self.to_dict()
+        jurisdiction = payload["jurisdiction"]
+        policy = payload["policy"]
+        execution = payload["execution"]
+        run = payload["run"]
+        lines = [
+            f"# {jurisdiction['attestation_title']}",
+            "",
+            f"> {payload['disclaimer']}",
+            "",
+            "## Jurisdiction decision support",
+            "",
+            f"- Jurisdiction: {jurisdiction['name']} ({jurisdiction['country_code']})",
+            f"- Legal reference: {jurisdiction['legal_reference']}",
+            f"- Attestation profile: `{payload['profile_id']}`",
+            f"- Template field: `{jurisdiction['guide_field']}`",
+            "",
+            jurisdiction["residency_statement"],
+            "",
+            "## Recorded execution posture",
+            "",
+            execution["host_local_statement"],
+            "",
+            execution["offline_statement"],
+            "",
+            f"- Generated at: `{payload['generated_at']}`",
+            f"- Host-local execution: `{str(execution['host_local']).lower()}`",
+            "- Offline assertion: "
+            f"`{str(execution['offline_assertion']['asserted']).lower()}`",
+            f"- Offline assertion source: `{execution['offline_assertion']['source']}`",
+            "",
+            "## Policy",
+            "",
+            f"- Name: `{policy['name']}`",
+            f"- Posture: `{policy['posture']}`",
+            f"- Policy schema version: `{policy['schema_version']}`",
+            f"- Default action: `{policy['default_action']}`",
+            "",
+            "## Model artifacts",
+            "",
+            "| Name | Path | Content checksum | Kind | Files |",
+            "|---|---|---|---|---:|",
+        ]
+        for model in payload["models"]:
+            lines.append(
+                "| "
+                + " | ".join(
+                    _markdown_cell(model[field])
+                    for field in ("name", "path", "checksum", "kind", "file_count")
+                )
+                + " |"
+            )
+        lines.extend(
+            [
+                "",
+                "## PHI-free run evidence",
+                "",
+                f"- Document length: `{run['document_length']}`",
+                f"- Redacted span count: `{run['span_count']}`",
+                f"- Input hash: `{run['input_hash']}`",
+                f"- De-identified output hash: `{run['deidentified_text_hash']}`",
+                f"- Audit repro hash: `{run['audit_repro_hash']}`",
+                f"- Model manifest hash: `{run['manifest_hash']}`",
+                f"- Attestation repro hash: `{payload['repro_hash']}`",
+                f"- Attestation integrity hash: `{payload['integrity_hash']}`",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+    def integrity_hash_matches(self) -> bool:
+        """Return whether the full payload matches its integrity hash."""
+
+        payload = self.to_dict()
+        expected = payload.pop("integrity_hash", "")
+        return expected == stable_hash(payload)
+
+    def repro_hash_matches(self) -> bool:
+        """Return whether stable run evidence matches its repro hash."""
+
+        payload = self.to_dict()
+        expected = payload.pop("repro_hash", "")
+        payload.pop("integrity_hash", None)
+        payload.pop("generated_at", None)
+        return expected == stable_hash(payload)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AttestationReport":
+        """Restore an attestation payload for offline integrity checks."""
+
+        return cls(data)
+
+    @classmethod
+    def from_json(cls, data: str | bytes) -> "AttestationReport":
+        """Restore an attestation from a JSON object."""
+
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON for AttestationReport: {exc}") from exc
+        if not isinstance(payload, Mapping):
+            raise ValueError("AttestationReport JSON must contain an object")
+        return cls(payload)
+
+
+def load_attestation_template(path: str | Path | None = None) -> dict[str, Any]:
+    """Load and validate a jurisdiction wording template."""
+
+    if path is None:
+        resource = resources.files(_TEMPLATE_PACKAGE).joinpath(
+            DEFAULT_ATTESTATION_TEMPLATE
+        )
+        with resource.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        source = str(resource)
+    else:
+        source_path = Path(path)
+        try:
+            payload = json.loads(source_path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            raise AttestationTemplateError(
+                f"Could not read attestation template {source_path}: {exc}"
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise AttestationTemplateError(
+                f"Invalid JSON in attestation template {source_path}: {exc}"
+            ) from exc
+        source = str(source_path)
+    return _validate_template(payload, source=source)
+
+
+def list_attestation_profiles(
+    template_path: str | Path | None = None,
+) -> tuple[str, ...]:
+    """Return the profile identifiers in a validated template."""
+
+    template = load_attestation_template(template_path)
+    return tuple(str(profile["id"]) for profile in template["profiles"])
+
+
+def generate_attestation(
+    audit_report: AuditReport,
+    profile: str,
+    *,
+    model_artifacts: Mapping[str, str | Path],
+    generated_at: datetime | str | None = None,
+    template_path: str | Path | None = None,
+) -> AttestationReport:
+    """Generate JSON and Markdown residency evidence for an audit report.
+
+    Raw source text, redacted text, span text, surrogates, and mappings are not
+    copied. The output contains only hashes, counts, policy metadata, offline
+    posture metadata, jurisdiction wording, and model artifact provenance.
+    """
+
+    if not isinstance(audit_report, AuditReport):
+        raise TypeError("audit_report must be an AuditReport")
+    if not audit_report.repro_hash_matches():
+        raise ValueError(
+            "Audit report repro hash does not match its canonical PHI-free payload"
+        )
+    template = load_attestation_template(template_path)
+    jurisdiction_profile = _profile(template, profile)
+    try:
+        policy = load_policy(audit_report.policy)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"Attestation policy profile {audit_report.policy!r} could not be loaded: "
+            f"{exc}"
+        ) from exc
+    expected_policy = jurisdiction_profile["policy_profile"]
+    if policy.name != expected_policy:
+        raise ValueError(
+            f"Attestation profile {profile!r} requires policy {expected_policy!r}; "
+            f"the audit report records {policy.name!r}"
+        )
+
+    offline = _safe_offline_assertion(
+        audit_report.resolved_profile.get("offline_assertion")
+    )
+    offline_statement_key = (
+        "offline_enabled_statement"
+        if offline["asserted"]
+        else "offline_disabled_statement"
+    )
+    models = _model_artifact_records(model_artifacts)
+    payload: dict[str, Any] = {
+        "schema_version": ATTESTATION_SCHEMA_VERSION,
+        "template": {
+            "id": template["template_id"],
+            "version": template["template_version"],
+            "hash": stable_hash(template),
+        },
+        "profile_id": jurisdiction_profile["id"],
+        "generated_at": _iso_timestamp(generated_at),
+        "disclaimer": template["disclaimer"],
+        "jurisdiction": {
+            "name": jurisdiction_profile["jurisdiction"],
+            "country_code": jurisdiction_profile["country_code"],
+            "legal_reference": jurisdiction_profile["legal_reference"],
+            "source_url": jurisdiction_profile["source_url"],
+            "attestation_title": jurisdiction_profile["attestation_title"],
+            "residency_statement": jurisdiction_profile["residency_statement"],
+            "guide_field": jurisdiction_profile["guide_field"],
+        },
+        "policy": {
+            "name": policy.name,
+            "posture": policy.posture,
+            "schema_version": policy.schema_version,
+            "default_action": policy.default_action,
+        },
+        "execution": {
+            "host_local": True,
+            "host_local_statement": jurisdiction_profile["host_local_statement"],
+            "offline_statement": jurisdiction_profile[offline_statement_key],
+            "offline_assertion": offline,
+        },
+        "models": models,
+        "run": {
+            "document_length": audit_report.document_length,
+            "span_count": len(audit_report.spans),
+            "input_hash": audit_report.input_hash,
+            "deidentified_text_hash": audit_report.deidentified_text_hash,
+            "audit_repro_hash": audit_report.repro_hash,
+            "manifest_hash": audit_report.manifest_hash,
+            "openmed_version": audit_report.openmed_version,
+        },
+    }
+    repro_payload = copy.deepcopy(payload)
+    repro_payload.pop("generated_at")
+    payload["repro_hash"] = stable_hash(repro_payload)
+    payload["integrity_hash"] = stable_hash(payload)
+    return AttestationReport(payload)
+
+
+def _validate_template(payload: Any, *, source: str) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise AttestationTemplateError(
+            f"Attestation template {source} must be an object"
+        )
+    template = copy.deepcopy(dict(payload))
+    if template.get("template_version") != ATTESTATION_SCHEMA_VERSION:
+        raise AttestationTemplateError(
+            f"Attestation template {source} must use template_version "
+            f"{ATTESTATION_SCHEMA_VERSION}"
+        )
+    for field in ("template_id", "disclaimer"):
+        if not isinstance(template.get(field), str) or not template[field].strip():
+            raise AttestationTemplateError(
+                f"Attestation template {source} field {field!r} must be non-empty"
+            )
+    disclaimer = template["disclaimer"].lower()
+    if "decision-support" not in disclaimer or "not legal advice" not in disclaimer:
+        raise AttestationTemplateError(
+            f"Attestation template {source} disclaimer must state decision-support "
+            "and not legal advice"
+        )
+    profiles = template.get("profiles")
+    if not isinstance(profiles, list) or not profiles:
+        raise AttestationTemplateError(
+            f"Attestation template {source} profiles must be a non-empty list"
+        )
+    identifiers: set[str] = set()
+    for index, profile in enumerate(profiles):
+        if not isinstance(profile, Mapping):
+            raise AttestationTemplateError(
+                f"Attestation template {source} profile {index} must be an object"
+            )
+        for field in _TEMPLATE_FIELDS:
+            value = profile.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise AttestationTemplateError(
+                    f"Attestation template {source} profile {index} field "
+                    f"{field!r} must be non-empty"
+                )
+        identifier = str(profile["id"])
+        if identifier in identifiers:
+            raise AttestationTemplateError(
+                f"Attestation template {source} repeats profile {identifier!r}"
+            )
+        identifiers.add(identifier)
+        try:
+            loaded = load_policy(str(profile["policy_profile"]))
+        except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise AttestationTemplateError(
+                f"Attestation template {source} profile {identifier!r} names an "
+                f"invalid policy: {exc}"
+            ) from exc
+        if loaded.name != profile["policy_profile"]:
+            raise AttestationTemplateError(
+                f"Attestation template {source} profile {identifier!r} must use "
+                f"canonical policy name {loaded.name!r}"
+            )
+    return template
+
+
+def _profile(template: Mapping[str, Any], identifier: str) -> dict[str, str]:
+    for profile in template["profiles"]:
+        if profile["id"] == identifier:
+            return dict(profile)
+    available = ", ".join(str(item["id"]) for item in template["profiles"])
+    raise ValueError(
+        f"Unknown attestation profile {identifier!r}; available profiles: {available}"
+    )
+
+
+def _safe_offline_assertion(value: Any) -> dict[str, Any]:
+    # Attest only to evidence captured with the audited run. Falling back to
+    # the environment at attestation-generation time could incorrectly upgrade
+    # a legacy or incomplete audit report to an offline run.
+    source = value if isinstance(value, Mapping) else {}
+    environment = source.get("environment_flags")
+    environment_flags = environment if isinstance(environment, Mapping) else {}
+    allowed_flags = (OFFLINE_ENV_VAR, *HF_OFFLINE_ENV_VARS)
+    normalized_flags = {
+        name: bool(environment_flags.get(name, False)) for name in allowed_flags
+    }
+    source_name = str(source.get("source", "none"))
+    if source_name not in {"none", "config", "environment", "config+environment"}:
+        source_name = "none"
+    raw_local_only = bool(source.get("local_only", False))
+    source_is_consistent = (
+        (source_name == "config" and raw_local_only)
+        or (
+            source_name == "environment"
+            and raw_local_only
+            and normalized_flags[OFFLINE_ENV_VAR]
+        )
+        or (
+            source_name == "config+environment"
+            and raw_local_only
+            and normalized_flags[OFFLINE_ENV_VAR]
+        )
+    )
+    if not source_is_consistent:
+        source_name = "none"
+    local_only = bool(raw_local_only and source_name != "none")
+    network_guard_requested = bool(
+        source.get("network_guard_requested", False) and local_only
+    )
+    dependency_flags_enabled = all(
+        normalized_flags[name] for name in HF_OFFLINE_ENV_VARS
+    )
+    asserted = bool(
+        source.get("asserted", False)
+        and local_only
+        and network_guard_requested
+        and dependency_flags_enabled
+    )
+    return {
+        "asserted": asserted,
+        "local_only": local_only,
+        "source": source_name,
+        "network_guard_requested": network_guard_requested,
+        "dependency_flags_enabled": dependency_flags_enabled,
+        "environment_flags": normalized_flags,
+    }
+
+
+def _model_artifact_records(
+    model_artifacts: Mapping[str, str | Path],
+) -> list[dict[str, Any]]:
+    if not isinstance(model_artifacts, Mapping) or not model_artifacts:
+        raise ValueError("model_artifacts must be a non-empty mapping")
+    records: list[dict[str, Any]] = []
+    for name, raw_path in sorted(
+        model_artifacts.items(), key=lambda item: str(item[0])
+    ):
+        model_name = str(name).strip()
+        if not model_name:
+            raise ValueError("model_artifacts names must be non-empty")
+        path = Path(raw_path).expanduser()
+        try:
+            resolved = path.resolve(strict=True)
+        except OSError as exc:
+            raise ValueError(
+                f"Model artifact {model_name!r} does not exist at {path}"
+            ) from exc
+        checksum, kind, file_count = _hash_artifact(resolved)
+        records.append(
+            {
+                "name": model_name,
+                "path": str(resolved),
+                "checksum": checksum,
+                "kind": kind,
+                "file_count": file_count,
+            }
+        )
+    return records
+
+
+def _hash_artifact(path: Path) -> tuple[str, str, int]:
+    if path.is_file():
+        return _hash_file(path), "file", 1
+    if not path.is_dir():
+        raise ValueError(f"Model artifact path is not a file or directory: {path}")
+
+    records: list[dict[str, str]] = []
+    for item in sorted(path.rglob("*"), key=lambda candidate: candidate.as_posix()):
+        if item.is_file():
+            records.append(
+                {
+                    "path": item.relative_to(path).as_posix(),
+                    "checksum": _hash_file(item),
+                }
+            )
+    return stable_hash(records), "directory", len(records)
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _iso_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        parsed = datetime.now(timezone.utc)
+    elif isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(
+                f"generated_at must be an ISO-8601 timestamp: {exc}"
+            ) from exc
+    else:
+        raise TypeError("generated_at must be datetime, str, or None")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("generated_at must include a timezone")
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _markdown_cell(value: Any) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+__all__ = [
+    "ATTESTATION_SCHEMA_VERSION",
+    "AttestationReport",
+    "AttestationTemplateError",
+    "generate_attestation",
+    "list_attestation_profiles",
+    "load_attestation_template",
+]

--- a/openmed/core/attestation_templates/__init__.py
+++ b/openmed/core/attestation_templates/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled wording templates for data-residency attestations."""

--- a/openmed/core/attestation_templates/africa-data-residency.json
+++ b/openmed/core/attestation_templates/africa-data-residency.json
@@ -1,0 +1,63 @@
+{
+  "template_version": 1,
+  "template_id": "africa-data-residency",
+  "disclaimer": "Decision-support evidence only; this attestation is not legal advice, a regulator filing, or a certification of compliance.",
+  "profiles": [
+    {
+      "id": "rwanda-law-058-2021",
+      "jurisdiction": "Rwanda",
+      "country_code": "RW",
+      "legal_reference": "Law No. 058/2021, Articles 48-50",
+      "source_url": "https://dpo.gov.rw/fileadmin/DPO/Law_relating_to_the_protection_of_personal_data_and_privacy.pdf",
+      "policy_profile": "strict_no_leak",
+      "attestation_title": "Rwanda host-local processing attestation",
+      "residency_statement": "This artifact records host-local de-identification evidence that an organization can use when assessing Rwanda's rules for transfers and storage outside Rwanda. It does not establish whether every system in the organization's wider data flow stores personal data in Rwanda.",
+      "host_local_statement": "OpenMed reports that the de-identification computation ran in-process on the host. The attestation does not name the host and contains no source document content.",
+      "offline_enabled_statement": "The captured run evidence records OpenMed local-only mode and all bundled dependency offline flags as enabled. Confirm operating-system and network controls separately.",
+      "offline_disabled_statement": "The captured run evidence does not contain a complete OpenMed offline assertion. Treat the artifact as host-local processing evidence, not proof of an air-gapped or no-egress deployment.",
+      "guide_field": "residency_statement"
+    },
+    {
+      "id": "ethiopia-proclamation-1321-2024",
+      "jurisdiction": "Ethiopia",
+      "country_code": "ET",
+      "legal_reference": "Personal Data Protection Proclamation No. 1321/2024, Articles 18-22",
+      "source_url": "https://pdp.eca.et/files/pdfs/pdp-proclamation/pdp_personal_data_protection_proclamation_No_1321_2024.pdf",
+      "policy_profile": "strict_no_leak",
+      "attestation_title": "Ethiopia host-local processing attestation",
+      "residency_statement": "This artifact records host-local de-identification evidence that an organization can use when assessing Ethiopia's local-storage and cross-border transfer rules, including the local-server requirement for personal data collected or obtained locally and prior approval for cross-border transfer of sensitive personal data. It does not replace an Authority determination or approval.",
+      "host_local_statement": "OpenMed reports that the de-identification computation ran in-process on the host. The attestation does not name the host and contains no source document content.",
+      "offline_enabled_statement": "The captured run evidence records OpenMed local-only mode and all bundled dependency offline flags as enabled. Confirm operating-system and network controls separately.",
+      "offline_disabled_statement": "The captured run evidence does not contain a complete OpenMed offline assertion. Treat the artifact as host-local processing evidence, not proof of an air-gapped or no-egress deployment.",
+      "guide_field": "residency_statement"
+    },
+    {
+      "id": "kenya-dpa-2019",
+      "jurisdiction": "Kenya",
+      "country_code": "KE",
+      "legal_reference": "Data Protection Act No. 24 of 2019, sections 48-50",
+      "source_url": "https://new.kenyalaw.org/akn/ke/act/2019/24/eng@2022-12-31",
+      "policy_profile": "strict_no_leak",
+      "attestation_title": "Kenya host-local processing attestation",
+      "residency_statement": "This artifact records host-local de-identification evidence that an organization can use when assessing Kenya's safeguards, consent, and prescribed-local-processing requirements for transfers outside Kenya. It does not determine whether a transfer exception or prescribed category applies.",
+      "host_local_statement": "OpenMed reports that the de-identification computation ran in-process on the host. The attestation does not name the host and contains no source document content.",
+      "offline_enabled_statement": "The captured run evidence records OpenMed local-only mode and all bundled dependency offline flags as enabled. Confirm operating-system and network controls separately.",
+      "offline_disabled_statement": "The captured run evidence does not contain a complete OpenMed offline assertion. Treat the artifact as host-local processing evidence, not proof of an air-gapped or no-egress deployment.",
+      "guide_field": "residency_statement"
+    },
+    {
+      "id": "egypt-pdpl-151-2020",
+      "jurisdiction": "Egypt",
+      "country_code": "EG",
+      "legal_reference": "Personal Data Protection Law No. 151 of 2020, Articles 14-16",
+      "source_url": "https://sis.gov.eg/ar/%D8%A7%D9%84%D8%B1%D8%A6%D8%A7%D8%B3%D8%A9/%D8%B4%D8%A6%D9%88%D9%86-%D8%AF%D8%A7%D8%AE%D9%84%D9%8A%D8%A9/%D8%A7%D9%84%D9%82%D8%B1%D8%A7%D8%B1%D8%A7%D8%AA-%D8%A7%D9%84%D8%B1%D8%A6%D8%A7%D8%B3%D9%8A%D8%A9/%D8%A7%D9%84%D8%B1%D8%A6%D9%8A%D8%B3-%D8%A7%D9%84%D8%B3%D9%8A%D8%B3%D9%89%D9%8A-%D9%8A-%D8%B5%D8%AF-%D9%82-%D8%B9%D9%84%D9%89-%D9%82%D8%A7%D9%86%D9%88%D9%86-%D8%AD%D9%85%D8%A7%D9%8A%D8%A9-%D8%A7%D9%84%D8%A8%D9%8A%D8%A7%D9%86%D8%A7%D8%AA-%D8%A7%D9%84%D8%B4%D8%AE%D8%B5%D9%8A%D8%A9/",
+      "policy_profile": "strict_no_leak",
+      "attestation_title": "Egypt host-local processing attestation",
+      "residency_statement": "This artifact records host-local de-identification evidence that an organization can use when assessing Egypt's licensing or authorization rules for cross-border transfer, storage, sharing, or processing. It is not a licence, permit, or adequacy decision from the Personal Data Protection Center.",
+      "host_local_statement": "OpenMed reports that the de-identification computation ran in-process on the host. The attestation does not name the host and contains no source document content.",
+      "offline_enabled_statement": "The captured run evidence records OpenMed local-only mode and all bundled dependency offline flags as enabled. Confirm operating-system and network controls separately.",
+      "offline_disabled_statement": "The captured run evidence does not contain a complete OpenMed offline assertion. Treat the artifact as host-local processing evidence, not proof of an air-gapped or no-egress deployment.",
+      "guide_field": "residency_statement"
+    }
+  ]
+}

--- a/openmed/core/audit.py
+++ b/openmed/core/audit.py
@@ -662,6 +662,39 @@ class AuditReport:
     def export_review_bundle_json(self) -> str:
         return _canonical_json(self.export_review_bundle())
 
+    def attest(
+        self,
+        profile: str,
+        *,
+        model_artifacts: Mapping[str, str | Path],
+        generated_at: Any = None,
+        template_path: str | Path | None = None,
+    ) -> Any:
+        """Create a data-residency attestation from this audit report.
+
+        Args:
+            profile: Bundled jurisdiction attestation profile identifier.
+            model_artifacts: Mapping of model labels to local files or
+                directories. Contents are hashed without being copied into the
+                attestation.
+            generated_at: Optional timezone-aware timestamp override.
+            template_path: Optional JSON template path for controlled wording
+                overrides.
+
+        Returns:
+            An ``AttestationReport`` with JSON and Markdown renderers.
+        """
+
+        from .attestation import generate_attestation
+
+        return generate_attestation(
+            self,
+            profile,
+            model_artifacts=model_artifacts,
+            generated_at=generated_at,
+            template_path=template_path,
+        )
+
 
 def recompute_repro_hash(report: AuditReport | Mapping[str, Any]) -> str:
     """Offline helper to recompute a report hash from an object or mapping."""

--- a/openmed/core/offline.py
+++ b/openmed/core/offline.py
@@ -56,6 +56,44 @@ def configure_offline_mode(config: Any = None) -> bool:
     return False
 
 
+def offline_mode_assertion(config: Any = None) -> dict[str, Any]:
+    """Return PHI-free evidence describing the configured offline posture.
+
+    The assertion distinguishes OpenMed's socket guard from dependency-specific
+    cache-only flags.  Hugging Face flags alone do not prove that OpenMed's
+    outbound socket guard was requested, while ``OPENMED_OFFLINE`` or
+    ``config.local_only`` does.
+    """
+
+    config_local_only = bool(getattr(config, "local_only", False))
+    environment_local_only = env_flag_enabled(os.getenv(OFFLINE_ENV_VAR))
+    local_only = config_local_only or environment_local_only
+    environment_flags = {
+        OFFLINE_ENV_VAR: environment_local_only,
+        **{name: env_flag_enabled(os.getenv(name)) for name in HF_OFFLINE_ENV_VARS},
+    }
+    dependency_flags_enabled = all(
+        environment_flags[name] for name in HF_OFFLINE_ENV_VARS
+    )
+    if config_local_only and environment_local_only:
+        source = "config+environment"
+    elif config_local_only:
+        source = "config"
+    elif environment_local_only:
+        source = "environment"
+    else:
+        source = "none"
+
+    return {
+        "asserted": bool(local_only and dependency_flags_enabled),
+        "local_only": local_only,
+        "source": source,
+        "network_guard_requested": local_only,
+        "dependency_flags_enabled": dependency_flags_enabled,
+        "environment_flags": environment_flags,
+    }
+
+
 def raise_offline_error(action: str) -> None:
     """Raise a clear error for a blocked remote action."""
     raise OfflineModeError(f"{OFFLINE_NETWORK_ERROR} Blocked action: {action}.")

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1752,7 +1752,10 @@ def _resolved_audit_profile(
     normalize_accents: Optional[bool],
     use_smart_merging: bool,
     use_safety_sweep: bool,
+    config: Any = None,
 ) -> dict[str, Any]:
+    from .offline import offline_mode_assertion
+
     return {
         "method": method,
         "model_name": model_name,
@@ -1763,6 +1766,7 @@ def _resolved_audit_profile(
         "normalize_accents": normalize_accents,
         "use_smart_merging": bool(use_smart_merging),
         "use_safety_sweep": bool(use_safety_sweep),
+        "offline_assertion": offline_mode_assertion(config),
     }
 
 
@@ -1823,6 +1827,7 @@ def _build_audit_report(
     use_smart_merging: bool,
     use_safety_sweep: bool,
     policy: str,
+    config: Any = None,
 ) -> Any:
     from ..__about__ import __version__
     from .audit import AuditReport, hash_text, manifest_hash
@@ -1859,6 +1864,7 @@ def _build_audit_report(
             normalize_accents=normalize_accents,
             use_smart_merging=use_smart_merging,
             use_safety_sweep=use_safety_sweep,
+            config=config,
         ),
         detectors=_detector_infos(
             pii_result,
@@ -1908,6 +1914,7 @@ def _build_deidentification_result(
     policy_name: Optional[str] = None,
     policy: str = "hipaa_safe_harbor",
     audit: bool = False,
+    config: Any = None,
 ) -> DeidentificationResult:
     """Build a de-identification result from an existing PII result."""
     from .labels import normalize_label
@@ -2093,6 +2100,7 @@ def _build_deidentification_result(
             use_smart_merging=use_smart_merging,
             use_safety_sweep=use_safety_sweep,
             policy=policy,
+            config=config,
         )
 
     return DeidentificationResult(

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -766,6 +766,7 @@ class Pipeline:
                     self.policy.name if self.policy is not None else "hipaa_safe_harbor"
                 ),
                 audit=audit,
+                config=self.config,
             )
         final_spans = (
             sweep_spans if self.policy is not None else (sweep_spans or policy_spans)
@@ -1326,6 +1327,7 @@ class Pipeline:
         policy_name: Optional[str] = None,
         policy: str = "hipaa_safe_harbor",
         audit: bool = False,
+        config: Any = None,
     ) -> Any:
         from . import pii
 
@@ -1353,6 +1355,7 @@ class Pipeline:
             policy_name=policy_name,
             policy=policy,
             audit=audit,
+            config=config,
         )
 
     def _entities_to_spans(

--- a/openmed/core/schemas/json/attestation.schema.json
+++ b/openmed/core/schemas/json/attestation.schema.json
@@ -1,0 +1,315 @@
+{
+  "$id": "https://openmed.dev/schemas/v1/attestation.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": 1,
+      "type": "integer"
+    },
+    "template": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "hash": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "version",
+        "hash"
+      ],
+      "type": "object"
+    },
+    "profile_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "generated_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "disclaimer": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "jurisdiction": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "country_code": {
+          "pattern": "^[A-Z]{2}$",
+          "type": "string"
+        },
+        "legal_reference": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "source_url": {
+          "format": "uri",
+          "type": "string"
+        },
+        "attestation_title": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "residency_statement": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "guide_field": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "country_code",
+        "legal_reference",
+        "source_url",
+        "attestation_title",
+        "residency_statement",
+        "guide_field"
+      ],
+      "type": "object"
+    },
+    "policy": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "posture": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "schema_version": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "default_action": {
+          "enum": [
+            "keep",
+            "redact",
+            "replace",
+            "mask",
+            "hash",
+            "format_preserve"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "posture",
+        "schema_version",
+        "default_action"
+      ],
+      "type": "object"
+    },
+    "execution": {
+      "additionalProperties": false,
+      "properties": {
+        "host_local": {
+          "const": true,
+          "type": "boolean"
+        },
+        "host_local_statement": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "offline_statement": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "offline_assertion": {
+          "additionalProperties": false,
+          "properties": {
+            "asserted": {
+              "type": "boolean"
+            },
+            "local_only": {
+              "type": "boolean"
+            },
+            "source": {
+              "enum": [
+                "none",
+                "config",
+                "environment",
+                "config+environment"
+              ],
+              "type": "string"
+            },
+            "network_guard_requested": {
+              "type": "boolean"
+            },
+            "dependency_flags_enabled": {
+              "type": "boolean"
+            },
+            "environment_flags": {
+              "additionalProperties": false,
+              "properties": {
+                "OPENMED_OFFLINE": {
+                  "type": "boolean"
+                },
+                "HF_HUB_OFFLINE": {
+                  "type": "boolean"
+                },
+                "TRANSFORMERS_OFFLINE": {
+                  "type": "boolean"
+                },
+                "HF_DATASETS_OFFLINE": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "OPENMED_OFFLINE",
+                "HF_HUB_OFFLINE",
+                "TRANSFORMERS_OFFLINE",
+                "HF_DATASETS_OFFLINE"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "asserted",
+            "local_only",
+            "source",
+            "network_guard_requested",
+            "dependency_flags_enabled",
+            "environment_flags"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "host_local",
+        "host_local_statement",
+        "offline_statement",
+        "offline_assertion"
+      ],
+      "type": "object"
+    },
+    "models": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "path": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "checksum": {
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "file",
+              "directory"
+            ],
+            "type": "string"
+          },
+          "file_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "path",
+          "checksum",
+          "kind",
+          "file_count"
+        ],
+        "type": "object"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "run": {
+      "additionalProperties": false,
+      "properties": {
+        "document_length": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "span_count": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "input_hash": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "deidentified_text_hash": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "audit_repro_hash": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "manifest_hash": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "openmed_version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "document_length",
+        "span_count",
+        "input_hash",
+        "deidentified_text_hash",
+        "audit_repro_hash",
+        "manifest_hash",
+        "openmed_version"
+      ],
+      "type": "object"
+    },
+    "repro_hash": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "integrity_hash": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "template",
+    "profile_id",
+    "generated_at",
+    "disclaimer",
+    "jurisdiction",
+    "policy",
+    "execution",
+    "models",
+    "run",
+    "repro_hash",
+    "integrity_hash"
+  ],
+  "schema_version": 1,
+  "title": "OpenMedDataResidencyAttestation",
+  "type": "object"
+}

--- a/openmed/core/schemas/json/schema-fingerprints.json
+++ b/openmed/core/schemas/json/schema-fingerprints.json
@@ -43,6 +43,38 @@
     ],
     "schema_version": 1
   },
+  "attestation": {
+    "fingerprint": "sha256:c15d894ac1b2e1096dffd14efbac45912b1d5c498cbdd9ed130681cec00e4689",
+    "properties": [
+      "disclaimer",
+      "execution",
+      "generated_at",
+      "integrity_hash",
+      "jurisdiction",
+      "models",
+      "policy",
+      "profile_id",
+      "repro_hash",
+      "run",
+      "schema_version",
+      "template"
+    ],
+    "required": [
+      "disclaimer",
+      "execution",
+      "generated_at",
+      "integrity_hash",
+      "jurisdiction",
+      "models",
+      "policy",
+      "profile_id",
+      "repro_hash",
+      "run",
+      "schema_version",
+      "template"
+    ],
+    "schema_version": 1
+  },
   "code": {
     "fingerprint": "sha256:ad4e56848f6cbf9cf3d3935af4ab264c318479ad81a16fb5f3de4db6ee1af48f",
     "properties": [

--- a/openmed/core/schemas/span.py
+++ b/openmed/core/schemas/span.py
@@ -20,6 +20,7 @@ SCHEMA_NAMES = (
     "span",
     "action",
     "audit",
+    "attestation",
     "entity",
     "relation",
     "code",

--- a/tests/unit/core/test_attestation.py
+++ b/tests/unit/core/test_attestation.py
@@ -1,0 +1,392 @@
+"""Tests for PHI-free, template-driven data-residency attestations."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from jsonschema import validate
+
+from openmed import AttestationReport
+from openmed.core.attestation import (
+    generate_attestation,
+    list_attestation_profiles,
+    load_attestation_template,
+)
+from openmed.core.audit import AuditReport, AuditSpan, DetectorInfo, hash_text
+from openmed.core.offline import (
+    HF_OFFLINE_ENV_VARS,
+    OFFLINE_ENV_VAR,
+    offline_mode_assertion,
+)
+from openmed.core.policy import load_policy
+from openmed.core.schemas import load_schema
+
+_SOURCE_TEXT = "Patient Amara Test, national ID RW-123-456-789."
+_OUTPUT_TEXT = "Patient [NAME], national ID [ID]."
+_GENERATED_AT = datetime(2026, 7, 18, 12, 0, tzinfo=timezone.utc)
+_EXPECTED_PROFILES = (
+    "rwanda-law-058-2021",
+    "ethiopia-proclamation-1321-2024",
+    "kenya-dpa-2019",
+    "egypt-pdpl-151-2020",
+)
+
+
+def _audit_report(*, policy: str = "strict_no_leak") -> AuditReport:
+    return AuditReport(
+        policy=policy,
+        resolved_profile={
+            "method": "mask",
+            "model_name": "synthetic-local-model",
+            "offline_assertion": {
+                "asserted": True,
+                "local_only": True,
+                "source": "config",
+                "network_guard_requested": True,
+                "dependency_flags_enabled": True,
+                "environment_flags": {
+                    OFFLINE_ENV_VAR: False,
+                    **{name: True for name in HF_OFFLINE_ENV_VARS},
+                },
+            },
+        },
+        detectors=[
+            DetectorInfo(
+                source="ml",
+                model_id="synthetic-local-model",
+                model_format="transformers",
+                commit="0123456789abcdef",
+            )
+        ],
+        safety_sweep={"enabled": True, "spans_added": 0},
+        spans=[
+            AuditSpan(
+                start=8,
+                end=18,
+                label="NAME",
+                canonical_label="PERSON",
+                sources=["ml"],
+                confidence=0.99,
+                threshold=0.7,
+                action="mask",
+                surrogate=None,
+                text_hash=hash_text("Amara Test"),
+            )
+        ],
+        thresholds={"PERSON": 0.7},
+        residual_risk={"projected_leakage": 0.01},
+        openmed_version="1.9.0",
+        manifest_hash=hash_text("synthetic manifest"),
+        document_length=len(_SOURCE_TEXT),
+        input_hash=hash_text(_SOURCE_TEXT),
+        deidentified_text_hash=hash_text(_OUTPUT_TEXT),
+    )
+
+
+@pytest.fixture
+def model_artifact(tmp_path: Path) -> Path:
+    path = tmp_path / "model.bin"
+    path.write_bytes(b"synthetic model weights")
+    return path
+
+
+@pytest.mark.parametrize("profile", _EXPECTED_PROFILES)
+def test_every_bundled_african_profile_generates_schema_valid_json_and_markdown(
+    profile: str,
+    model_artifact: Path,
+) -> None:
+    report = _audit_report()
+
+    attestation = report.attest(
+        profile,
+        model_artifacts={"pii-model": model_artifact},
+        generated_at=_GENERATED_AT,
+    )
+    payload = attestation.to_dict()
+    markdown = attestation.to_markdown()
+
+    validate(payload, load_schema("attestation"))
+    assert json.loads(attestation.to_json()) == payload
+    assert payload["profile_id"] == profile
+    assert payload["policy"]["name"] == "strict_no_leak"
+    assert payload["policy"]["posture"] == "maximum_recall_no_leak"
+    assert payload["execution"]["offline_assertion"]["asserted"] is True
+    assert "Decision-support evidence only" in markdown
+    assert payload["jurisdiction"]["residency_statement"] in markdown
+    assert attestation.repro_hash_matches()
+    assert attestation.integrity_hash_matches()
+
+
+def test_bundled_profile_list_is_stable() -> None:
+    assert list_attestation_profiles() == _EXPECTED_PROFILES
+
+
+def test_policy_loader_records_exact_profile_and_fails_cleanly(
+    model_artifact: Path,
+) -> None:
+    payload = generate_attestation(
+        _audit_report(),
+        _EXPECTED_PROFILES[0],
+        model_artifacts={"pii-model": model_artifact},
+        generated_at=_GENERATED_AT,
+    ).to_dict()
+
+    loaded = load_policy("strict_no_leak")
+    assert payload["policy"] == {
+        "name": loaded.name,
+        "posture": loaded.posture,
+        "schema_version": loaded.schema_version,
+        "default_action": loaded.default_action,
+    }
+
+    with pytest.raises(ValueError, match="could not be loaded"):
+        generate_attestation(
+            _audit_report(policy="missing_africa_policy"),
+            _EXPECTED_PROFILES[0],
+            model_artifacts={"pii-model": model_artifact},
+        )
+
+    with pytest.raises(ValueError, match="requires policy 'strict_no_leak'"):
+        generate_attestation(
+            _audit_report(policy="gdpr_art9_health"),
+            _EXPECTED_PROFILES[0],
+            model_artifacts={"pii-model": model_artifact},
+        )
+
+
+def test_repro_hash_is_timestamp_independent_but_integrity_hash_is_not(
+    model_artifact: Path,
+) -> None:
+    report = _audit_report()
+    first = report.attest(
+        _EXPECTED_PROFILES[0],
+        model_artifacts={"pii-model": model_artifact},
+        generated_at="2026-07-18T12:00:00Z",
+    )
+    second = report.attest(
+        _EXPECTED_PROFILES[0],
+        model_artifacts={"pii-model": model_artifact},
+        generated_at="2026-07-18T13:00:00+00:00",
+    )
+
+    assert first.to_dict()["repro_hash"] == second.to_dict()["repro_hash"]
+    assert first.to_dict()["integrity_hash"] != second.to_dict()["integrity_hash"]
+
+    restored = AttestationReport.from_json(first.to_json())
+    assert restored.repro_hash_matches()
+    assert restored.integrity_hash_matches()
+    tampered = restored.to_dict()
+    tampered["run"]["span_count"] += 1
+    assert not AttestationReport.from_dict(tampered).repro_hash_matches()
+    assert not AttestationReport.from_dict(tampered).integrity_hash_matches()
+
+    tampered_audit = _audit_report()
+    tampered_audit.document_length += 1
+    with pytest.raises(ValueError, match="Audit report repro hash does not match"):
+        tampered_audit.attest(
+            _EXPECTED_PROFILES[0],
+            model_artifacts={"pii-model": model_artifact},
+        )
+
+
+def test_offline_assertion_requires_openmed_and_dependency_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+    for name in HF_OFFLINE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    assert offline_mode_assertion()["asserted"] is False
+
+    for name in HF_OFFLINE_ENV_VARS:
+        monkeypatch.setenv(name, "1")
+    dependency_only = offline_mode_assertion()
+    assert dependency_only["dependency_flags_enabled"] is True
+    assert dependency_only["network_guard_requested"] is False
+    assert dependency_only["asserted"] is False
+
+    monkeypatch.setenv(OFFLINE_ENV_VAR, "true")
+    complete = offline_mode_assertion()
+    assert complete["source"] == "environment"
+    assert complete["network_guard_requested"] is True
+    assert complete["asserted"] is True
+
+
+def test_attestation_never_substitutes_generation_environment_for_run_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    model_artifact: Path,
+) -> None:
+    monkeypatch.setenv(OFFLINE_ENV_VAR, "1")
+    for name in HF_OFFLINE_ENV_VARS:
+        monkeypatch.setenv(name, "1")
+    report = _audit_report()
+    report.resolved_profile.pop("offline_assertion")
+    report.repro_hash = report.recompute_repro_hash()
+
+    payload = report.attest(
+        _EXPECTED_PROFILES[0],
+        model_artifacts={"pii-model": model_artifact},
+        generated_at=_GENERATED_AT,
+    ).to_dict()
+
+    assertion = payload["execution"]["offline_assertion"]
+    assert assertion["asserted"] is False
+    assert assertion["local_only"] is False
+    assert assertion["source"] == "none"
+
+
+def test_attestation_downgrades_inconsistent_offline_evidence(
+    model_artifact: Path,
+) -> None:
+    report = _audit_report()
+    report.resolved_profile["offline_assertion"] = {
+        "asserted": True,
+        "local_only": True,
+        "source": "untrusted",
+        "network_guard_requested": True,
+        "dependency_flags_enabled": True,
+        "environment_flags": {
+            OFFLINE_ENV_VAR: False,
+            **{name: False for name in HF_OFFLINE_ENV_VARS},
+        },
+    }
+    report.repro_hash = report.recompute_repro_hash()
+
+    payload = report.attest(
+        _EXPECTED_PROFILES[0],
+        model_artifacts={"pii-model": model_artifact},
+        generated_at=_GENERATED_AT,
+    ).to_dict()
+
+    assertion = payload["execution"]["offline_assertion"]
+    assert assertion["asserted"] is False
+    assert assertion["network_guard_requested"] is False
+    assert assertion["dependency_flags_enabled"] is False
+    assert assertion["source"] == "none"
+    validate(payload, load_schema("attestation"))
+
+
+def test_template_controls_jurisdiction_rendering(
+    tmp_path: Path,
+    model_artifact: Path,
+) -> None:
+    template = load_attestation_template()
+    template["profiles"][0]["attestation_title"] = "Controlled local title"
+    template["profiles"][0]["residency_statement"] = (
+        "Controlled jurisdiction wording from JSON."
+    )
+    path = tmp_path / "template.json"
+    path.write_text(json.dumps(template), encoding="utf-8")
+
+    attestation = generate_attestation(
+        _audit_report(),
+        _EXPECTED_PROFILES[0],
+        model_artifacts={"pii-model": model_artifact},
+        generated_at=_GENERATED_AT,
+        template_path=path,
+    )
+
+    assert "# Controlled local title" in attestation.to_markdown()
+    assert "Controlled jurisdiction wording from JSON." in attestation.to_markdown()
+    assert (
+        attestation.to_dict()["jurisdiction"]["residency_statement"]
+        == "Controlled jurisdiction wording from JSON."
+    )
+
+
+def test_guide_covers_each_profile_policy_and_template_field() -> None:
+    repository_root = Path(__file__).resolve().parents[3]
+    guide = (
+        repository_root / "docs/compliance/africa-data-residency-guide.md"
+    ).read_text(encoding="utf-8")
+    docs_template = json.loads(
+        (
+            repository_root
+            / "docs/compliance/templates/africa-data-residency-attestation.json"
+        ).read_text(encoding="utf-8")
+    )
+    runtime_template = load_attestation_template()
+
+    assert docs_template == runtime_template
+    assert "decision-support material, not legal advice" in guide
+    for profile in runtime_template["profiles"]:
+        loaded = load_policy(profile["policy_profile"])
+        assert loaded.name == profile["policy_profile"]
+        assert f"## {profile['jurisdiction']}" in guide
+        assert f"Attestation profile: `{profile['id']}`" in guide
+        assert f"Policy profile: `{loaded.name}`" in guide
+        assert f"Template field: `{profile['guide_field']}`" in guide
+
+
+def test_attestation_artifacts_do_not_leak_source_text_or_identifiers(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "model-with-sensitive-looking-test-bytes.bin"
+    artifact.write_text(
+        _SOURCE_TEXT + " amara.test@example.invalid +250 788 123 456",
+        encoding="utf-8",
+    )
+    attestation = _audit_report().attest(
+        _EXPECTED_PROFILES[0],
+        model_artifacts={"pii-model": artifact},
+        generated_at=_GENERATED_AT,
+    )
+    serialized = attestation.to_json() + attestation.to_markdown()
+
+    for secret in (
+        _SOURCE_TEXT,
+        "Amara Test",
+        "RW-123-456-789",
+        "amara.test@example.invalid",
+        "+250 788 123 456",
+    ):
+        assert secret not in serialized
+    payload = attestation.to_dict()
+    assert payload["run"]["document_length"] == len(_SOURCE_TEXT)
+    assert payload["run"]["span_count"] == 1
+    assert payload["run"]["input_hash"] == hash_text(_SOURCE_TEXT)
+
+
+def test_missing_model_artifact_fails_without_network_access(tmp_path: Path) -> None:
+    missing = tmp_path / "missing-model.bin"
+
+    with pytest.raises(ValueError, match="does not exist"):
+        _audit_report().attest(
+            _EXPECTED_PROFILES[0],
+            model_artifacts={"pii-model": missing},
+        )
+
+
+def test_directory_checksum_is_content_and_path_stable(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text("{}", encoding="utf-8")
+    weights = model_dir / "weights.bin"
+    weights.write_bytes(b"weights-v1")
+
+    first = _audit_report().attest(
+        _EXPECTED_PROFILES[0],
+        model_artifacts={"pii-model": model_dir},
+        generated_at=_GENERATED_AT,
+    )
+    second = _audit_report().attest(
+        _EXPECTED_PROFILES[0],
+        model_artifacts={"pii-model": model_dir},
+        generated_at=_GENERATED_AT,
+    )
+    assert first.to_dict()["models"] == second.to_dict()["models"]
+    assert first.to_dict()["models"][0]["file_count"] == 2
+
+    weights.write_bytes(b"weights-v2")
+    changed = _audit_report().attest(
+        _EXPECTED_PROFILES[0],
+        model_artifacts={"pii-model": model_dir},
+        generated_at=_GENERATED_AT,
+    )
+    assert (
+        changed.to_dict()["models"][0]["checksum"]
+        != first.to_dict()["models"][0]["checksum"]
+    )

--- a/tests/unit/core/test_deid_provenance.py
+++ b/tests/unit/core/test_deid_provenance.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from unittest.mock import patch
 
 from openmed.core.audit import AuditReport, verify_repro_hash
+from openmed.core.config import OpenMedConfig
+from openmed.core.offline import HF_OFFLINE_ENV_VARS, OFFLINE_ENV_VAR
 from openmed.core.pii import deidentify
 from openmed.core.safety_sweep import SAFETY_SWEEP_SOURCE
 from openmed.processing.outputs import EntityPrediction, PredictionResult
@@ -67,6 +69,28 @@ def test_audit_repro_hash_is_stable_for_identical_inputs(mock_extract):
 
     assert first.repro_hash == second.repro_hash
     assert first.to_json() == second.to_json()
+
+
+@patch("openmed.core.pii.extract_pii")
+def test_audit_captures_local_only_evidence_at_run_time(mock_extract, monkeypatch):
+    text = "Patient John Doe."
+    mock_extract.return_value = _prediction(text)
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+    for name in HF_OFFLINE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    report = deidentify(
+        text,
+        method="mask",
+        config=OpenMedConfig(local_only=True),
+        audit=True,
+    )
+
+    assertion = report.resolved_profile["offline_assertion"]
+    assert assertion["asserted"] is True
+    assert assertion["source"] == "config"
+    assert assertion["network_guard_requested"] is True
+    assert assertion["dependency_flags_enabled"] is True
 
 
 @patch("openmed.core.pii.extract_pii")


### PR DESCRIPTION
# Pull Request

## Description

Adds a data-driven Africa data-residency attestation API that converts PHI-free de-identification audit reports into schema-valid JSON and human-readable Markdown. It records the exact policy posture, model artifact paths and content checksums, captured run-time offline evidence, host-local execution wording, timestamps, stable repro hashes, and full-payload integrity hashes without copying source text or identifiers.

Closes #1446.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Added the public attestation generator, audit-report hook, bundled jurisdiction wording profiles, model artifact hashing, and captured offline-mode evidence.
- Made missing or internally inconsistent offline evidence fail closed instead of inheriting the environment at attestation-generation time.
- Added a versioned JSON Schema plus tests for all four bundled jurisdiction profiles, policy loading, hash stability, template rendering, no-network assertions, guide coverage, and artifact leakage.
- Added the Africa data-residency deployment guide and review template for Rwanda, Ethiopia, Kenya, and Egypt, including current local-storage and health-care processing rules with explicit decision-support and not-legal-advice framing.
- Added the public API to the changelog and packaged the runtime template and schema in the wheel.

## Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different model artifact shapes and jurisdiction profiles

Validation completed on the rebased final head:

- Full test suite: 6,894 passed, 47 skipped
- Focused attestation, audit, provenance, policy, schema, and offline suite: 130 passed
- Canonical formatting, lint, formatting-check, and scoped type-check gates passed
- Scoped repository hooks, security scan, secret scan, and conflict checks passed
- Strict documentation build passed
- Wheel and source distribution builds passed; the wheel contains the attestation template, schema, and schema fingerprint snapshot

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran the canonical formatting, lint, formatting-check, and type-check gates
- [ ] Swift/OpenMedKit formatting and linting — not applicable
- [x] I have performed a self-review of my own code
- [x] I have commented the fail-closed evidence handling
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have organized my commits appropriately

## Related Issues

Closes #1446

## Screenshots/Examples

The guide includes a complete API example for generating and verifying both JSON and Markdown attestation artifacts.
