### PR TITLE
Add LlamaIndex node redaction postprocessor

### DIFF
--- a/docs/integrations-llamaindex.md
+++ b/docs/integrations-llamaindex.md
@@ -1,0 +1,106 @@
+# LlamaIndex Redaction Postprocessor
+
+OpenMed can redact retrieved LlamaIndex nodes locally before response synthesis.
+The integration is optional: importing `openmed` or `openmed.interop` does not
+import LlamaIndex, and the adapter loads `llama-index-core` only when you create
+a postprocessor, ingestion transform, or framework tool.
+
+```bash
+pip install "openmed[llamaindex]"
+```
+
+## Redact retrieved nodes before synthesis
+
+Pass the postprocessor to a LlamaIndex query engine. It copies each retrieved
+node, runs `openmed.core.pii.deidentify()` over its text and string-valued
+metadata, and preserves the node score and metadata structure. The original
+retrieved node is not mutated. Metadata is included because LlamaIndex may add
+it to the content sent for synthesis. The copied node excludes all metadata from
+LLM and embedding content rendering after sanitizing the string values.
+
+```python
+from openmed.interop.llamaindex import create_redaction_postprocessor
+
+redact_nodes = create_redaction_postprocessor()
+
+query_engine = index.as_query_engine(
+    node_postprocessors=[redact_nodes],
+)
+response = query_engine.query(
+    "What follow-up is documented for this patient?"
+)
+```
+
+`create_redaction_postprocessor()` uses masking defaults and the deterministic
+safety sweep. Tune the de-identification settings with
+`LlamaIndexRedactionConfig`.
+
+```python
+from openmed.interop.llamaindex import (
+    LlamaIndexRedactionConfig,
+    create_redaction_postprocessor,
+)
+
+redact_nodes = create_redaction_postprocessor(
+    config=LlamaIndexRedactionConfig(
+        method="mask",
+        confidence_threshold=0.6,
+        lang="en",
+        redact_metadata=True,
+        use_safety_sweep=True,
+    )
+)
+```
+
+This postprocessor protects the context sent to response synthesis. It does not
+rewrite text already stored in an index or vector store. String values inside
+nested metadata mappings and sequences, including string keys, are redacted by
+default. Numbers, booleans, and nulls are preserved but excluded from LLM and
+embedding content. Unsupported objects and cyclic metadata fail closed. Set
+`redact_metadata=False` only when an upstream control guarantees that metadata
+contains no personal data.
+
+## Redact during ingestion
+
+Use the optional transform when PHI must be removed before nodes are embedded or
+stored. Place it before splitting, caching, embedding, or storage so every later
+stage sees only the copied, redacted document.
+
+```python
+from llama_index.core.ingestion import IngestionPipeline
+from llama_index.core.node_parser import SentenceSplitter
+
+from openmed.interop.llamaindex import (
+    LlamaIndexRedactionConfig,
+    create_redaction_transform,
+)
+
+redaction_config = LlamaIndexRedactionConfig(
+    numeric_metadata_allowlist=("page_number",),
+)
+
+pipeline = IngestionPipeline(
+    transformations=[
+        create_redaction_transform(config=redaction_config),
+        SentenceSplitter(chunk_size=512, chunk_overlap=32),
+        embed_model,
+    ],
+    disable_cache=True,
+)
+redacted_nodes = pipeline.run(documents=documents, store_doc_text=False)
+```
+
+The transform also copies nodes before changing their text and string metadata.
+For storage safety, it replaces node and relationship ids with deterministic
+UUID pseudonyms and replaces numeric metadata with deterministic tokens. Put
+only reviewed, non-identifying numeric fields such as page numbers in
+`numeric_metadata_allowlist`; other numeric values are pseudonymized. These
+deterministic values preserve linkage and therefore remain personal data rather
+than establishing anonymization.
+
+OpenMed performs the redaction; LlamaIndex remains an optional orchestration
+consumer and is never a core dependency. Keep ingestion caching disabled unless
+its persistence, retention, and access controls are approved for the input. Do
+not attach a pipeline docstore to raw documents; if a docstore is required, keep
+`store_doc_text=False` and write only the returned redacted nodes through a
+separately reviewed storage path.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
       - No-Raw-PHI Logging: security/no-raw-phi-logging.md
       - Tamper-evident Audit Log: security/tamper-evident-audit-log.md
       - LangChain Redaction Wrapper: integrations-langchain.md
+      - LlamaIndex Redaction Postprocessor: integrations-llamaindex.md
       - Columnar Redactor: integrations/columnar-redactor.md
       - Lakehouse Table Redaction: integrations/lakehouse-redaction.md
       - Dask DataFrame De-identification: integrations/dask.md

--- a/openmed/interop/__init__.py
+++ b/openmed/interop/__init__.py
@@ -69,7 +69,7 @@ _ADAPTERS: Final[dict[str, AdapterSpec]] = {
         name="llamaindex",
         module="openmed.interop.llamaindex",
         extra="llamaindex",
-        description="LlamaIndex FunctionTool adapter",
+        description="LlamaIndex node redaction and FunctionTool adapters",
     ),
     "pandas": AdapterSpec(
         name="pandas",

--- a/openmed/interop/llamaindex.py
+++ b/openmed/interop/llamaindex.py
@@ -1,9 +1,16 @@
-"""LlamaIndex tool adapters rendered from the OpenMed tool registry."""
+"""LlamaIndex redaction and tool adapters backed by OpenMed."""
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+from hashlib import sha256
 from importlib import import_module as _import_module
+from pathlib import Path
 from typing import Any
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 from openmed.interop.function_tools import (
     RuntimeProvider,
@@ -11,6 +18,352 @@ from openmed.interop.function_tools import (
     registry_tool_specs,
 )
 from openmed.mcp.tool_registry import render_adapter_tool_definitions
+
+Deidentifier = Callable[..., Any]
+_NODE_ID_NAMESPACE = uuid5(NAMESPACE_URL, "https://openmed.ai/llamaindex-redaction")
+
+
+@dataclass(frozen=True)
+class LlamaIndexRedactionConfig:
+    """Runtime options forwarded to OpenMed's de-identification engine."""
+
+    method: str = "mask"
+    model_name: str | None = None
+    confidence_threshold: float = 0.7
+    keep_year: bool = False
+    keep_mapping: bool = False
+    use_smart_merging: bool = True
+    lang: str = "en"
+    redact_metadata: bool = True
+    numeric_metadata_allowlist: tuple[str, ...] = ()
+    normalize_accents: bool | None = None
+    use_safety_sweep: bool = True
+    consistent: bool = False
+    seed: int | None = None
+    locale: str | None = None
+    policy: str | None = None
+    calibration_thresholds_path: str | Path | None = None
+    extra_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_deidentify_kwargs(self) -> dict[str, Any]:
+        """Return keyword arguments for ``openmed.core.pii.deidentify``."""
+
+        kwargs: dict[str, Any] = {
+            "method": self.method,
+            "model_name": self.model_name,
+            "confidence_threshold": self.confidence_threshold,
+            "keep_year": self.keep_year,
+            "keep_mapping": self.keep_mapping,
+            "use_smart_merging": self.use_smart_merging,
+            "lang": self.lang,
+            "normalize_accents": self.normalize_accents,
+            "use_safety_sweep": self.use_safety_sweep,
+            "consistent": self.consistent,
+            "seed": self.seed,
+            "locale": self.locale,
+            "policy": self.policy,
+            "calibration_thresholds_path": self.calibration_thresholds_path,
+        }
+
+        extras = dict(self.extra_kwargs)
+        collisions = sorted(kwargs.keys() & extras.keys())
+        if collisions:
+            fields = ", ".join(collisions)
+            raise ValueError(
+                f"extra_kwargs cannot override named configuration fields: {fields}"
+            )
+        kwargs.update(extras)
+        return {key: value for key, value in kwargs.items() if value is not None}
+
+
+class _NodeRedactor:
+    def __init__(
+        self,
+        *,
+        config: LlamaIndexRedactionConfig,
+        deidentifier: Deidentifier | None,
+        storage_safe: bool,
+    ) -> None:
+        self.config = config
+        self._deidentifier = deidentifier
+        self._storage_safe = storage_safe
+
+    def redact_scored_nodes(self, nodes: Sequence[Any]) -> list[Any]:
+        return [self._redact_scored_node(node) for node in nodes]
+
+    def redact_nodes(self, nodes: Sequence[Any]) -> list[Any]:
+        return [self._redact_node(node) for node in nodes]
+
+    def _redact_scored_node(self, scored_node: Any) -> Any:
+        try:
+            redacted = _clone(scored_node)
+            self._redact_node(redacted.node, clone=False)
+        except AttributeError as exc:
+            raise TypeError(
+                "LlamaIndex postprocessor inputs must expose a node attribute"
+            ) from exc
+        return redacted
+
+    def _redact_node(self, node: Any, *, clone: bool = True) -> Any:
+        redacted = _clone(node) if clone else node
+        text = _node_text(redacted)
+        if text:
+            _set_node_text(redacted, self._redact_text(text))
+
+        metadata = getattr(redacted, "metadata", None)
+        if self.config.redact_metadata and isinstance(metadata, Mapping):
+            sanitized_metadata = self._redact_metadata_value(metadata)
+            _set_node_metadata(redacted, sanitized_metadata)
+            _exclude_metadata_from_content(redacted, sanitized_metadata)
+        if self._storage_safe:
+            self._pseudonymize_node_identifiers(redacted)
+        return redacted
+
+    def _redact_text(self, text: str) -> str:
+        result = self._deidentifier_or_default()(
+            text,
+            **self.config.to_deidentify_kwargs(),
+        )
+        return _deidentified_text(result)
+
+    def _redact_metadata_value(
+        self,
+        value: Any,
+        *,
+        ancestors: frozenset[int] = frozenset(),
+        field_name: str | None = None,
+    ) -> Any:
+        if isinstance(value, str):
+            return self._redact_text(value) if value else value
+        if isinstance(value, Mapping):
+            next_ancestors = _metadata_ancestors(value, ancestors)
+            redacted: dict[str, Any] = {}
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise TypeError(
+                        "LlamaIndex metadata keys must be strings when "
+                        "redact_metadata=True"
+                    )
+                redacted_key = self._redact_text(key) if key else key
+                if redacted_key in redacted:
+                    raise ValueError("LlamaIndex metadata keys collide after redaction")
+                redacted[redacted_key] = self._redact_metadata_value(
+                    item,
+                    ancestors=next_ancestors,
+                    field_name=key,
+                )
+            return redacted
+        if isinstance(value, list):
+            next_ancestors = _metadata_ancestors(value, ancestors)
+            return [
+                self._redact_metadata_value(
+                    item,
+                    ancestors=next_ancestors,
+                    field_name=field_name,
+                )
+                for item in value
+            ]
+        if isinstance(value, tuple):
+            next_ancestors = _metadata_ancestors(value, ancestors)
+            return tuple(
+                self._redact_metadata_value(
+                    item,
+                    ancestors=next_ancestors,
+                    field_name=field_name,
+                )
+                for item in value
+            )
+        if value is None or isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            if (
+                self._storage_safe
+                and field_name not in self.config.numeric_metadata_allowlist
+            ):
+                return _pseudonymized_identifier(value)
+            return value
+        raise TypeError(
+            "LlamaIndex metadata values must be strings, numbers, booleans, "
+            "null, mappings, lists, or tuples when redact_metadata=True"
+        )
+
+    def _pseudonymize_node_identifiers(self, node: Any) -> None:
+        node_id = getattr(node, "id_", None)
+        if isinstance(node_id, str) and node_id:
+            try:
+                node.id_ = _pseudonymized_node_id(node_id)
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise TypeError("LlamaIndex node id is not mutable") from exc
+
+        relationships = getattr(node, "relationships", None)
+        if isinstance(relationships, Mapping):
+            for related in relationships.values():
+                self._pseudonymize_related_node_ids(related)
+
+    def _pseudonymize_related_node_ids(self, related: Any) -> None:
+        if isinstance(related, list):
+            for item in related:
+                self._pseudonymize_related_node_ids(item)
+            return
+
+        metadata = getattr(related, "metadata", None)
+        if self.config.redact_metadata and isinstance(metadata, Mapping):
+            sanitized_metadata = self._redact_metadata_value(metadata)
+            try:
+                related.metadata = sanitized_metadata
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise TypeError(
+                    "LlamaIndex related-node metadata is not mutable"
+                ) from exc
+
+        node_id = getattr(related, "node_id", None)
+        if not isinstance(node_id, str) or not node_id:
+            return
+        try:
+            related.node_id = _pseudonymized_node_id(node_id)
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise TypeError("LlamaIndex related-node id is not mutable") from exc
+
+    def _deidentifier_or_default(self) -> Deidentifier:
+        if self._deidentifier is not None:
+            return self._deidentifier
+
+        from openmed.core.pii import deidentify
+
+        return deidentify
+
+
+def create_redaction_postprocessor(
+    *,
+    config: LlamaIndexRedactionConfig | None = None,
+    deidentifier: Deidentifier | None = None,
+) -> Any:
+    """Create a LlamaIndex node postprocessor that redacts retrieved text."""
+
+    base = _load_optional_class(
+        "llama_index.core.postprocessor.types",
+        "BaseNodePostprocessor",
+        feature="node postprocessors",
+    )
+    redactor = _NodeRedactor(
+        config=config or LlamaIndexRedactionConfig(),
+        deidentifier=deidentifier,
+        storage_safe=False,
+    )
+
+    class OpenMedRedactionPostprocessor(base):
+        @classmethod
+        def class_name(cls) -> str:
+            return "OpenMedRedactionPostprocessor"
+
+        def __init__(self) -> None:
+            super().__init__()
+            object.__setattr__(self, "_openmed_redactor", redactor)
+
+        def _postprocess_nodes(
+            self,
+            nodes: list[Any],
+            query_bundle: Any | None = None,
+        ) -> list[Any]:
+            del query_bundle
+            return self._openmed_redactor.redact_scored_nodes(nodes)
+
+        async def apostprocess_nodes(
+            self,
+            nodes: list[Any],
+            query_bundle: Any | None = None,
+            query_str: str | None = None,
+        ) -> list[Any]:
+            return await asyncio.to_thread(
+                self.postprocess_nodes,
+                nodes,
+                query_bundle=query_bundle,
+                query_str=query_str,
+            )
+
+    OpenMedRedactionPostprocessor.__module__ = __name__
+    return OpenMedRedactionPostprocessor()
+
+
+def create_redaction_transform(
+    *,
+    config: LlamaIndexRedactionConfig | None = None,
+    deidentifier: Deidentifier | None = None,
+    _cache_identity: str | None = None,
+) -> Any:
+    """Create an optional ingestion transform that redacts nodes before storage."""
+
+    base = _load_optional_class(
+        "llama_index.core.schema",
+        "TransformComponent",
+        feature="ingestion transforms",
+    )
+    resolved_config = config or LlamaIndexRedactionConfig()
+    redactor = _NodeRedactor(
+        config=resolved_config,
+        deidentifier=deidentifier,
+        storage_safe=True,
+    )
+    cache_identity = _cache_identity or _redaction_cache_identity(
+        resolved_config,
+        deidentifier,
+    )
+
+    class OpenMedRedactionTransform(base):
+        @classmethod
+        def class_name(cls) -> str:
+            return "OpenMedRedactionTransform"
+
+        def __init__(self) -> None:
+            super().__init__()
+            object.__setattr__(self, "_openmed_redactor", redactor)
+            object.__setattr__(self, "_openmed_cache_identity", cache_identity)
+
+        def __call__(self, nodes: Sequence[Any], **kwargs: Any) -> list[Any]:
+            del kwargs
+            return self._openmed_redactor.redact_nodes(nodes)
+
+        def to_dict(self, **kwargs: Any) -> dict[str, Any]:
+            del kwargs
+            return {
+                "class_name": self.class_name(),
+                "openmed_cache_identity": self._openmed_cache_identity,
+            }
+
+        def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+            return (
+                _rebuild_redaction_transform,
+                (
+                    self._openmed_redactor.config,
+                    self._openmed_redactor._deidentifier,
+                    self._openmed_cache_identity,
+                ),
+            )
+
+    OpenMedRedactionTransform.__module__ = __name__
+    return OpenMedRedactionTransform()
+
+
+def _rebuild_redaction_transform(
+    config: LlamaIndexRedactionConfig,
+    deidentifier: Deidentifier | None,
+    cache_identity: str,
+) -> Any:
+    return create_redaction_transform(
+        config=config,
+        deidentifier=deidentifier,
+        _cache_identity=cache_identity,
+    )
+
+
+def _redaction_cache_identity(
+    config: LlamaIndexRedactionConfig,
+    deidentifier: Deidentifier | None,
+) -> str:
+    if deidentifier is not None:
+        return f"custom:{uuid4().hex}"
+    digest = sha256(repr(config).encode("utf-8")).hexdigest()
+    return f"default:{digest}"
 
 
 def create_tool_definitions() -> tuple[dict[str, Any], ...]:
@@ -54,23 +407,118 @@ def _function_tool_from_spec(
 
 
 def _load_function_tool() -> Any:
+    return _load_optional_class(
+        "llama_index.core.tools",
+        "FunctionTool",
+        feature="tools",
+    )
+
+
+def _load_optional_class(module_name: str, class_name: str, *, feature: str) -> Any:
     try:
-        module = _import_module("llama_index.core.tools")
+        module = _import_module(module_name)
     except ImportError as exc:
         raise ImportError(
-            "LlamaIndex tools require the 'llamaindex' extra. "
+            f"LlamaIndex {feature} require the 'llamaindex' extra. "
             "Install with `pip install openmed[llamaindex]`."
         ) from exc
 
     try:
-        return module.FunctionTool
+        return getattr(module, class_name)
     except AttributeError as exc:
         raise ImportError(
-            "LlamaIndex tools require llama-index-core with FunctionTool."
+            f"LlamaIndex {feature} require llama-index-core with {class_name}."
+        ) from exc
+
+
+def _clone(value: Any) -> Any:
+    model_copy = getattr(value, "model_copy", None)
+    if callable(model_copy):
+        return model_copy(deep=True)
+    return deepcopy(value)
+
+
+def _node_text(node: Any) -> str | None:
+    text = getattr(node, "text", None)
+    if isinstance(text, str):
+        return text
+
+    get_content = getattr(node, "get_content", None)
+    if callable(get_content):
+        content = get_content()
+        if isinstance(content, str):
+            return content
+    return None
+
+
+def _set_node_text(node: Any, text: str) -> None:
+    set_content = getattr(node, "set_content", None)
+    if callable(set_content):
+        set_content(text)
+        return
+    if hasattr(node, "text"):
+        node.text = text
+        return
+    raise TypeError("LlamaIndex node does not expose mutable text content")
+
+
+def _set_node_metadata(node: Any, metadata: dict[Any, Any]) -> None:
+    try:
+        node.metadata = metadata
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise TypeError(
+            "LlamaIndex node does not expose mutable metadata content"
+        ) from exc
+
+
+def _exclude_metadata_from_content(node: Any, metadata: Mapping[Any, Any]) -> None:
+    keys = [key for key in metadata if isinstance(key, str)]
+    for attribute in (
+        "excluded_llm_metadata_keys",
+        "excluded_embed_metadata_keys",
+    ):
+        current = getattr(node, attribute, None)
+        if not isinstance(current, list):
+            continue
+        setattr(node, attribute, list(dict.fromkeys([*current, *keys])))
+
+
+def _metadata_ancestors(
+    value: Any,
+    ancestors: frozenset[int],
+) -> frozenset[int]:
+    identity = id(value)
+    if identity in ancestors:
+        raise ValueError("LlamaIndex metadata must not contain cycles")
+    return ancestors | {identity}
+
+
+def _pseudonymized_identifier(value: str | int | float) -> str:
+    typed_value = f"{type(value).__name__}:{value}"
+    digest = sha256(typed_value.encode("utf-8")).hexdigest()
+    return f"openmed-{digest}"
+
+
+def _pseudonymized_node_id(value: str) -> str:
+    return str(uuid5(_NODE_ID_NAMESPACE, value))
+
+
+def _deidentified_text(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    try:
+        return str(result.deidentified_text)
+    except AttributeError as exc:
+        raise TypeError(
+            "deidentifier must return a string or an object with deidentified_text"
         ) from exc
 
 
 __all__ = [
+    "Deidentifier",
+    "LlamaIndexRedactionConfig",
+    "create_redaction_postprocessor",
+    "create_redaction_transform",
     "create_tool_definitions",
     "get_llamaindex_tools",
 ]

--- a/tests/unit/interop/test_llamaindex_redaction.py
+++ b/tests/unit/interop/test_llamaindex_redaction.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import asyncio
+import pickle
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from openmed.interop import adapter_spec, get_adapter
+from openmed.interop import llamaindex as llamaindex_adapter
+
+
+@dataclass
+class FixtureNode:
+    text: str
+    metadata: dict[str, object]
+    id_: str = "fixture-node"
+    excluded_llm_metadata_keys: list[str] = field(default_factory=list)
+    excluded_embed_metadata_keys: list[str] = field(default_factory=list)
+
+    def set_content(self, text: str) -> None:
+        self.text = text
+
+
+@dataclass
+class FixtureNodeWithScore:
+    node: FixtureNode
+    score: float
+
+
+class BaseNodePostprocessorLike:
+    callback_manager = None
+
+    def postprocess_nodes(self, nodes, query_bundle=None, query_str=None):
+        del query_str
+        return self._postprocess_nodes(nodes, query_bundle=query_bundle)
+
+
+class TransformComponentLike:
+    async def acall(self, nodes, **kwargs):
+        return self(nodes, **kwargs)
+
+
+def fake_import(name: str):
+    if name == "llama_index.core.postprocessor.types":
+        return SimpleNamespace(BaseNodePostprocessor=BaseNodePostprocessorLike)
+    if name == "llama_index.core.schema":
+        return SimpleNamespace(TransformComponent=TransformComponentLike)
+    raise ImportError(name)
+
+
+def fake_deidentify(text: str, **kwargs):
+    assert kwargs["method"] == "mask"
+    assert kwargs["keep_year"] is False
+    assert kwargs["use_safety_sweep"] is True
+    redacted = (
+        text.replace("Jane Roe", "[PERSON]")
+        .replace("jane.roe@example.com", "[EMAIL]")
+        .replace("555-0100", "[PHONE]")
+    )
+    return SimpleNamespace(deidentified_text=redacted)
+
+
+def fake_mask_deidentify(text: str, **kwargs):
+    del kwargs
+    return SimpleNamespace(deidentified_text=f"MASKED:{text}")
+
+
+def fake_remove_deidentify(text: str, **kwargs):
+    del kwargs
+    return SimpleNamespace(deidentified_text=f"REMOVED:{text}")
+
+
+def test_registry_loads_llamaindex_redaction_adapter_lazily() -> None:
+    for name in list(sys.modules):
+        if name == "llama_index" or name.startswith("llama_index."):
+            sys.modules.pop(name, None)
+
+    adapter = get_adapter("llamaindex")
+
+    assert adapter is llamaindex_adapter
+    assert adapter_spec("llamaindex").extra == "llamaindex"
+    assert hasattr(adapter, "create_redaction_postprocessor")
+    assert not any(
+        name == "llama_index" or name.startswith("llama_index.") for name in sys.modules
+    )
+
+
+def test_postprocessor_redacts_fixture_nodes_without_an_llm(monkeypatch) -> None:
+    monkeypatch.setattr(llamaindex_adapter, "_import_module", fake_import)
+    original = FixtureNodeWithScore(
+        node=FixtureNode(
+            text="Patient Jane Roe called jane.roe@example.com or 555-0100.",
+            metadata={"source": "synthetic-fixture"},
+        ),
+        score=0.93,
+    )
+
+    postprocessor = llamaindex_adapter.create_redaction_postprocessor(
+        deidentifier=fake_deidentify,
+    )
+    processed = postprocessor.postprocess_nodes([original])
+
+    assert isinstance(postprocessor, BaseNodePostprocessorLike)
+    assert processed[0].node.text == ("Patient [PERSON] called [EMAIL] or [PHONE].")
+    assert processed[0].node.metadata == {"source": "synthetic-fixture"}
+    assert processed[0].score == pytest.approx(0.93)
+    assert original.node.text == (
+        "Patient Jane Roe called jane.roe@example.com or 555-0100."
+    )
+
+
+def test_postprocessor_supports_async_retrieval(monkeypatch) -> None:
+    monkeypatch.setattr(llamaindex_adapter, "_import_module", fake_import)
+    postprocessor = llamaindex_adapter.create_redaction_postprocessor(
+        deidentifier=fake_deidentify,
+    )
+    original = FixtureNodeWithScore(
+        node=FixtureNode("Jane Roe", {}),
+        score=0.7,
+    )
+
+    processed = asyncio.run(postprocessor.apostprocess_nodes([original]))
+
+    assert processed[0].node.text == "[PERSON]"
+
+
+def test_postprocessor_redacts_string_metadata_without_mutating_source(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(llamaindex_adapter, "_import_module", fake_import)
+    original = FixtureNodeWithScore(
+        node=FixtureNode(
+            text="Jane Roe",
+            metadata={
+                "patient_name": "Jane Roe",
+                "contacts": ["jane.roe@example.com", "555-0100"],
+                "Jane Roe": "primary patient",
+                "sequence": 7,
+            },
+        ),
+        score=0.7,
+    )
+
+    postprocessor = llamaindex_adapter.create_redaction_postprocessor(
+        deidentifier=fake_deidentify,
+    )
+    processed = postprocessor.postprocess_nodes([original])
+
+    assert processed[0].node.metadata == {
+        "patient_name": "[PERSON]",
+        "contacts": ["[EMAIL]", "[PHONE]"],
+        "[PERSON]": "primary patient",
+        "sequence": 7,
+    }
+    assert original.node.metadata["patient_name"] == "Jane Roe"
+    assert original.node.metadata["contacts"] == [
+        "jane.roe@example.com",
+        "555-0100",
+    ]
+    expected_exclusions = [
+        "patient_name",
+        "contacts",
+        "[PERSON]",
+        "sequence",
+    ]
+    assert processed[0].node.excluded_llm_metadata_keys == expected_exclusions
+    assert processed[0].node.excluded_embed_metadata_keys == expected_exclusions
+    assert original.node.excluded_llm_metadata_keys == []
+    assert original.node.excluded_embed_metadata_keys == []
+
+
+def test_postprocessor_rejects_unsupported_or_cyclic_metadata(monkeypatch) -> None:
+    monkeypatch.setattr(llamaindex_adapter, "_import_module", fake_import)
+    postprocessor = llamaindex_adapter.create_redaction_postprocessor(
+        deidentifier=fake_deidentify,
+    )
+    unsupported = FixtureNodeWithScore(
+        node=FixtureNode("Jane Roe", {"source": Path("Jane Roe.txt")}),
+        score=0.7,
+    )
+
+    with pytest.raises(TypeError, match="metadata values must be"):
+        postprocessor.postprocess_nodes([unsupported])
+
+    cyclic_metadata: dict[str, object] = {}
+    cyclic_metadata["self"] = cyclic_metadata
+    cyclic = FixtureNodeWithScore(
+        node=FixtureNode("Jane Roe", cyclic_metadata),
+        score=0.7,
+    )
+    with pytest.raises(ValueError, match="metadata must not contain cycles"):
+        postprocessor.postprocess_nodes([cyclic])
+
+
+def test_real_llamaindex_content_excludes_metadata_when_extra_is_installed() -> None:
+    schema = pytest.importorskip("llama_index.core.schema")
+    original = schema.TextNode(
+        text="Patient Jane Roe",
+        metadata={"patient_name": "Jane Roe", "record_number": 1234567},
+    )
+    scored = schema.NodeWithScore(node=original, score=0.9)
+
+    postprocessor = llamaindex_adapter.create_redaction_postprocessor(
+        deidentifier=fake_deidentify,
+    )
+    processed = postprocessor.postprocess_nodes([scored])[0].node
+
+    assert processed.get_content(metadata_mode=schema.MetadataMode.LLM) == (
+        "Patient [PERSON]"
+    )
+    assert processed.get_content(metadata_mode=schema.MetadataMode.EMBED) == (
+        "Patient [PERSON]"
+    )
+    assert processed.metadata == {
+        "patient_name": "[PERSON]",
+        "record_number": 1234567,
+    }
+    assert original.metadata == {
+        "patient_name": "Jane Roe",
+        "record_number": 1234567,
+    }
+
+
+def test_real_llamaindex_transform_is_picklable_when_extra_is_installed() -> None:
+    schema = pytest.importorskip("llama_index.core.schema")
+    transform = llamaindex_adapter.create_redaction_transform(
+        deidentifier=fake_mask_deidentify,
+    )
+
+    restored = pickle.loads(pickle.dumps(transform))
+    processed = restored([schema.TextNode(text="Jane Roe")])
+
+    assert processed[0].text == "MASKED:Jane Roe"
+    assert restored.to_dict() == transform.to_dict()
+
+
+def test_real_llamaindex_parallel_ingestion_when_extra_is_installed() -> None:
+    ingestion = pytest.importorskip("llama_index.core.ingestion")
+    schema = pytest.importorskip("llama_index.core.schema")
+    pipeline = ingestion.IngestionPipeline(
+        transformations=[
+            llamaindex_adapter.create_redaction_transform(
+                deidentifier=fake_mask_deidentify,
+            )
+        ],
+        disable_cache=True,
+    )
+
+    processed = pipeline.run(
+        nodes=[schema.TextNode(text="Jane Roe")],
+        num_workers=2,
+    )
+
+    assert processed[0].text == "MASKED:Jane Roe"
+
+
+def test_real_ingestion_sanitizes_related_node_metadata() -> None:
+    schema = pytest.importorskip("llama_index.core.schema")
+    vector_utils = pytest.importorskip("llama_index.core.vector_stores.utils")
+    original = schema.TextNode(
+        text="Jane Roe",
+        id_="patient-1234567",
+        relationships={
+            schema.NodeRelationship.SOURCE: schema.RelatedNodeInfo(
+                node_id="document-1234567",
+                metadata={"patient_name": "Jane Roe", "numeric_mrn": 1234567},
+            )
+        },
+    )
+
+    transformed = llamaindex_adapter.create_redaction_transform(
+        deidentifier=fake_deidentify,
+    )([original])[0]
+    stored_metadata = vector_utils.node_to_metadata_dict(
+        transformed,
+        remove_text=True,
+    )
+    serialized = repr(stored_metadata)
+
+    assert "Jane Roe" not in serialized
+    assert "patient-1234567" not in serialized
+    assert "document-1234567" not in serialized
+    assert "1234567" not in serialized
+    UUID(transformed.id_)
+    UUID(transformed.source_node.node_id)
+    assert transformed.source_node.metadata["patient_name"] == "[PERSON]"
+    assert transformed.source_node.metadata["numeric_mrn"].startswith("openmed-")
+    assert original.source_node.metadata["patient_name"] == "Jane Roe"
+    assert original.source_node.metadata["numeric_mrn"] == 1234567
+
+
+def test_real_llamaindex_cache_separates_configs_when_extra_is_installed() -> None:
+    ingestion = pytest.importorskip("llama_index.core.ingestion")
+    schema = pytest.importorskip("llama_index.core.schema")
+    cache = ingestion.IngestionCache()
+    original = schema.TextNode(text="Jane Roe")
+
+    masked_pipeline = ingestion.IngestionPipeline(
+        transformations=[
+            llamaindex_adapter.create_redaction_transform(
+                config=llamaindex_adapter.LlamaIndexRedactionConfig(method="mask"),
+                deidentifier=fake_mask_deidentify,
+            )
+        ],
+        cache=cache,
+    )
+    removed_pipeline = ingestion.IngestionPipeline(
+        transformations=[
+            llamaindex_adapter.create_redaction_transform(
+                config=llamaindex_adapter.LlamaIndexRedactionConfig(method="remove"),
+                deidentifier=fake_remove_deidentify,
+            )
+        ],
+        cache=cache,
+    )
+
+    masked = masked_pipeline.run(nodes=[original])
+    removed = removed_pipeline.run(nodes=[original])
+
+    assert masked[0].text == "MASKED:Jane Roe"
+    assert removed[0].text == "REMOVED:Jane Roe"
+    assert masked_pipeline.transformations[0].to_dict() != (
+        removed_pipeline.transformations[0].to_dict()
+    )
+
+
+def test_default_cache_identity_is_stable_and_config_specific(monkeypatch) -> None:
+    monkeypatch.setattr(llamaindex_adapter, "_import_module", fake_import)
+    mask_config = llamaindex_adapter.LlamaIndexRedactionConfig(method="mask")
+    remove_config = llamaindex_adapter.LlamaIndexRedactionConfig(method="remove")
+
+    first_mask = llamaindex_adapter.create_redaction_transform(config=mask_config)
+    second_mask = llamaindex_adapter.create_redaction_transform(config=mask_config)
+    remove = llamaindex_adapter.create_redaction_transform(config=remove_config)
+
+    assert first_mask.to_dict() == second_mask.to_dict()
+    assert first_mask.to_dict() != remove.to_dict()
+
+
+def test_ingestion_transform_redacts_copies_before_storage(monkeypatch) -> None:
+    monkeypatch.setattr(llamaindex_adapter, "_import_module", fake_import)
+    original = FixtureNode(
+        text="Jane Roe can be reached at 555-0100.",
+        metadata={
+            "source": "synthetic-fixture",
+            "record_number": 1234567,
+            "page_number": 2,
+        },
+        id_="patient-1234567",
+    )
+
+    transform = llamaindex_adapter.create_redaction_transform(
+        config=llamaindex_adapter.LlamaIndexRedactionConfig(
+            numeric_metadata_allowlist=("page_number",),
+        ),
+        deidentifier=fake_deidentify,
+    )
+    processed = transform([original])
+
+    assert isinstance(transform, TransformComponentLike)
+    assert processed[0].text == "[PERSON] can be reached at [PHONE]."
+    assert processed[0].metadata["source"] == "synthetic-fixture"
+    assert processed[0].metadata["record_number"].startswith("openmed-")
+    assert processed[0].metadata["record_number"] != "1234567"
+    assert processed[0].metadata["page_number"] == 2
+    assert processed[0].id_ != "patient-1234567"
+    UUID(processed[0].id_)
+    assert original.text == "Jane Roe can be reached at 555-0100."
+    assert original.metadata["record_number"] == 1234567
+    assert original.id_ == "patient-1234567"
+
+
+def test_redaction_factories_raise_clear_error_without_extra(monkeypatch) -> None:
+    def missing_dependency(name: str):
+        raise ImportError(name)
+
+    monkeypatch.setattr(llamaindex_adapter, "_import_module", missing_dependency)
+
+    with pytest.raises(ImportError, match=r"openmed\[llamaindex\]"):
+        llamaindex_adapter.create_redaction_postprocessor(
+            deidentifier=fake_deidentify,
+        )
+    with pytest.raises(ImportError, match=r"openmed\[llamaindex\]"):
+        llamaindex_adapter.create_redaction_transform(deidentifier=fake_deidentify)
+
+
+def test_extra_kwargs_cannot_override_named_safety_configuration(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(llamaindex_adapter, "_import_module", fake_import)
+    config = llamaindex_adapter.LlamaIndexRedactionConfig(
+        use_safety_sweep=True,
+        extra_kwargs={"use_safety_sweep": False},
+    )
+    postprocessor = llamaindex_adapter.create_redaction_postprocessor(
+        config=config,
+        deidentifier=fake_deidentify,
+    )
+    original = FixtureNodeWithScore(
+        node=FixtureNode("Jane Roe", {}),
+        score=0.7,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="cannot override named configuration fields: use_safety_sweep",
+    ):
+        postprocessor.postprocess_nodes([original])
+
+    with pytest.raises(
+        ValueError,
+        match="cannot override named configuration fields: model_name",
+    ):
+        llamaindex_adapter.LlamaIndexRedactionConfig(
+            extra_kwargs={"model_name": "unreviewed-model"},
+        ).to_deidentify_kwargs()


### PR DESCRIPTION
## Description

Adds a local redaction stage for LlamaIndex retrieval and ingestion flows so clinical node text can be de-identified before response synthesis or storage. The adapter remains optional and preserves the existing tool integration.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- add factories for a `BaseNodePostprocessor` and ingestion `TransformComponent` backed by OpenMed de-identification
- copy nodes before redaction while preserving scores and metadata
- keep LlamaIndex behind the existing optional extra and lazy adapter boundary
- document retrieval-time and ingestion-time RAG redaction
- cover fixture-node redaction, async retrieval, lazy imports, missing extras, and non-mutation without an LLM call

## Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different framework paths

Validation completed:

- `.venv/bin/python -m pytest tests/ -q` — 5,132 passed, 50 skipped
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m mkdocs build --strict`
- real `llama-index-core 0.14.23` postprocessor and ingestion-transform smoke test

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies; the existing `llamaindex` extra already supplies `llama-index-core`

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have organized my commits appropriately

## Related Issues

Closes #1460

## Screenshots/Examples

Not applicable; usage examples are included in the new integration guide.
