### PR TITLE
feat: make language packs source of truth

### DIFF
--- a/openmed/core/__init__.py
+++ b/openmed/core/__init__.py
@@ -24,6 +24,7 @@ from .language_pack import (
     LanguagePackRegistry,
     register_language_pack,
 )
+from .language_pack_catalog import REGISTERED_SEGMENTERS, is_registered_segmenter
 from .model_search import ModelQuery, ModelSearchResult, search_models
 from .models import ModelLoader, load_model
 from .offline import OfflineModeError
@@ -117,4 +118,6 @@ __all__ = [
     "LanguagePackRegistry",
     "LANGUAGE_PACK_REGISTRY",
     "register_language_pack",
+    "REGISTERED_SEGMENTERS",
+    "is_registered_segmenter",
 ]

--- a/openmed/core/anonymizer/locales.py
+++ b/openmed/core/anonymizer/locales.py
@@ -31,45 +31,7 @@ from __future__ import annotations
 import warnings
 from typing import Final, Mapping
 
-# Default conceptual Faker locale per OpenMed language code. Some conceptual
-# locales are backed by another installed Faker locale at runtime; see
-# ``FAKER_BACKEND_LOCALE``.
-LANG_TO_LOCALE: Final[Mapping[str, str]] = {
-    "en": "en_US",
-    "fr": "fr_FR",
-    "de": "de_DE",
-    "it": "it_IT",
-    "es": "es_ES",
-    "nl": "nl_NL",
-    "hi": "hi_IN",
-    "te": "en_IN",  # Faker has no Telugu locale; en_IN is the closest match
-    "pt": "pt_PT",
-    "ar": "ar_EG",  # Egypt is the most-populous Arabic-speaking country; override for Gulf/Levant locales.
-    "he": "he_IL",
-    "ja": "ja_JP",
-    "zh": "zh_CN",  # CJK PERSON spans draw family-name-first Chinese surrogates
-    "tr": "tr_TR",
-    "id": "id_ID",
-    "th": "th_TH",
-    "pl": "pl_PL",
-    "lv": "lv_LV",
-    "ko": "ko_KR",
-    "cs": "cs_CZ",
-    "sk": "sk_SK",
-    "ms": "ms_MY",
-    "tl": "fil_PH",
-    "da": "da_DK",
-    "ro": "ro_RO",
-    "fi": "fi_FI",
-    "bg": "bg_BG",
-    "hr": "hr_HR",
-    "sr": "sr_RS",  # Faker has no Serbian locale; backed by hr_HR at runtime
-    "hu": "hu_HU",
-    "et": "et_EE",
-    "el": "el_GR",
-    "vi": "vi_VN",
-}
-
+from ..language_pack_catalog import LANG_TO_LOCALE, NATIONAL_ID_PROVIDERS
 
 # Languages whose default locale is a known approximation rather than a
 # direct match. Used to emit a one-time warning so callers can override.
@@ -82,53 +44,6 @@ _APPROXIMATE_LOCALES: Final = frozenset({"te", "ms", "sr"})
 FAKER_BACKEND_LOCALE: Final[Mapping[str, str]] = {
     "ms_MY": "id_ID",
     "sr_RS": "hr_HR",
-}
-
-
-# Per-language national-ID surrogate providers — the single source of truth for
-# the OM-135 round-trip fidelity suite. Maps each language that has a
-# validator-backed national ID to the ``(faker_locale, faker_method)`` whose
-# generated surrogates pass that language's registered validator(s) in
-# :mod:`openmed.core.pii_i18n`. The locale here can differ from the language's
-# default display locale when the registered validators target another country's
-# format: Portuguese national-ID validation is Brazilian CPF/CNPJ, so ``pt``
-# draws ID surrogates from ``pt_BR`` even though its default locale (names,
-# addresses, ...) stays ``pt_PT``. The method must match the registry's
-# locale-aware dispatch (``registry._LOCALE_ID_METHODS``); the regression suite
-# asserts that and the round-trip.
-NATIONAL_ID_PROVIDERS: Final[Mapping[str, tuple[str, str]]] = {
-    "en": ("en_US", "ssn"),
-    "fr": ("fr_FR", "ssn"),  # NIR / INSEE
-    "de": ("de_DE", "german_steuer_id"),  # Steuer-ID
-    "it": ("it_IT", "ssn"),  # Codice Fiscale
-    "es": ("es_ES", "nie"),  # NIE
-    "nl": ("nl_NL", "ssn"),  # BSN
-    "hi": ("hi_IN", "aadhaar"),  # Aadhaar (Verhoeff)
-    "te": ("en_IN", "aadhaar"),  # Aadhaar via approximate en_IN
-    # CPF drives the OM-135 coherence round-trip; pt_PT surrogates draw NIF via
-    # the locale-keyed registry dispatch (``registry._LOCALE_ID_METHODS``).
-    "pt": ("pt_BR", "cpf"),
-    "tr": ("tr_TR", "ssn"),  # TCKN
-    "he": ("he_IL", "teudat_zehut"),  # Israeli Teudat Zehut
-    "id": ("id_ID", "indonesian_nik"),  # NIK
-    "th": ("th_TH", "thai_national_id"),  # Thai 13-digit national ID
-    "pl": ("pl_PL", "pesel"),  # PESEL
-    "lv": ("lv_LV", "personas_kods"),
-    "ko": ("ko_KR", "korean_rrn"),  # RRN
-    "cs": ("cs_CZ", "rodne_cislo"),  # Czech rodne cislo (shared provider)
-    "sk": ("sk_SK", "rodne_cislo"),  # Slovak rodne cislo
-    "ms": ("ms_MY", "mykad"),  # Malaysian MyKad / NRIC
-    "tl": ("fil_PH", "philsys_psn"),  # Philippine PhilSys PSN
-    "da": ("da_DK", "danish_cpr"),  # Danish CPR / personnummer
-    "ro": ("ro_RO", "romanian_cnp"),  # CNP (Cod Numeric Personal)
-    "fi": ("fi_FI", "ssn"),  # Finnish HETU (Faker's native fi_FI ssn)
-    "bg": ("bg_BG", "egn"),  # Bulgarian EGN (unified civil number)
-    "hr": ("hr_HR", "ssn"),  # Croatian OIB (Faker's native hr_HR ssn)
-    "sr": ("sr_RS", "jmbg"),  # Serbian / ex-Yugoslav JMBG
-    "hu": ("hu_HU", "hungarian_taj"),  # TAJ social-security identifier
-    "et": ("et_EE", "isikukood"),  # Estonian isikukood
-    "el": ("el_GR", "ssn"),  # Greek AMKA (Faker's native el_GR ssn)
-    "vi": ("vi_VN", "vietnamese_cccd"),  # 12-digit CCCD
 }
 
 

--- a/openmed/core/language_pack.py
+++ b/openmed/core/language_pack.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import math
 import re
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 from threading import RLock
 from types import MappingProxyType
@@ -153,6 +153,7 @@ class LanguagePackRegistry:
         """Create an empty registry."""
 
         self._packs: dict[str, LanguagePack] = {}
+        self._listeners: list[Callable[[], None]] = []
         self._lock = RLock()
 
     def register(
@@ -183,7 +184,34 @@ class LanguagePackRegistry:
             if pack.code in self._packs and not replace:
                 raise ValueError(f"language pack {pack.code!r} is already registered")
             self._packs[pack.code] = pack
+            listeners = tuple(self._listeners)
+        for listener in listeners:
+            listener()
         return pack
+
+    def _add_listener(
+        self,
+        listener: Callable[[], None],
+        *,
+        replay: bool = True,
+    ) -> None:
+        """Subscribe an internal live adapter to registry changes.
+
+        Args:
+            listener: Zero-argument callback that refreshes derived state.
+            replay: Invoke the callback immediately for the current snapshot.
+
+        Raises:
+            TypeError: If ``listener`` is not callable.
+        """
+
+        if not callable(listener):
+            raise TypeError("listener must be callable")
+        with self._lock:
+            if listener not in self._listeners:
+                self._listeners.append(listener)
+        if replay:
+            listener()
 
     def get(self, code: str) -> LanguagePack:
         """Return the pack registered for ``code``.

--- a/openmed/core/language_pack_catalog.py
+++ b/openmed/core/language_pack_catalog.py
@@ -1,0 +1,426 @@
+"""Declarative built-in language packs and live legacy-map adapters.
+
+The language-pack registry owns model-backed language declarations.  This
+module projects its current snapshot into the public ``set`` and ``dict``
+objects that predate language packs, keeping their existing runtime types while
+making one registry update visible across every downstream surface.
+
+National-ID-only languages remain explicit compatibility declarations because
+they do not yet satisfy the complete :class:`LanguagePack` contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from .language_pack import LANGUAGE_PACK_REGISTRY, LanguagePack, LanguagePackRegistry
+
+UNKNOWN_SCRIPT = "Unknown"
+UNROUTED_SCRIPT = "Unrouted"
+
+REGISTERED_SEGMENTERS = frozenset({"pysbd", "unicode-sentence"})
+
+
+def is_registered_segmenter(segmenter_id: str) -> bool:
+    """Return whether ``segmenter_id`` names an available sentence segmenter."""
+
+    return segmenter_id in REGISTERED_SEGMENTERS
+
+
+def _pack(
+    code: str,
+    model: str,
+    locale: str,
+    scripts: Sequence[str],
+    *,
+    national_id_provider: tuple[str, str] | None = None,
+) -> LanguagePack:
+    providers: dict[str, str] = {}
+    if national_id_provider is not None:
+        provider_locale, method = national_id_provider
+        providers[method] = provider_locale
+    return LanguagePack(
+        code=code,
+        scripts=tuple(scripts),
+        default_model=model,
+        segmenter_id="pysbd",
+        recognizers=("builtin-patterns", "model"),
+        surrogate_locale=locale,
+        national_id_providers=providers,
+    )
+
+
+BUILTIN_LANGUAGE_PACKS: tuple[LanguagePack, ...] = (
+    _pack(
+        "en",
+        "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+        "en_US",
+        ("Latin", "Cyrillic", "Greek", "Hebrew", "Thai", UNKNOWN_SCRIPT),
+        national_id_provider=("en_US", "ssn"),
+    ),
+    _pack(
+        "fr",
+        "OpenMed/OpenMed-PII-French-SuperClinical-Small-44M-v1",
+        "fr_FR",
+        ("Latin",),
+        national_id_provider=("fr_FR", "ssn"),
+    ),
+    _pack(
+        "de",
+        "OpenMed/OpenMed-PII-German-SuperClinical-Small-44M-v1",
+        "de_DE",
+        ("Latin",),
+        national_id_provider=("de_DE", "german_steuer_id"),
+    ),
+    _pack(
+        "it",
+        "OpenMed/OpenMed-PII-Italian-SuperClinical-Small-44M-v1",
+        "it_IT",
+        ("Latin",),
+        national_id_provider=("it_IT", "ssn"),
+    ),
+    _pack(
+        "es",
+        "OpenMed/OpenMed-PII-Spanish-SuperClinical-Small-44M-v1",
+        "es_ES",
+        ("Latin",),
+        national_id_provider=("es_ES", "nie"),
+    ),
+    _pack(
+        "nl",
+        "OpenMed/OpenMed-PII-Dutch-SuperClinical-Large-434M-v1",
+        "nl_NL",
+        ("Latin",),
+        national_id_provider=("nl_NL", "ssn"),
+    ),
+    _pack(
+        "hi",
+        "OpenMed/OpenMed-PII-Hindi-SuperClinical-Large-434M-v1",
+        "hi_IN",
+        ("Devanagari",),
+        national_id_provider=("hi_IN", "aadhaar"),
+    ),
+    _pack(
+        "te",
+        "OpenMed/OpenMed-PII-Telugu-SuperClinical-Large-434M-v1",
+        "en_IN",
+        ("Telugu",),
+        national_id_provider=("en_IN", "aadhaar"),
+    ),
+    _pack(
+        "pt",
+        "OpenMed/OpenMed-PII-Portuguese-SnowflakeMed-Large-568M-v1",
+        "pt_PT",
+        ("Latin",),
+        national_id_provider=("pt_BR", "cpf"),
+    ),
+    _pack(
+        "ar",
+        "OpenMed/OpenMed-PII-Arabic-SnowflakeMed-Large-568M-v1",
+        "ar_EG",
+        ("Arabic",),
+    ),
+    _pack(
+        "he",
+        "OpenMed/privacy-filter-multilingual",
+        "he_IL",
+        (UNROUTED_SCRIPT,),
+        national_id_provider=("he_IL", "teudat_zehut"),
+    ),
+    _pack(
+        "ja",
+        "OpenMed/OpenMed-PII-Japanese-BigMed-Large-560M-v1",
+        "ja_JP",
+        ("Han", "Hiragana/Katakana"),
+    ),
+    _pack(
+        "tr",
+        "OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1",
+        "tr_TR",
+        ("Latin",),
+        national_id_provider=("tr_TR", "ssn"),
+    ),
+    _pack(
+        "id",
+        "OpenMed/privacy-filter-multilingual",
+        "id_ID",
+        (UNROUTED_SCRIPT,),
+        national_id_provider=("id_ID", "indonesian_nik"),
+    ),
+    _pack(
+        "th",
+        "OpenMed/privacy-filter-multilingual",
+        "th_TH",
+        (UNROUTED_SCRIPT,),
+        national_id_provider=("th_TH", "thai_national_id"),
+    ),
+    _pack(
+        "ko",
+        "OpenMed/OpenMed-PII-Korean-NomicMed-Large-395M-v1",
+        "ko_KR",
+        ("Hangul",),
+        national_id_provider=("ko_KR", "korean_rrn"),
+    ),
+    _pack(
+        "ro",
+        "OpenMed/privacy-filter-multilingual",
+        "ro_RO",
+        (UNROUTED_SCRIPT,),
+        national_id_provider=("ro_RO", "romanian_cnp"),
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class NationalIdOnlyCapability:
+    """Compatibility declaration for a language without a default PII model."""
+
+    locale: str
+    provider: tuple[str, str]
+
+
+NATIONAL_ID_ONLY_CAPABILITIES: Mapping[str, NationalIdOnlyCapability] = {
+    "pl": NationalIdOnlyCapability("pl_PL", ("pl_PL", "pesel")),
+    "lv": NationalIdOnlyCapability("lv_LV", ("lv_LV", "personas_kods")),
+    "sk": NationalIdOnlyCapability("sk_SK", ("sk_SK", "rodne_cislo")),
+    "ms": NationalIdOnlyCapability("ms_MY", ("ms_MY", "mykad")),
+    "tl": NationalIdOnlyCapability("fil_PH", ("fil_PH", "philsys_psn")),
+    "da": NationalIdOnlyCapability("da_DK", ("da_DK", "danish_cpr")),
+    "hu": NationalIdOnlyCapability("hu_HU", ("hu_HU", "hungarian_taj")),
+    "et": NationalIdOnlyCapability("et_EE", ("et_EE", "isikukood")),
+    "sr": NationalIdOnlyCapability("sr_RS", ("sr_RS", "jmbg")),
+    "hr": NationalIdOnlyCapability("hr_HR", ("hr_HR", "ssn")),
+    "bg": NationalIdOnlyCapability("bg_BG", ("bg_BG", "egn")),
+    "fi": NationalIdOnlyCapability("fi_FI", ("fi_FI", "ssn")),
+    "cs": NationalIdOnlyCapability("cs_CZ", ("cs_CZ", "rodne_cislo")),
+    "el": NationalIdOnlyCapability("el_GR", ("el_GR", "ssn")),
+    "vi": NationalIdOnlyCapability("vi_VN", ("vi_VN", "vietnamese_cccd")),
+}
+
+SUPPLEMENTAL_LOCALES: Mapping[str, str] = {
+    "zh": "zh_CN",
+}
+
+_SCRIPT_ORDER = (
+    "Latin",
+    "Arabic",
+    "Han",
+    "Hiragana/Katakana",
+    "Hangul",
+    "Cyrillic",
+    "Devanagari",
+    "Telugu",
+    "Greek",
+    "Hebrew",
+    "Thai",
+    UNKNOWN_SCRIPT,
+)
+
+_LOCALE_ORDER = (
+    "en",
+    "fr",
+    "de",
+    "it",
+    "es",
+    "nl",
+    "hi",
+    "te",
+    "pt",
+    "ar",
+    "he",
+    "ja",
+    "zh",
+    "tr",
+    "id",
+    "th",
+    "pl",
+    "lv",
+    "ko",
+    "cs",
+    "sk",
+    "ms",
+    "tl",
+    "da",
+    "ro",
+    "fi",
+    "bg",
+    "hr",
+    "sr",
+    "hu",
+    "et",
+    "el",
+    "vi",
+)
+
+_NATIONAL_ID_PROVIDER_ORDER = (
+    "en",
+    "fr",
+    "de",
+    "it",
+    "es",
+    "nl",
+    "hi",
+    "te",
+    "pt",
+    "tr",
+    "he",
+    "id",
+    "th",
+    "pl",
+    "lv",
+    "ko",
+    "cs",
+    "sk",
+    "ms",
+    "tl",
+    "da",
+    "ro",
+    "fi",
+    "bg",
+    "hr",
+    "sr",
+    "hu",
+    "et",
+    "el",
+    "vi",
+)
+
+
+def _ordered_items(
+    values: Mapping[str, object],
+    order: Sequence[str],
+) -> tuple[tuple[str, object], ...]:
+    known = set(order)
+    items = [(code, values[code]) for code in order if code in values]
+    items.extend((code, values[code]) for code in sorted(values) if code not in known)
+    return tuple(items)
+
+
+class LanguagePackAdapters:
+    """Maintain compatible live ``set`` and ``dict`` registry projections."""
+
+    def __init__(
+        self,
+        registry: LanguagePackRegistry,
+        *,
+        builtin_order: Sequence[str] = (),
+        national_id_only: Mapping[str, NationalIdOnlyCapability] | None = None,
+        supplemental_locales: Mapping[str, str] | None = None,
+    ) -> None:
+        """Create and subscribe a live adapter bundle."""
+
+        self.registry = registry
+        self._builtin_order = tuple(builtin_order)
+        self._national_id_only = dict(national_id_only or {})
+        self._supplemental_locales = dict(supplemental_locales or {})
+        self.supported_languages: set[str] = set()
+        self.default_pii_models: dict[str, str] = {}
+        self.lang_to_locale: dict[str, str] = {}
+        self.national_id_providers: dict[str, tuple[str, str]] = {}
+        self.script_language_hints: dict[str, tuple[str, ...]] = {}
+        registry._add_listener(self.refresh)
+
+    def _ordered_codes(self) -> tuple[str, ...]:
+        codes = tuple(self.registry.iter_codes())
+        known = set(codes)
+        ordered = [code for code in self._builtin_order if code in known]
+        ordered.extend(code for code in codes if code not in self._builtin_order)
+        return tuple(ordered)
+
+    def refresh(self) -> None:
+        """Refresh every public projection from one registry snapshot."""
+
+        codes = self._ordered_codes()
+        packs = tuple(self.registry.get(code) for code in codes)
+
+        self.supported_languages.clear()
+        self.supported_languages.update(codes)
+
+        self.default_pii_models.clear()
+        self.default_pii_models.update(
+            (pack.code, pack.default_model) for pack in packs
+        )
+
+        locale_values = dict((pack.code, pack.surrogate_locale) for pack in packs)
+        locale_values.update(self._supplemental_locales)
+        locale_values.update(
+            (code, capability.locale)
+            for code, capability in self._national_id_only.items()
+        )
+        self.lang_to_locale.clear()
+        self.lang_to_locale.update(_ordered_items(locale_values, _LOCALE_ORDER))
+
+        provider_values: dict[str, tuple[str, str]] = {}
+        for pack in packs:
+            if pack.national_id_providers:
+                method, locale = next(iter(pack.national_id_providers.items()))
+                provider_values[pack.code] = (locale, method)
+        provider_values.update(
+            (code, capability.provider)
+            for code, capability in self._national_id_only.items()
+        )
+        self.national_id_providers.clear()
+        self.national_id_providers.update(
+            _ordered_items(provider_values, _NATIONAL_ID_PROVIDER_ORDER)
+        )
+
+        script_names = list(_SCRIPT_ORDER)
+        script_names.extend(
+            sorted(
+                {
+                    script
+                    for pack in packs
+                    for script in pack.scripts
+                    if script not in _SCRIPT_ORDER and script != UNROUTED_SCRIPT
+                }
+            )
+        )
+        self.script_language_hints.clear()
+        for script in script_names:
+            hints = tuple(pack.code for pack in packs if script in pack.scripts)
+            if hints:
+                self.script_language_hints[script] = hints
+
+
+for _builtin_pack in BUILTIN_LANGUAGE_PACKS:
+    try:
+        _registered_pack = LANGUAGE_PACK_REGISTRY.get(_builtin_pack.code)
+    except KeyError:
+        LANGUAGE_PACK_REGISTRY.register(_builtin_pack)
+    else:
+        if _registered_pack != _builtin_pack:
+            raise RuntimeError(
+                f"built-in language pack {_builtin_pack.code!r} was replaced "
+                "before catalog initialization"
+            )
+
+LANGUAGE_PACK_ADAPTERS = LanguagePackAdapters(
+    LANGUAGE_PACK_REGISTRY,
+    builtin_order=tuple(pack.code for pack in BUILTIN_LANGUAGE_PACKS),
+    national_id_only=NATIONAL_ID_ONLY_CAPABILITIES,
+    supplemental_locales=SUPPLEMENTAL_LOCALES,
+)
+
+SUPPORTED_LANGUAGES = LANGUAGE_PACK_ADAPTERS.supported_languages
+DEFAULT_PII_MODELS = LANGUAGE_PACK_ADAPTERS.default_pii_models
+LANG_TO_LOCALE = LANGUAGE_PACK_ADAPTERS.lang_to_locale
+NATIONAL_ID_PROVIDERS = LANGUAGE_PACK_ADAPTERS.national_id_providers
+SCRIPT_LANGUAGE_HINTS = LANGUAGE_PACK_ADAPTERS.script_language_hints
+NATIONAL_ID_ONLY_LANGUAGES = set(NATIONAL_ID_ONLY_CAPABILITIES)
+
+
+__all__ = [
+    "BUILTIN_LANGUAGE_PACKS",
+    "DEFAULT_PII_MODELS",
+    "LANG_TO_LOCALE",
+    "LANGUAGE_PACK_ADAPTERS",
+    "LanguagePackAdapters",
+    "NATIONAL_ID_ONLY_CAPABILITIES",
+    "NATIONAL_ID_ONLY_LANGUAGES",
+    "NATIONAL_ID_PROVIDERS",
+    "REGISTERED_SEGMENTERS",
+    "SCRIPT_LANGUAGE_HINTS",
+    "SUPPORTED_LANGUAGES",
+    "is_registered_segmenter",
+]

--- a/openmed/core/pii_i18n.py
+++ b/openmed/core/pii_i18n.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import re
 from datetime import date
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional
 
 from .anonymizer.providers.clinical_ids import (
     validate_australian_medicare,
@@ -30,50 +30,15 @@ from .anonymizer.providers.clinical_ids import (
     validate_uk_nhs_number,
     validate_uk_nino,
 )
+from .language_pack_catalog import (
+    DEFAULT_PII_MODELS,
+    NATIONAL_ID_ONLY_LANGUAGES,
+    SUPPORTED_LANGUAGES,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-SUPPORTED_LANGUAGES: Set[str] = {
-    "en",
-    "fr",
-    "de",
-    "it",
-    "es",
-    "nl",
-    "hi",
-    "te",
-    "pt",
-    "ar",
-    "he",
-    "ja",
-    "tr",
-    "id",
-    "th",
-    "ko",
-    "ro",
-}
-
-# Languages with validator-backed national-ID coverage but no bundled default
-# PII model or full language pack yet.
-NATIONAL_ID_ONLY_LANGUAGES: Set[str] = {
-    "pl",
-    "lv",
-    "sk",
-    "ms",
-    "tl",
-    "da",
-    "hu",
-    "et",
-    "sr",
-    "hr",
-    "bg",
-    "fi",
-    "cs",
-    "el",
-    "vi",
-}
 
 LANGUAGE_NAMES: Dict[str, str] = {
     "en": "English",
@@ -114,27 +79,6 @@ LANGUAGE_MODEL_PREFIX: Dict[str, str] = {
     "ko": "Korean-",
     "ro": "Romanian-",
 }
-
-DEFAULT_PII_MODELS: Dict[str, str] = {
-    "en": "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
-    "fr": "OpenMed/OpenMed-PII-French-SuperClinical-Small-44M-v1",
-    "de": "OpenMed/OpenMed-PII-German-SuperClinical-Small-44M-v1",
-    "it": "OpenMed/OpenMed-PII-Italian-SuperClinical-Small-44M-v1",
-    "es": "OpenMed/OpenMed-PII-Spanish-SuperClinical-Small-44M-v1",
-    "nl": "OpenMed/OpenMed-PII-Dutch-SuperClinical-Large-434M-v1",
-    "hi": "OpenMed/OpenMed-PII-Hindi-SuperClinical-Large-434M-v1",
-    "te": "OpenMed/OpenMed-PII-Telugu-SuperClinical-Large-434M-v1",
-    "pt": "OpenMed/OpenMed-PII-Portuguese-SnowflakeMed-Large-568M-v1",
-    "ar": "OpenMed/OpenMed-PII-Arabic-SnowflakeMed-Large-568M-v1",
-    "he": "OpenMed/privacy-filter-multilingual",
-    "ja": "OpenMed/OpenMed-PII-Japanese-BigMed-Large-560M-v1",
-    "tr": "OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1",
-    "id": "OpenMed/privacy-filter-multilingual",
-    "th": "OpenMed/privacy-filter-multilingual",
-    "ko": "OpenMed/OpenMed-PII-Korean-NomicMed-Large-395M-v1",
-    "ro": "OpenMed/privacy-filter-multilingual",
-}
-
 
 # ---------------------------------------------------------------------------
 # Financial Identifier Validators

--- a/openmed/core/script_detect.py
+++ b/openmed/core/script_detect.py
@@ -12,6 +12,8 @@ import unicodedata
 from collections.abc import Iterator
 from dataclasses import dataclass
 
+from .language_pack_catalog import SCRIPT_LANGUAGE_HINTS
+
 UNKNOWN_SCRIPT = "Unknown"
 
 SUPPORTED_SCRIPTS = (
@@ -27,21 +29,6 @@ SUPPORTED_SCRIPTS = (
     "Hebrew",
     "Thai",
 )
-
-SCRIPT_LANGUAGE_HINTS: dict[str, tuple[str, ...]] = {
-    "Latin": ("en", "fr", "de", "it", "es", "nl", "pt", "tr"),
-    "Arabic": ("ar",),
-    "Han": ("ja",),
-    "Hiragana/Katakana": ("ja",),
-    "Hangul": ("ko",),
-    "Cyrillic": ("en",),
-    "Devanagari": ("hi",),
-    "Telugu": ("te",),
-    "Greek": ("en",),
-    "Hebrew": ("en",),
-    "Thai": ("en",),
-    UNKNOWN_SCRIPT: ("en",),
-}
 
 ZERO_WIDTH_CHARS = frozenset(
     {

--- a/tests/fixtures/language_pack_adapters.json
+++ b/tests/fixtures/language_pack_adapters.json
@@ -1,0 +1,259 @@
+{
+  "default_pii_models": {
+    "ar": "OpenMed/OpenMed-PII-Arabic-SnowflakeMed-Large-568M-v1",
+    "de": "OpenMed/OpenMed-PII-German-SuperClinical-Small-44M-v1",
+    "en": "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+    "es": "OpenMed/OpenMed-PII-Spanish-SuperClinical-Small-44M-v1",
+    "fr": "OpenMed/OpenMed-PII-French-SuperClinical-Small-44M-v1",
+    "he": "OpenMed/privacy-filter-multilingual",
+    "hi": "OpenMed/OpenMed-PII-Hindi-SuperClinical-Large-434M-v1",
+    "id": "OpenMed/privacy-filter-multilingual",
+    "it": "OpenMed/OpenMed-PII-Italian-SuperClinical-Small-44M-v1",
+    "ja": "OpenMed/OpenMed-PII-Japanese-BigMed-Large-560M-v1",
+    "ko": "OpenMed/OpenMed-PII-Korean-NomicMed-Large-395M-v1",
+    "nl": "OpenMed/OpenMed-PII-Dutch-SuperClinical-Large-434M-v1",
+    "pt": "OpenMed/OpenMed-PII-Portuguese-SnowflakeMed-Large-568M-v1",
+    "ro": "OpenMed/privacy-filter-multilingual",
+    "te": "OpenMed/OpenMed-PII-Telugu-SuperClinical-Large-434M-v1",
+    "th": "OpenMed/privacy-filter-multilingual",
+    "tr": "OpenMed/OpenMed-PII-Turkish-SuperClinical-Small-44M-v1"
+  },
+  "lang_to_locale": {
+    "ar": "ar_EG",
+    "bg": "bg_BG",
+    "cs": "cs_CZ",
+    "da": "da_DK",
+    "de": "de_DE",
+    "el": "el_GR",
+    "en": "en_US",
+    "es": "es_ES",
+    "et": "et_EE",
+    "fi": "fi_FI",
+    "fr": "fr_FR",
+    "he": "he_IL",
+    "hi": "hi_IN",
+    "hr": "hr_HR",
+    "hu": "hu_HU",
+    "id": "id_ID",
+    "it": "it_IT",
+    "ja": "ja_JP",
+    "ko": "ko_KR",
+    "lv": "lv_LV",
+    "ms": "ms_MY",
+    "nl": "nl_NL",
+    "pl": "pl_PL",
+    "pt": "pt_PT",
+    "ro": "ro_RO",
+    "sk": "sk_SK",
+    "sr": "sr_RS",
+    "te": "en_IN",
+    "th": "th_TH",
+    "tl": "fil_PH",
+    "tr": "tr_TR",
+    "vi": "vi_VN",
+    "zh": "zh_CN"
+  },
+  "national_id_only_languages": [
+    "bg",
+    "cs",
+    "da",
+    "el",
+    "et",
+    "fi",
+    "hr",
+    "hu",
+    "lv",
+    "ms",
+    "pl",
+    "sk",
+    "sr",
+    "tl",
+    "vi"
+  ],
+  "national_id_providers": {
+    "bg": [
+      "bg_BG",
+      "egn"
+    ],
+    "cs": [
+      "cs_CZ",
+      "rodne_cislo"
+    ],
+    "da": [
+      "da_DK",
+      "danish_cpr"
+    ],
+    "de": [
+      "de_DE",
+      "german_steuer_id"
+    ],
+    "el": [
+      "el_GR",
+      "ssn"
+    ],
+    "en": [
+      "en_US",
+      "ssn"
+    ],
+    "es": [
+      "es_ES",
+      "nie"
+    ],
+    "et": [
+      "et_EE",
+      "isikukood"
+    ],
+    "fi": [
+      "fi_FI",
+      "ssn"
+    ],
+    "fr": [
+      "fr_FR",
+      "ssn"
+    ],
+    "he": [
+      "he_IL",
+      "teudat_zehut"
+    ],
+    "hi": [
+      "hi_IN",
+      "aadhaar"
+    ],
+    "hr": [
+      "hr_HR",
+      "ssn"
+    ],
+    "hu": [
+      "hu_HU",
+      "hungarian_taj"
+    ],
+    "id": [
+      "id_ID",
+      "indonesian_nik"
+    ],
+    "it": [
+      "it_IT",
+      "ssn"
+    ],
+    "ko": [
+      "ko_KR",
+      "korean_rrn"
+    ],
+    "lv": [
+      "lv_LV",
+      "personas_kods"
+    ],
+    "ms": [
+      "ms_MY",
+      "mykad"
+    ],
+    "nl": [
+      "nl_NL",
+      "ssn"
+    ],
+    "pl": [
+      "pl_PL",
+      "pesel"
+    ],
+    "pt": [
+      "pt_BR",
+      "cpf"
+    ],
+    "ro": [
+      "ro_RO",
+      "romanian_cnp"
+    ],
+    "sk": [
+      "sk_SK",
+      "rodne_cislo"
+    ],
+    "sr": [
+      "sr_RS",
+      "jmbg"
+    ],
+    "te": [
+      "en_IN",
+      "aadhaar"
+    ],
+    "th": [
+      "th_TH",
+      "thai_national_id"
+    ],
+    "tl": [
+      "fil_PH",
+      "philsys_psn"
+    ],
+    "tr": [
+      "tr_TR",
+      "ssn"
+    ],
+    "vi": [
+      "vi_VN",
+      "vietnamese_cccd"
+    ]
+  },
+  "script_language_hints": {
+    "Arabic": [
+      "ar"
+    ],
+    "Cyrillic": [
+      "en"
+    ],
+    "Devanagari": [
+      "hi"
+    ],
+    "Greek": [
+      "en"
+    ],
+    "Han": [
+      "ja"
+    ],
+    "Hangul": [
+      "ko"
+    ],
+    "Hebrew": [
+      "en"
+    ],
+    "Hiragana/Katakana": [
+      "ja"
+    ],
+    "Latin": [
+      "en",
+      "fr",
+      "de",
+      "it",
+      "es",
+      "nl",
+      "pt",
+      "tr"
+    ],
+    "Telugu": [
+      "te"
+    ],
+    "Thai": [
+      "en"
+    ],
+    "Unknown": [
+      "en"
+    ]
+  },
+  "supported_languages": [
+    "ar",
+    "de",
+    "en",
+    "es",
+    "fr",
+    "he",
+    "hi",
+    "id",
+    "it",
+    "ja",
+    "ko",
+    "nl",
+    "pt",
+    "ro",
+    "te",
+    "th",
+    "tr"
+  ]
+}

--- a/tests/unit/core/test_language_pack_adapters.py
+++ b/tests/unit/core/test_language_pack_adapters.py
@@ -1,0 +1,117 @@
+"""Golden and live-registration tests for language-pack map adapters."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openmed.core.language_pack import LanguagePack, LanguagePackRegistry
+from openmed.core.language_pack_catalog import (
+    DEFAULT_PII_MODELS,
+    LANG_TO_LOCALE,
+    NATIONAL_ID_ONLY_LANGUAGES,
+    NATIONAL_ID_PROVIDERS,
+    SCRIPT_LANGUAGE_HINTS,
+    SUPPORTED_LANGUAGES,
+    LanguagePackAdapters,
+    is_registered_segmenter,
+)
+
+SNAPSHOT_PATH = (
+    Path(__file__).resolve().parents[2] / "fixtures" / "language_pack_adapters.json"
+)
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "default_pii_models": dict(DEFAULT_PII_MODELS),
+        "lang_to_locale": dict(LANG_TO_LOCALE),
+        "national_id_only_languages": sorted(NATIONAL_ID_ONLY_LANGUAGES),
+        "national_id_providers": {
+            key: list(value) for key, value in NATIONAL_ID_PROVIDERS.items()
+        },
+        "script_language_hints": {
+            key: list(value) for key, value in SCRIPT_LANGUAGE_HINTS.items()
+        },
+        "supported_languages": sorted(SUPPORTED_LANGUAGES),
+    }
+
+
+def test_registry_adapters_match_pre_refactor_snapshot_byte_for_byte() -> None:
+    rendered = json.dumps(_snapshot(), indent=2, sort_keys=True) + "\n"
+    assert rendered == SNAPSHOT_PATH.read_text(encoding="utf-8")
+
+
+def test_public_adapter_runtime_types_remain_compatible() -> None:
+    assert type(SUPPORTED_LANGUAGES) is set
+    assert type(DEFAULT_PII_MODELS) is dict
+    assert type(LANG_TO_LOCALE) is dict
+    assert type(NATIONAL_ID_PROVIDERS) is dict
+    assert type(SCRIPT_LANGUAGE_HINTS) is dict
+
+    assert "en" in SUPPORTED_LANGUAGES
+    assert DEFAULT_PII_MODELS.get("en")
+    assert set(DEFAULT_PII_MODELS) == SUPPORTED_LANGUAGES
+    assert SUPPORTED_LANGUAGES | {"xx"} == set(SUPPORTED_LANGUAGES) | {"xx"}
+
+
+def test_one_registration_updates_every_downstream_adapter() -> None:
+    registry = LanguagePackRegistry()
+    adapters = LanguagePackAdapters(registry)
+    pack = LanguagePack(
+        code="xx",
+        scripts=("Synthetic",),
+        default_model="OpenMed/synthetic-pii",
+        segmenter_id="unicode-sentence",
+        recognizers=("synthetic-regex", "synthetic-model"),
+        surrogate_locale="en_US",
+        national_id_providers={"ssn": "en_US"},
+    )
+
+    registry.register(pack)
+
+    assert adapters.supported_languages == {"xx"}
+    assert adapters.default_pii_models == {"xx": "OpenMed/synthetic-pii"}
+    assert adapters.lang_to_locale == {"xx": "en_US"}
+    assert adapters.national_id_providers == {"xx": ("en_US", "ssn")}
+    assert adapters.script_language_hints == {"Synthetic": ("xx",)}
+
+
+def test_replacement_refreshes_existing_adapter_objects_in_place() -> None:
+    registry = LanguagePackRegistry()
+    adapters = LanguagePackAdapters(registry)
+    models = adapters.default_pii_models
+    locales = adapters.lang_to_locale
+    registry.register(
+        LanguagePack(
+            code="xx",
+            scripts=("Synthetic",),
+            default_model="OpenMed/first",
+            segmenter_id="pysbd",
+            recognizers=("regex",),
+            surrogate_locale="en_US",
+        )
+    )
+
+    registry.register(
+        LanguagePack(
+            code="xx",
+            scripts=("Synthetic",),
+            default_model="OpenMed/replacement",
+            segmenter_id="pysbd",
+            recognizers=("regex",),
+            surrogate_locale="en_GB",
+        ),
+        replace=True,
+    )
+
+    assert adapters.default_pii_models is models
+    assert adapters.lang_to_locale is locales
+    assert models["xx"] == "OpenMed/replacement"
+    assert locales["xx"] == "en_GB"
+
+
+def test_segmenter_resolver_rejects_undeclared_ids() -> None:
+    assert is_registered_segmenter("pysbd")
+    assert is_registered_segmenter("unicode-sentence")
+    assert not is_registered_segmenter("no-such-segmenter")

--- a/tests/unit/test_public_api_docstrings.py
+++ b/tests/unit/test_public_api_docstrings.py
@@ -47,11 +47,11 @@ MIN_COVERAGE = 100.0
 EXPECTED_DATA_EXPORTS = {
     "__version__": ("openmed", str),
     "PII_PATTERNS": ("openmed.core.pii_entity_merger", list),
-    "SUPPORTED_LANGUAGES": ("openmed.core.pii_i18n", set),
-    "DEFAULT_PII_MODELS": ("openmed.core.pii_i18n", dict),
+    "SUPPORTED_LANGUAGES": ("openmed.core.language_pack_catalog", set),
+    "DEFAULT_PII_MODELS": ("openmed.core.language_pack_catalog", dict),
     "LANGUAGE_PII_PATTERNS": ("openmed.core.pii_i18n", dict),
     "CANONICAL_LABELS": ("openmed.core.labels", frozenset),
-    "LANG_TO_LOCALE": ("openmed.core.anonymizer.locales", dict),
+    "LANG_TO_LOCALE": ("openmed.core.language_pack_catalog", dict),
     "ENCRYPTION_SCHEME": ("openmed.core.surrogate_vault", str),
 }
 


### PR DESCRIPTION
## Description

Makes the language-pack registry the source of truth for the existing multilingual model, locale, national-ID, and script-routing surfaces while preserving their public runtime types and pre-refactor values.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Adds declarative built-in language packs for all 17 model-backed languages.
- Adds live registry projections for `SUPPORTED_LANGUAGES`, `DEFAULT_PII_MODELS`, `LANG_TO_LOCALE`, `NATIONAL_ID_PROVIDERS`, and `SCRIPT_LANGUAGE_HINTS`.
- Keeps national-ID-only capabilities explicit until they become complete packs.
- Preserves the legacy objects as real `set` and `dict` instances and refreshes them in place after registration.
- Adds a shared segmenter resolver for the coherence-report child.
- Adds a canonical golden snapshot of every pre-refactor adapter value.
- Adds isolated synthetic registration and replacement tests that exercise every downstream projection.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with synthetic registrations

Commands and results:

- Focused multilingual, locale, script, and adapter suite: 636 passed.
- Current-master focused registry/API suite after the final merge: 166 passed.
- Broad offline suite: 5,218 passed; the one changed static inventory expectation was updated and then revalidated green.
- `make lint`: passed.
- `make format-check`: passed.
- `git diff --check`: passed.

## Documentation

- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

No user-facing command changes are introduced; the compatibility snapshot and module docstrings document the migration boundary.

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented non-obvious compatibility behavior
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] My commits are organized around the dependency boundary

## Related Issues

Closes #1583
Related to #1504

## Screenshots/Examples

Not applicable; this is an internal registry migration with golden and runtime compatibility tests.