### PR TITLE
Add executable UDF column redaction adapter

### DIFF
--- a/examples/executable-udf/README.md
+++ b/examples/executable-udf/README.md
@@ -1,0 +1,88 @@
+# Executable UDF column redaction
+
+OpenMed can run as a one-column `TabSeparated` transform for ClickHouse-style
+executable user-defined functions. Each input row on stdin produces exactly one
+redacted output row on stdout, in the same order. The adapter buffers rows and
+reuses one model loader across batches; it never writes raw values to logs or
+diagnostics.
+
+Install OpenMed and cache the selected PII model before enabling the function.
+The database host can then run with `OPENMED_OFFLINE=1` so query-time inference
+does not require network access.
+
+## Run the adapter directly
+
+The package installs a dedicated console entrypoint:
+
+```bash
+printf 'Patient Jane Roe called 555-0100\n' \
+  | OPENMED_OFFLINE=1 openmed-executable-udf --batch-size 32
+```
+
+Output is one escaped TSV string per row:
+
+```text
+Patient [NAME] called [PHONE]
+```
+
+Use `--policy`, `--method`, `--model-name`, `--lang`, and
+`--confidence-threshold` to select the same de-identification behavior used by
+the Python API. The default safety sweep stays enabled.
+
+## Register the ClickHouse function
+
+ClickHouse searches direct executable commands under its configured
+`user_scripts_path`. Create `/var/lib/clickhouse/user_scripts/openmed-redact`
+with an absolute path to the environment where OpenMed is installed:
+
+```sh
+#!/bin/sh
+export OPENMED_OFFLINE=1
+exec /opt/openmed/.venv/bin/openmed-executable-udf "$@"
+```
+
+Make the wrapper executable, readable only as appropriate for the ClickHouse
+service account, and test it as that account. Then add
+`/etc/clickhouse-server/openmed_redact_function.xml`:
+
+```xml
+<functions>
+    <function>
+        <type>executable</type>
+        <name>openmed_redact</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>String</type>
+            <name>text</name>
+        </argument>
+        <format>TabSeparated</format>
+        <command>openmed-redact --batch-size 32</command>
+        <execute_direct>true</execute_direct>
+        <send_chunk_header>false</send_chunk_header>
+        <command_read_timeout>120000</command_read_timeout>
+        <command_write_timeout>120000</command_write_timeout>
+        <stderr_reaction>throw</stderr_reaction>
+        <check_exit_code>true</check_exit_code>
+    </function>
+</functions>
+```
+
+Ensure the server's `user_defined_executable_functions_config` pattern matches
+that XML filename, reload the configuration, and confirm the function is
+available before using it:
+
+```sql
+SELECT name, origin
+FROM system.functions
+WHERE name = 'openmed_redact';
+
+SELECT openmed_redact(note_text)
+FROM synthetic_notes;
+```
+
+The adapter expects exactly one non-nullable `String` argument serialized as
+`TabSeparated`. It rejects extra TSV columns and fails the query when batch
+redaction cannot return exactly one valid result for every input row.
+
+See the [ClickHouse executable UDF documentation](https://clickhouse.com/docs/sql-reference/functions/udf#executable-user-defined-functions)
+for server paths, configuration reload behavior, and executable settings.

--- a/openmed/integrations/__init__.py
+++ b/openmed/integrations/__init__.py
@@ -6,6 +6,13 @@ from .columnar_redactor import (
     redact_columnar,
     redact_columnar_dataset,
 )
+from .executable_udf import (
+    DEFAULT_EXECUTABLE_UDF_MODEL,
+    ExecutableUDFConfig,
+    ExecutableUDFError,
+    redact_tsv_lines,
+    redact_tsv_stream,
+)
 from .lakehouse_redact import (
     LakehouseRedactionProgress,
     LakehouseRedactionResult,
@@ -34,12 +41,15 @@ from .spark_streaming import (
 __all__ = [
     "ColumnarProgress",
     "ColumnarRedactionResult",
+    "DEFAULT_EXECUTABLE_UDF_MODEL",
     "DEFAULT_LOG_MESSAGE_FIELDS",
     "DEFAULT_LOG_REDACTION_MODEL",
     "DEFAULT_BATCH_ID_COLUMN",
     "DEFAULT_SPARK_POLICY",
     "LakehouseRedactionProgress",
     "LakehouseRedactionResult",
+    "ExecutableUDFConfig",
+    "ExecutableUDFError",
     "LogRedactorConfig",
     "LogRedactorError",
     "SparkDeidentifyColumn",
@@ -53,5 +63,7 @@ __all__ = [
     "redact_log_events",
     "redact_ndjson_lines",
     "redact_ndjson_stream",
+    "redact_tsv_lines",
+    "redact_tsv_stream",
     "write_deidentified_stream",
 ]

--- a/openmed/integrations/executable_udf.py
+++ b/openmed/integrations/executable_udf.py
@@ -1,0 +1,378 @@
+"""Executable UDF adapter for streaming column redaction over stdin/stdout.
+
+The adapter implements a one-column ClickHouse ``TabSeparated`` transform:
+each input row contains one escaped string value and each output row contains
+the corresponding redacted value. Input rows are buffered into bounded batches
+before they are passed to :func:`openmed.processing.batch.process_batch`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, TextIO
+
+from openmed.core import ModelLoader
+from openmed.core.pii_i18n import DEFAULT_PII_MODELS
+from openmed.processing.batch import process_batch
+
+DEFAULT_EXECUTABLE_UDF_MODEL = DEFAULT_PII_MODELS["en"]
+
+_TSV_DECODE_ESCAPES = {
+    "0": "\0",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "\\": "\\",
+    "'": "'",
+}
+_TSV_ENCODE_ESCAPES = {
+    "\\": "\\\\",
+    "\0": "\\0",
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+}
+
+
+class ExecutableUDFError(RuntimeError):
+    """Raised when an executable UDF batch cannot be redacted safely."""
+
+
+@dataclass(frozen=True)
+class ExecutableUDFConfig:
+    """Configuration for the executable UDF stream.
+
+    Args:
+        batch_size: Maximum number of rows passed to one batch call.
+        model_name: PII model passed to batch de-identification.
+        method: De-identification method.
+        confidence_threshold: Minimum confidence for PII detection.
+        deidentify_kwargs: Extra keyword arguments forwarded to batch
+            de-identification.
+    """
+
+    batch_size: int = 32
+    model_name: str = DEFAULT_EXECUTABLE_UDF_MODEL
+    method: str = "mask"
+    confidence_threshold: float | None = 0.7
+    deidentify_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.batch_size < 1:
+            raise ValueError("batch_size must be positive")
+
+
+def redact_tsv_lines(
+    lines: Iterable[str],
+    *,
+    batch_size: int = 32,
+    model_name: str = DEFAULT_EXECUTABLE_UDF_MODEL,
+    method: str = "mask",
+    confidence_threshold: float | None = 0.7,
+    config: Any | None = None,
+    loader: Any | None = None,
+    **deidentify_kwargs: Any,
+) -> Iterator[str]:
+    """Yield redacted one-column TabSeparated rows.
+
+    A single shared model loader is reused for every buffered batch so a model
+    is not reloaded as the stream advances. Blank values are emitted as blank
+    output rows without calling the model; no input rows are skipped.
+
+    Args:
+        lines: Iterable containing one ClickHouse TabSeparated string per row.
+        batch_size: Maximum number of rows passed to one batch call.
+        model_name: PII model passed to batch de-identification.
+        method: De-identification method.
+        confidence_threshold: Minimum confidence for PII detection.
+        config: Optional OpenMed configuration.
+        loader: Optional shared model loader. A loader is created once when
+            omitted.
+        **deidentify_kwargs: Extra keyword arguments forwarded to batch
+            de-identification.
+
+    Yields:
+        Escaped redacted values with exactly one trailing newline per row.
+
+    Raises:
+        ExecutableUDFError: If input is not one-column TSV or batch redaction
+            fails, returns the wrong cardinality, or returns invalid results.
+    """
+
+    udf_config = ExecutableUDFConfig(
+        batch_size=batch_size,
+        model_name=model_name,
+        method=method,
+        confidence_threshold=confidence_threshold,
+        deidentify_kwargs=deidentify_kwargs,
+    )
+    shared_loader = loader if loader is not None else ModelLoader(config)
+    batch: list[str] = []
+
+    for line_number, raw_line in enumerate(lines, start=1):
+        batch.append(_parse_tsv_row(raw_line, line_number=line_number))
+        if len(batch) >= udf_config.batch_size:
+            yield from _redact_batch(
+                batch,
+                udf_config,
+                config=config,
+                loader=shared_loader,
+            )
+            batch = []
+
+    if batch:
+        yield from _redact_batch(
+            batch,
+            udf_config,
+            config=config,
+            loader=shared_loader,
+        )
+
+
+def redact_tsv_stream(
+    input_stream: TextIO,
+    output_stream: TextIO,
+    *,
+    batch_size: int = 32,
+    model_name: str = DEFAULT_EXECUTABLE_UDF_MODEL,
+    method: str = "mask",
+    confidence_threshold: float | None = 0.7,
+    config: Any | None = None,
+    loader: Any | None = None,
+    **deidentify_kwargs: Any,
+) -> int:
+    """Redact a one-column TabSeparated stream.
+
+    Args:
+        input_stream: Text stream containing one escaped string per row.
+        output_stream: Text stream receiving one redacted string per row.
+        batch_size: Maximum number of rows passed to one batch call.
+        model_name: PII model passed to batch de-identification.
+        method: De-identification method.
+        confidence_threshold: Minimum confidence for PII detection.
+        config: Optional OpenMed configuration.
+        loader: Optional shared model loader.
+        **deidentify_kwargs: Extra keyword arguments forwarded to batch
+            de-identification.
+
+    Returns:
+        Number of rows emitted.
+    """
+
+    emitted = 0
+    for redacted_line in redact_tsv_lines(
+        input_stream,
+        batch_size=batch_size,
+        model_name=model_name,
+        method=method,
+        confidence_threshold=confidence_threshold,
+        config=config,
+        loader=loader,
+        **deidentify_kwargs,
+    ):
+        output_stream.write(redacted_line)
+        emitted += 1
+        if emitted % batch_size == 0:
+            output_stream.flush()
+    output_stream.flush()
+    return emitted
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    """Run the executable UDF stdin/stdout transform.
+
+    Args:
+        argv: Optional command-line arguments.
+        stdin: Optional input stream override.
+        stdout: Optional output stream override.
+        stderr: Optional error stream override.
+
+    Returns:
+        Zero on success and one when the transform fails.
+    """
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    input_stream = stdin if stdin is not None else sys.stdin
+    output_stream = stdout if stdout is not None else sys.stdout
+    error_stream = stderr if stderr is not None else sys.stderr
+
+    try:
+        redact_tsv_stream(
+            input_stream,
+            output_stream,
+            batch_size=args.batch_size,
+            model_name=args.model_name,
+            method=args.method,
+            confidence_threshold=args.confidence_threshold,
+            lang=args.lang,
+            policy=args.policy,
+            keep_year=args.keep_year,
+            use_safety_sweep=args.use_safety_sweep,
+        )
+    except Exception:
+        error_stream.write("executable UDF redaction failed\n")
+        return 1
+
+    return 0
+
+
+def _redact_batch(
+    texts: Sequence[str],
+    udf_config: ExecutableUDFConfig,
+    *,
+    config: Any | None,
+    loader: Any,
+) -> Iterator[str]:
+    nonempty_positions = [index for index, text in enumerate(texts) if text]
+    if not nonempty_positions:
+        yield from ("\n" for _ in texts)
+        return
+
+    batch_texts = [texts[index] for index in nonempty_positions]
+    kwargs = dict(udf_config.deidentify_kwargs)
+    kwargs.update(
+        {
+            "operation": "deidentify",
+            "batch_size": len(batch_texts),
+            "continue_on_error": False,
+            "loader": loader,
+            "method": udf_config.method,
+            "confidence_threshold": udf_config.confidence_threshold,
+        }
+    )
+
+    try:
+        result = process_batch(
+            batch_texts,
+            model_name=udf_config.model_name,
+            config=config,
+            **kwargs,
+        )
+    except Exception:
+        raise ExecutableUDFError("failed to redact an input batch") from None
+
+    items = list(getattr(result, "items", []))
+    if len(items) != len(batch_texts):
+        raise ExecutableUDFError("batch result count did not match input row count")
+
+    redacted_values: list[str | None] = [None] * len(texts)
+    for index, item in zip(nonempty_positions, items):
+        redacted_values[index] = _redacted_text(item)
+
+    for redacted in redacted_values:
+        yield "\n" if redacted is None else _encode_tsv_value(redacted) + "\n"
+
+
+def _redacted_text(item: Any) -> str:
+    if not getattr(item, "success", False):
+        raise ExecutableUDFError("one or more input rows could not be redacted")
+    redacted = getattr(getattr(item, "result", None), "deidentified_text", None)
+    if not isinstance(redacted, str):
+        raise ExecutableUDFError("batch redaction returned an invalid result")
+    return redacted
+
+
+def _parse_tsv_row(raw_line: str, *, line_number: int) -> str:
+    row = raw_line.removesuffix("\n").removesuffix("\r")
+    if "\t" in row:
+        raise ExecutableUDFError(
+            f"input line {line_number} contains more than one TSV column"
+        )
+    return _decode_tsv_value(row)
+
+
+def _decode_tsv_value(value: str) -> str:
+    decoded: list[str] = []
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if character != "\\" or index + 1 == len(value):
+            decoded.append(character)
+            index += 1
+            continue
+
+        escaped = value[index + 1]
+        decoded.append(_TSV_DECODE_ESCAPES.get(escaped, escaped))
+        index += 2
+    return "".join(decoded)
+
+
+def _encode_tsv_value(value: str) -> str:
+    return "".join(_TSV_ENCODE_ESCAPES.get(character, character) for character in value)
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Redact one ClickHouse TabSeparated string per stdin row.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=_positive_int,
+        default=32,
+        help="Number of rows buffered before batch redaction.",
+    )
+    parser.add_argument(
+        "--model-name",
+        default=DEFAULT_EXECUTABLE_UDF_MODEL,
+        help="PII model identifier passed to OpenMed batch de-identification.",
+    )
+    parser.add_argument(
+        "--method",
+        default="mask",
+        choices=("mask", "remove", "replace", "hash", "shift_dates"),
+        help="De-identification method.",
+    )
+    parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.7,
+        help="Minimum PII detection confidence.",
+    )
+    parser.add_argument(
+        "--lang",
+        default="en",
+        help="Language hint forwarded to de-identification.",
+    )
+    parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy profile forwarded to de-identification.",
+    )
+    parser.add_argument(
+        "--keep-year",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Keep or redact the year in detected dates.",
+    )
+    parser.add_argument(
+        "--use-safety-sweep",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable or disable deterministic structured-identifier detection.",
+    )
+    return parser
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ docs = [
 
 [project.scripts]
 openmed = "openmed.cli:main"
+openmed-executable-udf = "openmed.integrations.executable_udf:main"
 
 [tool.hatch.build]
 include = [

--- a/tests/unit/integrations/test_executable_udf.py
+++ b/tests/unit/integrations/test_executable_udf.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from openmed.integrations import executable_udf
+
+
+def _fake_redact(text: str) -> str:
+    return (
+        text.replace("Jane Roe", "[NAME]")
+        .replace("John Doe", "[NAME]")
+        .replace("555-0100", "[PHONE]")
+        .replace("jane.roe@example.org", "[EMAIL]")
+    )
+
+
+def _batch_result(texts: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                success=True,
+                result=SimpleNamespace(deidentified_text=_fake_redact(text)),
+            )
+            for text in texts
+        ]
+    )
+
+
+def test_stdin_stdout_adapter_redacts_every_row_in_order_and_batches(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+    shared_loader = object()
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        calls.append((list(texts), dict(kwargs)))
+        return _batch_result(list(texts))
+
+    monkeypatch.setattr(executable_udf, "process_batch", fake_process_batch)
+    input_rows = [
+        "Patient Jane Roe called 555-0100",
+        "No identifiers in this row",
+        "Escalate John Doe",
+        "",
+        "Email jane.roe@example.org",
+    ]
+    stdin = io.StringIO("\n".join(input_rows) + "\n")
+    stdout = io.StringIO()
+
+    emitted = executable_udf.redact_tsv_stream(
+        stdin,
+        stdout,
+        batch_size=2,
+        loader=shared_loader,
+        use_safety_sweep=False,
+    )
+
+    output_rows = stdout.getvalue().splitlines()
+    assert emitted == len(input_rows)
+    assert len(output_rows) == len(input_rows)
+    assert output_rows == [
+        "Patient [NAME] called [PHONE]",
+        "No identifiers in this row",
+        "Escalate [NAME]",
+        "",
+        "Email [EMAIL]",
+    ]
+    assert "Jane Roe" not in stdout.getvalue()
+    assert "John Doe" not in stdout.getvalue()
+    assert "555-0100" not in stdout.getvalue()
+    assert "jane.roe@example.org" not in stdout.getvalue()
+    assert [texts for texts, _ in calls] == [
+        input_rows[:2],
+        input_rows[2:3],
+        input_rows[4:],
+    ]
+    assert all(kwargs["operation"] == "deidentify" for _, kwargs in calls)
+    assert all(kwargs["continue_on_error"] is False for _, kwargs in calls)
+    assert all(kwargs["loader"] is shared_loader for _, kwargs in calls)
+    assert [kwargs["batch_size"] for _, kwargs in calls] == [2, 1, 1]
+    assert all(kwargs["use_safety_sweep"] is False for _, kwargs in calls)
+
+
+def test_tsv_escaping_round_trips_control_characters(monkeypatch) -> None:
+    received: list[str] = []
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        received.extend(texts)
+        return _batch_result(list(texts))
+
+    monkeypatch.setattr(executable_udf, "process_batch", fake_process_batch)
+    stdout = io.StringIO()
+
+    executable_udf.redact_tsv_stream(
+        io.StringIO("Jane Roe\\tcalled\\nagain\\\\soon\n"),
+        stdout,
+        loader=object(),
+    )
+
+    assert received == ["Jane Roe\tcalled\nagain\\soon"]
+    assert stdout.getvalue() == "[NAME]\\tcalled\\nagain\\\\soon\n"
+
+
+def test_cli_failure_does_not_echo_or_log_raw_phi(monkeypatch, caplog) -> None:
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        raise RuntimeError(f"model failed on {texts[0]}")
+
+    monkeypatch.setattr(executable_udf, "process_batch", fake_process_batch)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    code = executable_udf.main(
+        ["--batch-size", "2"],
+        stdin=io.StringIO("Patient Jane Roe called\n"),
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert code == 1
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == "executable UDF redaction failed\n"
+    assert "Jane Roe" not in stderr.getvalue()
+    assert "Jane Roe" not in caplog.text
+
+
+def test_cardinality_mismatch_fails_closed(monkeypatch) -> None:
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(items=[])
+
+    monkeypatch.setattr(executable_udf, "process_batch", fake_process_batch)
+
+    try:
+        list(
+            executable_udf.redact_tsv_lines(
+                ["Jane Roe\n"],
+                loader=object(),
+            )
+        )
+    except executable_udf.ExecutableUDFError as exc:
+        assert "result count" in str(exc)
+        assert "Jane Roe" not in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("cardinality mismatch should fail closed")
+
+
+def test_console_script_points_to_executable_udf_entrypoint() -> None:
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+    assert (
+        'openmed-executable-udf = "openmed.integrations.executable_udf:main"'
+        in pyproject
+    )


### PR DESCRIPTION
## Description

Adds a streaming executable UDF adapter that redacts one analytics-database text value per stdin row and emits exactly one ordered TSV result per stdout row. The process buffers bounded batches, reuses one model loader, and fails closed without exposing raw row text in diagnostics.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Added a one-column TabSeparated stdin/stdout adapter with bounded batching, shared model loading, escaping, cardinality checks, and PHI-safe errors.
- Added the `openmed-executable-udf` console entrypoint and public integration exports.
- Added a runnable direct-executable wrapper and XML configuration example.

## Testing

- [x] Added offline tests for ordered row redaction, batching, blank-row cardinality, TSV escaping, result-count mismatches, and PHI-safe failures.
- [x] New and existing unit tests pass locally.
- [x] Tested package construction and the generated console-script metadata.

Local validation:

- `make format`
- `make lint`
- `make format-check`
- `make type-check`
- `pre-commit run --files <changed files>`
- `make build`
- `.venv/bin/python -m pytest tests/ -q` — 5,203 passed, 46 skipped

## Documentation

- [x] Added executable UDF installation, offline runtime, configuration, and query examples.
- [x] Added docstrings to new public functions and classes.
- [ ] CHANGELOG.md is unchanged; release notes can include this feature when it ships.

## Code Quality

- [x] Ran the canonical Python formatting and lint checks.
- [x] Performed a self-review of the complete diff.
- [x] Kept stdout limited to redacted rows and failure diagnostics free of raw input.
- [x] The changes introduce no new warnings.

## Dependencies

- [x] No new dependencies were added.

## Checklist

- [x] Read the contributing guidelines.
- [x] Used a clear, focused commit.
- [x] Kept the branch scoped to OM-497.

## Related Issues

Closes #854

## Screenshots/Examples

Not applicable; the included example contains the runnable command, XML function definition, and SQL usage.
