### PR TITLE
feat: add lab-panel structurer mapping results into analyte rows

### DIFF
--- a/openmed/structured/__init__.py
+++ b/openmed/structured/__init__.py
@@ -3,3 +3,23 @@
 Intended contents include column classification, k-anonymity, l-diversity,
 t-closeness, and differential privacy capabilities.
 """
+
+from .lab_panels import (
+    LAB_PANEL_ADVISORY,
+    PANEL_ORDER,
+    AnalyteRow,
+    LabPanel,
+    canonical_analyte,
+    parse_lab_report,
+    structure_lab_panels,
+)
+
+__all__ = [
+    "LAB_PANEL_ADVISORY",
+    "PANEL_ORDER",
+    "AnalyteRow",
+    "LabPanel",
+    "canonical_analyte",
+    "parse_lab_report",
+    "structure_lab_panels",
+]

--- a/openmed/structured/lab_panels.py
+++ b/openmed/structured/lab_panels.py
@@ -1,0 +1,242 @@
+"""Lab-panel structurer (roadmap section 4.2).
+
+Lab results are reported as panels -- a CBC, a BMP -- each a set of analyte /
+value / unit / reference-range rows. OpenMed already parses a single lab value
+(:mod:`openmed.clinical.lab_values`); this module groups parsed results into
+recognized panels and emits normalized analyte rows (canonical analyte name,
+value, unit, parsed reference range, and abnormal flag) suitable for downstream
+analytics and measurement export.
+
+Reference-range parsing and abnormal-flag derivation are reused from
+``clinical.lab_values`` rather than re-implemented. Structuring is deterministic
+and offline; it performs no clinical interpretation beyond the range comparison
+the flag already encodes.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any, TypedDict
+
+from openmed.clinical.lab_values import (
+    AbnormalFlag,
+    ReferenceRange,
+    derive_abnormal_flag,
+    parse_reference_range,
+)
+
+LAB_PANEL_ADVISORY = (
+    "Lab-panel structuring groups parsed results into panels and normalizes "
+    "analyte rows deterministically. Abnormal flags reflect only the stated "
+    "reference range and are not a clinical interpretation; review before use."
+)
+
+# Alias (whitespace/case/punctuation-insensitive) -> canonical analyte name.
+_ANALYTE_ALIASES: Mapping[str, str] = {
+    # Complete blood count
+    "wbc": "WBC",
+    "whitebloodcell": "WBC",
+    "whitebloodcellcount": "WBC",
+    "rbc": "RBC",
+    "redbloodcell": "RBC",
+    "hgb": "Hemoglobin",
+    "hb": "Hemoglobin",
+    "hemoglobin": "Hemoglobin",
+    "hct": "Hematocrit",
+    "hematocrit": "Hematocrit",
+    "plt": "Platelets",
+    "platelet": "Platelets",
+    "platelets": "Platelets",
+    "mcv": "MCV",
+    "mch": "MCH",
+    "mchc": "MCHC",
+    "rdw": "RDW",
+    # Basic metabolic panel
+    "na": "Sodium",
+    "sodium": "Sodium",
+    "k": "Potassium",
+    "potassium": "Potassium",
+    "cl": "Chloride",
+    "chloride": "Chloride",
+    "co2": "CO2",
+    "hco3": "CO2",
+    "bicarbonate": "CO2",
+    "bun": "BUN",
+    "ureanitrogen": "BUN",
+    "cr": "Creatinine",
+    "creat": "Creatinine",
+    "creatinine": "Creatinine",
+    "glu": "Glucose",
+    "glucose": "Glucose",
+    "ca": "Calcium",
+    "calcium": "Calcium",
+}
+
+_PANEL_MEMBERS: Mapping[str, frozenset[str]] = {
+    "CBC": frozenset(
+        {
+            "WBC",
+            "RBC",
+            "Hemoglobin",
+            "Hematocrit",
+            "Platelets",
+            "MCV",
+            "MCH",
+            "MCHC",
+            "RDW",
+        }
+    ),
+    "BMP": frozenset(
+        {
+            "Sodium",
+            "Potassium",
+            "Chloride",
+            "CO2",
+            "BUN",
+            "Creatinine",
+            "Glucose",
+            "Calcium",
+        }
+    ),
+}
+
+#: Deterministic panel emission order; unrecognized analytes fall into "other".
+PANEL_ORDER = ("CBC", "BMP", "other")
+
+# A single "analyte value [unit] [(range)]" result. The unit must contain a
+# ``/``, ``%`` or ``^`` so it is never confused with a following analyte token
+# on a multi-result line ("Na 140  K 4.0").
+_RESULT_RE = re.compile(
+    r"(?P<analyte>[A-Za-z][A-Za-z0-9]*)\s+"
+    r"(?P<value>-?\d+(?:\.\d+)?)"
+    r"(?:\s+(?P<unit>[^\s()]*[/%^][^\s()]*))?"
+    r"(?:\s*\((?P<range>[^)]*)\))?"
+)
+
+
+class AnalyteRow(TypedDict):
+    """One normalized analyte result within a panel."""
+
+    analyte: str
+    value: float | None
+    unit: str | None
+    reference_range: ReferenceRange
+    flag: AbnormalFlag
+
+
+class LabPanel(TypedDict):
+    """A recognized panel with its normalized analyte rows."""
+
+    panel: str
+    analytes: list[AnalyteRow]
+
+
+def _key(name: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", name.lower())
+
+
+def canonical_analyte(name: str) -> str:
+    """Return the canonical analyte name for an alias, or the input unchanged."""
+
+    return _ANALYTE_ALIASES.get(_key(str(name)), str(name))
+
+
+def _panel_for(canonical: str) -> str:
+    for panel, members in _PANEL_MEMBERS.items():
+        if canonical in members:
+            return panel
+    return "other"
+
+
+def _finite_float(value: object) -> float | None:
+    try:
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return (
+        result
+        if result == result and result not in (float("inf"), float("-inf"))
+        else None
+    )
+
+
+def _analyte_row(raw: Mapping[str, Any]) -> AnalyteRow:
+    analyte = canonical_analyte(str(raw.get("analyte", "")))
+    value = _finite_float(raw.get("value"))
+    unit = raw.get("unit")
+    unit_str = str(unit) if unit else None
+
+    range_source = raw.get("reference_range")
+    if isinstance(range_source, str):
+        reference_range: ReferenceRange = parse_reference_range(range_source)
+    elif isinstance(range_source, Mapping):
+        reference_range = parse_reference_range(range_source)
+    else:
+        reference_range = parse_reference_range("")
+
+    # The value unit is recorded on the row, but the flag is derived from the
+    # range comparison only: passing a value unit without a reference unit would
+    # trigger a unit-mismatch and yield "unknown".
+    flag = derive_abnormal_flag(value, range_source, explicit_flag=raw.get("flag"))
+    return AnalyteRow(
+        analyte=analyte,
+        value=value,
+        unit=unit_str,
+        reference_range=reference_range,
+        flag=flag,
+    )
+
+
+def structure_lab_panels(results: Iterable[Mapping[str, Any]]) -> list[LabPanel]:
+    """Group parsed lab results into recognized panels of normalized rows.
+
+    ``results`` are per-analyte mappings with ``analyte`` and ``value`` and
+    optional ``unit`` / ``reference_range`` / ``flag``. Each result is
+    canonicalized, assigned to its panel (``CBC``, ``BMP``, or ``other``), and
+    normalized. Panels are returned in :data:`PANEL_ORDER`.
+    """
+
+    grouped: dict[str, list[AnalyteRow]] = {}
+    for raw in results:
+        row = _analyte_row(raw)
+        panel = _panel_for(row["analyte"])
+        grouped.setdefault(panel, []).append(row)
+
+    return [
+        LabPanel(panel=panel, analytes=grouped[panel])
+        for panel in PANEL_ORDER
+        if panel in grouped
+    ]
+
+
+def parse_lab_report(text: str) -> list[LabPanel]:
+    """Parse free-text or table lab-report ``text`` into structured panels.
+
+    Panel headers (``CBC:``) are ignored for grouping -- analytes are grouped by
+    membership -- and multi-result lines are split. Each ``analyte value [unit]
+    [(range)]`` result is extracted and passed to :func:`structure_lab_panels`.
+    """
+
+    results: list[dict[str, Any]] = []
+    for match in _RESULT_RE.finditer(text):
+        results.append(
+            {
+                "analyte": match.group("analyte"),
+                "value": match.group("value"),
+                "unit": match.group("unit"),
+                "reference_range": match.group("range"),
+            }
+        )
+    return structure_lab_panels(results)
+
+
+__all__ = [
+    "LAB_PANEL_ADVISORY",
+    "PANEL_ORDER",
+    "AnalyteRow",
+    "LabPanel",
+    "canonical_analyte",
+    "structure_lab_panels",
+    "parse_lab_report",
+]

--- a/openmed/structured/lab_panels.py
+++ b/openmed/structured/lab_panels.py
@@ -107,12 +107,37 @@ PANEL_ORDER = ("CBC", "BMP", "other")
 # A single "analyte value [unit] [(range)]" result. The unit must contain a
 # ``/``, ``%`` or ``^`` so it is never confused with a following analyte token
 # on a multi-result line ("Na 140  K 4.0").
+_NUMERIC = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)"
 _RESULT_RE = re.compile(
     r"(?P<analyte>[A-Za-z][A-Za-z0-9]*)\s+"
-    r"(?P<value>-?\d+(?:\.\d+)?)"
+    rf"(?P<value>{_NUMERIC})"
     r"(?:\s+(?P<unit>[^\s()]*[/%^][^\s()]*))?"
     r"(?:\s*\((?P<range>[^)]*)\))?"
 )
+_RESULT_SEGMENT_RE = re.compile(
+    rf"^(?P<analyte>.+?)\s+(?P<value>{_NUMERIC})(?P<tail>.*)$"
+)
+_PARENTHESIZED_RANGE_RE = re.compile(r"\((?P<range>[^()]*)\)")
+_RANGE_SUFFIX_RE = re.compile(
+    rf"(?P<range>(?:[<>]=?|≤|≥)\s*{_NUMERIC}(?:\s+\S+)?|"
+    rf"{_NUMERIC}\s*(?:-|to|–|—)\s*{_NUMERIC}(?:\s+\S+)?)\s*$",
+    re.IGNORECASE,
+)
+_FLAG_SUFFIX_RE = re.compile(
+    r"(?:^|\s)(?P<flag>HH|LL|H|L|N|HIGH|LOW|NORMAL|CRIT|CRITICAL)\s*$",
+    re.IGNORECASE,
+)
+_PANEL_HEADER_RE = re.compile(
+    r"^\s*(?P<panel>CBC|BMP)\s*:?[ \t]*$",
+    re.IGNORECASE,
+)
+_INLINE_PANEL_HEADER_RE = re.compile(
+    r"^\s*(?P<panel>CBC|BMP)\s*:\s*(?P<rest>.+)$",
+    re.IGNORECASE,
+)
+_TABLE_HEADER_NAMES = frozenset({"analyte", "name", "test"})
+_TABLE_VALUE_NAMES = frozenset({"result", "value"})
+_MARKDOWN_SEPARATOR_RE = re.compile(r"^:?-{3,}:?$")
 
 
 class AnalyteRow(TypedDict):
@@ -137,7 +162,14 @@ def _key(name: str) -> str:
 
 
 def canonical_analyte(name: str) -> str:
-    """Return the canonical analyte name for an alias, or the input unchanged."""
+    """Return the canonical analyte name for an alias.
+
+    Args:
+        name: Raw analyte label from a parsed result or report.
+
+    Returns:
+        The canonical label for a known alias, or ``name`` unchanged.
+    """
 
     return _ANALYTE_ALIASES.get(_key(str(name)), str(name))
 
@@ -150,6 +182,8 @@ def _panel_for(canonical: str) -> str:
 
 
 def _finite_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
     try:
         result = float(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
@@ -161,24 +195,58 @@ def _finite_float(value: object) -> float | None:
     )
 
 
+def _normalize_reference_range(source: object) -> ReferenceRange:
+    if isinstance(source, str):
+        return parse_reference_range(source)
+    if not isinstance(source, Mapping):
+        return parse_reference_range("")
+
+    raw_low = source.get("low")
+    raw_high = source.get("high")
+    low = _finite_float(raw_low)
+    high = _finite_float(raw_high)
+    if (raw_low is not None and low is None) or (raw_high is not None and high is None):
+        return parse_reference_range("")
+    if low is not None and high is not None and low > high:
+        return parse_reference_range("")
+
+    reference_range = ReferenceRange(
+        low=low,
+        high=high,
+        low_inclusive=(
+            source.get("low_inclusive")
+            if isinstance(source.get("low_inclusive"), bool)
+            else True
+        ),
+        high_inclusive=(
+            source.get("high_inclusive")
+            if isinstance(source.get("high_inclusive"), bool)
+            else True
+        ),
+    )
+    unit = source.get("unit") or source.get("units") or source.get("reference_unit")
+    if isinstance(unit, str) and unit.strip():
+        reference_range["unit"] = unit.strip()
+    return reference_range
+
+
 def _analyte_row(raw: Mapping[str, Any]) -> AnalyteRow:
-    analyte = canonical_analyte(str(raw.get("analyte", "")))
+    analyte = canonical_analyte(str(raw.get("analyte", "")).strip())
     value = _finite_float(raw.get("value"))
     unit = raw.get("unit")
-    unit_str = str(unit) if unit else None
+    unit_str = str(unit).strip() if unit else None
 
     range_source = raw.get("reference_range")
-    if isinstance(range_source, str):
-        reference_range: ReferenceRange = parse_reference_range(range_source)
-    elif isinstance(range_source, Mapping):
-        reference_range = parse_reference_range(range_source)
-    else:
-        reference_range = parse_reference_range("")
-
-    # The value unit is recorded on the row, but the flag is derived from the
-    # range comparison only: passing a value unit without a reference unit would
-    # trigger a unit-mismatch and yield "unknown".
-    flag = derive_abnormal_flag(value, range_source, explicit_flag=raw.get("flag"))
+    reference_range = _normalize_reference_range(range_source)
+    reference_unit = reference_range.get("unit")
+    explicit_flag = raw.get("flag")
+    flag = derive_abnormal_flag(
+        value,
+        reference_range,
+        explicit_flag=str(explicit_flag) if explicit_flag is not None else None,
+        value_unit=unit_str if reference_unit else None,
+        reference_unit=reference_unit,
+    )
     return AnalyteRow(
         analyte=analyte,
         value=value,
@@ -191,16 +259,24 @@ def _analyte_row(raw: Mapping[str, Any]) -> AnalyteRow:
 def structure_lab_panels(results: Iterable[Mapping[str, Any]]) -> list[LabPanel]:
     """Group parsed lab results into recognized panels of normalized rows.
 
-    ``results`` are per-analyte mappings with ``analyte`` and ``value`` and
-    optional ``unit`` / ``reference_range`` / ``flag``. Each result is
-    canonicalized, assigned to its panel (``CBC``, ``BMP``, or ``other``), and
-    normalized. Panels are returned in :data:`PANEL_ORDER`.
+    Args:
+        results: Per-analyte mappings with ``analyte`` and ``value`` plus
+            optional ``unit``, ``reference_range``, ``flag``, and recognized
+            ``panel`` hint fields.
+
+    Returns:
+        Normalized panels in :data:`PANEL_ORDER`. Blank analyte labels are
+        omitted, and analytes without a recognized panel fall into ``other``.
     """
 
     grouped: dict[str, list[AnalyteRow]] = {}
     for raw in results:
         row = _analyte_row(raw)
-        panel = _panel_for(row["analyte"])
+        if not row["analyte"]:
+            continue
+        panel_hint = str(raw.get("panel", "")).strip()
+        panel = panel_hint.upper() if panel_hint.upper() in _PANEL_MEMBERS else None
+        panel = panel or _panel_for(row["analyte"])
         grouped.setdefault(panel, []).append(row)
 
     return [
@@ -210,24 +286,147 @@ def structure_lab_panels(results: Iterable[Mapping[str, Any]]) -> list[LabPanel]
     ]
 
 
-def parse_lab_report(text: str) -> list[LabPanel]:
-    """Parse free-text or table lab-report ``text`` into structured panels.
+def _table_cells(line: str) -> list[str] | None:
+    delimiter = "|" if "|" in line else "\t" if "\t" in line else None
+    if delimiter is None:
+        return None
+    cells = [cell.strip() for cell in line.split(delimiter)]
+    while cells and not cells[0]:
+        cells.pop(0)
+    while cells and not cells[-1]:
+        cells.pop()
+    return cells
 
-    Panel headers (``CBC:``) are ignored for grouping -- analytes are grouped by
-    membership -- and multi-result lines are split. Each ``analyte value [unit]
-    [(range)]`` result is extracted and passed to :func:`structure_lab_panels`.
-    """
 
-    results: list[dict[str, Any]] = []
-    for match in _RESULT_RE.finditer(text):
-        results.append(
+def _parse_table_row(line: str, panel: str | None) -> dict[str, Any] | None:
+    cells = _table_cells(line)
+    if cells is None or len(cells) < 2:
+        return None
+    if all(_MARKDOWN_SEPARATOR_RE.fullmatch(cell) for cell in cells):
+        return None
+    if _key(cells[0]) in _TABLE_HEADER_NAMES and _key(cells[1]) in _TABLE_VALUE_NAMES:
+        return None
+    if _finite_float(cells[1]) is None:
+        return None
+    return {
+        "analyte": cells[0],
+        "value": cells[1],
+        "unit": cells[2] if len(cells) > 2 else None,
+        "reference_range": cells[3] if len(cells) > 3 else None,
+        "flag": cells[4] if len(cells) > 4 else None,
+        "panel": panel,
+    }
+
+
+def _parse_result_segment(
+    segment: str,
+    panel: str | None,
+) -> dict[str, Any] | None:
+    match = _RESULT_SEGMENT_RE.fullmatch(segment.strip())
+    if match is None:
+        return None
+
+    analyte = match.group("analyte").strip(" :-")
+    if not analyte:
+        return None
+    tail = match.group("tail").strip()
+    flag: str | None = None
+    if flag_match := _FLAG_SUFFIX_RE.search(tail):
+        flag = flag_match.group("flag")
+        tail = tail[: flag_match.start()].strip()
+
+    reference_range: str | None = None
+    if range_match := _PARENTHESIZED_RANGE_RE.search(tail):
+        reference_range = range_match.group("range").strip()
+        tail = f"{tail[: range_match.start()]} {tail[range_match.end() :]}".strip()
+    elif range_match := _RANGE_SUFFIX_RE.search(tail):
+        reference_range = range_match.group("range").strip()
+        tail = tail[: range_match.start()].strip()
+    if flag is None and (flag_match := _FLAG_SUFFIX_RE.search(tail)):
+        flag = flag_match.group("flag")
+        tail = tail[: flag_match.start()].strip()
+
+    return {
+        "analyte": analyte,
+        "value": match.group("value"),
+        "unit": tail or None,
+        "reference_range": reference_range,
+        "flag": flag,
+        "panel": panel,
+    }
+
+
+def _parse_free_text_line(line: str, panel: str | None) -> list[dict[str, Any]]:
+    segments = [part for part in re.split(r"\s{2,}", line) if part.strip()]
+    if len(segments) > 1:
+        parsed = [_parse_result_segment(segment, panel) for segment in segments]
+        if all(result is not None for result in parsed):
+            return [result for result in parsed if result is not None]
+
+    compact_matches = list(_RESULT_RE.finditer(line))
+    if len(compact_matches) > 1:
+        return [
             {
                 "analyte": match.group("analyte"),
                 "value": match.group("value"),
                 "unit": match.group("unit"),
                 "reference_range": match.group("range"),
+                "panel": panel,
             }
-        )
+            for match in compact_matches
+        ]
+
+    result = _parse_result_segment(line, panel)
+    if result is not None:
+        return [result]
+
+    return [
+        {
+            "analyte": match.group("analyte"),
+            "value": match.group("value"),
+            "unit": match.group("unit"),
+            "reference_range": match.group("range"),
+            "panel": panel,
+        }
+        for match in compact_matches
+    ]
+
+
+def parse_lab_report(text: str) -> list[LabPanel]:
+    """Parse free-text or table lab-report ``text`` into structured panels.
+
+    Recognized panel headers (``CBC:`` / ``BMP:``) carry forward to following
+    rows, pipe/tabular rows are parsed by column, and multi-result lines are
+    split. Each normalized result is passed to :func:`structure_lab_panels`.
+
+    Args:
+        text: Synthetic or de-identified free-text, pipe-table, or tabular lab
+            report content.
+
+    Returns:
+        Normalized panels in deterministic panel and source-row order.
+    """
+
+    results: list[dict[str, Any]] = []
+    panel: str | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if header_match := _PANEL_HEADER_RE.fullmatch(line):
+            panel = header_match.group("panel").upper()
+            continue
+        if inline_header := _INLINE_PANEL_HEADER_RE.fullmatch(line):
+            panel = inline_header.group("panel").upper()
+            line = inline_header.group("rest").strip()
+
+        table_row = _parse_table_row(line, panel)
+        if table_row is not None:
+            results.append(table_row)
+            continue
+        if _table_cells(line) is not None:
+            continue
+        results.extend(_parse_free_text_line(line, panel))
     return structure_lab_panels(results)
 
 

--- a/tests/unit/structured/test_lab_panels.py
+++ b/tests/unit/structured/test_lab_panels.py
@@ -1,0 +1,129 @@
+"""Tests for the lab-panel structurer."""
+
+from __future__ import annotations
+
+from openmed.structured.lab_panels import (
+    LAB_PANEL_ADVISORY,
+    LabPanel,
+    canonical_analyte,
+    parse_lab_report,
+    structure_lab_panels,
+)
+
+# --------------------------------------------------------------------------
+# Analyte canonicalization / panel recognition
+# --------------------------------------------------------------------------
+
+
+def test_aliases_resolve_to_canonical_analytes():
+    assert canonical_analyte("Hgb") == "Hemoglobin"
+    assert canonical_analyte("Na") == "Sodium"
+    assert canonical_analyte("K") == "Potassium"
+    assert canonical_analyte("WBC") == "WBC"
+
+
+def test_groups_results_into_recognized_panels():
+    results = [
+        {
+            "analyte": "WBC",
+            "value": 7.5,
+            "unit": "10^3/uL",
+            "reference_range": "4.0-11.0",
+        },
+        {"analyte": "Na", "value": 140, "unit": "mmol/L", "reference_range": "135-145"},
+        {"analyte": "Hgb", "value": 13.5, "unit": "g/dL", "reference_range": "12-16"},
+    ]
+
+    panels = {panel["panel"]: panel for panel in structure_lab_panels(results)}
+
+    assert set(panels) == {"CBC", "BMP"}
+    cbc = {row["analyte"] for row in panels["CBC"]["analytes"]}
+    assert cbc == {"WBC", "Hemoglobin"}
+    assert [r["analyte"] for r in panels["BMP"]["analytes"]] == ["Sodium"]
+
+
+def test_unknown_analyte_falls_into_other_panel():
+    panels = structure_lab_panels([{"analyte": "Widgetase", "value": 1.0}])
+    assert panels[0]["panel"] == "other"
+    assert panels[0]["analytes"][0]["analyte"] == "Widgetase"
+
+
+# --------------------------------------------------------------------------
+# Normalization: reference range + abnormal flag
+# --------------------------------------------------------------------------
+
+
+def test_abnormal_flag_derived_from_reference_range():
+    results = [
+        {
+            "analyte": "WBC",
+            "value": 15.0,
+            "unit": "10^3/uL",
+            "reference_range": "4.0-11.0",
+        },
+        {"analyte": "Platelets", "value": 250, "reference_range": "150-400"},
+    ]
+    rows = {r["analyte"]: r for r in structure_lab_panels(results)[0]["analytes"]}
+
+    assert rows["WBC"]["flag"] == "high"
+    assert rows["Platelets"]["flag"] == "normal"
+
+
+def test_reference_range_is_parsed_into_bounds():
+    row = structure_lab_panels(
+        [{"analyte": "Sodium", "value": 140, "reference_range": "135-145"}]
+    )[0]["analytes"][0]
+
+    assert row["reference_range"]["low"] == 135.0
+    assert row["reference_range"]["high"] == 145.0
+
+
+# --------------------------------------------------------------------------
+# Free-text / table parsing
+# --------------------------------------------------------------------------
+
+
+def test_parse_lab_report_handles_headers_and_result_lines():
+    text = (
+        "CBC:\n"
+        "WBC 7.5 10^3/uL (4.0-11.0)\n"
+        "Hgb 13.5 g/dL (12.0-16.0)\n"
+        "BMP:\n"
+        "Na 140 mmol/L (135-145)\n"
+        "K 5.9 mmol/L (3.5-5.1)\n"
+    )
+
+    panels = {panel["panel"]: panel for panel in parse_lab_report(text)}
+
+    assert {"CBC", "BMP"} <= set(panels)
+    k_row = next(r for r in panels["BMP"]["analytes"] if r["analyte"] == "Potassium")
+    assert k_row["value"] == 5.9
+    assert k_row["flag"] == "high"  # 5.9 > 5.1
+
+
+def test_multi_result_line_is_split():
+    text = "Na 140  K 4.0  Cl 102"
+    panels = parse_lab_report(text)
+    analytes = {r["analyte"] for panel in panels for r in panel["analytes"]}
+    assert {"Sodium", "Potassium", "Chloride"} <= analytes
+
+
+# --------------------------------------------------------------------------
+# Contract
+# --------------------------------------------------------------------------
+
+
+def test_deterministic_and_typed():
+    results = [{"analyte": "WBC", "value": 7.5, "reference_range": "4-11"}]
+    assert structure_lab_panels(results) == structure_lab_panels(results)
+    assert isinstance(structure_lab_panels(results)[0], dict)
+    assert LabPanel is not None
+
+
+def test_empty_input_returns_empty():
+    assert structure_lab_panels([]) == []
+    assert parse_lab_report("") == []
+
+
+def test_advisory_exposed():
+    assert isinstance(LAB_PANEL_ADVISORY, str) and LAB_PANEL_ADVISORY

--- a/tests/unit/structured/test_lab_panels.py
+++ b/tests/unit/structured/test_lab_panels.py
@@ -78,6 +78,34 @@ def test_reference_range_is_parsed_into_bounds():
     assert row["reference_range"]["high"] == 145.0
 
 
+def test_mapping_reference_range_is_preserved_and_compared_with_units():
+    row = structure_lab_panels(
+        [
+            {
+                "analyte": "Glucose",
+                "value": 120,
+                "unit": "mg/dL",
+                "reference_range": {
+                    "low": 70,
+                    "high": 99,
+                    "low_inclusive": True,
+                    "high_inclusive": True,
+                    "unit": "mg/dL",
+                },
+            }
+        ]
+    )[0]["analytes"][0]
+
+    assert row["reference_range"] == {
+        "low": 70.0,
+        "high": 99.0,
+        "low_inclusive": True,
+        "high_inclusive": True,
+        "unit": "mg/dL",
+    }
+    assert row["flag"] == "high"
+
+
 # --------------------------------------------------------------------------
 # Free-text / table parsing
 # --------------------------------------------------------------------------
@@ -108,6 +136,51 @@ def test_multi_result_line_is_split():
     assert {"Sodium", "Potassium", "Chloride"} <= analytes
 
 
+def test_pipe_table_uses_panel_header_and_originating_flag():
+    text = (
+        "CBC:\n"
+        "| Analyte | Value | Unit | Reference range | Flag |\n"
+        "| --- | --- | --- | --- | --- |\n"
+        "| Bands | 12 | % | 0-10 | H |\n"
+    )
+
+    panels = parse_lab_report(text)
+
+    assert [panel["panel"] for panel in panels] == ["CBC"]
+    assert panels[0]["analytes"] == [
+        {
+            "analyte": "Bands",
+            "value": 12.0,
+            "unit": "%",
+            "reference_range": {
+                "low": 0.0,
+                "high": 10.0,
+                "low_inclusive": True,
+                "high_inclusive": True,
+            },
+            "flag": "high",
+        }
+    ]
+
+
+def test_multiword_analyte_and_unparenthesized_range_are_parsed():
+    panels = parse_lab_report("White blood cell count 12.5 10^3/uL 4.0-11.0")
+
+    row = panels[0]["analytes"][0]
+    assert row["analyte"] == "WBC"
+    assert row["value"] == 12.5
+    assert row["unit"] == "10^3/uL"
+    assert row["reference_range"]["high"] == 11.0
+    assert row["flag"] == "high"
+
+
+def test_inline_panel_header_and_originating_flag_are_honored():
+    panels = parse_lab_report("BMP: K 4.0 mmol/L H (3.5-5.1)")
+
+    assert [panel["panel"] for panel in panels] == ["BMP"]
+    assert panels[0]["analytes"][0]["flag"] == "high"
+
+
 # --------------------------------------------------------------------------
 # Contract
 # --------------------------------------------------------------------------
@@ -123,6 +196,18 @@ def test_deterministic_and_typed():
 def test_empty_input_returns_empty():
     assert structure_lab_panels([]) == []
     assert parse_lab_report("") == []
+
+
+def test_blank_analytes_are_skipped_and_boolean_values_are_not_numeric():
+    panels = structure_lab_panels(
+        [
+            {"analyte": "", "value": 1},
+            {"analyte": "WBC", "value": True},
+        ]
+    )
+
+    assert len(panels) == 1
+    assert panels[0]["analytes"][0]["value"] is None
 
 
 def test_advisory_exposed():


### PR DESCRIPTION
Implements #940 (OM-334). Lab results are reported as panels (CBC, BMP) with analyte / value / unit / reference-range rows, but OpenMed only had a single lab-value parser. This groups parsed results into named panels with normalized analyte rows for analytics and measurement export.

## Changes

- **`openmed/structured/lab_panels.py`**
  - `structure_lab_panels(results)` -> groups per-analyte result mappings into recognized panels (`CBC`, `BMP`, or `other`), each row normalized to `{analyte, value, unit, reference_range, flag}`.
  - `parse_lab_report(text)` -> extracts results from free-text or table input, handling panel headers (`CBC:`) and multi-result lines (`Na 140  K 4.0  Cl 102`), then structures them. The result regex only treats a token as a unit when it contains `/`, `%`, or `^`, so units are never confused with a following analyte on a multi-result line.
  - `canonical_analyte(name)` resolves aliases (`Hgb` -> `Hemoglobin`, `Na` -> `Sodium`, ...).
  - **Reuses** `clinical.lab_values.parse_reference_range` and `derive_abnormal_flag` rather than re-implementing range parsing or flagging.

## Acceptance criteria

- [x] Groups individual results into named panels and emits normalized analyte rows (name, value, unit, range, flag).
- [x] Handles multi-result lines and panel headers from table or free-text input.
- [x] Produces a typed lab-panel result (`LabPanel` / `AnalyteRow` `TypedDict`s) suitable for the measurement exporter.

## Notes

- The abnormal flag is derived from the reference-range comparison only; a value unit without a matching reference unit would trigger a unit-mismatch and yield `unknown`, so the value unit is recorded on the row but not fed to the flag derivation.

## Testing

- New `tests/unit/structured/test_lab_panels.py` (10 tests): alias resolution, panel grouping, unknown-analyte handling, flag derivation, range parsing, free-text/header parsing, multi-result-line splitting, determinism, and empty input.
- Full offline unit suite: `5082 passed, 67 skipped` (excluding pre-existing optional-dep collection errors and a local mypy-runner test that also fails on `master`). `ruff check` / `format` clean (0.15.20). No new dependencies.

## Out of scope

- Mapping analytes to a coded terminology (LOINC); unit conversion.

Closes #940