### PR TITLE
Add bounded inference admission control

### DIFF
--- a/deploy/helm/openmed-service/ci-values.yaml
+++ b/deploy/helm/openmed-service/ci-values.yaml
@@ -17,6 +17,10 @@ config:
     enabled: true
     maxSize: 4
     maxWaitMs: 20
+    maxQueueSize: 32
+    highWatermark: 24
+    lowWatermark: 8
+    maxQueueWaitMs: 250
   coalescing:
     enabled: true
   metrics:

--- a/deploy/helm/openmed-service/templates/configmap.yaml
+++ b/deploy/helm/openmed-service/templates/configmap.yaml
@@ -16,6 +16,10 @@ data:
   OPENMED_SERVICE_BATCHING_ENABLED: {{ .Values.config.batching.enabled | quote }}
   OPENMED_SERVICE_BATCH_MAX_SIZE: {{ .Values.config.batching.maxSize | quote }}
   OPENMED_SERVICE_BATCH_MAX_WAIT_MS: {{ .Values.config.batching.maxWaitMs | quote }}
+  OPENMED_SERVICE_BATCH_MAX_QUEUE_SIZE: {{ .Values.config.batching.maxQueueSize | quote }}
+  OPENMED_SERVICE_BATCH_HIGH_WATERMARK: {{ .Values.config.batching.highWatermark | quote }}
+  OPENMED_SERVICE_BATCH_LOW_WATERMARK: {{ .Values.config.batching.lowWatermark | quote }}
+  OPENMED_SERVICE_BATCH_MAX_QUEUE_WAIT_MS: {{ .Values.config.batching.maxQueueWaitMs | quote }}
   OPENMED_SERVICE_COALESCING_ENABLED: {{ .Values.config.coalescing.enabled | quote }}
   OPENMED_SERVICE_SHUTDOWN_DRAIN_SECONDS: {{ .Values.config.shutdownDrainSeconds | quote }}
   OPENMED_SERVICE_METRICS_ENABLED: {{ .Values.config.metrics.enabled | quote }}

--- a/deploy/helm/openmed-service/values.yaml
+++ b/deploy/helm/openmed-service/values.yaml
@@ -58,6 +58,10 @@ config:
     enabled: false
     maxSize: 8
     maxWaitMs: 5
+    maxQueueSize: 256
+    highWatermark: 256
+    lowWatermark: 128
+    maxQueueWaitMs: 1000
   # Request coalescing for identical concurrent model-backed requests.
   coalescing:
     enabled: false

--- a/docs/deploy/helm.md
+++ b/docs/deploy/helm.md
@@ -98,6 +98,10 @@ extraEnv:
 | `config.batching.enabled` | `false` | `OPENMED_SERVICE_BATCHING_ENABLED`. |
 | `config.batching.maxSize` | `8` | `OPENMED_SERVICE_BATCH_MAX_SIZE`. |
 | `config.batching.maxWaitMs` | `5` | `OPENMED_SERVICE_BATCH_MAX_WAIT_MS`. |
+| `config.batching.maxQueueSize` | `256` | `OPENMED_SERVICE_BATCH_MAX_QUEUE_SIZE`. |
+| `config.batching.highWatermark` | `256` | `OPENMED_SERVICE_BATCH_HIGH_WATERMARK`. |
+| `config.batching.lowWatermark` | `128` | `OPENMED_SERVICE_BATCH_LOW_WATERMARK`. |
+| `config.batching.maxQueueWaitMs` | `1000` | `OPENMED_SERVICE_BATCH_MAX_QUEUE_WAIT_MS`. |
 | `config.coalescing.enabled` | `false` | `OPENMED_SERVICE_COALESCING_ENABLED`. |
 | `config.shutdownDrainSeconds` | `30` | `OPENMED_SERVICE_SHUTDOWN_DRAIN_SECONDS`. |
 | `config.metrics.enabled` | `false` | `OPENMED_SERVICE_METRICS_ENABLED`. |

--- a/docs/rest-service.md
+++ b/docs/rest-service.md
@@ -236,6 +236,9 @@ Optional dynamic request batching:
 OPENMED_SERVICE_BATCHING_ENABLED=true \
 OPENMED_SERVICE_BATCH_MAX_SIZE=8 \
 OPENMED_SERVICE_BATCH_MAX_WAIT_MS=25 \
+OPENMED_SERVICE_BATCH_HIGH_WATERMARK=256 \
+OPENMED_SERVICE_BATCH_LOW_WATERMARK=128 \
+OPENMED_SERVICE_BATCH_MAX_QUEUE_WAIT_MS=1000 \
 uvicorn openmed.service.app:app --host 127.0.0.1 --port 8080
 ```
 
@@ -248,7 +251,9 @@ batch helper falls back to per-text analysis still preserve per-request results.
 non-batch-compatible settings are still coalesced but executed independently.
 `OPENMED_SERVICE_BATCH_MAX_SIZE` must be a positive integer.
 `OPENMED_SERVICE_BATCH_MAX_WAIT_MS` is a non-negative wait window in
-milliseconds.
+milliseconds. Bounded admission, high/low-watermark hysteresis, maximum queue
+waits, `503` responses with `Retry-After`, and aggregate metrics are described
+in [`Serving Backpressure`](serving/backpressure.md).
 
 Optional request coalescing:
 

--- a/docs/serving/backpressure.md
+++ b/docs/serving/backpressure.md
@@ -1,0 +1,69 @@
+# Serving Backpressure
+
+OpenMed can put a bounded, in-process admission queue in front of each dynamic
+batching path. Admission control protects tail latency and memory during bursts
+by rejecting excess work while already-admitted requests continue to run.
+
+Backpressure is active only when dynamic batching is enabled:
+
+```bash
+OPENMED_SERVICE_BATCHING_ENABLED=true \
+OPENMED_SERVICE_BATCH_HIGH_WATERMARK=256 \
+OPENMED_SERVICE_BATCH_LOW_WATERMARK=128 \
+OPENMED_SERVICE_BATCH_MAX_QUEUE_WAIT_MS=1000 \
+uvicorn openmed.service.app:app --host 127.0.0.1 --port 8080
+```
+
+The admission depth counts both requests waiting for batch dispatch and batches
+currently executing. When depth reaches the high watermark, the queue enters
+shedding mode. It stays in that mode until outstanding depth drains to the low
+watermark; this hysteresis prevents rapid accept/reject oscillation near the
+limit. The `/analyze` and `/pii/extract` paths have independent queues.
+
+Requests rejected by the high watermark receive `503` with error code
+`backpressure` and a `Retry-After` header. A request that remains queued longer
+than `OPENMED_SERVICE_BATCH_MAX_QUEUE_WAIT_MS` receives the same status and
+header with `error.details.reason` set to `max_wait`. Error responses contain
+only aggregate queue state and configuration, never request text or other PHI.
+
+## Configuration
+
+| Environment variable | Default | Meaning |
+| --- | ---: | --- |
+| `OPENMED_SERVICE_BATCH_HIGH_WATERMARK` | `OPENMED_SERVICE_BATCH_MAX_QUEUE_SIZE` (default `256`) | Maximum outstanding requests admitted to one batching path. |
+| `OPENMED_SERVICE_BATCH_LOW_WATERMARK` | Half of the high watermark (default `128`) | Outstanding depth at or below which shedding stops. Must be lower than the high watermark. |
+| `OPENMED_SERVICE_BATCH_MAX_QUEUE_WAIT_MS` | `1000` | Maximum pre-dispatch wait. `0` allows only work that immediately fills and dispatches a batch. |
+| `OPENMED_SERVICE_BATCH_MAX_QUEUE_SIZE` | `256` | Hard capacity for each priority-specific pending queue. |
+| `OPENMED_SERVICE_BATCH_MAX_WAIT_MS` | `5` | Batch-formation window; this is separate from the maximum queue wait. |
+
+The high watermark is aggregate across priority classes. The existing
+per-priority hard capacity remains a final safety bound, so operators should
+normally keep `BATCH_MAX_QUEUE_SIZE` at or above the expected per-class share
+of the high watermark.
+
+## Metrics
+
+Enable the pull-only metrics endpoint with
+`OPENMED_SERVICE_METRICS_ENABLED=true`. Admission control exports only static
+queue names and aggregate values:
+
+- `openmed_service_admission_queue_depth{queue=...}`: outstanding admitted work.
+- `openmed_service_admission_queue_shedding{queue=...}`: `1` while shedding,
+  otherwise `0`.
+- `openmed_service_admission_queue_wait_seconds{queue=...}`: latest observed
+  pre-dispatch wait.
+- `openmed_service_admission_shed_total{queue=...}`: cumulative high-watermark
+  rejections and max-wait expirations.
+
+The existing `openmed_service_batch_queue_*` and
+`openmed_service_batch_shed_total` families remain available for per-priority
+pending-queue visibility.
+
+## Tuning
+
+Start with a high watermark no larger than the request volume that one replica
+can finish within its latency SLO. Set the low watermark between one-third and
+one-half of the high watermark, then load-test with production-like document
+sizes. Reduce the high watermark or maximum queue wait if p99 latency rises
+before shedding begins. Clients should honor `Retry-After` and retry with
+bounded exponential backoff and jitter.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - REST API Recipes: rest-recipes.md
       - REST Tracing: serving/tracing.md
       - Serving Resilience: serving/resilience.md
+      - Serving Backpressure: serving/backpressure.md
       - Hardened Service Image: deploy/hardened-image.md
       - Async REST Jobs & Webhooks: serving/async-jobs.md
       - gRPC Service: serving/grpc.md

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -210,6 +210,10 @@ def _attach_runtime(app: FastAPI, runtime: ServiceRuntime) -> None:
             max_batch_size=runtime.batching.max_batch_size,
             max_wait_ms=runtime.batching.max_wait_ms,
             max_queue_size_per_priority=runtime.batching.max_queue_size,
+            high_watermark=runtime.batching.high_watermark,
+            low_watermark=runtime.batching.low_watermark,
+            max_queue_wait_ms=runtime.batching.max_queue_wait_ms,
+            queue_name="analyze",
             metrics=runtime.metrics,
         )
         app.state.pii_extract_batcher = DynamicBatcher(
@@ -217,6 +221,10 @@ def _attach_runtime(app: FastAPI, runtime: ServiceRuntime) -> None:
             max_batch_size=runtime.batching.max_batch_size,
             max_wait_ms=runtime.batching.max_wait_ms,
             max_queue_size_per_priority=runtime.batching.max_queue_size,
+            high_watermark=runtime.batching.high_watermark,
+            low_watermark=runtime.batching.low_watermark,
+            max_queue_wait_ms=runtime.batching.max_queue_wait_ms,
+            queue_name="pii_extract",
             metrics=runtime.metrics,
         )
     app.state.throttle = ServiceThrottle(

--- a/openmed/service/backpressure.py
+++ b/openmed/service/backpressure.py
@@ -1,0 +1,192 @@
+"""Bounded admission and hysteretic load shedding for service batching."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class AdmissionSnapshot:
+    """Immutable aggregate state for one admission queue."""
+
+    queue_name: str
+    depth: int
+    high_watermark: int
+    low_watermark: int
+    shedding: bool
+
+
+class BackpressureError(RuntimeError):
+    """Raised when the inference admission queue cannot accept more work."""
+
+    def __init__(
+        self,
+        *,
+        priority: str,
+        queue_depth: int,
+        queue_capacity: int,
+        retry_after_seconds: float,
+        queue_name: str = "batch",
+        low_watermark: Optional[int] = None,
+        max_wait_ms: Optional[float] = None,
+        reason: str = "saturated",
+    ) -> None:
+        self.priority = str(priority)
+        self.queue_name = str(queue_name)
+        self.queue_depth = int(queue_depth)
+        self.queue_capacity = int(queue_capacity)
+        self.low_watermark = None if low_watermark is None else int(low_watermark)
+        self.max_wait_ms = None if max_wait_ms is None else float(max_wait_ms)
+        self.retry_after_seconds = max(float(retry_after_seconds), 0.0)
+        self.reason = str(reason)
+        super().__init__(f"{self.priority} inference queue is saturated; retry later")
+
+    def to_details(self) -> dict[str, Any]:
+        """Return the stable, PHI-free API details for this rejection."""
+        details: dict[str, Any] = {
+            "priority": self.priority,
+            "queue": self.queue_name,
+            "queue_depth": self.queue_depth,
+            "queue_capacity": self.queue_capacity,
+            "retry_after_seconds": self.retry_after_seconds,
+            "reason": self.reason,
+        }
+        if self.low_watermark is not None:
+            details["low_watermark"] = self.low_watermark
+        if self.max_wait_ms is not None:
+            details["max_wait_ms"] = self.max_wait_ms
+        return details
+
+
+class AdmissionQueue:
+    """Track bounded outstanding work with high/low-watermark hysteresis.
+
+    The owner must serialize calls to this object. ``DynamicBatcher`` does so
+    with its event-loop lock, which keeps admission, dispatch, cancellation,
+    and timeout transitions atomic without adding another lock.
+    """
+
+    def __init__(
+        self,
+        *,
+        queue_name: str,
+        high_watermark: int,
+        low_watermark: int,
+        max_wait_ms: float,
+        metrics: Optional[Any] = None,
+    ) -> None:
+        high = int(high_watermark)
+        low = int(low_watermark)
+        max_wait = float(max_wait_ms)
+        if high <= 0:
+            raise ValueError("high_watermark must be positive")
+        if low < 0:
+            raise ValueError("low_watermark must be greater than or equal to 0")
+        if low >= high:
+            raise ValueError("low_watermark must be less than high_watermark")
+        if max_wait < 0:
+            raise ValueError("max_wait_ms must be greater than or equal to 0")
+
+        self.queue_name = str(queue_name)
+        self.high_watermark = high
+        self.low_watermark = low
+        self.max_wait_ms = max_wait
+        self._metrics = metrics
+        self._depth = 0
+        self._shedding = False
+        self._record_state()
+        self.record_wait(0.0)
+
+    @property
+    def max_wait_seconds(self) -> float:
+        """Return the maximum pre-dispatch wait in seconds."""
+        return self.max_wait_ms / 1000.0
+
+    def snapshot(self) -> AdmissionSnapshot:
+        """Return the current queue state."""
+        return AdmissionSnapshot(
+            queue_name=self.queue_name,
+            depth=self._depth,
+            high_watermark=self.high_watermark,
+            low_watermark=self.low_watermark,
+            shedding=self._shedding,
+        )
+
+    def admit(self, *, priority: str) -> None:
+        """Reserve one bounded slot or raise a backpressure error."""
+        error = self.admission_error(priority=priority, record_shed=False)
+        if error is not None:
+            self._record_shed()
+            raise error
+
+        self._depth += 1
+        if self._depth >= self.high_watermark:
+            self._shedding = True
+        self._record_state()
+
+    def admission_error(
+        self,
+        *,
+        priority: str,
+        record_shed: bool = True,
+    ) -> Optional[BackpressureError]:
+        """Return an error while shedding, without reserving a slot."""
+        if not self._shedding and self._depth < self.high_watermark:
+            return None
+
+        if not self._shedding:
+            self._shedding = True
+            self._record_state()
+        if record_shed:
+            self._record_shed()
+        return self._error(priority=priority, reason="high_watermark")
+
+    def release(self) -> None:
+        """Release one completed or cancelled request from admission."""
+        if self._depth <= 0:
+            return
+        self._depth -= 1
+        if self._shedding and self._depth <= self.low_watermark:
+            self._shedding = False
+        self._record_state()
+
+    def wait_expired(self, *, priority: str) -> BackpressureError:
+        """Record and describe a request shed after excessive queue wait."""
+        self._record_shed()
+        return self._error(priority=priority, reason="max_wait")
+
+    def record_wait(self, wait_seconds: float) -> None:
+        """Record the latest pre-dispatch wait using aggregate metrics only."""
+        record = getattr(self._metrics, "record_admission_queue_wait", None)
+        if callable(record):
+            record(
+                queue=self.queue_name,
+                wait_seconds=max(float(wait_seconds), 0.0),
+            )
+
+    def _error(self, *, priority: str, reason: str) -> BackpressureError:
+        return BackpressureError(
+            priority=priority,
+            queue_name=self.queue_name,
+            queue_depth=self._depth,
+            queue_capacity=self.high_watermark,
+            low_watermark=self.low_watermark,
+            max_wait_ms=self.max_wait_ms,
+            retry_after_seconds=max(self.max_wait_seconds, 0.001),
+            reason=reason,
+        )
+
+    def _record_state(self) -> None:
+        record = getattr(self._metrics, "record_admission_queue_state", None)
+        if callable(record):
+            record(
+                queue=self.queue_name,
+                depth=self._depth,
+                shedding=self._shedding,
+            )
+
+    def _record_shed(self) -> None:
+        record = getattr(self._metrics, "record_admission_shed", None)
+        if callable(record):
+            record(queue=self.queue_name)

--- a/openmed/service/batcher.py
+++ b/openmed/service/batcher.py
@@ -10,6 +10,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Generic, Optional, Sequence, TypeVar, Union
 
+from .backpressure import AdmissionQueue, AdmissionSnapshot, BackpressureError
+
 T = TypeVar("T")
 R = TypeVar("R")
 BatchResult = Union[R, BaseException]
@@ -67,33 +69,6 @@ def priority_is_higher(candidate: str, current: str) -> bool:
     )
 
 
-class BackpressureError(RuntimeError):
-    """Raised when a priority queue is saturated and cannot admit work."""
-
-    def __init__(
-        self,
-        *,
-        priority: str,
-        queue_depth: int,
-        queue_capacity: int,
-        retry_after_seconds: float,
-    ) -> None:
-        self.priority = normalize_priority(priority)
-        self.queue_depth = int(queue_depth)
-        self.queue_capacity = int(queue_capacity)
-        self.retry_after_seconds = max(float(retry_after_seconds), 0.0)
-        super().__init__(f"{self.priority} inference queue is saturated; retry later")
-
-    def to_details(self) -> dict[str, Any]:
-        """Return the stable API details payload for this backpressure event."""
-        return {
-            "priority": self.priority,
-            "queue_depth": self.queue_depth,
-            "queue_capacity": self.queue_capacity,
-            "retry_after_seconds": self.retry_after_seconds,
-        }
-
-
 class BatchPriorityHandle:
     """Mutable priority handle shared by coalesced callers for one queued job."""
 
@@ -145,6 +120,7 @@ class _QueuedJob(Generic[T, R]):
     priority: str
     queued_at: float
     priority_handle: Optional[BatchPriorityHandle]
+    wait_timeout: Optional[asyncio.TimerHandle]
 
 
 class DynamicBatcher(Generic[T, R]):
@@ -159,6 +135,10 @@ class DynamicBatcher(Generic[T, R]):
         max_queue_size_per_priority: int | Mapping[str, int] = (
             DEFAULT_MAX_QUEUE_SIZE_PER_PRIORITY
         ),
+        high_watermark: Optional[int] = None,
+        low_watermark: Optional[int] = None,
+        max_queue_wait_ms: float = 1000.0,
+        queue_name: str = "batch",
         priority_weights: Optional[Mapping[str, int]] = None,
         metrics: Optional[Any] = None,
     ) -> None:
@@ -171,6 +151,21 @@ class DynamicBatcher(Generic[T, R]):
         self.max_wait_ms = float(max_wait_ms)
         self._dispatch = dispatch
         self._queue_limits = _normalize_queue_limits(max_queue_size_per_priority)
+        admission_high = (
+            sum(self._queue_limits.values())
+            if high_watermark is None
+            else int(high_watermark)
+        )
+        admission_low = (
+            max(0, admission_high // 2) if low_watermark is None else int(low_watermark)
+        )
+        self._admission = AdmissionQueue(
+            queue_name=queue_name,
+            high_watermark=admission_high,
+            low_watermark=admission_low,
+            max_wait_ms=max_queue_wait_ms,
+            metrics=metrics,
+        )
         self._queues: dict[str, deque[_QueuedJob[T, R]]] = {
             priority: deque() for priority in PRIORITY_CLASSES
         }
@@ -209,6 +204,12 @@ class DynamicBatcher(Generic[T, R]):
                 self._record_shed(requested_priority)
                 raise error
 
+            try:
+                self._admission.admit(priority=requested_priority)
+            except BackpressureError:
+                self._record_shed(requested_priority)
+                raise
+
             self._job_sequence += 1
             job = _QueuedJob(
                 job_id=self._job_sequence,
@@ -217,11 +218,13 @@ class DynamicBatcher(Generic[T, R]):
                 priority=requested_priority,
                 queued_at=time.monotonic(),
                 priority_handle=priority_handle,
+                wait_timeout=None,
             )
             if priority_handle is not None:
                 priority_handle._bind(self, job.job_id, loop)
             queue.append(job)
             self._jobs[job.job_id] = job
+            self._schedule_wait_timeout_locked(job, loop)
             self._record_queue_depth(job.priority)
 
             if self._pending_count_locked() == 1:
@@ -235,17 +238,23 @@ class DynamicBatcher(Generic[T, R]):
             future.cancel()
             await self._remove_pending_job(job.job_id)
             raise
+        finally:
+            async with self._lock:
+                self._admission.release()
 
     async def admission_error(self, priority: object) -> Optional[BackpressureError]:
         """Return a backpressure error if *priority* cannot admit more work."""
         normalized = normalize_priority(priority)
         async with self._lock:
             queue = self._queues[normalized]
-            if len(queue) < self._queue_limits[normalized]:
-                return None
+            if len(queue) >= self._queue_limits[normalized]:
+                error = self._backpressure_error_locked(normalized)
+                self._record_shed(normalized)
+                return error
 
-            error = self._backpressure_error_locked(normalized)
-            self._record_shed(normalized)
+            error = self._admission.admission_error(priority=normalized)
+            if error is not None:
+                self._record_shed(normalized)
             return error
 
     async def promote(self, job_id: int, priority: object) -> None:
@@ -276,6 +285,55 @@ class DynamicBatcher(Generic[T, R]):
             return {
                 priority: len(self._queues[priority]) for priority in PRIORITY_CLASSES
             }
+
+    async def admission_snapshot(self) -> AdmissionSnapshot:
+        """Return aggregate admitted work and hysteresis state."""
+        async with self._lock:
+            return self._admission.snapshot()
+
+    def _schedule_wait_timeout_locked(
+        self,
+        job: _QueuedJob[T, R],
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        wait_seconds = self._admission.max_wait_seconds
+        if wait_seconds <= 0:
+            job.wait_timeout = loop.call_soon(self._on_wait_timeout, job.job_id)
+        else:
+            job.wait_timeout = loop.call_later(
+                wait_seconds,
+                self._on_wait_timeout,
+                job.job_id,
+            )
+
+    def _on_wait_timeout(self, job_id: int) -> None:
+        asyncio.get_running_loop().create_task(self._expire_waiting_job(job_id))
+
+    async def _expire_waiting_job(self, job_id: int) -> None:
+        async with self._lock:
+            job = self._jobs.pop(job_id, None)
+            if job is None:
+                return
+            try:
+                self._queues[job.priority].remove(job)
+            except ValueError:
+                return
+
+            job.wait_timeout = None
+            if not self._jobs and self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+            waited = max(time.monotonic() - job.queued_at, 0.0)
+            self._record_queue_depth(job.priority)
+            self._record_queue_wait(job.priority, waited)
+            self._admission.record_wait(waited)
+            self._record_shed(job.priority)
+            if job.priority_handle is not None:
+                job.priority_handle._clear(job.job_id)
+            if not job.future.done():
+                job.future.set_exception(
+                    self._admission.wait_expired(priority=job.priority)
+                )
 
     def _schedule_flush_locked(self, loop: asyncio.AbstractEventLoop) -> None:
         if self._timer is not None:
@@ -317,8 +375,13 @@ class DynamicBatcher(Generic[T, R]):
             if job is None:
                 break
             self._jobs.pop(job.job_id, None)
+            if job.wait_timeout is not None:
+                job.wait_timeout.cancel()
+                job.wait_timeout = None
             self._record_queue_depth(job.priority)
-            self._record_queue_wait(job.priority, time.monotonic() - job.queued_at)
+            waited = max(time.monotonic() - job.queued_at, 0.0)
+            self._record_queue_wait(job.priority, waited)
+            self._admission.record_wait(waited)
             if job.priority_handle is not None:
                 job.priority_handle._clear(job.job_id)
             batch.append(job)
@@ -378,6 +441,12 @@ class DynamicBatcher(Generic[T, R]):
                 self._queues[job.priority].remove(job)
             except ValueError:
                 return
+            if job.wait_timeout is not None:
+                job.wait_timeout.cancel()
+                job.wait_timeout = None
+            if not self._jobs and self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
             self._record_queue_depth(job.priority)
             if job.priority_handle is not None:
                 job.priority_handle._clear(job.job_id)
@@ -388,6 +457,7 @@ class DynamicBatcher(Generic[T, R]):
     def _backpressure_error_locked(self, priority: str) -> BackpressureError:
         return BackpressureError(
             priority=priority,
+            queue_name=priority,
             queue_depth=len(self._queues[priority]),
             queue_capacity=self._queue_limits[priority],
             retry_after_seconds=max(self.max_wait_ms / 1000.0, 0.001),

--- a/openmed/service/metrics.py
+++ b/openmed/service/metrics.py
@@ -23,6 +23,10 @@ PAGED_KV_CACHE_BUDGET_BYTES_NAME = "openmed_service_mlx_paged_kv_cache_budget_by
 BATCH_QUEUE_DEPTH_NAME = "openmed_service_batch_queue_depth"
 BATCH_QUEUE_WAIT_NAME = "openmed_service_batch_queue_wait_seconds"
 BATCH_SHED_NAME = "openmed_service_batch_shed_total"
+ADMISSION_QUEUE_DEPTH_NAME = "openmed_service_admission_queue_depth"
+ADMISSION_QUEUE_SHEDDING_NAME = "openmed_service_admission_queue_shedding"
+ADMISSION_QUEUE_WAIT_NAME = "openmed_service_admission_queue_wait_seconds"
+ADMISSION_SHED_NAME = "openmed_service_admission_shed_total"
 CIRCUIT_BREAKER_CLOSED_NAME = "openmed_service_circuit_breaker_closed"
 CIRCUIT_BREAKER_OPEN_NAME = "openmed_service_circuit_breaker_open"
 CIRCUIT_BREAKER_HALF_OPEN_NAME = "openmed_service_circuit_breaker_half_open"
@@ -112,6 +116,10 @@ class PrometheusMetricsRegistry:
         self._batch_wait_count: dict[str, int] = {}
         self._batch_wait_sum: dict[str, float] = {}
         self._batch_shed_total: dict[str, int] = {}
+        self._admission_queue_depth: dict[str, int] = {}
+        self._admission_queue_shedding: dict[str, int] = {}
+        self._admission_queue_wait: dict[str, float] = {}
+        self._admission_shed_total: dict[str, int] = {}
         self._circuit_breaker_state_counts = {
             "closed": 0,
             "open": 0,
@@ -250,6 +258,39 @@ class PrometheusMetricsRegistry:
                 priority_label, 0
             ) + int(count)
 
+    def record_admission_queue_state(
+        self,
+        *,
+        queue: str,
+        depth: int,
+        shedding: bool,
+    ) -> None:
+        """Set aggregate outstanding depth and load-shedding state."""
+        queue_label = str(queue)
+        with self._lock:
+            self._admission_queue_depth[queue_label] = max(int(depth), 0)
+            self._admission_queue_shedding[queue_label] = int(bool(shedding))
+
+    def record_admission_queue_wait(
+        self,
+        *,
+        queue: str,
+        wait_seconds: float,
+    ) -> None:
+        """Set the latest bounded pre-dispatch wait for an admission queue."""
+        with self._lock:
+            self._admission_queue_wait[str(queue)] = max(float(wait_seconds), 0.0)
+
+    def record_admission_shed(self, *, queue: str, count: int = 1) -> None:
+        """Record requests rejected or expired by aggregate admission control."""
+        if count <= 0:
+            return
+        queue_label = str(queue)
+        with self._lock:
+            self._admission_shed_total[queue_label] = self._admission_shed_total.get(
+                queue_label, 0
+            ) + int(count)
+
     def set_circuit_breaker_state_counts(self, counts: Mapping[str, int]) -> None:
         """Replace aggregate circuit-breaker state gauges."""
         with self._lock:
@@ -337,6 +378,10 @@ class PrometheusMetricsRegistry:
             batch_wait_count = dict(self._batch_wait_count)
             batch_wait_sum = dict(self._batch_wait_sum)
             batch_shed_total = dict(self._batch_shed_total)
+            admission_queue_depth = dict(self._admission_queue_depth)
+            admission_queue_shedding = dict(self._admission_queue_shedding)
+            admission_queue_wait = dict(self._admission_queue_wait)
+            admission_shed_total = dict(self._admission_shed_total)
             circuit_breaker_state_counts = dict(self._circuit_breaker_state_counts)
             model_resident_total = self._model_resident_total
             model_resident_bytes = self._model_resident_bytes
@@ -461,6 +506,48 @@ class PrometheusMetricsRegistry:
         for priority, value in sorted(batch_shed_total.items()):
             labels = _label_suffix({"priority": priority})
             lines.append(f"{BATCH_SHED_NAME}{labels} {value}")
+
+        _append_family_header(
+            lines,
+            ADMISSION_QUEUE_DEPTH_NAME,
+            "Outstanding requests admitted to each dynamic-batching path.",
+            "gauge",
+        )
+        for queue, value in sorted(admission_queue_depth.items()):
+            labels = _label_suffix({"queue": queue})
+            lines.append(f"{ADMISSION_QUEUE_DEPTH_NAME}{labels} {value}")
+
+        _append_family_header(
+            lines,
+            ADMISSION_QUEUE_SHEDDING_NAME,
+            "Whether each dynamic-batching admission queue is shedding load.",
+            "gauge",
+        )
+        for queue, value in sorted(admission_queue_shedding.items()):
+            labels = _label_suffix({"queue": queue})
+            lines.append(f"{ADMISSION_QUEUE_SHEDDING_NAME}{labels} {value}")
+
+        _append_family_header(
+            lines,
+            ADMISSION_QUEUE_WAIT_NAME,
+            "Latest pre-dispatch wait in seconds for each admission queue.",
+            "gauge",
+        )
+        for queue, value in sorted(admission_queue_wait.items()):
+            labels = _label_suffix({"queue": queue})
+            lines.append(
+                f"{ADMISSION_QUEUE_WAIT_NAME}{labels} {_format_sample_value(value)}"
+            )
+
+        _append_family_header(
+            lines,
+            ADMISSION_SHED_NAME,
+            "Requests shed by bounded dynamic-batching admission control.",
+            "counter",
+        )
+        for queue, value in sorted(admission_shed_total.items()):
+            labels = _label_suffix({"queue": queue})
+            lines.append(f"{ADMISSION_SHED_NAME}{labels} {value}")
 
         _append_family_header(
             lines,

--- a/openmed/service/runtime.py
+++ b/openmed/service/runtime.py
@@ -37,6 +37,9 @@ SERVICE_BATCHING_ENABLED_ENV_VAR = "OPENMED_SERVICE_BATCHING_ENABLED"
 SERVICE_BATCH_MAX_SIZE_ENV_VAR = "OPENMED_SERVICE_BATCH_MAX_SIZE"
 SERVICE_BATCH_MAX_WAIT_MS_ENV_VAR = "OPENMED_SERVICE_BATCH_MAX_WAIT_MS"
 SERVICE_BATCH_MAX_QUEUE_SIZE_ENV_VAR = "OPENMED_SERVICE_BATCH_MAX_QUEUE_SIZE"
+SERVICE_BATCH_HIGH_WATERMARK_ENV_VAR = "OPENMED_SERVICE_BATCH_HIGH_WATERMARK"
+SERVICE_BATCH_LOW_WATERMARK_ENV_VAR = "OPENMED_SERVICE_BATCH_LOW_WATERMARK"
+SERVICE_BATCH_MAX_QUEUE_WAIT_MS_ENV_VAR = "OPENMED_SERVICE_BATCH_MAX_QUEUE_WAIT_MS"
 SERVICE_COALESCING_ENABLED_ENV_VAR = "OPENMED_SERVICE_COALESCING_ENABLED"
 SERVICE_SHUTDOWN_DRAIN_ENV_VAR = "OPENMED_SERVICE_SHUTDOWN_DRAIN_SECONDS"
 SERVICE_RATE_LIMIT_RPS_ENV_VAR = "OPENMED_SERVICE_RATE_LIMIT_RPS"
@@ -72,6 +75,9 @@ SERVICE_BREAKER_RECOVERY_TIMEOUT_ENV_VAR = (
 DEFAULT_SERVICE_BATCH_MAX_SIZE = 8
 DEFAULT_SERVICE_BATCH_MAX_WAIT_MS = 5.0
 DEFAULT_SERVICE_BATCH_MAX_QUEUE_SIZE = 256
+DEFAULT_SERVICE_BATCH_HIGH_WATERMARK = DEFAULT_SERVICE_BATCH_MAX_QUEUE_SIZE
+DEFAULT_SERVICE_BATCH_LOW_WATERMARK = DEFAULT_SERVICE_BATCH_HIGH_WATERMARK // 2
+DEFAULT_SERVICE_BATCH_MAX_QUEUE_WAIT_MS = 1000.0
 DEFAULT_SERVICE_SHUTDOWN_DRAIN_SECONDS = 30.0
 DEFAULT_SERVICE_CONCURRENCY_WAIT_SECONDS = 0.05
 DEFAULT_MLX_PAGED_KV_CACHE_PAGE_TOKENS = 128
@@ -127,6 +133,9 @@ class ServiceBatchingConfig:
     max_batch_size: int = DEFAULT_SERVICE_BATCH_MAX_SIZE
     max_wait_ms: float = DEFAULT_SERVICE_BATCH_MAX_WAIT_MS
     max_queue_size: int = DEFAULT_SERVICE_BATCH_MAX_QUEUE_SIZE
+    high_watermark: int = DEFAULT_SERVICE_BATCH_HIGH_WATERMARK
+    low_watermark: int = DEFAULT_SERVICE_BATCH_LOW_WATERMARK
+    max_queue_wait_ms: float = DEFAULT_SERVICE_BATCH_MAX_QUEUE_WAIT_MS
 
 
 @dataclass(frozen=True)
@@ -347,6 +356,73 @@ def parse_service_batch_max_queue_size(raw_value: Optional[str]) -> int:
     return parsed
 
 
+def parse_service_batch_high_watermark(
+    raw_value: Optional[str],
+    *,
+    default: int = DEFAULT_SERVICE_BATCH_HIGH_WATERMARK,
+) -> int:
+    """Parse the aggregate outstanding-request high watermark."""
+    if raw_value is None or not raw_value.strip():
+        return int(default)
+
+    try:
+        parsed = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{SERVICE_BATCH_HIGH_WATERMARK_ENV_VAR} must be a positive integer"
+        ) from exc
+    if parsed <= 0:
+        raise ValueError(
+            f"{SERVICE_BATCH_HIGH_WATERMARK_ENV_VAR} must be greater than 0"
+        )
+    return parsed
+
+
+def parse_service_batch_low_watermark(
+    raw_value: Optional[str],
+    *,
+    high_watermark: int,
+) -> int:
+    """Parse the depth below which hysteretic shedding stops."""
+    if raw_value is None or not raw_value.strip():
+        return max(0, int(high_watermark) // 2)
+
+    try:
+        parsed = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{SERVICE_BATCH_LOW_WATERMARK_ENV_VAR} must be a non-negative integer"
+        ) from exc
+    if parsed < 0:
+        raise ValueError(
+            f"{SERVICE_BATCH_LOW_WATERMARK_ENV_VAR} must be greater than or equal to 0"
+        )
+    if parsed >= high_watermark:
+        raise ValueError(
+            f"{SERVICE_BATCH_LOW_WATERMARK_ENV_VAR} must be less than "
+            f"{SERVICE_BATCH_HIGH_WATERMARK_ENV_VAR}"
+        )
+    return parsed
+
+
+def parse_service_batch_max_queue_wait_ms(raw_value: Optional[str]) -> float:
+    """Parse the maximum time a request may wait before batch dispatch."""
+    if raw_value is None or not raw_value.strip():
+        return DEFAULT_SERVICE_BATCH_MAX_QUEUE_WAIT_MS
+
+    try:
+        parsed = float(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{SERVICE_BATCH_MAX_QUEUE_WAIT_MS_ENV_VAR} must be a non-negative number"
+        ) from exc
+    if parsed < 0:
+        raise ValueError(
+            f"{SERVICE_BATCH_MAX_QUEUE_WAIT_MS_ENV_VAR} must be greater than or equal to 0"
+        )
+    return parsed
+
+
 def parse_shutdown_drain_seconds(raw_value: Optional[str]) -> float:
     """Parse the configured graceful-shutdown drain window in seconds."""
     if raw_value is None or not raw_value.strip():
@@ -493,6 +569,13 @@ def parse_service_throttle_config() -> ServiceThrottleConfig:
 
 def parse_service_batching_config() -> ServiceBatchingConfig:
     """Read dynamic-batching settings from the current process environment."""
+    max_queue_size = parse_service_batch_max_queue_size(
+        os.getenv(SERVICE_BATCH_MAX_QUEUE_SIZE_ENV_VAR)
+    )
+    high_watermark = parse_service_batch_high_watermark(
+        os.getenv(SERVICE_BATCH_HIGH_WATERMARK_ENV_VAR),
+        default=max_queue_size,
+    )
     return ServiceBatchingConfig(
         enabled=parse_service_batching_enabled(
             os.getenv(SERVICE_BATCHING_ENABLED_ENV_VAR)
@@ -503,8 +586,14 @@ def parse_service_batching_config() -> ServiceBatchingConfig:
         max_wait_ms=parse_service_batch_max_wait_ms(
             os.getenv(SERVICE_BATCH_MAX_WAIT_MS_ENV_VAR)
         ),
-        max_queue_size=parse_service_batch_max_queue_size(
-            os.getenv(SERVICE_BATCH_MAX_QUEUE_SIZE_ENV_VAR)
+        max_queue_size=max_queue_size,
+        high_watermark=high_watermark,
+        low_watermark=parse_service_batch_low_watermark(
+            os.getenv(SERVICE_BATCH_LOW_WATERMARK_ENV_VAR),
+            high_watermark=high_watermark,
+        ),
+        max_queue_wait_ms=parse_service_batch_max_queue_wait_ms(
+            os.getenv(SERVICE_BATCH_MAX_QUEUE_WAIT_MS_ENV_VAR)
         ),
     )
 

--- a/tests/unit/deploy/test_helm_chart.py
+++ b/tests/unit/deploy/test_helm_chart.py
@@ -110,3 +110,7 @@ def test_synthetic_values_exercise_image_resources_and_secret_env():
         == "disease_detection_superclinical"
     )
     assert configmap["data"]["OPENMED_SERVICE_METRICS_ENABLED"] == "true"
+    assert configmap["data"]["OPENMED_SERVICE_BATCH_MAX_QUEUE_SIZE"] == "32"
+    assert configmap["data"]["OPENMED_SERVICE_BATCH_HIGH_WATERMARK"] == "24"
+    assert configmap["data"]["OPENMED_SERVICE_BATCH_LOW_WATERMARK"] == "8"
+    assert configmap["data"]["OPENMED_SERVICE_BATCH_MAX_QUEUE_WAIT_MS"] == "250"

--- a/tests/unit/service/test_backpressure_shedding.py
+++ b/tests/unit/service/test_backpressure_shedding.py
@@ -1,0 +1,282 @@
+"""Tests for bounded batching admission and hysteretic load shedding."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from datetime import datetime
+from typing import Any
+
+import httpx
+import pytest
+
+import openmed
+from openmed.processing.outputs import PredictionResult
+from openmed.service import runtime as service_runtime
+from openmed.service.app import create_app
+from openmed.service.backpressure import AdmissionQueue, BackpressureError
+from openmed.service.batcher import DynamicBatcher
+from openmed.service.metrics import (
+    ADMISSION_QUEUE_DEPTH_NAME,
+    ADMISSION_QUEUE_SHEDDING_NAME,
+    ADMISSION_QUEUE_WAIT_NAME,
+    ADMISSION_SHED_NAME,
+    PrometheusMetricsRegistry,
+)
+
+LOOPBACK_BASE_URL = "http://127.0.0.1"
+
+
+class FakeLoader:
+    """Minimal loader double that keeps the burst test offline."""
+
+    def __init__(self, config: Any) -> None:
+        self.config = config
+
+    def resolve_model_name(self, model_name: str) -> str:
+        return model_name
+
+    def create_pipeline(self, model_name: str, **_: Any) -> object:
+        del model_name
+        return object()
+
+    def loaded_models(self) -> dict[str, dict[str, int]]:
+        return {}
+
+
+def _prediction_result(text: str) -> PredictionResult:
+    return PredictionResult(
+        text=text,
+        entities=[],
+        model_name="disease_detection_superclinical",
+        timestamp=datetime.now().isoformat(),
+        processing_time=0.01,
+    )
+
+
+def test_admission_queue_sheds_until_depth_reaches_low_watermark() -> None:
+    queue = AdmissionQueue(
+        queue_name="analyze",
+        high_watermark=3,
+        low_watermark=1,
+        max_wait_ms=50,
+    )
+
+    for _ in range(3):
+        queue.admit(priority="interactive")
+
+    assert queue.snapshot().shedding is True
+    with pytest.raises(BackpressureError) as at_high:
+        queue.admit(priority="interactive")
+    assert at_high.value.reason == "high_watermark"
+
+    queue.release()
+    assert queue.snapshot().depth == 2
+    assert queue.snapshot().shedding is True
+    with pytest.raises(BackpressureError):
+        queue.admit(priority="interactive")
+
+    queue.release()
+    assert queue.snapshot().depth == 1
+    assert queue.snapshot().shedding is False
+    queue.admit(priority="interactive")
+    assert queue.snapshot().depth == 2
+
+
+def test_synthetic_burst_sheds_while_inflight_batch_completes_within_slo() -> None:
+    async def scenario() -> tuple[list[str], BackpressureError, float]:
+        dispatch_started = asyncio.Event()
+        release_dispatch = asyncio.Event()
+
+        async def dispatch(items: list[str]) -> list[str]:
+            dispatch_started.set()
+            await release_dispatch.wait()
+            return list(items)
+
+        batcher = DynamicBatcher(
+            dispatch,
+            max_batch_size=2,
+            max_wait_ms=1000,
+            max_queue_size_per_priority=8,
+            high_watermark=2,
+            low_watermark=0,
+            max_queue_wait_ms=500,
+            queue_name="analyze",
+        )
+        admitted = [
+            asyncio.create_task(batcher.submit("first")),
+            asyncio.create_task(batcher.submit("second")),
+        ]
+        await asyncio.wait_for(dispatch_started.wait(), timeout=0.2)
+
+        snapshot = await batcher.admission_snapshot()
+        assert snapshot.depth == 2
+        assert snapshot.shedding is True
+        with pytest.raises(BackpressureError) as shed:
+            await batcher.submit("excess")
+
+        released_at = time.perf_counter()
+        release_dispatch.set()
+        completed = await asyncio.wait_for(asyncio.gather(*admitted), timeout=0.5)
+        completion_latency = time.perf_counter() - released_at
+
+        drained = await batcher.admission_snapshot()
+        assert drained.depth == 0
+        assert drained.shedding is False
+        return completed, shed.value, completion_latency
+
+    completed, shed, completion_latency = asyncio.run(scenario())
+
+    assert completed == ["first", "second"]
+    assert shed.reason == "high_watermark"
+    assert shed.queue_depth == 2
+    assert completion_latency < 0.5
+
+
+def test_request_waiting_beyond_maximum_is_shed_and_releases_admission() -> None:
+    async def dispatch(items: list[str]) -> list[str]:
+        return list(items)
+
+    async def scenario() -> tuple[BackpressureError, int, bool]:
+        batcher = DynamicBatcher(
+            dispatch,
+            max_batch_size=8,
+            max_wait_ms=1000,
+            high_watermark=2,
+            low_watermark=0,
+            max_queue_wait_ms=10,
+            queue_name="analyze",
+        )
+        with pytest.raises(BackpressureError) as expired:
+            await batcher.submit("stale")
+        snapshot = await batcher.admission_snapshot()
+        return expired.value, snapshot.depth, snapshot.shedding
+
+    expired, depth, shedding = asyncio.run(scenario())
+
+    assert expired.reason == "max_wait"
+    assert expired.max_wait_ms == 10
+    assert depth == 0
+    assert shedding is False
+
+
+def test_admission_metrics_expose_depth_state_wait_and_shed_count() -> None:
+    metrics = PrometheusMetricsRegistry()
+    queue = AdmissionQueue(
+        queue_name="analyze",
+        high_watermark=2,
+        low_watermark=0,
+        max_wait_ms=25,
+        metrics=metrics,
+    )
+
+    queue.admit(priority="interactive")
+    queue.admit(priority="interactive")
+    with pytest.raises(BackpressureError):
+        queue.admit(priority="interactive")
+    queue.record_wait(0.012)
+
+    rendered = metrics.render()
+    assert f'{ADMISSION_QUEUE_DEPTH_NAME}{{queue="analyze"}} 2' in rendered
+    assert f'{ADMISSION_QUEUE_SHEDDING_NAME}{{queue="analyze"}} 1' in rendered
+    assert f'{ADMISSION_QUEUE_WAIT_NAME}{{queue="analyze"}} 0.012' in rendered
+    assert f'{ADMISSION_SHED_NAME}{{queue="analyze"}} 1' in rendered
+
+
+def test_batch_backpressure_config_reads_watermarks_and_max_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENMED_SERVICE_BATCHING_ENABLED", "true")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_MAX_QUEUE_SIZE", "20")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_HIGH_WATERMARK", "12")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_LOW_WATERMARK", "4")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_MAX_QUEUE_WAIT_MS", "75.5")
+
+    config = service_runtime.parse_service_batching_config()
+
+    assert config.enabled is True
+    assert config.max_queue_size == 20
+    assert config.high_watermark == 12
+    assert config.low_watermark == 4
+    assert config.max_queue_wait_ms == 75.5
+
+
+def test_batch_backpressure_config_rejects_invalid_watermark_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_HIGH_WATERMARK", "4")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_LOW_WATERMARK", "4")
+
+    with pytest.raises(ValueError, match="must be less than"):
+        service_runtime.parse_service_batching_config()
+
+
+def test_rest_burst_returns_503_retry_after_without_interrupting_inflight_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENMED_PROFILE", "test")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCHING_ENABLED", "true")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_MAX_SIZE", "1")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_MAX_WAIT_MS", "0")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_MAX_QUEUE_SIZE", "8")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_HIGH_WATERMARK", "1")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_LOW_WATERMARK", "0")
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_MAX_QUEUE_WAIT_MS", "1000")
+    monkeypatch.setenv("OPENMED_SERVICE_METRICS_ENABLED", "true")
+    monkeypatch.delenv("OPENMED_SERVICE_PRELOAD_MODELS", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_COALESCING_ENABLED", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_RATE_LIMIT_RPS", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_RATE_LIMIT_BURST", raising=False)
+    monkeypatch.delenv("OPENMED_SERVICE_RATE_LIMIT_MAX_CONCURRENCY", raising=False)
+
+    first_started = threading.Event()
+    release_first = threading.Event()
+
+    def fake_analyze(text: str, **_: Any) -> PredictionResult:
+        first_started.set()
+        assert release_first.wait(timeout=2)
+        return _prediction_result(text)
+
+    monkeypatch.setattr(openmed, "analyze_text", fake_analyze)
+    monkeypatch.setattr(service_runtime, "ModelLoader", FakeLoader)
+    app = create_app()
+
+    async def scenario() -> tuple[httpx.Response, httpx.Response, str, float]:
+        async with app.router.lifespan_context(app):
+            transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+            async with httpx.AsyncClient(
+                transport=transport,
+                base_url=LOOPBACK_BASE_URL,
+            ) as client:
+                first_task = asyncio.create_task(
+                    client.post("/analyze", json={"text": "inflight"})
+                )
+                assert await asyncio.to_thread(first_started.wait, 1)
+                shed = await client.post("/analyze", json={"text": "excess"})
+                metrics_text = (await client.get("/metrics")).text
+                released_at = time.perf_counter()
+                release_first.set()
+                first = await asyncio.wait_for(first_task, timeout=0.5)
+                return (
+                    first,
+                    shed,
+                    metrics_text,
+                    time.perf_counter() - released_at,
+                )
+
+    first, shed, metrics_text, completion_latency = asyncio.run(scenario())
+
+    assert first.status_code == 200
+    assert shed.status_code == 503
+    assert int(shed.headers["Retry-After"]) >= 1
+    error = shed.json()["error"]
+    assert error["code"] == "backpressure"
+    assert error["details"]["queue"] == "analyze"
+    assert error["details"]["reason"] == "high_watermark"
+    assert "inflight" not in shed.text
+    assert "excess" not in shed.text
+    assert f'{ADMISSION_QUEUE_DEPTH_NAME}{{queue="analyze"}} 1' in metrics_text
+    assert f'{ADMISSION_QUEUE_SHEDDING_NAME}{{queue="analyze"}} 1' in metrics_text
+    assert f'{ADMISSION_SHED_NAME}{{queue="analyze"}} 1' in metrics_text
+    assert completion_latency < 0.5

--- a/tests/unit/service/test_metrics_endpoint.py
+++ b/tests/unit/service/test_metrics_endpoint.py
@@ -217,6 +217,7 @@ def test_served_request_updates_metrics_without_phi_labels(monkeypatch) -> None:
             "status_code",
             "le",
             "priority",
+            "queue",
         }
 
 


### PR DESCRIPTION
## Description

Adds bounded admission control in front of the dynamic inference batching paths so sustained bursts cannot grow outstanding work without limit. The controller uses high/low-watermark hysteresis, preserves already-admitted work during shedding, expires requests that exceed the configured pre-dispatch wait, and returns PHI-free `503` responses with `Retry-After`.

The existing per-priority queue limits covered pending jobs only; dispatched batches no longer contributed to queue depth, and the service had no hysteretic recovery threshold or explicit maximum queue wait. This change tracks queued and in-flight requests together while retaining the per-priority hard caps.

Closes #850.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added a reusable admission queue with configurable high/low watermarks, bounded pre-dispatch wait, and deterministic hysteretic shedding.
- Integrated aggregate admission with `/analyze` and `/pii/extract` while preserving priority scheduling, coalescing, hard queue caps, and in-flight completion.
- Added aggregate Prometheus depth, shedding-state, wait, and shed-count metrics using static PHI-free queue labels.
- Exposed the new environment settings through runtime parsing and the Helm chart.
- Added a serving runbook covering error behavior, metrics, tuning, and client retry guidance.

## Testing
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested burst, drain/recovery, max-wait, metrics, REST response, and Helm configuration paths

Commands run:
- `make format`
- `make lint`
- `make format-check`
- `make docs-build`
- `make type-check`
- `.venv/bin/python -m pytest tests/unit/service/test_backpressure_shedding.py tests/unit/service/test_dynamic_batcher.py tests/unit/service/test_throttle.py tests/unit/service/test_metrics_endpoint.py tests/unit/deploy/test_helm_chart.py -q` (41 passed)
- `.venv/bin/python -m pytest tests/ -q` (5,178 passed, 46 skipped)

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift` (not applicable)
- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious concurrency behavior
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #850

## Screenshots/Examples
Not applicable; this change affects service admission behavior, metrics, configuration, tests, and documentation.
