### PR TITLE
Add a local FFI plugin for on-device de-identification

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -1,0 +1,91 @@
+name: Flutter plugin
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/flutter-ci.yml'
+      - 'js/openmedkit-flutter/**'
+      - 'tests/mobile/test_flutter_ffi.*'
+      - 'tests/mobile/fixtures/flutter_ffi_golden.json'
+      - 'examples/flutter/**'
+  pull_request:
+    paths:
+      - '.github/workflows/flutter-ci.yml'
+      - 'js/openmedkit-flutter/**'
+      - 'tests/mobile/test_flutter_ffi.*'
+      - 'tests/mobile/fixtures/flutter_ffi_golden.json'
+      - 'examples/flutter/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ffi-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - name: Build native fixture session
+        run: |
+          cmake -S js/openmedkit-flutter/native -B build/flutter-ffi \
+            -DOPENMED_FFI_ENABLE_TEST_SESSION=ON \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build/flutter-ffi --config Release
+      - name: Run Dart FFI tests
+        working-directory: js/openmedkit-flutter
+        env:
+          OPENMED_FFI_LIBRARY: ${{ github.workspace }}/build/flutter-ffi/libopenmed_ffi.so
+          OPENMED_FFI_TEST_SESSION: '1'
+        run: |
+          flutter pub get
+          flutter test test/openmedkit_ffi_test.dart
+
+  mobile-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - name: Build Android consumer
+        run: |
+          flutter create --platforms=android --project-name=openmed_flutter_mobile \
+            "$RUNNER_TEMP/openmed_flutter_mobile"
+          cd "$RUNNER_TEMP/openmed_flutter_mobile"
+          perl -0pi -e 's/minSdk = flutter\.minSdkVersion/minSdk = 26/' \
+            android/app/build.gradle.kts
+          flutter pub add openmedkit_flutter \
+            --path "$GITHUB_WORKSPACE/js/openmedkit-flutter"
+          flutter build apk --debug
+
+  desktop-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - name: Install Linux desktop toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes clang cmake libgtk-3-dev ninja-build pkg-config
+      - name: Build Linux consumer
+        run: |
+          flutter config --enable-linux-desktop
+          flutter create --platforms=linux --project-name=openmed_flutter_desktop \
+            "$RUNNER_TEMP/openmed_flutter_desktop"
+          cd "$RUNNER_TEMP/openmed_flutter_desktop"
+          flutter pub add openmedkit_flutter \
+            --path "$GITHUB_WORKSPACE/js/openmedkit-flutter"
+          flutter build linux --debug

--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,22 @@ __pycache__/
 .Python
 build/
 node_modules/
+
+# Flutter / Dart local state
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+js/openmedkit-flutter/android/.cxx/
+js/openmedkit-flutter/pubspec.lock
 develop-eggs/
 dist/
 downloads/
 eggs/
 .eggs/
 lib/
+!js/openmedkit-flutter/lib/
+!js/openmedkit-flutter/lib/**
 lib64/
 parts/
 sdist/

--- a/examples/flutter/redact_widget.dart
+++ b/examples/flutter/redact_widget.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:openmedkit_flutter/openmedkit.dart';
+
+/// Small offline example that redacts a fully synthetic clinical note.
+class RedactSyntheticNote extends StatefulWidget {
+  const RedactSyntheticNote({Key? key, required this.openMedKit})
+    : super(key: key);
+
+  final OpenMedKit openMedKit;
+
+  @override
+  State<RedactSyntheticNote> createState() => _RedactSyntheticNoteState();
+}
+
+class _RedactSyntheticNoteState extends State<RedactSyntheticNote> {
+  static const String _syntheticNote =
+      'Patient Alice Nguyen was born on 1979-04-12. '
+      'Email alice@example.org.';
+
+  String _displayText = _syntheticNote;
+  bool _working = false;
+
+  Future<void> _redact() async {
+    setState(() => _working = true);
+    try {
+      final OpenMedDeidentificationResult result = await widget.openMedKit
+          .deidentify(_syntheticNote);
+      if (mounted) {
+        setState(() => _displayText = result.deidentifiedText);
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _working = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Text('Synthetic note'),
+        const SizedBox(height: 8),
+        SelectableText(_displayText),
+        const SizedBox(height: 12),
+        ElevatedButton(
+          onPressed: _working ? null : _redact,
+          child: Text(_working ? 'Redacting locally…' : 'Redact locally'),
+        ),
+      ],
+    );
+  }
+}

--- a/js/openmedkit-flutter/CHANGELOG.md
+++ b/js/openmedkit-flutter/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add the cross-platform C ABI and typed Dart FFI surface.
+- Add offline platform registration and synthetic privacy regression tests.

--- a/js/openmedkit-flutter/README.md
+++ b/js/openmedkit-flutter/README.md
@@ -1,0 +1,40 @@
+# OpenMedKit Flutter
+
+`openmedkit_flutter` is a local-first Flutter FFI plugin for OpenMed ONNX
+token-classification exports. It exposes typed `extractPii` and `deidentify`
+operations without adding matched source text to span records or logs.
+
+The package does not download models. A model directory must already contain
+`id2label.json`, `tokenizer.json`, and one of `model_int8.onnx`, `model.onnx`,
+or `model_fp16.onnx`. Platform registration validates that directory before the
+Dart bindings create the native runtime.
+
+```dart
+final openmed = await OpenMedKit.loadModel(
+  modelDirectory: localModelDirectory,
+  tokenizer: localTokenizer.encode,
+);
+
+final result = await openmed.deidentify(syntheticNote);
+try {
+  useRedactedText(result.deidentifiedText);
+} finally {
+  openmed.close();
+}
+```
+
+## Native session contract
+
+`native/openmed_ffi.h` defines a narrow `openmed_session_api`. Android and Apple
+builds bind it to ONNX Runtime 1.20.0 from Maven Central and CocoaPods. Other
+desktop builds can register the same vtable or set `OPENMED_ONNXRUNTIME_ROOT`
+to a local ONNX Runtime package. The adapter receives a local model path plus
+tokenized `input_ids`, `attention_mask`, and offsets. The shared C shim owns
+logits decoding, typed span allocation, and masking, so Dart sees the same
+contract on every target.
+
+Tokenizer adapters must operate from local assets and return Unicode-scalar
+offsets. Long-running inference should be invoked away from the UI isolate by
+applications processing large notes.
+
+The package is intentionally not configured for pub.dev publication.

--- a/js/openmedkit-flutter/analysis_options.yaml
+++ b/js/openmedkit-flutter/analysis_options.yaml
@@ -1,0 +1,11 @@
+analyzer:
+  exclude:
+    - build/**
+
+linter:
+  rules:
+    - avoid_print
+    - directives_ordering
+    - prefer_final_fields
+    - prefer_final_locals
+    - unnecessary_lambdas

--- a/js/openmedkit-flutter/android/build.gradle
+++ b/js/openmedkit-flutter/android/build.gradle
@@ -1,0 +1,86 @@
+group 'org.openmed.openmedkit.flutter'
+version '0.1.0'
+
+buildscript {
+    ext.kotlin_version = '1.9.24'
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+configurations {
+    onnxRuntimeArchive
+}
+
+def onnxRuntimeVersion = '1.20.0'
+def extractedOnnxRuntime = layout.buildDirectory.dir('onnxruntime')
+def extractOnnxRuntime = tasks.register('extractOnnxRuntime', Sync) {
+    from {
+        configurations.onnxRuntimeArchive.collect { archive -> zipTree(archive) }
+    }
+    into extractedOnnxRuntime
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    namespace 'org.openmed.openmedkit.flutter'
+    compileSdk 35
+
+    defaultConfig {
+        minSdk 26
+        externalNativeBuild {
+            cmake {
+                arguments '-DOPENMED_FFI_ENABLE_TEST_SESSION=OFF',
+                    "-DOPENMED_ONNXRUNTIME_ROOT=${extractedOnnxRuntime.get().asFile.absolutePath}"
+            }
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = '11'
+    }
+
+    externalNativeBuild {
+        cmake {
+            path file('../native/CMakeLists.txt')
+            version '3.22.1'
+        }
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "com.microsoft.onnxruntime:onnxruntime-android:$onnxRuntimeVersion"
+    onnxRuntimeArchive(
+        "com.microsoft.onnxruntime:onnxruntime-android:$onnxRuntimeVersion@aar"
+    ) {
+        transitive = false
+    }
+}
+
+tasks.configureEach { task ->
+    if (task.name.startsWith('configureCMake') ||
+        task.name.startsWith('buildCMake') ||
+        task.name == 'preBuild') {
+        task.dependsOn(extractOnnxRuntime)
+    }
+}

--- a/js/openmedkit-flutter/android/src/main/AndroidManifest.xml
+++ b/js/openmedkit-flutter/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/js/openmedkit-flutter/android/src/main/kotlin/org/openmed/openmedkit/flutter/OpenMedKitFlutterPlugin.kt
+++ b/js/openmedkit-flutter/android/src/main/kotlin/org/openmed/openmedkit/flutter/OpenMedKitFlutterPlugin.kt
@@ -1,0 +1,42 @@
+package org.openmed.openmedkit.flutter
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+
+/** Registers the offline model-path channel and bundled FFI library. */
+class OpenMedKitFlutterPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
+    private lateinit var channel: MethodChannel
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        System.loadLibrary("openmed_ffi")
+        channel = MethodChannel(
+            binding.binaryMessenger,
+            "org.openmed.openmedkit_flutter/platform",
+        )
+        channel.setMethodCallHandler(this)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        if (call.method != "prepareModel") {
+            result.notImplemented()
+            return
+        }
+        val modelDirectory = call.argument<String>("modelDirectory")
+        if (modelDirectory.isNullOrBlank() || modelDirectory.contains("://")) {
+            result.error("invalid_model_directory", "A local model directory is required.", null)
+            return
+        }
+        val directory = File(modelDirectory)
+        if (!directory.isDirectory) {
+            result.error("model_directory_missing", "The local model directory is unavailable.", null)
+            return
+        }
+        result.success(directory.absolutePath)
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
+}

--- a/js/openmedkit-flutter/ios/Classes/OpenMedKitFlutterPlugin.swift
+++ b/js/openmedkit-flutter/ios/Classes/OpenMedKitFlutterPlugin.swift
@@ -1,0 +1,43 @@
+import Flutter
+import Foundation
+
+public final class OpenMedKitFlutterPlugin: NSObject, FlutterPlugin {
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(
+            name: "org.openmed.openmedkit_flutter/platform",
+            binaryMessenger: registrar.messenger()
+        )
+        registrar.addMethodCallDelegate(OpenMedKitFlutterPlugin(), channel: channel)
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard call.method == "prepareModel" else {
+            result(FlutterMethodNotImplemented)
+            return
+        }
+        guard
+            let arguments = call.arguments as? [String: Any],
+            let path = arguments["modelDirectory"] as? String,
+            !path.isEmpty,
+            !path.contains("://")
+        else {
+            result(FlutterError(
+                code: "invalid_model_directory",
+                message: "A local model directory is required.",
+                details: nil
+            ))
+            return
+        }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            result(FlutterError(
+                code: "model_directory_missing",
+                message: "The local model directory is unavailable.",
+                details: nil
+            ))
+            return
+        }
+        result(URL(fileURLWithPath: path).standardizedFileURL.path)
+    }
+}

--- a/js/openmedkit-flutter/ios/Classes/openmed_ffi.c
+++ b/js/openmedkit-flutter/ios/Classes/openmed_ffi.c
@@ -1,0 +1,1 @@
+#include "../../native/openmed_ffi.c"

--- a/js/openmedkit-flutter/ios/openmedkit_flutter.podspec
+++ b/js/openmedkit-flutter/ios/openmedkit_flutter.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name             = 'openmedkit_flutter'
+  s.version          = '0.1.0'
+  s.summary          = 'Local-first OpenMed token classification for Flutter.'
+  s.description      = <<-DESC
+Typed Dart FFI bindings and offline platform registration for OpenMed.
+                       DESC
+  s.homepage         = 'https://github.com/maziyarpanahi/openmed'
+  s.license          = { :type => 'Apache-2.0', :file => '../../../LICENSE' }
+  s.author           = { 'Maziyar Panahi' => 'maziyar.panahi@iscpif.fr' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'Classes/**/*'
+  s.dependency 'Flutter'
+  s.dependency 'onnxruntime-c', '1.20.0'
+  s.platform = :ios, '13.0'
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'GCC_C_LANGUAGE_STANDARD' => 'c11',
+    'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) OPENMED_FFI_BUILDING_LIBRARY=1 OPENMED_FFI_ONNXRUNTIME=1'
+  }
+  s.swift_version = '5.0'
+end

--- a/js/openmedkit-flutter/lib/openmedkit.dart
+++ b/js/openmedkit-flutter/lib/openmedkit.dart
@@ -1,0 +1,616 @@
+library openmedkit_flutter;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ffi' as ffi;
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter/services.dart';
+
+/// Name shared by the Dart API and every native platform registrar.
+const String openMedKitFlutterChannelName =
+    'org.openmed.openmedkit_flutter/platform';
+
+/// Current native C ABI expected by these Dart bindings.
+const int openMedKitFfiAbiVersion = 1;
+
+/// One half-open token offset into the source text, measured in Unicode scalars.
+class OpenMedTokenOffset {
+  const OpenMedTokenOffset(this.start, this.end)
+      : assert(start >= 0),
+        assert(end >= start);
+
+  final int start;
+  final int end;
+}
+
+/// Tokenizer output consumed by the ONNX token-classification session.
+class OpenMedTokenBatch {
+  OpenMedTokenBatch({
+    required List<int> inputIds,
+    required List<OpenMedTokenOffset> offsets,
+    List<int>? attentionMask,
+  })  : inputIds = List<int>.unmodifiable(inputIds),
+        attentionMask = List<int>.unmodifiable(
+          attentionMask ?? List<int>.filled(inputIds.length, 1),
+        ),
+        offsets = List<OpenMedTokenOffset>.unmodifiable(offsets) {
+    if (inputIds.isEmpty ||
+        inputIds.length != this.attentionMask.length ||
+        inputIds.length != offsets.length) {
+      throw ArgumentError(
+        'inputIds, attentionMask, and offsets must have the same non-zero length',
+      );
+    }
+  }
+
+  final List<int> inputIds;
+  final List<int> attentionMask;
+  final List<OpenMedTokenOffset> offsets;
+
+  int get tokenCount => inputIds.length;
+}
+
+/// Offline tokenizer adapter supplied by the host application.
+///
+/// Android applications can reuse the same tokenizer directory consumed by
+/// OpenMedKit Android. Desktop applications can bind an equivalent local fast
+/// tokenizer. Implementations must not download assets while encoding.
+typedef OpenMedTokenizer = FutureOr<OpenMedTokenBatch> Function(String text);
+
+/// A privacy-safe typed span returned through the C ABI.
+///
+/// Span records intentionally omit the matched source substring. [start] and
+/// [end] are half-open Unicode-scalar offsets into the caller's source text.
+class OpenMedSpan {
+  const OpenMedSpan({
+    required this.start,
+    required this.end,
+    required this.label,
+    required this.score,
+  });
+
+  final int start;
+  final int end;
+  final String label;
+  final double score;
+
+  Map<String, Object> toJson() => <String, Object>{
+        'start': start,
+        'end': end,
+        'label': label,
+        'score': score,
+      };
+}
+
+/// Result of local de-identification.
+class OpenMedDeidentificationResult {
+  const OpenMedDeidentificationResult({
+    required this.deidentifiedText,
+    required this.spans,
+  });
+
+  final String deidentifiedText;
+  final List<OpenMedSpan> spans;
+
+  Map<String, Object> toJson() => <String, Object>{
+        'deidentified_text': deidentifiedText,
+        'spans': spans.map((OpenMedSpan span) => span.toJson()).toList(),
+      };
+}
+
+/// Failure reported by the native FFI layer.
+class OpenMedFfiException implements Exception {
+  const OpenMedFfiException(this.status, this.message);
+
+  final int status;
+  final String message;
+
+  @override
+  String toString() =>
+      'OpenMedFfiException(status: $status, message: $message)';
+}
+
+/// Local OpenMed token-classification and de-identification runtime.
+class OpenMedKit {
+  OpenMedKit._(
+    this._bindings,
+    this._runtime,
+    this._tokenizer,
+    this.defaultThreshold,
+  );
+
+  static const List<String> _autoModelNames = <String>[
+    'model_int8.onnx',
+    'model.onnx',
+    'model_fp16.onnx',
+  ];
+
+  final _OpenMedBindings _bindings;
+  final ffi.Pointer<_NativeRuntime> _runtime;
+  final OpenMedTokenizer _tokenizer;
+  final double defaultThreshold;
+  bool _closed = false;
+
+  /// Loads a local OpenMed ONNX export without performing network requests.
+  ///
+  /// [modelDirectory] must contain `id2label.json` plus the selected ONNX
+  /// graph. [tokenizer] must encode from already-local assets. A native ONNX
+  /// session adapter registers the session vtable declared in `openmed_ffi.h`.
+  static Future<OpenMedKit> loadModel({
+    required String modelDirectory,
+    required OpenMedTokenizer tokenizer,
+    String variant = 'auto',
+    double defaultThreshold = 0.5,
+    String? nativeLibraryPath,
+    MethodChannel? platformChannel,
+  }) async {
+    if (modelDirectory.trim().isEmpty || _looksRemote(modelDirectory)) {
+      throw ArgumentError.value(
+        modelDirectory,
+        'modelDirectory',
+        'must be a non-empty local filesystem path',
+      );
+    }
+    _validateThreshold(defaultThreshold);
+    final MethodChannel channel =
+        platformChannel ?? const MethodChannel(openMedKitFlutterChannelName);
+    final String? preparedDirectory = await channel.invokeMethod<String>(
+      'prepareModel',
+      <String, Object>{'modelDirectory': modelDirectory},
+    );
+    if (preparedDirectory == null || preparedDirectory.isEmpty) {
+      throw const OpenMedFfiException(
+        1,
+        'the platform registrar did not return a model directory',
+      );
+    }
+
+    final String modelPath = _resolveModelPath(preparedDirectory, variant);
+    final List<String> labels = _readLabels(preparedDirectory);
+    final _OpenMedBindings bindings = _OpenMedBindings.open(
+      nativeLibraryPath,
+    );
+    if (bindings.abiVersion() != openMedKitFfiAbiVersion) {
+      throw OpenMedFfiException(
+        1,
+        'native ABI ${bindings.abiVersion()} does not match '
+        '$openMedKitFfiAbiVersion',
+      );
+    }
+    final ffi.Pointer<ffi.Pointer<_NativeRuntime>> runtimeOut =
+        calloc<ffi.Pointer<_NativeRuntime>>();
+    final ffi.Pointer<Utf8> nativeModelPath = modelPath.toNativeUtf8();
+    final ffi.Pointer<ffi.Pointer<Utf8>> nativeLabels =
+        calloc<ffi.Pointer<Utf8>>(labels.length);
+    try {
+      for (int index = 0; index < labels.length; ++index) {
+        nativeLabels[index] = labels[index].toNativeUtf8();
+      }
+      final int status = bindings.runtimeCreate(
+        nativeModelPath,
+        nativeLabels,
+        labels.length,
+        runtimeOut,
+      );
+      bindings.checkStatus(status);
+      return OpenMedKit._(
+        bindings,
+        runtimeOut.value,
+        tokenizer,
+        defaultThreshold,
+      );
+    } finally {
+      for (int index = 0; index < labels.length; ++index) {
+        calloc.free(nativeLabels[index]);
+      }
+      calloc.free(nativeLabels);
+      calloc.free(nativeModelPath);
+      calloc.free(runtimeOut);
+    }
+  }
+
+  /// Detects PII locally and returns typed spans without matched source text.
+  Future<List<OpenMedSpan>> extractPii(
+    String text, {
+    double? threshold,
+  }) async {
+    _ensureOpen();
+    _validateText(text);
+    final double resolvedThreshold = threshold ?? defaultThreshold;
+    _validateThreshold(resolvedThreshold);
+    final OpenMedTokenBatch batch = await _tokenizer(text);
+    _validateBatch(text, batch);
+    return _withNativeBatch<List<OpenMedSpan>>(
+      text,
+      batch,
+      (ffi.Pointer<Utf8> nativeText,
+          ffi.Pointer<_NativeTokenBatch> nativeBatch) {
+        final ffi.Pointer<_NativeSpanList> spans = calloc<_NativeSpanList>();
+        try {
+          final int status = _bindings.runtimeExtractPii(
+            _runtime,
+            nativeText,
+            nativeBatch,
+            resolvedThreshold,
+            spans,
+          );
+          _bindings.checkStatus(status);
+          return _copySpans(spans.ref);
+        } finally {
+          _bindings.spanListFree(spans);
+          calloc.free(spans);
+        }
+      },
+    );
+  }
+
+  /// Detects and masks PII locally using `[LABEL]` replacements.
+  Future<OpenMedDeidentificationResult> deidentify(
+    String text, {
+    double? threshold,
+  }) async {
+    _ensureOpen();
+    _validateText(text);
+    final double resolvedThreshold = threshold ?? defaultThreshold;
+    _validateThreshold(resolvedThreshold);
+    final OpenMedTokenBatch batch = await _tokenizer(text);
+    _validateBatch(text, batch);
+    return _withNativeBatch<OpenMedDeidentificationResult>(
+      text,
+      batch,
+      (ffi.Pointer<Utf8> nativeText,
+          ffi.Pointer<_NativeTokenBatch> nativeBatch) {
+        final ffi.Pointer<ffi.Pointer<Utf8>> output =
+            calloc<ffi.Pointer<Utf8>>();
+        final ffi.Pointer<_NativeSpanList> spans = calloc<_NativeSpanList>();
+        try {
+          final int status = _bindings.runtimeDeidentify(
+            _runtime,
+            nativeText,
+            nativeBatch,
+            resolvedThreshold,
+            output,
+            spans,
+          );
+          _bindings.checkStatus(status);
+          return OpenMedDeidentificationResult(
+            deidentifiedText: output.value.toDartString(),
+            spans: _copySpans(spans.ref),
+          );
+        } finally {
+          if (output.value != ffi.nullptr) {
+            _bindings.stringFree(output.value);
+          }
+          _bindings.spanListFree(spans);
+          calloc.free(spans);
+          calloc.free(output);
+        }
+      },
+    );
+  }
+
+  /// Releases the native token-classification session.
+  void close() {
+    if (_closed) {
+      return;
+    }
+    _bindings.runtimeDestroy(_runtime);
+    _closed = true;
+  }
+
+  T _withNativeBatch<T>(
+    String text,
+    OpenMedTokenBatch batch,
+    T Function(
+      ffi.Pointer<Utf8> text,
+      ffi.Pointer<_NativeTokenBatch> batch,
+    ) operation,
+  ) {
+    final ffi.Pointer<Utf8> nativeText = text.toNativeUtf8();
+    final ffi.Pointer<ffi.Int64> inputIds = calloc<ffi.Int64>(batch.tokenCount);
+    final ffi.Pointer<ffi.Int64> attentionMask =
+        calloc<ffi.Int64>(batch.tokenCount);
+    final ffi.Pointer<ffi.Int64> starts = calloc<ffi.Int64>(batch.tokenCount);
+    final ffi.Pointer<ffi.Int64> ends = calloc<ffi.Int64>(batch.tokenCount);
+    final ffi.Pointer<_NativeTokenBatch> nativeBatch =
+        calloc<_NativeTokenBatch>();
+    try {
+      for (int index = 0; index < batch.tokenCount; ++index) {
+        inputIds[index] = batch.inputIds[index];
+        attentionMask[index] = batch.attentionMask[index];
+        starts[index] = batch.offsets[index].start;
+        ends[index] = batch.offsets[index].end;
+      }
+      nativeBatch.ref
+        ..inputIds = inputIds
+        ..attentionMask = attentionMask
+        ..startOffsets = starts
+        ..endOffsets = ends
+        ..tokenCount = batch.tokenCount;
+      return operation(nativeText, nativeBatch);
+    } finally {
+      calloc.free(nativeBatch);
+      calloc.free(ends);
+      calloc.free(starts);
+      calloc.free(attentionMask);
+      calloc.free(inputIds);
+      calloc.free(nativeText);
+    }
+  }
+
+  List<OpenMedSpan> _copySpans(_NativeSpanList native) {
+    return List<OpenMedSpan>.unmodifiable(
+      List<OpenMedSpan>.generate(native.count, (int index) {
+        final _NativeSpan span = native.items[index];
+        return OpenMedSpan(
+          start: span.start,
+          end: span.end,
+          label: span.label.toDartString(),
+          score: span.score,
+        );
+      }),
+    );
+  }
+
+  void _ensureOpen() {
+    if (_closed) {
+      throw StateError('OpenMedKit has been closed');
+    }
+  }
+
+  static void _validateText(String text) {
+    if (text.isEmpty) {
+      throw ArgumentError.value(text, 'text', 'must not be empty');
+    }
+  }
+
+  static void _validateThreshold(double value) {
+    if (value < 0.0 || value > 1.0) {
+      throw ArgumentError.value(value, 'threshold', 'must be between 0 and 1');
+    }
+  }
+
+  static void _validateBatch(String text, OpenMedTokenBatch batch) {
+    final int textLength = text.runes.length;
+    for (final OpenMedTokenOffset offset in batch.offsets) {
+      if (offset.end > textLength) {
+        throw ArgumentError(
+          'token offsets must be Unicode-scalar offsets within the source text',
+        );
+      }
+    }
+  }
+
+  static bool _looksRemote(String value) {
+    final String normalized = value.trim().toLowerCase();
+    return normalized.startsWith('http://') ||
+        normalized.startsWith('https://');
+  }
+
+  static String _resolveModelPath(String directory, String variant) {
+    final List<String> candidates;
+    switch (variant.trim().toLowerCase()) {
+      case 'auto':
+        candidates = _autoModelNames;
+        break;
+      case 'int8':
+        candidates = const <String>['model_int8.onnx'];
+        break;
+      case 'fp32':
+        candidates = const <String>['model.onnx'];
+        break;
+      case 'fp16':
+        candidates = const <String>['model_fp16.onnx'];
+        break;
+      default:
+        candidates = <String>[variant];
+    }
+    for (final String candidate in candidates) {
+      final File file = File(_join(directory, candidate));
+      if (file.existsSync()) {
+        return file.absolute.path;
+      }
+    }
+    throw FileSystemException(
+      'no local ONNX graph found for variant $variant',
+      directory,
+    );
+  }
+
+  static List<String> _readLabels(String directory) {
+    final File file = File(_join(directory, 'id2label.json'));
+    if (!file.existsSync()) {
+      throw FileSystemException('id2label.json is required', file.path);
+    }
+    final Object? decoded = jsonDecode(file.readAsStringSync());
+    if (decoded is! Map<String, dynamic> || decoded.isEmpty) {
+      throw const FormatException('id2label.json must contain a non-empty map');
+    }
+    final Map<int, String> indexed = <int, String>{};
+    decoded.forEach((String key, dynamic value) {
+      final int? index = int.tryParse(key);
+      if (index == null || index < 0 || value is! String || value.isEmpty) {
+        throw const FormatException(
+            'id2label entries must map integer keys to labels');
+      }
+      indexed[index] = value;
+    });
+    final int largest = indexed.keys.reduce(
+      (int left, int right) => left > right ? left : right,
+    );
+    return List<String>.generate(
+      largest + 1,
+      (int index) => indexed[index] ?? 'O',
+      growable: false,
+    );
+  }
+
+  static String _join(String directory, String name) {
+    final String separator = Platform.pathSeparator;
+    return directory.endsWith(separator)
+        ? '$directory$name'
+        : '$directory$separator$name';
+  }
+}
+
+class _NativeRuntime extends ffi.Opaque {}
+
+class _NativeSpan extends ffi.Struct {
+  @ffi.Int64()
+  external int start;
+
+  @ffi.Int64()
+  external int end;
+
+  @ffi.Double()
+  external double score;
+
+  external ffi.Pointer<Utf8> label;
+}
+
+class _NativeSpanList extends ffi.Struct {
+  external ffi.Pointer<_NativeSpan> items;
+
+  @ffi.IntPtr()
+  external int count;
+}
+
+class _NativeTokenBatch extends ffi.Struct {
+  external ffi.Pointer<ffi.Int64> inputIds;
+  external ffi.Pointer<ffi.Int64> attentionMask;
+  external ffi.Pointer<ffi.Int64> startOffsets;
+  external ffi.Pointer<ffi.Int64> endOffsets;
+
+  @ffi.IntPtr()
+  external int tokenCount;
+}
+
+typedef _AbiVersionNative = ffi.Uint32 Function();
+typedef _AbiVersionDart = int Function();
+typedef _RuntimeCreateNative = ffi.Int32 Function(
+  ffi.Pointer<Utf8>,
+  ffi.Pointer<ffi.Pointer<Utf8>>,
+  ffi.IntPtr,
+  ffi.Pointer<ffi.Pointer<_NativeRuntime>>,
+);
+typedef _RuntimeCreateDart = int Function(
+  ffi.Pointer<Utf8>,
+  ffi.Pointer<ffi.Pointer<Utf8>>,
+  int,
+  ffi.Pointer<ffi.Pointer<_NativeRuntime>>,
+);
+typedef _RuntimeDestroyNative = ffi.Void Function(
+  ffi.Pointer<_NativeRuntime>,
+);
+typedef _RuntimeDestroyDart = void Function(ffi.Pointer<_NativeRuntime>);
+typedef _RuntimeExtractPiiNative = ffi.Int32 Function(
+  ffi.Pointer<_NativeRuntime>,
+  ffi.Pointer<Utf8>,
+  ffi.Pointer<_NativeTokenBatch>,
+  ffi.Double,
+  ffi.Pointer<_NativeSpanList>,
+);
+typedef _RuntimeExtractPiiDart = int Function(
+  ffi.Pointer<_NativeRuntime>,
+  ffi.Pointer<Utf8>,
+  ffi.Pointer<_NativeTokenBatch>,
+  double,
+  ffi.Pointer<_NativeSpanList>,
+);
+typedef _RuntimeDeidentifyNative = ffi.Int32 Function(
+  ffi.Pointer<_NativeRuntime>,
+  ffi.Pointer<Utf8>,
+  ffi.Pointer<_NativeTokenBatch>,
+  ffi.Double,
+  ffi.Pointer<ffi.Pointer<Utf8>>,
+  ffi.Pointer<_NativeSpanList>,
+);
+typedef _RuntimeDeidentifyDart = int Function(
+  ffi.Pointer<_NativeRuntime>,
+  ffi.Pointer<Utf8>,
+  ffi.Pointer<_NativeTokenBatch>,
+  double,
+  ffi.Pointer<ffi.Pointer<Utf8>>,
+  ffi.Pointer<_NativeSpanList>,
+);
+typedef _SpanListFreeNative = ffi.Void Function(
+  ffi.Pointer<_NativeSpanList>,
+);
+typedef _SpanListFreeDart = void Function(ffi.Pointer<_NativeSpanList>);
+typedef _StringFreeNative = ffi.Void Function(ffi.Pointer<Utf8>);
+typedef _StringFreeDart = void Function(ffi.Pointer<Utf8>);
+typedef _LastErrorNative = ffi.Pointer<Utf8> Function();
+typedef _LastErrorDart = ffi.Pointer<Utf8> Function();
+
+class _OpenMedBindings {
+  _OpenMedBindings(ffi.DynamicLibrary library)
+      : abiVersion = library.lookupFunction<_AbiVersionNative, _AbiVersionDart>(
+          'openmed_ffi_abi_version',
+        ),
+        runtimeCreate =
+            library.lookupFunction<_RuntimeCreateNative, _RuntimeCreateDart>(
+          'openmed_runtime_create',
+        ),
+        runtimeDestroy =
+            library.lookupFunction<_RuntimeDestroyNative, _RuntimeDestroyDart>(
+          'openmed_runtime_destroy',
+        ),
+        runtimeExtractPii = library.lookupFunction<_RuntimeExtractPiiNative,
+            _RuntimeExtractPiiDart>('openmed_runtime_extract_pii'),
+        runtimeDeidentify = library.lookupFunction<_RuntimeDeidentifyNative,
+            _RuntimeDeidentifyDart>('openmed_runtime_deidentify'),
+        spanListFree =
+            library.lookupFunction<_SpanListFreeNative, _SpanListFreeDart>(
+          'openmed_span_list_free',
+        ),
+        stringFree = library.lookupFunction<_StringFreeNative, _StringFreeDart>(
+          'openmed_string_free',
+        ),
+        lastError = library.lookupFunction<_LastErrorNative, _LastErrorDart>(
+          'openmed_last_error',
+        );
+
+  factory _OpenMedBindings.open(String? explicitPath) {
+    if (explicitPath != null && explicitPath.isNotEmpty) {
+      return _OpenMedBindings(ffi.DynamicLibrary.open(explicitPath));
+    }
+    final String? environmentPath = Platform.environment['OPENMED_FFI_LIBRARY'];
+    if (environmentPath != null && environmentPath.isNotEmpty) {
+      return _OpenMedBindings(ffi.DynamicLibrary.open(environmentPath));
+    }
+    if (Platform.isIOS || Platform.isMacOS) {
+      return _OpenMedBindings(ffi.DynamicLibrary.process());
+    }
+    if (Platform.isWindows) {
+      return _OpenMedBindings(ffi.DynamicLibrary.open('openmed_ffi.dll'));
+    }
+    if (Platform.isAndroid || Platform.isLinux) {
+      return _OpenMedBindings(ffi.DynamicLibrary.open('libopenmed_ffi.so'));
+    }
+    throw UnsupportedError('OpenMedKit Flutter does not support this platform');
+  }
+
+  final _AbiVersionDart abiVersion;
+  final _RuntimeCreateDart runtimeCreate;
+  final _RuntimeDestroyDart runtimeDestroy;
+  final _RuntimeExtractPiiDart runtimeExtractPii;
+  final _RuntimeDeidentifyDart runtimeDeidentify;
+  final _SpanListFreeDart spanListFree;
+  final _StringFreeDart stringFree;
+  final _LastErrorDart lastError;
+
+  void checkStatus(int status) {
+    if (status == 0) {
+      return;
+    }
+    final ffi.Pointer<Utf8> message = lastError();
+    throw OpenMedFfiException(
+      status,
+      message == ffi.nullptr
+          ? 'native OpenMed operation failed'
+          : message.toDartString(),
+    );
+  }
+}

--- a/js/openmedkit-flutter/linux/CMakeLists.txt
+++ b/js/openmedkit-flutter/linux/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.13)
+set(PROJECT_NAME "openmedkit_flutter")
+project(${PROJECT_NAME} LANGUAGES C CXX)
+
+set(PLUGIN_NAME "openmedkit_flutter_plugin")
+
+add_library(${PLUGIN_NAME} SHARED
+  "open_med_kit_flutter_plugin.cc"
+)
+apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden
+)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
+target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+
+add_subdirectory(
+  "${CMAKE_CURRENT_SOURCE_DIR}/../native"
+  "${CMAKE_CURRENT_BINARY_DIR}/openmed_ffi"
+)
+target_link_libraries(${PLUGIN_NAME} PRIVATE openmed_ffi)
+
+set(openmedkit_flutter_bundled_libraries
+  "$<TARGET_FILE:openmed_ffi>"
+  PARENT_SCOPE
+)

--- a/js/openmedkit-flutter/linux/include/openmedkit_flutter/open_med_kit_flutter_plugin.h
+++ b/js/openmedkit-flutter/linux/include/openmedkit_flutter/open_med_kit_flutter_plugin.h
@@ -1,0 +1,19 @@
+#ifndef FLUTTER_PLUGIN_OPEN_MED_KIT_FLUTTER_PLUGIN_H_
+#define FLUTTER_PLUGIN_OPEN_MED_KIT_FLUTTER_PLUGIN_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+G_BEGIN_DECLS
+
+#if defined(FLUTTER_PLUGIN_IMPL)
+#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+FLUTTER_PLUGIN_EXPORT void open_med_kit_flutter_plugin_register_with_registrar(
+    FlPluginRegistrar *registrar);
+
+G_END_DECLS
+
+#endif

--- a/js/openmedkit-flutter/linux/open_med_kit_flutter_plugin.cc
+++ b/js/openmedkit-flutter/linux/open_med_kit_flutter_plugin.cc
@@ -1,0 +1,71 @@
+#include "include/openmedkit_flutter/open_med_kit_flutter_plugin.h"
+
+#include <glib.h>
+
+namespace {
+
+constexpr char kChannelName[] = "org.openmed.openmedkit_flutter/platform";
+
+void HandleMethodCall(
+    FlMethodChannel* channel,
+    FlMethodCall* method_call,
+    gpointer user_data) {
+  (void)channel;
+  (void)user_data;
+  const gchar* method = fl_method_call_get_name(method_call);
+  if (g_strcmp0(method, "prepareModel") != 0) {
+    g_autoptr(FlMethodResponse) response = FL_METHOD_RESPONSE(
+        fl_method_not_implemented_response_new());
+    fl_method_call_respond(method_call, response, nullptr);
+    return;
+  }
+
+  FlValue* arguments = fl_method_call_get_args(method_call);
+  FlValue* value = arguments == nullptr
+      ? nullptr
+      : fl_value_lookup_string(arguments, "modelDirectory");
+  const gchar* path = value != nullptr && fl_value_get_type(value) == FL_VALUE_TYPE_STRING
+      ? fl_value_get_string(value)
+      : nullptr;
+  if (path == nullptr || path[0] == '\0' || g_strstr_len(path, -1, "://") != nullptr) {
+    g_autoptr(FlMethodResponse) response = FL_METHOD_RESPONSE(
+        fl_method_error_response_new(
+            "invalid_model_directory",
+            "A local model directory is required.",
+            nullptr));
+    fl_method_call_respond(method_call, response, nullptr);
+    return;
+  }
+  if (!g_path_is_absolute(path) || !g_file_test(path, G_FILE_TEST_IS_DIR)) {
+    g_autoptr(FlMethodResponse) response = FL_METHOD_RESPONSE(
+        fl_method_error_response_new(
+            "model_directory_missing",
+            "The local model directory is unavailable.",
+            nullptr));
+    fl_method_call_respond(method_call, response, nullptr);
+    return;
+  }
+
+  g_autofree gchar* canonical = g_canonicalize_filename(path, nullptr);
+  g_autoptr(FlValue) result = fl_value_new_string(canonical);
+  g_autoptr(FlMethodResponse) response = FL_METHOD_RESPONSE(
+      fl_method_success_response_new(result));
+  fl_method_call_respond(method_call, response, nullptr);
+}
+
+}  // namespace
+
+void open_med_kit_flutter_plugin_register_with_registrar(
+    FlPluginRegistrar* registrar) {
+  FlBinaryMessenger* messenger = fl_plugin_registrar_get_messenger(registrar);
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  g_autoptr(FlMethodChannel) channel = fl_method_channel_new(
+      messenger,
+      kChannelName,
+      FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(
+      channel,
+      HandleMethodCall,
+      nullptr,
+      nullptr);
+}

--- a/js/openmedkit-flutter/macos/Classes/OpenMedKitFlutterPlugin.swift
+++ b/js/openmedkit-flutter/macos/Classes/OpenMedKitFlutterPlugin.swift
@@ -1,0 +1,44 @@
+import Cocoa
+import FlutterMacOS
+
+public final class OpenMedKitFlutterPlugin: NSObject, FlutterPlugin {
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(
+            name: "org.openmed.openmedkit_flutter/platform",
+            binaryMessenger: registrar.messenger
+        )
+        let instance = OpenMedKitFlutterPlugin()
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard call.method == "prepareModel" else {
+            result(FlutterMethodNotImplemented)
+            return
+        }
+        guard
+            let arguments = call.arguments as? [String: Any],
+            let path = arguments["modelDirectory"] as? String,
+            !path.isEmpty,
+            !path.contains("://")
+        else {
+            result(FlutterError(
+                code: "invalid_model_directory",
+                message: "A local model directory is required.",
+                details: nil
+            ))
+            return
+        }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            result(FlutterError(
+                code: "model_directory_missing",
+                message: "The local model directory is unavailable.",
+                details: nil
+            ))
+            return
+        }
+        result(URL(fileURLWithPath: path).standardizedFileURL.path)
+    }
+}

--- a/js/openmedkit-flutter/macos/Classes/openmed_ffi.c
+++ b/js/openmedkit-flutter/macos/Classes/openmed_ffi.c
@@ -1,0 +1,1 @@
+#include "../../native/openmed_ffi.c"

--- a/js/openmedkit-flutter/macos/openmedkit_flutter.podspec
+++ b/js/openmedkit-flutter/macos/openmedkit_flutter.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name             = 'openmedkit_flutter'
+  s.version          = '0.1.0'
+  s.summary          = 'Local-first OpenMed token classification for Flutter.'
+  s.description      = <<-DESC
+Typed Dart FFI bindings and offline platform registration for OpenMed.
+                       DESC
+  s.homepage         = 'https://github.com/maziyarpanahi/openmed'
+  s.license          = { :type => 'Apache-2.0', :file => '../../../LICENSE' }
+  s.author           = { 'Maziyar Panahi' => 'maziyar.panahi@iscpif.fr' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'Classes/**/*'
+  s.dependency 'FlutterMacOS'
+  s.dependency 'onnxruntime-c', '1.20.0'
+  s.platform = :osx, '11.0'
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'GCC_C_LANGUAGE_STANDARD' => 'c11',
+    'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) OPENMED_FFI_BUILDING_LIBRARY=1 OPENMED_FFI_ONNXRUNTIME=1'
+  }
+  s.swift_version = '5.0'
+end

--- a/js/openmedkit-flutter/native/CMakeLists.txt
+++ b/js/openmedkit-flutter/native/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.14)
+project(openmed_ffi LANGUAGES C)
+
+option(
+  OPENMED_FFI_ENABLE_TEST_SESSION
+  "Build the synthetic token-classification session used by tests"
+  OFF
+)
+set(
+  OPENMED_ONNXRUNTIME_ROOT
+  ""
+  CACHE PATH
+  "Extracted ONNX Runtime package containing headers and native libraries"
+)
+
+add_library(openmed_ffi SHARED openmed_ffi.c)
+target_compile_features(openmed_ffi PRIVATE c_std_11)
+target_compile_definitions(openmed_ffi PRIVATE OPENMED_FFI_BUILDING_LIBRARY)
+target_include_directories(openmed_ffi PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+
+if(OPENMED_FFI_ENABLE_TEST_SESSION)
+  target_compile_definitions(openmed_ffi PRIVATE OPENMED_FFI_ENABLE_TEST_SESSION)
+endif()
+
+if(OPENMED_ONNXRUNTIME_ROOT)
+  target_compile_definitions(openmed_ffi PRIVATE OPENMED_FFI_ONNXRUNTIME)
+  target_include_directories(
+    openmed_ffi
+    PRIVATE "${OPENMED_ONNXRUNTIME_ROOT}/headers"
+  )
+  if(ANDROID)
+    add_library(onnxruntime SHARED IMPORTED)
+    set_target_properties(
+      onnxruntime
+      PROPERTIES IMPORTED_LOCATION
+        "${OPENMED_ONNXRUNTIME_ROOT}/jni/${ANDROID_ABI}/libonnxruntime.so"
+    )
+    target_link_libraries(openmed_ffi PRIVATE onnxruntime)
+  elseif(WIN32)
+    target_link_libraries(
+      openmed_ffi
+      PRIVATE "${OPENMED_ONNXRUNTIME_ROOT}/lib/onnxruntime.lib"
+    )
+  else()
+    find_library(
+      OPENMED_ONNXRUNTIME_LIBRARY
+      NAMES onnxruntime
+      PATHS "${OPENMED_ONNXRUNTIME_ROOT}/lib"
+      NO_DEFAULT_PATH
+      REQUIRED
+    )
+    target_link_libraries(openmed_ffi PRIVATE "${OPENMED_ONNXRUNTIME_LIBRARY}")
+  endif()
+endif()
+
+if(UNIX AND NOT APPLE)
+  target_link_libraries(openmed_ffi PRIVATE m)
+endif()
+
+set_target_properties(
+  openmed_ffi
+  PROPERTIES
+    C_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN YES
+    OUTPUT_NAME openmed_ffi
+)

--- a/js/openmedkit-flutter/native/openmed_ffi.c
+++ b/js/openmedkit-flutter/native/openmed_ffi.c
@@ -1,0 +1,1022 @@
+#include "openmed_ffi.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(OPENMED_FFI_ONNXRUNTIME)
+#include <onnxruntime_c_api.h>
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+#endif
+
+#define OPENMED_ERROR_CAPACITY 256
+
+#if defined(_MSC_VER)
+#define OPENMED_THREAD_LOCAL __declspec(thread)
+#else
+#define OPENMED_THREAD_LOCAL _Thread_local
+#endif
+
+struct openmed_runtime {
+    char **labels;
+    size_t label_count;
+    openmed_session_api session_api;
+    void *session;
+    int fixture_session;
+};
+
+typedef struct pending_span {
+    int active;
+    int64_t start;
+    int64_t end;
+    double score_sum;
+    size_t score_count;
+    const char *label;
+    size_t label_length;
+} pending_span;
+
+static OPENMED_THREAD_LOCAL char openmed_error[OPENMED_ERROR_CAPACITY];
+static openmed_session_api registered_session_api;
+static int has_registered_session_api;
+
+#if defined(OPENMED_FFI_ONNXRUNTIME)
+typedef struct openmed_onnx_session {
+    const OrtApi *api;
+    OrtEnv *environment;
+    OrtSession *session;
+    OrtMemoryInfo *memory_info;
+    size_t input_count;
+} openmed_onnx_session;
+
+static int onnx_status_ok(
+    const OrtApi *api,
+    OrtStatus *status,
+    char *error,
+    size_t error_capacity
+) {
+    const char *message;
+    if (status == NULL) {
+        return 1;
+    }
+    message = api->GetErrorMessage(status);
+    (void)snprintf(
+        error,
+        error_capacity,
+        "ONNX Runtime operation failed: %s",
+        message == NULL ? "unknown error" : message
+    );
+    api->ReleaseStatus(status);
+    return 0;
+}
+
+static void destroy_onnx_session(void *opaque) {
+    openmed_onnx_session *session = (openmed_onnx_session *)opaque;
+    if (session == NULL) {
+        return;
+    }
+    if (session->memory_info != NULL) {
+        session->api->ReleaseMemoryInfo(session->memory_info);
+    }
+    if (session->session != NULL) {
+        session->api->ReleaseSession(session->session);
+    }
+    if (session->environment != NULL) {
+        session->api->ReleaseEnv(session->environment);
+    }
+    free(session);
+}
+
+#if defined(_WIN32)
+static wchar_t *onnx_model_path(const char *model_path) {
+    int length = MultiByteToWideChar(CP_UTF8, 0, model_path, -1, NULL, 0);
+    wchar_t *wide_path;
+    if (length <= 0) {
+        return NULL;
+    }
+    wide_path = (wchar_t *)malloc((size_t)length * sizeof(wchar_t));
+    if (wide_path == NULL) {
+        return NULL;
+    }
+    if (MultiByteToWideChar(CP_UTF8, 0, model_path, -1, wide_path, length) <= 0) {
+        free(wide_path);
+        return NULL;
+    }
+    return wide_path;
+}
+#endif
+
+static void *create_onnx_session(
+    const char *model_path,
+    const char *const *labels,
+    size_t label_count,
+    char *error,
+    size_t error_capacity
+) {
+    const OrtApiBase *api_base = OrtGetApiBase();
+    openmed_onnx_session *created;
+    OrtSessionOptions *options = NULL;
+    OrtStatus *status;
+    (void)labels;
+    (void)label_count;
+    if (api_base == NULL) {
+        (void)snprintf(error, error_capacity, "ONNX Runtime API is unavailable");
+        return NULL;
+    }
+    created = (openmed_onnx_session *)calloc(1, sizeof(openmed_onnx_session));
+    if (created == NULL) {
+        (void)snprintf(error, error_capacity, "could not allocate an ONNX session");
+        return NULL;
+    }
+    created->api = api_base->GetApi(ORT_API_VERSION);
+    if (created->api == NULL) {
+        (void)snprintf(error, error_capacity, "ONNX Runtime ABI is incompatible");
+        free(created);
+        return NULL;
+    }
+    status = created->api->CreateEnv(
+        ORT_LOGGING_LEVEL_WARNING,
+        "openmed_flutter",
+        &created->environment
+    );
+    if (!onnx_status_ok(created->api, status, error, error_capacity)) {
+        destroy_onnx_session(created);
+        return NULL;
+    }
+    status = created->api->CreateSessionOptions(&options);
+    if (!onnx_status_ok(created->api, status, error, error_capacity)) {
+        destroy_onnx_session(created);
+        return NULL;
+    }
+    status = created->api->SetIntraOpNumThreads(options, 1);
+    if (!onnx_status_ok(created->api, status, error, error_capacity)) {
+        created->api->ReleaseSessionOptions(options);
+        destroy_onnx_session(created);
+        return NULL;
+    }
+    status = created->api->SetSessionGraphOptimizationLevel(
+        options,
+        ORT_ENABLE_ALL
+    );
+    if (!onnx_status_ok(created->api, status, error, error_capacity)) {
+        created->api->ReleaseSessionOptions(options);
+        destroy_onnx_session(created);
+        return NULL;
+    }
+#if defined(_WIN32)
+    {
+        wchar_t *wide_path = onnx_model_path(model_path);
+        if (wide_path == NULL) {
+            created->api->ReleaseSessionOptions(options);
+            destroy_onnx_session(created);
+            (void)snprintf(error, error_capacity, "model path is not valid UTF-8");
+            return NULL;
+        }
+        status = created->api->CreateSession(
+            created->environment,
+            wide_path,
+            options,
+            &created->session
+        );
+        free(wide_path);
+    }
+#else
+    status = created->api->CreateSession(
+        created->environment,
+        model_path,
+        options,
+        &created->session
+    );
+#endif
+    created->api->ReleaseSessionOptions(options);
+    if (!onnx_status_ok(created->api, status, error, error_capacity)) {
+        destroy_onnx_session(created);
+        return NULL;
+    }
+    status = created->api->CreateCpuMemoryInfo(
+        OrtArenaAllocator,
+        OrtMemTypeDefault,
+        &created->memory_info
+    );
+    if (!onnx_status_ok(created->api, status, error, error_capacity)) {
+        destroy_onnx_session(created);
+        return NULL;
+    }
+    status = created->api->SessionGetInputCount(
+        created->session,
+        &created->input_count
+    );
+    if (!onnx_status_ok(created->api, status, error, error_capacity)) {
+        destroy_onnx_session(created);
+        return NULL;
+    }
+    if (created->input_count != 2 && created->input_count != 3) {
+        (void)snprintf(
+            error,
+            error_capacity,
+            "ONNX model must expose input_ids, attention_mask, and optional token_type_ids"
+        );
+        destroy_onnx_session(created);
+        return NULL;
+    }
+    return created;
+}
+
+static int create_onnx_tensor(
+    openmed_onnx_session *session,
+    int64_t *values,
+    size_t token_count,
+    OrtValue **tensor,
+    char *error,
+    size_t error_capacity
+) {
+    int64_t shape[2] = {1, (int64_t)token_count};
+    OrtStatus *status = session->api->CreateTensorWithDataAsOrtValue(
+        session->memory_info,
+        values,
+        token_count * sizeof(int64_t),
+        shape,
+        2,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64,
+        tensor
+    );
+    return onnx_status_ok(session->api, status, error, error_capacity);
+}
+
+static openmed_status run_onnx_session(
+    void *opaque,
+    const openmed_token_batch *batch,
+    float **logits,
+    size_t *sequence_length,
+    size_t *label_count,
+    char *error,
+    size_t error_capacity
+) {
+    openmed_onnx_session *session = (openmed_onnx_session *)opaque;
+    const char *input_names[3] = {
+        "input_ids",
+        "attention_mask",
+        "token_type_ids"
+    };
+    const char *output_names[1] = {"logits"};
+    OrtValue *inputs[3] = {NULL, NULL, NULL};
+    const OrtValue *input_values[3];
+    OrtValue *output = NULL;
+    OrtTensorTypeAndShapeInfo *shape_info = NULL;
+    int64_t dimensions[3] = {0, 0, 0};
+    int64_t *token_types = NULL;
+    ONNXTensorElementDataType element_type;
+    size_t dimension_count = 0;
+    size_t element_count = 0;
+    void *data = NULL;
+    OrtStatus *status;
+    size_t index;
+    openmed_status result = OPENMED_STATUS_INFERENCE_FAILED;
+
+    if (!create_onnx_tensor(
+            session,
+            (int64_t *)batch->input_ids,
+            batch->token_count,
+            &inputs[0],
+            error,
+            error_capacity) ||
+        !create_onnx_tensor(
+            session,
+            (int64_t *)batch->attention_mask,
+            batch->token_count,
+            &inputs[1],
+            error,
+            error_capacity)) {
+        goto cleanup;
+    }
+    if (session->input_count == 3) {
+        token_types = (int64_t *)calloc(batch->token_count, sizeof(int64_t));
+        if (token_types == NULL) {
+            (void)snprintf(error, error_capacity, "could not allocate token_type_ids");
+            result = OPENMED_STATUS_OUT_OF_MEMORY;
+            goto cleanup;
+        }
+        if (!create_onnx_tensor(
+                session,
+                token_types,
+                batch->token_count,
+                &inputs[2],
+                error,
+                error_capacity)) {
+            goto cleanup;
+        }
+    }
+    for (index = 0; index < session->input_count; ++index) {
+        input_values[index] = inputs[index];
+    }
+    status = session->api->Run(
+        session->session,
+        NULL,
+        input_names,
+        input_values,
+        session->input_count,
+        output_names,
+        1,
+        &output
+    );
+    if (!onnx_status_ok(session->api, status, error, error_capacity)) {
+        goto cleanup;
+    }
+    status = session->api->GetTensorTypeAndShape(output, &shape_info);
+    if (!onnx_status_ok(session->api, status, error, error_capacity)) {
+        goto cleanup;
+    }
+    status = session->api->GetDimensionsCount(shape_info, &dimension_count);
+    if (!onnx_status_ok(session->api, status, error, error_capacity)) {
+        goto cleanup;
+    }
+    status = session->api->GetTensorElementType(shape_info, &element_type);
+    if (!onnx_status_ok(session->api, status, error, error_capacity)) {
+        goto cleanup;
+    }
+    if (dimension_count != 3 || element_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        (void)snprintf(error, error_capacity, "logits must be a rank-3 float tensor");
+        result = OPENMED_STATUS_INVALID_OUTPUT;
+        goto cleanup;
+    }
+    status = session->api->GetDimensions(shape_info, dimensions, 3);
+    if (!onnx_status_ok(session->api, status, error, error_capacity)) {
+        goto cleanup;
+    }
+    status = session->api->GetTensorShapeElementCount(shape_info, &element_count);
+    if (!onnx_status_ok(session->api, status, error, error_capacity)) {
+        goto cleanup;
+    }
+    if (dimensions[0] != 1 || dimensions[1] < 0 || dimensions[2] <= 0 ||
+        (size_t)dimensions[1] != batch->token_count ||
+        element_count != (size_t)(dimensions[1] * dimensions[2])) {
+        (void)snprintf(error, error_capacity, "logits dimensions do not match the input batch");
+        result = OPENMED_STATUS_INVALID_OUTPUT;
+        goto cleanup;
+    }
+    status = session->api->GetTensorMutableData(output, &data);
+    if (!onnx_status_ok(session->api, status, error, error_capacity)) {
+        goto cleanup;
+    }
+    *logits = (float *)malloc(element_count * sizeof(float));
+    if (*logits == NULL) {
+        (void)snprintf(error, error_capacity, "could not allocate logits output");
+        result = OPENMED_STATUS_OUT_OF_MEMORY;
+        goto cleanup;
+    }
+    memcpy(*logits, data, element_count * sizeof(float));
+    *sequence_length = (size_t)dimensions[1];
+    *label_count = (size_t)dimensions[2];
+    result = OPENMED_STATUS_OK;
+
+cleanup:
+    if (shape_info != NULL) {
+        session->api->ReleaseTensorTypeAndShapeInfo(shape_info);
+    }
+    if (output != NULL) {
+        session->api->ReleaseValue(output);
+    }
+    for (index = 0; index < 3; ++index) {
+        if (inputs[index] != NULL) {
+            session->api->ReleaseValue(inputs[index]);
+        }
+    }
+    free(token_types);
+    return result;
+}
+
+static void release_onnx_logits(void *session, float *logits) {
+    (void)session;
+    free(logits);
+}
+
+static const openmed_session_api onnx_session_api = {
+    OPENMED_FFI_ABI_VERSION,
+    create_onnx_session,
+    run_onnx_session,
+    release_onnx_logits,
+    destroy_onnx_session
+};
+#endif
+
+static void set_error(const char *message) {
+    if (message == NULL || message[0] == '\0') {
+        openmed_error[0] = '\0';
+        return;
+    }
+    (void)snprintf(openmed_error, sizeof(openmed_error), "%s", message);
+}
+
+static char *copy_string(const char *value) {
+    size_t length;
+    char *copy;
+    if (value == NULL) {
+        return NULL;
+    }
+    length = strlen(value);
+    copy = (char *)malloc(length + 1);
+    if (copy != NULL) {
+        memcpy(copy, value, length + 1);
+    }
+    return copy;
+}
+
+static char *copy_substring(const char *value, size_t length) {
+    char *copy = (char *)malloc(length + 1);
+    if (copy != NULL) {
+        memcpy(copy, value, length);
+        copy[length] = '\0';
+    }
+    return copy;
+}
+
+static void free_labels(char **labels, size_t count) {
+    size_t index;
+    if (labels == NULL) {
+        return;
+    }
+    for (index = 0; index < count; ++index) {
+        free(labels[index]);
+    }
+    free(labels);
+}
+
+static openmed_status copy_labels(
+    const char *const *labels,
+    size_t count,
+    char ***output
+) {
+    char **copies;
+    size_t index;
+    copies = (char **)calloc(count, sizeof(char *));
+    if (copies == NULL) {
+        return OPENMED_STATUS_OUT_OF_MEMORY;
+    }
+    for (index = 0; index < count; ++index) {
+        if (labels[index] == NULL || labels[index][0] == '\0') {
+            free_labels(copies, count);
+            set_error("label values must not be empty");
+            return OPENMED_STATUS_INVALID_ARGUMENT;
+        }
+        copies[index] = copy_string(labels[index]);
+        if (copies[index] == NULL) {
+            free_labels(copies, count);
+            return OPENMED_STATUS_OUT_OF_MEMORY;
+        }
+    }
+    *output = copies;
+    return OPENMED_STATUS_OK;
+}
+
+static size_t utf8_length(const char *value) {
+    const unsigned char *cursor = (const unsigned char *)value;
+    size_t length = 0;
+    while (*cursor != '\0') {
+        if ((*cursor & 0xc0U) != 0x80U) {
+            ++length;
+        }
+        ++cursor;
+    }
+    return length;
+}
+
+static size_t utf8_byte_offset(const char *value, size_t character_offset) {
+    const unsigned char *cursor = (const unsigned char *)value;
+    size_t characters = 0;
+    while (*cursor != '\0' && characters < character_offset) {
+        ++cursor;
+        while ((*cursor & 0xc0U) == 0x80U) {
+            ++cursor;
+        }
+        ++characters;
+    }
+    return (size_t)(cursor - (const unsigned char *)value);
+}
+
+static void parse_label(
+    const char *raw,
+    char *prefix,
+    const char **label,
+    size_t *label_length
+) {
+    size_t length = strlen(raw);
+    *prefix = '\0';
+    *label = raw;
+    *label_length = length;
+    if (length > 2 && (raw[1] == '-' || raw[1] == '_')) {
+        char candidate = raw[0];
+        if (candidate >= 'a' && candidate <= 'z') {
+            candidate = (char)(candidate - ('a' - 'A'));
+        }
+        if (strchr("BIESUL", candidate) != NULL) {
+            *prefix = candidate;
+            *label = raw + 2;
+            *label_length = length - 2;
+        }
+    }
+}
+
+static int label_is_outside(const char *label, size_t length) {
+    return length == 1 && (label[0] == 'O' || label[0] == 'o');
+}
+
+static openmed_status append_pending(
+    openmed_span_list *spans,
+    pending_span *pending,
+    double threshold
+) {
+    openmed_span *items;
+    openmed_span *span;
+    double score;
+    if (!pending->active) {
+        return OPENMED_STATUS_OK;
+    }
+    score = pending->score_sum / (double)pending->score_count;
+    if (score < threshold) {
+        pending->active = 0;
+        return OPENMED_STATUS_OK;
+    }
+    items = (openmed_span *)realloc(
+        spans->items,
+        (spans->count + 1) * sizeof(openmed_span)
+    );
+    if (items == NULL) {
+        set_error("could not allocate decoded spans");
+        return OPENMED_STATUS_OUT_OF_MEMORY;
+    }
+    spans->items = items;
+    span = &spans->items[spans->count];
+    span->start = pending->start;
+    span->end = pending->end;
+    span->score = score;
+    span->label = copy_substring(pending->label, pending->label_length);
+    if (span->label == NULL) {
+        set_error("could not allocate a span label");
+        return OPENMED_STATUS_OUT_OF_MEMORY;
+    }
+    ++spans->count;
+    pending->active = 0;
+    return OPENMED_STATUS_OK;
+}
+
+static size_t maximum_label_index(const float *row, size_t label_count) {
+    size_t best_index = 0;
+    size_t index;
+    for (index = 1; index < label_count; ++index) {
+        if (row[index] > row[best_index]) {
+            best_index = index;
+        }
+    }
+    return best_index;
+}
+
+static double label_probability(
+    const float *row,
+    size_t label_count,
+    size_t best_index
+) {
+    double denominator = 0.0;
+    double maximum = (double)row[best_index];
+    size_t index;
+    for (index = 0; index < label_count; ++index) {
+        denominator += exp((double)row[index] - maximum);
+    }
+    return denominator == 0.0 ? 0.0 : 1.0 / denominator;
+}
+
+static openmed_status decode_logits(
+    openmed_runtime *runtime,
+    const char *text,
+    const openmed_token_batch *batch,
+    const float *logits,
+    size_t sequence_length,
+    size_t output_label_count,
+    double threshold,
+    openmed_span_list *spans
+) {
+    pending_span pending = {0};
+    size_t text_length = utf8_length(text);
+    size_t token_index;
+    if (sequence_length != batch->token_count ||
+        output_label_count != runtime->label_count) {
+        set_error("session logits do not match the token or label dimensions");
+        return OPENMED_STATUS_INVALID_OUTPUT;
+    }
+
+    for (token_index = 0; token_index < sequence_length; ++token_index) {
+        const float *row = logits + token_index * output_label_count;
+        size_t label_index = maximum_label_index(row, output_label_count);
+        const char *label;
+        size_t label_length;
+        char prefix;
+        int64_t start = batch->start_offsets[token_index];
+        int64_t end = batch->end_offsets[token_index];
+        double score;
+        openmed_status status;
+
+        if (start < 0 || end < start || (size_t)end > text_length) {
+            set_error("token offsets fall outside the source text");
+            return OPENMED_STATUS_INVALID_OUTPUT;
+        }
+        parse_label(
+            runtime->labels[label_index],
+            &prefix,
+            &label,
+            &label_length
+        );
+        if (start == end || label_is_outside(label, label_length)) {
+            status = append_pending(spans, &pending, threshold);
+            if (status != OPENMED_STATUS_OK) {
+                return status;
+            }
+            continue;
+        }
+        score = label_probability(row, output_label_count, label_index);
+
+        if (!pending.active || prefix == 'B' || prefix == 'S' || prefix == 'U' ||
+            pending.label_length != label_length ||
+            memcmp(pending.label, label, label_length) != 0 ||
+            (prefix != 'I' && prefix != 'E' && prefix != 'L' &&
+             start > pending.end)) {
+            status = append_pending(spans, &pending, threshold);
+            if (status != OPENMED_STATUS_OK) {
+                return status;
+            }
+            pending.active = 1;
+            pending.start = start;
+            pending.end = end;
+            pending.score_sum = score;
+            pending.score_count = 1;
+            pending.label = label;
+            pending.label_length = label_length;
+        } else {
+            if (end > pending.end) {
+                pending.end = end;
+            }
+            pending.score_sum += score;
+            ++pending.score_count;
+        }
+
+        if (prefix == 'E' || prefix == 'L' || prefix == 'S' || prefix == 'U') {
+            status = append_pending(spans, &pending, threshold);
+            if (status != OPENMED_STATUS_OK) {
+                return status;
+            }
+        }
+    }
+    return append_pending(spans, &pending, threshold);
+}
+
+#if defined(OPENMED_FFI_ENABLE_TEST_SESSION)
+static openmed_status fixture_logits(
+    openmed_runtime *runtime,
+    const openmed_token_batch *batch,
+    float **logits,
+    size_t *sequence_length,
+    size_t *label_count
+) {
+    size_t token_index;
+    size_t label_index;
+    size_t entity_index = 1;
+    if (runtime->label_count < 4) {
+        set_error("the synthetic fixture requires four labels");
+        return OPENMED_STATUS_INVALID_ARGUMENT;
+    }
+    *logits = (float *)malloc(
+        batch->token_count * runtime->label_count * sizeof(float)
+    );
+    if (*logits == NULL) {
+        return OPENMED_STATUS_OUT_OF_MEMORY;
+    }
+    for (token_index = 0; token_index < batch->token_count; ++token_index) {
+        size_t selected = 0;
+        if (batch->start_offsets[token_index] != batch->end_offsets[token_index] &&
+            entity_index < 4) {
+            selected = entity_index++;
+        }
+        for (label_index = 0; label_index < runtime->label_count; ++label_index) {
+            (*logits)[token_index * runtime->label_count + label_index] =
+                label_index == selected ? 5.0f : 0.0f;
+        }
+    }
+    *sequence_length = batch->token_count;
+    *label_count = runtime->label_count;
+    return OPENMED_STATUS_OK;
+}
+#endif
+
+static openmed_status run_session(
+    openmed_runtime *runtime,
+    const openmed_token_batch *batch,
+    float **logits,
+    size_t *sequence_length,
+    size_t *label_count
+) {
+#if defined(OPENMED_FFI_ENABLE_TEST_SESSION)
+    if (runtime->fixture_session) {
+        return fixture_logits(
+            runtime,
+            batch,
+            logits,
+            sequence_length,
+            label_count
+        );
+    }
+#endif
+    return runtime->session_api.run(
+        runtime->session,
+        batch,
+        logits,
+        sequence_length,
+        label_count,
+        openmed_error,
+        sizeof(openmed_error)
+    );
+}
+
+static int use_test_session(void) {
+#if defined(OPENMED_FFI_ENABLE_TEST_SESSION)
+    const char *value = getenv("OPENMED_FFI_TEST_SESSION");
+    return value != NULL && strcmp(value, "1") == 0;
+#else
+    return 0;
+#endif
+}
+
+static openmed_status validate_inference(
+    openmed_runtime *runtime,
+    const char *text,
+    const openmed_token_batch *batch,
+    double threshold,
+    openmed_span_list *spans
+) {
+    if (runtime == NULL || text == NULL || text[0] == '\0' || batch == NULL ||
+        spans == NULL || batch->token_count == 0 || batch->input_ids == NULL ||
+        batch->attention_mask == NULL || batch->start_offsets == NULL ||
+        batch->end_offsets == NULL) {
+        set_error("runtime, text, token batch, and span output are required");
+        return OPENMED_STATUS_INVALID_ARGUMENT;
+    }
+    if (threshold < 0.0 || threshold > 1.0) {
+        set_error("threshold must be between zero and one");
+        return OPENMED_STATUS_INVALID_ARGUMENT;
+    }
+    spans->items = NULL;
+    spans->count = 0;
+    return OPENMED_STATUS_OK;
+}
+
+uint32_t openmed_ffi_abi_version(void) {
+    return OPENMED_FFI_ABI_VERSION;
+}
+
+openmed_status openmed_register_session_api(const openmed_session_api *api) {
+    if (api == NULL || api->abi_version != OPENMED_FFI_ABI_VERSION ||
+        api->create == NULL || api->run == NULL ||
+        api->release_logits == NULL || api->destroy == NULL) {
+        set_error("session API is incomplete or has an incompatible ABI version");
+        return OPENMED_STATUS_INVALID_ARGUMENT;
+    }
+    registered_session_api = *api;
+    has_registered_session_api = 1;
+    set_error(NULL);
+    return OPENMED_STATUS_OK;
+}
+
+openmed_status openmed_runtime_create(
+    const char *model_path,
+    const char *const *labels,
+    size_t label_count,
+    openmed_runtime **runtime
+) {
+    openmed_runtime *created;
+    openmed_status status;
+    if (model_path == NULL || model_path[0] == '\0' || labels == NULL ||
+        label_count == 0 || runtime == NULL) {
+        set_error("model path, labels, and runtime output are required");
+        return OPENMED_STATUS_INVALID_ARGUMENT;
+    }
+    *runtime = NULL;
+    created = (openmed_runtime *)calloc(1, sizeof(openmed_runtime));
+    if (created == NULL) {
+        set_error("could not allocate the OpenMed runtime");
+        return OPENMED_STATUS_OUT_OF_MEMORY;
+    }
+    status = copy_labels(labels, label_count, &created->labels);
+    if (status != OPENMED_STATUS_OK) {
+        free(created);
+        return status;
+    }
+    created->label_count = label_count;
+    created->fixture_session = use_test_session();
+    if (!created->fixture_session) {
+#if defined(OPENMED_FFI_ONNXRUNTIME)
+        created->session_api = has_registered_session_api
+            ? registered_session_api
+            : onnx_session_api;
+#else
+        if (has_registered_session_api) {
+            created->session_api = registered_session_api;
+        } else {
+            free_labels(created->labels, created->label_count);
+            free(created);
+            set_error(
+                "no ONNX token-classification session adapter is registered"
+            );
+            return OPENMED_STATUS_RUNTIME_UNAVAILABLE;
+        }
+#endif
+        created->session = created->session_api.create(
+            model_path,
+            (const char *const *)created->labels,
+            created->label_count,
+            openmed_error,
+            sizeof(openmed_error)
+        );
+        if (created->session == NULL) {
+            free_labels(created->labels, created->label_count);
+            free(created);
+            if (openmed_error[0] == '\0') {
+                set_error("the ONNX token-classification session could not be created");
+            }
+            return OPENMED_STATUS_RUNTIME_UNAVAILABLE;
+        }
+    }
+    *runtime = created;
+    set_error(NULL);
+    return OPENMED_STATUS_OK;
+}
+
+void openmed_runtime_destroy(openmed_runtime *runtime) {
+    if (runtime == NULL) {
+        return;
+    }
+    if (!runtime->fixture_session && runtime->session != NULL) {
+        runtime->session_api.destroy(runtime->session);
+    }
+    free_labels(runtime->labels, runtime->label_count);
+    free(runtime);
+}
+
+openmed_status openmed_runtime_extract_pii(
+    openmed_runtime *runtime,
+    const char *text,
+    const openmed_token_batch *batch,
+    double threshold,
+    openmed_span_list *spans
+) {
+    float *logits = NULL;
+    size_t sequence_length = 0;
+    size_t label_count = 0;
+    openmed_status status = validate_inference(
+        runtime,
+        text,
+        batch,
+        threshold,
+        spans
+    );
+    if (status != OPENMED_STATUS_OK) {
+        return status;
+    }
+    status = run_session(
+        runtime,
+        batch,
+        &logits,
+        &sequence_length,
+        &label_count
+    );
+    if (status != OPENMED_STATUS_OK) {
+        if (openmed_error[0] == '\0') {
+            set_error("the ONNX token-classification session failed");
+        }
+        return status;
+    }
+    if (logits == NULL) {
+        set_error("the ONNX token-classification session returned no logits");
+        return OPENMED_STATUS_INVALID_OUTPUT;
+    }
+    status = decode_logits(
+        runtime,
+        text,
+        batch,
+        logits,
+        sequence_length,
+        label_count,
+        threshold,
+        spans
+    );
+    if (runtime->fixture_session) {
+        free(logits);
+    } else {
+        runtime->session_api.release_logits(runtime->session, logits);
+    }
+    if (status != OPENMED_STATUS_OK) {
+        openmed_span_list_free(spans);
+        return status;
+    }
+    set_error(NULL);
+    return OPENMED_STATUS_OK;
+}
+
+openmed_status openmed_runtime_deidentify(
+    openmed_runtime *runtime,
+    const char *text,
+    const openmed_token_batch *batch,
+    double threshold,
+    char **deidentified_text,
+    openmed_span_list *spans
+) {
+    openmed_status status;
+    size_t source_bytes;
+    size_t output_bytes;
+    size_t prior_character = 0;
+    size_t output_offset = 0;
+    size_t index;
+    char *output;
+    if (deidentified_text == NULL) {
+        set_error("de-identified text output is required");
+        return OPENMED_STATUS_INVALID_ARGUMENT;
+    }
+    *deidentified_text = NULL;
+    status = openmed_runtime_extract_pii(
+        runtime,
+        text,
+        batch,
+        threshold,
+        spans
+    );
+    if (status != OPENMED_STATUS_OK) {
+        return status;
+    }
+    source_bytes = strlen(text);
+    output_bytes = source_bytes;
+    for (index = 0; index < spans->count; ++index) {
+        size_t start_byte;
+        size_t end_byte;
+        size_t replacement_bytes = strlen(spans->items[index].label) + 2;
+        if ((size_t)spans->items[index].start < prior_character) {
+            openmed_span_list_free(spans);
+            set_error("decoded spans overlap or are not ordered");
+            return OPENMED_STATUS_INVALID_OUTPUT;
+        }
+        start_byte = utf8_byte_offset(text, (size_t)spans->items[index].start);
+        end_byte = utf8_byte_offset(text, (size_t)spans->items[index].end);
+        output_bytes = output_bytes - (end_byte - start_byte) + replacement_bytes;
+        prior_character = (size_t)spans->items[index].end;
+    }
+    output = (char *)malloc(output_bytes + 1);
+    if (output == NULL) {
+        openmed_span_list_free(spans);
+        set_error("could not allocate de-identified output");
+        return OPENMED_STATUS_OUT_OF_MEMORY;
+    }
+    prior_character = 0;
+    for (index = 0; index < spans->count; ++index) {
+        size_t prior_byte = utf8_byte_offset(text, prior_character);
+        size_t start_byte = utf8_byte_offset(
+            text,
+            (size_t)spans->items[index].start
+        );
+        size_t prefix_bytes = start_byte - prior_byte;
+        size_t label_bytes = strlen(spans->items[index].label);
+        memcpy(output + output_offset, text + prior_byte, prefix_bytes);
+        output_offset += prefix_bytes;
+        output[output_offset++] = '[';
+        memcpy(output + output_offset, spans->items[index].label, label_bytes);
+        output_offset += label_bytes;
+        output[output_offset++] = ']';
+        prior_character = (size_t)spans->items[index].end;
+    }
+    {
+        size_t prior_byte = utf8_byte_offset(text, prior_character);
+        size_t suffix_bytes = source_bytes - prior_byte;
+        memcpy(output + output_offset, text + prior_byte, suffix_bytes);
+        output_offset += suffix_bytes;
+    }
+    output[output_offset] = '\0';
+    *deidentified_text = output;
+    return OPENMED_STATUS_OK;
+}
+
+void openmed_span_list_free(openmed_span_list *spans) {
+    size_t index;
+    if (spans == NULL) {
+        return;
+    }
+    for (index = 0; index < spans->count; ++index) {
+        free(spans->items[index].label);
+    }
+    free(spans->items);
+    spans->items = NULL;
+    spans->count = 0;
+}
+
+void openmed_string_free(char *value) {
+    free(value);
+}
+
+const char *openmed_last_error(void) {
+    return openmed_error;
+}

--- a/js/openmedkit-flutter/native/openmed_ffi.h
+++ b/js/openmedkit-flutter/native/openmed_ffi.h
@@ -1,0 +1,124 @@
+#ifndef OPENMED_FFI_H
+#define OPENMED_FFI_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(_WIN32)
+#if defined(OPENMED_FFI_BUILDING_LIBRARY)
+#define OPENMED_FFI_API __declspec(dllexport)
+#else
+#define OPENMED_FFI_API __declspec(dllimport)
+#endif
+#else
+#define OPENMED_FFI_API __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OPENMED_FFI_ABI_VERSION 1
+
+typedef enum openmed_status {
+    OPENMED_STATUS_OK = 0,
+    OPENMED_STATUS_INVALID_ARGUMENT = 1,
+    OPENMED_STATUS_OUT_OF_MEMORY = 2,
+    OPENMED_STATUS_RUNTIME_UNAVAILABLE = 3,
+    OPENMED_STATUS_INFERENCE_FAILED = 4,
+    OPENMED_STATUS_INVALID_OUTPUT = 5
+} openmed_status;
+
+typedef struct openmed_runtime openmed_runtime;
+
+typedef struct openmed_span {
+    int64_t start;
+    int64_t end;
+    double score;
+    char *label;
+} openmed_span;
+
+typedef struct openmed_span_list {
+    openmed_span *items;
+    size_t count;
+} openmed_span_list;
+
+typedef struct openmed_token_batch {
+    const int64_t *input_ids;
+    const int64_t *attention_mask;
+    const int64_t *start_offsets;
+    const int64_t *end_offsets;
+    size_t token_count;
+} openmed_token_batch;
+
+/*
+ * Native ONNX Runtime adapters register this narrow session interface once at
+ * process start. The adapter owns its session and logits allocations; the shim
+ * owns decoding, span allocation, and de-identification.
+ */
+typedef struct openmed_session_api {
+    uint32_t abi_version;
+    void *(*create)(
+        const char *model_path,
+        const char *const *labels,
+        size_t label_count,
+        char *error,
+        size_t error_capacity
+    );
+    openmed_status (*run)(
+        void *session,
+        const openmed_token_batch *batch,
+        float **logits,
+        size_t *sequence_length,
+        size_t *label_count,
+        char *error,
+        size_t error_capacity
+    );
+    void (*release_logits)(void *session, float *logits);
+    void (*destroy)(void *session);
+} openmed_session_api;
+
+OPENMED_FFI_API uint32_t openmed_ffi_abi_version(void);
+
+OPENMED_FFI_API openmed_status openmed_register_session_api(
+    const openmed_session_api *api
+);
+
+OPENMED_FFI_API openmed_status openmed_runtime_create(
+    const char *model_path,
+    const char *const *labels,
+    size_t label_count,
+    openmed_runtime **runtime
+);
+
+OPENMED_FFI_API void openmed_runtime_destroy(openmed_runtime *runtime);
+
+OPENMED_FFI_API openmed_status openmed_runtime_extract_pii(
+    openmed_runtime *runtime,
+    const char *text,
+    const openmed_token_batch *batch,
+    double threshold,
+    openmed_span_list *spans
+);
+
+OPENMED_FFI_API openmed_status openmed_runtime_deidentify(
+    openmed_runtime *runtime,
+    const char *text,
+    const openmed_token_batch *batch,
+    double threshold,
+    char **deidentified_text,
+    openmed_span_list *spans
+);
+
+OPENMED_FFI_API void openmed_span_list_free(openmed_span_list *spans);
+
+OPENMED_FFI_API void openmed_string_free(char *value);
+
+/* The returned message never contains source note text. */
+OPENMED_FFI_API const char *openmed_last_error(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/js/openmedkit-flutter/pubspec.yaml
+++ b/js/openmedkit-flutter/pubspec.yaml
@@ -1,0 +1,34 @@
+name: openmedkit_flutter
+description: Local-first Flutter FFI bindings for OpenMed token classification.
+version: 0.1.0
+homepage: https://github.com/maziyarpanahi/openmed
+repository: https://github.com/maziyarpanahi/openmed
+publish_to: none
+
+environment:
+  sdk: ">=2.14.0 <4.0.0"
+  flutter: ">=2.5.0"
+
+dependencies:
+  ffi: ">=1.1.2 <3.0.0"
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: org.openmed.openmedkit.flutter
+        pluginClass: OpenMedKitFlutterPlugin
+      ios:
+        pluginClass: OpenMedKitFlutterPlugin
+      linux:
+        pluginClass: OpenMedKitFlutterPlugin
+      macos:
+        pluginClass: OpenMedKitFlutterPlugin
+      windows:
+        pluginClass: OpenMedKitFlutterPlugin

--- a/js/openmedkit-flutter/test/openmedkit_ffi_test.dart
+++ b/js/openmedkit-flutter/test/openmedkit_ffi_test.dart
@@ -1,0 +1,3 @@
+import '../../../tests/mobile/test_flutter_ffi.dart' as ffi_test;
+
+void main() => ffi_test.main();

--- a/js/openmedkit-flutter/windows/CMakeLists.txt
+++ b/js/openmedkit-flutter/windows/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.14)
+set(PROJECT_NAME "openmedkit_flutter")
+project(${PROJECT_NAME} LANGUAGES C CXX)
+
+set(PLUGIN_NAME "openmedkit_flutter_plugin")
+
+add_library(${PLUGIN_NAME} SHARED
+  "open_med_kit_flutter_plugin.cpp"
+)
+apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden
+)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+
+add_subdirectory(
+  "${CMAKE_CURRENT_SOURCE_DIR}/../native"
+  "${CMAKE_CURRENT_BINARY_DIR}/openmed_ffi"
+)
+target_link_libraries(${PLUGIN_NAME} PRIVATE openmed_ffi)
+
+set(openmedkit_flutter_bundled_libraries
+  "$<TARGET_FILE:openmed_ffi>"
+  PARENT_SCOPE
+)

--- a/js/openmedkit-flutter/windows/include/openmedkit_flutter/open_med_kit_flutter_plugin.h
+++ b/js/openmedkit-flutter/windows/include/openmedkit_flutter/open_med_kit_flutter_plugin.h
@@ -1,0 +1,39 @@
+#ifndef FLUTTER_PLUGIN_OPEN_MED_KIT_FLUTTER_PLUGIN_H_
+#define FLUTTER_PLUGIN_OPEN_MED_KIT_FLUTTER_PLUGIN_H_
+
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar_windows.h>
+
+#include <memory>
+
+#if defined(FLUTTER_PLUGIN_IMPL)
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllimport)
+#endif
+
+namespace openmedkit_flutter {
+
+class OpenMedKitFlutterPlugin : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar);
+
+  OpenMedKitFlutterPlugin();
+  ~OpenMedKitFlutterPlugin() override;
+
+  OpenMedKitFlutterPlugin(const OpenMedKitFlutterPlugin&) = delete;
+  OpenMedKitFlutterPlugin& operator=(const OpenMedKitFlutterPlugin&) = delete;
+
+ private:
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue>& method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+};
+
+}  // namespace openmedkit_flutter
+
+extern "C" FLUTTER_PLUGIN_EXPORT void
+OpenMedKitFlutterPluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar);
+
+#endif

--- a/js/openmedkit-flutter/windows/open_med_kit_flutter_plugin.cpp
+++ b/js/openmedkit-flutter/windows/open_med_kit_flutter_plugin.cpp
@@ -1,0 +1,78 @@
+#include "include/openmedkit_flutter/open_med_kit_flutter_plugin.h"
+
+#include <flutter/standard_method_codec.h>
+
+#include <filesystem>
+#include <string>
+
+namespace openmedkit_flutter {
+
+namespace {
+
+constexpr char kChannelName[] = "org.openmed.openmedkit_flutter/platform";
+
+}  // namespace
+
+OpenMedKitFlutterPlugin::OpenMedKitFlutterPlugin() = default;
+
+OpenMedKitFlutterPlugin::~OpenMedKitFlutterPlugin() = default;
+
+void OpenMedKitFlutterPlugin::RegisterWithRegistrar(
+    flutter::PluginRegistrarWindows* registrar) {
+  auto channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+      registrar->messenger(),
+      kChannelName,
+      &flutter::StandardMethodCodec::GetInstance());
+  auto plugin = std::make_unique<OpenMedKitFlutterPlugin>();
+  channel->SetMethodCallHandler(
+      [plugin_pointer = plugin.get()](const auto& call, auto result) {
+        plugin_pointer->HandleMethodCall(call, std::move(result));
+      });
+  registrar->AddPlugin(std::move(plugin));
+}
+
+void OpenMedKitFlutterPlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue>& method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  if (method_call.method_name() != "prepareModel") {
+    result->NotImplemented();
+    return;
+  }
+  const auto* arguments = std::get_if<flutter::EncodableMap>(
+      method_call.arguments());
+  if (arguments == nullptr) {
+    result->Error(
+        "invalid_model_directory",
+        "A local model directory is required.");
+    return;
+  }
+  const auto iterator = arguments->find(
+      flutter::EncodableValue("modelDirectory"));
+  const auto* path_value = iterator == arguments->end()
+      ? nullptr
+      : std::get_if<std::string>(&iterator->second);
+  if (path_value == nullptr || path_value->empty() ||
+      path_value->find("://") != std::string::npos) {
+    result->Error(
+        "invalid_model_directory",
+        "A local model directory is required.");
+    return;
+  }
+  const std::filesystem::path path = std::filesystem::absolute(*path_value);
+  if (!std::filesystem::is_directory(path)) {
+    result->Error(
+        "model_directory_missing",
+        "The local model directory is unavailable.");
+    return;
+  }
+  result->Success(flutter::EncodableValue(path.u8string()));
+}
+
+}  // namespace openmedkit_flutter
+
+void OpenMedKitFlutterPluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  openmedkit_flutter::OpenMedKitFlutterPlugin::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+}

--- a/tests/mobile/fixtures/flutter_ffi_golden.json
+++ b/tests/mobile/fixtures/flutter_ffi_golden.json
@@ -1,0 +1,27 @@
+{
+  "format": "openmed-flutter-ffi-golden",
+  "version": 1,
+  "text": "Patient Alice Nguyen was born on 1979-04-12. Email alice@example.org.",
+  "deidentified_text": "Patient [PERSON] was born on [DATE_OF_BIRTH]. Email [EMAIL].",
+  "score_tolerance": 0.02,
+  "spans": [
+    {
+      "start": 8,
+      "end": 20,
+      "label": "PERSON",
+      "score": 0.98
+    },
+    {
+      "start": 33,
+      "end": 43,
+      "label": "DATE_OF_BIRTH",
+      "score": 0.98
+    },
+    {
+      "start": 51,
+      "end": 68,
+      "label": "EMAIL",
+      "score": 0.98
+    }
+  ]
+}

--- a/tests/mobile/test_flutter_ffi.dart
+++ b/tests/mobile/test_flutter_ffi.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openmedkit_flutter/openmedkit.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const MethodChannel channel = MethodChannel(openMedKitFlutterChannelName);
+  late Directory modelDirectory;
+
+  setUp(() async {
+    modelDirectory = await Directory.systemTemp.createTemp(
+      'openmed-flutter-ffi-model-',
+    );
+    await File(
+      '${modelDirectory.path}${Platform.pathSeparator}model_int8.onnx',
+    ).writeAsBytes(<int>[0]);
+    await File(
+      '${modelDirectory.path}${Platform.pathSeparator}id2label.json',
+    ).writeAsString(
+      jsonEncode(<String, String>{
+        '0': 'O',
+        '1': 'B-PERSON',
+        '2': 'B-DATE_OF_BIRTH',
+        '3': 'B-EMAIL',
+      }),
+    );
+    channel.setMockMethodCallHandler((MethodCall call) async {
+      expect(call.method, 'prepareModel');
+      return modelDirectory.absolute.path;
+    });
+  });
+
+  tearDown(() async {
+    channel.setMockMethodCallHandler(null);
+    await modelDirectory.delete(recursive: true);
+  });
+
+  test('deidentifies a synthetic note and matches the committed golden', () async {
+    final File goldenFile = File(
+      '${Directory.current.path}${Platform.pathSeparator}..${Platform.pathSeparator}..'
+      '${Platform.pathSeparator}tests${Platform.pathSeparator}mobile'
+      '${Platform.pathSeparator}fixtures${Platform.pathSeparator}flutter_ffi_golden.json',
+    );
+    final Map<String, dynamic> golden =
+        jsonDecode(await goldenFile.readAsString()) as Map<String, dynamic>;
+    final String text = golden['text'] as String;
+    final String? libraryPath = Platform.environment['OPENMED_FFI_LIBRARY'];
+    expect(
+      libraryPath,
+      isNotNull,
+      reason: 'the native fixture library is required',
+    );
+
+    final List<String> output = <String>[];
+    final DebugPrintCallback previousDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) {
+        output.add(message);
+      }
+    };
+
+    OpenMedKit? runtime;
+    try {
+      await runZoned(
+        () async {
+          runtime = await OpenMedKit.loadModel(
+            modelDirectory: modelDirectory.path,
+            tokenizer: _fixtureTokenizer,
+            nativeLibraryPath: libraryPath,
+            platformChannel: channel,
+          );
+          final List<OpenMedSpan> extracted = await runtime!.extractPii(text);
+          final OpenMedDeidentificationResult result = await runtime!
+              .deidentify(text);
+
+          expect(result.deidentifiedText, golden['deidentified_text']);
+          _expectSpansMatchGolden(
+            extracted,
+            golden['spans'] as List<dynamic>,
+            golden['score_tolerance'] as double,
+          );
+          _expectSpansMatchGolden(
+            result.spans,
+            golden['spans'] as List<dynamic>,
+            golden['score_tolerance'] as double,
+          );
+
+          final String serialized = jsonEncode(result.toJson());
+          for (final String fragment in <String>[
+            'Alice Nguyen',
+            '1979-04-12',
+            'alice@example.org',
+          ]) {
+            expect(serialized, isNot(contains(fragment)));
+          }
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
+            output.add(line);
+          },
+        ),
+      );
+      expect(
+        output,
+        isEmpty,
+        reason: 'raw PHI must never be written to Dart logs',
+      );
+    } finally {
+      runtime?.close();
+      debugPrint = previousDebugPrint;
+    }
+  });
+
+  test('rejects remote model paths before invoking platform code', () async {
+    expect(
+      () => OpenMedKit.loadModel(
+        modelDirectory: 'https://example.invalid/model',
+        tokenizer: _fixtureTokenizer,
+        platformChannel: channel,
+      ),
+      throwsArgumentError,
+    );
+  });
+}
+
+OpenMedTokenBatch _fixtureTokenizer(String text) {
+  expect(
+    text,
+    'Patient Alice Nguyen was born on 1979-04-12. Email alice@example.org.',
+  );
+  return OpenMedTokenBatch(
+    inputIds: const <int>[101, 1001, 1002, 1003, 102],
+    attentionMask: const <int>[1, 1, 1, 1, 1],
+    offsets: const <OpenMedTokenOffset>[
+      OpenMedTokenOffset(0, 0),
+      OpenMedTokenOffset(8, 20),
+      OpenMedTokenOffset(33, 43),
+      OpenMedTokenOffset(51, 68),
+      OpenMedTokenOffset(0, 0),
+    ],
+  );
+}
+
+void _expectSpansMatchGolden(
+  List<OpenMedSpan> actual,
+  List<dynamic> expected,
+  double tolerance,
+) {
+  expect(actual, hasLength(expected.length));
+  for (int index = 0; index < expected.length; ++index) {
+    final Map<String, dynamic> golden = expected[index] as Map<String, dynamic>;
+    expect(actual[index].start, golden['start']);
+    expect(actual[index].end, golden['end']);
+    expect(actual[index].label, golden['label']);
+    expect(actual[index].score, closeTo(golden['score'] as double, tolerance));
+  }
+}

--- a/tests/mobile/test_flutter_ffi.py
+++ b/tests/mobile/test_flutter_ffi.py
@@ -1,0 +1,77 @@
+"""Pytest bridge for the OpenMedKit Flutter FFI package checks."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_DIR = ROOT / "js" / "openmedkit-flutter"
+
+
+def test_openmedkit_flutter_ffi_package(tmp_path: Path) -> None:
+    flutter = shutil.which("flutter")
+    cmake = shutil.which("cmake")
+    if flutter is None or cmake is None:
+        pytest.skip("Flutter and CMake are required for OpenMedKit Flutter checks")
+
+    build_dir = tmp_path / "native"
+    configure = [
+        cmake,
+        "-S",
+        str(PACKAGE_DIR / "native"),
+        "-B",
+        str(build_dir),
+        "-DOPENMED_FFI_ENABLE_TEST_SESSION=ON",
+        "-DCMAKE_BUILD_TYPE=Release",
+    ]
+    if platform.system() == "Darwin":
+        configure.append("-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64")
+    _run(configure, cwd=ROOT)
+    _run([cmake, "--build", str(build_dir), "--config", "Release"], cwd=ROOT)
+
+    library = _find_native_library(build_dir)
+    environment = os.environ.copy()
+    environment["OPENMED_FFI_LIBRARY"] = str(library)
+    environment["OPENMED_FFI_TEST_SESSION"] = "1"
+    _run([flutter, "pub", "get"], cwd=PACKAGE_DIR, env=environment)
+    _run(
+        [flutter, "test", "test/openmedkit_ffi_test.dart"],
+        cwd=PACKAGE_DIR,
+        env=environment,
+    )
+
+
+def _find_native_library(build_dir: Path) -> Path:
+    candidates = [
+        *build_dir.rglob("libopenmed_ffi.dylib"),
+        *build_dir.rglob("libopenmed_ffi.so"),
+        *build_dir.rglob("openmed_ffi.dll"),
+    ]
+    assert len(candidates) == 1, f"expected one native FFI library, got {candidates}"
+    return candidates[0]
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> None:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert completed.returncode == 0, completed.stdout


### PR DESCRIPTION
# Pull Request

## Description

Adds a local-first cross-platform FFI plugin for on-device token classification and de-identification. The native layer loads model assets from local directories, returns typed spans without matched source text, and exposes the same contract across mobile and desktop targets.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add a narrow native C ABI over the token-classification session with typed span allocation, masking, and de-identification.
- Add local model preparation and platform registration for Android, iOS, Linux, macOS, and Windows.
- Add typed FFI bindings, a synthetic golden fixture, malformed-input coverage, privacy-safe log assertions, and a redaction widget example.
- Rebase the adopted implementation onto current master and harden Unicode/NUL/offset and model-path validation.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Validation completed:

- Synthetic native build and focused FFI test — passed (4 cases)
- Focused Python bridge test — passed (1 test)
- Package analysis and changed-file formatting/lint checks — passed
- C warnings-as-errors syntax check and workflow YAML parse — passed
- Mobile and desktop consumer build jobs are defined in CI; broad platform-matrix execution remains CI-owned

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality

- [x] I performed a self-review of the implementation
- [x] The changed native code is warning-clean
- [x] The focused validation commands are recorded above

## Dependencies

- [ ] I have not added any new dependencies
- [x] The native inference runtime linkage is required for supported local model targets.

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have organized the adopted implementation and follow-up fix commits.

## Related Issues

Closes #822
