### PR TITLE
Add ARM SMS latency benchmark and budget gate

### DIFF
--- a/.github/workflows/container-multiarch.yml
+++ b/.github/workflows/container-multiarch.yml
@@ -103,10 +103,66 @@ jobs:
           print(f"OpenMed {openmed.__version__} synthetic de-identification passed")
           PY
 
+  arm-latency:
+    name: ARM64 SMS latency budget
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARM_LATENCY_MODEL: OpenMed/OpenMed-PII-ClinicalE5-Small-33M-v1-onnx-android
+      ARM_LATENCY_REVISION: 79f7db205869b1be4be23ac4f42aa95bdedc5aee
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Verify native ARM64 runner
+        shell: bash
+        run: test "$(uname -m)" = "aarch64"
+
+      - name: Install benchmark dependencies
+        run: python -m pip install -e ".[dev,onnx-runtime]"
+
+      - name: Verify intentionally slowed fixture fails the gate
+        run: >-
+          python -m pytest
+          tests/unit/eval/test_arm_latency.py::test_intentionally_slowed_fixture_trips_gate
+          -q
+
+      - name: Prefetch pinned INT8 model
+        shell: bash
+        run: |
+          hf download "$ARM_LATENCY_MODEL" \
+            model_int8.onnx config.json id2label.json tokenizer.json tokenizer_config.json \
+            --revision "$ARM_LATENCY_REVISION" \
+            --local-dir "$RUNNER_TEMP/openmed-pii-int8"
+
+      - name: Enforce offline SMS latency budget
+        env:
+          OPENMED_OFFLINE: "1"
+        shell: bash
+        run: |
+          openmed benchmark latency \
+            --model "$RUNNER_TEMP/openmed-pii-int8" \
+            --revision "$ARM_LATENCY_REVISION" \
+            --output arm-latency-report.json
+
+      - name: Upload ARM latency report
+        uses: actions/upload-artifact@v7
+        with:
+          name: arm-latency-report
+          path: arm-latency-report.json
+          if-no-files-found: error
+          retention-days: 90
+
   publish:
     name: Publish manifest list
     runs-on: ubuntu-latest
-    needs: smoke
+    needs:
+      - smoke
+      - arm-latency
     if: github.event_name != 'pull_request'
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an offline, native ARM64 SMS-scale INT8 latency benchmark with a
+  committed synthetic corpus, exact model artifact provenance, aggregate
+  p50/p95/throughput/peak-RSS reporting, a Raspberry Pi 5 target envelope, and
+  a CI gate that fails regressions beyond the permitted 20% tolerance (#1456).
 - Added a Swahili README and an African developer onboarding guide covering
   bandwidth-aware model sizing and offline setup, POPIA/NDPA policy pointers,
   OpenMRS FHIR and DHIS2 Tracker recipes, community links, and shared

--- a/docs/benchmarks/arm-latency.md
+++ b/docs/benchmarks/arm-latency.md
@@ -1,0 +1,104 @@
+# ARM SMS Latency Budget
+
+OpenMed gates cached INT8 ONNX PII inference over a committed corpus of
+synthetic clinical messages. Every message is 280 characters or shorter, the
+report contains aggregate measurements only, and the measured command blocks
+Python socket connections for its entire model-load and inference window.
+
+## Raspberry Pi 5 reference envelope
+
+The clinic-grade reference is a Raspberry Pi 5 with 8 GB RAM and its 4-core Arm
+Cortex-A76 CPU. Issue #1456 records a p95 target of 1.5 seconds per SMS-scale
+text. The committed budget applies the allowed 20% regression tolerance only
+at gate time.
+
+| Metric | Reference number |
+|---|---:|
+| p95 single-text latency budget | 1,500 ms |
+| Throughput implied by the p95 budget | 0.667 texts/s |
+| Permitted regression | 20% |
+| Gated maximum p95 | 1,800 ms |
+
+The source specification did not include a raw Raspberry Pi capture for p50 or
+peak RSS, so those values are deliberately not invented here. Each JSON report
+records the measured p50, p95, throughput, and peak RSS for the machine that ran
+it, together with OS, architecture, CPU count, model revision, ONNX artifact,
+and quantization metadata. A Raspberry Pi reference run should retain that JSON
+alongside the exact OpenMed and model revisions before its measured p50 and RSS
+are promoted into this table.
+
+## Exact reproduction
+
+Install the runtime and download the pinned model while networking is allowed:
+
+```bash
+python -m pip install -e ".[onnx-runtime]"
+export OPENMED_ARM_MODEL_DIR="${PWD}/.cache/openmed-pii-int8"
+hf download OpenMed/OpenMed-PII-ClinicalE5-Small-33M-v1-onnx-android \
+  model_int8.onnx config.json id2label.json tokenizer.json tokenizer_config.json \
+  --revision 79f7db205869b1be4be23ac4f42aa95bdedc5aee \
+  --local-dir "$OPENMED_ARM_MODEL_DIR"
+```
+
+Then disconnect networking if desired and run the cache-only benchmark:
+
+```bash
+OPENMED_OFFLINE=1 openmed benchmark latency \
+  --model "$OPENMED_ARM_MODEL_DIR" \
+  --revision 79f7db205869b1be4be23ac4f42aa95bdedc5aee \
+  --output arm-latency-report.json
+```
+
+The command always requests `model_int8.onnx`, passes
+`local_files_only=True`, and activates OpenMed's socket guard even when
+`OPENMED_OFFLINE` was not already set. It exits non-zero when measured p95 is
+greater than 1,800 ms, while still writing and printing the JSON report.
+
+The default run performs one excluded warm-up inference and measures three
+passes over `openmed/eval/fixtures/sms_clinical.jsonl`. Override `--repeat` or
+`--warmup-runs` only when recording an explicitly different experiment.
+
+## Report contract
+
+The JSON document includes these stable top-level measurements:
+
+```json
+{
+  "benchmark": "sms_arm_latency",
+  "latency_ms": {"p50": 0.0, "p95": 0.0},
+  "throughput_texts_per_second": 0.0,
+  "peak_rss_mib": 0.0,
+  "offline": true,
+  "passed": true
+}
+```
+
+Values above are schema placeholders, not claimed measurements. The real
+report also includes the corpus bounds, machine and model provenance, sample
+count, total duration, and the complete budget verdict. It never includes the
+synthetic source messages.
+
+## CI gate and negative test
+
+`.github/workflows/container-multiarch.yml` runs the benchmark on GitHub's
+native 4-core `ubuntu-24.04-arm` runner. The job downloads the pinned artifact
+before the measured phase, sets `OPENMED_OFFLINE=1`, executes the command, and
+uploads `arm-latency-report.json`. Container publication depends on this job.
+The hosted runner is the reproducible regression sentinel; it does not pretend
+to be a Raspberry Pi measurement.
+
+The intentionally slowed fixture proves that the 20% envelope fails closed:
+
+```bash
+python -m pytest \
+  tests/unit/eval/test_arm_latency.py::test_intentionally_slowed_fixture_trips_gate \
+  -q
+```
+
+The CLI socket-guard assertion is covered separately:
+
+```bash
+python -m pytest \
+  tests/unit/cli/test_benchmark_cli.py::test_latency_command_emits_offline_int8_json_and_blocks_sockets \
+  -q
+```

--- a/docs/benchmarks/arm-latency.md
+++ b/docs/benchmarks/arm-latency.md
@@ -3,7 +3,9 @@
 OpenMed gates cached INT8 ONNX PII inference over a committed corpus of
 synthetic clinical messages. Every message is 280 characters or shorter, the
 report contains aggregate measurements only, and the measured command blocks
-Python socket connections for its entire model-load and inference window.
+Python socket connections for its entire model-load and inference window. It
+also verifies the exact `model_int8.onnx` bytes against the committed SHA-256
+digest before any warm-up or measured inference.
 
 ## Raspberry Pi 5 reference envelope
 
@@ -51,8 +53,11 @@ OPENMED_OFFLINE=1 openmed benchmark latency \
 
 The command always requests `model_int8.onnx`, passes
 `local_files_only=True`, and activates OpenMed's socket guard even when
-`OPENMED_OFFLINE` was not already set. It exits non-zero when measured p95 is
-greater than 1,800 ms, while still writing and printing the JSON report.
+`OPENMED_OFFLINE` was not already set. Before measuring, it requires SHA-256
+`48a0b2e9269933bef0cf8913239d07996fa2afb107cd223ced95c8decd24ae6b`,
+which pins the downloaded INT8 graph in addition to the model revision. It
+exits non-zero when measured p95 is greater than 1,800 ms, while still writing
+and printing the JSON report.
 
 The default run performs one excluded warm-up inference and measures three
 passes over `openmed/eval/fixtures/sms_clinical.jsonl`. Override `--repeat` or
@@ -68,6 +73,10 @@ The JSON document includes these stable top-level measurements:
   "latency_ms": {"p50": 0.0, "p95": 0.0},
   "throughput_texts_per_second": 0.0,
   "peak_rss_mib": 0.0,
+  "model": {
+    "artifact": "model_int8.onnx",
+    "artifact_sha256": "48a0b2e9269933bef0cf8913239d07996fa2afb107cd223ced95c8decd24ae6b"
+  },
   "offline": true,
   "passed": true
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - Testing & QA: testing.md
       - Eval Harness & Metrics: eval-harness.md
       - Public Benchmark Leaderboard: eval/leaderboard.md
+      - ARM SMS Latency Budget: benchmarks/arm-latency.md
       - Experiencer Refinement: clinical/experiencer-refinement.md
       - OpenVINO Runtime: runtimes/openvino.md
       - Device Tiers & SLOs: tiers.md

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -2528,7 +2528,7 @@ def _handle_benchmark_latency(args: argparse.Namespace) -> int:
             )
             report = arm_latency_module.run_arm_latency_benchmark(
                 model,
-                model_id=str(args.model),
+                model_id=budget.model_id,
                 model_revision=str(args.revision),
                 documents=documents,
                 budget=budget,

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -1368,6 +1368,60 @@ def _add_benchmark_command(subparsers: argparse._SubParsersAction) -> None:
     )
     mobile_parser.set_defaults(handler=_handle_benchmark_mobile)
 
+    from openmed.eval import arm_latency as arm_latency_module
+
+    latency_parser = benchmark_sub.add_parser(
+        "latency",
+        help="Gate cached INT8 ONNX latency over synthetic SMS-scale text.",
+    )
+    latency_parser.add_argument(
+        "--model",
+        default=arm_latency_module.DEFAULT_ARM_LATENCY_MODEL,
+        help="Cached model repository id or local ONNX artifact directory.",
+    )
+    latency_parser.add_argument(
+        "--revision",
+        default=arm_latency_module.DEFAULT_ARM_LATENCY_MODEL_REVISION,
+        help="Pinned model revision recorded in the report.",
+    )
+    latency_parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Optional pre-populated Hugging Face cache directory.",
+    )
+    latency_parser.add_argument(
+        "--corpus",
+        type=Path,
+        default=arm_latency_module.DEFAULT_ARM_LATENCY_CORPUS,
+        help="Synthetic SMS-scale JSONL corpus.",
+    )
+    latency_parser.add_argument(
+        "--budget",
+        type=Path,
+        default=arm_latency_module.DEFAULT_ARM_LATENCY_BUDGET,
+        help="Committed ARM p95 budget JSON.",
+    )
+    latency_parser.add_argument(
+        "--warmup-runs",
+        type=int,
+        default=1,
+        help="Warm-up inferences excluded from the latency distribution.",
+    )
+    latency_parser.add_argument(
+        "--repeat",
+        type=int,
+        default=3,
+        help="Measured repetitions of the committed corpus.",
+    )
+    latency_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path for the JSON report; JSON is always emitted to stdout.",
+    )
+    latency_parser.set_defaults(handler=_handle_benchmark_latency)
+
     false_negatives_parser = benchmark_sub.add_parser(
         "false-negatives",
         help="Explore missed gold PHI spans from an error-analysis report.",
@@ -2454,6 +2508,50 @@ def _handle_benchmark_mobile(args: argparse.Namespace) -> int:
         payload = {"reports": [report.to_dict() for report in reports]}
         human = json.dumps(payload, indent=2, sort_keys=True)
     return emit(args, payload, human=human)
+
+
+def _handle_benchmark_latency(args: argparse.Namespace) -> int:
+    from openmed.core.offline import network_blocked_if_offline
+    from openmed.eval import arm_latency as arm_latency_module
+    from openmed.onnx.inference import OnnxModel
+
+    try:
+        budget = arm_latency_module.load_arm_latency_budget(args.budget)
+        documents = arm_latency_module.load_latency_documents(args.corpus)
+        with network_blocked_if_offline(local_only=True):
+            model = OnnxModel.from_pretrained(
+                args.model,
+                variant="int8",
+                revision=str(args.revision),
+                cache_dir=args.cache_dir,
+                local_files_only=True,
+            )
+            report = arm_latency_module.run_arm_latency_benchmark(
+                model,
+                model_id=str(args.model),
+                model_revision=str(args.revision),
+                documents=documents,
+                budget=budget,
+                corpus_path=args.corpus,
+                warmup_runs=args.warmup_runs,
+                repeat=args.repeat,
+                metadata={"execution_provider": "CPUExecutionProvider"},
+            )
+        if args.output is not None:
+            report.write_json(args.output)
+    except (ImportError, OSError, RuntimeError, ValueError) as exc:
+        sys.stderr.write(f"ARM latency benchmark failed: {exc}\n")
+        return 1
+
+    sys.stdout.write(report.to_json() + "\n")
+    if not report.passed:
+        sys.stderr.write(
+            "ARM latency budget exceeded: "
+            f"p95 {report.p95_ms:.3f} ms > "
+            f"{report.verdict.maximum_p95_ms:.3f} ms\n"
+        )
+        return 1
+    return 0
 
 
 def _handle_profile_memory(args: argparse.Namespace) -> int:

--- a/openmed/eval/arm_latency.py
+++ b/openmed/eval/arm_latency.py
@@ -1,0 +1,440 @@
+"""Offline SMS-scale latency benchmarking for ARM CPU deployments."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from openmed.eval.metrics import compute_latency_summary
+
+DEFAULT_ARM_LATENCY_CORPUS = Path(__file__).with_name("fixtures") / "sms_clinical.jsonl"
+DEFAULT_ARM_LATENCY_BUDGET = Path(__file__).with_name("budgets") / "arm_latency.json"
+DEFAULT_ARM_LATENCY_MODEL = "OpenMed/OpenMed-PII-ClinicalE5-Small-33M-v1-onnx-android"
+DEFAULT_ARM_LATENCY_MODEL_REVISION = "79f7db205869b1be4be23ac4f42aa95bdedc5aee"
+MAX_SMS_CHARACTERS = 280
+
+LatencyRunner = Callable[[Any, "LatencyDocument"], Any]
+Clock = Callable[[], float]
+RssSampler = Callable[[], int | None]
+
+
+@dataclass(frozen=True)
+class LatencyDocument:
+    """One explicitly synthetic SMS-scale clinical benchmark document."""
+
+    document_id: str
+    text: str
+    language: str = "en"
+    synthetic: bool = True
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "LatencyDocument":
+        """Build and validate a document from a JSON-compatible mapping."""
+
+        return cls(
+            document_id=str(data.get("id") or data.get("document_id") or ""),
+            text=str(data.get("text") or ""),
+            language=str(data.get("language") or "en"),
+            synthetic=data.get("synthetic") is True,
+        )
+
+
+@dataclass(frozen=True)
+class ArmLatencyBudget:
+    """Committed p95 reference and permitted regression tolerance."""
+
+    name: str
+    reference_device: str
+    reference_cpu: str
+    reference_p95_ms: float
+    regression_tolerance: float
+    model_id: str
+    model_revision: str
+    quantization: str
+
+    @property
+    def maximum_p95_ms(self) -> float:
+        """Return the inclusive p95 gate after applying the tolerance."""
+
+        return self.reference_p95_ms * (1.0 + self.regression_tolerance)
+
+    def evaluate(self, measured_p95_ms: float) -> "ArmLatencyVerdict":
+        """Compare a measured p95 against the inclusive regression gate."""
+
+        return ArmLatencyVerdict(
+            measured_p95_ms=measured_p95_ms,
+            maximum_p95_ms=self.maximum_p95_ms,
+            passed=measured_p95_ms <= self.maximum_p95_ms,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return stable JSON-compatible budget metadata."""
+
+        return {
+            "maximum_p95_ms": round(self.maximum_p95_ms, 6),
+            "model_id": self.model_id,
+            "model_revision": self.model_revision,
+            "name": self.name,
+            "quantization": self.quantization,
+            "reference_cpu": self.reference_cpu,
+            "reference_device": self.reference_device,
+            "reference_p95_ms": self.reference_p95_ms,
+            "regression_tolerance": self.regression_tolerance,
+        }
+
+
+@dataclass(frozen=True)
+class ArmLatencyVerdict:
+    """Result of applying the committed p95 regression gate."""
+
+    measured_p95_ms: float
+    maximum_p95_ms: float
+    passed: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return stable JSON-compatible gate output."""
+
+        return {
+            "maximum_p95_ms": round(self.maximum_p95_ms, 6),
+            "measured_p95_ms": round(self.measured_p95_ms, 6),
+            "passed": self.passed,
+        }
+
+
+@dataclass(frozen=True)
+class ArmLatencyReport:
+    """Aggregate latency, throughput, memory, and provenance report."""
+
+    document_count: int
+    sample_count: int
+    total_seconds: float
+    throughput_texts_per_second: float
+    p50_ms: float
+    p95_ms: float
+    peak_rss_mib: float | None
+    model: Mapping[str, Any]
+    machine: Mapping[str, Any]
+    corpus: Mapping[str, Any]
+    budget: ArmLatencyBudget
+    verdict: ArmLatencyVerdict
+    warmup_runs: int
+    repeat: int
+    generated_at: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        """Return whether the p95 latency stayed inside the gated envelope."""
+
+        return self.verdict.passed
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable aggregate report without benchmark source text."""
+
+        return {
+            "benchmark": "sms_arm_latency",
+            "budget": self.budget.to_dict(),
+            "corpus": dict(self.corpus),
+            "document_count": self.document_count,
+            "generated_at": self.generated_at,
+            "latency_ms": {
+                "p50": round(self.p50_ms, 6),
+                "p95": round(self.p95_ms, 6),
+            },
+            "machine": dict(self.machine),
+            "metadata": dict(self.metadata),
+            "model": dict(self.model),
+            "offline": True,
+            "passed": self.passed,
+            "peak_rss_mib": (
+                None if self.peak_rss_mib is None else round(self.peak_rss_mib, 6)
+            ),
+            "repeat": self.repeat,
+            "sample_count": self.sample_count,
+            "schema_version": 1,
+            "throughput_texts_per_second": round(
+                self.throughput_texts_per_second,
+                6,
+            ),
+            "total_seconds": round(self.total_seconds, 6),
+            "verdict": self.verdict.to_dict(),
+            "warmup_runs": self.warmup_runs,
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Serialize the report as deterministic JSON."""
+
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            indent=indent,
+            sort_keys=True,
+        )
+
+    def write_json(self, path: str | Path) -> Path:
+        """Write the deterministic report to *path*."""
+
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(self.to_json() + "\n", encoding="utf-8")
+        return output_path
+
+
+def load_latency_documents(
+    path: str | Path = DEFAULT_ARM_LATENCY_CORPUS,
+) -> list[LatencyDocument]:
+    """Load the committed synthetic SMS corpus from JSONL."""
+
+    corpus_path = Path(path)
+    documents = [
+        LatencyDocument.from_mapping(json.loads(line))
+        for line in corpus_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    _validate_documents(documents)
+    return documents
+
+
+def load_arm_latency_budget(
+    path: str | Path = DEFAULT_ARM_LATENCY_BUDGET,
+) -> ArmLatencyBudget:
+    """Load and validate the committed ARM latency budget."""
+
+    budget_path = Path(path)
+    payload = json.loads(budget_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("ARM latency budget must contain a JSON object")
+    reference = payload.get("reference")
+    if not isinstance(reference, Mapping):
+        raise ValueError("ARM latency budget must contain a reference object")
+    budget = ArmLatencyBudget(
+        name=str(payload.get("name") or ""),
+        reference_device=str(reference.get("device") or ""),
+        reference_cpu=str(reference.get("cpu") or ""),
+        reference_p95_ms=float(reference.get("p95_latency_ms", 0.0)),
+        regression_tolerance=float(payload.get("regression_tolerance", -1.0)),
+        model_id=str(reference.get("model_id") or ""),
+        model_revision=str(reference.get("model_revision") or ""),
+        quantization=str(reference.get("quantization") or ""),
+    )
+    _validate_budget(budget)
+    return budget
+
+
+def run_arm_latency_benchmark(
+    model: Any,
+    *,
+    model_id: str,
+    model_revision: str,
+    documents: Sequence[LatencyDocument] | None = None,
+    budget: ArmLatencyBudget | None = None,
+    corpus_path: str | Path = DEFAULT_ARM_LATENCY_CORPUS,
+    runner: LatencyRunner | None = None,
+    clock: Clock | None = None,
+    rss_sampler: RssSampler | None = None,
+    warmup_runs: int = 1,
+    repeat: int = 3,
+    generated_at: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> ArmLatencyReport:
+    """Benchmark one cached INT8 ONNX model over synthetic SMS-scale texts.
+
+    Warm-up calls are excluded from p50, p95, and throughput. The caller is
+    responsible for activating OpenMed's offline socket guard around model
+    loading and this function.
+    """
+
+    if warmup_runs < 0:
+        raise ValueError("warmup_runs must be non-negative")
+    if repeat < 1:
+        raise ValueError("repeat must be positive")
+
+    selected_documents = list(
+        documents if documents is not None else load_latency_documents(corpus_path)
+    )
+    _validate_documents(selected_documents)
+    selected_budget = budget or load_arm_latency_budget()
+    if model_revision != selected_budget.model_revision:
+        raise ValueError(
+            "model revision does not match the committed ARM latency budget"
+        )
+    _validate_int8_model(model)
+
+    run_document = runner or _default_latency_runner
+    now = clock or time.perf_counter
+    sample_rss = rss_sampler or _peak_rss_bytes
+
+    for index in range(warmup_runs):
+        run_document(model, selected_documents[index % len(selected_documents)])
+
+    rss_values: list[int] = []
+    initial_rss = sample_rss()
+    if initial_rss is not None:
+        rss_values.append(initial_rss)
+
+    latencies_ms: list[float] = []
+    total_started = now()
+    for _ in range(repeat):
+        for document in selected_documents:
+            started = now()
+            run_document(model, document)
+            latencies_ms.append(max(now() - started, 0.0) * 1000.0)
+            current_rss = sample_rss()
+            if current_rss is not None:
+                rss_values.append(current_rss)
+    total_seconds = max(now() - total_started, 0.0)
+
+    latency = compute_latency_summary(latencies_ms)
+    sample_count = len(latencies_ms)
+    throughput = sample_count / total_seconds if total_seconds > 0.0 else 0.0
+    peak_rss_mib = max(rss_values) / (1024.0 * 1024.0) if rss_values else None
+    verdict = selected_budget.evaluate(latency.p95_ms)
+    resolved_corpus_path = Path(corpus_path)
+
+    return ArmLatencyReport(
+        document_count=len(selected_documents),
+        sample_count=sample_count,
+        total_seconds=total_seconds,
+        throughput_texts_per_second=throughput,
+        p50_ms=latency.p50_ms,
+        p95_ms=latency.p95_ms,
+        peak_rss_mib=peak_rss_mib,
+        model=_model_metadata(model, model_id=model_id, revision=model_revision),
+        machine=_machine_metadata(),
+        corpus={
+            "max_characters": max(len(item.text) for item in selected_documents),
+            "name": resolved_corpus_path.name,
+            "synthetic": True,
+        },
+        budget=selected_budget,
+        verdict=verdict,
+        warmup_runs=warmup_runs,
+        repeat=repeat,
+        generated_at=generated_at or _utc_now(),
+        metadata=dict(metadata or {}),
+    )
+
+
+def _default_latency_runner(model: Any, document: LatencyDocument) -> Any:
+    return model.predict(document.text)
+
+
+def _validate_documents(documents: Sequence[LatencyDocument]) -> None:
+    if not documents:
+        raise ValueError("latency benchmark corpus must contain at least one document")
+    seen: set[str] = set()
+    for document in documents:
+        if not document.document_id:
+            raise ValueError("latency benchmark documents require a non-empty id")
+        if document.document_id in seen:
+            raise ValueError(f"duplicate latency document id: {document.document_id}")
+        seen.add(document.document_id)
+        if not document.synthetic:
+            raise ValueError(
+                f"latency benchmark document {document.document_id!r} is not synthetic"
+            )
+        if not document.text:
+            raise ValueError(
+                f"latency benchmark document {document.document_id!r} is empty"
+            )
+        if len(document.text) > MAX_SMS_CHARACTERS:
+            raise ValueError(
+                f"latency benchmark document {document.document_id!r} exceeds "
+                f"{MAX_SMS_CHARACTERS} characters"
+            )
+
+
+def _validate_budget(budget: ArmLatencyBudget) -> None:
+    if not budget.name:
+        raise ValueError("ARM latency budget requires a name")
+    if budget.reference_p95_ms <= 0.0:
+        raise ValueError("ARM latency reference p95 must be positive")
+    if not 0.0 <= budget.regression_tolerance <= 1.0:
+        raise ValueError("ARM latency regression_tolerance must be between 0 and 1")
+    if budget.quantization != "int8":
+        raise ValueError("ARM latency budget must target int8 quantization")
+    if not budget.model_id or not budget.model_revision:
+        raise ValueError("ARM latency budget requires pinned model provenance")
+
+
+def _validate_int8_model(model: Any) -> None:
+    variant = str(getattr(model, "variant", "")).lower()
+    model_path = Path(str(getattr(model, "model_path", "")))
+    if variant != "int8" or model_path.name != "model_int8.onnx":
+        raise ValueError("ARM latency benchmark requires model_int8.onnx")
+
+
+def _model_metadata(
+    model: Any,
+    *,
+    model_id: str,
+    revision: str,
+) -> dict[str, Any]:
+    model_path = Path(str(getattr(model, "model_path", "")))
+    return {
+        "artifact": model_path.name,
+        "id": model_id,
+        "onnxruntime_version": _package_version("onnxruntime"),
+        "quantization": "int8",
+        "revision": revision,
+    }
+
+
+def _machine_metadata() -> dict[str, Any]:
+    uname = platform.uname()
+    return {
+        "architecture": uname.machine,
+        "cpu_count": os.cpu_count(),
+        "operating_system": uname.system,
+        "processor": uname.processor or platform.processor(),
+        "release": uname.release,
+    }
+
+
+def _package_version(package: str) -> str | None:
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return None
+
+
+def _peak_rss_bytes() -> int | None:
+    try:
+        import resource
+    except ImportError:
+        return None
+    rss = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return rss if sys.platform == "darwin" else rss * 1024
+
+
+def _utc_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+__all__ = [
+    "DEFAULT_ARM_LATENCY_BUDGET",
+    "DEFAULT_ARM_LATENCY_CORPUS",
+    "DEFAULT_ARM_LATENCY_MODEL",
+    "DEFAULT_ARM_LATENCY_MODEL_REVISION",
+    "MAX_SMS_CHARACTERS",
+    "ArmLatencyBudget",
+    "ArmLatencyReport",
+    "ArmLatencyVerdict",
+    "LatencyDocument",
+    "load_arm_latency_budget",
+    "load_latency_documents",
+    "run_arm_latency_benchmark",
+]

--- a/openmed/eval/arm_latency.py
+++ b/openmed/eval/arm_latency.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import platform
@@ -58,6 +59,7 @@ class ArmLatencyBudget:
     regression_tolerance: float
     model_id: str
     model_revision: str
+    artifact_sha256: str
     quantization: str
 
     @property
@@ -80,6 +82,7 @@ class ArmLatencyBudget:
 
         return {
             "maximum_p95_ms": round(self.maximum_p95_ms, 6),
+            "artifact_sha256": self.artifact_sha256,
             "model_id": self.model_id,
             "model_revision": self.model_revision,
             "name": self.name,
@@ -223,6 +226,7 @@ def load_arm_latency_budget(
         regression_tolerance=float(payload.get("regression_tolerance", -1.0)),
         model_id=str(reference.get("model_id") or ""),
         model_revision=str(reference.get("model_revision") or ""),
+        artifact_sha256=str(reference.get("artifact_sha256") or ""),
         quantization=str(reference.get("quantization") or ""),
     )
     _validate_budget(budget)
@@ -262,11 +266,17 @@ def run_arm_latency_benchmark(
     )
     _validate_documents(selected_documents)
     selected_budget = budget or load_arm_latency_budget()
+    _validate_budget(selected_budget)
+    if model_id != selected_budget.model_id:
+        raise ValueError("model id does not match the committed ARM latency budget")
     if model_revision != selected_budget.model_revision:
         raise ValueError(
             "model revision does not match the committed ARM latency budget"
         )
-    _validate_int8_model(model)
+    artifact_sha256 = _validate_int8_model(
+        model,
+        expected_sha256=selected_budget.artifact_sha256,
+    )
 
     run_document = runner or _default_latency_runner
     now = clock or time.perf_counter
@@ -307,7 +317,12 @@ def run_arm_latency_benchmark(
         p50_ms=latency.p50_ms,
         p95_ms=latency.p95_ms,
         peak_rss_mib=peak_rss_mib,
-        model=_model_metadata(model, model_id=model_id, revision=model_revision),
+        model=_model_metadata(
+            model,
+            model_id=model_id,
+            revision=model_revision,
+            artifact_sha256=artifact_sha256,
+        ),
         machine=_machine_metadata(),
         corpus={
             "max_characters": max(len(item.text) for item in selected_documents),
@@ -361,15 +376,42 @@ def _validate_budget(budget: ArmLatencyBudget) -> None:
         raise ValueError("ARM latency regression_tolerance must be between 0 and 1")
     if budget.quantization != "int8":
         raise ValueError("ARM latency budget must target int8 quantization")
-    if not budget.model_id or not budget.model_revision:
+    if not budget.model_id:
         raise ValueError("ARM latency budget requires pinned model provenance")
+    if len(budget.model_revision) != 40 or any(
+        character not in "0123456789abcdef" for character in budget.model_revision
+    ):
+        raise ValueError(
+            "ARM latency budget requires a lowercase 40-character revision"
+        )
+    if len(budget.artifact_sha256) != 64 or any(
+        character not in "0123456789abcdef" for character in budget.artifact_sha256
+    ):
+        raise ValueError("ARM latency budget requires a lowercase SHA-256 digest")
 
 
-def _validate_int8_model(model: Any) -> None:
+def _validate_int8_model(model: Any, *, expected_sha256: str) -> str:
     variant = str(getattr(model, "variant", "")).lower()
     model_path = Path(str(getattr(model, "model_path", "")))
     if variant != "int8" or model_path.name != "model_int8.onnx":
         raise ValueError("ARM latency benchmark requires model_int8.onnx")
+    if not model_path.is_file():
+        raise ValueError("ARM latency benchmark model_int8.onnx does not exist")
+    artifact_sha256 = _sha256_file(model_path)
+    if artifact_sha256 != expected_sha256:
+        raise ValueError(
+            "ARM latency benchmark model_int8.onnx does not match the committed "
+            "SHA-256 digest"
+        )
+    return artifact_sha256
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _model_metadata(
@@ -377,10 +419,12 @@ def _model_metadata(
     *,
     model_id: str,
     revision: str,
+    artifact_sha256: str,
 ) -> dict[str, Any]:
     model_path = Path(str(getattr(model, "model_path", "")))
     return {
         "artifact": model_path.name,
+        "artifact_sha256": artifact_sha256,
         "id": model_id,
         "onnxruntime_version": _package_version("onnxruntime"),
         "quantization": "int8",

--- a/openmed/eval/budgets/arm_latency.json
+++ b/openmed/eval/budgets/arm_latency.json
@@ -1,0 +1,13 @@
+{
+  "name": "raspberry-pi-5-8gb-sms-int8",
+  "reference": {
+    "cpu": "4-core Arm Cortex-A76",
+    "device": "Raspberry Pi 5 8GB",
+    "model_id": "OpenMed/OpenMed-PII-ClinicalE5-Small-33M-v1-onnx-android",
+    "model_revision": "79f7db205869b1be4be23ac4f42aa95bdedc5aee",
+    "p95_latency_ms": 1500.0,
+    "quantization": "int8"
+  },
+  "regression_tolerance": 0.2,
+  "schema_version": 1
+}

--- a/openmed/eval/budgets/arm_latency.json
+++ b/openmed/eval/budgets/arm_latency.json
@@ -1,6 +1,7 @@
 {
   "name": "raspberry-pi-5-8gb-sms-int8",
   "reference": {
+    "artifact_sha256": "48a0b2e9269933bef0cf8913239d07996fa2afb107cd223ced95c8decd24ae6b",
     "cpu": "4-core Arm Cortex-A76",
     "device": "Raspberry Pi 5 8GB",
     "model_id": "OpenMed/OpenMed-PII-ClinicalE5-Small-33M-v1-onnx-android",

--- a/openmed/eval/fixtures/sms_clinical.jsonl
+++ b/openmed/eval/fixtures/sms_clinical.jsonl
@@ -1,0 +1,12 @@
+{"id":"sms-001","language":"en","synthetic":true,"text":"Amina Example, your clinic visit is Tue 14 May at 09:30. Reply YES to confirm. Call 555-0101 if you need to reschedule."}
+{"id":"sms-002","language":"en","synthetic":true,"text":"Patient Jordan Sample (MRN TEST-00421) should continue amoxicillin 500 mg three times daily through Friday."}
+{"id":"sms-003","language":"en","synthetic":true,"text":"Synthetic lab notice for Casey Demo: HbA1c 7.2%. Please book a routine review using casey.demo@example.org."}
+{"id":"sms-004","language":"en","synthetic":true,"text":"Discharge follow-up: Taylor Example reports no fever and pain 2/10. Review at North Clinic on 2026-08-04."}
+{"id":"sms-005","language":"en","synthetic":true,"text":"Reminder for Morgan Test: bring inhaler and medication list to the respiratory clinic at 10:15 tomorrow."}
+{"id":"sms-006","language":"en","synthetic":true,"text":"Synthetic referral REF-1006: Priya Example, cardiology triage received your request. No urgent action is required."}
+{"id":"sms-007","language":"en","synthetic":true,"text":"Alex Sample called from 555-0117 about dizziness after the morning dose. A clinician will return the call today."}
+{"id":"sms-008","language":"en","synthetic":true,"text":"For demo patient Sam Example only: blood pressure 128/78, pulse 72. Continue the current monitoring plan."}
+{"id":"sms-009","language":"en","synthetic":true,"text":"Imaging reminder for Lee Sample, test record IMG-009: arrive at Example Hospital reception by 13:45."}
+{"id":"sms-010","language":"en","synthetic":true,"text":"Nora Example's synthetic prescription is ready at Demo Pharmacy, 10 Sample Road. Reference RX-0010."}
+{"id":"sms-011","language":"en","synthetic":true,"text":"Test patient Omar Sample: fasting glucose check due Monday. Do not eat after 22:00 Sunday; water is allowed."}
+{"id":"sms-012","language":"en","synthetic":true,"text":"Care-team demo: Mei Example prefers contact by mei.example@example.org. Next review is 2026-09-18."}

--- a/tests/unit/cli/test_benchmark_cli.py
+++ b/tests/unit/cli/test_benchmark_cli.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import socket
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
 from openmed.cli import main_module
 from openmed.core.offline import HF_OFFLINE_ENV_VARS, OfflineModeError
+from openmed.eval import arm_latency as arm_latency_module
 from openmed.eval import harness
 from openmed.eval.report import BenchmarkReport
 from openmed.onnx.inference import OnnxModel
@@ -212,27 +215,41 @@ def test_latency_command_emits_offline_int8_json_and_blocks_sockets(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    model_path = tmp_path / "model_int8.onnx"
+    model_path.write_bytes(b"")
+    loader_socket_guard_seen = False
+    inference_socket_guard_seen = False
+
     class FakeModel:
         variant = "int8"
-        model_path = Path("model_int8.onnx")
+
+        def __init__(self) -> None:
+            self.model_path = model_path
 
         def predict(self, text: str) -> list[object]:
+            nonlocal inference_socket_guard_seen
+            with pytest.raises(OfflineModeError, match="socket connection"):
+                socket.create_connection(("example.invalid", 443))
+            inference_socket_guard_seen = True
             return []
 
-    socket_guard_seen = False
-
     def fake_from_pretrained(cls, model_id, **kwargs):
-        nonlocal socket_guard_seen
+        nonlocal loader_socket_guard_seen
         assert kwargs["variant"] == "int8"
         assert kwargs["local_files_only"] is True
         with pytest.raises(OfflineModeError, match="socket connection"):
             socket.create_connection(("example.invalid", 443))
-        socket_guard_seen = True
+        loader_socket_guard_seen = True
         return FakeModel()
 
     monkeypatch.setenv("OPENMED_OFFLINE", "1")
     for name in HF_OFFLINE_ENV_VARS:
         monkeypatch.setenv(name, "0")
+    budget = replace(
+        arm_latency_module.load_arm_latency_budget(),
+        artifact_sha256=hashlib.sha256(b"").hexdigest(),
+    )
+    monkeypatch.setattr(arm_latency_module, "load_arm_latency_budget", lambda _: budget)
     monkeypatch.setattr(OnnxModel, "from_pretrained", classmethod(fake_from_pretrained))
     output_path = tmp_path / "arm-latency.json"
 
@@ -252,13 +269,16 @@ def test_latency_command_emits_offline_int8_json_and_blocks_sockets(
     )
 
     assert result == 0
-    assert socket_guard_seen is True
+    assert loader_socket_guard_seen is True
+    assert inference_socket_guard_seen is True
     captured = capsys.readouterr()
     assert captured.err == ""
     payload = json.loads(captured.out)
     assert payload["benchmark"] == "sms_arm_latency"
     assert payload["offline"] is True
     assert payload["model"]["artifact"] == "model_int8.onnx"
+    assert payload["model"]["artifact_sha256"] == hashlib.sha256(b"").hexdigest()
+    assert payload["model"]["id"] == budget.model_id
     assert payload["model"]["quantization"] == "int8"
     assert payload["latency_ms"]["p50"] >= 0.0
     assert "throughput_texts_per_second" in payload

--- a/tests/unit/cli/test_benchmark_cli.py
+++ b/tests/unit/cli/test_benchmark_cli.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import json
+import socket
 from pathlib import Path
 
 import pytest
 
 from openmed.cli import main_module
+from openmed.core.offline import HF_OFFLINE_ENV_VARS, OfflineModeError
 from openmed.eval import harness
 from openmed.eval.report import BenchmarkReport
+from openmed.onnx.inference import OnnxModel
 
 
 def test_benchmark_pii_golden_writes_report_from_committed_fixtures(
@@ -202,3 +205,62 @@ def test_mobile_command_default_workload_writes_report_to_stdout(
     assert payload["tier"] == "base"
     assert payload["canonical_tier"] == "Base"
     assert payload["slo_results"]["p95_latency_ms"]["passed"] is True
+
+
+def test_latency_command_emits_offline_int8_json_and_blocks_sockets(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FakeModel:
+        variant = "int8"
+        model_path = Path("model_int8.onnx")
+
+        def predict(self, text: str) -> list[object]:
+            return []
+
+    socket_guard_seen = False
+
+    def fake_from_pretrained(cls, model_id, **kwargs):
+        nonlocal socket_guard_seen
+        assert kwargs["variant"] == "int8"
+        assert kwargs["local_files_only"] is True
+        with pytest.raises(OfflineModeError, match="socket connection"):
+            socket.create_connection(("example.invalid", 443))
+        socket_guard_seen = True
+        return FakeModel()
+
+    monkeypatch.setenv("OPENMED_OFFLINE", "1")
+    for name in HF_OFFLINE_ENV_VARS:
+        monkeypatch.setenv(name, "0")
+    monkeypatch.setattr(OnnxModel, "from_pretrained", classmethod(fake_from_pretrained))
+    output_path = tmp_path / "arm-latency.json"
+
+    result = main_module.main(
+        [
+            "benchmark",
+            "latency",
+            "--model",
+            str(tmp_path / "cached-model"),
+            "--warmup-runs",
+            "0",
+            "--repeat",
+            "1",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert result == 0
+    assert socket_guard_seen is True
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["benchmark"] == "sms_arm_latency"
+    assert payload["offline"] is True
+    assert payload["model"]["artifact"] == "model_int8.onnx"
+    assert payload["model"]["quantization"] == "int8"
+    assert payload["latency_ms"]["p50"] >= 0.0
+    assert "throughput_texts_per_second" in payload
+    assert "peak_rss_mib" in payload
+    assert json.loads(output_path.read_text(encoding="utf-8")) == payload

--- a/tests/unit/deploy/test_container_multiarch.py
+++ b/tests/unit/deploy/test_container_multiarch.py
@@ -67,6 +67,8 @@ def test_arm_latency_docs_record_budget_and_reproduction_commands():
     assert "1,800 ms" in content
     assert "OPENMED_OFFLINE=1 openmed benchmark latency" in content
     assert "model_int8.onnx" in content
+    assert "48a0b2e9269933bef0cf8913239d07996fa2afb107cd223ced95c8decd24ae6b" in content
+    assert "SHA-256" in content
     assert "test_intentionally_slowed_fixture_trips_gate" in content
     assert "test_latency_command_emits_offline_int8_json_and_blocks_sockets" in content
 

--- a/tests/unit/deploy/test_container_multiarch.py
+++ b/tests/unit/deploy/test_container_multiarch.py
@@ -9,6 +9,7 @@ ROOT = Path(__file__).resolve().parents[3]
 DEPLOY_DOCKERFILE = ROOT / "deploy" / "docker" / "Dockerfile"
 ROOT_DOCKERFILE = ROOT / "Dockerfile"
 WORKFLOW = ROOT / ".github" / "workflows" / "container-multiarch.yml"
+ARM_LATENCY_DOCS = ROOT / "docs" / "benchmarks" / "arm-latency.md"
 DOCS = ROOT / "docs" / "deploy" / "multi-arch.md"
 MKDOCS = ROOT / "mkdocs.yml"
 
@@ -43,6 +44,31 @@ def test_multiarch_workflow_builds_manifest_and_smokes_each_platform():
     assert "openmed.deidentify" in content
     assert "linux/amd64" in content
     assert "linux/arm64" in content
+
+
+def test_multiarch_workflow_gates_native_arm_sms_latency_offline():
+    content = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "runs-on: ubuntu-24.04-arm" in content
+    assert 'test "$(uname -m)" = "aarch64"' in content
+    assert "test_intentionally_slowed_fixture_trips_gate" in content
+    assert 'OPENMED_OFFLINE: "1"' in content
+    assert "openmed benchmark latency" in content
+    assert "--output arm-latency-report.json" in content
+    assert "name: arm-latency-report" in content
+    assert "- arm-latency" in content
+
+
+def test_arm_latency_docs_record_budget_and_reproduction_commands():
+    content = ARM_LATENCY_DOCS.read_text(encoding="utf-8")
+
+    assert "Raspberry Pi 5 with 8 GB RAM" in content
+    assert "1,500 ms" in content
+    assert "1,800 ms" in content
+    assert "OPENMED_OFFLINE=1 openmed benchmark latency" in content
+    assert "model_int8.onnx" in content
+    assert "test_intentionally_slowed_fixture_trips_gate" in content
+    assert "test_latency_command_emits_offline_int8_json_and_blocks_sockets" in content
 
 
 def test_multiarch_docs_cover_supported_platforms_and_pull_commands():

--- a/tests/unit/eval/test_arm_latency.py
+++ b/tests/unit/eval/test_arm_latency.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -18,7 +19,9 @@ from openmed.eval.arm_latency import (
 
 class _FakeInt8Model:
     variant = "int8"
-    model_path = Path("model_int8.onnx")
+
+    def __init__(self, model_path: Path = Path("model_int8.onnx")) -> None:
+        self.model_path = model_path
 
     def predict(self, text: str) -> list[object]:
         return []
@@ -27,6 +30,12 @@ class _FakeInt8Model:
 def _clock(values: list[float]):
     iterator = iter(values)
     return lambda: next(iterator)
+
+
+def _empty_int8_model(tmp_path: Path) -> _FakeInt8Model:
+    model_path = tmp_path / "model_int8.onnx"
+    model_path.write_bytes(b"")
+    return _FakeInt8Model(model_path)
 
 
 def _budget(*, reference_p95_ms: float = 200.0) -> ArmLatencyBudget:
@@ -38,6 +47,7 @@ def _budget(*, reference_p95_ms: float = 200.0) -> ArmLatencyBudget:
         regression_tolerance=0.2,
         model_id="OpenMed/unit-int8",
         model_revision="a" * 40,
+        artifact_sha256=hashlib.sha256(b"").hexdigest(),
         quantization="int8",
     )
 
@@ -61,15 +71,21 @@ def test_committed_budget_applies_exact_twenty_percent_tolerance() -> None:
     budget = load_arm_latency_budget()
 
     assert budget.reference_p95_ms == 1500.0
+    assert (
+        budget.artifact_sha256
+        == "48a0b2e9269933bef0cf8913239d07996fa2afb107cd223ced95c8decd24ae6b"
+    )
     assert budget.maximum_p95_ms == pytest.approx(1800.0)
     assert budget.evaluate(1800.0).passed is True
     assert budget.evaluate(1800.001).passed is False
 
 
-def test_report_emits_aggregate_latency_throughput_rss_and_metadata() -> None:
+def test_report_emits_aggregate_latency_throughput_rss_and_metadata(
+    tmp_path: Path,
+) -> None:
     rss = iter([100 * 1024**2, 110 * 1024**2, 120 * 1024**2])
     report = run_arm_latency_benchmark(
-        _FakeInt8Model(),
+        _empty_int8_model(tmp_path),
         model_id="OpenMed/unit-int8",
         model_revision="a" * 40,
         documents=_documents(),
@@ -86,15 +102,16 @@ def test_report_emits_aggregate_latency_throughput_rss_and_metadata() -> None:
     assert payload["throughput_texts_per_second"] == pytest.approx(6.666667)
     assert payload["peak_rss_mib"] == 120.0
     assert payload["model"]["quantization"] == "int8"
+    assert payload["model"]["artifact_sha256"] == hashlib.sha256(b"").hexdigest()
     assert payload["machine"]["cpu_count"]
     assert payload["corpus"]["synthetic"] is True
     assert payload["passed"] is True
     assert "Synthetic patient" not in report.to_json()
 
 
-def test_intentionally_slowed_fixture_trips_gate() -> None:
+def test_intentionally_slowed_fixture_trips_gate(tmp_path: Path) -> None:
     report = run_arm_latency_benchmark(
-        _FakeInt8Model(),
+        _empty_int8_model(tmp_path),
         model_id="OpenMed/unit-int8",
         model_revision="a" * 40,
         documents=[LatencyDocument("slow", "Synthetic slowed fixture")],
@@ -118,10 +135,52 @@ def test_non_int8_graph_is_rejected() -> None:
     with pytest.raises(ValueError, match="model_int8.onnx"):
         run_arm_latency_benchmark(
             model,
-            model_id="OpenMed/unit-fp32",
+            model_id="OpenMed/unit-int8",
             model_revision="a" * 40,
             documents=_documents(),
             budget=_budget(),
+            warmup_runs=0,
+            repeat=1,
+        )
+
+
+def test_wrong_int8_artifact_hash_fails_closed(tmp_path: Path) -> None:
+    model_path = tmp_path / "model_int8.onnx"
+    model_path.write_bytes(b"unexpected model bytes")
+
+    with pytest.raises(ValueError, match="SHA-256"):
+        run_arm_latency_benchmark(
+            _FakeInt8Model(model_path),
+            model_id="OpenMed/unit-int8",
+            model_revision="a" * 40,
+            documents=_documents(),
+            budget=_budget(),
+            warmup_runs=0,
+            repeat=1,
+        )
+
+
+def test_unpinned_artifact_hash_fails_closed(tmp_path: Path) -> None:
+    budget = _budget()
+    unpinned_budget = ArmLatencyBudget(
+        name=budget.name,
+        reference_device=budget.reference_device,
+        reference_cpu=budget.reference_cpu,
+        reference_p95_ms=budget.reference_p95_ms,
+        regression_tolerance=budget.regression_tolerance,
+        model_id=budget.model_id,
+        model_revision=budget.model_revision,
+        artifact_sha256="",
+        quantization=budget.quantization,
+    )
+
+    with pytest.raises(ValueError, match="SHA-256"):
+        run_arm_latency_benchmark(
+            _empty_int8_model(tmp_path),
+            model_id="OpenMed/unit-int8",
+            model_revision="a" * 40,
+            documents=_documents(),
+            budget=unpinned_budget,
             warmup_runs=0,
             repeat=1,
         )
@@ -134,6 +193,17 @@ def test_empty_corpus_and_unpinned_revision_fail_closed() -> None:
             model_id="OpenMed/unit-int8",
             model_revision="a" * 40,
             documents=[],
+            budget=_budget(),
+            warmup_runs=0,
+            repeat=1,
+        )
+
+    with pytest.raises(ValueError, match="model id"):
+        run_arm_latency_benchmark(
+            _FakeInt8Model(),
+            model_id="OpenMed/different-model",
+            model_revision="a" * 40,
+            documents=_documents(),
             budget=_budget(),
             warmup_runs=0,
             repeat=1,

--- a/tests/unit/eval/test_arm_latency.py
+++ b/tests/unit/eval/test_arm_latency.py
@@ -1,0 +1,174 @@
+"""Tests for the offline ARM SMS latency benchmark."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openmed.eval.arm_latency import (
+    MAX_SMS_CHARACTERS,
+    ArmLatencyBudget,
+    LatencyDocument,
+    load_arm_latency_budget,
+    load_latency_documents,
+    run_arm_latency_benchmark,
+)
+
+
+class _FakeInt8Model:
+    variant = "int8"
+    model_path = Path("model_int8.onnx")
+
+    def predict(self, text: str) -> list[object]:
+        return []
+
+
+def _clock(values: list[float]):
+    iterator = iter(values)
+    return lambda: next(iterator)
+
+
+def _budget(*, reference_p95_ms: float = 200.0) -> ArmLatencyBudget:
+    return ArmLatencyBudget(
+        name="unit-arm-budget",
+        reference_device="Raspberry Pi 5 8GB",
+        reference_cpu="4-core Arm Cortex-A76",
+        reference_p95_ms=reference_p95_ms,
+        regression_tolerance=0.2,
+        model_id="OpenMed/unit-int8",
+        model_revision="a" * 40,
+        quantization="int8",
+    )
+
+
+def _documents() -> list[LatencyDocument]:
+    return [
+        LatencyDocument("sms-a", "Synthetic patient A called 555-0100."),
+        LatencyDocument("sms-b", "Synthetic patient B has a review tomorrow."),
+    ]
+
+
+def test_committed_corpus_is_synthetic_and_sms_scale() -> None:
+    documents = load_latency_documents()
+
+    assert len(documents) >= 10
+    assert all(document.synthetic for document in documents)
+    assert max(len(document.text) for document in documents) <= MAX_SMS_CHARACTERS
+
+
+def test_committed_budget_applies_exact_twenty_percent_tolerance() -> None:
+    budget = load_arm_latency_budget()
+
+    assert budget.reference_p95_ms == 1500.0
+    assert budget.maximum_p95_ms == pytest.approx(1800.0)
+    assert budget.evaluate(1800.0).passed is True
+    assert budget.evaluate(1800.001).passed is False
+
+
+def test_report_emits_aggregate_latency_throughput_rss_and_metadata() -> None:
+    rss = iter([100 * 1024**2, 110 * 1024**2, 120 * 1024**2])
+    report = run_arm_latency_benchmark(
+        _FakeInt8Model(),
+        model_id="OpenMed/unit-int8",
+        model_revision="a" * 40,
+        documents=_documents(),
+        budget=_budget(),
+        clock=_clock([0.0, 0.0, 0.1, 0.1, 0.3, 0.3]),
+        rss_sampler=lambda: next(rss),
+        warmup_runs=0,
+        repeat=1,
+        generated_at="2026-07-18T00:00:00Z",
+    )
+
+    payload = report.to_dict()
+    assert payload["latency_ms"] == {"p50": 100.0, "p95": 200.0}
+    assert payload["throughput_texts_per_second"] == pytest.approx(6.666667)
+    assert payload["peak_rss_mib"] == 120.0
+    assert payload["model"]["quantization"] == "int8"
+    assert payload["machine"]["cpu_count"]
+    assert payload["corpus"]["synthetic"] is True
+    assert payload["passed"] is True
+    assert "Synthetic patient" not in report.to_json()
+
+
+def test_intentionally_slowed_fixture_trips_gate() -> None:
+    report = run_arm_latency_benchmark(
+        _FakeInt8Model(),
+        model_id="OpenMed/unit-int8",
+        model_revision="a" * 40,
+        documents=[LatencyDocument("slow", "Synthetic slowed fixture")],
+        budget=_budget(reference_p95_ms=1500.0),
+        clock=_clock([0.0, 0.0, 1.801, 1.801]),
+        rss_sampler=lambda: None,
+        warmup_runs=0,
+        repeat=1,
+    )
+
+    assert report.p95_ms == pytest.approx(1801.0)
+    assert report.verdict.maximum_p95_ms == pytest.approx(1800.0)
+    assert report.passed is False
+
+
+def test_non_int8_graph_is_rejected() -> None:
+    model = _FakeInt8Model()
+    model.variant = "fp32"
+    model.model_path = Path("model.onnx")
+
+    with pytest.raises(ValueError, match="model_int8.onnx"):
+        run_arm_latency_benchmark(
+            model,
+            model_id="OpenMed/unit-fp32",
+            model_revision="a" * 40,
+            documents=_documents(),
+            budget=_budget(),
+            warmup_runs=0,
+            repeat=1,
+        )
+
+
+def test_empty_corpus_and_unpinned_revision_fail_closed() -> None:
+    with pytest.raises(ValueError, match="at least one document"):
+        run_arm_latency_benchmark(
+            _FakeInt8Model(),
+            model_id="OpenMed/unit-int8",
+            model_revision="a" * 40,
+            documents=[],
+            budget=_budget(),
+            warmup_runs=0,
+            repeat=1,
+        )
+
+    with pytest.raises(ValueError, match="model revision"):
+        run_arm_latency_benchmark(
+            _FakeInt8Model(),
+            model_id="OpenMed/unit-int8",
+            model_revision="b" * 40,
+            documents=_documents(),
+            budget=_budget(),
+            warmup_runs=0,
+            repeat=1,
+        )
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        LatencyDocument("", "Synthetic text"),
+        LatencyDocument("real", "Synthetic text", synthetic=False),
+        LatencyDocument("long", "x" * (MAX_SMS_CHARACTERS + 1)),
+    ],
+)
+def test_invalid_or_non_synthetic_documents_fail_closed(
+    document: LatencyDocument,
+) -> None:
+    with pytest.raises(ValueError):
+        run_arm_latency_benchmark(
+            _FakeInt8Model(),
+            model_id="OpenMed/unit-int8",
+            model_revision="a" * 40,
+            documents=[document],
+            budget=_budget(),
+            warmup_runs=0,
+            repeat=1,
+        )


### PR DESCRIPTION
## Description

Adds a cache-only INT8 ONNX benchmark for SMS-scale synthetic clinical text, with aggregate p50/p95 latency, throughput, peak RSS, machine/model provenance, and a committed Raspberry Pi 5 reference envelope. The command blocks outbound sockets during model loading and inference, verifies the exact pinned ONNX artifact digest before measuring, and fails when p95 exceeds the 1,500 ms reference by more than 20%.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add `openmed benchmark latency` with a pinned cache-only INT8 model and deterministic JSON reporting.
- Add a committed 12-message synthetic corpus and the 1,500 ms p95 / 20% tolerance budget.
- Pin the exact `model_int8.onnx` SHA-256 digest and emit the canonical model ID, revision, artifact, digest, and quantization in reports.
- Add a native 4-core ARM64 CI gate, offline report artifact, negative regression fixture, and socket-guard coverage across loading and inference.
- Document the Raspberry Pi 5 envelope, exact reproduction commands, report contract, and measurement provenance limits.

## Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with the pinned INT8 model and synthetic inputs

Validation completed after rebasing onto current `master`:

- `.venv/bin/python -m pytest tests/ -q` — 7,051 passed, 48 skipped
- Focused benchmark, CLI, container, workflow-reference, and provenance tests — 43 passed
- `make format`, `make lint`, `make format-check`, and `make type-check`
- Scoped pre-commit checks
- Strict documentation build
- Source distribution and wheel build, including the packaged corpus and budget
- Fresh native ARM64 hosted run — p95 5.581 ms, 219.566 texts/s, 251.316 MiB peak RSS, exact pinned artifact digest verified, budget passed
- Full hosted OS/Python, container, security, policy, build, benchmark, provenance, and SBOM checks

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran the repository format, lint, format-check, and type-check gates
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

The benchmark uses the existing `onnx-runtime` optional extra.

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have organized the commits so the maintainer hardening remains reviewable

## Related Issues

Closes #1456

## Screenshots/Examples

The command emits aggregate JSON to stdout and optionally writes the same report with `--output`; no synthetic source text is included.
