### PR TITLE
Add a discharge-summary section structurer with typed slots

### DIFF
--- a/openmed/structured/__init__.py
+++ b/openmed/structured/__init__.py
@@ -4,6 +4,14 @@ Intended contents include column classification, k-anonymity, l-diversity,
 t-closeness, and differential privacy capabilities.
 """
 
+from .discharge_summary import (
+    REQUIRED_DISCHARGE_SLOTS,
+    DischargeSlotName,
+    DischargeSummary,
+    DischargeSummarySection,
+    canonical_discharge_slot,
+    structure_discharge_summary,
+)
 from .flowsheet import (
     FLOWSHEET_ADVISORY,
     Flowsheet,
@@ -25,13 +33,19 @@ __all__ = [
     "FLOWSHEET_ADVISORY",
     "LAB_PANEL_ADVISORY",
     "PANEL_ORDER",
+    "REQUIRED_DISCHARGE_SLOTS",
     "AnalyteRow",
+    "DischargeSlotName",
+    "DischargeSummary",
+    "DischargeSummarySection",
     "Flowsheet",
     "LabPanel",
     "ParameterSeries",
     "TimeSeriesPoint",
     "canonical_analyte",
+    "canonical_discharge_slot",
     "parse_lab_report",
+    "structure_discharge_summary",
     "structure_flowsheet",
     "structure_lab_panels",
 ]

--- a/openmed/structured/discharge_summary.py
+++ b/openmed/structured/discharge_summary.py
@@ -1,0 +1,285 @@
+"""Typed discharge-summary section structuring.
+
+This module consumes section spans produced by a clinical section detector and
+maps discharge-specific header aliases into four canonical slots. It does not
+perform generic section detection or summarize section content. Emitted
+``start``/``end`` offsets always index the returned ``content`` in the source
+text so callers can retain provenance for downstream review and export.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, Literal, TypedDict
+
+from openmed.clinical.lexicons import normalize_section_header
+
+DischargeSlotName = Literal[
+    "admission_diagnosis",
+    "hospital_course",
+    "discharge_medications",
+    "follow_up",
+]
+
+REQUIRED_DISCHARGE_SLOTS: tuple[DischargeSlotName, ...] = (
+    "admission_diagnosis",
+    "hospital_course",
+    "discharge_medications",
+    "follow_up",
+)
+
+_SLOT_ALIASES: Mapping[DischargeSlotName, tuple[str, ...]] = {
+    "admission_diagnosis": (
+        "admission diagnosis",
+        "admission diagnoses",
+        "admission dx",
+        "admitting diagnosis",
+        "admitting diagnoses",
+        "admitting dx",
+        "diagnosis on admission",
+        "diagnoses on admission",
+    ),
+    "hospital_course": (
+        "hospital course",
+        "brief hospital course",
+        "clinical course",
+        "course in hospital",
+        "inpatient course",
+        "summary of hospital course",
+    ),
+    "discharge_medications": (
+        "discharge medication",
+        "discharge medications",
+        "discharge med",
+        "discharge meds",
+        "discharge med list",
+        "d/c med",
+        "d/c meds",
+        "dc med",
+        "dc meds",
+        "medication at discharge",
+        "medications at discharge",
+        "medication on discharge",
+        "medications on discharge",
+        "meds at discharge",
+        "meds on discharge",
+    ),
+    "follow_up": (
+        "follow up",
+        "followup",
+        "follow up instructions",
+        "follow up plan",
+        "discharge follow up",
+        "post discharge follow up",
+        "follow up appointments",
+    ),
+}
+
+_ALIAS_TO_SLOT: dict[str, DischargeSlotName] = {
+    normalize_section_header(alias): slot
+    for slot, aliases in _SLOT_ALIASES.items()
+    for alias in (slot, *aliases)
+}
+_LABEL_FIELDS = (
+    "label",
+    "name",
+    "section",
+    "section_label",
+    "section_name",
+    "title",
+)
+_HEADER_DELIMITERS = frozenset(":：﹕꞉")
+
+
+class DischargeSummarySection(TypedDict):
+    """One canonical discharge-summary slot with source provenance."""
+
+    slot: DischargeSlotName
+    header: str
+    content: str
+    start: int
+    end: int
+
+
+class DischargeSummary(TypedDict):
+    """Typed discharge-summary section record."""
+
+    admission_diagnosis: DischargeSummarySection | None
+    hospital_course: DischargeSummarySection | None
+    discharge_medications: DischargeSummarySection | None
+    follow_up: DischargeSummarySection | None
+    missing_required_slots: list[DischargeSlotName]
+
+
+def canonical_discharge_slot(header: str) -> DischargeSlotName | None:
+    """Normalize a discharge-section header or label to its canonical slot.
+
+    Args:
+        header: Raw detector header or section label.
+
+    Returns:
+        A canonical discharge slot name, or ``None`` when the value is not a
+        recognized discharge-section alias.
+    """
+
+    return _ALIAS_TO_SLOT.get(normalize_section_header(header))
+
+
+def structure_discharge_summary(
+    text: str,
+    sections: Iterable[Any],
+) -> DischargeSummary:
+    """Map detected section spans into a typed discharge-summary record.
+
+    A detected section may be a mapping or an object with attributes. The
+    canonical slot is resolved from its ``header`` first and then from common
+    label fields. Section ranges use half-open source offsets. When supplied,
+    ``content_start`` and ``content_end`` delimit the body; otherwise the
+    section range is used, with a supplied header excluded when it occurs at
+    the beginning of that range. Surrounding whitespace is removed while the
+    returned offsets continue to round-trip exactly to ``text``.
+
+    If multiple detected sections map to the same slot, the earliest one in
+    source order is retained deterministically.
+
+    Args:
+        text: Original discharge-summary text.
+        sections: Section detector output containing labels and source ranges.
+
+    Returns:
+        Four fixed canonical slots plus required slot names that were not
+        detected.
+
+    Raises:
+        ValueError: If a recognized section carries invalid source offsets.
+    """
+
+    slots: dict[DischargeSlotName, DischargeSummarySection | None] = {
+        slot: None for slot in REQUIRED_DISCHARGE_SLOTS
+    }
+    recognized: list[tuple[int, DischargeSlotName, Any, str]] = []
+    for section in sections:
+        header = _text_field(section, "header")
+        label = _first_text_field(section, _LABEL_FIELDS)
+        slot = canonical_discharge_slot(header or "")
+        if slot is None:
+            slot = canonical_discharge_slot(label or "")
+        if slot is None:
+            continue
+
+        section_start = _required_offset(section, "start")
+        recognized.append((section_start, slot, section, header or label or slot))
+
+    for _, slot, section, header in sorted(recognized, key=lambda item: item[0]):
+        if slots[slot] is not None:
+            continue
+        start, end = _content_range(text, section, header)
+        slots[slot] = DischargeSummarySection(
+            slot=slot,
+            header=header,
+            content=text[start:end],
+            start=start,
+            end=end,
+        )
+
+    return DischargeSummary(
+        admission_diagnosis=slots["admission_diagnosis"],
+        hospital_course=slots["hospital_course"],
+        discharge_medications=slots["discharge_medications"],
+        follow_up=slots["follow_up"],
+        missing_required_slots=[
+            slot for slot in REQUIRED_DISCHARGE_SLOTS if slots[slot] is None
+        ],
+    )
+
+
+def _field(section: Any, name: str) -> Any:
+    if isinstance(section, Mapping):
+        return section.get(name)
+    return getattr(section, name, None)
+
+
+def _text_field(section: Any, name: str) -> str | None:
+    value = _field(section, name)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _first_text_field(section: Any, names: Iterable[str]) -> str | None:
+    for name in names:
+        if value := _text_field(section, name):
+            return value
+    return None
+
+
+def _required_offset(section: Any, name: str) -> int:
+    value = _field(section, name)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"recognized discharge section {name} must be an integer")
+    return value
+
+
+def _optional_offset(section: Any, name: str, default: int) -> int:
+    value = _field(section, name)
+    if value is None:
+        return default
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"recognized discharge section {name} must be an integer")
+    return value
+
+
+def _content_range(text: str, section: Any, header: str) -> tuple[int, int]:
+    section_start = _required_offset(section, "start")
+    section_end = _required_offset(section, "end")
+    if not 0 <= section_start < section_end <= len(text):
+        raise ValueError("recognized discharge section offsets are outside source text")
+
+    explicit_content_start = _field(section, "content_start")
+    start = _optional_offset(section, "content_start", section_start)
+    end = _optional_offset(section, "content_end", section_end)
+    if not section_start <= start <= end <= section_end:
+        raise ValueError(
+            "recognized discharge content offsets exceed its section range"
+        )
+
+    if explicit_content_start is None:
+        header_end = _field(section, "header_end")
+        if isinstance(header_end, int) and not isinstance(header_end, bool):
+            if not section_start <= header_end <= section_end:
+                raise ValueError(
+                    "recognized discharge header_end exceeds its section range"
+                )
+            start = header_end
+        else:
+            header_start = text.find(header, section_start, section_end)
+            if header_start >= section_start and not text[
+                section_start:header_start
+            ].strip(" \t-*•0123456789.)"):
+                start = header_start + len(header)
+        start = _skip_header_delimiter(text, start, end)
+
+    while start < end and text[start].isspace():
+        start += 1
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
+def _skip_header_delimiter(text: str, start: int, end: int) -> int:
+    while start < end and text[start] in " \t":
+        start += 1
+    if start < end and text[start] in _HEADER_DELIMITERS:
+        start += 1
+    return start
+
+
+__all__ = [
+    "REQUIRED_DISCHARGE_SLOTS",
+    "DischargeSlotName",
+    "DischargeSummary",
+    "DischargeSummarySection",
+    "canonical_discharge_slot",
+    "structure_discharge_summary",
+]

--- a/tests/unit/structured/test_discharge_summary.py
+++ b/tests/unit/structured/test_discharge_summary.py
@@ -1,0 +1,117 @@
+from openmed.structured import (
+    REQUIRED_DISCHARGE_SLOTS,
+    canonical_discharge_slot,
+    structure_discharge_summary,
+)
+
+
+def _detected_sections(text: str, headers: list[tuple[str, str]]) -> list[dict]:
+    sections: list[dict] = []
+    for index, (label, header) in enumerate(headers):
+        start = text.index(header)
+        end = (
+            text.index(headers[index + 1][1]) if index + 1 < len(headers) else len(text)
+        )
+        sections.append(
+            {
+                "label": label,
+                "header": header,
+                "start": start,
+                "end": end,
+                "header_start": start,
+                "header_end": start + len(header),
+                "content_start": text.index(":", start) + 1,
+            }
+        )
+    return sections
+
+
+def test_structures_synthetic_discharge_sections_with_content_offsets():
+    text = (
+        "Admission Diagnosis: Synthetic pneumonia\n"
+        "Hospital Course: Improved with supportive care.\n"
+        "D/C Meds: Example tablet once daily\n"
+        "Follow-up: Primary care in seven days.\n"
+    )
+    sections = _detected_sections(
+        text,
+        [
+            ("admission_diagnosis", "Admission Diagnosis"),
+            ("hospital_course", "Hospital Course"),
+            ("medications", "D/C Meds"),
+            ("follow_up", "Follow-up"),
+        ],
+    )
+
+    result = structure_discharge_summary(text, sections)
+
+    expected_content = {
+        "admission_diagnosis": "Synthetic pneumonia",
+        "hospital_course": "Improved with supportive care.",
+        "discharge_medications": "Example tablet once daily",
+        "follow_up": "Primary care in seven days.",
+    }
+    for slot_name, expected in expected_content.items():
+        slot = result[slot_name]
+        assert slot is not None
+        assert slot["slot"] == slot_name
+        assert slot["content"] == expected
+        assert text[slot["start"] : slot["end"]] == expected
+    assert result["missing_required_slots"] == []
+
+
+def test_normalizes_common_header_aliases_to_canonical_slots():
+    assert canonical_discharge_slot("Admission Dx") == "admission_diagnosis"
+    assert canonical_discharge_slot("BRIEF HOSPITAL COURSE") == "hospital_course"
+    assert canonical_discharge_slot("D/C Meds") == "discharge_medications"
+    assert canonical_discharge_slot("Follow-Up Instructions") == "follow_up"
+    assert canonical_discharge_slot("Past Medical History") is None
+
+
+def test_reports_missing_required_slots_in_canonical_order():
+    text = "Hospital Course: Stable throughout the synthetic admission."
+    result = structure_discharge_summary(
+        text,
+        [
+            {
+                "label": "hospital_course",
+                "start": 0,
+                "end": len(text),
+                "header": "Hospital Course",
+            }
+        ],
+    )
+
+    assert result["hospital_course"] == {
+        "slot": "hospital_course",
+        "header": "Hospital Course",
+        "content": "Stable throughout the synthetic admission.",
+        "start": text.index("Stable"),
+        "end": len(text),
+    }
+    assert result["missing_required_slots"] == [
+        slot for slot in REQUIRED_DISCHARGE_SLOTS if slot != "hospital_course"
+    ]
+    assert result["admission_diagnosis"] is None
+    assert result["discharge_medications"] is None
+    assert result["follow_up"] is None
+
+
+def test_rejects_recognized_sections_with_invalid_offsets():
+    text = "D/C Meds: Example tablet"
+
+    try:
+        structure_discharge_summary(
+            text,
+            [
+                {
+                    "header": "D/C Meds",
+                    "start": 0,
+                    "end": len(text) + 1,
+                }
+            ],
+        )
+    except ValueError as error:
+        assert "outside source text" in str(error)
+    else:
+        raise AssertionError("invalid source offsets must be rejected")


### PR DESCRIPTION
## Description

Adds a deterministic discharge-summary section structurer that maps already-detected section spans into typed canonical slots for admission diagnosis, hospital course, discharge medications, and follow-up. It preserves source-round-trippable content offsets, normalizes common header aliases such as `D/C Meds`, and reports missing required slots for downstream review and export.

Closes #942.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made

- Add typed discharge-summary slot and record definitions with a public structuring entry point.
- Normalize discharge-specific aliases while consuming mapping- or object-based detector output.
- Validate and preserve half-open source offsets, report missing required slots, and cover the acceptance criteria with synthetic tests.

## Testing

- [x] I have added tests that prove my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I tested canonical aliases, missing slots, invalid offsets, and mapping inputs.
- [x] `.venv/bin/python -m pytest tests/ -q` — 5202 passed, 46 skipped.

## Documentation

- [x] I have added docstrings to new public functions/classes.
- [ ] Documentation pages are not changed because this is a focused Python API addition.
- [ ] CHANGELOG.md is not changed because release notes are outside this issue's scope.

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`.
- [x] I have performed a self-review of my own code.
- [x] I have commented the offset behavior where needed.
- [x] My changes generate no new warnings.

## Dependencies

- [x] I have not added any new dependencies.

## Checklist

- [x] I have read the contributing guidelines.
- [x] My commit has a clear, descriptive message.
- [x] My commit is organized to the issue's scope.

## Related Issues

Closes #942

## Screenshots/Examples

Not applicable; this change adds a Python structuring API and unit coverage.
