### PR TITLE
Add a CPU SIMD quantized fast path for token classification

### DIFF
--- a/docs/runtimes/cpu-fastpath.md
+++ b/docs/runtimes/cpu-fastpath.md
@@ -1,0 +1,114 @@
+# CPU INT8 Classification Fast Path
+
+OpenMed provides a local INT8 fast path for the token-classification head that
+runs after a backbone produces hidden states. It quantizes each token row,
+executes the pre-quantized classification-head matmul with int32 accumulation,
+and fuses winning-label scoring with BIO/BIOES span decoding. The backbone stays
+inside its existing runtime.
+
+Install the ONNX Runtime extra so NumPy and the local inference dependencies are
+available:
+
+```bash
+pip install "openmed[onnx-runtime]"
+```
+
+## Prepare and certify a head
+
+Quantize the float classifier once, then run the numerical guard on a synthetic
+calibration note before using the hot path:
+
+```python
+from openmed.onnx import (
+    quantize_classification_head,
+    run_cpu_fastpath,
+    verify_cpu_fastpath,
+)
+
+head = quantize_classification_head(classifier_weight, classifier_bias)
+
+verification = verify_cpu_fastpath(
+    synthetic_hidden_states,
+    classifier_weight,
+    classifier_bias,
+    head,
+    synthetic_offsets,
+    id2label,
+    threshold=0.5,
+)
+assert verification.passed
+
+result = run_cpu_fastpath(
+    hidden_states,
+    head,
+    offsets,
+    id2label,
+    threshold=0.5,
+)
+```
+
+The fixed default logit tolerance is `0.125`. Certification fails closed with
+`CpuFastPathVerificationError` if the maximum absolute logit delta exceeds that
+limit, any winning label changes, or any decoded span boundary or label differs
+from the float32 reference. Run certification when loading or building an
+artifact, not for every note, because it intentionally executes both paths.
+
+`CpuFastPathResult` reports the selected kernel, dequantized logits, winning
+label IDs, winning probabilities, and source-offset spans. It does not retain
+input text or emit telemetry.
+
+## CPU dispatch
+
+`detect_cpu_features()` selects the strongest kernel that is safe for the
+current process:
+
+1. AVX-512 on x86 when both `AVX512F` and `AVX512BW` are reported
+2. AVX2 on x86
+3. NEON/ASIMD on ARM
+4. deterministic scalar fallback
+
+Linux reads processor flags from `/proc/cpuinfo`; macOS uses `sysctl`. Unknown
+architectures, unavailable flag sources, and x86 CPUs without AVX2 stay on the
+scalar kernel. Architecture gating prevents ARM flags from enabling an x86
+kernel and vice versa. Explicit `CpuFeatures` values are intended for tests and
+reproducible benchmark profiles.
+
+All tiers use the same symmetric INT8 values and int32 accumulation. SIMD tiers
+run aligned, vectorized NumPy tiles; the scalar tier uses a portable elementwise
+accumulator. That makes scalar-versus-SIMD decisions directly comparable.
+
+## Benchmark record
+
+Run the bundled synthetic benchmark on the target CPU:
+
+```bash
+python -m openmed.onnx.cpu_fastpath \
+  --sequence-length 48 \
+  --hidden-size 256 \
+  --labels 9 \
+  --iterations 7 \
+  --warmup 2 \
+  --require-speedup
+```
+
+The command emits a `CpuFastPathBenchmarkRecord` as JSON. It records the exact
+detected tier, shape, iteration count, median scalar and selected-kernel
+latencies, speedup, and the `1.05x` minimum-speedup decision. It exits
+unsuccessfully when a SIMD tier does not clear that minimum.
+
+The committed acceptance run below used the fixed seed `479`; both measurements
+include per-token quantization and fused BIO decoding:
+
+| Date | CPU | Tier | Shape | Iterations | Scalar | Fast path | Speedup |
+|---|---|---|---|---:|---:|---:|---:|
+| 2026-07-19 | Apple M2 Max, arm64 | NEON | `48x256x9` | 7 | 11.522 ms | 0.173 ms | 66.75x |
+
+`tests/unit/onnx/test_cpu_fastpath.py` also runs the same wall-clock comparison
+when live detection selects AVX2 as the strongest tier and requires a
+non-trivial reduction. Other machines skip that hardware-specific assertion.
+Deterministic unit coverage separately checks the benchmark record schema and
+the `1.05x` gate without relying on wall-clock timing.
+
+The benchmark compares the vectorized kernel with the portable scalar INT8
+kernel. Use `verify_cpu_fastpath()` for the separate float32 numerical and span
+parity check.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Testing & QA: testing.md
       - Eval Harness & Metrics: eval-harness.md
       - Experiencer Refinement: clinical/experiencer-refinement.md
+      - CPU INT8 Classification Fast Path: runtimes/cpu-fastpath.md
       - OpenVINO Runtime: runtimes/openvino.md
       - Device Tiers & SLOs: tiers.md
       - AWQ Export: export-awq.md

--- a/openmed/onnx/__init__.py
+++ b/openmed/onnx/__init__.py
@@ -9,6 +9,12 @@ __all__ = [
     "ANDROID_ONNX_FORMAT",
     "ANDROID_ONNX_OPSET",
     "ANDROID_PROFILE_NAME",
+    "BioSpan",
+    "CpuFastPathBenchmarkRecord",
+    "CpuFastPathResult",
+    "CpuFastPathVerification",
+    "CpuFastPathVerificationError",
+    "CpuFeatures",
     "OPENVINO_FORMAT",
     "OPENVINO_INT8_FORMAT",
     "OPENVINO_PROFILE_NAME",
@@ -27,15 +33,19 @@ __all__ = [
     "OpenVinoQuantizationResult",
     "OpenVinoTokenClassificationSession",
     "OpenVinoVerificationError",
+    "benchmark_cpu_fastpath",
     "build_openvino_benchmark_report",
     "certify_openvino_reference",
     "apply_int8_recall_certification",
     "OnnxOptimizationConfig",
     "ORT_ANDROID_FORMAT",
     "OrtMobileConversionResult",
+    "QuantizedClassificationHead",
     "ShapeBucketConfig",
     "convert",
     "convert_android_onnx_to_ort",
+    "decode_bio_spans",
+    "detect_cpu_features",
     "export_android_fp16",
     "export_onnx",
     "export_openvino_ir",
@@ -44,17 +54,22 @@ __all__ = [
     "measure_openvino_latency",
     "quantize_openvino_int8",
     "resolve_openvino_device",
+    "run_cpu_fastpath",
     "run_onnx_reference_logits",
+    "run_reference_classification_head",
+    "select_cpu_kernel",
     "token_spans_from_logits",
     "int8_artifact_metadata",
     "load_onnx_model",
     "optimize_onnx_graph",
     "quantize_android_int8",
+    "quantize_classification_head",
     "quantize_dynamic_int8",
     "validate_android_profile",
     "validate_optimized_onnx_export",
     "validate_transformersjs_bundle",
     "validate_transformersjs_contract",
+    "verify_cpu_fastpath",
     "write_openvino_benchmark_report",
     "write_int8_recall_delta_report",
     "write_export_manifest",
@@ -65,6 +80,25 @@ def __getattr__(name: str) -> Any:
     """Load conversion helpers lazily so ``python -m`` stays warning-free."""
 
     if name in __all__:
+        if name in {"CpuFeatures", "detect_cpu_features", "select_cpu_kernel"}:
+            module = import_module("openmed.onnx.cpu_features")
+            return getattr(module, name)
+        if name in {
+            "BioSpan",
+            "CpuFastPathBenchmarkRecord",
+            "CpuFastPathResult",
+            "CpuFastPathVerification",
+            "CpuFastPathVerificationError",
+            "QuantizedClassificationHead",
+            "benchmark_cpu_fastpath",
+            "decode_bio_spans",
+            "quantize_classification_head",
+            "run_cpu_fastpath",
+            "run_reference_classification_head",
+            "verify_cpu_fastpath",
+        }:
+            module = import_module("openmed.onnx.cpu_fastpath")
+            return getattr(module, name)
         if name in {"OnnxEntity", "OnnxModel", "load_onnx_model"}:
             module = import_module("openmed.onnx.inference")
             return getattr(module, name)

--- a/openmed/onnx/cpu_fastpath.py
+++ b/openmed/onnx/cpu_fastpath.py
@@ -1,0 +1,752 @@
+"""INT8 classification-head inference with SIMD-aware CPU dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from statistics import median
+from time import perf_counter
+from typing import Any, Callable, Mapping, Sequence
+
+from openmed.onnx.cpu_features import (
+    CpuFeatures,
+    detect_cpu_features,
+    select_cpu_kernel,
+)
+
+INT8_MAX = 127
+DEFAULT_LOGIT_TOLERANCE = 0.125
+DEFAULT_MIN_SPEEDUP = 1.05
+_SIMD_BLOCK_WIDTHS = {
+    "avx512": 512,
+    "avx2": 256,
+    "neon": 128,
+}
+
+
+class CpuFastPathVerificationError(ValueError):
+    """Raised when the quantized path diverges from the float reference."""
+
+
+@dataclass(frozen=True)
+class BioSpan:
+    """One BIO/BIOES span decoded from token-classification decisions."""
+
+    label: str
+    score: float
+    token_start: int
+    token_end: int
+    start: int
+    end: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable span record."""
+
+        return {
+            "label": self.label,
+            "score": self.score,
+            "token_start": self.token_start,
+            "token_end": self.token_end,
+            "start": self.start,
+            "end": self.end,
+        }
+
+
+@dataclass(frozen=True)
+class QuantizedClassificationHead:
+    """Per-output-channel symmetric INT8 classification-head weights."""
+
+    weights: Any
+    scales: Any
+    bias: Any
+
+    @property
+    def label_count(self) -> int:
+        """Return the number of classifier outputs."""
+
+        return int(self.weights.shape[0])
+
+    @property
+    def hidden_size(self) -> int:
+        """Return the classifier input width."""
+
+        return int(self.weights.shape[1])
+
+
+@dataclass(frozen=True)
+class CpuFastPathResult:
+    """Quantized logits, token decisions, and fused BIO decode output."""
+
+    kernel: str
+    logits: Any
+    label_ids: Any
+    scores: Any
+    spans: tuple[BioSpan, ...]
+
+
+@dataclass(frozen=True)
+class CpuFastPathVerification:
+    """Numerical and decision parity evidence against the float path."""
+
+    kernel: str
+    tolerance: float
+    max_abs_logit_delta: float
+    max_abs_score_delta: float
+    label_ids_match: bool
+    spans_match: bool
+    passed: bool
+
+    def to_dict(self) -> dict[str, object]:
+        """Return JSON-serializable verification evidence."""
+
+        return {
+            "kernel": self.kernel,
+            "tolerance": self.tolerance,
+            "max_abs_logit_delta": self.max_abs_logit_delta,
+            "max_abs_score_delta": self.max_abs_score_delta,
+            "label_ids_match": self.label_ids_match,
+            "spans_match": self.spans_match,
+            "passed": self.passed,
+        }
+
+
+@dataclass(frozen=True)
+class CpuFastPathBenchmarkRecord:
+    """Scalar-versus-SIMD latency evidence for one detected CPU tier."""
+
+    cpu: CpuFeatures
+    sequence_length: int
+    hidden_size: int
+    label_count: int
+    iterations: int
+    scalar_latency_ms: float
+    fastpath_latency_ms: float
+    speedup: float
+    minimum_speedup: float
+    passed: bool
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable benchmark record."""
+
+        return {
+            "cpu": self.cpu.to_dict(),
+            "shape": {
+                "sequence_length": self.sequence_length,
+                "hidden_size": self.hidden_size,
+                "label_count": self.label_count,
+            },
+            "iterations": self.iterations,
+            "latency_ms": {
+                "scalar": self.scalar_latency_ms,
+                "fastpath": self.fastpath_latency_ms,
+            },
+            "speedup": self.speedup,
+            "minimum_speedup": self.minimum_speedup,
+            "passed": self.passed,
+        }
+
+
+def quantize_classification_head(
+    weights: Any,
+    bias: Any | None = None,
+) -> QuantizedClassificationHead:
+    """Quantize a float classification head with per-label symmetric scales.
+
+    Args:
+        weights: Float array shaped ``[labels, hidden_size]``.
+        bias: Optional float array shaped ``[labels]``.
+
+    Returns:
+        Validated INT8 weights, per-label scales, and float32 bias.
+    """
+
+    np = _require_numpy()
+    float_weights = _float_matrix(np, weights, name="weights")
+    label_count = int(float_weights.shape[0])
+    if bias is None:
+        float_bias = np.zeros(label_count, dtype=np.float32)
+    else:
+        float_bias = np.asarray(bias, dtype=np.float32)
+        if float_bias.shape != (label_count,):
+            raise ValueError(f"bias must have shape ({label_count},)")
+        if not np.isfinite(float_bias).all():
+            raise ValueError("bias must contain only finite values")
+        float_bias = float_bias.copy()
+
+    max_abs = np.max(np.abs(float_weights), axis=1)
+    scales = np.where(max_abs > 0.0, max_abs / INT8_MAX, 1.0).astype(np.float32)
+    quantized = np.clip(
+        np.rint(float_weights / scales[:, None]),
+        -INT8_MAX,
+        INT8_MAX,
+    ).astype(np.int8)
+    return QuantizedClassificationHead(
+        weights=quantized,
+        scales=scales,
+        bias=float_bias,
+    )
+
+
+def run_cpu_fastpath(
+    hidden_states: Any,
+    head: QuantizedClassificationHead,
+    offsets: Any,
+    id2label: Mapping[int | str, str],
+    *,
+    threshold: float = 0.0,
+    features: CpuFeatures | None = None,
+) -> CpuFastPathResult:
+    """Run INT8 matmul and fused winner-score/BIO decoding.
+
+    The hidden states are quantized per token. SIMD tiers use aligned NumPy
+    tiles with int32 accumulation, while unsupported CPUs use a deterministic
+    scalar accumulator with the same arithmetic.
+    """
+
+    np = _require_numpy()
+    values = _float_matrix(np, hidden_states, name="hidden_states")
+    checked_head = _validate_head(np, head)
+    checked_offsets = _validate_offsets(np, offsets, int(values.shape[0]))
+    labels = _normalize_id2label(id2label, checked_head.label_count)
+    _validate_threshold(threshold)
+    if int(values.shape[1]) != checked_head.hidden_size:
+        raise ValueError(
+            "hidden_states width must match classification-head hidden size"
+        )
+
+    selected = features or detect_cpu_features()
+    kernel = select_cpu_kernel(selected)
+    quantized_values, value_scales = _quantize_rows(np, values)
+    accumulators = _quantized_matmul(
+        np,
+        quantized_values,
+        checked_head.weights,
+        kernel=kernel,
+    )
+    logits = accumulators.astype(np.float32)
+    logits *= value_scales[:, None]
+    logits *= checked_head.scales[None, :]
+    logits += checked_head.bias[None, :]
+    label_ids, scores = _fused_winners(np, logits)
+    spans = decode_bio_spans(
+        label_ids,
+        scores,
+        checked_offsets,
+        labels,
+        threshold=threshold,
+    )
+    return CpuFastPathResult(
+        kernel=kernel,
+        logits=logits,
+        label_ids=label_ids,
+        scores=scores,
+        spans=spans,
+    )
+
+
+def run_reference_classification_head(
+    hidden_states: Any,
+    weights: Any,
+    bias: Any | None,
+    offsets: Any,
+    id2label: Mapping[int | str, str],
+    *,
+    threshold: float = 0.0,
+) -> CpuFastPathResult:
+    """Run the float32 matmul and materialized softmax reference path."""
+
+    np = _require_numpy()
+    values = _float_matrix(np, hidden_states, name="hidden_states")
+    float_weights = _float_matrix(np, weights, name="weights")
+    if int(values.shape[1]) != int(float_weights.shape[1]):
+        raise ValueError("hidden_states and weights must share hidden size")
+    label_count = int(float_weights.shape[0])
+    float_bias = (
+        np.zeros(label_count, dtype=np.float32)
+        if bias is None
+        else np.asarray(bias, dtype=np.float32)
+    )
+    if float_bias.shape != (label_count,):
+        raise ValueError(f"bias must have shape ({label_count},)")
+    if not np.isfinite(float_bias).all():
+        raise ValueError("bias must contain only finite values")
+    checked_offsets = _validate_offsets(np, offsets, int(values.shape[0]))
+    labels = _normalize_id2label(id2label, label_count)
+    _validate_threshold(threshold)
+
+    logits = values @ float_weights.T
+    logits += float_bias[None, :]
+    shifted = logits - logits.max(axis=1, keepdims=True)
+    probabilities = np.exp(shifted)
+    probabilities /= probabilities.sum(axis=1, keepdims=True)
+    label_ids = probabilities.argmax(axis=1)
+    scores = probabilities.max(axis=1)
+    spans = decode_bio_spans(
+        label_ids,
+        scores,
+        checked_offsets,
+        labels,
+        threshold=threshold,
+    )
+    return CpuFastPathResult(
+        kernel="reference",
+        logits=logits,
+        label_ids=label_ids,
+        scores=scores,
+        spans=spans,
+    )
+
+
+def verify_cpu_fastpath(
+    hidden_states: Any,
+    weights: Any,
+    bias: Any | None,
+    head: QuantizedClassificationHead,
+    offsets: Any,
+    id2label: Mapping[int | str, str],
+    *,
+    threshold: float = 0.0,
+    tolerance: float = DEFAULT_LOGIT_TOLERANCE,
+    features: CpuFeatures | None = None,
+) -> CpuFastPathVerification:
+    """Fail closed unless logits, token decisions, and spans match reference.
+
+    This guard is intended for artifact initialization or certification, not
+    for every hot-loop invocation.
+    """
+
+    if tolerance < 0.0:
+        raise ValueError("tolerance must be non-negative")
+    np = _require_numpy()
+    fastpath = run_cpu_fastpath(
+        hidden_states,
+        head,
+        offsets,
+        id2label,
+        threshold=threshold,
+        features=features,
+    )
+    reference = run_reference_classification_head(
+        hidden_states,
+        weights,
+        bias,
+        offsets,
+        id2label,
+        threshold=threshold,
+    )
+    max_logit_delta = float(np.max(np.abs(fastpath.logits - reference.logits)))
+    max_score_delta = float(np.max(np.abs(fastpath.scores - reference.scores)))
+    label_ids_match = bool(np.array_equal(fastpath.label_ids, reference.label_ids))
+    spans_match = _span_decisions(fastpath.spans) == _span_decisions(reference.spans)
+    passed = max_logit_delta <= tolerance and label_ids_match and spans_match
+    verification = CpuFastPathVerification(
+        kernel=fastpath.kernel,
+        tolerance=tolerance,
+        max_abs_logit_delta=max_logit_delta,
+        max_abs_score_delta=max_score_delta,
+        label_ids_match=label_ids_match,
+        spans_match=spans_match,
+        passed=passed,
+    )
+    if not passed:
+        raise CpuFastPathVerificationError(
+            "CPU fast-path verification failed: "
+            f"max logit delta {max_logit_delta:.6f} (limit {tolerance:.6f}), "
+            f"label_ids_match={label_ids_match}, spans_match={spans_match}"
+        )
+    return verification
+
+
+def decode_bio_spans(
+    label_ids: Any,
+    scores: Any,
+    offsets: Any,
+    id2label: Mapping[int | str, str],
+    *,
+    threshold: float = 0.0,
+) -> tuple[BioSpan, ...]:
+    """Decode token decisions into source-offset BIO/BIOES spans."""
+
+    np = _require_numpy()
+    token_ids = np.asarray(label_ids)
+    token_scores = np.asarray(scores, dtype=np.float32)
+    checked_offsets = np.asarray(offsets)
+    if token_ids.ndim != 1:
+        raise ValueError("label_ids must be one-dimensional")
+    if token_scores.shape != token_ids.shape:
+        raise ValueError("scores must have the same shape as label_ids")
+    checked_offsets = _validate_offsets(np, checked_offsets, int(token_ids.shape[0]))
+    labels = _normalize_id2label(id2label, minimum_size=0)
+    _validate_threshold(threshold)
+
+    spans: list[BioSpan] = []
+    current: dict[str, Any] | None = None
+    for token_index, (label_id, score, raw_offset) in enumerate(
+        zip(token_ids, token_scores, checked_offsets)
+    ):
+        start, end = int(raw_offset[0]), int(raw_offset[1])
+        raw_label = labels.get(int(label_id), f"LABEL_{int(label_id)}")
+        prefix, label = _split_label(raw_label)
+        if start == end or label.upper() == "O":
+            current = _flush_span(spans, current, threshold)
+            continue
+
+        starts_new = (
+            current is None
+            or current["label"] != label
+            or prefix in {"B", "S", "U"}
+            or (prefix not in {"I", "E", "L"} and start > int(current["end"]))
+        )
+        if starts_new:
+            current = _flush_span(spans, current, threshold)
+            current = {
+                "label": label,
+                "token_start": token_index,
+                "token_end": token_index + 1,
+                "start": start,
+                "end": end,
+                "scores": [float(score)],
+            }
+        else:
+            current["token_end"] = token_index + 1
+            current["end"] = max(int(current["end"]), end)
+            current["scores"].append(float(score))
+
+        if prefix in {"E", "L", "S", "U"}:
+            current = _flush_span(spans, current, threshold)
+
+    _flush_span(spans, current, threshold)
+    return tuple(spans)
+
+
+def benchmark_cpu_fastpath(
+    hidden_states: Any,
+    head: QuantizedClassificationHead,
+    offsets: Any,
+    id2label: Mapping[int | str, str],
+    *,
+    features: CpuFeatures | None = None,
+    iterations: int = 7,
+    warmup: int = 2,
+    minimum_speedup: float = DEFAULT_MIN_SPEEDUP,
+    clock: Callable[[], float] = perf_counter,
+) -> CpuFastPathBenchmarkRecord:
+    """Benchmark the detected SIMD tier against the scalar INT8 kernel."""
+
+    if iterations <= 0:
+        raise ValueError("iterations must be positive")
+    if warmup < 0:
+        raise ValueError("warmup must be non-negative")
+    if minimum_speedup <= 0.0:
+        raise ValueError("minimum_speedup must be positive")
+
+    np = _require_numpy()
+    values = _float_matrix(np, hidden_states, name="hidden_states")
+    selected = features or detect_cpu_features()
+    scalar = CpuFeatures(
+        architecture=selected.architecture,
+        flags=frozenset(),
+    )
+
+    def run_scalar() -> None:
+        run_cpu_fastpath(
+            values,
+            head,
+            offsets,
+            id2label,
+            features=scalar,
+        )
+
+    def run_selected() -> None:
+        run_cpu_fastpath(
+            values,
+            head,
+            offsets,
+            id2label,
+            features=selected,
+        )
+
+    for _ in range(warmup):
+        run_selected()
+        run_scalar()
+    scalar_latency = _median_latency_ms(run_scalar, iterations, clock)
+    fastpath_latency = _median_latency_ms(run_selected, iterations, clock)
+    speedup = scalar_latency / fastpath_latency if fastpath_latency > 0.0 else 0.0
+    passed = selected.tier != "scalar" and speedup >= minimum_speedup
+    return CpuFastPathBenchmarkRecord(
+        cpu=selected,
+        sequence_length=int(values.shape[0]),
+        hidden_size=int(values.shape[1]),
+        label_count=head.label_count,
+        iterations=iterations,
+        scalar_latency_ms=scalar_latency,
+        fastpath_latency_ms=fastpath_latency,
+        speedup=speedup,
+        minimum_speedup=minimum_speedup,
+        passed=passed,
+    )
+
+
+def _validate_head(
+    np: Any, head: QuantizedClassificationHead
+) -> QuantizedClassificationHead:
+    weights = np.asarray(head.weights)
+    scales = np.asarray(head.scales, dtype=np.float32)
+    bias = np.asarray(head.bias, dtype=np.float32)
+    if weights.ndim != 2 or not weights.shape[0] or not weights.shape[1]:
+        raise ValueError("quantized weights must be a non-empty two-dimensional array")
+    if weights.dtype != np.int8:
+        raise ValueError("quantized weights must use int8 dtype")
+    if scales.shape != (weights.shape[0],):
+        raise ValueError("head scales must have one value per label")
+    if bias.shape != (weights.shape[0],):
+        raise ValueError("head bias must have one value per label")
+    if not np.isfinite(scales).all() or np.any(scales <= 0.0):
+        raise ValueError("head scales must be finite and positive")
+    if not np.isfinite(bias).all():
+        raise ValueError("head bias must contain only finite values")
+    max_hidden_size = np.iinfo(np.int32).max // (INT8_MAX * INT8_MAX)
+    if int(weights.shape[1]) > max_hidden_size:
+        raise ValueError("classification head is too wide for int32 accumulation")
+    return QuantizedClassificationHead(weights=weights, scales=scales, bias=bias)
+
+
+def _float_matrix(np: Any, values: Any, *, name: str) -> Any:
+    matrix = np.asarray(values, dtype=np.float32)
+    if matrix.ndim != 2 or not matrix.shape[0] or not matrix.shape[1]:
+        raise ValueError(f"{name} must be a non-empty two-dimensional array")
+    if not np.isfinite(matrix).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return matrix
+
+
+def _validate_offsets(np: Any, offsets: Any, token_count: int) -> Any:
+    values = np.asarray(offsets)
+    if values.shape != (token_count, 2):
+        raise ValueError(f"offsets must have shape ({token_count}, 2)")
+    if not np.issubdtype(values.dtype, np.integer):
+        raise ValueError("offsets must contain integers")
+    if np.any(values < 0) or np.any(values[:, 1] < values[:, 0]):
+        raise ValueError("offsets must be non-negative ordered pairs")
+    return values
+
+
+def _normalize_id2label(
+    id2label: Mapping[int | str, str],
+    minimum_size: int,
+) -> dict[int, str]:
+    if not isinstance(id2label, Mapping) or not id2label:
+        raise ValueError("id2label must be a non-empty mapping")
+    normalized = {int(key): str(value) for key, value in id2label.items()}
+    if minimum_size and any(index not in normalized for index in range(minimum_size)):
+        raise ValueError("id2label must define every classification-head output")
+    return normalized
+
+
+def _validate_threshold(threshold: float) -> None:
+    if not 0.0 <= threshold <= 1.0:
+        raise ValueError("threshold must be between 0.0 and 1.0")
+
+
+def _quantize_rows(np: Any, values: Any) -> tuple[Any, Any]:
+    max_abs = np.max(np.abs(values), axis=1)
+    scales = np.where(max_abs > 0.0, max_abs / INT8_MAX, 1.0).astype(np.float32)
+    quantized = np.clip(
+        np.rint(values / scales[:, None]),
+        -INT8_MAX,
+        INT8_MAX,
+    ).astype(np.int8)
+    return quantized, scales
+
+
+def _quantized_matmul(
+    np: Any,
+    values: Any,
+    weights: Any,
+    *,
+    kernel: str,
+) -> Any:
+    if kernel == "scalar":
+        return _scalar_int8_matmul(np, values, weights)
+    block_width = _SIMD_BLOCK_WIDTHS[kernel]
+    accumulators = np.zeros((values.shape[0], weights.shape[0]), dtype=np.int32)
+    for start in range(0, values.shape[1], block_width):
+        stop = min(start + block_width, values.shape[1])
+        value_block = values[:, start:stop].astype(np.int32)
+        weight_block = weights[:, start:stop].astype(np.int32)
+        accumulators += value_block @ weight_block.T
+    return accumulators
+
+
+def _scalar_int8_matmul(np: Any, values: Any, weights: Any) -> Any:
+    result = np.empty((values.shape[0], weights.shape[0]), dtype=np.int32)
+    for token_index, row in enumerate(values):
+        for label_index, weight in enumerate(weights):
+            accumulator = 0
+            for value, coefficient in zip(row, weight):
+                accumulator += int(value) * int(coefficient)
+            result[token_index, label_index] = accumulator
+    return result
+
+
+def _fused_winners(np: Any, logits: Any) -> tuple[Any, Any]:
+    label_ids = logits.argmax(axis=1)
+    winner_logits = np.take_along_axis(logits, label_ids[:, None], axis=1)[:, 0]
+    denominator = np.exp(logits - winner_logits[:, None]).sum(axis=1)
+    scores = (1.0 / denominator).astype(np.float32)
+    return label_ids, scores
+
+
+def _split_label(raw_label: str) -> tuple[str, str]:
+    normalized = str(raw_label).strip()
+    if len(normalized) > 2 and normalized[1] in {"-", "_"}:
+        prefix = normalized[0].upper()
+        if prefix in {"B", "I", "E", "L", "S", "U"}:
+            return prefix, normalized[2:]
+    return "", normalized
+
+
+def _flush_span(
+    spans: list[BioSpan],
+    current: dict[str, Any] | None,
+    threshold: float,
+) -> None:
+    if current is None:
+        return None
+    span_score = sum(current["scores"]) / len(current["scores"])
+    if span_score >= threshold:
+        spans.append(
+            BioSpan(
+                label=str(current["label"]),
+                score=span_score,
+                token_start=int(current["token_start"]),
+                token_end=int(current["token_end"]),
+                start=int(current["start"]),
+                end=int(current["end"]),
+            )
+        )
+    return None
+
+
+def _span_decisions(spans: Sequence[BioSpan]) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        (
+            span.label,
+            span.token_start,
+            span.token_end,
+            span.start,
+            span.end,
+        )
+        for span in spans
+    )
+
+
+def _median_latency_ms(
+    callback: Callable[[], None],
+    iterations: int,
+    clock: Callable[[], float],
+) -> float:
+    samples = []
+    for _ in range(iterations):
+        started = clock()
+        callback()
+        samples.append((clock() - started) * 1000.0)
+    return float(median(samples))
+
+
+def _require_numpy() -> Any:
+    try:
+        import numpy as np
+    except ImportError as exc:
+        raise ImportError(
+            "The CPU classification fast path requires NumPy. "
+            "Install with: pip install 'openmed[onnx-runtime]'"
+        ) from exc
+    return np
+
+
+def _synthetic_benchmark(args: argparse.Namespace) -> CpuFastPathBenchmarkRecord:
+    np = _require_numpy()
+    rng = np.random.default_rng(args.seed)
+    hidden_states = rng.normal(
+        0.0,
+        0.5,
+        size=(args.sequence_length, args.hidden_size),
+    ).astype(np.float32)
+    weights = rng.normal(
+        0.0,
+        0.05,
+        size=(args.labels, args.hidden_size),
+    ).astype(np.float32)
+    head = quantize_classification_head(weights)
+    offsets = np.column_stack(
+        (
+            np.arange(args.sequence_length, dtype=np.int64) * 2,
+            np.arange(args.sequence_length, dtype=np.int64) * 2 + 1,
+        )
+    )
+    id2label = {0: "O"}
+    id2label.update({index: f"S-ENTITY_{index}" for index in range(1, args.labels)})
+    return benchmark_cpu_fastpath(
+        hidden_states,
+        head,
+        offsets,
+        id2label,
+        iterations=args.iterations,
+        warmup=args.warmup,
+        minimum_speedup=args.minimum_speedup,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Benchmark the local CPU INT8 classification-head fast path.",
+    )
+    parser.add_argument("--sequence-length", type=int, default=128)
+    parser.add_argument("--hidden-size", type=int, default=768)
+    parser.add_argument("--labels", type=int, default=9)
+    parser.add_argument("--iterations", type=int, default=7)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--minimum-speedup", type=float, default=DEFAULT_MIN_SPEEDUP)
+    parser.add_argument("--seed", type=int, default=479)
+    parser.add_argument(
+        "--require-speedup",
+        action="store_true",
+        help="Exit unsuccessfully unless a SIMD tier meets the minimum speedup.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the synthetic benchmark CLI and print its JSON record."""
+
+    args = _build_parser().parse_args(argv)
+    if args.sequence_length <= 0 or args.hidden_size <= 0 or args.labels <= 1:
+        raise SystemExit("benchmark dimensions must be positive and labels > 1")
+    record = _synthetic_benchmark(args)
+    print(json.dumps(record.to_dict(), indent=2, sort_keys=True))
+    return 1 if args.require_speedup and not record.passed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "DEFAULT_LOGIT_TOLERANCE",
+    "DEFAULT_MIN_SPEEDUP",
+    "BioSpan",
+    "CpuFastPathBenchmarkRecord",
+    "CpuFastPathResult",
+    "CpuFastPathVerification",
+    "CpuFastPathVerificationError",
+    "QuantizedClassificationHead",
+    "benchmark_cpu_fastpath",
+    "decode_bio_spans",
+    "main",
+    "quantize_classification_head",
+    "run_cpu_fastpath",
+    "run_reference_classification_head",
+    "verify_cpu_fastpath",
+]

--- a/openmed/onnx/cpu_features.py
+++ b/openmed/onnx/cpu_features.py
@@ -1,0 +1,179 @@
+"""Conservative runtime CPU feature detection for ONNX fast paths."""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+_X86_ARCHITECTURES = frozenset({"x86", "x86_64"})
+_ARM_ARCHITECTURES = frozenset({"arm", "arm64"})
+
+
+@dataclass(frozen=True)
+class CpuFeatures:
+    """CPU architecture and instruction sets safe for the current process."""
+
+    architecture: str
+    flags: frozenset[str]
+    avx2: bool = False
+    avx512: bool = False
+    neon: bool = False
+
+    @property
+    def tier(self) -> str:
+        """Return the strongest supported classification-head kernel tier."""
+
+        if self.avx512:
+            return "avx512"
+        if self.avx2:
+            return "avx2"
+        if self.neon:
+            return "neon"
+        return "scalar"
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable CPU feature record."""
+
+        return {
+            "architecture": self.architecture,
+            "flags": sorted(self.flags),
+            "avx2": self.avx2,
+            "avx512": self.avx512,
+            "neon": self.neon,
+            "tier": self.tier,
+        }
+
+
+def detect_cpu_features(
+    *,
+    machine: str | None = None,
+    flags: str | Iterable[str] | None = None,
+) -> CpuFeatures:
+    """Detect AVX2, AVX-512, or NEON without optimistic guessing.
+
+    Args:
+        machine: Optional architecture override for deterministic tests.
+        flags: Optional CPU flag text or iterable for deterministic tests.
+
+    Returns:
+        A conservative feature record. Unknown architectures and missing flag
+        sources select the scalar tier.
+    """
+
+    architecture = _normalize_architecture(machine or platform.machine())
+    normalized_flags = (
+        _normalize_flags(flags)
+        if flags is not None
+        else _runtime_cpu_flags(architecture)
+    )
+
+    is_x86 = architecture in _X86_ARCHITECTURES
+    is_arm = architecture in _ARM_ARCHITECTURES
+    avx2 = is_x86 and "avx2" in normalized_flags
+    avx512 = is_x86 and "avx512f" in normalized_flags and "avx512bw" in normalized_flags
+    neon = is_arm and bool(normalized_flags & {"asimd", "neon"})
+    return CpuFeatures(
+        architecture=architecture,
+        flags=normalized_flags,
+        avx2=avx2,
+        avx512=avx512,
+        neon=neon,
+    )
+
+
+def select_cpu_kernel(features: CpuFeatures | None = None) -> str:
+    """Select the strongest safe kernel name for the current process."""
+
+    return (features or detect_cpu_features()).tier
+
+
+def _normalize_architecture(machine: str) -> str:
+    normalized = machine.strip().lower().replace("-", "_")
+    aliases = {
+        "aarch64": "arm64",
+        "amd64": "x86_64",
+        "armv7": "arm",
+        "armv7l": "arm",
+        "i386": "x86",
+        "i686": "x86",
+        "x64": "x86_64",
+    }
+    return aliases.get(normalized, normalized or "unknown")
+
+
+def _normalize_flags(flags: str | Iterable[str]) -> frozenset[str]:
+    values = flags.replace(",", " ").split() if isinstance(flags, str) else flags
+    return frozenset(
+        str(flag).strip().lower().replace(".", "_")
+        for flag in values
+        if str(flag).strip()
+    )
+
+
+def _runtime_cpu_flags(architecture: str) -> frozenset[str]:
+    system = platform.system().lower()
+    if system == "linux":
+        return _linux_cpu_flags()
+    if system == "darwin":
+        return _darwin_cpu_flags(architecture)
+    if system == "windows":
+        return _normalize_flags(platform.processor())
+    return frozenset()
+
+
+def _linux_cpu_flags() -> frozenset[str]:
+    try:
+        cpuinfo = Path("/proc/cpuinfo").read_text(
+            encoding="utf-8",
+            errors="ignore",
+        )
+    except OSError:
+        return frozenset()
+
+    per_processor: list[frozenset[str]] = []
+    for line in cpuinfo.splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key.strip().lower() in {"features", "flags"}:
+            per_processor.append(_normalize_flags(value))
+    if not per_processor:
+        return frozenset()
+    return frozenset.intersection(*per_processor)
+
+
+def _darwin_cpu_flags(architecture: str) -> frozenset[str]:
+    collected: set[str] = set()
+    for key in ("machdep.cpu.features", "machdep.cpu.leaf7_features"):
+        value = _read_sysctl(key)
+        if value:
+            collected.update(_normalize_flags(value))
+
+    if architecture in _ARM_ARCHITECTURES:
+        for key, flag in (
+            ("hw.optional.neon", "neon"),
+            ("hw.optional.arm.FEAT_DotProd", "dotprod"),
+        ):
+            if _read_sysctl(key) == "1":
+                collected.add(flag)
+    return frozenset(collected)
+
+
+def _read_sysctl(key: str) -> str:
+    try:
+        completed = subprocess.run(
+            ["sysctl", "-n", key],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip()
+
+
+__all__ = ["CpuFeatures", "detect_cpu_features", "select_cpu_kernel"]

--- a/tests/unit/onnx/test_cpu_fastpath.py
+++ b/tests/unit/onnx/test_cpu_fastpath.py
@@ -1,0 +1,297 @@
+"""Tests for the SIMD-aware INT8 token-classification fast path."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import numpy as np
+import pytest
+
+import openmed.onnx as onnx
+from openmed.onnx import cpu_fastpath, cpu_features
+
+
+def _synthetic_case():
+    hidden_states = np.array(
+        [
+            [4.0, 0.0, 0.0, 0.0],
+            [0.0, 4.0, 0.0, 0.0],
+            [0.0, 0.0, 4.0, 0.0],
+            [4.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    weights = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    bias = np.zeros(3, dtype=np.float32)
+    offsets = np.array([[0, 0], [0, 5], [6, 12], [0, 0]], dtype=np.int64)
+    id2label = {0: "O", 1: "B-PERSON", 2: "E-PERSON"}
+    return hidden_states, weights, bias, offsets, id2label
+
+
+def _features(tier: str) -> cpu_features.CpuFeatures:
+    if tier == "avx512":
+        return cpu_features.detect_cpu_features(
+            machine="x86_64",
+            flags="avx2 avx512f avx512bw",
+        )
+    if tier == "avx2":
+        return cpu_features.detect_cpu_features(machine="x86_64", flags="avx2")
+    if tier == "neon":
+        return cpu_features.detect_cpu_features(machine="aarch64", flags="asimd")
+    return cpu_features.detect_cpu_features(machine="x86_64", flags="")
+
+
+@pytest.mark.parametrize("tier", ["scalar", "avx2", "avx512", "neon"])
+def test_fastpath_matches_reference_spans_bit_for_decision(tier: str) -> None:
+    hidden_states, weights, bias, offsets, id2label = _synthetic_case()
+    head = cpu_fastpath.quantize_classification_head(weights, bias)
+
+    result = cpu_fastpath.run_cpu_fastpath(
+        hidden_states,
+        head,
+        offsets,
+        id2label,
+        features=_features(tier),
+    )
+    reference = cpu_fastpath.run_reference_classification_head(
+        hidden_states,
+        weights,
+        bias,
+        offsets,
+        id2label,
+    )
+
+    assert result.kernel == tier
+    assert np.array_equal(result.label_ids, reference.label_ids)
+    assert [(span.label, span.start, span.end) for span in result.spans] == [
+        ("PERSON", 0, 12)
+    ]
+    assert [
+        (span.label, span.token_start, span.token_end, span.start, span.end)
+        for span in result.spans
+    ] == [
+        (span.label, span.token_start, span.token_end, span.start, span.end)
+        for span in reference.spans
+    ]
+
+
+def test_numerical_equivalence_guard_accepts_synthetic_note() -> None:
+    hidden_states, weights, bias, offsets, id2label = _synthetic_case()
+    head = cpu_fastpath.quantize_classification_head(weights, bias)
+
+    verification = cpu_fastpath.verify_cpu_fastpath(
+        hidden_states,
+        weights,
+        bias,
+        head,
+        offsets,
+        id2label,
+        features=_features("avx2"),
+    )
+
+    assert verification.passed is True
+    assert verification.label_ids_match is True
+    assert verification.spans_match is True
+    assert verification.max_abs_logit_delta == pytest.approx(0.0, abs=1e-6)
+    assert verification.to_dict()["tolerance"] == (cpu_fastpath.DEFAULT_LOGIT_TOLERANCE)
+
+
+def test_numerical_equivalence_guard_fails_closed_on_decision_drift() -> None:
+    hidden_states, weights, bias, offsets, id2label = _synthetic_case()
+    drifted_head = cpu_fastpath.quantize_classification_head(
+        weights[[1, 0, 2]],
+        bias,
+    )
+
+    with pytest.raises(
+        cpu_fastpath.CpuFastPathVerificationError,
+        match="label_ids_match=False",
+    ):
+        cpu_fastpath.verify_cpu_fastpath(
+            hidden_states,
+            weights,
+            bias,
+            drifted_head,
+            offsets,
+            id2label,
+            features=_features("neon"),
+        )
+
+
+def test_feature_detection_selects_scalar_deterministically_without_simd() -> None:
+    features = cpu_features.detect_cpu_features(
+        machine="x86_64",
+        flags="sse sse2 sse4_2",
+    )
+
+    assert features.tier == "scalar"
+    assert features.avx2 is False
+    assert features.avx512 is False
+    assert features.neon is False
+    assert cpu_features.select_cpu_kernel(features) == "scalar"
+
+
+def test_feature_detection_prefers_avx512_and_gates_flags_by_architecture() -> None:
+    avx512 = cpu_features.detect_cpu_features(
+        machine="AMD64",
+        flags="AVX2 AVX512F AVX512BW",
+    )
+    arm = cpu_features.detect_cpu_features(
+        machine="aarch64",
+        flags="avx2 avx512f avx512bw neon",
+    )
+
+    assert avx512.architecture == "x86_64"
+    assert avx512.tier == "avx512"
+    assert arm.architecture == "arm64"
+    assert arm.tier == "neon"
+    assert arm.avx2 is False
+
+
+def test_linux_feature_detection_intersects_all_processor_flags(monkeypatch) -> None:
+    cpuinfo = """processor: 0
+flags: sse2 avx2
+processor: 1
+flags: sse2
+"""
+    monkeypatch.setattr(
+        cpu_features.Path,
+        "read_text",
+        lambda self, **kwargs: cpuinfo,
+    )
+
+    assert cpu_features._linux_cpu_flags() == frozenset({"sse2"})
+
+
+def test_fastpath_public_api_is_available_from_onnx_package() -> None:
+    assert onnx.CpuFeatures is cpu_features.CpuFeatures
+    assert onnx.CpuFastPathResult is cpu_fastpath.CpuFastPathResult
+    assert onnx.quantize_classification_head is (
+        cpu_fastpath.quantize_classification_head
+    )
+    assert onnx.verify_cpu_fastpath is cpu_fastpath.verify_cpu_fastpath
+
+
+def test_quantization_uses_positive_scale_for_zero_rows() -> None:
+    head = cpu_fastpath.quantize_classification_head(np.zeros((2, 4), dtype=np.float32))
+
+    assert head.weights.dtype == np.int8
+    assert np.array_equal(head.weights, np.zeros((2, 4), dtype=np.int8))
+    assert np.array_equal(head.scales, np.ones(2, dtype=np.float32))
+
+
+def test_bio_decode_honors_special_offsets_boundaries_and_threshold() -> None:
+    spans = cpu_fastpath.decode_bio_spans(
+        np.array([0, 1, 2, 3, 0]),
+        np.array([1.0, 0.9, 0.8, 0.5, 1.0]),
+        np.array([[0, 0], [0, 4], [5, 9], [10, 12], [0, 0]]),
+        {0: "O", 1: "B-NAME", 2: "E-NAME", 3: "S-ID"},
+        threshold=0.6,
+    )
+
+    assert [span.to_dict() for span in spans] == [
+        {
+            "label": "NAME",
+            "score": pytest.approx(0.85),
+            "token_start": 1,
+            "token_end": 3,
+            "start": 0,
+            "end": 9,
+        }
+    ]
+
+
+def test_benchmark_record_captures_avx2_speedup_with_deterministic_clock() -> None:
+    hidden_states, weights, bias, offsets, id2label = _synthetic_case()
+    head = cpu_fastpath.quantize_classification_head(weights, bias)
+    times: Iterator[float] = iter(
+        [
+            0.000,
+            0.010,
+            0.010,
+            0.020,
+            0.020,
+            0.030,
+            0.030,
+            0.032,
+            0.032,
+            0.034,
+            0.034,
+            0.036,
+        ]
+    )
+
+    record = cpu_fastpath.benchmark_cpu_fastpath(
+        hidden_states,
+        head,
+        offsets,
+        id2label,
+        features=_features("avx2"),
+        iterations=3,
+        warmup=0,
+        clock=lambda: next(times),
+    )
+
+    assert record.cpu.tier == "avx2"
+    assert record.scalar_latency_ms == pytest.approx(10.0)
+    assert record.fastpath_latency_ms == pytest.approx(2.0)
+    assert record.speedup == pytest.approx(5.0)
+    assert record.passed is True
+    assert record.to_dict()["shape"] == {
+        "sequence_length": 4,
+        "hidden_size": 4,
+        "label_count": 3,
+    }
+
+
+def test_avx2_runner_records_nontrivial_latency_reduction() -> None:
+    detected = cpu_features.detect_cpu_features()
+    if detected.tier != "avx2":
+        pytest.skip("requires a runner whose strongest detected tier is AVX2")
+
+    rng = np.random.default_rng(479)
+    hidden_states = rng.normal(size=(48, 256)).astype(np.float32)
+    weights = rng.normal(scale=0.05, size=(9, 256)).astype(np.float32)
+    offsets = np.column_stack(
+        (
+            np.arange(48, dtype=np.int64) * 2,
+            np.arange(48, dtype=np.int64) * 2 + 1,
+        )
+    )
+    id2label = {0: "O", **{index: f"S-PHI_{index}" for index in range(1, 9)}}
+    record = cpu_fastpath.benchmark_cpu_fastpath(
+        hidden_states,
+        cpu_fastpath.quantize_classification_head(weights),
+        offsets,
+        id2label,
+        features=detected,
+        iterations=5,
+        warmup=2,
+    )
+
+    assert record.cpu.tier == "avx2"
+    assert record.speedup >= cpu_fastpath.DEFAULT_MIN_SPEEDUP
+    assert record.passed is True
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"weights": np.zeros((0, 4))}, "non-empty"),
+        ({"weights": np.zeros((2, 4)), "bias": np.zeros(3)}, "bias"),
+        ({"weights": np.array([[np.nan, 0.0]])}, "finite"),
+    ],
+)
+def test_quantize_classification_head_rejects_invalid_inputs(
+    kwargs: dict,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        cpu_fastpath.quantize_classification_head(**kwargs)


### PR DESCRIPTION
# Pull Request

## Description
Adds a SIMD-aware INT8 fast path for token-classification heads on CPU-only edge runtimes. The new path detects AVX2, AVX-512, and NEON conservatively, keeps a deterministic scalar fallback, fuses winning-label scoring with BIO/BIOES span decoding, and fails closed when numerical or span parity differs from the float32 reference.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality not to work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added per-label symmetric INT8 classification-head quantization with scalar, AVX2, AVX-512, and NEON dispatch.
- Added fused winner-score and BIO/BIOES span decoding plus a fixed-tolerance float32 parity guard.
- Added deterministic feature-selection tests, an AVX2 hardware speedup gate, a benchmark record, public lazy exports, and a runtime guide.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/python -m pytest tests/unit/onnx/ -q` — 82 passed, 1 skipped
- `.venv/bin/python -m pytest tests/ -q` — 5,179 passed, 48 skipped
- `.venv/bin/mkdocs build --strict`
- `.venv/bin/python -m openmed.onnx.cpu_fastpath --sequence-length 48 --hidden-size 256 --labels 9 --iterations 7 --warmup 2 --require-speedup` — NEON 66.75x over the scalar INT8 kernel

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #836

## Screenshots/Examples
Not applicable.
