### PR TITLE
Add a SQLAlchemy redacting type and write-time event hook

### DIFF
--- a/docs/integrations/sqlalchemy.md
+++ b/docs/integrations/sqlalchemy.md
@@ -1,0 +1,148 @@
+# SQLAlchemy Write-time Redaction
+
+OpenMed can de-identify clinical free text at the ORM persistence boundary. The
+integration is opt-in: use the `RedactedText` type for declarative column-level
+protection, or install a SQLAlchemy event hook when an existing schema must keep
+ordinary `Text` columns.
+
+Install the optional dependency:
+
+```bash
+pip install "openmed[sqlalchemy]"
+```
+
+## Redacting text type
+
+`RedactedText` processes non-null values during SQL parameter binding. Values
+loaded from the database are returned unchanged because only already-redacted
+text is persisted.
+
+```python
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+from openmed.integrations.sqlalchemy_redact import RedactedText
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class ClinicalNote(Base):
+    __tablename__ = "clinical_notes"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    body: Mapped[str] = mapped_column(
+        RedactedText(policy_profile="hipaa_safe_harbor")
+    )
+
+
+engine = create_engine("sqlite+pysqlite:///clinical.db")
+Base.metadata.create_all(engine)
+
+with Session(engine) as session:
+    session.add(ClinicalNote(body="Patient identifiers are redacted on commit"))
+    session.commit()
+```
+
+`policy` is accepted as an alias for `policy_profile`.
+
+## Existing `Text` columns
+
+For an existing mapped schema, install a `before_flush` listener on a session
+instance, session subclass, or another target accepted by SQLAlchemy's session
+event API. The mapping is explicit so unrelated model attributes are never
+examined or changed.
+
+```python
+from sqlalchemy import Text
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from openmed.integrations.sqlalchemy_redact import install_session_redaction
+
+
+class ImportedNote(Base):
+    __tablename__ = "imported_notes"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    body: Mapped[str] = mapped_column(Text)
+
+
+with Session(engine) as session:
+    registration = install_session_redaction(
+        session,
+        {ImportedNote: ("body",)},
+        policy_profile="strict_no_leak",
+    )
+    try:
+        session.add(ImportedNote(body="Clinical free text"))
+        session.commit()
+    finally:
+        registration.remove()
+```
+
+New objects are redacted before their first flush. On dirty objects, configured
+columns are processed only when their own value changed.
+
+For applications that prefer mapper events, `install_mapper_redaction` attaches
+the same behavior to `before_insert` for one mapped class:
+
+```python
+from openmed.integrations.sqlalchemy_redact import install_mapper_redaction
+
+registration = install_mapper_redaction(
+    ImportedNote,
+    columns="body",
+    policy_profile="hipaa_safe_harbor",
+)
+```
+
+Keep the returned registration for as long as the hook is needed, then call
+`registration.remove()` during application shutdown or test cleanup.
+
+## Reusing one pipeline
+
+The default registry is cached by immutable redaction configuration. For
+explicit application or engine scoping, construct one registry and pass it to
+every protected type and event hook. The OpenMed pipeline is created lazily on
+the first non-empty write and reused instead of being instantiated per row.
+
+```python
+from openmed.integrations.sqlalchemy_redact import (
+    RedactedText,
+    RedactionPipelineRegistry,
+    SQLAlchemyRedactionConfig,
+    install_session_redaction,
+)
+
+config = SQLAlchemyRedactionConfig(
+    policy_profile="strict_no_leak",
+    confidence_threshold=0.65,
+    lang="en",
+)
+registry = RedactionPipelineRegistry(config)
+
+# Use RedactedText(registry=registry) on declarative columns, and share it with
+# event-based mappings in the same persistence boundary.
+registration = install_session_redaction(
+    session,
+    {ImportedNote: "body"},
+    registry=registry,
+)
+```
+
+Pipeline execution is synchronized because model backends may not be safe to
+invoke concurrently through one instance. Create separate registries when
+different policies or independent concurrency domains are required.
+
+## Boundaries
+
+- Values must be `str` or `None`; other values fail before persistence.
+- Redaction is one-way. This integration does not persist reversible pseudonym
+  mappings and never re-identifies values during reads.
+- Do not configure both `RedactedText` and an event hook for the same column;
+  choose one write boundary per field.
+- SQLAlchemy's synchronous ORM events are supported. Native async event wiring
+  is outside this integration; `AsyncSession` users may deliberately install a
+  hook on the synchronous session class they control after reviewing SQLAlchemy's
+  async event guidance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - Columnar Redactor: integrations/columnar-redactor.md
       - Lakehouse Table Redaction: integrations/lakehouse-redaction.md
       - Dask DataFrame De-identification: integrations/dask.md
+      - SQLAlchemy Write-time Redaction: integrations/sqlalchemy.md
       - DuckDB De-identification UDFs: duckdb-deidentification.md
       - spaCy Pipeline Component: spacy-component.md
       - HL7 v2 De-identification: hl7v2-deidentification.md

--- a/openmed/integrations/sqlalchemy_redact.py
+++ b/openmed/integrations/sqlalchemy_redact.py
@@ -1,0 +1,420 @@
+"""SQLAlchemy write-time de-identification helpers.
+
+This optional integration provides a :class:`RedactedText` type for declarative
+column-level redaction and event installers for applications that need to keep
+ordinary SQLAlchemy ``Text`` columns. Redaction happens before a value reaches
+the database; result processing never attempts to re-identify or transform
+stored values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from threading import RLock
+from typing import Any, Callable
+
+try:
+    from sqlalchemy import Text, event, inspect
+    from sqlalchemy.types import TypeDecorator
+except ImportError as exc:  # pragma: no cover - exercised by packaging users
+    raise ImportError(
+        "SQLAlchemy redaction requires the 'sqlalchemy' extra. "
+        "Install with `pip install openmed[sqlalchemy]`."
+    ) from exc
+
+DEFAULT_SQLALCHEMY_POLICY = "hipaa_safe_harbor"
+
+PipelineFactory = Callable[["SQLAlchemyRedactionConfig"], Any]
+
+
+@dataclass(frozen=True)
+class SQLAlchemyRedactionConfig:
+    """Configuration shared by SQLAlchemy write-time redaction helpers.
+
+    Args:
+        policy_profile: OpenMed policy profile applied to every configured value.
+        method: De-identification method passed to the cached pipeline.
+        model_name: Optional model registry key or model identifier. ``None`` uses
+            OpenMed's default PII model.
+        confidence_threshold: Minimum model confidence for redaction.
+        keep_year: Preserve the year when redacting date entities.
+        use_smart_merging: Enable semantic span merging.
+        lang: ISO 639-1 language hint.
+        normalize_accents: Optional accent-normalization override.
+        use_safety_sweep: Enable deterministic structured-identifier detection.
+    """
+
+    policy_profile: str = DEFAULT_SQLALCHEMY_POLICY
+    method: str = "mask"
+    model_name: str | None = None
+    confidence_threshold: float = 0.7
+    keep_year: bool = False
+    use_smart_merging: bool = True
+    lang: str = "en"
+    normalize_accents: bool | None = None
+    use_safety_sweep: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.policy_profile.strip():
+            raise ValueError("policy_profile must not be empty")
+        if not 0.0 <= self.confidence_threshold <= 1.0:
+            raise ValueError("confidence_threshold must be between 0 and 1")
+        if not self.lang.strip():
+            raise ValueError("lang must not be empty")
+
+
+class RedactionPipelineRegistry:
+    """Own one lazily constructed pipeline for a redaction configuration.
+
+    A registry can be shared by multiple mapped columns and event hooks. Pipeline
+    creation and execution are synchronized so the same warmed pipeline is reused
+    safely across concurrent ORM writes instead of being rebuilt per row.
+
+    Args:
+        config: Redaction configuration for this registry.
+        pipeline_factory: Optional pipeline constructor, primarily useful for
+            offline adapters and tests. It receives ``config`` once.
+    """
+
+    def __init__(
+        self,
+        config: SQLAlchemyRedactionConfig | None = None,
+        *,
+        pipeline_factory: PipelineFactory | None = None,
+    ) -> None:
+        self.config = config or SQLAlchemyRedactionConfig()
+        self._pipeline_factory = pipeline_factory or _create_pipeline
+        self._pipeline: Any | None = None
+        self._creation_lock = RLock()
+        self._run_lock = RLock()
+
+    @property
+    def pipeline(self) -> Any:
+        """Return the registry pipeline, constructing it at most once."""
+
+        if self._pipeline is None:
+            with self._creation_lock:
+                if self._pipeline is None:
+                    self._pipeline = self._pipeline_factory(self.config)
+        return self._pipeline
+
+    def redact(self, value: str | None) -> str | None:
+        """Return a write-safe redacted value while preserving ``None``."""
+
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise TypeError("redacted SQLAlchemy columns accept only str or None")
+        if value == "":
+            return value
+
+        with self._run_lock:
+            result = self.pipeline.run(
+                value,
+                method=self.config.method,
+                keep_year=self.config.keep_year,
+            )
+        return _deidentified_text(result)
+
+
+class RedactedText(TypeDecorator[str]):
+    """SQLAlchemy text type that de-identifies non-null values on bind.
+
+    Reads return the already-redacted database value unchanged. Pass the same
+    :class:`RedactionPipelineRegistry` to multiple columns or hooks to share one
+    pipeline explicitly.
+
+    Args:
+        length: Optional SQLAlchemy text length hint.
+        policy_profile: OpenMed policy profile name. ``policy`` is an alias.
+        policy: Alias for ``policy_profile``.
+        config: Complete redaction configuration.
+        registry: Explicit pipeline registry to share across columns or hooks.
+    """
+
+    impl = Text
+    cache_ok = True
+
+    def __init__(
+        self,
+        length: int | None = None,
+        *,
+        policy_profile: str | None = None,
+        policy: str | None = None,
+        config: SQLAlchemyRedactionConfig | None = None,
+        registry: RedactionPipelineRegistry | None = None,
+    ) -> None:
+        self.registry = _resolve_registry(
+            policy_profile=policy_profile,
+            policy=policy,
+            config=config,
+            registry=registry,
+        )
+        super().__init__(length=length)
+
+    def process_bind_param(self, value: str | None, dialect: Any) -> str | None:
+        """De-identify ``value`` immediately before SQL parameter binding."""
+
+        del dialect
+        return self.registry.redact(value)
+
+    def process_result_value(self, value: str | None, dialect: Any) -> str | None:
+        """Return the already-redacted stored value without transformation."""
+
+        del dialect
+        return value
+
+
+@dataclass
+class RedactionEventRegistration:
+    """Handle for removing an installed SQLAlchemy redaction event."""
+
+    target: Any
+    event_name: str
+    listener: Callable[..., None]
+    _removed: bool = False
+
+    def remove(self) -> None:
+        """Remove the event listener. Repeated calls are harmless."""
+
+        if self._removed:
+            return
+        event.remove(self.target, self.event_name, self.listener)
+        self._removed = True
+
+
+def install_session_redaction(
+    session_target: Any,
+    columns: Mapping[type[Any], Sequence[str] | str],
+    *,
+    policy_profile: str | None = None,
+    policy: str | None = None,
+    config: SQLAlchemyRedactionConfig | None = None,
+    registry: RedactionPipelineRegistry | None = None,
+) -> RedactionEventRegistration:
+    """Install an opt-in ``before_flush`` redactor on a session target.
+
+    ``session_target`` may be a SQLAlchemy ``Session`` instance, ``Session``
+    subclass, or session factory accepted by SQLAlchemy's event API. ``columns``
+    maps each model class to one column name or a sequence of column names.
+
+    New objects are always inspected. Dirty objects are redacted only when the
+    configured attribute changed during the current unit of work.
+
+    Args:
+        session_target: SQLAlchemy session event target.
+        columns: Model-to-column mapping for write-time redaction.
+        policy_profile: OpenMed policy profile name. ``policy`` is an alias.
+        policy: Alias for ``policy_profile``.
+        config: Complete redaction configuration.
+        registry: Explicit pipeline registry to share with other hooks or types.
+
+    Returns:
+        A removable event-registration handle.
+    """
+
+    normalized = _normalize_model_columns(columns)
+    resolved_registry = _resolve_registry(
+        policy_profile=policy_profile,
+        policy=policy,
+        config=config,
+        registry=registry,
+    )
+
+    def before_flush(session: Any, flush_context: Any, instances: Any) -> None:
+        del flush_context, instances
+        new_object_ids = {id(instance) for instance in session.new}
+        for instance in (*session.new, *session.dirty):
+            is_new = id(instance) in new_object_ids
+            for model, column_names in normalized:
+                if isinstance(instance, model):
+                    _redact_instance(
+                        instance,
+                        column_names,
+                        resolved_registry,
+                        changed_only=not is_new,
+                    )
+
+    event.listen(session_target, "before_flush", before_flush)
+    return RedactionEventRegistration(session_target, "before_flush", before_flush)
+
+
+def install_mapper_redaction(
+    model: type[Any],
+    columns: Sequence[str] | str,
+    *,
+    policy_profile: str | None = None,
+    policy: str | None = None,
+    config: SQLAlchemyRedactionConfig | None = None,
+    registry: RedactionPipelineRegistry | None = None,
+    propagate: bool = True,
+) -> RedactionEventRegistration:
+    """Install an opt-in ``before_insert`` redactor for one mapped model.
+
+    Args:
+        model: Declarative mapped class that owns the configured attributes.
+        columns: One column name or a sequence of column names to redact.
+        policy_profile: OpenMed policy profile name. ``policy`` is an alias.
+        policy: Alias for ``policy_profile``.
+        config: Complete redaction configuration.
+        registry: Explicit pipeline registry to share with other hooks or types.
+        propagate: Apply the mapper event to mapped subclasses as well.
+
+    Returns:
+        A removable event-registration handle.
+    """
+
+    column_names = _normalize_column_names(columns)
+    resolved_registry = _resolve_registry(
+        policy_profile=policy_profile,
+        policy=policy,
+        config=config,
+        registry=registry,
+    )
+
+    def before_insert(mapper: Any, connection: Any, instance: Any) -> None:
+        del mapper, connection
+        _redact_instance(
+            instance,
+            column_names,
+            resolved_registry,
+            changed_only=False,
+        )
+
+    event.listen(model, "before_insert", before_insert, propagate=propagate)
+    return RedactionEventRegistration(model, "before_insert", before_insert)
+
+
+def _create_pipeline(config: SQLAlchemyRedactionConfig) -> Any:
+    from openmed.core.pipeline import Pipeline
+
+    kwargs: dict[str, Any] = {
+        "confidence_threshold": config.confidence_threshold,
+        "use_smart_merging": config.use_smart_merging,
+        "lang": config.lang,
+        "normalize_accents": config.normalize_accents,
+        "use_safety_sweep": config.use_safety_sweep,
+        "policy": config.policy_profile,
+    }
+    if config.model_name is not None:
+        kwargs["model_name"] = config.model_name
+    return Pipeline(**kwargs)
+
+
+@lru_cache(maxsize=32)
+def _default_registry(
+    config: SQLAlchemyRedactionConfig,
+) -> RedactionPipelineRegistry:
+    return RedactionPipelineRegistry(config)
+
+
+def _resolve_registry(
+    *,
+    policy_profile: str | None,
+    policy: str | None,
+    config: SQLAlchemyRedactionConfig | None,
+    registry: RedactionPipelineRegistry | None,
+) -> RedactionPipelineRegistry:
+    requested_policy = _resolve_policy(policy_profile, policy)
+
+    if config is not None and requested_policy is not None:
+        if config.policy_profile != requested_policy:
+            raise ValueError("config and policy_profile must select the same policy")
+    resolved_config = config or SQLAlchemyRedactionConfig(
+        policy_profile=requested_policy or DEFAULT_SQLALCHEMY_POLICY
+    )
+
+    if registry is not None:
+        if config is not None and registry.config != config:
+            raise ValueError("registry and config must use the same configuration")
+        if (
+            requested_policy is not None
+            and registry.config.policy_profile != requested_policy
+        ):
+            raise ValueError("registry and policy_profile must select the same policy")
+        return registry
+
+    return _default_registry(resolved_config)
+
+
+def _resolve_policy(
+    policy_profile: str | None,
+    policy: str | None,
+) -> str | None:
+    if policy_profile is not None and policy is not None and policy_profile != policy:
+        raise ValueError("policy and policy_profile must match when both are provided")
+    resolved = policy_profile if policy_profile is not None else policy
+    if resolved is not None and not resolved.strip():
+        raise ValueError("policy_profile must not be empty")
+    return resolved
+
+
+def _normalize_model_columns(
+    columns: Mapping[type[Any], Sequence[str] | str],
+) -> tuple[tuple[type[Any], tuple[str, ...]], ...]:
+    if not columns:
+        raise ValueError("columns must configure at least one mapped model")
+    normalized: list[tuple[type[Any], tuple[str, ...]]] = []
+    for model, names in columns.items():
+        if not isinstance(model, type):
+            raise TypeError("columns keys must be mapped model classes")
+        normalized.append((model, _normalize_column_names(names)))
+    return tuple(normalized)
+
+
+def _normalize_column_names(columns: Sequence[str] | str) -> tuple[str, ...]:
+    values = (columns,) if isinstance(columns, str) else tuple(columns)
+    if not values:
+        raise ValueError("columns must not be empty")
+    normalized: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("column names must be non-empty strings")
+        if value not in normalized:
+            normalized.append(value)
+    return tuple(normalized)
+
+
+def _redact_instance(
+    instance: Any,
+    column_names: tuple[str, ...],
+    registry: RedactionPipelineRegistry,
+    *,
+    changed_only: bool,
+) -> None:
+    state = inspect(instance)
+    for column_name in column_names:
+        if column_name not in state.attrs:
+            raise AttributeError(
+                f"{type(instance).__name__} has no mapped attribute {column_name!r}"
+            )
+        attribute = state.attrs[column_name]
+        if changed_only and not attribute.history.has_changes():
+            continue
+        value = getattr(instance, column_name)
+        redacted = registry.redact(value)
+        if redacted != value:
+            setattr(instance, column_name, redacted)
+
+
+def _deidentified_text(result: Any) -> str:
+    candidate = getattr(result, "deidentification_result", result)
+    if isinstance(candidate, str):
+        return candidate
+    value = getattr(candidate, "deidentified_text", None)
+    if not isinstance(value, str):
+        raise TypeError("redaction pipeline must return de-identified text as a string")
+    return value
+
+
+__all__ = [
+    "DEFAULT_SQLALCHEMY_POLICY",
+    "RedactedText",
+    "RedactionEventRegistration",
+    "RedactionPipelineRegistry",
+    "SQLAlchemyRedactionConfig",
+    "install_mapper_redaction",
+    "install_session_redaction",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
   "grpcio-tools>=1.64",
   "protobuf>=5.26,<7",
   "ruff==0.15.20",
+  "sqlalchemy>=2.0,<3",
   "tomli>=2.0; python_version < '3.11'",
 ]
 
@@ -97,6 +98,10 @@ columnar = [
 
 dask = [
   "dask[dataframe]>=2024.8",
+]
+
+sqlalchemy = [
+  "sqlalchemy>=2.0,<3",
 ]
 
 spacy = [

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -118,6 +118,7 @@ REVIEWED_LICENSES = {
     "s3fs": "BSD-3-Clause",
     "safetensors": "Apache-2.0",
     "spacy": "MIT",
+    "sqlalchemy": "MIT",
     "tiktoken": "MIT",
     "tokenizers": "Apache-2.0",
     "torch": "BSD-3-Clause",

--- a/tests/unit/integrations/test_sqlalchemy_redact.py
+++ b/tests/unit/integrations/test_sqlalchemy_redact.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import Integer, Text, create_engine, select, text
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+from openmed.core.pipeline import Pipeline
+from openmed.integrations.sqlalchemy_redact import (
+    RedactedText,
+    RedactionPipelineRegistry,
+    SQLAlchemyRedactionConfig,
+    install_mapper_redaction,
+    install_session_redaction,
+)
+from openmed.processing.outputs import PredictionResult
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class TypedNote(Base):
+    __tablename__ = "typed_notes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    body: Mapped[str | None] = mapped_column(RedactedText(), nullable=True)
+
+
+class HookedNote(Base):
+    __tablename__ = "hooked_notes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    body: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(Text, default="new")
+
+
+class InsertHookNote(Base):
+    __tablename__ = "insert_hook_notes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    body: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class _CountingPipelineFactory:
+    def __init__(self) -> None:
+        self.created = 0
+        self.pipeline: _CountingPipeline | None = None
+
+    def __call__(self, config: SQLAlchemyRedactionConfig) -> _CountingPipeline:
+        self.created += 1
+        self.pipeline = _CountingPipeline(
+            Pipeline(
+                model_name=config.model_name,
+                confidence_threshold=config.confidence_threshold,
+                use_smart_merging=config.use_smart_merging,
+                lang=config.lang,
+                normalize_accents=config.normalize_accents,
+                use_safety_sweep=config.use_safety_sweep,
+                policy=config.policy_profile,
+                model_detector=_empty_model_detector,
+            )
+        )
+        return self.pipeline
+
+
+class _CountingPipeline:
+    def __init__(self, pipeline: Pipeline) -> None:
+        self._pipeline = pipeline
+        self.run_calls = 0
+
+    def run(self, *args, **kwargs):
+        self.run_calls += 1
+        return self._pipeline.run(*args, **kwargs)
+
+
+def _empty_model_detector(text_value: str, **kwargs) -> PredictionResult:
+    return PredictionResult(
+        text=text_value,
+        entities=[],
+        model_name=kwargs["model_name"],
+        timestamp=datetime.now().isoformat(),
+    )
+
+
+def _registry() -> tuple[RedactionPipelineRegistry, _CountingPipelineFactory]:
+    factory = _CountingPipelineFactory()
+    registry = RedactionPipelineRegistry(
+        SQLAlchemyRedactionConfig(policy_profile="hipaa_safe_harbor"),
+        pipeline_factory=factory,
+    )
+    return registry, factory
+
+
+def test_type_and_before_flush_hook_redact_sqlite_writes_and_reuse_pipeline():
+    registry, factory = _registry()
+    TypedNote.__table__.c.body.type.registry = registry
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    seeded_phi = "SSN 123-45-6789; email patient842@example.test; IP 203.0.113.42"
+
+    with Session(engine) as session:
+        registration = install_session_redaction(
+            session,
+            {HookedNote: "body"},
+            registry=registry,
+        )
+        try:
+            session.add_all(
+                [
+                    TypedNote(body=seeded_phi),
+                    TypedNote(body="Account 555-55-1234"),
+                    HookedNote(body=seeded_phi),
+                    HookedNote(body=None),
+                ]
+            )
+            session.commit()
+
+            hooked = session.scalar(select(HookedNote).where(HookedNote.id == 1))
+            assert hooked is not None
+            hooked.status = "reviewed"
+            session.commit()
+        finally:
+            registration.remove()
+
+    assert factory.created == 1
+    assert factory.pipeline is registry.pipeline
+    assert factory.pipeline.run_calls == 3
+
+    with engine.connect() as connection:
+        typed_values = (
+            connection.execute(text("SELECT body FROM typed_notes ORDER BY id"))
+            .scalars()
+            .all()
+        )
+        hooked_values = (
+            connection.execute(text("SELECT body FROM hooked_notes ORDER BY id"))
+            .scalars()
+            .all()
+        )
+
+    assert typed_values[0] == hooked_values[0]
+    assert typed_values[0] != seeded_phi
+    assert typed_values[1] != "Account 555-55-1234"
+    assert hooked_values[1] is None
+    for stored in (typed_values[0], typed_values[1], hooked_values[0]):
+        assert "123-45-6789" not in stored
+        assert "patient842@example.test" not in stored
+        assert "203.0.113.42" not in stored
+
+    with Session(engine) as session:
+        typed_read = session.scalar(select(TypedNote).where(TypedNote.id == 1))
+        hooked_read = session.scalar(select(HookedNote).where(HookedNote.id == 1))
+
+    assert typed_read is not None
+    assert hooked_read is not None
+    assert typed_read.body == typed_values[0]
+    assert hooked_read.body == hooked_values[0]
+    assert factory.created == 1
+    assert factory.pipeline.run_calls == 3
+
+
+def test_before_insert_hook_redacts_configured_columns():
+    registry, factory = _registry()
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    registration = install_mapper_redaction(
+        InsertHookNote,
+        columns=("body",),
+        registry=registry,
+    )
+    try:
+        with Session(engine) as session:
+            session.add_all(
+                [
+                    InsertHookNote(body="SSN 123-45-6789"),
+                    InsertHookNote(body="Email insert842@example.test"),
+                ]
+            )
+            session.commit()
+    finally:
+        registration.remove()
+
+    with engine.connect() as connection:
+        values = (
+            connection.execute(text("SELECT body FROM insert_hook_notes ORDER BY id"))
+            .scalars()
+            .all()
+        )
+
+    assert factory.created == 1
+    assert factory.pipeline is not None
+    assert factory.pipeline.run_calls == 2
+    assert "123-45-6789" not in values[0]
+    assert "insert842@example.test" not in values[1]
+
+
+def test_configuration_validation_and_non_string_values():
+    with pytest.raises(ValueError, match="must match"):
+        RedactedText(policy="strict_no_leak", policy_profile="hipaa_safe_harbor")
+
+    registry, _ = _registry()
+    with pytest.raises(TypeError, match="str or None"):
+        registry.redact(42)  # type: ignore[arg-type]

--- a/uv.lock
+++ b/uv.lock
@@ -4497,6 +4497,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "python-dateutil" },
     { name = "ruff" },
+    { name = "sqlalchemy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 docs = [
@@ -4616,6 +4617,9 @@ spacy = [
 spark = [
     { name = "pyspark" },
 ]
+sqlalchemy = [
+    { name = "sqlalchemy" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -4714,6 +4718,8 @@ requires-dist = [
     { name = "s3fs", marker = "extra == 'cloud'", specifier = ">=2025.9.0" },
     { name = "safetensors", marker = "extra == 'mlx'", specifier = ">=0.4" },
     { name = "spacy", marker = "extra == 'spacy'", specifier = ">=3.5" },
+    { name = "sqlalchemy", marker = "extra == 'dev'", specifier = ">=2.0,<3" },
+    { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=2.0,<3" },
     { name = "tiktoken", marker = "extra == 'mlx'", specifier = ">=0.7" },
     { name = "tokenizers", marker = "extra == 'hf'", specifier = ">=0.15" },
     { name = "tokenizers", marker = "extra == 'mlx'", specifier = ">=0.15" },
@@ -4730,7 +4736,7 @@ requires-dist = [
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'service'", specifier = ">=0.29" },
 ]
-provides-extras = ["agents", "awq", "cli", "cloud", "columnar", "coreml", "dask", "dev", "docs", "duckdb", "gliner", "gptq", "grounding", "hf", "kafka", "langchain", "llamaindex", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "onnx-runtime", "openvino", "pandas", "philter", "polars", "presidio", "pydeid", "service", "spacy", "spark"]
+provides-extras = ["agents", "awq", "cli", "cloud", "columnar", "coreml", "dask", "dev", "docs", "duckdb", "gliner", "gptq", "grounding", "hf", "kafka", "langchain", "llamaindex", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "onnx-runtime", "openvino", "pandas", "philter", "polars", "presidio", "pydeid", "service", "spacy", "spark", "sqlalchemy"]
 
 [[package]]
 name = "opentelemetry-api"


### PR DESCRIPTION
## Description
Adds an opt-in persistence-boundary integration that de-identifies clinical free text before SQLAlchemy writes. It supports a declarative redacting text type, session and mapper event hooks, configurable policy profiles, and a shared lazy pipeline registry so row writes do not rebuild the pipeline.

Closes #842.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made
- Add `RedactedText` with unchanged read processing and write-time de-identification.
- Add removable `before_flush` and `before_insert` registrations for existing text columns.
- Add a thread-safe registry that constructs one pipeline per configured registry and exposes policy-profile settings.
- Add the `sqlalchemy` optional dependency extra and integration documentation.

## Testing
- [x] Offline in-memory SQLite coverage for type and event-hook inserts
- [x] Stored-value and unchanged-read assertions with synthetic identifiers
- [x] One-time pipeline construction assertion across multiple rows
- [x] `.venv/bin/python -m pytest tests/ -q` (5162 passed, 51 skipped)
- [x] `make format`, `make lint`, and `make format-check`
- [x] `make docs-build`

## Documentation
- [x] Added installation, type, event-hook, pipeline reuse, and async-boundary guidance
- [x] Added the guide to the documentation navigation

## Dependencies
- [x] Added SQLAlchemy 2.x as an optional `sqlalchemy` extra and as a development test dependency

## Code Quality
- [x] Performed a self-review
- [x] New public APIs include docstrings
- [x] No new warnings are introduced by the integration tests