### PR TITLE
docs: add Windows uv installation steps

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,14 +5,27 @@ This guide gets you from a blank workstation to copying results from the docs wi
 
 ## 1. Bootstrap the environment
 
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh  # install uv (skip if already installed)
-uv venv --python 3.11                           # create a dedicated virtualenv
-source .venv/bin/activate                       # or use `uv python` directly
+=== "macOS/Linux"
 
-# install OpenMed with Hugging Face extras and doc tooling
-uv pip install ".[hf]"
-```
+    ```bash
+    curl -LsSf https://astral.sh/uv/install.sh | sh  # install uv (skip if already installed)
+    uv venv --python 3.11                           # create a dedicated virtualenv
+    source .venv/bin/activate                       # or use `uv python` directly
+
+    # install OpenMed with Hugging Face extras and doc tooling
+    uv pip install ".[hf]"
+    ```
+
+=== "Windows PowerShell"
+
+    ```powershell
+    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    uv venv --python 3.11
+    .venv\Scripts\Activate.ps1
+
+    # install OpenMed with Hugging Face extras and doc tooling
+    uv pip install ".[hf]"
+    ```
 
 Need the zero-shot GLiNER stack or dev tools? Stack extras as needed:
 

--- a/docs/quickstarts.md
+++ b/docs/quickstarts.md
@@ -22,12 +22,23 @@ Pick the track that matches how you'll use OpenMed:
 
 All tracks assume a working install. The minimal setup is:
 
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh   # install uv (skip if present)
-uv venv --python 3.11
-source .venv/bin/activate
-uv pip install "openmed[hf]"                      # core + Hugging Face models
-```
+=== "macOS/Linux"
+
+    ```bash
+    curl -LsSf https://astral.sh/uv/install.sh | sh   # install uv (skip if present)
+    uv venv --python 3.11
+    source .venv/bin/activate
+    uv pip install "openmed[hf]"                      # core + Hugging Face models
+    ```
+
+=== "Windows PowerShell"
+
+    ```powershell
+    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    uv venv --python 3.11
+    .venv\Scripts\Activate.ps1
+    uv pip install "openmed[hf]"                      # core + Hugging Face models
+    ```
 
 The first model-backed call may download model artifacts. Clinical text is still
 processed locally; after warming the cache, use


### PR DESCRIPTION
# Pull Request

## Description
Document platform-specific uv bootstrap commands in both quick-start guides.

The guides previously showed only Astral's macOS/Linux shell installer. On
Windows, the installer endpoint's HTTP redirect can surface as a Cloudflare 301
page when the command is not handled by a redirect-following curl
implementation. Astral's supported Windows path is the PowerShell installer.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Changes Made
- Keep the official shell installer under a macOS/Linux tab.
- Add the official Windows PowerShell installer and virtual-environment activation commands.
- Apply the same platform split to the general and persona quick-start guides.

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs
- [x] `uv run --extra docs mkdocs build --strict`
- [x] `uv run --extra dev pre-commit run --files docs/getting-started.md docs/quickstarts.md`

## Documentation
- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1843

## Screenshots/Examples
Not applicable; the strict MkDocs build validates the tabbed documentation
markup.
