### PR TITLE
Add ProGuard/R8 consumer rules so the OpenMedKit AAR shrinks cleanly

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -52,6 +52,12 @@ baseline for on-device inference work because it preserves broad device support
 while keeping runtime, storage, and execution APIs modern enough for the planned
 local-first pipeline.
 
+## R8 and ProGuard
+
+The OpenMedKit AAR includes consumer rules for reflectively loaded inference
+classes, JNI-bound ONNX Runtime types, and model catalog serialization. Apps can
+enable R8 or ProGuard without adding any OpenMedKit-specific configuration.
+
 ## Optional Maven Central Publishing
 
 JitPack is the public installation path documented above. The separate, optional

--- a/android/openmedkit/build.gradle.kts
+++ b/android/openmedkit/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.zip.ZipFile
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -65,6 +67,7 @@ android {
         // runtime and filesystem APIs without forcing recent-only devices.
         minSdk = 26
         targetSdk = 33
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     compileOptions {
@@ -108,6 +111,44 @@ tasks.matching { it.name.endsWith("Assets") }.configureEach {
 
 tasks.matching { it.name.startsWith("test") }.configureEach {
     dependsOn(generateAndroidModelCatalog)
+}
+
+val verifyReleaseConsumerRules by tasks.registering {
+    group = "verification"
+    description = "Verifies that the release AAR contains OpenMedKit consumer rules."
+    dependsOn("bundleReleaseAar")
+
+    val releaseAar = layout.buildDirectory.file("outputs/aar/openmedkit-release.aar")
+    inputs.file(layout.projectDirectory.file("consumer-rules.pro"))
+    inputs.file(releaseAar)
+
+    doLast {
+        val aarFile = releaseAar.get().asFile
+        check(aarFile.isFile) {
+            "Release AAR was not created at ${aarFile.absolutePath}"
+        }
+
+        val packagedRules = ZipFile(aarFile).use { archive ->
+            val rulesEntry = archive.getEntry("proguard.txt")
+                ?: throw GradleException(
+                    "Release AAR does not contain the packaged consumer rules at proguard.txt.",
+                )
+            archive.getInputStream(rulesEntry).bufferedReader().use { it.readText() }
+        }
+        listOf(
+            "com.openmed.openmedkit.BackendOnnxTokenClassifier",
+            "ai.onnxruntime.**",
+            "com.openmed.openmedkit.catalog.ModelCatalogEntry",
+        ).forEach { requiredRule ->
+            check(requiredRule in packagedRules) {
+                "Release AAR consumer rules are missing $requiredRule"
+            }
+        }
+    }
+}
+
+tasks.matching { it.name == "assembleRelease" }.configureEach {
+    finalizedBy(verifyReleaseConsumerRules)
 }
 
 val verifyReleasePublicationVersion by tasks.registering {

--- a/android/openmedkit/consumer-rules.pro
+++ b/android/openmedkit/consumer-rules.pro
@@ -1,0 +1,25 @@
+# OpenMedKit inference entry points can be created by class name from host
+# integrations. Preserve their names and public constructors while allowing R8
+# to optimize their implementations.
+-keep,allowoptimization class com.openmed.openmedkit.BackendOnnxTokenClassifier {
+    public <init>(...);
+}
+-keep,allowoptimization class com.openmed.openmedkit.onnx.OnnxTokenClassifier {
+    public <init>(...);
+}
+
+# ONNX Runtime's Java API is backed by libonnxruntime4j_jni. Preserve native
+# method and declaring-class names, along with every type used in JNI method
+# descriptors.
+-keepclasseswithmembernames,includedescriptorclasses class ai.onnxruntime.** {
+    native <methods>;
+}
+
+# Model catalog rows are parsed with kotlinx.serialization JSON. Preserve the
+# concrete model and its schema-facing field names without disabling method
+# optimization for the rest of the catalog implementation.
+-keepnames class com.openmed.openmedkit.catalog.ModelCatalogEntry
+-keepclassmembers,allowoptimization class com.openmed.openmedkit.catalog.ModelCatalogEntry {
+    <fields>;
+}
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault


### PR DESCRIPTION
# Pull Request

## Description

Ships targeted consumer shrinker rules with the OpenMedKit AAR so release apps retain reflection, JNI, and catalog serialization contracts without app-specific configuration. The release assembly now verifies that all required rule groups are present in the packaged artifact.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Added targeted consumer rules for reflectively loaded inference entry points, JNI-bound runtime members, and model catalog fields.
- Wired the consumer rules into the OpenMedKit library release configuration.
- Added an `assembleRelease` verification task that inspects the AAR and fails if a required rule group is absent.
- Documented that consuming apps do not need extra OpenMedKit shrinker configuration.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Validated with:

- `cd android && ./gradlew :openmedkit:assembleRelease`
- `cd android && ./gradlew test`
- `.venv/bin/python -m pytest tests/ -q` (5,159 passed, 51 skipped)
- Scoped pre-commit hooks for all changed files
- Direct R8 parsing of `consumer-rules.pro`

## Documentation

- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #584

## Screenshots/Examples

Not applicable; this change affects AAR metadata, release verification, and documentation.
