### PR TITLE
Add XLSX cell-level spreadsheet redaction

### DIFF
--- a/docs/multimodal/xlsx-cell-redaction.md
+++ b/docs/multimodal/xlsx-cell-redaction.md
@@ -1,0 +1,58 @@
+# XLSX Cell Redaction
+
+OpenMed can de-identify string cells in `.xlsx` workbooks while preserving
+worksheets, formulas, numeric and date values, styles, and other workbook
+structure supported by `openpyxl`.
+
+Install the multimodal dependencies first:
+
+```bash
+pip install "openmed[multimodal]"
+```
+
+Then write a redacted copy to a different path:
+
+```python
+from openmed.multimodal import redact_xlsx
+
+result = redact_xlsx(
+    "clinical-workbook.xlsx",
+    "clinical-workbook.redacted.xlsx",
+)
+
+for entry in result.redaction_report:
+    print(entry)
+```
+
+By default, row 1 of each worksheet is treated as its header. OpenMed reuses
+the CSV/TSV header and value-sampling rules to identify PHI columns. Every
+other string cell is also analyzed individually, which catches PHI embedded in
+free text even when its column looks safe. Use `header_row` to select a
+different one-based header row, or pass the same `header_heuristics` and
+`action_overrides` mappings accepted by the CSV adapter.
+
+Formula cells are identified from their workbook cell type and are never sent
+to the de-identifier. Numeric, Boolean, date, blank, and error cells are also
+left untouched. The source workbook cannot be used as the output path, so a
+failed or partial run cannot overwrite the original PHI-bearing file.
+
+## PHI-safe report
+
+Each changed cell produces a record shaped like this:
+
+```python
+{
+    "sheet_index": 0,
+    "coordinate": "C7",
+    "labels": ["PERSON", "PHONE"],
+}
+```
+
+The report intentionally omits original values, replacements, and worksheet
+names. Worksheet names can themselves contain PHI, so worksheets are addressed
+by their zero-based position instead. Store and transmit the redacted workbook
+under the same controls used for other clinical artifacts; formulas can still
+encode sensitive logic even when their displayed string cells are redacted.
+
+Charts, pivot tables, macros, and VBA content are outside this adapter's scope.
+Only `.xlsx` files are accepted.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - Examples & Copy/Paste Recipes: examples.md
       - Document Adapter Provenance: document-adapter-provenance.md
       - EPUB Extraction: multimodal/epub-extraction.md
+      - XLSX Cell Redaction: multimodal/xlsx-cell-redaction.md
       - Testing & QA: testing.md
       - Eval Harness & Metrics: eval-harness.md
       - Experiencer Refinement: clinical/experiencer-refinement.md

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -109,6 +109,7 @@ from .verify_pdf import (
     RegionFidelity,
     verify_redacted_pdf,
 )
+from .xlsx import XlsxCellRedaction, XlsxRedactionResult, redact_xlsx
 
 __all__ = [
     "ExtractedDocument",
@@ -181,4 +182,7 @@ __all__ = [
     "RegionFidelity",
     "RedactionFidelityError",
     "verify_redacted_pdf",
+    "XlsxCellRedaction",
+    "XlsxRedactionResult",
+    "redact_xlsx",
 ]

--- a/openmed/multimodal/base.py
+++ b/openmed/multimodal/base.py
@@ -25,6 +25,7 @@ _MULTIMODAL_DEPENDENCIES: tuple[tuple[str, str], ...] = (
     ("piexif", "piexif"),
     ("pikepdf", "pikepdf"),
     ("pydicom", "pydicom"),
+    ("openpyxl", "openpyxl"),
 )
 
 _MULTIMODAL_INSTALL_HINT = 'Install with: pip install "openmed[multimodal]".'

--- a/openmed/multimodal/xlsx.py
+++ b/openmed/multimodal/xlsx.py
@@ -1,0 +1,491 @@
+"""Cell-level XLSX redaction with PHI-safe coordinate reporting.
+
+The adapter preserves workbook structure by editing only string-valued data
+cells in a normal ``openpyxl`` workbook. Column classification is shared with
+the CSV/TSV adapter, while cells in otherwise safe columns still receive
+free-text de-identification so embedded PHI is not missed.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openmed.core.labels import OTHER, normalize_label
+
+from .base import ExtractedDocument
+from .exceptions import MissingDependencyError
+from .tabular_csv import (
+    ACTION_DATE_SHIFT,
+    ACTION_FREE_TEXT_REDACT,
+    ACTION_KEEP,
+    ColumnDecision,
+    _date_shift_for_row,
+    _merge_policy_options,
+    _redact_cell,
+    classify_columns,
+)
+
+_XLSX_HINT = 'Install with: pip install "openmed[multimodal]".'
+_MASK_LABEL_RE = re.compile(r"\[([A-Za-z][A-Za-z0-9_]*)\]")
+
+CellDeidentifier = Callable[[str], Any]
+
+
+@dataclass(frozen=True)
+class XlsxCellRedaction:
+    """PHI-safe location and labels for one changed workbook cell."""
+
+    sheet_index: int
+    coordinate: str
+    labels: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a report entry that never includes cell or sheet text."""
+        return {
+            "sheet_index": self.sheet_index,
+            "coordinate": self.coordinate,
+            "labels": list(self.labels),
+        }
+
+
+@dataclass(frozen=True)
+class XlsxRedactionResult:
+    """Saved workbook location and PHI-safe cell-level redaction report."""
+
+    output_path: Path
+    sheet_count: int
+    redactions: tuple[XlsxCellRedaction, ...]
+
+    @property
+    def redaction_report(self) -> tuple[dict[str, Any], ...]:
+        """Return coordinate/label records without raw cell or sheet text."""
+        return tuple(redaction.to_dict() for redaction in self.redactions)
+
+    def to_document(self) -> ExtractedDocument:
+        """Bridge the binary workbook result into the multimodal contract."""
+        return ExtractedDocument(
+            text="",
+            metadata={
+                "format": "xlsx",
+                "sheet_count": self.sheet_count,
+                "redaction_count": len(self.redactions),
+                "redaction_report": list(self.redaction_report),
+            },
+        )
+
+
+def redact_xlsx(
+    source: str | os.PathLike[str],
+    output_path: str | os.PathLike[str],
+    *,
+    policy: Any | None = None,
+    models: Any | None = None,
+    lang: str = "en",
+    header_row: int = 1,
+    header_heuristics: Mapping[str, str] | None = None,
+    action_overrides: Mapping[str, str] | None = None,
+    date_shift_days: int | None = None,
+    date_shift_seed: str = "openmed-xlsx-v1",
+    keep_year: bool = True,
+    sample_size: int = 50,
+    cell_deidentifier: CellDeidentifier | None = None,
+) -> XlsxRedactionResult:
+    """Redact PHI in XLSX string cells while preserving workbook structure.
+
+    The first row is treated as the column-header row by default. Its names and
+    sampled string values are classified with the CSV/TSV PHI-column rules.
+    Formula cells and non-string values are never passed to de-identification
+    and are never changed. String cells not covered by a PHI-column action are
+    still analyzed individually for free-text PHI.
+
+    Args:
+        source: Input ``.xlsx`` workbook path.
+        output_path: Destination ``.xlsx`` path. It must differ from ``source``.
+        policy: Optional tabular mapping with ``header_heuristics`` and
+            ``action_overrides``, or a core policy profile name for the default
+            cell de-identifier.
+        models: Optional callable, mapping, or object exposing
+            ``cell_deidentifier``, ``deidentifier``, or ``text_redactor``.
+        lang: Language passed to the default OpenMed de-identification path.
+        header_row: One-based row containing column names on every worksheet.
+        header_heuristics: Additional CSV-compatible header label mappings.
+        action_overrides: Additional CSV-compatible column action mappings.
+        date_shift_days: Optional fixed shift for string date columns.
+        date_shift_seed: Seed for deterministic per-row date shifts.
+        keep_year: Preserve years when shifting string dates.
+        sample_size: Non-empty string cells sampled per column.
+        cell_deidentifier: Optional callable for free-text cells. It may return
+            an OpenMed ``DeidentificationResult``, ``(text, labels)``, a mapping
+            with ``deidentified_text`` and labels/entities, or a redacted string.
+
+    Returns:
+        The saved output path and a report containing only sheet indexes, cell
+        coordinates, and canonical labels.
+
+    Raises:
+        ValueError: If paths or row/sample options are invalid.
+        MissingDependencyError: If ``openpyxl`` is not installed.
+    """
+    source_path = Path(source)
+    destination = Path(output_path)
+    _validate_paths(source_path, destination)
+    if header_row < 1:
+        raise ValueError("header_row must be at least 1")
+    if sample_size < 1:
+        raise ValueError("sample_size must be at least 1")
+
+    load_workbook = _load_workbook_function()
+    workbook = load_workbook(
+        filename=source_path,
+        read_only=False,
+        data_only=False,
+        keep_links=True,
+    )
+    resolved_deidentifier = _resolve_cell_deidentifier(
+        explicit=cell_deidentifier,
+        models=models,
+        policy=policy,
+        lang=lang,
+    )
+    merged_headers, merged_actions = _merge_policy_options(
+        policy,
+        header_heuristics=header_heuristics,
+        action_overrides=action_overrides,
+    )
+    sheet_count = len(workbook.worksheets)
+    redactions: list[XlsxCellRedaction] = []
+
+    try:
+        for sheet_index, worksheet in enumerate(workbook.worksheets):
+            decisions = _worksheet_decisions(
+                worksheet,
+                header_row=header_row,
+                header_heuristics=merged_headers,
+                action_overrides=merged_actions,
+                sample_size=sample_size,
+            )
+            _redact_worksheet(
+                worksheet,
+                sheet_index=sheet_index,
+                header_row=header_row,
+                decisions=decisions,
+                deidentifier=resolved_deidentifier,
+                date_shift_days=date_shift_days,
+                date_shift_seed=date_shift_seed,
+                keep_year=keep_year,
+                lang=lang,
+                redactions=redactions,
+            )
+        _save_workbook_atomically(workbook, destination)
+    finally:
+        workbook.close()
+
+    return XlsxRedactionResult(
+        output_path=destination,
+        sheet_count=sheet_count,
+        redactions=tuple(redactions),
+    )
+
+
+def _validate_paths(source: Path, destination: Path) -> None:
+    if source.suffix.lower() != ".xlsx":
+        raise ValueError("source must be an .xlsx workbook")
+    if destination.suffix.lower() != ".xlsx":
+        raise ValueError("output_path must end in .xlsx")
+    if source.resolve() == destination.resolve():
+        raise ValueError("output_path must differ from source")
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    if not destination.parent.is_dir():
+        raise FileNotFoundError(destination.parent)
+
+
+def _load_workbook_function() -> Callable[..., Any]:
+    try:
+        from openpyxl import load_workbook
+    except ImportError as exc:
+        raise MissingDependencyError(
+            dependency="openpyxl",
+            instruction=_XLSX_HINT,
+        ) from exc
+    return load_workbook
+
+
+def _worksheet_decisions(
+    worksheet: Any,
+    *,
+    header_row: int,
+    header_heuristics: Mapping[str, str] | None,
+    action_overrides: Mapping[str, str] | None,
+    sample_size: int,
+) -> tuple[ColumnDecision, ...]:
+    if header_row > worksheet.max_row or _worksheet_is_empty(worksheet):
+        return ()
+
+    headers = tuple(
+        _header_name(worksheet.cell(row=header_row, column=column).value, column)
+        for column in range(1, worksheet.max_column + 1)
+    )
+    rows = _sample_string_rows(
+        worksheet,
+        header_row=header_row,
+        width=worksheet.max_column,
+        sample_size=sample_size,
+    )
+    return classify_columns(
+        headers,
+        rows,
+        header_heuristics=header_heuristics,
+        action_overrides=action_overrides,
+        sample_size=sample_size,
+    )
+
+
+def _sample_string_rows(
+    worksheet: Any,
+    *,
+    header_row: int,
+    width: int,
+    sample_size: int,
+) -> tuple[tuple[str, ...], ...]:
+    counts = [0] * width
+    rows: list[tuple[str, ...]] = []
+    for row_index in range(header_row + 1, worksheet.max_row + 1):
+        values = tuple(
+            _classification_value(worksheet.cell(row=row_index, column=column))
+            for column in range(1, width + 1)
+        )
+        contributes = tuple(
+            bool(value.strip()) and counts[index] < sample_size
+            for index, value in enumerate(values)
+        )
+        if not any(contributes):
+            continue
+        rows.append(values)
+        for index, contributes_to_column in enumerate(contributes):
+            if contributes_to_column:
+                counts[index] += 1
+        if all(count >= sample_size for count in counts):
+            break
+    return tuple(rows)
+
+
+def _worksheet_is_empty(worksheet: Any) -> bool:
+    return (
+        worksheet.max_row == 1
+        and worksheet.max_column == 1
+        and worksheet.cell(row=1, column=1).value is None
+    )
+
+
+def _header_name(value: Any, column: int) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return f"column_{column}"
+
+
+def _classification_value(cell: Any) -> str:
+    if cell.data_type == "f" or not isinstance(cell.value, str):
+        return ""
+    return cell.value
+
+
+def _redact_worksheet(
+    worksheet: Any,
+    *,
+    sheet_index: int,
+    header_row: int,
+    decisions: Sequence[ColumnDecision],
+    deidentifier: CellDeidentifier,
+    date_shift_days: int | None,
+    date_shift_seed: str,
+    keep_year: bool,
+    lang: str,
+    redactions: list[XlsxCellRedaction],
+) -> None:
+    for row_index in range(header_row + 1, worksheet.max_row + 1):
+        row_values = tuple(
+            _classification_value(worksheet.cell(row=row_index, column=column))
+            for column in range(1, len(decisions) + 1)
+        )
+        row_shift_days: int | None = None
+        for decision in decisions:
+            cell = worksheet.cell(row=row_index, column=decision.index + 1)
+            if cell.data_type == "f" or not isinstance(cell.value, str):
+                continue
+
+            original = cell.value
+            if decision.action in {ACTION_KEEP, ACTION_FREE_TEXT_REDACT}:
+                redacted, labels = _run_cell_deidentifier(original, deidentifier)
+            else:
+                if decision.action == ACTION_DATE_SHIFT and row_shift_days is None:
+                    row_shift_days = _date_shift_for_row(
+                        row_values,
+                        row_index=row_index - header_row - 1,
+                        fixed_days=date_shift_days,
+                        seed=date_shift_seed,
+                    )
+                redacted, changed = _redact_cell(
+                    original,
+                    decision,
+                    date_shift_days=row_shift_days,
+                    keep_year=keep_year,
+                    lang=lang,
+                    text_redactor=None,
+                )
+                labels = (
+                    (_normalize_report_label(decision.canonical_label or "PHI"),)
+                    if changed
+                    else ()
+                )
+
+            if redacted == original:
+                continue
+            cell.value = redacted
+            redactions.append(
+                XlsxCellRedaction(
+                    sheet_index=sheet_index,
+                    coordinate=cell.coordinate,
+                    labels=_unique_labels(labels) or ("PHI",),
+                )
+            )
+
+
+def _resolve_cell_deidentifier(
+    *,
+    explicit: CellDeidentifier | None,
+    models: Any | None,
+    policy: Any | None,
+    lang: str,
+) -> CellDeidentifier:
+    if explicit is not None:
+        return explicit
+    if callable(models):
+        return models
+    if isinstance(models, Mapping):
+        for key in ("cell_deidentifier", "deidentifier", "text_redactor"):
+            candidate = models.get(key)
+            if callable(candidate):
+                return candidate
+    for attribute in ("cell_deidentifier", "deidentifier", "text_redactor"):
+        candidate = getattr(models, attribute, None)
+        if callable(candidate):
+            return candidate
+
+    core_policy = policy if isinstance(policy, str) else None
+
+    def default_deidentifier(text: str) -> Any:
+        from openmed.core.pii import deidentify
+
+        return deidentify(text, method="mask", lang=lang, policy=core_policy)
+
+    return default_deidentifier
+
+
+def _run_cell_deidentifier(
+    value: str,
+    deidentifier: CellDeidentifier,
+) -> tuple[str, tuple[str, ...]]:
+    result = deidentifier(value)
+    redacted, labels = _coerce_deidentification_result(result)
+    if redacted == value:
+        return value, ()
+    if not labels:
+        labels = tuple(_MASK_LABEL_RE.findall(redacted))
+    return redacted, _unique_labels(labels) or ("PHI",)
+
+
+def _coerce_deidentification_result(result: Any) -> tuple[str, tuple[str, ...]]:
+    if isinstance(result, str):
+        return result, ()
+    if isinstance(result, tuple) and len(result) == 2:
+        return str(result[0]), _coerce_labels(result[1])
+    if isinstance(result, Mapping):
+        redacted = result.get("deidentified_text", result.get("text"))
+        if redacted is None:
+            raise TypeError("cell de-identifier mapping must include deidentified_text")
+        labels = _coerce_labels(result.get("labels"))
+        if not labels:
+            labels = _labels_from_entities(result.get("pii_entities", ()))
+        return str(redacted), labels
+
+    redacted = getattr(result, "deidentified_text", None)
+    if redacted is None:
+        raise TypeError(
+            "cell de-identifier must return text, (text, labels), a mapping, "
+            "or an object with deidentified_text"
+        )
+    labels = _labels_from_entities(getattr(result, "pii_entities", ()))
+    return str(redacted), labels
+
+
+def _labels_from_entities(entities: Iterable[Any] | None) -> tuple[str, ...]:
+    if entities is None:
+        return ()
+    labels: list[str] = []
+    for entity in entities:
+        if isinstance(entity, Mapping):
+            label = (
+                entity.get("canonical_label")
+                or entity.get("label")
+                or entity.get("entity_type")
+            )
+        else:
+            label = (
+                getattr(entity, "canonical_label", None)
+                or getattr(entity, "label", None)
+                or getattr(entity, "entity_type", None)
+            )
+        if label:
+            labels.append(str(label))
+    return tuple(labels)
+
+
+def _coerce_labels(labels: Any) -> tuple[str, ...]:
+    if labels is None:
+        return ()
+    if isinstance(labels, str):
+        return (labels,)
+    try:
+        return tuple(str(label) for label in labels)
+    except TypeError:
+        return (str(labels),)
+
+
+def _normalize_report_label(label: str) -> str:
+    canonical = normalize_label(str(label))
+    if canonical != OTHER:
+        return canonical
+    return "PHI" if str(label).strip().upper() == "PHI" else OTHER
+
+
+def _unique_labels(labels: Iterable[str]) -> tuple[str, ...]:
+    return tuple(
+        dict.fromkeys(
+            _normalize_report_label(label) for label in labels if str(label).strip()
+        )
+    )
+
+
+def _save_workbook_atomically(workbook: Any, destination: Path) -> None:
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix=f".{destination.stem}.",
+            suffix=".xlsx",
+            dir=destination.parent,
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+        workbook.save(temporary_path)
+        os.replace(temporary_path, destination)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
   "mypy==2.2.0",
   "duckdb>=1.0,<2",
   "numpy>=1.26",
+  "openpyxl>=3.1,<4",
   "fastapi>=0.110",
   "httpx>=0.27",
   "dask[dataframe]>=2024.8",
@@ -106,6 +107,7 @@ spacy = [
 
 multimodal = [
   "numpy>=1.26",
+  "openpyxl>=3.1,<4",
   "pdfplumber>=0.11",
   "python-docx>=1.1",
   "Pillow>=10.0",

--- a/scripts/release/check_license_policy.py
+++ b/scripts/release/check_license_policy.py
@@ -92,6 +92,7 @@ REVIEWED_LICENSES = {
     "opentelemetry-api": "Apache-2.0",
     "opentelemetry-exporter-otlp-proto-http": "Apache-2.0",
     "opentelemetry-sdk": "Apache-2.0",
+    "openpyxl": "MIT",
     "openvino": "Apache-2.0",
     "paddleocr": "Apache-2.0",
     "pandas": "BSD-3-Clause",

--- a/tests/unit/multimodal/test_multimodal_extra.py
+++ b/tests/unit/multimodal/test_multimodal_extra.py
@@ -29,6 +29,7 @@ HEAVY_MODULES = (
     "easyocr",
     "paddleocr",
     "markdown_it",
+    "openpyxl",
 )
 
 

--- a/tests/unit/multimodal/test_xlsx_redact.py
+++ b/tests/unit/multimodal/test_xlsx_redact.py
@@ -1,0 +1,118 @@
+"""Tests for cell-level XLSX redaction and PHI-safe reporting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+openpyxl = pytest.importorskip("openpyxl", exc_type=ImportError)
+
+from openmed.multimodal.xlsx import redact_xlsx
+
+
+def _synthetic_workbook(path: Path) -> None:
+    workbook = openpyxl.Workbook()
+    patients = workbook.active
+    patients.title = "Patient John Doe"
+    patients.append(["patient_name", "age", "notes", "calculated"])
+    patients.append(["John Doe", 42, "Call John Doe at 555-0101", "=B2*2"])
+    patients.append(["Jane Roe", 37, "No PHI in this cell", "=B3*2"])
+    patients.freeze_panes = "A2"
+
+    archive = workbook.create_sheet("Archive")
+    archive.append(["ssn", "status"])
+    archive.append(["123-45-6789", "active"])
+    workbook.save(path)
+    workbook.close()
+
+
+def _cell_deidentifier(value: str) -> tuple[str, tuple[str, ...]]:
+    if value == "Call John Doe at 555-0101":
+        return "Call [PERSON] at [PHONE]", ("PERSON", "PHONE")
+    return value, ()
+
+
+def test_redact_xlsx_preserves_structure_formulas_and_non_string_cells(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "synthetic.xlsx"
+    output = tmp_path / "synthetic.redacted.xlsx"
+    _synthetic_workbook(source)
+
+    result = redact_xlsx(
+        source,
+        output,
+        cell_deidentifier=_cell_deidentifier,
+    )
+
+    workbook = openpyxl.load_workbook(output, data_only=False)
+    assert workbook.sheetnames == ["Patient John Doe", "Archive"]
+    assert workbook["Patient John Doe"]["A2"].value == "[PERSON]"
+    assert workbook["Patient John Doe"]["A3"].value == "[PERSON]"
+    assert workbook["Patient John Doe"]["B2"].value == 42
+    assert workbook["Patient John Doe"]["B3"].value == 37
+    assert workbook["Patient John Doe"]["C2"].value == ("Call [PERSON] at [PHONE]")
+    assert workbook["Patient John Doe"]["C3"].value == "No PHI in this cell"
+    assert workbook["Patient John Doe"]["D2"].value == "=B2*2"
+    assert workbook["Patient John Doe"]["D3"].value == "=B3*2"
+    assert workbook["Patient John Doe"].freeze_panes == "A2"
+    assert workbook["Archive"]["A2"].value == "[SSN]"
+    assert workbook["Archive"]["B2"].value == "active"
+    workbook.close()
+
+    original = openpyxl.load_workbook(source, data_only=False)
+    assert original["Patient John Doe"]["A2"].value == "John Doe"
+    assert original["Archive"]["A2"].value == "123-45-6789"
+    original.close()
+
+    assert result.output_path == output
+    assert result.sheet_count == 2
+
+
+def test_redaction_report_contains_coordinates_and_labels_without_raw_phi(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "synthetic.xlsx"
+    output = tmp_path / "synthetic.redacted.xlsx"
+    _synthetic_workbook(source)
+
+    result = redact_xlsx(
+        source,
+        output,
+        cell_deidentifier=_cell_deidentifier,
+    )
+    report = result.redaction_report
+
+    assert report == (
+        {"sheet_index": 0, "coordinate": "A2", "labels": ["PERSON"]},
+        {
+            "sheet_index": 0,
+            "coordinate": "C2",
+            "labels": ["PERSON", "PHONE"],
+        },
+        {"sheet_index": 0, "coordinate": "A3", "labels": ["PERSON"]},
+        {"sheet_index": 1, "coordinate": "A2", "labels": ["SSN"]},
+    )
+    serialized = str(report)
+    assert "John Doe" not in serialized
+    assert "Jane Roe" not in serialized
+    assert "123-45-6789" not in serialized
+    assert "Patient John Doe" not in serialized
+    assert all(
+        set(entry) == {"sheet_index", "coordinate", "labels"} for entry in report
+    )
+
+    document = result.to_document()
+    assert document.text == ""
+    assert document.metadata["format"] == "xlsx"
+    assert document.metadata["sheet_count"] == 2
+    assert document.metadata["redaction_report"] == list(report)
+
+
+def test_redact_xlsx_rejects_in_place_redaction(tmp_path: Path) -> None:
+    source = tmp_path / "synthetic.xlsx"
+    _synthetic_workbook(source)
+
+    with pytest.raises(ValueError, match="must differ"):
+        redact_xlsx(source, source, cell_deidentifier=_cell_deidentifier)

--- a/uv.lock
+++ b/uv.lock
@@ -1844,6 +1844,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4776,6 +4785,7 @@ dev = [
     { name = "jsonschema" },
     { name = "mypy" },
     { name = "numpy" },
+    { name = "openpyxl" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
@@ -4843,6 +4853,7 @@ multimodal = [
     { name = "easyocr" },
     { name = "markdown-it-py" },
     { name = "numpy" },
+    { name = "openpyxl" },
     { name = "pdfplumber" },
     { name = "piexif" },
     { name = "pikepdf" },
@@ -4967,6 +4978,8 @@ requires-dist = [
     { name = "onnxruntime", marker = "extra == 'onnx-runtime'", specifier = ">=1.16" },
     { name = "onnxruntime", marker = "extra == 'openvino'", specifier = ">=1.16" },
     { name = "onnxscript", marker = "extra == 'onnx'", specifier = ">=0.1.0" },
+    { name = "openpyxl", marker = "extra == 'dev'", specifier = ">=3.1,<4" },
+    { name = "openpyxl", marker = "extra == 'multimodal'", specifier = ">=3.1,<4" },
     { name = "opentelemetry-api", marker = "extra == 'dev'", specifier = ">=1.26,<2" },
     { name = "opentelemetry-api", marker = "extra == 'service'", specifier = ">=1.26,<2" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'dev'", specifier = ">=1.26,<2" },
@@ -5025,6 +5038,18 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'service'", specifier = ">=0.29" },
 ]
 provides-extras = ["agents", "awq", "cli", "cloud", "columnar", "coreml", "dask", "dev", "docs", "duckdb", "gliner", "gptq", "grounding", "hf", "kafka", "langchain", "llamaindex", "mcp", "mlx", "multimodal", "ocr-paddle", "onnx", "onnx-runtime", "openvino", "pandas", "philter", "polars", "prefect", "presidio", "pydeid", "service", "spacy", "spark"]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
 
 [[package]]
 name = "opentelemetry-api"


### PR DESCRIPTION
## Description

Adds native XLSX cell-level redaction while preserving workbook structure, formulas, and non-string cell values. The implementation reuses the existing CSV/TSV column classifier and also analyzes otherwise safe string cells for embedded free-text PHI.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Add a lazy-loaded XLSX redaction API with atomic output writes.
- Preserve worksheets, formulas, numbers, dates, and non-PHI cells.
- Emit PHI-safe reports containing only worksheet indexes, cell coordinates, and canonical labels.
- Add synthetic multi-sheet coverage and document installation, behavior, and scope limits.
- Add `openpyxl` to the development and multimodal dependency sets.

## Testing

- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally
- [x] I tested multi-sheet workbooks, formulas, numeric cells, PHI columns, free-text cells, and report leakage

Commands run:

- `.venv/bin/python -m pytest tests/ -q` — 5166 passed, 51 skipped
- `make format`
- `make lint`
- `make format-check`
- `make type-check`
- `uv run --extra docs mkdocs build --strict`

## Documentation

- [x] Added the XLSX cell-redaction guide and navigation entry
- [x] Added docstrings to the public API
- [ ] Updated the changelog

## Code Quality

- [x] Ran the canonical formatter and lint checks
- [x] Performed a self-review
- [x] Changes generate no new warnings

## Dependencies

- [ ] No new dependencies
- [x] Added `openpyxl>=3.1,<4` for XLSX workbook reading and writing through the multimodal extra

## Related Issues

Closes #853

## Screenshots/Examples

Not applicable; the documentation includes a runnable API example and PHI-safe report shape.
