### PR TITLE
test: locate py.typed through importlib.resources

### DIFF
--- a/tests/unit/test_packaging_typed.py
+++ b/tests/unit/test_packaging_typed.py
@@ -14,6 +14,7 @@ consumers:
 from __future__ import annotations
 
 import importlib
+import importlib.resources
 import inspect
 import subprocess
 import sys
@@ -51,8 +52,8 @@ def _load_pyproject() -> dict:
 
 
 def test_py_typed_marker_present_in_package() -> None:
-    """The PEP 561 marker must live inside the installed package tree."""
-    marker = PACKAGE_ROOT / "py.typed"
+    """The PEP 561 marker must be available as a package resource."""
+    marker = importlib.resources.files("openmed").joinpath("py.typed")
     assert marker.is_file(), (
         "openmed/py.typed marker is missing; downstream type checkers will treat "
         "openmed as untyped without it"


### PR DESCRIPTION
## Description
Use the package-resource API requested by #254 to verify that `openmed/py.typed` is discoverable at runtime. The marker, Hatch include entry, and explicit top-level return annotations are already present on `master`; this closes the remaining test-coverage gap without duplicating those changes.

## Type of Change
- [x] Test addition/improvement

## Changes Made
- Resolve the PEP 561 marker with `importlib.resources.files("openmed")`.
- Assert the resolved package resource is a file.
- Preserve the existing Hatch configuration and scoped type-check coverage.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs (not applicable)

Validation performed:
- `.venv/bin/python -m pytest tests/unit/test_packaging_typed.py -q` (7 passed)
- `.venv/bin/python -m pytest tests/ -q` (5,183 passed, 58 skipped)
- `make format`
- `make lint`
- `make format-check`
- `make type-check`
- `make clean build`
- verified `openmed/py.typed` is present in both the wheel and sdist

## Documentation
No documentation changes are needed for this test-only correction.

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #254

## Screenshots/Examples
Not applicable.