### PR TITLE
Add transliteration-robust Indian name matching

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,8 @@ device = "cuda"
 cache_dir = "/mnt/cache/openmed"
 torch_attention_backend = "auto"
 cjk_width_convention = "cjk"
+transliteration_aware_name_matching = false
+indic_name_similarity_threshold = 0.80
 ```
 
 Runtime environment controls can select the config path, provide Hub
@@ -48,6 +50,12 @@ export OPENMED_CONFIG=/etc/openmed/config.toml
 export HF_TOKEN=hf_xxx
 export OPENMED_TORCH_DEVICE=cuda:1
 ```
+
+For Indic personal-name pseudonymization, enable
+`transliteration_aware_name_matching` and reuse the same setting when reopening
+a file-backed surrogate vault. The collision threshold and optional local
+transliterator adapter are described in
+[Transliteration-aware Indic name matching](indic-name-matching.md).
 
 ## CJK width normalization
 

--- a/docs/indic-name-matching.md
+++ b/docs/indic-name-matching.md
@@ -1,0 +1,82 @@
+# Transliteration-aware Indic name matching
+
+OpenMed can link Devanagari or other supported Brahmic-script personal names
+to their Latin spelling variants before a surrogate-vault key is created. The
+feature is opt-in so existing vault behavior remains unchanged.
+
+```python
+from openmed import OpenMedConfig, SurrogateVault, deidentify
+
+config = OpenMedConfig(
+    transliteration_aware_name_matching=True,
+    indic_name_similarity_threshold=0.80,
+)
+vault = SurrogateVault.in_memory("replace-with-a-local-secret", config=config)
+
+result = deidentify(
+    "संजय is also recorded as Sanjay and Sanjai.",
+    method="replace",
+    lang="hi",
+    config=config,
+    surrogate_vault=vault,
+    consistent=True,
+    seed=668,
+)
+```
+
+The vault stores one encrypted Latin surrogate identity for the canonical
+name key. Latin mentions receive the Latin surface; Indic-script mentions
+receive a deterministic surrogate rendered in the source script. The
+persisted key contains an HMAC-SHA256 digest, the canonical `PERSON` label,
+and the `indic` language bucket. Raw names and raw canonical keys are never
+written to the vault.
+
+## Stdlib fallback and collision threshold
+
+The default normalizer has no runtime dependency beyond Python. It folds the
+major Brahmic scripts to conservative Latin phonetic forms and handles common
+romanization differences such as `Sanjay`/`Sanjai`,
+`Krishna`/`Krishnaa`, and `Lakshmi`/`Laxmi`.
+
+`indic_name_similarity_threshold` accepts values from `0.5` through `1.0`.
+The default `0.80` admits the supported spelling folds while keeping nearby
+names such as `Sanjay` and `Sanjana` separate. Raise the threshold when false
+joins are more costly than missed joins. The equivalent environment settings
+are:
+
+```bash
+export OPENMED_TRANSLITERATION_AWARE_NAME_MATCHING=1
+export OPENMED_INDIC_NAME_SIMILARITY_THRESHOLD=0.80
+```
+
+## Optional local transliteration weights
+
+OpenMed does not download or bundle IndicXlit or Aksharantar weights. If an
+application already has a local IndicXlit-style model, pass an adapter when
+the vault is created:
+
+```python
+class LocalTransliterator:
+    def to_latin(self, text: str) -> str:
+        return local_model.to_latin(text)
+
+    def from_latin(self, text: str, target_script: str) -> str:
+        return local_model.from_latin(text, target_script)
+
+
+vault = SurrogateVault.in_memory(
+    "replace-with-a-local-secret",
+    config=config,
+    transliterator=LocalTransliterator(),
+)
+```
+
+A callable that accepts a source string and returns Latin text is also valid
+for canonicalization; output rendering then uses the stdlib fallback. Keep the
+model local for PHI workflows. A file-backed vault created with a user-supplied
+transliterator must be reopened with the same adapter and weights so canonical
+keys remain reproducible.
+
+The bundled synthetic `indic-name-consistency` evaluation suite checks name
+identity reuse, negative-name collisions, code-mixed leakage, script rendering,
+and deterministic fallback behavior.

--- a/docs/indic-name-matching.md
+++ b/docs/indic-name-matching.md
@@ -29,7 +29,9 @@ name key. Latin mentions receive the Latin surface; Indic-script mentions
 receive a deterministic surrogate rendered in the source script. The
 persisted key contains an HMAC-SHA256 digest, the canonical `PERSON` label,
 and the `indic` language bucket. Raw names and raw canonical keys are never
-written to the vault.
+written to the vault. The matching backend, version, and threshold are stored
+as non-sensitive metadata and authenticated with the vault key so an edited
+file cannot silently change identity-linking behavior.
 
 ## Stdlib fallback and collision threshold
 
@@ -48,6 +50,10 @@ are:
 export OPENMED_TRANSLITERATION_AWARE_NAME_MATCHING=1
 export OPENMED_INDIC_NAME_SIMILARITY_THRESHOLD=0.80
 ```
+
+Surfaces longer than 512 characters bypass phonetic folding and receive a
+distinct bounded digest key. This fail-closed path prevents pathological input
+from causing expensive fuzzy work or collapsing oversized spans together.
 
 ## Optional local transliteration weights
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - SMS Short-Text De-identification: sms-short-text-deid.md
       - PII Anonymization: anonymization.md
       - CHW Form Export De-identification: chw-form-deid.md
+      - Indic Name Matching: indic-name-matching.md
       - Per-Language De-identification: languages.md
       - India Health-ID De-identification: india-health-id-deidentification.md
       - Smart Entity Merging: pii-smart-merging.md

--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -34,6 +34,12 @@ from .core.hf_hub import (
     prefetch_model,
     resolve_repo_id,
 )
+from .core.indic_name_match import (
+    IndicNameNormalizer,
+    canonical_indic_name_key,
+    detect_name_script,
+    indic_names_match,
+)
 from .core.labels import CANONICAL_LABELS, normalize_label
 from .core.model_registry import (
     get_all_models,
@@ -842,4 +848,8 @@ __all__ = [
     "InMemorySurrogateStore",
     "JsonFileSurrogateStore",
     "ENCRYPTION_SCHEME",
+    "IndicNameNormalizer",
+    "canonical_indic_name_key",
+    "indic_names_match",
+    "detect_name_script",
 ]

--- a/openmed/core/__init__.py
+++ b/openmed/core/__init__.py
@@ -26,6 +26,14 @@ from .hf_hub import (
     prefetch_model,
     resolve_repo_id,
 )
+from .indic_name_match import (
+    DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD,
+    INDIC_LANGUAGE_CODES,
+    IndicNameNormalizer,
+    canonical_indic_name_key,
+    detect_name_script,
+    indic_names_match,
+)
 from .language_pack import (
     LANGUAGE_PACK_REGISTRY,
     LanguagePack,
@@ -132,6 +140,12 @@ __all__ = [
     "InMemorySurrogateStore",
     "JsonFileSurrogateStore",
     "ENCRYPTION_SCHEME",
+    "IndicNameNormalizer",
+    "canonical_indic_name_key",
+    "indic_names_match",
+    "detect_name_script",
+    "INDIC_LANGUAGE_CODES",
+    "DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD",
     "PROFILE_PRESETS",
     "list_profiles",
     "get_profile",

--- a/openmed/core/anonymizer/engine.py
+++ b/openmed/core/anonymizer/engine.py
@@ -92,6 +92,11 @@ class AnonymizerConfig:
     indic_name_similarity_threshold: float = DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD
     indic_name_normalizer: IndicNameNormalizer | None = None
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.transliteration_aware_name_matching, bool):
+            raise TypeError("transliteration_aware_name_matching must be a boolean")
+        IndicNameNormalizer(similarity_threshold=self.indic_name_similarity_threshold)
+
 
 # ---------------------------------------------------------------------------
 # Anonymizer
@@ -398,7 +403,7 @@ class Anonymizer:
             source_label=canonical_label,
         )
         try:
-            return generator(faker, original, locale="en_IN")
+            return generator(faker, "", locale="en_IN")
         except Exception as exc:  # noqa: BLE001 - retain safe anonymizer fallback
             warnings.warn(
                 "Anonymizer fallback for transliteration-aware PERSON at "

--- a/openmed/core/anonymizer/engine.py
+++ b/openmed/core/anonymizer/engine.py
@@ -35,6 +35,11 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Literal, Optional
 
 from .. import labels as L
+from ..indic_name_match import (
+    DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD,
+    IndicNameNormalizer,
+    is_indic_name_candidate,
+)
 from ..labels import normalize_label
 from ..language_pack import get_language_pack
 from ..name_order import CJK_LANGUAGES, normalize_person_span
@@ -70,6 +75,12 @@ class AnonymizerConfig:
             ``consistent=True``, surrogates are stable across sessions.
         custom_providers: Additional Faker providers to register on every
             new locale instance.
+        transliteration_aware_name_matching: Link Indic-script and Latin
+            PERSON spellings through one canonical surrogate identity.
+        indic_name_similarity_threshold: Collision-safety threshold used by
+            the stdlib romanization fallback.
+        indic_name_normalizer: Optional preconfigured normalizer carrying a
+            caller-supplied local transliterator.
     """
 
     lang: str = "en"
@@ -77,6 +88,9 @@ class AnonymizerConfig:
     consistent: bool = False
     seed: Optional[int] = None
     custom_providers: list[Any] = field(default_factory=list)
+    transliteration_aware_name_matching: bool = False
+    indic_name_similarity_threshold: float = DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD
+    indic_name_normalizer: IndicNameNormalizer | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -94,6 +108,11 @@ class Anonymizer:
         locale: Optional[str] = None,
         consistent: bool = False,
         seed: Optional[int] = None,
+        transliteration_aware_name_matching: bool = False,
+        indic_name_similarity_threshold: float = (
+            DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD
+        ),
+        indic_name_normalizer: IndicNameNormalizer | None = None,
         config: Optional[AnonymizerConfig] = None,
     ) -> None:
         if config is not None:
@@ -104,7 +123,17 @@ class Anonymizer:
                 locale=locale,
                 consistent=consistent,
                 seed=seed,
+                transliteration_aware_name_matching=(
+                    transliteration_aware_name_matching
+                ),
+                indic_name_similarity_threshold=indic_name_similarity_threshold,
+                indic_name_normalizer=indic_name_normalizer,
             )
+        self._indic_name_normalizer = self.config.indic_name_normalizer or (
+            IndicNameNormalizer(
+                similarity_threshold=self.config.indic_name_similarity_threshold
+            )
+        )
         self._faker_cache: Dict[str, Any] = {}
 
     # ------------------------------------------------------------------
@@ -200,6 +229,17 @@ class Anonymizer:
         effective_lang = lang or self.config.lang
         canonical = normalize_label(label, effective_lang)
 
+        if (
+            canonical == L.PERSON
+            and self.config.transliteration_aware_name_matching
+            and is_indic_name_candidate(original, lang=effective_lang)
+        ):
+            identity = self._indic_name_identity(
+                original,
+                canonical_label=canonical,
+            )
+            return self.render_name_surrogate(identity, source_surface=original)
+
         # CJK PERSON spans: peel a trailing honorific (さん/様/씨/님/先生/…) so
         # the name is swapped while the honorific is re-attached verbatim.
         # Only ja/ko/zh PERSON spans take this path; all other languages and
@@ -290,6 +330,83 @@ class Anonymizer:
                 locale="en_IN",
             )
         raise ValueError("strategy must be 'uidai_mask' or 'surrogate'")
+
+    def surrogate_identity(
+        self,
+        original: str,
+        label: str,
+        *,
+        lang: Optional[str] = None,
+        locale: Optional[str] = None,
+        attempt: int = 0,
+    ) -> str:
+        """Return the stored Latin identity for a transliteration-aware name.
+
+        Non-Indic names and disabled configurations retain :meth:`surrogate`
+        behavior. The method is primarily used by :class:`SurrogateVault`,
+        which stores one identity and renders it for each source script.
+        """
+
+        effective_lang = lang or self.config.lang
+        canonical = normalize_label(label, effective_lang)
+        if (
+            canonical == L.PERSON
+            and self.config.transliteration_aware_name_matching
+            and is_indic_name_candidate(original, lang=effective_lang)
+        ):
+            return self._indic_name_identity(
+                original,
+                canonical_label=canonical,
+                attempt=attempt,
+            )
+        return self.surrogate(
+            original,
+            label,
+            lang=effective_lang,
+            locale=locale,
+        )
+
+    def render_name_surrogate(self, identity: str, *, source_surface: str) -> str:
+        """Render a stored Latin PERSON identity in ``source_surface``'s script."""
+
+        if not self.config.transliteration_aware_name_matching:
+            return identity
+        return self._indic_name_normalizer.render_surrogate(
+            identity,
+            source_surface=source_surface,
+        )
+
+    def _indic_name_identity(
+        self,
+        original: str,
+        *,
+        canonical_label: str,
+        attempt: int = 0,
+    ) -> str:
+        """Generate one Latin surrogate identity without retaining raw names."""
+
+        faker = self._get_faker("en_IN")
+        canonical_key = self._indic_name_normalizer.canonical_key(original)
+        if self.config.consistent:
+            faker.seed_instance(
+                self._derive_seed(canonical_label, f"{canonical_key}|{attempt}")
+            )
+        generator, _ = resolve_label_generator(
+            canonical_label,
+            language_pack=get_language_pack("en"),
+            script="Latin",
+            source_label=canonical_label,
+        )
+        try:
+            return generator(faker, original, locale="en_IN")
+        except Exception as exc:  # noqa: BLE001 - retain safe anonymizer fallback
+            warnings.warn(
+                "Anonymizer fallback for transliteration-aware PERSON at "
+                f"locale 'en_IN': {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return "[PERSON]"
 
     def can_format_preserve(
         self,

--- a/openmed/core/config.py
+++ b/openmed/core/config.py
@@ -172,6 +172,10 @@ class OpenMedConfig:
                     setattr(self, key, value)
             self.profile = env_profile
 
+        if not isinstance(self.transliteration_aware_name_matching, bool):
+            raise TypeError("transliteration_aware_name_matching must be a boolean")
+        if isinstance(self.indic_name_similarity_threshold, bool):
+            raise TypeError("indic_name_similarity_threshold must be a real number")
         self.indic_name_similarity_threshold = float(
             self.indic_name_similarity_threshold
         )
@@ -286,8 +290,8 @@ class OpenMedConfig:
 
         env_indic_matching = os.getenv("OPENMED_TRANSLITERATION_AWARE_NAME_MATCHING")
         if env_indic_matching is not None:
-            self.transliteration_aware_name_matching = (
-                env_indic_matching.lower() not in {"0", "false", "no"}
+            self.transliteration_aware_name_matching = env_flag_enabled(
+                env_indic_matching
             )
 
         env_indic_threshold = os.getenv("OPENMED_INDIC_NAME_SIMILARITY_THRESHOLD")

--- a/openmed/core/config.py
+++ b/openmed/core/config.py
@@ -148,6 +148,11 @@ class OpenMedConfig:
     # otherwise mixed variants are canonicalized before model inference.
     chinese_target_script: Optional[str] = None
 
+    # Link Indic personal-name spellings through a transliteration-safe vault
+    # key. Disabled by default to preserve existing pseudonymization behavior.
+    transliteration_aware_name_matching: bool = False
+    indic_name_similarity_threshold: float = 0.80
+
     # Active profile name (if any)
     profile: Optional[str] = None
 
@@ -166,6 +171,10 @@ class OpenMedConfig:
                 for key, value in profile_data.items():
                     setattr(self, key, value)
             self.profile = env_profile
+
+        self.indic_name_similarity_threshold = float(
+            self.indic_name_similarity_threshold
+        )
 
         if self.cjk_width_convention not in {"cjk", "nfkc"}:
             raise ValueError(
@@ -188,6 +197,10 @@ class OpenMedConfig:
             raise ValueError(
                 "chinese_target_script must be None, 'simplified', or "
                 f"'traditional', got {self.chinese_target_script!r}"
+            )
+        if not 0.5 <= self.indic_name_similarity_threshold <= 1.0:
+            raise ValueError(
+                "indic_name_similarity_threshold must be between 0.5 and 1.0"
             )
 
         if self.hf_token is None:
@@ -271,6 +284,21 @@ class OpenMedConfig:
                 "no",
             }
 
+        env_indic_matching = os.getenv("OPENMED_TRANSLITERATION_AWARE_NAME_MATCHING")
+        if env_indic_matching is not None:
+            self.transliteration_aware_name_matching = (
+                env_indic_matching.lower() not in {"0", "false", "no"}
+            )
+
+        env_indic_threshold = os.getenv("OPENMED_INDIC_NAME_SIMILARITY_THRESHOLD")
+        if env_indic_threshold is not None:
+            self.indic_name_similarity_threshold = float(env_indic_threshold)
+            if not 0.5 <= self.indic_name_similarity_threshold <= 1.0:
+                raise ValueError(
+                    "OPENMED_INDIC_NAME_SIMILARITY_THRESHOLD must be between "
+                    "0.5 and 1.0"
+                )
+
         env_offline = os.getenv(OFFLINE_ENV_VAR)
         if env_offline is not None:
             self.local_only = self.local_only or env_flag_enabled(env_offline)
@@ -310,6 +338,8 @@ class OpenMedConfig:
             "local_only",
             "cjk_width_convention",
             "chinese_target_script",
+            "transliteration_aware_name_matching",
+            "indic_name_similarity_threshold",
             "profile",
         }
         filtered = {k: v for k, v in config_dict.items() if k in valid_keys}
@@ -383,6 +413,10 @@ class OpenMedConfig:
             "local_only": self.local_only,
             "cjk_width_convention": self.cjk_width_convention,
             "chinese_target_script": self.chinese_target_script,
+            "transliteration_aware_name_matching": (
+                self.transliteration_aware_name_matching
+            ),
+            "indic_name_similarity_threshold": self.indic_name_similarity_threshold,
             "profile": self.profile,
         }
 

--- a/openmed/core/indic_name_match.py
+++ b/openmed/core/indic_name_match.py
@@ -9,15 +9,19 @@ uses only :mod:`unicodedata` and supports the major Brahmic scripts.
 
 from __future__ import annotations
 
+import hashlib
 import re
 import unicodedata
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from difflib import SequenceMatcher
+from math import isfinite
+from numbers import Real
 from typing import Any
 
 DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD = 0.80
 INDIC_NAME_KEY_VERSION = "indic-name-v1"
+MAX_INDIC_NAME_SURFACE_CHARS = 512
 
 INDIC_LANGUAGE_CODES = frozenset(
     {
@@ -208,17 +212,29 @@ class IndicNameNormalizer:
 
     def __post_init__(self) -> None:
         _validate_threshold(self.similarity_threshold)
+        object.__setattr__(
+            self, "similarity_threshold", float(self.similarity_threshold)
+        )
 
     def canonical_key(self, surface: str) -> str:
         """Return a versioned in-memory canonical match key for ``surface``."""
 
-        latin = self.to_latin(surface)
+        source = str(surface or "").strip()
+        if not source:
+            raise ValueError("name surface must be non-empty")
+        if len(source) > MAX_INDIC_NAME_SURFACE_CHARS:
+            folded_bytes = (
+                unicodedata.normalize("NFKC", source).casefold().encode("utf-8")
+            )
+            digest = hashlib.sha256(folded_bytes).hexdigest()
+            return f"{INDIC_NAME_KEY_VERSION}:overflow:{digest}"
+        latin = self.to_latin(source)
         tokens = _latin_tokens(latin)
-        folded = [
+        folded_tokens = [
             _collision_safe_fold(token, threshold=self.similarity_threshold)
             for token in tokens
         ]
-        return f"{INDIC_NAME_KEY_VERSION}:{' '.join(folded)}"
+        return f"{INDIC_NAME_KEY_VERSION}:{' '.join(folded_tokens)}"
 
     def to_latin(self, surface: str) -> str:
         """Return deterministic Latin text using a local model or stdlib."""
@@ -229,7 +245,7 @@ class IndicNameNormalizer:
         script = detect_name_script(source)
         if script in _SCRIPT_PREFIXES and self.transliterator is not None:
             translated = _model_to_latin(self.transliterator, source, script)
-            if translated:
+            if translated and len(translated) <= MAX_INDIC_NAME_SURFACE_CHARS:
                 return translated
         return _stdlib_to_latin(source)
 
@@ -246,9 +262,12 @@ class IndicNameNormalizer:
             return identity
         if self.transliterator is not None:
             translated = _model_from_latin(self.transliterator, identity, script)
-            if translated and detect_name_script(translated) == script:
+            if _is_script_pure(translated, script):
                 return translated
-        return _stdlib_from_latin(identity, script)
+        rendered = _stdlib_from_latin(identity, script)
+        if _is_script_pure(rendered, script):
+            return rendered
+        return _stdlib_from_latin("Person", script)
 
 
 def canonical_indic_name_key(
@@ -520,6 +539,16 @@ def _model_from_latin(model: Transliterator, text: str, script: str) -> str:
     return ""
 
 
+def _is_script_pure(value: str, script: str) -> bool:
+    prefix = _SCRIPT_PREFIXES[script]
+    letters = [
+        char for char in str(value or "") if unicodedata.category(char).startswith("L")
+    ]
+    return bool(letters) and all(
+        unicodedata.name(char, "").startswith(f"{prefix} ") for char in letters
+    )
+
+
 def _try_model_calls(calls: Sequence[Callable[[], Any]]) -> str:
     for call in calls:
         try:
@@ -553,7 +582,10 @@ def _coerce_model_result(value: Any) -> str:
 
 
 def _validate_threshold(value: float) -> None:
-    if not 0.5 <= float(value) <= 1.0:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError("similarity_threshold must be a real number")
+    numeric = float(value)
+    if not isfinite(numeric) or not 0.5 <= numeric <= 1.0:
         raise ValueError("similarity_threshold must be between 0.5 and 1.0")
 
 
@@ -561,6 +593,7 @@ __all__ = [
     "DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD",
     "INDIC_LANGUAGE_CODES",
     "INDIC_NAME_KEY_VERSION",
+    "MAX_INDIC_NAME_SURFACE_CHARS",
     "IndicNameNormalizer",
     "canonical_indic_name_key",
     "detect_name_script",

--- a/openmed/core/indic_name_match.py
+++ b/openmed/core/indic_name_match.py
@@ -1,0 +1,569 @@
+"""Deterministic, privacy-conscious matching for Indic personal names.
+
+The normalizer converts an Indic or Latin name surface into a conservative
+Latin phonetic key.  Callers must treat that key as sensitive transient data;
+the surrogate vault HMACs it before storage.  No model weights are bundled.
+Applications may provide a local transliterator, while the built-in fallback
+uses only :mod:`unicodedata` and supports the major Brahmic scripts.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any
+
+DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD = 0.80
+INDIC_NAME_KEY_VERSION = "indic-name-v1"
+
+INDIC_LANGUAGE_CODES = frozenset(
+    {
+        "as",
+        "bn",
+        "gu",
+        "hi",
+        "kn",
+        "kok",
+        "mai",
+        "ml",
+        "mr",
+        "ne",
+        "or",
+        "pa",
+        "sa",
+        "ta",
+        "te",
+    }
+)
+
+_SCRIPT_PREFIXES = {
+    "devanagari": "DEVANAGARI",
+    "bengali": "BENGALI",
+    "gurmukhi": "GURMUKHI",
+    "gujarati": "GUJARATI",
+    "odia": "ORIYA",
+    "tamil": "TAMIL",
+    "telugu": "TELUGU",
+    "kannada": "KANNADA",
+    "malayalam": "MALAYALAM",
+}
+
+_CONSONANTS = {
+    "KA": "k",
+    "KHA": "kh",
+    "GA": "g",
+    "GHA": "gh",
+    "NGA": "ng",
+    "CA": "ch",
+    "CHA": "chh",
+    "JA": "j",
+    "JHA": "jh",
+    "NYA": "ny",
+    "TTA": "t",
+    "TTHA": "th",
+    "DDA": "d",
+    "DDHA": "dh",
+    "NNA": "n",
+    "TA": "t",
+    "THA": "th",
+    "DA": "d",
+    "DHA": "dh",
+    "NA": "n",
+    "PA": "p",
+    "PHA": "ph",
+    "BA": "b",
+    "BHA": "bh",
+    "MA": "m",
+    "YA": "y",
+    "RA": "r",
+    "RRA": "r",
+    "LA": "l",
+    "LLA": "l",
+    "VA": "v",
+    "SHA": "sh",
+    "SSA": "sh",
+    "SA": "s",
+    "HA": "h",
+    "QA": "q",
+    "KHHA": "kh",
+    "GHHA": "gh",
+    "ZA": "z",
+    "FA": "f",
+    "YYA": "y",
+}
+
+_VOWELS = {
+    "A": "a",
+    "AA": "aa",
+    "I": "i",
+    "II": "ii",
+    "U": "u",
+    "UU": "uu",
+    "VOCALIC R": "ri",
+    "VOCALIC RR": "ri",
+    "VOCALIC L": "li",
+    "E": "e",
+    "AI": "ai",
+    "O": "o",
+    "AU": "au",
+    "SHORT E": "e",
+    "SHORT O": "o",
+}
+
+_LATIN_DIACRITIC_FOLDS = str.maketrans(
+    {
+        "ṛ": "ri",
+        "ṝ": "ri",
+        "ṟ": "r",
+        "ḷ": "l",
+        "ḹ": "l",
+        "ṣ": "sh",
+        "ś": "sh",
+        "ṅ": "n",
+        "ñ": "n",
+        "ṇ": "n",
+        "ṃ": "n",
+        "ṁ": "n",
+        "ḥ": "h",
+    }
+)
+
+_ROMAN_CONSONANT_SUFFIX = {
+    "k": "KA",
+    "kh": "KHA",
+    "g": "GA",
+    "gh": "GHA",
+    "ng": "NGA",
+    "ch": "CA",
+    "chh": "CHA",
+    "c": "KA",
+    "j": "JA",
+    "jh": "JHA",
+    "ny": "NYA",
+    "t": "TA",
+    "th": "THA",
+    "d": "DA",
+    "dh": "DHA",
+    "n": "NA",
+    "p": "PA",
+    "ph": "PHA",
+    "b": "BA",
+    "bh": "BHA",
+    "m": "MA",
+    "y": "YA",
+    "r": "RA",
+    "l": "LA",
+    "v": "VA",
+    "w": "VA",
+    "sh": "SHA",
+    "s": "SA",
+    "h": "HA",
+    "q": "KA",
+    "f": "PHA",
+    "x": "KA",
+    "z": "JA",
+}
+_ROMAN_VOWEL_SUFFIX = {
+    "a": "A",
+    "aa": "AA",
+    "i": "I",
+    "ii": "II",
+    "u": "U",
+    "uu": "UU",
+    "e": "E",
+    "ai": "AI",
+    "o": "O",
+    "au": "AU",
+}
+_ROMAN_TOKENS = tuple(
+    sorted(
+        {*_ROMAN_CONSONANT_SUFFIX, *_ROMAN_VOWEL_SUFFIX, "ksh"},
+        key=len,
+        reverse=True,
+    )
+)
+
+Transliterator = Callable[[str], Any] | Any
+
+
+@dataclass(frozen=True)
+class IndicNameNormalizer:
+    """Build conservative canonical keys and render Indic surrogate surfaces.
+
+    Args:
+        similarity_threshold: Minimum edit similarity required before a
+            romanization fold (for example ``x`` to ``ksh``) is accepted.
+            Higher values reduce matching and therefore reduce collision risk.
+        transliterator: Optional local callable or object. A callable should
+            return a Latin string. Objects may provide ``to_latin`` and
+            ``from_latin`` methods, or a ``transliterate`` method accepting
+            ``source_script`` and ``target_script`` keyword arguments.
+    """
+
+    similarity_threshold: float = DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD
+    transliterator: Transliterator | None = None
+
+    def __post_init__(self) -> None:
+        _validate_threshold(self.similarity_threshold)
+
+    def canonical_key(self, surface: str) -> str:
+        """Return a versioned in-memory canonical match key for ``surface``."""
+
+        latin = self.to_latin(surface)
+        tokens = _latin_tokens(latin)
+        folded = [
+            _collision_safe_fold(token, threshold=self.similarity_threshold)
+            for token in tokens
+        ]
+        return f"{INDIC_NAME_KEY_VERSION}:{' '.join(folded)}"
+
+    def to_latin(self, surface: str) -> str:
+        """Return deterministic Latin text using a local model or stdlib."""
+
+        source = str(surface or "").strip()
+        if not source:
+            raise ValueError("name surface must be non-empty")
+        script = detect_name_script(source)
+        if script in _SCRIPT_PREFIXES and self.transliterator is not None:
+            translated = _model_to_latin(self.transliterator, source, script)
+            if translated:
+                return translated
+        return _stdlib_to_latin(source)
+
+    def matches(self, left: str, right: str) -> bool:
+        """Return whether two surfaces produce the same collision-safe key."""
+
+        return self.canonical_key(left) == self.canonical_key(right)
+
+    def render_surrogate(self, identity: str, *, source_surface: str) -> str:
+        """Render a stored Latin surrogate in the source surface's script."""
+
+        script = detect_name_script(source_surface)
+        if script not in _SCRIPT_PREFIXES:
+            return identity
+        if self.transliterator is not None:
+            translated = _model_from_latin(self.transliterator, identity, script)
+            if translated and detect_name_script(translated) == script:
+                return translated
+        return _stdlib_from_latin(identity, script)
+
+
+def canonical_indic_name_key(
+    surface: str,
+    *,
+    similarity_threshold: float = DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD,
+    transliterator: Transliterator | None = None,
+) -> str:
+    """Return a deterministic canonical key for an Indic name surface."""
+
+    return IndicNameNormalizer(
+        similarity_threshold=similarity_threshold,
+        transliterator=transliterator,
+    ).canonical_key(surface)
+
+
+def indic_names_match(
+    left: str,
+    right: str,
+    *,
+    similarity_threshold: float = DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD,
+    transliterator: Transliterator | None = None,
+) -> bool:
+    """Return whether two name surfaces share a conservative canonical key."""
+
+    return IndicNameNormalizer(
+        similarity_threshold=similarity_threshold,
+        transliterator=transliterator,
+    ).matches(left, right)
+
+
+def detect_name_script(surface: str) -> str:
+    """Return the Indic script name, ``latin``, or ``other`` for ``surface``."""
+
+    indic_counts = {script: 0 for script in _SCRIPT_PREFIXES}
+    latin_count = 0
+    for char in str(surface or ""):
+        name = unicodedata.name(char, "")
+        for script, prefix in _SCRIPT_PREFIXES.items():
+            if name.startswith(f"{prefix} "):
+                indic_counts[script] += 1
+                break
+        else:
+            if "LATIN" in name and unicodedata.category(char).startswith("L"):
+                latin_count += 1
+    script, count = max(indic_counts.items(), key=lambda item: item[1])
+    if count:
+        return script
+    return "latin" if latin_count else "other"
+
+
+def is_indic_name_candidate(surface: str, *, lang: str = "") -> bool:
+    """Return whether transliteration-aware matching should apply."""
+
+    language = str(lang or "").split("-", 1)[0].split("_", 1)[0].lower()
+    return detect_name_script(surface) in _SCRIPT_PREFIXES or language in (
+        INDIC_LANGUAGE_CODES
+    )
+
+
+def _stdlib_to_latin(surface: str) -> str:
+    result: list[str] = []
+    for char in unicodedata.normalize("NFC", surface):
+        name = unicodedata.name(char, "")
+        script_prefix = next(
+            (
+                prefix
+                for prefix in _SCRIPT_PREFIXES.values()
+                if name.startswith(f"{prefix} ")
+            ),
+            None,
+        )
+        if script_prefix is None:
+            result.append(char)
+            continue
+
+        tail = name[len(script_prefix) + 1 :]
+        if tail.startswith("LETTER "):
+            suffix = tail.removeprefix("LETTER ")
+            consonant = _CONSONANTS.get(suffix)
+            if consonant is not None:
+                result.append(f"{consonant}a")
+                continue
+            vowel = _VOWELS.get(suffix)
+            if vowel is not None:
+                result.append(vowel)
+                continue
+        if tail.startswith("VOWEL SIGN "):
+            vowel = _VOWELS.get(tail.removeprefix("VOWEL SIGN "))
+            if vowel is not None:
+                _replace_inherent_vowel(result, vowel)
+                continue
+        if tail in {"SIGN VIRAMA", "SIGN HALANT"}:
+            _replace_inherent_vowel(result, "")
+        elif tail in {"SIGN ANUSVARA", "SIGN CANDRABINDU"}:
+            result.append("n")
+        elif tail == "SIGN VISARGA":
+            result.append("h")
+        elif tail in {"SIGN NUKTA", "SIGN AVAGRAHA"} or "JOINER" in tail:
+            continue
+    return "".join(result)
+
+
+def _replace_inherent_vowel(result: list[str], vowel: str) -> None:
+    if result and result[-1].endswith("a"):
+        result[-1] = f"{result[-1][:-1]}{vowel}"
+
+
+def _latin_tokens(value: str) -> list[str]:
+    folded = value.casefold().translate(_LATIN_DIACRITIC_FOLDS)
+    decomposed = unicodedata.normalize("NFKD", folded)
+    ascii_value = "".join(
+        char for char in decomposed if not unicodedata.combining(char)
+    )
+    tokens = re.findall(r"[a-z]+", ascii_value)
+    if not tokens:
+        raise ValueError("name surface must contain Latin or supported Indic letters")
+    return tokens
+
+
+def _collision_safe_fold(value: str, *, threshold: float) -> str:
+    # ``x`` is the conventional Latin shorthand for the Indic ``ksh``
+    # conjunct, so account for that zero-cost phonetic expansion before the
+    # edit-similarity gate is applied to the remaining optional folds.
+    phonetic_base = value.replace("x", "ksh").replace("q", "k")
+    candidate = phonetic_base
+    candidate = re.sub(r"ee", "i", candidate)
+    candidate = re.sub(r"oo", "u", candidate)
+    candidate = re.sub(r"ii+", "i", candidate)
+    candidate = re.sub(r"uu+", "u", candidate)
+    candidate = re.sub(r"aya$", "ay", candidate)
+    candidate = re.sub(r"ai$", "ay", candidate)
+    candidate = re.sub(r"aa$", "a", candidate)
+    similarity = SequenceMatcher(
+        None,
+        phonetic_base,
+        candidate,
+        autojunk=False,
+    ).ratio()
+    return candidate if similarity >= threshold else phonetic_base
+
+
+def _stdlib_from_latin(identity: str, script: str) -> str:
+    prefix = _SCRIPT_PREFIXES[script]
+    rendered = [
+        _render_roman_word(word, prefix) if word else word
+        for word in re.split(r"([A-Za-z]+)", identity)
+    ]
+    value = "".join(rendered)
+    return value if value.strip() else identity
+
+
+def _render_roman_word(word: str, prefix: str) -> str:
+    tokens: list[str] = []
+    lower = word.casefold()
+    index = 0
+    while index < len(lower):
+        token = next(
+            (item for item in _ROMAN_TOKENS if lower.startswith(item, index)),
+            lower[index],
+        )
+        tokens.append(token)
+        index += len(token)
+
+    output: list[str] = []
+    pending_consonant = False
+    for token in tokens:
+        consonant_suffix = (
+            "KA" if token in {"ksh", "x"} else _ROMAN_CONSONANT_SUFFIX.get(token)
+        )
+        if consonant_suffix is not None:
+            if pending_consonant:
+                virama = _lookup(prefix, "SIGN VIRAMA")
+                if virama:
+                    output.append(virama)
+            letter = _lookup_letter(prefix, consonant_suffix)
+            if letter:
+                output.append(letter)
+                if token in {"ksh", "x"}:
+                    virama = _lookup(prefix, "SIGN VIRAMA")
+                    sha = _lookup_letter(prefix, "SHA")
+                    if virama and sha:
+                        output.extend((virama, sha))
+                pending_consonant = True
+            continue
+
+        vowel_suffix = _ROMAN_VOWEL_SUFFIX.get(token)
+        if vowel_suffix is None:
+            output.append(token)
+            pending_consonant = False
+            continue
+        if pending_consonant:
+            if vowel_suffix != "A":
+                sign = _lookup(prefix, f"VOWEL SIGN {vowel_suffix}")
+                if sign:
+                    output.append(sign)
+            pending_consonant = False
+        else:
+            vowel = _lookup(prefix, f"LETTER {vowel_suffix}")
+            if vowel:
+                output.append(vowel)
+    return "".join(output) or word
+
+
+def _lookup_letter(prefix: str, suffix: str) -> str:
+    alternatives = {
+        "KHA": ("KHA", "KA"),
+        "GHA": ("GHA", "GA"),
+        "CHA": ("CHA", "CA"),
+        "JHA": ("JHA", "JA"),
+        "THA": ("THA", "TA"),
+        "DHA": ("DHA", "DA"),
+        "PHA": ("PHA", "PA"),
+        "BHA": ("BHA", "BA"),
+        "SHA": ("SHA", "SA"),
+    }.get(suffix, (suffix,))
+    for candidate in alternatives:
+        value = _lookup(prefix, f"LETTER {candidate}")
+        if value:
+            return value
+    return ""
+
+
+def _lookup(prefix: str, suffix: str) -> str:
+    try:
+        return unicodedata.lookup(f"{prefix} {suffix}")
+    except KeyError:
+        return ""
+
+
+def _model_to_latin(model: Transliterator, text: str, script: str) -> str:
+    to_latin = getattr(model, "to_latin", None)
+    if callable(to_latin):
+        return _coerce_model_result(to_latin(text))
+    method = getattr(model, "transliterate", None)
+    if callable(method):
+        return _try_model_calls(
+            (
+                lambda: method(
+                    text,
+                    source_script=script,
+                    target_script="latin",
+                ),
+                lambda: method(text, target_script="latin"),
+                lambda: method(text),
+            )
+        )
+    if callable(model):
+        return _coerce_model_result(model(text))
+    return ""
+
+
+def _model_from_latin(model: Transliterator, text: str, script: str) -> str:
+    from_latin = getattr(model, "from_latin", None)
+    if callable(from_latin):
+        return _coerce_model_result(from_latin(text, script))
+    method = getattr(model, "transliterate", None)
+    if callable(method):
+        return _try_model_calls(
+            (
+                lambda: method(
+                    text,
+                    source_script="latin",
+                    target_script=script,
+                ),
+                lambda: method(text, target_script=script),
+            )
+        )
+    return ""
+
+
+def _try_model_calls(calls: Sequence[Callable[[], Any]]) -> str:
+    for call in calls:
+        try:
+            value = _coerce_model_result(call())
+        except (KeyError, TypeError, ValueError):
+            continue
+        if value:
+            return value
+    return ""
+
+
+def _coerce_model_result(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, Mapping):
+        for key in ("latin", "en", "text", "output"):
+            if key in value:
+                result = _coerce_model_result(value[key])
+                if result:
+                    return result
+        for item in value.values():
+            result = _coerce_model_result(item)
+            if result:
+                return result
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        for item in value:
+            result = _coerce_model_result(item)
+            if result:
+                return result
+    return ""
+
+
+def _validate_threshold(value: float) -> None:
+    if not 0.5 <= float(value) <= 1.0:
+        raise ValueError("similarity_threshold must be between 0.5 and 1.0")
+
+
+__all__ = [
+    "DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD",
+    "INDIC_LANGUAGE_CODES",
+    "INDIC_NAME_KEY_VERSION",
+    "IndicNameNormalizer",
+    "canonical_indic_name_key",
+    "detect_name_script",
+    "indic_names_match",
+    "is_indic_name_candidate",
+]

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -2032,11 +2032,32 @@ def _build_deidentification_result(
         from .anonymizer import Anonymizer
 
         effective_consistent = consistent or seed is not None
+        vault_name_matching = bool(
+            surrogate_vault is not None
+            and getattr(
+                surrogate_vault,
+                "transliteration_aware_name_matching",
+                False,
+            )
+        )
         anonymizer = Anonymizer(
             lang=lang,
             locale=locale,
             consistent=effective_consistent,
             seed=seed,
+            transliteration_aware_name_matching=vault_name_matching,
+            indic_name_similarity_threshold=float(
+                getattr(
+                    surrogate_vault,
+                    "indic_name_similarity_threshold",
+                    0.80,
+                )
+            ),
+            indic_name_normalizer=getattr(
+                surrogate_vault,
+                "indic_name_normalizer",
+                None,
+            ),
         )
 
     deidentified = text
@@ -2697,11 +2718,33 @@ def _redact_entity(
                 )
 
                 def _create_surrogate(attempt: int) -> str:
-                    source = original if attempt == 0 else f"{original}|{attempt}"
-                    return anonymizer.surrogate(
-                        source,
-                        surrogate_label,
+                    key = surrogate_vault.key_for(
+                        original,
+                        label=label,
                         lang=lang,
+                    )
+                    if key.lang == "indic":
+                        return anonymizer.surrogate_identity(
+                            original,
+                            surrogate_label,
+                            lang=lang,
+                            attempt=attempt,
+                        )
+                    source = original if attempt == 0 else f"{original}|{attempt}"
+                    return anonymizer.surrogate(source, surrogate_label, lang=lang)
+
+                key = surrogate_vault.key_for(
+                    original,
+                    label=label,
+                    lang=lang,
+                )
+                render_surrogate = None
+                if key.lang == "indic":
+                    render_surrogate = lambda identity: (
+                        anonymizer.render_name_surrogate(
+                            identity,
+                            source_surface=original,
+                        )
                     )
 
                 return surrogate_vault.get_or_create(
@@ -2710,6 +2753,7 @@ def _redact_entity(
                     lang=lang,
                     create_surrogate=_create_surrogate,
                     required_script=_surrogate_script_constraint(entity),
+                    render_surrogate=render_surrogate,
                 )
             return anonymizer.surrogate(
                 original,

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -788,6 +788,25 @@ class Pipeline:
             normalized,
             self.hmac_secret,
         )
+        if surrogate_vault is not None and bool(
+            getattr(
+                self.config,
+                "transliteration_aware_name_matching",
+                False,
+            )
+        ):
+            normalizer = getattr(surrogate_vault, "indic_name_normalizer", None)
+            surrogate_vault.configure_name_matching(
+                enabled=True,
+                similarity_threshold=float(
+                    getattr(
+                        self.config,
+                        "indic_name_similarity_threshold",
+                        0.80,
+                    )
+                ),
+                transliterator=getattr(normalizer, "transliterator", None),
+            )
         with _stage_timer(stage_durations_ms, STAGE_NAMES[9]):
             deidentified = self.stage10_emit(
                 normalized.original_text,

--- a/openmed/core/surrogate_vault.py
+++ b/openmed/core/surrogate_vault.py
@@ -23,7 +23,13 @@ from pathlib import Path
 from threading import RLock
 from typing import AbstractSet, Any, Callable
 
-from .labels import normalize_label
+from .indic_name_match import (
+    DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD,
+    INDIC_NAME_KEY_VERSION,
+    IndicNameNormalizer,
+    is_indic_name_candidate,
+)
+from .labels import PERSON, normalize_label
 from .schemas.span import hmac_text_hash
 from .script_detect import (
     canonical_indian_name,
@@ -278,10 +284,12 @@ class InMemorySurrogateStore:
         entries: Iterable[SurrogateEntry] = (),
         *,
         epoch_manager: _EpochManager | None = None,
+        name_matching_metadata: Mapping[str, Any] | None = None,
     ) -> None:
         self._entries: dict[SurrogateKey, SurrogateEntry] = {}
         self._lock = RLock()
         self._epoch_manager = epoch_manager
+        self._name_matching_metadata = dict(name_matching_metadata or {})
         for entry in entries:
             self.set(entry.key, entry.surrogate, key_id=entry.key_id)
 
@@ -303,6 +311,19 @@ class InMemorySurrogateStore:
                 )
                 for key, entry in self._entries.items()
             }
+
+    @property
+    def name_matching_metadata(self) -> dict[str, Any]:
+        """Return non-sensitive persisted name-matching configuration."""
+
+        with self._lock:
+            return dict(self._name_matching_metadata)
+
+    def set_name_matching_metadata(self, metadata: Mapping[str, Any]) -> None:
+        """Replace non-sensitive name-matching configuration metadata."""
+
+        with self._lock:
+            self._name_matching_metadata = dict(metadata)
 
     def get(self, key: SurrogateKey) -> str | None:
         """Return the surrogate for ``key``, if present."""
@@ -380,6 +401,8 @@ class InMemorySurrogateStore:
             **self._epoch_manager.payload(),
             "entries": [],
         }
+        if self._name_matching_metadata:
+            payload["name_matching"] = dict(self._name_matching_metadata)
         entries_payload: list[dict[str, str]] = []
         for entry in self.entries():
             key_id = entry.key_id or current_key.key_id
@@ -439,7 +462,14 @@ class InMemorySurrogateStore:
         entries = [
             _decrypt_entry_payload(entry, current_key) for entry in entries_payload
         ]
-        return cls(entries, epoch_manager=manager)
+        metadata = payload.get("name_matching") or {}
+        if not isinstance(metadata, Mapping):
+            raise ValueError("surrogate vault name_matching must be an object")
+        return cls(
+            entries,
+            epoch_manager=manager,
+            name_matching_metadata=metadata,
+        )
 
     @classmethod
     def _from_legacy_payload(
@@ -468,7 +498,14 @@ class InMemorySurrogateStore:
                 )
                 for entry in entries
             ]
-        return cls(entries, epoch_manager=manager)
+        metadata = payload.get("name_matching") or {}
+        if not isinstance(metadata, Mapping):
+            raise ValueError("surrogate vault name_matching must be an object")
+        return cls(
+            entries,
+            epoch_manager=manager,
+            name_matching_metadata=metadata,
+        )
 
 
 class JsonFileSurrogateStore(InMemorySurrogateStore):
@@ -481,11 +518,16 @@ class JsonFileSurrogateStore(InMemorySurrogateStore):
         *,
         autosave: bool = True,
         epoch_manager: _EpochManager | None = None,
+        name_matching_metadata: Mapping[str, Any] | None = None,
     ) -> None:
         self.path = Path(path)
         self.autosave = bool(autosave)
         self._hydrating = True
-        super().__init__(entries, epoch_manager=epoch_manager)
+        super().__init__(
+            entries,
+            epoch_manager=epoch_manager,
+            name_matching_metadata=name_matching_metadata,
+        )
         self._hydrating = False
 
     @classmethod
@@ -519,6 +561,7 @@ class JsonFileSurrogateStore(InMemorySurrogateStore):
             loaded.entries(),
             autosave=autosave,
             epoch_manager=loaded.epoch_manager,
+            name_matching_metadata=loaded.name_matching_metadata,
         )
 
     def set(
@@ -570,6 +613,7 @@ class JsonFileSurrogateStore(InMemorySurrogateStore):
 
 
 SurrogateFactory = Callable[[int], str]
+SurrogateRenderer = Callable[[str], str]
 ConsistencySnapshot = Mapping[str, str]
 
 
@@ -613,6 +657,10 @@ class SurrogateVault:
         hmac_secret: str | bytes,
         *,
         store: InMemorySurrogateStore | None = None,
+        config: Any = None,
+        transliteration_aware_name_matching: bool | None = None,
+        indic_name_similarity_threshold: float | None = None,
+        transliterator: Any = None,
     ) -> None:
         _secret_bytes(hmac_secret)
         self.hmac_secret = hmac_secret
@@ -627,11 +675,74 @@ class SurrogateVault:
             raise ValueError("surrogate vault store is missing epoch metadata")
         self._epoch_manager = self.store.epoch_manager
 
+        persisted = self.store.name_matching_metadata
+        if transliteration_aware_name_matching is None and config is not None:
+            transliteration_aware_name_matching = bool(
+                getattr(config, "transliteration_aware_name_matching", False)
+            )
+        if indic_name_similarity_threshold is None and config is not None:
+            indic_name_similarity_threshold = float(
+                getattr(
+                    config,
+                    "indic_name_similarity_threshold",
+                    DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD,
+                )
+            )
+        if transliteration_aware_name_matching is None:
+            transliteration_aware_name_matching = bool(persisted.get("enabled", False))
+        if indic_name_similarity_threshold is None:
+            indic_name_similarity_threshold = float(
+                persisted.get(
+                    "similarity_threshold",
+                    DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD,
+                )
+            )
+
+        persisted_backend = str(persisted.get("backend", ""))
+        if (
+            persisted_backend == "user-supplied"
+            and transliterator is None
+            and self.entries()
+        ):
+            raise ValueError(
+                "this vault requires the user-supplied Indic transliterator "
+                "used when it was created"
+            )
+        if (
+            not persisted
+            and self.entries()
+            and bool(transliteration_aware_name_matching)
+        ):
+            raise ValueError(
+                "transliteration-aware matching cannot be enabled on a legacy "
+                "vault that already contains entries"
+            )
+        self._set_name_matching(
+            enabled=bool(transliteration_aware_name_matching),
+            similarity_threshold=float(indic_name_similarity_threshold),
+            transliterator=transliterator,
+            allow_existing=persisted == {},
+        )
+
     @classmethod
-    def in_memory(cls, hmac_secret: str | bytes) -> "SurrogateVault":
+    def in_memory(
+        cls,
+        hmac_secret: str | bytes,
+        *,
+        config: Any = None,
+        transliteration_aware_name_matching: bool | None = None,
+        indic_name_similarity_threshold: float | None = None,
+        transliterator: Any = None,
+    ) -> "SurrogateVault":
         """Create a vault backed by memory only."""
 
-        return cls(hmac_secret)
+        return cls(
+            hmac_secret,
+            config=config,
+            transliteration_aware_name_matching=(transliteration_aware_name_matching),
+            indic_name_similarity_threshold=indic_name_similarity_threshold,
+            transliterator=transliterator,
+        )
 
     @classmethod
     def from_file(
@@ -641,6 +752,10 @@ class SurrogateVault:
         hmac_secret: str | bytes,
         create: bool = True,
         autosave: bool = True,
+        config: Any = None,
+        transliteration_aware_name_matching: bool | None = None,
+        indic_name_similarity_threshold: float | None = None,
+        transliterator: Any = None,
     ) -> "SurrogateVault":
         """Create a vault backed by a deterministic encrypted JSON file."""
 
@@ -652,6 +767,10 @@ class SurrogateVault:
                 autosave=autosave,
                 hmac_secret=hmac_secret,
             ),
+            config=config,
+            transliteration_aware_name_matching=(transliteration_aware_name_matching),
+            indic_name_similarity_threshold=indic_name_similarity_threshold,
+            transliterator=transliterator,
         )
 
     def __repr__(self) -> str:
@@ -678,6 +797,41 @@ class SurrogateVault:
         """Return revoked epoch identifiers."""
 
         return tuple(sorted(self._epoch_manager.revoked_key_ids))
+
+    @property
+    def transliteration_aware_name_matching(self) -> bool:
+        """Return whether Indic PERSON surfaces use canonical match keys."""
+
+        return self._transliteration_aware_name_matching
+
+    @property
+    def indic_name_similarity_threshold(self) -> float:
+        """Return the configured collision-safety threshold."""
+
+        return self._indic_name_normalizer.similarity_threshold
+
+    @property
+    def indic_name_normalizer(self) -> IndicNameNormalizer:
+        """Return the in-memory normalizer used for PERSON vault keys."""
+
+        return self._indic_name_normalizer
+
+    def configure_name_matching(
+        self,
+        *,
+        enabled: bool,
+        similarity_threshold: float = DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD,
+        transliterator: Any = None,
+    ) -> None:
+        """Configure transliteration matching before the first entry is stored."""
+
+        self._set_name_matching(
+            enabled=enabled,
+            similarity_threshold=similarity_threshold,
+            transliterator=transliterator,
+            allow_existing=False,
+        )
+        self._save_if_file_backed()
 
     def text_hash(self, source_text: str | bytes) -> str:
         """Return the current-epoch vault HMAC for ``source_text``."""
@@ -731,15 +885,20 @@ class SurrogateVault:
         lang: str = "en",
         create_surrogate: SurrogateFactory,
         required_script: str | None = None,
+        render_surrogate: SurrogateRenderer | None = None,
     ) -> str:
-        """Return a stable surrogate, optionally constrained to one script run."""
+        """Return a stable surrogate, optionally rendered or script-constrained."""
 
         source = _source(source_text=source_text, label=label, lang=lang)
-        identity = _source_identity(source)
+        identity = self._source_identity(source)
         key = self._key_for_epoch(source, self._epoch_manager.current_key)
         existing = self.store.get(key)
         if existing is not None:
-            rendered = self._render_for_source(existing, source)
+            rendered = self._render_for_source(
+                existing,
+                source,
+                renderer=render_surrogate,
+            )
             assert rendered is not None
             if not _matches_required_script(rendered, required_script):
                 raise ValueError("existing surrogate does not satisfy required_script")
@@ -754,10 +913,14 @@ class SurrogateVault:
             if existing is not None:
                 stored_existing = (
                     canonical_indian_name(existing)
-                    if identity.render_script is not None
+                    if identity.key_lang == _INDIAN_NAME_KEY_LANG
                     else existing
                 )
-                rendered = self._render_for_source(stored_existing, source)
+                rendered = self._render_for_source(
+                    stored_existing,
+                    source,
+                    renderer=render_surrogate,
+                )
                 assert rendered is not None
                 if not _matches_required_script(rendered, required_script):
                     raise ValueError(
@@ -772,6 +935,7 @@ class SurrogateVault:
                     normalized_rendered = self._render_for_source(
                         normalized_existing,
                         source,
+                        renderer=render_surrogate,
                     )
                     assert normalized_rendered is not None
                     if not _matches_required_script(
@@ -792,7 +956,7 @@ class SurrogateVault:
             candidate = create_surrogate(attempt)
             if not candidate:
                 continue
-            if identity.render_script is not None:
+            if identity.key_lang == _INDIAN_NAME_KEY_LANG:
                 candidate = canonical_indian_name(candidate)
                 if not candidate:
                     continue
@@ -800,6 +964,21 @@ class SurrogateVault:
                 rendered_candidate = render_indian_name(
                     candidate,
                     identity.render_script,
+                )
+            elif identity.key_lang == "indic":
+                leaks_source = self._indic_candidate_leaks_source(
+                    candidate,
+                    source_text,
+                )
+                rendered_candidate = self._render_for_source(
+                    candidate,
+                    source,
+                    renderer=render_surrogate,
+                )
+                assert rendered_candidate is not None
+                leaks_source = leaks_source or _contains_source_surface(
+                    rendered_candidate,
+                    source_text,
                 )
             else:
                 leaks_source = _contains_source_surface(candidate, source_text)
@@ -816,21 +995,33 @@ class SurrogateVault:
         if not surrogate:
             suffix = key.text_hash.rsplit(":", 1)[-1][:8]
             base = create_surrogate(0) or key.canonical_label
-            if identity.render_script is not None:
+            if identity.key_lang == _INDIAN_NAME_KEY_LANG:
                 base = canonical_indian_name(base) or key.canonical_label.casefold()
                 leaks_source = _contains_indian_name(base, identity.key_text)
+            elif identity.key_lang == "indic":
+                leaks_source = self._indic_candidate_leaks_source(base, source_text)
             else:
                 leaks_source = _contains_source_surface(base, source_text)
             if leaks_source or base in used:
                 base = key.canonical_label.casefold()
             surrogate = f"{base}_{suffix}"
-            rendered_surrogate = self._render_for_source(surrogate, source)
+            rendered_surrogate = self._render_for_source(
+                surrogate,
+                source,
+                renderer=render_surrogate,
+            )
             assert rendered_surrogate is not None
             if not _matches_required_script(rendered_surrogate, required_script):
                 raise ValueError("unable to create a surrogate in required_script")
 
         self.store.set(key, surrogate, key_id=self.current_key_id)
-        return self._render_for_source(surrogate, source)
+        rendered = self._render_for_source(
+            surrogate,
+            source,
+            renderer=render_surrogate,
+        )
+        assert rendered is not None
+        return rendered
 
     def entries(self) -> tuple[SurrogateEntry, ...]:
         """Return the current sorted vault entries."""
@@ -997,7 +1188,7 @@ class SurrogateVault:
         save()
 
     def _key_for_epoch(self, source: SurrogateSource, epoch: _EpochKey) -> SurrogateKey:
-        identity = _source_identity(source)
+        identity = self._source_identity(source)
         return SurrogateKey(
             canonical_label=identity.canonical_label,
             lang=identity.key_lang,
@@ -1016,6 +1207,16 @@ class SurrogateVault:
             text_hash=hmac_text_hash(source_text, epoch.linkage_key),
         )
 
+    def _exact_indian_key_for_epoch(
+        self, source: SurrogateSource, epoch: _EpochKey
+    ) -> SurrogateKey:
+        identity = _source_identity(source)
+        return SurrogateKey(
+            canonical_label=identity.canonical_label,
+            lang=identity.key_lang,
+            text_hash=hmac_text_hash(identity.key_text, epoch.linkage_key),
+        )
+
     def _legacy_key_for_epoch(
         self, source: SurrogateSource, epoch: _EpochKey
     ) -> SurrogateKey:
@@ -1032,24 +1233,98 @@ class SurrogateVault:
     ) -> tuple[SurrogateKey, ...]:
         candidates = (
             self._normalized_legacy_key_for_epoch(source, epoch),
+            self._exact_indian_key_for_epoch(source, epoch),
             self._legacy_key_for_epoch(source, epoch),
         )
         return tuple(dict.fromkeys(candidates))
+
+    def _source_identity(self, source: SurrogateSource) -> _SourceIdentity:
+        effective_lang = str(source.lang or "en")
+        canonical_label = normalize_label(str(source.label), effective_lang)
+        if (
+            self.transliteration_aware_name_matching
+            and canonical_label == PERSON
+            and is_indic_name_candidate(source.source_text, lang=effective_lang)
+        ):
+            script = indian_name_script(source.source_text, effective_lang)
+            if script is not None:
+                return _SourceIdentity(
+                    canonical_label=canonical_label,
+                    key_lang="indic",
+                    key_text=self.indic_name_normalizer.canonical_key(
+                        source.source_text
+                    ),
+                    render_script=script,
+                )
+        return _source_identity(source)
 
     def _render_for_source(
         self,
         stored_surrogate: str | None,
         source: SurrogateSource,
+        *,
+        renderer: SurrogateRenderer | None = None,
     ) -> str | None:
         if stored_surrogate is None:
             return None
-        script = _source_identity(source).render_script
+        identity = self._source_identity(source)
+        if identity.key_lang == "indic":
+            rendered = (
+                renderer(stored_surrogate)
+                if renderer is not None
+                else self.indic_name_normalizer.render_surrogate(
+                    stored_surrogate,
+                    source_surface=source.source_text,
+                )
+            )
+            if not rendered or _contains_source_surface(rendered, source.source_text):
+                return stored_surrogate
+            return rendered
+        script = identity.render_script
         if script is None:
             return stored_surrogate
         return render_indian_name(stored_surrogate, script)
 
+    def _indic_candidate_leaks_source(
+        self,
+        candidate: str,
+        source_text: str,
+    ) -> bool:
+        try:
+            return self.indic_name_normalizer.matches(candidate, source_text)
+        except ValueError:
+            return _contains_source_surface(candidate, source_text)
+
+    def _set_name_matching(
+        self,
+        *,
+        enabled: bool,
+        similarity_threshold: float,
+        transliterator: Any,
+        allow_existing: bool,
+    ) -> None:
+        normalizer = IndicNameNormalizer(
+            similarity_threshold=similarity_threshold,
+            transliterator=transliterator,
+        )
+        metadata = {
+            "backend": "user-supplied" if transliterator is not None else "stdlib",
+            "enabled": bool(enabled),
+            "normalizer_version": INDIC_NAME_KEY_VERSION,
+            "similarity_threshold": normalizer.similarity_threshold,
+        }
+        current = self.store.name_matching_metadata
+        changed = bool(current and current != metadata)
+        if self.entries() and changed and not allow_existing:
+            raise ValueError(
+                "name matching configuration cannot change after vault entries exist"
+            )
+        self._transliteration_aware_name_matching = bool(enabled)
+        self._indic_name_normalizer = normalizer
+        self.store.set_name_matching_metadata(metadata)
+
     def _source_proof(self, source: SurrogateSource) -> str:
-        identity = _source_identity(source)
+        identity = self._source_identity(source)
         material = json.dumps(
             {
                 "canonical_label": identity.canonical_label,
@@ -1096,10 +1371,10 @@ class SurrogateVault:
                 missing.append(entry.key.text_hash)
                 continue
             next_key = self._key_for_epoch(matched_source, to_key)
-            identity = _source_identity(matched_source)
+            identity = self._source_identity(matched_source)
             next_surrogate = (
                 canonical_indian_name(entry.surrogate)
-                if identity.render_script is not None
+                if identity.key_lang == _INDIAN_NAME_KEY_LANG
                 else entry.surrogate
             )
             next_entry = SurrogateEntry(next_key, next_surrogate, to_key.key_id)

--- a/openmed/core/surrogate_vault.py
+++ b/openmed/core/surrogate_vault.py
@@ -19,6 +19,8 @@ import tempfile
 import unicodedata
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+from math import isfinite
+from numbers import Real
 from pathlib import Path
 from threading import RLock
 from typing import AbstractSet, Any, Callable
@@ -27,6 +29,7 @@ from .indic_name_match import (
     DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD,
     INDIC_NAME_KEY_VERSION,
     IndicNameNormalizer,
+    detect_name_script,
     is_indic_name_candidate,
 )
 from .labels import PERSON, normalize_label
@@ -47,6 +50,18 @@ _KEY_ID_BYTES = 8
 _NONCE_BYTES = 16
 _INDIAN_NAME_KEY_LANG = "india"
 _INDIAN_NAME_LABELS = frozenset({"PERSON", "FIRST_NAME", "LAST_NAME"})
+_SCRIPT_NAME_PREFIXES = {
+    "bengali": "BENGALI",
+    "devanagari": "DEVANAGARI",
+    "gurmukhi": "GURMUKHI",
+    "gujarati": "GUJARATI",
+    "kannada": "KANNADA",
+    "latin": "LATIN",
+    "malayalam": "MALAYALAM",
+    "odia": "ORIYA",
+    "tamil": "TAMIL",
+    "telugu": "TELUGU",
+}
 
 
 @dataclass(frozen=True, order=True)
@@ -276,6 +291,67 @@ class _EpochManager:
         }
 
 
+def _validated_name_matching_metadata(
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if not metadata:
+        return {}
+    allowed = {
+        "backend",
+        "enabled",
+        "normalizer_version",
+        "similarity_threshold",
+    }
+    unknown = set(metadata) - allowed
+    if unknown:
+        raise ValueError(
+            "surrogate vault name_matching may not contain fields: "
+            + ", ".join(sorted(map(str, unknown)))
+        )
+    if set(metadata) != allowed:
+        raise ValueError("surrogate vault name_matching metadata is incomplete")
+    backend = metadata["backend"]
+    enabled = metadata["enabled"]
+    version = metadata["normalizer_version"]
+    threshold = metadata["similarity_threshold"]
+    if backend not in {"stdlib", "user-supplied"}:
+        raise ValueError("surrogate vault name_matching backend is unsupported")
+    if not isinstance(enabled, bool):
+        raise ValueError("surrogate vault name_matching enabled must be boolean")
+    if version != INDIC_NAME_KEY_VERSION:
+        raise ValueError("surrogate vault name_matching version is unsupported")
+    if isinstance(threshold, bool) or not isinstance(threshold, Real):
+        raise ValueError(
+            "surrogate vault name_matching similarity_threshold must be numeric"
+        )
+    numeric_threshold = float(threshold)
+    if not isfinite(numeric_threshold) or not 0.5 <= numeric_threshold <= 1.0:
+        raise ValueError(
+            "surrogate vault name_matching similarity_threshold is out of range"
+        )
+    return {
+        "backend": backend,
+        "enabled": enabled,
+        "normalizer_version": version,
+        "similarity_threshold": numeric_threshold,
+    }
+
+
+def _name_matching_tag(metadata: Mapping[str, Any], epoch: _EpochKey) -> str:
+    material = json.dumps(
+        dict(metadata),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    digest = hmac.new(
+        epoch.encryption_key,
+        b"openmed-surrogate-vault:name-matching:1:" + material,
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{HMAC_SCHEME}:{digest}"
+
+
 class InMemorySurrogateStore:
     """In-memory store for surrogate vault entries."""
 
@@ -289,7 +365,9 @@ class InMemorySurrogateStore:
         self._entries: dict[SurrogateKey, SurrogateEntry] = {}
         self._lock = RLock()
         self._epoch_manager = epoch_manager
-        self._name_matching_metadata = dict(name_matching_metadata or {})
+        self._name_matching_metadata = _validated_name_matching_metadata(
+            name_matching_metadata
+        )
         for entry in entries:
             self.set(entry.key, entry.surrogate, key_id=entry.key_id)
 
@@ -323,7 +401,7 @@ class InMemorySurrogateStore:
         """Replace non-sensitive name-matching configuration metadata."""
 
         with self._lock:
-            self._name_matching_metadata = dict(metadata)
+            self._name_matching_metadata = _validated_name_matching_metadata(metadata)
 
     def get(self, key: SurrogateKey) -> str | None:
         """Return the surrogate for ``key``, if present."""
@@ -403,6 +481,10 @@ class InMemorySurrogateStore:
         }
         if self._name_matching_metadata:
             payload["name_matching"] = dict(self._name_matching_metadata)
+            payload["name_matching_tag"] = _name_matching_tag(
+                self._name_matching_metadata,
+                current_key,
+            )
         entries_payload: list[dict[str, str]] = []
         for entry in self.entries():
             key_id = entry.key_id or current_key.key_id
@@ -465,10 +547,22 @@ class InMemorySurrogateStore:
         metadata = payload.get("name_matching") or {}
         if not isinstance(metadata, Mapping):
             raise ValueError("surrogate vault name_matching must be an object")
+        validated_metadata = _validated_name_matching_metadata(metadata)
+        persisted_tag = payload.get("name_matching_tag")
+        if validated_metadata:
+            if not isinstance(persisted_tag, str):
+                raise ValueError("surrogate vault name_matching_tag is required")
+            expected_tag = _name_matching_tag(validated_metadata, current_key)
+            if not hmac.compare_digest(persisted_tag, expected_tag):
+                raise ValueError("surrogate vault name_matching metadata is invalid")
+        elif persisted_tag is not None:
+            raise ValueError(
+                "surrogate vault name_matching_tag requires name_matching metadata"
+            )
         return cls(
             entries,
             epoch_manager=manager,
-            name_matching_metadata=metadata,
+            name_matching_metadata=validated_metadata,
         )
 
     @classmethod
@@ -501,10 +595,13 @@ class InMemorySurrogateStore:
         metadata = payload.get("name_matching") or {}
         if not isinstance(metadata, Mapping):
             raise ValueError("surrogate vault name_matching must be an object")
+        if metadata or payload.get("name_matching_tag") is not None:
+            raise ValueError(
+                "legacy surrogate vaults may not contain name_matching metadata"
+            )
         return cls(
             entries,
             epoch_manager=manager,
-            name_matching_metadata=metadata,
         )
 
 
@@ -636,6 +733,18 @@ def _matches_required_script(candidate: str, required_script: str | None) -> boo
     )
 
 
+def _matches_render_script(candidate: str, render_script: str | None) -> bool:
+    if render_script is None:
+        return True
+    prefix = _SCRIPT_NAME_PREFIXES.get(render_script.casefold())
+    if prefix is None:
+        return False
+    letters = [char for char in candidate if char.isalpha()]
+    return bool(letters) and all(
+        unicodedata.name(char, "").startswith(f"{prefix} ") for char in letters
+    )
+
+
 def _contains_indian_name(candidate: str, canonical_source: str) -> bool:
     if candidate == canonical_source:
         return True
@@ -677,8 +786,10 @@ class SurrogateVault:
 
         persisted = self.store.name_matching_metadata
         if transliteration_aware_name_matching is None and config is not None:
-            transliteration_aware_name_matching = bool(
-                getattr(config, "transliteration_aware_name_matching", False)
+            transliteration_aware_name_matching = getattr(
+                config,
+                "transliteration_aware_name_matching",
+                False,
             )
         if indic_name_similarity_threshold is None and config is not None:
             indic_name_similarity_threshold = float(
@@ -689,7 +800,7 @@ class SurrogateVault:
                 )
             )
         if transliteration_aware_name_matching is None:
-            transliteration_aware_name_matching = bool(persisted.get("enabled", False))
+            transliteration_aware_name_matching = persisted.get("enabled", False)
         if indic_name_similarity_threshold is None:
             indic_name_similarity_threshold = float(
                 persisted.get(
@@ -697,6 +808,9 @@ class SurrogateVault:
                     DEFAULT_INDIC_NAME_SIMILARITY_THRESHOLD,
                 )
             )
+
+        if not isinstance(transliteration_aware_name_matching, bool):
+            raise TypeError("transliteration_aware_name_matching must be a boolean")
 
         persisted_backend = str(persisted.get("backend", ""))
         if (
@@ -708,18 +822,14 @@ class SurrogateVault:
                 "this vault requires the user-supplied Indic transliterator "
                 "used when it was created"
             )
-        if (
-            not persisted
-            and self.entries()
-            and bool(transliteration_aware_name_matching)
-        ):
+        if not persisted and self.entries() and transliteration_aware_name_matching:
             raise ValueError(
                 "transliteration-aware matching cannot be enabled on a legacy "
                 "vault that already contains entries"
             )
         self._set_name_matching(
-            enabled=bool(transliteration_aware_name_matching),
-            similarity_threshold=float(indic_name_similarity_threshold),
+            enabled=transliteration_aware_name_matching,
+            similarity_threshold=indic_name_similarity_threshold,
             transliterator=transliterator,
             allow_existing=persisted == {},
         )
@@ -956,26 +1066,30 @@ class SurrogateVault:
             candidate = create_surrogate(attempt)
             if not candidate:
                 continue
+            rendered_candidate: str
             if identity.key_lang == _INDIAN_NAME_KEY_LANG:
                 candidate = canonical_indian_name(candidate)
                 if not candidate:
                     continue
                 leaks_source = _contains_indian_name(candidate, identity.key_text)
+                render_script = identity.render_script
+                assert render_script is not None
                 rendered_candidate = render_indian_name(
                     candidate,
-                    identity.render_script,
+                    render_script,
                 )
             elif identity.key_lang == "indic":
                 leaks_source = self._indic_candidate_leaks_source(
                     candidate,
                     source_text,
                 )
-                rendered_candidate = self._render_for_source(
+                rendered_value = self._render_for_source(
                     candidate,
                     source,
                     renderer=render_surrogate,
                 )
-                assert rendered_candidate is not None
+                assert rendered_value is not None
+                rendered_candidate = rendered_value
                 leaks_source = leaks_source or _contains_source_surface(
                     rendered_candidate,
                     source_text,
@@ -1246,8 +1360,8 @@ class SurrogateVault:
             and canonical_label == PERSON
             and is_indic_name_candidate(source.source_text, lang=effective_lang)
         ):
-            script = indian_name_script(source.source_text, effective_lang)
-            if script is not None:
+            script = detect_name_script(source.source_text)
+            if script in _SCRIPT_NAME_PREFIXES:
                 return _SourceIdentity(
                     canonical_label=canonical_label,
                     key_lang="indic",
@@ -1269,20 +1383,35 @@ class SurrogateVault:
             return None
         identity = self._source_identity(source)
         if identity.key_lang == "indic":
-            rendered = (
-                renderer(stored_surrogate)
-                if renderer is not None
-                else self.indic_name_normalizer.render_surrogate(
-                    stored_surrogate,
-                    source_surface=source.source_text,
-                )
+            if renderer is not None:
+                rendered = renderer(stored_surrogate)
+                if (
+                    rendered
+                    and _matches_render_script(rendered, identity.render_script)
+                    and not _contains_source_surface(rendered, source.source_text)
+                ):
+                    return rendered
+            rendered = self.indic_name_normalizer.render_surrogate(
+                stored_surrogate,
+                source_surface=source.source_text,
             )
-            if not rendered or _contains_source_surface(rendered, source.source_text):
-                return stored_surrogate
-            return rendered
+            if (
+                rendered
+                and _matches_render_script(rendered, identity.render_script)
+                and not _contains_source_surface(rendered, source.source_text)
+            ):
+                return rendered
+            placeholder = self.indic_name_normalizer.render_surrogate(
+                "Person",
+                source_surface=source.source_text,
+            )
+            if not _matches_render_script(placeholder, identity.render_script):
+                raise ValueError("unable to render Indic surrogate in source script")
+            return placeholder
         script = identity.render_script
         if script is None:
             return stored_surrogate
+        assert script is not None
         return render_indian_name(stored_surrogate, script)
 
     def _indic_candidate_leaks_source(
@@ -1303,13 +1432,15 @@ class SurrogateVault:
         transliterator: Any,
         allow_existing: bool,
     ) -> None:
+        if not isinstance(enabled, bool):
+            raise TypeError("enabled must be a boolean")
         normalizer = IndicNameNormalizer(
             similarity_threshold=similarity_threshold,
             transliterator=transliterator,
         )
         metadata = {
             "backend": "user-supplied" if transliterator is not None else "stdlib",
-            "enabled": bool(enabled),
+            "enabled": enabled,
             "normalizer_version": INDIC_NAME_KEY_VERSION,
             "similarity_threshold": normalizer.similarity_threshold,
         }
@@ -1319,7 +1450,7 @@ class SurrogateVault:
             raise ValueError(
                 "name matching configuration cannot change after vault entries exist"
             )
-        self._transliteration_aware_name_matching = bool(enabled)
+        self._transliteration_aware_name_matching = enabled
         self._indic_name_normalizer = normalizer
         self.store.set_name_matching_metadata(metadata)
 

--- a/openmed/eval/golden/README.md
+++ b/openmed/eval/golden/README.md
@@ -39,6 +39,9 @@ Required fields:
 - `metadata.category`: one of `nested_overlapping`, `chunk_boundary`,
   `multilingual`, `checksum_ids`, `financial_ids`, `date_arithmetic`,
   `policy_profile_actions`, `hard_negatives`, or `critical_findings`.
+  The standalone `indic_name_variants` fixture uses its dedicated consistency
+  suite schema because it groups multiple spellings under one synthetic
+  identity rather than representing detector spans.
 - `metadata.expected_output`: expected post-action output, including `method`
   and resulting `text`.
 - `metadata.synthetic`: must be `true`.

--- a/openmed/eval/golden/fixtures/indic_name_variants.json
+++ b/openmed/eval/golden/fixtures/indic_name_variants.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "category": "indic_name_variants",
+    "contains_real_phi": false,
+    "synthetic": true
+  },
+  "groups": [
+    {
+      "id": "synthetic-sanjay",
+      "language": "hi",
+      "note": "Synthetic patient संजय is also written as Sanjay and Sanjai.",
+      "variants": ["संजय", "Sanjay", "Sanjai"],
+      "negative_surfaces": ["Sanjana"]
+    },
+    {
+      "id": "synthetic-krishna",
+      "language": "hi",
+      "note": "Synthetic patient कृष्णा is also written as Krishna and Krishnaa.",
+      "variants": ["कृष्णा", "Krishna", "Krishnaa"],
+      "negative_surfaces": ["Kritika"]
+    },
+    {
+      "id": "synthetic-lakshmi",
+      "language": "hi",
+      "note": "Synthetic patient लक्ष्मी is also written as Lakshmi and Laxmi.",
+      "variants": ["लक्ष्मी", "Lakshmi", "Laxmi"],
+      "negative_surfaces": ["Lakshman"]
+    }
+  ]
+}

--- a/openmed/eval/golden/loader.py
+++ b/openmed/eval/golden/loader.py
@@ -49,6 +49,7 @@ _SPECIALIZED_FIXTURE_NAMES = frozenset(
         "code_mixed_deidentification.jsonl",
         "grounding_crosslingual.jsonl",
         "india_clinical.jsonl",
+        "indic_name_variants.json",
         "relation_assertion.jsonl",
         "relation_gold.jsonl",
         "surrogate_multilingual.jsonl",
@@ -177,7 +178,11 @@ def list_fixture_paths(path: str | Path | None = None) -> tuple[Path, ...]:
     if fixture_path.is_file():
         return (fixture_path,)
     paths = [
-        *fixture_path.glob("*.json"),
+        *(
+            path
+            for path in fixture_path.glob("*.json")
+            if path.name not in _SPECIALIZED_FIXTURE_NAMES
+        ),
         *(
             path
             for path in fixture_path.glob("**/*.jsonl")

--- a/openmed/eval/suites/__init__.py
+++ b/openmed/eval/suites/__init__.py
@@ -97,6 +97,12 @@ from openmed.eval.suites.indian_ids import (
     load_indian_id_fixtures,
     run_indian_id_evaluation,
 )
+from openmed.eval.suites.indic_name_consistency import (
+    INDIC_NAME_CONSISTENCY,
+    evaluate_indic_name_consistency,
+    indic_name_consistency_metadata,
+    load_indic_name_fixtures,
+)
 from openmed.eval.suites.multimodal_dicom import (
     MULTIMODAL_DICOM,
     generate_synthetic_dicom_corpus,
@@ -150,6 +156,7 @@ DEFAULT_SUITES: tuple[str, ...] = (
     CODE_MIXED_ROUTING,
     INDIA_HEALTH_ID_LEAKAGE,
     INDIAN_MULTI_ID,
+    INDIC_NAME_CONSISTENCY,
 )
 
 
@@ -209,6 +216,8 @@ def load_suite_fixtures(name: str, **kwargs: Any) -> list[Any]:
         return load_india_health_id_fixtures(**kwargs)
     if suite == INDIAN_MULTI_ID:
         return load_indian_id_fixtures(kwargs.get("path"))
+    if suite == INDIC_NAME_CONSISTENCY:
+        return load_indic_name_fixtures(kwargs.get("path"))
     raise ValueError(f"benchmark suite {suite!r} does not have a concrete loader yet")
 
 
@@ -246,6 +255,8 @@ def suite_metadata(name: str, **kwargs: Any) -> dict[str, Any]:
         return india_health_id_metadata(**kwargs)
     if suite == INDIAN_MULTI_ID:
         return indian_id_suite_metadata(**kwargs)
+    if suite == INDIC_NAME_CONSISTENCY:
+        return indic_name_consistency_metadata(**kwargs)
     return {"suite": suite}
 
 
@@ -343,6 +354,7 @@ __all__ = [
     "CODE_MIXED_ROUTING",
     "INDIA_HEALTH_ID_LEAKAGE",
     "INDIAN_MULTI_ID",
+    "INDIC_NAME_CONSISTENCY",
     "RELATIONS",
     "RelationFixture",
     "RelationTrap",
@@ -405,4 +417,7 @@ __all__ = [
     "indian_id_suite_metadata",
     "load_indian_id_fixtures",
     "run_indian_id_evaluation",
+    "load_indic_name_fixtures",
+    "indic_name_consistency_metadata",
+    "evaluate_indic_name_consistency",
 ]

--- a/openmed/eval/suites/indic_name_consistency.py
+++ b/openmed/eval/suites/indic_name_consistency.py
@@ -1,0 +1,289 @@
+"""Synthetic consistency gate for Indic personal-name surrogates."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openmed.core.anonymizer import Anonymizer
+from openmed.core.indic_name_match import detect_name_script
+from openmed.core.surrogate_vault import SurrogateVault
+
+INDIC_NAME_CONSISTENCY = "indic-name-consistency"
+INDIC_NAME_FIXTURE_PATH = (
+    Path(__file__).parents[1] / "golden" / "fixtures" / "indic_name_variants.json"
+)
+_EVAL_SECRET = "openmed-synthetic-indic-name-consistency"
+
+
+@dataclass(frozen=True)
+class IndicNameVariantGroup:
+    """One synthetic identity, its spellings, and collision negatives."""
+
+    fixture_id: str
+    language: str
+    note: str
+    variants: tuple[str, ...]
+    negative_surfaces: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class IndicNameConsistencyResult:
+    """Aggregate privacy-safe outcome for the Indic name consistency gate."""
+
+    passed: bool
+    group_count: int
+    variant_count: int
+    surrogate_identity_count: int
+    collision_count: int
+    leakage_count: int
+    script_mismatch_count: int
+    deterministic: bool
+    failures: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-ready result without raw name surfaces."""
+
+        return {
+            "collision_count": self.collision_count,
+            "deterministic": self.deterministic,
+            "failures": list(self.failures),
+            "group_count": self.group_count,
+            "leakage_count": self.leakage_count,
+            "passed": self.passed,
+            "script_mismatch_count": self.script_mismatch_count,
+            "surrogate_identity_count": self.surrogate_identity_count,
+            "variant_count": self.variant_count,
+        }
+
+
+@dataclass(frozen=True)
+class _RunEvidence:
+    identity_hashes: tuple[str, ...]
+    rendered_surrogates: tuple[str, ...]
+    collision_count: int
+    leakage_count: int
+    script_mismatch_count: int
+    failures: tuple[str, ...]
+
+
+def load_indic_name_fixtures(
+    path: str | Path | None = None,
+) -> list[IndicNameVariantGroup]:
+    """Load and validate the bundled synthetic Indic name fixture set."""
+
+    fixture_path = Path(path) if path is not None else INDIC_NAME_FIXTURE_PATH
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != 1:
+        raise ValueError("Indic name fixture schema_version must be 1")
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict) or metadata.get("synthetic") is not True:
+        raise ValueError("Indic name fixtures must be explicitly synthetic")
+    if metadata.get("contains_real_phi") is not False:
+        raise ValueError("Indic name fixtures must declare contains_real_phi=false")
+
+    groups_payload = payload.get("groups")
+    if not isinstance(groups_payload, list) or not groups_payload:
+        raise ValueError("Indic name fixtures must contain at least one group")
+    groups: list[IndicNameVariantGroup] = []
+    seen_ids: set[str] = set()
+    for item in groups_payload:
+        if not isinstance(item, dict):
+            raise ValueError("Indic name fixture groups must be objects")
+        fixture_id = str(item.get("id") or "")
+        variants = tuple(str(value) for value in item.get("variants") or ())
+        negatives = tuple(str(value) for value in item.get("negative_surfaces") or ())
+        if not fixture_id or fixture_id in seen_ids:
+            raise ValueError("Indic name fixture ids must be non-empty and unique")
+        if len(variants) < 3:
+            raise ValueError(f"{fixture_id} must contain at least three variants")
+        if not any(detect_name_script(value) != "latin" for value in variants):
+            raise ValueError(f"{fixture_id} must contain an Indic-script variant")
+        if sum(detect_name_script(value) == "latin" for value in variants) < 2:
+            raise ValueError(f"{fixture_id} must contain two Latin romanizations")
+        if not negatives:
+            raise ValueError(f"{fixture_id} must contain collision negatives")
+        seen_ids.add(fixture_id)
+        groups.append(
+            IndicNameVariantGroup(
+                fixture_id=fixture_id,
+                language=str(item.get("language") or "hi"),
+                note=str(item.get("note") or ""),
+                variants=variants,
+                negative_surfaces=negatives,
+            )
+        )
+    return groups
+
+
+def indic_name_consistency_metadata(
+    *,
+    fixture_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Return metadata for the synthetic Indic name consistency suite."""
+
+    resolved = Path(fixture_path) if fixture_path else INDIC_NAME_FIXTURE_PATH
+    return {
+        "collision_gate": "zero",
+        "fixture_path": str(resolved),
+        "leakage_gate": "zero",
+        "stdlib_fallback": True,
+        "suite": INDIC_NAME_CONSISTENCY,
+        "synthetic": True,
+    }
+
+
+def evaluate_indic_name_consistency(
+    fixtures: list[IndicNameVariantGroup] | None = None,
+    *,
+    similarity_threshold: float = 0.80,
+    seed: int = 668,
+) -> IndicNameConsistencyResult:
+    """Evaluate identity reuse, collisions, leakage, scripts, and determinism."""
+
+    resolved = fixtures if fixtures is not None else load_indic_name_fixtures()
+    first = _run_once(
+        resolved,
+        similarity_threshold=similarity_threshold,
+        seed=seed,
+    )
+    second = _run_once(
+        resolved,
+        similarity_threshold=similarity_threshold,
+        seed=seed,
+    )
+    deterministic = (
+        first.identity_hashes == second.identity_hashes
+        and first.rendered_surrogates == second.rendered_surrogates
+    )
+    failures = list(first.failures)
+    if not deterministic:
+        failures.append("suite:nondeterministic")
+    group_count = len(resolved)
+    return IndicNameConsistencyResult(
+        passed=(
+            not failures
+            and first.collision_count == 0
+            and first.leakage_count == 0
+            and first.script_mismatch_count == 0
+            and deterministic
+        ),
+        group_count=group_count,
+        variant_count=sum(len(group.variants) for group in resolved),
+        surrogate_identity_count=len(set(first.identity_hashes)),
+        collision_count=first.collision_count,
+        leakage_count=first.leakage_count,
+        script_mismatch_count=first.script_mismatch_count,
+        deterministic=deterministic,
+        failures=tuple(failures),
+    )
+
+
+def _run_once(
+    fixtures: list[IndicNameVariantGroup],
+    *,
+    similarity_threshold: float,
+    seed: int,
+) -> _RunEvidence:
+    vault = SurrogateVault.in_memory(
+        _EVAL_SECRET,
+        transliteration_aware_name_matching=True,
+        indic_name_similarity_threshold=similarity_threshold,
+    )
+    anonymizer = Anonymizer(
+        lang="hi",
+        consistent=True,
+        seed=seed,
+        transliteration_aware_name_matching=True,
+        indic_name_normalizer=vault.indic_name_normalizer,
+    )
+    identity_hashes: list[str] = []
+    rendered_surrogates: list[str] = []
+    failures: list[str] = []
+    collision_count = 0
+    leakage_count = 0
+    script_mismatch_count = 0
+
+    for group in fixtures:
+        group_keys = [
+            vault.key_for(surface, label="PERSON", lang=group.language)
+            for surface in group.variants
+        ]
+        if len({key.text_hash for key in group_keys}) != 1:
+            failures.append(f"{group.fixture_id}:identity_mismatch")
+        identity_hashes.append(group_keys[0].text_hash)
+
+        replacements: dict[str, str] = {}
+        for surface in group.variants:
+
+            def create(attempt: int, source: str = surface) -> str:
+                return anonymizer.surrogate_identity(
+                    source,
+                    "PERSON",
+                    lang=group.language,
+                    attempt=attempt,
+                )
+
+            def render(identity: str, source: str = surface) -> str:
+                return anonymizer.render_name_surrogate(
+                    identity,
+                    source_surface=source,
+                )
+
+            replacement = vault.get_or_create(
+                surface,
+                label="PERSON",
+                lang=group.language,
+                create_surrogate=create,
+                render_surrogate=render,
+            )
+            replacements[surface] = replacement
+            rendered_surrogates.append(replacement)
+            source_script = detect_name_script(surface)
+            if (
+                source_script != "other"
+                and detect_name_script(replacement) != source_script
+            ):
+                script_mismatch_count += 1
+                failures.append(f"{group.fixture_id}:script_mismatch")
+
+        output = group.note
+        for surface in sorted(group.variants, key=len, reverse=True):
+            output = output.replace(surface, replacements[surface])
+        folded_output = output.casefold()
+        if any(surface.casefold() in folded_output for surface in group.variants):
+            leakage_count += 1
+            failures.append(f"{group.fixture_id}:variant_leakage")
+
+        group_key = group_keys[0]
+        for negative in group.negative_surfaces:
+            negative_key = vault.key_for(
+                negative,
+                label="PERSON",
+                lang=group.language,
+            )
+            if negative_key == group_key:
+                collision_count += 1
+                failures.append(f"{group.fixture_id}:negative_collision")
+
+    return _RunEvidence(
+        identity_hashes=tuple(identity_hashes),
+        rendered_surrogates=tuple(rendered_surrogates),
+        collision_count=collision_count,
+        leakage_count=leakage_count,
+        script_mismatch_count=script_mismatch_count,
+        failures=tuple(failures),
+    )
+
+
+__all__ = [
+    "INDIC_NAME_CONSISTENCY",
+    "INDIC_NAME_FIXTURE_PATH",
+    "IndicNameConsistencyResult",
+    "IndicNameVariantGroup",
+    "evaluate_indic_name_consistency",
+    "indic_name_consistency_metadata",
+    "load_indic_name_fixtures",
+]

--- a/tests/unit/core/test_indic_name_match.py
+++ b/tests/unit/core/test_indic_name_match.py
@@ -1,0 +1,258 @@
+"""Tests for transliteration-aware Indic personal-name matching."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.core.anonymizer import Anonymizer
+from openmed.core.config import OpenMedConfig
+from openmed.core.indic_name_match import (
+    IndicNameNormalizer,
+    canonical_indic_name_key,
+    detect_name_script,
+    indic_names_match,
+)
+from openmed.core.pii import deidentify
+from openmed.core.surrogate_vault import SurrogateVault
+from openmed.processing.outputs import EntityPrediction, PredictionResult
+
+
+@pytest.mark.parametrize(
+    ("variants", "expected_suffix"),
+    [
+        (("संजय", "Sanjay", "Sanjai"), "sanjay"),
+        (("कृष्णा", "Krishna", "Krishnaa"), "krishna"),
+        (("लक्ष्मी", "Lakshmi", "Laxmi"), "lakshmi"),
+    ],
+)
+def test_stdlib_normalizer_folds_script_and_romanization_variants(
+    variants,
+    expected_suffix,
+):
+    keys = {canonical_indic_name_key(surface) for surface in variants}
+
+    assert keys == {f"indic-name-v1:{expected_suffix}"}
+
+
+def test_collision_gate_keeps_distinct_names_separate():
+    assert indic_names_match("संजय", "Sanjai") is True
+    assert indic_names_match("Sanjay", "Sanjana") is False
+
+
+def test_similarity_threshold_is_validated_and_tunable():
+    assert indic_names_match("Sanjay", "Sanjai", similarity_threshold=0.80)
+    assert not indic_names_match("Sanjay", "Sanjai", similarity_threshold=0.90)
+    with pytest.raises(ValueError, match="between 0.5 and 1.0"):
+        IndicNameNormalizer(similarity_threshold=0.49)
+
+
+def test_user_supplied_transliterator_is_used_without_bundled_weights():
+    class LocalAdapter:
+        def to_latin(self, text: str) -> str:
+            assert text == "सं जय"
+            return "Sanjai"
+
+        def from_latin(self, text: str, target_script: str) -> str:
+            assert target_script == "devanagari"
+            return "नव नाम"
+
+    normalizer = IndicNameNormalizer(transliterator=LocalAdapter())
+
+    assert normalizer.canonical_key("सं जय") == "indic-name-v1:sanjay"
+    assert normalizer.render_surrogate("New Name", source_surface="सं जय") == "नव नाम"
+
+
+def test_stdlib_rendering_preserves_source_script_class():
+    normalizer = IndicNameNormalizer()
+    rendered = normalizer.render_surrogate(
+        "Ketan Sharma",
+        source_surface="संजय",
+    )
+
+    assert detect_name_script(rendered) == "devanagari"
+    assert (
+        normalizer.render_surrogate(
+            "Ketan Sharma",
+            source_surface="Sanjay",
+        )
+        == "Ketan Sharma"
+    )
+
+
+def test_anonymizer_reuses_identity_while_rendering_each_script():
+    anonymizer = Anonymizer(
+        lang="hi",
+        consistent=True,
+        seed=668,
+        transliteration_aware_name_matching=True,
+    )
+    variants = ("संजय", "Sanjay", "Sanjai")
+
+    identities = {
+        anonymizer.surrogate_identity(surface, "PERSON", lang="hi")
+        for surface in variants
+    }
+    assert len(identities) == 1
+    assert anonymizer.surrogate("Sanjay", "PERSON", lang="hi") == anonymizer.surrogate(
+        "Sanjai", "PERSON", lang="hi"
+    )
+    assert (
+        detect_name_script(anonymizer.surrogate("संजय", "PERSON", lang="hi"))
+        == "devanagari"
+    )
+
+
+def test_config_round_trip_and_environment(monkeypatch):
+    config = OpenMedConfig.from_dict(
+        {
+            "transliteration_aware_name_matching": True,
+            "indic_name_similarity_threshold": 0.85,
+        }
+    )
+    assert config.to_dict()["transliteration_aware_name_matching"] is True
+    assert config.to_dict()["indic_name_similarity_threshold"] == 0.85
+
+    monkeypatch.setenv("OPENMED_TRANSLITERATION_AWARE_NAME_MATCHING", "1")
+    monkeypatch.setenv("OPENMED_INDIC_NAME_SIMILARITY_THRESHOLD", "0.90")
+    environment_config = OpenMedConfig()
+    assert environment_config.transliteration_aware_name_matching is True
+    assert environment_config.indic_name_similarity_threshold == 0.90
+
+
+def test_vault_links_variants_and_renders_one_identity_per_script(tmp_path):
+    path = tmp_path / "indic-vault.json"
+    vault = SurrogateVault.from_file(
+        path,
+        hmac_secret="synthetic-test-secret",
+        transliteration_aware_name_matching=True,
+    )
+
+    def create(attempt: int) -> str:
+        return "Ketan Sharma" if attempt == 0 else f"Ketan Sharma {attempt}"
+
+    normalizer = vault.indic_name_normalizer
+    surfaces = {}
+    for source in ("संजय", "Sanjay", "Sanjai"):
+        surfaces[source] = vault.get_or_create(
+            source,
+            label="PERSON",
+            lang="hi",
+            create_surrogate=create,
+            render_surrogate=lambda identity, source=source: (
+                normalizer.render_surrogate(identity, source_surface=source)
+            ),
+        )
+
+    assert len(vault.entries()) == 1
+    assert {entry.surrogate for entry in vault.entries()} == {"Ketan Sharma"}
+    assert surfaces["Sanjay"] == surfaces["Sanjai"] == "Ketan Sharma"
+    assert detect_name_script(surfaces["संजय"]) == "devanagari"
+    assert (
+        detect_name_script(vault.get("संजय", label="PERSON", lang="hi") or "")
+        == "devanagari"
+    )
+    assert vault.get("Sanjai", label="PERSON", lang="hi") == "Ketan Sharma"
+    assert vault.key_for("Sanjay", label="PERSON", lang="hi").lang == "indic"
+
+    negative_key = vault.key_for("Sanjana", label="PERSON", lang="hi")
+    assert negative_key != vault.key_for("Sanjay", label="PERSON", lang="hi")
+
+    persisted = path.read_text(encoding="utf-8")
+    assert all(source not in persisted for source in ("संजय", "Sanjay", "Sanjai"))
+    payload = json.loads(persisted)
+    assert payload["name_matching"] == {
+        "backend": "stdlib",
+        "enabled": True,
+        "normalizer_version": "indic-name-v1",
+        "similarity_threshold": 0.8,
+    }
+
+    reloaded = SurrogateVault.from_file(
+        path,
+        hmac_secret="synthetic-test-secret",
+    )
+    assert reloaded.transliteration_aware_name_matching is True
+    assert reloaded.get("Sanjai", label="PERSON", lang="hi") == "Ketan Sharma"
+
+
+def test_disabled_vault_keeps_existing_exact_cross_script_behavior():
+    vault = SurrogateVault.in_memory(
+        "synthetic-test-secret",
+        transliteration_aware_name_matching=False,
+    )
+    for index, source in enumerate(("संजय", "Sanjay", "Sanjai")):
+        vault.get_or_create(
+            source,
+            label="PERSON",
+            lang="hi",
+            create_surrogate=lambda attempt, index=index: f"Synthetic {index}",
+        )
+
+    assert vault.key_for("संजय", label="PERSON", lang="hi") == vault.key_for(
+        "Sanjay", label="PERSON", lang="hi"
+    )
+    assert vault.key_for("Sanjai", label="PERSON", lang="hi") != vault.key_for(
+        "Sanjay", label="PERSON", lang="hi"
+    )
+    assert len(vault.entries()) == 2
+
+
+def test_deidentify_config_enables_code_mixed_vault_matching(monkeypatch):
+    text = "Synthetic patient संजय is also Sanjay and Sanjai."
+    variants = ("संजय", "Sanjay", "Sanjai")
+
+    def fake_extract(value: str, *args, **kwargs) -> PredictionResult:
+        entities = [
+            EntityPrediction(
+                text=surface,
+                label="PERSON",
+                start=value.index(surface),
+                end=value.index(surface) + len(surface),
+                confidence=0.99,
+            )
+            for surface in variants
+        ]
+        return PredictionResult(
+            text=value,
+            entities=entities,
+            model_name="synthetic-test",
+            timestamp="now",
+        )
+
+    monkeypatch.setattr("openmed.core.pii.extract_pii", fake_extract)
+    config = OpenMedConfig(transliteration_aware_name_matching=True)
+    vault = SurrogateVault.in_memory("synthetic-test-secret")
+
+    result = deidentify(
+        text,
+        method="replace",
+        lang="hi",
+        config=config,
+        consistent=True,
+        seed=668,
+        surrogate_vault=vault,
+        use_safety_sweep=False,
+    )
+
+    assert len(vault.entries()) == 1
+    assert (
+        len({vault.key_for(surface, label="PERSON", lang="hi") for surface in variants})
+        == 1
+    )
+    assert len({entry.surrogate for entry in vault.entries()}) == 1
+    assert all(surface not in result.deidentified_text for surface in variants)
+    latin_surrogates = {
+        entity.surrogate
+        for entity in result.pii_entities
+        if detect_name_script(entity.original_text or "") == "latin"
+    }
+    assert len(latin_surrogates) == 1
+    indic_surrogate = next(
+        entity.surrogate
+        for entity in result.pii_entities
+        if detect_name_script(entity.original_text or "") == "devanagari"
+    )
+    assert indic_surrogate is not None
+    assert detect_name_script(indic_surrogate) == "devanagari"

--- a/tests/unit/core/test_indic_name_match.py
+++ b/tests/unit/core/test_indic_name_match.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+import unicodedata
 
 import pytest
 
 from openmed.core.anonymizer import Anonymizer
 from openmed.core.config import OpenMedConfig
 from openmed.core.indic_name_match import (
+    MAX_INDIC_NAME_SURFACE_CHARS,
     IndicNameNormalizer,
     canonical_indic_name_key,
     detect_name_script,
@@ -46,6 +48,22 @@ def test_similarity_threshold_is_validated_and_tunable():
     assert not indic_names_match("Sanjay", "Sanjai", similarity_threshold=0.90)
     with pytest.raises(ValueError, match="between 0.5 and 1.0"):
         IndicNameNormalizer(similarity_threshold=0.49)
+    with pytest.raises(TypeError, match="real number"):
+        IndicNameNormalizer(similarity_threshold=True)
+    with pytest.raises(ValueError, match="between 0.5 and 1.0"):
+        IndicNameNormalizer(similarity_threshold=float("nan"))
+
+
+def test_oversized_surfaces_use_distinct_bounded_fallback_keys():
+    normalizer = IndicNameNormalizer()
+    prefix = "S" * MAX_INDIC_NAME_SURFACE_CHARS
+
+    first = normalizer.canonical_key(f"{prefix}a")
+    second = normalizer.canonical_key(f"{prefix}b")
+
+    assert first.startswith("indic-name-v1:overflow:")
+    assert second.startswith("indic-name-v1:overflow:")
+    assert first != second
 
 
 def test_user_supplied_transliterator_is_used_without_bundled_weights():
@@ -79,6 +97,77 @@ def test_stdlib_rendering_preserves_source_script_class():
         )
         == "Ketan Sharma"
     )
+
+
+def test_stdlib_rendering_never_leaves_latin_letters_in_indic_output():
+    rendered = IndicNameNormalizer().render_surrogate(
+        "Victor Xavier C. Fox",
+        source_surface="संजय",
+    )
+
+    letters = [char for char in rendered if char.isalpha()]
+    assert letters
+    assert all(unicodedata.name(char, "").startswith("DEVANAGARI ") for char in letters)
+
+
+@pytest.mark.parametrize(
+    ("surface", "lang", "script", "unicode_prefix"),
+    [
+        ("रवि", "hi", "devanagari", "DEVANAGARI "),
+        ("রবি", "bn", "bengali", "BENGALI "),
+        ("ਰਵੀ", "pa", "gurmukhi", "GURMUKHI "),
+        ("રવિ", "gu", "gujarati", "GUJARATI "),
+        ("ରବି", "or", "odia", "ORIYA "),
+        ("ரவி", "ta", "tamil", "TAMIL "),
+        ("రవి", "te", "telugu", "TELUGU "),
+        ("ರವಿ", "kn", "kannada", "KANNADA "),
+        ("രവി", "ml", "malayalam", "MALAYALAM "),
+    ],
+)
+def test_vault_renders_supported_brahmic_scripts_without_mixed_letters(
+    surface,
+    lang,
+    script,
+    unicode_prefix,
+):
+    vault = SurrogateVault.in_memory(
+        "synthetic-test-secret",
+        transliteration_aware_name_matching=True,
+    )
+
+    rendered = vault.get_or_create(
+        surface,
+        label="PERSON",
+        lang=lang,
+        create_surrogate=lambda attempt: "Victor Xavier C. Fox",
+    )
+
+    assert vault.key_for(surface, label="PERSON", lang=lang).lang == "indic"
+    assert detect_name_script(rendered) == script
+    letters = [char for char in rendered if char.isalpha()]
+    assert letters
+    assert all(
+        unicodedata.name(char, "").startswith(unicode_prefix) for char in letters
+    )
+
+
+def test_vault_rejects_mixed_script_renderer_output():
+    vault = SurrogateVault.in_memory(
+        "synthetic-test-secret",
+        transliteration_aware_name_matching=True,
+    )
+
+    rendered = vault.get_or_create(
+        "संजय",
+        label="PERSON",
+        lang="hi",
+        create_surrogate=lambda attempt: "Victor Cross",
+        render_surrogate=lambda identity: "विक्टरMixed",
+    )
+
+    letters = [char for char in rendered if char.isalpha()]
+    assert letters
+    assert all(unicodedata.name(char, "").startswith("DEVANAGARI ") for char in letters)
 
 
 def test_anonymizer_reuses_identity_while_rendering_each_script():
@@ -119,6 +208,14 @@ def test_config_round_trip_and_environment(monkeypatch):
     environment_config = OpenMedConfig()
     assert environment_config.transliteration_aware_name_matching is True
     assert environment_config.indic_name_similarity_threshold == 0.90
+
+    monkeypatch.setenv("OPENMED_TRANSLITERATION_AWARE_NAME_MATCHING", " false ")
+    assert OpenMedConfig().transliteration_aware_name_matching is False
+
+    with pytest.raises(TypeError, match="must be a boolean"):
+        OpenMedConfig(transliteration_aware_name_matching="false")
+    with pytest.raises(TypeError, match="real number"):
+        OpenMedConfig(indic_name_similarity_threshold=True)
 
 
 def test_vault_links_variants_and_renders_one_identity_per_script(tmp_path):
@@ -168,6 +265,7 @@ def test_vault_links_variants_and_renders_one_identity_per_script(tmp_path):
         "normalizer_version": "indic-name-v1",
         "similarity_threshold": 0.8,
     }
+    assert payload["name_matching_tag"].startswith("hmac-sha256:")
 
     reloaded = SurrogateVault.from_file(
         path,
@@ -175,6 +273,35 @@ def test_vault_links_variants_and_renders_one_identity_per_script(tmp_path):
     )
     assert reloaded.transliteration_aware_name_matching is True
     assert reloaded.get("Sanjai", label="PERSON", lang="hi") == "Ketan Sharma"
+
+
+def test_file_vault_rejects_tampered_name_matching_metadata(tmp_path):
+    path = tmp_path / "tampered-indic-vault.json"
+    vault = SurrogateVault.from_file(
+        path,
+        hmac_secret="synthetic-test-secret",
+        transliteration_aware_name_matching=True,
+    )
+    vault.get_or_create(
+        "Sanjay",
+        label="PERSON",
+        lang="hi",
+        create_surrogate=lambda attempt: "Ketan Sharma",
+    )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["name_matching"]["similarity_threshold"] = 0.9
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="metadata is invalid"):
+        SurrogateVault.from_file(path, hmac_secret="synthetic-test-secret")
+
+
+def test_vault_rejects_ambiguous_matching_flag():
+    with pytest.raises(TypeError, match="must be a boolean"):
+        SurrogateVault.in_memory(
+            "synthetic-test-secret",
+            transliteration_aware_name_matching="false",
+        )
 
 
 def test_disabled_vault_keeps_existing_exact_cross_script_behavior():

--- a/tests/unit/eval/suites/test_indic_name_consistency.py
+++ b/tests/unit/eval/suites/test_indic_name_consistency.py
@@ -1,0 +1,34 @@
+"""Tests for the synthetic Indic name consistency evaluation suite."""
+
+from openmed.eval.suites import (
+    INDIC_NAME_CONSISTENCY,
+    evaluate_indic_name_consistency,
+    load_indic_name_fixtures,
+    load_suite_fixtures,
+    suite_metadata,
+)
+
+
+def test_indic_name_fixture_loader_and_registry():
+    fixtures = load_indic_name_fixtures()
+
+    assert len(fixtures) == 3
+    assert load_suite_fixtures(INDIC_NAME_CONSISTENCY) == fixtures
+    metadata = suite_metadata(INDIC_NAME_CONSISTENCY)
+    assert metadata["suite"] == INDIC_NAME_CONSISTENCY
+    assert metadata["synthetic"] is True
+    assert metadata["leakage_gate"] == "zero"
+
+
+def test_indic_name_consistency_gate_passes_stdlib_fallback():
+    result = evaluate_indic_name_consistency()
+
+    assert result.passed is True
+    assert result.group_count == 3
+    assert result.variant_count == 9
+    assert result.surrogate_identity_count == 3
+    assert result.collision_count == 0
+    assert result.leakage_count == 0
+    assert result.script_mismatch_count == 0
+    assert result.deterministic is True
+    assert result.failures == ()

--- a/tests/unit/eval/test_metrics.py
+++ b/tests/unit/eval/test_metrics.py
@@ -53,6 +53,7 @@ def test_eval_modules_import_cleanly():
         "code_mixed_routing",
         "india_health_id_leakage",
         "indian_multi_id",
+        "indic-name-consistency",
     )
 
 


### PR DESCRIPTION
## Description

Adds opt-in transliteration-aware matching for Indic personal names so Devanagari and Latin spelling variants reuse one privacy-safe surrogate identity while emitting a surrogate in the source script. The implementation includes a deterministic standard-library fallback, an adapter boundary for user-supplied local transliteration weights, collision controls, persisted vault configuration metadata, synthetic fixtures, and a dedicated consistency gate.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Canonicalize supported Indic scripts and common Latin romanization variants before HMAC vault keying.
- Store one encrypted Latin surrogate identity and render script-appropriate output surfaces without persisting raw names.
- Add opt-in configuration, a tunable similarity threshold, synthetic code-mixed fixtures, collision negatives, and deterministic evaluation coverage.

## Testing

- [x] Added tests for variant identity reuse, distinct-name collision safety, zero code-mixed leakage, deterministic fallback behavior, file persistence, and script-aware rendering.
- [x] Full test suite passes locally: 5,212 passed, 46 skipped.
- [x] Canonical formatting, lint, scoped type checks, strict documentation build, and repository hooks pass.

## Documentation

- [x] Updated configuration documentation.
- [x] Added usage and optional local-weights documentation.
- [x] Added docstrings to new public functions and classes.
- [ ] Changelog update is not required for this scoped feature PR.

## Code Quality

- [x] Performed a self-review.
- [x] Added comments for the collision-safe phonetic fold and persistence behavior.
- [x] No new dependencies or warnings were introduced.

## Related Issues

Closes #1494

## Examples

The bundled synthetic gate verifies that `संजय`, `Sanjay`, and `Sanjai` share one vault identity, while `Sanjana` remains distinct.
