### PR TITLE
Add iOS Share and Action extensions for on-device redaction

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,19 @@ let package = Package(
         .library(
             name: "OpenMedKit",
             targets: ["OpenMedKit"]
-        )
+        ),
+        .library(
+            name: "OpenMedExtensionSupport",
+            targets: ["OpenMedExtensionSupport"]
+        ),
+        .library(
+            name: "OpenMedShareExtension",
+            targets: ["ShareExtension"]
+        ),
+        .library(
+            name: "OpenMedActionExtension",
+            targets: ["ActionExtension"]
+        ),
     ],
     dependencies: [
         .package(
@@ -42,10 +54,35 @@ let package = Package(
                 .process("Resources")
             ]
         ),
+        .target(
+            name: "OpenMedExtensionSupport",
+            dependencies: ["OpenMedKit"],
+            path: "swift/OpenMedKit/Sources/OpenMedExtensionSupport"
+        ),
+        .target(
+            name: "ShareExtension",
+            dependencies: ["OpenMedExtensionSupport"],
+            path: "swift/OpenMedKit/Sources/ShareExtension"
+        ),
+        .target(
+            name: "ActionExtension",
+            dependencies: ["OpenMedExtensionSupport"],
+            path: "swift/OpenMedKit/Sources/ActionExtension"
+        ),
         .testTarget(
             name: "OpenMedKitTests",
             dependencies: ["OpenMedKit"],
             path: "swift/OpenMedKit/Tests/OpenMedKitTests"
+        ),
+        .testTarget(
+            name: "ExtensionTests",
+            dependencies: [
+                "OpenMedKit",
+                "OpenMedExtensionSupport",
+                "ShareExtension",
+                "ActionExtension",
+            ],
+            path: "swift/OpenMedKit/Tests/ExtensionTests"
         ),
     ]
 )

--- a/docs/runtimes/ios-share-extension.md
+++ b/docs/runtimes/ios-share-extension.md
@@ -1,0 +1,108 @@
+# iOS Share and Action Extensions
+
+OpenMedKit includes reusable Swift targets for redacting selected text inside an
+iOS Share extension or Action extension. Both paths use bundled policy profiles,
+return the redacted text to the host app, and keep model loading and inference on
+the device.
+
+The package provides three products:
+
+- `OpenMedExtensionSupport` contains the item handler, span result, local model
+  guard, and memory budget.
+- `OpenMedShareExtension` contains `RedactionShareViewController` and a policy
+  picker backed by `Policy.bundledProfileNames`.
+- `OpenMedActionExtension` contains `RedactionActionRequestHandler` for a non-UI
+  Action extension.
+
+Swift Package Manager supplies the reusable code. Create and embed the Share and
+Action extension targets in the host Xcode project; App Store provisioning and
+submission remain host-app responsibilities.
+
+## Bundle a Nano model
+
+Extensions must not download model or tokenizer files. Add this folder to both
+extension targets as a folder reference:
+
+```text
+OpenMedPIINano/
+├── OpenMedPIINano.mlmodelc
+├── id2label.json
+└── tokenizer/
+    ├── tokenizer.json
+    └── tokenizer_config.json
+```
+
+Use a precompiled, INT8 Core ML PII model. The extension Nano packaging profile
+accepts no more than 40 MiB of model, label, and tokenizer assets, caps token
+sequences at 256, and reserves 56 MiB for tokenizer, Core ML, input, and output
+working memory. Its maximum estimated peak is therefore 96 MiB, below the
+package's conservative 120 MiB extension envelope. Model loading fails before
+inference when the asset budget is exceeded.
+
+`NanoModelConfiguration` accepts only local `file:` URLs and verifies that the
+compiled model, label map, and required tokenizer files exist. The runtime uses
+the tokenizer folder with `allowNetworkAccess: false`, so missing assets fail
+closed instead of falling back to a download.
+
+## Add the Share extension
+
+1. In Xcode, add an iOS Share Extension target.
+2. Link the `OpenMedShareExtension` package product to that target.
+3. Replace the generated view controller with a thin host-target subclass and
+   keep `$(PRODUCT_MODULE_NAME).ShareViewController` as the principal class:
+
+   ```swift
+   import ShareExtension
+
+   final class ShareViewController: RedactionShareViewController {}
+   ```
+
+4. Restrict the activation rule to plain text with
+   `NSExtensionActivationSupportsText = true`.
+5. Add the `OpenMedPIINano` folder to the extension target's Copy Bundle
+   Resources phase.
+
+The controller reads `NSExtensionItem` plain-text attachments, displays the
+selected text and every bundled policy profile, runs the Nano model after the
+user confirms, and completes the request with a new plain-text attachment.
+
+## Add the Action extension
+
+1. In Xcode, add an iOS Action Extension target.
+2. Link the `OpenMedActionExtension` package product to that target.
+3. Replace the generated request handler with a thin host-target subclass and
+   keep `$(PRODUCT_MODULE_NAME).ActionRequestHandler` as the principal class:
+
+   ```swift
+   import ActionExtension
+
+   final class ActionRequestHandler: RedactionActionRequestHandler {}
+   ```
+
+   Configure the target with a text activation rule.
+4. Add the same `OpenMedPIINano` folder to the Action target.
+
+The request handler processes text attachments sequentially and returns one
+redacted `NSExtensionItem` for each input. It defaults to
+`hipaa_safe_harbor`. A host can choose another bundled profile by setting the
+input item's `OpenMedPolicyProfile` user-info value.
+
+## Privacy and failure behavior
+
+- The extension source modules call no networking API and request no networking
+  entitlement. A source guard test rejects additions such as `URLSession`,
+  `NWConnection`, or a network-client entitlement, and a runtime test verifies
+  that missing tokenizer assets fail closed.
+- Remote model URLs are rejected even if the host app passes one accidentally.
+- Input is limited to 16,384 characters. Image and PDF attachments are not
+  accepted.
+- Raw input and detected span text are not logged or written to audit artifacts.
+- The model runtime is released after each request and OpenMedKit clears unused
+  runtime buffers before the extension exits.
+
+Run the extension contract tests with:
+
+```bash
+cd swift/OpenMedKit
+swift test --filter ShareRedactionTests
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Android Span Parity: android-parity.md
       - CoreML Packaging: coreml-export.md
       - Swift Package (OpenMedKit): swift-openmedkit.md
+      - iOS Share and Action Extensions: runtimes/ios-share-extension.md
       - Swift-Kotlin API Parity: swift-kotlin-parity.md
   - Project:
       - FAQ: faq.md

--- a/swift/OpenMedKit/Package.swift
+++ b/swift/OpenMedKit/Package.swift
@@ -13,7 +13,19 @@ let package = Package(
         .library(
             name: "OpenMedKit",
             targets: ["OpenMedKit"]
-        )
+        ),
+        .library(
+            name: "OpenMedExtensionSupport",
+            targets: ["OpenMedExtensionSupport"]
+        ),
+        .library(
+            name: "OpenMedShareExtension",
+            targets: ["ShareExtension"]
+        ),
+        .library(
+            name: "OpenMedActionExtension",
+            targets: ["ActionExtension"]
+        ),
     ],
     dependencies: [
         // swift-transformers for HuggingFace-compatible tokenization
@@ -34,9 +46,30 @@ let package = Package(
                 .process("Resources")
             ]
         ),
+        .target(
+            name: "OpenMedExtensionSupport",
+            dependencies: ["OpenMedKit"]
+        ),
+        .target(
+            name: "ShareExtension",
+            dependencies: ["OpenMedExtensionSupport"]
+        ),
+        .target(
+            name: "ActionExtension",
+            dependencies: ["OpenMedExtensionSupport"]
+        ),
         .testTarget(
             name: "OpenMedKitTests",
             dependencies: ["OpenMedKit"]
+        ),
+        .testTarget(
+            name: "ExtensionTests",
+            dependencies: [
+                "OpenMedKit",
+                "OpenMedExtensionSupport",
+                "ShareExtension",
+                "ActionExtension",
+            ]
         ),
     ]
 )

--- a/swift/OpenMedKit/Sources/ActionExtension/RedactionActionRequestHandler.swift
+++ b/swift/OpenMedKit/Sources/ActionExtension/RedactionActionRequestHandler.swift
@@ -1,0 +1,45 @@
+#if canImport(UIKit)
+    import OpenMedExtensionSupport
+    import OpenMedKit
+    import UIKit
+
+    /// Non-UI Action extension handler that returns locally redacted text to its host.
+    open class RedactionActionRequestHandler: NSObject, NSExtensionRequestHandling {
+        public static let policyProfileUserInfoKey = "OpenMedPolicyProfile"
+
+        public final func beginRequest(with context: NSExtensionContext) {
+            Task {
+                do {
+                    let texts = try await ExtensionItemCodec.plainText(from: context.inputItems)
+                    let policyName = Self.policyName(from: context.inputItems)
+                    let configuration = try NanoModelConfiguration.bundled()
+                    let redactedTexts = try await Task.detached(priority: .userInitiated) {
+                        let results: [String]
+                        do {
+                            let handler = try ExtensionRedactionHandler(configuration: configuration)
+                            results = try texts.map {
+                                try handler.redact($0, policyName: policyName).redactedText
+                            }
+                        }
+                        OpenMed.clearRuntimeMemoryCache()
+                        return results
+                    }.value
+                    context.completeRequest(
+                        returningItems: ExtensionItemCodec.extensionItems(for: redactedTexts)
+                    )
+                } catch {
+                    context.cancelRequest(withError: error)
+                }
+            }
+        }
+
+        private static func policyName(from inputItems: [Any]) -> String {
+            for item in inputItems.compactMap({ $0 as? NSExtensionItem }) {
+                if let value = item.userInfo?[policyProfileUserInfoKey] as? String {
+                    return value
+                }
+            }
+            return Policy.defaultName
+        }
+    }
+#endif

--- a/swift/OpenMedKit/Sources/OpenMedExtensionSupport/ExtensionItemCodec.swift
+++ b/swift/OpenMedKit/Sources/OpenMedExtensionSupport/ExtensionItemCodec.swift
@@ -1,0 +1,62 @@
+#if canImport(UIKit) && canImport(UniformTypeIdentifiers)
+    import Foundation
+    import UIKit
+    import UniformTypeIdentifiers
+
+    /// Converts between iOS extension items and OpenMed's plain-text contract.
+    public enum ExtensionItemCodec {
+        /// Load every plain-text attachment supplied by the host app.
+        public static func plainText(from inputItems: [Any]) async throws -> [String] {
+            var texts: [String] = []
+            for item in inputItems.compactMap({ $0 as? NSExtensionItem }) {
+                for provider in item.attachments ?? []
+                where provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
+                    texts.append(try await plainText(from: provider))
+                }
+            }
+
+            guard !texts.isEmpty else {
+                throw ExtensionRedactionError.missingPlainTextInput
+            }
+            return texts
+        }
+
+        /// Create host-returnable text items after local redaction.
+        public static func extensionItems(for texts: [String]) -> [NSExtensionItem] {
+            texts.map { text in
+                let item = NSExtensionItem()
+                item.attachments = [NSItemProvider(object: text as NSString)]
+                return item
+            }
+        }
+
+        private static func plainText(from provider: NSItemProvider) async throws -> String {
+            try await withCheckedThrowingContinuation { continuation in
+                provider.loadItem(
+                    forTypeIdentifier: UTType.plainText.identifier,
+                    options: nil
+                ) { item, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    if let text = item as? String {
+                        continuation.resume(returning: text)
+                        return
+                    }
+                    if let text = item as? NSString {
+                        continuation.resume(returning: text as String)
+                        return
+                    }
+                    if let data = item as? Data,
+                        let text = String(data: data, encoding: .utf8)
+                    {
+                        continuation.resume(returning: text)
+                        return
+                    }
+                    continuation.resume(throwing: ExtensionRedactionError.missingPlainTextInput)
+                }
+            }
+        }
+    }
+#endif

--- a/swift/OpenMedKit/Sources/OpenMedExtensionSupport/ExtensionRedactionHandler.swift
+++ b/swift/OpenMedKit/Sources/OpenMedExtensionSupport/ExtensionRedactionHandler.swift
@@ -1,0 +1,286 @@
+import Foundation
+import OpenMedKit
+
+/// Errors raised before extension input or local model assets are processed.
+public enum ExtensionRedactionError: Error, Equatable, LocalizedError, Sendable {
+    case emptyInput
+    case inputTooLarge(actual: Int, limit: Int)
+    case missingPlainTextInput
+    case nonLocalAsset(URL)
+    case missingAsset(String)
+    case unsupportedModelFormat(String)
+    case modelAssetsTooLarge(actual: Int64, limit: Int64)
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyInput:
+            return "The extension did not receive any text to redact."
+        case .inputTooLarge(let actual, let limit):
+            return "The selected text has \(actual) characters; the extension limit is \(limit)."
+        case .missingPlainTextInput:
+            return "The host app did not provide a plain-text extension item."
+        case .nonLocalAsset(let url):
+            return "Extension model assets must be local files, not \(url.scheme ?? "unknown") URLs."
+        case .missingAsset(let path):
+            return "A required extension model asset is missing at \(path)."
+        case .unsupportedModelFormat(let fileName):
+            return "The extension requires a precompiled .mlmodelc model; received \(fileName)."
+        case .modelAssetsTooLarge(let actual, let limit):
+            return "The Nano model assets use \(actual) bytes; the extension limit is \(limit)."
+        }
+    }
+}
+
+/// Static security properties enforced by the extension support layer.
+public enum ExtensionSecurityPolicy {
+    /// Extension inference is intentionally local-only.
+    public static let allowsNetworkAccess = false
+
+    /// The only URL scheme accepted for model, label, and tokenizer assets.
+    public static let modelAssetURLScheme = "file"
+}
+
+/// Conservative memory limits for an iOS Share or Action extension model.
+public struct NanoModelMemoryBudget: Equatable, Sendable {
+    public static let extensionWorkingSetEnvelopeBytes: Int64 = 120 * 1_024 * 1_024
+    public static let maximumEstimatedPeakBytes: Int64 = 96 * 1_024 * 1_024
+    public static let maximumModelAssetBytes: Int64 = 40 * 1_024 * 1_024
+    public static let runtimeHeadroomBytes: Int64 = 56 * 1_024 * 1_024
+
+    public let modelAssetBytes: Int64
+
+    public var estimatedPeakBytes: Int64 {
+        modelAssetBytes + Self.runtimeHeadroomBytes
+    }
+
+    public init(modelAssetBytes: Int64) throws {
+        guard modelAssetBytes >= 0,
+            modelAssetBytes <= Self.maximumModelAssetBytes,
+            modelAssetBytes + Self.runtimeHeadroomBytes <= Self.maximumEstimatedPeakBytes
+        else {
+            throw ExtensionRedactionError.modelAssetsTooLarge(
+                actual: modelAssetBytes,
+                limit: Self.maximumModelAssetBytes
+            )
+        }
+        self.modelAssetBytes = modelAssetBytes
+    }
+}
+
+/// Local Core ML assets accepted by the extension-safe model loader.
+public struct NanoModelConfiguration: Sendable {
+    public static let resourceDirectoryName = "OpenMedPIINano"
+    public static let compiledModelName = "OpenMedPIINano"
+    public static let maximumSequenceLength = 256
+
+    public let modelURL: URL
+    public let id2labelURL: URL
+    public let tokenizerFolderURL: URL
+    public let memoryBudget: NanoModelMemoryBudget
+
+    public init(
+        modelURL: URL,
+        id2labelURL: URL,
+        tokenizerFolderURL: URL
+    ) throws {
+        let assetURLs = [modelURL, id2labelURL, tokenizerFolderURL]
+        for url in assetURLs {
+            guard url.isFileURL else {
+                throw ExtensionRedactionError.nonLocalAsset(url)
+            }
+        }
+
+        guard modelURL.pathExtension == "mlmodelc" else {
+            throw ExtensionRedactionError.unsupportedModelFormat(modelURL.lastPathComponent)
+        }
+
+        let fileManager = FileManager.default
+        for url in assetURLs where !fileManager.fileExists(atPath: url.path) {
+            throw ExtensionRedactionError.missingAsset(url.path)
+        }
+
+        for fileName in ["tokenizer.json", "tokenizer_config.json"] {
+            let url = tokenizerFolderURL.appending(path: fileName)
+            guard fileManager.fileExists(atPath: url.path) else {
+                throw ExtensionRedactionError.missingAsset(url.path)
+            }
+        }
+
+        let assetBytes = try assetURLs.reduce(Int64(0)) { total, url in
+            try total + Self.logicalFileSize(at: url, fileManager: fileManager)
+        }
+
+        self.modelURL = modelURL.standardizedFileURL
+        self.id2labelURL = id2labelURL.standardizedFileURL
+        self.tokenizerFolderURL = tokenizerFolderURL.standardizedFileURL
+        self.memoryBudget = try NanoModelMemoryBudget(modelAssetBytes: assetBytes)
+    }
+
+    /// Resolve the expected pre-bundled Nano Core ML model and tokenizer assets.
+    public static func bundled(in bundle: Bundle = .main) throws -> Self {
+        guard let resources = bundle.resourceURL else {
+            throw ExtensionRedactionError.missingAsset(bundle.bundlePath)
+        }
+        let directory = resources.appending(
+            path: resourceDirectoryName,
+            directoryHint: .isDirectory
+        )
+        return try Self(
+            modelURL: directory.appending(
+                path: "\(compiledModelName).mlmodelc",
+                directoryHint: .isDirectory
+            ),
+            id2labelURL: directory.appending(path: "id2label.json"),
+            tokenizerFolderURL: directory.appending(
+                path: "tokenizer",
+                directoryHint: .isDirectory
+            )
+        )
+    }
+
+    fileprivate func makeRuntime() throws -> OpenMed {
+        try OpenMed(
+            backend: .coreML(
+                modelURL: modelURL,
+                id2labelURL: id2labelURL,
+                tokenizerName: Self.compiledModelName,
+                tokenizerFolderURL: tokenizerFolderURL
+            ),
+            maxSeqLength: Self.maximumSequenceLength,
+            allowNetworkAccess: ExtensionSecurityPolicy.allowsNetworkAccess
+        )
+    }
+
+    private static func logicalFileSize(
+        at url: URL,
+        fileManager: FileManager
+    ) throws -> Int64 {
+        let values = try url.resourceValues(forKeys: [.isDirectoryKey, .fileSizeKey])
+        guard values.isDirectory == true else {
+            return Int64(values.fileSize ?? 0)
+        }
+
+        let keys: [URLResourceKey] = [.isRegularFileKey, .fileSizeKey]
+        guard
+            let enumerator = fileManager.enumerator(
+                at: url,
+                includingPropertiesForKeys: keys,
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            throw ExtensionRedactionError.missingAsset(url.path)
+        }
+
+        var total: Int64 = 0
+        for case let childURL as URL in enumerator {
+            let childValues = try childURL.resourceValues(forKeys: Set(keys))
+            if childValues.isRegularFile == true {
+                total += Int64(childValues.fileSize ?? 0)
+            }
+        }
+        return total
+    }
+}
+
+/// A redaction action returned to the host while preserving original offsets.
+public struct ExtensionRedactedSpan: Equatable, Sendable {
+    public let label: String
+    public let canonicalLabel: String
+    public let action: PolicyAction
+    public let start: Int
+    public let end: Int
+    public let confidence: Float
+    public let replacement: String?
+
+    public init(
+        label: String,
+        canonicalLabel: String,
+        action: PolicyAction,
+        start: Int,
+        end: Int,
+        confidence: Float,
+        replacement: String?
+    ) {
+        self.label = label
+        self.canonicalLabel = canonicalLabel
+        self.action = action
+        self.start = start
+        self.end = end
+        self.confidence = confidence
+        self.replacement = replacement
+    }
+}
+
+/// Redacted extension output with action spans relative to the original input.
+public struct ExtensionRedactionOutput: Equatable, Sendable {
+    public let redactedText: String
+    public let policyName: String
+    public let spans: [ExtensionRedactedSpan]
+
+    public init(
+        redactedText: String,
+        policyName: String,
+        spans: [ExtensionRedactedSpan]
+    ) {
+        self.redactedText = redactedText
+        self.policyName = policyName
+        self.spans = spans
+    }
+}
+
+/// Applies OpenMedKit policy redaction to plain text supplied by a host app.
+public final class ExtensionRedactionHandler {
+    public static let maximumInputCharacters = 16_384
+
+    public typealias Redact = (String, Policy) throws -> PolicyDeidentificationResult
+
+    private let redactWithPolicy: Redact
+
+    /// Create a handler around a test or app-provided OpenMedKit redaction function.
+    public init(redact: @escaping Redact) {
+        self.redactWithPolicy = redact
+    }
+
+    /// Load one validated Nano runtime for the lifetime of this handler.
+    public convenience init(configuration: NanoModelConfiguration) throws {
+        let runtime = try configuration.makeRuntime()
+        self.init { text, policy in
+            try runtime.deidentify(text, policy: policy)
+        }
+    }
+
+    /// Redact a selected text item with a bundled policy profile.
+    public func redact(
+        _ text: String,
+        policyName: String = Policy.defaultName
+    ) throws -> ExtensionRedactionOutput {
+        guard !text.isEmpty else {
+            throw ExtensionRedactionError.emptyInput
+        }
+        guard text.count <= Self.maximumInputCharacters else {
+            throw ExtensionRedactionError.inputTooLarge(
+                actual: text.count,
+                limit: Self.maximumInputCharacters
+            )
+        }
+
+        let policy = try Policy(named: policyName)
+        let result = try redactWithPolicy(text, policy)
+        let spans = result.actions.map { action in
+            ExtensionRedactedSpan(
+                label: action.label,
+                canonicalLabel: action.canonicalLabel,
+                action: action.action,
+                start: action.start,
+                end: action.end,
+                confidence: action.confidence,
+                replacement: action.replacement
+            )
+        }
+        return ExtensionRedactionOutput(
+            redactedText: result.redactedText,
+            policyName: result.policyName,
+            spans: spans
+        )
+    }
+}

--- a/swift/OpenMedKit/Sources/OpenMedKit/OpenMedKit.swift
+++ b/swift/OpenMedKit/Sources/OpenMedKit/OpenMedKit.swift
@@ -45,7 +45,8 @@ public final class OpenMed {
     /// Initialize OpenMed with an explicit backend.
     public init(
         backend: OpenMedBackend,
-        maxSeqLength: Int = 512
+        maxSeqLength: Int = 512,
+        allowNetworkAccess: Bool = true
     ) throws {
         switch backend {
         case .coreML(let modelURL, let id2labelURL, let tokenizerName, let tokenizerFolderURL):
@@ -57,7 +58,8 @@ public final class OpenMed {
             self.runtime = .coreML(pipeline)
             self.tokenizer = try Self.loadTokenizer(
                 tokenizerName: tokenizerName,
-                tokenizerFolderURL: tokenizerFolderURL
+                tokenizerFolderURL: tokenizerFolderURL,
+                allowNetworkAccess: allowNetworkAccess
             )
             self.maxSeqLength = maxSeqLength
 
@@ -79,7 +81,8 @@ public final class OpenMed {
                 self.runtime = .mlx(pipeline)
                 self.tokenizer = try Self.loadTokenizer(
                     tokenizerName: pipeline.tokenizerName ?? modelDirectoryURL.path,
-                    tokenizerFolderURL: pipeline.tokenizerDirectoryURL
+                    tokenizerFolderURL: pipeline.tokenizerDirectoryURL,
+                    allowNetworkAccess: allowNetworkAccess
                 )
                 self.maxSeqLength = pipeline.resolvedMaxSequenceLength
             }
@@ -94,12 +97,14 @@ public final class OpenMed {
     ///   - tokenizerName: HuggingFace tokenizer name for text tokenization.
     ///   - tokenizerFolderURL: Optional local tokenizer asset directory for offline use.
     ///   - maxSeqLength: Maximum token sequence length (default: 512).
+    ///   - allowNetworkAccess: Whether missing tokenizer assets may be downloaded.
     public convenience init(
         modelURL: URL,
         id2labelURL: URL,
         tokenizerName: String = "OpenMed/OpenMed-PII-ClinicalE5-Small-33M-v1",
         tokenizerFolderURL: URL? = nil,
-        maxSeqLength: Int = 512
+        maxSeqLength: Int = 512,
+        allowNetworkAccess: Bool = true
     ) throws {
         try self.init(
             backend: .coreML(
@@ -108,7 +113,8 @@ public final class OpenMed {
                 tokenizerName: tokenizerName,
                 tokenizerFolderURL: tokenizerFolderURL
             ),
-            maxSeqLength: maxSeqLength
+            maxSeqLength: maxSeqLength,
+            allowNetworkAccess: allowNetworkAccess
         )
     }
 
@@ -707,7 +713,8 @@ public final class OpenMed {
 
     static func loadTokenizer(
         tokenizerName: String,
-        tokenizerFolderURL: URL?
+        tokenizerFolderURL: URL?,
+        allowNetworkAccess: Bool = true
     ) throws -> any Tokenizer {
         let semaphore = DispatchSemaphore(value: 0)
         var result: Result<any Tokenizer, Error>?
@@ -716,7 +723,8 @@ public final class OpenMed {
             do {
                 let tokenizer = try await loadTokenizerAsync(
                     tokenizerName: tokenizerName,
-                    tokenizerFolderURL: tokenizerFolderURL
+                    tokenizerFolderURL: tokenizerFolderURL,
+                    allowNetworkAccess: allowNetworkAccess
                 )
                 result = .success(tokenizer)
             } catch {
@@ -731,13 +739,18 @@ public final class OpenMed {
 
     private static func loadTokenizerAsync(
         tokenizerName: String,
-        tokenizerFolderURL: URL?
+        tokenizerFolderURL: URL?,
+        allowNetworkAccess: Bool
     ) async throws -> any Tokenizer {
         if let tokenizerFolderURL {
             return try loadTokenizerFromDirectory(
                 tokenizerFolderURL,
-                fallbackTokenizerName: tokenizerName
+                fallbackTokenizerName: allowNetworkAccess ? tokenizerName : nil
             )
+        }
+
+        guard allowNetworkAccess else {
+            throw TokenizerError.missingConfig
         }
 
         if tokenizerName.contains("/") {

--- a/swift/OpenMedKit/Sources/ShareExtension/RedactionShareViewController.swift
+++ b/swift/OpenMedKit/Sources/ShareExtension/RedactionShareViewController.swift
@@ -1,0 +1,152 @@
+#if canImport(UIKit)
+    import OpenMedExtensionSupport
+    import OpenMedKit
+    import UIKit
+
+    /// Share extension UI for policy-selectable, on-device text redaction.
+    @MainActor
+    open class RedactionShareViewController: UIViewController {
+        private let textView = UITextView()
+        private let policyPicker = UIPickerView()
+        private let statusLabel = UILabel()
+        private let redactButton = UIButton(type: .system)
+        private let cancelButton = UIButton(type: .system)
+        private let policies = Policy.bundledProfileNames
+        private var inputText = ""
+
+        public final override func viewDidLoad() {
+            super.viewDidLoad()
+            configureView()
+            Task {
+                await loadInputText()
+            }
+        }
+
+        private func configureView() {
+            view.backgroundColor = .systemBackground
+
+            textView.isEditable = false
+            textView.font = .preferredFont(forTextStyle: .body)
+            textView.layer.borderColor = UIColor.separator.cgColor
+            textView.layer.borderWidth = 1
+            textView.layer.cornerRadius = 8
+
+            policyPicker.dataSource = self
+            policyPicker.delegate = self
+            policyPicker.selectRow(
+                policies.firstIndex(of: Policy.defaultName) ?? 0,
+                inComponent: 0,
+                animated: false
+            )
+
+            statusLabel.font = .preferredFont(forTextStyle: .footnote)
+            statusLabel.numberOfLines = 0
+            statusLabel.textColor = .secondaryLabel
+            statusLabel.text = "Loading selected text…"
+
+            redactButton.setTitle("Redact and Return", for: .normal)
+            redactButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+            redactButton.isEnabled = false
+            redactButton.addTarget(self, action: #selector(redactSelection), for: .touchUpInside)
+
+            cancelButton.setTitle("Cancel", for: .normal)
+            cancelButton.addTarget(self, action: #selector(cancelRequest), for: .touchUpInside)
+
+            let buttonRow = UIStackView(arrangedSubviews: [cancelButton, redactButton])
+            buttonRow.axis = .horizontal
+            buttonRow.distribution = .equalSpacing
+
+            let stack = UIStackView(arrangedSubviews: [textView, policyPicker, statusLabel, buttonRow])
+            stack.axis = .vertical
+            stack.spacing = 12
+            stack.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(stack)
+
+            NSLayoutConstraint.activate([
+                stack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+                stack.trailingAnchor.constraint(
+                    equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                    constant: -16
+                ),
+                stack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+                stack.bottomAnchor.constraint(
+                    equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                    constant: -16
+                ),
+                policyPicker.heightAnchor.constraint(equalToConstant: 112),
+            ])
+        }
+
+        private func loadInputText() async {
+            do {
+                let texts = try await ExtensionItemCodec.plainText(
+                    from: extensionContext?.inputItems ?? []
+                )
+                inputText = texts.joined(separator: "\n\n")
+                textView.text = inputText
+                statusLabel.text = "Choose a bundled policy profile. Processing stays on this device."
+                redactButton.isEnabled = true
+            } catch {
+                show(error)
+            }
+        }
+
+        @objc private func redactSelection() {
+            let policyName = policies[policyPicker.selectedRow(inComponent: 0)]
+            let text = inputText
+            redactButton.isEnabled = false
+            statusLabel.text = "Redacting with the local Nano model…"
+
+            Task {
+                do {
+                    let configuration = try NanoModelConfiguration.bundled()
+                    let output = try await Task.detached(priority: .userInitiated) {
+                        let result: ExtensionRedactionOutput
+                        do {
+                            let handler = try ExtensionRedactionHandler(configuration: configuration)
+                            result = try handler.redact(text, policyName: policyName)
+                        }
+                        OpenMed.clearRuntimeMemoryCache()
+                        return result
+                    }.value
+                    textView.text = output.redactedText
+                    extensionContext?.completeRequest(
+                        returningItems: ExtensionItemCodec.extensionItems(for: [output.redactedText])
+                    )
+                } catch {
+                    show(error)
+                    redactButton.isEnabled = true
+                }
+            }
+        }
+
+        @objc private func cancelRequest() {
+            extensionContext?.cancelRequest(withError: ExtensionRedactionError.emptyInput)
+        }
+
+        private func show(_ error: Error) {
+            statusLabel.text = error.localizedDescription
+            statusLabel.textColor = .systemRed
+        }
+    }
+
+    extension RedactionShareViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+        public func numberOfComponents(in pickerView: UIPickerView) -> Int {
+            1
+        }
+
+        public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+            policies.count
+        }
+
+        public func pickerView(
+            _ pickerView: UIPickerView,
+            titleForRow row: Int,
+            forComponent component: Int
+        ) -> String? {
+            policies[row]
+                .replacingOccurrences(of: "_", with: " ")
+                .capitalized
+        }
+    }
+#endif

--- a/swift/OpenMedKit/Tests/ExtensionTests/ShareRedactionTests.swift
+++ b/swift/OpenMedKit/Tests/ExtensionTests/ShareRedactionTests.swift
@@ -1,0 +1,166 @@
+import ActionExtension
+import Foundation
+import OpenMedExtensionSupport
+import ShareExtension
+import XCTest
+
+@testable import OpenMedKit
+
+final class ShareRedactionTests: XCTestCase {
+    func testSyntheticTextMatchesOpenMedKitReferenceSpans() throws {
+        let text = "Name Ada DOB 04/01/2026"
+        let policy = try Policy(named: "gdpr")
+        let entities = [
+            entity(label: "first_name", value: "Ada", in: text),
+            entity(label: "date_of_birth", value: "04/01/2026", in: text),
+        ]
+        let reference = OpenMed.deidentify(text, entities: entities, policy: policy)
+        let handler = ExtensionRedactionHandler { receivedText, receivedPolicy in
+            XCTAssertEqual(receivedText, text)
+            XCTAssertEqual(receivedPolicy, policy)
+            return reference
+        }
+
+        let output = try handler.redact(text, policyName: "gdpr")
+
+        XCTAssertEqual(output.redactedText, reference.redactedText)
+        XCTAssertEqual(output.policyName, reference.policyName)
+        XCTAssertEqual(output.spans.count, reference.actions.count)
+        for (span, expected) in zip(output.spans, reference.actions) {
+            XCTAssertLessThanOrEqual(abs(span.start - expected.start), 0)
+            XCTAssertLessThanOrEqual(abs(span.end - expected.end), 0)
+            XCTAssertEqual(span.canonicalLabel, expected.canonicalLabel)
+            XCTAssertEqual(span.action, expected.action)
+            XCTAssertEqual(span.replacement, expected.replacement)
+        }
+    }
+
+    func testExtensionHasNoNetworkCapabilityOrNetworkingAPIs() throws {
+        XCTAssertFalse(ExtensionSecurityPolicy.allowsNetworkAccess)
+        XCTAssertEqual(ExtensionSecurityPolicy.modelAssetURLScheme, "file")
+
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceDirectories = [
+            "Sources/OpenMedExtensionSupport",
+            "Sources/ShareExtension",
+            "Sources/ActionExtension",
+        ]
+        let forbiddenTokens = [
+            "URLSession",
+            "NWConnection",
+            "import Network",
+            "com.apple.security.network.client",
+        ]
+
+        for directory in sourceDirectories {
+            let directoryURL = packageRoot.appending(path: directory, directoryHint: .isDirectory)
+            let files = try FileManager.default.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: nil
+            )
+            for file in files where file.pathExtension == "swift" {
+                let source = try String(contentsOf: file, encoding: .utf8)
+                for token in forbiddenTokens {
+                    XCTAssertFalse(source.contains(token), "\(file.lastPathComponent) contains \(token)")
+                }
+            }
+        }
+    }
+
+    func testRemoteModelAssetsAreRejectedBeforeLoading() {
+        let remote = URL(string: "https://example.invalid/OpenMedPIINano.mlmodelc")!
+        let local = URL(fileURLWithPath: "/tmp/openmed-extension-fixture")
+
+        XCTAssertThrowsError(
+            try NanoModelConfiguration(
+                modelURL: remote,
+                id2labelURL: local.appending(path: "id2label.json"),
+                tokenizerFolderURL: local.appending(path: "tokenizer")
+            )
+        ) { error in
+            guard case ExtensionRedactionError.nonLocalAsset(let url) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(url, remote)
+        }
+    }
+
+    func testLocalOnlyTokenizerLoadingFailsClosedWithoutAssets() {
+        let missingFolder = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+
+        XCTAssertThrowsError(
+            try OpenMed.loadTokenizer(
+                tokenizerName: "OpenMed/remote-fallback-must-not-run",
+                tokenizerFolderURL: missingFolder,
+                allowNetworkAccess: false
+            )
+        )
+    }
+
+    func testNanoBudgetStaysBelowExtensionEnvelope() throws {
+        let budget = try NanoModelMemoryBudget(
+            modelAssetBytes: NanoModelMemoryBudget.maximumModelAssetBytes
+        )
+
+        XCTAssertEqual(
+            budget.estimatedPeakBytes,
+            NanoModelMemoryBudget.maximumEstimatedPeakBytes
+        )
+        XCTAssertLessThan(
+            budget.estimatedPeakBytes,
+            NanoModelMemoryBudget.extensionWorkingSetEnvelopeBytes
+        )
+        XCTAssertThrowsError(
+            try NanoModelMemoryBudget(
+                modelAssetBytes: NanoModelMemoryBudget.maximumModelAssetBytes + 1
+            )
+        )
+    }
+
+    func testOversizedExtensionInputIsRejectedBeforeInference() throws {
+        let text = "x"
+        let policy = try Policy(named: Policy.defaultName)
+        let reference = OpenMed.deidentify(text, entities: [], policy: policy)
+        let handler = ExtensionRedactionHandler { _, _ in reference }
+        let oversized = String(
+            repeating: "x",
+            count: ExtensionRedactionHandler.maximumInputCharacters + 1
+        )
+
+        XCTAssertThrowsError(try handler.redact(oversized)) { error in
+            guard case ExtensionRedactionError.inputTooLarge(let actual, let limit) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(actual, oversized.count)
+            XCTAssertEqual(limit, ExtensionRedactionHandler.maximumInputCharacters)
+        }
+    }
+
+    func testPolicyPickerUsesEveryBundledProfile() throws {
+        XCTAssertTrue(Policy.bundledProfileNames.contains(Policy.defaultName))
+        for profile in Policy.bundledProfileNames {
+            XCTAssertNoThrow(try Policy(named: profile))
+        }
+    }
+
+    private func entity(
+        label: String,
+        value: String,
+        in text: String
+    ) -> EntityPrediction {
+        let range = text.range(of: value)!
+        return EntityPrediction(
+            label: label,
+            text: value,
+            confidence: 0.99,
+            start: text.distance(from: text.startIndex, to: range.lowerBound),
+            end: text.distance(from: text.startIndex, to: range.upperBound)
+        )
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
Closes #835.

Adds reusable iOS Share and Action extension modules that accept plain-text extension items, redact them with OpenMedKit policy profiles, and return redacted text to the host app. Extension inference is local-only and uses a guarded Nano Core ML configuration sized for the extension sandbox.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added Share and Action extension products, plain-text item handling, a policy-profile picker, and host-returnable redaction output with original span offsets.
- Added a file-only Nano model loader with a 40 MiB asset cap, 96 MiB estimated peak budget, bounded input, and fail-closed tokenizer loading with network access disabled.
- Added extension contract tests and an iOS integration guide covering target setup, resource packaging, privacy, and memory limits.

## Testing
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with these changes
- [ ] I have tested this change with different production models

Commands run:
- `.venv/bin/python -m pytest tests/ -q` — 5,159 passed, 51 skipped
- `arch -arm64 swift test` from the repository root — 72 passed, 14 environment-gated skips
- `arch -arm64 swift test` from `swift/OpenMedKit` — 72 passed, 14 environment-gated skips
- iOS Simulator builds for `OpenMedShareExtension` and `OpenMedActionExtension`
- `make format-swift`
- `make lint-swift`
- `make lint`
- `make format-check`
- `make docs-build`
- scoped pre-commit checks

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added documentation comments to new public functions and classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [x] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious security and memory contracts
- [x] My changes generate no new code warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] The change is organized as one focused commit

## Related Issues
Closes #835

## Screenshots/Examples
Not applicable; the Share extension UI is programmatic and covered by the integration guide.
