### PR TITLE
OpenHIE mediator packaging: run the de-identification service as an OpenHIM mediator

### DIFF
--- a/.github/workflows/openhim-mediator.yml
+++ b/.github/workflows/openhim-mediator.yml
@@ -1,0 +1,67 @@
+name: OpenHIM mediator container
+
+on:
+  pull_request:
+    paths:
+      - "openmed/service/**"
+      - "examples/openhim-mediator/**"
+      - "tests/integration/test_openhim_mediator_container.py"
+      - ".github/workflows/openhim-mediator.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      OPENMED_OPENHIM_CORE_URL: http://openhim-fixture:8081
+      OPENMED_OPENHIM_USERNAME: openhim@example.org
+      OPENMED_OPENHIM_PASSWORD: synthetic-password
+      OPENMED_OPENHIM_ALLOW_INSECURE_HTTP: "true"
+    defaults:
+      run:
+        working-directory: examples/openhim-mediator
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Start recorded core fixture
+        run: docker compose --profile fixture up -d openhim-fixture
+
+      - name: Wait for fixture
+        run: |
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:8081/health > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          docker compose --profile fixture logs openhim-fixture
+          exit 1
+
+      - name: Build and start mediator
+        run: docker compose up -d --build openmed-mediator
+
+      - name: Verify registration and heartbeat
+        run: |
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent http://127.0.0.1:8080/openhim/heartbeat > mediator.json; then
+              break
+            fi
+            sleep 2
+          done
+          test "$(jq -r .registered mediator.json)" = "true"
+          test "$(jq -r .last_heartbeat_at mediator.json)" != "null"
+          curl --fail --silent http://127.0.0.1:8081/health > fixture.json
+          test "$(jq -r .registration_count fixture.json)" = "1"
+          test "$(jq -r .heartbeat_count fixture.json)" -ge 1
+
+      - name: Show logs
+        if: always()
+        run: docker compose --profile fixture logs
+
+      - name: Stop example
+        if: always()
+        run: docker compose --profile fixture down --volumes --remove-orphans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an opt-in OpenHIM de-identification mediator with authenticated
+  registration and heartbeats, FHIR and text transformation envelopes,
+  byte-preserving opaque pass-through, and an offline container smoke fixture
+  for deployment inside an HIE trust boundary (#1448).
 - Added data-driven African healthcare-context safety-sweep terms for named
   facilities, mobile-money references, and context-gated ethnic affiliations,
   with non-keep defaults across the initial African policy profiles and

--- a/docs/deploy/openhim-mediator.md
+++ b/docs/deploy/openhim-mediator.md
@@ -1,0 +1,118 @@
+# OpenHIM De-identification Mediator
+
+OpenMed can run as an [OpenHIM mediator](https://openhim.org/docs/configuration/mediators/) that de-identifies FHIR JSON and plain-text transactions inside a health information exchange. The integration is feature-flagged and off by default. When enabled, the service registers with OpenHIM core at startup, sends an immediate heartbeat requesting current configuration, and continues heartbeats every 10 seconds.
+
+!!! important "Keep PHI inside the trust boundary"
+
+    Deploy the mediator on infrastructure controlled by the national, regional, or facility HIE. Route identifiable transactions to OpenMed before any system outside that trust boundary. OpenMed does not send mediator payloads to OpenHIM's management API; registration and heartbeat calls contain only mediator metadata and uptime.
+
+## Registration payload
+
+The example registration is in `examples/openhim-mediator/mediator-config.json`. It declares:
+
+- URN `urn:openhim-mediator:openmed-deidentification`
+- the default `/openmed/deidentify` OpenHIM channel
+- the mediator route `/openhim/deidentify` on port `8080`
+- the endpoint displayed in the OpenHIM Console
+
+OpenHIM core accepts mediator registration at `POST /mediators` and heartbeats at `POST /mediators/:urn/heartbeat`. The first heartbeat includes `config: true`; later heartbeats include uptime only. Registration is safe to call repeatedly across service restarts, while a running service instance suppresses duplicate registration attempts.
+
+## Configure the service
+
+Set the following variables on the OpenMed service:
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `OPENMED_OPENHIM_MEDIATOR_ENABLED` | yes | `false` | Enables registration, heartbeat, and mediator routes. |
+| `OPENMED_OPENHIM_CORE_URL` | when enabled | none | OpenHIM management API URL, including its API port, such as `https://openhim-core:8080`. |
+| `OPENMED_OPENHIM_USERNAME` | when enabled | none | OpenHIM administrative API username. |
+| `OPENMED_OPENHIM_PASSWORD` | when enabled | none | OpenHIM administrative API password. Supply it through a secret store, not the JSON config. |
+| `OPENMED_OPENHIM_AUTH_MODE` | no | `basic` | Management API authentication: `basic`, or the deprecated OpenHIM `token` handshake for older deployments. |
+| `OPENMED_OPENHIM_POLICY` | no | `hipaa_safe_harbor` | Bundled policy applied to mediator payloads. Validated once at startup. |
+| `OPENMED_OPENHIM_METHOD` | no | `replace` | De-identification method applied to mediator payloads. Validated once at startup. |
+| `OPENMED_OPENHIM_CONFIG_PATH` | no | built-in config | Mounted mediator registration JSON. |
+| `OPENMED_OPENHIM_VERIFY_TLS` | no | `true` | Verifies the OpenHIM API certificate. Keep enabled outside isolated fixture tests. |
+| `OPENMED_OPENHIM_ALLOW_INSECURE_HTTP` | no | `false` | Allows a plaintext management URL only for the bundled synthetic fixture. Never enable it for a real HIE. |
+| `OPENMED_OPENHIM_HEARTBEAT_INTERVAL_SECONDS` | no | `10` | Heartbeat interval; accepted values are greater than zero and no more than 30 seconds. |
+| `OPENMED_OPENHIM_REQUEST_TIMEOUT_SECONDS` | no | `10` | Registration and heartbeat request timeout. |
+
+The management credentials authorize mediator registration and heartbeat, so keep them out of `mediator-config.json`, source control, images, and logs. OpenHIM's management API uses HTTPS; OpenMed rejects plaintext management URLs unless the fixture-only override is explicitly enabled. Basic authentication is the default. Set `OPENMED_OPENHIM_AUTH_MODE=token` only when connecting to an older deployment configured for OpenHIM's deprecated salt-and-timestamp token headers.
+
+The policy and method are deployment settings, not request parameters. Incoming
+query strings cannot weaken the configured de-identification posture. Change
+these settings only through the mediator deployment configuration and restart
+the service so startup validation runs again.
+
+## Run with an existing OpenHIM core
+
+From the repository root, set the real management API and credentials, then start the example:
+
+```bash
+export OPENMED_OPENHIM_CORE_URL=https://openhim-core.internal:8080
+export OPENMED_OPENHIM_USERNAME=mediator-admin@example.org
+export OPENMED_OPENHIM_PASSWORD='use-your-secret-store'
+
+docker compose -f examples/openhim-mediator/docker-compose.yml \
+  up --build openmed-mediator
+```
+
+The compose service mounts `mediator-config.json` read-only at `/etc/openmed/mediator-config.json`. If OpenHIM resolves the service under a different hostname, update `host` in both the channel route and endpoint before starting the mediator.
+
+After registration, open the mediator in the OpenHIM Console and install the **OpenMed De-identification** default channel. The channel matches `POST /openmed/deidentify` on the OpenHIM router and forwards it to the mediator's `/openhim/deidentify` route.
+
+## Send a FHIR transaction
+
+Send a Bundle through the OpenHIM router, not its management API:
+
+```bash
+export OPENHIM_CLIENT_USERNAME=openhim-client
+
+curl --request POST https://openhim-core.internal:5000/openmed/deidentify \
+  --user "${OPENHIM_CLIENT_USERNAME}" \
+  --header 'Content-Type: application/fhir+json' \
+  --data @synthetic-bundle.json
+```
+
+With only the username supplied, `curl` prompts for the client password instead
+of placing it in the command or shell history.
+
+For FHIR resources and Bundles, OpenMed de-identifies free-text and direct identifier values with `openmed.interop.fhir_operations`. Coded elements, systems, resource IDs, `fullUrl` values, request blocks, and references remain unchanged. Plain `text/*` bodies use the same OpenMed privacy pipeline. Other media types pass through byte-for-byte instead of being forced into a JSON envelope. Only response-safe representation and correlation headers are reflected; credentials, cookies, and unbounded custom clinical metadata are not copied into mediator response metadata.
+
+Transformed responses use the required `application/json+openhim` media type. The envelope contains `x-mediator-urn`, the client response, and an orchestration step for the OpenHIM Console. The orchestration request intentionally omits the raw body, so identifiable input is not duplicated into transaction metadata. Errors return PHI-free messages.
+
+## Health and heartbeat
+
+The existing `/health`, `/livez`, and `/readyz` routes retain their normal meanings. When mediator mode is enabled, `GET /openhim/heartbeat` reports local registration and heartbeat state without exposing credentials:
+
+```bash
+curl http://127.0.0.1:8080/openhim/heartbeat
+```
+
+A healthy response has `registered: true`, a non-null `last_heartbeat_at`, and `last_error: null`.
+
+## Offline container smoke test
+
+The compose file includes a small recorded handshake fixture, not OpenHIM core. It exists only to test registration and heartbeat without operating or bundling the real interoperability layer:
+
+```bash
+export OPENMED_OPENHIM_CORE_URL=http://openhim-fixture:8081
+export OPENMED_OPENHIM_USERNAME=openhim@example.org
+export OPENMED_OPENHIM_PASSWORD=synthetic-password
+export OPENMED_OPENHIM_ALLOW_INSECURE_HTTP=true
+
+docker compose -f examples/openhim-mediator/docker-compose.yml \
+  --profile fixture up -d openhim-fixture
+
+docker compose -f examples/openhim-mediator/docker-compose.yml \
+  up -d --build openmed-mediator
+
+curl http://127.0.0.1:8080/openhim/heartbeat
+curl http://127.0.0.1:8081/health
+
+docker compose -f examples/openhim-mediator/docker-compose.yml \
+  --profile fixture down --volumes --remove-orphans
+```
+
+The fixture uses synthetic credentials and payloads. Never use it as an HIE
+component. Unset those four variables before configuring a real OpenHIM
+deployment.

--- a/examples/openhim-mediator/Dockerfile
+++ b/examples/openhim-mediator/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.11-slim@sha256:e031123e3d85762b141ad1cbc56452ba69c6e722ebf2f042cc0dc86c47c0d8b3
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    OPENMED_PROFILE=prod \
+    OPENMED_SERVICE_KEEP_ALIVE=10m \
+    OPENMED_OPENHIM_MEDIATOR_ENABLED=true \
+    OPENMED_OPENHIM_CONFIG_PATH=/etc/openmed/mediator-config.json
+
+WORKDIR /app
+
+COPY pyproject.toml README.md LICENSE /app/
+COPY openmed /app/openmed
+COPY examples/openhim-mediator/mediator-config.json /etc/openmed/mediator-config.json
+
+RUN python -m pip install --no-cache-dir --upgrade \
+        "pip==26.1.2" \
+        "setuptools==83.0.0" \
+        "wheel==0.47.0" \
+        "jaraco.context==6.1.2" \
+    && pip install --no-cache-dir ".[service]"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=20s --retries=5 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/openhim/heartbeat', timeout=2)"
+
+CMD ["uvicorn", "openmed.service.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/examples/openhim-mediator/docker-compose.yml
+++ b/examples/openhim-mediator/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  openmed-mediator:
+    build:
+      context: ../..
+      dockerfile: examples/openhim-mediator/Dockerfile
+    environment:
+      OPENMED_OPENHIM_CORE_URL: ${OPENMED_OPENHIM_CORE_URL:?Set OPENMED_OPENHIM_CORE_URL}
+      OPENMED_OPENHIM_USERNAME: ${OPENMED_OPENHIM_USERNAME:?Set OPENMED_OPENHIM_USERNAME}
+      OPENMED_OPENHIM_PASSWORD: ${OPENMED_OPENHIM_PASSWORD:?Set OPENMED_OPENHIM_PASSWORD}
+      OPENMED_OPENHIM_AUTH_MODE: ${OPENMED_OPENHIM_AUTH_MODE:-basic}
+      OPENMED_OPENHIM_POLICY: ${OPENMED_OPENHIM_POLICY:-hipaa_safe_harbor}
+      OPENMED_OPENHIM_METHOD: ${OPENMED_OPENHIM_METHOD:-replace}
+      OPENMED_OPENHIM_VERIFY_TLS: ${OPENMED_OPENHIM_VERIFY_TLS:-true}
+      OPENMED_OPENHIM_ALLOW_INSECURE_HTTP: ${OPENMED_OPENHIM_ALLOW_INSECURE_HTTP:-false}
+      OPENMED_OPENHIM_HEARTBEAT_INTERVAL_SECONDS: ${OPENMED_OPENHIM_HEARTBEAT_INTERVAL_SECONDS:-10}
+    ports:
+      - "127.0.0.1:${OPENMED_OPENHIM_HOST_PORT:-8080}:8080"
+    volumes:
+      - ./mediator-config.json:/etc/openmed/mediator-config.json:ro
+    restart: unless-stopped
+
+  openhim-fixture:
+    image: python:3.11-slim@sha256:e031123e3d85762b141ad1cbc56452ba69c6e722ebf2f042cc0dc86c47c0d8b3
+    profiles:
+      - fixture
+    command:
+      - python
+      - /fixture/fixture_server.py
+    environment:
+      OPENHIM_FIXTURE_USERNAME: openhim@example.org
+      OPENHIM_FIXTURE_PASSWORD: synthetic-password
+    ports:
+      - "127.0.0.1:${OPENMED_OPENHIM_FIXTURE_HOST_PORT:-8081}:8081"
+    volumes:
+      - ./fixture_server.py:/fixture/fixture_server.py:ro
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request; urllib.request.urlopen('http://127.0.0.1:8081/health', timeout=2)
+      interval: 2s
+      timeout: 2s
+      retries: 15

--- a/examples/openhim-mediator/fixture_server.py
+++ b/examples/openhim-mediator/fixture_server.py
@@ -1,0 +1,77 @@
+"""Synthetic OpenHIM-core handshake fixture for container smoke tests."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import unquote
+
+USERNAME = os.environ.get("OPENHIM_FIXTURE_USERNAME", "openhim@example.org")
+PASSWORD = os.environ.get("OPENHIM_FIXTURE_PASSWORD", "synthetic-password")
+EXPECTED_AUTH = "Basic " + base64.b64encode(
+    f"{USERNAME}:{PASSWORD}".encode("utf-8")
+).decode("ascii")
+STATE = {"registration_count": 0, "heartbeat_count": 0, "urn": None}
+
+
+class FixtureHandler(BaseHTTPRequestHandler):
+    """Serve only the OpenHIM endpoints exercised by the mediator client."""
+
+    server_version = "OpenHIMFixture/1.0"
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == f"/authenticate/{USERNAME.replace('@', '%40')}":
+            self._json(200, {"salt": "synthetic", "ts": "2026-01-01T00:00:00Z"})
+            return
+        if self.path == "/health":
+            self._json(200, {"status": "ok", **STATE})
+            return
+        self._json(404, {"status": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.headers.get("Authorization") != EXPECTED_AUTH:
+            self._json(401, {"status": "unauthorized"})
+            return
+        try:
+            payload = json.loads(
+                self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            )
+        except json.JSONDecodeError:
+            self._json(400, {"status": "invalid_json"})
+            return
+
+        if self.path == "/mediators":
+            STATE["registration_count"] += 1
+            STATE["urn"] = payload.get("urn")
+            self._json(201, {"registered": True})
+            return
+
+        if self.path.startswith("/mediators/") and self.path.endswith("/heartbeat"):
+            encoded_urn = self.path.removeprefix("/mediators/").removesuffix(
+                "/heartbeat"
+            )
+            if unquote(encoded_urn) != STATE["urn"]:
+                self._json(404, {"status": "unknown_mediator"})
+                return
+            STATE["heartbeat_count"] += 1
+            self._json(200, {"config": {}} if payload.get("config") else {})
+            return
+
+        self._json(404, {"status": "not_found"})
+
+    def _json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *args: object) -> None:
+        return
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("0.0.0.0", 8081), FixtureHandler).serve_forever()

--- a/examples/openhim-mediator/mediator-config.json
+++ b/examples/openhim-mediator/mediator-config.json
@@ -1,0 +1,40 @@
+{
+  "urn": "urn:openhim-mediator:openmed-deidentification",
+  "version": "1.9.1",
+  "name": "OpenMed De-identification Mediator",
+  "description": "Local-first FHIR and clinical free-text de-identification for OpenHIM",
+  "defaultChannelConfig": [
+    {
+      "name": "OpenMed De-identification",
+      "description": "De-identify clinical payloads inside the HIE boundary",
+      "urlPattern": "^/openmed/deidentify$",
+      "routes": [
+        {
+          "name": "OpenMed de-identification route",
+          "host": "openmed-mediator",
+          "path": "/openhim/deidentify",
+          "port": 8080,
+          "primary": true,
+          "type": "http"
+        }
+      ],
+      "allow": [
+        "admin"
+      ],
+      "methods": [
+        "POST"
+      ],
+      "type": "http"
+    }
+  ],
+  "endpoints": [
+    {
+      "name": "OpenMed de-identification endpoint",
+      "host": "openmed-mediator",
+      "path": "/openhim/deidentify",
+      "port": 8080,
+      "primary": true,
+      "type": "http"
+    }
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
       - gRPC Service: serving/grpc.md
       - REST Authentication: serving/authentication.md
       - Helm Deployment: deploy/helm.md
+      - OpenHIM De-identification Mediator: deploy/openhim-mediator.md
       - Multi-Arch Containers: deploy/multi-arch.md
       - ModelLoader & Pipelines: model-loader.md
       - Model Registry: model-registry.md

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -41,6 +41,17 @@ from .metrics import (
     PrometheusMetricsRegistry,
     metrics_enabled_from_env,
 )
+from .openhim_mediator import (
+    OPENHIM_HEARTBEAT_PATH,
+    OPENHIM_MEDIA_TYPE,
+    OPENHIM_MEDIATOR_PATH,
+    OpenHIMMediatorSettings,
+    build_openhim_envelope,
+    create_openhim_mediator,
+    failed_openhim_result,
+    mediator_response_headers,
+    transform_mediator_payload,
+)
 from .privacy_gateway import (
     HttpExternalLLMTransport,
     InMemoryReidentificationStore,
@@ -93,6 +104,7 @@ _MODEL_BACKED_PATHS = frozenset(
         "/jobs",
         _PRIVACY_GATEWAY_PATH,
         _SMART_BACKEND_START_PATH,
+        OPENHIM_MEDIATOR_PATH,
     }
 )
 _ServicePayload = Dict[str, Any]
@@ -372,6 +384,8 @@ def _metrics_route_label(request: Request) -> str:
 def create_app() -> FastAPI:
     """Create and configure the OpenMed REST FastAPI app."""
 
+    openhim_settings = OpenHIMMediatorSettings.from_env()
+
     @asynccontextmanager
     async def lifespan(fastapi_app: FastAPI):
         runtime = ServiceRuntime.from_env(
@@ -383,9 +397,19 @@ def create_app() -> FastAPI:
         fastapi_app.state.ready = False
         fastapi_app.state.shutting_down = False
         fastapi_app.state.inflight = 0
+        fastapi_app.state.openhim_mediator = None
 
         if runtime.preload_models:
             await run_in_threadpool(runtime.preload)
+
+        if openhim_settings.enabled:
+            mediator = create_openhim_mediator(openhim_settings)
+            fastapi_app.state.openhim_mediator = mediator
+            try:
+                await mediator.start()
+            except Exception:
+                await mediator.stop()
+                raise
 
         fastapi_app.state.ready = True
 
@@ -394,6 +418,9 @@ def create_app() -> FastAPI:
         finally:
             fastapi_app.state.ready = False
             fastapi_app.state.shutting_down = True
+            mediator = getattr(fastapi_app.state, "openhim_mediator", None)
+            if mediator is not None:
+                await mediator.stop()
             loop = asyncio.get_event_loop()
             deadline = loop.time() + float(
                 getattr(runtime, "shutdown_drain_seconds", 0.0) or 0.0
@@ -440,6 +467,8 @@ def create_app() -> FastAPI:
         PrometheusMetricsRegistry() if metrics_enabled_from_env() else None
     )
     app.state.tracing = service_tracing_from_env()
+    app.state.openhim_settings = openhim_settings
+    app.state.openhim_deidentifier = None
 
     @app.middleware("http")
     async def _readiness_middleware(request: Request, call_next):
@@ -658,6 +687,76 @@ def create_app() -> FastAPI:
             "Service preload has not completed",
             details=None,
         )
+
+    if openhim_settings.enabled:
+
+        @app.get(OPENHIM_HEARTBEAT_PATH)
+        async def openhim_heartbeat(request: Request) -> Dict[str, Any]:
+            mediator = getattr(request.app.state, "openhim_mediator", None)
+            if mediator is None:
+                return {
+                    "enabled": True,
+                    "registered": False,
+                    "urn": str(openhim_settings.registration["urn"]),
+                    "last_heartbeat_at": None,
+                    "last_error": "not_started",
+                }
+            return mediator.status()
+
+        @app.post(OPENHIM_MEDIATOR_PATH)
+        async def openhim_deidentify(request: Request) -> Response:
+            runtime = _get_service_runtime(request)
+            headers = mediator_response_headers(request.headers)
+            body = await request.body()
+            configured_deidentifier = getattr(
+                request.app.state, "openhim_deidentifier", None
+            )
+
+            def _runtime_deidentifier(text: str, **kwargs: Any) -> Any:
+                if configured_deidentifier is not None:
+                    return configured_deidentifier(text, **kwargs)
+                return openmed.deidentify(
+                    text,
+                    config=runtime.config,
+                    loader=runtime.get_loader(),
+                    **kwargs,
+                )
+
+            def _transform() -> Any:
+                return transform_mediator_payload(
+                    body,
+                    headers,
+                    200,
+                    deidentifier=_runtime_deidentifier,
+                    policy=openhim_settings.policy,
+                    method=openhim_settings.method,
+                )
+
+            try:
+                result = await _run_with_timeout(runtime, _transform)
+            except (TypeError, ValueError, UnicodeError, json.JSONDecodeError):
+                result = failed_openhim_result(400, "invalid_payload")
+            except Exception:
+                result = failed_openhim_result(500, "processing_failed")
+
+            if not result.transformed:
+                return Response(
+                    content=result.body,
+                    status_code=result.status_code,
+                    headers=dict(result.headers),
+                )
+
+            envelope = build_openhim_envelope(
+                result,
+                urn=str(openhim_settings.registration["urn"]),
+                request_method=request.method,
+                request_path=request.url.path,
+            )
+            return Response(
+                content=json.dumps(envelope, ensure_ascii=False, separators=(",", ":")),
+                status_code=200,
+                media_type=OPENHIM_MEDIA_TYPE,
+            )
 
     @app.get("/models/loaded")
     async def loaded_models(request: Request) -> Dict[str, Any]:

--- a/openmed/service/openhim_mediator.py
+++ b/openmed/service/openhim_mediator.py
@@ -1,0 +1,772 @@
+"""OpenHIM mediator registration, heartbeat, and response helpers.
+
+The integration is deliberately opt-in.  Importing this module or creating the
+REST application does not contact OpenHIM; network activity only begins when
+``OPENMED_OPENHIM_MEDIATOR_ENABLED`` is true and the service lifespan starts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import time
+from contextlib import suppress
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+from urllib.parse import quote, urlsplit
+
+import httpx
+
+from openmed.__about__ import __version__
+
+OPENHIM_MEDIA_TYPE = "application/json+openhim"
+OPENHIM_MEDIATOR_PATH = "/openhim/deidentify"
+OPENHIM_HEARTBEAT_PATH = "/openhim/heartbeat"
+DEFAULT_MEDIATOR_URN = "urn:openhim-mediator:openmed-deidentification"
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+_RESPONSE_HEADER_ALLOWLIST = frozenset(
+    {
+        "cache-control",
+        "content-encoding",
+        "content-language",
+        "content-type",
+        "x-request-id",
+    }
+)
+
+Deidentifier = Callable[..., Any]
+
+
+class OpenHIMMediatorConfigurationError(ValueError):
+    """Raised when opt-in OpenHIM mediator settings are invalid."""
+
+
+class OpenHIMMediatorProtocolError(RuntimeError):
+    """Raised when OpenHIM core rejects registration or a heartbeat."""
+
+
+def _parse_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+    raise OpenHIMMediatorConfigurationError(
+        f"{name} must be one of: 1, 0, true, false, yes, no, on, off"
+    )
+
+
+def _parse_positive_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise OpenHIMMediatorConfigurationError(f"{name} must be a number") from exc
+    if parsed <= 0:
+        raise OpenHIMMediatorConfigurationError(f"{name} must be greater than zero")
+    return parsed
+
+
+def _parse_choice(name: str, default: str, choices: frozenset[str]) -> str:
+    value = os.environ.get(name, default).strip().lower()
+    if value not in choices:
+        raise OpenHIMMediatorConfigurationError(
+            f"{name} must be one of: {', '.join(sorted(choices))}"
+        )
+    return value
+
+
+def default_mediator_registration(
+    *,
+    host: str = "openmed-mediator",
+    port: int = 8080,
+) -> dict[str, Any]:
+    """Return the built-in OpenMed registration payload.
+
+    Args:
+        host: Hostname OpenHIM core should use to reach the mediator.
+        port: TCP port exposed by the mediator.
+
+    Returns:
+        An OpenHIM mediator registration mapping.
+    """
+
+    route = {
+        "name": "OpenMed de-identification route",
+        "host": host,
+        "path": OPENHIM_MEDIATOR_PATH,
+        "port": port,
+        "primary": True,
+        "type": "http",
+    }
+    return {
+        "urn": DEFAULT_MEDIATOR_URN,
+        "version": __version__,
+        "name": "OpenMed De-identification Mediator",
+        "description": (
+            "Local-first FHIR and clinical free-text de-identification for OpenHIM"
+        ),
+        "defaultChannelConfig": [
+            {
+                "name": "OpenMed De-identification",
+                "description": "De-identify clinical payloads inside the HIE boundary",
+                "urlPattern": "^/openmed/deidentify$",
+                "routes": [dict(route)],
+                "allow": ["admin"],
+                "methods": ["POST"],
+                "type": "http",
+            }
+        ],
+        "endpoints": [{**route, "name": "OpenMed de-identification endpoint"}],
+    }
+
+
+def load_mediator_registration(path: Optional[str]) -> dict[str, Any]:
+    """Load and validate a mediator registration payload.
+
+    Args:
+        path: Optional JSON path.  When omitted, the built-in payload is used.
+
+    Returns:
+        A validated, mutable registration mapping.
+    """
+
+    if path:
+        config_path = Path(path)
+        try:
+            raw = config_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise OpenHIMMediatorConfigurationError(
+                f"Unable to read OpenHIM mediator config: {config_path}"
+            ) from exc
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise OpenHIMMediatorConfigurationError(
+                f"OpenHIM mediator config is not valid JSON: {config_path}"
+            ) from exc
+    else:
+        host = os.environ.get("OPENMED_OPENHIM_MEDIATOR_HOST", "openmed-mediator")
+        raw_port = os.environ.get("OPENMED_OPENHIM_MEDIATOR_PORT", "8080")
+        try:
+            port = int(raw_port)
+        except ValueError as exc:
+            raise OpenHIMMediatorConfigurationError(
+                "OPENMED_OPENHIM_MEDIATOR_PORT must be an integer"
+            ) from exc
+        if not 1 <= port <= 65535:
+            raise OpenHIMMediatorConfigurationError(
+                "OPENMED_OPENHIM_MEDIATOR_PORT must be between 1 and 65535"
+            )
+        payload = default_mediator_registration(host=host, port=port)
+
+    if not isinstance(payload, dict):
+        raise OpenHIMMediatorConfigurationError(
+            "OpenHIM mediator config must be a JSON object"
+        )
+    for key in ("urn", "name", "version"):
+        if not isinstance(payload.get(key), str) or not payload[key].strip():
+            raise OpenHIMMediatorConfigurationError(
+                f"OpenHIM mediator config requires a non-empty {key}"
+            )
+    for key in ("defaultChannelConfig", "endpoints"):
+        if not isinstance(payload.get(key), list) or not payload[key]:
+            raise OpenHIMMediatorConfigurationError(
+                f"OpenHIM mediator config requires a non-empty {key} array"
+            )
+    return dict(payload)
+
+
+@dataclass(frozen=True)
+class OpenHIMMediatorSettings:
+    """Environment-derived configuration for the OpenHIM lifecycle client."""
+
+    enabled: bool = False
+    api_url: str = ""
+    username: str = ""
+    password: str = field(default="", repr=False)
+    auth_mode: str = "basic"
+    verify_tls: bool = True
+    allow_insecure_http: bool = False
+    heartbeat_interval_seconds: float = 10.0
+    request_timeout_seconds: float = 10.0
+    policy: str = "hipaa_safe_harbor"
+    method: str = "replace"
+    registration: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_env(cls) -> "OpenHIMMediatorSettings":
+        """Parse mediator settings without contacting OpenHIM core."""
+
+        enabled = _parse_bool("OPENMED_OPENHIM_MEDIATOR_ENABLED", False)
+        if not enabled:
+            return cls()
+
+        api_url = os.environ.get("OPENMED_OPENHIM_CORE_URL", "").strip().rstrip("/")
+        username = os.environ.get("OPENMED_OPENHIM_USERNAME", "").strip()
+        password = os.environ.get("OPENMED_OPENHIM_PASSWORD", "")
+        missing = [
+            name
+            for name, value in (
+                ("OPENMED_OPENHIM_CORE_URL", api_url),
+                ("OPENMED_OPENHIM_USERNAME", username),
+                ("OPENMED_OPENHIM_PASSWORD", password),
+            )
+            if not value
+        ]
+        if missing:
+            raise OpenHIMMediatorConfigurationError(
+                "OpenHIM mediator is enabled but required settings are missing: "
+                + ", ".join(missing)
+            )
+        parsed_api_url = urlsplit(api_url)
+        if parsed_api_url.scheme not in {"http", "https"} or not parsed_api_url.netloc:
+            raise OpenHIMMediatorConfigurationError(
+                "OPENMED_OPENHIM_CORE_URL must be an absolute HTTP(S) URL"
+            )
+        if parsed_api_url.username is not None or parsed_api_url.password is not None:
+            raise OpenHIMMediatorConfigurationError(
+                "OPENMED_OPENHIM_CORE_URL must not contain credentials"
+            )
+        allow_insecure_http = _parse_bool("OPENMED_OPENHIM_ALLOW_INSECURE_HTTP", False)
+        if parsed_api_url.scheme == "http" and not allow_insecure_http:
+            raise OpenHIMMediatorConfigurationError(
+                "OPENMED_OPENHIM_CORE_URL must use https:// unless "
+                "OPENMED_OPENHIM_ALLOW_INSECURE_HTTP is explicitly enabled"
+            )
+
+        heartbeat_interval = _parse_positive_float(
+            "OPENMED_OPENHIM_HEARTBEAT_INTERVAL_SECONDS", 10.0
+        )
+        if heartbeat_interval > 30:
+            raise OpenHIMMediatorConfigurationError(
+                "OPENMED_OPENHIM_HEARTBEAT_INTERVAL_SECONDS must not exceed 30"
+            )
+
+        registration = load_mediator_registration(
+            os.environ.get("OPENMED_OPENHIM_CONFIG_PATH")
+        )
+        policy = os.environ.get("OPENMED_OPENHIM_POLICY", "hipaa_safe_harbor").strip()
+        if not policy:
+            raise OpenHIMMediatorConfigurationError(
+                "OPENMED_OPENHIM_POLICY must be non-empty"
+            )
+        try:
+            from openmed.core.policy import load_policy
+
+            policy = load_policy(policy).name
+        except ValueError as exc:
+            raise OpenHIMMediatorConfigurationError(
+                "OPENMED_OPENHIM_POLICY must name a bundled policy"
+            ) from exc
+        return cls(
+            enabled=True,
+            api_url=api_url,
+            username=username,
+            password=password,
+            auth_mode=_parse_choice(
+                "OPENMED_OPENHIM_AUTH_MODE",
+                "basic",
+                frozenset({"basic", "token"}),
+            ),
+            verify_tls=_parse_bool("OPENMED_OPENHIM_VERIFY_TLS", True),
+            allow_insecure_http=allow_insecure_http,
+            heartbeat_interval_seconds=heartbeat_interval,
+            request_timeout_seconds=_parse_positive_float(
+                "OPENMED_OPENHIM_REQUEST_TIMEOUT_SECONDS", 10.0
+            ),
+            policy=policy,
+            method=_parse_choice(
+                "OPENMED_OPENHIM_METHOD",
+                "replace",
+                frozenset(
+                    {
+                        "aadhaar_mask",
+                        "format_preserve",
+                        "hash",
+                        "mask",
+                        "remove",
+                        "replace",
+                        "shift_dates",
+                    }
+                ),
+            ),
+            registration=registration,
+        )
+
+
+class OpenHIMMediatorClient:
+    """Register the mediator and maintain its OpenHIM heartbeat."""
+
+    def __init__(
+        self,
+        settings: OpenHIMMediatorSettings,
+        *,
+        client: Optional[httpx.AsyncClient] = None,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if not settings.enabled:
+            raise OpenHIMMediatorConfigurationError(
+                "Cannot create an OpenHIM client while the integration is disabled"
+            )
+        self.settings = settings
+        self._monotonic = monotonic
+        self._started_at = monotonic()
+        self._client = client or httpx.AsyncClient(
+            timeout=settings.request_timeout_seconds,
+            verify=settings.verify_tls,
+        )
+        self._owns_client = client is None
+        self._registered = False
+        self._last_heartbeat_at: Optional[str] = None
+        self._last_error: Optional[str] = None
+        self._heartbeat_task: Optional[asyncio.Task[None]] = None
+        self._register_lock = asyncio.Lock()
+        self._start_lock = asyncio.Lock()
+
+    @property
+    def urn(self) -> str:
+        """Return the configured mediator URN."""
+
+        return str(self.settings.registration["urn"])
+
+    async def _authentication_kwargs(self) -> dict[str, Any]:
+        if self.settings.auth_mode == "basic":
+            return {
+                "auth": httpx.BasicAuth(
+                    self.settings.username,
+                    self.settings.password,
+                )
+            }
+
+        username = quote(self.settings.username, safe="")
+        response = await self._client.get(
+            f"{self.settings.api_url}/authenticate/{username}"
+        )
+        if response.status_code != 200:
+            raise OpenHIMMediatorProtocolError(
+                f"OpenHIM authentication preflight returned {response.status_code}"
+            )
+        try:
+            details = response.json()
+        except ValueError as exc:
+            raise OpenHIMMediatorProtocolError(
+                "OpenHIM authentication preflight returned invalid JSON"
+            ) from exc
+        if not isinstance(details, Mapping):
+            raise OpenHIMMediatorProtocolError(
+                "OpenHIM authentication preflight returned an invalid payload"
+            )
+        salt = details.get("salt")
+        timestamp = details.get("ts")
+        if (
+            not isinstance(salt, str)
+            or not salt
+            or not isinstance(timestamp, str)
+            or not timestamp
+        ):
+            raise OpenHIMMediatorProtocolError(
+                "OpenHIM authentication preflight omitted salt or timestamp"
+            )
+
+        password_hash = hashlib.sha512(
+            f"{salt}{self.settings.password}".encode("utf-8")
+        ).hexdigest()
+        token = hashlib.sha512(
+            f"{password_hash}{salt}{timestamp}".encode("utf-8")
+        ).hexdigest()
+        return {
+            "headers": {
+                "auth-username": self.settings.username,
+                "auth-ts": timestamp,
+                "auth-salt": salt,
+                "auth-token": token,
+            }
+        }
+
+    async def register(self) -> None:
+        """Register once per client instance, even when called concurrently."""
+
+        if self._registered:
+            return
+        async with self._register_lock:
+            if self._registered:
+                return
+            authentication = await self._authentication_kwargs()
+            response = await self._client.post(
+                f"{self.settings.api_url}/mediators",
+                json=dict(self.settings.registration),
+                **authentication,
+            )
+            if response.status_code != 201:
+                raise OpenHIMMediatorProtocolError(
+                    f"OpenHIM mediator registration returned {response.status_code}"
+                )
+            self._registered = True
+            self._last_error = None
+
+    async def heartbeat(self, *, force_config: bool = False) -> Optional[Any]:
+        """Send one heartbeat and return any updated OpenHIM configuration."""
+
+        await self.register()
+        payload: dict[str, Any] = {
+            "uptime": max(0.0, self._monotonic() - self._started_at)
+        }
+        if force_config:
+            payload["config"] = True
+        encoded_urn = quote(self.urn, safe="")
+        authentication = await self._authentication_kwargs()
+        response = await self._client.post(
+            f"{self.settings.api_url}/mediators/{encoded_urn}/heartbeat",
+            json=payload,
+            **authentication,
+        )
+        if response.status_code != 200:
+            raise OpenHIMMediatorProtocolError(
+                f"OpenHIM mediator heartbeat returned {response.status_code}"
+            )
+        self._last_heartbeat_at = _utc_timestamp()
+        self._last_error = None
+        if not response.content or response.text == "OK":
+            return None
+        try:
+            return response.json()
+        except json.JSONDecodeError:
+            return response.text
+
+    async def start(self) -> None:
+        """Register, fetch initial config, and start periodic heartbeats."""
+
+        async with self._start_lock:
+            if self._heartbeat_task is not None:
+                return
+            await self.register()
+            await self.heartbeat(force_config=True)
+            self._heartbeat_task = asyncio.create_task(
+                self._heartbeat_loop(), name="openhim-mediator-heartbeat"
+            )
+
+    async def _heartbeat_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self.settings.heartbeat_interval_seconds)
+            try:
+                await self.heartbeat()
+            except asyncio.CancelledError:
+                raise
+            except (httpx.HTTPError, OpenHIMMediatorProtocolError) as exc:
+                self._last_error = type(exc).__name__
+
+    async def stop(self) -> None:
+        """Stop periodic heartbeats and close the owned HTTP client."""
+
+        task = self._heartbeat_task
+        self._heartbeat_task = None
+        if task is not None:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        if self._owns_client:
+            await self._client.aclose()
+
+    def status(self) -> dict[str, Any]:
+        """Return non-secret local heartbeat state for health checks."""
+
+        return {
+            "enabled": True,
+            "registered": self._registered,
+            "urn": self.urn,
+            "last_heartbeat_at": self._last_heartbeat_at,
+            "last_error": self._last_error,
+        }
+
+
+def create_openhim_mediator(
+    settings: OpenHIMMediatorSettings,
+) -> OpenHIMMediatorClient:
+    """Create the lifecycle client used by the REST application."""
+
+    return OpenHIMMediatorClient(settings)
+
+
+@dataclass(frozen=True)
+class MediatorTransformResult:
+    """A transformed or byte-preserved mediator response."""
+
+    body: bytes
+    headers: Mapping[str, str]
+    status_code: int
+    transformed: bool
+    operation: str
+
+
+def mediator_response_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    """Copy response-safe representation and correlation headers only."""
+
+    return {
+        str(key): str(value)
+        for key, value in headers.items()
+        if str(key).lower() in _RESPONSE_HEADER_ALLOWLIST
+    }
+
+
+def transform_mediator_payload(
+    body: bytes,
+    headers: Mapping[str, str],
+    status_code: int,
+    *,
+    deidentifier: Optional[Deidentifier] = None,
+    policy: str = "hipaa_safe_harbor",
+    method: str = "replace",
+) -> MediatorTransformResult:
+    """De-identify supported text while preserving opaque payloads exactly.
+
+    FHIR JSON resources and Bundles use ``openmed.interop.fhir_operations``.
+    Plain-text media types use the same core privacy pipeline.  Any other body
+    is returned byte-for-byte with the supplied headers and status code.
+    """
+
+    copied_headers = dict(headers)
+    media_type = _media_type(copied_headers)
+
+    if media_type == "application/fhir+json" or media_type in {
+        "application/json",
+        "application/json+fhir",
+    }:
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            if media_type == "application/fhir+json":
+                raise ValueError("FHIR payload must be valid UTF-8 JSON") from None
+            return MediatorTransformResult(
+                body=body,
+                headers=copied_headers,
+                status_code=status_code,
+                transformed=False,
+                operation="pass-through",
+            )
+
+        resource_type = (
+            payload.get("resourceType") if isinstance(payload, dict) else None
+        )
+        if resource_type is None:
+            if media_type == "application/fhir+json":
+                raise ValueError("FHIR payload requires resourceType")
+            return MediatorTransformResult(
+                body=body,
+                headers=copied_headers,
+                status_code=status_code,
+                transformed=False,
+                operation="pass-through",
+            )
+
+        from openmed.interop.fhir_operations import (
+            de_identify,
+            de_identify_bundle,
+            de_identify_resource,
+        )
+
+        if resource_type == "Bundle":
+            transformed = de_identify_bundle(
+                payload,
+                policy=policy,
+                method=method,
+                deidentifier=deidentifier,
+            )
+            operation = "fhir-bundle-de-identify"
+        elif resource_type == "Parameters":
+            transformed = de_identify(
+                _configured_fhir_parameters(
+                    payload,
+                    policy=policy,
+                    method=method,
+                ),
+                deidentifier=deidentifier,
+            )
+            operation = "fhir-operation-de-identify"
+        else:
+            transformed = de_identify_resource(
+                payload,
+                policy=policy,
+                method=method,
+                deidentifier=deidentifier,
+            )
+            operation = "fhir-resource-de-identify"
+        return MediatorTransformResult(
+            body=json.dumps(
+                transformed, ensure_ascii=False, separators=(",", ":")
+            ).encode("utf-8"),
+            headers=copied_headers,
+            status_code=status_code,
+            transformed=True,
+            operation=operation,
+        )
+
+    if media_type.startswith("text/"):
+        try:
+            text = body.decode(_charset(copied_headers))
+        except (LookupError, UnicodeDecodeError) as exc:
+            raise ValueError("Text payload encoding is invalid") from exc
+        result = _deidentify_text(
+            text,
+            deidentifier=deidentifier,
+            policy=policy,
+            method=method,
+        )
+        return MediatorTransformResult(
+            body=result.encode(_charset(copied_headers)),
+            headers=copied_headers,
+            status_code=status_code,
+            transformed=True,
+            operation="text-de-identify",
+        )
+
+    return MediatorTransformResult(
+        body=body,
+        headers=copied_headers,
+        status_code=status_code,
+        transformed=False,
+        operation="pass-through",
+    )
+
+
+def build_openhim_envelope(
+    result: MediatorTransformResult,
+    *,
+    urn: str,
+    request_method: str = "POST",
+    request_path: str = OPENHIM_MEDIATOR_PATH,
+) -> dict[str, Any]:
+    """Build the structured response consumed by OpenHIM core."""
+
+    timestamp = _utc_timestamp()
+    response = {
+        "status": result.status_code,
+        "headers": dict(result.headers),
+        "body": result.body.decode(_charset(result.headers)),
+        "timestamp": timestamp,
+    }
+    if 200 <= result.status_code < 300:
+        transaction_status = "Successful"
+    elif result.status_code >= 500:
+        transaction_status = "Failed"
+    else:
+        transaction_status = "Completed with error(s)"
+    envelope: dict[str, Any] = {
+        "x-mediator-urn": urn,
+        "status": transaction_status,
+        "response": response,
+        "orchestrations": [
+            {
+                "name": "OpenMed local de-identification",
+                "request": {
+                    "method": request_method,
+                    "path": request_path,
+                    "headers": {},
+                    "timestamp": timestamp,
+                },
+                "response": dict(response),
+            }
+        ],
+        "properties": {
+            "openmed.operation": result.operation,
+            "openmed.local-first": True,
+        },
+    }
+    if result.status_code >= 500:
+        envelope["error"] = {"message": "Mediator request failed"}
+    return envelope
+
+
+def failed_openhim_result(status_code: int, code: str) -> MediatorTransformResult:
+    """Return a PHI-free structured error body for the mediator envelope."""
+
+    body = json.dumps(
+        {"error": {"code": code, "message": "Mediator request failed"}},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return MediatorTransformResult(
+        body=body,
+        headers={"content-type": "application/json"},
+        status_code=status_code,
+        transformed=True,
+        operation="de-identification-error",
+    )
+
+
+def _deidentify_text(
+    text: str,
+    *,
+    deidentifier: Optional[Deidentifier],
+    policy: str,
+    method: str,
+) -> str:
+    if deidentifier is None:
+        from openmed.core.pii import deidentify
+
+        deidentifier = deidentify
+    result = deidentifier(text, policy=policy, method=method)
+    clean_text = getattr(result, "deidentified_text", None)
+    if not isinstance(clean_text, str):
+        raise TypeError("deidentifier must return an object with deidentified_text")
+    return clean_text
+
+
+def _configured_fhir_parameters(
+    payload: Mapping[str, Any],
+    *,
+    policy: str,
+    method: str,
+) -> dict[str, Any]:
+    parameters = payload.get("parameter")
+    retained = (
+        [
+            item
+            for item in parameters
+            if not (
+                isinstance(item, Mapping) and item.get("name") in {"policy", "method"}
+            )
+        ]
+        if isinstance(parameters, list)
+        else []
+    )
+    return {
+        **dict(payload),
+        "parameter": [
+            *retained,
+            {"name": "policy", "valueString": policy},
+            {"name": "method", "valueCode": method},
+        ],
+    }
+
+
+def _media_type(headers: Mapping[str, str]) -> str:
+    for key, value in headers.items():
+        if key.lower() == "content-type":
+            return value.split(";", 1)[0].strip().lower()
+    return "application/octet-stream"
+
+
+def _charset(headers: Mapping[str, str]) -> str:
+    for key, value in headers.items():
+        if key.lower() != "content-type":
+            continue
+        for parameter in value.split(";")[1:]:
+            name, separator, charset = parameter.partition("=")
+            if separator and name.strip().lower() == "charset":
+                return charset.strip().strip('"')
+    return "utf-8"
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/tests/fixtures/openhim/fhir_bundle.json
+++ b/tests/fixtures/openhim/fhir_bundle.json
@@ -1,0 +1,71 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:patient-1",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "patient-1",
+        "identifier": [
+          {
+            "system": "https://facility.example/mrn",
+            "value": "MRN-871-1448"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "text": "Amina Example",
+            "family": "Example",
+            "given": [
+              "Amina"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+256-700-871-1448",
+            "use": "mobile"
+          }
+        ],
+        "gender": "female"
+      },
+      "request": {
+        "method": "POST",
+        "url": "Patient"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:observation-1",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "observation-1",
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "29463-7",
+              "display": "Body Weight"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/patient-1",
+          "display": "Amina Example"
+        },
+        "note": [
+          {
+            "text": "Amina Example called from +256-700-871-1448."
+          }
+        ]
+      },
+      "request": {
+        "method": "POST",
+        "url": "Observation"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/openhim/handshake.json
+++ b/tests/fixtures/openhim/handshake.json
@@ -1,0 +1,29 @@
+{
+  "authenticate": {
+    "method": "GET",
+    "path": "/authenticate/openhim%40example.org",
+    "response_status": 200,
+    "response_body": {
+      "salt": "synthetic-fixture-salt",
+      "ts": "2026-01-01T00:00:00.000Z"
+    }
+  },
+  "registration": {
+    "method": "POST",
+    "path": "/mediators",
+    "response_status": 201,
+    "response_body": {
+      "registered": true
+    }
+  },
+  "heartbeat": {
+    "method": "POST",
+    "path": "/mediators/urn%3Aopenhim-mediator%3Aopenmed-deidentification/heartbeat",
+    "response_status": 200,
+    "response_body": {
+      "config": {
+        "policy": "hipaa_safe_harbor"
+      }
+    }
+  }
+}

--- a/tests/integration/test_openhim_mediator_container.py
+++ b/tests/integration/test_openhim_mediator_container.py
@@ -1,0 +1,141 @@
+"""Container smoke coverage for the OpenHIM mediator example."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+import yaml
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+EXAMPLE_DIR = BASE_DIR / "examples" / "openhim-mediator"
+COMPOSE_FILE = EXAMPLE_DIR / "docker-compose.yml"
+DOCKERFILE = EXAMPLE_DIR / "Dockerfile"
+RUN_CONTAINER_TEST_ENV = "OPENMED_RUN_OPENHIM_CONTAINER_TEST"
+
+
+def test_openhim_container_example_mounts_registration_config() -> None:
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    mediator = compose["services"]["openmed-mediator"]
+
+    assert mediator["build"]["dockerfile"] == "examples/openhim-mediator/Dockerfile"
+    assert (
+        "./mediator-config.json:/etc/openmed/mediator-config.json:ro"
+        in mediator["volumes"]
+    )
+    assert "openhim-fixture" in compose["services"]
+    assert compose["services"]["openhim-fixture"]["profiles"] == ["fixture"]
+
+
+def test_openhim_dockerfile_probes_local_heartbeat() -> None:
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "OPENMED_OPENHIM_MEDIATOR_ENABLED=true" in dockerfile
+    assert "OPENMED_OPENHIM_CONFIG_PATH=/etc/openmed/mediator-config.json" in dockerfile
+    assert "127.0.0.1:8080/openhim/heartbeat" in dockerfile
+
+
+def _run(
+    args: list[str],
+    *,
+    env: dict[str, str],
+    timeout: int = 120,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        args,
+        cwd=EXAMPLE_DIR,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+    if check and completed.returncode != 0:
+        raise AssertionError(
+            f"Command failed ({completed.returncode}): {' '.join(args)}\n"
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        )
+    return completed
+
+
+def _unused_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_json(url: str, *, timeout_seconds: float) -> dict:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+            time.sleep(1)
+    raise AssertionError(f"{url} did not become ready: {last_error!r}")
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_compose_example_registers_and_serves_heartbeat() -> None:
+    if os.environ.get(RUN_CONTAINER_TEST_ENV) != "1":
+        pytest.skip(f"set {RUN_CONTAINER_TEST_ENV}=1 to build and run the example")
+    if shutil.which("docker") is None:
+        pytest.skip("Docker CLI is not installed")
+
+    project = f"openmed-openhim-{uuid4().hex[:10]}"
+    mediator_port = _unused_port()
+    fixture_port = _unused_port()
+    env = {
+        **os.environ,
+        "OPENMED_OPENHIM_HOST_PORT": str(mediator_port),
+        "OPENMED_OPENHIM_FIXTURE_HOST_PORT": str(fixture_port),
+        "OPENMED_OPENHIM_CORE_URL": "http://openhim-fixture:8081",
+        "OPENMED_OPENHIM_USERNAME": "openhim@example.org",
+        "OPENMED_OPENHIM_PASSWORD": "synthetic-password",
+        "OPENMED_OPENHIM_ALLOW_INSECURE_HTTP": "true",
+    }
+    compose = ["docker", "compose", "-p", project, "-f", str(COMPOSE_FILE)]
+
+    try:
+        _run(
+            [*compose, "--profile", "fixture", "up", "-d", "openhim-fixture"],
+            env=env,
+            timeout=180,
+        )
+        _wait_for_json(f"http://127.0.0.1:{fixture_port}/health", timeout_seconds=60)
+        _run(
+            [*compose, "up", "-d", "--build", "openmed-mediator"],
+            env=env,
+            timeout=1200,
+        )
+        mediator = _wait_for_json(
+            f"http://127.0.0.1:{mediator_port}/openhim/heartbeat",
+            timeout_seconds=120,
+        )
+        fixture = _wait_for_json(
+            f"http://127.0.0.1:{fixture_port}/health", timeout_seconds=30
+        )
+
+        assert mediator["registered"] is True
+        assert mediator["last_heartbeat_at"] is not None
+        assert fixture["registration_count"] == 1
+        assert fixture["heartbeat_count"] >= 1
+    finally:
+        _run(
+            [*compose, "--profile", "fixture", "down", "--volumes", "--remove-orphans"],
+            env=env,
+            timeout=180,
+            check=False,
+        )

--- a/tests/unit/service/test_openhim_mediator.py
+++ b/tests/unit/service/test_openhim_mediator.py
@@ -1,0 +1,564 @@
+"""Offline conformance coverage for the OpenHIM mediator integration."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+import openmed
+from openmed.interop.gateway import assert_redacted
+from openmed.service.openhim_mediator import (
+    DEFAULT_MEDIATOR_URN,
+    OPENHIM_MEDIA_TYPE,
+    MediatorTransformResult,
+    OpenHIMMediatorClient,
+    OpenHIMMediatorConfigurationError,
+    OpenHIMMediatorSettings,
+    build_openhim_envelope,
+    default_mediator_registration,
+    failed_openhim_result,
+    load_mediator_registration,
+    mediator_response_headers,
+    transform_mediator_payload,
+)
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "openhim"
+EXAMPLE_CONFIG = (
+    Path(__file__).resolve().parents[3]
+    / "examples"
+    / "openhim-mediator"
+    / "mediator-config.json"
+)
+SYNTHETIC_MAPPING = {
+    "[NAME]": "Amina Example",
+    "[FIRST]": "Amina",
+    "[LAST]": "Example",
+    "[MRN]": "MRN-871-1448",
+    "[PHONE]": "+256-700-871-1448",
+}
+REPLACEMENTS = sorted(
+    ((original, replacement) for replacement, original in SYNTHETIC_MAPPING.items()),
+    key=lambda item: len(item[0]),
+    reverse=True,
+)
+service_app = importlib.import_module("openmed.service.app")
+
+
+@dataclass
+class _FakeResult:
+    deidentified_text: str
+
+
+def _fake_deidentify(text: str, **_: Any) -> _FakeResult:
+    redacted = text
+    for original, replacement in REPLACEMENTS:
+        redacted = redacted.replace(original, replacement)
+    return _FakeResult(redacted)
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _enabled_settings(
+    registration: dict[str, Any],
+    *,
+    auth_mode: str = "basic",
+) -> OpenHIMMediatorSettings:
+    return OpenHIMMediatorSettings(
+        enabled=True,
+        api_url="https://openhim-core.example:8080",
+        username="openhim@example.org",
+        password="synthetic-password",
+        auth_mode=auth_mode,
+        verify_tls=True,
+        heartbeat_interval_seconds=10,
+        request_timeout_seconds=2,
+        registration=registration,
+    )
+
+
+def _set_enabled_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENMED_OPENHIM_MEDIATOR_ENABLED", "true")
+    monkeypatch.setenv("OPENMED_OPENHIM_CORE_URL", "https://openhim-core.example:8080")
+    monkeypatch.setenv("OPENMED_OPENHIM_USERNAME", "openhim@example.org")
+    monkeypatch.setenv("OPENMED_OPENHIM_PASSWORD", "synthetic-password")
+    monkeypatch.setenv("OPENMED_OPENHIM_CONFIG_PATH", str(EXAMPLE_CONFIG))
+    monkeypatch.setenv("OPENMED_PROFILE", "test")
+    monkeypatch.delenv("OPENMED_SERVICE_PRELOAD_MODELS", raising=False)
+
+
+def test_feature_flag_is_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENMED_OPENHIM_MEDIATOR_ENABLED", raising=False)
+
+    settings = OpenHIMMediatorSettings.from_env()
+    app = service_app.create_app()
+
+    assert settings.enabled is False
+    with TestClient(app, base_url="http://localhost") as client:
+        assert client.get("/health").status_code == 200
+        assert client.get("/openhim/heartbeat").status_code == 404
+        assert (
+            client.post("/openhim/deidentify", content=b"unchanged").status_code == 404
+        )
+
+
+def test_registration_payload_has_openhim_required_fields() -> None:
+    generated = default_mediator_registration()
+    mounted = load_mediator_registration(str(EXAMPLE_CONFIG))
+
+    for payload in (generated, mounted):
+        assert payload["urn"] == DEFAULT_MEDIATOR_URN
+        assert payload["version"] == openmed.__version__
+        assert payload["name"] == "OpenMed De-identification Mediator"
+        assert payload["defaultChannelConfig"][0]["routes"][0]["path"] == (
+            "/openhim/deidentify"
+        )
+        assert payload["endpoints"][0]["path"] == "/openhim/deidentify"
+
+
+def test_enabled_settings_require_core_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENMED_OPENHIM_MEDIATOR_ENABLED", "true")
+    for name in (
+        "OPENMED_OPENHIM_CORE_URL",
+        "OPENMED_OPENHIM_USERNAME",
+        "OPENMED_OPENHIM_PASSWORD",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(OpenHIMMediatorConfigurationError, match="required settings"):
+        OpenHIMMediatorSettings.from_env()
+
+
+def test_heartbeat_interval_is_bounded_by_openhim_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_enabled_env(monkeypatch)
+    monkeypatch.setenv("OPENMED_OPENHIM_HEARTBEAT_INTERVAL_SECONDS", "31")
+
+    with pytest.raises(OpenHIMMediatorConfigurationError, match="must not exceed 30"):
+        OpenHIMMediatorSettings.from_env()
+
+
+def test_management_api_requires_tls_unless_fixture_override_is_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_enabled_env(monkeypatch)
+    monkeypatch.setenv("OPENMED_OPENHIM_CORE_URL", "http://openhim-fixture:8081")
+
+    with pytest.raises(OpenHIMMediatorConfigurationError, match="must use https"):
+        OpenHIMMediatorSettings.from_env()
+
+    monkeypatch.setenv("OPENMED_OPENHIM_ALLOW_INSECURE_HTTP", "true")
+    settings = OpenHIMMediatorSettings.from_env()
+
+    assert settings.allow_insecure_http is True
+
+
+def test_management_api_url_rejects_embedded_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_enabled_env(monkeypatch)
+    monkeypatch.setenv(
+        "OPENMED_OPENHIM_CORE_URL",
+        "https://user:password@openhim-core.example:8080",
+    )
+
+    with pytest.raises(
+        OpenHIMMediatorConfigurationError,
+        match="must not contain credentials",
+    ):
+        OpenHIMMediatorSettings.from_env()
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "message"),
+    [
+        ("OPENMED_OPENHIM_AUTH_MODE", "session", "must be one of"),
+        ("OPENMED_OPENHIM_METHOD", "keep", "must be one of"),
+        ("OPENMED_OPENHIM_POLICY", "not_a_policy", "bundled policy"),
+    ],
+)
+def test_processing_and_authentication_settings_are_validated_at_startup(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: str,
+    message: str,
+) -> None:
+    _set_enabled_env(monkeypatch)
+    monkeypatch.setenv(name, value)
+
+    with pytest.raises(OpenHIMMediatorConfigurationError, match=message):
+        OpenHIMMediatorSettings.from_env()
+
+
+def test_recorded_token_registration_and_heartbeat_handshake_is_idempotent() -> None:
+    fixture = _fixture("handshake.json")
+    registration = default_mediator_registration()
+    observed: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raw_path = request.url.raw_path.decode("ascii")
+        observed.append(
+            {
+                "method": request.method,
+                "path": raw_path,
+                "authorization": request.headers.get("authorization"),
+                "auth_username": request.headers.get("auth-username"),
+                "auth_timestamp": request.headers.get("auth-ts"),
+                "auth_salt": request.headers.get("auth-salt"),
+                "auth_token": request.headers.get("auth-token"),
+                "body": json.loads(request.content) if request.content else None,
+            }
+        )
+        for step_name in ("authenticate", "registration", "heartbeat"):
+            step = fixture[step_name]
+            if request.method == step["method"] and raw_path == step["path"]:
+                return httpx.Response(
+                    step["response_status"], json=step["response_body"]
+                )
+        return httpx.Response(404)
+
+    async def scenario() -> None:
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            ticks = iter((100.0, 105.0))
+            client = OpenHIMMediatorClient(
+                _enabled_settings(registration, auth_mode="token"),
+                client=http_client,
+                monotonic=lambda: next(ticks),
+            )
+            await client.start()
+            await client.start()
+            assert client.status()["registered"] is True
+            assert client.status()["last_heartbeat_at"] is not None
+            await client.stop()
+
+    asyncio.run(scenario())
+
+    assert [item["path"] for item in observed] == [
+        fixture["authenticate"]["path"],
+        fixture["registration"]["path"],
+        fixture["authenticate"]["path"],
+        fixture["heartbeat"]["path"],
+    ]
+    salt = fixture["authenticate"]["response_body"]["salt"]
+    timestamp = fixture["authenticate"]["response_body"]["ts"]
+    password_hash = hashlib.sha512(
+        f"{salt}synthetic-password".encode("utf-8")
+    ).hexdigest()
+    expected_token = hashlib.sha512(
+        f"{password_hash}{salt}{timestamp}".encode("utf-8")
+    ).hexdigest()
+    for request in (observed[1], observed[3]):
+        assert request["authorization"] is None
+        assert request["auth_username"] == "openhim@example.org"
+        assert request["auth_timestamp"] == timestamp
+        assert request["auth_salt"] == salt
+        assert request["auth_token"] == expected_token
+    assert observed[1]["body"] == registration
+    assert observed[3]["body"]["config"] is True
+    assert observed[3]["body"]["uptime"] == 5.0
+
+
+def test_basic_authentication_does_not_call_token_preflight() -> None:
+    registration = default_mediator_registration()
+    observed: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        observed.append(request)
+        if request.url.path == "/mediators":
+            return httpx.Response(201)
+        if request.url.path.endswith("/heartbeat"):
+            return httpx.Response(200)
+        return httpx.Response(404)
+
+    async def scenario() -> None:
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            client = OpenHIMMediatorClient(
+                _enabled_settings(registration),
+                client=http_client,
+            )
+            await client.heartbeat(force_config=True)
+            await client.stop()
+
+    asyncio.run(scenario())
+
+    assert [request.url.path for request in observed] == [
+        "/mediators",
+        f"/mediators/{DEFAULT_MEDIATOR_URN}/heartbeat",
+    ]
+    assert all(
+        request.headers["authorization"].startswith("Basic ") for request in observed
+    )
+
+
+def test_fhir_bundle_envelope_redacts_phi_and_preserves_coded_bytes() -> None:
+    source = _fixture("fhir_bundle.json")
+    result = transform_mediator_payload(
+        json.dumps(source).encode("utf-8"),
+        {"content-type": "application/fhir+json", "x-request-id": "synthetic-871"},
+        202,
+        deidentifier=_fake_deidentify,
+    )
+    envelope = build_openhim_envelope(result, urn=DEFAULT_MEDIATOR_URN)
+    output = json.loads(envelope["response"]["body"])
+
+    assert result.transformed is True
+    assert envelope["x-mediator-urn"] == DEFAULT_MEDIATOR_URN
+    assert envelope["status"] == "Successful"
+    assert envelope["response"]["status"] == 202
+    assert envelope["response"]["headers"]["x-request-id"] == "synthetic-871"
+    assert envelope["orchestrations"][0]["name"] == ("OpenMed local de-identification")
+    assert envelope["orchestrations"][0]["request"].get("body") is None
+    assert_redacted(json.dumps(output), SYNTHETIC_MAPPING)
+
+    for index, entry in enumerate(source["entry"]):
+        output_entry = output["entry"][index]
+        assert _canonical_bytes(output_entry["fullUrl"]) == _canonical_bytes(
+            entry["fullUrl"]
+        )
+        assert _canonical_bytes(output_entry["request"]) == _canonical_bytes(
+            entry["request"]
+        )
+    source_observation = source["entry"][1]["resource"]
+    output_observation = output["entry"][1]["resource"]
+    assert _canonical_bytes(output_observation["code"]) == _canonical_bytes(
+        source_observation["code"]
+    )
+    assert _canonical_bytes(output_observation["subject"]["reference"]) == (
+        _canonical_bytes(source_observation["subject"]["reference"])
+    )
+
+
+def test_fhir_parameters_cannot_override_deployment_policy_or_method() -> None:
+    observed: list[dict[str, Any]] = []
+
+    def deidentifier(text: str, **kwargs: Any) -> _FakeResult:
+        observed.append(dict(kwargs))
+        return _FakeResult(text.replace("Amina Example", "[NAME]"))
+
+    source = {
+        "resourceType": "Parameters",
+        "parameter": [
+            {
+                "name": "resource",
+                "resource": {
+                    "resourceType": "Patient",
+                    "name": [{"text": "Amina Example"}],
+                },
+            },
+            {"name": "policy", "valueString": "clinical_minimal_redaction"},
+            {"name": "method", "valueCode": "remove"},
+        ],
+    }
+
+    result = transform_mediator_payload(
+        json.dumps(source).encode(),
+        {"content-type": "application/fhir+json"},
+        200,
+        deidentifier=deidentifier,
+        policy="hipaa_safe_harbor",
+        method="replace",
+    )
+    output = json.loads(result.body)
+
+    assert observed == [
+        {
+            "policy": "hipaa_safe_harbor",
+            "method": "replace",
+            "consistent": True,
+        }
+    ]
+    assert "Amina Example" not in result.body.decode()
+    assert {item["name"]: item for item in output["parameter"]}["policy"] == {
+        "name": "policy",
+        "valueString": "hipaa_safe_harbor",
+    }
+    assert {item["name"]: item for item in output["parameter"]}["method"] == {
+        "name": "method",
+        "valueCode": "replace",
+    }
+
+
+def test_non_text_payload_preserves_bytes_headers_and_status() -> None:
+    body = b"\x00\xff\x10synthetic-binary\x00"
+    headers = {
+        "content-type": "application/octet-stream",
+        "content-disposition": 'attachment; filename="scan.bin"',
+        "x-request-id": "opaque-871",
+    }
+
+    result = transform_mediator_payload(body, headers, 206)
+
+    assert result == MediatorTransformResult(
+        body=body,
+        headers=headers,
+        status_code=206,
+        transformed=False,
+        operation="pass-through",
+    )
+
+
+def test_response_headers_drop_credentials_and_unbounded_clinical_metadata() -> None:
+    headers = mediator_response_headers(
+        {
+            "content-type": "application/octet-stream",
+            "content-encoding": "gzip",
+            "x-request-id": "synthetic-871",
+            "content-disposition": 'attachment; filename="Amina Example.pdf"',
+            "authorization": "Basic secret",
+            "cookie": "session=secret",
+            "traceparent": "Amina Example",
+            "x-patient-name": "Amina Example",
+        }
+    )
+
+    assert headers == {
+        "content-type": "application/octet-stream",
+        "content-encoding": "gzip",
+        "x-request-id": "synthetic-871",
+    }
+
+
+def test_openhim_envelope_decodes_declared_text_charset() -> None:
+    result = MediatorTransformResult(
+        body="dé-identifié".encode("iso-8859-1"),
+        headers={"content-type": "text/plain; charset=iso-8859-1"},
+        status_code=200,
+        transformed=True,
+        operation="text-de-identify",
+    )
+
+    envelope = build_openhim_envelope(result, urn=DEFAULT_MEDIATOR_URN)
+
+    assert envelope["response"]["body"] == "dé-identifié"
+
+
+def test_failed_envelope_requests_retry_without_exposing_exception_details() -> None:
+    envelope = build_openhim_envelope(
+        failed_openhim_result(500, "processing_failed"),
+        urn=DEFAULT_MEDIATOR_URN,
+    )
+
+    assert envelope["status"] == "Failed"
+    assert envelope["error"] == {"message": "Mediator request failed"}
+    assert "stack" not in envelope["error"]
+
+
+class _FakeLifecycleClient:
+    def __init__(self, urn: str) -> None:
+        self.urn = urn
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "enabled": True,
+            "registered": self.started,
+            "urn": self.urn,
+            "last_heartbeat_at": "2026-01-01T00:00:00Z",
+            "last_error": None,
+        }
+
+
+def test_enabled_app_returns_well_formed_openhim_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_enabled_env(monkeypatch)
+    lifecycle = _FakeLifecycleClient(DEFAULT_MEDIATOR_URN)
+    monkeypatch.setattr(service_app, "create_openhim_mediator", lambda _: lifecycle)
+    app = service_app.create_app()
+    app.state.openhim_deidentifier = _fake_deidentify
+    source = _fixture("fhir_bundle.json")
+
+    with TestClient(app, base_url="http://localhost") as client:
+        heartbeat = client.get("/openhim/heartbeat")
+        response = client.post(
+            "/openhim/deidentify",
+            content=json.dumps(source).encode("utf-8"),
+            headers={
+                "content-type": "application/fhir+json",
+                "x-request-id": "app-fixture-871",
+            },
+        )
+
+    assert lifecycle.started is True
+    assert lifecycle.stopped is True
+    assert heartbeat.json()["registered"] is True
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(OPENHIM_MEDIA_TYPE)
+    envelope = response.json()
+    assert envelope["response"]["headers"]["x-request-id"] == "app-fixture-871"
+    assert envelope["properties"]["openmed.operation"] == ("fhir-bundle-de-identify")
+    assert_redacted(envelope["response"]["body"], SYNTHETIC_MAPPING)
+
+
+def test_enabled_app_keeps_opaque_body_outside_json_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_enabled_env(monkeypatch)
+    lifecycle = _FakeLifecycleClient(DEFAULT_MEDIATOR_URN)
+    monkeypatch.setattr(service_app, "create_openhim_mediator", lambda _: lifecycle)
+    app = service_app.create_app()
+    body = b"\x00\xff\x10opaque"
+
+    with TestClient(app, base_url="http://localhost") as client:
+        response = client.post(
+            "/openhim/deidentify",
+            content=body,
+            headers={"content-type": "application/octet-stream"},
+        )
+
+    assert response.status_code == 200
+    assert response.content == body
+    assert response.headers["content-type"] == "application/octet-stream"
+
+
+def test_request_query_cannot_weaken_deidentification_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_enabled_env(monkeypatch)
+    lifecycle = _FakeLifecycleClient(DEFAULT_MEDIATOR_URN)
+    monkeypatch.setattr(service_app, "create_openhim_mediator", lambda _: lifecycle)
+    observed: list[dict[str, Any]] = []
+
+    def deidentifier(text: str, **kwargs: Any) -> _FakeResult:
+        observed.append(dict(kwargs))
+        return _FakeResult(text.replace("Amina Example", "[NAME]"))
+
+    app = service_app.create_app()
+    app.state.openhim_deidentifier = deidentifier
+
+    with TestClient(app, base_url="http://localhost") as client:
+        response = client.post(
+            "/openhim/deidentify?policy=clinical_minimal_redaction&method=remove",
+            content="Patient Amina Example".encode(),
+            headers={"content-type": "text/plain"},
+        )
+
+    assert response.status_code == 200
+    assert observed == [{"policy": "hipaa_safe_harbor", "method": "replace"}]
+    assert "Amina Example" not in response.json()["response"]["body"]

--- a/tests/unit/test_no_telemetry.py
+++ b/tests/unit/test_no_telemetry.py
@@ -67,6 +67,9 @@ ALLOWED_NETWORK_MODULES: dict[str, str] = {
     "eval/suites/shield.py": "opt-in evaluation dataset/rows fetch",
     "interop/openmrs.py": "opt-in facility-local OpenMRS HTTP client",
     "service/client.py": "opt-in REST service HTTP client",
+    "service/openhim_mediator.py": (
+        "opt-in OpenHIM mediator registration/heartbeat (user-configured)"
+    ),
     "service/privacy_gateway.py": "opt-in privacy-gateway forwarding (user-configured)",
     "service/smart_backend.py": "opt-in smart-backend routing (user-configured)",
     "service/webhooks.py": "opt-in user-configured webhooks",


### PR DESCRIPTION
## Description

Adds an opt-in OpenHIM de-identification mediator to the existing REST service. The mediator registers at startup, sends initial and periodic heartbeats, produces OpenHIM transaction envelopes for FHIR and plain-text de-identification, and preserves unsupported payload bytes and response semantics.

The deployment example keeps processing inside the HIE trust boundary and includes a synthetic fixture service for offline registration and heartbeat smoke tests without bundling OpenHIM core.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [x] Test addition/improvement

## Changes Made

- Add disabled-by-default registration, heartbeat, status, and structured response support.
- Support current Basic authentication and the legacy token handshake without sending management credentials over plaintext by default.
- Pin policy and method at deployment startup so request query strings and FHIR `Parameters` cannot weaken the configured posture.
- Add FHIR no-PHI-leak and coded/reference fidelity coverage using synthetic recorded fixtures.
- Reflect only response-safe representation and correlation headers; errors remain PHI-free.
- Add container packaging, compose configuration, a fixture-backed CI smoke test, and deployment guidance.
- Add the reviewed opt-in network surface to the no-telemetry policy inventory.

## Testing

- [x] Full suite: `6954 passed, 48 skipped`.
- [x] Focused OpenHIM/no-telemetry suite: `31 passed, 1 deselected`.
- [x] Live Docker compose smoke: `1 passed, 2 deselected`.
- [x] `make format`, `make lint`, `make format-check`, and `make type-check`.
- [x] Scoped pre-commit hooks, including Bandit and secret detection.
- [x] Strict documentation build.

## Documentation

- [x] Added the OpenHIM deployment and channel setup guide.
- [x] Added docstrings to new public functions and classes.
- [x] Updated the changelog.

## Code Quality

- [x] Performed a maintainer security and protocol review against the OpenHIM mediator and authentication contracts.
- [x] No new runtime dependency was added.

## Related Issues

Closes #1448

## Screenshots/Examples

The compose example includes a synthetic handshake fixture and live health/heartbeat probes; no UI changes are included.
