### PR TITLE
Add ISO 27701/27001 control-evidence pack generator

### DIFF
--- a/docs/compliance/iso-27701-control-evidence.md
+++ b/docs/compliance/iso-27701-control-evidence.md
@@ -1,0 +1,79 @@
+# ISO 27701/27001 control-evidence pack
+
+OpenMed can generate a deterministic technical-evidence pack that maps its
+privacy and release-safety capabilities to selected ISO/IEC 27701:2025 and
+ISO/IEC 27001:2022 controls. The pack covers no-PHI logging, local-only offline
+mode, tamper-evident audit records, surrogate-vault key lifecycle operations,
+and release-gate evidence.
+
+The output is an implementation crosswalk, not a certification audit,
+Statement of Applicability, or organization-specific policy. An adopting
+organization still owns its PIMS/ISMS scope, risk treatment, legal basis,
+retention rules, key custody, access controls, operating evidence, and
+independent assessment.
+
+## Generate the pack
+
+Generation uses the Python standard library, bundled mappings, and local file
+writes only. It does not inspect patient data or make external calls.
+
+```python
+from pathlib import Path
+
+from openmed.compliance import generate_control_evidence_pack
+
+result = generate_control_evidence_pack(Path("audit-evidence/iso"))
+print(result.manifest_path)
+print(result.markdown_path)
+```
+
+The destination contains:
+
+- `iso-27701-control-evidence.json`: structured manifest validated by the
+  committed `control_evidence.schema.json` schema.
+- `iso-27701-control-evidence.md`: human-readable rendering of the same
+  controls, statuses, rationales, capabilities, and evidence pointers.
+
+Repeated runs of the same OpenMed version produce identical file content. No
+wall-clock timestamp or host-specific path is embedded.
+
+## Status model
+
+| Status | Meaning |
+|---|---|
+| `covered` | OpenMed directly implements and tests its product responsibility for the mapped control. Organization-level deployment obligations can still apply. |
+| `partial` | OpenMed supplies relevant technical behavior or evidence, but an adopter must add organizational or deployment controls. |
+| `out-of-scope` | The control is outside a software library's responsibility; the manifest includes an explicit rationale and does not claim evidence. |
+
+Evidence pointers are machine-readable and typed as configuration flags, guard
+tests, implementations, report artifacts, or documentation. They point to
+concrete OpenMed sources such as `OPENMED_OFFLINE`, the no-raw-PHI logging guard,
+the hash-chain audit log, vault rotation tests, and release-gate manifests.
+
+## Validate the JSON manifest
+
+The schema is bundled with the package and can be loaded without a network
+schema resolver:
+
+```python
+from jsonschema import Draft202012Validator
+
+from openmed.compliance import load_control_evidence_schema
+
+schema = load_control_evidence_schema()
+Draft202012Validator(schema).validate(result.manifest)
+```
+
+`jsonschema` is a development dependency rather than a runtime dependency. The
+generator itself remains stdlib-only.
+
+## Auditor handoff
+
+Give both files to the control owner together with the referenced test results
+and actual deployment evidence. Treat `partial` entries as a collection queue,
+not as passed controls. Review out-of-scope rationales against the
+organization's own Statement of Applicability before relying on them.
+
+The mapping targets the current ISO/IEC 27701:2025 PIMS structure and
+ISO/IEC 27001:2022 Annex A identifiers. It intentionally paraphrases control
+topics and does not reproduce either standard.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - Africa Attestation Review Template: compliance/templates/africa-data-residency-attestation.md
       - African Context-sensitive Attributes: compliance/africa-context-sensitive-attributes.md
       - HIPAA Safe Harbor Attestation: compliance/hipaa-safe-harbor-attestation.md
+      - ISO 27701/27001 Evidence Pack: compliance/iso-27701-control-evidence.md
       - Breach Notification Runbook: compliance/breach-notification-runbook.md
       - Breach Report Template: compliance/templates/breach-report-template.md
       - FHIR Interop Helpers: fhir-interop.md

--- a/openmed/compliance/__init__.py
+++ b/openmed/compliance/__init__.py
@@ -1,8 +1,8 @@
-"""Local-first compliance reporting and subject-access helpers.
+"""Local-first compliance reporting, subject-access, and evidence helpers.
 
 This package hosts local-first, access-logged compliance workflows built on the
 surrogate vault, de-identification audit reports, and a tamper-evident audit
-chain.
+chain, plus deterministic technical control crosswalks for auditor handoff.
 """
 
 from .audit_chain import (
@@ -21,6 +21,19 @@ from .dsar import (
     assemble_dsar_package,
     plan_erasure,
     render_dsar_summary,
+)
+from .iso27701 import (
+    CONTROL_STATUSES,
+    MANIFEST_FILENAME,
+    MARKDOWN_FILENAME,
+    ControlEvidence,
+    ControlEvidencePack,
+    ControlEvidencePackResult,
+    EvidencePointer,
+    build_control_evidence_pack,
+    generate_control_evidence_pack,
+    load_control_evidence_schema,
+    render_control_evidence_markdown,
 )
 from .safe_harbor import (
     SAFE_HARBOR_ATTESTATION_NOTICE,
@@ -47,6 +60,17 @@ __all__ = [
     "assemble_dsar_package",
     "render_dsar_summary",
     "plan_erasure",
+    "CONTROL_STATUSES",
+    "MANIFEST_FILENAME",
+    "MARKDOWN_FILENAME",
+    "ControlEvidence",
+    "ControlEvidencePack",
+    "ControlEvidencePackResult",
+    "EvidencePointer",
+    "build_control_evidence_pack",
+    "generate_control_evidence_pack",
+    "load_control_evidence_schema",
+    "render_control_evidence_markdown",
     "SAFE_HARBOR_ATTESTATION_NOTICE",
     "SAFE_HARBOR_ATTESTATION_SCHEMA_VERSION",
     "SAFE_HARBOR_CATEGORY_LABELS",

--- a/openmed/compliance/iso27701.py
+++ b/openmed/compliance/iso27701.py
@@ -1,0 +1,569 @@
+"""Generate an ISO 27701/27001 control-evidence pack for OpenMed.
+
+The pack is a deterministic technical crosswalk. It maps product capabilities
+to a focused set of ISO/IEC 27701:2025 and ISO/IEC 27001:2022 controls, while
+making the boundary between OpenMed evidence and organization-owned controls
+explicit. Generation uses only bundled metadata and local filesystem writes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_VERSION = "openmed.iso_control_evidence.v1"
+PACK_ID = "openmed-iso-27701-27001-control-evidence"
+MANIFEST_FILENAME = "iso-27701-control-evidence.json"
+MARKDOWN_FILENAME = "iso-27701-control-evidence.md"
+
+CONTROL_STATUSES = ("covered", "partial", "out-of-scope")
+EVIDENCE_TYPES = (
+    "config-flag",
+    "documentation",
+    "guard-test",
+    "implementation",
+    "report-artifact",
+)
+CAPABILITIES = (
+    "audit-chain",
+    "key-lifecycle",
+    "no-phi-logging",
+    "offline-mode",
+    "release-gates",
+)
+
+PACK_SCOPE = (
+    "Technical controls implemented by the OpenMed library and the bundled "
+    "evidence that demonstrates those controls."
+)
+PACK_DISCLAIMER = (
+    "This pack is a product-level technical evidence crosswalk, not an ISO "
+    "certification, audit opinion, Statement of Applicability, or "
+    "organization-specific policy. The adopting organization remains "
+    "responsible for its ISMS/PIMS scope, risk treatment, operating evidence, "
+    "legal basis, retention, access control, and independent audit."
+)
+
+
+@dataclass(frozen=True)
+class EvidencePointer:
+    """One machine-readable pointer to local control evidence."""
+
+    evidence_type: str
+    reference: str
+    description: str
+
+    def __post_init__(self) -> None:
+        if self.evidence_type not in EVIDENCE_TYPES:
+            raise ValueError(f"unsupported evidence type: {self.evidence_type!r}")
+        if not self.reference.strip():
+            raise ValueError("evidence reference must be non-empty")
+        if not self.description.strip():
+            raise ValueError("evidence description must be non-empty")
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize the pointer to JSON-compatible fields."""
+
+        return {
+            "type": self.evidence_type,
+            "reference": self.reference,
+            "description": self.description,
+        }
+
+
+@dataclass(frozen=True)
+class ControlEvidence:
+    """OpenMed evidence and scope rationale for one standard control."""
+
+    framework: str
+    control_id: str
+    title: str
+    status: str
+    rationale: str
+    capabilities: tuple[str, ...] = ()
+    evidence: tuple[EvidencePointer, ...] = ()
+
+    def __post_init__(self) -> None:
+        for field_name in ("framework", "control_id", "title", "rationale"):
+            if not str(getattr(self, field_name)).strip():
+                raise ValueError(f"{field_name} must be non-empty")
+        if self.status not in CONTROL_STATUSES:
+            raise ValueError(f"unsupported control status: {self.status!r}")
+        unknown = set(self.capabilities).difference(CAPABILITIES)
+        if unknown:
+            raise ValueError(f"unsupported capabilities: {sorted(unknown)!r}")
+        if self.status == "out-of-scope":
+            if self.capabilities or self.evidence:
+                raise ValueError(
+                    "out-of-scope controls cannot claim capabilities or evidence"
+                )
+        elif not self.capabilities or not self.evidence:
+            raise ValueError(
+                "covered and partial controls require capabilities and evidence"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the control mapping to JSON-compatible fields."""
+
+        return {
+            "framework": self.framework,
+            "control_id": self.control_id,
+            "title": self.title,
+            "status": self.status,
+            "rationale": self.rationale,
+            "capabilities": list(self.capabilities),
+            "evidence": [pointer.to_dict() for pointer in self.evidence],
+        }
+
+
+@dataclass(frozen=True)
+class ControlEvidencePack:
+    """Deterministic ISO control-evidence pack."""
+
+    controls: tuple[ControlEvidence, ...]
+    schema_version: str = SCHEMA_VERSION
+    pack_id: str = PACK_ID
+    title: str = "OpenMed ISO 27701/27001 control-evidence pack"
+    scope: str = PACK_SCOPE
+    disclaimer: str = PACK_DISCLAIMER
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}")
+        if not self.controls:
+            raise ValueError("control-evidence pack must contain controls")
+        identities = [
+            (control.framework, control.control_id) for control in self.controls
+        ]
+        if len(identities) != len(set(identities)):
+            raise ValueError("control framework/id pairs must be unique")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the complete pack to its manifest representation."""
+
+        status_counts = {
+            status: sum(control.status == status for control in self.controls)
+            for status in CONTROL_STATUSES
+        }
+        return {
+            "schema_version": self.schema_version,
+            "pack_id": self.pack_id,
+            "title": self.title,
+            "frameworks": sorted({control.framework for control in self.controls}),
+            "scope": self.scope,
+            "disclaimer": self.disclaimer,
+            "summary": {
+                "total": len(self.controls),
+                **status_counts,
+            },
+            "controls": [control.to_dict() for control in self.controls],
+        }
+
+
+@dataclass(frozen=True)
+class ControlEvidencePackResult:
+    """Paths and in-memory content produced by pack generation."""
+
+    output_dir: Path
+    manifest_path: Path
+    markdown_path: Path
+    pack: ControlEvidencePack
+    manifest: Mapping[str, Any]
+    markdown: str
+
+
+def _pointer(
+    evidence_type: str,
+    reference: str,
+    description: str,
+) -> EvidencePointer:
+    return EvidencePointer(evidence_type, reference, description)
+
+
+def _default_controls() -> tuple[ControlEvidence, ...]:
+    no_phi_guard = _pointer(
+        "guard-test",
+        "tests/unit/test_no_raw_text_logging.py::"
+        "test_pii_processing_and_service_paths_do_not_log_raw_phi",
+        "Exercises core, batch, and REST paths and rejects raw PHI in logs.",
+    )
+    audit_chain = _pointer(
+        "implementation",
+        "openmed/compliance/audit_chain.py::HashChainAuditLog",
+        "Links privacy-safe audit records so later mutation is detectable.",
+    )
+    audit_chain_guard = _pointer(
+        "guard-test",
+        "tests/unit/compliance/test_audit_chain.py::test_records_form_a_hash_chain",
+        "Verifies record linkage and tamper detection.",
+    )
+    offline_flag = _pointer(
+        "config-flag",
+        "OPENMED_OFFLINE / OpenMedConfig.local_only",
+        "Selects cache-only execution and fail-closed network blocking.",
+    )
+    offline_guard = _pointer(
+        "guard-test",
+        "tests/unit/test_offline_mode.py::"
+        "test_pii_deidentification_path_runs_with_sockets_blocked",
+        "Runs PII extraction and de-identification while socket use is blocked.",
+    )
+    key_lifecycle = _pointer(
+        "implementation",
+        "openmed/core/surrogate_vault.py::SurrogateVault.rotate",
+        "Rotates locally derived vault epochs and migrates encrypted entries.",
+    )
+    key_revocation_guard = _pointer(
+        "guard-test",
+        "tests/unit/core/test_surrogate_vault.py::"
+        "test_revoke_current_epoch_reencrypts_forward_and_retires_old_key",
+        "Verifies forward re-encryption and retirement of revoked key material.",
+    )
+    gate_bundler = _pointer(
+        "implementation",
+        "openmed/eval/evidence_bundle.py::bundle_gate_evidence",
+        "Collects release-gate artifacts into a deterministic hashed manifest.",
+    )
+    gate_artifact = _pointer(
+        "report-artifact",
+        "gate-evidence/manifest.json",
+        "Machine-readable release-gate decisions, artifact hashes, and gaps.",
+    )
+    audit_artifact = _pointer(
+        "report-artifact",
+        "AuditReport.to_dict()",
+        "Machine-readable span provenance, risk results, and optional signature.",
+    )
+
+    return (
+        ControlEvidence(
+            framework="ISO/IEC 27701:2025",
+            control_id="A.1.4.5",
+            title="PII minimization objectives",
+            status="partial",
+            rationale=(
+                "OpenMed provides de-identification, no-PHI logging, and measurable "
+                "release gates, but each organization must define and approve its "
+                "own minimization objectives."
+            ),
+            capabilities=("no-phi-logging", "release-gates"),
+            evidence=(no_phi_guard, gate_bundler, gate_artifact),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27701:2025",
+            control_id="A.1.4.6",
+            title="PII de-identification and deletion at end of processing",
+            status="partial",
+            rationale=(
+                "OpenMed implements local de-identification and privacy-safe audit "
+                "evidence. Retention triggers and deletion of source systems remain "
+                "deployment responsibilities."
+            ),
+            capabilities=("audit-chain", "no-phi-logging", "offline-mode"),
+            evidence=(no_phi_guard, audit_chain, offline_guard, audit_artifact),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27701:2025",
+            control_id="A.3.25",
+            title="Logging",
+            status="covered",
+            rationale=(
+                "Within the OpenMed product boundary, logs are guarded against raw "
+                "PHI and compliance events can be recorded in a tamper-evident, "
+                "privacy-safe chain."
+            ),
+            capabilities=("audit-chain", "no-phi-logging"),
+            evidence=(no_phi_guard, audit_chain, audit_chain_guard, audit_artifact),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27701:2025",
+            control_id="A.3.26",
+            title="Use of cryptography",
+            status="partial",
+            rationale=(
+                "OpenMed supplies HMAC-derived identifiers, encrypted vault entries, "
+                "rotation, and revocation. Root-secret custody, rotation schedules, "
+                "and enterprise key-management policy remain organization-owned."
+            ),
+            capabilities=("key-lifecycle",),
+            evidence=(key_lifecycle, key_revocation_guard),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27701:2025",
+            control_id="9.1",
+            title="Monitoring, measurement, analysis and evaluation",
+            status="partial",
+            rationale=(
+                "Release gates and deterministic evidence bundles support product "
+                "measurement. They do not replace an organization's PIMS metrics, "
+                "management review, or internal-audit programme."
+            ),
+            capabilities=("release-gates",),
+            evidence=(gate_bundler, gate_artifact),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27701:2025",
+            control_id="A.1.2.3",
+            title="Identify lawful basis",
+            status="out-of-scope",
+            rationale=(
+                "Lawful basis depends on the adopting organization's purposes, "
+                "jurisdiction, relationships, and legal analysis; OpenMed cannot "
+                "determine it from technical processing."
+            ),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27701:2025",
+            control_id="A.1.2.7",
+            title="Contracts with PII processors",
+            status="out-of-scope",
+            rationale=(
+                "Supplier selection, data-processing agreements, and contractual "
+                "oversight are organizational governance activities outside the "
+                "OpenMed library."
+            ),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27001:2022",
+            control_id="A.5.34",
+            title="Privacy and protection of PII",
+            status="partial",
+            rationale=(
+                "OpenMed contributes de-identification, local-only execution, "
+                "privacy-safe logging, and audit evidence. The complete control also "
+                "depends on organization-wide legal and operational measures."
+            ),
+            capabilities=(
+                "audit-chain",
+                "no-phi-logging",
+                "offline-mode",
+                "release-gates",
+            ),
+            evidence=(
+                no_phi_guard,
+                offline_flag,
+                offline_guard,
+                audit_chain,
+                gate_artifact,
+            ),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27001:2022",
+            control_id="A.8.9",
+            title="Configuration management",
+            status="partial",
+            rationale=(
+                "OpenMed exposes explicit offline configuration and tests fail-closed "
+                "behavior, while deployment baselines, approvals, and configuration "
+                "inventory remain organization-owned."
+            ),
+            capabilities=("offline-mode",),
+            evidence=(offline_flag, offline_guard),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27001:2022",
+            control_id="A.8.15",
+            title="Logging",
+            status="covered",
+            rationale=(
+                "OpenMed's product responsibilities are evidenced by the no-raw-PHI "
+                "logging guard and tamper-evident audit records. Deployment log "
+                "retention and access policy remain part of the adopter's ISMS."
+            ),
+            capabilities=("audit-chain", "no-phi-logging"),
+            evidence=(no_phi_guard, audit_chain, audit_chain_guard, audit_artifact),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27001:2022",
+            control_id="A.8.24",
+            title="Use of cryptography",
+            status="partial",
+            rationale=(
+                "The surrogate vault implements cryptographic protection and key "
+                "epoch lifecycle operations, but enterprise key custody and policy "
+                "are outside the library boundary."
+            ),
+            capabilities=("key-lifecycle",),
+            evidence=(key_lifecycle, key_revocation_guard),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27001:2022",
+            control_id="A.8.25",
+            title="Secure development life cycle",
+            status="partial",
+            rationale=(
+                "Fail-closed release gates and hashed evidence bundles support "
+                "software release decisions. Organization-wide development policy, "
+                "approvals, and change governance remain outside OpenMed."
+            ),
+            capabilities=("release-gates",),
+            evidence=(gate_bundler, gate_artifact),
+        ),
+        ControlEvidence(
+            framework="ISO/IEC 27001:2022",
+            control_id="A.7.1",
+            title="Physical security perimeters",
+            status="out-of-scope",
+            rationale=(
+                "OpenMed is a software library and cannot implement or evidence the "
+                "physical boundaries of facilities, devices, or hosting locations."
+            ),
+        ),
+    )
+
+
+def build_control_evidence_pack() -> ControlEvidencePack:
+    """Build the bundled ISO control-evidence mapping without external calls.
+
+    Returns:
+        The deterministic control-evidence pack.
+    """
+
+    return ControlEvidencePack(controls=_default_controls())
+
+
+def render_control_evidence_markdown(pack: ControlEvidencePack) -> str:
+    """Render a pack as deterministic auditor-oriented Markdown.
+
+    Args:
+        pack: Structured control-evidence pack to render.
+
+    Returns:
+        Markdown containing the pack metadata and every control mapping.
+    """
+
+    manifest = pack.to_dict()
+    summary = manifest["summary"]
+    lines = [
+        f"# {pack.title}",
+        "",
+        f"> {pack.disclaimer}",
+        "",
+        "## Pack metadata",
+        "",
+        f"- Schema version: `{pack.schema_version}`",
+        f"- Pack ID: `{pack.pack_id}`",
+        f"- Frameworks: {', '.join(manifest['frameworks'])}",
+        f"- Scope: {pack.scope}",
+        "- Generation: deterministic and offline; no external calls are made",
+        "",
+        "## Status summary",
+        "",
+        f"- Covered: {summary['covered']}",
+        f"- Partial: {summary['partial']}",
+        f"- Out of scope: {summary['out-of-scope']}",
+        f"- Total: {summary['total']}",
+        "",
+        "`covered` applies only to OpenMed's product responsibility. `partial` "
+        "requires adopter controls in addition to OpenMed evidence. "
+        "`out-of-scope` identifies an explicit product boundary.",
+        "",
+        "## Control mapping",
+    ]
+
+    for control in pack.controls:
+        lines.extend(
+            [
+                "",
+                f"### {control.framework} {control.control_id} — {control.title}",
+                "",
+                f"- Status: **{control.status}**",
+                f"- Rationale: {control.rationale}",
+            ]
+        )
+        if control.capabilities:
+            lines.append(
+                "- OpenMed capabilities: "
+                + ", ".join(f"`{item}`" for item in control.capabilities)
+            )
+        if control.evidence:
+            lines.extend(["- Evidence:", ""])
+            lines.extend(
+                "  - "
+                f"`{pointer.evidence_type}` — `{pointer.reference}`: "
+                f"{pointer.description}"
+                for pointer in control.evidence
+            )
+        else:
+            lines.append("- Evidence: none; see the explicit scope rationale above")
+
+    return "\n".join(lines) + "\n"
+
+
+def load_control_evidence_schema() -> dict[str, Any]:
+    """Load the committed JSON Schema for control-evidence manifests.
+
+    Returns:
+        Parsed Draft 2020-12 JSON Schema.
+    """
+
+    resource = resources.files("openmed.compliance").joinpath(
+        "schemas/control_evidence.schema.json"
+    )
+    with resource.open("r", encoding="utf-8") as handle:
+        schema = json.load(handle)
+    if not isinstance(schema, dict):
+        raise ValueError("control-evidence schema must be a JSON object")
+    return schema
+
+
+def generate_control_evidence_pack(
+    output_dir: str | Path,
+) -> ControlEvidencePackResult:
+    """Write the ISO control-evidence JSON manifest and Markdown rendering.
+
+    The generator does not inspect the environment, read user data, or perform
+    network calls. Repeated runs against the same package version produce the
+    same manifest and Markdown bytes.
+
+    Args:
+        output_dir: Local destination for the JSON and Markdown files.
+
+    Returns:
+        Paths and in-memory representations of both generated artifacts.
+    """
+
+    destination = Path(output_dir)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    pack = build_control_evidence_pack()
+    manifest = pack.to_dict()
+    markdown = render_control_evidence_markdown(pack)
+    manifest_path = destination / MANIFEST_FILENAME
+    markdown_path = destination / MARKDOWN_FILENAME
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(markdown, encoding="utf-8")
+
+    return ControlEvidencePackResult(
+        output_dir=destination,
+        manifest_path=manifest_path,
+        markdown_path=markdown_path,
+        pack=pack,
+        manifest=manifest,
+        markdown=markdown,
+    )
+
+
+__all__ = [
+    "CAPABILITIES",
+    "CONTROL_STATUSES",
+    "EVIDENCE_TYPES",
+    "MANIFEST_FILENAME",
+    "MARKDOWN_FILENAME",
+    "PACK_ID",
+    "SCHEMA_VERSION",
+    "ControlEvidence",
+    "ControlEvidencePack",
+    "ControlEvidencePackResult",
+    "EvidencePointer",
+    "build_control_evidence_pack",
+    "generate_control_evidence_pack",
+    "load_control_evidence_schema",
+    "render_control_evidence_markdown",
+]

--- a/openmed/compliance/schemas/control_evidence.schema.json
+++ b/openmed/compliance/schemas/control_evidence.schema.json
@@ -1,0 +1,226 @@
+{
+  "$id": "https://openmed.life/schemas/compliance/control_evidence.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "openmed.iso_control_evidence.v1",
+      "type": "string"
+    },
+    "pack_id": {
+      "const": "openmed-iso-27701-27001-control-evidence",
+      "type": "string"
+    },
+    "title": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "frameworks": {
+      "items": {
+        "enum": [
+          "ISO/IEC 27001:2022",
+          "ISO/IEC 27701:2025"
+        ]
+      },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "scope": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "disclaimer": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "summary": {
+      "additionalProperties": false,
+      "properties": {
+        "total": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "covered": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "partial": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "out-of-scope": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "total",
+        "covered",
+        "partial",
+        "out-of-scope"
+      ],
+      "type": "object"
+    },
+    "controls": {
+      "items": {
+        "$ref": "#/$defs/control"
+      },
+      "minItems": 1,
+      "type": "array"
+    }
+  },
+  "required": [
+    "schema_version",
+    "pack_id",
+    "title",
+    "frameworks",
+    "scope",
+    "disclaimer",
+    "summary",
+    "controls"
+  ],
+  "title": "OpenMedIsoControlEvidencePack",
+  "type": "object",
+  "$defs": {
+    "control": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "enum": [
+                  "covered",
+                  "partial"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "capabilities": {
+                "minItems": 1
+              },
+              "evidence": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "out-of-scope"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "capabilities": {
+                "maxItems": 0
+              },
+              "evidence": {
+                "maxItems": 0
+              },
+              "rationale": {
+                "minLength": 1
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "framework": {
+          "enum": [
+            "ISO/IEC 27001:2022",
+            "ISO/IEC 27701:2025"
+          ]
+        },
+        "control_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "title": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "covered",
+            "partial",
+            "out-of-scope"
+          ]
+        },
+        "rationale": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "capabilities": {
+          "items": {
+            "enum": [
+              "audit-chain",
+              "key-lifecycle",
+              "no-phi-logging",
+              "offline-mode",
+              "release-gates"
+            ]
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "evidence": {
+          "items": {
+            "$ref": "#/$defs/evidencePointer"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "framework",
+        "control_id",
+        "title",
+        "status",
+        "rationale",
+        "capabilities",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "evidencePointer": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "enum": [
+            "config-flag",
+            "documentation",
+            "guard-test",
+            "implementation",
+            "report-artifact"
+          ]
+        },
+        "reference": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "description": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "reference",
+        "description"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/tests/unit/compliance/test_iso27701.py
+++ b/tests/unit/compliance/test_iso27701.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import copy
+import json
+import socket
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+from openmed.compliance.iso27701 import (
+    CAPABILITIES,
+    MANIFEST_FILENAME,
+    MARKDOWN_FILENAME,
+    build_control_evidence_pack,
+    generate_control_evidence_pack,
+    load_control_evidence_schema,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_pack_enumerates_statuses_capabilities_and_evidence_pointers() -> None:
+    pack = build_control_evidence_pack()
+    manifest = pack.to_dict()
+
+    statuses = {control["status"] for control in manifest["controls"]}
+    capabilities = {
+        capability
+        for control in manifest["controls"]
+        for capability in control["capabilities"]
+    }
+    evidence_types = {
+        pointer["type"]
+        for control in manifest["controls"]
+        for pointer in control["evidence"]
+    }
+
+    assert statuses == {"covered", "partial", "out-of-scope"}
+    assert capabilities == set(CAPABILITIES)
+    assert {"config-flag", "guard-test", "report-artifact"} <= evidence_types
+    assert manifest["summary"]["total"] == len(manifest["controls"])
+    assert sum(
+        manifest["summary"][status] for status in ("covered", "partial", "out-of-scope")
+    ) == len(manifest["controls"])
+
+
+def test_out_of_scope_controls_have_rationale_without_claimed_evidence() -> None:
+    controls = build_control_evidence_pack().to_dict()["controls"]
+    out_of_scope = [
+        control for control in controls if control["status"] == "out-of-scope"
+    ]
+
+    assert out_of_scope
+    assert all(control["rationale"].strip() for control in out_of_scope)
+    assert all(control["capabilities"] == [] for control in out_of_scope)
+    assert all(control["evidence"] == [] for control in out_of_scope)
+
+
+def test_local_evidence_references_point_to_committed_sources() -> None:
+    controls = build_control_evidence_pack().to_dict()["controls"]
+    local_pointer_types = {"documentation", "guard-test", "implementation"}
+
+    for control in controls:
+        for pointer in control["evidence"]:
+            if pointer["type"] not in local_pointer_types:
+                continue
+            path_text = pointer["reference"].split("::", maxsplit=1)[0]
+            assert (REPO_ROOT / path_text).is_file(), pointer["reference"]
+
+
+def test_generated_manifest_validates_against_committed_schema(tmp_path: Path) -> None:
+    schema = load_control_evidence_schema()
+    Draft202012Validator.check_schema(schema)
+    result = generate_control_evidence_pack(tmp_path)
+
+    Draft202012Validator(schema).validate(result.manifest)
+    assert json.loads(result.manifest_path.read_text(encoding="utf-8")) == (
+        result.manifest
+    )
+
+
+def test_schema_rejects_out_of_scope_control_without_rationale() -> None:
+    manifest = copy.deepcopy(build_control_evidence_pack().to_dict())
+    out_of_scope = next(
+        control
+        for control in manifest["controls"]
+        if control["status"] == "out-of-scope"
+    )
+    out_of_scope["rationale"] = ""
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(load_control_evidence_schema()).validate(manifest)
+
+
+def test_generation_writes_matching_deterministic_json_and_markdown(
+    tmp_path: Path,
+) -> None:
+    first = generate_control_evidence_pack(tmp_path / "first")
+    second = generate_control_evidence_pack(tmp_path / "second")
+
+    assert first.manifest_path.name == MANIFEST_FILENAME
+    assert first.markdown_path.name == MARKDOWN_FILENAME
+    assert first.manifest == second.manifest
+    assert first.markdown == second.markdown
+    assert first.manifest_path.read_bytes() == second.manifest_path.read_bytes()
+    assert first.markdown_path.read_bytes() == second.markdown_path.read_bytes()
+    assert "## Control mapping" in first.markdown
+    assert "out-of-scope" in first.markdown
+    for control in first.manifest["controls"]:
+        heading = (
+            f"### {control['framework']} {control['control_id']} — {control['title']}"
+        )
+        assert heading in first.markdown
+        assert f"- Status: **{control['status']}**" in first.markdown
+
+
+def test_generation_runs_with_all_socket_connections_blocked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_network(*args: object, **kwargs: object) -> None:
+        raise AssertionError("control-evidence generation attempted network access")
+
+    monkeypatch.setattr(socket.socket, "connect", fail_network)
+    monkeypatch.setattr(socket.socket, "connect_ex", fail_network)
+    monkeypatch.setattr(socket, "create_connection", fail_network)
+
+    result = generate_control_evidence_pack(tmp_path)
+
+    assert result.manifest_path.is_file()
+    assert result.markdown_path.is_file()


### PR DESCRIPTION
## Description

Adds a deterministic, offline control-evidence pack generator that maps OpenMed's privacy and release-safety capabilities to selected ISO/IEC 27701:2025 and ISO/IEC 27001:2022 controls. The generated JSON manifest and matching Markdown distinguish covered, partial, and out-of-scope controls so adopters can collect technical evidence without treating the output as a certification audit or organization-specific policy.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add typed control mappings for no-PHI logging, offline mode, audit chaining, key lifecycle operations, and release-gate evidence.
- Add a committed Draft 2020-12 JSON Schema plus deterministic JSON and Markdown renderers.
- Add offline-generation, schema-validation, evidence-pointer, scope-rationale, and determinism tests.
- Document generation, validation, status semantics, and auditor handoff; include the guide in the documentation navigation.

## Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs (not applicable; generation uses bundled metadata only)

Validation completed:

- `.venv/bin/python -m pytest tests/ -q` — 5,178 passed, 46 skipped
- `make format`, `make lint`, and `make format-check`
- scoped pre-commit hooks
- `make docs-build` with strict mode
- `make build`, with the schema verified in both wheel and sdist

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md (not required for this scoped feature PR)

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift` (not applicable)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #915

## Screenshots/Examples

The generator writes `iso-27701-control-evidence.json` and `iso-27701-control-evidence.md` to the caller-selected local directory. No UI screenshots are applicable.
