### PR TITLE
Add a Ray Data map-batches de-identification stage with shared model actors

### DIFF
--- a/docs/integrations/ray-map-batches.md
+++ b/docs/integrations/ray-map-batches.md
@@ -1,0 +1,96 @@
+# Ray Data map-batches de-identification
+
+OpenMed provides a stateful `Dataset.map_batches` stage for distributed,
+columnar de-identification. Ray runs the callable class in an actor pool, and
+each actor loads one OpenMed model pipeline in its constructor and reuses that
+pipeline for every batch it processes.
+
+Install OpenMed's model dependencies and Ray Data:
+
+```bash
+pip install "openmed[hf]" "ray[data]"
+```
+
+## Apply the stage
+
+Choose the free-text column explicitly. Non-target columns, null values, batch
+row counts, and the dataset's total row count pass through unchanged.
+
+```python
+import ray
+
+from openmed.integrations.ray_map_batches import map_batches_deidentify
+
+ray.init()
+
+records = ray.data.from_items(
+    [
+        {"record_id": "a", "clinical_note": "Patient Jane Roe called."},
+        {"record_id": "b", "clinical_note": "No identifiers here."},
+    ]
+)
+
+redacted = map_batches_deidentify(
+    records,
+    column="clinical_note",
+    policy_profile="hipaa_safe_harbor",
+    batch_size=256,
+    batch_format="pyarrow",
+    concurrency=4,
+)
+
+redacted.write_parquet("/secure/output/redacted-notes")
+```
+
+The returned dataset is lazy. A terminal operation such as `write_parquet`,
+`materialize`, or `take_all` starts execution.
+
+## Actor pool and batch format
+
+`concurrency=4` creates a fixed pool of four model actors. Use `(minimum,
+maximum)` for an autoscaling pool, or `(minimum, maximum, initial)` to set its
+initial size as well:
+
+```python
+redacted = map_batches_deidentify(
+    records,
+    column="clinical_note",
+    policy_profile="strict_no_leak",
+    batch_size=512,
+    batch_format="pandas",
+    concurrency=(1, 8, 2),
+    num_cpus=2,
+)
+```
+
+Supported batch formats are `"pyarrow"` and `"pandas"`. The stage copies the
+batch before replacing the target column, leaving Ray's zero-copy input buffers
+untouched. `num_cpus`, `num_gpus`, and other Ray worker resource arguments are
+forwarded to `Dataset.map_batches`.
+
+## Use the callable class directly
+
+For custom Ray Data plans, pass `RayDeidentifyBatch` to `map_batches`. A class
+UDF is important here: a function UDF is stateless and would not retain the
+loaded model between calls.
+
+```python
+from ray.data import ActorPoolStrategy
+
+from openmed.integrations.ray_map_batches import RayDeidentifyBatch
+
+redacted = records.map_batches(
+    RayDeidentifyBatch,
+    batch_size=256,
+    batch_format="pyarrow",
+    compute=ActorPoolStrategy(size=4),
+    fn_constructor_kwargs={
+        "column": "clinical_note",
+        "policy_profile": "hipaa_safe_harbor",
+    },
+)
+```
+
+Ray's object store and worker processes temporarily hold the input batches.
+Deploy this stage only on a trusted, access-controlled cluster appropriate for
+the sensitivity of the source data, and write results only to approved storage.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - Columnar Redactor: integrations/columnar-redactor.md
       - Lakehouse Table Redaction: integrations/lakehouse-redaction.md
       - Dask DataFrame De-identification: integrations/dask.md
+      - Ray Data Batch De-identification: integrations/ray-map-batches.md
       - DuckDB De-identification UDFs: duckdb-deidentification.md
       - spaCy Pipeline Component: spacy-component.md
       - HL7 v2 De-identification: hl7v2-deidentification.md

--- a/openmed/integrations/ray_map_batches.py
+++ b/openmed/integrations/ray_map_batches.py
@@ -1,0 +1,381 @@
+"""Stateful Ray Data batch de-identification with shared model actors.
+
+The callable class in this module is intended for
+``ray.data.Dataset.map_batches``. Ray runs callable classes as actors, so each
+actor constructs one OpenMed batch pipeline and reuses its loaded model across
+all batches assigned to that worker.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Literal, Protocol, TypeAlias
+
+DEFAULT_RAY_PII_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+
+BatchFormat: TypeAlias = Literal["pandas", "pyarrow"]
+ActorPoolConcurrency: TypeAlias = int | tuple[int, int] | tuple[int, int, int]
+
+
+class BatchPipeline(Protocol):
+    """Protocol implemented by actor-local batch processing pipelines."""
+
+    def process_texts(
+        self,
+        texts: Sequence[str],
+        ids: Sequence[str] | None = None,
+    ) -> Any:
+        """De-identify a batch of text values."""
+
+
+PipelineFactory: TypeAlias = Callable[..., BatchPipeline]
+
+
+class RayDeidentifyBatch:
+    """Callable Ray Data actor that de-identifies one column per batch.
+
+    Ray constructs this class once per actor. The constructor eagerly builds
+    and warms one OpenMed batch pipeline; subsequent ``__call__`` invocations
+    reuse the same model resources.
+
+    Args:
+        column: Name of the text column to de-identify.
+        policy_profile: Optional OpenMed policy profile passed as ``policy`` to
+            batch de-identification.
+        model_name: OpenMed model registry key or model identifier.
+        method: De-identification method, such as ``"mask"``.
+        process_batch_size: Maximum number of text values processed together
+            inside the actor pipeline.
+        process_batch_kwargs: Additional keyword arguments forwarded to the
+            actor-local OpenMed batch processor.
+        pipeline_factory: Optional factory used to construct the actor-local
+            pipeline. This is primarily useful for offline tests.
+    """
+
+    def __init__(
+        self,
+        column: str,
+        policy_profile: str | None = None,
+        *,
+        model_name: str = DEFAULT_RAY_PII_MODEL,
+        method: str = "mask",
+        process_batch_size: int = 512,
+        process_batch_kwargs: Mapping[str, Any] | None = None,
+        pipeline_factory: PipelineFactory | None = None,
+    ) -> None:
+        if not isinstance(column, str) or not column.strip():
+            raise ValueError("column must be a non-empty string")
+
+        kwargs = dict(process_batch_kwargs or {})
+        reserved = {
+            "batch_size",
+            "method",
+            "model_name",
+            "operation",
+            "policy",
+            "policy_profile",
+        }
+        conflicts = sorted(reserved.intersection(kwargs))
+        if conflicts:
+            joined = ", ".join(conflicts)
+            raise ValueError(
+                "process_batch_kwargs contains reserved argument(s): " + joined
+            )
+
+        self.column = column
+        self.policy_profile = policy_profile
+        self.model_name = model_name
+        self.method = method
+        factory = pipeline_factory or _create_openmed_batch_pipeline
+        self._pipeline = factory(
+            model_name=model_name,
+            method=method,
+            policy_profile=policy_profile,
+            process_batch_size=process_batch_size,
+            process_batch_kwargs=kwargs,
+        )
+
+    def __call__(self, batch: Any) -> Any:
+        """Return the batch with the configured text column de-identified."""
+
+        values = _target_values(batch, self.column)
+        positions: list[int] = []
+        texts: list[str] = []
+        for position, value in enumerate(values):
+            if _is_missing(value) or value == "":
+                continue
+            if not isinstance(value, str):
+                raise TypeError(
+                    f"Ray batch column {self.column!r} must contain strings or nulls"
+                )
+            positions.append(position)
+            texts.append(value)
+
+        redacted_values = list(values)
+        if texts:
+            ids = [f"ray_batch_{position}" for position in positions]
+            result = self._pipeline.process_texts(texts, ids=ids)
+            redacted_texts = _deidentified_texts(result, expected=len(texts))
+            for position, redacted in zip(positions, redacted_texts):
+                redacted_values[position] = redacted
+
+        if len(redacted_values) != len(values):  # pragma: no cover - invariant
+            raise RuntimeError("Ray de-identification changed the batch row count")
+        return _replace_target_values(batch, self.column, redacted_values)
+
+
+RayMapBatchesDeidentifier = RayDeidentifyBatch
+
+
+def map_batches_deidentify(
+    dataset: Any,
+    *,
+    column: str,
+    policy_profile: str | None = None,
+    model_name: str = DEFAULT_RAY_PII_MODEL,
+    method: str = "mask",
+    batch_size: int | None = None,
+    batch_format: BatchFormat = "pyarrow",
+    concurrency: ActorPoolConcurrency = 1,
+    process_batch_kwargs: Mapping[str, Any] | None = None,
+    pipeline_factory: PipelineFactory | None = None,
+    **ray_remote_args: Any,
+) -> Any:
+    """Apply actor-backed batch de-identification to a Ray Dataset.
+
+    Args:
+        dataset: A ``ray.data.Dataset`` instance.
+        column: Name of the text column to de-identify.
+        policy_profile: Optional OpenMed policy profile.
+        model_name: OpenMed model registry key or model identifier.
+        method: De-identification method, such as ``"mask"``.
+        batch_size: Desired number of dataset rows in each Ray batch.
+        batch_format: Either ``"pandas"`` or ``"pyarrow"``.
+        concurrency: Fixed actor count, ``(min, max)`` autoscaling range, or
+            ``(min, max, initial)`` autoscaling configuration.
+        process_batch_kwargs: Extra OpenMed batch-processing arguments.
+        pipeline_factory: Optional actor-local pipeline factory, primarily for
+            offline tests.
+        **ray_remote_args: Resource requirements forwarded to
+            ``Dataset.map_batches``, such as ``num_cpus`` or ``num_gpus``.
+
+    Returns:
+        A lazy Ray Dataset with the same rows and non-target columns.
+    """
+
+    if batch_format not in {"pandas", "pyarrow"}:
+        raise ValueError("batch_format must be 'pandas' or 'pyarrow'")
+    if batch_size is not None and (
+        isinstance(batch_size, bool)
+        or not isinstance(batch_size, int)
+        or batch_size < 1
+    ):
+        raise ValueError("batch_size must be a positive integer or None")
+
+    try:
+        from ray.data import ActorPoolStrategy
+    except ImportError as exc:  # pragma: no cover - packaging users
+        raise ImportError(
+            "Ray Data support requires Ray. Install with `pip install 'ray[data]'`."
+        ) from exc
+
+    compute = _actor_pool_strategy(ActorPoolStrategy, concurrency)
+    constructor_kwargs = {
+        "column": column,
+        "policy_profile": policy_profile,
+        "model_name": model_name,
+        "method": method,
+        "process_batch_size": batch_size or 512,
+        "process_batch_kwargs": dict(process_batch_kwargs or {}),
+        "pipeline_factory": pipeline_factory,
+    }
+    return dataset.map_batches(
+        RayDeidentifyBatch,
+        batch_size=batch_size,
+        batch_format=batch_format,
+        compute=compute,
+        fn_constructor_kwargs=constructor_kwargs,
+        zero_copy_batch=True,
+        udf_modifying_row_count=False,
+        **ray_remote_args,
+    )
+
+
+def _create_openmed_batch_pipeline(
+    *,
+    model_name: str,
+    method: str,
+    policy_profile: str | None,
+    process_batch_size: int,
+    process_batch_kwargs: Mapping[str, Any],
+) -> BatchPipeline:
+    """Create and eagerly warm one actor-local OpenMed batch pipeline."""
+
+    from openmed.processing.batch import BatchProcessor
+
+    processor = BatchProcessor(
+        model_name=model_name,
+        operation="deidentify",
+        batch_size=process_batch_size,
+        method=method,
+        policy=policy_profile,
+        **dict(process_batch_kwargs),
+    )
+
+    privacy_pipeline = processor._get_privacy_filter_pipeline()
+    if privacy_pipeline is None:
+        loader = processor._get_shared_loader()
+        if loader is None:
+            raise ImportError(
+                "Ray de-identification requires model dependencies. "
+                "Install with `pip install 'openmed[hf]'`."
+            )
+
+        from openmed.core.pii import _resolve_effective_pii_model
+
+        effective_model = _resolve_effective_pii_model(
+            model_name,
+            str(processor.analyze_kwargs.get("lang", "en")),
+        )
+        loader.create_pipeline(
+            effective_model,
+            task="token-classification",
+            aggregation_strategy=processor.aggregation_strategy,
+            use_fast_tokenizer=True,
+        )
+
+    return processor
+
+
+def _actor_pool_strategy(
+    strategy_type: Callable[..., Any],
+    concurrency: ActorPoolConcurrency,
+) -> Any:
+    if isinstance(concurrency, bool):
+        raise ValueError("concurrency must use positive integer actor counts")
+    if isinstance(concurrency, int):
+        if concurrency < 1:
+            raise ValueError("concurrency must be at least 1")
+        return strategy_type(size=concurrency)
+    if not isinstance(concurrency, tuple) or len(concurrency) not in {2, 3}:
+        raise ValueError(
+            "concurrency must be an int, (min, max), or (min, max, initial)"
+        )
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) for value in concurrency
+    ):
+        raise ValueError("concurrency values must be integers")
+
+    minimum, maximum = concurrency[:2]
+    if minimum < 1 or maximum < minimum:
+        raise ValueError("concurrency requires 1 <= min <= max")
+    if len(concurrency) == 2:
+        return strategy_type(min_size=minimum, max_size=maximum)
+
+    initial = concurrency[2]
+    if initial < minimum or initial > maximum:
+        raise ValueError("initial concurrency must be between min and max")
+    return strategy_type(
+        min_size=minimum,
+        max_size=maximum,
+        initial_size=initial,
+    )
+
+
+def _target_values(batch: Any, column: str) -> list[Any]:
+    try:
+        import pandas as pd
+    except ImportError:  # pragma: no cover - Ray installs pandas
+        pd = None  # type: ignore[assignment]
+    if pd is not None and isinstance(batch, pd.DataFrame):
+        if column not in batch.columns:
+            raise KeyError(f"Ray batch is missing column {column!r}")
+        return batch[column].tolist()
+
+    try:
+        import pyarrow as pa
+    except ImportError:  # pragma: no cover - Ray installs PyArrow
+        pa = None  # type: ignore[assignment]
+    if pa is not None and isinstance(batch, pa.Table):
+        if column not in batch.column_names:
+            raise KeyError(f"Ray batch is missing column {column!r}")
+        return batch.column(column).to_pylist()
+
+    raise TypeError("RayDeidentifyBatch expects a pandas DataFrame or pyarrow Table")
+
+
+def _replace_target_values(batch: Any, column: str, values: Sequence[Any]) -> Any:
+    try:
+        import pandas as pd
+    except ImportError:  # pragma: no cover - Ray installs pandas
+        pd = None  # type: ignore[assignment]
+    if pd is not None and isinstance(batch, pd.DataFrame):
+        result = batch.copy(deep=True)
+        result[column] = list(values)
+        return result
+
+    try:
+        import pyarrow as pa
+    except ImportError:  # pragma: no cover - Ray installs PyArrow
+        pa = None  # type: ignore[assignment]
+    if pa is not None and isinstance(batch, pa.Table):
+        index = batch.schema.get_field_index(column)
+        field = batch.schema.field(index)
+        replacement = pa.array(values, type=field.type)
+        return batch.set_column(index, field, replacement)
+
+    raise TypeError("RayDeidentifyBatch expects a pandas DataFrame or pyarrow Table")
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    try:
+        import pandas as pd
+    except ImportError:  # pragma: no cover - Ray installs pandas
+        return False
+    try:
+        missing = pd.isna(value)
+    except (TypeError, ValueError):
+        return False
+    try:
+        return bool(missing)
+    except ValueError:
+        return False
+
+
+def _deidentified_texts(result: Any, *, expected: int) -> list[str]:
+    items = getattr(result, "items", result)
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes, bytearray)):
+        raise TypeError("OpenMed batch results must contain an item sequence")
+    if len(items) != expected:
+        raise ValueError(
+            f"OpenMed returned {len(items)} result(s) for {expected} input(s)"
+        )
+    return [_deidentified_text(item) for item in items]
+
+
+def _deidentified_text(item: Any) -> str:
+    if getattr(item, "error", None):
+        raise RuntimeError("Ray batch de-identification failed for one or more cells")
+    if hasattr(item, "success") and not item.success:
+        raise RuntimeError("Ray batch de-identification failed for one or more cells")
+
+    value = getattr(item, "result", item)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping) and "deidentified_text" in value:
+        return str(value["deidentified_text"])
+    if hasattr(value, "deidentified_text"):
+        return str(value.deidentified_text)
+    raise TypeError("OpenMed batch results must expose deidentified_text")
+
+
+__all__ = [
+    "ActorPoolConcurrency",
+    "BatchFormat",
+    "DEFAULT_RAY_PII_MODEL",
+    "RayDeidentifyBatch",
+    "RayMapBatchesDeidentifier",
+    "map_batches_deidentify",
+]

--- a/tests/unit/integrations/test_ray_map_batches.py
+++ b/tests/unit/integrations/test_ray_map_batches.py
@@ -1,0 +1,195 @@
+"""Offline tests for actor-backed Ray Data batch de-identification."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from openmed.integrations.ray_map_batches import (
+    RayDeidentifyBatch,
+    map_batches_deidentify,
+)
+
+
+class _FakeBatchPipeline:
+    def __init__(self, stats: Any | None = None) -> None:
+        self._stats = stats
+
+    def process_texts(self, texts, ids=None):
+        if self._stats is not None:
+            import ray
+
+            ray.get(self._stats.record_batch.remote(len(texts)))
+        items = [
+            SimpleNamespace(
+                id=ids[index] if ids else f"item_{index}",
+                success=True,
+                result=SimpleNamespace(
+                    deidentified_text=text.replace("Jane Roe", "[PERSON]")
+                    .replace("John Doe", "[PERSON]")
+                    .replace("555-0100", "[PHONE]")
+                    .replace("555-0199", "[PHONE]")
+                ),
+            )
+            for index, text in enumerate(texts)
+        ]
+        return SimpleNamespace(items=items)
+
+
+@pytest.mark.parametrize("batch_format", ["pandas", "pyarrow"])
+def test_callable_preserves_batch_shape_and_non_target_columns(batch_format):
+    pd = pytest.importorskip("pandas", exc_type=ImportError)
+    frame = pd.DataFrame(
+        {
+            "record_id": ["a", "b", "c"],
+            "note": ["Jane Roe called 555-0100", None, "No identifiers"],
+            "score": [1, 2, 3],
+        }
+    )
+    batch = frame
+    if batch_format == "pyarrow":
+        pa = pytest.importorskip("pyarrow", exc_type=ImportError)
+        batch = pa.Table.from_pandas(frame, preserve_index=False)
+
+    actor = RayDeidentifyBatch(
+        column="note",
+        policy_profile="hipaa_safe_harbor",
+        pipeline_factory=lambda **_: _FakeBatchPipeline(),
+    )
+    output = actor(batch)
+    output_frame = output if batch_format == "pandas" else output.to_pandas()
+
+    assert len(output_frame) == len(frame)
+    assert output_frame["record_id"].tolist() == frame["record_id"].tolist()
+    assert output_frame["score"].tolist() == frame["score"].tolist()
+    assert output_frame["note"].tolist()[0] == "[PERSON] called [PHONE]"
+    assert pd.isna(output_frame["note"].tolist()[1])
+    assert output_frame["note"].tolist()[2] == "No identifiers"
+
+
+def test_ray_dataset_uses_one_loaded_pipeline_per_actor():
+    ray = pytest.importorskip("ray", exc_type=ImportError)
+    pytest.importorskip("ray.data", exc_type=ImportError)
+
+    class PipelineStats:
+        def __init__(self) -> None:
+            self.loads: list[tuple[str, str | None]] = []
+            self.batch_sizes: list[int] = []
+
+        def record_load(self, model_name: str, policy_profile: str | None) -> None:
+            self.loads.append((model_name, policy_profile))
+
+        def record_batch(self, batch_size: int) -> None:
+            self.batch_sizes.append(batch_size)
+
+        def snapshot(self) -> dict[str, Any]:
+            return {
+                "loads": list(self.loads),
+                "batch_sizes": list(self.batch_sizes),
+            }
+
+    class FakeBatchPipeline:
+        def __init__(self, stats: Any) -> None:
+            self._stats = stats
+
+        def process_texts(self, texts, ids=None):
+            ray.get(self._stats.record_batch.remote(len(texts)))
+            items = [
+                SimpleNamespace(
+                    id=ids[index] if ids else f"item_{index}",
+                    success=True,
+                    result=SimpleNamespace(
+                        deidentified_text=text.replace("Jane Roe", "[PERSON]")
+                        .replace("John Doe", "[PERSON]")
+                        .replace("555-0100", "[PHONE]")
+                        .replace("555-0199", "[PHONE]")
+                    ),
+                )
+                for index, text in enumerate(texts)
+            ]
+            return SimpleNamespace(items=items)
+
+    class FakePipelineFactory:
+        def __init__(self, stats: Any) -> None:
+            self._stats = stats
+
+        def __call__(self, **kwargs):
+            ray.get(
+                self._stats.record_load.remote(
+                    kwargs["model_name"],
+                    kwargs["policy_profile"],
+                )
+            )
+            return FakeBatchPipeline(self._stats)
+
+    ray.shutdown()
+    try:
+        ray.init(local_mode=True, num_cpus=2, include_dashboard=False)
+    except RuntimeError as exc:
+        if "local_mode` is no longer supported" not in str(exc):
+            raise
+        ray.init(address="local", num_cpus=2, include_dashboard=False)
+    try:
+        stats_type = ray.remote(num_cpus=0)(PipelineStats)
+        stats = stats_type.remote()
+        records = [
+            {
+                "record_id": "a",
+                "note": "Jane Roe called 555-0100",
+                "score": 1,
+            },
+            {"record_id": "b", "note": "No identifiers", "score": 2},
+            {
+                "record_id": "c",
+                "note": "John Doe called 555-0199",
+                "score": 3,
+            },
+            {"record_id": "d", "note": "Follow-up", "score": 4},
+            {"record_id": "e", "note": "Discharge summary", "score": 5},
+        ]
+        dataset = ray.data.from_items(records, override_num_blocks=3)
+
+        redacted = map_batches_deidentify(
+            dataset,
+            column="note",
+            policy_profile="strict_no_leak",
+            model_name="fixture-pii-model",
+            batch_size=2,
+            batch_format="pandas",
+            concurrency=1,
+            pipeline_factory=FakePipelineFactory(stats),
+        ).materialize()
+        output = redacted.to_pandas()
+        snapshot = ray.get(stats.snapshot.remote())
+
+        assert len(output) == len(records)
+        assert output["record_id"].tolist() == [row["record_id"] for row in records]
+        assert output["score"].tolist() == [row["score"] for row in records]
+        assert "Jane Roe" not in "\n".join(output["note"])
+        assert "John Doe" not in "\n".join(output["note"])
+        assert snapshot["loads"] == [("fixture-pii-model", "strict_no_leak")]
+        assert sum(snapshot["batch_sizes"]) == len(records)
+        assert max(snapshot["batch_sizes"]) <= 2
+    finally:
+        ray.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("concurrency", "message"),
+    [
+        (0, "at least 1"),
+        ((2, 1), "1 <= min <= max"),
+        ((1, 3, 4), "between min and max"),
+    ],
+)
+def test_invalid_actor_pool_concurrency_is_rejected(concurrency, message):
+    class Strategy:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    from openmed.integrations.ray_map_batches import _actor_pool_strategy
+
+    with pytest.raises(ValueError, match=message):
+        _actor_pool_strategy(Strategy, concurrency)


### PR DESCRIPTION
## Description

Adds a stateful Ray Data `map_batches` integration that creates one de-identification pipeline per actor and reuses its loaded model across batches. The helper supports pandas and PyArrow batches, fixed or autoscaling actor pools, explicit policy/column selection, and preserves row counts plus non-target columns.

Closes #848.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Add `RayDeidentifyBatch` and `map_batches_deidentify` with actor-local model reuse.
- Preserve batch shape, nulls, non-target columns, and end-to-end row counts for pandas and PyArrow inputs.
- Add an offline single-node Ray Dataset test and integration guide with actor-pool configuration examples.

## Testing

- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different production models

Validation run:

- `.venv/bin/python -m pytest tests/ -q` — 5,173 passed, 46 skipped
- `make format`
- `make lint`
- `make format-check`
- `pre-commit run --files ...`
- `mkdocs build --strict`

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious actor/pipeline behavior

## Dependencies

- [x] I have not added any new project dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have organized the commit appropriately

## Related Issues

Closes #848

## Screenshots/Examples

The new integration guide includes fixed-size and autoscaling actor-pool examples for both supported batch formats.
