### PR TITLE
Add GDPR and EU AI Act compliance templates

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -34,6 +34,22 @@ issue, and without including real patient data.
   capture the canonical policy literals and default action posture used by the
   runtime.
 
+## Deployment Templates
+
+These artifacts are templates requiring legal review, not legal advice. Adapt
+them to the actual parties, purpose, data, jurisdiction, deployment boundaries,
+and supervisory-authority guidance:
+
+- [Data Protection Impact Assessment template](compliance/dpia-template.md)
+  connects a deployment's processing description, policy profile, audit
+  residual-risk score, validation evidence, safeguards, and approval decision.
+- [Data Processing Agreement template](compliance/dpa-template.md) covers the
+  local/on-device baseline, no-telemetry posture, sub-processor inventory, data
+  return or deletion, and reversible-pseudonymization key custody.
+- [EU AI Act and GDPR model-card field specification](compliance/model-card-eu-ai-act-fields.md)
+  defines intended-purpose, limitation, accuracy/leakage, human-oversight,
+  robustness, and GDPR fields for manifest- and `BenchmarkReport`-backed cards.
+
 ## Policy Literals
 
 Use these exact literals in docs, examples, and deployment configuration:

--- a/docs/compliance/dpa-template.md
+++ b/docs/compliance/dpa-template.md
@@ -1,0 +1,262 @@
+# Data Processing Agreement Template
+
+> **Template — requires legal review. Not legal advice.** This is not a signed
+> agreement and does not establish that OpenMed's maintainers are a processor.
+> Adapt it to the parties, processing, jurisdiction, and deployment before use.
+
+OpenMed is a local-first software library. Installing or running it does not by
+itself send personal data to the OpenMed project or create a
+controller-processor relationship. Use this template only when the actual facts
+create a processor relationship, such as between a deployer and an organization
+operating OpenMed on the deployer's documented instructions.
+
+Replace every `[bracketed placeholder]`. If the deployment adds hosted model
+downloads, remote inference, storage, observability, support, or other services,
+describe those services and their sub-processors instead of retaining the local
+runtime defaults below.
+
+## Agreement Details
+
+This Data Processing Agreement (DPA) forms part of `[master agreement]` between:
+
+- **Controller:** `[legal name, address, registration number]`
+- **Processor:** `[legal name, address, registration number]`
+- **Effective date and term:** `[date and duration]`
+- **Governing law and venue:** `[jurisdiction]`
+- **Privacy contacts:** `[controller contact]`; `[processor contact]`
+
+The parties intend this DPA to address GDPR Article 28 and applicable national
+data-protection law. Defined terms have the meanings assigned by the GDPR unless
+the master agreement states otherwise.
+
+## 1. Scope and Documented Instructions
+
+1. The Processor shall process personal data only on the Controller's documented
+   instructions, including instructions concerning transfers, unless Union or
+   Member State law requires otherwise. The Processor shall inform the Controller
+   of that legal requirement before processing unless prohibited by law.
+2. The current instructions are the processing details in Annex A, the approved
+   OpenMed configuration, and later written instructions agreed by authorized
+   contacts.
+3. The Processor shall immediately inform the Controller if, in its opinion, an
+   instruction infringes applicable data-protection law and shall pause the
+   affected processing where legally and contractually appropriate.
+4. Processing for the Processor's own analytics, advertising, model training,
+   product telemetry, or unrelated purposes is prohibited unless separately
+   documented with a valid legal basis and role allocation.
+
+## 2. Confidentiality and Personnel
+
+The Processor shall limit access to authorized personnel who need it to perform
+the services, are bound by confidentiality, receive appropriate privacy and
+security training, and are subject to documented access review and revocation.
+
+## 3. Security of Processing
+
+The Processor shall maintain measures appropriate to the risk, including the
+controls in Annex B and any measures required under GDPR Article 32. The parties
+shall record who is responsible for each control rather than assuming that a
+library default covers the surrounding deployment.
+
+## 4. On-Device and Local Processing Baseline
+
+For the agreed baseline deployment:
+
+- processing occurs **on-device** or inside `[controller-approved local
+  environment]` after approved model artifacts have been acquired;
+- OpenMed has **no telemetry by default** and personal data shall not be added to
+  analytics, product telemetry, error reporting, or support bundles;
+- runtime network egress is `[blocked / restricted as described]`;
+- raw input, de-identified output, audit evidence, caches, and temporary files
+  remain within `[location and legal entity]` unless Annex A states otherwise;
+- logs use counts, durations, labels, offsets, hashes, and safe identifiers, not
+  raw clinical text, identifiers, or reversible mappings; and
+- changes to these facts require documented Controller approval and a DPA/DPIA
+  review before deployment.
+
+Model acquisition, operating-system services, backups, remote administration,
+hosted APIs, and monitoring are separate processing surfaces and must be listed
+in Annex A even when OpenMed inference itself is local.
+
+## 5. Sub-Processors
+
+**Sub-processors: none for the OpenMed local runtime baseline.**
+
+The Processor shall not engage a sub-processor for the covered processing
+without the Controller's prior specific or general written authorization. For a
+general authorization, the Processor shall give `[notice period]` advance notice
+of additions or replacements so the Controller can object on reasonable
+data-protection grounds.
+
+The Processor shall impose obligations providing at least the same protection as
+this DPA and remains responsible for the sub-processor's performance. Any actual
+hosting, storage, model registry, support, monitoring, or remote administration
+provider must be entered in Annex D. Do not leave "none" in place if such a
+provider can access personal data.
+
+## 6. Assistance to the Controller
+
+Taking into account the nature of processing and available information, the
+Processor shall reasonably assist the Controller with:
+
+- data-subject requests and verification of access, rectification, erasure,
+  restriction, objection, and portability workflows;
+- security, breach assessment, notification, and communication obligations;
+- DPIAs, risk reassessment, and prior consultation with a supervisory authority;
+- records demonstrating compliance, including configuration, aggregate metrics,
+  audit hashes, and approved residual-risk evidence; and
+- inquiries from supervisory authorities.
+
+The assistance process, contacts, response times, and fees are: `[terms]`.
+
+## 7. Personal Data Breaches
+
+The Processor shall notify the Controller without undue delay and within
+`[contractual target]` after becoming aware of a personal data breach. The notice
+shall include available information about the nature and scope, affected data and
+data subjects, likely consequences, containment, remediation, and a contact for
+follow-up. Information may be supplied in phases without delaying the initial
+notice.
+
+Notification does not transfer the Controller's legal assessment or
+supervisory-authority notification duties to the Processor.
+
+## 8. Audit and Demonstration of Compliance
+
+The Processor shall make information reasonably necessary to demonstrate
+compliance available to the Controller and allow proportionate audits or
+inspections by the Controller or its mandated auditor. The parties shall agree
+scope, confidentiality, security, scheduling, and cost controls without preventing
+an audit required by law or a competent authority.
+
+Privacy-safe evidence should use hashes, offsets, counts, aggregate metrics,
+configuration, and provenance. It shall not include raw patient content or
+re-identification mappings unless strictly necessary, authorized, and protected.
+
+## 9. International Transfers and Processing Locations
+
+- Approved processing and storage locations: `[locations]`
+- Approved remote-access locations: `[locations or none]`
+- Transfer mechanism and supplementary measures: `[not applicable / adequacy /
+  SCCs / other]`
+- Transfer impact assessment reference: `[reference]`
+
+The Processor shall not change a processing location or enable a restricted
+transfer without documented authorization and required safeguards.
+
+## 10. Return, Deletion, and End of Services
+
+At the Controller's choice, the Processor shall return or securely delete the
+personal data and copies at the end of services, unless applicable law requires
+retention. The Processor shall identify legally retained data, isolate it from
+ordinary use, and delete it when the legal period expires.
+
+Deletion must cover or separately schedule inputs, outputs, local caches,
+temporary files, logs, mappings, keys, audit artifacts, replicas, and backups.
+Deletion method, timing, evidence, and exceptions: `[terms]`.
+
+## 11. Reversible Pseudonymization and Key Custody
+
+This section applies when the deployment uses the exact policy literal
+`gdpr_pseudonymization`, which sets `keep_mapping=True` and
+`reversible_id=True`. Pseudonymized data remains personal data.
+
+1. The Controller retains `[exclusive / allocated]` custody and control of the
+   re-identification key and mapping.
+2. The key, mapping, and pseudonymized dataset shall be separated using
+   `[technical and organizational separation]`.
+3. The Processor shall not re-identify, link, disclose, export, or use the
+   mapping except on a documented instruction from `[authorized role]` for
+   `[approved purpose]`.
+4. Key creation, storage, access, rotation, recovery, revocation, destruction,
+   and emergency use shall follow Annex C.
+5. Key and mapping access shall be least-privilege, authenticated, logged, and
+   periodically reviewed without recording cleartext identifiers in operational
+   logs.
+6. Suspected key or mapping compromise shall be handled as a security incident
+   and assessed as a potential personal data breach.
+
+If the policy literal `hipaa_safe_harbor` is used instead, the parties shall
+document that its masking posture does not itself establish anonymization under
+the GDPR and shall still assess residual identifiability.
+
+## 12. Liability, Order of Precedence, and Changes
+
+Liability, indemnity, governing law, and dispute terms are `[master agreement
+references or negotiated clauses]`. If this DPA conflicts with the master
+agreement on personal-data protection, `[order of precedence]` applies. Material
+changes to purpose, data, model, policy, hosting, recipients, locations,
+sub-processors, retention, or key custody require written change control and a
+privacy-risk review.
+
+## Annex A — Processing Details
+
+| Field | Agreed detail |
+|---|---|
+| Subject matter | [OpenMed-assisted de-identification or other service] |
+| Duration | [Term plus deletion period] |
+| Nature and purpose | [Operations and explicit purposes] |
+| Data subjects | [Categories] |
+| Personal-data types | [Categories, including any health or genetic data] |
+| Processing operations | [Collect, load, detect, replace/mask, review, store, delete] |
+| OpenMed policy literal | `[hipaa_safe_harbor or gdpr_pseudonymization]` |
+| Model and software | [Ids, versions, revisions, hashes] |
+| Inputs and sources | [Systems and formats] |
+| Outputs and recipients | [Systems, roles, legal entities] |
+| Locations and network boundaries | [Locations and data flow] |
+| Retention | [Per artifact] |
+| Controller instructions | [References] |
+
+## Annex B — Technical and Organizational Measures
+
+| Control area | Measure, owner, and evidence |
+|---|---|
+| Local/offline execution and egress | [Measure] |
+| Encryption in transit and at rest | [Measure] |
+| Identity, access, and privilege review | [Measure] |
+| No-raw-PHI logs and telemetry controls | [Measure] |
+| Model, manifest, dependency, and configuration integrity | [Measure] |
+| Leakage, recall, residual-risk, and robustness validation | [Measure] |
+| Vulnerability and patch management | [Measure] |
+| Backup, restore, retention, and deletion | [Measure] |
+| Incident detection and response | [Measure] |
+| Business continuity and availability | [Measure] |
+| Personnel confidentiality and training | [Measure] |
+| Control testing and review cadence | [Measure] |
+
+## Annex C — Pseudonymization Key-Custody Record
+
+| Field | Agreed detail |
+|---|---|
+| Key owner and system | [Values] |
+| Mapping owner and system | [Values] |
+| Legal and physical locations | [Values] |
+| Authorized roles | [Values] |
+| Separation of duties | [Values] |
+| Rotation and expiry | [Values] |
+| Backup and recovery | [Values] |
+| Re-identification approval | [Values] |
+| Access-log review | [Values] |
+| Revocation and destruction | [Values] |
+| Compromise response | [Values] |
+
+## Annex D — Authorized Sub-Processors
+
+| Sub-processor | Service | Data and access | Location/transfer | Authorization date |
+|---|---|---|---|---|
+| None for the OpenMed local runtime baseline | Not applicable | None | Not applicable | Not applicable |
+
+## Signatures
+
+| Party | Name, title, signature, date |
+|---|---|
+| Controller | [Values] |
+| Processor | [Values] |
+
+## Primary References
+
+- [GDPR, including Articles 28, 32, 35, and 36](https://eur-lex.europa.eu/eli/reg/2016/679/oj)
+- [OpenMed compliance posture](../compliance.md)
+- [OpenMed no-telemetry policy](../security/no-telemetry.md)
+- [OpenMed no-raw-PHI logging policy](../security/no-raw-phi-logging.md)
+- [OpenMed DPIA template](dpia-template.md)

--- a/docs/compliance/dpia-template.md
+++ b/docs/compliance/dpia-template.md
@@ -1,0 +1,261 @@
+# Data Protection Impact Assessment Template
+
+> **Template — requires legal review. Not legal advice.** Adapt this document to
+> the actual processing, jurisdiction, supervisory-authority guidance, and
+> deployment controls before relying on it.
+
+This template helps a controller document a Data Protection Impact Assessment
+(DPIA) for a deployment that uses OpenMed. It is structured around GDPR Article
+35 and the OpenMed de-identification evidence that can inform, but cannot replace,
+the controller's assessment.
+
+Replace every `[bracketed placeholder]`. Record only references, aggregate
+metrics, hashes, and approved classifications in this document. Do not paste raw
+health data, identifiers, de-identification mappings, or cleartext audit spans.
+
+## 1. Document Control
+
+| Field | Entry |
+|---|---|
+| Controller and business unit | [Legal entity and owner] |
+| Joint controllers | [None, or legal entities and allocation reference] |
+| Processors and sub-processors | [Legal entities, services, locations, and DPA references] |
+| Processing activity | [Name and short description] |
+| Planned launch and end dates | [Dates, or ongoing with review trigger] |
+| DPIA version | [Version and change summary] |
+| DPIA owner | [Name or role] |
+| Data protection officer | [Name or role; or not appointed, with reason] |
+| Security reviewer | [Name or role] |
+| OpenMed version and model | [Version, model id, model revision, artifact hash] |
+| Deployment environment | [Device, workstation, private service, or other] |
+| Status | [Draft / approved / rejected / prior consultation required] |
+| Approval date | [YYYY-MM-DD] |
+| Next review | [Date or triggering event] |
+| Assessment scope and exclusions | [Systems, processing stages, and explicit exclusions] |
+| Publication and sharing | [Public summary, internal circulation, or reason not published] |
+| Related records | [ROPA, retention policy, incident plan, DPA, model card] |
+
+## 2. Screening and Consultation Decision
+
+### Why a DPIA is or is not required
+
+- Nature, scope, context, and purposes of the processing: [Assessment]
+- Special-category or health data involved: [Yes/no and categories]
+- Scale, frequency, duration, and number of data subjects: [Assessment]
+- Vulnerable data subjects, systematic monitoring, matching, profiling, or
+  automated decisions: [Assessment]
+- New technology or material change to an existing system: [Assessment]
+- Applicable supervisory-authority DPIA list or sector rule: [Citation and
+  conclusion]
+- Final screening decision and rationale: [Decision]
+
+### Consultation record
+
+| Consultation | Record |
+|---|---|
+| DPO advice | [Advice, date, and how it was addressed] |
+| Security and clinical safety advice | [Advice and disposition] |
+| Data-subject or representative views | [Views, or why consultation was not appropriate] |
+| Prior supervisory-authority consultation | [Not required / required under Article 36 / reference] |
+
+If high residual risk remains after reasonable measures, stop the processing
+until counsel and the DPO determine whether prior consultation is required.
+
+## 3. Processing Description
+
+### Purpose and outcome
+
+- Intended purpose: [Specific, explicit purpose]
+- Expected benefit: [Benefit to patients, staff, research, or operations]
+- Output and downstream use: [De-identified text, structured entities, review
+  bundle, or other]
+- Prohibited uses: [Uses outside the approved purpose]
+- Human decisions influenced by the output: [None, or describe safeguards]
+
+### Data inventory
+
+| Item | Description |
+|---|---|
+| Data subjects | [Patients, clinicians, staff, research participants, or other] |
+| Personal-data categories | [Identifiers, demographics, contact data, or other] |
+| Special-category data | [Health, genetic, biometric, or other Article 9 data] |
+| Sources | [Systems and collection channels] |
+| Recipients | [Roles, systems, legal entities, and locations] |
+| Volume and frequency | [Records, size, cadence, peak load] |
+| Retention | [Input, output, audit evidence, mapping, backups] |
+| International transfers | [None, or transfer mechanism and destination] |
+
+### OpenMed data flow
+
+1. `[input source]` supplies clinical content inside `[controlled environment]`.
+2. OpenMed loads `[local model path or approved model id/revision]` and applies
+   `[policy literal]` with `[method and threshold configuration]`.
+3. The deployment stores or forwards only `[approved output]` to `[recipient]`.
+4. The deployment records a privacy-safe audit report containing offsets,
+   hashes, provenance, configuration, and residual-risk evidence, not raw span
+   text.
+5. If reversible pseudonymization is enabled, the mapping and its key are stored
+   separately under the key-custody controls in section 7.
+6. Input, output, caches, logs, temporary files, and backups follow `[retention
+   and deletion controls]`.
+
+Document every network boundary. OpenMed supports local processing after model
+download and collects no telemetry by default, but the controller must separately
+assess model acquisition, service wrappers, storage, monitoring, backups, and any
+third-party infrastructure.
+
+## 4. Policy Profile and Configuration
+
+Use the exact runtime literal and attach the resolved profile from the audit
+report. A profile is a technical control, not a legal conclusion.
+
+| Exact policy literal | OpenMed posture | Deployment decision |
+|---|---|---|
+| `hipaa_safe_harbor` | Masks configured identifier and clinical labels; `keep_mapping=False` and `reversible_id=False`. It does not establish GDPR anonymization. | [Used / not used; why] |
+| `gdpr_pseudonymization` | Replaces identifiers with reversible pseudonyms; `keep_mapping=True` and `reversible_id=True`. Pseudonymized data remains personal data. | [Used / not used; why] |
+
+- Selected literal: `[hipaa_safe_harbor or gdpr_pseudonymization]`
+- OpenMed and model version: [Values]
+- Model artifact and manifest hashes: [Values]
+- Languages and document types: [Values]
+- Detection thresholds and safety-sweep state: [Values]
+- Replacement, date-shifting, and consistency settings: [Values]
+- Unsupported inputs and fallback behavior: [Values]
+- Configuration owner and change-control reference: [Values]
+
+## 5. Lawfulness, Necessity, and Proportionality
+
+| Question | Assessment |
+|---|---|
+| GDPR Article 6 lawful basis | [Basis and legal analysis] |
+| GDPR Article 9 condition | [Condition for special-category data] |
+| Purpose limitation | [Why each operation is compatible with the stated purpose] |
+| Data minimization | [Fields removed, excluded, or transformed before processing] |
+| Accuracy | [Validation, correction, and version-control process] |
+| Storage limitation | [Retention periods and deletion enforcement] |
+| Transparency | [Notice supplied to data subjects] |
+| Rights handling | [Access, rectification, erasure, restriction, objection, portability] |
+| Approved codes of conduct | [Applicable code and adherence evidence, or none] |
+| Less intrusive alternatives | [Alternatives assessed and why rejected] |
+| Proportionality | [Why benefits justify the remaining interference] |
+
+State whether de-identification is an objective in itself or a safeguard for a
+separate processing purpose. Pseudonymization does not create a new lawful basis
+and does not remove data-subject rights.
+
+## 6. OpenMed Evidence and Residual Risk
+
+Record evidence for the actual model, language, document type, policy, thresholds,
+and deployment device. Do not substitute aggregate benchmark performance for
+local validation.
+
+| Evidence | Source | Recorded value or reference |
+|---|---|---|
+| Policy and resolved configuration | `AuditReport.policy` and `AuditReport.resolved_profile` | [Value/reference] |
+| Audit residual-risk score | `AuditReport.residual_risk.risk_report_record_score` | [0.0–1.0 value, run range, and report hash] |
+| Confidence-derived leakage indicator | `AuditReport.residual_risk.projected_leakage` | [Value and interpretation] |
+| Re-identification details | `AuditReport.residual_risk.risk_report` | [Leakage/re-id rates and privacy-safe summary] |
+| Direct-identifier recall | `BenchmarkReport.metrics.recall_slices` | [Value, confidence interval, suite hash] |
+| Character leakage | `BenchmarkReport.metrics.leakage.overall` | [Overall and critical-label results] |
+| Span accuracy | `BenchmarkReport.metrics.exact_span_f1.f1` and `relaxed_span_f1.f1` | [Values] |
+| Robustness | [Perturbation/adversarial `BenchmarkReport` references] | [Values and failures] |
+
+`risk_report_record_score` is a technical record-level indicator derived from
+measured leakage, re-identification rate, and singleton risk. It is not the DPIA's
+overall risk rating. Interpret it together with severity, scale, downstream
+linkability, adversary access, key compromise, and consequences for data
+subjects.
+
+### Risk-assessment method and baseline
+
+- Method and source: [Method, guidance, or organizational standard]
+- Likelihood and severity scales: [Definitions, evidence, and time horizon]
+- Risk-prioritization and acceptance rules: [Matrix, thresholds, and approver]
+- Baseline for comparison: [Risk before planned controls / with current controls]
+- Normal-operation risks: [Harms possible even when processing works as designed]
+- Failure, accidental, and adversarial risks: [Errors, outages, misuse, or attacks]
+
+Do not reduce likelihood because a safeguard is merely planned. Record its
+implementation status, evidence, and tested effectiveness before taking credit
+for it in the residual-risk rating.
+
+### Risk register
+
+Use one row per credible risk and assess it from the data subject's perspective.
+
+| Risk scenario | Affected rights or harms | Existing controls | Likelihood | Severity | Residual risk | Owner and due date |
+|---|---|---|---|---|---|---|
+| Identifier missed by the model, rule layer, or safety sweep | Confidentiality loss, discrimination, distress, identity harm | Local benchmark, direct-identifier recall gate, human sampling | [L/M/H] | [L/M/H] | [L/M/H] | [Owner/date] |
+| Reversible mapping or pseudonymization key is exposed | Re-identification and unauthorized disclosure | Separated key store, least privilege, rotation, access logging | [L/M/H] | [L/M/H] | [L/M/H] | [Owner/date] |
+| Output is linked with auxiliary data | Singling out or inference of identity | Recipient limits, minimization, linkage testing, contractual controls | [L/M/H] | [L/M/H] | [L/M/H] | [Owner/date] |
+| Model underperforms for a language, format, or population | Unequal protection and hidden leakage | Representative fixtures, per-language metrics, abstention or block | [L/M/H] | [L/M/H] | [L/M/H] | [Owner/date] |
+| Raw content enters logs, traces, caches, or support channels | Unauthorized disclosure and loss of control | No-raw-PHI policy, static tests, encrypted storage, deletion | [L/M/H] | [L/M/H] | [L/M/H] | [Owner/date] |
+| Incorrect reliance on de-identified output | Unlawful disclosure or incompatible reuse | Legal review, recipient validation, purpose and use restrictions | [L/M/H] | [L/M/H] | [L/M/H] | [Owner/date] |
+
+Overall residual-risk decision: [Accept / remediate / reject / consult authority].
+
+Approved quantitative and qualitative thresholds: [Thresholds, approver, and
+rationale].
+
+## 7. Measures and Safeguards
+
+For every measure below, record `[planned / partially implemented / implemented;
+owner; evidence; tested effectiveness]` rather than only naming the control.
+
+### Technical measures
+
+- Run locally or on approved infrastructure with network egress restricted after
+  model acquisition: [Control]
+- Encrypt inputs, outputs, audit reports, mappings, keys, and backups: [Control]
+- Prevent raw PHI or personal data in logs, traces, metrics, support bundles, and
+  exception messages: [Control]
+- Pin and verify OpenMed, model, manifest, and configuration versions: [Control]
+- Validate direct-identifier recall, critical leakage, span integrity, and
+  robustness on representative synthetic or lawfully obtained fixtures: [Control]
+- Block unsupported languages, formats, or low-confidence outputs: [Control]
+- Apply access control, authentication, least privilege, and tamper-evident audit
+  retention: [Control]
+- Test deletion, backup expiry, incident response, and recovery: [Control]
+
+### Reversible pseudonymization and key custody
+
+Complete this subsection when using `gdpr_pseudonymization`.
+
+- Mapping owner and approved re-identification purpose: [Values]
+- Key-management system and physical/legal location: [Values]
+- Separation between pseudonymized data, mapping, and key: [Control]
+- Roles allowed to create, read, rotate, recover, or destroy keys: [Roles]
+- Rotation, escrow, recovery, revocation, and deletion schedule: [Process]
+- Authorization and audit process for re-identification: [Process]
+- Response to suspected key or mapping compromise: [Process]
+
+### Organizational measures
+
+- Training, confidentiality, and acceptable-use obligations: [Controls]
+- Human review, escalation, and override authority: [Controls]
+- Processor and sub-processor contracts: [References]
+- Data-subject request and complaint handling: [Process]
+- Incident detection, notification, and evidence preservation: [Process]
+
+## 8. Approval and Review
+
+| Role | Decision, name, date |
+|---|---|
+| Controller/business owner | [Decision] |
+| Data protection officer | [Advice] |
+| Security owner | [Decision] |
+| Clinical safety or domain owner | [Decision] |
+| Legal reviewer | [Decision] |
+
+Reopen this DPIA after a purpose, dataset, model, language, policy, threshold,
+deployment boundary, recipient, key-custody, retention, legal, or material-risk
+change, and after relevant incidents or significant validation regressions.
+
+## Primary References
+
+- [GDPR, including Articles 28, 32, 35, and 36](https://eur-lex.europa.eu/eli/reg/2016/679/oj)
+- [EDPB data protection impact assessment guidance](https://www.edpb.europa.eu/topics/accountability-and-compliance-tools/data-protection-impact-assessment_en)
+- [EDPB DPIA template consultation page (2026 draft, not final guidance)](https://www.edpb.europa.eu/public-consultations/template-for-data-protection-impact-assessment_en)
+- [OpenMed compliance posture](../compliance.md)
+- [OpenMed evaluation harness and metric bundle](../eval-harness.md)
+- [OpenMed no-raw-PHI logging policy](../security/no-raw-phi-logging.md)

--- a/docs/compliance/model-card-eu-ai-act-fields.md
+++ b/docs/compliance/model-card-eu-ai-act-fields.md
@@ -1,0 +1,195 @@
+# EU AI Act and GDPR Model-Card Field Specification
+
+> **Template — requires legal review. Not legal advice.** Completing this block
+> does not classify a system, demonstrate conformity, complete a GDPR DPIA, or
+> replace the technical documentation required for a particular deployment.
+
+This specification defines the EU AI Act / GDPR block for OpenMed model cards.
+It gives model-card generation a stable target for evidence from `models.jsonl`,
+`BenchmarkReport`, release-gate artifacts, and deployer-supplied governance
+fields.
+
+The provider and deployer remain responsible for deciding whether a system is
+high-risk, determining their legal roles and obligations, performing conformity
+assessment where required, and keeping the full technical documentation current.
+
+## Rendering Rules
+
+1. Render every field in the block. Use **Not evaluated**, **Not provided**, or
+   **Not applicable — [reason]** rather than omitting a field.
+2. Copy measured values from immutable evidence. Do not infer, average, round
+   away a gate failure, or convert a missing value into zero.
+3. Include the model, dataset or fixture, device, language, format, policy,
+   threshold profile, timestamp, and artifact hash needed to interpret a metric.
+4. Keep provider evidence separate from deployment decisions. Manifest and
+   `BenchmarkReport` fields may be generated; intended workflow, legal basis,
+   oversight, and key custody require deployer review.
+5. Publish only aggregate, privacy-safe evidence. Never include raw clinical
+   text, identifiers, prompts, cleartext spans, or reversible mappings.
+6. Update the block after a material model, dataset, threshold, policy, format,
+   intended-purpose, oversight, or robustness change.
+
+## Model-Card Template Block
+
+Copy this section into a model-card template. Values in `{{ double braces }}`
+identify source fields; values in `[square brackets]` require an accountable
+human owner.
+
+```markdown
+## EU AI Act / GDPR Compliance Fields
+
+> **Template — requires legal review. Not legal advice.** This section is
+> evidence for deployment review, not a conformity assessment or legal opinion.
+
+### System and regulatory context
+
+| Field | Value |
+|---|---|
+| Model and version | `{{ manifest.repo_id }}`; released `{{ manifest.released }}` |
+| Artifact formats and hashes | {{ manifest.formats }}; {{ manifest.reproducibility_hash }} |
+| Provider/deployer roles | [Provider, deployer, controller, and processor allocation] |
+| AI Act classification | [High-risk / not high-risk / undecided, with rationale and owner] |
+| GDPR processing role | [Controller / joint controller / processor / not applicable, with rationale] |
+| Technical-documentation owner | [Role and record location] |
+| Review date and status | [Date; draft / approved / rejected] |
+
+### Intended purpose
+
+| Field | Value |
+|---|---|
+| Model task and family | {{ manifest.task }}; {{ manifest.family }} |
+| Intended clinical or operational purpose | [Specific workflow and expected output] |
+| Intended users and affected persons | [Qualified users and populations] |
+| Intended languages and environments | {{ manifest.languages }}; {{ manifest.tier }}; {{ benchmark.device }} |
+| Integration and deployment mode | [On-device, local service, API, dependencies, and interfaces] |
+| Permitted decisions | [How output may inform a decision] |
+| Prohibited uses | [Unsupported, autonomous, or safety-critical uses] |
+
+### Known limitations and reasonably foreseeable misuse
+
+| Field | Value |
+|---|---|
+| Unsupported populations, languages, or inputs | [Measured gaps and exclusions] |
+| Data and evaluation limitations | [Representativeness, sample size, labels, and known gaps] |
+| Known failure modes | [False negatives, false positives, boundary errors, drift, and other failures] |
+| Release-gate failures or blocked formats | [Gate, reason, affected format, and disposition] |
+| Foreseeable misuse | [Scenarios and preventive controls] |
+| Required local validation | [Deployment-specific tests and acceptance thresholds] |
+
+### Accuracy and leakage metrics
+
+| Metric | Value | Evidence context |
+|---|---:|---|
+| Exact-span F1 | {{ benchmark.metrics.exact_span_f1.f1 }} | {{ benchmark.suite }}; {{ benchmark.generated_at }} |
+| Relaxed-span F1 | {{ benchmark.metrics.relaxed_span_f1.f1 }} | {{ benchmark.suite }}; {{ benchmark.generated_at }} |
+| Character recall | {{ benchmark.metrics.character_recall.rate }} | {{ benchmark.fixture_count }} fixtures; {{ benchmark.device }} |
+| Direct-identifier recall by label/language | {{ benchmark.metrics.recall_slices }} | [Critical labels and minimum approved threshold] |
+| Character leakage | {{ benchmark.metrics.leakage.overall }} | [Overall, critical labels, and confidence interval] |
+| Critical leakage count | {{ gate_report.critical_leakage_count }} | {{ gate_report.leakage_fixture_hash }} |
+| Residual leakage rate and target | {{ gate_report.residual_leakage_rate }} / {{ gate_report.target_leakage_rate }} | [Gate decision and blocked formats] |
+| Quantization recall delta | {{ gate_report.quant_recall_delta }} | [Format and reference precision] |
+
+Metrics are estimates on the named fixtures, not guarantees of zero leakage or
+clinical performance. Report **Not evaluated** when the applicable evidence is
+absent.
+
+### Human oversight
+
+| Field | Value |
+|---|---|
+| Oversight owner and qualifications | [Role, training, and authority] |
+| Review point | [Before use, before disclosure, sampled review, or other] |
+| Information shown to reviewer | [Output, confidence, provenance, limitations, and safe audit evidence] |
+| Escalation and abstention triggers | [Thresholds, unsupported inputs, drift, and gate failures] |
+| Override and stop authority | [Who can reject output or suspend the system] |
+| Automation restriction | [Decisions the model must not make without human review] |
+| Oversight effectiveness review | [Metric, cadence, and owner] |
+
+### Robustness, cybersecurity, and monitoring evidence
+
+| Field | Value |
+|---|---|
+| Robustness suites | [OCR noise, typos, casing, multilingual, adversarial, or other suites] |
+| Robustness results and failures | [Aggregate results, thresholds, and unresolved failures] |
+| Evaluation and fixture hashes | {{ benchmark.metadata }}; [artifact hashes] |
+| Device/format performance envelope | [Latency, memory, device, runtime, and format] |
+| Integrity and provenance | {{ manifest.reproducibility_hash }}; [signature and dependency evidence] |
+| Cybersecurity and local-processing controls | [Egress, signing, access control, logging, and patching] |
+| Drift and incident monitoring | [Signals, cadence, thresholds, and response owner] |
+
+### GDPR and de-identification evidence
+
+| Field | Value |
+|---|---|
+| Processing purpose and lawful basis | [Article 6 basis and Article 9 condition, where applicable] |
+| OpenMed policy profile | `[hipaa_safe_harbor or gdpr_pseudonymization]` |
+| Audit residual-risk score | `{{ audit.residual_risk.risk_report_record_score }}` |
+| Other audit risk indicators | `{{ audit.residual_risk.projected_leakage }}`; `{{ audit.residual_risk.risk_report }}` |
+| Pseudonymization and key custody | [Not used, or mapping/key owner, separation, access, rotation, and deletion] |
+| DPIA and DPA records | [Approved record ids, dates, owners, and review triggers] |
+| Retention and deletion | [Inputs, outputs, audit evidence, mappings, logs, caches, and backups] |
+| Data-subject rights process | [Notice and request-handling reference] |
+
+Pseudonymized data remains personal data. The `hipaa_safe_harbor` profile does
+not by itself establish anonymization under the GDPR.
+```
+
+## Field Sources and Ownership
+
+| Section | Source of generated evidence | Human-owned completion |
+|---|---|---|
+| System context | `models.jsonl`: `repo_id`, `released`, `formats`, `reproducibility_hash` | Legal roles, classification, documentation owner, approval |
+| Intended purpose | Manifest: `task`, `family`, `languages`, `tier`; `BenchmarkReport.device` | Workflow, users, populations, decisions, integration, prohibited uses |
+| Limitations | Failed release gates and documented artifact limitations | Foreseeable misuse, deployment gaps, local-validation requirements |
+| Accuracy/leakage | `BenchmarkReport.suite`, `fixture_count`, `generated_at`, `device`, and `metrics`; signed release-gate report | Metric applicability, thresholds, interpretation, disposition of failures |
+| Human oversight | No safe default | Reviewer competence, timing, escalation, override, stop authority, effectiveness |
+| Robustness | Robustness `BenchmarkReport` payloads, artifact hashes, manifest provenance | Applicable threats, acceptance thresholds, monitoring and incident response |
+| GDPR | `AuditReport.policy`, `resolved_profile`, and privacy-safe `residual_risk` fields | Lawful basis, DPIA/DPA, retention, rights, recipients, and key custody |
+
+### Accuracy and leakage minimums
+
+For de-identification model cards, include at least:
+
+- exact-span and relaxed-span F1 where applicable;
+- character recall and direct-identifier recall, sliced by critical label and
+  supported language;
+- overall and critical-label character leakage, with confidence intervals when
+  emitted;
+- critical leakage count, residual leakage rate, target leakage rate, and the
+  release decision;
+- quantized-versus-reference recall delta for each published quantized format;
+- fixture count, dataset or suite name, device, model/format, policy, threshold
+  profile, generated timestamp, and evidence hashes; and
+- every failed, waived, or not-evaluated gate without concealment.
+
+### Human-oversight minimums
+
+The oversight description must identify a natural-person role with sufficient
+competence, authority, and information to understand limitations, detect
+automation bias, interpret or disregard output, escalate uncertainty, and stop
+use. A generic statement such as "human in the loop" is insufficient.
+
+### Robustness minimums
+
+Describe the relevant perturbation and adversarial suites, test population,
+acceptance thresholds, results, failures, artifact hashes, device/runtime, and
+monitoring plan. Separate measured robustness from architectural claims such as
+local-only execution or signed evidence.
+
+## Relationship to Other Records
+
+The model-card block is a summary and index. Keep detailed evidence in the
+versioned manifest, `BenchmarkReport` files, signed gate reports, audit reports,
+DPIA, DPA, risk-management record, incident process, and deployment technical
+documentation. The deployment owner should link those records rather than copy
+personal data into a public model card.
+
+## Primary References
+
+- [EU AI Act, including Articles 11, 14, 15 and Annex IV](https://eur-lex.europa.eu/eli/reg/2024/1689/oj?locale=en)
+- [GDPR](https://eur-lex.europa.eu/eli/reg/2016/679/oj)
+- [OpenMed compliance posture](../compliance.md)
+- [OpenMed DPIA template](dpia-template.md)
+- [OpenMed DPA template](dpa-template.md)
+- [OpenMed model manifest](../model-manifest.md)
+- [OpenMed evaluation harness](../eval-harness.md)

--- a/tests/unit/eval/test_tiers.py
+++ b/tests/unit/eval/test_tiers.py
@@ -1,4 +1,4 @@
-"""Tests for canonical device-tier budgets and compliance caveats."""
+"""Tests for canonical device-tier budgets and compliance documentation."""
 
 from __future__ import annotations
 
@@ -96,3 +96,64 @@ def test_compliance_doc_covers_frameworks_and_evidence_links() -> None:
         "Residual re-identification risk",
     ):
         assert expected in text
+
+
+def test_compliance_templates_cover_required_legal_review_fields() -> None:
+    compliance_dir = ROOT / "docs" / "compliance"
+    dpia = (compliance_dir / "dpia-template.md").read_text(encoding="utf-8")
+    dpa = (compliance_dir / "dpa-template.md").read_text(encoding="utf-8")
+    model_card = (compliance_dir / "model-card-eu-ai-act-fields.md").read_text(
+        encoding="utf-8"
+    )
+
+    for artifact in (dpia, dpa, model_card):
+        assert "Template — requires legal review. Not legal advice." in artifact
+
+    for expected in (
+        "`hipaa_safe_harbor`",
+        "`gdpr_pseudonymization`",
+        "AuditReport.residual_risk.risk_report_record_score",
+        "BenchmarkReport.metrics.exact_span_f1.f1",
+        "BenchmarkReport.metrics.leakage.overall",
+        "Risk-assessment method and baseline",
+        "planned / partially implemented / implemented",
+        "Processors and sub-processors",
+    ):
+        assert expected in dpia
+
+    for expected in (
+        "on-device",
+        "no telemetry by default",
+        "Sub-processors: none",
+        "Reversible Pseudonymization and Key Custody",
+        "`gdpr_pseudonymization`",
+        "immediately inform the Controller",
+    ):
+        assert expected in dpa
+
+    for expected in (
+        "## EU AI Act / GDPR Compliance Fields",
+        "### Intended purpose",
+        "### Known limitations and reasonably foreseeable misuse",
+        "### Accuracy and leakage metrics",
+        "### Human oversight",
+        "### Robustness, cybersecurity, and monitoring evidence",
+        "`models.jsonl`",
+        "`BenchmarkReport`",
+        "benchmark.metrics.exact_span_f1.f1",
+        "benchmark.metrics.relaxed_span_f1.f1",
+        "benchmark.metrics.character_recall.rate",
+        "benchmark.metrics.leakage.overall",
+    ):
+        assert expected in model_card
+
+
+def test_compliance_posture_links_deployment_templates() -> None:
+    text = (ROOT / "docs" / "compliance.md").read_text(encoding="utf-8")
+
+    for link in (
+        "compliance/dpia-template.md",
+        "compliance/dpa-template.md",
+        "compliance/model-card-eu-ai-act-fields.md",
+    ):
+        assert link in text


### PR DESCRIPTION
## Description

Adds deployer-facing GDPR and EU AI Act compliance templates grounded in OpenMed's local de-identification, audit, policy-profile, and evaluation evidence. Each artifact is explicitly a template requiring legal review and not legal advice.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Add a GDPR Article 35 DPIA template covering the OpenMed data flow, exact policy literals, audit residual-risk score, validation evidence, risk treatment, key custody, approval, and review triggers.
- Add a GDPR Article 28 DPA template covering the on-device/local baseline, no-telemetry posture, no sub-processors for the local runtime, security and assistance duties, deletion, transfers, audit, and reversible-pseudonymization key custody.
- Define a stable EU AI Act / GDPR model-card block for intended purpose, limitations, accuracy and leakage metrics, human oversight, robustness, cybersecurity, and privacy evidence, with explicit manifest and BenchmarkReport source mappings.
- Link all three artifacts from the compliance posture page and add regression coverage for the required fields and disclaimers.

## Testing

- [x] `.venv/bin/python -m pytest tests/unit/eval/test_tiers.py -q` — 8 passed
- [x] `.venv/bin/python -m pytest tests/ -q` — 5,125 passed, 51 skipped
- [x] `.venv/bin/python -m mkdocs build --strict`
- [x] Targeted pre-commit checks passed

## Documentation

- [x] Documentation updated with the new templates and navigation links
- [x] Primary GDPR, EDPB, and EU AI Act references included
- [ ] CHANGELOG update not required for this scoped documentation feature

## Code Quality

- [x] Ran `make format`, `make lint`, and `make format-check`
- [x] Performed a self-review
- [x] No new runtime dependencies or warnings introduced

## Dependencies

- [x] No new dependencies

## Checklist

- [x] Read the contributing guidelines
- [x] Commit has a clear, descriptive message
- [x] Change is focused on the requested scope

## Related Issues

Closes #1458

## Screenshots/Examples

Not applicable; the rendered Markdown artifacts were validated with the strict documentation build.
