### PR TITLE
Add an Arrow Flight de-identification service over record batches

### DIFF
--- a/docs/integrations/arrow-flight.md
+++ b/docs/integrations/arrow-flight.md
@@ -1,0 +1,90 @@
+# Arrow Flight De-identification
+
+OpenMed's Arrow Flight integration accepts a stream of Arrow record batches,
+de-identifies one configured string column, and returns each redacted batch as
+soon as it is processed. The service preserves the input schema, row count,
+nulls, and every non-target column. It never materializes the complete stream.
+
+Install the optional columnar dependency:
+
+```bash
+uv pip install -e ".[columnar]"
+```
+
+## Start a Server
+
+```python
+from openmed.integrations.arrow_flight import (
+    ArrowFlightDeidentificationServer,
+)
+
+server = ArrowFlightDeidentificationServer(
+    "grpc://127.0.0.1:8815",
+    batch_size=512,
+)
+server.serve()
+```
+
+`ArrowFlightDeidentificationServer` uses OpenMed's PII model and
+`process_batch(operation="deidentify")` by default. You can set server-wide
+defaults with `text_column=` and `policy=`, or select them per exchange in the
+Flight command descriptor.
+
+## Exchange Record Batches
+
+```python
+import pyarrow as pa
+import pyarrow.flight as flight
+
+from openmed.integrations.arrow_flight import make_deidentify_descriptor
+
+client = flight.connect("grpc://127.0.0.1:8815")
+descriptor = make_deidentify_descriptor(
+    "clinical_note",
+    policy="hipaa_safe_harbor",
+)
+writer, reader = client.do_exchange(descriptor)
+
+schema = pa.schema(
+    [
+        ("record_id", pa.int64()),
+        ("clinical_note", pa.string()),
+        ("status", pa.string()),
+    ]
+)
+writer.begin(schema)
+
+for input_batch in source_batches:
+    writer.write_batch(input_batch)
+    output_batch = reader.read_chunk().data
+    consume(output_batch)
+
+writer.done_writing()
+```
+
+The helper creates a versioned JSON `FlightDescriptor` command. For
+`DoExchange`, the descriptor is the request-metadata channel; its policy takes
+precedence over a server default. Keeping configuration in the descriptor lets
+one server apply different OpenMed policy profiles without mixing raw clinical
+cells into RPC metadata.
+
+## Privacy and Streaming Contract
+
+- Each incoming `RecordBatch` is passed to `process_batch` and returned before
+  the server reads the entire stream.
+- Only the target string column is converted to Python values for redaction.
+  All other Arrow arrays are passed through unchanged.
+- Response batches retain the input schema and number of rows, including null
+  placement.
+- The service does not log raw or redacted cell values. Errors identify only
+  the column and row position.
+- The command descriptor must not contain patient data. It is only for the
+  text-column name, policy name, and descriptor version.
+
+## Authentication and TLS Hooks
+
+The server constructor forwards Arrow Flight's `auth_handler`,
+`tls_certificates`, `verify_client`, `root_certificates`, and `middleware`
+options. These are deployment hooks, not a complete security policy. Production
+operators remain responsible for certificate management, authentication design,
+network isolation, and authorization.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Smart Entity Merging: pii-smart-merging.md
       - No-Raw-PHI Logging: security/no-raw-phi-logging.md
       - LangChain Redaction Wrapper: integrations-langchain.md
+      - Arrow Flight De-identification: integrations/arrow-flight.md
       - Columnar Redactor: integrations/columnar-redactor.md
       - Lakehouse Table Redaction: integrations/lakehouse-redaction.md
       - Dask DataFrame De-identification: integrations/dask.md

--- a/openmed/integrations/arrow_flight.py
+++ b/openmed/integrations/arrow_flight.py
@@ -1,0 +1,298 @@
+"""Arrow Flight service for streaming record-batch de-identification.
+
+The service implements ``DoExchange`` so clients can send Arrow record batches
+and receive one redacted batch for every input batch. Only the configured text
+column is materialized for de-identification; the service never materializes
+the complete input stream.
+
+Request configuration is carried in a versioned JSON command descriptor. Raw
+cell values are intentionally never logged or included in service errors.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+try:
+    import pyarrow as pa
+    import pyarrow.flight as flight
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "Arrow Flight de-identification requires pyarrow. Install "
+        "openmed[columnar] or install pyarrow directly."
+    ) from exc
+
+from openmed.processing.batch import process_batch
+
+DEFAULT_ARROW_FLIGHT_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+ARROW_FLIGHT_DESCRIPTOR_VERSION = 1
+
+ProcessBatchCallable = Callable[..., Any]
+
+_PROTECTED_PROCESS_BATCH_OPTIONS = {
+    "batch_size",
+    "ids",
+    "model_name",
+    "operation",
+    "policy",
+    "texts",
+}
+
+
+def make_deidentify_descriptor(
+    text_column: str | None = None,
+    *,
+    policy: str | None = None,
+) -> flight.FlightDescriptor:
+    """Build a command descriptor for a de-identification exchange.
+
+    Args:
+        text_column: Optional string column to redact in every incoming record
+            batch. It may be omitted when the server defines a default.
+        policy: Optional OpenMed de-identification policy profile.
+
+    Returns:
+        A Flight command descriptor containing versioned JSON metadata.
+    """
+    payload: dict[str, Any] = {"version": ARROW_FLIGHT_DESCRIPTOR_VERSION}
+    if text_column is not None:
+        payload["text_column"] = _normalize_required_string(text_column, "text_column")
+    if policy is not None:
+        payload["policy"] = _normalize_required_string(policy, "policy")
+    command = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return flight.FlightDescriptor.for_command(command)
+
+
+class ArrowFlightDeidentificationServer(flight.FlightServerBase):
+    """Stream Arrow record batches through OpenMed de-identification.
+
+    Args:
+        location: Flight listen location. Port ``0`` requests a free local port.
+        text_column: Optional default text column when a descriptor omits it.
+        policy: Optional default de-identification policy profile.
+        model_name: PII model forwarded to :func:`process_batch`.
+        batch_size: Internal OpenMed processing batch size for each Arrow batch.
+        process_batch_options: Additional de-identification options, such as
+            ``method``, ``lang``, or ``use_safety_sweep``.
+        process_batch_fn: Test or embedding seam. Defaults to OpenMed's
+            :func:`process_batch`.
+        auth_handler: Optional Arrow Flight authentication handler.
+        tls_certificates: Optional Flight TLS certificate/key pairs.
+        verify_client: Whether Flight should require client certificates.
+        root_certificates: Optional roots used to verify client certificates.
+        middleware: Optional Arrow Flight server middleware mapping.
+
+    The authentication and TLS arguments are configuration hooks only. This
+    integration does not define an authentication policy or certificate
+    lifecycle.
+    """
+
+    def __init__(
+        self,
+        location: str | tuple[str, int] | flight.Location = "grpc://127.0.0.1:0",
+        *,
+        text_column: str | None = None,
+        policy: str | None = None,
+        model_name: str = DEFAULT_ARROW_FLIGHT_MODEL,
+        batch_size: int = 512,
+        process_batch_options: Mapping[str, Any] | None = None,
+        process_batch_fn: ProcessBatchCallable | None = None,
+        auth_handler: Any = None,
+        tls_certificates: Sequence[tuple[bytes, bytes]] | None = None,
+        verify_client: bool = False,
+        root_certificates: bytes | None = None,
+        middleware: Mapping[str, Any] | None = None,
+    ) -> None:
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        self._text_column = (
+            _normalize_required_string(text_column, "text_column")
+            if text_column is not None
+            else None
+        )
+        self._policy = (
+            _normalize_required_string(policy, "policy") if policy is not None else None
+        )
+        self._model_name = _normalize_required_string(model_name, "model_name")
+        self._batch_size = batch_size
+        self._process_batch_options = dict(process_batch_options or {})
+        protected = sorted(
+            _PROTECTED_PROCESS_BATCH_OPTIONS.intersection(self._process_batch_options)
+        )
+        if protected:
+            joined = ", ".join(protected)
+            raise ValueError(
+                "process_batch_options cannot override managed option(s): " + joined
+            )
+        self._process_batch = process_batch_fn or process_batch
+        super().__init__(
+            location,
+            auth_handler=auth_handler,
+            tls_certificates=tls_certificates,
+            verify_client=verify_client,
+            root_certificates=root_certificates,
+            middleware=dict(middleware) if middleware is not None else None,
+        )
+
+    def do_exchange(
+        self,
+        context: flight.ServerCallContext,
+        descriptor: flight.FlightDescriptor,
+        reader: flight.MetadataRecordBatchReader,
+        writer: flight.MetadataRecordBatchWriter,
+    ) -> None:
+        """Redact each incoming record batch and stream it back immediately."""
+        request = _parse_descriptor(descriptor)
+        text_column = request.get("text_column", self._text_column)
+        if text_column is None:
+            raise ValueError(
+                "A text_column is required in the Flight descriptor or server config"
+            )
+        policy = request["policy"] if "policy" in request else self._policy
+
+        schema = reader.schema
+        column_index = _validate_text_column(schema, text_column)
+        writer.begin(schema)
+
+        for chunk in reader:
+            if context.is_cancelled():
+                break
+            record_batch = chunk.data
+            if record_batch is None:
+                continue
+            redacted = self._redact_record_batch(
+                record_batch,
+                column_index=column_index,
+                text_column=text_column,
+                policy=policy,
+            )
+            if chunk.app_metadata is None:
+                writer.write_batch(redacted)
+            else:
+                writer.write_with_metadata(redacted, chunk.app_metadata)
+
+    def _redact_record_batch(
+        self,
+        record_batch: pa.RecordBatch,
+        *,
+        column_index: int,
+        text_column: str,
+        policy: str | None,
+    ) -> pa.RecordBatch:
+        field = record_batch.schema.field(column_index)
+        values = record_batch.column(column_index).to_pylist()
+        row_indexes = [index for index, value in enumerate(values) if value is not None]
+        if not row_indexes:
+            return record_batch
+
+        texts = [str(values[index]) for index in row_indexes]
+        ids = [f"flight_row_{index}" for index in row_indexes]
+        options = dict(self._process_batch_options)
+        options.update(
+            {
+                "operation": "deidentify",
+                "batch_size": self._batch_size,
+                "policy": policy,
+            }
+        )
+        try:
+            result = self._process_batch(
+                texts,
+                model_name=self._model_name,
+                ids=ids,
+                **options,
+            )
+        except Exception:
+            raise RuntimeError(
+                f"De-identification failed for column {text_column!r}"
+            ) from None
+        items = list(getattr(result, "items", ()) or ())
+        if len(items) != len(row_indexes):
+            raise RuntimeError(
+                "process_batch returned an unexpected number of results for "
+                f"column {text_column!r}"
+            )
+
+        redacted_values = list(values)
+        for row_index, item in zip(row_indexes, items):
+            if getattr(item, "error", None):
+                raise RuntimeError(
+                    "De-identification failed for "
+                    f"column {text_column!r} at row {row_index}"
+                )
+            redacted_values[row_index] = _deidentified_text(
+                getattr(item, "result", item)
+            )
+
+        redacted_array = pa.array(redacted_values, type=field.type)
+        return record_batch.set_column(column_index, field, redacted_array)
+
+
+def _parse_descriptor(descriptor: flight.FlightDescriptor) -> dict[str, Any]:
+    if descriptor.descriptor_type != flight.DescriptorType.CMD:
+        raise ValueError("Arrow Flight de-identification requires a command descriptor")
+    try:
+        payload = json.loads(descriptor.command.decode("utf-8"))
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            "Arrow Flight command descriptor must contain valid UTF-8 JSON"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Arrow Flight command descriptor must contain a JSON object")
+    if payload.get("version") != ARROW_FLIGHT_DESCRIPTOR_VERSION:
+        raise ValueError(
+            "Unsupported Arrow Flight descriptor version; "
+            f"expected {ARROW_FLIGHT_DESCRIPTOR_VERSION}"
+        )
+
+    if set(payload).difference({"version", "text_column", "policy"}):
+        raise ValueError("Arrow Flight command descriptor has unsupported fields")
+
+    request: dict[str, Any] = {}
+    if "text_column" in payload:
+        request["text_column"] = _normalize_required_string(
+            payload["text_column"], "text_column"
+        )
+    if "policy" in payload:
+        request["policy"] = _normalize_required_string(payload["policy"], "policy")
+    return request
+
+
+def _validate_text_column(schema: pa.Schema, text_column: str) -> int:
+    column_index = schema.get_field_index(text_column)
+    if column_index < 0:
+        raise ValueError(f"Text column is missing from the Arrow schema: {text_column}")
+    field_type = schema.field(column_index).type
+    if not (
+        pa.types.is_string(field_type)
+        or pa.types.is_large_string(field_type)
+        or pa.types.is_null(field_type)
+    ):
+        raise ValueError(f"Arrow text column must be string-typed: {text_column}")
+    return column_index
+
+
+def _deidentified_text(result: Any) -> str:
+    if hasattr(result, "deidentified_text"):
+        return str(result.deidentified_text)
+    if isinstance(result, Mapping) and "deidentified_text" in result:
+        return str(result["deidentified_text"])
+    if isinstance(result, str):
+        return result
+    raise TypeError("process_batch results must expose deidentified_text")
+
+
+def _normalize_required_string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+__all__ = [
+    "ARROW_FLIGHT_DESCRIPTOR_VERSION",
+    "DEFAULT_ARROW_FLIGHT_MODEL",
+    "ArrowFlightDeidentificationServer",
+    "make_deidentify_descriptor",
+]

--- a/tests/unit/integrations/test_arrow_flight.py
+++ b/tests/unit/integrations/test_arrow_flight.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+flight = pytest.importorskip("pyarrow.flight")
+
+from openmed.integrations.arrow_flight import (  # noqa: E402
+    ARROW_FLIGHT_DESCRIPTOR_VERSION,
+    ArrowFlightDeidentificationServer,
+    make_deidentify_descriptor,
+)
+
+
+def test_do_exchange_redacts_each_record_batch_without_buffering_stream(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_names = ("Jane Doe", "John Roe", "Sam Poe")
+    calls: list[dict[str, Any]] = []
+
+    def fake_process_batch(texts, **kwargs):
+        calls.append({"texts": tuple(texts), **kwargs})
+        redacted_texts = []
+        for text in texts:
+            for name in raw_names:
+                text = text.replace(name, "[NAME]")
+            redacted_texts.append(text)
+        items = [
+            SimpleNamespace(
+                result=SimpleNamespace(deidentified_text=text),
+                error=None,
+            )
+            for text in redacted_texts
+        ]
+        return SimpleNamespace(items=items)
+
+    server = ArrowFlightDeidentificationServer(
+        ("127.0.0.1", 0),
+        batch_size=32,
+        process_batch_fn=fake_process_batch,
+    )
+    client = flight.connect(("127.0.0.1", server.port))
+    schema = pa.schema(
+        [
+            pa.field("record_id", pa.int64(), nullable=False),
+            pa.field("clinical_note", pa.string()),
+            pa.field("status", pa.string()),
+        ],
+        metadata={b"dataset": b"synthetic"},
+    )
+    first = pa.RecordBatch.from_pylist(
+        [
+            {
+                "record_id": 1,
+                "clinical_note": "Patient Jane Doe called today",
+                "status": "open",
+            },
+            {
+                "record_id": 2,
+                "clinical_note": "John Roe has a follow-up",
+                "status": "closed",
+            },
+        ],
+        schema=schema,
+    )
+    second = pa.RecordBatch.from_pylist(
+        [
+            {
+                "record_id": 3,
+                "clinical_note": "Sam Poe requested records",
+                "status": "open",
+            },
+            {
+                "record_id": 4,
+                "clinical_note": None,
+                "status": "pending",
+            },
+        ],
+        schema=schema,
+    )
+
+    caplog.set_level(logging.DEBUG)
+    try:
+        writer, reader = client.do_exchange(
+            make_deidentify_descriptor(
+                "clinical_note",
+                policy="hipaa_safe_harbor",
+            )
+        )
+        writer.begin(schema)
+
+        writer.write_batch(first)
+        first_response = reader.read_chunk().data
+        assert first_response.column("clinical_note").to_pylist() == [
+            "Patient [NAME] called today",
+            "[NAME] has a follow-up",
+        ]
+        assert len(calls) == 1
+
+        writer.write_batch(second)
+        second_response = reader.read_chunk().data
+        assert second_response.column("clinical_note").to_pylist() == [
+            "[NAME] requested records",
+            None,
+        ]
+        assert len(calls) == 2
+
+        writer.done_writing()
+        with pytest.raises(StopIteration):
+            reader.read_chunk()
+    finally:
+        client.close()
+        server.shutdown()
+
+    assert first_response.schema == schema
+    assert second_response.schema == schema
+    assert first_response.num_rows + second_response.num_rows == 4
+    assert first_response.column("record_id").to_pylist() == [1, 2]
+    assert second_response.column("record_id").to_pylist() == [3, 4]
+    assert first_response.column("status").to_pylist() == ["open", "closed"]
+    assert second_response.column("status").to_pylist() == ["open", "pending"]
+    assert [len(call["texts"]) for call in calls] == [2, 1]
+    assert all(call["operation"] == "deidentify" for call in calls)
+    assert all(call["policy"] == "hipaa_safe_harbor" for call in calls)
+    assert all(call["batch_size"] == 32 for call in calls)
+
+    log_output = "\n".join(record.getMessage() for record in caplog.records)
+    assert all(name not in log_output for name in raw_names)
+
+
+def test_descriptor_is_versioned_and_carries_policy() -> None:
+    descriptor = make_deidentify_descriptor(
+        "note",
+        policy="hipaa_safe_harbor",
+    )
+
+    assert descriptor.descriptor_type == flight.DescriptorType.CMD
+    assert descriptor.command == (
+        b'{"policy":"hipaa_safe_harbor","text_column":"note","version":1}'
+    )
+    assert ARROW_FLIGHT_DESCRIPTOR_VERSION == 1
+
+
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_server_rejects_non_positive_batch_size(batch_size: int) -> None:
+    with pytest.raises(ValueError, match="batch_size must be positive"):
+        ArrowFlightDeidentificationServer(batch_size=batch_size)
+
+
+def test_server_rejects_managed_process_batch_overrides() -> None:
+    with pytest.raises(ValueError, match="cannot override managed option.*policy"):
+        ArrowFlightDeidentificationServer(
+            process_batch_options={"policy": "not-from-descriptor"}
+        )


### PR DESCRIPTION
## Description

Adds a streaming Arrow Flight `DoExchange` service that de-identifies a configured text column one record batch at a time. Response batches preserve the input schema, row count, null placement, application metadata, and every non-target column while policy selection is carried in versioned command-descriptor metadata.

Closes #844

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Added a configurable de-identification server with authentication and TLS hooks.
- Added versioned descriptor metadata for text-column and policy selection.
- Added an offline local-port exchange test covering per-batch streaming, PHI removal, schema preservation, non-target columns, nulls, and no raw-cell logging.
- Added an integration guide and navigation entry.

## Testing

- [x] The new offline exchange tests pass.
- [x] The full test suite passes: 5,168 passed and 47 skipped.
- [x] Repository lint, formatting, type checks, scoped quality hooks, and strict documentation build pass.

## Documentation

- [x] Updated the integration documentation.
- [x] Added public API docstrings.
- [ ] Updated the changelog (not required for this scoped feature PR).

## Code Quality

- [x] Ran the canonical format, lint, and format-check gates.
- [x] Performed a self-review.
- [x] The change introduces no new warnings.

## Dependencies

- [x] No new dependency was added; the existing optional columnar dependency provides the Flight runtime.

## Checklist

- [x] Read the contributing guidelines.
- [x] Commit history is focused and descriptive.

## Related Issues

Closes #844

## Screenshots/Examples

Not applicable; the integration guide includes server and client examples.
