### PR TITLE
Add a model-sharding and streaming weight loader for low-RAM devices

### DIFF
--- a/docs/runtimes/low-ram-loading.md
+++ b/docs/runtimes/low-ram-loading.md
@@ -1,0 +1,98 @@
+# Low-RAM Sharded Weight Loading
+
+`StreamingWeightLoader` bounds transient weight-loading memory on edge devices.
+It discovers logical layers deterministically, memory-maps only the current
+layer group, and closes those mappings before advancing. A measured
+incremental-RSS budget is enforced before and after every group; loading stops
+with `RamBudgetExceeded` if the next group cannot fit.
+
+## Supported local formats
+
+The source must already exist on local storage. Repository IDs, URLs, and shard
+paths outside the artifact directory are rejected.
+
+- A standard `model.safetensors.index.json` with a `weight_map` and local
+  `.safetensors` shards.
+- One `.safetensors` file, or a directory of deterministically sorted
+  `.safetensors` shards.
+- An ONNX graph whose initializers use ONNX external data. The external tensor
+  files may be one sidecar or multiple shards.
+
+Inline ONNX initializers are rejected because parsing them would materialize
+weights outside the streaming budget. Export those weights as external data
+first.
+
+## Stream layers into a runtime
+
+Pass a required RAM budget in bytes or use `RamBudget.from_mib`:
+
+```python
+import numpy as np
+
+from openmed.onnx import RamBudget, StreamingWeightLoader
+
+loader = StreamingWeightLoader(
+    "artifacts/model.safetensors.index.json",
+    ram_budget=RamBudget.from_mib(192),
+    layers_per_group=1,
+)
+
+
+def install_layer(group):
+    # Replace this example dictionary with the target runtime's layer setter.
+    # Copying here is intentional: mapped views expire when the callback ends.
+    runtime_layers[group.name] = {
+        name: np.array(weight, copy=True)
+        for name, weight in group.tensors.items()
+    }
+
+
+runtime_layers = {}
+report = loader.stream(install_layer)
+
+print(report.groups_loaded)
+print(report.peak_ram.peak_incremental_bytes)
+```
+
+Each `group.tensors` value is a read-only NumPy view over a local file mapping.
+The loader releases the views, advises the operating system to discard mapped
+pages where supported, and closes the mappings as soon as the callback returns.
+Do not retain a mapped view. Copy a value needed later, or pass it to a runtime
+API that copies the value during the callback. Retaining a view fails with
+`BufferReleaseError` instead of silently defeating the memory bound.
+
+Layer names are inferred from common `encoder.layer.N`, `layers.N`, `block.N`,
+and `transformer.h.N` tensor paths. Embeddings load first, numbered layers use
+numeric order, and classification heads load last. `layers_per_group` combines
+consecutive logical layers when the device has more headroom.
+
+## RAM budget semantics
+
+The budget covers incremental process resident memory above a baseline sampled
+when streaming starts. Before mapping a group, the loader reserves its full
+tensor byte size against the remaining budget. It samples current RSS again
+after mapping, after the consumer runs, and after release. The report records
+the highest sampled RSS and its baseline-relative peak.
+
+RSS measurement uses platform-native current-memory APIs on Linux, macOS, and
+Windows. If current RSS cannot be measured, the loader raises
+`RamProbeUnavailable` and reads no weights. This fail-closed behavior prevents a
+low-RAM deployment from quietly continuing without an enforceable limit.
+
+Use the smallest budget that covers the final runtime model plus one transient
+layer group. If a single logical layer is larger than the budget, loading aborts
+before that layer is mapped; increase the budget or export smaller layer shards.
+
+## Determinism and parity
+
+Shard index order does not affect loading order. Tensor and layer names are
+natural-sorted, and the loader performs no network calls. The unit coverage
+builds a synthetic token-classification note, runs it once with all weights and
+once through streamed layer groups, and requires identical decoded spans:
+
+```bash
+.venv/bin/python -m pytest tests/unit/onnx/test_streaming_loader.py -q
+```
+
+The same tests measure a successful load below budget and verify that both a
+projected oversized group and an observed RSS spike abort with a clear error.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - MLX Quantized Export: export-mlx-quant.md
       - Transformers.js Export: export-transformersjs.md
       - ONNX Runtime Web Loader: runtimes/onnxruntime-web.md
+      - Low-RAM Sharded Weight Loading: runtimes/low-ram-loading.md
       - Android Quickstart: android-quickstart.md
       - Android ONNX Export: export-onnx-android.md
       - Android Tokenization: android-tokenization.md

--- a/openmed/onnx/__init__.py
+++ b/openmed/onnx/__init__.py
@@ -13,8 +13,11 @@ __all__ = [
     "OPENVINO_INT8_FORMAT",
     "OPENVINO_PROFILE_NAME",
     "AndroidProfileValidation",
+    "BufferReleaseError",
     "ExportArtifact",
     "INT8_ONNX_FILENAME",
+    "LayerGroupSpec",
+    "LocalWeightsRequired",
     "ONNX_INT8_FORMAT",
     "OnnxEntity",
     "OnnxModel",
@@ -31,9 +34,18 @@ __all__ = [
     "certify_openvino_reference",
     "apply_int8_recall_certification",
     "OnnxOptimizationConfig",
+    "PeakRamProbe",
+    "PeakRamReport",
     "ORT_ANDROID_FORMAT",
     "OrtMobileConversionResult",
     "ShapeBucketConfig",
+    "RamBudget",
+    "RamBudgetExceeded",
+    "RamProbeUnavailable",
+    "ShardFormatError",
+    "StreamedLayerGroup",
+    "StreamingLoadReport",
+    "StreamingWeightLoader",
     "convert",
     "convert_android_onnx_to_ort",
     "export_android_fp16",
@@ -65,6 +77,26 @@ def __getattr__(name: str) -> Any:
     """Load conversion helpers lazily so ``python -m`` stays warning-free."""
 
     if name in __all__:
+        if name in {
+            "PeakRamProbe",
+            "PeakRamReport",
+            "RamBudget",
+            "RamBudgetExceeded",
+            "RamProbeUnavailable",
+        }:
+            module = import_module("openmed.onnx.ram_budget")
+            return getattr(module, name)
+        if name in {
+            "BufferReleaseError",
+            "LayerGroupSpec",
+            "LocalWeightsRequired",
+            "ShardFormatError",
+            "StreamedLayerGroup",
+            "StreamingLoadReport",
+            "StreamingWeightLoader",
+        }:
+            module = import_module("openmed.onnx.streaming_loader")
+            return getattr(module, name)
         if name in {"OnnxEntity", "OnnxModel", "load_onnx_model"}:
             module = import_module("openmed.onnx.inference")
             return getattr(module, name)

--- a/openmed/onnx/ram_budget.py
+++ b/openmed/onnx/ram_budget.py
@@ -322,8 +322,20 @@ def _windows_current_rss_bytes() -> int | None:
         counters = _ProcessMemoryCounters()
         counters.cb = ctypes.sizeof(counters)
         windll = getattr(ctypes, "windll")
-        process = windll.kernel32.GetCurrentProcess()
-        ok = windll.psapi.GetProcessMemoryInfo(
+        get_current_process = windll.kernel32.GetCurrentProcess
+        get_current_process.argtypes = ()
+        get_current_process.restype = ctypes.c_void_p
+        get_process_memory_info = windll.psapi.GetProcessMemoryInfo
+        get_process_memory_info.argtypes = (
+            ctypes.c_void_p,
+            ctypes.POINTER(_ProcessMemoryCounters),
+            ctypes.c_ulong,
+        )
+        get_process_memory_info.restype = ctypes.c_int
+        process = get_current_process()
+        if not process:
+            return None
+        ok = get_process_memory_info(
             process,
             ctypes.byref(counters),
             counters.cb,

--- a/openmed/onnx/ram_budget.py
+++ b/openmed/onnx/ram_budget.py
@@ -1,0 +1,349 @@
+"""Fail-closed resident-memory budgets for streaming model loading."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+RssSampler = Callable[[], int | None]
+
+
+class RamProbeUnavailable(RuntimeError):
+    """Raised when current resident memory cannot be measured safely."""
+
+
+class RamBudgetExceeded(MemoryError):
+    """Raised before or after an operation would exceed its RAM budget."""
+
+    def __init__(
+        self,
+        *,
+        budget_bytes: int,
+        observed_bytes: int,
+        requested_bytes: int = 0,
+        operation: str = "operation",
+    ) -> None:
+        self.budget_bytes = budget_bytes
+        self.observed_bytes = observed_bytes
+        self.requested_bytes = requested_bytes
+        self.operation = operation
+        projected = observed_bytes + requested_bytes
+        super().__init__(
+            f"RAM budget exceeded while {operation}: projected incremental RSS "
+            f"{_format_bytes(projected)} exceeds the configured budget "
+            f"{_format_bytes(budget_bytes)} (observed {_format_bytes(observed_bytes)}, "
+            f"requested {_format_bytes(requested_bytes)})"
+        )
+
+
+@dataclass(frozen=True)
+class RamBudget:
+    """Maximum incremental resident memory allowed during one load."""
+
+    max_bytes: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.max_bytes, bool) or self.max_bytes <= 0:
+            raise ValueError("RAM budget must be a positive number of bytes")
+
+    @classmethod
+    def from_mib(cls, max_mib: float) -> "RamBudget":
+        """Build a budget from mebibytes."""
+
+        if isinstance(max_mib, bool) or max_mib <= 0:
+            raise ValueError("RAM budget must be a positive number of MiB")
+        return cls(max_bytes=int(max_mib * 1024 * 1024))
+
+
+@dataclass(frozen=True)
+class PeakRamReport:
+    """Measured process RSS for one budgeted operation."""
+
+    budget_bytes: int
+    baseline_rss_bytes: int
+    peak_rss_bytes: int
+
+    @property
+    def peak_incremental_bytes(self) -> int:
+        """Return peak RSS above the operation baseline."""
+
+        return max(self.peak_rss_bytes - self.baseline_rss_bytes, 0)
+
+    @property
+    def within_budget(self) -> bool:
+        """Return whether the measured peak stayed within the budget."""
+
+        return self.peak_incremental_bytes <= self.budget_bytes
+
+
+class PeakRamProbe:
+    """Measure and enforce an incremental process-RSS budget.
+
+    The probe intentionally fails closed when the platform cannot provide a
+    current RSS value. Call :meth:`reserve` immediately before mapping or
+    allocating a known amount, and :meth:`checkpoint` after the operation.
+    """
+
+    def __init__(
+        self,
+        budget: RamBudget | int,
+        *,
+        rss_sampler: RssSampler | None = None,
+        poll_interval_seconds: float | None = 0.01,
+    ) -> None:
+        if poll_interval_seconds is not None and poll_interval_seconds <= 0:
+            raise ValueError("poll_interval_seconds must be positive or None")
+        self.budget = budget if isinstance(budget, RamBudget) else RamBudget(budget)
+        self._rss_sampler = rss_sampler or current_rss_bytes
+        self._poll_interval_seconds = poll_interval_seconds
+        self._baseline: int | None = None
+        self._peak: int | None = None
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._monitor: threading.Thread | None = None
+        self._monitor_error: RamProbeUnavailable | None = None
+
+    @property
+    def started(self) -> bool:
+        """Return whether the probe has recorded a baseline."""
+
+        return self._baseline is not None
+
+    @property
+    def report(self) -> PeakRamReport:
+        """Return the measurements recorded so far."""
+
+        with self._lock:
+            if self._baseline is None or self._peak is None:
+                raise RuntimeError("RAM probe has not been started")
+            return PeakRamReport(
+                budget_bytes=self.budget.max_bytes,
+                baseline_rss_bytes=self._baseline,
+                peak_rss_bytes=self._peak,
+            )
+
+    def start(self) -> int:
+        """Record and return the current RSS baseline."""
+
+        if self.started:
+            raise RuntimeError("RAM probe is already started")
+        baseline = self._sample()
+        with self._lock:
+            self._baseline = baseline
+            self._peak = baseline
+        if self._poll_interval_seconds is not None:
+            self._monitor = threading.Thread(
+                target=self._poll,
+                name="openmed-streaming-rss-monitor",
+                daemon=True,
+            )
+            self._monitor.start()
+        return baseline
+
+    def checkpoint(self, operation: str = "checking memory") -> int:
+        """Record current RSS and raise if the budget is already exceeded."""
+
+        if self._baseline is None:
+            raise RuntimeError("RAM probe has not been started")
+        self._raise_monitor_error()
+        current = self._sample()
+        self._record(current)
+        self._raise_monitor_error()
+        report = self.report
+        observed = report.peak_incremental_bytes
+        if observed > self.budget.max_bytes:
+            raise RamBudgetExceeded(
+                budget_bytes=self.budget.max_bytes,
+                observed_bytes=observed,
+                operation=operation,
+            )
+        return current
+
+    def reserve(self, requested_bytes: int, operation: str) -> None:
+        """Fail before an operation whose known working set cannot fit."""
+
+        if isinstance(requested_bytes, bool) or requested_bytes < 0:
+            raise ValueError("requested_bytes must be a non-negative integer")
+        self.checkpoint(operation)
+        observed = self.report.peak_incremental_bytes
+        if observed + requested_bytes > self.budget.max_bytes:
+            raise RamBudgetExceeded(
+                budget_bytes=self.budget.max_bytes,
+                observed_bytes=observed,
+                requested_bytes=requested_bytes,
+                operation=operation,
+            )
+
+    def stop(self) -> PeakRamReport:
+        """Take a final checked sample and return the peak report."""
+
+        self._stop_monitor()
+        self.checkpoint("finalizing the streaming load")
+        return self.report
+
+    def __enter__(self) -> "PeakRamProbe":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        if exc_type is None:
+            self.stop()
+        elif self.started:
+            self._stop_monitor()
+            try:
+                current = self._sample()
+            except RamProbeUnavailable:
+                pass
+            else:
+                self._record(current)
+        return False
+
+    def _poll(self) -> None:
+        assert self._poll_interval_seconds is not None
+        while not self._stop_event.wait(self._poll_interval_seconds):
+            try:
+                self._record(self._sample())
+            except RamProbeUnavailable as exc:
+                self._monitor_error = exc
+                self._stop_event.set()
+                return
+
+    def _record(self, value: int) -> None:
+        with self._lock:
+            self._peak = value if self._peak is None else max(self._peak, value)
+
+    def _raise_monitor_error(self) -> None:
+        if self._monitor_error is not None:
+            raise self._monitor_error
+
+    def _stop_monitor(self) -> None:
+        self._stop_event.set()
+        if self._monitor is not None:
+            self._monitor.join(timeout=1.0)
+            self._monitor = None
+
+    def _sample(self) -> int:
+        try:
+            value = self._rss_sampler()
+        except Exception as exc:
+            raise RamProbeUnavailable(
+                "Current RSS measurement failed; refusing to load weights "
+                "without enforceable RAM limits"
+            ) from exc
+        if value is None or isinstance(value, bool) or int(value) < 0:
+            raise RamProbeUnavailable(
+                "Current RSS is unavailable; refusing to load weights without "
+                "enforceable RAM limits"
+            )
+        return int(value)
+
+
+def current_rss_bytes() -> int | None:
+    """Return current process resident memory using platform-native APIs."""
+
+    if sys.platform.startswith("linux"):
+        try:
+            resident_pages = int(
+                Path("/proc/self/statm").read_text(encoding="ascii").split()[1]
+            )
+            return resident_pages * int(os.sysconf("SC_PAGE_SIZE"))
+        except (IndexError, OSError, TypeError, ValueError):
+            return None
+    if sys.platform == "darwin":
+        return _darwin_current_rss_bytes()
+    if os.name == "nt":
+        return _windows_current_rss_bytes()
+    return None
+
+
+class _TimeValue(ctypes.Structure):
+    _fields_ = [("seconds", ctypes.c_int), ("microseconds", ctypes.c_int)]
+
+
+class _MachTaskBasicInfo(ctypes.Structure):
+    _fields_ = [
+        ("virtual_size", ctypes.c_uint64),
+        ("resident_size", ctypes.c_uint64),
+        ("resident_size_max", ctypes.c_uint64),
+        ("user_time", _TimeValue),
+        ("system_time", _TimeValue),
+        ("policy", ctypes.c_int),
+        ("suspend_count", ctypes.c_int),
+    ]
+
+
+def _darwin_current_rss_bytes() -> int | None:
+    try:
+        libc = ctypes.CDLL("/usr/lib/libSystem.B.dylib")
+        libc.mach_task_self.restype = ctypes.c_uint
+        libc.task_info.argtypes = (
+            ctypes.c_uint,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_uint),
+        )
+        info = _MachTaskBasicInfo()
+        count = ctypes.c_uint(
+            ctypes.sizeof(_MachTaskBasicInfo) // ctypes.sizeof(ctypes.c_uint)
+        )
+        status = libc.task_info(
+            libc.mach_task_self(),
+            20,
+            ctypes.byref(info),
+            ctypes.byref(count),
+        )
+        return int(info.resident_size) if status == 0 else None
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+
+
+class _ProcessMemoryCounters(ctypes.Structure):
+    _fields_ = [
+        ("cb", ctypes.c_ulong),
+        ("page_fault_count", ctypes.c_ulong),
+        ("peak_working_set_size", ctypes.c_size_t),
+        ("working_set_size", ctypes.c_size_t),
+        ("quota_peak_paged_pool_usage", ctypes.c_size_t),
+        ("quota_paged_pool_usage", ctypes.c_size_t),
+        ("quota_peak_non_paged_pool_usage", ctypes.c_size_t),
+        ("quota_non_paged_pool_usage", ctypes.c_size_t),
+        ("pagefile_usage", ctypes.c_size_t),
+        ("peak_pagefile_usage", ctypes.c_size_t),
+    ]
+
+
+def _windows_current_rss_bytes() -> int | None:
+    try:
+        counters = _ProcessMemoryCounters()
+        counters.cb = ctypes.sizeof(counters)
+        windll = getattr(ctypes, "windll")
+        process = windll.kernel32.GetCurrentProcess()
+        ok = windll.psapi.GetProcessMemoryInfo(
+            process,
+            ctypes.byref(counters),
+            counters.cb,
+        )
+        return int(counters.working_set_size) if ok else None
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+
+
+def _format_bytes(value: int) -> str:
+    if value < 1024:
+        return f"{value} B"
+    return f"{value / (1024 * 1024):.2f} MiB"
+
+
+__all__ = [
+    "PeakRamProbe",
+    "PeakRamReport",
+    "RamBudget",
+    "RamBudgetExceeded",
+    "RamProbeUnavailable",
+    "current_rss_bytes",
+]

--- a/openmed/onnx/streaming_loader.py
+++ b/openmed/onnx/streaming_loader.py
@@ -1,0 +1,843 @@
+"""Deterministic, local-only streaming for sharded model weights.
+
+The loader understands standard Safetensors shard indexes and ONNX graphs
+whose initializers use ONNX external data. It maps one deterministic layer
+group at a time and releases those mappings before advancing to the next
+group. A consumer can therefore copy each group into its runtime model without
+temporarily materializing every source weight at once.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import math
+import mmap
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Callable, Iterator, Mapping
+
+from openmed.onnx.ram_budget import (
+    PeakRamProbe,
+    PeakRamReport,
+    RamBudget,
+    RssSampler,
+)
+
+_SAFETENSORS_INDEX_SUFFIX = ".safetensors.index.json"
+_PARAMETER_SUFFIX = re.compile(
+    r"(?:[./](?:weight|bias|gamma|beta|running_mean|running_var))$",
+    re.IGNORECASE,
+)
+_NUMBERED_LAYER = re.compile(
+    r"(?:^|[./])(?:encoder[./])?"
+    r"(?:layer|layers|block|blocks|transformer[./]h|h)[./](\d+)(?:[./]|$)",
+    re.IGNORECASE,
+)
+
+_SAFETENSORS_ITEM_SIZES = {
+    "BOOL": 1,
+    "I8": 1,
+    "U8": 1,
+    "I16": 2,
+    "U16": 2,
+    "F16": 2,
+    "BF16": 2,
+    "I32": 4,
+    "U32": 4,
+    "F32": 4,
+    "I64": 8,
+    "U64": 8,
+    "F64": 8,
+}
+
+
+class ShardFormatError(ValueError):
+    """Raised when a shard or its metadata is incomplete or unsafe."""
+
+
+class LocalWeightsRequired(ValueError):
+    """Raised when a source could resolve outside its local artifact root."""
+
+
+class BufferReleaseError(RuntimeError):
+    """Raised when a consumer retains a mapped tensor beyond its callback."""
+
+
+@dataclass(frozen=True)
+class LayerGroupSpec:
+    """Metadata for one deterministic group without any mapped tensors."""
+
+    name: str
+    tensor_names: tuple[str, ...]
+    source_files: tuple[Path, ...]
+    mapped_bytes: int
+
+
+@dataclass(frozen=True)
+class StreamingLoadReport:
+    """Memory and shard counts recorded for a completed streaming load."""
+
+    source: Path
+    source_format: str
+    groups_loaded: int
+    tensors_loaded: int
+    bytes_mapped: int
+    peak_ram: PeakRamReport
+
+
+@dataclass(frozen=True)
+class _TensorSpec:
+    name: str
+    path: Path
+    offset: int
+    nbytes: int
+    shape: tuple[int, ...]
+    dtype: str
+
+
+@dataclass(frozen=True)
+class _PlannedGroup:
+    public: LayerGroupSpec
+    tensors: tuple[_TensorSpec, ...]
+
+
+@dataclass(frozen=True)
+class _LoadPlan:
+    source: Path
+    source_format: str
+    groups: tuple[_PlannedGroup, ...]
+
+
+class StreamedLayerGroup:
+    """Read-only tensor views valid for the duration of one load callback.
+
+    Call :meth:`release` after copying or applying the tensors. A loader-owned
+    group is released automatically when iteration advances. Retaining an
+    array view after that boundary is rejected because it would defeat the RAM
+    bound.
+    """
+
+    def __init__(
+        self,
+        spec: LayerGroupSpec,
+        tensors: dict[str, Any],
+        mappings: list[mmap.mmap],
+    ) -> None:
+        self.spec = spec
+        self._tensor_storage = tensors
+        self._tensors = MappingProxyType(tensors)
+        self._mappings = mappings
+        self._released = False
+
+    @property
+    def name(self) -> str:
+        """Return the deterministic layer-group name."""
+
+        return self.spec.name
+
+    @property
+    def tensors(self) -> Mapping[str, Any]:
+        """Return read-only, memory-mapped NumPy tensor views."""
+
+        if self._released:
+            raise RuntimeError(f"Layer group {self.name!r} has been released")
+        return self._tensors
+
+    @property
+    def released(self) -> bool:
+        """Return whether all file mappings have been closed."""
+
+        return self._released
+
+    def release(self) -> None:
+        """Drop tensor views and close their file mappings immediately."""
+
+        if self._released:
+            return
+        self._tensor_storage.clear()
+        gc.collect()
+        failed: list[mmap.mmap] = []
+        for mapping in self._mappings:
+            _discard_mapped_pages(mapping)
+            try:
+                mapping.close()
+            except BufferError:
+                failed.append(mapping)
+        self._mappings = failed
+        if failed:
+            raise BufferReleaseError(
+                f"Layer group {self.name!r} still has retained tensor views; "
+                "copy values needed after the streaming callback instead of "
+                "retaining mapped arrays"
+            )
+        self._released = True
+
+    def __enter__(self) -> "StreamedLayerGroup":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        self.release()
+        return False
+
+    def __del__(self) -> None:
+        if not getattr(self, "_released", True):
+            try:
+                self.release()
+            except Exception:
+                pass
+
+
+class StreamingWeightLoader:
+    """Stream local sharded weights under a measured incremental-RSS budget.
+
+    Args:
+        source: Local ``.onnx`` graph, ``.safetensors`` file, standard
+            ``.safetensors.index.json`` file, or artifact directory.
+        ram_budget: Positive incremental-RSS budget in bytes or a
+            :class:`RamBudget`.
+        ram_budget_bytes: Byte-oriented alternative to ``ram_budget``.
+        layers_per_group: Consecutive logical layers mapped together.
+        rss_sampler: Optional current-RSS sampler for platform integration or
+            deterministic testing.
+    """
+
+    def __init__(
+        self,
+        source: str | Path,
+        *,
+        ram_budget: RamBudget | int | None = None,
+        ram_budget_bytes: int | None = None,
+        layers_per_group: int = 1,
+        rss_sampler: RssSampler | None = None,
+    ) -> None:
+        if ram_budget is None and ram_budget_bytes is None:
+            raise ValueError("A fail-closed RAM budget is required")
+        if ram_budget is not None and ram_budget_bytes is not None:
+            raise ValueError("Pass ram_budget or ram_budget_bytes, not both")
+        selected_budget = ram_budget if ram_budget is not None else ram_budget_bytes
+        assert selected_budget is not None
+        if isinstance(layers_per_group, bool) or layers_per_group <= 0:
+            raise ValueError("layers_per_group must be a positive integer")
+
+        self.source = _resolve_local_source(source)
+        self.ram_budget = (
+            selected_budget
+            if isinstance(selected_budget, RamBudget)
+            else RamBudget(selected_budget)
+        )
+        self.layers_per_group = layers_per_group
+        self._rss_sampler = rss_sampler
+        self._plan: _LoadPlan | None = None
+        self.last_report: StreamingLoadReport | None = None
+
+    @property
+    def layer_groups(self) -> tuple[LayerGroupSpec, ...]:
+        """Return deterministic group metadata without mapping weight data."""
+
+        if self._plan is None:
+            with PeakRamProbe(
+                self.ram_budget,
+                rss_sampler=self._rss_sampler,
+            ) as probe:
+                self._plan = self._discover(probe)
+        return tuple(group.public for group in self._plan.groups)
+
+    @property
+    def source_format(self) -> str:
+        """Return ``"onnx-external-data"`` or ``"safetensors"``."""
+
+        if self._plan is None:
+            self.layer_groups
+        assert self._plan is not None
+        return self._plan.source_format
+
+    def iter_layer_groups(self) -> Iterator[StreamedLayerGroup]:
+        """Yield and automatically release one mapped layer group at a time."""
+
+        probe = PeakRamProbe(self.ram_budget, rss_sampler=self._rss_sampler)
+        groups_loaded = 0
+        tensors_loaded = 0
+        bytes_mapped = 0
+        plan: _LoadPlan | None = None
+
+        try:
+            with probe:
+                plan = self._plan or self._discover(probe)
+                self._plan = plan
+                for planned in plan.groups:
+                    probe.reserve(
+                        planned.public.mapped_bytes,
+                        f"mapping layer group {planned.public.name!r}",
+                    )
+                    group = _open_group(planned)
+                    groups_loaded += 1
+                    tensors_loaded += len(planned.tensors)
+                    bytes_mapped += planned.public.mapped_bytes
+                    try:
+                        probe.checkpoint(f"mapping layer group {planned.public.name!r}")
+                        yield group
+                        probe.checkpoint(
+                            f"applying layer group {planned.public.name!r}"
+                        )
+                    finally:
+                        group.release()
+                    probe.checkpoint(f"releasing layer group {planned.public.name!r}")
+        finally:
+            if probe.started:
+                report_source = plan.source if plan is not None else self.source
+                report_format = (
+                    plan.source_format if plan is not None else "undiscovered"
+                )
+                self.last_report = StreamingLoadReport(
+                    source=report_source,
+                    source_format=report_format,
+                    groups_loaded=groups_loaded,
+                    tensors_loaded=tensors_loaded,
+                    bytes_mapped=bytes_mapped,
+                    peak_ram=probe.report,
+                )
+
+    def stream(
+        self,
+        consumer: Callable[[StreamedLayerGroup], Any],
+    ) -> StreamingLoadReport:
+        """Apply ``consumer`` to each group and return measured load metadata."""
+
+        if not callable(consumer):
+            raise TypeError("consumer must be callable")
+        for group in self.iter_layer_groups():
+            consumer(group)
+        assert self.last_report is not None
+        return self.last_report
+
+    def load(
+        self,
+        consumer: Callable[[StreamedLayerGroup], Any],
+    ) -> StreamingLoadReport:
+        """Alias for :meth:`stream` for loader-style integrations."""
+
+        return self.stream(consumer)
+
+    def _discover(self, probe: PeakRamProbe) -> _LoadPlan:
+        selected = _select_source(self.source)
+        if selected.name.endswith(_SAFETENSORS_INDEX_SUFFIX):
+            tensors = _discover_safetensors_index(selected, probe)
+            source_format = "safetensors"
+        elif selected.is_dir() or selected.suffix.lower() == ".safetensors":
+            paths = (
+                tuple(sorted(selected.glob("*.safetensors")))
+                if selected.is_dir()
+                else (selected,)
+            )
+            tensors = _discover_safetensors_files(paths, probe)
+            source_format = "safetensors"
+        elif selected.suffix.lower() == ".onnx":
+            tensors = _discover_onnx_external_data(selected, probe)
+            source_format = "onnx-external-data"
+        else:
+            raise ShardFormatError(f"Unsupported weight source: {selected}")
+
+        groups = _group_tensors(tensors, self.layers_per_group)
+        if not groups:
+            raise ShardFormatError(f"No weight tensors found in {selected}")
+        return _LoadPlan(
+            source=selected,
+            source_format=source_format,
+            groups=groups,
+        )
+
+
+def _resolve_local_source(source: str | Path) -> Path:
+    raw = str(source)
+    if "://" in raw or raw.startswith(("hf:", "http:", "https:")):
+        raise LocalWeightsRequired(
+            "Streaming weights must come from a local path; network identifiers "
+            "are not allowed"
+        )
+    path = Path(source).expanduser()
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Weight source not found: {path}") from exc
+    if not (resolved.is_file() or resolved.is_dir()):
+        raise FileNotFoundError(f"Weight source is not a file or directory: {path}")
+    return resolved
+
+
+def _select_source(source: Path) -> Path:
+    if source.is_file():
+        return source
+
+    indexes = tuple(sorted(source.glob(f"*{_SAFETENSORS_INDEX_SUFFIX}")))
+    if len(indexes) == 1:
+        return indexes[0]
+    if len(indexes) > 1:
+        raise ShardFormatError(
+            f"Artifact directory contains multiple Safetensors indexes: {source}"
+        )
+
+    standard_onnx = source / "model.onnx"
+    if standard_onnx.is_file():
+        return standard_onnx
+
+    safetensors_paths = tuple(sorted(source.glob("*.safetensors")))
+    if safetensors_paths:
+        return source
+
+    onnx_paths = tuple(sorted(source.glob("*.onnx")))
+    if len(onnx_paths) == 1:
+        return onnx_paths[0]
+    if len(onnx_paths) > 1:
+        raise ShardFormatError(
+            f"Artifact directory contains multiple ONNX graphs: {source}"
+        )
+    raise ShardFormatError(f"No sharded ONNX or Safetensors weights in {source}")
+
+
+def _discover_safetensors_index(
+    index_path: Path,
+    probe: PeakRamProbe,
+) -> tuple[_TensorSpec, ...]:
+    probe.reserve(index_path.stat().st_size, "reading the Safetensors shard index")
+    payload = _read_json_object(index_path)
+    probe.checkpoint("reading the Safetensors shard index")
+    weight_map = payload.get("weight_map")
+    if not isinstance(weight_map, Mapping) or not weight_map:
+        raise ShardFormatError(
+            f"Safetensors index must contain a non-empty weight_map: {index_path}"
+        )
+
+    expected: dict[str, Path] = {}
+    root = index_path.parent.resolve()
+    for name, location in weight_map.items():
+        if not isinstance(name, str) or not name:
+            raise ShardFormatError("Safetensors tensor names must be non-empty strings")
+        if not isinstance(location, str) or not location:
+            raise ShardFormatError(f"Shard location for {name!r} must be a string")
+        expected[name] = _resolve_artifact_file(root, location)
+
+    discovered_by_file: dict[Path, dict[str, _TensorSpec]] = {}
+    for path in sorted(set(expected.values())):
+        discovered_by_file[path] = {
+            tensor.name: tensor for tensor in _read_safetensors_header(path, probe)
+        }
+
+    tensors: list[_TensorSpec] = []
+    for name in sorted(expected, key=_natural_key):
+        path = expected[name]
+        tensor = discovered_by_file[path].get(name)
+        if tensor is None:
+            raise ShardFormatError(
+                f"Safetensors index maps {name!r} to {path.name}, but the tensor "
+                "is absent from that shard"
+            )
+        tensors.append(tensor)
+    return tuple(tensors)
+
+
+def _discover_safetensors_files(
+    paths: tuple[Path, ...],
+    probe: PeakRamProbe,
+) -> tuple[_TensorSpec, ...]:
+    if not paths:
+        raise ShardFormatError("No Safetensors shard files were found")
+    by_name: dict[str, _TensorSpec] = {}
+    for path in sorted(paths):
+        for tensor in _read_safetensors_header(path, probe):
+            if tensor.name in by_name:
+                raise ShardFormatError(
+                    f"Duplicate tensor {tensor.name!r} across Safetensors shards"
+                )
+            by_name[tensor.name] = tensor
+    return tuple(by_name[name] for name in sorted(by_name, key=_natural_key))
+
+
+def _read_safetensors_header(
+    path: Path,
+    probe: PeakRamProbe,
+) -> tuple[_TensorSpec, ...]:
+    file_size = path.stat().st_size
+    if file_size < 8:
+        raise ShardFormatError(f"Safetensors shard is shorter than its header: {path}")
+    with path.open("rb") as handle:
+        raw_length = handle.read(8)
+        header_length = int.from_bytes(raw_length, "little", signed=False)
+        if header_length <= 0 or header_length > file_size - 8:
+            raise ShardFormatError(f"Invalid Safetensors header length in {path}")
+        probe.reserve(
+            header_length + 8,
+            f"reading Safetensors metadata from {path.name}",
+        )
+        header_bytes = handle.read(header_length)
+    try:
+        header = json.loads(header_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ShardFormatError(f"Invalid Safetensors JSON header in {path}") from exc
+    if not isinstance(header, Mapping):
+        raise ShardFormatError(f"Safetensors header must be an object: {path}")
+    probe.checkpoint(f"reading Safetensors metadata from {path.name}")
+
+    data_start = 8 + header_length
+    tensors: list[_TensorSpec] = []
+    for name in sorted(
+        (item for item in header if item != "__metadata__"),
+        key=_natural_key,
+    ):
+        metadata = header[name]
+        if not isinstance(name, str) or not name or not isinstance(metadata, Mapping):
+            raise ShardFormatError(f"Invalid tensor entry in {path}")
+        dtype = metadata.get("dtype")
+        shape = metadata.get("shape")
+        offsets = metadata.get("data_offsets")
+        if dtype not in _SAFETENSORS_ITEM_SIZES:
+            raise ShardFormatError(
+                f"Unsupported Safetensors dtype {dtype!r} for tensor {name!r}"
+            )
+        normalized_shape = _validate_shape(shape, name)
+        if (
+            not isinstance(offsets, list)
+            or len(offsets) != 2
+            or any(
+                isinstance(value, bool) or not isinstance(value, int)
+                for value in offsets
+            )
+        ):
+            raise ShardFormatError(f"Invalid data_offsets for tensor {name!r}")
+        start, end = offsets
+        if start < 0 or end < start:
+            raise ShardFormatError(f"Invalid data_offsets for tensor {name!r}")
+        expected_bytes = _shape_size(normalized_shape) * _SAFETENSORS_ITEM_SIZES[dtype]
+        if end - start != expected_bytes:
+            raise ShardFormatError(
+                f"Safetensors byte length does not match shape for tensor {name!r}"
+            )
+        absolute_end = data_start + end
+        if absolute_end > file_size:
+            raise ShardFormatError(f"Tensor {name!r} extends beyond shard {path.name}")
+        tensors.append(
+            _TensorSpec(
+                name=name,
+                path=path,
+                offset=data_start + start,
+                nbytes=expected_bytes,
+                shape=normalized_shape,
+                dtype=dtype,
+            )
+        )
+    return tuple(tensors)
+
+
+def _discover_onnx_external_data(
+    model_path: Path,
+    probe: PeakRamProbe,
+) -> tuple[_TensorSpec, ...]:
+    try:
+        import onnx
+    except ImportError as exc:
+        raise ImportError(
+            "ONNX external-data loading requires the ONNX extra. "
+            "Install with: pip install 'openmed[onnx]'"
+        ) from exc
+    np = _load_numpy()
+    probe.reserve(model_path.stat().st_size, "reading ONNX graph metadata")
+    model = onnx.load(str(model_path), load_external_data=False)
+    probe.checkpoint("reading ONNX graph metadata")
+
+    root = model_path.parent.resolve()
+    tensors: list[_TensorSpec] = []
+    try:
+        for tensor in model.graph.initializer:
+            name = str(tensor.name)
+            if not name:
+                raise ShardFormatError("ONNX initializers must have stable names")
+            try:
+                dtype = np.dtype(onnx.helper.tensor_dtype_to_np_dtype(tensor.data_type))
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ShardFormatError(
+                    f"Unsupported ONNX dtype for initializer {name!r}"
+                ) from exc
+            if dtype.hasobject:
+                raise ShardFormatError(
+                    f"Object/string ONNX initializer {name!r} cannot be memory mapped"
+                )
+            shape = tuple(int(value) for value in tensor.dims)
+            nbytes = _shape_size(shape) * dtype.itemsize
+            external = {str(item.key): str(item.value) for item in tensor.external_data}
+            if not external:
+                if nbytes == 0:
+                    continue
+                raise ShardFormatError(
+                    f"ONNX initializer {name!r} is inline; streaming requires "
+                    "external-data weights"
+                )
+            location = external.get("location")
+            if not location:
+                raise ShardFormatError(
+                    f"ONNX initializer {name!r} has no external-data location"
+                )
+            path = _resolve_artifact_file(root, location)
+            offset = _parse_non_negative_int(
+                external.get("offset", "0"), name, "offset"
+            )
+            declared_length = _parse_non_negative_int(
+                external.get("length", str(nbytes)),
+                name,
+                "length",
+            )
+            if declared_length < nbytes:
+                raise ShardFormatError(
+                    f"ONNX external data is shorter than initializer {name!r}"
+                )
+            if offset + declared_length > path.stat().st_size:
+                raise ShardFormatError(
+                    f"ONNX initializer {name!r} extends beyond {path.name}"
+                )
+            tensors.append(
+                _TensorSpec(
+                    name=name,
+                    path=path,
+                    offset=offset,
+                    nbytes=nbytes,
+                    shape=shape,
+                    dtype=dtype.newbyteorder("<").str,
+                )
+            )
+    finally:
+        del model
+        gc.collect()
+        probe.checkpoint("releasing ONNX graph metadata")
+    return tuple(sorted(tensors, key=lambda item: _natural_key(item.name)))
+
+
+def _resolve_artifact_file(root: Path, location: str) -> Path:
+    if "://" in location:
+        raise LocalWeightsRequired(
+            f"Shard location must be local to the artifact: {location!r}"
+        )
+    relative = Path(location)
+    if relative.is_absolute():
+        raise LocalWeightsRequired(
+            f"Shard location must be relative to the artifact: {location!r}"
+        )
+    try:
+        candidate = (root / relative).resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Weight shard not found: {location}") from exc
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise LocalWeightsRequired(
+            f"Shard location escapes the local artifact directory: {location!r}"
+        ) from exc
+    if not candidate.is_file():
+        raise FileNotFoundError(f"Weight shard is not a file: {candidate}")
+    return candidate
+
+
+def _group_tensors(
+    tensors: tuple[_TensorSpec, ...],
+    layers_per_group: int,
+) -> tuple[_PlannedGroup, ...]:
+    buckets: dict[str, list[_TensorSpec]] = {}
+    ordering: dict[str, tuple[Any, ...]] = {}
+    for tensor in tensors:
+        key, order = _layer_bucket(tensor.name)
+        buckets.setdefault(key, []).append(tensor)
+        ordering[key] = order
+
+    layer_keys = sorted(buckets, key=lambda key: ordering[key])
+    groups: list[_PlannedGroup] = []
+    for start in range(0, len(layer_keys), layers_per_group):
+        keys = layer_keys[start : start + layers_per_group]
+        selected = tuple(
+            sorted(
+                (tensor for key in keys for tensor in buckets[key]),
+                key=lambda item: _natural_key(item.name),
+            )
+        )
+        name = keys[0] if len(keys) == 1 else f"{keys[0]}..{keys[-1]}"
+        public = LayerGroupSpec(
+            name=name,
+            tensor_names=tuple(tensor.name for tensor in selected),
+            source_files=tuple(sorted({tensor.path for tensor in selected})),
+            mapped_bytes=sum(tensor.nbytes for tensor in selected),
+        )
+        groups.append(_PlannedGroup(public=public, tensors=selected))
+    return tuple(groups)
+
+
+def _layer_bucket(name: str) -> tuple[str, tuple[Any, ...]]:
+    normalized = name.replace("/", ".")
+    numbered = _NUMBERED_LAYER.search(normalized)
+    if numbered:
+        index = int(numbered.group(1))
+        return f"layer-{index:04d}", (1, index, _natural_key(normalized))
+    lowered = normalized.lower()
+    if "embedding" in lowered:
+        return "embeddings", (0, 0, _natural_key(normalized))
+    if any(
+        part in lowered for part in ("classifier", "classification_head", "lm_head")
+    ):
+        return "classifier", (3, 0, _natural_key(normalized))
+    module = _PARAMETER_SUFFIX.sub("", normalized)
+    return module, (2, 0, _natural_key(module))
+
+
+def _open_group(planned: _PlannedGroup) -> StreamedLayerGroup:
+    np = _load_numpy()
+    tensors: dict[str, Any] = {}
+    mappings: list[mmap.mmap] = []
+    try:
+        for spec in planned.tensors:
+            if spec.nbytes == 0:
+                array = np.empty(spec.shape, dtype=_numpy_dtype(np, spec.dtype))
+                array.setflags(write=False)
+                tensors[spec.name] = array
+                continue
+            mapping, delta = _map_region(spec.path, spec.offset, spec.nbytes)
+            mappings.append(mapping)
+            array = np.ndarray(
+                spec.shape,
+                dtype=_numpy_dtype(np, spec.dtype),
+                buffer=mapping,
+                offset=delta,
+            )
+            array.setflags(write=False)
+            tensors[spec.name] = array
+        return StreamedLayerGroup(planned.public, tensors, mappings)
+    except Exception:
+        tensors.clear()
+        gc.collect()
+        for mapping in mappings:
+            try:
+                mapping.close()
+            except BufferError:
+                pass
+        raise
+
+
+def _map_region(path: Path, offset: int, length: int) -> tuple[mmap.mmap, int]:
+    file_size = path.stat().st_size
+    if offset < 0 or length < 0 or offset + length > file_size:
+        raise ShardFormatError(f"Mapped tensor range is outside shard {path.name}")
+    granularity = mmap.ALLOCATIONGRANULARITY
+    map_offset = offset - (offset % granularity)
+    delta = offset - map_offset
+    map_length = delta + length
+    with path.open("rb") as handle:
+        mapping = mmap.mmap(
+            handle.fileno(),
+            length=map_length,
+            access=mmap.ACCESS_READ,
+            offset=map_offset,
+        )
+    return mapping, delta
+
+
+def _discard_mapped_pages(mapping: mmap.mmap) -> None:
+    advice = getattr(mmap, "MADV_DONTNEED", None)
+    madvise = getattr(mapping, "madvise", None)
+    if advice is None or madvise is None:
+        return
+    try:
+        madvise(advice)
+    except (OSError, ValueError):
+        pass
+
+
+def _numpy_dtype(np: Any, dtype: str) -> Any:
+    if dtype == "BF16":
+        try:
+            return np.dtype("bfloat16")
+        except TypeError:
+            try:
+                from ml_dtypes import bfloat16
+            except ImportError as exc:
+                raise ShardFormatError(
+                    "BF16 Safetensors require NumPy bfloat16 support or ml_dtypes"
+                ) from exc
+            return np.dtype(bfloat16)
+    safetensors_dtypes = {
+        "BOOL": "?",
+        "I8": "i1",
+        "U8": "u1",
+        "I16": "<i2",
+        "U16": "<u2",
+        "F16": "<f2",
+        "I32": "<i4",
+        "U32": "<u4",
+        "F32": "<f4",
+        "I64": "<i8",
+        "U64": "<u8",
+        "F64": "<f8",
+    }
+    return np.dtype(safetensors_dtypes.get(dtype, dtype))
+
+
+def _load_numpy() -> Any:
+    try:
+        import numpy as np
+    except ImportError as exc:
+        raise ImportError(
+            "Streaming weight loading requires NumPy. "
+            "Install with: pip install 'openmed[onnx-runtime]'"
+        ) from exc
+    return np
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ShardFormatError(f"Invalid JSON metadata: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ShardFormatError(f"JSON metadata must contain an object: {path}")
+    return payload
+
+
+def _validate_shape(value: Any, tensor_name: str) -> tuple[int, ...]:
+    if not isinstance(value, list) or any(
+        isinstance(dimension, bool) or not isinstance(dimension, int) or dimension < 0
+        for dimension in value
+    ):
+        raise ShardFormatError(f"Invalid shape for tensor {tensor_name!r}")
+    return tuple(value)
+
+
+def _shape_size(shape: tuple[int, ...]) -> int:
+    return math.prod(shape, start=1)
+
+
+def _parse_non_negative_int(value: str, name: str, field: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ShardFormatError(
+            f"Invalid ONNX external-data {field} for initializer {name!r}"
+        ) from exc
+    if parsed < 0:
+        raise ShardFormatError(
+            f"Invalid ONNX external-data {field} for initializer {name!r}"
+        )
+    return parsed
+
+
+def _natural_key(value: str) -> tuple[Any, ...]:
+    return tuple(
+        int(part) if part.isdigit() else part.lower()
+        for part in re.split(r"(\d+)", value)
+    )
+
+
+__all__ = [
+    "BufferReleaseError",
+    "LayerGroupSpec",
+    "LocalWeightsRequired",
+    "ShardFormatError",
+    "StreamedLayerGroup",
+    "StreamingLoadReport",
+    "StreamingWeightLoader",
+]

--- a/tests/unit/onnx/test_streaming_loader.py
+++ b/tests/unit/onnx/test_streaming_loader.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import ctypes
 import json
 import struct
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Mapping
 
 import numpy as np
 import pytest
 
+from openmed.onnx import ram_budget as ram_budget_module
 from openmed.onnx.ram_budget import (
     PeakRamProbe,
     RamBudget,
@@ -169,6 +172,46 @@ def test_peak_ram_probe_uses_current_process_rss() -> None:
     assert probe.report.baseline_rss_bytes > 0
     assert probe.report.peak_rss_bytes >= probe.report.baseline_rss_bytes
     assert probe.report.within_budget is True
+
+
+def test_windows_rss_probe_configures_64_bit_process_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeWindowsFunction:
+        def __init__(self, callback):
+            self.callback = callback
+            self.argtypes = None
+            self.restype = None
+
+        def __call__(self, *args):
+            return self.callback(*args)
+
+    get_current_process = FakeWindowsFunction(lambda: 12_345)
+
+    def fill_memory_counters(_process, counters_pointer, _size):
+        counters = ctypes.cast(
+            counters_pointer,
+            ctypes.POINTER(ram_budget_module._ProcessMemoryCounters),
+        ).contents
+        counters.working_set_size = 987_654
+        return 1
+
+    get_process_memory_info = FakeWindowsFunction(fill_memory_counters)
+    windll = SimpleNamespace(
+        kernel32=SimpleNamespace(GetCurrentProcess=get_current_process),
+        psapi=SimpleNamespace(GetProcessMemoryInfo=get_process_memory_info),
+    )
+    monkeypatch.setattr(ram_budget_module.ctypes, "windll", windll, raising=False)
+
+    assert ram_budget_module._windows_current_rss_bytes() == 987_654
+    assert get_current_process.argtypes == ()
+    assert get_current_process.restype is ctypes.c_void_p
+    assert get_process_memory_info.argtypes == (
+        ctypes.c_void_p,
+        ctypes.POINTER(ram_budget_module._ProcessMemoryCounters),
+        ctypes.c_ulong,
+    )
+    assert get_process_memory_info.restype is ctypes.c_int
 
 
 def test_peak_ram_probe_rejects_a_transient_sampled_spike() -> None:

--- a/tests/unit/onnx/test_streaming_loader.py
+++ b/tests/unit/onnx/test_streaming_loader.py
@@ -1,0 +1,397 @@
+"""Tests for deterministic low-RAM ONNX and Safetensors loading."""
+
+from __future__ import annotations
+
+import json
+import struct
+import time
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+import pytest
+
+from openmed.onnx.ram_budget import (
+    PeakRamProbe,
+    RamBudget,
+    RamBudgetExceeded,
+    RamProbeUnavailable,
+)
+from openmed.onnx.streaming_loader import (
+    LocalWeightsRequired,
+    ShardFormatError,
+    StreamingWeightLoader,
+)
+
+
+def test_streamed_safetensors_matches_full_inference_spans(
+    tmp_path: Path,
+) -> None:
+    note = "Dr Alice Smith"
+    token_features = np.asarray(
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+    weights = {
+        "embeddings.scale": np.asarray(1.0, dtype=np.float32),
+        "encoder.layer.0.weight": np.eye(3, dtype=np.float32),
+        "encoder.layer.0.bias": np.zeros(3, dtype=np.float32),
+        "encoder.layer.1.weight": np.eye(3, dtype=np.float32),
+        "encoder.layer.1.bias": np.zeros(3, dtype=np.float32),
+        "classifier.weight": np.eye(3, dtype=np.float32),
+        "classifier.bias": np.zeros(3, dtype=np.float32),
+    }
+    index_path = _write_sharded_safetensors(tmp_path, weights)
+
+    full_logits = _run_full(token_features, weights)
+    full_spans = _decode_synthetic_spans(note, full_logits)
+
+    loader = StreamingWeightLoader(
+        index_path,
+        ram_budget_bytes=16 * 1024,
+        rss_sampler=lambda: 10_000,
+    )
+    state = token_features.copy()
+    released_groups = []
+
+    def apply_group(group) -> None:
+        nonlocal state
+        tensors = group.tensors
+        if group.name == "embeddings":
+            state = state * tensors["embeddings.scale"]
+        elif group.name.startswith("layer-"):
+            prefix = (
+                "encoder.layer.0" if group.name == "layer-0000" else "encoder.layer.1"
+            )
+            state = state @ tensors[f"{prefix}.weight"] + tensors[f"{prefix}.bias"]
+        elif group.name == "classifier":
+            state = state @ tensors["classifier.weight"] + tensors["classifier.bias"]
+        released_groups.append(group)
+
+    report = loader.stream(apply_group)
+    streamed_spans = _decode_synthetic_spans(note, state)
+
+    assert streamed_spans == full_spans == [("NAME", 3, 14, "Alice Smith")]
+    assert [group.name for group in released_groups] == [
+        "embeddings",
+        "layer-0000",
+        "layer-0001",
+        "classifier",
+    ]
+    assert all(group.released for group in released_groups)
+    assert report.source_format == "safetensors"
+    assert report.groups_loaded == 4
+    assert report.tensors_loaded == len(weights)
+    assert report.bytes_mapped == sum(array.nbytes for array in weights.values())
+    assert report.peak_ram.within_budget is True
+
+
+def test_safetensors_index_and_group_order_are_deterministic(tmp_path: Path) -> None:
+    weights = {
+        "encoder.layer.10.weight": np.asarray([10.0], dtype=np.float32),
+        "encoder.layer.2.weight": np.asarray([2.0], dtype=np.float32),
+        "encoder.layer.1.weight": np.asarray([1.0], dtype=np.float32),
+        "classifier.bias": np.asarray([0.0], dtype=np.float32),
+    }
+    index_path = _write_sharded_safetensors(tmp_path, weights)
+    loader = StreamingWeightLoader(
+        index_path,
+        ram_budget_bytes=16 * 1024,
+        layers_per_group=2,
+        rss_sampler=lambda: 1_000,
+    )
+
+    first = loader.layer_groups
+    second = loader.layer_groups
+
+    assert first == second
+    assert [group.name for group in first] == [
+        "layer-0001..layer-0002",
+        "layer-0010..classifier",
+    ]
+    assert first[0].tensor_names == (
+        "encoder.layer.1.weight",
+        "encoder.layer.2.weight",
+    )
+
+
+def test_large_group_is_rejected_before_it_is_mapped(tmp_path: Path) -> None:
+    weights = {
+        "encoder.layer.0.weight": np.zeros(32 * 1024, dtype=np.float32),
+    }
+    index_path = _write_sharded_safetensors(tmp_path, weights)
+    loader = StreamingWeightLoader(
+        index_path,
+        ram_budget_bytes=64 * 1024,
+        rss_sampler=lambda: 5_000,
+    )
+
+    with pytest.raises(RamBudgetExceeded, match="mapping layer group") as exc:
+        loader.stream(lambda group: pytest.fail("oversized group must not be mapped"))
+
+    assert exc.value.budget_bytes == 64 * 1024
+    assert exc.value.requested_bytes == weights["encoder.layer.0.weight"].nbytes
+    assert loader.last_report is not None
+    assert loader.last_report.groups_loaded == 0
+
+
+def test_peak_ram_probe_measures_under_budget_and_aborts_on_spike() -> None:
+    values = iter([1_000, 1_100, 1_250, 1_200])
+    probe = PeakRamProbe(
+        300,
+        rss_sampler=lambda: next(values),
+        poll_interval_seconds=None,
+    )
+
+    with probe:
+        probe.reserve(100, "mapping a small layer")
+        probe.checkpoint("applying a small layer")
+
+    assert probe.report.peak_incremental_bytes == 250
+    assert probe.report.within_budget is True
+
+    spike_values = iter([1_000, 1_101, 1_101])
+    with pytest.raises(RamBudgetExceeded, match="synthetic allocation"):
+        with PeakRamProbe(
+            100,
+            rss_sampler=lambda: next(spike_values),
+            poll_interval_seconds=None,
+        ) as exceeded:
+            exceeded.checkpoint("synthetic allocation")
+
+
+def test_peak_ram_probe_uses_current_process_rss() -> None:
+    with PeakRamProbe(RamBudget.from_mib(64)) as probe:
+        payload = bytearray(512 * 1024)
+        payload[::4096] = b"x" * len(payload[::4096])
+        probe.checkpoint("measuring a synthetic mapped buffer")
+
+    assert probe.report.baseline_rss_bytes > 0
+    assert probe.report.peak_rss_bytes >= probe.report.baseline_rss_bytes
+    assert probe.report.within_budget is True
+
+
+def test_peak_ram_probe_rejects_a_transient_sampled_spike() -> None:
+    rss = {"value": 1_000}
+
+    with pytest.raises(RamBudgetExceeded, match="sampled transient spike"):
+        with PeakRamProbe(
+            100,
+            rss_sampler=lambda: rss["value"],
+            poll_interval_seconds=0.001,
+        ) as probe:
+            rss["value"] = 1_250
+            deadline = time.monotonic() + 0.5
+            while probe.report.peak_rss_bytes < 1_250 and time.monotonic() < deadline:
+                time.sleep(0.002)
+            assert probe.report.peak_rss_bytes == 1_250
+            rss["value"] = 1_000
+            probe.checkpoint("checking a sampled transient spike")
+
+
+def test_peak_ram_probe_fails_closed_without_rss_measurement() -> None:
+    with pytest.raises(RamProbeUnavailable, match="refusing to load weights"):
+        with PeakRamProbe(1_024, rss_sampler=lambda: None):
+            pass
+
+
+def test_loader_rejects_network_and_escaping_shard_paths(tmp_path: Path) -> None:
+    with pytest.raises(LocalWeightsRequired, match="local path"):
+        StreamingWeightLoader("https://example.test/model.safetensors", ram_budget=1)
+
+    outside = tmp_path / "outside.safetensors"
+    _write_safetensors(outside, {"layer.weight": np.asarray([1.0], dtype=np.float32)})
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    index_path = artifact / "model.safetensors.index.json"
+    index_path.write_text(
+        json.dumps({"weight_map": {"layer.weight": "../outside.safetensors"}}),
+        encoding="utf-8",
+    )
+    loader = StreamingWeightLoader(
+        index_path,
+        ram_budget_bytes=4_096,
+        rss_sampler=lambda: 1_000,
+    )
+
+    with pytest.raises(LocalWeightsRequired, match="escapes"):
+        loader.layer_groups
+
+
+def test_onnx_external_data_is_streamed_by_layer(tmp_path: Path) -> None:
+    onnx = pytest.importorskip("onnx")
+    initializers = [
+        onnx.numpy_helper.from_array(
+            np.eye(2, dtype=np.float32),
+            name="encoder.layer.0.weight",
+        ),
+        onnx.numpy_helper.from_array(
+            np.asarray([0.25, -0.25], dtype=np.float32),
+            name="classifier.bias",
+        ),
+    ]
+    model = onnx.helper.make_model(
+        onnx.helper.make_graph([], "streaming-test", [], [], initializers)
+    )
+    model_path = tmp_path / "model.onnx"
+    onnx.save_model(
+        model,
+        str(model_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location="model.onnx.data",
+        size_threshold=0,
+    )
+    loader = StreamingWeightLoader(
+        model_path,
+        ram_budget_bytes=64 * 1024,
+        rss_sampler=lambda: 1_000,
+    )
+    copied: dict[str, np.ndarray] = {}
+
+    report = loader.stream(
+        lambda group: copied.update(
+            {name: np.array(value, copy=True) for name, value in group.tensors.items()}
+        )
+    )
+
+    np.testing.assert_array_equal(
+        copied["encoder.layer.0.weight"],
+        np.eye(2, dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        copied["classifier.bias"],
+        np.asarray([0.25, -0.25], dtype=np.float32),
+    )
+    assert report.source_format == "onnx-external-data"
+    assert [group.name for group in loader.layer_groups] == [
+        "layer-0000",
+        "classifier",
+    ]
+    assert report.peak_ram.within_budget is True
+
+
+def test_inline_onnx_weights_are_rejected_as_non_streamable(tmp_path: Path) -> None:
+    onnx = pytest.importorskip("onnx")
+    initializer = onnx.numpy_helper.from_array(
+        np.asarray([1.0], dtype=np.float32),
+        name="encoder.layer.0.weight",
+    )
+    model = onnx.helper.make_model(
+        onnx.helper.make_graph([], "inline-test", [], [], [initializer])
+    )
+    model_path = tmp_path / "model.onnx"
+    onnx.save(model, str(model_path))
+    loader = StreamingWeightLoader(
+        model_path,
+        ram_budget_bytes=64 * 1024,
+        rss_sampler=lambda: 1_000,
+    )
+
+    with pytest.raises(ShardFormatError, match="inline"):
+        loader.layer_groups
+
+
+def _run_full(
+    token_features: np.ndarray,
+    weights: Mapping[str, np.ndarray],
+) -> np.ndarray:
+    state = token_features * weights["embeddings.scale"]
+    for layer in range(2):
+        prefix = f"encoder.layer.{layer}"
+        state = state @ weights[f"{prefix}.weight"] + weights[f"{prefix}.bias"]
+    return state @ weights["classifier.weight"] + weights["classifier.bias"]
+
+
+def _decode_synthetic_spans(
+    note: str,
+    logits: np.ndarray,
+) -> list[tuple[str, int, int, str]]:
+    labels = ("O", "B-NAME", "I-NAME")
+    offsets = ((0, 2), (3, 8), (9, 14))
+    spans: list[tuple[str, int, int, str]] = []
+    active_start: int | None = None
+    active_end = 0
+    for label_id, (start, end) in zip(logits.argmax(axis=-1), offsets):
+        label = labels[int(label_id)]
+        if label == "B-NAME":
+            if active_start is not None:
+                spans.append(
+                    ("NAME", active_start, active_end, note[active_start:active_end])
+                )
+            active_start, active_end = start, end
+        elif label == "I-NAME" and active_start is not None:
+            active_end = end
+        elif active_start is not None:
+            spans.append(
+                ("NAME", active_start, active_end, note[active_start:active_end])
+            )
+            active_start = None
+    if active_start is not None:
+        spans.append(("NAME", active_start, active_end, note[active_start:active_end]))
+    return spans
+
+
+def _write_sharded_safetensors(
+    root: Path,
+    tensors: Mapping[str, np.ndarray],
+) -> Path:
+    names = sorted(tensors, reverse=True)
+    split = max(len(names) // 2, 1)
+    shards = (
+        ("model-00001-of-00002.safetensors", names[:split]),
+        ("model-00002-of-00002.safetensors", names[split:]),
+    )
+    weight_map: dict[str, str] = {}
+    for filename, shard_names in shards:
+        if not shard_names:
+            continue
+        _write_safetensors(
+            root / filename,
+            {name: tensors[name] for name in shard_names},
+        )
+        for name in shard_names:
+            weight_map[name] = filename
+    index_path = root / "model.safetensors.index.json"
+    index_path.write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map}),
+        encoding="utf-8",
+    )
+    return index_path
+
+
+def _write_safetensors(
+    path: Path,
+    tensors: Mapping[str, np.ndarray],
+) -> None:
+    header: dict[str, Any] = {}
+    chunks: list[bytes] = []
+    offset = 0
+    for name, value in tensors.items():
+        array = np.asarray(value)
+        data = array.tobytes(order="C")
+        header[name] = {
+            "dtype": _safetensors_dtype(array.dtype),
+            "shape": list(array.shape),
+            "data_offsets": [offset, offset + len(data)],
+        }
+        chunks.append(data)
+        offset += len(data)
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    header_bytes += b" " * ((8 - len(header_bytes) % 8) % 8)
+    path.write_bytes(
+        struct.pack("<Q", len(header_bytes)) + header_bytes + b"".join(chunks)
+    )
+
+
+def _safetensors_dtype(dtype: np.dtype[Any]) -> str:
+    mapping = {
+        np.dtype("float32"): "F32",
+        np.dtype("float64"): "F64",
+        np.dtype("float16"): "F16",
+        np.dtype("int64"): "I64",
+        np.dtype("int32"): "I32",
+        np.dtype("uint8"): "U8",
+        np.dtype("bool"): "BOOL",
+    }
+    return mapping[np.dtype(dtype)]


### PR DESCRIPTION
## Description

Adds a local-only streaming loader for standard Safetensors shards and ONNX external-data tensors. It maps deterministic logical layer groups, releases mapped pages before advancing, and continuously enforces a configurable incremental-RSS budget so low-memory devices fail closed instead of exhausting memory.

Closes #905

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add standard sharded Safetensors-index and ONNX external-data discovery with local-path containment checks.
- Add read-only per-layer mappings, explicit page discard and buffer release, deterministic grouping, and continuous peak-RSS enforcement.
- Add synthetic full-load versus streamed-inference span parity, measured budget, fail-closed, format-validation, and local-only coverage.
- Document supported artifacts, integration lifetime rules, grouping, reports, and budget semantics.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Full suite: 5,181 passed, 46 skipped.
ONNX unit suite: 78 passed.
Strict documentation build: passed.
Formatting and lint gates: passed.

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran the canonical formatting, lint, and format-check gates
- [ ] For Swift/OpenMedKit changes, I ran the Swift formatting and lint gates
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have organized my commits appropriately

## Related Issues

Closes #905

## Screenshots/Examples

Not applicable; this change adds a local runtime-loading API and documentation.
