### PR TITLE
Add a WASM/WebGPU browser inference demo and load-time benchmark page

### DIFF
--- a/docs/demo/web/README.md
+++ b/docs/demo/web/README.md
@@ -1,0 +1,88 @@
+# Browser PII inference and load benchmark
+
+This static demo loads a published Transformers.js token-classification bundle,
+runs PII detection entirely in the browser, and records two cold-path timings
+for both WASM and WebGPU:
+
+- **Model load** measures construction of a backend-specific pipeline, including
+  model download or browser-cache access and runtime session initialization.
+- **First inference** measures only the first token-classification call after
+  that pipeline has loaded.
+
+The default, `onnx-community/multilang-pii-ner-ONNX`, is a public PII model with
+the browser bundle layout needed to run the page without credentials. The page
+does not upload input text, but it downloads the JavaScript runtime and model
+artifacts from their configured hosts. Use synthetic text only.
+
+## Run it locally
+
+No application build is required. Start any static file server from the
+repository root, then open the demo:
+
+```bash
+.venv/bin/python -m http.server 8000
+```
+
+```text
+http://localhost:8000/docs/demo/web/
+```
+
+Opening `index.html` through `file://` is not supported because browser module
+and model requests require an HTTP origin. A basic static server is sufficient;
+WASM does not require a server-side inference process.
+
+WebGPU requires a browser and device that expose `navigator.gpu`. When WebGPU is
+not available, select WASM. The page reports that WebGPU is unavailable rather
+than silently changing the selected backend.
+
+## Target a manifest `repo_id`
+
+The model field is a Hugging Face repository id, not a URL. To use a model from
+the canonical [`models.jsonl`](../../../models.jsonl) manifest:
+
+1. Select a token-classification row whose `formats` include
+   `transformersjs`.
+2. Copy that row's `repo_id`, such as `OpenMed/example-pii-transformersjs`,
+   into the model field.
+3. Reset the benchmarks and run one backend, or use **Benchmark both**.
+
+The same value can be supplied in the page URL:
+
+```text
+http://localhost:8000/docs/demo/web/?repo_id=OpenMed/example-pii-transformersjs
+```
+
+The referenced model repository must be browser-accessible and use the bundle
+contract produced by `openmed.onnx.transformersjs`:
+
+```text
+config.json
+tokenizer.json
+tokenizer_config.json
+quantize_config.json
+transformersjs-contract.json
+onnx/model.onnx
+onnx/model_quantized.onnx
+```
+
+`config.json` must contain `id2label`, and the ONNX graph must accept
+`input_ids` and `attention_mask` and return `logits`. The demo uses the
+half-precision `onnx/model_fp16.onnx` artifact for WebGPU and the q8
+`onnx/model_quantized.onnx` artifact for WASM through Transformers.js 4.2.0.
+
+Private or gated repositories require the user to arrange browser
+authentication separately. Do not put access tokens in `app.js`, the URL, or a
+committed file.
+
+## Read the benchmark
+
+Each backend gets its own pipeline so the timing rows do not accidentally share
+a runtime session. **Reset benchmarks** disposes those in-memory pipelines but
+does not clear the browser's persistent model cache. For a true uncached
+download comparison, clear site data or use a fresh browser profile before
+loading the page.
+
+WebGPU support and performance vary by browser, operating system, driver, and
+model operators. The benchmark is a local diagnostic, not a cross-device
+performance claim. Detection output is demonstrative and must not be treated as
+proof that a document is fully de-identified.

--- a/docs/demo/web/app.js
+++ b/docs/demo/web/app.js
@@ -1,0 +1,321 @@
+import { pipeline } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
+
+const DEFAULT_REPO_ID = "onnx-community/multilang-pii-ner-ONNX";
+const BACKENDS = ["wasm", "webgpu"];
+const PIPELINE_DTYPES = { wasm: "q8", webgpu: "fp16" };
+
+const repoInput = document.querySelector("#repo-id");
+const backendSelect = document.querySelector("#backend");
+const textInput = document.querySelector("#input-text");
+const runButton = document.querySelector("#run-selected");
+const benchmarkButton = document.querySelector("#benchmark-both");
+const resetButton = document.querySelector("#reset");
+const status = document.querySelector("#status");
+const results = document.querySelector("#results");
+const entities = document.querySelector("#entities");
+const webGpuSupport = document.querySelector("#webgpu-support");
+
+let activeRepoId = DEFAULT_REPO_ID;
+const detectors = new Map();
+const timings = createTimings();
+
+repoInput.value = new URLSearchParams(window.location.search).get("repo_id") ?? DEFAULT_REPO_ID;
+webGpuSupport.textContent = navigator.gpu
+  ? "WebGPU is available in this browser."
+  : "WebGPU is unavailable; the WASM path remains usable.";
+
+runButton.addEventListener("click", () => runSelectedBackend());
+benchmarkButton.addEventListener("click", () => benchmarkBothBackends());
+resetButton.addEventListener("click", () => resetBenchmarks());
+repoInput.addEventListener("change", () => {
+  try {
+    resetForModel(repoId());
+  } catch (error) {
+    setStatus(errorMessage(error), "error");
+  }
+});
+
+async function runSelectedBackend() {
+  await withBusyState(async () => {
+    const backend = backendSelect.value;
+    const output = await runBackend(backend);
+    renderOutput(textInput.value, output, backend);
+  });
+}
+
+async function benchmarkBothBackends() {
+  await withBusyState(async () => {
+    let completed = 0;
+    for (const backend of BACKENDS) {
+      try {
+        const output = await runBackend(backend);
+        renderOutput(textInput.value, output, backend);
+        completed += 1;
+      } catch (error) {
+        setTimingError(backend);
+        setStatus(`${backendLabel(backend)} failed: ${errorMessage(error)}`, "error");
+      }
+    }
+    if (completed === BACKENDS.length) {
+      setStatus("WASM and WebGPU benchmarks completed.");
+    } else if (completed > 0) {
+      setStatus("Benchmark completed for the available backend; see timing panel.");
+    }
+  });
+}
+
+async function runBackend(backend) {
+  if (!BACKENDS.includes(backend)) {
+    throw new Error(`Unsupported backend: ${backend}`);
+  }
+  if (backend === "webgpu" && !navigator.gpu) {
+    throw new Error("this browser does not expose navigator.gpu");
+  }
+
+  const selectedRepoId = repoId();
+  resetForModel(selectedRepoId);
+  const detector = await loadDetector(selectedRepoId, backend);
+  const input = textInput.value.trim();
+  if (!input) {
+    throw new Error("enter synthetic text before running inference");
+  }
+
+  setStatus(`Running first ${backendLabel(backend)} inference…`);
+  const startedAt = performance.now();
+  const output = await detector(input, { aggregation_strategy: "simple" });
+  const elapsed = performance.now() - startedAt;
+  if (timings[backend].firstInferenceMs === null) {
+    timings[backend].firstInferenceMs = elapsed;
+  }
+  renderTimings();
+  setStatus(`${backendLabel(backend)} inference completed in ${formatMs(elapsed)}.`);
+  return normalizeOutput(output, input);
+}
+
+async function loadDetector(selectedRepoId, backend) {
+  if (detectors.has(backend)) {
+    return detectors.get(backend);
+  }
+
+  setStatus(`Loading ${selectedRepoId} for ${backendLabel(backend)}…`);
+  const startedAt = performance.now();
+  const detector = await pipeline("token-classification", selectedRepoId, {
+    device: backend,
+    dtype: PIPELINE_DTYPES[backend],
+  });
+  timings[backend].loadMs = performance.now() - startedAt;
+  detectors.set(backend, detector);
+  renderTimings();
+  return detector;
+}
+
+function resetForModel(selectedRepoId) {
+  if (selectedRepoId === activeRepoId) {
+    return;
+  }
+  activeRepoId = selectedRepoId;
+  resetBenchmarks({ keepStatus: true });
+  setStatus(`Model changed to ${selectedRepoId}; benchmark state reset.`);
+}
+
+function resetBenchmarks({ keepStatus = false } = {}) {
+  for (const detector of detectors.values()) {
+    detector.dispose?.();
+  }
+  detectors.clear();
+  Object.assign(timings, createTimings());
+  renderTimings();
+  if (!keepStatus) {
+    setStatus("Benchmark state reset. The browser asset cache is unchanged.");
+  }
+}
+
+function createTimings() {
+  return Object.fromEntries(
+    BACKENDS.map((backend) => [
+      backend,
+      { loadMs: null, firstInferenceMs: null, error: false },
+    ]),
+  );
+}
+
+function renderTimings() {
+  for (const backend of BACKENDS) {
+    const timing = timings[backend];
+    document.querySelector(`#${backend}-load`).textContent = timing.error
+      ? "Unavailable"
+      : formatMs(timing.loadMs);
+    document.querySelector(`#${backend}-first`).textContent = timing.error
+      ? "Unavailable"
+      : formatMs(timing.firstInferenceMs);
+  }
+}
+
+function setTimingError(backend) {
+  timings[backend].error = true;
+  renderTimings();
+}
+
+function normalizeOutput(output, text) {
+  const flat = Array.isArray(output?.[0]) ? output.flat() : output;
+  if (!Array.isArray(flat)) {
+    return [];
+  }
+
+  const located = [];
+  let searchCursor = 0;
+  for (const item of flat) {
+    const label = item.entity_group ?? item.entity ?? "PII";
+    if (label === "O") {
+      continue;
+    }
+
+    let start = Number(item.start);
+    let end = Number(item.end);
+    if (!Number.isInteger(start) || !Number.isInteger(end) || end <= start) {
+      const match = locateWord(text, item.word ?? "", searchCursor);
+      if (!match) {
+        continue;
+      }
+      ({ start, end } = match);
+    }
+    searchCursor = end;
+    located.push({
+      label,
+      score: Number(item.score ?? 0),
+      start,
+      end,
+      word: item.word ?? "",
+    });
+  }
+
+  return mergeBioSpans(located, text);
+}
+
+function locateWord(text, modelWord, searchCursor) {
+  const cleaned = String(modelWord)
+    .replace(/^##/, "")
+    .replace(/^[▁Ġ]+/, "")
+    .trim();
+  if (!cleaned) {
+    return null;
+  }
+
+  const start = text.toLocaleLowerCase().indexOf(
+    cleaned.toLocaleLowerCase(),
+    searchCursor,
+  );
+  return start === -1 ? null : { start, end: start + cleaned.length };
+}
+
+function mergeBioSpans(spans, text) {
+  const merged = [];
+  for (const span of spans) {
+    const match = /^([BIES])-([\s\S]+)$/.exec(span.label);
+    const prefix = match?.[1] ?? null;
+    const label = match?.[2] ?? span.label;
+    const previous = merged.at(-1);
+    const gap = previous ? text.slice(previous.end, span.start) : "";
+    const continuesPrevious =
+      previous &&
+      previous.label === label &&
+      (((prefix === "I" || prefix === "E") &&
+        /^[\s.,@+:/()\-]*$/.test(gap)) ||
+        (prefix === null && gap === ""));
+
+    if (continuesPrevious) {
+      previous.end = span.end;
+      previous.score = (previous.score + span.score) / 2;
+      continue;
+    }
+    merged.push({ ...span, label });
+  }
+  return merged;
+}
+
+function renderOutput(text, spans, backend) {
+  results.replaceChildren();
+  entities.replaceChildren();
+
+  if (spans.length === 0) {
+    results.textContent = text;
+    const empty = document.createElement("li");
+    empty.textContent = `No spans returned by ${backendLabel(backend)}.`;
+    entities.append(empty);
+    return;
+  }
+
+  let cursor = 0;
+  for (const span of nonOverlappingSpans(spans, text.length)) {
+    results.append(document.createTextNode(text.slice(cursor, span.start)));
+    const mark = document.createElement("mark");
+    mark.textContent = text.slice(span.start, span.end);
+    mark.title = `${span.label} · ${(span.score * 100).toFixed(1)}%`;
+    results.append(mark);
+    cursor = span.end;
+
+    const item = document.createElement("li");
+    item.textContent = `${span.label}: ${text.slice(span.start, span.end)} (${(
+      span.score * 100
+    ).toFixed(1)}%)`;
+    entities.append(item);
+  }
+  results.append(document.createTextNode(text.slice(cursor)));
+}
+
+function nonOverlappingSpans(spans, textLength) {
+  const accepted = [];
+  let cursor = 0;
+  for (const span of spans) {
+    const start = Math.max(0, Math.min(span.start, textLength));
+    const end = Math.max(start, Math.min(span.end, textLength));
+    if (start < cursor || end === start) {
+      continue;
+    }
+    accepted.push({ ...span, start, end });
+    cursor = end;
+  }
+  return accepted;
+}
+
+async function withBusyState(callback) {
+  setButtonsDisabled(true);
+  try {
+    await callback();
+  } catch (error) {
+    setStatus(errorMessage(error), "error");
+  } finally {
+    setButtonsDisabled(false);
+  }
+}
+
+function setButtonsDisabled(disabled) {
+  runButton.disabled = disabled;
+  benchmarkButton.disabled = disabled;
+  resetButton.disabled = disabled;
+}
+
+function repoId() {
+  const selectedRepoId = repoInput.value.trim();
+  if (!selectedRepoId || !selectedRepoId.includes("/")) {
+    throw new Error("repo_id must look like owner/model-name");
+  }
+  return selectedRepoId;
+}
+
+function setStatus(message, kind = "info") {
+  status.textContent = message;
+  status.dataset.kind = kind;
+}
+
+function backendLabel(backend) {
+  return backend === "webgpu" ? "WebGPU" : "WASM";
+}
+
+function formatMs(value) {
+  return value === null ? "—" : `${value.toFixed(1)} ms`;
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/docs/demo/web/index.html
+++ b/docs/demo/web/index.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="referrer" content="no-referrer" />
+    <link rel="icon" href="data:," />
+    <title>OpenMed browser PII benchmark</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        --background: #f4f7f5;
+        --surface: #ffffff;
+        --text: #17201b;
+        --muted: #5d6b63;
+        --border: #cfdbd3;
+        --accent: #0c7450;
+        --accent-strong: #07563b;
+        --mark: #ffe59a;
+        --error: #b42318;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --background: #111713;
+          --surface: #19221c;
+          --text: #f0f6f2;
+          --muted: #adbbb2;
+          --border: #34443a;
+          --accent: #65d6a7;
+          --accent-strong: #9be8c7;
+          --mark: #725a12;
+          --error: #ffb4ab;
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--background);
+        color: var(--text);
+      }
+
+      main {
+        width: min(960px, calc(100% - 2rem));
+        margin: 3rem auto;
+      }
+
+      h1,
+      h2 {
+        line-height: 1.2;
+      }
+
+      h1 {
+        margin-bottom: 0.5rem;
+        font-size: clamp(2rem, 5vw, 3.5rem);
+      }
+
+      h2 {
+        margin-top: 0;
+        font-size: 1.15rem;
+      }
+
+      p {
+        line-height: 1.6;
+      }
+
+      .eyebrow {
+        color: var(--accent);
+        font-size: 0.78rem;
+        font-weight: 750;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      .lede {
+        max-width: 65ch;
+        color: var(--muted);
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: 1rem;
+        margin-top: 2rem;
+      }
+
+      .card {
+        padding: 1.25rem;
+        border: 1px solid var(--border);
+        border-radius: 0.85rem;
+        background: var(--surface);
+      }
+
+      .card.full {
+        grid-column: 1 / -1;
+      }
+
+      label,
+      legend {
+        display: block;
+        margin-bottom: 0.45rem;
+        font-weight: 700;
+      }
+
+      input,
+      select,
+      textarea,
+      button {
+        width: 100%;
+        border: 1px solid var(--border);
+        border-radius: 0.55rem;
+        font: inherit;
+      }
+
+      input,
+      select,
+      textarea {
+        padding: 0.72rem 0.8rem;
+        background: var(--surface);
+        color: var(--text);
+      }
+
+      textarea {
+        min-height: 12rem;
+        resize: vertical;
+        line-height: 1.5;
+      }
+
+      .field + .field {
+        margin-top: 1rem;
+      }
+
+      .actions {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(155px, 1fr));
+        gap: 0.65rem;
+        margin-top: 1rem;
+      }
+
+      button {
+        padding: 0.75rem 1rem;
+        cursor: pointer;
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #ffffff;
+        font-weight: 750;
+      }
+
+      button.secondary {
+        background: transparent;
+        color: var(--accent-strong);
+      }
+
+      button:disabled {
+        cursor: wait;
+        opacity: 0.65;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-variant-numeric: tabular-nums;
+      }
+
+      th,
+      td {
+        padding: 0.7rem 0.55rem;
+        border-bottom: 1px solid var(--border);
+        text-align: left;
+      }
+
+      th {
+        color: var(--muted);
+        font-size: 0.8rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      .status {
+        min-height: 1.5rem;
+        margin: 1rem 0 0;
+        color: var(--muted);
+      }
+
+      .status[data-kind="error"] {
+        color: var(--error);
+      }
+
+      .results {
+        min-height: 4rem;
+        padding: 1rem;
+        border: 1px dashed var(--border);
+        border-radius: 0.55rem;
+        line-height: 1.8;
+        overflow-wrap: anywhere;
+        white-space: pre-wrap;
+      }
+
+      mark {
+        padding: 0.08rem 0.16rem;
+        border-radius: 0.2rem;
+        background: var(--mark);
+        color: inherit;
+      }
+
+      .entities {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+        margin: 0.85rem 0 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .entities li {
+        padding: 0.35rem 0.55rem;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        font-size: 0.86rem;
+      }
+
+      .note {
+        color: var(--muted);
+        font-size: 0.88rem;
+      }
+
+      code {
+        overflow-wrap: anywhere;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="eyebrow">Local browser inference</div>
+      <h1>WASM vs WebGPU PII detection</h1>
+      <p class="lede">
+        Load a Transformers.js token-classification bundle, detect sensitive
+        spans in synthetic text, and compare cold model load with first
+        inference latency. Inference runs in this browser; model and runtime
+        assets are downloaded from their configured hosts.
+      </p>
+
+      <div class="grid">
+        <section class="card" aria-labelledby="settings-heading">
+          <h2 id="settings-heading">Model and backend</h2>
+          <div class="field">
+            <label for="repo-id">Manifest <code>repo_id</code></label>
+            <input
+              id="repo-id"
+              name="repo-id"
+              value="onnx-community/multilang-pii-ner-ONNX"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
+          <div class="field">
+            <label for="backend">Execution backend</label>
+            <select id="backend" name="backend">
+              <option value="wasm">WASM (CPU)</option>
+              <option value="webgpu">WebGPU</option>
+            </select>
+          </div>
+          <p id="webgpu-support" class="note"></p>
+        </section>
+
+        <section class="card" aria-labelledby="timing-heading">
+          <h2 id="timing-heading">Timing panel</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Backend</th>
+                <th>Model load</th>
+                <th>First inference</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>WASM</td>
+                <td id="wasm-load">—</td>
+                <td id="wasm-first">—</td>
+              </tr>
+              <tr>
+                <td>WebGPU</td>
+                <td id="webgpu-load">—</td>
+                <td id="webgpu-first">—</td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="note">
+            Reset before a new cold-load comparison. Browser disk caches may
+            make later downloads faster.
+          </p>
+        </section>
+
+        <section class="card full" aria-labelledby="input-heading">
+          <h2 id="input-heading">Synthetic input</h2>
+          <label for="input-text">Text to inspect</label>
+          <textarea id="input-text" name="input-text">John Doe was born on 12/12/1990 and lives in Berlin.</textarea>
+          <div class="actions">
+            <button id="run-selected" type="button">Run selected backend</button>
+            <button id="benchmark-both" type="button">Benchmark both</button>
+            <button id="reset" class="secondary" type="button">
+              Reset benchmarks
+            </button>
+          </div>
+          <p id="status" class="status" role="status" aria-live="polite">
+            Ready. Use synthetic data only.
+          </p>
+        </section>
+
+        <section class="card full" aria-labelledby="results-heading">
+          <h2 id="results-heading">Detected spans</h2>
+          <div id="results" class="results">No inference run yet.</div>
+          <ul id="entities" class="entities" aria-label="Detected entities"></ul>
+        </section>
+      </div>
+
+      <p class="note">
+        Demonstration only. Results can be incomplete and must not be used to
+        make clinical decisions or certify that text is de-identified.
+      </p>
+    </main>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -297,5 +297,6 @@ watch:
   - openmed/zero_shot
 
 exclude_docs: |
+  demo/web/README.md
   website/**
   brand/**

--- a/tests/unit/test_web_demo_layout.py
+++ b/tests/unit/test_web_demo_layout.py
@@ -1,0 +1,71 @@
+"""Structural checks for the static WASM/WebGPU browser demo."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from openmed.onnx.transformersjs import REQUIRED_BUNDLE_FILES
+
+ROOT = Path(__file__).resolve().parents[2]
+DEMO_DIR = ROOT / "docs" / "demo" / "web"
+
+
+def test_web_demo_has_static_entrypoint_and_controls() -> None:
+    """The static page must expose model, backend, timing, and result controls."""
+
+    html = (DEMO_DIR / "index.html").read_text(encoding="utf-8")
+
+    assert '<script type="module" src="./app.js"></script>' in html
+    assert 'id="repo-id"' in html
+    assert 'value="wasm"' in html
+    assert 'value="webgpu"' in html
+    for element_id in (
+        "wasm-load",
+        "wasm-first",
+        "webgpu-load",
+        "webgpu-first",
+        "run-selected",
+        "benchmark-both",
+        "results",
+    ):
+        assert f'id="{element_id}"' in html
+
+
+def test_web_demo_wires_transformersjs_backends_and_separate_timings() -> None:
+    """Both execution providers must use one token-classification code path."""
+
+    app = (DEMO_DIR / "app.js").read_text(encoding="utf-8")
+
+    assert "@huggingface/transformers@4.2.0" in app
+    assert 'const BACKENDS = ["wasm", "webgpu"]' in app
+    assert 'pipeline("token-classification"' in app
+    assert "device: backend" in app
+    assert 'wasm: "q8"' in app
+    assert 'webgpu: "fp16"' in app
+    assert 'aggregation_strategy: "simple"' in app
+    assert app.count("performance.now()") >= 4
+    assert "loadMs" in app
+    assert "firstInferenceMs" in app
+    assert "locateWord" in app
+    assert "mergeBioSpans" in app
+
+
+def test_web_demo_documents_manifest_repo_and_export_bundle_layout() -> None:
+    """The runbook must map a manifest repo id to the validated export layout."""
+
+    readme = (DEMO_DIR / "README.md").read_text(encoding="utf-8")
+
+    assert "models.jsonl" in readme
+    assert "`repo_id`" in readme
+    assert "formats" in readme and "transformersjs" in readme
+    assert "python -m http.server" in readme
+    for relative_path in REQUIRED_BUNDLE_FILES:
+        assert relative_path in readme
+
+    default_match = re.search(
+        r'const DEFAULT_REPO_ID = "(?P<repo_id>[^\"]+)";',
+        (DEMO_DIR / "app.js").read_text(encoding="utf-8"),
+    )
+    assert default_match is not None
+    assert default_match.group("repo_id").count("/") == 1


### PR DESCRIPTION
## Description
Adds a static browser PII demo with selectable WASM and WebGPU execution, separate cold model-load and first-inference timing, and highlighted entity spans. It also documents manifest repo_id targeting and local static serving.

## Type of Change
- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made
- Added a configurable browser token-classification demo with independent backend sessions.
- Added a per-backend timing panel, safe span rendering, reset behavior, and capability feedback.
- Added the bundle-layout runbook and structural CI coverage.

## Testing
- [x] Full suite passed: 5,162 passed and 51 skipped.
- [x] Repository lint, formatting, strict documentation, and focused pre-commit gates passed.
- [x] Live browser smoke tests completed for both WASM and WebGPU with populated timing rows and detected spans.

## Documentation and Dependencies
- Added local-serving, manifest repo_id, bundle-layout, cache, and limitations guidance.
- No new project dependencies.
- No changelog entry is needed for this scoped demo.

## Related Issues
Closes #1461.