### PR TITLE
Add mutual-TLS client-certificate authentication to the service

### DIFF
--- a/docs/serving/authentication.md
+++ b/docs/serving/authentication.md
@@ -87,3 +87,9 @@ OPENMED_SERVICE_AUTH_FAILURE_RATE_LIMIT_KEY=peer
 
 The failure limiter only counts failed authentication attempts. Successful
 authenticated requests are not charged against it.
+
+## Mutual TLS
+
+For certificate-bearing workload identity, including deployments that require
+mTLS before JWT or API-key authorization, see
+[Mutual TLS Client Authentication](mtls.md).

--- a/docs/serving/mtls.md
+++ b/docs/serving/mtls.md
@@ -1,0 +1,124 @@
+# Mutual TLS Client Authentication
+
+Mutual TLS (mTLS) can require every REST caller to present a client
+certificate issued by a configured private CA. OpenMed validates the client
+chain again at the application boundary, exposes the verified certificate
+identity to handlers, and can map an exact subject or subject alternative name
+(SAN) to the principal and scopes used by route authorization.
+
+mTLS is disabled by default. Enable it without changing application code:
+
+```bash
+OPENMED_SERVICE_MTLS_ENABLED=true \
+OPENMED_SERVICE_MTLS_CA_BUNDLE=/etc/openmed/client-ca.pem \
+uvicorn openmed.service.app:app --host 127.0.0.1 --port 8080
+```
+
+`OPENMED_SERVICE_MTLS_CA_BUNDLE` must contain at least one trusted CA
+certificate. It must not contain a production private key. Online CRL and OCSP
+checking are not performed; certificate issuance and revocation infrastructure
+remain the deployer's responsibility.
+
+## Terminate TLS at the application
+
+For direct TLS, use an ASGI server that implements the ASGI TLS extension and
+places the leaf-first PEM client chain in
+`scope["extensions"]["tls"]["client_cert_chain"]`. Configure the server to
+require client certificates against the same CA bundle. For example, the
+corresponding Uvicorn transport flags are:
+
+```bash
+uvicorn openmed.service.app:app \
+  --host 0.0.0.0 \
+  --port 8443 \
+  --ssl-keyfile /etc/openmed/server-key.pem \
+  --ssl-certfile /etc/openmed/server-cert.pem \
+  --ssl-cert-reqs 2 \
+  --ssl-ca-certs /etc/openmed/client-ca.pem
+```
+
+The transport must both enforce the TLS handshake and expose the verified
+chain through the ASGI TLS extension. If the server does not expose that
+extension, OpenMed cannot recover the peer certificate from an HTTP request and
+returns `mtls_certificate_required`; use a compatible server or the trusted
+proxy pattern below.
+
+## Terminate TLS at a sidecar or ingress
+
+A sidecar or ingress may terminate mTLS and forward a URL-escaped PEM client
+chain in a dedicated header. Configure both the header name and the exact proxy
+addresses or CIDR networks allowed to supply it:
+
+```bash
+OPENMED_SERVICE_MTLS_ENABLED=true \
+OPENMED_SERVICE_MTLS_CA_BUNDLE=/etc/openmed/client-ca.pem \
+OPENMED_SERVICE_MTLS_CLIENT_CERT_HEADER=X-OpenMed-Client-Cert \
+OPENMED_SERVICE_MTLS_TRUSTED_PROXIES=127.0.0.1/32,10.42.0.0/16 \
+uvicorn openmed.service.app:app --host 127.0.0.1 --port 8080 --no-proxy-headers
+```
+
+The proxy must:
+
+1. remove the client-supplied `X-OpenMed-Client-Cert` header;
+2. require and verify a client certificate at its TLS listener;
+3. URL-escape the leaf-first PEM chain into the configured header; and
+4. connect to OpenMed only from an address in the trusted-proxy list.
+
+OpenMed rejects the header from any other peer and independently verifies the
+forwarded chain against `OPENMED_SERVICE_MTLS_CA_BUNDLE`. Do not configure a
+public or shared proxy network as trusted. The ASGI `scope["client"]` value must
+remain the transport peer address used for this check. Disable generic proxy
+header rewriting as shown above, or configure the server so untrusted
+`X-Forwarded-For` input cannot replace that peer address.
+
+## Map certificates to principals and scopes
+
+Verified certificate details are available to handlers as
+`request.state.mtls_identity`:
+
+- `subject`: the RFC 4514 distinguished name;
+- `sans`: typed values such as `uri:spiffe://openmed.test/clinic-api`,
+  `dns:clinic-api.internal`, or `ip:10.42.0.8`; and
+- `fingerprint_sha256`: the lowercase leaf-certificate fingerprint.
+
+Use exact subject or SAN values to assign a stable, non-PHI service principal
+and route scopes:
+
+```bash
+OPENMED_SERVICE_MTLS_PRINCIPALS='[
+  {
+    "identities": ["uri:spiffe://clinic.example/workload/openmed-client"],
+    "principal": "clinic-api",
+    "scopes": ["analyze:write", "pii:read", "pii:write", "models:read"]
+  }
+]'
+```
+
+The mapped `AuthPrincipal` is available as `request.state.auth_principal` and
+`request.scope["openmed.auth"]`. When no mapping matches, OpenMed uses
+`mtls:<sha256-fingerprint>` with no scopes. This authenticates the certificate
+without silently granting application permissions.
+
+## Combine mTLS with JWT or API keys
+
+mTLS protects the connection and supplies a workload identity. REST
+authentication remains independently configurable with
+`OPENMED_SERVICE_AUTH_ENABLED=true`. An explicit JWT or API key takes
+precedence for route authorization, while `request.state.mtls_identity`
+continues to identify the certificate-bearing workload. Without an explicit
+credential, the mapped mTLS principal is used, so only scopes granted by
+`OPENMED_SERVICE_MTLS_PRINCIPALS` can authorize scoped routes.
+
+To require JWT on normal application routes, leave the mTLS principal without
+route scopes and configure JWT keys and route scopes as described in
+[REST Service Authentication](authentication.md). The TLS certificate is still
+required before the JWT is evaluated.
+
+## Logging and PHI safety
+
+Client certificate PEM, subject, SANs, and fingerprint are never written to
+access logs. A successful mTLS request adds only the configured principal (or
+the fallback fingerprint-based service identifier) as `identity`, plus
+`credential_type=mtls`. Use machine and workload identities in certificates;
+do not put patient names, record identifiers, or other PHI in certificate
+subjects, SANs, or principal mappings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
       - Async REST Jobs & Webhooks: serving/async-jobs.md
       - gRPC Service: serving/grpc.md
       - REST Authentication: serving/authentication.md
+      - Mutual TLS Authentication: serving/mtls.md
       - Helm Deployment: deploy/helm.md
       - Multi-Arch Containers: deploy/multi-arch.md
       - ModelLoader & Pipelines: model-loader.md

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -41,6 +41,7 @@ from .metrics import (
     PrometheusMetricsRegistry,
     metrics_enabled_from_env,
 )
+from .mtls import ServiceMTLS, parse_service_mtls_config
 from .privacy_gateway import (
     HttpExternalLLMTransport,
     InMemoryReidentificationStore,
@@ -436,6 +437,10 @@ def create_app() -> FastAPI:
         parse_service_auth_config(),
         error_response=_error_response,
     )
+    app.state.mtls = ServiceMTLS(
+        parse_service_mtls_config(),
+        error_response=_error_response,
+    )
     app.state.metrics = (
         PrometheusMetricsRegistry() if metrics_enabled_from_env() else None
     )
@@ -504,9 +509,16 @@ def create_app() -> FastAPI:
     @app.middleware("http")
     async def _auth_middleware(request: Request, call_next):
         auth = getattr(request.app.state, "auth", None)
-        if auth is None:
-            return await call_next(request)
-        return await auth.dispatch(request, call_next)
+        mtls = getattr(request.app.state, "mtls", None)
+
+        async def dispatch_auth(auth_request: Request) -> Response:
+            if auth is None:
+                return await call_next(auth_request)
+            return await auth.dispatch(auth_request, call_next)
+
+        if mtls is None:
+            return await dispatch_auth(request)
+        return await mtls.dispatch(request, dispatch_auth)
 
     @app.exception_handler(RequestValidationError)
     async def _request_validation_handler(

--- a/openmed/service/auth.py
+++ b/openmed/service/auth.py
@@ -444,6 +444,9 @@ class ServiceAuth:
 
         authorization = request.headers.get("authorization")
         if not authorization:
+            mtls_principal = request.scope.get("openmed.auth")
+            if isinstance(mtls_principal, AuthPrincipal):
+                return mtls_principal
             raise missing_credentials()
 
         scheme, _, value = authorization.strip().partition(" ")

--- a/openmed/service/logging.py
+++ b/openmed/service/logging.py
@@ -19,6 +19,8 @@ REQUEST_ID_HEADER = "X-Request-ID"
 SERVICE_LOG_LEVEL_ENV_VAR = "OPENMED_SERVICE_LOG_LEVEL"
 SERVICE_LOG_FORMAT_ENV_VAR = "OPENMED_SERVICE_LOG_FORMAT"
 _MODEL_NAME_SCOPE_KEY = "openmed.access_log_model_name"
+_IDENTITY_SCOPE_KEY = "openmed.access_log_identity"
+_CREDENTIAL_TYPE_SCOPE_KEY = "openmed.access_log_credential_type"
 
 _REQUEST_ID: ContextVar[Optional[str]] = ContextVar(
     "openmed_service_request_id",
@@ -73,6 +75,17 @@ def set_access_log_model_name(request: Any, model_name: Optional[str]) -> None:
         request.scope[_MODEL_NAME_SCOPE_KEY] = str(model_name)
 
 
+def set_access_log_identity(
+    request: Any,
+    *,
+    principal: str,
+    credential_type: str,
+) -> None:
+    """Attach a non-PHI caller identity to the current request access log."""
+    request.scope[_IDENTITY_SCOPE_KEY] = str(principal)
+    request.scope[_CREDENTIAL_TYPE_SCOPE_KEY] = str(credential_type)
+
+
 class CorrelationIdMiddleware:
     """Add request IDs and emit PHI-free structured access logs."""
 
@@ -118,6 +131,8 @@ class CorrelationIdMiddleware:
                         "status_code": status_code,
                         "duration_ms": round(duration_ms, 3),
                         "model_name": scope.get(_MODEL_NAME_SCOPE_KEY),
+                        "identity": scope.get(_IDENTITY_SCOPE_KEY),
+                        "credential_type": scope.get(_CREDENTIAL_TYPE_SCOPE_KEY),
                         "request_id": request_id,
                     },
                 )
@@ -165,7 +180,9 @@ def _format_access_log(payload: Mapping[str, Any], config: ServiceLogConfig) -> 
             f"{payload.get('status_code', 0)} "
             f"{payload.get('duration_ms', 0)}ms "
             f"request_id={payload.get('request_id', '')} "
-            f"model_name={payload.get('model_name') or '-'}"
+            f"model_name={payload.get('model_name') or '-'} "
+            f"identity={payload.get('identity') or '-'} "
+            f"credential_type={payload.get('credential_type') or '-'}"
         )
     return _json_dumps(payload)
 
@@ -213,5 +230,6 @@ __all__ = [
     "StructuredJsonLogFormatter",
     "current_request_id",
     "service_log_config_from_env",
+    "set_access_log_identity",
     "set_access_log_model_name",
 ]

--- a/openmed/service/mtls.py
+++ b/openmed/service/mtls.py
@@ -1,0 +1,510 @@
+"""Mutual-TLS client certificate authentication for the REST service."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import os
+import re
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import unquote_to_bytes
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.x509.verification import (
+    PolicyBuilder,
+    Store,
+    VerificationError,
+)
+from fastapi import Request
+from starlette.responses import Response
+
+from .auth import AuthPrincipal, parse_bool
+from .logging import set_access_log_identity
+
+SERVICE_MTLS_ENABLED_ENV_VAR = "OPENMED_SERVICE_MTLS_ENABLED"
+SERVICE_MTLS_CA_BUNDLE_ENV_VAR = "OPENMED_SERVICE_MTLS_CA_BUNDLE"
+SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR = "OPENMED_SERVICE_MTLS_CLIENT_CERT_HEADER"
+SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR = "OPENMED_SERVICE_MTLS_TRUSTED_PROXIES"
+SERVICE_MTLS_PRINCIPALS_ENV_VAR = "OPENMED_SERVICE_MTLS_PRINCIPALS"
+
+MAX_CLIENT_CERT_CHAIN_BYTES = 256 * 1024
+_HEADER_NAME_PATTERN = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+
+ErrorResponseFactory = Callable[..., Response]
+CallNext = Callable[[Request], Awaitable[Response]]
+IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+@dataclass(frozen=True)
+class MTLSPrincipalMapping:
+    """Map exact certificate identities to a route-authorization principal."""
+
+    identities: frozenset[str]
+    principal: str
+    scopes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class MTLSClientIdentity:
+    """Verified client certificate identity exposed to request handlers."""
+
+    subject: str
+    sans: tuple[str, ...]
+    fingerprint_sha256: str
+
+    @property
+    def identifiers(self) -> tuple[str, ...]:
+        """Return exact values eligible for configured principal mapping."""
+        return (self.subject, *self.sans)
+
+
+@dataclass(frozen=True)
+class ServiceMTLSConfig:
+    """Mutual-TLS settings for the REST service."""
+
+    enabled: bool = False
+    ca_bundle: Optional[Path] = None
+    client_cert_header: Optional[str] = None
+    trusted_proxies: tuple[IPNetwork, ...] = ()
+    principals: tuple[MTLSPrincipalMapping, ...] = ()
+
+
+class MTLSAuthenticationError(ValueError):
+    """mTLS authentication failure safe to expose through the API envelope."""
+
+    def __init__(self, *, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def parse_service_mtls_config() -> ServiceMTLSConfig:
+    """Read mTLS settings from the current process environment."""
+    enabled = parse_bool(
+        os.getenv(SERVICE_MTLS_ENABLED_ENV_VAR),
+        env_var=SERVICE_MTLS_ENABLED_ENV_VAR,
+        default=False,
+    )
+    if not enabled:
+        return ServiceMTLSConfig(enabled=False)
+
+    raw_ca_bundle = os.getenv(SERVICE_MTLS_CA_BUNDLE_ENV_VAR)
+    if raw_ca_bundle is None or not raw_ca_bundle.strip():
+        raise ValueError(
+            f"{SERVICE_MTLS_CA_BUNDLE_ENV_VAR} is required when mTLS is enabled"
+        )
+    ca_bundle = Path(raw_ca_bundle.strip())
+    if not ca_bundle.is_file():
+        raise ValueError(f"{SERVICE_MTLS_CA_BUNDLE_ENV_VAR} must name a readable file")
+
+    client_cert_header = _parse_client_cert_header(
+        os.getenv(SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR)
+    )
+    trusted_proxies = parse_trusted_proxies(
+        os.getenv(SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR)
+    )
+    if client_cert_header is not None and not trusted_proxies:
+        raise ValueError(
+            f"{SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR} is required when "
+            f"{SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR} is configured"
+        )
+
+    return ServiceMTLSConfig(
+        enabled=True,
+        ca_bundle=ca_bundle,
+        client_cert_header=client_cert_header,
+        trusted_proxies=trusted_proxies,
+        principals=parse_principal_mappings(os.getenv(SERVICE_MTLS_PRINCIPALS_ENV_VAR)),
+    )
+
+
+def parse_trusted_proxies(raw_value: Optional[str]) -> tuple[IPNetwork, ...]:
+    """Parse comma-separated trusted proxy addresses and CIDR networks."""
+    if raw_value is None or not raw_value.strip():
+        return ()
+
+    parsed: list[IPNetwork] = []
+    for item in raw_value.split(","):
+        value = item.strip()
+        if not value:
+            continue
+        try:
+            parsed.append(ipaddress.ip_network(value, strict=False))
+        except ValueError as exc:
+            raise ValueError(
+                f"{SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR} contains an invalid "
+                f"address or network"
+            ) from exc
+    return tuple(parsed)
+
+
+def parse_principal_mappings(
+    raw_value: Optional[str],
+) -> tuple[MTLSPrincipalMapping, ...]:
+    """Parse exact subject/SAN-to-principal mappings from JSON."""
+    if raw_value is None or not raw_value.strip():
+        return ()
+
+    try:
+        payload = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR} must be valid JSON"
+        ) from exc
+    if not isinstance(payload, list):
+        raise ValueError(f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR} must be a JSON list")
+
+    mappings: list[MTLSPrincipalMapping] = []
+    claimed_identities: set[str] = set()
+    for index, item in enumerate(payload):
+        if not isinstance(item, Mapping):
+            raise ValueError(
+                f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR}[{index}] must be a JSON object"
+            )
+        identities = _normalize_identities(
+            item.get("identities", item.get("identity")),
+            index=index,
+        )
+        duplicate = claimed_identities.intersection(identities)
+        if duplicate:
+            raise ValueError(
+                f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR} contains a duplicate identity"
+            )
+        claimed_identities.update(identities)
+
+        principal = str(item.get("principal") or "").strip()
+        if not principal:
+            raise ValueError(
+                f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR}[{index}] requires principal"
+            )
+        mappings.append(
+            MTLSPrincipalMapping(
+                identities=frozenset(identities),
+                principal=principal,
+                scopes=_normalize_scopes(item.get("scopes", item.get("scope"))),
+            )
+        )
+    return tuple(mappings)
+
+
+def verify_client_certificate_chain(
+    client_cert_chain: Sequence[str],
+    ca_bundle: str | Path,
+) -> MTLSClientIdentity:
+    """Verify a PEM client chain against a CA bundle and return its identity.
+
+    Args:
+        client_cert_chain: Leaf-first PEM client certificate chain.
+        ca_bundle: PEM bundle containing one or more trusted CA certificates.
+
+    Returns:
+        Subject, SAN values, and SHA-256 fingerprint from the verified leaf.
+
+    Raises:
+        ValueError: If the chain or CA bundle is invalid or untrusted.
+    """
+    ca_path = Path(ca_bundle)
+    try:
+        ca_certificates = x509.load_pem_x509_certificates(ca_path.read_bytes())
+    except (OSError, ValueError) as exc:
+        raise ValueError("mTLS CA bundle is invalid") from exc
+    if not ca_certificates:
+        raise ValueError("mTLS CA bundle does not contain a certificate")
+    return _verify_client_certificate_chain(client_cert_chain, Store(ca_certificates))
+
+
+class ServiceMTLS:
+    """Verify and attach an mTLS client principal to each HTTP request."""
+
+    def __init__(
+        self,
+        config: ServiceMTLSConfig,
+        *,
+        error_response: ErrorResponseFactory,
+    ) -> None:
+        self.config = config
+        self._error_response = error_response
+        self._store: Optional[Store] = None
+        if config.enabled:
+            if config.ca_bundle is None:
+                raise ValueError("mTLS CA bundle is required")
+            try:
+                ca_certificates = x509.load_pem_x509_certificates(
+                    config.ca_bundle.read_bytes()
+                )
+            except (OSError, ValueError) as exc:
+                raise ValueError("mTLS CA bundle is invalid") from exc
+            if not ca_certificates:
+                raise ValueError("mTLS CA bundle does not contain a certificate")
+            self._store = Store(ca_certificates)
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether mTLS authentication is active."""
+        return self.config.enabled
+
+    async def dispatch(self, request: Request, call_next: CallNext) -> Response:
+        """Require a trusted client certificate and attach its principal."""
+        if not self.enabled:
+            return await call_next(request)
+
+        try:
+            chain = self._certificate_chain(request)
+            if self._store is None:
+                raise invalid_client_certificate()
+            identity = _verify_client_certificate_chain(chain, self._store)
+        except MTLSAuthenticationError as exc:
+            return self._authentication_failure(exc)
+        except ValueError:
+            return self._authentication_failure(invalid_client_certificate())
+
+        principal = self._principal_for(identity)
+        request.state.mtls_identity = identity
+        request.state.auth_principal = principal
+        request.scope["openmed.mtls"] = identity
+        request.scope["openmed.auth"] = principal
+        set_access_log_identity(
+            request,
+            principal=principal.subject,
+            credential_type=principal.credential_type,
+        )
+        return await call_next(request)
+
+    def _certificate_chain(self, request: Request) -> tuple[str, ...]:
+        extensions = request.scope.get("extensions")
+        tls_extension: Any = None
+        if isinstance(extensions, Mapping):
+            tls_extension = extensions.get("tls")
+        if isinstance(tls_extension, Mapping):
+            if tls_extension.get("client_cert_error"):
+                raise invalid_client_certificate()
+            chain = tls_extension.get("client_cert_chain", ())
+            normalized = _normalize_pem_chain(chain)
+            if normalized:
+                return normalized
+
+        header_name = self.config.client_cert_header
+        if header_name is not None:
+            forwarded_certificate = request.headers.get(header_name)
+            if forwarded_certificate is not None:
+                if not _peer_is_trusted(request, self.config.trusted_proxies):
+                    raise invalid_client_certificate()
+                try:
+                    decoded = unquote_to_bytes(forwarded_certificate).decode("ascii")
+                except (UnicodeDecodeError, ValueError) as exc:
+                    raise invalid_client_certificate() from exc
+                return _normalize_pem_chain(decoded)
+
+        raise client_certificate_required()
+
+    def _principal_for(self, identity: MTLSClientIdentity) -> AuthPrincipal:
+        identifiers = set(identity.identifiers)
+        for mapping in self.config.principals:
+            if identifiers.intersection(mapping.identities):
+                principal = mapping.principal
+                scopes = mapping.scopes
+                break
+        else:
+            principal = f"mtls:{identity.fingerprint_sha256}"
+            scopes = ()
+
+        return AuthPrincipal(
+            subject=principal,
+            credential_type="mtls",
+            scopes=scopes,
+            claims={
+                "certificate_subject": identity.subject,
+                "certificate_sans": identity.sans,
+                "certificate_sha256": identity.fingerprint_sha256,
+            },
+        )
+
+    def _authentication_failure(self, exc: MTLSAuthenticationError) -> Response:
+        return self._error_response(
+            401,
+            exc.code,
+            exc.message,
+            details=None,
+        )
+
+
+def client_certificate_required() -> MTLSAuthenticationError:
+    """Return a missing-client-certificate error."""
+    return MTLSAuthenticationError(
+        code="mtls_certificate_required",
+        message="A verified client certificate is required",
+    )
+
+
+def invalid_client_certificate() -> MTLSAuthenticationError:
+    """Return a generic invalid-client-certificate error."""
+    return MTLSAuthenticationError(
+        code="mtls_certificate_invalid",
+        message="The client certificate is invalid or untrusted",
+    )
+
+
+def _verify_client_certificate_chain(
+    client_cert_chain: Sequence[str],
+    store: Store,
+) -> MTLSClientIdentity:
+    chain = _load_client_certificates(client_cert_chain)
+    try:
+        PolicyBuilder().store(store).build_client_verifier().verify(
+            chain[0], list(chain[1:])
+        )
+    except (VerificationError, x509.UnsupportedGeneralNameType) as exc:
+        raise ValueError("client certificate chain is untrusted") from exc
+
+    leaf = chain[0]
+    der = leaf.public_bytes(serialization.Encoding.DER)
+    return MTLSClientIdentity(
+        subject=leaf.subject.rfc4514_string(),
+        sans=_certificate_sans(leaf),
+        fingerprint_sha256=hashlib.sha256(der).hexdigest(),
+    )
+
+
+def _load_client_certificates(
+    client_cert_chain: Sequence[str],
+) -> tuple[x509.Certificate, ...]:
+    normalized = _normalize_pem_chain(client_cert_chain)
+    if not normalized:
+        raise ValueError("client certificate chain is empty")
+    certificates: list[x509.Certificate] = []
+    try:
+        for pem in normalized:
+            certificates.extend(x509.load_pem_x509_certificates(pem.encode("ascii")))
+    except (UnicodeEncodeError, ValueError) as exc:
+        raise ValueError("client certificate chain is invalid") from exc
+    if not certificates:
+        raise ValueError("client certificate chain is empty")
+    return tuple(certificates)
+
+
+def _normalize_pem_chain(raw_chain: Any) -> tuple[str, ...]:
+    if raw_chain is None:
+        return ()
+    if isinstance(raw_chain, str):
+        chain = (raw_chain,)
+    elif isinstance(raw_chain, Sequence) and not isinstance(
+        raw_chain, (bytes, bytearray)
+    ):
+        chain = tuple(str(item) for item in raw_chain)
+    else:
+        raise ValueError("client certificate chain is invalid")
+
+    total_bytes = 0
+    normalized: list[str] = []
+    for certificate in chain:
+        value = certificate.strip()
+        if not value:
+            continue
+        try:
+            total_bytes += len(value.encode("ascii"))
+        except UnicodeEncodeError as exc:
+            raise ValueError("client certificate chain is invalid") from exc
+        if total_bytes > MAX_CLIENT_CERT_CHAIN_BYTES:
+            raise ValueError("client certificate chain is too large")
+        normalized.append(value)
+    return tuple(normalized)
+
+
+def _certificate_sans(certificate: x509.Certificate) -> tuple[str, ...]:
+    try:
+        extension = certificate.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
+        ).value
+    except x509.ExtensionNotFound:
+        return ()
+
+    sans: list[str] = []
+    for name in extension:
+        if isinstance(name, x509.DNSName):
+            sans.append(f"dns:{name.value}")
+        elif isinstance(name, x509.UniformResourceIdentifier):
+            sans.append(f"uri:{name.value}")
+        elif isinstance(name, x509.IPAddress):
+            sans.append(f"ip:{name.value}")
+        elif isinstance(name, x509.RFC822Name):
+            sans.append(f"email:{name.value}")
+    return tuple(sans)
+
+
+def _parse_client_cert_header(raw_value: Optional[str]) -> Optional[str]:
+    if raw_value is None or not raw_value.strip():
+        return None
+    value = raw_value.strip()
+    if not _HEADER_NAME_PATTERN.fullmatch(value):
+        raise ValueError(
+            f"{SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR} must be a valid HTTP "
+            "header name"
+        )
+    return value
+
+
+def _peer_is_trusted(request: Request, networks: Sequence[IPNetwork]) -> bool:
+    if request.client is None:
+        return False
+    try:
+        peer = ipaddress.ip_address(request.client.host)
+    except ValueError:
+        return False
+    return any(peer in network for network in networks)
+
+
+def _normalize_identities(raw_value: Any, *, index: int) -> tuple[str, ...]:
+    if isinstance(raw_value, str):
+        values = (raw_value,)
+    elif isinstance(raw_value, Sequence) and not isinstance(
+        raw_value, (bytes, bytearray)
+    ):
+        values = tuple(str(item) for item in raw_value)
+    else:
+        raise ValueError(
+            f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR}[{index}] requires identity or identities"
+        )
+    normalized = tuple(value.strip() for value in values if value.strip())
+    if not normalized:
+        raise ValueError(
+            f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR}[{index}] requires identity or identities"
+        )
+    return normalized
+
+
+def _normalize_scopes(raw_value: Any) -> tuple[str, ...]:
+    if raw_value is None:
+        return ()
+    if isinstance(raw_value, str):
+        values = raw_value.replace(",", " ").split()
+    elif isinstance(raw_value, Sequence) and not isinstance(
+        raw_value, (bytes, bytearray)
+    ):
+        values = [str(value).strip() for value in raw_value]
+    else:
+        raise ValueError("mTLS principal scopes must be a string or list")
+    return tuple(dict.fromkeys(value for value in values if value))
+
+
+__all__ = [
+    "MAX_CLIENT_CERT_CHAIN_BYTES",
+    "MTLSAuthenticationError",
+    "MTLSClientIdentity",
+    "MTLSPrincipalMapping",
+    "SERVICE_MTLS_CA_BUNDLE_ENV_VAR",
+    "SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR",
+    "SERVICE_MTLS_ENABLED_ENV_VAR",
+    "SERVICE_MTLS_PRINCIPALS_ENV_VAR",
+    "SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR",
+    "ServiceMTLS",
+    "ServiceMTLSConfig",
+    "parse_principal_mappings",
+    "parse_service_mtls_config",
+    "parse_trusted_proxies",
+    "verify_client_certificate_chain",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ authors = [
 
 [project.optional-dependencies]
 dev = [
+  "cryptography>=43,<50",
   "pre-commit>=4.0",
   "pytest>=7.0",
   "pytest-cov>=4.0",
@@ -177,6 +178,7 @@ hf = [
 ]
 
 service = [
+  "cryptography>=43,<50",
   "fastapi>=0.110",
   "grpcio>=1.64",
   "httpx>=0.27",

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -61,6 +61,7 @@ REVIEWED_LICENSES = {
     "click": "BSD-3-Clause",
     "confluent-kafka": "Apache-2.0",
     "coremltools": "BSD-3-Clause",
+    "cryptography": "Apache-2.0 OR BSD-3-Clause",
     "dask": "BSD-3-Clause",
     "duckdb": "MIT",
     "easyocr": "Apache-2.0",

--- a/tests/fixtures/mtls/README.md
+++ b/tests/fixtures/mtls/README.md
@@ -1,0 +1,17 @@
+# Synthetic mTLS test material
+
+`tests/unit/service/test_mtls_auth.py` creates a synthetic root CA, a trusted
+client certificate, and a client certificate signed by a different CA in the
+pytest temporary directory. It uses short-lived RSA keys and certificates with
+synthetic workload-only names:
+
+- subject: `CN=synthetic-clinic-client,O=OpenMed Test`
+- URI SAN: `spiffe://openmed.test/clinic-api`
+- DNS SAN: `clinic-api.test`
+- extended key usage: TLS client authentication
+
+The generated client chain exercises successful authentication, principal and
+scope mapping, handler-visible subject/SAN fields, and rejection of an
+untrusted issuer. The material is regenerated for each test session. No private
+keys, production certificates, patient identifiers, or other PHI are committed
+to the repository.

--- a/tests/unit/service/test_mtls_auth.py
+++ b/tests/unit/service/test_mtls_auth.py
@@ -1,0 +1,553 @@
+"""Unit tests for mutual-TLS client certificate authentication."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import quote
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+from fastapi import Request
+from fastapi.testclient import TestClient
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from openmed.service.app import create_app
+from openmed.service.auth import hash_api_key
+from openmed.service.logging import ACCESS_LOGGER_NAME
+from openmed.service.mtls import (
+    SERVICE_MTLS_CA_BUNDLE_ENV_VAR,
+    SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR,
+    SERVICE_MTLS_ENABLED_ENV_VAR,
+    SERVICE_MTLS_PRINCIPALS_ENV_VAR,
+    SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR,
+    parse_service_mtls_config,
+    verify_client_certificate_chain,
+)
+
+LOOPBACK_BASE_URL = "https://127.0.0.1"
+SYNTHETIC_URI_SAN = "uri:spiffe://openmed.test/clinic-api"
+SYNTHETIC_DNS_SAN = "dns:clinic-api.test"
+_SERVICE_ENV_VARS = (
+    SERVICE_MTLS_ENABLED_ENV_VAR,
+    SERVICE_MTLS_CA_BUNDLE_ENV_VAR,
+    SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR,
+    SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR,
+    SERVICE_MTLS_PRINCIPALS_ENV_VAR,
+    "OPENMED_SERVICE_AUTH_ENABLED",
+    "OPENMED_SERVICE_AUTH_DENY_BY_DEFAULT",
+    "OPENMED_SERVICE_AUTH_API_KEYS",
+    "OPENMED_SERVICE_AUTH_JWKS",
+    "OPENMED_SERVICE_AUTH_JWKS_FILE",
+    "OPENMED_SERVICE_AUTH_ROUTE_SCOPES",
+    "OPENMED_SERVICE_PRELOAD_MODELS",
+    "OPENMED_SERVICE_LOG_FORMAT",
+    "OPENMED_SERVICE_LOG_LEVEL",
+)
+
+
+@dataclass(frozen=True)
+class SyntheticMTLSMaterial:
+    """Short-lived synthetic certificates used by the mTLS tests."""
+
+    ca_bundle: Path
+    client_pem: str
+    untrusted_client_pem: str
+    subject: str
+
+
+class TLSClientScopeMiddleware:
+    """Add synthetic ASGI TLS extension data to HTTP request scopes."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        client_cert_chain: Sequence[str] = (),
+        client_cert_error: Optional[str] = None,
+        client: Optional[tuple[str, int]] = None,
+    ) -> None:
+        self.app = app
+        self.client_cert_chain = tuple(client_cert_chain)
+        self.client_cert_error = client_cert_error
+        self.client = client
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        request_scope = dict(scope)
+        extensions = dict(request_scope.get("extensions", {}))
+        extensions["tls"] = {
+            "server_cert": None,
+            "client_cert_chain": self.client_cert_chain,
+            "client_cert_name": None,
+            "client_cert_error": self.client_cert_error,
+        }
+        request_scope["extensions"] = extensions
+        if self.client is not None:
+            request_scope["client"] = self.client
+        await self.app(request_scope, receive, send)
+
+
+class PeerScopeMiddleware:
+    """Override the HTTP peer address for trusted-proxy tests."""
+
+    def __init__(self, app: ASGIApp, client: tuple[str, int]) -> None:
+        self.app = app
+        self.client = client
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            scope = dict(scope)
+            scope["client"] = self.client
+        await self.app(scope, receive, send)
+
+
+@pytest.fixture(autouse=True)
+def clean_service_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENMED_PROFILE", "test")
+    for env_var in _SERVICE_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+@pytest.fixture(scope="module")
+def synthetic_mtls_material(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> SyntheticMTLSMaterial:
+    fixture_dir = tmp_path_factory.mktemp("openmed-mtls")
+    now = datetime.now(timezone.utc)
+
+    ca_key, ca_certificate = _build_ca("OpenMed Synthetic Test CA", now=now)
+    client_certificate = _build_client_certificate(
+        ca_key,
+        ca_certificate,
+        common_name="synthetic-clinic-client",
+        now=now,
+    )
+    untrusted_ca_key, untrusted_ca = _build_ca("Untrusted Synthetic CA", now=now)
+    untrusted_client = _build_client_certificate(
+        untrusted_ca_key,
+        untrusted_ca,
+        common_name="untrusted-synthetic-client",
+        now=now,
+    )
+
+    ca_bundle = fixture_dir / "ca.pem"
+    ca_bundle.write_bytes(ca_certificate.public_bytes(serialization.Encoding.PEM))
+    return SyntheticMTLSMaterial(
+        ca_bundle=ca_bundle,
+        client_pem=client_certificate.public_bytes(serialization.Encoding.PEM).decode(
+            "ascii"
+        ),
+        untrusted_client_pem=untrusted_client.public_bytes(
+            serialization.Encoding.PEM
+        ).decode("ascii"),
+        subject=client_certificate.subject.rfc4514_string(),
+    )
+
+
+def test_mtls_defaults_to_disabled() -> None:
+    config = parse_service_mtls_config()
+
+    assert config.enabled is False
+    assert config.ca_bundle is None
+
+
+def test_enabling_mtls_requires_a_ca_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(SERVICE_MTLS_ENABLED_ENV_VAR, "true")
+
+    with pytest.raises(ValueError, match=SERVICE_MTLS_CA_BUNDLE_ENV_VAR):
+        parse_service_mtls_config()
+
+
+def test_valid_synthetic_client_certificate_verifies_and_exposes_identity(
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    identity = verify_client_certificate_chain(
+        [synthetic_mtls_material.client_pem],
+        synthetic_mtls_material.ca_bundle,
+    )
+
+    assert identity.subject == synthetic_mtls_material.subject
+    assert identity.sans == (SYNTHETIC_URI_SAN, SYNTHETIC_DNS_SAN)
+    assert len(identity.fingerprint_sha256) == 64
+
+
+def test_untrusted_synthetic_client_certificate_is_rejected(
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    with pytest.raises(ValueError, match="untrusted"):
+        verify_client_certificate_chain(
+            [synthetic_mtls_material.untrusted_client_pem],
+            synthetic_mtls_material.ca_bundle,
+        )
+
+
+def test_mtls_toggle_requires_certificate_without_code_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    disabled_app = create_app()
+    with TestClient(
+        disabled_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        disabled_response = client.get("/health")
+
+    _enable_mtls(monkeypatch, synthetic_mtls_material)
+    enabled_app = create_app()
+    with TestClient(
+        enabled_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        enabled_response = client.get("/health")
+
+    assert disabled_response.status_code == 200
+    _assert_error(enabled_response, 401, "mtls_certificate_required")
+
+
+def test_valid_request_maps_san_to_route_authorization_principal(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    _enable_mtls(
+        monkeypatch,
+        synthetic_mtls_material,
+        scopes=["identity:read"],
+    )
+    monkeypatch.setenv("OPENMED_SERVICE_AUTH_ENABLED", "true")
+    monkeypatch.setenv(
+        "OPENMED_SERVICE_AUTH_ROUTE_SCOPES",
+        json.dumps({"GET /whoami": ["identity:read"]}),
+    )
+    app = create_app()
+
+    @app.get("/whoami")
+    async def whoami(request: Request) -> dict[str, Any]:
+        principal = request.state.auth_principal
+        identity = request.state.mtls_identity
+        return {
+            "principal": principal.subject,
+            "credential_type": principal.credential_type,
+            "scopes": list(principal.scopes),
+            "subject": identity.subject,
+            "sans": list(identity.sans),
+        }
+
+    asgi_app = TLSClientScopeMiddleware(
+        app,
+        client_cert_chain=[synthetic_mtls_material.client_pem],
+    )
+    with TestClient(
+        asgi_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/whoami")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "principal": "synthetic-clinic-api",
+        "credential_type": "mtls",
+        "scopes": ["identity:read"],
+        "subject": synthetic_mtls_material.subject,
+        "sans": [SYNTHETIC_URI_SAN, SYNTHETIC_DNS_SAN],
+    }
+
+
+def test_untrusted_request_returns_generic_authentication_error(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    _enable_mtls(monkeypatch, synthetic_mtls_material)
+    app = TLSClientScopeMiddleware(
+        create_app(),
+        client_cert_chain=[synthetic_mtls_material.untrusted_client_pem],
+    )
+
+    with TestClient(
+        app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/health")
+
+    payload = _assert_error(response, 401, "mtls_certificate_invalid")
+    rendered = json.dumps(payload)
+    assert "Untrusted Synthetic CA" not in rendered
+    assert synthetic_mtls_material.untrusted_client_pem not in rendered
+
+
+def test_forwarded_certificate_requires_a_trusted_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    _enable_mtls(monkeypatch, synthetic_mtls_material)
+    monkeypatch.setenv(
+        SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR,
+        "X-OpenMed-Client-Cert",
+    )
+    monkeypatch.setenv(SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR, "127.0.0.1/32")
+    header_value = quote(synthetic_mtls_material.client_pem, safe="")
+
+    trusted_app = PeerScopeMiddleware(create_app(), ("127.0.0.1", 54321))
+    with TestClient(
+        trusted_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        trusted = client.get(
+            "/health",
+            headers={"X-OpenMed-Client-Cert": header_value},
+        )
+
+    untrusted_app = PeerScopeMiddleware(create_app(), ("203.0.113.9", 54321))
+    with TestClient(
+        untrusted_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        untrusted = client.get(
+            "/health",
+            headers={"X-OpenMed-Client-Cert": header_value},
+        )
+
+    assert trusted.status_code == 200
+    _assert_error(untrusted, 401, "mtls_certificate_invalid")
+
+
+def test_explicit_api_key_can_authorize_inside_mtls_connection(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    _enable_mtls(monkeypatch, synthetic_mtls_material)
+    monkeypatch.setenv("OPENMED_SERVICE_AUTH_ENABLED", "true")
+    monkeypatch.setenv(
+        "OPENMED_SERVICE_AUTH_API_KEYS",
+        json.dumps(
+            [
+                {
+                    "id": "synthetic-key",
+                    "key_hash": hash_api_key("synthetic-secret"),
+                    "principal": "jwt-layer-principal",
+                    "scopes": ["identity:read"],
+                }
+            ]
+        ),
+    )
+    monkeypatch.setenv(
+        "OPENMED_SERVICE_AUTH_ROUTE_SCOPES",
+        json.dumps({"GET /whoami": ["identity:read"]}),
+    )
+    app = create_app()
+
+    @app.get("/whoami")
+    async def whoami(request: Request) -> dict[str, Any]:
+        return {
+            "principal": request.state.auth_principal.subject,
+            "credential_type": request.state.auth_principal.credential_type,
+            "mtls_subject": request.state.mtls_identity.subject,
+        }
+
+    asgi_app = TLSClientScopeMiddleware(
+        app,
+        client_cert_chain=[synthetic_mtls_material.client_pem],
+    )
+    with TestClient(
+        asgi_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get(
+            "/whoami",
+            headers={"X-API-Key": "synthetic-secret"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "principal": "jwt-layer-principal",
+        "credential_type": "api_key",
+        "mtls_subject": synthetic_mtls_material.subject,
+    }
+
+
+def test_access_log_contains_only_stable_mtls_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _enable_mtls(monkeypatch, synthetic_mtls_material)
+    caplog.set_level(logging.INFO, logger=ACCESS_LOGGER_NAME)
+    app = TLSClientScopeMiddleware(
+        create_app(),
+        client_cert_chain=[synthetic_mtls_material.client_pem],
+    )
+
+    with TestClient(
+        app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    records = [record for record in caplog.records if record.name == ACCESS_LOGGER_NAME]
+    assert len(records) == 1
+    rendered = records[0].getMessage()
+    payload = json.loads(rendered)
+    assert payload["identity"] == "synthetic-clinic-api"
+    assert payload["credential_type"] == "mtls"
+    assert synthetic_mtls_material.subject not in rendered
+    assert SYNTHETIC_URI_SAN not in rendered
+    assert SYNTHETIC_DNS_SAN not in rendered
+    assert synthetic_mtls_material.client_pem not in rendered
+
+
+def _enable_mtls(
+    monkeypatch: pytest.MonkeyPatch,
+    material: SyntheticMTLSMaterial,
+    *,
+    scopes: Optional[list[str]] = None,
+) -> None:
+    monkeypatch.setenv(SERVICE_MTLS_ENABLED_ENV_VAR, "true")
+    monkeypatch.setenv(SERVICE_MTLS_CA_BUNDLE_ENV_VAR, str(material.ca_bundle))
+    monkeypatch.setenv(
+        SERVICE_MTLS_PRINCIPALS_ENV_VAR,
+        json.dumps(
+            [
+                {
+                    "identities": [SYNTHETIC_URI_SAN],
+                    "principal": "synthetic-clinic-api",
+                    "scopes": scopes or [],
+                }
+            ]
+        ),
+    )
+
+
+def _assert_error(response: Any, status_code: int, code: str) -> dict[str, Any]:
+    assert response.status_code == status_code
+    payload = response.json()
+    assert payload["error"]["code"] == code
+    assert "message" in payload["error"]
+    assert "details" in payload["error"]
+    return payload
+
+
+def _build_ca(
+    common_name: str,
+    *,
+    now: datetime,
+) -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "OpenMed Test"),
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ]
+    )
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(days=1))
+        .not_valid_after(now + timedelta(days=30))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return key, certificate
+
+
+def _build_client_certificate(
+    ca_key: rsa.RSAPrivateKey,
+    ca_certificate: x509.Certificate,
+    *,
+    common_name: str,
+    now: datetime,
+) -> x509.Certificate:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "OpenMed Test"),
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ]
+    )
+    return (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca_certificate.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(hours=1))
+        .not_valid_after(now + timedelta(days=7))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=True,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.UniformResourceIdentifier("spiffe://openmed.test/clinic-api"),
+                    x509.DNSName("clinic-api.test"),
+                ]
+            ),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(
+                ca_certificate.public_key()
+            ),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -4475,6 +4475,7 @@ dask = [
     { name = "dask", extra = ["dataframe"] },
 ]
 dev = [
+    { name = "cryptography" },
     { name = "dask", extra = ["dataframe"] },
     { name = "duckdb" },
     { name = "fastapi" },
@@ -4600,6 +4601,7 @@ pydeid = [
     { name = "pydeid" },
 ]
 service = [
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "grpcio" },
     { name = "httpx" },
@@ -4626,6 +4628,8 @@ requires-dist = [
     { name = "click", marker = "extra == 'spacy'", specifier = ">=8.0" },
     { name = "confluent-kafka", marker = "extra == 'kafka'", specifier = ">=2.3" },
     { name = "coremltools", marker = "extra == 'coreml'", specifier = ">=8.0" },
+    { name = "cryptography", marker = "extra == 'dev'", specifier = ">=43,<50" },
+    { name = "cryptography", marker = "extra == 'service'", specifier = ">=43,<50" },
     { name = "dask", extras = ["dataframe"], marker = "extra == 'dask'", specifier = ">=2024.8" },
     { name = "dask", extras = ["dataframe"], marker = "extra == 'dev'", specifier = ">=2024.8" },
     { name = "duckdb", marker = "extra == 'dev'", specifier = ">=1.0,<2" },


### PR DESCRIPTION
## Description

Adds configurable mutual-TLS client-certificate authentication to the REST service. Client chains are required and verified against a configured CA bundle, exact certificate subjects or SANs can map to stable principals and route scopes, and certificate identity remains available when JWT or API-key authorization is layered on top.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Verify leaf-first client certificate chains from the ASGI TLS extension or an explicitly trusted proxy header.
- Map exact subject/SAN identities to stable principals and route-authorization scopes while keeping raw certificate identity out of access logs.
- Document direct and sidecar/ingress termination, layered JWT/API-key authorization, trusted-proxy hardening, and synthetic test material.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different certificate inputs

Validation completed:

- Full test suite: 5,169 passed, 51 skipped
- Repository formatting, lint, and scoped type checks passed
- Strict documentation build passed
- Source distribution and wheel build passed

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran the repository formatting and lint gates
- [ ] For Swift/OpenMedKit changes, I ran the Swift formatting and lint gates
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [ ] I have not added any new dependencies
- [x] OR I have added a new service dependency, justified because standards-compliant X.509 path validation and identity extraction are required to reject untrusted client chains safely.

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #832

## Screenshots/Examples

Not applicable; this is a service authentication and documentation change.
