### PR TITLE
Add HorizontalPodAutoscaler metrics and an autoscaling guide

### DIFF
--- a/deploy/k8s/hpa.yaml
+++ b/deploy/k8s/hpa.yaml
@@ -1,0 +1,32 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: openmed-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: openmed-service
+  minReplicas: 2
+  maxReplicas: 20
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+    - type: Pods
+      pods:
+        metric:
+          name: openmed_service_scaling_queue_depth
+        target:
+          type: AverageValue
+          averageValue: "8"
+    - type: Pods
+      pods:
+        metric:
+          name: openmed_service_scaling_inflight_requests
+        target:
+          type: AverageValue
+          averageValue: "4"

--- a/docs/deploy/autoscaling.md
+++ b/docs/deploy/autoscaling.md
@@ -1,0 +1,168 @@
+# Kubernetes Autoscaling
+
+OpenMed exposes two label-free gauges for scaling model-backed service work:
+
+- `openmed_service_scaling_queue_depth`: pending requests across the pod's
+  dynamic batch queues
+- `openmed_service_scaling_inflight_requests`: active requests on model-backed
+  routes
+
+Both are emitted by the opt-in [`GET /metrics`](../rest-service.md#prometheus-metrics)
+surface. They contain no request, client, model, document, or PHI labels.
+Prometheus adds the Kubernetes `namespace` and `pod` resource labels while
+scraping; the application does not export them itself.
+
+The sample
+[`deploy/k8s/hpa.yaml`](https://github.com/maziyarpanahi/openmed/blob/master/deploy/k8s/hpa.yaml)
+targets an `openmed-service` Deployment with 2 to 20 replicas. It asks
+Kubernetes to keep average queue depth at 8 per pod, average in-flight work at 4
+per pod, and average CPU utilization at 60%. The HPA uses the largest
+recommendation, so CPU remains an independent scaling floor when the custom
+metrics are quiet.
+
+## Prerequisites
+
+The manifest is intentionally cluster-neutral. Supply these components in the
+cluster rather than bundling a cloud-provider-specific metrics service:
+
+1. Kubernetes resource metrics for the CPU target.
+2. Prometheus scraping OpenMed pods.
+3. A Prometheus Adapter serving `custom.metrics.k8s.io`.
+
+Enable metrics and batching in the OpenMed Helm release. The HPA CPU target also
+requires a CPU request, which the chart sets by default:
+
+```bash
+helm upgrade --install openmed-service deploy/helm/openmed-service \
+  --namespace openmed \
+  --create-namespace \
+  --set config.metrics.enabled=true \
+  --set config.batching.enabled=true \
+  --set replicaCount=2
+```
+
+## Scrape the service
+
+For Prometheus Operator, this `ServiceMonitor` selects the labels produced by
+the release command above. Store it in your cluster configuration and apply it
+in the same namespace:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: openmed-service
+  namespace: openmed
+spec:
+  namespaceSelector:
+    matchNames:
+      - openmed
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: openmed-service
+      app.kubernetes.io/name: openmed-service
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+```
+
+If Prometheus is configured without the Operator, use Kubernetes pod discovery
+and retain `namespace` and `pod` as target labels. The adapter rules below need
+both labels to associate each sample with a Kubernetes Pod.
+
+## Configure Prometheus Adapter
+
+Merge these entries into the Prometheus Adapter chart's `rules.custom` values.
+The queries preserve the adapter's requested pod grouping and expose the exact
+metric names referenced by the HPA:
+
+```yaml
+rules:
+  custom:
+    - seriesQuery: >-
+        openmed_service_scaling_queue_depth{namespace!="",pod!=""}
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^openmed_service_scaling_queue_depth$
+        as: openmed_service_scaling_queue_depth
+      metricsQuery: >-
+        sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+    - seriesQuery: >-
+        openmed_service_scaling_inflight_requests{namespace!="",pod!=""}
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^openmed_service_scaling_inflight_requests$
+        as: openmed_service_scaling_inflight_requests
+      metricsQuery: >-
+        sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+```
+
+After the adapter reloads, verify both Pod metrics before applying the HPA:
+
+```bash
+kubectl get --raw \
+  '/apis/custom.metrics.k8s.io/v1beta2/namespaces/openmed/pods/%2A/openmed_service_scaling_queue_depth'
+kubectl get --raw \
+  '/apis/custom.metrics.k8s.io/v1beta2/namespaces/openmed/pods/%2A/openmed_service_scaling_inflight_requests'
+kubectl apply --namespace openmed --filename deploy/k8s/hpa.yaml
+kubectl describe hpa openmed-service --namespace openmed
+```
+
+If either custom metric is missing, check the OpenMed metrics flag, Prometheus
+target health, retained target labels, and adapter discovery before tuning the
+HPA. Kubernetes avoids a scale-down when one of the configured metrics cannot
+be read.
+
+## Reproduce the replica mapping
+
+For a Pods `AverageValue` target, the raw recommendation is equivalent to
+`ceil(total metric value / target average)`. CPU uses
+`ceil(current replicas * current average CPU / target CPU)`. The HPA selects the
+largest signal, then enforces the 2-to-20 replica bounds.
+
+| Load shape | Current replicas | Queue | In flight | CPU | Queue recommendation | In-flight recommendation | CPU recommendation | Desired replicas |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Idle | 2 | 0 | 2 | 25% | 0 | 1 | 1 | 2 |
+| Steady | 2 | 12 | 9 | 45% | 2 | 3 | 2 | 3 |
+| Burst | 3 | 37 | 18 | 75% | 5 | 5 | 4 | 5 |
+| Queue-bound | 5 | 96 | 28 | 85% | 12 | 7 | 8 | 12 |
+| CPU-bound | 4 | 4 | 3 | 95% | 1 | 1 | 7 | 7 |
+
+Run this dependency-free snippet to reproduce the table:
+
+```python
+from math import ceil
+
+cases = [
+    ("Idle", 2, 0, 2, 25),
+    ("Steady", 2, 12, 9, 45),
+    ("Burst", 3, 37, 18, 75),
+    ("Queue-bound", 5, 96, 28, 85),
+    ("CPU-bound", 4, 4, 3, 95),
+]
+
+for name, current, queue, inflight, cpu in cases:
+    signals = (
+        ceil(queue / 8),
+        ceil(inflight / 4),
+        ceil(current * cpu / 60),
+    )
+    desired = max(2, min(20, max(signals)))
+    print(name, *signals, desired)
+```
+
+These are raw recommendations. Kubernetes tolerance, readiness filtering, and
+scale-down stabilization can delay an actual replica change. Tune targets from
+representative synthetic traffic and service-level objectives; never add
+request-derived or PHI-bearing labels to make the metrics more granular.

--- a/docs/deploy/helm.md
+++ b/docs/deploy/helm.md
@@ -41,7 +41,9 @@ helm upgrade openmed-service deploy/helm/openmed-service \
 
 The chart does not create an Ingress or autoscaling object. Add those in
 environment-specific overlays so cluster ingress classes, certificates, and HPA
-policy stay outside the reusable chart.
+policy stay outside the reusable chart. The cluster-neutral
+[autoscaling guide](autoscaling.md) provides an HPA manifest and Prometheus
+Adapter wiring for the service's queue-depth and in-flight metrics.
 
 ## Probes
 

--- a/docs/rest-service.md
+++ b/docs/rest-service.md
@@ -291,7 +291,9 @@ and the service waits up to this timeout for in-flight `/analyze`,
 `/pii/extract`, `/pii/deidentify`, and `/privacy-gateway/complete` requests to
 finish. The default is `30`.
 
-Optional pull-only Prometheus metrics endpoint:
+### Prometheus metrics
+
+Enable the optional pull-only Prometheus metrics endpoint:
 
 ```bash
 OPENMED_SERVICE_METRICS_ENABLED=true uvicorn openmed.service.app:app --host 127.0.0.1 --port 8080
@@ -302,7 +304,11 @@ OPENMED_SERVICE_METRICS_ENABLED=true uvicorn openmed.service.app:app --host 127.
 `1` before the app starts. When enabled, the endpoint renders Prometheus 0.0.4
 text exposition for aggregate request counts, request duration histograms,
 in-flight request count, warm-pool model load/eviction counters, and aggregate
-circuit-breaker state gauges. Metrics
+circuit-breaker state gauges. The label-free
+`openmed_service_scaling_queue_depth` and
+`openmed_service_scaling_inflight_requests` gauges are suitable for a
+Prometheus Adapter and Kubernetes HPA; see the
+[autoscaling guide](deploy/autoscaling.md). Metrics
 are pull-only: OpenMed does not push them to any remote service. Scrape it from
 a locally scoped Prometheus or sidecar, and avoid exposing it directly to
 untrusted networks. Metric labels are limited to static route templates and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - gRPC Service: serving/grpc.md
       - REST Authentication: serving/authentication.md
       - Helm Deployment: deploy/helm.md
+      - Kubernetes Autoscaling: deploy/autoscaling.md
       - Multi-Arch Containers: deploy/multi-arch.md
       - ModelLoader & Pipelines: model-loader.md
       - Model Registry: model-registry.md

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -211,6 +211,7 @@ def _attach_runtime(app: FastAPI, runtime: ServiceRuntime) -> None:
             max_wait_ms=runtime.batching.max_wait_ms,
             max_queue_size_per_priority=runtime.batching.max_queue_size,
             metrics=runtime.metrics,
+            metrics_queue="analyze",
         )
         app.state.pii_extract_batcher = DynamicBatcher(
             lambda jobs: _dispatch_pii_extract_batch(runtime, jobs),
@@ -218,6 +219,7 @@ def _attach_runtime(app: FastAPI, runtime: ServiceRuntime) -> None:
             max_wait_ms=runtime.batching.max_wait_ms,
             max_queue_size_per_priority=runtime.batching.max_queue_size,
             metrics=runtime.metrics,
+            metrics_queue="pii_extract",
         )
     app.state.throttle = ServiceThrottle(
         runtime.throttle,
@@ -454,10 +456,17 @@ def create_app() -> FastAPI:
                     details=None,
                 )
             state.inflight = getattr(state, "inflight", 0) + 1
+            metrics = getattr(state, "metrics", None)
+            scaling_started = getattr(metrics, "scaling_request_started", None)
+            scaling_finished = getattr(metrics, "scaling_request_finished", None)
+            if callable(scaling_started):
+                scaling_started()
             try:
                 return await call_next(request)
             finally:
                 state.inflight = getattr(state, "inflight", 0) - 1
+                if callable(scaling_finished):
+                    scaling_finished()
         return await call_next(request)
 
     if app.state.metrics is not None:

--- a/openmed/service/batcher.py
+++ b/openmed/service/batcher.py
@@ -161,6 +161,7 @@ class DynamicBatcher(Generic[T, R]):
         ),
         priority_weights: Optional[Mapping[str, int]] = None,
         metrics: Optional[Any] = None,
+        metrics_queue: Optional[str] = None,
     ) -> None:
         if max_batch_size <= 0:
             raise ValueError("max_batch_size must be positive")
@@ -179,6 +180,7 @@ class DynamicBatcher(Generic[T, R]):
         self._scheduler_cycle = _normalize_priority_weights(priority_weights)
         self._scheduler_index = 0
         self._metrics = metrics
+        self._metrics_queue = metrics_queue
         self._lock = asyncio.Lock()
         self._timer: Optional[asyncio.TimerHandle] = None
         for priority in PRIORITY_CLASSES:
@@ -396,7 +398,13 @@ class DynamicBatcher(Generic[T, R]):
     def _record_queue_depth(self, priority: str) -> None:
         record = getattr(self._metrics, "record_batch_queue_depth", None)
         if callable(record):
-            record(priority=priority, depth=len(self._queues[priority]))
+            kwargs = {
+                "priority": priority,
+                "depth": len(self._queues[priority]),
+            }
+            if self._metrics_queue is not None:
+                kwargs["queue"] = self._metrics_queue
+            record(**kwargs)
 
     def _record_queue_wait(self, priority: str, wait_seconds: float) -> None:
         record = getattr(self._metrics, "record_batch_queue_wait", None)

--- a/openmed/service/metrics.py
+++ b/openmed/service/metrics.py
@@ -7,6 +7,12 @@ import os
 import threading
 from typing import Mapping
 
+from .scaling_metrics import (
+    SCALING_INFLIGHT_NAME,
+    SCALING_QUEUE_DEPTH_NAME,
+    ScalingMetrics,
+)
+
 METRICS_ENABLED_ENV_VAR = "OPENMED_SERVICE_METRICS_ENABLED"
 PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 
@@ -100,6 +106,7 @@ class PrometheusMetricsRegistry:
         self._duration_count: dict[str, int] = {}
         self._duration_sum: dict[str, float] = {}
         self._inflight_requests = 0
+        self._scaling_metrics = ScalingMetrics()
         self._model_load_total = 0
         self._model_eviction_total = 0
         self._paged_kv_cache_occupancy_pages = 0
@@ -134,6 +141,14 @@ class PrometheusMetricsRegistry:
         """Increment the active request gauge."""
         with self._lock:
             self._inflight_requests += 1
+
+    def scaling_request_started(self) -> None:
+        """Increment the model-backed request gauge used for autoscaling."""
+        self._scaling_metrics.request_started()
+
+    def scaling_request_finished(self) -> None:
+        """Decrement the model-backed request gauge used for autoscaling."""
+        self._scaling_metrics.request_finished()
 
     def request_finished(
         self,
@@ -207,11 +222,22 @@ class PrometheusMetricsRegistry:
             if evictions > 0:
                 self._paged_kv_cache_eviction_total += int(evictions)
 
-    def record_batch_queue_depth(self, *, priority: str, depth: int) -> None:
+    def record_batch_queue_depth(
+        self,
+        *,
+        priority: str,
+        depth: int,
+        queue: str = "default",
+    ) -> None:
         """Set the current dynamic-batcher queue depth for one priority."""
         priority_label = str(priority)
         with self._lock:
             self._batch_queue_depth[priority_label] = max(int(depth), 0)
+        self._scaling_metrics.record_queue_depth(
+            queue=queue,
+            priority=priority_label,
+            depth=depth,
+        )
 
     def record_batch_queue_wait(
         self,
@@ -313,6 +339,7 @@ class PrometheusMetricsRegistry:
 
     def render(self) -> str:
         """Render metrics using the Prometheus 0.0.4 text format."""
+        scaling_snapshot = self._scaling_metrics.snapshot()
         with self._lock:
             request_total = dict(self._request_total)
             duration_bucket_counts = {
@@ -395,6 +422,22 @@ class PrometheusMetricsRegistry:
             "gauge",
         )
         lines.append(f"{INFLIGHT_NAME} {inflight_requests}")
+
+        _append_family_header(
+            lines,
+            SCALING_QUEUE_DEPTH_NAME,
+            "Pending model requests across this pod's dynamic batch queues.",
+            "gauge",
+        )
+        lines.append(f"{SCALING_QUEUE_DEPTH_NAME} {scaling_snapshot.queue_depth}")
+
+        _append_family_header(
+            lines,
+            SCALING_INFLIGHT_NAME,
+            "Active model-backed requests currently handled by this pod.",
+            "gauge",
+        )
+        lines.append(f"{SCALING_INFLIGHT_NAME} {scaling_snapshot.inflight_requests}")
 
         _append_family_header(
             lines,

--- a/openmed/service/scaling_metrics.py
+++ b/openmed/service/scaling_metrics.py
@@ -1,0 +1,74 @@
+"""Low-cardinality gauges used to autoscale the OpenMed REST service."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+SCALING_QUEUE_DEPTH_NAME = "openmed_service_scaling_queue_depth"
+SCALING_INFLIGHT_NAME = "openmed_service_scaling_inflight_requests"
+
+
+@dataclass(frozen=True)
+class ScalingMetricSnapshot:
+    """Point-in-time autoscaling values for one service process.
+
+    Attributes:
+        queue_depth: Pending requests across all registered queue partitions.
+        inflight_requests: Active model-backed requests in this process.
+    """
+
+    queue_depth: int
+    inflight_requests: int
+
+
+class ScalingMetrics:
+    """Track aggregate model-work signals without exporting labels.
+
+    Queue identifiers and priority classes are retained only as internal keys so
+    multiple dynamic batchers can contribute to one per-pod queue depth. They
+    are intentionally absent from the exported samples, which keeps the custom
+    metrics surface bounded and prevents request-derived values from becoming
+    metric labels.
+    """
+
+    def __init__(self) -> None:
+        self._queue_depths: dict[tuple[str, str], int] = {}
+        self._inflight_requests = 0
+        self._lock = threading.RLock()
+
+    def request_started(self) -> None:
+        """Increment the active model-backed request count."""
+        with self._lock:
+            self._inflight_requests += 1
+
+    def request_finished(self) -> None:
+        """Decrement the active model-backed request count without underflow."""
+        with self._lock:
+            self._inflight_requests = max(self._inflight_requests - 1, 0)
+
+    def record_queue_depth(
+        self,
+        *,
+        queue: str,
+        priority: str,
+        depth: int,
+    ) -> None:
+        """Replace one internal queue partition's current pending-work count.
+
+        Args:
+            queue: Stable internal name for the contributing batch queue.
+            priority: Stable internal priority partition name.
+            depth: Current number of pending requests in the partition.
+        """
+        key = (str(queue), str(priority))
+        with self._lock:
+            self._queue_depths[key] = max(int(depth), 0)
+
+    def snapshot(self) -> ScalingMetricSnapshot:
+        """Return aggregate, label-free values suitable for pod metrics."""
+        with self._lock:
+            return ScalingMetricSnapshot(
+                queue_depth=sum(self._queue_depths.values()),
+                inflight_requests=self._inflight_requests,
+            )

--- a/tests/unit/service/test_scaling_metrics.py
+++ b/tests/unit/service/test_scaling_metrics.py
@@ -1,0 +1,110 @@
+"""Tests for REST service autoscaling metrics and the HPA manifest."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import yaml
+
+from openmed.service.batcher import DynamicBatcher
+from openmed.service.metrics import PrometheusMetricsRegistry
+from openmed.service.scaling_metrics import (
+    SCALING_INFLIGHT_NAME,
+    SCALING_QUEUE_DEPTH_NAME,
+    ScalingMetrics,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+HPA_MANIFEST = ROOT / "deploy" / "k8s" / "hpa.yaml"
+
+
+def test_scaling_metrics_aggregate_queue_partitions_and_clamp_values() -> None:
+    metrics = ScalingMetrics()
+
+    metrics.request_finished()
+    metrics.request_started()
+    metrics.request_started()
+    metrics.request_finished()
+    metrics.record_queue_depth(queue="analyze", priority="interactive", depth=3)
+    metrics.record_queue_depth(queue="analyze", priority="bulk", depth=-1)
+    metrics.record_queue_depth(queue="pii_extract", priority="bulk", depth=2)
+
+    snapshot = metrics.snapshot()
+
+    assert snapshot.queue_depth == 5
+    assert snapshot.inflight_requests == 1
+
+
+def test_synthetic_load_is_exposed_as_label_free_scaling_gauges() -> None:
+    async def run_load() -> str:
+        registry = PrometheusMetricsRegistry()
+        analyze_batcher = DynamicBatcher(
+            lambda items: list(items),
+            max_batch_size=16,
+            max_wait_ms=60_000,
+            metrics=registry,
+            metrics_queue="analyze",
+        )
+        pii_batcher = DynamicBatcher(
+            lambda items: list(items),
+            max_batch_size=16,
+            max_wait_ms=60_000,
+            metrics=registry,
+            metrics_queue="pii_extract",
+        )
+        pending = [
+            asyncio.create_task(analyze_batcher.submit("a", priority="interactive")),
+            asyncio.create_task(analyze_batcher.submit("b", priority="bulk")),
+            asyncio.create_task(pii_batcher.submit("c", priority="bulk")),
+        ]
+        await asyncio.sleep(0)
+        for _ in range(4):
+            registry.scaling_request_started()
+
+        rendered = registry.render()
+
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        return rendered
+
+    rendered = asyncio.run(run_load())
+
+    assert f"# TYPE {SCALING_QUEUE_DEPTH_NAME} gauge" in rendered
+    assert f"{SCALING_QUEUE_DEPTH_NAME} 3" in rendered
+    assert f"# TYPE {SCALING_INFLIGHT_NAME} gauge" in rendered
+    assert f"{SCALING_INFLIGHT_NAME} 4" in rendered
+    assert f"{SCALING_QUEUE_DEPTH_NAME}{{" not in rendered
+    assert f"{SCALING_INFLIGHT_NAME}{{" not in rendered
+
+
+def test_hpa_manifest_targets_cpu_and_both_custom_metrics() -> None:
+    manifest = yaml.safe_load(HPA_MANIFEST.read_text(encoding="utf-8"))
+
+    assert manifest["apiVersion"] == "autoscaling/v2"
+    assert manifest["kind"] == "HorizontalPodAutoscaler"
+    assert manifest["spec"]["scaleTargetRef"] == {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "name": "openmed-service",
+    }
+    assert manifest["spec"]["minReplicas"] == 2
+    assert manifest["spec"]["maxReplicas"] == 20
+
+    metrics = manifest["spec"]["metrics"]
+    cpu = next(metric["resource"] for metric in metrics if metric["type"] == "Resource")
+    pods = {
+        metric["pods"]["metric"]["name"]: metric["pods"]["target"]
+        for metric in metrics
+        if metric["type"] == "Pods"
+    }
+
+    assert cpu == {
+        "name": "cpu",
+        "target": {"type": "Utilization", "averageUtilization": 60},
+    }
+    assert pods == {
+        SCALING_QUEUE_DEPTH_NAME: {"type": "AverageValue", "averageValue": "8"},
+        SCALING_INFLIGHT_NAME: {"type": "AverageValue", "averageValue": "4"},
+    }


### PR DESCRIPTION
## Description

Adds stable, label-free queue-depth and model-backed in-flight gauges for Kubernetes autoscaling. It also provides a cluster-neutral HorizontalPodAutoscaler manifest, adapter wiring, and a reproducible load-to-replica guide.

Closes #831.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Aggregate pending work across both dynamic batch queues without exporting internal or request-derived labels.
- Track active model-backed requests separately from general HTTP traffic.
- Add an autoscaling/v2 manifest using queue depth, in-flight work, and CPU targets.
- Document scraping, custom-metrics adapter rules, verification, and threshold-to-replica calculations.

## Testing

- [x] Full test suite passes: 5,166 passed and 47 skipped.
- [x] Formatting, lint, format-check, type-check, and scoped pre-commit checks pass.
- [x] Strict documentation build and Helm rendering pass.
- [x] Synthetic-load gauge tests and offline HPA manifest validation pass.

## Documentation

- [x] Added the Kubernetes autoscaling guide and navigation entry.
- [x] Linked the new guide from the REST metrics and Helm deployment documentation.

## Dependencies

- [x] No new dependencies.

## Related Issues

Closes #831
