### PR TITLE
Add a Nix flake for reproducible builds and dev shells

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,42 @@
+name: Nix
+
+on:
+  push:
+    branches: [main, master, develop]
+    paths:
+      - ".github/workflows/nix.yml"
+      - "flake.lock"
+      - "flake.nix"
+      - "openmed/**"
+      - "pyproject.toml"
+      - "tests/**"
+  pull_request:
+    branches: [main, master, develop]
+    paths:
+      - ".github/workflows/nix.yml"
+      - "flake.lock"
+      - "flake.nix"
+      - "openmed/**"
+      - "pyproject.toml"
+      - "tests/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  flake-check:
+    name: Build package and dev shell
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31.11.0
+
+      - name: Check flake outputs
+        run: nix flake check --print-build-logs
+
+      - name: Run the test suite in the dev shell
+        run: nix develop --command python -m pytest tests/ -q

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,63 @@
+# Nix Development
+
+OpenMed includes a Nix flake for a pinned package build and a reproducible
+development shell. This is an additional build path for NixOS and nix-darwin
+users; the existing uv and pip workflows remain supported.
+
+## Enter the development shell
+
+Install Nix with flakes enabled, clone the repository, and run:
+
+```bash
+nix develop
+```
+
+The shell provides Python 3.12, OpenMed, the tools and Python packages from the
+`dev` extra, and the test-only PyArrow dependency used by the collected suite.
+Optional ML and platform extras such as MLX and Core ML are not part of the Nix
+shell.
+
+Run the same test command used by the repository gate:
+
+```bash
+python -m pytest tests/ -q
+```
+
+For a single non-interactive command, use:
+
+```bash
+nix develop --command python -m pytest tests/ -q
+```
+
+## Build the package
+
+Build the default OpenMed package with:
+
+```bash
+nix build
+```
+
+The `result` symlink points to the package in the Nix store. The package uses
+`buildPythonPackage` with Hatchling and contains the `openmed` command and
+Python package.
+
+## Validate and update the pin
+
+Run the flake checks before submitting a Nix-related change:
+
+```bash
+nix flake check --print-build-logs
+```
+
+This builds both the OpenMed package and development shell. CI also runs the
+complete test suite inside that shell on Linux.
+
+`flake.lock` records the exact nixpkgs 26.05 revision and content hash. Update
+that pin only as an intentional dependency-maintenance change, then validate
+and commit both lock and flake files together:
+
+```bash
+nix flake update
+nix flake check --print-build-logs
+nix develop --command python -m pytest tests/ -q
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784280462,
+        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
             build-system = [ python.pkgs.hatchling ];
             dependencies = with python.pkgs; [
               faker
+              jieba
               pysbd
               pyyaml
             ];
@@ -93,15 +94,18 @@
 
           devPythonPackages =
             (with python.pkgs; [
+              cryptography
               dask
               duckdb
               fastapi
               fsspec
+              huggingface-hub
               httpx
               hypothesis
               jsonschema
               mypy
               numpy
+              opencc
               opentelemetry-api
               opentelemetry-exporter-otlp-proto-http
               opentelemetry-sdk
@@ -111,7 +115,10 @@
               protobuf
               pytest
               pytest-cov
+              pytest-timeout
               python-dateutil
+              rich
+              typer
             ])
             ++ [
               grpcio

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,147 @@
+{
+  description = "OpenMed reproducible package and development shell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          python = pkgs.python312;
+          version = builtins.elemAt (
+            builtins.match
+              ''.*__version__ = "([^"]+)".*''
+              (builtins.replaceStrings [ "\n" ] [ " " ] (builtins.readFile ./openmed/__about__.py))
+          ) 0;
+        in
+        rec {
+          openmed = python.pkgs.buildPythonPackage {
+            pname = "openmed";
+            inherit version;
+            pyproject = true;
+
+            src = self;
+
+            build-system = [ python.pkgs.hatchling ];
+            dependencies = with python.pkgs; [
+              faker
+              pysbd
+              pyyaml
+            ];
+
+            # The full suite runs in the development shell in nix.yml. Keeping
+            # package checks import-only avoids pulling development tools into
+            # the runtime closure.
+            doCheck = false;
+            pythonImportsCheck = [ "openmed" ];
+
+            meta = {
+              description = "Local-first clinical NLP and de-identification toolkit";
+              homepage = "https://github.com/maziyarpanahi/openmed";
+              license = pkgs.lib.licenses.asl20;
+              mainProgram = "openmed";
+            };
+          };
+
+          default = openmed;
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          python = pkgs.python312;
+          openmed = self.packages.${system}.openmed;
+
+          # The generated service stubs require grpcio >= 1.81.1. Keep the
+          # runtime and code generator paired until that patch release lands
+          # in the pinned nixpkgs branch.
+          grpcio = python.pkgs.grpcio.overridePythonAttrs (_: {
+            version = "1.81.1";
+            src = pkgs.fetchPypi {
+              pname = "grpcio";
+              version = "1.81.1";
+              hash = "sha256-b6EKdnFDpegujqq1ORivDNiQmleif4yyKIuAphOsZxs=";
+            };
+          });
+          grpcio-tools = python.pkgs.grpcio-tools.overridePythonAttrs (_: {
+            version = "1.81.1";
+            src = pkgs.fetchPypi {
+              pname = "grpcio_tools";
+              version = "1.81.1";
+              hash = "sha256-oio4cBgJJ/3YTisn0HnvW39fjGEQGBtnNq/BekY0gfE=";
+            };
+            dependencies = [
+              grpcio
+              python.pkgs.protobuf
+              python.pkgs.setuptools
+            ];
+          });
+
+          devPythonPackages =
+            (with python.pkgs; [
+              dask
+              duckdb
+              fastapi
+              fsspec
+              httpx
+              hypothesis
+              jsonschema
+              mypy
+              numpy
+              opentelemetry-api
+              opentelemetry-exporter-otlp-proto-http
+              opentelemetry-sdk
+              pandas
+              pyarrow
+              polars
+              protobuf
+              pytest
+              pytest-cov
+              python-dateutil
+            ])
+            ++ [
+              grpcio
+              grpcio-tools
+              openmed
+            ];
+          pythonPath = python.pkgs.makePythonPath devPythonPackages;
+        in
+        {
+          default = pkgs.mkShell {
+            packages =
+              [
+                python
+                pkgs.pre-commit
+                pkgs.ruff
+              ]
+              ++ devPythonPackages;
+
+            # Use the unwrapped interpreter so subprocess sandbox checks see
+            # the real standard-library prefix rather than a symlink farm.
+            shellHook = ''
+              export PYTHONPATH="${pythonPath}''${PYTHONPATH:+:}$PYTHONPATH"
+            '';
+          };
+        }
+      );
+
+      checks = forAllSystems (system: {
+        package = self.packages.${system}.openmed;
+        dev-shell = self.devShells.${system}.default;
+      });
+    };
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
       - Onboarding: onboarding.md
       - v1 to v2 Migration: migration.md
       - Contributing & Releases: contributing.md
+      - Nix Development: development.md
       - Reproducible Dependencies: contributing/reproducible-dependencies.md
       - Security & Disclosure: security/disclosure-policy.md
       - Redactor Threat Model: security/threat-model.md


### PR DESCRIPTION
# Pull Request

## Description
Adds a pinned Nix flake that builds the OpenMed Python package and provides a reproducible Python 3.12 development shell with the repository's development and test dependencies. A Linux CI workflow now builds the flake outputs and runs the full suite inside the shell.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Add `flake.nix` and a committed `flake.lock` pinned to nixpkgs 26.05.
- Package OpenMed through `buildPythonPackage` with Hatchling and expose a development shell for all supported Linux and macOS architectures.
- Add a Linux flake validation workflow and document `nix develop`, `nix build`, checks, and intentional lock updates.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Validated with:
- `nix flake check --print-build-logs`
- `nix build --no-link --print-build-logs`
- `nix flake show --all-systems`
- `nix develop --command python -m pytest tests/ -q` (5,180 passed, 61 skipped)
- `.venv/bin/python -m pytest tests/ -q` (5,186 passed, 55 skipped)
- `actionlint .github/workflows/nix.yml`
- `.venv/bin/python scripts/release/check_github_actions_refs.py`
- `uv run --extra docs mkdocs build --strict`
- `.venv/bin/pre-commit run --files .github/workflows/nix.yml docs/development.md flake.lock flake.nix mkdocs.yml`

## Documentation
- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [ ] I have not added any new dependencies
- [x] OR I have added new dependencies and they are justified because: the flake pins nixpkgs as the reproducible Nix package source and CI installs Nix through a versioned action; Python runtime dependencies are unchanged.

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1464

## Screenshots/Examples
Not applicable; this change adds build, shell, CI, and documentation surfaces.
