### PR TITLE
feat: de-identify community health worker form exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added local, structure-preserving de-identification for ODK Central,
+  CommCare HQ, and KoBoToolbox JSON/CSV form exports, including XForm path
+  semantics, repeat fidelity, safe unknown-text handling, geopoint
+  generalization, and value-free policy manifests (#1450).
 - Added an opt-in OpenHIM de-identification mediator with authenticated
   registration and heartbeats, FHIR and text transformation envelopes,
   byte-preserving opaque pass-through, and an offline container smoke fixture

--- a/docs/chw-form-deid.md
+++ b/docs/chw-form-deid.md
@@ -1,0 +1,142 @@
+# Community Health Worker Form De-identification
+
+OpenMed can de-identify local submission exports from ODK Central, CommCare HQ,
+and KoBoToolbox before a form leaves the collection device or facility. The
+handler accepts nested JSON and CSV/TSV, including long-format repeat exports,
+and does not call any platform API.
+
+## Quick start
+
+Use `redact_chw_form` when you need the structured result and PHI-free manifest:
+
+```python
+from pathlib import Path
+
+from openmed.multimodal import redact_chw_form
+
+result = redact_chw_form(
+    Path("submissions.csv"),
+    platform="odk",  # optional when platform metadata is present
+)
+
+Path("submissions.deidentified.csv").write_text(result.text, encoding="utf-8")
+print(result.platform, result.row_count)
+print(result.manifest)  # policies and counts only; never raw form values
+```
+
+The generic multimodal dispatcher also detects XForm exports before falling
+back to the normal tabular CSV handler:
+
+```python
+from openmed.multimodal import redact_document
+
+document = redact_document("submissions.json")
+print(document.metadata["platform"])
+print(document.metadata["redaction_manifest"])
+```
+
+The narrative pass uses OpenMed's regular text de-identification pipeline. Keep
+the selected model cached on the facility machine when the workflow must remain
+fully offline.
+
+## XForm field policy
+
+Slash- and dot-delimited paths are interpreted as group/repeat paths. For
+example, `household/members/national_id` and
+`form.household.members.national_id` both classify the leaf as `ID_NUM` while
+retaining the original key or column header.
+
+| Field shape | Default action |
+| --- | --- |
+| `_uuid`, `_submission_time`, `deviceid`, `instanceID`, case IDs, `KEY`, `PARENT_KEY` | Deterministic hash |
+| Person, phone, date of birth, and street-address paths | Canonical-label mask |
+| National, patient, household, and record IDs | Deterministic hash |
+| Visit/encounter dates | Deterministic per-record date shift that preserves intervals |
+| `geopoint`, `geotrace`, `geoshape`, GPS, and coordinate paths | Generalize latitude/longitude; remove altitude and accuracy |
+| Narrative descriptions, comments, counselling notes, and visit notes | Text de-identification pipeline |
+| Unclassified text, including select-one/select-multiple answers | Run the text pipeline; coded values without detected PII remain unchanged |
+
+The default geopoint output retains only rounded latitude and longitude. For a
+district-only release, prefer dropping the coordinate and releasing a separate
+district code obtained from the program's local administrative hierarchy. This
+mirrors the DHIS2 rule of releasing the district ancestor rather than a
+facility or household location.
+
+## Policy overrides
+
+Platform metadata and coordinates can be removed instead of transformed:
+
+```python
+result = redact_chw_form(
+    "submissions.json",
+    policy={
+        "metadata_action": "drop",
+        "geopoint_action": "drop",
+    },
+)
+```
+
+Metadata supports `hash` or `drop`. Geopoints support `generalize_geo` or
+`drop`. `geo_precision` controls rounding from 0 through 4 decimal places. Use
+`header_heuristics` to map a program-specific field to a canonical label and
+`action_overrides` to set a specific path, leaf, canonical label, or policy
+class to `keep`, `mask`, `hash`, `drop`, `date_shift`,
+`free_text_redact`, or `generalize_geo`.
+
+```python
+result = redact_chw_form(
+    "submissions.csv",
+    policy={
+        "header_heuristics": {"beneficiary_alias": "PERSON"},
+        "action_overrides": {
+            "visit/other_answer": "free_text_redact",
+            "household/geopoint": "drop",
+        },
+    },
+)
+```
+
+Dropping a CSV field removes that column. Dropping a JSON field removes its key;
+repeat lists and the remaining nested structure are preserved.
+
+## Synthetic platform fixtures
+
+The repository includes paired JSON and CSV fixtures for each supported export
+shape under `tests/unit/multimodal/fixtures/chw_forms/`:
+
+- `odk.json` and `odk.csv`: ODK Central/OData-style metadata, slash paths, and
+  repeat rows
+- `commcare.json` and `commcare.csv`: nested `form`, `meta`, `case`, and dotted
+  paths
+- `kobo.json` and `kobo.csv`: KoBo metadata, slash-delimited fields, and nested
+  repeats
+
+Run the file-based example against any fixture:
+
+```bash
+uv run python examples/chw_form_deid.py \
+  tests/unit/multimodal/fixtures/chw_forms/odk.json \
+  --platform odk \
+  --output /tmp/odk.deidentified.json \
+  --manifest /tmp/odk.manifest.json
+```
+
+The output is deterministic for the same input, policy, and deterministic text
+redactor. JSON is emitted with stable key ordering, and CSV uses stable headers,
+row order, and line endings. The manifest includes field paths, canonical
+labels, actions, row counts, value counts, and affected counts, but never cell
+or answer values.
+
+For safety, an unrecognized text field is not assumed to be coded: it passes
+through the text de-identification pipeline. Numeric and boolean JSON values
+retain their original types, and coded text with no detected PII is emitted
+unchanged. CSV rows with a different width from the header are rejected rather
+than truncated.
+
+## Privacy boundary
+
+Only file exports are in scope. The handler does not fetch submissions from ODK
+Central, CommCare HQ, or KoBoToolbox and does not upload the result. Media
+attachments require the existing image/OCR redaction paths. Use only synthetic
+fixtures in tests and keep raw production exports inside the facility's
+authorized storage boundary.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -78,6 +78,7 @@ content-security policy blocks the optional inline styling.
 | `examples/gradio_deid_app.py` | Interactive Gradio UI to paste synthetic text, pick a `mask`/`replace`/`hash` method, and view the de-identified output plus detected entities (optional `pip install gradio`). |
 | `examples/v16_policy_audit_release_gates.py` | Demonstrates v1.6 policy profiles, canonical spans, signed audit reports, review bundles, redaction previews, leakage heatmaps, and k-anonymity metrics without model downloads. |
 | `examples/v17_multimodal_browser_interop.py` | Demonstrates v1.7 multimodal and interop surfaces: AsciiDoc offset projection, OCR contracts, chat JSONL, CSV manifests, FHIR, HL7 v2, and Transformers.js browser bundle checks. |
+| `examples/chw_form_deid.py` | De-identifies local ODK, CommCare, or KoBoToolbox JSON/CSV form exports and emits a value-free field-policy manifest. |
 | `examples/privacy_gateway_quickstart.py` | Shows redaction before an external model call and safe re-identification after the protected boundary. |
 | `examples/dbt-deidentify/` | Demonstrates the v1.8 warehouse transformation package for table redaction macros and redacted staging models. |
 | `examples/spark-streaming/` | Demonstrates Spark structured-streaming de-identification against synthetic records. |

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -26,6 +26,7 @@ coverage, see
 | Markup and metadata | Markdown/AsciiDoc and EPUB extraction, DOCX offset extraction, source text redaction, image/PDF/DOCX metadata scrubbing, and residual metadata verification. | `openmed/multimodal/documents_docx.py`, `openmed/multimodal/epub.py`, `openmed/multimodal/metadata_scrub.py`, `examples/v17_multimodal_browser_interop.py` |
 | DICOM, contacts, and PDFs | DICOM header de-identification, burned-in pixel OCR redaction, vCard/iCalendar PHI redaction, and redacted-PDF text-layer leakage/fidelity checks. | `openmed/multimodal/dicom.py`, `openmed/multimodal/contacts_calendar.py`, `openmed/multimodal/verify_pdf.py`, [EPUB Extraction](./multimodal/epub-extraction.md) |
 | Chat logs and tabular data | JSONL chat-log redaction with speaker pseudonymization, CSV/TSV PHI column classification, column actions, and PHI-safe manifests. | `openmed/multimodal/chatlog_jsonl.py`, `openmed/multimodal/tabular_csv.py`, `examples/v17_multimodal_browser_interop.py` |
+| Community health worker forms | ODK, CommCare, and KoBoToolbox JSON/CSV export detection, XForm path semantics, repeat preservation, narrative de-identification, metadata hashing, and coordinate generalization. | `openmed/multimodal/chw_forms.py`, [CHW Form Export De-identification](./chw-form-deid.md), `examples/chw_form_deid.py` |
 
 ## Health-data Interop
 

--- a/examples/chw_form_deid.py
+++ b/examples/chw_form_deid.py
@@ -1,0 +1,76 @@
+"""De-identify a local ODK, CommCare, or KoBoToolbox form export."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from openmed.multimodal import redact_chw_form
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CHW form example command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path, help="Local JSON, CSV, or TSV export")
+    parser.add_argument("--platform", choices=("odk", "commcare", "kobo"))
+    parser.add_argument("--output", type=Path, help="Write the redacted export here")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        help="Write the PHI-free policy/count manifest as JSON",
+    )
+    parser.add_argument(
+        "--drop-metadata",
+        action="store_true",
+        help="Drop platform metadata instead of hashing it",
+    )
+    parser.add_argument(
+        "--drop-geopoints",
+        action="store_true",
+        help="Drop geopoint/geotrace fields instead of generalizing them",
+    )
+    return parser
+
+
+def run(
+    source: Path,
+    *,
+    platform: str | None = None,
+    drop_metadata: bool = False,
+    drop_geopoints: bool = False,
+) -> tuple[str, str]:
+    """Return the redacted export and serialized PHI-free manifest."""
+    policy = {
+        "metadata_action": "drop" if drop_metadata else "hash",
+        "geopoint_action": "drop" if drop_geopoints else "generalize_geo",
+    }
+    result = redact_chw_form(source, platform=platform, policy=policy)
+    manifest = json.dumps(result.manifest, indent=2, sort_keys=True) + "\n"
+    return result.text, manifest
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the local-file example without any platform API calls."""
+    args = build_parser().parse_args(argv)
+    redacted, manifest = run(
+        args.source,
+        platform=args.platform,
+        drop_metadata=args.drop_metadata,
+        drop_geopoints=args.drop_geopoints,
+    )
+
+    if args.output:
+        args.output.write_text(redacted, encoding="utf-8")
+    else:
+        print(redacted, end="")
+    if args.manifest:
+        args.manifest.write_text(manifest, encoding="utf-8")
+    else:
+        print(manifest, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - De-identification API: api/deidentification.md
       - SMS Short-Text De-identification: sms-short-text-deid.md
       - PII Anonymization: anonymization.md
+      - CHW Form Export De-identification: chw-form-deid.md
       - Per-Language De-identification: languages.md
       - India Health-ID De-identification: india-health-id-deidentification.md
       - Smart Entity Merging: pii-smart-merging.md

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -36,6 +36,14 @@ from .chatlog_jsonl import (
     redact_chatlog_jsonl,
     write_redacted_chatlog_jsonl,
 )
+from .chw_forms import (
+    ACTION_GENERALIZE_GEO,
+    ChwFieldDecision,
+    RedactedChwForm,
+    classify_chw_field,
+    parse_xform_path,
+    redact_chw_form,
+)
 from .contacts_calendar import redact_contacts_calendar
 from .dicom import (
     DicomHeaderAction,
@@ -142,6 +150,12 @@ __all__ = [
     "iter_redacted_chatlog_jsonl",
     "redact_chatlog_jsonl",
     "write_redacted_chatlog_jsonl",
+    "ACTION_GENERALIZE_GEO",
+    "ChwFieldDecision",
+    "RedactedChwForm",
+    "classify_chw_field",
+    "parse_xform_path",
+    "redact_chw_form",
     "redact_contacts_calendar",
     "DicomHeaderAction",
     "DicomHeaderDeidPolicy",

--- a/openmed/multimodal/chw_forms.py
+++ b/openmed/multimodal/chw_forms.py
@@ -1,0 +1,1153 @@
+"""De-identification for ODK, CommCare, and KoBoToolbox form exports.
+
+The XForms ecosystem represents the same submission in several shapes: nested
+JSON, flat CSV with slash-delimited paths, and long-format repeat CSVs.  This
+module keeps those structures intact while applying field-level privacy rules.
+It uses only the standard library at import time; the regular OpenMed text
+de-identification pipeline is imported lazily only for narrative answers.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+import os
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openmed.core.labels import (
+    DATE,
+    DATE_OF_BIRTH,
+    DIRECT_IDENTIFIER,
+    GPS_COORDINATES,
+    ID_NUM,
+    LABEL_METADATA,
+    LOCATION,
+    OTHER,
+    PERSON,
+    PHONE,
+    QUASI_IDENTIFIER,
+    STREET_ADDRESS,
+    normalize_label,
+)
+
+from .base import ExtractedDocument, register_handler
+from .tabular_csv import (
+    ACTION_DATE_SHIFT,
+    ACTION_DROP,
+    ACTION_FREE_TEXT_REDACT,
+    ACTION_HASH,
+    ACTION_KEEP,
+    ACTION_MASK,
+    DIRECT_ID,
+    QUASI_ID,
+    SAFE,
+    derive_date_shift_days,
+)
+
+ACTION_GENERALIZE_GEO = "generalize_geo"
+
+SUPPORTED_CHW_ACTIONS = frozenset(
+    {
+        ACTION_DATE_SHIFT,
+        ACTION_DROP,
+        ACTION_FREE_TEXT_REDACT,
+        ACTION_GENERALIZE_GEO,
+        ACTION_HASH,
+        ACTION_KEEP,
+        ACTION_MASK,
+    }
+)
+
+TextRedactor = Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class ChwFieldDecision:
+    """Classification and action for one logical XForm field path."""
+
+    field_path: str
+    path_parts: tuple[str, ...]
+    assigned_class: str
+    action: str
+    canonical_label: str | None = None
+    policy_label: str | None = None
+    detection_source: str = "default"
+
+    def to_manifest(
+        self,
+        *,
+        platform: str,
+        row_count: int,
+        value_count: int,
+        value_count_affected: int,
+    ) -> dict[str, Any]:
+        """Return a PHI-free manifest entry containing policy and counts only."""
+        return {
+            "platform": platform,
+            "column_name": self.field_path,
+            "field_path": self.field_path,
+            "path_parts": list(self.path_parts),
+            "assigned_class": self.assigned_class,
+            "canonical_label": self.canonical_label,
+            "policy_label": self.policy_label,
+            "action": self.action,
+            "detection_source": self.detection_source,
+            "row_count": row_count,
+            "value_count": value_count,
+            "value_count_affected": value_count_affected,
+        }
+
+
+@dataclass(frozen=True)
+class RedactedChwForm:
+    """A structure-preserving CHW form export and its PHI-safe manifest."""
+
+    text: str
+    format: str
+    platform: str
+    row_count: int
+    manifest: tuple[dict[str, Any], ...]
+    data: Any
+    delimiter: str | None = None
+
+    def to_document(self) -> ExtractedDocument:
+        """Bridge the export into the shared multimodal document contract."""
+        metadata: dict[str, Any] = {
+            "format": f"chw_form_{self.format}",
+            "platform": self.platform,
+            "row_count": self.row_count,
+            "redaction_manifest": list(self.manifest),
+        }
+        if self.delimiter is not None:
+            metadata["delimiter"] = self.delimiter
+        return ExtractedDocument(text=self.text, metadata=metadata)
+
+
+@dataclass(frozen=True)
+class _PolicyOptions:
+    metadata_action: str = ACTION_HASH
+    geopoint_action: str = ACTION_GENERALIZE_GEO
+    geo_precision: int = 2
+    date_shift_days: int | None = None
+    header_heuristics: Mapping[str, str] | None = None
+    action_overrides: Mapping[str, str] | None = None
+
+
+@dataclass
+class _FieldStats:
+    decision: ChwFieldDecision
+    value_count: int = 0
+    affected_count: int = 0
+
+
+_DROP_VALUE = object()
+_WRAPPER_KEYS = frozenset({"data", "rows", "submissions", "value"})
+
+_METADATA_KEYS = frozenset(
+    {
+        "caseid",
+        "deviceid",
+        "instanceid",
+        "parentkey",
+        "submissiontime",
+        "uuid",
+    }
+)
+_METADATA_RAW_KEYS = frozenset(
+    {
+        "__id",
+        "__version__",
+        "_id",
+        "_index",
+        "_parent_index",
+        "_parent_table_name",
+        "_status",
+        "_submission__uuid",
+        "_submission_time",
+        "_submitted_by",
+        "_validation_status",
+        "_uuid",
+        "@case_id",
+        "case_id",
+        "deviceid",
+        "instanceid",
+        "key",
+        "parent_key",
+    }
+)
+
+_PERSON_KEYS = frozenset(
+    {
+        "beneficiaryname",
+        "childname",
+        "clientname",
+        "firstname",
+        "fullname",
+        "householdhead",
+        "lastname",
+        "membername",
+        "mothername",
+        "name",
+        "patientname",
+        "respondentname",
+    }
+)
+_PHONE_KEYS = frozenset(
+    {
+        "contactnumber",
+        "mobile",
+        "mobilenumber",
+        "msisdn",
+        "phone",
+        "phonenumber",
+        "telephone",
+    }
+)
+_ID_KEYS = frozenset(
+    {
+        "beneficiaryid",
+        "birthcertificatenumber",
+        "clientid",
+        "householdid",
+        "idnumber",
+        "nationalid",
+        "nationalidnumber",
+        "nhifnumber",
+        "passportnumber",
+        "patientid",
+        "recordid",
+    }
+)
+_DOB_KEYS = frozenset({"birthdate", "dateofbirth", "dob"})
+_DATE_KEYS = frozenset(
+    {
+        "admissiondate",
+        "encounterdate",
+        "eventdate",
+        "followupdate",
+        "servicedate",
+        "visitdate",
+    }
+)
+_ADDRESS_KEYS = frozenset(
+    {
+        "address",
+        "homeaddress",
+        "physicaladdress",
+        "residentialaddress",
+        "streetaddress",
+    }
+)
+_LOCATION_KEYS = frozenset(
+    {"county", "district", "location", "province", "subcounty", "village", "ward"}
+)
+_GEO_KEYS = frozenset(
+    {
+        "coordinate",
+        "coordinates",
+        "geo",
+        "geolocation",
+        "geopoint",
+        "geoshape",
+        "geotrace",
+        "gps",
+        "gpscoordinates",
+        "latitude",
+        "longitude",
+    }
+)
+_FREE_TEXT_MARKERS = (
+    "comment",
+    "counsellingnote",
+    "describe",
+    "description",
+    "freetext",
+    "narrative",
+    "note",
+    "otherspecify",
+    "visitdetail",
+)
+
+_JSON_MARKERS = frozenset(
+    {
+        "__id",
+        "_submission_time",
+        "_uuid",
+        "@case_id",
+        "case_id",
+        "deviceid",
+        "instanceid",
+    }
+)
+_NUMBER_RE = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$")
+
+
+def parse_xform_path(header: str) -> tuple[str, ...]:
+    """Split slash/dot-delimited XForm group and repeat paths."""
+    return tuple(part.strip() for part in re.split(r"[/.]", header) if part.strip())
+
+
+def classify_chw_field(
+    field_path: str,
+    *,
+    sample_values: Sequence[str] = (),
+    policy: Mapping[str, Any] | None = None,
+) -> ChwFieldDecision:
+    """Classify one XForm path using platform metadata and canonical labels."""
+    options = _policy_options(policy)
+    parts = parse_xform_path(field_path) or (field_path,)
+    raw_leaf = parts[-1].strip()
+    leaf = _field_key(raw_leaf)
+    normalized_parts = tuple(_field_key(part) for part in parts)
+
+    if _is_metadata_path(parts):
+        decision = _decision(
+            field_path,
+            parts,
+            ID_NUM,
+            options.metadata_action,
+            "platform_metadata",
+        )
+    elif _is_geo_path(normalized_parts) or any(
+        _looks_like_geopoint(value) for value in sample_values
+    ):
+        decision = ChwFieldDecision(
+            field_path=field_path,
+            path_parts=parts,
+            assigned_class=QUASI_ID,
+            action=options.geopoint_action,
+            canonical_label=GPS_COORDINATES,
+            policy_label=QUASI_IDENTIFIER,
+            detection_source="xform_geopoint",
+        )
+    else:
+        configured_label = _configured_label(field_path, leaf, options)
+        label = configured_label or _canonical_label_for_key(leaf)
+        if label is not None:
+            source = "policy_header" if configured_label else "xform_header"
+            decision = _decision(
+                field_path,
+                parts,
+                label,
+                _default_action(label),
+                source,
+            )
+        elif any(marker in leaf for marker in _FREE_TEXT_MARKERS):
+            decision = ChwFieldDecision(
+                field_path=field_path,
+                path_parts=parts,
+                assigned_class=SAFE,
+                action=ACTION_FREE_TEXT_REDACT,
+                detection_source="narrative_header",
+            )
+        else:
+            decision = ChwFieldDecision(
+                field_path=field_path,
+                path_parts=parts,
+                assigned_class=SAFE,
+                action=ACTION_FREE_TEXT_REDACT,
+                detection_source="unclassified_text_safety",
+            )
+
+    override = _action_override(decision, options.action_overrides)
+    if override is None:
+        return decision
+    return ChwFieldDecision(
+        field_path=decision.field_path,
+        path_parts=decision.path_parts,
+        assigned_class=decision.assigned_class,
+        action=override,
+        canonical_label=decision.canonical_label,
+        policy_label=decision.policy_label,
+        detection_source=decision.detection_source,
+    )
+
+
+def redact_chw_form(
+    source: str | os.PathLike[str] | Any,
+    *,
+    platform: str | None = None,
+    policy: Mapping[str, Any] | None = None,
+    models: Any | None = None,
+    lang: str = "en",
+    text_redactor: TextRedactor | None = None,
+) -> RedactedChwForm:
+    """De-identify a JSON or CSV submission export without changing its shape.
+
+    ``policy`` accepts ``metadata_action`` (``hash`` or ``drop``),
+    ``geopoint_action`` (``generalize_geo`` or ``drop``), ``geo_precision``,
+    ``date_shift_days``, ``header_heuristics``, and ``action_overrides``.
+    """
+    text = _read_text(source)
+    export_format = _export_format(source, text)
+    options = _policy_options(policy)
+    redactor = text_redactor or _text_redactor_from_models(models)
+
+    if export_format == "json":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError("invalid CHW form JSON export") from exc
+        resolved_platform = _normalize_platform(platform) or _detect_json_platform(data)
+        return _redact_json_export(
+            data,
+            platform=resolved_platform,
+            options=options,
+            lang=lang,
+            text_redactor=redactor,
+        )
+
+    return _redact_csv_export(
+        text,
+        platform=_normalize_platform(platform),
+        options=options,
+        lang=lang,
+        text_redactor=redactor,
+    )
+
+
+def _redact_json_export(
+    data: Any,
+    *,
+    platform: str,
+    options: _PolicyOptions,
+    lang: str,
+    text_redactor: TextRedactor | None,
+) -> RedactedChwForm:
+    values: dict[tuple[str, ...], list[str]] = {}
+    _collect_json_values(data, (), values)
+    decisions = {
+        path: classify_chw_field(
+            "/".join(path),
+            sample_values=samples,
+            policy=_options_mapping(options),
+        )
+        for path, samples in values.items()
+        if path
+    }
+    stats = {path: _FieldStats(decision) for path, decision in decisions.items()}
+    transformed = _transform_json(
+        data,
+        (),
+        decisions=decisions,
+        stats=stats,
+        options=options,
+        lang=lang,
+        text_redactor=text_redactor,
+        record_date_shift_days=_record_date_shift_days(data, 0, options),
+    )
+    output_text = (
+        json.dumps(
+            transformed,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    row_count = _json_row_count(data)
+    manifest = _manifest(stats, platform=platform, row_count=row_count)
+    return RedactedChwForm(
+        text=output_text,
+        format="json",
+        platform=platform,
+        row_count=row_count,
+        manifest=manifest,
+        data=transformed,
+    )
+
+
+def _redact_csv_export(
+    text: str,
+    *,
+    platform: str | None,
+    options: _PolicyOptions,
+    lang: str,
+    text_redactor: TextRedactor | None,
+) -> RedactedChwForm:
+    delimiter = _sniff_delimiter(text)
+    records = list(csv.reader(io.StringIO(text, newline=""), delimiter=delimiter))
+    if not records:
+        raise ValueError("CHW form CSV export is empty")
+    headers = tuple(records[0])
+    width = len(headers)
+    if any(len(row) != width for row in records[1:]):
+        raise ValueError("CHW form CSV rows must match the header width")
+    rows = [tuple(row) for row in records[1:]]
+    resolved_platform = platform or _detect_csv_platform(headers)
+
+    decisions: list[ChwFieldDecision] = []
+    for index, header in enumerate(headers):
+        samples = tuple(row[index] for row in rows if row[index])[:50]
+        decisions.append(
+            classify_chw_field(
+                header,
+                sample_values=samples,
+                policy=_options_mapping(options),
+            )
+        )
+    stats = {(decision.field_path,): _FieldStats(decision) for decision in decisions}
+    output_indices = [
+        index
+        for index, decision in enumerate(decisions)
+        if decision.action != ACTION_DROP
+    ]
+    output_rows: list[tuple[str, ...]] = []
+    for row_index, row in enumerate(rows):
+        record_date_shift_days = derive_date_shift_days(
+            row,
+            record_index=row_index,
+            fixed_days=options.date_shift_days,
+            seed="openmed-chw-csv-v1",
+        )
+        output_row: list[str] = []
+        for index, decision in enumerate(decisions):
+            stat = stats[(decision.field_path,)]
+            value = row[index]
+            if value:
+                stat.value_count += 1
+            redacted, changed = _apply_action(
+                value,
+                decision,
+                options=options,
+                lang=lang,
+                text_redactor=text_redactor,
+                record_date_shift_days=record_date_shift_days,
+            )
+            if changed:
+                stat.affected_count += 1
+            if index in output_indices:
+                output_row.append(str(redacted))
+        output_rows.append(tuple(output_row))
+
+    stream = io.StringIO(newline="")
+    writer = csv.writer(stream, delimiter=delimiter, lineterminator="\n")
+    writer.writerow([headers[index] for index in output_indices])
+    writer.writerows(output_rows)
+    output_text = stream.getvalue()
+    manifest = _manifest(stats, platform=resolved_platform, row_count=len(rows))
+    return RedactedChwForm(
+        text=output_text,
+        format="csv" if delimiter == "," else "tsv",
+        platform=resolved_platform,
+        row_count=len(rows),
+        manifest=manifest,
+        data=tuple(output_rows),
+        delimiter=delimiter,
+    )
+
+
+def _collect_json_values(
+    value: Any,
+    path: tuple[str, ...],
+    fields: dict[tuple[str, ...], list[str]],
+) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            child_path = _json_child_path(path, str(key), child)
+            _collect_json_values(child, child_path, fields)
+        return
+    if isinstance(value, list):
+        for child in value:
+            _collect_json_values(child, path, fields)
+        return
+    if path and value is not None:
+        fields.setdefault(path, []).append(str(value))
+
+
+def _transform_json(
+    value: Any,
+    path: tuple[str, ...],
+    *,
+    decisions: Mapping[tuple[str, ...], ChwFieldDecision],
+    stats: Mapping[tuple[str, ...], _FieldStats],
+    options: _PolicyOptions,
+    lang: str,
+    text_redactor: TextRedactor | None,
+    record_date_shift_days: int,
+) -> Any:
+    if isinstance(value, Mapping):
+        output: dict[str, Any] = {}
+        for key, child in value.items():
+            child_path = _json_child_path(path, str(key), child)
+            transformed = _transform_json(
+                child,
+                child_path,
+                decisions=decisions,
+                stats=stats,
+                options=options,
+                lang=lang,
+                text_redactor=text_redactor,
+                record_date_shift_days=record_date_shift_days,
+            )
+            if transformed is not _DROP_VALUE:
+                output[str(key)] = transformed
+        return output
+    if isinstance(value, list):
+        output_list: list[Any] = []
+        for index, child in enumerate(value):
+            child_date_shift_days = record_date_shift_days
+            if not path:
+                child_date_shift_days = _record_date_shift_days(
+                    child,
+                    index,
+                    options,
+                )
+            transformed = _transform_json(
+                child,
+                path,
+                decisions=decisions,
+                stats=stats,
+                options=options,
+                lang=lang,
+                text_redactor=text_redactor,
+                record_date_shift_days=child_date_shift_days,
+            )
+            output_list.append(None if transformed is _DROP_VALUE else transformed)
+        return output_list
+    if value is None or not path:
+        return value
+
+    decision = decisions[path]
+    stat = stats[path]
+    stat.value_count += 1
+    transformed, changed = _apply_action(
+        value,
+        decision,
+        options=options,
+        lang=lang,
+        text_redactor=text_redactor,
+        record_date_shift_days=record_date_shift_days,
+    )
+    if changed:
+        stat.affected_count += 1
+    return transformed
+
+
+def _apply_action(
+    value: Any,
+    decision: ChwFieldDecision,
+    *,
+    options: _PolicyOptions,
+    lang: str,
+    text_redactor: TextRedactor | None,
+    record_date_shift_days: int,
+) -> tuple[Any, bool]:
+    if decision.action == ACTION_KEEP or value is None:
+        return value, False
+    if decision.action == ACTION_DROP:
+        return _DROP_VALUE, bool(value)
+    if value == "":
+        return value, False
+    if decision.action == ACTION_HASH:
+        redacted = _hash_value(value, decision.canonical_label or ID_NUM)
+    elif decision.action == ACTION_MASK:
+        redacted = f"[{decision.canonical_label or 'PHI'}]"
+    elif decision.action == ACTION_GENERALIZE_GEO:
+        redacted = _generalize_geo(value, precision=options.geo_precision)
+    elif decision.action == ACTION_FREE_TEXT_REDACT:
+        if not isinstance(value, str):
+            return value, False
+        redacted = _redact_free_text(
+            str(value),
+            text_redactor=text_redactor,
+            lang=lang,
+        )
+    elif decision.action == ACTION_DATE_SHIFT:
+        redacted = _shift_date_value(
+            str(value),
+            decision.canonical_label or DATE,
+            shift_days=record_date_shift_days,
+            lang=lang,
+        )
+    else:  # pragma: no cover - policy validation prevents this branch
+        raise ValueError(f"unsupported CHW form action: {decision.action!r}")
+    return redacted, redacted != value
+
+
+def _decision(
+    field_path: str,
+    parts: tuple[str, ...],
+    label: str,
+    action: str,
+    source: str,
+) -> ChwFieldDecision:
+    assigned_class, policy_label = _class_for_label(label)
+    return ChwFieldDecision(
+        field_path=field_path,
+        path_parts=parts,
+        assigned_class=assigned_class,
+        action=action,
+        canonical_label=label,
+        policy_label=policy_label,
+        detection_source=source,
+    )
+
+
+def _class_for_label(label: str) -> tuple[str, str | None]:
+    metadata = LABEL_METADATA.get(label)
+    policy_label = str(metadata["policy_label"]) if metadata else None
+    if policy_label == DIRECT_IDENTIFIER:
+        return DIRECT_ID, policy_label
+    if policy_label == QUASI_IDENTIFIER:
+        return QUASI_ID, policy_label
+    return SAFE, policy_label
+
+
+def _default_action(label: str) -> str:
+    if label == DATE:
+        return ACTION_DATE_SHIFT
+    if label == ID_NUM:
+        return ACTION_HASH
+    assigned_class, _ = _class_for_label(label)
+    if assigned_class in {DIRECT_ID, QUASI_ID}:
+        return ACTION_MASK
+    return ACTION_KEEP
+
+
+def _canonical_label_for_key(key: str) -> str | None:
+    if key in _PERSON_KEYS:
+        return PERSON
+    if key in _PHONE_KEYS:
+        return PHONE
+    if key in _ID_KEYS or key.endswith(("idnumber", "nationalidentifier")):
+        return ID_NUM
+    if key in _DOB_KEYS:
+        return DATE_OF_BIRTH
+    if key in _DATE_KEYS:
+        return DATE
+    if key in _ADDRESS_KEYS:
+        return STREET_ADDRESS
+    if key in _LOCATION_KEYS:
+        return LOCATION
+    canonical = normalize_label(key)
+    return canonical if canonical != OTHER else None
+
+
+def _configured_label(
+    field_path: str,
+    leaf: str,
+    options: _PolicyOptions,
+) -> str | None:
+    if not options.header_heuristics:
+        return None
+    normalized: dict[str, str] = {}
+    for key, value in options.header_heuristics.items():
+        normalized[str(key).lower()] = str(value)
+        normalized[_field_key(str(key))] = str(value)
+    candidates = (field_path.lower(), _field_key(field_path), leaf)
+    for candidate in candidates:
+        raw_label = normalized.get(candidate)
+        if raw_label is not None:
+            label = normalize_label(raw_label)
+            return label if label != OTHER else None
+    return None
+
+
+def _action_override(
+    decision: ChwFieldDecision,
+    overrides: Mapping[str, str] | None,
+) -> str | None:
+    if not overrides:
+        return None
+    normalized = {str(key).lower(): str(value) for key, value in overrides.items()}
+    leaf = _field_key(decision.path_parts[-1])
+    candidates = (
+        decision.field_path.lower(),
+        _field_key(decision.field_path),
+        leaf,
+        (decision.canonical_label or "").lower(),
+        decision.assigned_class.lower(),
+    )
+    for candidate in candidates:
+        if candidate and candidate in normalized:
+            action = normalized[candidate]
+            if action not in SUPPORTED_CHW_ACTIONS:
+                raise ValueError(f"unsupported CHW form redaction action: {action!r}")
+            return action
+    return None
+
+
+def _is_metadata_path(parts: Sequence[str]) -> bool:
+    raw_leaf = parts[-1].strip().lower()
+    leaf = _field_key(raw_leaf)
+    if raw_leaf in _METADATA_RAW_KEYS or leaf in _METADATA_KEYS:
+        return True
+    normalized_parts = tuple(_field_key(part) for part in parts)
+    if {"meta", "system"} & set(normalized_parts[:-1]) and leaf in {
+        "end",
+        "receivedon",
+        "start",
+        "submissiondate",
+        "timeend",
+        "timestart",
+        "username",
+    }:
+        return True
+    return bool("case" in normalized_parts and leaf in {"caseid", "id"})
+
+
+def _is_geo_path(parts: Sequence[str]) -> bool:
+    return any(part in _GEO_KEYS for part in parts)
+
+
+def _looks_like_geopoint(value: str) -> bool:
+    first_point = value.split(";", 1)[0].strip().split()
+    if len(first_point) < 2:
+        return False
+    if not all(_NUMBER_RE.fullmatch(item) for item in first_point[:2]):
+        return False
+    latitude, longitude = (float(item) for item in first_point[:2])
+    return -90 <= latitude <= 90 and -180 <= longitude <= 180
+
+
+def _generalize_geo(value: Any, *, precision: int) -> Any:
+    if isinstance(value, bool):
+        return ""
+    if isinstance(value, (int, float)):
+        return _rounded_number(value, precision)
+    if isinstance(value, list):
+        return [_generalize_geo(item, precision=precision) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_generalize_geo(item, precision=precision) for item in value)
+    if isinstance(value, Mapping):
+        return {
+            str(key): _generalize_geo(item, precision=precision)
+            for key, item in value.items()
+        }
+
+    points: list[str] = []
+    for point in str(value).split(";"):
+        components = point.strip().split()
+        if len(components) < 2 or not all(
+            _NUMBER_RE.fullmatch(item) for item in components[:2]
+        ):
+            return ""
+        points.append(
+            " ".join(
+                _format_coordinate(float(item), precision) for item in components[:2]
+            )
+        )
+    return ";".join(points)
+
+
+def _rounded_number(value: int | float, precision: int) -> float:
+    rounded = round(float(value), precision)
+    return 0.0 if rounded == 0 else rounded
+
+
+def _format_coordinate(value: float, precision: int) -> str:
+    rounded = _rounded_number(value, precision)
+    return f"{rounded:.{precision}f}"
+
+
+def _hash_value(value: Any, label: str) -> str:
+    digest = hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:12]
+    return f"{label}_{digest}"
+
+
+def _shift_date_value(value: str, label: str, *, shift_days: int, lang: str) -> str:
+    from .tabular_csv import _redact_with_core
+
+    return _redact_with_core(
+        value,
+        label=label,
+        method="shift_dates",
+        date_shift_days=shift_days,
+        keep_year=True,
+        lang=lang,
+    )
+
+
+def _record_date_shift_days(
+    value: Any,
+    record_index: int,
+    options: _PolicyOptions,
+) -> int:
+    material = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return derive_date_shift_days(
+        (material,),
+        record_index=record_index,
+        fixed_days=options.date_shift_days,
+        seed="openmed-chw-json-v1",
+    )
+
+
+def _redact_free_text(
+    value: str,
+    *,
+    text_redactor: TextRedactor | None,
+    lang: str,
+) -> str:
+    if text_redactor is not None:
+        return str(text_redactor(value))
+    from openmed.core.pii import deidentify
+
+    return deidentify(value, method="mask", lang=lang).deidentified_text
+
+
+def _text_redactor_from_models(models: Any | None) -> TextRedactor | None:
+    if callable(models):
+        return lambda text: str(models(text))
+    if isinstance(models, Mapping):
+        candidate = models.get("text_redactor")
+        if callable(candidate):
+            return lambda text: str(candidate(text))
+    candidate = getattr(models, "text_redactor", None)
+    if callable(candidate):
+        return lambda text: str(candidate(text))
+    return None
+
+
+def _policy_options(policy: Mapping[str, Any] | None) -> _PolicyOptions:
+    values = policy if isinstance(policy, Mapping) else {}
+    metadata_action = str(values.get("metadata_action", ACTION_HASH))
+    geopoint_action = str(values.get("geopoint_action", ACTION_GENERALIZE_GEO))
+    if metadata_action not in {ACTION_HASH, ACTION_DROP}:
+        raise ValueError("metadata_action must be 'hash' or 'drop'")
+    if geopoint_action not in {ACTION_GENERALIZE_GEO, ACTION_DROP}:
+        raise ValueError("geopoint_action must be 'generalize_geo' or 'drop'")
+    geo_precision = int(values.get("geo_precision", 2))
+    if not 0 <= geo_precision <= 4:
+        raise ValueError("geo_precision must be between 0 and 4")
+    date_shift_days_value = values.get("date_shift_days")
+    date_shift_days = (
+        int(date_shift_days_value) if date_shift_days_value is not None else None
+    )
+    header_heuristics = values.get("header_heuristics")
+    action_overrides = values.get("action_overrides")
+    return _PolicyOptions(
+        metadata_action=metadata_action,
+        geopoint_action=geopoint_action,
+        geo_precision=geo_precision,
+        date_shift_days=date_shift_days,
+        header_heuristics=(
+            header_heuristics if isinstance(header_heuristics, Mapping) else None
+        ),
+        action_overrides=(
+            action_overrides if isinstance(action_overrides, Mapping) else None
+        ),
+    )
+
+
+def _options_mapping(options: _PolicyOptions) -> dict[str, Any]:
+    return {
+        "metadata_action": options.metadata_action,
+        "geopoint_action": options.geopoint_action,
+        "geo_precision": options.geo_precision,
+        "date_shift_days": options.date_shift_days,
+        "header_heuristics": options.header_heuristics,
+        "action_overrides": options.action_overrides,
+    }
+
+
+def _manifest(
+    stats: Mapping[Any, _FieldStats],
+    *,
+    platform: str,
+    row_count: int,
+) -> tuple[dict[str, Any], ...]:
+    ordered = sorted(stats.values(), key=lambda stat: stat.decision.field_path)
+    return tuple(
+        stat.decision.to_manifest(
+            platform=platform,
+            row_count=row_count,
+            value_count=stat.value_count,
+            value_count_affected=stat.affected_count,
+        )
+        for stat in ordered
+    )
+
+
+def _json_child_path(path: tuple[str, ...], key: str, value: Any) -> tuple[str, ...]:
+    if not path and key.lower() in _WRAPPER_KEYS and isinstance(value, list):
+        return path
+    parts = parse_xform_path(key) or (key,)
+    return path + parts
+
+
+def _json_row_count(data: Any) -> int:
+    if isinstance(data, list):
+        return len(data)
+    if isinstance(data, Mapping):
+        for key, value in data.items():
+            if key.lower() in _WRAPPER_KEYS and isinstance(value, list):
+                return len(value)
+        return 1
+    return 0
+
+
+def _read_text(source: str | os.PathLike[str] | Any) -> str:
+    if hasattr(source, "read"):
+        content = source.read()
+        if not isinstance(content, str):
+            raise TypeError("source file-like object must return text")
+        return content.removeprefix("\ufeff")
+    if isinstance(source, os.PathLike):
+        return Path(source).read_text(encoding="utf-8-sig")
+    if isinstance(source, str):
+        content = source.removeprefix("\ufeff")
+        if (
+            "\n" in content
+            or "\r" in content
+            or content.lstrip().startswith(("{", "["))
+        ):
+            return content
+        path = Path(content)
+        try:
+            if path.exists():
+                return path.read_text(encoding="utf-8-sig")
+        except OSError:
+            pass
+        return content
+    raise TypeError("source must be a path, text content, or text file-like object")
+
+
+def _export_format(source: Any, text: str) -> str:
+    suffix = (
+        Path(str(source)).suffix.lower()
+        if isinstance(source, (str, os.PathLike))
+        else ""
+    )
+    if suffix == ".json" or text.lstrip().startswith(("{", "[")):
+        return "json"
+    return "csv"
+
+
+def _sniff_delimiter(text: str) -> str:
+    try:
+        dialect = csv.Sniffer().sniff(text[:8192], delimiters=",\t")
+        return str(dialect.delimiter)
+    except csv.Error:
+        first_line = text.splitlines()[0] if text.splitlines() else ""
+        return "\t" if "\t" in first_line and "," not in first_line else ","
+
+
+def _normalize_platform(platform: str | None) -> str | None:
+    if platform is None:
+        return None
+    normalized = platform.strip().lower().replace("toolbox", "").strip()
+    aliases = {"odk central": "odk", "commcare hq": "commcare", "kobo": "kobo"}
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in {"odk", "commcare", "kobo"}:
+        raise ValueError("platform must be 'odk', 'commcare', or 'kobo'")
+    return normalized
+
+
+def _detect_json_platform(data: Any) -> str:
+    paths: list[str] = []
+    _collect_json_paths(data, (), paths)
+    lowered = {path.lower() for path in paths}
+    if any("_submission_time" in path or "_uuid" in path for path in lowered):
+        return "kobo"
+    if any(path.startswith("form/") or "/case/" in path for path in lowered):
+        return "commcare"
+    return "odk"
+
+
+def _detect_csv_platform(headers: Sequence[str]) -> str:
+    lowered = tuple(header.lower() for header in headers)
+    if any("_submission_time" in header or "_uuid" in header for header in lowered):
+        return "kobo"
+    if any(
+        header.startswith("form.") or header.startswith("case.") for header in lowered
+    ):
+        return "commcare"
+    return "odk"
+
+
+def _collect_json_paths(value: Any, path: tuple[str, ...], paths: list[str]) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            child_path = _json_child_path(path, str(key), child)
+            _collect_json_paths(child, child_path, paths)
+    elif isinstance(value, list):
+        for child in value[:3]:
+            _collect_json_paths(child, path, paths)
+    elif path:
+        paths.append("/".join(path))
+
+
+def _looks_like_chw_form(path: str | Path) -> bool:
+    source = Path(path)
+    try:
+        text = source.read_text(encoding="utf-8-sig")
+    except (OSError, UnicodeError):
+        return False
+    if source.suffix.lower() == ".json":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return False
+        paths: list[str] = []
+        _collect_json_paths(data, (), paths)
+        raw = {parse_xform_path(item)[-1].lower() for item in paths if item}
+        return bool(raw & _JSON_MARKERS)
+
+    try:
+        delimiter = _sniff_delimiter(text)
+        headers = next(csv.reader(io.StringIO(text), delimiter=delimiter))
+    except (csv.Error, StopIteration):
+        return False
+    metadata_headers = [
+        header
+        for header in headers
+        if _is_metadata_path(parse_xform_path(header) or (header,))
+    ]
+    if any(
+        header.strip().lower() not in {"key", "parent_key"}
+        for header in metadata_headers
+    ):
+        return True
+    return bool(
+        metadata_headers and any("/" in header or "." in header for header in headers)
+    )
+
+
+def _chw_form_handler(
+    path: str | os.PathLike[str],
+    *,
+    policy: Mapping[str, Any] | None = None,
+    models: Any | None = None,
+    lang: str | None = None,
+) -> ExtractedDocument:
+    return redact_chw_form(
+        path,
+        policy=policy,
+        models=models,
+        lang=lang or "en",
+    ).to_document()
+
+
+def _field_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.strip().lower())
+
+
+register_handler(
+    (".json", ".csv", ".tsv"),
+    _chw_form_handler,
+    detector=_looks_like_chw_form,
+    requires_multimodal=False,
+)
+
+
+__all__ = [
+    "ACTION_GENERALIZE_GEO",
+    "ChwFieldDecision",
+    "RedactedChwForm",
+    "classify_chw_field",
+    "parse_xform_path",
+    "redact_chw_form",
+]

--- a/tests/unit/multimodal/fixtures/chw_forms/commcare.csv
+++ b/tests/unit/multimodal/fixtures/chw_forms/commcare.csv
@@ -1,0 +1,3 @@
+form.meta.instanceID,form.meta.deviceID,form.case.@case_id,form.patient.name,form.patient.mobile,form.patient.national_id,form.patient.gps,form.symptoms,form.counselling_notes,form.children.name,form.children.status
+uuid:commcare-csv-873-001,commcare-csv-device-873-001,commcare-case-873-001,Lindiwe Dlamini,+27821234567,ZA-873-001,-26.204103 28.047305 1753 6,fever_cough,Lindiwe Dlamini received counselling,Sipho Dlamini,enrolled
+uuid:commcare-csv-873-001,commcare-csv-device-873-001,commcare-case-873-001,Lindiwe Dlamini,+27821234567,ZA-873-001,-26.204103 28.047305 1753 6,fever_cough,Follow-up for Lindiwe Dlamini,Zola Dlamini,referred

--- a/tests/unit/multimodal/fixtures/chw_forms/commcare.json
+++ b/tests/unit/multimodal/fixtures/chw_forms/commcare.json
@@ -1,0 +1,56 @@
+[
+  {
+    "form": {
+      "meta": {
+        "instanceID": "uuid:commcare-instance-873-001",
+        "deviceID": "commcare-device-873-001"
+      },
+      "case": {
+        "@case_id": "commcare-case-873-001"
+      },
+      "patient": {
+        "name": "Lindiwe Dlamini",
+        "mobile": "+27821234567",
+        "national_id": "ZA-873-001",
+        "gps": "-26.204103 28.047305 1753 6"
+      },
+      "symptoms": "fever_cough",
+      "counselling_notes": "Lindiwe Dlamini received counselling",
+      "children": [
+        {
+          "name": "Sipho Dlamini",
+          "status": "enrolled"
+        },
+        {
+          "name": "Zola Dlamini",
+          "status": "referred"
+        }
+      ]
+    }
+  },
+  {
+    "form": {
+      "meta": {
+        "instanceID": "uuid:commcare-instance-873-002",
+        "deviceID": "commcare-device-873-002"
+      },
+      "case": {
+        "@case_id": "commcare-case-873-002"
+      },
+      "patient": {
+        "name": "Thabo Mokoena",
+        "mobile": "+27821234568",
+        "national_id": "ZA-873-002",
+        "gps": "-25.747868 28.229271 1339 7"
+      },
+      "symptoms": "none",
+      "counselling_notes": "Thabo Mokoena requested a referral",
+      "children": [
+        {
+          "name": "Naledi Mokoena",
+          "status": "enrolled"
+        }
+      ]
+    }
+  }
+]

--- a/tests/unit/multimodal/fixtures/chw_forms/kobo.csv
+++ b/tests/unit/multimodal/fixtures/chw_forms/kobo.csv
@@ -1,0 +1,3 @@
+_id,_uuid,_submission_time,household/name,household/phone,household/national_id,household/geolocation,household/symptoms,household/counselling_notes,children/name,children/status
+kobo-row-873-001,uuid:kobo-csv-873-001,2026-07-18T08:00:00Z,Mariam Diallo,+221771112233,SN-873-001,14.716677 -17.467686 25 3,fever malaria_test,Mariam Diallo received counselling,Awa Diallo,registered
+kobo-row-873-001,uuid:kobo-csv-873-001,2026-07-18T08:00:00Z,Mariam Diallo,+221771112233,SN-873-001,14.716677 -17.467686 25 3,fever malaria_test,Follow-up for Mariam Diallo,Ibrahima Diallo,follow_up

--- a/tests/unit/multimodal/fixtures/chw_forms/kobo.json
+++ b/tests/unit/multimodal/fixtures/chw_forms/kobo.json
@@ -1,0 +1,40 @@
+[
+  {
+    "_id": "kobo-row-873-001",
+    "_uuid": "uuid:kobo-873-001",
+    "_submission_time": "2026-07-18T08:00:00Z",
+    "household/respondent_name": "Mariam Diallo",
+    "household/phone": "+221771112233",
+    "household/national_id": "SN-873-001",
+    "household/geolocation": "14.716677 -17.467686 25 3",
+    "household/symptoms": "fever malaria_test",
+    "household/counselling_notes": "Mariam Diallo received counselling",
+    "children": [
+      {
+        "name": "Awa Diallo",
+        "status": "registered"
+      },
+      {
+        "name": "Ibrahima Diallo",
+        "status": "follow_up"
+      }
+    ]
+  },
+  {
+    "_id": "kobo-row-873-002",
+    "_uuid": "uuid:kobo-873-002",
+    "_submission_time": "2026-07-18T09:00:00Z",
+    "household/respondent_name": "Fatou Sarr",
+    "household/phone": "+221771112234",
+    "household/national_id": "SN-873-002",
+    "household/geolocation": "14.692778 -17.446667 22 4",
+    "household/symptoms": "none",
+    "household/counselling_notes": "Fatou Sarr requested follow-up",
+    "children": [
+      {
+        "name": "Moussa Sarr",
+        "status": "registered"
+      }
+    ]
+  }
+]

--- a/tests/unit/multimodal/fixtures/chw_forms/odk.csv
+++ b/tests/unit/multimodal/fixtures/chw_forms/odk.csv
@@ -1,0 +1,3 @@
+KEY,meta/instanceID,meta/deviceID,household/respondent_name,household/phone,household/national_id,household/geopoint,household/symptoms,household/visit_note,children/name,children/immunization_status
+odk-key-873-001,uuid:odk-csv-873-001,odk-csv-device-873-001,Amina Njeri,+254700111222,KEN-873-001,-1.292066 36.821946 1798 4,fever cough,Visited Amina Njeri at home,Neema Njeri,complete
+odk-key-873-001,uuid:odk-csv-873-001,odk-csv-device-873-001,Amina Njeri,+254700111222,KEN-873-001,-1.292066 36.821946 1798 4,fever cough,Second visit with Amina Njeri,Juma Njeri,due_soon

--- a/tests/unit/multimodal/fixtures/chw_forms/odk.json
+++ b/tests/unit/multimodal/fixtures/chw_forms/odk.json
@@ -1,0 +1,51 @@
+{
+  "@odata.context": "synthetic ODK Central export",
+  "value": [
+    {
+      "__id": "uuid:odk-873-001",
+      "meta": {
+        "instanceID": "uuid:odk-instance-873-001",
+        "deviceID": "odk-device-873-001"
+      },
+      "household": {
+        "respondent_name": "Amina Njeri",
+        "phone": "+254700111222",
+        "national_id": "KEN-873-001",
+        "geopoint": "-1.292066 36.821946 1798 4",
+        "symptoms": "fever cough",
+        "visit_note": "Visited Amina Njeri at home"
+      },
+      "children": [
+        {
+          "name": "Neema Njeri",
+          "immunization_status": "complete"
+        },
+        {
+          "name": "Juma Njeri",
+          "immunization_status": "due_soon"
+        }
+      ]
+    },
+    {
+      "__id": "uuid:odk-873-002",
+      "meta": {
+        "instanceID": "uuid:odk-instance-873-002",
+        "deviceID": "odk-device-873-002"
+      },
+      "household": {
+        "respondent_name": "Otieno Kamau",
+        "phone": "+254700111223",
+        "national_id": "KEN-873-002",
+        "geopoint": "-1.283330 36.816670 1790 5",
+        "symptoms": "none",
+        "visit_note": "Otieno Kamau requested a follow-up"
+      },
+      "children": [
+        {
+          "name": "Ayo Kamau",
+          "immunization_status": "complete"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/multimodal/test_chw_forms.py
+++ b/tests/unit/multimodal/test_chw_forms.py
@@ -1,0 +1,421 @@
+"""Tests for ODK, CommCare, and KoBoToolbox export de-identification."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import openmed.multimodal.base as base
+from openmed.interop import assert_redacted
+from openmed.multimodal import ExtractedDocument, redact_document
+from openmed.multimodal.chw_forms import (
+    ACTION_GENERALIZE_GEO,
+    classify_chw_field,
+    parse_xform_path,
+    redact_chw_form,
+)
+from openmed.multimodal.tabular_csv import (
+    ACTION_DROP,
+    ACTION_FREE_TEXT_REDACT,
+    ACTION_HASH,
+    ACTION_MASK,
+    DIRECT_ID,
+    QUASI_ID,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "chw_forms"
+
+PLATFORM_EXPORTS = (
+    ("odk", "json"),
+    ("odk", "csv"),
+    ("commcare", "json"),
+    ("commcare", "csv"),
+    ("kobo", "json"),
+    ("kobo", "csv"),
+)
+
+SEEDED_NAMES = (
+    "Amina Njeri",
+    "Neema Njeri",
+    "Juma Njeri",
+    "Otieno Kamau",
+    "Ayo Kamau",
+    "Lindiwe Dlamini",
+    "Sipho Dlamini",
+    "Zola Dlamini",
+    "Thabo Mokoena",
+    "Naledi Mokoena",
+    "Mariam Diallo",
+    "Awa Diallo",
+    "Ibrahima Diallo",
+    "Fatou Sarr",
+    "Moussa Sarr",
+)
+
+SEEDED_IDENTIFIERS = SEEDED_NAMES + (
+    "+254700111222",
+    "+254700111223",
+    "+27821234567",
+    "+27821234568",
+    "+221771112233",
+    "+221771112234",
+    "KEN-873-001",
+    "KEN-873-002",
+    "ZA-873-001",
+    "ZA-873-002",
+    "SN-873-001",
+    "SN-873-002",
+    "-1.292066 36.821946 1798 4",
+    "-1.283330 36.816670 1790 5",
+    "-26.204103 28.047305 1753 6",
+    "-25.747868 28.229271 1339 7",
+    "14.716677 -17.467686 25 3",
+    "14.692778 -17.446667 22 4",
+    "uuid:odk-instance-873-001",
+    "uuid:commcare-instance-873-001",
+    "uuid:kobo-873-001",
+    "commcare-case-873-001",
+)
+
+
+def _synthetic_text_redactor(text: str) -> str:
+    for name in SEEDED_NAMES:
+        text = text.replace(name, "[PERSON]")
+    return text
+
+
+def _json_schema(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _json_schema(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_json_schema(child) for child in value]
+    return type(value).__name__
+
+
+def _list_lengths(value: Any, path: str = "root") -> dict[str, int]:
+    lengths: dict[str, int] = {}
+    if isinstance(value, dict):
+        for key, child in value.items():
+            lengths.update(_list_lengths(child, f"{path}/{key}"))
+    elif isinstance(value, list):
+        lengths[path] = len(value)
+        for index, child in enumerate(value):
+            lengths.update(_list_lengths(child, f"{path}/{index}"))
+    return lengths
+
+
+def _coded_json_values(value: Any, path: str = "") -> dict[str, list[Any]]:
+    coded: dict[str, list[Any]] = {}
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}/{key}" if path else key
+            coded.update(_coded_json_values(child, child_path))
+    elif isinstance(value, list):
+        for child in value:
+            for key, entries in _coded_json_values(child, path).items():
+                coded.setdefault(key, []).extend(entries)
+    elif path.lower().endswith(("symptoms", "status", "immunization_status")):
+        coded.setdefault(path, []).append(value)
+    return coded
+
+
+@pytest.mark.parametrize("platform,extension", PLATFORM_EXPORTS)
+def test_platform_exports_round_trip_without_structural_loss(platform, extension):
+    source_path = FIXTURES / f"{platform}.{extension}"
+    result = redact_chw_form(
+        source_path,
+        text_redactor=_synthetic_text_redactor,
+    )
+
+    assert result.platform == platform
+    assert result.row_count == 2
+    if extension == "json":
+        source = json.loads(source_path.read_text(encoding="utf-8"))
+        output = json.loads(result.text)
+        assert _json_schema(output) == _json_schema(source)
+        assert _list_lengths(output) == _list_lengths(source)
+        assert _coded_json_values(output) == _coded_json_values(source)
+    else:
+        source_rows = list(csv.DictReader(source_path.open(encoding="utf-8")))
+        output_rows = list(csv.DictReader(io.StringIO(result.text)))
+        assert output_rows[0].keys() == source_rows[0].keys()
+        assert len(output_rows) == len(source_rows)
+        coded_headers = [
+            header
+            for header in source_rows[0]
+            if header.lower().endswith(("symptoms", "status"))
+        ]
+        for header in coded_headers:
+            assert [row[header] for row in output_rows] == [
+                row[header] for row in source_rows
+            ]
+
+
+@pytest.mark.parametrize("platform,extension", PLATFORM_EXPORTS)
+def test_no_seeded_phi_leaks_to_output_or_manifest(platform, extension):
+    result = redact_chw_form(
+        FIXTURES / f"{platform}.{extension}",
+        text_redactor=_synthetic_text_redactor,
+    )
+    serialized = result.text + json.dumps(result.manifest, sort_keys=True)
+    mapping = {f"seed-{index}": value for index, value in enumerate(SEEDED_IDENTIFIERS)}
+
+    assert_redacted(serialized, mapping)
+    assert not any(value in serialized for value in SEEDED_IDENTIFIERS)
+
+
+def test_nested_xform_paths_map_to_canonical_semantics():
+    assert parse_xform_path("form.household/repeats/national_id") == (
+        "form",
+        "household",
+        "repeats",
+        "national_id",
+    )
+
+    national_id = classify_chw_field("form.household/repeats/national_id")
+    person = classify_chw_field("household/members/respondent_name")
+    phone = classify_chw_field("form.patient.mobile")
+    birth_date = classify_chw_field("household/child/date_of_birth")
+    address = classify_chw_field("form.patient/residential_address")
+    narrative = classify_chw_field("visit/counselling_notes")
+    coded = classify_chw_field("visit/symptoms")
+
+    assert (national_id.canonical_label, national_id.action) == ("ID_NUM", ACTION_HASH)
+    assert (person.canonical_label, person.action) == ("PERSON", ACTION_MASK)
+    assert (phone.canonical_label, phone.action) == ("PHONE", ACTION_MASK)
+    assert (birth_date.canonical_label, birth_date.assigned_class) == (
+        "DATE_OF_BIRTH",
+        DIRECT_ID,
+    )
+    assert address.canonical_label == "STREET_ADDRESS"
+    assert narrative.action == ACTION_FREE_TEXT_REDACT
+    assert coded.action == ACTION_FREE_TEXT_REDACT
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "_uuid",
+        "_submission_time",
+        "meta/deviceID",
+        "form.meta.instanceID",
+        "form/case/@case_id",
+        "KEY",
+        "PARENT_KEY",
+    ),
+)
+def test_platform_metadata_is_hashed_or_dropped(path):
+    hashed = classify_chw_field(path)
+    dropped = classify_chw_field(path, policy={"metadata_action": "drop"})
+
+    assert hashed.action == ACTION_HASH
+    assert hashed.assigned_class == DIRECT_ID
+    assert hashed.detection_source == "platform_metadata"
+    assert dropped.action == ACTION_DROP
+
+
+def test_geopoints_are_quasi_identifiers_and_are_generalized_or_dropped():
+    decision = classify_chw_field(
+        "household/repeat/geotrace",
+        sample_values=("-1.292066 36.821946 1798 4",),
+    )
+    assert decision.canonical_label == "GPS_COORDINATES"
+    assert decision.assigned_class == QUASI_ID
+    assert decision.action == ACTION_GENERALIZE_GEO
+
+    generalized = redact_chw_form(
+        FIXTURES / "odk.csv",
+        text_redactor=_synthetic_text_redactor,
+    )
+    dropped = redact_chw_form(
+        FIXTURES / "odk.csv",
+        policy={"geopoint_action": "drop"},
+        text_redactor=_synthetic_text_redactor,
+    )
+
+    assert "-1.29 36.82" in generalized.text
+    assert "-1.292066" not in generalized.text
+    assert "household/geopoint" not in next(csv.reader(io.StringIO(dropped.text)))
+
+
+def test_manifest_contains_field_policy_and_counts_but_no_values():
+    result = redact_chw_form(
+        FIXTURES / "kobo.json",
+        text_redactor=_synthetic_text_redactor,
+    )
+    manifest = {entry["field_path"]: entry for entry in result.manifest}
+
+    assert manifest["_uuid"]["action"] == ACTION_HASH
+    assert manifest["household/geolocation"]["action"] == ACTION_GENERALIZE_GEO
+    assert manifest["household/counselling_notes"]["value_count_affected"] == 2
+    assert manifest["children/status"]["action"] == ACTION_FREE_TEXT_REDACT
+    assert manifest["children/status"]["value_count"] == 3
+    assert "Mariam Diallo" not in json.dumps(result.manifest)
+    assert "14.716677" not in json.dumps(result.manifest)
+
+
+@pytest.mark.parametrize("extension", ("json", "csv"))
+def test_same_input_and_policy_are_byte_deterministic(extension):
+    path = FIXTURES / f"commcare.{extension}"
+    first = redact_chw_form(path, text_redactor=_synthetic_text_redactor)
+    second = redact_chw_form(path, text_redactor=_synthetic_text_redactor)
+
+    assert first.text.encode() == second.text.encode()
+    assert (
+        json.dumps(first.manifest, sort_keys=True).encode()
+        == json.dumps(
+            second.manifest,
+            sort_keys=True,
+        ).encode()
+    )
+
+
+@pytest.mark.parametrize("platform,extension", PLATFORM_EXPORTS)
+def test_registered_handler_is_lazy_and_optional_dependency_free(
+    monkeypatch,
+    platform,
+    extension,
+):
+    def fail_if_called():
+        raise AssertionError("optional multimodal dependency check was called")
+
+    monkeypatch.setattr(base, "ensure_multimodal_available", fail_if_called)
+    document = redact_document(
+        FIXTURES / f"{platform}.{extension}",
+        models={"text_redactor": _synthetic_text_redactor},
+    )
+
+    assert isinstance(document, ExtractedDocument)
+    assert document.metadata["format"] == f"chw_form_{extension}"
+    assert document.metadata["platform"] == platform
+    assert document.metadata["row_count"] == 2
+    assert document.metadata["redaction_manifest"]
+
+
+def test_drop_policy_removes_metadata_without_disturbing_repeats():
+    source = json.loads((FIXTURES / "commcare.json").read_text(encoding="utf-8"))
+    result = redact_chw_form(
+        FIXTURES / "commcare.json",
+        policy={"metadata_action": "drop"},
+        text_redactor=_synthetic_text_redactor,
+    )
+    output = json.loads(result.text)
+
+    assert "instanceID" not in output[0]["form"]["meta"]
+    assert "deviceID" not in output[0]["form"]["meta"]
+    assert "@case_id" not in output[0]["form"]["case"]
+    assert len(output[0]["form"]["children"]) == len(source[0]["form"]["children"])
+
+
+def test_policy_can_map_custom_headers_and_override_actions():
+    result = redact_chw_form(
+        "meta/instanceID,beneficiary/custom_contact,visit/other_answer\n"
+        "uuid:custom-873,Amina Njeri,Amina Njeri requested help\n",
+        platform="odk",
+        policy={
+            "header_heuristics": {"custom_contact": "PERSON"},
+            "action_overrides": {"visit/other_answer": "free_text_redact"},
+        },
+        text_redactor=_synthetic_text_redactor,
+    )
+    row = next(csv.DictReader(io.StringIO(result.text)))
+
+    assert row["beneficiary/custom_contact"] == "[PERSON]"
+    assert row["visit/other_answer"] == "[PERSON] requested help"
+
+
+def test_unknown_text_is_redacted_while_codes_and_scalar_types_survive():
+    source = {
+        "_uuid": "uuid:custom-873",
+        "unexpected_answer": "Amina Njeri requested help",
+        "symptoms": "fever cough",
+        "visit_count": 3,
+        "consent": True,
+    }
+
+    result = redact_chw_form(
+        json.dumps(source),
+        platform="odk",
+        text_redactor=_synthetic_text_redactor,
+    )
+    output = json.loads(result.text)
+
+    assert output["unexpected_answer"] == "[PERSON] requested help"
+    assert output["symptoms"] == source["symptoms"]
+    assert output["visit_count"] == 3
+    assert output["consent"] is True
+
+
+def test_default_narrative_pipeline_receives_language_hint(monkeypatch):
+    observed: list[tuple[str, dict[str, Any]]] = []
+
+    class Result:
+        deidentified_text = "[PERSON] requested help"
+
+    def fake_deidentify(text: str, **kwargs: Any) -> Result:
+        observed.append((text, dict(kwargs)))
+        return Result()
+
+    monkeypatch.setattr("openmed.core.pii.deidentify", fake_deidentify)
+    result = redact_chw_form(
+        '{"unexpected_answer":"Amina Njeri requested help"}',
+        platform="odk",
+        lang="fr",
+    )
+
+    assert json.loads(result.text)["unexpected_answer"] == "[PERSON] requested help"
+    assert observed == [
+        (
+            "Amina Njeri requested help",
+            {"method": "mask", "lang": "fr"},
+        )
+    ]
+
+
+def test_default_date_shift_preserves_intervals_within_json_record():
+    result = redact_chw_form(
+        '{"visit_date":"2026-03-10","followup_date":"2026-03-20"}',
+        platform="odk",
+    )
+    output = json.loads(result.text)
+
+    source_interval = date.fromisoformat("2026-03-20") - date.fromisoformat(
+        "2026-03-10"
+    )
+    output_interval = date.fromisoformat(output["followup_date"]) - date.fromisoformat(
+        output["visit_date"]
+    )
+    assert output_interval == source_interval
+
+
+def test_bom_prefixed_csv_still_uses_chw_handler_and_protects_metadata(tmp_path):
+    path = tmp_path / "submissions.csv"
+    path.write_text(
+        "\ufeff_uuid,visit/note\nuuid:custom-873,Amina Njeri requested help\n",
+        encoding="utf-8",
+    )
+    document = redact_document(
+        path,
+        models={"text_redactor": _synthetic_text_redactor},
+    )
+    row = next(csv.DictReader(io.StringIO(document.text)))
+
+    assert "_uuid" in row
+    assert row["_uuid"].startswith("ID_NUM_")
+    assert "uuid:custom-873" not in document.text
+    assert document.metadata["format"] == "chw_form_csv"
+
+
+def test_csv_width_mismatch_is_rejected_without_silent_truncation():
+    with pytest.raises(ValueError, match="header width"):
+        redact_chw_form(
+            "_uuid,visit/note\nuuid:custom-873,Amina Njeri,unexpected\n",
+            platform="odk",
+            text_redactor=_synthetic_text_redactor,
+        )


### PR DESCRIPTION
## Description

Adds local, structure-preserving de-identification for ODK Central, CommCare HQ, and KoBoToolbox JSON/CSV/TSV submission exports. The handler understands XForm group and repeat paths, protects platform metadata and precise coordinates, routes unclassified text through the privacy pipeline, and preserves coded values when no PII is detected.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [x] Test addition/improvement

## Changes Made

- Add a standard-library-only CHW form handler with content-aware multimodal registration.
- Classify slash/dot XForm paths into canonical privacy labels, hash-or-drop platform metadata, and generalize-or-drop geopoints.
- Preserve nested JSON repeats, scalar JSON types, and long-format CSV rows while emitting deterministic, value-free field policy manifests.
- Treat unknown text as potentially narrative instead of keeping it verbatim; trusted coded fields can still be explicitly overridden to `keep`.
- Preserve within-record date intervals with deterministic per-record shifts.
- Handle BOM-prefixed exports and reject inconsistent CSV row widths rather than silently truncating data.
- Add paired synthetic ODK, CommCare, and KoBoToolbox fixtures, a runnable file example, a user guide, and a changelog entry.

## Testing

- [x] Full suite: `6991 passed, 48 skipped`.
- [x] Full multimodal unit area: `154 passed, 11 skipped`.
- [x] Focused CHW/tabular/base/optional-dependency coverage: `59 passed`.
- [x] `make format`, `make lint`, `make format-check`, and `make type-check`.
- [x] Scoped pre-commit hooks, including Bandit and secret detection.
- [x] Strict documentation build.

## Documentation

- [x] Added the CHW form export guide and runnable example.
- [x] Added public API docstrings.
- [x] Updated the feature map, examples index, navigation, and changelog.

## Code Quality

- [x] Performed a maintainer privacy and structural-fidelity review.
- [x] No new runtime dependency was added.

## Related Issues

Closes #1450

## Screenshots/Examples

`examples/chw_form_deid.py` accepts a local platform export and can write both the de-identified export and its PHI-free manifest. No UI changes are included.
