### PR TITLE
Add HMAC request signing with replay protection to the service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added versioned HMAC-SHA256 request signing over method, path, timestamp,
+  nonce, and body digest, with client-side header helpers, bounded fail-closed
+  replay protection, and verifier-compatible signatures on async job webhooks
+  (#849).
 - Added a Prefect integration with a `deidentify_file_task` task and a
   `deidentify_dataset_flow` flow that fan the local dataset redaction runner
   over lists of files and return PHI-free count summaries. Prefect stays an

--- a/docs/serving/async-jobs.md
+++ b/docs/serving/async-jobs.md
@@ -86,11 +86,14 @@ Webhook requests include:
 
 - `X-OpenMed-Event`: `job.done` or `job.failed`
 - `X-OpenMed-Timestamp`: Unix timestamp
+- `X-OpenMed-Nonce`: unique opaque request nonce
 - `X-OpenMed-Signature`: `sha256=<hmac>`
 
-The signature is computed over `<timestamp>.<canonical-json-body>` using the
-configured shared secret and HMAC-SHA256. Non-2xx responses and transport
-errors are retried with exponential backoff.
+The signature uses the shared
+[HMAC request-signing scheme](request-signing.md), covering `POST`, the exact
+callback path and query, timestamp, nonce, and SHA-256 digest of the canonical
+JSON body. Non-2xx responses and transport errors are retried with exponential
+backoff.
 
 ## Local Store Configuration
 

--- a/docs/serving/request-signing.md
+++ b/docs/serving/request-signing.md
@@ -1,0 +1,130 @@
+# HMAC Request Signing
+
+OpenMed provides a shared HMAC-SHA256 scheme for callers that need request
+integrity and replay protection. It is available for inbound request
+verification and is also used by async job webhooks.
+
+This is an application-level integrity check. Keep using HTTPS, service
+authentication, and a secret manager; request signing does not replace them.
+
+## Signature Headers
+
+Every signed request carries exactly these headers:
+
+- `X-OpenMed-Timestamp`: Unix time in whole seconds
+- `X-OpenMed-Nonce`: a unique, opaque value for this request
+- `X-OpenMed-Signature`: `sha256=<64 lowercase hex characters>`
+
+The default freshness window is 300 seconds. Keep clocks synchronized and
+generate a new nonce for every new request.
+
+## Canonical String
+
+The version 1 canonical string is UTF-8 encoded with newline separators:
+
+```text
+OPENMED-HMAC-SHA256-V1
+<UPPERCASE HTTP METHOD>
+<EXACT PATH AND QUERY>
+<UNIX TIMESTAMP>
+<NONCE>
+sha256:<LOWERCASE SHA-256 OF THE EXACT BODY BYTES>
+```
+
+Use the origin-form request target, such as `/jobs?mode=async`. Do not include
+the scheme, host, or URL fragment, and do not decode or reorder query
+parameters. The body hash—not the body—is placed in the canonical string, so
+raw PHI is never copied into signing or replay-cache state.
+
+The signature is the lowercase hexadecimal HMAC-SHA256 digest of those bytes.
+Header names are matched case-insensitively, but their values and the request
+target must be preserved exactly.
+
+## Sign a Client Request
+
+Serialize the body once, sign those exact bytes, and send those same bytes:
+
+```python
+import json
+import os
+
+import httpx
+
+from openmed.service.signing import sign_request
+
+body = json.dumps(
+    {"document_hash": "sha256:...", "offsets": [[8, 20]]},
+    separators=(",", ":"),
+    sort_keys=True,
+).encode("utf-8")
+headers = sign_request(
+    "POST",
+    "/jobs",
+    body,
+    secret=os.environ["OPENMED_HMAC_SECRET"],
+)
+headers["Content-Type"] = "application/json"
+
+response = httpx.post(
+    "https://openmed.example.com/jobs",
+    content=body,
+    headers=headers,
+)
+response.raise_for_status()
+```
+
+`sign_request_headers` is an equivalent, explicitly named helper for clients.
+Both helpers generate a cryptographically random nonce unless one is supplied.
+
+## Verify a Request
+
+Create one cache per shared-secret verification domain and keep it for the life
+of the process:
+
+```python
+import os
+
+from openmed.service.signing import (
+    NonceCache,
+    SignatureVerificationError,
+    verify_request_signature,
+)
+
+nonce_cache = NonceCache(max_entries=10_000, window_seconds=300)
+
+
+def verify(method, path_and_query, body, headers):
+    try:
+        verify_request_signature(
+            method,
+            path_and_query,
+            body,
+            headers,
+            secret=os.environ["OPENMED_HMAC_SECRET"],
+            nonce_cache=nonce_cache,
+            max_skew_seconds=300,
+        )
+    except SignatureVerificationError:
+        return False
+    return True
+```
+
+Verification checks freshness and the HMAC before atomically consuming the
+nonce. A tampered method, path, timestamp, nonce, or body fails without
+occupying cache space. A successful request consumes its nonce, so calling the
+verifier again for that request correctly reports a replay.
+
+The cache removes nonces only after their acceptance windows pass. It never
+evicts an active nonce just to make room: if `max_entries` is reached, new
+requests fail closed with `NonceCacheFullError`. Increase the bound for the
+expected peak number of signed requests per window. The cache is local to one
+process; deployments that require cross-process replay protection need an
+external nonce store, which is outside this feature's scope.
+
+## Signed Webhooks
+
+Async job callbacks use this same canonical scheme with method `POST`, the
+callback URL's exact path and query, and the canonical JSON bytes sent on the
+wire. Receivers can pass the callback request directly to
+`verify_request_signature`. See [Async REST Jobs & Webhooks](async-jobs.md) for
+delivery and retry behavior.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Serving Resilience: serving/resilience.md
       - Hardened Service Image: deploy/hardened-image.md
       - Async REST Jobs & Webhooks: serving/async-jobs.md
+      - HMAC Request Signing: serving/request-signing.md
       - gRPC Service: serving/grpc.md
       - REST Authentication: serving/authentication.md
       - Helm Deployment: deploy/helm.md

--- a/openmed/service/signing.py
+++ b/openmed/service/signing.py
@@ -1,0 +1,400 @@
+"""HMAC-SHA256 request signing with bounded local replay protection."""
+
+from __future__ import annotations
+
+import hashlib
+import heapq
+import hmac
+import math
+import re
+import secrets
+import threading
+import time
+from collections.abc import Mapping
+from typing import Optional, Union
+
+SIGNATURE_HEADER = "X-OpenMed-Signature"
+TIMESTAMP_HEADER = "X-OpenMed-Timestamp"
+NONCE_HEADER = "X-OpenMed-Nonce"
+SIGNATURE_PREFIX = "sha256="
+DEFAULT_MAX_SKEW_SECONDS = 300
+DEFAULT_NONCE_CACHE_SIZE = 10_000
+
+_SIGNING_SCHEME = "OPENMED-HMAC-SHA256-V1"
+_HTTP_METHOD_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_NONCE_RE = re.compile(r"^[\x21-\x7e]{1,256}$")
+_SIGNATURE_RE = re.compile(r"^[0-9a-f]{64}$")
+
+Body = Union[bytes, bytearray, memoryview, str]
+Secret = Union[bytes, str]
+
+
+class SignatureVerificationError(ValueError):
+    """Base class for request-signature verification failures."""
+
+
+class InvalidSignatureError(SignatureVerificationError):
+    """Raised when signature headers or the HMAC digest are invalid."""
+
+
+class StaleTimestampError(SignatureVerificationError):
+    """Raised when a signed timestamp falls outside the accepted window."""
+
+
+class ReplayDetectedError(SignatureVerificationError):
+    """Raised when a nonce has already been accepted in the active window."""
+
+
+class NonceCacheFullError(SignatureVerificationError):
+    """Raised when replay protection cannot safely accept another nonce."""
+
+
+class NonceCache:
+    """Thread-safe, bounded in-memory cache for accepted request nonces.
+
+    Active entries are never evicted merely to make space because that would
+    allow their requests to be replayed. Expired entries are removed before a
+    nonce is claimed; when all entries are active, the cache fails closed.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_entries: int = DEFAULT_NONCE_CACHE_SIZE,
+        window_seconds: Union[int, float] = DEFAULT_MAX_SKEW_SECONDS,
+    ) -> None:
+        if (
+            isinstance(max_entries, bool)
+            or not isinstance(max_entries, int)
+            or max_entries < 1
+        ):
+            raise ValueError("max_entries must be at least 1")
+        if isinstance(window_seconds, bool) or window_seconds <= 0:
+            raise ValueError("window_seconds must be greater than 0")
+
+        self.max_entries = max_entries
+        self.window_seconds = float(window_seconds)
+        self._entries: dict[str, float] = {}
+        self._expirations: list[tuple[float, int, str]] = []
+        self._sequence = 0
+        self._lock = threading.Lock()
+
+    def check_and_store(
+        self,
+        nonce: str,
+        *,
+        timestamp: Optional[Union[int, float]] = None,
+        now: Optional[Union[int, float]] = None,
+        window_seconds: Optional[Union[int, float]] = None,
+    ) -> bool:
+        """Atomically claim ``nonce`` and return whether it was newly stored.
+
+        The entry remains active until the signed timestamp's acceptance
+        window has passed. ``False`` means the nonce is already active or its
+        requested expiration is already past.
+        """
+        normalized_nonce = _normalize_nonce(nonce)
+        current_time = _normalize_clock_value(now, default=time.time())
+        signed_at = _normalize_clock_value(timestamp, default=current_time)
+        active_window = (
+            self.window_seconds
+            if window_seconds is None
+            else _normalize_window(window_seconds)
+        )
+        expires_at = signed_at + active_window
+
+        with self._lock:
+            self._purge_expired_locked(current_time)
+            if normalized_nonce in self._entries or expires_at < current_time:
+                return False
+            if len(self._entries) >= self.max_entries:
+                raise NonceCacheFullError(
+                    "Nonce cache is full with unexpired entries; request rejected"
+                )
+
+            self._sequence += 1
+            self._entries[normalized_nonce] = expires_at
+            heapq.heappush(
+                self._expirations,
+                (expires_at, self._sequence, normalized_nonce),
+            )
+            return True
+
+    def purge_expired(self, *, now: Optional[Union[int, float]] = None) -> int:
+        """Remove entries past their replay window and return the count."""
+        current_time = _normalize_clock_value(now, default=time.time())
+        with self._lock:
+            before = len(self._entries)
+            self._purge_expired_locked(current_time)
+            return before - len(self._entries)
+
+    def clear(self) -> None:
+        """Remove all cached nonces."""
+        with self._lock:
+            self._entries.clear()
+            self._expirations.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+    def _purge_expired_locked(self, now: float) -> None:
+        while self._expirations and self._expirations[0][0] < now:
+            expires_at, _, nonce = heapq.heappop(self._expirations)
+            if self._entries.get(nonce) == expires_at:
+                del self._entries[nonce]
+
+
+def canonical_signing_string(
+    method: str,
+    path: str,
+    timestamp: int,
+    nonce: str,
+    body: Body = b"",
+) -> bytes:
+    """Build the versioned request string covered by the HMAC.
+
+    Only the body's SHA-256 digest is included, so the canonical string never
+    contains raw request content or PHI.
+    """
+    normalized_method = _normalize_method(method)
+    normalized_path = _normalize_path(path)
+    normalized_timestamp = _normalize_timestamp(timestamp)
+    normalized_nonce = _normalize_nonce(nonce)
+    body_digest = hashlib.sha256(_body_bytes(body)).hexdigest()
+    return "\n".join(
+        (
+            _SIGNING_SCHEME,
+            normalized_method,
+            normalized_path,
+            str(normalized_timestamp),
+            normalized_nonce,
+            f"sha256:{body_digest}",
+        )
+    ).encode("utf-8")
+
+
+def sign_request(
+    method: str,
+    path: str,
+    body: Body = b"",
+    *,
+    secret: Secret,
+    timestamp: Optional[int] = None,
+    nonce: Optional[str] = None,
+) -> dict[str, str]:
+    """Return headers that sign the exact request method, target, and body."""
+    issued_at = _normalize_timestamp(
+        int(time.time()) if timestamp is None else timestamp
+    )
+    request_nonce = _normalize_nonce(nonce or secrets.token_urlsafe(24))
+    digest = _signature_digest(
+        secret,
+        canonical_signing_string(method, path, issued_at, request_nonce, body),
+    )
+    return {
+        TIMESTAMP_HEADER: str(issued_at),
+        NONCE_HEADER: request_nonce,
+        SIGNATURE_HEADER: f"{SIGNATURE_PREFIX}{digest}",
+    }
+
+
+def sign_request_headers(
+    method: str,
+    path: str,
+    body: Body = b"",
+    *,
+    secret: Secret,
+    timestamp: Optional[int] = None,
+    nonce: Optional[str] = None,
+) -> dict[str, str]:
+    """Alias for :func:`sign_request` for client-side header construction."""
+    return sign_request(
+        method,
+        path,
+        body,
+        secret=secret,
+        timestamp=timestamp,
+        nonce=nonce,
+    )
+
+
+def verify_request_signature(
+    method: str,
+    path: str,
+    body: Body,
+    headers: Mapping[str, str],
+    *,
+    secret: Secret,
+    nonce_cache: NonceCache,
+    max_skew_seconds: Union[int, float] = DEFAULT_MAX_SKEW_SECONDS,
+    now: Optional[Union[int, float]] = None,
+) -> bool:
+    """Verify request integrity, freshness, and one-time nonce use.
+
+    Successful verification atomically consumes the nonce. Failures raise a
+    :class:`SignatureVerificationError` subclass and do not claim the nonce.
+    """
+    active_window = _normalize_window(max_skew_seconds)
+    current_time = _normalize_clock_value(now, default=time.time())
+    timestamp_value = _required_header(headers, TIMESTAMP_HEADER)
+    nonce = _required_header(headers, NONCE_HEADER)
+    signature_value = _required_header(headers, SIGNATURE_HEADER)
+
+    issued_at = _parse_timestamp_header(timestamp_value)
+    try:
+        normalized_nonce = _normalize_nonce(nonce)
+    except (TypeError, ValueError) as exc:
+        raise InvalidSignatureError("Invalid request signature headers") from exc
+
+    if abs(current_time - issued_at) > active_window:
+        raise StaleTimestampError("Signed timestamp is outside the accepted window")
+
+    if not signature_value.startswith(SIGNATURE_PREFIX):
+        raise InvalidSignatureError("Invalid request signature")
+    provided_digest = signature_value[len(SIGNATURE_PREFIX) :]
+    if not _SIGNATURE_RE.fullmatch(provided_digest):
+        raise InvalidSignatureError("Invalid request signature")
+
+    expected_digest = _signature_digest(
+        secret,
+        canonical_signing_string(
+            method,
+            path,
+            issued_at,
+            normalized_nonce,
+            body,
+        ),
+    )
+    if not hmac.compare_digest(provided_digest, expected_digest):
+        raise InvalidSignatureError("Invalid request signature")
+
+    if not nonce_cache.check_and_store(
+        normalized_nonce,
+        timestamp=issued_at,
+        now=current_time,
+        window_seconds=active_window,
+    ):
+        raise ReplayDetectedError("Request nonce has already been used")
+    return True
+
+
+def _required_header(headers: Mapping[str, str], target: str) -> str:
+    values = [
+        value
+        for name, value in headers.items()
+        if isinstance(name, str) and name.casefold() == target.casefold()
+    ]
+    if len(values) != 1 or not isinstance(values[0], str):
+        raise InvalidSignatureError("Missing or duplicate request signature header")
+    return values[0]
+
+
+def _parse_timestamp_header(value: str) -> int:
+    if not value.isascii() or not value.isdigit():
+        raise InvalidSignatureError("Invalid signed timestamp")
+    issued_at = int(value)
+    if value != str(issued_at):
+        raise InvalidSignatureError("Invalid signed timestamp")
+    return issued_at
+
+
+def _signature_digest(secret: Secret, signing_string: bytes) -> str:
+    return hmac.new(_secret_bytes(secret), signing_string, hashlib.sha256).hexdigest()
+
+
+def _secret_bytes(secret: Secret) -> bytes:
+    if isinstance(secret, str):
+        secret_bytes = secret.encode("utf-8")
+    elif isinstance(secret, bytes):
+        secret_bytes = secret
+    else:
+        raise TypeError("secret must be bytes or str")
+    if not secret_bytes:
+        raise ValueError("secret must not be blank")
+    return secret_bytes
+
+
+def _body_bytes(body: Body) -> bytes:
+    if isinstance(body, str):
+        return body.encode("utf-8")
+    if isinstance(body, bytes):
+        return body
+    if isinstance(body, (bytearray, memoryview)):
+        return bytes(body)
+    raise TypeError("body must be bytes-like or str")
+
+
+def _normalize_method(method: str) -> str:
+    if not isinstance(method, str) or not _HTTP_METHOD_RE.fullmatch(method):
+        raise ValueError("method must be a valid HTTP method token")
+    return method.upper()
+
+
+def _normalize_path(path: str) -> str:
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise ValueError("path must be an origin-form request target")
+    if "#" in path or any(not "!" <= character <= "~" for character in path):
+        raise ValueError(
+            "path must be a printable ASCII request target without a fragment"
+        )
+    return path
+
+
+def _normalize_timestamp(timestamp: int) -> int:
+    if isinstance(timestamp, bool) or not isinstance(timestamp, int):
+        raise TypeError("timestamp must be an integer Unix timestamp")
+    if timestamp < 0:
+        raise ValueError("timestamp must not be negative")
+    return timestamp
+
+
+def _normalize_nonce(nonce: str) -> str:
+    if not isinstance(nonce, str):
+        raise TypeError("nonce must be a string")
+    if not _NONCE_RE.fullmatch(nonce):
+        raise ValueError("nonce must contain 1-256 printable ASCII characters")
+    return nonce
+
+
+def _normalize_clock_value(
+    value: Optional[Union[int, float]], *, default: Union[int, float]
+) -> float:
+    normalized = default if value is None else value
+    if isinstance(normalized, bool) or not isinstance(normalized, (int, float)):
+        raise TypeError("clock values must be numeric")
+    clock_value = float(normalized)
+    if not math.isfinite(clock_value):
+        raise ValueError("clock values must be finite")
+    return clock_value
+
+
+def _normalize_window(value: Union[int, float]) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError("max_skew_seconds must be greater than 0")
+    return float(value)
+
+
+__all__ = [
+    "DEFAULT_MAX_SKEW_SECONDS",
+    "DEFAULT_NONCE_CACHE_SIZE",
+    "InvalidSignatureError",
+    "NONCE_HEADER",
+    "NonceCache",
+    "NonceCacheFullError",
+    "ReplayDetectedError",
+    "SIGNATURE_HEADER",
+    "SIGNATURE_PREFIX",
+    "SignatureVerificationError",
+    "StaleTimestampError",
+    "TIMESTAMP_HEADER",
+    "canonical_signing_string",
+    "sign_request",
+    "sign_request_headers",
+    "verify_request_signature",
+]

--- a/openmed/service/webhooks.py
+++ b/openmed/service/webhooks.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import json
 import time
 from dataclasses import dataclass
@@ -11,10 +9,15 @@ from typing import Any, Callable, Optional
 
 import httpx
 
-SIGNATURE_HEADER = "X-OpenMed-Signature"
-TIMESTAMP_HEADER = "X-OpenMed-Timestamp"
+from .signing import (
+    NONCE_HEADER,
+    SIGNATURE_HEADER,
+    SIGNATURE_PREFIX,
+    TIMESTAMP_HEADER,
+    sign_request,
+)
+
 EVENT_HEADER = "X-OpenMed-Event"
-SIGNATURE_PREFIX = "sha256="
 DEFAULT_WEBHOOK_TIMEOUT_SECONDS = 10.0
 
 
@@ -52,16 +55,26 @@ def sign_webhook_payload(
     payload: Any,
     *,
     secret: str,
+    path: str = "/",
     timestamp: Optional[int] = None,
-) -> tuple[bytes, str, str]:
-    """Return canonical body bytes, timestamp, and HMAC signature header value."""
-    if not secret:
-        raise ValueError("Webhook secret must not be blank")
+    nonce: Optional[str] = None,
+) -> tuple[bytes, str, str, str]:
+    """Return body bytes plus timestamp, nonce, and signature header values."""
     body = canonical_json_bytes(payload)
-    issued_at = str(int(time.time() if timestamp is None else timestamp))
-    signed = issued_at.encode("ascii") + b"." + body
-    digest = hmac.new(secret.encode("utf-8"), signed, hashlib.sha256).hexdigest()
-    return body, issued_at, f"{SIGNATURE_PREFIX}{digest}"
+    headers = sign_request(
+        "POST",
+        path,
+        body,
+        secret=secret,
+        timestamp=timestamp,
+        nonce=nonce,
+    )
+    return (
+        body,
+        headers[TIMESTAMP_HEADER],
+        headers[NONCE_HEADER],
+        headers[SIGNATURE_HEADER],
+    )
 
 
 def deliver_webhook(
@@ -81,11 +94,17 @@ def deliver_webhook(
     if backoff_seconds < 0:
         raise ValueError("backoff_seconds must be greater than or equal to 0")
 
-    body, timestamp, signature = sign_webhook_payload(payload, secret=secret)
+    request_path = httpx.URL(url).raw_path.decode("ascii")
+    body, timestamp, nonce, signature = sign_webhook_payload(
+        payload,
+        secret=secret,
+        path=request_path,
+    )
     headers = {
         "Content-Type": "application/json",
         EVENT_HEADER: str(payload.get("event", "job.terminal")),
         TIMESTAMP_HEADER: timestamp,
+        NONCE_HEADER: nonce,
         SIGNATURE_HEADER: signature,
     }
 

--- a/tests/unit/service/test_hmac_signing_replay.py
+++ b/tests/unit/service/test_hmac_signing_replay.py
@@ -1,0 +1,176 @@
+"""Tests for HMAC request signing and local replay protection."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from openmed.service.signing import (
+    NONCE_HEADER,
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    InvalidSignatureError,
+    NonceCache,
+    NonceCacheFullError,
+    ReplayDetectedError,
+    StaleTimestampError,
+    canonical_signing_string,
+    sign_request,
+    verify_request_signature,
+)
+from openmed.service.webhooks import deliver_webhook
+
+
+def test_signed_request_verifies_and_rejects_tampering_and_replay() -> None:
+    body = b'{"document_hash":"sha256:abc","offsets":[[4,12]]}'
+    headers = sign_request(
+        "POST",
+        "/jobs?mode=async",
+        body,
+        secret="shared-secret",
+        timestamp=1_800_000_000,
+        nonce="synthetic-request-1",
+    )
+    cache = NonceCache(max_entries=10, window_seconds=300)
+
+    with pytest.raises(InvalidSignatureError):
+        verify_request_signature(
+            "POST",
+            "/jobs?mode=async",
+            body + b" ",
+            headers,
+            secret="shared-secret",
+            nonce_cache=cache,
+            now=1_800_000_000,
+        )
+
+    assert verify_request_signature(
+        "POST",
+        "/jobs?mode=async",
+        body,
+        headers,
+        secret="shared-secret",
+        nonce_cache=cache,
+        now=1_800_000_000,
+    )
+
+    with pytest.raises(ReplayDetectedError):
+        verify_request_signature(
+            "POST",
+            "/jobs?mode=async",
+            body,
+            headers,
+            secret="shared-secret",
+            nonce_cache=cache,
+            now=1_800_000_001,
+        )
+
+
+def test_stale_timestamp_is_rejected_without_consuming_nonce() -> None:
+    headers = sign_request(
+        "GET",
+        "/jobs/abc",
+        secret="shared-secret",
+        timestamp=1_800_000_000,
+        nonce="stale-request",
+    )
+    cache = NonceCache(window_seconds=30)
+
+    with pytest.raises(StaleTimestampError):
+        verify_request_signature(
+            "GET",
+            "/jobs/abc",
+            b"",
+            headers,
+            secret="shared-secret",
+            nonce_cache=cache,
+            max_skew_seconds=30,
+            now=1_800_000_031,
+        )
+
+    assert len(cache) == 0
+
+
+def test_canonical_string_contains_body_hash_not_raw_body() -> None:
+    body = b"Patient Maria Garcia"
+
+    canonical = canonical_signing_string(
+        "post",
+        "/pii/deidentify",
+        1_800_000_000,
+        "privacy-safe-nonce",
+        body,
+    )
+
+    assert b"Patient" not in canonical
+    assert b"Maria" not in canonical
+    assert canonical.startswith(b"OPENMED-HMAC-SHA256-V1\nPOST\n")
+    assert canonical.endswith(
+        b"sha256:96d954518f3d24df5c23dfe61bb203c80c41561ab480a0b198d3125320deed1e"
+    )
+
+
+def test_nonce_cache_is_bounded_and_evicts_only_past_window() -> None:
+    cache = NonceCache(max_entries=2, window_seconds=10)
+
+    assert cache.check_and_store("nonce-a", timestamp=100, now=100)
+    assert cache.check_and_store("nonce-b", timestamp=101, now=101)
+    with pytest.raises(NonceCacheFullError):
+        cache.check_and_store("nonce-c", timestamp=102, now=102)
+    assert len(cache) == 2
+
+    assert cache.purge_expired(now=111) == 1
+    assert len(cache) == 1
+    assert cache.check_and_store("nonce-c", timestamp=111, now=111)
+    assert len(cache) == 2
+
+
+def test_outbound_webhook_carries_a_verifiable_signature() -> None:
+    cache = NonceCache()
+    verified = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal verified
+        verified = verify_request_signature(
+            request.method,
+            request.url.raw_path.decode("ascii"),
+            request.content,
+            request.headers,
+            secret="webhook-secret",
+            nonce_cache=cache,
+            now=int(request.headers[TIMESTAMP_HEADER]),
+        )
+        assert request.headers[NONCE_HEADER]
+        assert request.headers[SIGNATURE_HEADER].startswith("sha256=")
+        return httpx.Response(204)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    result = deliver_webhook(
+        "https://callbacks.example.test/openmed/jobs?source=openmed",
+        {"event": "job.done", "job_id": "abc", "status": "done"},
+        secret="webhook-secret",
+        client=client,
+    )
+
+    assert result.success is True
+    assert verified is True
+
+
+def test_client_signer_returns_only_the_three_signature_headers() -> None:
+    headers = sign_request(
+        "POST",
+        "/jobs",
+        json.dumps({"document_hash": "sha256:abc"}).encode(),
+        secret=b"shared-secret",
+        timestamp=1_800_000_000,
+        nonce="client-nonce",
+    )
+
+    assert headers == {
+        TIMESTAMP_HEADER: "1800000000",
+        NONCE_HEADER: "client-nonce",
+        SIGNATURE_HEADER: headers[SIGNATURE_HEADER],
+    }
+    assert headers[SIGNATURE_HEADER].startswith("sha256=")

--- a/tests/unit/service/test_webhooks.py
+++ b/tests/unit/service/test_webhooks.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import hmac
 import json
 
 import httpx
 
+from openmed.service.signing import NONCE_HEADER, sign_request
 from openmed.service.webhooks import (
     SIGNATURE_HEADER,
     TIMESTAMP_HEADER,
@@ -19,20 +19,26 @@ from openmed.service.webhooks import (
 def test_sign_webhook_payload_uses_canonical_json_and_timestamp() -> None:
     payload = {"status": "done", "job_id": "abc", "label_histogram": {"NAME": 1}}
 
-    body, timestamp, signature = sign_webhook_payload(
+    body, timestamp, nonce, signature = sign_webhook_payload(
         payload,
         secret="secret",
+        path="/openmed?source=jobs",
         timestamp=1_800_000_000,
+        nonce="webhook-nonce",
     )
 
     assert body == canonical_json_bytes(payload)
     assert timestamp == "1800000000"
-    expected = hmac.digest(
-        b"secret",
-        b"1800000000." + body,
-        "sha256",
-    ).hex()
-    assert signature == f"sha256={expected}"
+    assert nonce == "webhook-nonce"
+    expected = sign_request(
+        "POST",
+        "/openmed?source=jobs",
+        body,
+        secret="secret",
+        timestamp=1_800_000_000,
+        nonce="webhook-nonce",
+    )
+    assert signature == expected[SIGNATURE_HEADER]
 
 
 def test_deliver_webhook_retries_with_backoff_until_success() -> None:
@@ -67,6 +73,7 @@ def test_deliver_webhook_retries_with_backoff_until_success() -> None:
     assert seen_request is not None
     assert seen_request.headers[SIGNATURE_HEADER].startswith("sha256=")
     assert seen_request.headers[TIMESTAMP_HEADER]
+    assert seen_request.headers[NONCE_HEADER]
 
 
 def test_deliver_webhook_reports_failure_after_attempts() -> None:


### PR DESCRIPTION
## Description

Adds a versioned HMAC-SHA256 request-signing contract and bounded local replay protection for service callers. Async job callbacks now use the same method, path, timestamp, nonce, and body-digest scheme, while client helpers and serving documentation show how to sign and verify the exact bytes sent on the wire without placing raw PHI in canonical or cache state.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Added canonical signing, client header helpers, constant-time verification, timestamp validation, and typed verification failures.
- Added a thread-safe bounded nonce cache that evicts expired entries and fails closed instead of evicting active replay state.
- Updated async job webhooks to emit verifier-compatible timestamp, nonce, and signature headers over canonical JSON bytes.
- Documented the wire contract, client signing, receiver verification, operational bounds, and webhook behavior.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested tampered bodies, stale timestamps, replayed nonces, cache capacity/expiration, and outbound webhook verification

Validation performed:

- `.venv/bin/python -m pytest tests/ -q` — 5,177 passed, 46 skipped
- `make format && make lint && make format-check`
- `make type-check`
- Targeted pre-commit hooks, including Bandit and secret detection
- `make docs-build` in strict mode

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift` (not applicable)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #849

## Screenshots/Examples

Not applicable; this change adds a Python signing API, webhook headers, tests, and serving documentation.
