### PR TITLE
Add an AAR size and cold-start budget gate for the Android library

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -44,6 +44,45 @@ jobs:
       working-directory: android
       run: ./gradlew :openmedkit:testDebugUnitTest --stacktrace
 
+    - name: Verify Android library budgets
+      working-directory: android
+      run: ./gradlew :openmedkit:verifyAndroidBudgets --continue --stacktrace
+
+    - name: Publish Android budget summary
+      if: always()
+      shell: bash
+      run: |
+        read_budget_value() {
+          awk -F= -v key="$2" '$1 == key { print $2 }' "$1"
+        }
+
+        aar_report="android/openmedkit/build/reports/budgets/release-aar-size.properties"
+        cold_start_report="android/openmedkit/build/reports/budgets/testDebugUnitTest-cold-start.properties"
+        aar_measured="not measured"
+        aar_budget="$(read_budget_value android/gradle/budgets.properties aar.maxBytes)"
+        aar_status="NOT RUN"
+        cold_start_measured="not measured"
+        cold_start_budget="$(read_budget_value android/gradle/budgets.properties coldStart.maxMillis)"
+        cold_start_status="NOT RUN"
+
+        if [[ -f "$aar_report" ]]; then
+          aar_measured="$(read_budget_value "$aar_report" measuredBytes)"
+          aar_status="$(read_budget_value "$aar_report" status)"
+        fi
+        if [[ -f "$cold_start_report" ]]; then
+          cold_start_measured="$(read_budget_value "$cold_start_report" measuredMillis)"
+          cold_start_status="$(read_budget_value "$cold_start_report" status)"
+        fi
+
+        {
+          echo "### Android library budgets"
+          echo
+          echo "| Gate | Measured | Budget | Status |"
+          echo "| --- | ---: | ---: | :---: |"
+          echo "| Release AAR size | ${aar_measured} bytes | ${aar_budget} bytes | ${aar_status} |"
+          echo "| Cold-start initialization | ${cold_start_measured} ms | ${cold_start_budget} ms | ${cold_start_status} |"
+        } >> "$GITHUB_STEP_SUMMARY"
+
     - name: Upload unit test report
       if: failure()
       uses: actions/upload-artifact@v7

--- a/android/gradle/budgets.properties
+++ b/android/gradle/budgets.properties
@@ -1,0 +1,5 @@
+# Release AAR size ceiling (512 KiB). Increase only with an explicit footprint review.
+aar.maxBytes=524288
+
+# Catalog load plus downloader/cache construction, measured in a Robolectric JVM test.
+coldStart.maxMillis=500

--- a/android/openmedkit/build.gradle.kts
+++ b/android/openmedkit/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import org.gradle.api.tasks.testing.Test
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -28,7 +31,23 @@ val centralPortalBundle = layout.buildDirectory.dir("central-portal")
 val pythonExecutable = providers.gradleProperty("openmedPython")
     .orElse(providers.environmentVariable("PYTHON"))
     .orElse("python3")
+val budgetPropertiesFile = rootProject.layout.projectDirectory.file("gradle/budgets.properties")
+val releaseAar = layout.buildDirectory.file("outputs/aar/${project.name}-release.aar")
+val aarSizeBudgetReport = layout.buildDirectory.file(
+    "reports/budgets/release-aar-size.properties",
+)
 val releaseVersionPattern = Regex("""\d+\.\d+\.\d+([.-][A-Za-z0-9][A-Za-z0-9.-]*)?""")
+
+fun readPositiveBudget(key: String): Long {
+    val properties = Properties()
+    budgetPropertiesFile.asFile.inputStream().use { input ->
+        properties.load(input)
+    }
+    val rawValue = properties.getProperty(key)
+        ?: throw GradleException("Missing Android budget '$key' in ${budgetPropertiesFile.asFile}.")
+    return rawValue.toLongOrNull()?.takeIf { it > 0 }
+        ?: throw GradleException("Android budget '$key' must be a positive integer, got '$rawValue'.")
+}
 
 fun isSnapshotVersion(): Boolean {
     return version.toString().contains("SNAPSHOT", ignoreCase = true)
@@ -108,6 +127,72 @@ tasks.matching { it.name.endsWith("Assets") }.configureEach {
 
 tasks.matching { it.name.startsWith("test") }.configureEach {
     dependsOn(generateAndroidModelCatalog)
+}
+
+tasks.withType<Test>().configureEach {
+    val coldStartBudgetReport = layout.buildDirectory.file(
+        "reports/budgets/${name}-cold-start.properties",
+    )
+
+    inputs.file(budgetPropertiesFile)
+    outputs.file(coldStartBudgetReport)
+
+    doFirst {
+        systemProperty(
+            "openmed.coldStart.maxMillis",
+            readPositiveBudget("coldStart.maxMillis"),
+        )
+        systemProperty(
+            "openmed.coldStart.measurementFile",
+            coldStartBudgetReport.get().asFile.absolutePath,
+        )
+    }
+}
+
+val verifyReleaseAarSize by tasks.registering {
+    group = "verification"
+    description = "Fails when the release OpenMedKit AAR exceeds its committed size budget."
+    dependsOn("bundleReleaseAar")
+
+    inputs.file(budgetPropertiesFile)
+    inputs.file(releaseAar)
+    outputs.file(aarSizeBudgetReport)
+
+    doLast {
+        val artifact = releaseAar.get().asFile
+        if (!artifact.isFile) {
+            throw GradleException("Release AAR was not produced at ${artifact.absolutePath}.")
+        }
+
+        val measuredBytes = artifact.length()
+        val maximumBytes = readPositiveBudget("aar.maxBytes")
+        val passed = measuredBytes <= maximumBytes
+        val report = aarSizeBudgetReport.get().asFile
+        report.parentFile.mkdirs()
+        report.writeText(
+            """
+            measuredBytes=$measuredBytes
+            maxBytes=$maximumBytes
+            status=${if (passed) "PASS" else "FAIL"}
+            """.trimIndent() + "\n",
+        )
+
+        logger.lifecycle(
+            "OpenMedKit release AAR size: $measuredBytes bytes (budget: $maximumBytes bytes)",
+        )
+        if (!passed) {
+            throw GradleException(
+                "OpenMedKit release AAR is $measuredBytes bytes, exceeding the " +
+                    "$maximumBytes-byte budget.",
+            )
+        }
+    }
+}
+
+tasks.register("verifyAndroidBudgets") {
+    group = "verification"
+    description = "Runs the release AAR size and library cold-start budget gates."
+    dependsOn(verifyReleaseAarSize, "testDebugUnitTest")
 }
 
 val verifyReleasePublicationVersion by tasks.registering {

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/ColdStartBudgetTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/ColdStartBudgetTest.kt
@@ -1,0 +1,95 @@
+package com.openmed.openmedkit
+
+import com.openmed.openmedkit.cache.ModelCache
+import com.openmed.openmedkit.catalog.ModelCatalog
+import com.openmed.openmedkit.download.HuggingFaceModelClient
+import com.openmed.openmedkit.download.HuggingFaceModelInfo
+import com.openmed.openmedkit.download.ModelDownloader
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [26])
+class ColdStartBudgetTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun libraryInitializationStaysWithinCommittedBudget() {
+        val maximumMillis = requiredPositiveLongProperty("openmed.coldStart.maxMillis")
+        val measurementFile = File(
+            requireNotNull(System.getProperty("openmed.coldStart.measurementFile")) {
+                "Missing openmed.coldStart.measurementFile system property"
+            },
+        )
+        val context = RuntimeEnvironment.getApplication()
+        val cacheDirectory = temporaryFolder.newFolder("cold-start-cache")
+
+        val startedAtNanos = System.nanoTime()
+        val catalog = ModelCatalog.load(context)
+        val cache = ModelCache(cacheDirectory)
+        val downloader = ModelDownloader(cache, NetworkRejectingClient)
+        val elapsedNanos = System.nanoTime() - startedAtNanos
+        val elapsedMillis = (elapsedNanos + NANOS_PER_MILLISECOND - 1) / NANOS_PER_MILLISECOND
+        val passed = elapsedMillis <= maximumMillis
+
+        measurementFile.parentFile?.mkdirs()
+        measurementFile.writeText(
+            """
+            measuredMillis=$elapsedMillis
+            maxMillis=$maximumMillis
+            catalogEntries=${catalog.entries.size}
+            status=${if (passed) "PASS" else "FAIL"}
+            """.trimIndent() + "\n",
+        )
+        println(
+            "OpenMedKit cold start: $elapsedMillis ms " +
+                "(budget: $maximumMillis ms, catalog entries: ${catalog.entries.size})",
+        )
+
+        assertNotNull(downloader)
+        assertTrue(
+            "OpenMedKit cold start took $elapsedMillis ms, exceeding the " +
+                "$maximumMillis ms budget",
+            passed,
+        )
+    }
+
+    private fun requiredPositiveLongProperty(name: String): Long {
+        val value = requireNotNull(System.getProperty(name)) {
+            "Missing $name system property"
+        }
+        return requireNotNull(value.toLongOrNull()?.takeIf { it > 0 }) {
+            "$name must be a positive integer, got '$value'"
+        }
+    }
+
+    private object NetworkRejectingClient : HuggingFaceModelClient {
+        override fun fetchModelInfo(
+            repoId: String,
+            revision: String?,
+        ): HuggingFaceModelInfo =
+            throw AssertionError("Cold-start initialization must not access the network")
+
+        override fun downloadFile(
+            repoId: String,
+            path: String,
+            revision: String,
+            destination: File,
+        ) {
+            throw AssertionError("Cold-start initialization must not access the network")
+        }
+    }
+
+    private companion object {
+        const val NANOS_PER_MILLISECOND = 1_000_000L
+    }
+}


### PR DESCRIPTION
## Description

Adds explicit, reviewable footprint and initialization budgets for the Android library so artifact growth and cold-start regressions fail the Android CI gate. The gate also publishes both measurements in the job summary for every relevant change.

Closes #596.

## Type of Change

- [x] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Added committed ceilings of 512 KiB for the release AAR and 500 ms for offline library initialization.
- Added release artifact measurement plus a cold-start test covering catalog load and downloader/cache construction without network access.
- Added the combined budget gate and an always-emitted measurement table to the Android CI workflow.

## Testing

- [x] I have added tests that prove the gate is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Both gates pass at the committed thresholds and fail at temporary 1-byte and 1-ms thresholds.
- Android full test suite passed.
- Repository full test suite passed: 5,155 passed and 55 skipped.
- Workflow lint, action-reference policy, repository policy, pre-commit, and diff checks passed.

## Documentation

No user-facing documentation change is needed. The committed budget file documents both thresholds and the review expectation for future changes.

## Code Quality

- [x] I have performed a self-review of my own code.
- [x] I have commented the thresholds and non-obvious gate behavior.
- [x] My changes generate no new warnings.

## Dependencies

- [x] I have not added any new dependencies.

## Checklist

- [x] I have read the contributing guidelines.
- [x] My commit has a clear, descriptive message.
- [x] The branch contains one focused commit.

## Related Issues

Closes #596

## Screenshots/Examples

Not applicable.
