### PR TITLE
Add on-device browser PHI guard extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,8 +249,33 @@ jobs:
       run: |
         pytest tests/unit/interop/test_spacy_component.py -q
 
+  browser-extension:
+    needs: repo-policy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: "24"
+        cache: npm
+        cache-dependency-path: web/extension/package-lock.json
+
+    - name: Install extension dependencies
+      working-directory: web/extension
+      run: npm ci
+
+    - name: Install headless Chromium
+      working-directory: web/extension
+      run: npx playwright install --with-deps chromium
+
+    - name: Test browser extension
+      working-directory: web/extension
+      run: npm test
+
   build:
-    needs: [repo-policy, lint, test, security, spacy-integration]
+    needs: [repo-policy, lint, test, security, spacy-integration, browser-extension]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7

--- a/docs/runtimes/browser-extension.md
+++ b/docs/runtimes/browser-extension.md
@@ -1,0 +1,70 @@
+# Browser extension PHI guard
+
+OpenMed PHI Guard is a Manifest V3 WebExtension under `web/extension/`. It
+detects PHI in editable fields and page text, then lets a user mask an active
+field before submitting it. Page text is visually masked in place. Detection
+runs in the extension's private background context through the typed `openmed`
+npm package; clinical text never leaves the browser. Chromium uses the Manifest
+V3 service worker, while Firefox uses the same bundle as a non-persistent
+background script.
+
+## Install for development
+
+Build the unpacked extension with Node.js 20 or newer:
+
+```bash
+cd web/extension
+npm ci
+npm run build
+```
+
+Load `web/extension/dist/` as an unpacked extension in Chromium-based browsers,
+or as a temporary add-on in Firefox. Store listing and submission are outside
+this package's scope.
+
+The in-page panel provides:
+
+- a **Mask PHI** action for the active editable field;
+- a per-site enable/disable control stored in browser-local extension storage;
+- HIPAA Safe Harbor, clinical minimal-redaction, and strict no-leak profiles
+  sourced from OpenMed's bundled policy JSON files.
+
+The content script also blocks form submission when an unmasked active field
+has detected spans. Review the masked result before submitting it because no
+automated detector guarantees complete recall.
+
+## Offline and privacy guarantees
+
+The manifest declares only the `storage` permission and an empty
+`host_permissions` list. HTTP and HTTPS content-script matches allow the guard
+to inspect editable text, but no code path sends that text over the network.
+The background worker uses a compact local detector and the npm
+de-identification API, and its content security policy sets
+`connect-src 'none'`.
+
+Only a site's enabled state and selected policy profile are persisted. Page
+text, raw identifiers, span output, and hashes are not stored. Password fields
+and non-text media are not inspected. See `web/extension/PRIVACY.md` for the
+user-facing privacy notice.
+
+## Test
+
+Install the Playwright Chromium runtime once, then run the extension checks:
+
+```bash
+cd web/extension
+npx playwright install chromium
+npm test
+```
+
+The headless test loads the real unpacked extension on a synthetic page. It
+asserts that editable and text-node spans match the bundled detector output,
+masking produces the expected replacements, detection emits no HTTP(S)
+requests, per-site disable persists across reloads, and profile selection
+changes redaction behavior.
+
+## Limitations
+
+This first version handles text only. It does not redact images, PDFs rendered
+to canvas, cross-origin frames, or browser-internal pages. It is a privacy
+safeguard, not a medical device, and it must not trigger clinical decisions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - De-identification API: api/deidentification.md
       - PII Anonymization: anonymization.md
       - Per-Language De-identification: languages.md
+      - Browser Extension PHI Guard: runtimes/browser-extension.md
       - Smart Entity Merging: pii-smart-merging.md
       - No-Raw-PHI Logging: security/no-raw-phi-logging.md
       - LangChain Redaction Wrapper: integrations-langchain.md

--- a/tests/web/test_extension_redaction.spec.ts
+++ b/tests/web/test_extension_redaction.spec.ts
@@ -1,0 +1,192 @@
+import { createServer, type Server } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  chromium,
+  expect,
+  test,
+  type BrowserContext,
+} from "../../web/extension/tests/playwright";
+
+import { bundledPhiPipeline } from "../../web/extension/src/detector";
+
+const repositoryDir = resolve(process.cwd(), "../..");
+const extensionDir = resolve(repositoryDir, "web/extension/dist");
+const syntheticNote =
+  "Patient Alice Nguyen, DOB 1979-04-12, email alice@example.org.";
+
+test("extension matches local model spans, masks without network, and honors site controls", async () => {
+  const manifest = JSON.parse(
+    await readFile(resolve(extensionDir, "manifest.json"), "utf8"),
+  ) as {
+    background: { scripts: string[]; service_worker: string };
+    browser_specific_settings: {
+      gecko: { data_collection_permissions: { required: string[] } };
+    };
+    host_permissions: string[];
+  };
+  expect(manifest.background).toMatchObject({
+    scripts: ["worker.js"],
+    service_worker: "worker.js",
+  });
+  expect(
+    manifest.browser_specific_settings.gecko.data_collection_permissions,
+  ).toEqual({ required: ["none"] });
+  expect(manifest.host_permissions).toEqual([]);
+
+  const server = await startFixtureServer();
+  const userDataDir = await mkdtemp(join(tmpdir(), "openmed-extension-"));
+  let context: BrowserContext | undefined;
+
+  try {
+    context = await chromium.launchPersistentContext(userDataDir, {
+      channel: "chromium",
+      headless: true,
+      args: [
+        `--disable-extensions-except=${extensionDir}`,
+        `--load-extension=${extensionDir}`,
+      ],
+    });
+    await waitForExtensionWorker(context);
+
+    const page = await context.newPage();
+    await page.goto(server.url);
+    const panel = page.locator("#openmed-phi-guard");
+    const status = panel.locator("[data-testid='openmed-status']");
+    const mask = panel.locator("[data-testid='openmed-mask']");
+    const toggle = panel.locator("[data-testid='openmed-site-toggle']");
+    const policy = panel.locator("[data-testid='openmed-policy']");
+    const note = page.locator("#clinical-note");
+    await expect(status).toHaveText("OpenMed PHI Guard is ready.");
+    await expect(mask).toBeDisabled();
+
+    const outboundRequests: string[] = [];
+    page.on("request", (request) => {
+      if (/^https?:/.test(request.url())) {
+        outboundRequests.push(request.url());
+      }
+    });
+
+    const rawModelOutput = await bundledPhiPipeline(syntheticNote);
+    const modelOutput = rawModelOutput.flatMap((span) =>
+      Array.isArray(span) ? span : [span],
+    );
+    const expectedLabels = modelOutput.map((span) =>
+      (span.entity ?? "").replace(/^S-/, ""),
+    );
+    await note.fill(syntheticNote);
+    await expect(note).toHaveAttribute(
+      "data-openmed-phi-count",
+      String(modelOutput.length),
+    );
+    await expect(note).toHaveAttribute(
+      "data-openmed-phi-labels",
+      expectedLabels.join(","),
+    );
+    await expect(status).toContainText("PHI spans detected on-device");
+    await expect(mask).toBeEnabled();
+    expect(outboundRequests).toEqual([]);
+
+    await page.locator("button[type='submit']").click();
+    await expect(status).toContainText("Mask it before submitting");
+    expect(outboundRequests).toEqual([]);
+
+    await mask.click();
+    await expect(note).toHaveValue(
+      "Patient [PERSON], DOB [DATE_OF_BIRTH], email [EMAIL].",
+    );
+    await expect(status).toContainText("PHI masked on-device");
+
+    await page.locator("#copy").evaluate((element, text) => {
+      element.textContent = text;
+    }, syntheticNote);
+    const textMarks = page.locator(
+      "[data-openmed-text-redaction] mark[data-openmed-phi]",
+    );
+    await expect(textMarks).toHaveCount(modelOutput.length);
+    await expect(page.locator("#copy")).toContainText("[PERSON]");
+    expect(outboundRequests).toEqual([]);
+
+    await toggle.click();
+    await expect(status).toContainText("disabled on this site");
+    await expect(page.locator("[data-openmed-text-redaction]")).toHaveCount(0);
+    await note.fill(syntheticNote);
+    await page.waitForTimeout(350);
+    await expect(note).not.toHaveAttribute("data-openmed-phi-count");
+    await expect(mask).toBeDisabled();
+    expect(outboundRequests).toEqual([]);
+
+    await page.reload();
+    await expect(status).toContainText("disabled on this site");
+    outboundRequests.length = 0;
+    await note.fill(syntheticNote);
+    await page.waitForTimeout(350);
+    await expect(note).not.toHaveAttribute("data-openmed-phi-count");
+
+    await toggle.click();
+    await expect(status).toContainText("ready");
+    await policy.selectOption("clinical_minimal_redaction");
+    await note.fill("Seen on 2026-07-19.");
+    await expect(note).toHaveAttribute("data-openmed-phi-count", "0");
+    await expect(status).toContainText("No PHI detected");
+
+    await policy.selectOption("hipaa_safe_harbor");
+    await expect(note).toHaveAttribute("data-openmed-phi-count", "1");
+    expect(outboundRequests).toEqual([]);
+  } finally {
+    await context?.close();
+    await server.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});
+
+async function waitForExtensionWorker(context: BrowserContext): Promise<void> {
+  if (context.serviceWorkers().length > 0) {
+    return;
+  }
+  await context.waitForEvent("serviceworker");
+}
+
+async function startFixtureServer(): Promise<{
+  url: string;
+  close: () => Promise<void>;
+}> {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+    });
+    response.end(`<!doctype html>
+      <html lang="en">
+        <head><meta charset="utf-8"><title>OpenMed synthetic fixture</title></head>
+        <body>
+          <form>
+            <label for="clinical-note">Synthetic clinical note</label>
+            <textarea id="clinical-note"></textarea>
+            <button type="submit">Submit</button>
+          </form>
+          <p id="copy"></p>
+        </body>
+      </html>`);
+  });
+  await new Promise<void>((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Fixture server did not bind to a TCP port");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}/`,
+    close: () => closeServer(server),
+  };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolveClose, reject) => {
+    server.close((error) => (error === undefined ? resolveClose() : reject(error)));
+  });
+}

--- a/web/extension/PRIVACY.md
+++ b/web/extension/PRIVACY.md
@@ -1,0 +1,20 @@
+# OpenMed PHI Guard privacy notice
+
+OpenMed PHI Guard examines page text only inside the browser. Detection runs in
+the extension's private background context with the bundled OpenMed web
+package. The extension does not send page text, detected spans, or settings to
+OpenMed or to any other service.
+
+The extension requests only browser storage, which holds the enabled state and
+selected policy profile for each site. It does not store page text or detected
+identifiers. Its manifest declares no host permissions for outbound access, and
+its extension-page content security policy disables network connections.
+
+The content script runs on HTTP and HTTPS pages so it can warn before text is
+submitted. It does not inspect password fields, browser-internal pages, or
+non-text content. Users can disable scanning for any site from the in-page
+OpenMed panel.
+
+This privacy guard is an assistive safeguard, not a guarantee that every
+identifier will be found. Review masked text before sharing it. OpenMed is not a
+medical device and must not be used to make autonomous clinical decisions.

--- a/web/extension/manifest.json
+++ b/web/extension/manifest.json
@@ -1,0 +1,34 @@
+{
+  "manifest_version": 3,
+  "name": "OpenMed PHI Guard",
+  "version": "1.0.0",
+  "minimum_chrome_version": "121",
+  "description": "Flags and masks PHI in web pages using only on-device processing.",
+  "permissions": ["storage"],
+  "host_permissions": [],
+  "background": {
+    "scripts": ["worker.js"],
+    "service_worker": "worker.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle",
+      "all_frames": false
+    }
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'none'; connect-src 'none'"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "phi-guard@openmed.life",
+      "strict_min_version": "140.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
+    }
+  }
+}

--- a/web/extension/package-lock.json
+++ b/web/extension/package-lock.json
@@ -1,0 +1,668 @@
+{
+  "name": "@openmed/browser-extension",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openmed/browser-extension",
+      "version": "1.0.0",
+      "dependencies": {
+        "openmed": "file:../../js/openmedkit-web"
+      },
+      "devDependencies": {
+        "@playwright/test": "1.61.1",
+        "@types/chrome": "0.2.2",
+        "@types/node": "24.13.3",
+        "esbuild": "0.28.1",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "../../js/openmedkit-web": {
+      "name": "openmed",
+      "version": "1.9.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "tsup": "^8.3.5",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@huggingface/transformers": ">=3.0.0",
+        "onnxruntime-web": ">=1.20.0"
+      },
+      "peerDependenciesMeta": {
+        "@huggingface/transformers": {
+          "optional": true
+        },
+        "onnxruntime-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.2.tgz",
+      "integrity": "sha512-8rSMZ4cvo2xmaSyQg0sN5yRL7oiDkntLoiHxUhfwQnv1mvnkrdoZ25SlNrKWmYKaeP50WvrfWj1pmc02+U9KKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/openmed": {
+      "resolved": "../../js/openmedkit-web",
+      "link": true
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/web/extension/package.json
+++ b/web/extension/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@openmed/browser-extension",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cross-browser on-device PHI redaction extension.",
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "typecheck": "tsc --noEmit",
+    "test:browser": "playwright test --config playwright.config.ts",
+    "test": "npm run build && npm run typecheck && npm run test:browser"
+  },
+  "dependencies": {
+    "openmed": "file:../../js/openmedkit-web"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1",
+    "@types/chrome": "0.2.2",
+    "@types/node": "24.13.3",
+    "esbuild": "0.28.1",
+    "typescript": "5.9.3"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/web/extension/playwright.config.ts
+++ b/web/extension/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "../../tests/web",
+  testMatch: "test_extension_redaction.spec.ts",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 30_000,
+  outputDir: "dist/test-results",
+  use: {
+    trace: "retain-on-failure",
+  },
+});

--- a/web/extension/scripts/build.mjs
+++ b/web/extension/scripts/build.mjs
@@ -1,0 +1,69 @@
+import { copyFile, mkdir, rm } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { build } from "esbuild";
+
+const extensionDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryDir = resolve(extensionDir, "../..");
+const outputDir = resolve(extensionDir, "dist");
+const openmedEntry = resolve(
+  repositoryDir,
+  "js/openmedkit-web/src/index.ts",
+);
+
+const browserCryptoShim = {
+  name: "browser-crypto-shim",
+  setup(builder) {
+    builder.onResolve({ filter: /^node:crypto$/ }, () => ({
+      path: "node:crypto",
+      namespace: "openmed-browser",
+    }));
+    builder.onLoad(
+      { filter: /.*/, namespace: "openmed-browser" },
+      () => ({
+        contents:
+          "export function createHmac() { throw new Error('Web Crypto is required'); }",
+        loader: "js",
+      }),
+    );
+  },
+};
+
+await rm(outputDir, { recursive: true, force: true });
+await mkdir(outputDir, { recursive: true });
+
+const shared = {
+  bundle: true,
+  platform: "browser",
+  target: ["chrome121", "firefox140"],
+  sourcemap: true,
+  legalComments: "none",
+  alias: {
+    openmed: openmedEntry,
+  },
+  plugins: [browserCryptoShim],
+};
+
+await Promise.all([
+  build({
+    ...shared,
+    entryPoints: [resolve(extensionDir, "src/content.ts")],
+    outfile: resolve(outputDir, "content.js"),
+    format: "iife",
+  }),
+  build({
+    ...shared,
+    entryPoints: [resolve(extensionDir, "src/worker.ts")],
+    outfile: resolve(outputDir, "worker.js"),
+    format: "esm",
+  }),
+  copyFile(
+    resolve(extensionDir, "manifest.json"),
+    resolve(outputDir, "manifest.json"),
+  ),
+  copyFile(
+    resolve(extensionDir, "PRIVACY.md"),
+    resolve(outputDir, "PRIVACY.md"),
+  ),
+]);

--- a/web/extension/src/content.ts
+++ b/web/extension/src/content.ts
@@ -1,0 +1,504 @@
+import type { OpenMedSpan } from "openmed";
+
+import {
+  DEFAULT_POLICY,
+  POLICY_OPTIONS,
+  isPolicyName,
+  type PolicyName,
+} from "./policy";
+
+type EditableElement = HTMLInputElement | HTMLTextAreaElement | HTMLElement;
+
+interface SiteSettingsResponse {
+  ok: boolean;
+  enabled?: boolean;
+  policy?: string;
+  error?: string;
+}
+
+interface ScanResponse extends SiteSettingsResponse {
+  text?: string;
+  deidentifiedText?: string;
+  spans?: OpenMedSpan[];
+}
+
+interface UiElements {
+  host: HTMLElement;
+  status: HTMLElement;
+  policy: HTMLSelectElement;
+  toggle: HTMLButtonElement;
+  mask: HTMLButtonElement;
+}
+
+const extensionApi =
+  (globalThis as typeof globalThis & { browser?: typeof chrome }).browser ??
+  chrome;
+const editableResults = new Map<EditableElement, ScanResponse>();
+const debounceTimers = new Map<EditableElement, number>();
+const textRedactions = new Map<HTMLElement, string>();
+const ui = createUi();
+let enabled = true;
+let currentPolicy: PolicyName = DEFAULT_POLICY;
+let activeEditable: EditableElement | null = null;
+
+void initialize();
+
+async function initialize(): Promise<void> {
+  const settings = await sendMessage<SiteSettingsResponse>({
+    type: "openmed:get-settings",
+  });
+  if (!settings.ok) {
+    showError(settings.error ?? "Unable to load extension settings");
+    return;
+  }
+  enabled = settings.enabled ?? true;
+  currentPolicy = isPolicyName(settings.policy)
+    ? settings.policy
+    : DEFAULT_POLICY;
+  ui.policy.value = currentPolicy;
+  renderEnabledState();
+  installPageListeners();
+  if (enabled) {
+    scanExistingPage();
+  }
+}
+
+function installPageListeners(): void {
+  document.addEventListener("input", handleEditableEvent, true);
+  document.addEventListener("focusin", handleEditableEvent, true);
+  document.addEventListener("submit", handleSubmit, true);
+  ui.toggle.addEventListener("click", () => void toggleSite());
+  ui.mask.addEventListener("click", maskActiveEditable);
+  ui.policy.addEventListener("change", () => void changePolicy());
+
+  const observer = new MutationObserver((records) => {
+    if (!enabled) {
+      return;
+    }
+    for (const record of records) {
+      for (const node of record.addedNodes) {
+        scanNodeTree(node);
+      }
+    }
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+}
+
+function handleEditableEvent(event: Event): void {
+  const target = editableFromTarget(event.target);
+  if (target === null) {
+    return;
+  }
+  activeEditable = target;
+  if (event.type === "focusin") {
+    renderEditableResult(target);
+  }
+  scheduleEditableScan(target);
+}
+
+function handleSubmit(event: Event): void {
+  if (!enabled || !(event.target instanceof HTMLFormElement)) {
+    return;
+  }
+  const riskyEntry = [...editableResults.entries()].find(
+    ([element, result]) =>
+      event.target instanceof HTMLFormElement &&
+      event.target.contains(element) &&
+      result.text === editableText(element) &&
+      (result.spans?.length ?? 0) > 0,
+  );
+  if (riskyEntry === undefined) {
+    return;
+  }
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  activeEditable = riskyEntry[0];
+  ui.mask.disabled = false;
+  setStatus("PHI detected. Mask it before submitting.", "warning");
+}
+
+function scheduleEditableScan(target: EditableElement): void {
+  const pending = debounceTimers.get(target);
+  if (pending !== undefined) {
+    window.clearTimeout(pending);
+  }
+  if (!enabled) {
+    clearEditableResult(target);
+    return;
+  }
+  const timer = window.setTimeout(() => {
+    debounceTimers.delete(target);
+    void scanEditable(target);
+  }, 150);
+  debounceTimers.set(target, timer);
+}
+
+async function scanEditable(target: EditableElement): Promise<void> {
+  const text = editableText(target);
+  if (!enabled || text.trim().length === 0) {
+    clearEditableResult(target);
+    return;
+  }
+  const response = await scanText(text);
+  if (!enabled || editableText(target) !== text) {
+    return;
+  }
+  if (!response.ok) {
+    showError(response.error ?? "Detection failed");
+    return;
+  }
+  editableResults.set(target, response);
+  const spans = response.spans ?? [];
+  target.dataset.openmedPhiCount = String(spans.length);
+  target.dataset.openmedPhiLabels = spans
+    .map((span) => span.canonical_label)
+    .join(",");
+  if (activeEditable === target) {
+    renderEditableResult(target);
+  }
+}
+
+function renderEditableResult(target: EditableElement): void {
+  const response = editableResults.get(target);
+  const count = response?.spans?.length ?? 0;
+  ui.mask.disabled = count === 0 || !enabled;
+  if (count === 0) {
+    setStatus("No PHI detected in the active field.", "safe");
+    return;
+  }
+  setStatus(
+    `${count} PHI span${count === 1 ? "" : "s"} detected on-device.`,
+    "warning",
+  );
+}
+
+function clearEditableResult(target: EditableElement): void {
+  editableResults.delete(target);
+  delete target.dataset.openmedPhiCount;
+  delete target.dataset.openmedPhiLabels;
+  if (activeEditable === target) {
+    ui.mask.disabled = true;
+  }
+}
+
+function maskActiveEditable(): void {
+  if (!enabled || activeEditable === null) {
+    return;
+  }
+  const result = editableResults.get(activeEditable);
+  if (result?.deidentifiedText === undefined || (result.spans?.length ?? 0) === 0) {
+    return;
+  }
+  setEditableText(activeEditable, result.deidentifiedText);
+  clearEditableResult(activeEditable);
+  activeEditable.dispatchEvent(new Event("input", { bubbles: true }));
+  setStatus("PHI masked on-device. Review the text before sharing.", "safe");
+}
+
+async function toggleSite(): Promise<void> {
+  const nextEnabled = !enabled;
+  const response = await sendMessage<SiteSettingsResponse>({
+    type: "openmed:set-enabled",
+    enabled: nextEnabled,
+  });
+  if (!response.ok) {
+    showError(response.error ?? "Unable to update this site");
+    return;
+  }
+  enabled = nextEnabled;
+  if (!enabled) {
+    clearAllPageState();
+  }
+  renderEnabledState();
+  if (enabled) {
+    scanExistingPage();
+  }
+}
+
+async function changePolicy(): Promise<void> {
+  const selected = ui.policy.value;
+  if (!isPolicyName(selected)) {
+    showError("Unknown policy profile");
+    return;
+  }
+  const response = await sendMessage<SiteSettingsResponse>({
+    type: "openmed:set-policy",
+    policy: selected,
+  });
+  if (!response.ok) {
+    showError(response.error ?? "Unable to update the policy profile");
+    return;
+  }
+  currentPolicy = selected;
+  restoreTextRedactions();
+  for (const editable of editableResults.keys()) {
+    clearEditableResult(editable);
+    scheduleEditableScan(editable);
+  }
+  setStatus(`Using ${selected.replaceAll("_", " ")}.`, "ready");
+  scanDocumentText();
+}
+
+function scanExistingPage(): void {
+  for (const element of document.querySelectorAll("input, textarea, [contenteditable='true']")) {
+    const editable = editableFromTarget(element);
+    if (editable !== null && editableText(editable).trim().length > 0) {
+      scheduleEditableScan(editable);
+    }
+  }
+  scanDocumentText();
+}
+
+function scanDocumentText(): void {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  while (walker.nextNode()) {
+    if (walker.currentNode instanceof Text) {
+      nodes.push(walker.currentNode);
+    }
+  }
+  for (const node of nodes) {
+    void scanTextNode(node);
+  }
+}
+
+function scanNodeTree(node: Node): void {
+  if (node instanceof Text) {
+    void scanTextNode(node);
+    return;
+  }
+  if (!(node instanceof Element) || shouldSkipElement(node)) {
+    return;
+  }
+  const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
+  while (walker.nextNode()) {
+    if (walker.currentNode instanceof Text) {
+      void scanTextNode(walker.currentNode);
+    }
+  }
+}
+
+async function scanTextNode(node: Text): Promise<void> {
+  const parent = node.parentElement;
+  const text = node.data;
+  if (
+    !enabled ||
+    parent === null ||
+    shouldSkipElement(parent) ||
+    text.trim().length < 3 ||
+    !/[\d@]|\b(?:Patient|Doctor|Dr\.)\b/.test(text)
+  ) {
+    return;
+  }
+  const response = await scanText(text);
+  if (!enabled || !node.isConnected || node.data !== text || !response.ok) {
+    return;
+  }
+  const spans = response.spans ?? [];
+  if (spans.length === 0) {
+    return;
+  }
+  const wrapper = document.createElement("span");
+  wrapper.dataset.openmedTextRedaction = "true";
+  let cursor = 0;
+  for (const span of spans.sort((left, right) => left.start - right.start)) {
+    wrapper.append(text.slice(cursor, span.start));
+    const mark = document.createElement("mark");
+    mark.dataset.openmedPhi = span.canonical_label;
+    mark.title = `OpenMed masked ${span.canonical_label}`;
+    mark.textContent = `[${span.canonical_label}]`;
+    mark.style.background = "#ffe2a8";
+    mark.style.color = "#532f00";
+    mark.style.borderRadius = "0.2em";
+    mark.style.padding = "0 0.15em";
+    wrapper.append(mark);
+    cursor = span.end;
+  }
+  wrapper.append(text.slice(cursor));
+  textRedactions.set(wrapper, text);
+  node.replaceWith(wrapper);
+}
+
+function shouldSkipElement(element: Element): boolean {
+  return (
+    element.closest(
+      "#openmed-phi-guard, [data-openmed-text-redaction], script, style, noscript, textarea, input, [contenteditable='true']",
+    ) !== null
+  );
+}
+
+async function scanText(text: string): Promise<ScanResponse> {
+  return sendMessage<ScanResponse>({ type: "openmed:scan", text });
+}
+
+function clearAllPageState(): void {
+  for (const timer of debounceTimers.values()) {
+    window.clearTimeout(timer);
+  }
+  debounceTimers.clear();
+  for (const editable of editableResults.keys()) {
+    clearEditableResult(editable);
+  }
+  restoreTextRedactions();
+  ui.mask.disabled = true;
+}
+
+function restoreTextRedactions(): void {
+  for (const [wrapper, original] of textRedactions) {
+    if (wrapper.isConnected) {
+      wrapper.replaceWith(document.createTextNode(original));
+    }
+  }
+  textRedactions.clear();
+}
+
+function renderEnabledState(): void {
+  ui.toggle.textContent = enabled ? "Disable on this site" : "Enable on this site";
+  ui.toggle.dataset.enabled = String(enabled);
+  ui.policy.disabled = !enabled;
+  const activeCount =
+    activeEditable === null
+      ? 0
+      : (editableResults.get(activeEditable)?.spans?.length ?? 0);
+  ui.mask.disabled = !enabled || activeCount === 0;
+  setStatus(
+    enabled
+      ? "OpenMed PHI Guard is ready."
+      : "OpenMed PHI Guard is disabled on this site.",
+    enabled ? "ready" : "disabled",
+  );
+}
+
+function showError(message: string): void {
+  setStatus(message, "error");
+}
+
+function setStatus(message: string, state: string): void {
+  ui.status.textContent = message;
+  ui.status.dataset.state = state;
+}
+
+function editableFromTarget(target: EventTarget | null): EditableElement | null {
+  if (target instanceof HTMLTextAreaElement) {
+    return target;
+  }
+  if (target instanceof HTMLInputElement) {
+    const supportedTypes = new Set(["", "email", "search", "tel", "text", "url"]);
+    return supportedTypes.has(target.type) ? target : null;
+  }
+  if (target instanceof HTMLElement && target.isContentEditable) {
+    return target;
+  }
+  return null;
+}
+
+function editableText(target: EditableElement): string {
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+    return target.value;
+  }
+  return target.textContent ?? "";
+}
+
+function setEditableText(target: EditableElement, text: string): void {
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+    const prototype =
+      target instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+    setter?.call(target, text);
+    return;
+  }
+  target.textContent = text;
+}
+
+async function sendMessage<T>(message: object): Promise<T> {
+  try {
+    return (await extensionApi.runtime.sendMessage(message)) as T;
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Extension worker unavailable",
+    } as T;
+  }
+}
+
+function createUi(): UiElements {
+  const host = document.createElement("aside");
+  host.id = "openmed-phi-guard";
+  host.setAttribute("aria-label", "OpenMed PHI Guard");
+  const shadow = host.attachShadow({ mode: "open" });
+  const style = document.createElement("style");
+  style.textContent = `
+    :host { all: initial; }
+    .panel {
+      position: fixed;
+      right: 16px;
+      bottom: 16px;
+      z-index: 2147483647;
+      width: 280px;
+      box-sizing: border-box;
+      padding: 14px;
+      border: 1px solid #b9c8c2;
+      border-radius: 12px;
+      background: #f8fffc;
+      color: #15352d;
+      box-shadow: 0 8px 28px rgb(20 53 45 / 22%);
+      font: 13px/1.4 system-ui, sans-serif;
+    }
+    strong { display: block; margin-bottom: 6px; font-size: 14px; }
+    [data-state="warning"] { color: #8a3d00; }
+    [data-state="error"] { color: #a01818; }
+    label { display: block; margin-top: 10px; font-size: 12px; }
+    select, button {
+      width: 100%;
+      box-sizing: border-box;
+      margin-top: 5px;
+      padding: 7px 9px;
+      border: 1px solid #91aaa1;
+      border-radius: 7px;
+      background: white;
+      color: #15352d;
+      font: inherit;
+    }
+    button { cursor: pointer; }
+    button:disabled { cursor: default; opacity: 0.55; }
+    .primary { background: #176b54; color: white; border-color: #176b54; }
+  `;
+  const panel = document.createElement("section");
+  panel.className = "panel";
+
+  const title = document.createElement("strong");
+  title.textContent = "OpenMed PHI Guard";
+  const status = document.createElement("div");
+  status.dataset.testid = "openmed-status";
+  status.setAttribute("aria-live", "polite");
+
+  const policyLabel = document.createElement("label");
+  policyLabel.textContent = "Policy profile";
+  const policy = document.createElement("select");
+  policy.dataset.testid = "openmed-policy";
+  for (const option of POLICY_OPTIONS) {
+    const element = document.createElement("option");
+    element.value = option.name;
+    element.textContent = option.label;
+    policy.append(element);
+  }
+  policyLabel.append(policy);
+
+  const mask = document.createElement("button");
+  mask.type = "button";
+  mask.className = "primary";
+  mask.dataset.testid = "openmed-mask";
+  mask.textContent = "Mask PHI";
+  mask.disabled = true;
+
+  const toggle = document.createElement("button");
+  toggle.type = "button";
+  toggle.dataset.testid = "openmed-site-toggle";
+
+  panel.append(title, status, policyLabel, mask, toggle);
+  shadow.append(style, panel);
+  document.documentElement.append(host);
+  return { host, status, policy, toggle, mask };
+}

--- a/web/extension/src/detector.ts
+++ b/web/extension/src/detector.ts
@@ -1,0 +1,97 @@
+import type {
+  TokenClassificationEntity,
+  TokenClassificationPipeline,
+} from "openmed";
+
+interface DetectorRule {
+  label: string;
+  pattern: RegExp;
+  captureGroup?: number;
+}
+
+interface Candidate extends TokenClassificationEntity {
+  priority: number;
+}
+
+const DETECTOR_RULES: DetectorRule[] = [
+  {
+    label: "PERSON",
+    pattern:
+      /\b(?:Patient|Dr\.?|Doctor)\s+([A-Z][A-Za-z'-]+(?:\s+[A-Z][A-Za-z'-]+){1,2})\b/g,
+    captureGroup: 1,
+  },
+  {
+    label: "EMAIL",
+    pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+  },
+  {
+    label: "SSN",
+    pattern: /\b\d{3}-\d{2}-\d{4}\b/g,
+  },
+  {
+    label: "PHONE",
+    pattern:
+      /\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]\d{4}\b/g,
+  },
+  {
+    label: "DATE_OF_BIRTH",
+    pattern:
+      /\b(?:DOB|Date of birth|Born)[:\s]+(\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{4})\b/gi,
+    captureGroup: 1,
+  },
+  {
+    label: "DATE",
+    pattern: /\b(?:19|20)\d{2}-\d{2}-\d{2}\b/g,
+  },
+];
+
+/** Compact, deterministic detector bundled with the offline extension. */
+export const bundledPhiPipeline: TokenClassificationPipeline = (text) => {
+  const candidates: Candidate[] = [];
+
+  for (const [priority, rule] of DETECTOR_RULES.entries()) {
+    rule.pattern.lastIndex = 0;
+    for (const match of text.matchAll(rule.pattern)) {
+      const surface = match[rule.captureGroup ?? 0];
+      if (surface === undefined || match.index === undefined) {
+        continue;
+      }
+      const fullMatch = match[0];
+      const start =
+        match.index +
+        (rule.captureGroup === undefined ? 0 : fullMatch.indexOf(surface));
+      candidates.push({
+        entity: `S-${rule.label}`,
+        word: surface,
+        score: 0.99,
+        start,
+        end: start + surface.length,
+        priority,
+      });
+    }
+  }
+
+  const accepted: Candidate[] = [];
+  for (const candidate of candidates.sort(
+    (left, right) =>
+      left.start - right.start ||
+      left.priority - right.priority ||
+      right.end - right.start - (left.end - left.start),
+  )) {
+    if (
+      accepted.some(
+        (span) => candidate.start < span.end && candidate.end > span.start,
+      )
+    ) {
+      continue;
+    }
+    accepted.push(candidate);
+  }
+
+  return accepted
+    .sort((left, right) => left.start - right.start)
+    .map(({ priority: _priority, ...entity }, index) => ({
+      ...entity,
+      index,
+    }));
+};

--- a/web/extension/src/policy.ts
+++ b/web/extension/src/policy.ts
@@ -1,0 +1,73 @@
+import type { OpenMedSpan, SpanAction } from "openmed";
+
+import clinicalMinimalRedaction from "../../../openmed/core/policies/clinical_minimal_redaction.json";
+import hipaaSafeHarbor from "../../../openmed/core/policies/hipaa_safe_harbor.json";
+import strictNoLeak from "../../../openmed/core/policies/strict_no_leak.json";
+
+type PolicyAction = SpanAction | "remove";
+
+export interface PolicyProfile {
+  name: string;
+  default_action: PolicyAction;
+  policy_label_actions: Record<string, PolicyAction>;
+  actions: Record<string, PolicyAction>;
+}
+
+export const BUNDLED_POLICIES = {
+  hipaa_safe_harbor: hipaaSafeHarbor as PolicyProfile,
+  clinical_minimal_redaction: clinicalMinimalRedaction as PolicyProfile,
+  strict_no_leak: strictNoLeak as PolicyProfile,
+} as const;
+
+export type PolicyName = keyof typeof BUNDLED_POLICIES;
+
+export const DEFAULT_POLICY: PolicyName = "hipaa_safe_harbor";
+
+export const POLICY_OPTIONS: ReadonlyArray<{
+  name: PolicyName;
+  label: string;
+}> = [
+  { name: "hipaa_safe_harbor", label: "HIPAA Safe Harbor" },
+  {
+    name: "clinical_minimal_redaction",
+    label: "Clinical minimal redaction",
+  },
+  { name: "strict_no_leak", label: "Strict no-leak" },
+];
+
+export function isPolicyName(value: unknown): value is PolicyName {
+  return typeof value === "string" && value in BUNDLED_POLICIES;
+}
+
+export function applyPolicy(
+  spans: OpenMedSpan[],
+  policyName: PolicyName,
+): OpenMedSpan[] {
+  const profile = BUNDLED_POLICIES[policyName];
+  const selected: OpenMedSpan[] = [];
+
+  for (const span of spans) {
+    const configuredAction =
+      profile.actions[span.canonical_label] ??
+      profile.policy_label_actions[span.policy_label] ??
+      profile.default_action;
+    if (configuredAction === "keep") {
+      continue;
+    }
+    selected.push({
+      ...span,
+      action: extensionAction(configuredAction),
+      replacement: `[${span.canonical_label}]`,
+      metadata: {
+        ...span.metadata,
+        policy_profile: policyName,
+        policy_action: configuredAction,
+      },
+    });
+  }
+  return selected;
+}
+
+function extensionAction(action: PolicyAction): SpanAction {
+  return action === "remove" ? "redact" : action;
+}

--- a/web/extension/src/worker.ts
+++ b/web/extension/src/worker.ts
@@ -1,0 +1,146 @@
+import {
+  deidentify,
+  spansToRedactedText,
+  type OpenMedSpan,
+} from "openmed";
+
+import { bundledPhiPipeline } from "./detector";
+import {
+  DEFAULT_POLICY,
+  applyPolicy,
+  isPolicyName,
+  type PolicyName,
+} from "./policy";
+
+interface SiteSettings {
+  enabled: boolean;
+  policy: PolicyName;
+}
+
+type ExtensionRequest =
+  | { type: "openmed:get-settings" }
+  | { type: "openmed:set-enabled"; enabled: boolean }
+  | { type: "openmed:set-policy"; policy: string }
+  | { type: "openmed:scan"; text: string };
+
+interface ScanResponse {
+  ok: true;
+  enabled: boolean;
+  policy: PolicyName;
+  text: string;
+  deidentifiedText: string;
+  spans: OpenMedSpan[];
+}
+
+const extensionApi =
+  (globalThis as typeof globalThis & { browser?: typeof chrome }).browser ??
+  chrome;
+const workerHashSecret = crypto.randomUUID();
+
+extensionApi.runtime.onMessage.addListener(
+  (
+    message: ExtensionRequest,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response: unknown) => void,
+  ) => {
+    void handleMessage(message, sender)
+      .then(sendResponse)
+      .catch((error: unknown) => {
+        sendResponse({
+          ok: false,
+          error: error instanceof Error ? error.message : "Detection failed",
+        });
+      });
+    return true;
+  },
+);
+
+async function handleMessage(
+  message: ExtensionRequest,
+  sender: chrome.runtime.MessageSender,
+): Promise<unknown> {
+  const origin = senderOrigin(sender);
+  const settings = await readSettings(origin);
+
+  if (message.type === "openmed:get-settings") {
+    return { ok: true, ...settings };
+  }
+
+  if (message.type === "openmed:set-enabled") {
+    const updated = { ...settings, enabled: message.enabled };
+    await writeSettings(origin, updated);
+    return { ok: true, ...updated };
+  }
+
+  if (message.type === "openmed:set-policy") {
+    if (!isPolicyName(message.policy)) {
+      throw new Error(`Unknown policy profile: ${message.policy}`);
+    }
+    const updated = { ...settings, policy: message.policy };
+    await writeSettings(origin, updated);
+    return { ok: true, ...updated };
+  }
+
+  if (message.type === "openmed:scan") {
+    if (!settings.enabled) {
+      return emptyScan(message.text, settings);
+    }
+    const result = await deidentify(message.text, {
+      pipeline: bundledPhiPipeline,
+      detector: "browser-extension-local",
+      hashSecret: workerHashSecret,
+      metadata: { runtime: "extension-background" },
+    });
+    const spans = applyPolicy(result.spans, settings.policy);
+    return {
+      ok: true,
+      enabled: true,
+      policy: settings.policy,
+      text: message.text,
+      deidentifiedText: spansToRedactedText(message.text, spans),
+      spans,
+    } satisfies ScanResponse;
+  }
+
+  throw new Error("Unsupported extension request");
+}
+
+function emptyScan(text: string, settings: SiteSettings): ScanResponse {
+  return {
+    ok: true,
+    enabled: false,
+    policy: settings.policy,
+    text,
+    deidentifiedText: text,
+    spans: [],
+  };
+}
+
+function senderOrigin(sender: chrome.runtime.MessageSender): string {
+  const senderUrl = sender.tab?.url ?? sender.url;
+  if (senderUrl === undefined) {
+    throw new Error("Cannot determine the requesting site");
+  }
+  return new URL(senderUrl).origin;
+}
+
+function settingsKey(origin: string): string {
+  return `openmed:site:${origin}`;
+}
+
+async function readSettings(origin: string): Promise<SiteSettings> {
+  const key = settingsKey(origin);
+  const stored = await extensionApi.storage.local.get(key);
+  const candidate = stored[key] as Partial<SiteSettings> | undefined;
+  return {
+    enabled: candidate?.enabled ?? true,
+    policy: isPolicyName(candidate?.policy) ? candidate.policy : DEFAULT_POLICY,
+  };
+}
+
+async function writeSettings(
+  origin: string,
+  settings: SiteSettings,
+): Promise<void> {
+  await extensionApi.storage.local.set({ [settingsKey(origin)]: settings });
+}

--- a/web/extension/tests/playwright.ts
+++ b/web/extension/tests/playwright.ts
@@ -1,0 +1,2 @@
+export { chromium, expect, test } from "@playwright/test";
+export type { BrowserContext } from "@playwright/test";

--- a/web/extension/tsconfig.json
+++ b/web/extension/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
+    "types": ["chrome", "node"],
+    "baseUrl": ".",
+    "paths": {
+      "openmed": ["../../js/openmedkit-web/src/index.ts"]
+    },
+    "resolveJsonModule": true,
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts",
+    "playwright.config.ts",
+    "../../tests/web/test_extension_redaction.spec.ts"
+  ]
+}


### PR DESCRIPTION
## Description

Adds a cross-browser Manifest V3 privacy guard that detects PHI in editable fields and page text, masks it locally, and warns before form submission. Detection runs in the extension background context through the typed OpenMed web package; page content is never sent off-device.

Per-site enablement and the selected policy profile are stored locally. The manifest has no outbound host permissions, declares no data collection, and enforces a no-connect extension policy.

Closes #820

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add the background detector, content guard, per-site controls, and bundled HIPAA, clinical-minimal, and strict policy profiles.
- Add explicit privacy metadata, an empty outbound host-permission list, a no-connect content policy, and cross-browser background declarations.
- Add a synthetic headless browser test and a dedicated CI gate covering span parity, masking, pre-submit warning, zero outbound detection requests, persistent site disable, and profile selection.
- Add installation, privacy, testing, and limitation documentation.

## Testing

- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have tested this change with different profiles and inputs

Validation completed:

- Clean dependency install, build, type check, and headless extension test: 1 passed; dependency audit: 0 vulnerabilities.
- Full repository suite: 5,159 passed, 51 skipped.
- Repository lint, formatting, pre-commit, workflow-policy, repository-policy, and strict documentation gates passed.

## Documentation

- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran the repository lint and format checks
- [ ] For Swift/OpenMedKit changes, I ran the Swift format and lint checks
- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious detector and browser-runtime paths
- [x] My changes generate no new warnings

## Dependencies

- [ ] I have not added any new dependencies
- [x] I have added development-only build, type-check, and headless browser-test dependencies; the shipped extension remains fully local and contains no network runtime dependency.

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] I have organized the change as one focused commit

## Related Issues

Closes #820

## Screenshots/Examples

Synthetic field input:

`Patient Alice Nguyen, DOB 1979-04-12, email alice@example.org.`

Masked output:

`Patient [PERSON], DOB [DATE_OF_BIRTH], email [EMAIL].`
