### PR TITLE
Add a GraphQL endpoint for de-identification and entity queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a read-only Strawberry GraphQL endpoint for selective analysis and
+  de-identification fields, canonical entity discovery, policy details, safe
+  aggregate risk facets, introspection, and deterministic SDL export (#828).
 - Added an offline Vietnamese (`vi`) PII language pack with context-gated CCCD
   and legacy CMND detection, Vietnamese dates, phone numbers, addresses and
   five-digit postal codes, plus `vi_VN` surrogates and a synthetic golden

--- a/docs/api/graphql-schema.graphql
+++ b/docs/api/graphql-schema.graphql
@@ -1,0 +1,131 @@
+input AnalyzeInput {
+  text: String!
+  modelName: String! = "disease_detection_superclinical"
+  confidenceThreshold: Float = 0
+  groupEntities: Boolean! = false
+  aggregationStrategy: String = "simple"
+  sentenceDetection: Boolean! = true
+  sentenceLanguage: String! = "en"
+  sentenceClean: Boolean! = false
+  useFastTokenizer: Boolean! = true
+  keepAlive: JSON = null
+}
+
+type AnalyzePayload {
+  text: String!
+  entities: [Entity!]!
+  spans: [OpenMedSpan!]!
+  modelName: String!
+  timestamp: String!
+  processingTime: Float
+  metadata: JSON!
+}
+
+input DeidentifyInput {
+  text: String!
+  method: String! = "mask"
+  modelName: String! = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+  confidenceThreshold: Float! = 0.7
+  keepYear: Boolean! = false
+  shiftDates: Boolean = null
+  dateShiftDays: Int = null
+  keepMapping: Boolean! = false
+  policy: String = null
+  useSmartMerging: Boolean! = true
+  useSafetySweep: Boolean! = true
+  lang: String! = "en"
+  normalizeAccents: Boolean = null
+  keepAlive: JSON = null
+}
+
+type DeidentifyPayload {
+  originalText: String!
+  deidentifiedText: String!
+  entities: [Entity!]!
+  spans: [OpenMedSpan!]!
+  method: String!
+  timestamp: String!
+  numEntitiesRedacted: Int!
+  metadata: JSON!
+  mapping: JSON
+  policy: PolicyProfile
+  risk: RiskFacets!
+}
+
+type Entity {
+  text: String!
+  label: String!
+  confidence: Float!
+  start: Int
+  end: Int
+  metadata: JSON!
+}
+
+type EntityType {
+  label: String!
+  policyLabel: String!
+}
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
+"""
+scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
+
+type OpenMedSpan {
+  label: String!
+  start: Int
+  end: Int
+  text: String
+  schemaVersion: Int
+  docId: String
+  textHash: String
+  entityType: String
+  canonicalLabel: String
+  policyLabel: String
+  regulatoryTags: [String!]!
+  score: Float
+  detector: String
+  evidence: JSON!
+  action: String
+  replacement: String
+  reversibleId: String
+  section: String
+  metadata: JSON!
+}
+
+type PolicyAction {
+  label: String!
+  action: String!
+}
+
+type PolicyProfile {
+  name: String!
+  schemaVersion: Int!
+  posture: String!
+  thresholdProfile: String!
+  defaultAction: String!
+  defaultActionBias: String!
+  arbitrationMode: String!
+  strictNoLeak: Boolean!
+  safetySweepMandatory: Boolean!
+  keepMapping: Boolean!
+  reversibleId: Boolean!
+  forcedCascadeTiers: [String!]!
+  actions: [PolicyAction!]!
+  policyLabelActions: [PolicyAction!]!
+  metadata: JSON!
+}
+
+type Query {
+  analyze(input: AnalyzeInput!): AnalyzePayload!
+  deidentify(input: DeidentifyInput!): DeidentifyPayload!
+  entityTypes: [EntityType!]!
+}
+
+type RiskFacets {
+  leakageRate: Float!
+  reidentificationRate: Float!
+  minimumK: Int!
+  singletonRecordCount: Int!
+  quasiIdentifierCount: Int!
+}

--- a/docs/serving/graphql.md
+++ b/docs/serving/graphql.md
@@ -1,0 +1,91 @@
+# GraphQL service
+
+OpenMed exposes a read-only GraphQL endpoint at `POST /graphql`. It uses the
+same service configuration, model loader, warm pool, timeout, retry, and circuit
+breaker as the REST endpoints. Install the service extra before starting the
+application:
+
+```bash
+pip install "openmed[service]"
+uvicorn openmed.service.app:app --host 127.0.0.1 --port 8000
+```
+
+The schema has three root queries:
+
+- `analyze` runs clinical entity analysis.
+- `deidentify` returns redacted text, entities, canonical spans, the selected
+  policy profile, and aggregate risk facets.
+- `entityTypes` lists canonical labels and their policy categories without
+  loading a model.
+
+There are no mutations or subscriptions. Authentication is not part of this
+endpoint yet, so place it behind a trusted application boundary until GraphQL
+auth middleware is available.
+
+## Select only the fields you need
+
+This synthetic example requests only the label and start offset for each span.
+The source span text and all other response fields are omitted:
+
+```graphql
+query Analyze($input: AnalyzeInput!) {
+  analyze(input: $input) {
+    spans {
+      label
+      start
+    }
+  }
+}
+```
+
+```json
+{
+  "input": {
+    "text": "Patient Jane Example reports nausea."
+  }
+}
+```
+
+A de-identification query can combine redacted output, policy configuration,
+and privacy-safe aggregate risk facets in the same request:
+
+```graphql
+query Deidentify($input: DeidentifyInput!) {
+  deidentify(input: $input) {
+    deidentifiedText
+    spans {
+      label
+      start
+      action
+    }
+    policy {
+      name
+      defaultAction
+    }
+    risk {
+      leakageRate
+      reidentificationRate
+      minimumK
+    }
+  }
+}
+```
+
+Resolver failures return a generic `OPENMED_RESOLVER_ERROR`. OpenMed suppresses
+exception-derived GraphQL messages and the GraphQL execution logger so raw
+input text is not copied into resolver errors or logs.
+
+## Introspection and SDL export
+
+Standard GraphQL introspection is enabled. A browser can open `/graphql` for
+the GraphiQL interface, and code generators can consume the committed schema
+at `docs/api/graphql-schema.graphql`.
+
+Regenerate that artifact after changing the schema:
+
+```bash
+.venv/bin/python scripts/export_graphql_schema.py
+```
+
+The unit test compares the committed SDL byte-for-byte with the live Strawberry
+schema so drift fails CI.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - Hardened Service Image: deploy/hardened-image.md
       - Async REST Jobs & Webhooks: serving/async-jobs.md
       - gRPC Service: serving/grpc.md
+      - GraphQL Service: serving/graphql.md
       - REST Authentication: serving/authentication.md
       - Helm Deployment: deploy/helm.md
       - Multi-Arch Containers: deploy/multi-arch.md

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -86,6 +86,7 @@ _PRIVACY_GATEWAY_PATH = "/privacy-gateway/complete"
 _SMART_BACKEND_START_PATH = "/fhir/smart-backend/ingestions"
 _MODEL_BACKED_PATHS = frozenset(
     {
+        "/graphql",
         "/analyze",
         "/pii/extract",
         "/pii/extract/stream",
@@ -915,6 +916,10 @@ def create_app() -> FastAPI:
         if record is None:
             raise HTTPException(status_code=404, detail="job not found")
         return job_response_payload(record, status_url=f"/jobs/{job_id}")
+
+    from .graphql_app import mount_graphql
+
+    mount_graphql(app, runtime_getter=_get_service_runtime)
 
     if app.state.tracing.enabled:
         app.add_middleware(

--- a/openmed/service/graphql_app.py
+++ b/openmed/service/graphql_app.py
@@ -1,0 +1,72 @@
+"""FastAPI integration for the OpenMed GraphQL schema."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from fastapi import FastAPI, Request
+from strawberry.fastapi import GraphQLRouter
+from strawberry.http import GraphQLHTTPResponse
+from strawberry.types import ExecutionResult
+
+from .graphql_schema import SAFE_RESOLVER_ERROR, OpenMedGraphQLContext, schema
+from .runtime import ServiceRuntime
+
+GRAPHQL_PATH = "/graphql"
+
+
+class PrivacySafeGraphQLRouter(GraphQLRouter):
+    """GraphQL router that masks all resolver execution failures."""
+
+    async def process_result(
+        self,
+        request: Request,
+        result: ExecutionResult,
+    ) -> GraphQLHTTPResponse:
+        """Return GraphQL data while removing exception-derived messages."""
+        response: dict[str, Any] = {"data": result.data}
+        if result.errors:
+            response["errors"] = [
+                _safe_formatted_error(error) for error in result.errors
+            ]
+        if result.extensions:
+            response["extensions"] = result.extensions
+        return response  # type: ignore[return-value]
+
+
+def mount_graphql(
+    app: FastAPI,
+    *,
+    runtime_getter: Callable[[Request], ServiceRuntime],
+) -> None:
+    """Mount the GraphQL endpoint on an existing OpenMed service app."""
+
+    async def get_context(request: Request) -> OpenMedGraphQLContext:
+        return OpenMedGraphQLContext(runtime_getter(request))
+
+    router = PrivacySafeGraphQLRouter(
+        schema,
+        context_getter=get_context,
+        graphql_ide="graphiql",
+        allow_queries_via_get=True,
+        subscription_protocols=(),
+        multipart_uploads_enabled=False,
+    )
+    app.include_router(router, prefix=GRAPHQL_PATH, include_in_schema=False)
+
+
+def _safe_formatted_error(error: Any) -> dict[str, Any]:
+    formatted = dict(error.formatted)
+    if error.original_error is None:
+        return formatted
+
+    safe_error: dict[str, Any] = {
+        "message": SAFE_RESOLVER_ERROR,
+        "extensions": {"code": "OPENMED_RESOLVER_ERROR"},
+    }
+    if formatted.get("locations") is not None:
+        safe_error["locations"] = formatted["locations"]
+    if formatted.get("path") is not None:
+        safe_error["path"] = formatted["path"]
+    return safe_error

--- a/openmed/service/graphql_schema.py
+++ b/openmed/service/graphql_schema.py
@@ -1,0 +1,477 @@
+"""Typed GraphQL schema for the OpenMed service."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
+
+import strawberry
+from graphql import GraphQLError
+from strawberry.fastapi import BaseContext
+from strawberry.scalars import JSON
+from strawberry.types import Info
+
+from openmed.core.labels import CANONICAL_LABELS, policy_label_for
+from openmed.core.policy import PolicyProfile, load_policy
+from openmed.risk import risk_report
+
+from .runtime import ServiceRuntime
+from .schemas import AnalyzeRequest, PIIDeidentifyRequest
+
+_DEFAULT_PII_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+SAFE_RESOLVER_ERROR = "The OpenMed GraphQL operation could not be completed."
+
+
+class OpenMedGraphQLContext(BaseContext):
+    """Request context carrying the service's shared runtime."""
+
+    def __init__(self, runtime: ServiceRuntime) -> None:
+        self.runtime = runtime
+
+
+@strawberry.input
+class AnalyzeInput:
+    """Inputs accepted by the ``analyze`` query."""
+
+    text: str
+    model_name: str = "disease_detection_superclinical"
+    confidence_threshold: Optional[float] = 0.0
+    group_entities: bool = False
+    aggregation_strategy: Optional[str] = "simple"
+    sentence_detection: bool = True
+    sentence_language: str = "en"
+    sentence_clean: bool = False
+    use_fast_tokenizer: bool = True
+    keep_alive: Optional[JSON] = None
+
+    def to_request(self) -> AnalyzeRequest:
+        """Validate and convert this input to the REST pipeline contract."""
+        return AnalyzeRequest(
+            text=self.text,
+            model_name=self.model_name,
+            confidence_threshold=self.confidence_threshold,
+            group_entities=self.group_entities,
+            aggregation_strategy=self.aggregation_strategy,
+            sentence_detection=self.sentence_detection,
+            sentence_language=self.sentence_language,
+            sentence_clean=self.sentence_clean,
+            use_fast_tokenizer=self.use_fast_tokenizer,
+            keep_alive=self.keep_alive,
+        )
+
+
+@strawberry.input
+class DeidentifyInput:
+    """Inputs accepted by the ``deidentify`` query."""
+
+    text: str
+    method: str = "mask"
+    model_name: str = _DEFAULT_PII_MODEL
+    confidence_threshold: float = 0.7
+    keep_year: bool = False
+    shift_dates: Optional[bool] = None
+    date_shift_days: Optional[int] = None
+    keep_mapping: bool = False
+    policy: Optional[str] = None
+    use_smart_merging: bool = True
+    use_safety_sweep: bool = True
+    lang: str = "en"
+    normalize_accents: Optional[bool] = None
+    keep_alive: Optional[JSON] = None
+
+    def to_request(self) -> PIIDeidentifyRequest:
+        """Validate and convert this input to the REST pipeline contract."""
+        return PIIDeidentifyRequest(
+            text=self.text,
+            method=self.method,
+            model_name=self.model_name,
+            confidence_threshold=self.confidence_threshold,
+            keep_year=self.keep_year,
+            shift_dates=self.shift_dates,
+            date_shift_days=self.date_shift_days,
+            keep_mapping=self.keep_mapping,
+            policy=self.policy,
+            use_smart_merging=self.use_smart_merging,
+            use_safety_sweep=self.use_safety_sweep,
+            lang=self.lang,
+            normalize_accents=self.normalize_accents,
+            keep_alive=self.keep_alive,
+        )
+
+
+@strawberry.type
+class Entity:
+    """A model-produced entity with source offsets."""
+
+    text: str
+    label: str
+    confidence: float
+    start: Optional[int]
+    end: Optional[int]
+    metadata: JSON
+
+    @classmethod
+    def from_mapping(cls, item: Mapping[str, Any]) -> Entity:
+        """Build a typed entity from a service payload."""
+        return cls(
+            text=str(item.get("text") or ""),
+            label=str(item.get("label") or item.get("entity_type") or "UNKNOWN"),
+            confidence=_float(item.get("confidence")),
+            start=_optional_int(item.get("start")),
+            end=_optional_int(item.get("end")),
+            metadata=_json_mapping(item.get("metadata")),
+        )
+
+
+@strawberry.type(name="OpenMedSpan")
+class OpenMedSpanType:
+    """Canonical OpenMed span fields exposed for selective retrieval."""
+
+    label: str
+    start: Optional[int]
+    end: Optional[int]
+    text: Optional[str]
+    schema_version: Optional[int]
+    doc_id: Optional[str]
+    text_hash: Optional[str]
+    entity_type: Optional[str]
+    canonical_label: Optional[str]
+    policy_label: Optional[str]
+    regulatory_tags: list[str]
+    score: Optional[float]
+    detector: Optional[str]
+    evidence: JSON
+    action: Optional[str]
+    replacement: Optional[str]
+    reversible_id: Optional[str]
+    section: Optional[str]
+    metadata: JSON
+
+    @classmethod
+    def from_mapping(cls, item: Mapping[str, Any]) -> OpenMedSpanType:
+        """Build a canonical span view from a span or entity mapping."""
+        entity_type = _optional_str(item.get("entity_type"))
+        canonical_label = _optional_str(item.get("canonical_label"))
+        label = str(item.get("label") or canonical_label or entity_type or "UNKNOWN")
+        score_value = item.get("score", item.get("confidence"))
+        return cls(
+            label=label,
+            start=_optional_int(item.get("start")),
+            end=_optional_int(item.get("end")),
+            text=_optional_str(item.get("text")),
+            schema_version=_optional_int(item.get("schema_version")),
+            doc_id=_optional_str(item.get("doc_id")),
+            text_hash=_optional_str(item.get("text_hash")),
+            entity_type=entity_type,
+            canonical_label=canonical_label,
+            policy_label=_optional_str(item.get("policy_label")),
+            regulatory_tags=[str(tag) for tag in item.get("regulatory_tags") or ()],
+            score=_optional_float(score_value),
+            detector=_optional_str(item.get("detector")),
+            evidence=_json_mapping(item.get("evidence")),
+            action=_optional_str(item.get("action")),
+            replacement=_optional_str(
+                item.get("replacement", item.get("redacted_text"))
+            ),
+            reversible_id=_optional_str(item.get("reversible_id")),
+            section=_optional_str(item.get("section")),
+            metadata=_json_mapping(item.get("metadata")),
+        )
+
+
+@strawberry.type
+class PolicyAction:
+    """One label-to-action entry from a policy profile."""
+
+    label: str
+    action: str
+
+
+@strawberry.type(name="PolicyProfile")
+class PolicyProfileType:
+    """Selected de-identification policy details."""
+
+    name: str
+    schema_version: int
+    posture: str
+    threshold_profile: str
+    default_action: str
+    default_action_bias: str
+    arbitration_mode: str
+    strict_no_leak: bool
+    safety_sweep_mandatory: bool
+    keep_mapping: bool
+    reversible_id: bool
+    forced_cascade_tiers: list[str]
+    actions: list[PolicyAction]
+    policy_label_actions: list[PolicyAction]
+    metadata: JSON
+
+    @classmethod
+    def from_profile(cls, profile: PolicyProfile) -> PolicyProfileType:
+        """Build a field-selectable policy profile."""
+        return cls(
+            name=profile.name,
+            schema_version=profile.schema_version,
+            posture=profile.posture,
+            threshold_profile=profile.threshold_profile,
+            default_action=profile.default_action,
+            default_action_bias=profile.default_action_bias,
+            arbitration_mode=profile.arbitration_mode,
+            strict_no_leak=profile.strict_no_leak,
+            safety_sweep_mandatory=profile.safety_sweep_mandatory,
+            keep_mapping=profile.keep_mapping,
+            reversible_id=profile.reversible_id,
+            forced_cascade_tiers=list(profile.forced_cascade_tiers),
+            actions=[
+                PolicyAction(label=label, action=action)
+                for label, action in sorted(profile.actions.items())
+            ],
+            policy_label_actions=[
+                PolicyAction(label=label, action=action)
+                for label, action in sorted(profile.policy_label_actions.items())
+            ],
+            metadata=dict(profile.metadata),
+        )
+
+
+@strawberry.type
+class RiskFacets:
+    """Aggregate residual-risk facets without source identifier values."""
+
+    leakage_rate: float
+    reidentification_rate: float
+    minimum_k: int
+    singleton_record_count: int
+    quasi_identifier_count: int
+
+    @classmethod
+    def from_result(cls, result: Mapping[str, Any]) -> RiskFacets:
+        """Compute safe aggregate risk facets for a de-identification result."""
+        report = risk_report(
+            str(result.get("deidentified_text") or ""),
+            original=str(result.get("original_text") or ""),
+        )
+        return cls(
+            leakage_rate=_float(report.get("leakage_rate")),
+            reidentification_rate=_float(report.get("reid_rate")),
+            minimum_k=int(report.get("k_min") or 0),
+            singleton_record_count=len(report.get("singleton_records") or ()),
+            quasi_identifier_count=len(report.get("quasi_identifiers") or ()),
+        )
+
+
+@strawberry.type
+class EntityType:
+    """A canonical entity label and its policy category."""
+
+    label: str
+    policy_label: str
+
+
+@strawberry.type
+class AnalyzePayload:
+    """Typed result returned by the ``analyze`` query."""
+
+    text: str
+    entities: list[Entity]
+    spans: list[OpenMedSpanType]
+    model_name: str
+    timestamp: str
+    processing_time: Optional[float]
+    metadata: JSON
+
+    @classmethod
+    def from_mapping(cls, result: Mapping[str, Any]) -> AnalyzePayload:
+        """Build a typed analysis response from the service payload."""
+        entity_items = _mapping_items(result.get("entities"))
+        span_items = _mapping_items(result.get("spans")) or entity_items
+        return cls(
+            text=str(result.get("text") or ""),
+            entities=[Entity.from_mapping(item) for item in entity_items],
+            spans=[OpenMedSpanType.from_mapping(item) for item in span_items],
+            model_name=str(result.get("model_name") or ""),
+            timestamp=str(result.get("timestamp") or ""),
+            processing_time=_optional_float(result.get("processing_time")),
+            metadata=_json_mapping(result.get("metadata")),
+        )
+
+
+@strawberry.type
+class DeidentifyPayload:
+    """Typed result returned by the ``deidentify`` query."""
+
+    original_text: str
+    deidentified_text: str
+    entities: list[Entity]
+    spans: list[OpenMedSpanType]
+    method: str
+    timestamp: str
+    num_entities_redacted: int
+    metadata: JSON
+    mapping: Optional[JSON]
+    policy: Optional[PolicyProfileType]
+    risk: RiskFacets
+
+    @classmethod
+    def from_mapping(
+        cls,
+        result: Mapping[str, Any],
+        *,
+        policy_name: Optional[str],
+    ) -> DeidentifyPayload:
+        """Build a typed de-identification response from the service payload."""
+        entity_items = _mapping_items(result.get("pii_entities"))
+        span_items = _mapping_items(result.get("spans")) or entity_items
+        mapping = result.get("mapping")
+        return cls(
+            original_text=str(result.get("original_text") or ""),
+            deidentified_text=str(result.get("deidentified_text") or ""),
+            entities=[Entity.from_mapping(item) for item in entity_items],
+            spans=[OpenMedSpanType.from_mapping(item) for item in span_items],
+            method=str(result.get("method") or ""),
+            timestamp=str(result.get("timestamp") or ""),
+            num_entities_redacted=int(result.get("num_entities_redacted") or 0),
+            metadata=_json_mapping(result.get("metadata")),
+            mapping=dict(mapping) if isinstance(mapping, Mapping) else None,
+            policy=(
+                PolicyProfileType.from_profile(load_policy(policy_name))
+                if policy_name is not None
+                else None
+            ),
+            risk=RiskFacets.from_result(result),
+        )
+
+
+@strawberry.type
+class Query:
+    """Read-only OpenMed GraphQL operations."""
+
+    @strawberry.field
+    async def analyze(
+        self,
+        info: Info[OpenMedGraphQLContext, None],
+        input: AnalyzeInput,
+    ) -> AnalyzePayload:
+        """Analyze text with the shared service runtime and warm pool."""
+        try:
+            payload = input.to_request()
+            result = await _run_analyze(info.context.runtime, payload)
+            return AnalyzePayload.from_mapping(result)
+        except Exception:
+            raise GraphQLError(
+                SAFE_RESOLVER_ERROR,
+                extensions={"code": "OPENMED_RESOLVER_ERROR"},
+            ) from None
+
+    @strawberry.field
+    async def deidentify(
+        self,
+        info: Info[OpenMedGraphQLContext, None],
+        input: DeidentifyInput,
+    ) -> DeidentifyPayload:
+        """De-identify text with the shared service runtime and warm pool."""
+        try:
+            payload = input.to_request()
+            result = await _run_deidentify(info.context.runtime, payload)
+            return DeidentifyPayload.from_mapping(result, policy_name=payload.policy)
+        except Exception:
+            raise GraphQLError(
+                SAFE_RESOLVER_ERROR,
+                extensions={"code": "OPENMED_RESOLVER_ERROR"},
+            ) from None
+
+    @strawberry.field
+    async def entity_types(self) -> list[EntityType]:
+        """Return the canonical entity catalog without loading a model."""
+        return [
+            EntityType(label=label, policy_label=policy_label_for(label))
+            for label in sorted(CANONICAL_LABELS)
+        ]
+
+
+class PrivacySafeSchema(strawberry.Schema):
+    """Schema that never sends execution exceptions to a logger."""
+
+    def process_errors(
+        self,
+        errors: list[GraphQLError],
+        execution_context: Any = None,
+    ) -> None:
+        """Suppress Strawberry's default exception logger to protect PHI."""
+
+
+schema = PrivacySafeSchema(query=Query)
+
+
+async def _run_analyze(
+    runtime: ServiceRuntime,
+    payload: AnalyzeRequest,
+) -> Mapping[str, Any]:
+    from .app import _analyze_payload, _run_with_timeout
+
+    return await _run_with_timeout(
+        runtime,
+        lambda: runtime.run_model_request(
+            payload.model_name,
+            payload.keep_alive,
+            lambda: _analyze_payload(payload, runtime),
+        ),
+    )
+
+
+async def _run_deidentify(
+    runtime: ServiceRuntime,
+    payload: PIIDeidentifyRequest,
+) -> Mapping[str, Any]:
+    from .app import _pii_deidentify_payload, _run_with_timeout
+
+    return await _run_with_timeout(
+        runtime,
+        lambda: runtime.run_model_request(
+            payload.model_name,
+            payload.keep_alive,
+            lambda: _pii_deidentify_payload(payload, runtime),
+        ),
+    )
+
+
+def _mapping_items(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _json_mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _optional_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    return str(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
   "grpcio-tools>=1.64",
   "protobuf>=5.26,<7",
   "ruff==0.15.20",
+  "strawberry-graphql[fastapi]>=0.316,<1",
   "tomli>=2.0; python_version < '3.11'",
 ]
 
@@ -184,6 +185,7 @@ service = [
   "opentelemetry-exporter-otlp-proto-http>=1.26,<2",
   "opentelemetry-sdk>=1.26,<2",
   "protobuf>=5.26,<7",
+  "strawberry-graphql[fastapi]>=0.316,<1",
   "uvicorn[standard]>=0.29",
 ]
 

--- a/scripts/export_graphql_schema.py
+++ b/scripts/export_graphql_schema.py
@@ -1,0 +1,48 @@
+"""Export the service GraphQL schema as deterministic SDL."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from openmed.service.graphql_schema import schema
+
+DEFAULT_OUTPUT_PATH = REPO_ROOT / "docs" / "api" / "graphql-schema.graphql"
+
+
+def render_graphql_schema() -> str:
+    """Render the live GraphQL schema with stable trailing whitespace."""
+    return f"{str(schema).rstrip()}\n"
+
+
+def export_graphql_schema(output_path: Path = DEFAULT_OUTPUT_PATH) -> Path:
+    """Write the live GraphQL schema to ``output_path``."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_graphql_schema(), encoding="utf-8")
+    return output_path
+
+
+def main() -> int:
+    """Run the GraphQL SDL export command."""
+    parser = argparse.ArgumentParser(
+        description="Export the OpenMed service GraphQL schema."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="Destination SDL file. Defaults to docs/api/graphql-schema.graphql.",
+    )
+    args = parser.parse_args()
+
+    output_path = export_graphql_schema(args.output)
+    print(f"Wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/service/test_graphql_app.py
+++ b/tests/unit/service/test_graphql_app.py
@@ -1,0 +1,260 @@
+"""Unit tests for the OpenMed GraphQL service."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import openmed
+from openmed.core.pii import DeidentificationResult, PIIEntity
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+from openmed.service import runtime as service_runtime
+from openmed.service.app import create_app
+from openmed.service.graphql_schema import SAFE_RESOLVER_ERROR
+from scripts.export_graphql_schema import (
+    DEFAULT_OUTPUT_PATH,
+    render_graphql_schema,
+)
+
+LOOPBACK_BASE_URL = "http://127.0.0.1"
+SYNTHETIC_TEXT = "Paciente: Maria Garcia"
+
+
+class FakeLoader:
+    """Minimal model loader used to verify shared runtime wiring."""
+
+    instances: list[FakeLoader] = []
+
+    def __init__(self, config: Any) -> None:
+        self.config = config
+        self.instances.append(self)
+
+    def resolve_model_name(self, model_name: str) -> str:
+        return model_name
+
+    def loaded_models(self) -> dict[str, Any]:
+        return {}
+
+
+@pytest.fixture(autouse=True)
+def clear_service_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep service startup deterministic and offline."""
+    for name in (
+        "OPENMED_SERVICE_PRELOAD_MODELS",
+        "OPENMED_SERVICE_KEEP_ALIVE",
+        "OPENMED_SERVICE_MAX_RESIDENT_MODELS",
+        "OPENMED_SERVICE_MODEL_MEMORY_BUDGET_BYTES",
+        "OPENMED_SERVICE_DEFAULT_MODEL_FOOTPRINT_BYTES",
+        "OPENMED_SERVICE_MODEL_ADMISSION_WAIT_SECONDS",
+        "OPENMED_SERVICE_MAX_TEXT_LENGTH",
+        "OPENMED_SERVICE_BATCHING_ENABLED",
+        "OPENMED_SERVICE_COALESCING_ENABLED",
+        "OPENMED_SERVICE_RATE_LIMIT_RPS",
+        "OPENMED_SERVICE_RATE_LIMIT_BURST",
+        "OPENMED_SERVICE_RATE_LIMIT_MAX_CONCURRENCY",
+        "OPENMED_SERVICE_CORS_ORIGINS",
+        "OPENMED_SERVICE_TRUSTED_HOSTS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("OPENMED_PROFILE", "test")
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch):
+    """Create a GraphQL client backed by one shared fake loader."""
+    FakeLoader.instances = []
+    monkeypatch.setattr(service_runtime, "ModelLoader", FakeLoader)
+    app = create_app()
+    with TestClient(
+        app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as test_client:
+        yield test_client
+
+
+def _prediction_result() -> PredictionResult:
+    return PredictionResult(
+        text=SYNTHETIC_TEXT,
+        entities=[
+            EntityPrediction(
+                text="Maria Garcia",
+                label="NAME",
+                confidence=0.97,
+                start=10,
+                end=22,
+            )
+        ],
+        model_name="disease_detection_superclinical",
+        timestamp="2026-07-19T00:00:00",
+        processing_time=0.01,
+        metadata={"sentence_detection": True},
+    )
+
+
+def _deidentification_result() -> DeidentificationResult:
+    entity = PIIEntity(
+        text="Maria Garcia",
+        label="NAME",
+        confidence=0.98,
+        start=10,
+        end=22,
+        entity_type="NAME",
+        redacted_text="[NAME]",
+        original_text="Maria Garcia",
+        canonical_label="PERSON",
+        action="mask",
+    )
+    return DeidentificationResult(
+        original_text=SYNTHETIC_TEXT,
+        deidentified_text="Paciente: [NAME]",
+        pii_entities=[entity],
+        method="mask",
+        timestamp=datetime(2026, 7, 19),
+    )
+
+
+def test_analyze_query_returns_only_selected_span_fields(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GraphQL selection prevents unrequested span PHI from over-fetching."""
+
+    def fake_analyze(*args: Any, **kwargs: Any) -> PredictionResult:
+        assert kwargs["loader"].loader is FakeLoader.instances[0]
+        assert kwargs["config"].profile == "test"
+        return _prediction_result()
+
+    monkeypatch.setattr(openmed, "analyze_text", fake_analyze)
+    response = client.post(
+        "/graphql",
+        json={
+            "query": """
+                query Analyze($input: AnalyzeInput!) {
+                  analyze(input: $input) {
+                    spans { label start }
+                  }
+                }
+            """,
+            "variables": {"input": {"text": SYNTHETIC_TEXT}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": {"analyze": {"spans": [{"label": "NAME", "start": 10}]}}
+    }
+    assert "Maria Garcia" not in response.text
+
+
+def test_deidentify_query_exposes_policy_and_aggregate_risk_facets(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_deidentify(*args: Any, **kwargs: Any) -> DeidentificationResult:
+        captured["loader"] = kwargs["loader"]
+        captured["policy"] = kwargs["policy"]
+        return _deidentification_result()
+
+    monkeypatch.setattr(openmed, "deidentify", fake_deidentify)
+    response = client.post(
+        "/graphql",
+        json={
+            "query": """
+                query Deidentify($input: DeidentifyInput!) {
+                  deidentify(input: $input) {
+                    deidentifiedText
+                    entities { label start }
+                    policy { name defaultAction }
+                    risk { leakageRate minimumK }
+                  }
+                }
+            """,
+            "variables": {
+                "input": {
+                    "text": SYNTHETIC_TEXT,
+                    "policy": "hipaa_safe_harbor",
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()["data"]["deidentify"]
+    assert payload["deidentifiedText"] == "Paciente: [NAME]"
+    assert payload["entities"] == [{"label": "NAME", "start": 10}]
+    assert payload["policy"]["name"] == "hipaa_safe_harbor"
+    assert payload["risk"] == {"leakageRate": 0.0, "minimumK": 1}
+    assert captured["loader"].loader is FakeLoader.instances[0]
+    assert captured["policy"] == "hipaa_safe_harbor"
+
+
+def test_entity_types_and_introspection_are_available(client: TestClient) -> None:
+    response = client.post(
+        "/graphql",
+        json={
+            "query": """
+                {
+                  entityTypes { label policyLabel }
+                  __schema { queryType { fields { name } } }
+                }
+            """
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    entity_types = {item["label"]: item for item in payload["entityTypes"]}
+    assert entity_types["PERSON"]["policyLabel"] == "DIRECT_IDENTIFIER"
+    field_names = {
+        field["name"] for field in payload["__schema"]["queryType"]["fields"]
+    }
+    assert field_names == {"analyze", "deidentify", "entityTypes"}
+
+
+def test_resolver_errors_and_logs_never_contain_source_text(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    source_text = "Patient SECRET-PHI-471"
+
+    def fail_with_source_text(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError(f"backend failed for {source_text}")
+
+    monkeypatch.setattr(openmed, "analyze_text", fail_with_source_text)
+    caplog.set_level(logging.DEBUG)
+    response = client.post(
+        "/graphql",
+        json={
+            "query": "query($input: AnalyzeInput!) { analyze(input: $input) { text } }",
+            "variables": {"input": {"text": source_text}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["errors"][0]["message"] == SAFE_RESOLVER_ERROR
+    assert source_text not in response.text
+    assert source_text not in caplog.text
+
+
+def test_committed_sdl_matches_live_schema() -> None:
+    assert DEFAULT_OUTPUT_PATH.exists(), (
+        "GraphQL SDL is missing. Re-run "
+        ".venv/bin/python scripts/export_graphql_schema.py."
+    )
+    assert DEFAULT_OUTPUT_PATH.read_text(encoding="utf-8") == render_graphql_schema()
+
+
+def test_schema_is_read_only() -> None:
+    sdl = render_graphql_schema()
+
+    assert "type Query" in sdl
+    assert "type Mutation" not in sdl
+    assert "type Subscription" not in sdl

--- a/uv.lock
+++ b/uv.lock
@@ -1243,6 +1243,18 @@ wheels = [
 ]
 
 [[package]]
+name = "cross-web"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/a0/bdb8370215987cc5bde497cb8b976b17ab14841566ecef2aab6ae3e6c7b0/cross_web-0.7.0.tar.gz", hash = "sha256:15fbc8b9a824a055db8127fd6e43e0773074f620fdecb6b2b587d3d0a2bdd459", size = 332407, upload-time = "2026-05-19T14:18:48.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/4a/78b52ec2edcbd9b123638f4e0421fd8699ebe653ebf63ac5f82abd2665bc/cross_web-0.7.0-py3-none-any.whl", hash = "sha256:ddea9be3c68b48eaf16561847a5831a559786949c544b3701432e00a4e8d19d9", size = 25207, upload-time = "2026-05-19T14:18:47.614Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2096,6 +2108,15 @@ wheels = [
 [package.optional-dependencies]
 grpc = [
     { name = "grpcio" },
+]
+
+[[package]]
+name = "graphql-core"
+version = "3.2.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/90/f2aff026ab4aebd80eb71905106a0885f4cfde85dcf965543f45bed0d9ee/graphql_core-3.2.11.tar.gz", hash = "sha256:e7e156d10beb127cab5c89ff0da71416fc73d27c484a4757d3b2d35633774802", size = 528407, upload-time = "2026-06-05T13:45:22.915Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl", hash = "sha256:0b3e35ff41e9adba53021ab0cef475eb18f57c7f53f0f2ca55567fbf3c537ea0", size = 214879, upload-time = "2026-06-05T13:45:21.245Z" },
 ]
 
 [[package]]
@@ -4497,6 +4518,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "python-dateutil" },
     { name = "ruff" },
+    { name = "strawberry-graphql", extra = ["fastapi"] },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 docs = [
@@ -4607,6 +4629,7 @@ service = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "protobuf" },
+    { name = "strawberry-graphql", extra = ["fastapi"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
 spacy = [
@@ -4714,6 +4737,8 @@ requires-dist = [
     { name = "s3fs", marker = "extra == 'cloud'", specifier = ">=2025.9.0" },
     { name = "safetensors", marker = "extra == 'mlx'", specifier = ">=0.4" },
     { name = "spacy", marker = "extra == 'spacy'", specifier = ">=3.5" },
+    { name = "strawberry-graphql", extras = ["fastapi"], marker = "extra == 'dev'", specifier = ">=0.316,<1" },
+    { name = "strawberry-graphql", extras = ["fastapi"], marker = "extra == 'service'", specifier = ">=0.316,<1" },
     { name = "tiktoken", marker = "extra == 'mlx'", specifier = ">=0.7" },
     { name = "tokenizers", marker = "extra == 'hf'", specifier = ">=0.15" },
     { name = "tokenizers", marker = "extra == 'mlx'", specifier = ">=0.15" },
@@ -7685,6 +7710,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "strawberry-graphql"
+version = "0.322.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cross-web" },
+    { name = "graphql-core" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/45/0036c5be11d5a66bcaddc242d6c7255270edf8646ff14e330a205a49307c/strawberry_graphql-0.322.0.tar.gz", hash = "sha256:48b33ce1253c29da1bb6778ea7688f849d03822c8919ac5668cd1980e64384c3", size = 233437, upload-time = "2026-07-18T10:36:12.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/6f/7996d66a0afdcfda3f68787a3a77f9bc3ed0e503664b0e7302ffcf09a980/strawberry_graphql-0.322.0-py3-none-any.whl", hash = "sha256:601c0bfb49099b55325bc2f4298bd88860ebaa0af6134ffdf342a129c382626d", size = 336881, upload-time = "2026-07-18T10:36:11.198Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+    { name = "python-multipart" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #828.

## Description
Adds a read-only Strawberry GraphQL surface to the existing OpenMed service so frontend and BFF clients can select only the analysis, de-identification, entity, policy, and aggregate risk fields they need. The `/graphql` route reuses the service runtime, warm pool, configuration, timeout, retry, and circuit-breaker paths while masking resolver failures and suppressing exception logging to protect source text.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made
- Added typed `analyze`, `deidentify`, and `entityTypes` queries with canonical span, policy-profile, and aggregate risk types.
- Mounted `/graphql` on the existing FastAPI app with introspection and no mutations or subscriptions.
- Added deterministic SDL export, a committed schema snapshot, serving documentation, and regression coverage for field selection and PHI-safe errors.

## Testing
- [x] Added tests that prove the feature works
- [x] New and existing unit tests pass locally
- [x] Tested synthetic analysis and de-identification inputs

Commands run:
- `.venv/bin/python -m pytest tests/ -q` — 5165 passed, 51 skipped
- `.venv/bin/python -m pytest tests/unit/service/ -q` — 229 passed
- `uv run make format`
- `uv run make lint`
- `uv run make format-check`
- `uv run make docs-build`
- `.venv/bin/pre-commit run --files ...`
- `.venv/bin/python scripts/release/check_license_policy.py`
- `uv lock --check`

## Documentation
- [x] Updated the serving documentation
- [x] Added docstrings to new public functions and classes
- [x] Updated the changelog

## Dependencies
- [x] Added `strawberry-graphql[fastapi]` to the service and development extras. Strawberry provides the requested typed GraphQL schema and FastAPI router integration and is MIT licensed.

## Code Quality
- [x] Ran `make format`, `make lint`, and `make format-check`
- [x] Performed a self-review
- [x] Changes generate no new project warnings
