### PR TITLE
docs/examples: add synthetic datasets walkthrough

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -78,6 +78,7 @@ content-security policy blocks the optional inline styling.
 | `examples/dbt-deidentify/` | Demonstrates the v1.8 warehouse transformation package for table redaction macros and redacted staging models. |
 | `examples/spark-streaming/` | Demonstrates Spark structured-streaming de-identification against synthetic records. |
 | `examples/first_five_minutes_redact_extract_fhir.py` | Walks through synthetic redaction, deterministic clinical extraction, and FHIR Bundle assembly. |
+| `examples/datasets_walkthrough.py` | Loads one bundled synthetic golden fixture and runs the public `extract_pii`/`deidentify` API with offline-first model handling. |
 | `scripts/smoke_gliner.py` | Runs a bounded set of GLiNER models/texts to confirm zero-shot dependencies are installed before releasing. |
 | `tests/run-tests.sh` | Convenience runner that stitches together unit, integration, and smoke tests; extend it to include docs builds and API smoke checks. |
 
@@ -112,6 +113,12 @@ deployment paths:
 - Browser and mobile JavaScript: [ONNX Runtime Web Loader](./runtimes/onnxruntime-web.md), [Transformers.js Export](./export-transformersjs.md), and the React Native bridge under `js/openmedkit-react-native/`.
 - Service operations: [REST Authentication](./serving/authentication.md), [gRPC Service](./serving/grpc.md), [Async REST Jobs & Webhooks](./serving/async-jobs.md), [Serving Resilience](./serving/resilience.md), and [REST Tracing](./serving/tracing.md).
 - Structured-data jobs: [Columnar Redactor](./integrations/columnar-redactor.md), [Lakehouse Table Redaction](./integrations/lakehouse-redaction.md), [Dask DataFrame De-identification](./integrations/dask.md), [DuckDB De-identification UDFs](./duckdb-deidentification.md), and `examples/dbt-deidentify/`.
+
+The datasets walkthrough uses only bundled, synthetic, redistributable fixtures. The records do not require a data-use agreement (DUA), and the example does not download data. To try another fixture, update `FIXTURE_ID` in the script to an ID from `openmed/eval/golden/fixtures/multilingual.json`. Model downloads remain disabled by default; set `OPENMED_EXAMPLE_ALLOW_DOWNLOAD=1` only when you explicitly want to load a model.
+
+```bash
+python examples/datasets_walkthrough.py
+```
 
 ## Apple Silicon & Swift recipes
 

--- a/examples/datasets_walkthrough.py
+++ b/examples/datasets_walkthrough.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Walk through a bundled synthetic golden fixture with the public PII API."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from openmed import deidentify, extract_pii
+
+FIXTURE_ID = "golden-multilingual-en-ssn"
+ALLOW_DOWNLOAD_ENV = "OPENMED_EXAMPLE_ALLOW_DOWNLOAD"
+
+
+def fixture_path() -> Path:
+    """Return the repository-relative path to the bundled fixture file."""
+    return (
+        Path(__file__).resolve().parents[1]
+        / "openmed"
+        / "eval"
+        / "golden"
+        / "fixtures"
+        / "multilingual.json"
+    )
+
+
+def load_fixture(fixture_id: str = FIXTURE_ID) -> dict[str, Any]:
+    """Load one synthetic, redistributable fixture without model access."""
+    payload = json.loads(fixture_path().read_text(encoding="utf-8"))
+    for fixture in payload["fixtures"]:
+        if fixture["id"] == fixture_id:
+            if not fixture.get("metadata", {}).get("synthetic", False):
+                raise ValueError(f"Fixture is not marked synthetic: {fixture_id}")
+            return fixture
+    raise KeyError(f"Unknown bundled fixture: {fixture_id}")
+
+
+@contextmanager
+def offline_model_loading() -> Iterator[None]:
+    """Keep the walkthrough offline unless downloads are explicitly enabled."""
+    if os.getenv(ALLOW_DOWNLOAD_ENV) == "1":
+        yield
+        return
+
+    previous = {
+        name: os.environ.get(name)
+        for name in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE")
+    }
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    try:
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def run_walkthrough(fixture_id: str = FIXTURE_ID) -> None:
+    """Print a compact before/after summary for one bundled fixture."""
+    fixture = load_fixture(fixture_id)
+    text = fixture["text"]
+    expected = fixture["metadata"]["expected_output"]["text"]
+
+    print(f"Fixture: {fixture['id']} ({fixture['language']})")
+    print("Synthetic data: yes; no DUA or external dataset required")
+    print(f"Before: {text}")
+
+    try:
+        with offline_model_loading():
+            extracted = extract_pii(text, lang=fixture["language"])
+            result = deidentify(
+                text,
+                method="mask",
+                lang=fixture["language"],
+            )
+    except Exception as exc:
+        print(f"After: model unavailable offline ({exc})")
+        print("Set OPENMED_EXAMPLE_ALLOW_DOWNLOAD=1 to allow first-run downloads.")
+        return
+
+    print(f"Detected entities: {len(extracted.entities)}")
+    print(f"After: {result.deidentified_text}")
+    print(f"Matches bundled expected output: {result.deidentified_text == expected}")
+
+
+def main() -> None:
+    run_walkthrough()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_examples_smoke.py
+++ b/tests/unit/test_examples_smoke.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from examples import clinical_ner_families, gradio_deid_app
+from examples import clinical_ner_families, datasets_walkthrough, gradio_deid_app
 
 
 def test_clinical_ner_families_example_is_syntactically_valid():
@@ -160,3 +160,24 @@ def test_gradio_deid_app_missing_gradio_prints_hint(monkeypatch):
         gradio_deid_app.build_demo()
 
     assert "pip install gradio" in str(excinfo.value)
+
+
+def test_datasets_walkthrough_import_and_fixture_load_are_network_safe():
+    fixture = datasets_walkthrough.load_fixture()
+
+    assert datasets_walkthrough.fixture_path().is_file()
+    assert fixture["id"] == datasets_walkthrough.FIXTURE_ID
+    assert fixture["metadata"]["synthetic"] is True
+    assert fixture["text"]
+
+
+def test_datasets_walkthrough_reports_offline_unavailable(capsys, monkeypatch):
+    def unavailable_extractor(*args, **kwargs):
+        raise OSError("cached files not found")
+
+    monkeypatch.setattr(datasets_walkthrough, "extract_pii", unavailable_extractor)
+    datasets_walkthrough.run_walkthrough()
+
+    captured = capsys.readouterr().out
+    assert "Synthetic data: yes" in captured
+    assert "model unavailable offline" in captured


### PR DESCRIPTION
## Summary

- add `examples/datasets_walkthrough.py` using the bundled synthetic golden fixture and public `extract_pii`/`deidentify` APIs
- keep model loading offline by default with a clear opt-in for downloads
- document synthetic, redistributable, no-DUA fixture usage and add import/smoke coverage

## Validation

- `.venv/bin/python -m pytest tests/unit/test_examples_smoke.py -q` -> 12 passed
- `.venv/bin/ruff check examples/datasets_walkthrough.py tests/unit/test_examples_smoke.py`
- `.venv/bin/ruff format --check examples/datasets_walkthrough.py tests/unit/test_examples_smoke.py`
- `.venv/bin/python -m pytest tests/ -q` -> 5113 passed, 58 skipped, 5 environment/integration failures unrelated to this change (npm registry access, macOS sandbox port binding, PyArrow ORC sysctl, and npm package checks)
- offline example run completed without network access

The branch is rebased onto the current maintainer `master`.

Closes #479