### PR TITLE
Add a synthetic gold-corpus annotation toolkit with BRAT and CoNLL IO

### DIFF
--- a/openmed/eval/annotation/__init__.py
+++ b/openmed/eval/annotation/__init__.py
@@ -1,0 +1,45 @@
+"""Synthetic annotation task generation and BRAT/CoNLL interchange."""
+
+from openmed.eval.annotation.brat_io import (
+    format_brat,
+    parse_brat,
+    read_brat,
+    write_brat,
+)
+from openmed.eval.annotation.conll_io import (
+    format_conll,
+    parse_conll,
+    read_conll,
+    write_conll,
+)
+from openmed.eval.annotation.toolkit import (
+    AnnotationIssue,
+    AnnotationTask,
+    AnnotationValidationError,
+    Prelabeler,
+    SpanProposal,
+    generate_annotation_task,
+    generate_synthetic_annotation_task,
+    span_from_offsets,
+    validate_spans,
+)
+
+__all__ = [
+    "AnnotationIssue",
+    "AnnotationTask",
+    "AnnotationValidationError",
+    "Prelabeler",
+    "SpanProposal",
+    "format_brat",
+    "format_conll",
+    "generate_annotation_task",
+    "generate_synthetic_annotation_task",
+    "parse_brat",
+    "parse_conll",
+    "read_brat",
+    "read_conll",
+    "span_from_offsets",
+    "validate_spans",
+    "write_brat",
+    "write_conll",
+]

--- a/openmed/eval/annotation/brat_io.py
+++ b/openmed/eval/annotation/brat_io.py
@@ -1,0 +1,294 @@
+"""BRAT text-bound standoff readers and writers for ``OpenMedSpan``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from openmed.core.schemas import OpenMedSpan
+from openmed.eval.annotation.toolkit import (
+    AnnotationIssue,
+    AnnotationTask,
+    AnnotationValidationError,
+    span_from_offsets,
+    validate_spans,
+)
+
+
+def parse_brat(
+    text: str,
+    annotations: str,
+    *,
+    doc_id: str,
+    hash_secret: str | bytes,
+) -> tuple[OpenMedSpan, ...]:
+    """Parse BRAT text-bound annotations against exact source text.
+
+    The supported BRAT subset is one continuous text-bound annotation per
+    ``T`` record. Relations, attributes, events, and discontinuous spans are
+    rejected with line-specific guidance because they cannot map losslessly to
+    one ``OpenMedSpan``.
+
+    Args:
+        text: Exact contents of the paired ``.txt`` file.
+        annotations: Contents of the paired ``.ann`` file.
+        doc_id: Document identifier stored on imported spans.
+        hash_secret: Key used to HMAC imported span surfaces.
+
+    Returns:
+        Imported spans in deterministic offset order.
+
+    Raises:
+        AnnotationValidationError: If any standoff record is malformed.
+    """
+
+    if not doc_id:
+        raise AnnotationValidationError(
+            AnnotationIssue("doc_id must be non-empty"),
+            format_name="BRAT standoff",
+        )
+    issues: list[AnnotationIssue] = []
+    spans: list[OpenMedSpan] = []
+    annotation_ids: set[str] = set()
+
+    for line_number, line in enumerate(annotations.splitlines(), start=1):
+        if not line.strip():
+            continue
+        fields = line.split("\t", 2)
+        annotation_id = fields[0].strip() if fields else ""
+        if len(fields) != 3:
+            issues.append(
+                AnnotationIssue(
+                    "expected three tab-separated fields: ID, label offsets, text",
+                    line=line_number,
+                    annotation_id=annotation_id or None,
+                )
+            )
+            continue
+        if not annotation_id.startswith("T") or not annotation_id[1:].isdigit():
+            issues.append(
+                AnnotationIssue(
+                    "unsupported record; only text-bound IDs such as T1 are allowed",
+                    line=line_number,
+                    annotation_id=annotation_id or None,
+                )
+            )
+            continue
+        if annotation_id in annotation_ids:
+            issues.append(
+                AnnotationIssue(
+                    "duplicate annotation ID",
+                    line=line_number,
+                    annotation_id=annotation_id,
+                )
+            )
+            continue
+        annotation_ids.add(annotation_id)
+
+        descriptor = fields[1].strip()
+        if ";" in descriptor:
+            issues.append(
+                AnnotationIssue(
+                    "discontinuous spans are not supported; split into continuous spans",
+                    line=line_number,
+                    annotation_id=annotation_id,
+                )
+            )
+            continue
+        parts = descriptor.split()
+        if len(parts) != 3:
+            issues.append(
+                AnnotationIssue(
+                    "expected 'LABEL START END' in the second field",
+                    line=line_number,
+                    annotation_id=annotation_id,
+                )
+            )
+            continue
+        label, raw_start, raw_end = parts
+        try:
+            start, end = int(raw_start), int(raw_end)
+        except ValueError:
+            issues.append(
+                AnnotationIssue(
+                    "start and end offsets must be integers",
+                    line=line_number,
+                    annotation_id=annotation_id,
+                )
+            )
+            continue
+        if start < 0 or end > len(text) or start >= end:
+            issues.append(
+                AnnotationIssue(
+                    f"offsets {start}:{end} must satisfy "
+                    f"0 <= start < end <= {len(text)}",
+                    line=line_number,
+                    annotation_id=annotation_id,
+                )
+            )
+            continue
+        expected_surface = _brat_surface(text[start:end])
+        if fields[2] != expected_surface:
+            issues.append(
+                AnnotationIssue(
+                    f"annotated text does not match source offsets {start}:{end}",
+                    line=line_number,
+                    annotation_id=annotation_id,
+                )
+            )
+            continue
+        try:
+            spans.append(
+                span_from_offsets(
+                    doc_id=doc_id,
+                    text=text,
+                    start=start,
+                    end=end,
+                    label=label,
+                    hash_secret=hash_secret,
+                    entity_type=label,
+                    metadata={
+                        "annotation_format": "brat",
+                        "brat_id": annotation_id,
+                    },
+                )
+            )
+        except AnnotationValidationError as exc:
+            issues.extend(
+                AnnotationIssue(
+                    issue.message,
+                    line=line_number,
+                    annotation_id=annotation_id,
+                )
+                for issue in exc.issues
+            )
+
+    if issues:
+        raise AnnotationValidationError(issues, format_name="BRAT standoff")
+    try:
+        return validate_spans(text, spans, doc_id=doc_id, hash_secret=hash_secret)
+    except AnnotationValidationError as exc:
+        raise AnnotationValidationError(
+            exc.issues, format_name="BRAT standoff"
+        ) from exc
+
+
+def format_brat(text: str, spans: Iterable[OpenMedSpan]) -> str:
+    """Serialize continuous spans as deterministic BRAT ``T`` records.
+
+    Args:
+        text: Exact source text whose offsets the spans reference.
+        spans: Canonical spans from one document.
+
+    Returns:
+        UTF-8-ready contents for a BRAT ``.ann`` file.
+
+    Raises:
+        AnnotationValidationError: If a span is malformed or belongs to a
+            different document.
+    """
+
+    materialized = tuple(spans)
+    doc_id = materialized[0].doc_id if materialized else None
+    ordered = validate_spans(text, materialized, doc_id=doc_id)
+    lines = [
+        f"T{index}\t{span.canonical_label} {span.start} {span.end}\t"
+        f"{_brat_surface(text[span.start : span.end])}"
+        for index, span in enumerate(ordered, start=1)
+    ]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def read_brat(
+    text_path: str | Path,
+    ann_path: str | Path | None = None,
+    *,
+    doc_id: str | None = None,
+    hash_secret: str | bytes,
+    synthetic: bool = False,
+) -> AnnotationTask:
+    """Read paired BRAT ``.txt`` and ``.ann`` files as an annotation task.
+
+    Args:
+        text_path: Path to the source ``.txt`` file.
+        ann_path: Optional explicit ``.ann`` path; defaults beside ``text_path``.
+        doc_id: Optional document ID; defaults to the text file stem.
+        hash_secret: Key used to HMAC imported span surfaces.
+        synthetic: Whether the caller attests that the source is synthetic.
+
+    Returns:
+        The validated source document and imported spans.
+    """
+
+    resolved_text_path = Path(text_path)
+    resolved_ann_path = (
+        Path(ann_path)
+        if ann_path is not None
+        else resolved_text_path.with_suffix(".ann")
+    )
+    text = _read_exact(resolved_text_path)
+    annotations = _read_exact(resolved_ann_path)
+    resolved_doc_id = doc_id or resolved_text_path.stem
+    spans = parse_brat(
+        text,
+        annotations,
+        doc_id=resolved_doc_id,
+        hash_secret=hash_secret,
+    )
+    return AnnotationTask(
+        doc_id=resolved_doc_id,
+        text=text,
+        spans=spans,
+        synthetic=synthetic,
+        metadata={"annotation_format": "brat", "synthetic": synthetic},
+    )
+
+
+def write_brat(
+    text_path: str | Path,
+    text: str,
+    spans: Iterable[OpenMedSpan],
+    *,
+    ann_path: str | Path | None = None,
+) -> tuple[Path, Path]:
+    """Write paired BRAT files and return their resolved paths.
+
+    Args:
+        text_path: Destination for the source ``.txt`` file.
+        text: Exact source text.
+        spans: Canonical spans from one document.
+        ann_path: Optional explicit ``.ann`` destination.
+
+    Returns:
+        The resolved text and annotation paths, in that order.
+    """
+
+    resolved_text_path = Path(text_path)
+    resolved_ann_path = (
+        Path(ann_path)
+        if ann_path is not None
+        else resolved_text_path.with_suffix(".ann")
+    )
+    annotations = format_brat(text, spans)
+    resolved_text_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_ann_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_exact(resolved_text_path, text)
+    _write_exact(resolved_ann_path, annotations)
+    return resolved_text_path, resolved_ann_path
+
+
+def _brat_surface(text: str) -> str:
+    return text.replace("\r", " ").replace("\n", " ")
+
+
+def _read_exact(path: Path) -> str:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return handle.read()
+
+
+def _write_exact(path: Path, contents: str) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write(contents)
+
+
+__all__ = ["format_brat", "parse_brat", "read_brat", "write_brat"]

--- a/openmed/eval/annotation/conll_io.py
+++ b/openmed/eval/annotation/conll_io.py
@@ -1,0 +1,377 @@
+"""CoNLL-style BIO column readers and writers for ``OpenMedSpan``."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from openmed.core.schemas import OpenMedSpan
+from openmed.eval.annotation.toolkit import (
+    AnnotationIssue,
+    AnnotationTask,
+    AnnotationValidationError,
+    span_from_offsets,
+    validate_spans,
+)
+
+_TOKEN_RE = re.compile(r"\w+|[^\w\s]", flags=re.UNICODE)
+_TAG_RE = re.compile(r"^(?P<prefix>[BIESUL])-(?P<label>\S+)$")
+
+
+@dataclass(frozen=True)
+class _TokenRow:
+    token: str
+    tag: str
+    start: int
+    end: int
+    line: int
+    sentence_break: bool
+
+
+@dataclass
+class _ActiveSpan:
+    label: str
+    start: int
+    end: int
+    line: int
+
+
+def parse_conll(
+    text: str,
+    columns: str,
+    *,
+    doc_id: str,
+    hash_secret: str | bytes,
+) -> tuple[OpenMedSpan, ...]:
+    """Parse CoNLL token columns and align them to exact source text.
+
+    Two-column ``TOKEN TAG`` and traditional multi-column rows are accepted;
+    the first column is the token and the last is the NER tag. BIO is the
+    canonical output, while BIOES/BILOU tags are accepted on import. Blank
+    lines mark sentence boundaries.
+
+    Args:
+        text: Exact source text used to recover character offsets.
+        columns: CoNLL rows to parse.
+        doc_id: Document identifier stored on imported spans.
+        hash_secret: Key used to HMAC imported span surfaces.
+
+    Returns:
+        Imported spans in deterministic offset order.
+
+    Raises:
+        AnnotationValidationError: If rows, alignment, or tag transitions fail.
+    """
+
+    if not doc_id:
+        raise AnnotationValidationError(
+            AnnotationIssue("doc_id must be non-empty"), format_name="CoNLL"
+        )
+    rows, issues = _align_rows(text, columns)
+    if issues:
+        raise AnnotationValidationError(issues, format_name="CoNLL")
+
+    spans: list[OpenMedSpan] = []
+    active: _ActiveSpan | None = None
+
+    def close_active() -> None:
+        nonlocal active
+        if active is None:
+            return
+        try:
+            spans.append(
+                span_from_offsets(
+                    doc_id=doc_id,
+                    text=text,
+                    start=active.start,
+                    end=active.end,
+                    label=active.label,
+                    hash_secret=hash_secret,
+                    entity_type=active.label,
+                    metadata={"annotation_format": "conll"},
+                )
+            )
+        except AnnotationValidationError as exc:
+            issues.extend(
+                AnnotationIssue(issue.message, line=active.line) for issue in exc.issues
+            )
+        active = None
+
+    for row in rows:
+        if row.sentence_break:
+            close_active()
+        if row.tag == "O":
+            close_active()
+            continue
+        match = _TAG_RE.fullmatch(row.tag)
+        if match is None:
+            issues.append(
+                AnnotationIssue(
+                    "tag must be O or PREFIX-LABEL using BIO/BIOES/BILOU",
+                    line=row.line,
+                )
+            )
+            close_active()
+            continue
+        prefix = match.group("prefix")
+        label = match.group("label")
+        if prefix == "B":
+            close_active()
+            active = _ActiveSpan(label, row.start, row.end, row.line)
+        elif prefix in {"S", "U"}:
+            close_active()
+            active = _ActiveSpan(label, row.start, row.end, row.line)
+            close_active()
+        elif prefix == "I":
+            if active is None:
+                issues.append(
+                    AnnotationIssue(
+                        f"I-{label} cannot start an entity; use B-{label}",
+                        line=row.line,
+                    )
+                )
+            elif active.label != label:
+                issues.append(
+                    AnnotationIssue(
+                        f"I-{label} does not match active B-{active.label}",
+                        line=row.line,
+                    )
+                )
+                close_active()
+            else:
+                active.end = row.end
+        else:  # E or L
+            if active is None:
+                issues.append(
+                    AnnotationIssue(
+                        f"{prefix}-{label} has no matching entity start",
+                        line=row.line,
+                    )
+                )
+            elif active.label != label:
+                issues.append(
+                    AnnotationIssue(
+                        f"{prefix}-{label} does not match active B-{active.label}",
+                        line=row.line,
+                    )
+                )
+                close_active()
+            else:
+                active.end = row.end
+                close_active()
+    close_active()
+
+    if issues:
+        raise AnnotationValidationError(issues, format_name="CoNLL")
+    try:
+        return validate_spans(
+            text,
+            spans,
+            doc_id=doc_id,
+            hash_secret=hash_secret,
+            allow_overlap=False,
+        )
+    except AnnotationValidationError as exc:
+        raise AnnotationValidationError(exc.issues, format_name="CoNLL") from exc
+
+
+def format_conll(text: str, spans: Iterable[OpenMedSpan]) -> str:
+    """Serialize non-overlapping spans as two-column CoNLL BIO rows.
+
+    Args:
+        text: Exact source text whose offsets the spans reference.
+        spans: Canonical, non-overlapping spans from one document.
+
+    Returns:
+        UTF-8-ready ``TOKEN<TAB>TAG`` rows using BIO labels.
+
+    Raises:
+        AnnotationValidationError: If spans overlap, cross documents, or use
+            whitespace-only boundaries that CoNLL cannot represent.
+    """
+
+    materialized = tuple(spans)
+    doc_id = materialized[0].doc_id if materialized else None
+    ordered = validate_spans(
+        text,
+        materialized,
+        doc_id=doc_id,
+        allow_overlap=False,
+    )
+    tokens = _tokens_with_span_boundaries(text, ordered)
+    issues: list[AnnotationIssue] = []
+    for span in ordered:
+        covered = [
+            token for token in tokens if token[0] >= span.start and token[1] <= span.end
+        ]
+        if not covered or covered[0][0] != span.start or covered[-1][1] != span.end:
+            issues.append(
+                AnnotationIssue(
+                    f"span {span.start}:{span.end} must begin and end on a "
+                    "non-whitespace token boundary"
+                )
+            )
+    if issues:
+        raise AnnotationValidationError(issues, format_name="CoNLL")
+
+    lines: list[str] = []
+    for start, end, token in tokens:
+        owner = next(
+            (span for span in ordered if span.start <= start and end <= span.end),
+            None,
+        )
+        if owner is None:
+            tag = "O"
+        else:
+            prefix = "B" if start == owner.start else "I"
+            tag = f"{prefix}-{owner.canonical_label}"
+        lines.append(f"{token}\t{tag}")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def read_conll(
+    path: str | Path,
+    *,
+    text: str,
+    doc_id: str,
+    hash_secret: str | bytes,
+    synthetic: bool = False,
+) -> AnnotationTask:
+    """Read a CoNLL column file aligned against its exact source text.
+
+    Args:
+        path: Path to the CoNLL column file.
+        text: Exact paired source text used to recover offsets.
+        doc_id: Document identifier stored on imported spans.
+        hash_secret: Key used to HMAC imported span surfaces.
+        synthetic: Whether the caller attests that the source is synthetic.
+
+    Returns:
+        The validated source document and imported spans.
+    """
+
+    resolved_path = Path(path)
+    with resolved_path.open("r", encoding="utf-8", newline="") as handle:
+        columns = handle.read()
+    spans = parse_conll(
+        text,
+        columns,
+        doc_id=doc_id,
+        hash_secret=hash_secret,
+    )
+    return AnnotationTask(
+        doc_id=doc_id,
+        text=text,
+        spans=spans,
+        synthetic=synthetic,
+        metadata={"annotation_format": "conll", "synthetic": synthetic},
+    )
+
+
+def write_conll(
+    path: str | Path,
+    text: str,
+    spans: Iterable[OpenMedSpan],
+) -> Path:
+    """Write a two-column CoNLL BIO file and return its path.
+
+    Args:
+        path: Destination for the CoNLL column file.
+        text: Exact source text.
+        spans: Canonical, non-overlapping spans from one document.
+
+    Returns:
+        The resolved output path.
+    """
+
+    resolved_path = Path(path)
+    contents = format_conll(text, spans)
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    with resolved_path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write(contents)
+    return resolved_path
+
+
+def _align_rows(
+    text: str,
+    columns: str,
+) -> tuple[list[_TokenRow], list[AnnotationIssue]]:
+    rows: list[_TokenRow] = []
+    issues: list[AnnotationIssue] = []
+    cursor = 0
+    sentence_break = False
+
+    for line_number, line in enumerate(columns.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            sentence_break = True
+            continue
+        if stripped == "#" or stripped.startswith("# "):
+            continue
+        fields = stripped.split()
+        if fields[0] == "-DOCSTART-":
+            sentence_break = True
+            continue
+        if len(fields) < 2:
+            issues.append(
+                AnnotationIssue(
+                    "expected at least TOKEN and TAG columns", line=line_number
+                )
+            )
+            continue
+        token, tag = fields[0], fields[-1]
+        start = text.find(token, cursor)
+        if start < 0:
+            issues.append(
+                AnnotationIssue(
+                    "token cannot be aligned after the preceding source offset",
+                    line=line_number,
+                )
+            )
+            continue
+        if text[cursor:start].strip():
+            issues.append(
+                AnnotationIssue(
+                    "source text contains non-whitespace content before this token",
+                    line=line_number,
+                )
+            )
+        end = start + len(token)
+        rows.append(_TokenRow(token, tag, start, end, line_number, sentence_break))
+        cursor = end
+        sentence_break = False
+
+    if text[cursor:].strip():
+        issues.append(
+            AnnotationIssue("source text contains content after the final CoNLL token")
+        )
+    return rows, issues
+
+
+def _tokens_with_span_boundaries(
+    text: str,
+    spans: tuple[OpenMedSpan, ...],
+) -> list[tuple[int, int, str]]:
+    boundaries = {value for span in spans for value in (span.start, span.end)}
+    tokens: list[tuple[int, int, str]] = []
+    for match in _TOKEN_RE.finditer(text):
+        cuts = [
+            match.start(),
+            *sorted(
+                boundary
+                for boundary in boundaries
+                if match.start() < boundary < match.end()
+            ),
+            match.end(),
+        ]
+        tokens.extend(
+            (start, end, text[start:end])
+            for start, end in zip(cuts, cuts[1:])
+            if start < end
+        )
+    return tokens
+
+
+__all__ = ["format_conll", "parse_conll", "read_conll", "write_conll"]

--- a/openmed/eval/annotation/toolkit.py
+++ b/openmed/eval/annotation/toolkit.py
@@ -1,0 +1,380 @@
+"""Shared contracts for synthetic annotation tasks and annotation imports."""
+
+from __future__ import annotations
+
+import hmac
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from openmed.core.labels import OTHER, normalize_label
+from openmed.core.schemas import OpenMedSpan, hmac_text_hash
+
+
+@dataclass(frozen=True)
+class AnnotationIssue:
+    """One actionable problem found while reading annotation data."""
+
+    message: str
+    line: int | None = None
+    annotation_id: str | None = None
+
+    def render(self) -> str:
+        """Return a concise location-prefixed description."""
+
+        location: list[str] = []
+        if self.line is not None:
+            location.append(f"line {self.line}")
+        if self.annotation_id is not None:
+            location.append(f"annotation {self.annotation_id}")
+        prefix = ", ".join(location)
+        return f"{prefix}: {self.message}" if prefix else self.message
+
+
+class AnnotationValidationError(ValueError):
+    """Raised with one or more actionable annotation validation issues."""
+
+    def __init__(
+        self,
+        issues: AnnotationIssue | Iterable[AnnotationIssue],
+        *,
+        format_name: str = "annotation",
+    ) -> None:
+        if isinstance(issues, AnnotationIssue):
+            normalized = (issues,)
+        else:
+            normalized = tuple(issues)
+        if not normalized:
+            normalized = (AnnotationIssue("validation failed"),)
+        self.issues = normalized
+        self.format_name = format_name
+        details = "\n".join(f"- {issue.render()}" for issue in normalized)
+        super().__init__(f"Invalid {format_name} data:\n{details}")
+
+
+@dataclass(frozen=True)
+class AnnotationTask:
+    """A source document and its pre-labels for human annotation review."""
+
+    doc_id: str
+    text: str
+    spans: Sequence[OpenMedSpan] = field(default_factory=tuple)
+    synthetic: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.doc_id:
+            raise AnnotationValidationError(
+                AnnotationIssue("doc_id must be non-empty"),
+                format_name="annotation task",
+            )
+        if not self.text:
+            raise AnnotationValidationError(
+                AnnotationIssue("source text must be non-empty"),
+                format_name="annotation task",
+            )
+        if not isinstance(self.metadata, Mapping):
+            raise AnnotationValidationError(
+                AnnotationIssue("metadata must be a mapping"),
+                format_name="annotation task",
+            )
+        validated = validate_spans(self.text, self.spans, doc_id=self.doc_id)
+        object.__setattr__(self, "spans", validated)
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+
+SpanProposal = OpenMedSpan | Mapping[str, Any]
+Prelabeler = Callable[[str], Iterable[SpanProposal]]
+
+
+def validate_spans(
+    text: str,
+    spans: Iterable[OpenMedSpan],
+    *,
+    doc_id: str | None = None,
+    hash_secret: str | bytes | None = None,
+    allow_overlap: bool = True,
+) -> tuple[OpenMedSpan, ...]:
+    """Validate span bounds, document identity, hashes, and overlap policy.
+
+    Args:
+        text: Exact source text whose character offsets the spans reference.
+        spans: Canonical spans to validate.
+        doc_id: Optional expected document identifier.
+        hash_secret: Optional key used to verify each span's surface HMAC.
+        allow_overlap: Whether overlapping and nested spans are permitted.
+
+    Returns:
+        The spans in deterministic offset and label order.
+
+    Raises:
+        AnnotationValidationError: If one or more spans are malformed.
+    """
+
+    if hash_secret is not None:
+        _require_hash_secret(hash_secret)
+    materialized = tuple(spans)
+    type_issues = [
+        AnnotationIssue(
+            f"span {index} must be an OpenMedSpan, got {type(span).__name__}"
+        )
+        for index, span in enumerate(materialized, start=1)
+        if not isinstance(span, OpenMedSpan)
+    ]
+    if type_issues:
+        raise AnnotationValidationError(type_issues)
+    ordered = tuple(
+        sorted(
+            materialized,
+            key=lambda span: (span.start, span.end, span.canonical_label),
+        )
+    )
+    issues: list[AnnotationIssue] = []
+    seen: set[tuple[int, int, str]] = set()
+    previous: OpenMedSpan | None = None
+
+    for index, span in enumerate(ordered, start=1):
+        location = f"span {index} ({span.start}:{span.end})"
+        if doc_id is not None and span.doc_id != doc_id:
+            issues.append(
+                AnnotationIssue(f"{location} belongs to a different document")
+            )
+        if span.start < 0 or span.end > len(text) or span.start >= span.end:
+            issues.append(
+                AnnotationIssue(
+                    f"{location} must satisfy 0 <= start < end <= {len(text)}"
+                )
+            )
+            continue
+        identity = (span.start, span.end, span.canonical_label)
+        if identity in seen:
+            issues.append(AnnotationIssue(f"duplicate {location} and label"))
+        seen.add(identity)
+        if not allow_overlap and previous is not None and span.start < previous.end:
+            issues.append(
+                AnnotationIssue(
+                    f"{location} overlaps the preceding span "
+                    f"({previous.start}:{previous.end}); this format supports "
+                    "one label per token"
+                )
+            )
+        if previous is None or span.end > previous.end:
+            previous = span
+        if hash_secret is not None:
+            expected_hash = hmac_text_hash(text[span.start : span.end], hash_secret)
+            if not hmac.compare_digest(span.text_hash, expected_hash):
+                issues.append(
+                    AnnotationIssue(
+                        f"{location} text_hash does not match the source text"
+                    )
+                )
+
+    if issues:
+        raise AnnotationValidationError(issues)
+    return ordered
+
+
+def span_from_offsets(
+    *,
+    doc_id: str,
+    text: str,
+    start: int,
+    end: int,
+    label: str,
+    hash_secret: str | bytes,
+    entity_type: str | None = None,
+    score: float | None = None,
+    detector: str | None = "annotation_import",
+    metadata: Mapping[str, Any] | None = None,
+) -> OpenMedSpan:
+    """Build a canonical span from validated source-text offsets.
+
+    Unknown external labels are rejected instead of silently mapping to
+    ``OTHER`` so annotation mistakes remain visible to reviewers.
+
+    Args:
+        doc_id: Document identifier stored on the span.
+        text: Exact source text whose offsets are being imported.
+        start: Inclusive character offset.
+        end: Exclusive character offset.
+        label: External or canonical entity label.
+        hash_secret: Key used to HMAC the source surface.
+        entity_type: Optional original entity type; defaults to ``label``.
+        score: Optional pre-labeler confidence.
+        detector: Optional source recorded on the span.
+        metadata: Optional non-PHI provenance metadata.
+
+    Returns:
+        A canonical span whose hash matches the referenced source surface.
+
+    Raises:
+        AnnotationValidationError: If offsets or labels are invalid.
+    """
+
+    _require_hash_secret(hash_secret)
+    if not doc_id:
+        raise AnnotationValidationError(AnnotationIssue("doc_id must be non-empty"))
+    if not isinstance(start, int) or not isinstance(end, int):
+        raise AnnotationValidationError(
+            AnnotationIssue("span start and end must be integers")
+        )
+    if start < 0 or end > len(text) or start >= end:
+        raise AnnotationValidationError(
+            AnnotationIssue(
+                f"span {start}:{end} must satisfy 0 <= start < end <= {len(text)}"
+            )
+        )
+    source_label = label.strip()
+    if not source_label:
+        raise AnnotationValidationError(AnnotationIssue("span label must be non-empty"))
+    canonical_label = normalize_label(source_label)
+    if canonical_label == OTHER and source_label.upper() != OTHER:
+        raise AnnotationValidationError(
+            AnnotationIssue(
+                f"unknown label {source_label!r}; use an OpenMed canonical label"
+            )
+        )
+    try:
+        return OpenMedSpan(
+            doc_id=doc_id,
+            start=start,
+            end=end,
+            text_hash=hmac_text_hash(text[start:end], hash_secret),
+            entity_type=entity_type or source_label,
+            canonical_label=canonical_label,
+            score=score,
+            detector=detector,
+            metadata=dict(metadata or {}),
+        )
+    except (TypeError, ValueError) as exc:
+        raise AnnotationValidationError(AnnotationIssue(str(exc))) from exc
+
+
+def generate_synthetic_annotation_task(
+    doc_id: str,
+    text: str,
+    *,
+    hash_secret: str | bytes,
+    spans: Iterable[SpanProposal] | None = None,
+    prelabeler: Prelabeler | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> AnnotationTask:
+    """Generate a synthetic, pre-labeled task for human correction.
+
+    Exactly one of ``spans`` and ``prelabeler`` may be supplied. Mapping-based
+    proposals need ``start``, ``end``, and one of ``canonical_label``, ``label``,
+    or ``entity_type``. Existing ``OpenMedSpan`` records are preserved.
+
+    Args:
+        doc_id: Stable synthetic document identifier.
+        text: Synthetic source text to annotate.
+        hash_secret: Key used to HMAC proposal surfaces.
+        spans: Optional precomputed span proposals.
+        prelabeler: Optional callback that returns proposals for ``text``.
+        metadata: Optional task metadata.
+
+    Returns:
+        A synthetic annotation task marked as needing human review.
+    """
+
+    if spans is not None and prelabeler is not None:
+        raise AnnotationValidationError(
+            AnnotationIssue("provide spans or prelabeler, not both"),
+            format_name="annotation proposal",
+        )
+    proposals = prelabeler(text) if prelabeler is not None else (spans or ())
+    normalized: list[OpenMedSpan] = []
+    issues: list[AnnotationIssue] = []
+
+    for index, proposal in enumerate(proposals, start=1):
+        if isinstance(proposal, OpenMedSpan):
+            normalized.append(proposal)
+            continue
+        if not isinstance(proposal, Mapping):
+            issues.append(
+                AnnotationIssue(f"proposal {index} must be an OpenMedSpan or mapping")
+            )
+            continue
+        try:
+            start = int(proposal["start"])
+            end = int(proposal["end"])
+        except (KeyError, TypeError, ValueError):
+            issues.append(
+                AnnotationIssue(
+                    f"proposal {index} requires integer start and end offsets"
+                )
+            )
+            continue
+        label = str(
+            proposal.get("canonical_label")
+            or proposal.get("label")
+            or proposal.get("entity_type")
+            or ""
+        )
+        try:
+            normalized.append(
+                span_from_offsets(
+                    doc_id=doc_id,
+                    text=text,
+                    start=start,
+                    end=end,
+                    label=label,
+                    hash_secret=hash_secret,
+                    entity_type=str(proposal.get("entity_type") or label),
+                    score=proposal.get("score"),
+                    detector=str(proposal.get("detector") or "annotation_prelabeler"),
+                    metadata=proposal.get("metadata") or {},
+                )
+            )
+        except AnnotationValidationError as exc:
+            issues.extend(
+                AnnotationIssue(f"proposal {index}: {issue.message}")
+                for issue in exc.issues
+            )
+
+    if issues:
+        raise AnnotationValidationError(issues, format_name="annotation proposal")
+    task_metadata = {
+        **dict(metadata or {}),
+        "prelabeled": bool(normalized),
+        "review_status": "needs_human_review",
+        "synthetic": True,
+    }
+    return AnnotationTask(
+        doc_id=doc_id,
+        text=text,
+        spans=validate_spans(
+            text,
+            normalized,
+            doc_id=doc_id,
+            hash_secret=hash_secret,
+        ),
+        synthetic=True,
+        metadata=task_metadata,
+    )
+
+
+generate_annotation_task = generate_synthetic_annotation_task
+
+
+def _require_hash_secret(hash_secret: str | bytes) -> None:
+    if not isinstance(hash_secret, (str, bytes)):
+        raise AnnotationValidationError(
+            AnnotationIssue("hash_secret must be a string or bytes")
+        )
+    if not hash_secret:
+        raise AnnotationValidationError(
+            AnnotationIssue("hash_secret must be non-empty")
+        )
+
+
+__all__ = [
+    "AnnotationIssue",
+    "AnnotationTask",
+    "AnnotationValidationError",
+    "Prelabeler",
+    "SpanProposal",
+    "generate_annotation_task",
+    "generate_synthetic_annotation_task",
+    "span_from_offsets",
+    "validate_spans",
+]

--- a/tests/unit/eval/test_annotation_io.py
+++ b/tests/unit/eval/test_annotation_io.py
@@ -1,0 +1,260 @@
+"""Tests for synthetic annotation tasks and BRAT/CoNLL interchange."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.core.schemas import OpenMedSpan, hmac_text_hash
+from openmed.eval.annotation import (
+    AnnotationValidationError,
+    format_brat,
+    format_conll,
+    generate_synthetic_annotation_task,
+    parse_brat,
+    parse_conll,
+    read_brat,
+    read_conll,
+    write_brat,
+    write_conll,
+)
+
+_SECRET = "synthetic-test-key"
+_TEXT = "Patient Jane Roe visited on 2025-03-02."
+
+
+def _span(start: int, end: int, label: str) -> OpenMedSpan:
+    return OpenMedSpan(
+        doc_id="synthetic-note-1",
+        start=start,
+        end=end,
+        text_hash=hmac_text_hash(_TEXT[start:end], _SECRET),
+        entity_type=label.lower(),
+        canonical_label=label,
+        detector="synthetic_fixture",
+    )
+
+
+def _spans() -> tuple[OpenMedSpan, ...]:
+    return (_span(8, 16, "PERSON"), _span(28, 38, "DATE"))
+
+
+def _offset_labels(spans: tuple[OpenMedSpan, ...]) -> list[tuple[int, int, str]]:
+    return [(span.start, span.end, span.canonical_label) for span in spans]
+
+
+def test_brat_round_trip_preserves_offsets_and_labels(tmp_path) -> None:
+    text_path = tmp_path / "synthetic-note-1.txt"
+
+    written_text, written_ann = write_brat(text_path, _TEXT, _spans())
+    task = read_brat(written_text, written_ann, hash_secret=_SECRET, synthetic=True)
+
+    assert task.text == _TEXT
+    assert task.synthetic is True
+    assert _offset_labels(tuple(task.spans)) == _offset_labels(_spans())
+    assert format_brat(task.text, task.spans).startswith("T1\tPERSON 8 16\tJane Roe")
+
+
+@pytest.mark.parametrize(
+    ("annotations", "message"),
+    [
+        ("T1 PERSON 0 7 Patient", "three tab-separated fields"),
+        ("T1\tPERSON zero 7\tPatient", "offsets must be integers"),
+        ("T1\tPERSON 0 70\tPatient", "0 <= start < end"),
+        ("T1\tPERSON 8 16\tJohn Doe", "does not match source offsets"),
+        ("T1\tUNMAPPED 8 16\tJane Roe", "unknown label"),
+        ("R1\tRelated Arg1:T1 Arg2:T2\tunused", "only text-bound IDs"),
+        ("T1\tPERSON 8 12;13 16\tJane Roe", "discontinuous spans"),
+    ],
+)
+def test_malformed_brat_has_actionable_line_errors(
+    annotations: str,
+    message: str,
+) -> None:
+    with pytest.raises(AnnotationValidationError) as exc_info:
+        parse_brat(
+            _TEXT,
+            annotations,
+            doc_id="synthetic-note-1",
+            hash_secret=_SECRET,
+        )
+
+    rendered = str(exc_info.value)
+    assert "Invalid BRAT standoff data" in rendered
+    assert "line 1" in rendered
+    assert message in rendered
+
+
+def test_brat_collects_multiple_validation_issues() -> None:
+    annotations = "T1\tPERSON bad 16\tJane Roe\nT2\tDATE 28 99\t2025-03-02\n"
+
+    with pytest.raises(AnnotationValidationError) as exc_info:
+        parse_brat(
+            _TEXT,
+            annotations,
+            doc_id="synthetic-note-1",
+            hash_secret=_SECRET,
+        )
+
+    assert len(exc_info.value.issues) == 2
+    assert "line 1" in str(exc_info.value)
+    assert "line 2" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("hash_secret", ["", b""])
+def test_annotation_import_rejects_empty_hash_secret(
+    hash_secret: str | bytes,
+) -> None:
+    with pytest.raises(
+        AnnotationValidationError, match="hash_secret must be non-empty"
+    ):
+        parse_brat(
+            _TEXT,
+            "T1\tPERSON 8 16\tJane Roe\n",
+            doc_id="synthetic-note-1",
+            hash_secret=hash_secret,
+        )
+
+
+def test_conll_round_trip_preserves_offsets_and_labels(tmp_path) -> None:
+    conll_path = write_conll(tmp_path / "synthetic-note-1.conll", _TEXT, _spans())
+    task = read_conll(
+        conll_path,
+        text=_TEXT,
+        doc_id="synthetic-note-1",
+        hash_secret=_SECRET,
+        synthetic=True,
+    )
+
+    assert task.synthetic is True
+    assert _offset_labels(tuple(task.spans)) == _offset_labels(_spans())
+    assert "Jane\tB-PERSON\nRoe\tI-PERSON" in format_conll(_TEXT, _spans())
+
+
+def test_conll_round_trip_preserves_hash_tokens() -> None:
+    text = "Synthetic case #42."
+
+    columns = format_conll(text, ())
+    spans = parse_conll(
+        text,
+        columns,
+        doc_id="synthetic-case-42",
+        hash_secret=_SECRET,
+    )
+
+    assert "#\tO" in columns
+    assert spans == ()
+
+
+def test_conll_accepts_traditional_extra_columns_and_bilou() -> None:
+    columns = "\n".join(
+        [
+            "Patient NN B-NP O",
+            "Jane NNP B-NP B-PERSON",
+            "Roe NNP I-NP L-PERSON",
+            "visited VBD B-VP O",
+            "on IN B-PP O",
+            "2025-03-02 CD B-NP U-DATE",
+            ". . O O",
+        ]
+    )
+
+    spans = parse_conll(
+        _TEXT,
+        columns,
+        doc_id="synthetic-note-1",
+        hash_secret=_SECRET,
+    )
+
+    assert _offset_labels(spans) == _offset_labels(_spans())
+
+
+@pytest.mark.parametrize(
+    ("columns", "message"),
+    [
+        ("Patient\n", "at least TOKEN and TAG"),
+        (
+            "Patient O\nJane I-PERSON\nRoe O\nvisited O\non O\n"
+            "2025 O\n- O\n03 O\n- O\n02 O\n. O\n",
+            "cannot start an entity",
+        ),
+        ("Patient O\nMissing O\n", "cannot be aligned"),
+        (
+            "Patient X-PERSON\nJane O\nRoe O\nvisited O\non O\n"
+            "2025 O\n- O\n03 O\n- O\n02 O\n. O\n",
+            "BIO/BIOES/BILOU",
+        ),
+    ],
+)
+def test_malformed_conll_has_actionable_errors(columns: str, message: str) -> None:
+    with pytest.raises(AnnotationValidationError, match=message):
+        parse_conll(
+            _TEXT,
+            columns,
+            doc_id="synthetic-note-1",
+            hash_secret=_SECRET,
+        )
+
+
+def test_conll_rejects_overlapping_spans() -> None:
+    overlap = _span(8, 12, "FIRST_NAME")
+
+    with pytest.raises(AnnotationValidationError, match="one label per token"):
+        format_conll(_TEXT, (_spans()[0], overlap))
+
+
+def test_writers_reject_spans_from_different_documents() -> None:
+    other_document = OpenMedSpan(
+        doc_id="other-note",
+        start=28,
+        end=38,
+        text_hash=hmac_text_hash("2025-03-02", _SECRET),
+        entity_type="date",
+        canonical_label="DATE",
+    )
+
+    with pytest.raises(AnnotationValidationError, match="different document"):
+        format_brat(_TEXT, (_spans()[0], other_document))
+    with pytest.raises(AnnotationValidationError, match="different document"):
+        format_conll(_TEXT, (_spans()[0], other_document))
+
+
+def test_synthetic_task_generator_prelabels_for_human_review() -> None:
+    def prelabeler(text: str):
+        assert text == _TEXT
+        return [
+            {"start": 8, "end": 16, "label": "PERSON", "score": 0.91},
+            {"start": 28, "end": 38, "entity_type": "date"},
+        ]
+
+    task = generate_synthetic_annotation_task(
+        "synthetic-note-1",
+        _TEXT,
+        hash_secret=_SECRET,
+        prelabeler=prelabeler,
+        metadata={"scenario": "fictional outpatient note"},
+    )
+
+    assert task.synthetic is True
+    assert task.metadata["synthetic"] is True
+    assert task.metadata["prelabeled"] is True
+    assert task.metadata["review_status"] == "needs_human_review"
+    assert _offset_labels(tuple(task.spans)) == _offset_labels(_spans())
+
+
+def test_synthetic_task_generator_rejects_misaligned_existing_span() -> None:
+    wrong_document = OpenMedSpan(
+        doc_id="other-note",
+        start=8,
+        end=16,
+        text_hash=hmac_text_hash("Jane Roe", _SECRET),
+        entity_type="person",
+        canonical_label="PERSON",
+    )
+
+    with pytest.raises(AnnotationValidationError, match="different document"):
+        generate_synthetic_annotation_task(
+            "synthetic-note-1",
+            _TEXT,
+            hash_secret=_SECRET,
+            spans=[wrong_document],
+        )


### PR DESCRIPTION
## Description

Adds a synthetic gold-corpus annotation package for lossless OpenMedSpan interchange with BRAT standoff and CoNLL token columns. Imports validate offsets, surface alignment, labels, tag transitions, and document identity with aggregated actionable errors, while the task generator prepares pre-labeled synthetic documents for human correction.

Closes #913

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made

- Added paired BRAT string and file readers/writers for continuous text-bound annotations.
- Added source-aligned CoNLL BIO readers/writers with multi-column and BIOES/BILOU import support.
- Added synthetic annotation-task generation, safe span hashing, shared validation contracts, and malformed-input coverage.

## Testing

- [x] I have added tests that prove the feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I tested round trips and malformed inputs across both annotation formats.
- `.venv/bin/python -m pytest tests/ -q` — 5,190 passed, 46 skipped.
- Scoped pre-commit hooks, Bandit, and hardcoded-secret detection passed.

## Documentation

- [ ] User documentation update — not required for this scoped library addition.
- [x] I have added docstrings to new functions/classes.
- [ ] CHANGELOG update — deferred to release preparation.

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`.
- [x] I have performed a self-review of my own code.
- [x] I have commented the code where format transitions require explanation.
- [x] My changes generate no new warnings.

## Dependencies

- [x] I have not added any new dependencies.

## Checklist

- [x] I have read the contributing guidelines.
- [x] My commit has a clear, descriptive message.
- [x] The commit is scoped to this issue.

## Related Issues

Closes #913

## Screenshots/Examples

Not applicable; this change adds library APIs and automated tests.
