### PR TITLE
Add Android accelerator delegate selection

### DIFF
--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/OpenMedBackend.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/OpenMedBackend.kt
@@ -1,5 +1,6 @@
 package com.openmed.openmedkit
 
+import com.openmed.openmedkit.onnx.AcceleratorConfig
 import java.io.File
 
 /**
@@ -16,6 +17,7 @@ data class OpenMedBackend(
     val tokenizerConfig: File? = File(modelDirectory, "tokenizer_config.json"),
     val id2LabelFile: File = File(modelDirectory, "id2label.json"),
     val id2Label: Map<Int, String> = emptyMap(),
+    val acceleratorConfig: AcceleratorConfig = AcceleratorConfig(),
 ) {
     init {
         require(modelDirectory.path.isNotBlank()) {

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/Runtime.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/Runtime.kt
@@ -2,7 +2,8 @@ package com.openmed.openmedkit
 
 import ai.djl.huggingface.tokenizers.Encoding
 import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer
-import com.openmed.openmedkit.onnx.OnnxTokenClassifier as RuntimeOnnxTokenClassifier
+import com.openmed.openmedkit.onnx.AcceleratorSelection
+import com.openmed.openmedkit.onnx.AcceleratorSession
 import com.openmed.openmedkit.onnx.TokenOffset
 import com.openmed.openmedkit.onnx.TokenPrediction
 import java.io.Closeable
@@ -39,9 +40,17 @@ class BackendOnnxTokenClassifier(
     private val backend: OpenMedBackend,
 ) : OnnxTokenClassifier {
     private val classifier = if (backend.id2Label.isEmpty()) {
-        RuntimeOnnxTokenClassifier(backend.modelFile, backend.id2LabelFile)
+        AcceleratorSession(
+            backend.modelFile,
+            backend.id2LabelFile,
+            backend.acceleratorConfig,
+        )
     } else {
-        RuntimeOnnxTokenClassifier(backend.modelFile, backend.id2Label)
+        AcceleratorSession(
+            backend.modelFile,
+            backend.id2Label,
+            backend.acceleratorConfig,
+        )
     }
     private val tokenizer = try {
         loadTokenizer(backend)
@@ -49,6 +58,10 @@ class BackendOnnxTokenClassifier(
         classifier.close()
         throw error
     }
+
+    /** Provider and operator-partition decision for this model session. */
+    val acceleratorSelection: AcceleratorSelection
+        get() = classifier.selection
 
     override suspend fun predict(text: String): List<TokenClassificationPrediction> {
         require(text.isNotEmpty()) { "text must not be empty" }

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/onnx/AcceleratorSession.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/onnx/AcceleratorSession.kt
@@ -1,0 +1,706 @@
+package com.openmed.openmedkit.onnx
+
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtProvider
+import ai.onnxruntime.OrtSession
+import ai.onnxruntime.providers.NNAPIFlags
+import android.os.Build
+import java.io.Closeable
+import java.io.File
+import java.util.EnumSet
+import kotlin.math.abs
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/** Execution providers supported by the Android accelerator session. */
+public enum class AcceleratorProvider {
+    QNN,
+    NNAPI,
+    CPU,
+}
+
+/** Stable outcomes emitted while choosing an Android execution provider. */
+public enum class AcceleratorAttemptOutcome {
+    SELECTED,
+    NOT_AVAILABLE,
+    NO_SUPPORTED_OPERATORS,
+    SESSION_CREATION_FAILED,
+}
+
+/** One privacy-safe provider selection attempt. */
+public data class AcceleratorProviderAttempt(
+    val provider: AcceleratorProvider,
+    val outcome: AcceleratorAttemptOutcome,
+)
+
+/**
+ * Required operators and device-observed support for one model family.
+ *
+ * A missing provider key means coverage is unknown and ONNX Runtime performs
+ * its normal graph capability/partitioning pass. A present key, including an
+ * empty set, is treated as measured device-farm evidence.
+ */
+public data class ModelFamilyOperatorCoverage(
+    val family: String,
+    val requiredOperators: Set<String>,
+    val supportedOperators: Map<AcceleratorProvider, Set<String>> = emptyMap(),
+) {
+    init {
+        require(family.isNotBlank()) { "family must not be blank" }
+        require(requiredOperators.none(String::isBlank)) {
+            "requiredOperators must not contain blank names"
+        }
+        require(supportedOperators.values.flatten().none(String::isBlank)) {
+            "supportedOperators must not contain blank names"
+        }
+    }
+
+    public companion object {
+        /**
+         * Load a model family and operator list from an OpenMed ONNX manifest.
+         */
+        public fun fromManifest(
+            manifestFile: File,
+            modelFileName: String = "model.onnx",
+            supportedOperators: Map<AcceleratorProvider, Set<String>> = emptyMap(),
+        ): ModelFamilyOperatorCoverage {
+            if (!manifestFile.isFile) {
+                throw InferenceError.InvalidInput("ONNX manifest does not exist")
+            }
+            if (modelFileName.isBlank()) {
+                throw InferenceError.InvalidInput("modelFileName must not be blank")
+            }
+
+            val root = try {
+                Json.parseToJsonElement(manifestFile.readText()).jsonObject
+            } catch (error: Exception) {
+                throw InferenceError.InvalidInput(
+                    "ONNX manifest must contain a JSON object"
+                )
+            }
+            val family = try {
+                root["family"]?.jsonPrimitive?.contentOrNull
+                    ?.takeIf(String::isNotBlank)
+                    ?: "unknown"
+            } catch (error: Exception) {
+                throw InferenceError.InvalidInput(
+                    "ONNX manifest family must be a string"
+                )
+            }
+            val artifact = try {
+                root["artifacts"]?.jsonArray
+                    ?.map { it.jsonObject }
+                    ?.firstOrNull { entry ->
+                        entry["path"]?.jsonPrimitive?.contentOrNull == modelFileName
+                    }
+            } catch (error: Exception) {
+                throw InferenceError.InvalidInput(
+                    "ONNX manifest artifacts must be an array of objects"
+                )
+            } ?: throw InferenceError.InvalidInput(
+                "ONNX manifest does not describe $modelFileName"
+            )
+            val operators = try {
+                artifact["metadata"]?.jsonObject
+                    ?.get("operators")?.jsonArray
+                    ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+                    ?.toSet()
+                    .orEmpty()
+            } catch (error: Exception) {
+                throw InferenceError.InvalidInput(
+                    "ONNX manifest operators must be an array of strings"
+                )
+            }
+            if (operators.isEmpty()) {
+                throw InferenceError.InvalidInput(
+                    "ONNX manifest does not record operators for $modelFileName"
+                )
+            }
+            return ModelFamilyOperatorCoverage(
+                family = family,
+                requiredOperators = operators,
+                supportedOperators = supportedOperators,
+            )
+        }
+    }
+}
+
+/** Configuration for deterministic QNN, NNAPI, and CPU selection. */
+public data class AcceleratorConfig(
+    val preferredProviders: List<AcceleratorProvider> = listOf(
+        AcceleratorProvider.QNN,
+        AcceleratorProvider.NNAPI,
+        AcceleratorProvider.CPU,
+    ),
+    val qnnOptions: Map<String, String> = mapOf(
+        "backend_path" to "libQnnHtp.so",
+    ),
+    val nnapiAllowFp16: Boolean = false,
+    val nnapiUseNchw: Boolean = false,
+    val intraOpThreadCount: Int = 1,
+    val modelCoverage: ModelFamilyOperatorCoverage? = null,
+) {
+    init {
+        require(preferredProviders.isNotEmpty()) {
+            "preferredProviders must not be empty"
+        }
+        require(qnnOptions.keys.none(String::isBlank)) {
+            "qnnOptions must not contain blank keys"
+        }
+        require(intraOpThreadCount > 0) {
+            "intraOpThreadCount must be greater than zero"
+        }
+    }
+
+    public companion object {
+        /** A CPU-only configuration for deterministic baseline and parity runs. */
+        public fun cpuOnly(intraOpThreadCount: Int = 1): AcceleratorConfig =
+            AcceleratorConfig(
+                preferredProviders = listOf(AcceleratorProvider.CPU),
+                intraOpThreadCount = intraOpThreadCount,
+            )
+    }
+}
+
+/** Operator partition selected for a model family and provider. */
+public data class AcceleratorOperatorCoverage(
+    val family: String,
+    val provider: AcceleratorProvider,
+    val requiredOperators: Set<String>,
+    val providerOperators: Set<String>,
+    val cpuFallbackOperators: Set<String>,
+    val known: Boolean,
+) {
+    /** Whether measured coverage assigns any operators to the CPU partition. */
+    public val usesCpuPartition: Boolean
+        get() = known && cpuFallbackOperators.isNotEmpty()
+
+    /** Whether measured coverage assigns every required operator to the provider. */
+    public val fullyCovered: Boolean
+        get() = known && cpuFallbackOperators.isEmpty()
+}
+
+/** Result of the capability probe and provider/session creation sequence. */
+public data class AcceleratorSelection(
+    val selectedProvider: AcceleratorProvider,
+    val availableProviders: Set<AcceleratorProvider>,
+    val operatorCoverage: AcceleratorOperatorCoverage,
+    val attempts: List<AcceleratorProviderAttempt>,
+) {
+    /** True when a QNN or NNAPI session was selected. */
+    public val isAccelerated: Boolean
+        get() = selectedProvider != AcceleratorProvider.CPU
+}
+
+/** Device tiers used by accelerator latency evidence. */
+public enum class AndroidDeviceTier {
+    ENTRY,
+    MID_RANGE,
+    FLAGSHIP,
+    DEVICE_FARM_STUB,
+}
+
+/** Privacy-safe CPU/delegate latency evidence for one Android device tier. */
+public data class DeviceTierLatencyRecord(
+    val deviceTier: AndroidDeviceTier,
+    val provider: AcceleratorProvider,
+    val cpuP50Milliseconds: Double,
+    val delegateP50Milliseconds: Double,
+    val sampleCount: Int,
+) {
+    init {
+        require(provider != AcceleratorProvider.CPU) {
+            "latency record provider must be QNN or NNAPI"
+        }
+        require(cpuP50Milliseconds >= 0.0) {
+            "cpuP50Milliseconds must be non-negative"
+        }
+        require(delegateP50Milliseconds >= 0.0) {
+            "delegateP50Milliseconds must be non-negative"
+        }
+        require(sampleCount > 0) { "sampleCount must be greater than zero" }
+    }
+
+    /** CPU latency divided by delegate latency. */
+    public val speedup: Double
+        get() = if (delegateP50Milliseconds == 0.0) {
+            Double.POSITIVE_INFINITY
+        } else {
+            cpuP50Milliseconds / delegateP50Milliseconds
+        }
+}
+
+/** PHI-free span signature used for CPU/delegate parity evidence. */
+public data class AcceleratorSpanSignature(
+    val label: String,
+    val startOffset: Int,
+    val endOffset: Int,
+) {
+    init {
+        require(label.isNotBlank()) { "label must not be blank" }
+        require(startOffset >= 0) { "startOffset must be non-negative" }
+        require(endOffset >= startOffset) {
+            "endOffset must be greater than or equal to startOffset"
+        }
+    }
+}
+
+/**
+ * Device-farm evidence gate comparing accelerator output with the CPU baseline.
+ *
+ * Only labels, offsets, aggregate recall, and latency are retained; raw input
+ * text and span surface text are deliberately excluded.
+ */
+public data class AcceleratorValidationRecord(
+    val latency: DeviceTierLatencyRecord,
+    val cpuSpans: List<AcceleratorSpanSignature>,
+    val delegateSpans: List<AcceleratorSpanSignature>,
+    val cpuRecall: Double,
+    val delegateRecall: Double,
+    val boundaryToleranceCharacters: Int = 0,
+    val maxRecallDrop: Double = 0.0,
+) {
+    init {
+        require(cpuRecall in 0.0..1.0) { "cpuRecall must be between 0 and 1" }
+        require(delegateRecall in 0.0..1.0) {
+            "delegateRecall must be between 0 and 1"
+        }
+        require(boundaryToleranceCharacters >= 0) {
+            "boundaryToleranceCharacters must be non-negative"
+        }
+        require(maxRecallDrop >= 0.0) { "maxRecallDrop must be non-negative" }
+    }
+
+    /** Delegate recall minus CPU recall. */
+    public val recallDelta: Double
+        get() = delegateRecall - cpuRecall
+
+    /** Whether labels and boundaries match within the configured tolerance. */
+    public val spansWithinTolerance: Boolean
+        get() = cpuSpans.size == delegateSpans.size &&
+            cpuSpans.zip(delegateSpans).all { (cpu, delegate) ->
+                cpu.label == delegate.label &&
+                    abs(cpu.startOffset - delegate.startOffset) <=
+                    boundaryToleranceCharacters &&
+                    abs(cpu.endOffset - delegate.endOffset) <=
+                    boundaryToleranceCharacters
+            }
+
+    /** Whether delegate recall stays inside the configured CPU-relative budget. */
+    public val recallWithinTolerance: Boolean
+        get() = recallDelta + RECALL_COMPARISON_EPSILON >= -maxRecallDrop
+
+    /** Whether both span parity and recall-delta gates pass. */
+    public val passed: Boolean
+        get() = spansWithinTolerance && recallWithinTolerance
+
+    /** Reject evidence that does not meet span and recall-delta tolerances. */
+    public fun requirePassing(): AcceleratorValidationRecord {
+        check(spansWithinTolerance) {
+            "delegate spans do not match the CPU baseline within tolerance"
+        }
+        check(recallWithinTolerance) {
+            "delegate recall delta exceeds the CPU-relative tolerance"
+        }
+        return this
+    }
+
+    private companion object {
+        const val RECALL_COMPARISON_EPSILON = 1e-12
+    }
+}
+
+/**
+ * ONNX token-classification session with QNN/NNAPI preference and CPU fallback.
+ *
+ * ONNX Runtime keeps the CPU execution provider enabled for unsupported graph
+ * partitions. If provider registration or session creation fails, this class
+ * retries the next configured provider and always ends with a CPU attempt.
+ */
+public class AcceleratorSession private constructor(
+    private val classifier: OnnxTokenClassifier,
+    public val selection: AcceleratorSelection,
+) : Closeable {
+    public constructor(
+        modelFile: File,
+        id2LabelFile: File,
+        config: AcceleratorConfig = AcceleratorConfig(),
+        inputTensorType: TensorElementType = TensorElementType.INT64,
+    ) : this(
+        initialize(modelFile, id2LabelFile, config),
+        inputTensorType,
+    )
+
+    public constructor(
+        modelFile: File,
+        id2Label: Map<Int, String>,
+        config: AcceleratorConfig = AcceleratorConfig(),
+        inputTensorType: TensorElementType = TensorElementType.INT64,
+    ) : this(
+        initialize(modelFile, id2Label, config),
+        inputTensorType,
+    )
+
+    public constructor(
+        modelBytes: ByteArray,
+        id2Label: Map<Int, String>,
+        config: AcceleratorConfig = AcceleratorConfig(),
+        inputTensorType: TensorElementType = TensorElementType.INT64,
+    ) : this(
+        initialize(modelBytes, id2Label, config),
+        inputTensorType,
+    )
+
+    private constructor(
+        initialized: InitializedAcceleratorSession,
+        inputTensorType: TensorElementType,
+    ) : this(
+        initialized.runtime,
+        initialized.id2Label,
+        inputTensorType,
+    )
+
+    private constructor(
+        runtime: AcceleratorRuntimeComponents,
+        id2Label: Map<Int, String>,
+        inputTensorType: TensorElementType,
+    ) : this(
+        OnnxTokenClassifier(
+            environment = runtime.environment,
+            session = runtime.session,
+            id2Label = id2Label,
+            inputTensorType = inputTensorType,
+            ownsEnvironment = runtime.environment != null,
+        ),
+        runtime.selection,
+    )
+
+    /** Run token classification off the main thread. */
+    public suspend fun run(
+        inputIds: IntArray,
+        attentionMask: IntArray,
+        offsets: List<TokenOffset>,
+    ): List<TokenPrediction> = classifier.run(inputIds, attentionMask, offsets)
+
+    public override fun close() {
+        classifier.close()
+    }
+
+    internal companion object {
+        internal fun createForTesting(
+            id2Label: Map<Int, String>,
+            config: AcceleratorConfig,
+            availableProviders: Set<AcceleratorProvider>,
+            sessionFactory: AcceleratorTokenSessionFactory,
+            inputTensorType: TensorElementType = TensorElementType.INT64,
+        ): AcceleratorSession {
+            val labels = validateId2Label(id2Label)
+            val selected = selectSession(
+                config = config,
+                availableProviders = availableProviders + AcceleratorProvider.CPU,
+                sessionFactory = sessionFactory,
+            )
+            return AcceleratorSession(
+                runtime = AcceleratorRuntimeComponents(
+                    environment = null,
+                    session = selected.session,
+                    selection = selected.selection,
+                ),
+                id2Label = labels,
+                inputTensorType = inputTensorType,
+            )
+        }
+
+        private fun initialize(
+            modelFile: File,
+            id2LabelFile: File,
+            config: AcceleratorConfig,
+        ): InitializedAcceleratorSession {
+            val labels = OnnxTokenClassifier.loadId2Label(id2LabelFile)
+            return InitializedAcceleratorSession(
+                runtime = createRuntime(modelFile, config),
+                id2Label = labels,
+            )
+        }
+
+        private fun initialize(
+            modelFile: File,
+            id2Label: Map<Int, String>,
+            config: AcceleratorConfig,
+        ): InitializedAcceleratorSession {
+            val labels = validateId2Label(id2Label)
+            return InitializedAcceleratorSession(
+                runtime = createRuntime(modelFile, config),
+                id2Label = labels,
+            )
+        }
+
+        private fun initialize(
+            modelBytes: ByteArray,
+            id2Label: Map<Int, String>,
+            config: AcceleratorConfig,
+        ): InitializedAcceleratorSession {
+            val labels = validateId2Label(id2Label)
+            return InitializedAcceleratorSession(
+                runtime = createRuntime(modelBytes, config),
+                id2Label = labels,
+            )
+        }
+
+        private fun createRuntime(
+            modelFile: File,
+            config: AcceleratorConfig,
+        ): AcceleratorRuntimeComponents {
+            if (!modelFile.isFile) {
+                throw InferenceError.InvalidInput("model file does not exist")
+            }
+            val effectiveConfig = config.withDiscoveredCoverage(modelFile)
+            return createRuntime(effectiveConfig) { environment, options ->
+                environment.createSession(modelFile.absolutePath, options)
+            }
+        }
+
+        private fun createRuntime(
+            modelBytes: ByteArray,
+            config: AcceleratorConfig,
+        ): AcceleratorRuntimeComponents {
+            if (modelBytes.isEmpty()) {
+                throw InferenceError.InvalidInput("modelBytes must not be empty")
+            }
+            return createRuntime(config) { environment, options ->
+                environment.createSession(modelBytes, options)
+            }
+        }
+
+        private fun createRuntime(
+            config: AcceleratorConfig,
+            createOrtSession: (OrtEnvironment, OrtSession.SessionOptions) -> OrtSession,
+        ): AcceleratorRuntimeComponents {
+            val environment = OrtEnvironment.getEnvironment()
+            return try {
+                val availableProviders = availableAcceleratorProviders()
+                val selected = selectSession(
+                    config = config,
+                    availableProviders = availableProviders,
+                    sessionFactory = AcceleratorTokenSessionFactory { provider ->
+                        createSessionOptions(config, provider).use { options ->
+                            val session = createOrtSession(environment, options)
+                            OnnxRuntimeTokenClassificationSession(environment, session)
+                        }
+                    },
+                )
+                AcceleratorRuntimeComponents(
+                    environment = environment,
+                    session = selected.session,
+                    selection = selected.selection,
+                )
+            } catch (error: Throwable) {
+                try {
+                    environment.close()
+                } catch (closeError: Throwable) {
+                    error.addSuppressed(closeError)
+                }
+                throw error
+            }
+        }
+
+        private fun validateId2Label(id2Label: Map<Int, String>): Map<Int, String> {
+            if (id2Label.isEmpty()) {
+                throw InferenceError.InvalidInput("id2Label must not be empty")
+            }
+            return id2Label.toMap()
+        }
+    }
+}
+
+internal fun interface AcceleratorTokenSessionFactory {
+    fun create(provider: AcceleratorProvider): TokenClassificationSession
+}
+
+private data class SelectedTokenSession(
+    val session: TokenClassificationSession,
+    val selection: AcceleratorSelection,
+)
+
+private data class AcceleratorRuntimeComponents(
+    val environment: OrtEnvironment?,
+    val session: TokenClassificationSession,
+    val selection: AcceleratorSelection,
+)
+
+private data class InitializedAcceleratorSession(
+    val runtime: AcceleratorRuntimeComponents,
+    val id2Label: Map<Int, String>,
+)
+
+private fun selectSession(
+    config: AcceleratorConfig,
+    availableProviders: Set<AcceleratorProvider>,
+    sessionFactory: AcceleratorTokenSessionFactory,
+): SelectedTokenSession {
+    val attempts = mutableListOf<AcceleratorProviderAttempt>()
+    val candidates = (config.preferredProviders + AcceleratorProvider.CPU).distinct()
+
+    candidates.forEach { provider ->
+        if (provider !in availableProviders) {
+            attempts += AcceleratorProviderAttempt(
+                provider,
+                AcceleratorAttemptOutcome.NOT_AVAILABLE,
+            )
+            return@forEach
+        }
+
+        val coverage = operatorCoverage(config.modelCoverage, provider)
+        if (
+            provider != AcceleratorProvider.CPU &&
+            coverage.known &&
+            coverage.requiredOperators.isNotEmpty() &&
+            coverage.providerOperators.isEmpty()
+        ) {
+            attempts += AcceleratorProviderAttempt(
+                provider,
+                AcceleratorAttemptOutcome.NO_SUPPORTED_OPERATORS,
+            )
+            return@forEach
+        }
+
+        try {
+            val session = sessionFactory.create(provider)
+            val completedAttempts = attempts + AcceleratorProviderAttempt(
+                provider,
+                AcceleratorAttemptOutcome.SELECTED,
+            )
+            return SelectedTokenSession(
+                session = session,
+                selection = AcceleratorSelection(
+                    selectedProvider = provider,
+                    availableProviders = availableProviders.toSet(),
+                    operatorCoverage = coverage,
+                    attempts = completedAttempts,
+                ),
+            )
+        } catch (error: Exception) {
+            if (provider == AcceleratorProvider.CPU) {
+                throw InferenceError.SessionCreation(error)
+            }
+            attempts += AcceleratorProviderAttempt(
+                provider,
+                AcceleratorAttemptOutcome.SESSION_CREATION_FAILED,
+            )
+        } catch (error: UnsatisfiedLinkError) {
+            if (provider == AcceleratorProvider.CPU) {
+                throw InferenceError.SessionCreation(error)
+            }
+            attempts += AcceleratorProviderAttempt(
+                provider,
+                AcceleratorAttemptOutcome.SESSION_CREATION_FAILED,
+            )
+        }
+    }
+
+    throw InferenceError.SessionCreation()
+}
+
+private fun operatorCoverage(
+    modelCoverage: ModelFamilyOperatorCoverage?,
+    provider: AcceleratorProvider,
+): AcceleratorOperatorCoverage {
+    val family = modelCoverage?.family ?: "unknown"
+    val required = modelCoverage?.requiredOperators.orEmpty()
+    if (provider == AcceleratorProvider.CPU) {
+        return AcceleratorOperatorCoverage(
+            family = family,
+            provider = provider,
+            requiredOperators = required,
+            providerOperators = required,
+            cpuFallbackOperators = emptySet(),
+            known = true,
+        )
+    }
+
+    val support = modelCoverage?.supportedOperators?.get(provider)
+        ?: return AcceleratorOperatorCoverage(
+            family = family,
+            provider = provider,
+            requiredOperators = required,
+            providerOperators = emptySet(),
+            cpuFallbackOperators = emptySet(),
+            known = false,
+        )
+    val delegated = required.intersect(support)
+    return AcceleratorOperatorCoverage(
+        family = family,
+        provider = provider,
+        requiredOperators = required,
+        providerOperators = delegated,
+        cpuFallbackOperators = required - delegated,
+        known = true,
+    )
+}
+
+private fun AcceleratorConfig.withDiscoveredCoverage(modelFile: File): AcceleratorConfig {
+    if (modelCoverage != null) {
+        return this
+    }
+    val manifestFile = File(modelFile.parentFile, "openmed-onnx.json")
+    if (!manifestFile.isFile) {
+        return this
+    }
+    val discovered = try {
+        ModelFamilyOperatorCoverage.fromManifest(
+            manifestFile = manifestFile,
+            modelFileName = modelFile.name,
+        )
+    } catch (error: InferenceError.InvalidInput) {
+        null
+    }
+    return if (discovered == null) this else copy(modelCoverage = discovered)
+}
+
+private fun availableAcceleratorProviders(): Set<AcceleratorProvider> {
+    val ortProviders = OrtEnvironment.getAvailableProviders()
+    return buildSet {
+        add(AcceleratorProvider.CPU)
+        if (OrtProvider.QNN in ortProviders) {
+            add(AcceleratorProvider.QNN)
+        }
+        if (
+            OrtProvider.NNAPI in ortProviders &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
+        ) {
+            add(AcceleratorProvider.NNAPI)
+        }
+    }
+}
+
+private fun createSessionOptions(
+    config: AcceleratorConfig,
+    provider: AcceleratorProvider,
+): OrtSession.SessionOptions {
+    val options = OrtSession.SessionOptions()
+    try {
+        options.setIntraOpNumThreads(config.intraOpThreadCount)
+        when (provider) {
+            AcceleratorProvider.QNN -> options.addQnn(config.qnnOptions)
+            AcceleratorProvider.NNAPI -> options.addNnapi(config.nnapiFlags())
+            AcceleratorProvider.CPU -> Unit
+        }
+        return options
+    } catch (error: Throwable) {
+        options.close()
+        throw error
+    }
+}
+
+private fun AcceleratorConfig.nnapiFlags(): EnumSet<NNAPIFlags> =
+    EnumSet.noneOf(NNAPIFlags::class.java).also { flags ->
+        if (nnapiAllowFp16) {
+            flags.add(NNAPIFlags.USE_FP16)
+        }
+        if (nnapiUseNchw) {
+            flags.add(NNAPIFlags.USE_NCHW)
+        }
+    }

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/onnx/InferenceError.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/onnx/InferenceError.kt
@@ -11,4 +11,7 @@ public sealed class InferenceError(
 
     public class InvalidOutput(message: String, cause: Throwable? = null) :
         InferenceError(message, cause)
+
+    public class SessionCreation(cause: Throwable? = null) :
+        InferenceError("Unable to create an ONNX Runtime CPU session", cause)
 }

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/onnx/OnnxTokenClassifier.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/onnx/OnnxTokenClassifier.kt
@@ -406,7 +406,7 @@ private data class RuntimeComponents(
     val session: TokenClassificationSession,
 )
 
-private class OnnxRuntimeTokenClassificationSession(
+internal class OnnxRuntimeTokenClassificationSession(
     private val environment: OrtEnvironment,
     private val session: OrtSession,
 ) : TokenClassificationSession {

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/OpenMedKitApiTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/OpenMedKitApiTest.kt
@@ -155,6 +155,10 @@ class OpenMedKitApiTest {
         assertEquals(File("/models/openmed/model.onnx"), backend.modelFile)
         assertEquals(File("/models/openmed/tokenizer.json"), backend.tokenizerJson)
         assertEquals("PERSON", backend.id2Label[1])
+        assertEquals(
+            listOf("QNN", "NNAPI", "CPU"),
+            backend.acceleratorConfig.preferredProviders.map { it.name },
+        )
     }
 
     private class StaticClassifier(

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/onnx/AcceleratorFallbackTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/onnx/AcceleratorFallbackTest.kt
@@ -1,0 +1,355 @@
+package com.openmed.openmedkit.onnx
+
+import java.nio.file.Files
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AcceleratorFallbackTest {
+    @Test
+    fun deviceFarmStubSelectsQnnAndMatchesCpuWithinTolerance() = runTest {
+        val coverage = ModelFamilyOperatorCoverage(
+            family = "bert",
+            requiredOperators = setOf("MatMul", "Gelu", "LayerNormalization"),
+            supportedOperators = mapOf(
+                AcceleratorProvider.QNN to setOf("MatMul", "Gelu"),
+            ),
+        )
+        val qnnFactory = RecordingSessionFactory()
+        val cpuFactory = RecordingSessionFactory()
+        val labels = mapOf(0 to "O", 1 to "B-NAME")
+        val qnn = AcceleratorSession.createForTesting(
+            id2Label = labels,
+            config = AcceleratorConfig(modelCoverage = coverage),
+            availableProviders = setOf(
+                AcceleratorProvider.QNN,
+                AcceleratorProvider.CPU,
+            ),
+            sessionFactory = qnnFactory,
+        )
+        val cpu = AcceleratorSession.createForTesting(
+            id2Label = labels,
+            config = AcceleratorConfig.cpuOnly(),
+            availableProviders = setOf(AcceleratorProvider.CPU),
+            sessionFactory = cpuFactory,
+        )
+
+        try {
+            val qnnPredictions = qnn.run(
+                TEST_INPUT_IDS,
+                TEST_ATTENTION_MASK,
+                TEST_OFFSETS,
+            )
+            val cpuPredictions = cpu.run(
+                TEST_INPUT_IDS,
+                TEST_ATTENTION_MASK,
+                TEST_OFFSETS,
+            )
+            val evidence = AcceleratorValidationRecord(
+                latency = DeviceTierLatencyRecord(
+                    deviceTier = AndroidDeviceTier.DEVICE_FARM_STUB,
+                    provider = qnn.selection.selectedProvider,
+                    cpuP50Milliseconds = 24.0,
+                    delegateP50Milliseconds = 8.0,
+                    sampleCount = 50,
+                ),
+                cpuSpans = cpuPredictions.toSpanSignatures(),
+                delegateSpans = qnnPredictions.toSpanSignatures(),
+                cpuRecall = 1.0,
+                delegateRecall = 1.0,
+            ).requirePassing()
+
+            assertEquals(AcceleratorProvider.QNN, qnn.selection.selectedProvider)
+            assertTrue(qnn.selection.isAccelerated)
+            assertTrue(qnn.selection.operatorCoverage.usesCpuPartition)
+            assertEquals(
+                setOf("LayerNormalization"),
+                qnn.selection.operatorCoverage.cpuFallbackOperators,
+            )
+            assertEquals(listOf(AcceleratorProvider.QNN), qnnFactory.createdProviders)
+            assertEquals(cpuPredictions, qnnPredictions)
+            assertEquals(0.0, evidence.recallDelta)
+            assertEquals(3.0, evidence.latency.speedup)
+            assertTrue(evidence.passed)
+        } finally {
+            qnn.close()
+            cpu.close()
+        }
+    }
+
+    @Test
+    fun absentDelegatesFallBackToCpuDeterministically() = runTest {
+        val factory = RecordingSessionFactory()
+        val session = AcceleratorSession.createForTesting(
+            id2Label = mapOf(0 to "O", 1 to "B-NAME"),
+            config = AcceleratorConfig(),
+            availableProviders = setOf(AcceleratorProvider.CPU),
+            sessionFactory = factory,
+        )
+
+        try {
+            val predictions = session.run(
+                TEST_INPUT_IDS,
+                TEST_ATTENTION_MASK,
+                TEST_OFFSETS,
+            )
+
+            assertEquals(AcceleratorProvider.CPU, session.selection.selectedProvider)
+            assertFalse(session.selection.isAccelerated)
+            assertEquals(listOf(AcceleratorProvider.CPU), factory.createdProviders)
+            assertEquals(
+                listOf(
+                    AcceleratorProviderAttempt(
+                        AcceleratorProvider.QNN,
+                        AcceleratorAttemptOutcome.NOT_AVAILABLE,
+                    ),
+                    AcceleratorProviderAttempt(
+                        AcceleratorProvider.NNAPI,
+                        AcceleratorAttemptOutcome.NOT_AVAILABLE,
+                    ),
+                    AcceleratorProviderAttempt(
+                        AcceleratorProvider.CPU,
+                        AcceleratorAttemptOutcome.SELECTED,
+                    ),
+                ),
+                session.selection.attempts,
+            )
+            assertEquals(listOf("B-NAME"), predictions.map(TokenPrediction::label))
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun absentQnnSelectsNnapiBeforeCpu() {
+        val factory = RecordingSessionFactory()
+        val session = AcceleratorSession.createForTesting(
+            id2Label = mapOf(0 to "O", 1 to "B-NAME"),
+            config = AcceleratorConfig(),
+            availableProviders = setOf(
+                AcceleratorProvider.NNAPI,
+                AcceleratorProvider.CPU,
+            ),
+            sessionFactory = factory,
+        )
+
+        try {
+            assertEquals(
+                AcceleratorProvider.NNAPI,
+                session.selection.selectedProvider,
+            )
+            assertTrue(session.selection.isAccelerated)
+            assertEquals(listOf(AcceleratorProvider.NNAPI), factory.createdProviders)
+            assertEquals(
+                listOf(
+                    AcceleratorProviderAttempt(
+                        AcceleratorProvider.QNN,
+                        AcceleratorAttemptOutcome.NOT_AVAILABLE,
+                    ),
+                    AcceleratorProviderAttempt(
+                        AcceleratorProvider.NNAPI,
+                        AcceleratorAttemptOutcome.SELECTED,
+                    ),
+                ),
+                session.selection.attempts,
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun delegateSessionCreationFailureRetriesCpu() {
+        val factory = RecordingSessionFactory(
+            failingProviders = setOf(AcceleratorProvider.QNN),
+        )
+        val session = AcceleratorSession.createForTesting(
+            id2Label = mapOf(0 to "O", 1 to "B-NAME"),
+            config = AcceleratorConfig(
+                preferredProviders = listOf(
+                    AcceleratorProvider.QNN,
+                    AcceleratorProvider.CPU,
+                ),
+            ),
+            availableProviders = setOf(
+                AcceleratorProvider.QNN,
+                AcceleratorProvider.CPU,
+            ),
+            sessionFactory = factory,
+        )
+
+        try {
+            assertEquals(AcceleratorProvider.CPU, session.selection.selectedProvider)
+            assertEquals(
+                listOf(AcceleratorProvider.QNN, AcceleratorProvider.CPU),
+                factory.createdProviders,
+            )
+            assertEquals(
+                AcceleratorAttemptOutcome.SESSION_CREATION_FAILED,
+                session.selection.attempts.first().outcome,
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun measuredZeroCoverageSkipsDelegate() {
+        val factory = RecordingSessionFactory()
+        val session = AcceleratorSession.createForTesting(
+            id2Label = mapOf(0 to "O", 1 to "B-NAME"),
+            config = AcceleratorConfig(
+                preferredProviders = listOf(
+                    AcceleratorProvider.QNN,
+                    AcceleratorProvider.CPU,
+                ),
+                modelCoverage = ModelFamilyOperatorCoverage(
+                    family = "roberta",
+                    requiredOperators = setOf("LayerNormalization", "Gather"),
+                    supportedOperators = mapOf(
+                        AcceleratorProvider.QNN to emptySet(),
+                    ),
+                ),
+            ),
+            availableProviders = setOf(
+                AcceleratorProvider.QNN,
+                AcceleratorProvider.CPU,
+            ),
+            sessionFactory = factory,
+        )
+
+        try {
+            assertEquals(AcceleratorProvider.CPU, session.selection.selectedProvider)
+            assertEquals(listOf(AcceleratorProvider.CPU), factory.createdProviders)
+            assertEquals(
+                AcceleratorAttemptOutcome.NO_SUPPORTED_OPERATORS,
+                session.selection.attempts.first().outcome,
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun manifestLoadsFamilyAndPerArtifactOperators() {
+        val directory = Files.createTempDirectory("accelerator-manifest").toFile()
+        try {
+            val manifest = directory.resolve("openmed-onnx.json")
+            manifest.writeText(
+                """
+                {
+                  "family": "distilbert",
+                  "artifacts": [
+                    {
+                      "path": "model.onnx",
+                      "metadata": {
+                        "operators": ["Gather", "MatMul", "LayerNormalization"]
+                      }
+                    }
+                  ]
+                }
+                """.trimIndent()
+            )
+
+            val coverage = ModelFamilyOperatorCoverage.fromManifest(
+                manifestFile = manifest,
+                supportedOperators = mapOf(
+                    AcceleratorProvider.NNAPI to setOf("Gather", "MatMul"),
+                ),
+            )
+
+            assertEquals("distilbert", coverage.family)
+            assertEquals(
+                setOf("Gather", "MatMul", "LayerNormalization"),
+                coverage.requiredOperators,
+            )
+            assertEquals(
+                setOf("Gather", "MatMul"),
+                coverage.supportedOperators[AcceleratorProvider.NNAPI],
+            )
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun recallDeltaOutsideToleranceIsRejected() {
+        val evidence = AcceleratorValidationRecord(
+            latency = DeviceTierLatencyRecord(
+                deviceTier = AndroidDeviceTier.MID_RANGE,
+                provider = AcceleratorProvider.NNAPI,
+                cpuP50Milliseconds = 18.0,
+                delegateP50Milliseconds = 12.0,
+                sampleCount = 20,
+            ),
+            cpuSpans = listOf(AcceleratorSpanSignature("NAME", 0, 4)),
+            delegateSpans = listOf(AcceleratorSpanSignature("NAME", 0, 4)),
+            cpuRecall = 0.99,
+            delegateRecall = 0.98,
+            maxRecallDrop = 0.005,
+        )
+
+        assertFalse(evidence.recallWithinTolerance)
+        assertFailsWith<IllegalStateException> { evidence.requirePassing() }
+    }
+
+    private class RecordingSessionFactory(
+        private val failingProviders: Set<AcceleratorProvider> = emptySet(),
+    ) : AcceleratorTokenSessionFactory {
+        val createdProviders = mutableListOf<AcceleratorProvider>()
+
+        override fun create(provider: AcceleratorProvider): TokenClassificationSession {
+            createdProviders += provider
+            if (provider in failingProviders) {
+                throw IllegalStateException("stub provider failure")
+            }
+            return StaticTokenSession()
+        }
+    }
+
+    private class StaticTokenSession : TokenClassificationSession {
+        override val inputNames: Set<String> = setOf(
+            OnnxTokenClassifier.INPUT_IDS_NAME,
+            OnnxTokenClassifier.ATTENTION_MASK_NAME,
+        )
+
+        override fun run(inputs: Map<String, TokenInputTensor>): Map<String, Any?> {
+            val sequenceLength = inputs.getValue(OnnxTokenClassifier.INPUT_IDS_NAME).values.size
+            return mapOf(
+                OnnxTokenClassifier.LOGITS_NAME to arrayOf(
+                    Array(sequenceLength) { index ->
+                        if (index == 1) {
+                            floatArrayOf(0f, 5f)
+                        } else {
+                            floatArrayOf(5f, 0f)
+                        }
+                    }
+                )
+            )
+        }
+
+        override fun close() = Unit
+    }
+
+    private companion object {
+        val TEST_INPUT_IDS = intArrayOf(101, 42, 102)
+        val TEST_ATTENTION_MASK = intArrayOf(1, 1, 1)
+        val TEST_OFFSETS = listOf(
+            TokenOffset(0, 0),
+            TokenOffset(4, 8),
+            TokenOffset(0, 0),
+        )
+    }
+}
+
+private fun List<TokenPrediction>.toSpanSignatures(): List<AcceleratorSpanSignature> =
+    map { prediction ->
+        AcceleratorSpanSignature(
+            label = prediction.label,
+            startOffset = prediction.startOffset,
+            endOffset = prediction.endOffset,
+        )
+    }

--- a/docs/android-quickstart.md
+++ b/docs/android-quickstart.md
@@ -20,7 +20,9 @@ model from the catalog, and redact a synthetic clinical note.
 The library performs inference on device via ONNX Runtime Mobile. See
 [Android ONNX Export](export-onnx-android.md) for producing a compatible model
 artifact and [Android Span Parity](android-parity.md) for the cross-platform
-span guarantees.
+span guarantees. See [Android QNN and NNAPI Acceleration](runtimes/android-accelerators.md)
+for execution-provider selection, operator coverage, and deterministic CPU
+fallback.
 
 ## Install
 
@@ -139,4 +141,5 @@ Two runnable Android demos exercise the on-device path end to end:
 - [Swift Package (OpenMedKit)](swift-openmedkit.md) — the Apple-platform counterpart.
 - [Swift-Kotlin API Parity](swift-kotlin-parity.md) — cross-platform API alignment.
 - [Android ONNX Export](export-onnx-android.md) — producing a compatible on-device model.
+- [Android QNN and NNAPI Acceleration](runtimes/android-accelerators.md) — configuring delegate selection and CPU fallback.
 - [Model Manifest](model-manifest.md) — the model catalog and reproducibility metadata.

--- a/docs/export-onnx-android.md
+++ b/docs/export-onnx-android.md
@@ -143,6 +143,11 @@ corpus and keeps the exported graph callable through the same inputs and
 `model.required_operators_and_types.config` is the required-operators/types
 file to pass into an ONNX Runtime Android minimal build.
 
+The graph family and operator list in `openmed-onnx.json` also feed
+[Android QNN and NNAPI Acceleration](runtimes/android-accelerators.md). The
+Android runtime combines that manifest contract with device-observed provider
+coverage so unsupported subgraphs stay on CPU.
+
 If the optional ONNX Runtime conversion tooling is not available, export still
 finishes with the `.onnx` artifacts and logs a dependency-only skip reason. The
 message does not include source model text or sample input content.

--- a/docs/runtimes/android-accelerators.md
+++ b/docs/runtimes/android-accelerators.md
@@ -1,0 +1,173 @@
+# Android QNN and NNAPI Acceleration
+
+OpenMedKit can prefer Qualcomm QNN or Android NNAPI for local ONNX token
+classification while retaining ONNX Runtime's CPU execution provider as the
+deterministic fallback. The selection order is QNN, NNAPI, then CPU by default.
+Inference remains on device; accelerator fallback never invokes a network or
+cloud runtime.
+
+## Runtime Requirements
+
+| Provider | Runtime requirement | OpenMedKit behavior |
+| --- | --- | --- |
+| QNN | A custom ONNX Runtime Android build compiled with QNN plus app-supplied Qualcomm AI Runtime libraries | Probed first; session creation uses `libQnnHtp.so` by default |
+| NNAPI | Android 8.1 (API 27) or newer and an ONNX Runtime build with NNAPI | Probed after QNN; FP16 relaxation is disabled by default |
+| CPU | The standard ONNX Runtime CPU provider | Always appended as the final deterministic attempt |
+
+OpenMed does not bundle the Qualcomm SDK, QNN backend libraries, or a
+proprietary QNN-enabled AAR. Applications that opt into QNN are responsible for
+supplying compatible runtime libraries and complying with their licenses. The
+standard OpenMedKit dependency can still select NNAPI where the packaged ONNX
+Runtime and device expose it.
+
+## Configure a Session
+
+`OpenMedBackend` uses `AcceleratorConfig()` by default, so the normal
+`OpenMedKit` path automatically probes the provider order above. Use a CPU-only
+configuration for a baseline run:
+
+```kotlin
+import com.openmed.openmedkit.OpenMedBackend
+import com.openmed.openmedkit.onnx.AcceleratorConfig
+
+val cpuBackend = OpenMedBackend(
+    modelDirectory = modelDirectory,
+    acceleratorConfig = AcceleratorConfig.cpuOnly(),
+)
+```
+
+For a QNN-enabled application, keep the backend library path explicit when it
+differs from the Android default:
+
+```kotlin
+import com.openmed.openmedkit.onnx.AcceleratorConfig
+import com.openmed.openmedkit.onnx.AcceleratorProvider
+
+val acceleratorConfig = AcceleratorConfig(
+    preferredProviders = listOf(
+        AcceleratorProvider.QNN,
+        AcceleratorProvider.NNAPI,
+        AcceleratorProvider.CPU,
+    ),
+    qnnOptions = mapOf("backend_path" to "libQnnHtp.so"),
+)
+```
+
+`BackendOnnxTokenClassifier.acceleratorSelection` and
+`AcceleratorSession.selection` expose the selected provider, privacy-safe
+attempt outcomes, and the operator partition. They never contain input text or
+span surface text.
+
+## Capability Probe and Fallback
+
+OpenMedKit first asks ONNX Runtime which execution providers were compiled into
+the active Android package. NNAPI is excluded below API 27. Each eligible
+delegate gets its own session-creation attempt:
+
+1. If the provider is absent, OpenMedKit records `NOT_AVAILABLE` and tries the
+   next provider.
+2. If measured coverage shows that the provider supports none of the model's
+   operators, it records `NO_SUPPORTED_OPERATORS` without creating a session.
+3. If delegate registration or session creation fails, it records
+   `SESSION_CREATION_FAILED` and tries the next provider.
+4. CPU is attempted last. Failure to create the CPU session is a typed
+   `InferenceError.SessionCreation` instead of an accelerator-specific crash.
+
+NNAPI is registered without `CPU_DISABLED`, and the QNN path does not set
+`session.disable_cpu_ep_fallback`. ONNX Runtime can therefore assign supported
+subgraphs to the delegate and unsupported subgraphs to its CPU provider.
+
+## Per-Family Operator Coverage
+
+Android exports record the model family and graph operators in
+`openmed-onnx.json`. `AcceleratorSession` reads that metadata automatically when
+the manifest is next to the model. Hardware support still varies by device,
+driver, model precision, and operator attributes, so a release device matrix
+should supply observed support for each family:
+
+```kotlin
+import com.openmed.openmedkit.onnx.AcceleratorConfig
+import com.openmed.openmedkit.onnx.AcceleratorProvider
+import com.openmed.openmedkit.onnx.ModelFamilyOperatorCoverage
+import java.io.File
+
+val coverage = ModelFamilyOperatorCoverage.fromManifest(
+    manifestFile = File(modelDirectory, "openmed-onnx.json"),
+    supportedOperators = mapOf(
+        AcceleratorProvider.QNN to setOf(
+            "Gather",
+            "MatMul",
+            "Gelu",
+        ),
+    ),
+)
+val config = AcceleratorConfig(modelCoverage = coverage)
+```
+
+A missing provider entry means coverage is unknown: the runtime is allowed to
+perform its own capability and graph-partitioning pass. A present empty set is
+measured zero coverage and skips that delegate. Partial coverage selects the
+delegate and exposes the remainder through
+`selection.operatorCoverage.cpuFallbackOperators`.
+
+Do not treat a static operator name alone as certification. NNAPI and QNN may
+place constraints on shapes, data types, quantization, and constant inputs.
+Populate the support set from the same model artifact and device tier used by
+the parity run.
+
+## Device-Tier Parity and Recall Gate
+
+Every accelerated artifact should be compared with a CPU session over the same
+synthetic evaluation cases. Store only labels, offsets, aggregate recall, and
+latency:
+
+```kotlin
+val evidence = AcceleratorValidationRecord(
+    latency = DeviceTierLatencyRecord(
+        deviceTier = AndroidDeviceTier.MID_RANGE,
+        provider = acceleratorSession.selection.selectedProvider,
+        cpuP50Milliseconds = cpuP50,
+        delegateP50Milliseconds = delegateP50,
+        sampleCount = 100,
+    ),
+    cpuSpans = cpuPredictions.map {
+        AcceleratorSpanSignature(it.label, it.startOffset, it.endOffset)
+    },
+    delegateSpans = delegatePredictions.map {
+        AcceleratorSpanSignature(it.label, it.startOffset, it.endOffset)
+    },
+    cpuRecall = cpuRecall,
+    delegateRecall = delegateRecall,
+    boundaryToleranceCharacters = 0,
+    maxRecallDrop = 0.0,
+).requirePassing()
+```
+
+`requirePassing()` rejects label/boundary drift and recall loss beyond the
+configured CPU-relative budget. `DeviceTierLatencyRecord` reports the CPU and
+delegate p50 values, sample count, and computed speedup. The committed JVM test
+uses `DEVICE_FARM_STUB` to assert delegate selection, partial CPU partitioning,
+exact span parity, and zero recall delta without requiring Qualcomm hardware in
+CI.
+
+For INT8 artifacts, use the certified recall-delta budget recorded by the
+Android ONNX export rather than increasing the tolerance just to make a device
+run pass. All test inputs and fixtures must remain synthetic.
+
+## Operational Notes
+
+- QNN HTP generally expects a compatible quantized graph; session creation can
+  fall through to NNAPI or CPU when the model/backend combination is rejected.
+- NNAPI performance is device- and model-specific. Excessive CPU/delegate
+  partition boundaries can be slower than CPU-only execution, so retain the
+  per-tier latency record.
+- `nnapiAllowFp16` is off by default. Enabling it requires a fresh span and
+  recall comparison because lower precision can change outputs.
+- OpenMedKit never logs input text, detected spans, or redacted output while
+  selecting or falling back between providers.
+
+## See Also
+
+- [Android ONNX Export](../export-onnx-android.md)
+- [Android Span Parity](../android-parity.md)
+- [Android Quickstart](../android-quickstart.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - ONNX Runtime Web Loader: runtimes/onnxruntime-web.md
       - Android Quickstart: android-quickstart.md
       - Android ONNX Export: export-onnx-android.md
+      - Android QNN and NNAPI: runtimes/android-accelerators.md
       - Android Tokenization: android-tokenization.md
       - Android Span Parity: android-parity.md
       - CoreML Packaging: coreml-export.md


### PR DESCRIPTION
## Description

Adds Android hardware-delegate selection to the token-classification runtime with deterministic CPU fallback, model-family operator coverage, and privacy-safe parity and latency evidence. The normal local backend now probes the preferred delegate order while preserving on-device-only behavior and CPU execution for unsupported graph partitions.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Added capability probing, ordered delegate session creation, typed CPU fallback, and inspectable provider-attempt evidence.
- Added per-model-family operator coverage with partial CPU partition reporting and zero-coverage delegate skipping.
- Added synthetic device-farm tests for delegate selection, CPU parity, recall tolerance, and tiered latency records.
- Documented runtime requirements, configuration, fallback semantics, coverage evidence, and validation gates.

## Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different model-family coverage inputs

Validation performed:

- `cd android && ./gradlew test`
- `.venv/bin/python -m pytest tests/ -q` — 5159 passed, 55 skipped
- `pre-commit run --files <changed files>`
- `make docs-build`

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [ ] I ran `make format`, `make lint`, and `make format-check` (no Python files changed)
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift` (no Swift files changed)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #851

## Screenshots/Examples

Not applicable; this change affects the Android runtime and documentation surfaces.