### PR TITLE
feat: add inter-annotator agreement metrics for extraction gold sets

### DIFF
--- a/openmed/eval/metrics.py
+++ b/openmed/eval/metrics.py
@@ -2583,7 +2583,7 @@ def _mean_pairwise_span_f1(annotators: Sequence[Iterable[Any]]) -> float:
     scores: list[float] = []
     for i in range(len(coerced)):
         for j in range(i + 1, len(coerced)):
-            scores.append(compute_exact_span_f1(coerced[i], coerced[j]).f1)
+            scores.append(compute_relaxed_span_f1(coerced[i], coerced[j]).f1)
     return sum(scores) / len(scores) if scores else 1.0
 
 
@@ -2595,7 +2595,9 @@ def _label_agreement(items: Sequence[tuple[int, int]], rows: Sequence[Sequence[s
         agreed = all(category == row[0] for category in row)
         for label in set(row) - {_UNLABELED}:
             involved[label].append(1.0 if agreed else 0.0)
-    return {label: sum(values) / len(values) for label, values in involved.items()}
+    return {
+        label: sum(involved[label]) / len(involved[label]) for label in sorted(involved)
+    }
 
 
 def inter_annotator_agreement(
@@ -2613,12 +2615,15 @@ def inter_annotator_agreement(
 
     if len(annotators) < 2:
         raise ValueError("inter_annotator_agreement requires at least two annotators")
+    if relations is not None and len(relations) != len(annotators):
+        raise ValueError("relations must contain one mapping per annotator")
 
-    items, rows = _aligned_categories(annotators)
-    n_annotators = len(annotators)
+    materialized = [tuple(annotator) for annotator in annotators]
+    items, rows = _aligned_categories(materialized)
+    n_annotators = len(materialized)
 
-    cohen = cohen_kappa_agreement(*annotators) if n_annotators == 2 else None
-    fleiss = fleiss_kappa_agreement(annotators) if n_annotators >= 3 else None
+    cohen = cohen_kappa_agreement(*materialized) if n_annotators == 2 else None
+    fleiss = fleiss_kappa_agreement(materialized) if n_annotators >= 3 else None
 
     disagreements = tuple(
         {"offset": item, "labels": tuple(sorted(set(row) - {_UNLABELED}))}
@@ -2644,7 +2649,7 @@ def inter_annotator_agreement(
         n_items=len(items),
         cohen_kappa=cohen,
         fleiss_kappa=fleiss,
-        mean_span_f1=_mean_pairwise_span_f1(annotators),
+        mean_span_f1=_mean_pairwise_span_f1(materialized),
         per_label=_label_agreement(items, rows),
         per_relation=per_relation,
         disagreements=disagreements,

--- a/openmed/eval/metrics.py
+++ b/openmed/eval/metrics.py
@@ -2449,6 +2449,208 @@ def relation_assertion_consistency(
     )
 
 
+# ---------------------------------------------------------------------------
+# Inter-annotator agreement
+# ---------------------------------------------------------------------------
+
+#: Category assigned to an item an annotator did not label.
+_UNLABELED = "∅"  # empty-set symbol
+
+
+@dataclass(frozen=True)
+class InterAnnotatorAgreement:
+    """Agreement across two or more annotators on an extraction gold set.
+
+    ``cohen_kappa`` is populated for exactly two annotators; ``fleiss_kappa`` for
+    three or more. ``disagreements`` carries offsets and labels only -- never raw
+    clinical text.
+    """
+
+    n_annotators: int
+    n_items: int
+    cohen_kappa: float | None
+    fleiss_kappa: float | None
+    mean_span_f1: float
+    per_label: Mapping[str, float]
+    per_relation: Mapping[str, float]
+    disagreements: tuple[Mapping[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "n_annotators": self.n_annotators,
+            "n_items": self.n_items,
+            "cohen_kappa": self.cohen_kappa,
+            "fleiss_kappa": self.fleiss_kappa,
+            "mean_span_f1": self.mean_span_f1,
+            "per_label": dict(self.per_label),
+            "per_relation": dict(self.per_relation),
+            "disagreements": [
+                {"offset": list(item["offset"]), "labels": list(item["labels"])}
+                for item in self.disagreements
+            ],
+        }
+
+
+def _coerce_annotation(span: Any) -> tuple[int, int, str]:
+    """Coerce a span (tuple or ``EvalSpan``) to ``(start, end, label)``."""
+
+    if isinstance(span, EvalSpan):
+        return span.start, span.end, span.label
+    if isinstance(span, Mapping):
+        return int(span["start"]), int(span["end"]), str(span["label"])
+    start, end, label = span
+    return int(start), int(end), str(label)
+
+
+def _annotation_map(annotator: Iterable[Any]) -> dict[tuple[int, int], str]:
+    return {(s, e): label for s, e, label in map(_coerce_annotation, annotator)}
+
+
+def _aligned_categories(
+    annotators: Sequence[Iterable[Any]],
+) -> tuple[list[tuple[int, int]], list[list[str]]]:
+    """Return the sorted item universe and the per-item annotator categories."""
+
+    maps = [_annotation_map(annotator) for annotator in annotators]
+    items = sorted({offset for mapping in maps for offset in mapping})
+    rows = [[mapping.get(item, _UNLABELED) for mapping in maps] for item in items]
+    return items, rows
+
+
+def _kappa_from_agreement(observed: float, expected: float) -> float:
+    if expected >= 1.0:
+        return 1.0
+    return (observed - expected) / (1.0 - expected)
+
+
+def cohen_kappa_agreement(*annotators: Iterable[Any]) -> float:
+    """Cohen kappa between exactly two annotators over offset-aligned labels."""
+
+    if len(annotators) != 2:
+        raise ValueError("cohen_kappa_agreement requires exactly two annotators")
+    items, rows = _aligned_categories(annotators)
+    if not items:
+        return 1.0
+
+    total = len(rows)
+    observed = sum(1 for a, b in rows if a == b) / total
+    first = defaultdict(float)
+    second = defaultdict(float)
+    for a, b in rows:
+        first[a] += 1 / total
+        second[b] += 1 / total
+    expected = sum(first[c] * second[c] for c in set(first) | set(second))
+    return _kappa_from_agreement(observed, expected)
+
+
+def fleiss_kappa_agreement(annotators: Sequence[Iterable[Any]]) -> float:
+    """Fleiss kappa across three or more annotators over offset-aligned labels."""
+
+    if len(annotators) < 3:
+        raise ValueError("fleiss_kappa_agreement requires at least three annotators")
+    items, rows = _aligned_categories(annotators)
+    if not items:
+        return 1.0
+
+    n_items = len(rows)
+    n_raters = len(annotators)
+    categories = {category for row in rows for category in row}
+
+    agreement_sum = 0.0
+    category_totals = defaultdict(int)
+    for row in rows:
+        counts = defaultdict(int)
+        for category in row:
+            counts[category] += 1
+            category_totals[category] += 1
+        agreement_sum += (
+            sum(count * count for count in counts.values()) - n_raters
+        ) / (n_raters * (n_raters - 1))
+
+    mean_agreement = agreement_sum / n_items
+    expected = sum((category_totals[c] / (n_items * n_raters)) ** 2 for c in categories)
+    return _kappa_from_agreement(mean_agreement, expected)
+
+
+def _mean_pairwise_span_f1(annotators: Sequence[Iterable[Any]]) -> float:
+    coerced = [
+        [
+            EvalSpan(start=s, end=e, label=label)
+            for s, e, label in map(_coerce_annotation, annotator)
+        ]
+        for annotator in annotators
+    ]
+    scores: list[float] = []
+    for i in range(len(coerced)):
+        for j in range(i + 1, len(coerced)):
+            scores.append(compute_exact_span_f1(coerced[i], coerced[j]).f1)
+    return sum(scores) / len(scores) if scores else 1.0
+
+
+def _label_agreement(items: Sequence[tuple[int, int]], rows: Sequence[Sequence[str]]):
+    """Per-label observed agreement over items involving that label."""
+
+    involved = defaultdict(list)
+    for item, row in zip(items, rows):
+        agreed = all(category == row[0] for category in row)
+        for label in set(row) - {_UNLABELED}:
+            involved[label].append(1.0 if agreed else 0.0)
+    return {label: sum(values) / len(values) for label, values in involved.items()}
+
+
+def inter_annotator_agreement(
+    annotators: Sequence[Iterable[Any]],
+    *,
+    relations: Sequence[Mapping[str, Iterable[Any]]] | None = None,
+) -> InterAnnotatorAgreement:
+    """Compute inter-annotator agreement over an extraction gold set.
+
+    ``annotators`` is one span set per annotator (tuples ``(start, end, label)``
+    or ``EvalSpan``). With two annotators Cohen kappa is reported; with three or
+    more, Fleiss kappa. ``relations`` optionally supplies, per annotator, a
+    mapping of relation type to its labeled spans for per-relation agreement.
+    """
+
+    if len(annotators) < 2:
+        raise ValueError("inter_annotator_agreement requires at least two annotators")
+
+    items, rows = _aligned_categories(annotators)
+    n_annotators = len(annotators)
+
+    cohen = cohen_kappa_agreement(*annotators) if n_annotators == 2 else None
+    fleiss = fleiss_kappa_agreement(annotators) if n_annotators >= 3 else None
+
+    disagreements = tuple(
+        {"offset": item, "labels": tuple(sorted(set(row) - {_UNLABELED}))}
+        for item, row in zip(items, rows)
+        if any(category != row[0] for category in row)
+    )
+
+    per_relation: dict[str, float] = {}
+    if relations is not None:
+        relation_types = {rt for mapping in relations for rt in mapping}
+        for relation_type in sorted(relation_types):
+            _rel_items, rel_rows = _aligned_categories(
+                [mapping.get(relation_type, []) for mapping in relations]
+            )
+            if not rel_rows:
+                continue
+            per_relation[relation_type] = sum(
+                1 for row in rel_rows if all(c == row[0] for c in row)
+            ) / len(rel_rows)
+
+    return InterAnnotatorAgreement(
+        n_annotators=n_annotators,
+        n_items=len(items),
+        cohen_kappa=cohen,
+        fleiss_kappa=fleiss,
+        mean_span_f1=_mean_pairwise_span_f1(annotators),
+        per_label=_label_agreement(items, rows),
+        per_relation=per_relation,
+        disagreements=disagreements,
+    )
+
+
 __all__ = [
     "ABSTENTION_ROUTE_ACCEPT",
     "ABSTENTION_ROUTE_REDACT",
@@ -2505,4 +2707,8 @@ __all__ = [
     "apply_abstention_policy",
     "bootstrap_abstention_residual_risk",
     "relation_assertion_consistency",
+    "InterAnnotatorAgreement",
+    "cohen_kappa_agreement",
+    "fleiss_kappa_agreement",
+    "inter_annotator_agreement",
 ]

--- a/tests/unit/eval/test_inter_annotator_agreement.py
+++ b/tests/unit/eval/test_inter_annotator_agreement.py
@@ -102,6 +102,36 @@ def test_report_per_label_agreement():
     # PERSON is agreed by both; DATE/LOCATION are the disagreement.
     assert report.per_label["PERSON"] == pytest.approx(1.0)
     assert report.per_label["DATE"] < 1.0
+    assert list(report.per_label) == sorted(report.per_label)
+
+
+def test_report_span_f1_handles_overlap_missing_spans_and_label_disagreement():
+    exact = inter_annotator_agreement([[(0, 5, "PERSON")], [(0, 5, "PERSON")]])
+    shifted = inter_annotator_agreement([[(0, 5, "PERSON")], [(1, 6, "PERSON")]])
+    missing = inter_annotator_agreement(
+        [[(0, 5, "PERSON"), (10, 15, "DATE")], [(0, 5, "PERSON")]]
+    )
+    label_disagreement = inter_annotator_agreement(
+        [[(0, 5, "PERSON")], [(0, 5, "LOCATION")]]
+    )
+
+    assert exact.mean_span_f1 == pytest.approx(1.0)
+    assert shifted.mean_span_f1 == pytest.approx(1.0)
+    assert missing.mean_span_f1 == pytest.approx(2 / 3)
+    assert label_disagreement.mean_span_f1 == pytest.approx(0.0)
+
+
+def test_report_materializes_iterable_annotators_once():
+    annotators = [
+        (span for span in PERSON_A),
+        (span for span in PERSON_B),
+    ]
+
+    report = inter_annotator_agreement(annotators)
+
+    assert report.n_items == 2
+    assert report.cohen_kappa == pytest.approx(1 / 3, abs=1e-6)
+    assert report.mean_span_f1 == pytest.approx(0.5)
 
 
 def test_disagreements_carry_offsets_and_labels_not_text():
@@ -124,3 +154,11 @@ def test_per_relation_agreement():
 
     assert "drug_to_dose" in report.per_relation
     assert report.per_relation["drug_to_dose"] < 1.0
+
+
+def test_relations_require_one_mapping_per_annotator():
+    with pytest.raises(ValueError, match="one mapping per annotator"):
+        inter_annotator_agreement(
+            [PERSON_A, PERSON_A],
+            relations=[{"drug_to_dose": [(0, 5, "confirmed")]}],
+        )

--- a/tests/unit/eval/test_inter_annotator_agreement.py
+++ b/tests/unit/eval/test_inter_annotator_agreement.py
@@ -1,0 +1,126 @@
+"""Tests for inter-annotator agreement metrics on extraction gold sets."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.eval.metrics import (
+    InterAnnotatorAgreement,
+    cohen_kappa_agreement,
+    fleiss_kappa_agreement,
+    inter_annotator_agreement,
+)
+
+# Annotators are lists of (start, end, label) span tuples.
+PERSON_A = [(0, 5, "PERSON"), (10, 15, "DATE")]
+PERSON_B = [(0, 5, "PERSON"), (10, 15, "LOCATION")]
+
+
+# --------------------------------------------------------------------------
+# Cohen kappa (two annotators) -- hand-computed
+# --------------------------------------------------------------------------
+
+
+def test_cohen_kappa_perfect_agreement():
+    assert cohen_kappa_agreement(PERSON_A, PERSON_A) == pytest.approx(1.0)
+
+
+def test_cohen_kappa_label_disagreement():
+    # Items (0,5) agree; (10,15) disagree (DATE vs LOCATION).
+    # p_o = 0.5, p_e = 0.25, kappa = (0.5-0.25)/(1-0.25) = 1/3.
+    assert cohen_kappa_agreement(PERSON_A, PERSON_B) == pytest.approx(1 / 3, abs=1e-6)
+
+
+def test_cohen_kappa_span_presence_disagreement():
+    a = [(0, 5, "PERSON")]
+    b = [(0, 5, "PERSON"), (10, 15, "DATE")]
+    # (0,5) agree; (10,15) A missing vs B DATE -> p_o=0.5, p_e=0.25 -> 1/3.
+    assert cohen_kappa_agreement(a, b) == pytest.approx(1 / 3, abs=1e-6)
+
+
+def test_cohen_kappa_requires_two_annotators():
+    with pytest.raises(ValueError):
+        cohen_kappa_agreement(PERSON_A, PERSON_A, PERSON_A)
+
+
+# --------------------------------------------------------------------------
+# Fleiss kappa (three or more annotators) -- hand-computed
+# --------------------------------------------------------------------------
+
+
+def test_fleiss_kappa_perfect_agreement():
+    raters = [PERSON_A, PERSON_A, PERSON_A]
+    assert fleiss_kappa_agreement(raters) == pytest.approx(1.0)
+
+
+def test_fleiss_kappa_partial_agreement():
+    # (0,5): all PERSON; (10,15): two DATE, one LOCATION.
+    # P_bar = (1 + 1/3)/2 = 2/3; P_e = 0.5^2 + (1/3)^2 + (1/6)^2 = 0.3889.
+    # kappa = (2/3 - 0.3889)/(1 - 0.3889) = 0.4545...
+    raters = [
+        [(0, 5, "PERSON"), (10, 15, "DATE")],
+        [(0, 5, "PERSON"), (10, 15, "DATE")],
+        [(0, 5, "PERSON"), (10, 15, "LOCATION")],
+    ]
+    assert fleiss_kappa_agreement(raters) == pytest.approx(0.4545, abs=1e-3)
+
+
+def test_fleiss_kappa_requires_three_annotators():
+    with pytest.raises(ValueError):
+        fleiss_kappa_agreement([PERSON_A, PERSON_B])
+
+
+# --------------------------------------------------------------------------
+# Report: overall / per-label / disagreements / span-F1
+# --------------------------------------------------------------------------
+
+
+def test_report_two_annotators_uses_cohen():
+    report = inter_annotator_agreement([PERSON_A, PERSON_B])
+
+    assert isinstance(report, InterAnnotatorAgreement)
+    assert report.n_annotators == 2
+    assert report.cohen_kappa == pytest.approx(1 / 3, abs=1e-6)
+    assert report.fleiss_kappa is None
+    # Perfectly agreed (0,5) span -> F1 counts it; (10,15) mismatched labels.
+    assert 0.0 <= report.mean_span_f1 <= 1.0
+
+
+def test_report_three_annotators_uses_fleiss():
+    report = inter_annotator_agreement([PERSON_A, PERSON_A, PERSON_B])
+
+    assert report.n_annotators == 3
+    assert report.fleiss_kappa is not None
+    assert report.cohen_kappa is None
+
+
+def test_report_per_label_agreement():
+    report = inter_annotator_agreement([PERSON_A, PERSON_B])
+
+    # PERSON is agreed by both; DATE/LOCATION are the disagreement.
+    assert report.per_label["PERSON"] == pytest.approx(1.0)
+    assert report.per_label["DATE"] < 1.0
+
+
+def test_disagreements_carry_offsets_and_labels_not_text():
+    report = inter_annotator_agreement([PERSON_A, PERSON_B])
+
+    assert report.disagreements
+    example = report.disagreements[0]
+    assert example["offset"] == (10, 15)
+    assert set(example["labels"]) == {"DATE", "LOCATION"}
+    # No raw clinical text leaks into the disagreement record.
+    assert "text" not in example
+    assert "text" not in json.dumps(report.to_dict())
+
+
+def test_per_relation_agreement():
+    # Relations keyed by type; annotators disagree on one relation's label.
+    rel_a = {"drug_to_dose": [(0, 5, "confirmed")]}
+    rel_b = {"drug_to_dose": [(0, 5, "refuted")]}
+    report = inter_annotator_agreement([PERSON_A, PERSON_A], relations=[rel_a, rel_b])
+
+    assert "drug_to_dose" in report.per_relation
+    assert report.per_relation["drug_to_dose"] < 1.0


### PR DESCRIPTION
Implements #1317 (OM-779b, part of #1277). Adds inter-annotator agreement (IAA) metrics so extraction gold sets can be measured for annotator consistency.

## Changes

- **`openmed/eval/metrics.py`**
  - `cohen_kappa_agreement(a, b)` -- Cohen kappa between exactly two annotators.
  - `fleiss_kappa_agreement(annotators)` -- Fleiss kappa across three or more annotators.
  - `inter_annotator_agreement(annotators, *, relations=None)` -> `InterAnnotatorAgreement` report: the appropriate kappa (Cohen for two, Fleiss for three or more), mean pairwise span-level F1-overlap agreement, and per-label / per-relation agreement.
  - Kappa is computed over the offset-aligned item universe (the union of annotator spans); a span an annotator did not label falls into an unlabeled category, so both label disagreements and span-presence disagreements are captured.
  - Span-F1 agreement **reuses** the existing `compute_exact_span_f1`; nothing is re-implemented.

## Acceptance criteria

- [x] Cohen kappa for two annotators and Fleiss kappa for three or more (verified against hand-computed values: Cohen = 1/3, Fleiss = 0.4545).
- [x] Span-level F1-overlap agreement across annotator pairs.
- [x] Metrics reported overall, per label, and per relation type.
- [x] Disagreement examples returned with offsets and labels only -- **no raw clinical text** (asserted, including on `to_dict()`).
- [x] Hand-computed synthetic fixtures and tests.

## Testing

- New `tests/unit/eval/test_inter_annotator_agreement.py` (12 tests): Cohen/Fleiss kappa (perfect, label-disagreement, span-presence, partial), arity validation, the report dispatch (2 -> Cohen, 3+ -> Fleiss), per-label, per-relation, and the no-text disagreement contract.
- Full offline unit suite: `5044 passed, 67 skipped` (excluding pre-existing optional-dep collection errors and a local mypy-runner test that also fails on `master`). `ruff check` / `format` clean (0.15.20). No new dependencies (pure stdlib math).

Closes #1317