### PR TITLE
Add distributed SQL de-identification UDF

### DIFF
--- a/docs/integrations/distributed-sql-udf.md
+++ b/docs/integrations/distributed-sql-udf.md
@@ -1,0 +1,90 @@
+# Distributed SQL De-identification UDF
+
+OpenMed provides a Python entrypoint for distributed SQL UDF bridges that
+execute code inside worker processes. The SQL function is logically scalar:
+
+```sql
+openmed_deidentify(text VARCHAR, profile VARCHAR) -> VARCHAR
+```
+
+The Python bridge should invoke that function in vectorized mode. Each worker
+keeps one lazy OpenMed model loader and sends row windows through
+`process_batch`, avoiding one model initialization and one inference call per
+row. OpenMed does not ship a compiled engine plugin JAR; provisioning and
+securing the engine-specific Python bridge remains an operator responsibility.
+
+## Registration descriptor
+
+The engine-neutral descriptor is available as
+`OPENMED_DEIDENTIFY_DESCRIPTOR`:
+
+```python
+from openmed.integrations.distributed_sql_udf import (
+    OPENMED_DEIDENTIFY_DESCRIPTOR,
+)
+
+descriptor = OPENMED_DEIDENTIFY_DESCRIPTOR
+```
+
+Its registration fields are:
+
+```yaml
+name: openmed_deidentify
+language: python
+entrypoint: openmed.integrations.distributed_sql_udf:deidentify_batch
+arguments:
+  - name: text
+    sql_type: VARCHAR
+    python_batch: texts
+  - name: profile
+    sql_type: VARCHAR
+    python_batch: profiles
+return_type: VARCHAR
+vectorized: true
+null_handling: called_on_null_input
+default_batch_size: 64
+```
+
+Map the descriptor to the equivalent fields in the engine's Python UDF
+registration system. In particular, configure the bridge to pass arrays of
+`text` and `profile` values to `deidentify_batch`; the returned array aligns
+one-to-one with the input rows. SQL `NULL` stays `NULL`, and an empty string
+stays empty without loading the model.
+
+## Worker lifecycle
+
+For direct integration or an offline registration test, construct the callable
+once during worker setup and reuse it for every vector window:
+
+```python
+from openmed.integrations.distributed_sql_udf import (
+    DistributedSQLDeidentifyUDF,
+    DistributedSQLUDFConfig,
+)
+
+openmed_deidentify = DistributedSQLDeidentifyUDF(
+    config=DistributedSQLUDFConfig(
+        default_profile="hipaa_safe_harbor",
+        batch_size=64,
+    )
+)
+
+redacted = openmed_deidentify(
+    [
+        "Patient Jane Roe has hypertension.",
+        None,
+        "",
+    ],
+    ["hipaa_safe_harbor", None, "hipaa_safe_harbor"],
+)
+```
+
+The module-level `deidentify_batch` entrypoint uses the same process-local
+worker pattern automatically. `deidentify(text, profile)` is also available
+for scalar-only bridges, but a bridge that calls Python once per row cannot
+benefit from vector batching.
+
+Install the OpenMed model artifact on every worker before accepting queries if
+the deployment must remain fully offline. Raw input text is not logged by this
+adapter; engine query logs, failure capture, and spill configuration should be
+reviewed separately so they do not retain PHI.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Lakehouse Table Redaction: integrations/lakehouse-redaction.md
       - Dask DataFrame De-identification: integrations/dask.md
       - DuckDB De-identification UDFs: duckdb-deidentification.md
+      - Distributed SQL De-identification UDF: integrations/distributed-sql-udf.md
       - spaCy Pipeline Component: spacy-component.md
       - HL7 v2 De-identification: hl7v2-deidentification.md
       - Compliance Posture: compliance.md

--- a/openmed/integrations/distributed_sql_udf.py
+++ b/openmed/integrations/distributed_sql_udf.py
@@ -1,0 +1,324 @@
+"""Vectorized Python UDF entrypoint for distributed SQL engines."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any
+
+from openmed.core.policy import canonical_policy_name
+from openmed.utils.validation import validate_batch_size
+
+DEFAULT_DISTRIBUTED_SQL_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+DEFAULT_DISTRIBUTED_SQL_PROFILE = "hipaa_safe_harbor"
+DEFAULT_DISTRIBUTED_SQL_BATCH_SIZE = 64
+
+_PROFILE_ALIASES = {
+    "hipaa": DEFAULT_DISTRIBUTED_SQL_PROFILE,
+    "safe_harbor": DEFAULT_DISTRIBUTED_SQL_PROFILE,
+}
+_RESERVED_PROCESS_BATCH_KWARGS = frozenset(
+    {
+        "batch_size",
+        "continue_on_error",
+        "loader",
+        "method",
+        "model_name",
+        "operation",
+        "policy",
+    }
+)
+
+ProcessBatch = Callable[..., Any]
+LoaderFactory = Callable[[], Any | None]
+
+
+@dataclass(frozen=True)
+class DistributedSQLUDFConfig:
+    """Runtime settings for a distributed SQL de-identification worker."""
+
+    model_name: str = DEFAULT_DISTRIBUTED_SQL_MODEL
+    default_profile: str = DEFAULT_DISTRIBUTED_SQL_PROFILE
+    batch_size: int = DEFAULT_DISTRIBUTED_SQL_BATCH_SIZE
+    method: str = "mask"
+    confidence_threshold: float = 0.7
+    process_batch_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        model_name = _non_empty_string(self.model_name, "model_name")
+        method = _non_empty_string(self.method, "method")
+        default_profile = _canonical_profile(self.default_profile)
+        batch_size = validate_batch_size(self.batch_size)
+        confidence_threshold = float(self.confidence_threshold)
+        if not 0.0 <= confidence_threshold <= 1.0:
+            raise ValueError("confidence_threshold must be between 0.0 and 1.0")
+
+        process_batch_kwargs = dict(self.process_batch_kwargs)
+        reserved = sorted(_RESERVED_PROCESS_BATCH_KWARGS & process_batch_kwargs.keys())
+        if reserved:
+            names = ", ".join(reserved)
+            raise ValueError(
+                "process_batch_kwargs must not override reserved settings: " + names
+            )
+
+        object.__setattr__(self, "model_name", model_name)
+        object.__setattr__(self, "default_profile", default_profile)
+        object.__setattr__(self, "batch_size", batch_size)
+        object.__setattr__(self, "method", method)
+        object.__setattr__(self, "confidence_threshold", confidence_threshold)
+        object.__setattr__(self, "process_batch_kwargs", process_batch_kwargs)
+
+
+class DistributedSQLDeidentifyUDF:
+    """Process vector windows for one distributed SQL Python worker.
+
+    The object is intended to be constructed once in each worker process. Its
+    model loader is created only when the first non-empty batch arrives and is
+    then forwarded to every :func:`openmed.processing.process_batch` call.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: DistributedSQLUDFConfig | None = None,
+        process_batch_fn: ProcessBatch | None = None,
+        loader_factory: LoaderFactory | None = None,
+    ) -> None:
+        self.config = config or DistributedSQLUDFConfig()
+        self._process_batch_fn = process_batch_fn
+        self._loader_factory = loader_factory
+        self._loader: Any | None = None
+        self._loader_initialized = False
+
+    def __call__(
+        self,
+        texts: Sequence[str | None],
+        profiles: Sequence[str | None] | str | None = None,
+    ) -> list[str | None]:
+        """Return a vector of de-identified SQL cell values."""
+
+        return self.deidentify_batch(texts, profiles)
+
+    def deidentify(
+        self,
+        text: str | None,
+        profile: str | None = None,
+    ) -> str | None:
+        """Return one de-identified value for scalar compatibility."""
+
+        return self.deidentify_batch([text], profile)[0]
+
+    def deidentify_batch(
+        self,
+        texts: Sequence[str | None],
+        profiles: Sequence[str | None] | str | None = None,
+    ) -> list[str | None]:
+        """De-identify a vector while preserving nulls, empties, and row order."""
+
+        if isinstance(texts, (str, bytes)):
+            raise TypeError("texts must be a sequence of SQL cell values")
+
+        values = list(texts)
+        resolved_profiles = self._resolve_profiles(profiles, len(values))
+        output: list[str | None] = [None] * len(values)
+
+        for start in range(0, len(values), self.config.batch_size):
+            stop = min(start + self.config.batch_size, len(values))
+            self._process_window(
+                values,
+                resolved_profiles,
+                output,
+                start=start,
+                stop=stop,
+            )
+
+        return output
+
+    def _process_window(
+        self,
+        values: Sequence[str | None],
+        profiles: Sequence[str | None],
+        output: list[str | None],
+        *,
+        start: int,
+        stop: int,
+    ) -> None:
+        grouped_positions: dict[str, list[int]] = {}
+        for position in range(start, stop):
+            value = values[position]
+            if value is None:
+                output[position] = None
+                continue
+            if not isinstance(value, str):
+                raise TypeError(
+                    "distributed SQL text values must be strings or None; "
+                    f"row {position} is {type(value).__name__}"
+                )
+            if value == "":
+                output[position] = ""
+                continue
+            profile = _canonical_profile(
+                profiles[position] or self.config.default_profile
+            )
+            grouped_positions.setdefault(profile, []).append(position)
+
+        for profile, positions in grouped_positions.items():
+            batch_values = []
+            for position in positions:
+                value = values[position]
+                if not isinstance(value, str) or not value:
+                    raise RuntimeError("invalid internal distributed SQL row state")
+                batch_values.append(value)
+            batch_output = self._run_process_batch(batch_values, profile=profile)
+            for position, redacted in zip(positions, batch_output, strict=True):
+                output[position] = redacted
+
+    def _run_process_batch(
+        self,
+        texts: Sequence[str | None],
+        *,
+        profile: str,
+    ) -> list[str]:
+        process_batch = self._get_process_batch()
+        batch_result = process_batch(
+            list(texts),
+            model_name=self.config.model_name,
+            operation="deidentify",
+            batch_size=self.config.batch_size,
+            loader=self._get_loader(),
+            continue_on_error=False,
+            policy=profile,
+            method=self.config.method,
+            confidence_threshold=self.config.confidence_threshold,
+            **dict(self.config.process_batch_kwargs),
+        )
+        items = list(getattr(batch_result, "items", ()))
+        if len(items) != len(texts):
+            raise RuntimeError(
+                "process_batch returned "
+                f"{len(items)} results for {len(texts)} distributed SQL rows"
+            )
+
+        redacted: list[str] = []
+        for index, item in enumerate(items):
+            if getattr(item, "error", None) is not None:
+                raise RuntimeError(
+                    f"process_batch failed for distributed SQL row {index}"
+                )
+            redacted.append(_result_text(getattr(item, "result", None), index=index))
+        return redacted
+
+    def _resolve_profiles(
+        self,
+        profiles: Sequence[str | None] | str | None,
+        expected: int,
+    ) -> list[str | None]:
+        if profiles is None or isinstance(profiles, str):
+            return [profiles] * expected
+        if isinstance(profiles, bytes):
+            raise TypeError("profiles must be a string or a sequence of profile names")
+
+        values = list(profiles)
+        if len(values) != expected:
+            raise ValueError(
+                f"profiles contains {len(values)} values for {expected} text rows"
+            )
+        return values
+
+    def _get_process_batch(self) -> ProcessBatch:
+        if self._process_batch_fn is None:
+            from openmed.processing import process_batch
+
+            self._process_batch_fn = process_batch
+        return self._process_batch_fn
+
+    def _get_loader(self) -> Any | None:
+        if self._loader_initialized:
+            return self._loader
+
+        self._loader_initialized = True
+        factory = self._loader_factory or _default_loader_factory
+        self._loader = factory()
+        return self._loader
+
+
+OPENMED_DEIDENTIFY_DESCRIPTOR: dict[str, Any] = {
+    "name": "openmed_deidentify",
+    "language": "python",
+    "entrypoint": ("openmed.integrations.distributed_sql_udf:deidentify_batch"),
+    "arguments": [
+        {"name": "text", "sql_type": "VARCHAR", "python_batch": "texts"},
+        {"name": "profile", "sql_type": "VARCHAR", "python_batch": "profiles"},
+    ],
+    "return_type": "VARCHAR",
+    "vectorized": True,
+    "null_handling": "called_on_null_input",
+    "default_batch_size": DEFAULT_DISTRIBUTED_SQL_BATCH_SIZE,
+}
+
+
+@lru_cache(maxsize=1)
+def _default_worker() -> DistributedSQLDeidentifyUDF:
+    """Return the process-local worker used by module-level entrypoints."""
+
+    return DistributedSQLDeidentifyUDF()
+
+
+def deidentify(
+    text: str | None,
+    profile: str | None = None,
+) -> str | None:
+    """De-identify one logical SQL scalar value with the process-local worker."""
+
+    return _default_worker().deidentify(text, profile)
+
+
+def deidentify_batch(
+    texts: Sequence[str | None],
+    profiles: Sequence[str | None] | str | None = None,
+) -> list[str | None]:
+    """De-identify a vector window with the process-local worker."""
+
+    return _default_worker().deidentify_batch(texts, profiles)
+
+
+def _default_loader_factory() -> Any:
+    from openmed.core import ModelLoader
+
+    return ModelLoader()
+
+
+def _canonical_profile(profile: str) -> str:
+    normalized = _non_empty_string(profile, "profile").lower().replace("-", "_")
+    return canonical_policy_name(_PROFILE_ALIASES.get(normalized, normalized))
+
+
+def _non_empty_string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+def _result_text(result: Any, *, index: int) -> str:
+    if isinstance(result, str):
+        return result
+    value = getattr(result, "deidentified_text", None)
+    if isinstance(value, str):
+        return value
+    raise TypeError(
+        "process_batch result for distributed SQL row "
+        f"{index} must be a string or expose deidentified_text"
+    )
+
+
+__all__ = [
+    "DEFAULT_DISTRIBUTED_SQL_BATCH_SIZE",
+    "DEFAULT_DISTRIBUTED_SQL_MODEL",
+    "DEFAULT_DISTRIBUTED_SQL_PROFILE",
+    "DistributedSQLDeidentifyUDF",
+    "DistributedSQLUDFConfig",
+    "OPENMED_DEIDENTIFY_DESCRIPTOR",
+    "deidentify",
+    "deidentify_batch",
+]

--- a/tests/unit/integrations/test_distributed_sql_udf.py
+++ b/tests/unit/integrations/test_distributed_sql_udf.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from openmed.integrations.distributed_sql_udf import (
+    OPENMED_DEIDENTIFY_DESCRIPTOR,
+    DistributedSQLDeidentifyUDF,
+    DistributedSQLUDFConfig,
+)
+from openmed.processing.batch import BatchItemResult, BatchResult
+
+
+def _synthetic_process_batch(calls: list[dict[str, Any]]):
+    def process_batch(texts: list[str], **kwargs: Any) -> BatchResult:
+        calls.append({"texts": list(texts), **kwargs})
+        replacements = {
+            "Jane Roe": "[PERSON]",
+            "john.roe@example.test": "[EMAIL]",
+            "555-0101": "[PHONE]",
+        }
+        items = []
+        for index, text in enumerate(texts):
+            redacted = text
+            for identifier, placeholder in replacements.items():
+                redacted = redacted.replace(identifier, placeholder)
+            items.append(
+                BatchItemResult(
+                    id=f"item_{index}",
+                    result=SimpleNamespace(deidentified_text=redacted),
+                )
+            )
+        return BatchResult(items=items)
+
+    return process_batch
+
+
+def test_udf_callable_redacts_synthetic_vector_in_row_windows() -> None:
+    calls: list[dict[str, Any]] = []
+    loader = object()
+    loader_count = 0
+
+    def loader_factory() -> object:
+        nonlocal loader_count
+        loader_count += 1
+        return loader
+
+    udf = DistributedSQLDeidentifyUDF(
+        config=DistributedSQLUDFConfig(batch_size=2),
+        process_batch_fn=_synthetic_process_batch(calls),
+        loader_factory=loader_factory,
+    )
+    rows = [
+        "Jane Roe has hypertension and takes metformin.",
+        "Email john.roe@example.test about the diabetes follow-up.",
+        "Call 555-0101 after the cardiology appointment.",
+    ]
+
+    assert loader_count == 0
+    output = udf(rows, "hipaa_safe_harbor")
+
+    assert output == [
+        "[PERSON] has hypertension and takes metformin.",
+        "Email [EMAIL] about the diabetes follow-up.",
+        "Call [PHONE] after the cardiology appointment.",
+    ]
+    assert [len(call["texts"]) for call in calls] == [2, 1]
+    assert all(call["operation"] == "deidentify" for call in calls)
+    assert all(call["policy"] == "hipaa_safe_harbor" for call in calls)
+    assert all(call["loader"] is loader for call in calls)
+    assert loader_count == 1
+
+
+def test_null_and_empty_inputs_bypass_loader_and_process_batch() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def unexpected_loader() -> object:
+        raise AssertionError("loader must remain lazy for null and empty rows")
+
+    udf = DistributedSQLDeidentifyUDF(
+        process_batch_fn=_synthetic_process_batch(calls),
+        loader_factory=unexpected_loader,
+    )
+
+    assert udf([None, ""], ["not_a_profile", "also_invalid"]) == [None, ""]
+    assert udf.deidentify(None, "not_a_profile") is None
+    assert udf.deidentify("", "not_a_profile") == ""
+    assert calls == []
+
+
+def test_loader_is_reused_across_worker_calls_and_profiles_are_grouped() -> None:
+    calls: list[dict[str, Any]] = []
+    loaders: list[object] = []
+
+    def loader_factory() -> object:
+        loader = object()
+        loaders.append(loader)
+        return loader
+
+    udf = DistributedSQLDeidentifyUDF(
+        process_batch_fn=_synthetic_process_batch(calls),
+        loader_factory=loader_factory,
+    )
+
+    first = udf(
+        ["Jane Roe has asthma.", "Call 555-0101 for hypertension."],
+        ["hipaa", "gdpr"],
+    )
+    second = udf(["Jane Roe has diabetes."], "safe_harbor")
+
+    assert first == ["[PERSON] has asthma.", "Call [PHONE] for hypertension."]
+    assert second == ["[PERSON] has diabetes."]
+    assert len(loaders) == 1
+    assert all(call["loader"] is loaders[0] for call in calls)
+    assert [call["policy"] for call in calls] == [
+        "hipaa_safe_harbor",
+        "gdpr_pseudonymization",
+        "hipaa_safe_harbor",
+    ]
+
+
+def test_profiles_must_align_with_text_rows() -> None:
+    udf = DistributedSQLDeidentifyUDF(
+        process_batch_fn=_synthetic_process_batch([]),
+        loader_factory=object,
+    )
+
+    with pytest.raises(ValueError, match="1 values for 2 text rows"):
+        udf(["one", "two"], ["hipaa_safe_harbor"])
+
+
+def test_registration_descriptor_maps_scalar_sql_to_vector_entrypoint() -> None:
+    assert OPENMED_DEIDENTIFY_DESCRIPTOR == {
+        "name": "openmed_deidentify",
+        "language": "python",
+        "entrypoint": ("openmed.integrations.distributed_sql_udf:deidentify_batch"),
+        "arguments": [
+            {"name": "text", "sql_type": "VARCHAR", "python_batch": "texts"},
+            {
+                "name": "profile",
+                "sql_type": "VARCHAR",
+                "python_batch": "profiles",
+            },
+        ],
+        "return_type": "VARCHAR",
+        "vectorized": True,
+        "null_handling": "called_on_null_input",
+        "default_batch_size": 64,
+    }


### PR DESCRIPTION
## Description

Adds a vectorized distributed SQL de-identification entrypoint so query workers can redact free-text columns in row windows while reusing one lazily initialized model loader per process.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Added the logical `openmed_deidentify(text, profile)` scalar mapping and a vectorized batch entrypoint over `process_batch`.
- Preserved null and empty values without initializing the model, grouped mixed-profile windows safely, and retained output row order.
- Added an engine-neutral registration descriptor plus worker lifecycle, offline deployment, and PHI-handling guidance.

## Testing

- [x] Focused distributed SQL coverage passes: 5 passed.
- [x] Full suite passes: 5,168 passed and 47 skipped.
- [x] Formatting, lint, type, and strict documentation gates pass.

## Documentation

- [x] Added the distributed SQL registration and lifecycle guide to the documentation navigation.

## Dependencies

- [x] No new dependencies.

## Related Issues

Closes #840
