### PR TITLE
fix: format skills catalog test

### DIFF
--- a/tests/unit/test_skills_catalog.py
+++ b/tests/unit/test_skills_catalog.py
@@ -6,6 +6,7 @@ frontmatter, a folder/name mismatch, or accidental vendor attribution can't ship
 It reuses the repo's own ``skills/build_catalog.py`` validator (standard-library
 only) and additionally enforces strict-YAML parseability when PyYAML is present.
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -17,7 +18,9 @@ BUILDER = SKILLS_DIR / "build_catalog.py"
 
 
 def _load_builder():
-    spec = importlib.util.spec_from_file_location("openmed_skills_build_catalog", BUILDER)
+    spec = importlib.util.spec_from_file_location(
+        "openmed_skills_build_catalog", BUILDER
+    )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module


### PR DESCRIPTION
## Description
Restores the current `master` Ruff-format baseline for the skills catalog test added by #1743. Without this repair, any contributor branch refreshed from `master` fails the canonical lint job before its own changes are tested.

## Type of Change
- [x] Bug fix
- [x] Code refactoring

## Changes Made
- Format `tests/unit/test_skills_catalog.py` with the repository-pinned Ruff formatter.
- Keep the repair isolated from the contributor PRs it currently blocks.

## Testing
- `make lint`
- `make format-check` — 784 files already formatted
- `python -m pytest tests/unit/test_skills_catalog.py -q` — 4 passed
- `git diff --check`

## Documentation
- No documentation change required.

## Dependencies
- No new dependencies.

## Related Issues
Related to #1743

## Screenshots/Examples
Not applicable.