### PR TITLE
Add Electron in-process de-identification integration

### DIFF
--- a/docs/runtimes/electron.md
+++ b/docs/runtimes/electron.md
@@ -1,0 +1,71 @@
+# Electron In-Process De-identification
+
+OpenMed's Electron reference integration keeps inference off the main and
+renderer threads without sending a clinical note to a server. The renderer
+sends text over a single typed IPC channel, the main process forwards it to one
+Electron utility process, and the renderer receives only this projection of an
+`OpenMedSpan`:
+
+```ts
+type RendererOpenMedSpan = Pick<
+  OpenMedSpan,
+  | "schema_version"
+  | "start"
+  | "end"
+  | "entity_type"
+  | "canonical_label"
+  | "policy_label"
+  | "score"
+>;
+```
+
+Raw text, hashes, detector evidence, metadata, and model errors are not returned
+to the renderer. Redaction is applied locally from the returned offsets and
+canonical labels.
+
+## Integration
+
+The reference package lives in `js/openmedkit-electron`. Its main pieces are:
+
+- `ElectronDeidentifyService`, a lazily started utility-process owner
+- `registerElectronDeidentifyIpc`, the main-process handler
+- `createElectronDeidentifyClient`, the preload/renderer contract
+- `utility-process`, the worker entrypoint to bundle with the Electron app
+
+Create exactly one service after `app.whenReady()` and register it with the
+application's `ipcMain`. Point `workerPath` at the bundled utility entrypoint and
+`modelPath` at an absolute, pre-populated local model directory. See the
+[complete copy/paste example](https://github.com/maziyarpanahi/openmed/blob/master/examples/electron/redact-app.md).
+
+## Offline and cache behavior
+
+The utility process starts with `HF_HUB_OFFLINE=1` and
+`TRANSFORMERS_OFFLINE=1`, disables Fetch, Node HTTP(S), and raw socket entry
+points, and calls the OpenMed npm loader with both `localFilesOnly: true` and
+`allowRemoteModels: false`.
+Remote model identifiers and runtime downloads therefore fail closed.
+
+Pipelines are cached by absolute model path inside the utility process. Because
+the main-process service owns one worker for the whole app, all windows reuse
+the same loaded pipeline. A failed load is evicted so a repaired local cache can
+be retried without restarting the app.
+
+Populate the model directory during installation or through an explicit,
+non-PHI setup flow before inference. Model download and update UX is outside the
+request path and should never receive clinical text.
+
+## Logging and renderer hardening
+
+Use `contextIsolation: true` and `nodeIntegration: false`, and expose only the
+typed client through the preload bridge. The utility process uses ignored
+standard streams. Its error responses contain fixed error codes instead of raw
+exception text, which may include input or local paths.
+
+If a logger is supplied to `ElectronDeidentifyService`, it receives fixed event
+names plus a span count or safe error code. Do not add request text, IPC payloads,
+model outputs, or exception messages to main- or renderer-process logs.
+
+The Node test harness uses the committed synthetic npm golden, exercises two
+renderer clients against one service, traps all Fetch and HTTP(S) calls during
+inference, verifies pipeline reuse, and asserts that neither process log capture
+contains any synthetic identifier.

--- a/examples/electron/redact-app.md
+++ b/examples/electron/redact-app.md
@@ -1,0 +1,98 @@
+# Synthetic Electron redaction app
+
+This reference keeps the raw synthetic note inside the renderer that owns it,
+runs inference in one shared Electron utility process, and sends only span
+offsets, labels, and confidence scores back across IPC. Use `contextIsolation`
+and keep Node integration disabled in the renderer.
+
+Install the public de-identification package, build the repository integration,
+and add it as a workspace or local package:
+
+```bash
+npm install openmed electron
+npm --prefix ../openmed/js/openmedkit-electron ci
+npm --prefix ../openmed/js/openmedkit-electron run build
+npm install ../openmed/js/openmedkit-electron
+```
+
+Bundle `@openmed/openmedkit-electron/utility-process` as
+`openmed-utility-process.cjs` with the app's main-process build. The model cache
+must already contain a local Transformers.js export.
+
+## Main process
+
+```ts
+import { app, BrowserWindow, ipcMain, utilityProcess } from "electron/main";
+import { join } from "node:path";
+import {
+  ElectronDeidentifyService,
+  registerElectronDeidentifyIpc,
+} from "@openmed/openmedkit-electron";
+
+await app.whenReady();
+
+const service = new ElectronDeidentifyService({
+  utilityProcess,
+  workerPath: join(__dirname, "openmed-utility-process.cjs"),
+  modelPath: join(
+    app.getPath("userData"),
+    "openmed",
+    "models",
+    "privacy-filter-transformersjs",
+  ),
+});
+const unregister = registerElectronDeidentifyIpc(ipcMain, service);
+
+const window = new BrowserWindow({
+  webPreferences: {
+    contextIsolation: true,
+    nodeIntegration: false,
+    preload: join(__dirname, "preload.cjs"),
+  },
+});
+await window.loadFile("index.html");
+
+app.once("before-quit", () => {
+  unregister();
+  service.dispose();
+});
+```
+
+Create the service once, outside the window factory. Every window then shares
+the same utility process and its in-memory pipeline cache.
+
+## Preload
+
+```ts
+import { contextBridge, ipcRenderer } from "electron/renderer";
+import { createElectronDeidentifyClient } from "@openmed/openmedkit-electron";
+
+contextBridge.exposeInMainWorld(
+  "openmed",
+  createElectronDeidentifyClient(ipcRenderer),
+);
+```
+
+## Renderer
+
+```ts
+import { redactTextWithSpans } from "@openmed/openmedkit-electron";
+
+const note =
+  "Patient Alice Nguyen, DOB 1979-04-12, email alice@example.org.";
+const result = await window.openmed.deidentify(note);
+document.querySelector("#redacted")!.textContent = redactTextWithSpans(
+  note,
+  result.spans,
+);
+```
+
+The rendered output is:
+
+```text
+Patient [PERSON], DOB [DATE_OF_BIRTH], email [EMAIL].
+```
+
+Do not log the request, the source note, rejected inference values, or model
+errors. The service logger emits only fixed event names, safe error codes, and
+span counts.

--- a/js/openmedkit-electron/package-lock.json
+++ b/js/openmedkit-electron/package-lock.json
@@ -1,0 +1,1558 @@
+{
+  "name": "@openmed/openmedkit-electron",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openmed/openmedkit-electron",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "tsup": "^8.3.5",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "electron": ">=30",
+        "openmed": ">=1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "electron": {
+          "optional": true
+        },
+        "openmed": {
+          "optional": true
+        }
+      }
+    },
+    "../openmedkit-web": {
+      "name": "openmed",
+      "version": "1.9.1",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "tsup": "^8.3.5",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@huggingface/transformers": ">=3.0.0",
+        "onnxruntime-web": ">=1.20.0"
+      },
+      "peerDependenciesMeta": {
+        "@huggingface/transformers": {
+          "optional": true
+        },
+        "onnxruntime-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openmed": {
+      "resolved": "../openmedkit-web",
+      "link": true
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/js/openmedkit-electron/package.json
+++ b/js/openmedkit-electron/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@openmed/openmedkit-electron",
+  "version": "0.1.0",
+  "description": "Privacy-safe Electron integration for OpenMed de-identification.",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./utility-process": {
+      "import": {
+        "types": "./dist/utility-process.d.ts",
+        "default": "./dist/utility-process.js"
+      },
+      "require": {
+        "types": "./dist/utility-process.d.cts",
+        "default": "./dist/utility-process.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup src/index.ts src/utility-process.ts --format esm,cjs --dts --sourcemap --clean --out-dir dist",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && npm run typecheck && npm run test:node",
+    "test:node": "tsx --test ../../tests/web/test_electron_ipc.spec.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsup": "^8.3.5",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  },
+  "peerDependencies": {
+    "electron": ">=30",
+    "openmed": ">=1.9.0"
+  },
+  "peerDependenciesMeta": {
+    "electron": {
+      "optional": true
+    },
+    "openmed": {
+      "optional": true
+    }
+  },
+  "overrides": {
+    "esbuild": "0.28.1"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "Apache-2.0"
+}

--- a/js/openmedkit-electron/src/index.ts
+++ b/js/openmedkit-electron/src/index.ts
@@ -1,0 +1,20 @@
+export {
+  ElectronDeidentifyService,
+  type ElectronDeidentifyServiceEvent,
+  type ElectronDeidentifyServiceOptions,
+  type UtilityProcessLike,
+  type UtilityProcessModuleLike,
+} from "./main-service";
+export {
+  OPENMED_DEIDENTIFY_CHANNEL,
+  OPENMED_ELECTRON_SCHEMA_VERSION,
+  createElectronDeidentifyClient,
+  redactTextWithSpans,
+  registerElectronDeidentifyIpc,
+  type ElectronDeidentifyRequest,
+  type ElectronDeidentifyResponse,
+  type ElectronDeidentifyServiceLike,
+  type IpcMainLike,
+  type IpcRendererLike,
+  type RendererOpenMedSpan,
+} from "./ipc";

--- a/js/openmedkit-electron/src/ipc.ts
+++ b/js/openmedkit-electron/src/ipc.ts
@@ -1,0 +1,221 @@
+import type { OpenMedSpan } from "openmed";
+
+export const OPENMED_DEIDENTIFY_CHANNEL = "openmed:deidentify" as const;
+export const OPENMED_ELECTRON_SCHEMA_VERSION = 1 as const;
+
+const MAX_REQUEST_ID_LENGTH = 80;
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+let rendererRequestSequence = 0;
+
+export type RendererOpenMedSpan = Pick<
+  OpenMedSpan,
+  | "schema_version"
+  | "start"
+  | "end"
+  | "entity_type"
+  | "canonical_label"
+  | "policy_label"
+  | "score"
+>;
+
+export interface ElectronDeidentifyRequest {
+  schemaVersion: typeof OPENMED_ELECTRON_SCHEMA_VERSION;
+  requestId: string;
+  text: string;
+}
+
+export interface ElectronDeidentifyResponse {
+  schemaVersion: typeof OPENMED_ELECTRON_SCHEMA_VERSION;
+  requestId: string;
+  spans: RendererOpenMedSpan[];
+}
+
+export interface UtilityDeidentifyRequest extends ElectronDeidentifyRequest {
+  type: "deidentify";
+  modelPath: string;
+}
+
+export interface UtilityDeidentifySuccess {
+  type: "deidentify-result";
+  requestId: string;
+  ok: true;
+  spans: RendererOpenMedSpan[];
+}
+
+export interface UtilityDeidentifyFailure {
+  type: "deidentify-result";
+  requestId: string;
+  ok: false;
+  errorCode: "INVALID_REQUEST" | "INFERENCE_FAILED";
+}
+
+export type UtilityDeidentifyResponse =
+  | UtilityDeidentifySuccess
+  | UtilityDeidentifyFailure;
+
+export interface IpcMainLike {
+  handle(
+    channel: string,
+    listener: (event: unknown, request: unknown) => Promise<unknown> | unknown,
+  ): void;
+  removeHandler(channel: string): void;
+}
+
+export interface IpcRendererLike {
+  invoke(channel: string, request: unknown): Promise<unknown>;
+}
+
+export interface ElectronDeidentifyServiceLike {
+  deidentify(request: ElectronDeidentifyRequest): Promise<ElectronDeidentifyResponse>;
+}
+
+export function createElectronDeidentifyClient(ipcRenderer: IpcRendererLike): {
+  deidentify(text: string): Promise<ElectronDeidentifyResponse>;
+} {
+  return {
+    async deidentify(text: string): Promise<ElectronDeidentifyResponse> {
+      const request: ElectronDeidentifyRequest = {
+        schemaVersion: OPENMED_ELECTRON_SCHEMA_VERSION,
+        requestId: nextRendererRequestId(),
+        text,
+      };
+      const response = await ipcRenderer.invoke(OPENMED_DEIDENTIFY_CHANNEL, request);
+      assertElectronDeidentifyResponse(response, request.requestId);
+      return {
+        schemaVersion: response.schemaVersion,
+        requestId: response.requestId,
+        spans: response.spans.map(toRendererOpenMedSpan),
+      };
+    },
+  };
+}
+
+export function registerElectronDeidentifyIpc(
+  ipcMain: IpcMainLike,
+  service: ElectronDeidentifyServiceLike,
+): () => void {
+  ipcMain.handle(OPENMED_DEIDENTIFY_CHANNEL, async (_event, request) => {
+    assertElectronDeidentifyRequest(request);
+    return service.deidentify(request);
+  });
+  return () => ipcMain.removeHandler(OPENMED_DEIDENTIFY_CHANNEL);
+}
+
+export function toRendererOpenMedSpan(
+  span: RendererOpenMedSpan,
+): RendererOpenMedSpan {
+  return {
+    schema_version: span.schema_version,
+    start: span.start,
+    end: span.end,
+    entity_type: span.entity_type,
+    canonical_label: span.canonical_label,
+    policy_label: span.policy_label,
+    score: span.score,
+  };
+}
+
+export function redactTextWithSpans(
+  text: string,
+  spans: readonly RendererOpenMedSpan[],
+): string {
+  let redacted = text;
+  for (const span of [...spans].sort((left, right) => right.start - left.start)) {
+    if (span.start < 0 || span.end < span.start || span.end > text.length) {
+      throw new Error("OpenMed returned an invalid renderer span.");
+    }
+    redacted =
+      redacted.slice(0, span.start) +
+      `[${span.canonical_label}]` +
+      redacted.slice(span.end);
+  }
+  return redacted;
+}
+
+export function assertElectronDeidentifyRequest(
+  request: unknown,
+  maxTextLength = 1_000_000,
+): asserts request is ElectronDeidentifyRequest {
+  if (!isRecord(request)) {
+    throw new TypeError("Invalid OpenMed Electron request.");
+  }
+  if (request.schemaVersion !== OPENMED_ELECTRON_SCHEMA_VERSION) {
+    throw new TypeError("Unsupported OpenMed Electron schema version.");
+  }
+  if (
+    typeof request.requestId !== "string" ||
+    request.requestId.length === 0 ||
+    request.requestId.length > MAX_REQUEST_ID_LENGTH ||
+    !REQUEST_ID_PATTERN.test(request.requestId)
+  ) {
+    throw new TypeError("Invalid OpenMed Electron request identifier.");
+  }
+  if (
+    typeof request.text !== "string" ||
+    request.text.length === 0 ||
+    request.text.length > maxTextLength
+  ) {
+    throw new TypeError("Invalid OpenMed Electron request text.");
+  }
+}
+
+export function isUtilityDeidentifyResponse(
+  response: unknown,
+): response is UtilityDeidentifyResponse {
+  if (
+    !isRecord(response) ||
+    response.type !== "deidentify-result" ||
+    typeof response.requestId !== "string" ||
+    typeof response.ok !== "boolean"
+  ) {
+    return false;
+  }
+  return response.ok
+    ? Array.isArray(response.spans) && response.spans.every(isRendererOpenMedSpan)
+    : response.errorCode === "INVALID_REQUEST" ||
+        response.errorCode === "INFERENCE_FAILED";
+}
+
+function assertElectronDeidentifyResponse(
+  response: unknown,
+  requestId: string,
+): asserts response is ElectronDeidentifyResponse {
+  if (
+    !isRecord(response) ||
+    response.schemaVersion !== OPENMED_ELECTRON_SCHEMA_VERSION ||
+    response.requestId !== requestId ||
+    !Array.isArray(response.spans) ||
+    !response.spans.every(isRendererOpenMedSpan)
+  ) {
+    throw new TypeError("Invalid OpenMed Electron response.");
+  }
+}
+
+function isRendererOpenMedSpan(value: unknown): value is RendererOpenMedSpan {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    value.schema_version === 1 &&
+    Number.isInteger(value.start) &&
+    Number.isInteger(value.end) &&
+    typeof value.entity_type === "string" &&
+    typeof value.canonical_label === "string" &&
+    typeof value.policy_label === "string" &&
+    (value.score === null ||
+      (typeof value.score === "number" && Number.isFinite(value.score)))
+  );
+}
+
+function nextRendererRequestId(): string {
+  const randomUuid = globalThis.crypto?.randomUUID?.();
+  if (randomUuid) {
+    return `renderer-${randomUuid}`;
+  }
+  rendererRequestSequence += 1;
+  return `renderer-${Date.now()}-${rendererRequestSequence}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/js/openmedkit-electron/src/main-service.ts
+++ b/js/openmedkit-electron/src/main-service.ts
@@ -1,0 +1,212 @@
+import { isAbsolute } from "node:path";
+
+import {
+  OPENMED_ELECTRON_SCHEMA_VERSION,
+  assertElectronDeidentifyRequest,
+  isUtilityDeidentifyResponse,
+  toRendererOpenMedSpan,
+  type ElectronDeidentifyRequest,
+  type ElectronDeidentifyResponse,
+  type UtilityDeidentifyFailure,
+  type UtilityDeidentifyRequest,
+  type UtilityDeidentifyResponse,
+} from "./ipc";
+
+export interface UtilityProcessLike {
+  postMessage(message: unknown): void;
+  on(event: "message", listener: (message: unknown) => void): this;
+  on(event: "exit", listener: (code: number) => void): this;
+  kill(): boolean;
+}
+
+export interface UtilityProcessModuleLike {
+  fork(
+    modulePath: string,
+    args?: string[],
+    options?: {
+      env?: Record<string, string>;
+      serviceName?: string;
+      stdio?: "ignore";
+    },
+  ): UtilityProcessLike;
+}
+
+export type ElectronDeidentifyServiceEvent =
+  | { event: "request_started" }
+  | { event: "request_completed"; spanCount: number }
+  | { event: "request_failed"; errorCode: string };
+
+export interface ElectronDeidentifyServiceOptions {
+  utilityProcess: UtilityProcessModuleLike;
+  workerPath: string;
+  modelPath: string;
+  requestTimeoutMs?: number;
+  maxTextLength?: number;
+  logger?: (event: ElectronDeidentifyServiceEvent) => void;
+}
+
+interface PendingRequest {
+  resolve(response: ElectronDeidentifyResponse): void;
+  reject(error: Error): void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_TEXT_LENGTH = 1_000_000;
+
+export class ElectronDeidentifyService {
+  private child: UtilityProcessLike | undefined;
+  private readonly pending = new Map<string, PendingRequest>();
+  private disposed = false;
+
+  constructor(private readonly options: ElectronDeidentifyServiceOptions) {
+    if (!isAbsolute(options.workerPath)) {
+      throw new TypeError("The OpenMed utility-process path must be absolute.");
+    }
+    if (!isAbsolute(options.modelPath)) {
+      throw new TypeError("The OpenMed model cache path must be absolute.");
+    }
+  }
+
+  async deidentify(
+    request: ElectronDeidentifyRequest,
+  ): Promise<ElectronDeidentifyResponse> {
+    assertElectronDeidentifyRequest(
+      request,
+      this.options.maxTextLength ?? DEFAULT_MAX_TEXT_LENGTH,
+    );
+    if (this.disposed) {
+      throw new Error("The OpenMed de-identification service is disposed.");
+    }
+    if (this.pending.has(request.requestId)) {
+      throw new TypeError("Duplicate OpenMed Electron request identifier.");
+    }
+
+    const child = this.getOrCreateChild();
+    this.options.logger?.({ event: "request_started" });
+    return new Promise<ElectronDeidentifyResponse>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(request.requestId);
+        this.options.logger?.({
+          event: "request_failed",
+          errorCode: "REQUEST_TIMEOUT",
+        });
+        reject(new Error("OpenMed de-identification timed out."));
+      }, this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
+      this.pending.set(request.requestId, { resolve, reject, timeout });
+
+      const utilityRequest: UtilityDeidentifyRequest = {
+        ...request,
+        type: "deidentify",
+        modelPath: this.options.modelPath,
+      };
+      child.postMessage(utilityRequest);
+    });
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.rejectPending("SERVICE_DISPOSED", "OpenMed service was disposed.");
+    this.child?.kill();
+    this.child = undefined;
+  }
+
+  private getOrCreateChild(): UtilityProcessLike {
+    if (this.child) {
+      return this.child;
+    }
+    const child = this.options.utilityProcess.fork(this.options.workerPath, [], {
+      env: {
+        HF_HUB_OFFLINE: "1",
+        TRANSFORMERS_OFFLINE: "1",
+      },
+      serviceName: "OpenMed de-identification",
+      stdio: "ignore",
+    });
+    child.on("message", (message) => this.handleMessage(message));
+    child.on("exit", () => {
+      if (this.child === child) {
+        this.child = undefined;
+      }
+      this.rejectPending(
+        "UTILITY_PROCESS_EXITED",
+        "OpenMed utility process exited.",
+      );
+    });
+    this.child = child;
+    return child;
+  }
+
+  private handleMessage(message: unknown): void {
+    if (!isUtilityDeidentifyResponse(message)) {
+      return;
+    }
+    const pending = this.pending.get(message.requestId);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pending.delete(message.requestId);
+    if (message.ok) {
+      this.options.logger?.({
+        event: "request_completed",
+        spanCount: message.spans.length,
+      });
+      pending.resolve({
+        schemaVersion: OPENMED_ELECTRON_SCHEMA_VERSION,
+        requestId: message.requestId,
+        spans: message.spans.map(toRendererOpenMedSpan),
+      });
+      return;
+    }
+    this.options.logger?.({
+      event: "request_failed",
+      errorCode: message.errorCode,
+    });
+    pending.reject(new Error("OpenMed de-identification failed."));
+  }
+
+  private rejectPending(errorCode: string, message: string): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error(message));
+    }
+    if (this.pending.size > 0) {
+      this.options.logger?.({ event: "request_failed", errorCode });
+    }
+    this.pending.clear();
+  }
+}
+
+export function isUtilityDeidentifyMessage(
+  message: unknown,
+): message is UtilityDeidentifyRequest {
+  if (typeof message !== "object" || message === null) {
+    return false;
+  }
+  const candidate = message as Record<string, unknown>;
+  if (candidate.type !== "deidentify" || typeof candidate.modelPath !== "string") {
+    return false;
+  }
+  try {
+    assertElectronDeidentifyRequest(candidate);
+  } catch {
+    return false;
+  }
+  return isAbsolute(candidate.modelPath);
+}
+
+export function inferenceFailure(
+  requestId: string,
+  errorCode: UtilityDeidentifyFailure["errorCode"],
+): UtilityDeidentifyResponse {
+  return {
+    type: "deidentify-result",
+    requestId,
+    ok: false,
+    errorCode,
+  };
+}

--- a/js/openmedkit-electron/src/utility-process.ts
+++ b/js/openmedkit-electron/src/utility-process.ts
@@ -1,0 +1,127 @@
+import http from "node:http";
+import https from "node:https";
+import net from "node:net";
+import tls from "node:tls";
+
+import {
+  deidentify,
+  loadTokenClassificationPipeline,
+  type TokenClassificationPipeline,
+} from "openmed";
+
+import { toRendererOpenMedSpan, type UtilityDeidentifyResponse } from "./ipc";
+import { inferenceFailure, isUtilityDeidentifyMessage } from "./main-service";
+
+export interface UtilityMessageEvent {
+  data: unknown;
+}
+
+export interface UtilityParentPortLike {
+  on(event: "message", listener: (event: UtilityMessageEvent) => void): this;
+  postMessage(message: unknown): void;
+}
+
+export interface UtilityHandlerOptions {
+  loadPipeline?: (modelPath: string) => Promise<TokenClassificationPipeline>;
+}
+
+export function createUtilityDeidentifyHandler(
+  options: UtilityHandlerOptions = {},
+): (message: unknown) => Promise<UtilityDeidentifyResponse> {
+  const modelCache = new Map<string, Promise<TokenClassificationPipeline>>();
+  const loadPipeline =
+    options.loadPipeline ??
+    ((modelPath: string) =>
+      loadTokenClassificationPipeline(modelPath, {
+        allowRemoteModels: false,
+        localFilesOnly: true,
+      }));
+
+  return async (message: unknown): Promise<UtilityDeidentifyResponse> => {
+    if (!isUtilityDeidentifyMessage(message)) {
+      return inferenceFailure(requestIdFrom(message), "INVALID_REQUEST");
+    }
+    try {
+      let pipeline = modelCache.get(message.modelPath);
+      if (!pipeline) {
+        pipeline = loadPipeline(message.modelPath);
+        modelCache.set(message.modelPath, pipeline);
+      }
+      const result = await deidentify(message.text, {
+        pipeline: await pipeline,
+        docId: "electron-document",
+        detector: "electron-utility-process",
+      });
+      return {
+        type: "deidentify-result",
+        requestId: message.requestId,
+        ok: true,
+        spans: result.spans.map(toRendererOpenMedSpan),
+      };
+    } catch {
+      modelCache.delete(message.modelPath);
+      return inferenceFailure(message.requestId, "INFERENCE_FAILED");
+    }
+  };
+}
+
+export function installOfflineNetworkGuard(): () => void {
+  const originalFetch = globalThis.fetch;
+  const originalHttpRequest = http.request;
+  const originalHttpGet = http.get;
+  const originalHttpsRequest = https.request;
+  const originalHttpsGet = https.get;
+  const originalNetConnect = net.connect;
+  const originalNetCreateConnection = net.createConnection;
+  const originalTlsConnect = tls.connect;
+  const blocked = (): never => {
+    throw new Error("Network access is disabled in the OpenMed utility process.");
+  };
+
+  globalThis.fetch = blocked as typeof globalThis.fetch;
+  http.request = blocked as typeof http.request;
+  http.get = blocked as typeof http.get;
+  https.request = blocked as typeof https.request;
+  https.get = blocked as typeof https.get;
+  net.connect = blocked as typeof net.connect;
+  net.createConnection = blocked as typeof net.createConnection;
+  tls.connect = blocked as typeof tls.connect;
+
+  return () => {
+    globalThis.fetch = originalFetch;
+    http.request = originalHttpRequest;
+    http.get = originalHttpGet;
+    https.request = originalHttpsRequest;
+    https.get = originalHttpsGet;
+    net.connect = originalNetConnect;
+    net.createConnection = originalNetCreateConnection;
+    tls.connect = originalTlsConnect;
+  };
+}
+
+export function startUtilityProcess(parentPort: UtilityParentPortLike): void {
+  installOfflineNetworkGuard();
+  const handleMessage = createUtilityDeidentifyHandler();
+  parentPort.on("message", (event) => {
+    void handleMessage(event.data).then((response) => {
+      parentPort.postMessage(response);
+    });
+  });
+}
+
+function requestIdFrom(message: unknown): string {
+  if (typeof message === "object" && message !== null) {
+    const requestId = (message as Record<string, unknown>).requestId;
+    if (typeof requestId === "string") {
+      return requestId;
+    }
+  }
+  return "invalid-request";
+}
+
+const electronProcess = process as NodeJS.Process & {
+  parentPort?: UtilityParentPortLike | null;
+};
+if (electronProcess.parentPort) {
+  startUtilityProcess(electronProcess.parentPort);
+}

--- a/js/openmedkit-electron/tsconfig.json
+++ b/js/openmedkit-electron/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "openmed": ["../openmedkit-web/src/index.ts"]
+    },
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - MLX Quantized Export: export-mlx-quant.md
       - Transformers.js Export: export-transformersjs.md
       - ONNX Runtime Web Loader: runtimes/onnxruntime-web.md
+      - Electron In-Process De-identification: runtimes/electron.md
       - Android Quickstart: android-quickstart.md
       - Android ONNX Export: export-onnx-android.md
       - Android Tokenization: android-tokenization.md

--- a/tests/web/test_electron_ipc.py
+++ b/tests/web/test_electron_ipc.py
@@ -1,0 +1,36 @@
+"""Pytest bridge for the OpenMedKit Electron integration checks."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+ELECTRON_PACKAGE_DIR = ROOT / "js" / "openmedkit-electron"
+
+
+def test_openmedkit_electron_package_checks() -> None:
+    node = shutil.which("node")
+    npm = shutil.which("npm")
+    if node is None or npm is None:
+        pytest.skip("node and npm are required for OpenMedKit Electron checks")
+
+    _run([npm, "ci"], cwd=ELECTRON_PACKAGE_DIR)
+    _run([npm, "test"], cwd=ELECTRON_PACKAGE_DIR)
+
+
+def _run(command: list[str], *, cwd: Path) -> None:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert completed.returncode == 0, completed.stdout

--- a/tests/web/test_electron_ipc.spec.ts
+++ b/tests/web/test_electron_ipc.spec.ts
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { readFile } from "node:fs/promises";
+import http from "node:http";
+import net from "node:net";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  deidentify,
+  type OpenMedDeidentifyResult,
+  type OpenMedSpan,
+  type TokenClassificationPipeline,
+} from "../../js/openmedkit-web/src/index";
+import {
+  ElectronDeidentifyService,
+  OPENMED_DEIDENTIFY_CHANNEL,
+  createElectronDeidentifyClient,
+  redactTextWithSpans,
+  registerElectronDeidentifyIpc,
+  type IpcMainLike,
+  type RendererOpenMedSpan,
+  type UtilityProcessLike,
+  type UtilityProcessModuleLike,
+} from "../../js/openmedkit-electron/src/index";
+import {
+  createUtilityDeidentifyHandler,
+  installOfflineNetworkGuard,
+} from "../../js/openmedkit-electron/src/utility-process";
+
+const rootDir = fileURLToPath(new URL("../..", import.meta.url));
+const fixturePath = join(
+  rootDir,
+  "tests",
+  "web",
+  "fixtures",
+  "npm_deidentify_golden.json",
+);
+
+test("Electron IPC returns only renderer-safe spans matching the golden", async () => {
+  const golden = JSON.parse(
+    await readFile(fixturePath, "utf8"),
+  ) as OpenMedDeidentifyResult;
+  const mainLogs: unknown[] = [];
+  const rendererLogs: unknown[] = [];
+  let modelLoadCount = 0;
+  const handler = createUtilityDeidentifyHandler({
+    loadPipeline: async () => {
+      modelLoadCount += 1;
+      return fixturePipeline;
+    },
+  });
+  const utilityProcess = new FakeUtilityProcessModule(async (message) => {
+    const response = await handler(message);
+    if (!response.ok) {
+      return response;
+    }
+    return {
+      ...response,
+      spans: response.spans.map((span) => ({ ...span, rawText: golden.text })),
+    };
+  });
+  const service = new ElectronDeidentifyService({
+    utilityProcess,
+    workerPath: join(
+      rootDir,
+      "js",
+      "openmedkit-electron",
+      "dist",
+      "utility-process.js",
+    ),
+    modelPath: join(rootDir, "tests", "web", "fixtures", "local-model-cache"),
+    logger: (entry) => mainLogs.push(entry),
+  });
+  const ipcMain = new FakeIpcMain();
+  const unregister = registerElectronDeidentifyIpc(ipcMain, service);
+  const firstWindow = createElectronDeidentifyClient(
+    ipcMain.createRenderer(rendererLogs),
+  );
+  const secondWindow = createElectronDeidentifyClient(
+    ipcMain.createRenderer(rendererLogs),
+  );
+  const restoreNetwork = installOfflineNetworkGuard();
+  const restoreConsole = captureConsole(rendererLogs);
+
+  try {
+    assert.throws(
+      () => globalThis.fetch("https://example.invalid/model.onnx"),
+      /Network access is disabled/,
+    );
+    assert.throws(
+      () => http.request("http://example.invalid/model.onnx"),
+      /Network access is disabled/,
+    );
+    assert.throws(
+      () => net.connect(443, "example.invalid"),
+      /Network access is disabled/,
+    );
+
+    const first = await firstWindow.deidentify(golden.text);
+    const second = await secondWindow.deidentify(golden.text);
+    assertRendererSpansClose(
+      first.spans,
+      golden.spans.map(projectGoldenSpan),
+    );
+    assertRendererSpansClose(
+      second.spans,
+      golden.spans.map(projectGoldenSpan),
+    );
+    assert.equal(redactTextWithSpans(golden.text, first.spans), golden.deidentifiedText);
+    assert.equal(utilityProcess.forkCount, 1);
+    assert.equal(utilityProcess.lastFork?.workerPath.endsWith("utility-process.js"), true);
+    assert.equal(utilityProcess.lastFork?.options?.stdio, "ignore");
+    assert.deepEqual(utilityProcess.lastFork?.options?.env, {
+      HF_HUB_OFFLINE: "1",
+      TRANSFORMERS_OFFLINE: "1",
+    });
+    assert.equal(JSON.stringify(utilityProcess.lastFork).includes("Alice"), false);
+    assert.equal(modelLoadCount, 1, "model cache must be shared across windows");
+
+    for (const span of first.spans) {
+      assert.deepEqual(Object.keys(span).sort(), [
+        "canonical_label",
+        "end",
+        "entity_type",
+        "policy_label",
+        "schema_version",
+        "score",
+        "start",
+      ]);
+    }
+  } finally {
+    restoreConsole();
+    restoreNetwork();
+    unregister();
+    service.dispose();
+  }
+
+  const combinedLogs = JSON.stringify({ mainLogs, rendererLogs });
+  for (const phi of ["Alice", "Nguyen", "1979-04-12", "alice@example.org"]) {
+    assert.equal(combinedLogs.includes(phi), false, `logs leaked ${phi}`);
+  }
+});
+
+class FakeUtilityProcess extends EventEmitter implements UtilityProcessLike {
+  constructor(
+    private readonly handler: (message: unknown) => Promise<unknown>,
+  ) {
+    super();
+  }
+
+  postMessage(message: unknown): void {
+    void this.handler(message).then((response) => this.emit("message", response));
+  }
+
+  kill(): boolean {
+    this.emit("exit", 0);
+    return true;
+  }
+}
+
+class FakeUtilityProcessModule implements UtilityProcessModuleLike {
+  forkCount = 0;
+  lastFork:
+    | {
+        workerPath: string;
+        args: string[];
+        options?: {
+          env?: Record<string, string>;
+          serviceName?: string;
+          stdio?: "ignore";
+        };
+      }
+    | undefined;
+
+  constructor(
+    private readonly handler: (message: unknown) => Promise<unknown>,
+  ) {}
+
+  fork(
+    workerPath: string,
+    args: string[] = [],
+    options?: {
+      env?: Record<string, string>;
+      serviceName?: string;
+      stdio?: "ignore";
+    },
+  ): UtilityProcessLike {
+    this.forkCount += 1;
+    this.lastFork = options
+      ? { workerPath, args, options }
+      : { workerPath, args };
+    return new FakeUtilityProcess(this.handler);
+  }
+}
+
+class FakeIpcMain implements IpcMainLike {
+  private readonly handlers = new Map<
+    string,
+    (event: unknown, request: unknown) => Promise<unknown> | unknown
+  >();
+
+  handle(
+    channel: string,
+    listener: (event: unknown, request: unknown) => Promise<unknown> | unknown,
+  ): void {
+    this.handlers.set(channel, listener);
+  }
+
+  removeHandler(channel: string): void {
+    this.handlers.delete(channel);
+  }
+
+  createRenderer(logs: unknown[]) {
+    return {
+      invoke: async (channel: string, request: unknown): Promise<unknown> => {
+        assert.equal(channel, OPENMED_DEIDENTIFY_CHANNEL);
+        const handler = this.handlers.get(channel);
+        assert.ok(handler);
+        const response = await handler({ sender: "synthetic-window" }, request);
+        logs.push({ event: "deidentify_completed" });
+        return response;
+      },
+    };
+  }
+}
+
+function projectGoldenSpan(span: OpenMedSpan): RendererOpenMedSpan {
+  return {
+    schema_version: span.schema_version,
+    start: span.start,
+    end: span.end,
+    entity_type: span.entity_type,
+    canonical_label: span.canonical_label,
+    policy_label: span.policy_label,
+    score: span.score,
+  };
+}
+
+function assertRendererSpansClose(
+  actual: RendererOpenMedSpan[],
+  expected: RendererOpenMedSpan[],
+): void {
+  assert.equal(actual.length, expected.length);
+  for (const [index, actualSpan] of actual.entries()) {
+    const expectedSpan = expected[index];
+    assert.ok(expectedSpan, `missing expected span at ${index}`);
+    const { score: actualScore, ...actualRest } = actualSpan;
+    const { score: expectedScore, ...expectedRest } = expectedSpan;
+    assert.deepEqual(actualRest, expectedRest);
+    assert.ok(actualScore !== null);
+    assert.ok(expectedScore !== null);
+    assert.ok(Math.abs(actualScore - expectedScore) <= 1e-12);
+  }
+}
+
+const fixturePipeline: TokenClassificationPipeline = (text) => {
+  const aliceStart = text.indexOf("Alice");
+  const nguyenStart = text.indexOf("Nguyen");
+  const dobStart = text.indexOf("1979-04-12");
+  const emailStart = text.indexOf("alice@example.org");
+  return [
+    {
+      entity: "B-NAME",
+      score: 0.99,
+      start: aliceStart,
+      end: aliceStart + "Alice".length,
+    },
+    {
+      entity: "E-NAME",
+      score: 0.97,
+      start: nguyenStart,
+      end: nguyenStart + "Nguyen".length,
+    },
+    {
+      entity: "S-DATE_OF_BIRTH",
+      score: 0.96,
+      start: dobStart,
+      end: dobStart + "1979-04-12".length,
+    },
+    {
+      entity: "S-EMAIL",
+      score: 0.98,
+      start: emailStart,
+      end: emailStart + "alice@example.org".length,
+    },
+  ];
+};
+
+function captureConsole(logs: unknown[]): () => void {
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.log = (...args: unknown[]) => logs.push({ level: "log", args });
+  console.warn = (...args: unknown[]) => logs.push({ level: "warn", args });
+  console.error = (...args: unknown[]) => logs.push({ level: "error", args });
+  return () => {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  };
+}


### PR DESCRIPTION
## Description

Adds a vetted Electron main/renderer integration that runs OpenMed de-identification in one shared utility process, keeps model loading local-only, and returns a renderer-safe projection of OpenMed spans. The shared worker caches pipelines across windows while fixed error responses, ignored utility stdio, and narrow log events keep clinical text out of logs.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add a typed Electron IPC client/handler and singleton main-process utility service.
- Add an offline utility-process runtime with a model cache shared across renderer windows.
- Add golden parity, network-denial, renderer-boundary, and no-PHI-log guards plus an example and runtime guide.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Validation completed:

- `.venv/bin/python -m pytest tests/ -q` — 5160 passed, 51 skipped
- `npm test` in `js/openmedkit-electron`
- `make format`
- `make lint`
- `make format-check`
- `make docs-build`
- `npm pack --dry-run` in `js/openmedkit-electron`

## Documentation

- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [ ] I have not added any new dependencies
- [x] OR I have added new dependencies and they are justified because: the private Electron reference package uses Electron and OpenMed as runtime peers and the repository's existing TypeScript build/test toolchain as development-only dependencies.

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #824

## Screenshots/Examples

The committed synthetic example redacts:

```text
Patient [PERSON], DOB [DATE_OF_BIRTH], email [EMAIL].
```
