### PR TITLE
Add a search-engine ingest processor for inline document redaction

### DIFF
--- a/examples/search-ingest/README.md
+++ b/examples/search-ingest/README.md
@@ -1,0 +1,72 @@
+# Search-ingest inline redaction sidecar
+
+This example places an OpenMed HTTP processor in front of an
+Elasticsearch/OpenSearch-style indexing path. The processor receives the full
+ingest-document envelope, redacts only configured string fields in `_source`,
+and returns the same envelope for the indexing client or gateway to forward.
+
+All processing stays local after the selected OpenMed model is downloaded. Do
+not enable request-body logging in the sidecar, reverse proxy, or indexing
+gateway because ingest documents can contain PHI.
+
+## Start the processor
+
+Install the service extra and bind to loopback for local development:
+
+```bash
+uv pip install --upgrade "openmed[service]"
+uvicorn openmed.integrations.search_ingest_processor:app \
+  --host 127.0.0.1 --port 8090
+```
+
+Use authenticated TLS between the indexing gateway and sidecar in any remote
+deployment. The example service intentionally does not add a second auth model;
+deploy it on a private network boundary controlled by the gateway.
+
+## Configure a pipeline
+
+[`pipeline.json`](pipeline.json) is a vendor-neutral gateway manifest. It:
+
+1. registers the `openmed-inline-redaction` HTTP processor;
+2. configures the nested `_source` fields and policy profile for that pipeline;
+3. routes `clinical-documents-*` index actions through the processor.
+
+Load or translate this manifest in the indexing client, proxy, or ingest gateway
+that owns the route. Elasticsearch and OpenSearch run their built-in ingest
+processors inside the cluster and do not provide one portable arbitrary-HTTP
+processor definition. Therefore, do not submit this manifest directly to
+`_ingest/pipeline`; doing so would require a cluster-specific plugin, which is
+outside this example's scope.
+
+Field paths are relative to `_source`. Explicit envelope paths such as
+`_source.clinical.note` are also supported. A missing path, a non-string value,
+or an empty string is left unchanged. Each request supplies its pipeline policy,
+so multiple routes can use different OpenMed profiles with the same sidecar.
+
+## Request contract
+
+The pipeline sends the document envelope plus its configured fields and policy:
+
+```bash
+curl --fail-with-body http://127.0.0.1:8090/process \
+  -H 'Content-Type: application/json' \
+  --data-binary @- <<'JSON'
+{
+  "document": {
+    "_index": "clinical-documents-2026",
+    "_id": "synthetic-001",
+    "_source": {
+      "clinical": {"note": "Synthetic patient Jane Roe called 555-0100."},
+      "patient": {"summary": "Synthetic follow-up note."},
+      "status": "open"
+    },
+    "_ingest": {"timestamp": "2026-07-19T00:00:00Z"}
+  },
+  "fields": ["clinical.note", "patient.summary"],
+  "policy": "hipaa_safe_harbor"
+}
+JSON
+```
+
+The response is the modified document itself, not a second wrapper. `_index`,
+`_id`, `_routing`, `_ingest`, and all non-target `_source` values are preserved.

--- a/examples/search-ingest/pipeline.json
+++ b/examples/search-ingest/pipeline.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "processors": [
+    {
+      "id": "openmed-inline-redaction",
+      "type": "http",
+      "request": {
+        "method": "POST",
+        "url": "http://127.0.0.1:8090/process",
+        "timeout_seconds": 30,
+        "body": {
+          "document": "${document}",
+          "fields": [
+            "clinical.note",
+            "patient.summary"
+          ],
+          "policy": "hipaa_safe_harbor"
+        }
+      },
+      "response_document": "$"
+    }
+  ],
+  "pipeline": {
+    "id": "openmed-inline-redaction-v1",
+    "processors": [
+      "openmed-inline-redaction"
+    ]
+  },
+  "routes": [
+    {
+      "index_pattern": "clinical-documents-*",
+      "pipeline": "openmed-inline-redaction-v1"
+    }
+  ]
+}

--- a/openmed/integrations/search_ingest_processor.py
+++ b/openmed/integrations/search_ingest_processor.py
@@ -1,0 +1,303 @@
+"""HTTP sidecar for redacting search-ingest document envelopes."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, status
+
+from openmed.core.pii_i18n import DEFAULT_PII_MODELS
+from openmed.processing.batch import process_batch
+
+DEFAULT_SEARCH_INGEST_MODEL = DEFAULT_PII_MODELS["en"]
+ProcessBatchCallable = Callable[..., Any]
+
+
+class SearchIngestProcessorError(RuntimeError):
+    """Raised when an ingest document cannot be redacted safely."""
+
+
+@dataclass(frozen=True)
+class _Target:
+    field_name: str
+    path: tuple[str, ...]
+    text: str
+
+
+def redact_ingest_document(
+    document: Mapping[str, Any],
+    *,
+    fields: Sequence[str],
+    policy: str | None = None,
+    process_batch_fn: ProcessBatchCallable = process_batch,
+) -> dict[str, Any]:
+    """Return a redacted copy of a search ingest-document envelope.
+
+    Field names are resolved relative to ``_source`` by default. Paths that
+    start with ``_source.`` or another envelope key are also accepted. Missing
+    paths, non-string values, and empty strings are preserved without invoking
+    the batch processor.
+
+    Args:
+        document: Elasticsearch/OpenSearch-style ingest document envelope.
+        fields: Top-level or dotted paths to string fields that should be
+            redacted.
+        policy: Optional OpenMed policy profile for this pipeline invocation.
+        process_batch_fn: Batch processor implementation, replaceable for
+            offline tests and embedded deployments.
+
+    Returns:
+        A deep copy of ``document`` with configured string fields redacted.
+
+    Raises:
+        TypeError: If ``document`` is not a mapping.
+        ValueError: If a configured field path or policy is invalid.
+        SearchIngestProcessorError: If batch redaction fails or returns an
+            invalid result. Error messages never include document text.
+    """
+
+    if not isinstance(document, Mapping):
+        raise TypeError("document must be a mapping")
+
+    normalized_fields = _normalize_fields(fields)
+    normalized_policy = _normalize_policy(policy)
+    output = copy.deepcopy(dict(document))
+    targets = _collect_targets(output, normalized_fields)
+    if not targets:
+        return output
+
+    kwargs: dict[str, Any] = {
+        "model_name": DEFAULT_SEARCH_INGEST_MODEL,
+        "ids": [f"ingest:{target.field_name}" for target in targets],
+        "operation": "deidentify",
+        "batch_size": len(targets),
+        "method": "mask",
+        "confidence_threshold": 0.7,
+        "continue_on_error": False,
+        "use_safety_sweep": True,
+    }
+    if normalized_policy is not None:
+        kwargs["policy"] = normalized_policy
+
+    try:
+        batch_result = process_batch_fn(
+            [target.text for target in targets],
+            **kwargs,
+        )
+        redacted_texts = _extract_redacted_texts(
+            batch_result,
+            expected=len(targets),
+        )
+    except Exception:
+        raise SearchIngestProcessorError(
+            "failed to redact configured ingest document fields"
+        ) from None
+
+    for target, redacted_text in zip(targets, redacted_texts):
+        _set_path(output, target.path, redacted_text)
+    return output
+
+
+def create_app(
+    *,
+    process_batch_fn: ProcessBatchCallable = process_batch,
+) -> FastAPI:
+    """Create the search-ingest redaction sidecar application.
+
+    Args:
+        process_batch_fn: Batch processor implementation used by ``/process``.
+
+    Returns:
+        A configured FastAPI application.
+    """
+
+    app = FastAPI(
+        title="OpenMed search ingest redaction processor",
+        version="1.0.0",
+    )
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/process")
+    def process_document(payload: dict[str, Any]) -> dict[str, Any]:
+        document = payload.get("document")
+        fields = payload.get("fields")
+        policy = payload.get("policy")
+
+        if not isinstance(document, Mapping):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="document must be an object",
+            )
+        if not isinstance(fields, list) or any(
+            not isinstance(field, str) for field in fields
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="fields must be an array of strings",
+            )
+        if policy is not None and not isinstance(policy, str):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="policy must be a string or null",
+            )
+
+        try:
+            return redact_ingest_document(
+                document,
+                fields=fields,
+                policy=policy,
+                process_batch_fn=process_batch_fn,
+            )
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(exc),
+            ) from None
+        except SearchIngestProcessorError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=str(exc),
+            ) from None
+
+    return app
+
+
+def _normalize_fields(fields: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(fields, (str, bytes)):
+        raise TypeError("fields must be a sequence of strings")
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for field in fields:
+        if not isinstance(field, str):
+            raise TypeError("fields must contain only strings")
+        field_name = field.strip()
+        if not field_name:
+            raise ValueError("field paths must not be empty")
+        if any(not part for part in field_name.split(".")):
+            raise ValueError("field paths must not contain empty segments")
+        if field_name not in seen:
+            seen.add(field_name)
+            normalized.append(field_name)
+    return tuple(normalized)
+
+
+def _normalize_policy(policy: str | None) -> str | None:
+    if policy is None:
+        return None
+    if not isinstance(policy, str):
+        raise TypeError("policy must be a string or null")
+    normalized = policy.strip()
+    if not normalized:
+        raise ValueError("policy must not be empty")
+    return normalized
+
+
+def _collect_targets(
+    document: Mapping[str, Any],
+    fields: Sequence[str],
+) -> list[_Target]:
+    targets: list[_Target] = []
+    seen_paths: set[tuple[str, ...]] = set()
+    for field_name in fields:
+        path = _resolve_path(document, field_name)
+        if path is None or path in seen_paths:
+            continue
+        value = _get_path(document, path)
+        if isinstance(value, str) and value:
+            targets.append(_Target(field_name=field_name, path=path, text=value))
+            seen_paths.add(path)
+    return targets
+
+
+def _resolve_path(
+    document: Mapping[str, Any],
+    field_name: str,
+) -> tuple[str, ...] | None:
+    parts = tuple(field_name.split("."))
+    source = document.get("_source")
+
+    if parts[0] != "_source" and isinstance(source, Mapping):
+        if field_name in source:
+            return ("_source", field_name)
+        source_path = ("_source", *parts)
+        if _path_exists(document, source_path):
+            return source_path
+
+    if field_name in document:
+        return (field_name,)
+    if _path_exists(document, parts):
+        return parts
+    return None
+
+
+def _path_exists(document: Mapping[str, Any], path: Sequence[str]) -> bool:
+    try:
+        _get_path(document, path)
+    except (KeyError, TypeError):
+        return False
+    return True
+
+
+def _get_path(document: Mapping[str, Any], path: Sequence[str]) -> Any:
+    current: Any = document
+    for part in path:
+        if not isinstance(current, Mapping) or part not in current:
+            raise KeyError(part)
+        current = current[part]
+    return current
+
+
+def _set_path(document: dict[str, Any], path: Sequence[str], value: str) -> None:
+    current = document
+    for part in path[:-1]:
+        nested = current[part]
+        if not isinstance(nested, dict):
+            raise SearchIngestProcessorError(
+                "configured ingest field path is not an object"
+            )
+        current = nested
+    current[path[-1]] = value
+
+
+def _extract_redacted_texts(batch_result: Any, *, expected: int) -> list[str]:
+    raw_items = getattr(batch_result, "items", batch_result)
+    try:
+        items = list(raw_items)
+    except TypeError as exc:
+        raise SearchIngestProcessorError(
+            "ingest redaction returned an invalid result"
+        ) from exc
+
+    if len(items) != expected:
+        raise SearchIngestProcessorError(
+            "ingest redaction returned an unexpected result count"
+        )
+
+    redacted_texts: list[str] = []
+    for item in items:
+        if hasattr(item, "success") and not item.success:
+            raise SearchIngestProcessorError(
+                "ingest redaction failed for one or more configured fields"
+            )
+        result = getattr(item, "result", item)
+        redacted_text = (
+            result
+            if isinstance(result, str)
+            else getattr(result, "deidentified_text", None)
+        )
+        if not isinstance(redacted_text, str):
+            raise SearchIngestProcessorError(
+                "ingest redaction returned an invalid field result"
+            )
+        redacted_texts.append(redacted_text)
+    return redacted_texts
+
+
+app = create_app()

--- a/tests/unit/integrations/test_search_ingest_processor.py
+++ b/tests/unit/integrations/test_search_ingest_processor.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from openmed.integrations.search_ingest_processor import create_app
+
+
+def _fake_redact(text: str) -> str:
+    return (
+        text.replace("Jane Roe", "[NAME]")
+        .replace("555-0100", "[PHONE]")
+        .replace("jane.roe@example.test", "[EMAIL]")
+    )
+
+
+def _fake_result(texts: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                success=True,
+                result=SimpleNamespace(deidentified_text=_fake_redact(text)),
+            )
+            for text in texts
+        ]
+    )
+
+
+def test_http_processor_redacts_nested_fields_and_preserves_envelope(
+    caplog,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        calls.append({"texts": list(texts), "kwargs": dict(kwargs)})
+        return _fake_result(list(texts))
+
+    document = {
+        "_index": "synthetic-clinical-documents",
+        "_id": "synthetic-001",
+        "_routing": "tenant-a",
+        "_source": {
+            "note": "Patient Jane Roe called 555-0100.",
+            "patient": {
+                "summary": "Contact jane.roe@example.test for follow-up.",
+                "category": "synthetic",
+            },
+            "status": "open",
+        },
+        "_ingest": {"timestamp": "2026-07-19T00:00:00Z"},
+    }
+    original = deepcopy(document)
+    app = create_app(process_batch_fn=fake_process_batch)
+
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        response = client.post(
+            "/process",
+            json={
+                "document": document,
+                "fields": ["note", "patient.summary"],
+                "policy": "hipaa_safe_harbor",
+            },
+        )
+
+    assert response.status_code == 200
+    redacted = response.json()
+    assert set(redacted) == set(document)
+    assert redacted["_index"] == document["_index"]
+    assert redacted["_id"] == document["_id"]
+    assert redacted["_routing"] == document["_routing"]
+    assert redacted["_ingest"] == document["_ingest"]
+    assert redacted["_source"]["note"] == "Patient [NAME] called [PHONE]."
+    assert redacted["_source"]["patient"]["summary"] == "Contact [EMAIL] for follow-up."
+    assert redacted["_source"]["patient"]["category"] == "synthetic"
+    assert redacted["_source"]["status"] == "open"
+    assert document == original
+    assert calls[0]["texts"] == [
+        "Patient Jane Roe called 555-0100.",
+        "Contact jane.roe@example.test for follow-up.",
+    ]
+    assert calls[0]["kwargs"]["operation"] == "deidentify"
+    assert calls[0]["kwargs"]["policy"] == "hipaa_safe_harbor"
+    assert calls[0]["kwargs"]["continue_on_error"] is False
+    assert calls[0]["kwargs"]["use_safety_sweep"] is True
+    assert "Jane Roe" not in caplog.text
+    assert "555-0100" not in caplog.text
+    assert "jane.roe@example.test" not in caplog.text
+
+
+def test_unknown_and_non_string_field_paths_are_skipped_without_error() -> None:
+    calls: list[list[str]] = []
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        calls.append(list(texts))
+        return _fake_result(list(texts))
+
+    document = {
+        "_index": "synthetic-clinical-documents",
+        "_source": {
+            "note": "Patient Jane Roe called.",
+            "metadata": {"attempt": 2},
+        },
+    }
+    app = create_app(process_batch_fn=fake_process_batch)
+
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        response = client.post(
+            "/process",
+            json={
+                "document": document,
+                "fields": ["missing.path", "metadata.attempt", "_source.note"],
+                "policy": "strict_no_leak",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "_index": "synthetic-clinical-documents",
+        "_source": {
+            "note": "Patient [NAME] called.",
+            "metadata": {"attempt": 2},
+        },
+    }
+    assert calls == [["Patient Jane Roe called."]]
+
+
+def test_batch_failures_return_phi_safe_error_and_do_not_log_document(
+    caplog,
+) -> None:
+    synthetic_text = "Patient Jane Roe called 555-0100."
+
+    def failing_process_batch(texts: list[str], **kwargs: Any) -> None:
+        raise RuntimeError(f"model failure while processing {texts[0]}")
+
+    app = create_app(process_batch_fn=failing_process_batch)
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        response = client.post(
+            "/process",
+            json={
+                "document": {"_source": {"note": synthetic_text}},
+                "fields": ["note"],
+                "policy": "hipaa_safe_harbor",
+            },
+        )
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": "failed to redact configured ingest document fields"
+    }
+    assert synthetic_text not in response.text
+    assert "Jane Roe" not in caplog.text
+    assert "555-0100" not in caplog.text
+
+
+def test_pipeline_definition_registers_processor_and_route() -> None:
+    root = Path(__file__).resolve().parents[3]
+    pipeline = json.loads(
+        (root / "examples/search-ingest/pipeline.json").read_text(encoding="utf-8")
+    )
+
+    processor = pipeline["processors"][0]
+    assert processor["id"] == "openmed-inline-redaction"
+    assert processor["type"] == "http"
+    assert processor["request"]["url"].endswith("/process")
+    assert processor["request"]["body"]["policy"] == "hipaa_safe_harbor"
+    assert pipeline["pipeline"]["processors"] == ["openmed-inline-redaction"]
+    assert pipeline["routes"][0]["pipeline"] == pipeline["pipeline"]["id"]


### PR DESCRIPTION
## Description

Adds a self-hosted HTTP processor for search-ingest document envelopes. It batch-redacts configured nested string fields with a pipeline-specific policy, preserves all envelope and non-target data, skips unknown paths, and returns PHI-safe failures without logging original document text.

Closes #846

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Added the embeddable `/process` and `/health` HTTP application.
- Added nested `_source` path resolution, per-request policy forwarding, batch result validation, and sanitized failure handling.
- Added a vendor-neutral pipeline manifest and deployment/request documentation.
- Added offline HTTP tests for redaction, envelope preservation, unknown paths, policy forwarding, and PHI-safe failures.

## Testing

- [x] New and existing unit tests pass locally.
- [x] Full suite: 5,159 passed, 55 skipped.
- [x] Integration suite: 22 passed, 5 skipped.
- [x] Formatting, lint, type, staged-file policy, and diff checks pass.

## Documentation

- [x] Added setup, routing, request-contract, security-boundary, and platform-compatibility guidance.
- [x] Added docstrings to new public functions and classes.
- [ ] CHANGELOG update is not required for this scoped feature PR.

## Code Quality

- [x] Canonical formatting and lint checks pass.
- [x] Performed a self-review.
- [x] No new warnings or unrelated changes.

## Dependencies

- [x] No new dependencies.

## Checklist

- [x] Read the contributing guidelines.
- [x] Commit has a clear, descriptive message.
- [x] Commit is focused on one issue.

## Related Issues

Closes #846

## Screenshots/Examples

Not applicable; the README includes a synthetic request example and response contract.
