### PR TITLE
Add Android artifact fields to the model manifest and model card

### DIFF
--- a/docs/export-onnx-android.md
+++ b/docs/export-onnx-android.md
@@ -184,6 +184,32 @@ only writes the model and operator/type configuration consumed by that build.
 
 ## Mobile Compatibility Metadata
 
+Published Android rows in `models.jsonl` can describe their deployment contract
+with the canonical `formats` list and four optional top-level fields:
+
+```json
+{
+  "formats": ["onnx-android", "onnx-int8", "ort-android"],
+  "nnapi_compatible": true,
+  "min_sdk": 27,
+  "execution_providers": ["NNAPI", "XNNPACK"],
+  "tokenizer_assets": ["tokenizer.json", "tokenizer_config.json"]
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `formats` | Android artifacts present in the model repository. Use `onnx-android` for the fp32/fp16 graphs, `onnx-int8` for the dynamic INT8 graph, and `ort-android` for the ORT Mobile model. |
+| `nnapi_compatible` | Whether the published graph is compatible with the Android NNAPI execution provider. |
+| `min_sdk` | Lowest supported Android SDK/API level as a positive integer. |
+| `execution_providers` | Ordered runtime provider hints, such as `NNAPI` and `XNNPACK`. Availability still depends on the target device and runtime build. |
+| `tokenizer_assets` | Repository-relative tokenizer files bundled with the artifacts. |
+
+The four Android metadata fields are optional. Existing manifest rows validate
+unchanged when they are absent. When at least one is present, the generated
+model card includes an Android metadata section and the autonomous-clinical-
+decision disclaimer.
+
 `openmed-onnx.json` records the Android artifacts with the format string
 `onnx-android` for fp32/fp16 and `onnx-int8` for the dynamic INT8 graph. When
 ORT conversion succeeds, the manifest also records an `ort-android` artifact.

--- a/openmed/core/manifest_schema.py
+++ b/openmed/core/manifest_schema.py
@@ -37,7 +37,15 @@ OPTIONAL_ENRICHMENT_FIELDS = frozenset(
         "training_provenance",
     }
 )
-MANIFEST_FIELDS = REQUIRED_FIELDS | OPTIONAL_ENRICHMENT_FIELDS
+OPTIONAL_ANDROID_FIELDS = frozenset(
+    {
+        "execution_providers",
+        "min_sdk",
+        "nnapi_compatible",
+        "tokenizer_assets",
+    }
+)
+MANIFEST_FIELDS = REQUIRED_FIELDS | OPTIONAL_ENRICHMENT_FIELDS | OPTIONAL_ANDROID_FIELDS
 BENCHMARK_FIELDS = frozenset({"dataset", "micro_f1", "recall"})
 BENCHMARK_SUITE_FIELDS = frozenset(
     {"suite", "dataset", "micro_f1", "recall", "leakage"}
@@ -319,6 +327,27 @@ def validate_manifest_row(row: Any, line_number: int) -> list[ManifestViolation]
             row.get("reproducibility_hash"),
         )
 
+    if "nnapi_compatible" in row and not isinstance(row["nnapi_compatible"], bool):
+        violations.append(
+            ManifestViolation(line_number, "nnapi_compatible must be a boolean")
+        )
+
+    if "min_sdk" in row:
+        value = row["min_sdk"]
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            violations.append(
+                ManifestViolation(line_number, "min_sdk must be a positive integer")
+            )
+
+    for field in ("execution_providers", "tokenizer_assets"):
+        if field in row:
+            _validate_non_empty_string_list(
+                violations,
+                line_number,
+                row[field],
+                field,
+            )
+
     return violations
 
 
@@ -373,6 +402,28 @@ def _validate_string_list(
         if not isinstance(item, str):
             violations.append(
                 ManifestViolation(line_number, f"{field}[{index}] must be a string")
+            )
+
+
+def _validate_non_empty_string_list(
+    violations: list[ManifestViolation],
+    line_number: int,
+    value: Any,
+    field: str,
+) -> None:
+    if not isinstance(value, list) or not value:
+        violations.append(
+            ManifestViolation(line_number, f"{field} must be a non-empty list")
+        )
+        return
+
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            violations.append(
+                ManifestViolation(
+                    line_number,
+                    f"{field}[{index}] must be a non-empty string",
+                )
             )
 
 

--- a/openmed/core/model_card.py
+++ b/openmed/core/model_card.py
@@ -9,6 +9,16 @@ from openmed.__about__ import __version__
 
 DEFAULT_ARXIV = "2508.01630"
 
+_ANDROID_METADATA_FIELDS = frozenset(
+    {
+        "execution_providers",
+        "min_sdk",
+        "nnapi_compatible",
+        "tokenizer_assets",
+    }
+)
+_ANDROID_FORMATS = frozenset({"onnx-android", "onnx-int8", "ort-android"})
+
 _MODEL_LANGUAGES = {
     "Arabic": "ar",
     "Bengali": "bn",
@@ -209,6 +219,9 @@ def render_model_card(row: dict[str, Any]) -> str:
     artifact_lines = _artifact_format_block(formats)
     if artifact_lines:
         lines.extend(["", "## Artifact Format", "", *artifact_lines])
+    android_lines = _android_artifact_block(row, formats)
+    if android_lines:
+        lines.extend(["", *android_lines])
     distillation_lines = _distillation_block(row)
     if distillation_lines:
         lines.extend(["", "## Distillation Evidence", "", *distillation_lines])
@@ -235,6 +248,7 @@ def _render_android_onnx_model_card(
     source_model = _string(row.get("base_model"), "Not specified")
     license_name = _string(row.get("license"), "apache-2.0")
     arxiv = _string(row.get("arxiv"), DEFAULT_ARXIV)
+    android_lines = _android_artifact_block(row, formats)
     task_name = (
         "PII token classification"
         if family == "PII"
@@ -389,6 +403,7 @@ def _render_android_onnx_model_card(
             "",
             "Inference and tokenization remain on-device.",
             "",
+            *([*android_lines, ""] if android_lines else []),
             "## Included Artifacts",
             "",
             "| Artifact | Recommended use |",
@@ -638,6 +653,40 @@ def _artifact_format_block(formats: list[str]) -> list[str]:
         f"| Runtime artifacts | {_comma_or_unspecified(runtime_formats)} |",
         f"| Quantization | {_comma_or_unspecified(quantization_formats)} |",
     ]
+
+
+def _android_artifact_block(row: dict[str, Any], formats: list[str]) -> list[str]:
+    if not _ANDROID_METADATA_FIELDS.intersection(row):
+        return []
+
+    android_formats = [
+        value for value in formats if _normalize_format(value) in _ANDROID_FORMATS
+    ]
+    min_sdk = row.get("min_sdk")
+    min_sdk_text = (
+        str(min_sdk)
+        if isinstance(min_sdk, int) and not isinstance(min_sdk, bool) and min_sdk > 0
+        else "Not specified"
+    )
+    return [
+        "## Android",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Formats | {_code_list(android_formats)} |",
+        f"| NNAPI compatible | {_yes_no(row.get('nnapi_compatible'))} |",
+        f"| Minimum Android SDK | {min_sdk_text} |",
+        f"| Execution providers | {_code_list(_list(row.get('execution_providers')))} |",
+        f"| Tokenizer assets | {_code_list(_list(row.get('tokenizer_assets')))} |",
+        "",
+        "**Medical-device disclaimer:** Outputs are not for autonomous clinical decisions.",
+    ]
+
+
+def _code_list(values: list[str]) -> str:
+    if not values:
+        return "Not specified"
+    return ", ".join(f"`{value}`" for value in values)
 
 
 def _onnx_usage_block(repo_id: str, formats: list[str]) -> list[str]:

--- a/openmed/core/model_registry.py
+++ b/openmed/core/model_registry.py
@@ -30,6 +30,10 @@ class ModelInfo:
     architecture: Optional[str] = None
     base_model: Optional[str] = None
     formats: List[str] = field(default_factory=list)
+    nnapi_compatible: Optional[bool] = None
+    min_sdk: Optional[int] = None
+    execution_providers: List[str] = field(default_factory=list)
+    tokenizer_assets: List[str] = field(default_factory=list)
     benchmark: Dict[str, Any] | List[Dict[str, Any]] = field(default_factory=dict)
     latency_ms: Dict[str, float] = field(default_factory=dict)
     peak_ram_mb: Dict[str, float] = field(default_factory=dict)
@@ -530,6 +534,12 @@ def _model_info_from_row(row: Dict[str, Any]) -> ModelInfo:
         architecture=row.get("architecture"),
         base_model=row.get("base_model"),
         formats=list(row.get("formats") or []),
+        nnapi_compatible=row.get("nnapi_compatible")
+        if isinstance(row.get("nnapi_compatible"), bool)
+        else None,
+        min_sdk=_positive_int_from_row(row, "min_sdk"),
+        execution_providers=_string_list_from_row(row, "execution_providers"),
+        tokenizer_assets=_string_list_from_row(row, "tokenizer_assets"),
         benchmark=_benchmark_from_row(row),
         latency_ms=_number_map_from_row(row, "latency_ms"),
         peak_ram_mb=_number_map_from_row(row, "peak_ram_mb"),
@@ -561,6 +571,20 @@ def _number_map_from_row(row: Dict[str, Any], field_name: str) -> Dict[str, floa
         for device, measurement in value.items()
         if isinstance(measurement, (int, float)) and not isinstance(measurement, bool)
     }
+
+
+def _positive_int_from_row(row: Dict[str, Any], field_name: str) -> Optional[int]:
+    value = row.get(field_name)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
+def _string_list_from_row(row: Dict[str, Any], field_name: str) -> List[str]:
+    value = row.get(field_name)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
 
 
 def _language_prefix(row: Dict[str, Any]) -> str:

--- a/tests/unit/core/test_manifest_android_fields.py
+++ b/tests/unit/core/test_manifest_android_fields.py
@@ -1,0 +1,76 @@
+"""Tests for optional Android metadata in canonical manifest rows."""
+
+from __future__ import annotations
+
+from openmed.core import model_registry
+from openmed.core.manifest_schema import validate_manifest_row
+
+
+def _manifest_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "repo_id": "OpenMed/android-fixture-v1",
+        "family": "NER",
+        "task": "token-classification",
+        "languages": ["en"],
+        "tier": "Tiny",
+        "param_count": 65_000_000,
+        "architecture": "distilbert",
+        "base_model": "OpenMed/android-fixture",
+        "formats": ["pytorch"],
+        "canonical_labels": ["PERSON", "DATE"],
+        "benchmark": {"dataset": None, "micro_f1": None, "recall": None},
+        "arxiv": None,
+        "license": "apache-2.0",
+        "reproducibility_hash": "sha256:" + "1" * 64,
+        "released": "2026-07-18",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_manifest_row_accepts_optional_android_fields() -> None:
+    row = _manifest_row(
+        repo_id="OpenMed/android-fixture-v1-onnx-android",
+        formats=["onnx-android", "onnx-int8", "ort-android"],
+        nnapi_compatible=True,
+        min_sdk=27,
+        execution_providers=["NNAPI", "XNNPACK"],
+        tokenizer_assets=["tokenizer.json", "tokenizer_config.json"],
+    )
+
+    assert validate_manifest_row(row, line_number=1) == []
+
+    info = next(iter(model_registry._build_registry([row]).values()))
+    assert info.formats == ["onnx-android", "onnx-int8", "ort-android"]
+    assert info.nnapi_compatible is True
+    assert info.min_sdk == 27
+    assert info.execution_providers == ["NNAPI", "XNNPACK"]
+    assert info.tokenizer_assets == ["tokenizer.json", "tokenizer_config.json"]
+
+
+def test_manifest_row_without_android_fields_remains_valid() -> None:
+    row = _manifest_row()
+
+    assert validate_manifest_row(row, line_number=1) == []
+
+    info = next(iter(model_registry._build_registry([row]).values()))
+    assert info.nnapi_compatible is None
+    assert info.min_sdk is None
+    assert info.execution_providers == []
+    assert info.tokenizer_assets == []
+
+
+def test_manifest_row_rejects_invalid_android_field_types() -> None:
+    row = _manifest_row(
+        nnapi_compatible="yes",
+        min_sdk=True,
+        execution_providers=[],
+        tokenizer_assets=[""],
+    )
+
+    assert [str(item) for item in validate_manifest_row(row, line_number=3)] == [
+        "line 3: nnapi_compatible must be a boolean",
+        "line 3: min_sdk must be a positive integer",
+        "line 3: execution_providers must be a non-empty list",
+        "line 3: tokenizer_assets[0] must be a non-empty string",
+    ]

--- a/tests/unit/core/test_model_card_android.py
+++ b/tests/unit/core/test_model_card_android.py
@@ -1,0 +1,53 @@
+"""Tests for Android metadata in manifest-rendered model cards."""
+
+from __future__ import annotations
+
+from openmed.core.model_card import render_model_card
+
+
+def _android_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "repo_id": "OpenMed/android-fixture-v1-onnx-android",
+        "family": "NER",
+        "task": "token-classification",
+        "languages": ["en"],
+        "tier": "Tiny",
+        "param_count": 65_000_000,
+        "architecture": "distilbert",
+        "base_model": "OpenMed/android-fixture-v1",
+        "formats": ["onnx-android", "onnx-int8", "ort-android"],
+        "canonical_labels": ["PERSON", "DATE"],
+        "benchmark": {"dataset": None, "micro_f1": None, "recall": None},
+        "arxiv": "2508.01630",
+        "license": "apache-2.0",
+        "reproducibility_hash": "sha256:" + "1" * 64,
+        "released": "2026-07-18",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_model_card_renders_android_metadata_section() -> None:
+    card = render_model_card(
+        _android_row(
+            nnapi_compatible=True,
+            min_sdk=27,
+            execution_providers=["NNAPI", "XNNPACK"],
+            tokenizer_assets=["tokenizer.json", "tokenizer_config.json"],
+        )
+    )
+
+    assert "\n## Android\n" in card
+    assert "| Formats | `onnx-android`, `onnx-int8`, `ort-android` |" in card
+    assert "| NNAPI compatible | yes |" in card
+    assert "| Minimum Android SDK | 27 |" in card
+    assert "| Execution providers | `NNAPI`, `XNNPACK` |" in card
+    assert "| Tokenizer assets | `tokenizer.json`, `tokenizer_config.json` |" in card
+    assert "Outputs are not for autonomous clinical decisions." in card
+
+
+def test_model_card_omits_android_metadata_section_when_fields_are_absent() -> None:
+    card = render_model_card(_android_row())
+
+    assert "\n## Android\n" not in card
+    assert "Outputs are not for autonomous clinical decisions." not in card


### PR DESCRIPTION
# Pull Request

## Description

Adds optional Android deployment metadata to canonical model-manifest rows and surfaces it in generated model cards, so consumers can identify runtime compatibility and bundled tokenizer assets without changing existing rows.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Validate and expose `nnapi_compatible`, `min_sdk`, `execution_providers`, and `tokenizer_assets` as optional manifest fields.
- Render a dedicated Android metadata section and autonomous-clinical-decision disclaimer only when the new fields are present.
- Document the manifest contract and cover rows with and without Android metadata.

## Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] `.venv/bin/python -m pytest tests/ -q` (`5164 passed, 51 skipped`)
- [x] `make docs-build`

## Documentation

- [x] I have updated the documentation accordingly
- [x] New helpers are covered by existing module-level API documentation conventions

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] The branch is rebased on the latest `master`

## Related Issues

Closes #585

## Screenshots/Examples

Not applicable; this change affects manifest validation, generated Markdown, and documentation.
