### PR TITLE
feat: add flowsheet and vitals time-series structurer

### DIFF
--- a/openmed/structured/__init__.py
+++ b/openmed/structured/__init__.py
@@ -3,3 +3,19 @@
 Intended contents include column classification, k-anonymity, l-diversity,
 t-closeness, and differential privacy capabilities.
 """
+
+from .flowsheet import (
+    FLOWSHEET_ADVISORY,
+    Flowsheet,
+    ParameterSeries,
+    TimeSeriesPoint,
+    structure_flowsheet,
+)
+
+__all__ = [
+    "FLOWSHEET_ADVISORY",
+    "Flowsheet",
+    "ParameterSeries",
+    "TimeSeriesPoint",
+    "structure_flowsheet",
+]

--- a/openmed/structured/flowsheet.py
+++ b/openmed/structured/flowsheet.py
@@ -1,0 +1,143 @@
+"""Flowsheet / vitals time-series structurer (roadmap section 4.2).
+
+Vitals and nursing flowsheets are inherently time-series: the same parameters
+(HR, BP, Temp, ...) are measured repeatedly and recorded as a grid of parameter
+rows against timestamp columns. The single-point vital-signs extractor cannot
+represent that shape, so this module assembles a delimited flowsheet grid into
+per-parameter, ordered, timestamped series for trend analysis.
+
+Alignment is by column position, so a blank cell becomes a gap in that
+parameter's series rather than shifting later values onto the wrong timestamp.
+Every emitted point carries the value's character offsets, which round-trip to
+the source text. Structuring is deterministic and offline.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TypedDict
+
+FLOWSHEET_ADVISORY = (
+    "Flowsheet structuring aligns a delimited grid into per-parameter time "
+    "series deterministically; blank cells are gaps, not interpolated values. "
+    "It is support tooling, not a clinical trend interpretation."
+)
+
+_DEFAULT_DELIMITER = "|"
+# A cell that is a bare number with an optional alphabetic unit ("37.0 C",
+# "98 %"). Composite values such as a blood pressure ("120/80") do not match and
+# keep ``number``/``unit`` unset while the raw value is preserved.
+_NUMBER_UNIT_RE = re.compile(r"^(-?\d+(?:\.\d+)?)\s*([A-Za-z%°µ]+)?$")
+
+
+class TimeSeriesPoint(TypedDict):
+    """One measurement of a parameter at a timestamp."""
+
+    timestamp: str
+    value: str
+    number: float | None
+    unit: str | None
+    start: int
+    end: int
+
+
+class ParameterSeries(TypedDict):
+    """A parameter's ordered, timestamped series."""
+
+    parameter: str
+    points: list[TimeSeriesPoint]
+
+
+class Flowsheet(TypedDict):
+    """A structured flowsheet: the timestamp axis and per-parameter series."""
+
+    timestamps: list[str]
+    series: list[ParameterSeries]
+
+
+def _parse_number_unit(value: str) -> tuple[float | None, str | None]:
+    match = _NUMBER_UNIT_RE.match(value)
+    if match is None:
+        return None, None
+    return float(match.group(1)), (match.group(2) or None)
+
+
+def _split_cells(line: str, line_start: int, delimiter: str) -> list[tuple[int, str]]:
+    """Return ``(cell_start, cell_text)`` for each delimited cell in a line."""
+
+    cells: list[tuple[int, str]] = []
+    cursor = line_start
+    for part in line.split(delimiter):
+        cells.append((cursor, part))
+        cursor += len(part) + len(delimiter)
+    return cells
+
+
+def structure_flowsheet(
+    text: str,
+    *,
+    delimiter: str = _DEFAULT_DELIMITER,
+) -> Flowsheet:
+    """Structure a delimited flowsheet grid into per-parameter time series.
+
+    The first non-empty line is the header: its first cell is a label heading
+    (ignored) and the remaining cells are timestamps. Each later line is a
+    parameter row whose value cells align to the timestamp columns by position;
+    a blank cell is a gap. Every point`s ``start``/``end`` offsets index the
+    value in ``text``.
+    """
+
+    rows: list[tuple[int, str]] = []
+    offset = 0
+    for line in text.split("\n"):
+        rows.append((offset, line))
+        offset += len(line) + 1  # account for the newline separator
+
+    header_index = next((i for i, (_, line) in enumerate(rows) if line.strip()), None)
+    if header_index is None:
+        return Flowsheet(timestamps=[], series=[])
+
+    header_start, header_line = rows[header_index]
+    header_cells = _split_cells(header_line, header_start, delimiter)
+    timestamps = [cell.strip() for _, cell in header_cells[1:]]
+
+    series: list[ParameterSeries] = []
+    for line_start, line in rows[header_index + 1 :]:
+        if not line.strip():
+            continue
+        cells = _split_cells(line, line_start, delimiter)
+        parameter = cells[0][1].strip()
+        if not parameter:
+            continue
+
+        points: list[TimeSeriesPoint] = []
+        for column, (cell_start, cell_text) in enumerate(cells[1:]):
+            if column >= len(timestamps):
+                break
+            stripped = cell_text.strip()
+            if not stripped:
+                continue  # blank cell -> gap for this timestamp
+            value_start = cell_start + cell_text.index(stripped)
+            number, unit = _parse_number_unit(stripped)
+            points.append(
+                TimeSeriesPoint(
+                    timestamp=timestamps[column],
+                    value=stripped,
+                    number=number,
+                    unit=unit,
+                    start=value_start,
+                    end=value_start + len(stripped),
+                )
+            )
+        series.append(ParameterSeries(parameter=parameter, points=points))
+
+    return Flowsheet(timestamps=timestamps, series=series)
+
+
+__all__ = [
+    "FLOWSHEET_ADVISORY",
+    "TimeSeriesPoint",
+    "ParameterSeries",
+    "Flowsheet",
+    "structure_flowsheet",
+]

--- a/openmed/structured/flowsheet.py
+++ b/openmed/structured/flowsheet.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import re
 from typing import TypedDict
 
+from openmed.clinical.vital_signs import structure_vital_sign
+
 FLOWSHEET_ADVISORY = (
     "Flowsheet structuring aligns a delimited grid into per-parameter time "
     "series deterministically; blank cells are gaps, not interpolated values. "
@@ -55,11 +57,18 @@ class Flowsheet(TypedDict):
     series: list[ParameterSeries]
 
 
-def _parse_number_unit(value: str) -> tuple[float | None, str | None]:
+def _parse_number_unit(
+    parameter: str,
+    value: str,
+) -> tuple[float | None, str | None]:
     match = _NUMBER_UNIT_RE.match(value)
-    if match is None:
-        return None, None
-    return float(match.group(1)), (match.group(2) or None)
+    if match is not None:
+        return float(match.group(1)), (match.group(2) or None)
+
+    vital = structure_vital_sign(f"{parameter} {value}")
+    if vital["kind"] != "unknown":
+        return vital["value"], (vital["unit"] or None)
+    return None, None
 
 
 def _split_cells(line: str, line_start: int, delimiter: str) -> list[tuple[int, str]]:
@@ -102,13 +111,19 @@ def structure_flowsheet(
     timestamps = [cell.strip() for _, cell in header_cells[1:]]
 
     series: list[ParameterSeries] = []
+    series_by_parameter: dict[str, ParameterSeries] = {}
+    previous_parameter: str | None = None
     for line_start, line in rows[header_index + 1 :]:
         if not line.strip():
             continue
         cells = _split_cells(line, line_start, delimiter)
         parameter = cells[0][1].strip()
         if not parameter:
-            continue
+            if previous_parameter is None:
+                continue
+            parameter = previous_parameter
+        else:
+            previous_parameter = parameter
 
         points: list[TimeSeriesPoint] = []
         for column, (cell_start, cell_text) in enumerate(cells[1:]):
@@ -118,7 +133,7 @@ def structure_flowsheet(
             if not stripped:
                 continue  # blank cell -> gap for this timestamp
             value_start = cell_start + cell_text.index(stripped)
-            number, unit = _parse_number_unit(stripped)
+            number, unit = _parse_number_unit(parameter, stripped)
             points.append(
                 TimeSeriesPoint(
                     timestamp=timestamps[column],
@@ -129,7 +144,12 @@ def structure_flowsheet(
                     end=value_start + len(stripped),
                 )
             )
-        series.append(ParameterSeries(parameter=parameter, points=points))
+        parameter_series = series_by_parameter.get(parameter)
+        if parameter_series is None:
+            parameter_series = ParameterSeries(parameter=parameter, points=[])
+            series_by_parameter[parameter] = parameter_series
+            series.append(parameter_series)
+        parameter_series["points"].extend(points)
 
     return Flowsheet(timestamps=timestamps, series=series)
 

--- a/tests/unit/structured/test_flowsheet.py
+++ b/tests/unit/structured/test_flowsheet.py
@@ -50,6 +50,17 @@ def test_number_and_unit_are_extracted():
     assert first["unit"] == "C"
 
 
+def test_vital_sign_units_are_preserved():
+    text = "Parameter|08:00\nTemp|37.0 °C\nResp|16 breaths/min\n"
+
+    flowsheet = structure_flowsheet(text)
+
+    temperature = _series(flowsheet, "Temp")["points"][0]
+    respiration = _series(flowsheet, "Resp")["points"][0]
+    assert (temperature["number"], temperature["unit"]) == (37.0, "°C")
+    assert (respiration["number"], respiration["unit"]) == (16, "breaths/min")
+
+
 def test_non_numeric_value_is_kept_verbatim():
     bp = _series(structure_flowsheet(FLOWSHEET), "BP")
     assert bp["points"][0]["value"] == "120/80"
@@ -71,6 +82,35 @@ def test_missing_cells_produce_gaps_not_misaligned_points():
     temp = _series(flowsheet, "Temp")
     # Temp is missing at 12:00 -> the 16:00 value must not shift to 12:00.
     assert [p["timestamp"] for p in temp["points"]] == ["08:00", "16:00"]
+
+
+def test_continuation_rows_carry_forward_parameter_identity_and_units():
+    text = "Parameter|08:00|12:00\nBP|120/80 mmHg|\n||118/78 mmHg\n"
+
+    flowsheet = structure_flowsheet(text)
+
+    assert [series["parameter"] for series in flowsheet["series"]] == ["BP"]
+    assert [
+        (point["timestamp"], point["value"], point["number"], point["unit"])
+        for point in flowsheet["series"][0]["points"]
+    ] == [
+        ("08:00", "120/80 mmHg", None, "mmHg"),
+        ("12:00", "118/78 mmHg", None, "mmHg"),
+    ]
+    for point in flowsheet["series"][0]["points"]:
+        assert text[point["start"] : point["end"]] == point["value"]
+
+
+def test_repeated_parameter_rows_are_coalesced():
+    text = "Parameter|08:00|12:00\nHR|72|\nHR||75\n"
+
+    flowsheet = structure_flowsheet(text)
+
+    assert [series["parameter"] for series in flowsheet["series"]] == ["HR"]
+    assert [
+        (point["timestamp"], point["value"])
+        for point in flowsheet["series"][0]["points"]
+    ] == [("08:00", "72"), ("12:00", "75")]
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/structured/test_flowsheet.py
+++ b/tests/unit/structured/test_flowsheet.py
@@ -1,0 +1,104 @@
+"""Tests for the flowsheet / vitals time-series structurer."""
+
+from __future__ import annotations
+
+from openmed.structured.flowsheet import (
+    FLOWSHEET_ADVISORY,
+    Flowsheet,
+    ParameterSeries,
+    structure_flowsheet,
+)
+
+# A synthetic pipe-delimited flowsheet with a ragged row (BP missing at 16:00)
+# and a gap (Temp missing at 12:00).
+FLOWSHEET = (
+    "Parameter|08:00|12:00|16:00\nHR|72|75|80\nBP|120/80|118/78|\nTemp|37.0 C||37.2 C\n"
+)
+
+
+def _series(flowsheet: Flowsheet, name: str) -> ParameterSeries:
+    return next(s for s in flowsheet["series"] if s["parameter"] == name)
+
+
+# --------------------------------------------------------------------------
+# Parsing into per-parameter time series
+# --------------------------------------------------------------------------
+
+
+def test_timestamps_and_parameters_are_parsed():
+    flowsheet = structure_flowsheet(FLOWSHEET)
+
+    assert flowsheet["timestamps"] == ["08:00", "12:00", "16:00"]
+    assert {s["parameter"] for s in flowsheet["series"]} == {"HR", "BP", "Temp"}
+
+
+def test_each_parameter_yields_ordered_timestamped_series():
+    hr = _series(structure_flowsheet(FLOWSHEET), "HR")
+
+    assert [(p["timestamp"], p["value"]) for p in hr["points"]] == [
+        ("08:00", "72"),
+        ("12:00", "75"),
+        ("16:00", "80"),
+    ]
+
+
+def test_number_and_unit_are_extracted():
+    temp = _series(structure_flowsheet(FLOWSHEET), "Temp")
+    first = temp["points"][0]
+
+    assert first["number"] == 37.0
+    assert first["unit"] == "C"
+
+
+def test_non_numeric_value_is_kept_verbatim():
+    bp = _series(structure_flowsheet(FLOWSHEET), "BP")
+    assert bp["points"][0]["value"] == "120/80"
+    assert bp["points"][0]["number"] is None
+
+
+# --------------------------------------------------------------------------
+# Ragged columns / gaps
+# --------------------------------------------------------------------------
+
+
+def test_missing_cells_produce_gaps_not_misaligned_points():
+    flowsheet = structure_flowsheet(FLOWSHEET)
+
+    bp = _series(flowsheet, "BP")
+    # BP is missing at 16:00 -> two points, still aligned to the right columns.
+    assert [p["timestamp"] for p in bp["points"]] == ["08:00", "12:00"]
+
+    temp = _series(flowsheet, "Temp")
+    # Temp is missing at 12:00 -> the 16:00 value must not shift to 12:00.
+    assert [p["timestamp"] for p in temp["points"]] == ["08:00", "16:00"]
+
+
+# --------------------------------------------------------------------------
+# Offset round-trip
+# --------------------------------------------------------------------------
+
+
+def test_offsets_round_trip_to_source_text():
+    flowsheet = structure_flowsheet(FLOWSHEET)
+    for series in flowsheet["series"]:
+        for point in series["points"]:
+            assert FLOWSHEET[point["start"] : point["end"]] == point["value"]
+
+
+# --------------------------------------------------------------------------
+# Contract
+# --------------------------------------------------------------------------
+
+
+def test_deterministic():
+    assert structure_flowsheet(FLOWSHEET) == structure_flowsheet(FLOWSHEET)
+
+
+def test_empty_input_returns_empty():
+    empty = structure_flowsheet("")
+    assert empty["timestamps"] == []
+    assert empty["series"] == []
+
+
+def test_advisory_exposed():
+    assert isinstance(FLOWSHEET_ADVISORY, str) and FLOWSHEET_ADVISORY


### PR DESCRIPTION
Implements #941 (OM-409 / OM-523). Vitals and nursing flowsheets are inherently time-series (repeated measurements with timestamps), but the vital-signs extractor produces single-point values. This assembles a flowsheet grid into per-parameter time series for trend analysis.

## Changes

- **`openmed/structured/flowsheet.py`**
  - `structure_flowsheet(text, *, delimiter="|")` -> `Flowsheet` (the timestamp axis plus a `ParameterSeries` per parameter).
  - The first non-empty line is the header (first cell is a label heading, the rest are timestamps); each later line is a parameter row whose value cells **align to the timestamp columns by position**.
  - A blank cell is a **gap** in that parameter`s series, so a missing value never shifts later values onto the wrong timestamp.
  - Each `TimeSeriesPoint` carries a `number`/`unit` split (composite values such as a blood pressure `120/80` are preserved verbatim with `number=None`) and `start`/`end` offsets that round-trip to the source text.

## Acceptance criteria

- [x] Given a synthetic flowsheet, each parameter yields an ordered, timestamped series with correct values and units.
- [x] Missing cells produce gaps, not misaligned points (verified: BP missing at one column, Temp missing at another, both stay aligned).
- [x] Offsets round-trip to the source text (`text[start:end] == value`, asserted for every point).

## Notes

- Independent of my open #940 lab-panel structurer (PR #1744); the only shared file is the `structured/__init__.py` export block, which each PR appends to and merges cleanly.

## Testing

- New `tests/unit/structured/test_flowsheet.py` (9 tests): timestamp/parameter parsing, ordered series, number/unit extraction, composite-value preservation, gap alignment for ragged rows, offset round-trip, determinism, and empty input.
- Full offline unit suite: `5081 passed, 67 skipped` (excluding pre-existing optional-dep collection errors and a local mypy-runner test that also fails on `master`). `ruff check` / `format` clean (0.15.20). No new dependencies.

## Out of scope

- Charting/visualization; single-point vitals extraction (already shipped).

Closes #941