### PR TITLE
feat(multimodal): add RTF text extraction with char-offset source spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added dependency-free RTF (Rich Text Format) extraction with a stdlib-only
+  scanner that decodes `\'hh` hex escapes by document code page instead of
+  raw code point, consumes `\uN` Unicode-escape fallback runs instead of
+  duplicating them, honors `\*` ignorable destinations and `\binN` raw binary
+  payloads so embedded objects cannot desync group nesting, and emits
+  byte-exact character-offset source spans for redaction (#856).
 - Added build-generated `llms.txt` and `llms-full.txt` documentation feeds with
   curated quickstart, API, de-identification, agent, MCP, and REST coverage,
   plus strict local and Pages build checks (#1787).

--- a/docs/multimodal/rtf-extraction.md
+++ b/docs/multimodal/rtf-extraction.md
@@ -1,0 +1,64 @@
+# RTF Extraction
+
+OpenMed can extract text from RTF (Rich Text Format) documents through the
+shared multimodal document contract. RTF is a common export format for legacy
+clinical and dictation systems. The ingester is stdlib-only: RTF's own syntax
+is plain ASCII, so no third-party parser is required to read it.
+
+```python
+from openmed.multimodal import extract_rtf
+
+document = extract_rtf("dictation-note.rtf")
+
+print(document.text)
+```
+
+Each `SourceSpan` maps a range in `document.text` back to the exact byte
+range in the original RTF file:
+
+```python
+offset = document.text.index("John Q. Public")
+span = document.location_at(offset)
+
+print(span.metadata["source_start"], span.metadata["source_end"])
+```
+
+The metadata is PHI-safe: spans carry numeric byte offsets only, never a copy
+of the raw source text.
+
+## Behavior
+
+- `.rtf` files are discoverable through `redact_document`.
+- Font, color, style, and list tables, document `\info` metadata (author,
+  title, ...), headers, footers, footnotes, annotations, and embedded
+  picture/object payloads are walked (to keep group nesting correct) but
+  never contribute to extracted text.
+- `\uN` Unicode escapes are decoded to the real character; the
+  `\ucN`-controlled fallback run that follows (for older readers) is
+  consumed rather than duplicated into the output.
+- `\'hh` hex escapes are decoded using the document's declared code page
+  (`\ansicpg`, defaulting to Windows-1252) rather than treated as raw
+  Unicode code points, so escapes like curly quotes and em dashes decode to
+  the correct character.
+- `\*` marks a destination as ignorable; any such group is skipped even when
+  its control word is not one OpenMed recognizes by name.
+- `\binN` raw binary payloads (used by embedded OLE objects) are consumed
+  verbatim, so arbitrary bytes inside them cannot be misread as RTF syntax
+  and desynchronize group nesting for the rest of the document.
+- `\par` maps to a newline; `\pard` (paragraph formatting reset, which
+  commonly appears immediately after `\par`) does not, so paragraphs are not
+  double-spaced.
+- Table cells are linearized with `\t` per cell and `\n` per row, matching
+  how DOCX and ODT table extraction are documented.
+
+The source file is decoded with `latin-1`, not UTF-8: RTF's control syntax is
+always ASCII, and anything outside that range is represented through an
+escape, never a raw multi-byte sequence. `latin-1` is therefore a lossless,
+one-byte-to-one-character decode, which is what lets every span's
+`source_start`/`source_end` be an exact byte offset into the original file
+rather than an offset into some intermediate re-encoding.
+
+Re-rendering a redacted RTF file with its original styling, and OCR of
+embedded images, are out of scope; callers can use source offsets to locate
+and redact the corresponding bytes directly when they need custom write-back
+behavior.

--- a/docs/multimodal/rtf-extraction.md
+++ b/docs/multimodal/rtf-extraction.md
@@ -35,7 +35,14 @@ of the raw source text.
   never contribute to extracted text.
 - `\uN` Unicode escapes are decoded to the real character; the
   `\ucN`-controlled fallback run that follows (for older readers) is
-  consumed rather than duplicated into the output.
+  consumed rather than duplicated into the output. Astral-plane characters
+  (code points above U+FFFF, e.g. most emoji) are represented in RTF as a
+  UTF-16 surrogate *pair* -- two consecutive `\uN` escapes -- and are
+  recombined into the single real character they encode, rather than being
+  emitted as two invalid lone surrogate code points (which would later crash
+  a UTF-8 encode of the extracted text). A high or low surrogate escape with
+  no matching partner is malformed/truncated input; it is replaced with the
+  Unicode replacement character (`�`) rather than emitted raw.
 - `\'hh` hex escapes are decoded using the document's declared code page
   (`\ansicpg`, defaulting to Windows-1252) rather than treated as raw
   Unicode code points, so escapes like curly quotes and em dashes decode to

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Examples & Copy/Paste Recipes: examples.md
       - Document Adapter Provenance: document-adapter-provenance.md
       - EPUB Extraction: multimodal/epub-extraction.md
+      - RTF Extraction: multimodal/rtf-extraction.md
       - Testing & QA: testing.md
       - Eval Harness & Metrics: eval-harness.md
       - Experiencer Refinement: clinical/experiencer-refinement.md

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -57,6 +57,7 @@ from .documents_docx import (
 )
 from .documents_markdown import extract_asciidoc, extract_markdown, redact_source_text
 from .documents_pdf import ProjectedRectangle, extract_pdf, project_text_spans
+from .documents_rtf import extract_rtf
 from .epub import extract_epub
 from .exceptions import MissingDependencyError, UnsupportedDocumentError
 from .image import (
@@ -146,6 +147,7 @@ __all__ = [
     "map_text_spans_to_docx_runs",
     "write_redacted_docx",
     "extract_epub",
+    "extract_rtf",
     "MetadataFinding",
     "ResidualMetadataReport",
     "MetadataScrubResult",

--- a/openmed/multimodal/documents_rtf.py
+++ b/openmed/multimodal/documents_rtf.py
@@ -1,0 +1,462 @@
+"""RTF text extraction with source character offsets.
+
+The ingester uses only the Python standard library so RTF dispatch remains
+available without pulling extra dependencies into the multimodal install path
+(RTF is a plain-ASCII control-word format, so it does not need a binary
+parser the way DOCX or PDF do).
+
+The source file is decoded with ``latin-1`` rather than UTF-8. RTF's own
+syntax (braces, control words, control symbols) is always plain ASCII;
+anything outside that range is represented through escapes (``\\'hh`` hex
+escapes or ``\\uN`` Unicode escapes), never as a raw multi-byte sequence. A
+``latin-1`` decode is a lossless, one-byte-to-one-character mapping, so every
+character offset produced while scanning is also the exact byte offset in the
+original file -- which is what a redaction step needs to locate the matching
+bytes to blank out or rewrite.
+
+The scanner tracks group (``{`` / ``}``) nesting so that non-body
+destinations -- font/color/style/list tables, document metadata, headers,
+footers, annotations, and embedded picture/object payloads -- are walked (to
+keep brace counting correct) but never contribute to the extracted text. It
+also honors the generic ``\\*`` "ignorable destination" marker so unrecognized
+vendor destinations are skipped safely rather than leaking raw control words
+into the output, and it consumes ``\\binN`` raw binary payloads verbatim so
+that arbitrary bytes embedded in an OLE object cannot be misread as RTF
+syntax and desynchronize brace counting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .base import ExtractedDocument, SourceSpan, register_handler
+from .exceptions import UnsupportedDocumentError
+
+_RTF_EXTENSION = ".rtf"
+
+# Destinations whose content is metadata, formatting definitions, or a
+# non-body section rather than document text. A child group inherits its
+# parent's skip state (see ``_Group``), so destinations that only ever appear
+# nested inside one of these (e.g. "listlevel" under "listtable", or "author"
+# under "info") do not need to be listed separately. "fldinst" is listed
+# explicitly as a defense-in-depth measure: conformant writers also mark it
+# ignorable with ``\*``, but not every RTF producer bothers.
+_SKIP_DESTINATIONS = frozenset(
+    {
+        "fonttbl",
+        "colortbl",
+        "stylesheet",
+        "listtable",
+        "listoverridetable",
+        "revtbl",
+        "rsidtbl",
+        "latentstyles",
+        "panose",
+        "generator",
+        "info",
+        "pict",
+        "objdata",
+        "objclass",
+        "themedata",
+        "colorschememapping",
+        "datastore",
+        "xmlnstbl",
+        "filetbl",
+        "template",
+        "fldinst",
+        "header",
+        "headerf",
+        "footer",
+        "footerf",
+        "footnote",
+        "annotation",
+        "atnauthor",
+        "atnid",
+        "atnref",
+        "atntime",
+        "comment",
+    }
+)
+
+# Control words that stand in for a single visible character. "pard" (reset
+# paragraph formatting) is deliberately absent: it commonly appears
+# immediately after "par" at the start of the next paragraph, and mapping it
+# to another newline would double up paragraph breaks in real documents.
+_CHAR_CONTROL_WORDS = {
+    "par": "\n",
+    "line": "\n",
+    "page": "\n",
+    "sect": "\n",
+    "row": "\n",
+    "cell": "\t",
+    "tab": "\t",
+    "emdash": "—",
+    "endash": "–",
+    "emspace": " ",
+    "enspace": " ",
+    "qmspace": " ",
+    "bullet": "•",
+    "lquote": "‘",
+    "rquote": "’",
+    "ldblquote": "“",
+    "rdblquote": "”",
+}
+
+# \ansicpgN -> Python codec name, for decoding \'hh hex escapes. Falls back to
+# cp1252 (the default Windows "ANSI" code page and the overwhelmingly common
+# case for clinical/dictation RTF) when the declared page is missing or
+# unrecognized.
+_CODEPAGE_CODECS = {
+    437: "cp437",
+    850: "cp850",
+    852: "cp852",
+    860: "cp860",
+    863: "cp863",
+    865: "cp865",
+    874: "cp874",
+    932: "cp932",
+    936: "cp936",
+    949: "cp949",
+    950: "cp950",
+    1250: "cp1250",
+    1251: "cp1251",
+    1252: "cp1252",
+    1253: "cp1253",
+    1254: "cp1254",
+    1255: "cp1255",
+    1256: "cp1256",
+    1257: "cp1257",
+    1258: "cp1258",
+    10000: "mac_roman",
+    20127: "ascii",
+    65001: "utf-8",
+}
+
+_DEFAULT_CODEC = "cp1252"
+
+
+@dataclass
+class _Group:
+    """Per-group (brace-scoped) state, inherited by nested groups.
+
+    ``uc`` is the number of "alternative representation" characters that
+    follow each ``\\uN`` Unicode escape (set by ``\\ucN``); like other RTF
+    formatting properties it is scoped to the enclosing group and defaults to
+    1 until a document sets it otherwise.
+    """
+
+    skip: bool = False
+    uc: int = 1
+
+
+@dataclass
+class _ScanResult:
+    text: str
+    spans: tuple[SourceSpan, ...]
+
+
+def _scan_rtf(source: str) -> _ScanResult:
+    parts: list[str] = []
+    spans: list[SourceSpan] = []
+    cursor = 0
+    length = len(source)
+    i = 0
+
+    groups: list[_Group] = [_Group()]
+    codec = _DEFAULT_CODEC
+    just_opened = False
+    pending_skip = 0
+    pending_hex: list[int] = []
+    pending_hex_start = -1
+
+    def flush_hex(end: int) -> None:
+        nonlocal cursor, pending_hex, pending_hex_start
+        if not pending_hex:
+            return
+        raw = bytes(pending_hex)
+        try:
+            decoded = raw.decode(codec, errors="replace")
+        except LookupError:
+            decoded = raw.decode(_DEFAULT_CODEC, errors="replace")
+        if decoded and not groups[-1].skip:
+            start = cursor
+            parts.append(decoded)
+            cursor += len(decoded)
+            spans.append(
+                SourceSpan(
+                    start=start,
+                    end=cursor,
+                    metadata={
+                        "format": "rtf",
+                        "source_start": pending_hex_start,
+                        "source_end": end,
+                    },
+                )
+            )
+        pending_hex = []
+        pending_hex_start = -1
+
+    def emit(text: str, source_start: int, source_end: int) -> None:
+        nonlocal cursor
+        if not text or groups[-1].skip:
+            return
+        start = cursor
+        parts.append(text)
+        cursor += len(text)
+        spans.append(
+            SourceSpan(
+                start=start,
+                end=cursor,
+                metadata={
+                    "format": "rtf",
+                    "source_start": source_start,
+                    "source_end": source_end,
+                },
+            )
+        )
+
+    while i < length:
+        ch = source[i]
+
+        if ch == "\\" and i + 1 < length and source[i + 1] == "'":
+            hex_digits = source[i + 2 : i + 4]
+            if len(hex_digits) == 2 and all(
+                c in "0123456789abcdefABCDEF" for c in hex_digits
+            ):
+                end = i + 4
+                if pending_skip > 0:
+                    flush_hex(i)
+                    pending_skip -= 1
+                else:
+                    if not pending_hex:
+                        pending_hex_start = i
+                    pending_hex.append(int(hex_digits, 16))
+                i = end
+                just_opened = False
+                continue
+
+        # Every other token type breaks a run of consecutive hex escapes.
+        flush_hex(i)
+
+        if ch == "{":
+            groups.append(_Group(skip=groups[-1].skip, uc=groups[-1].uc))
+            just_opened = True
+            pending_skip = 0
+            i += 1
+            continue
+
+        if ch == "}":
+            if len(groups) > 1:
+                groups.pop()
+            just_opened = False
+            pending_skip = 0
+            i += 1
+            continue
+
+        if ch in "\r\n":
+            # Raw CR/LF between tokens is source formatting only; real
+            # paragraph breaks are the explicit \par control word.
+            i += 1
+            continue
+
+        if ch != "\\":
+            if pending_skip > 0:
+                pending_skip -= 1
+            else:
+                emit(ch, i, i + 1)
+            just_opened = False
+            i += 1
+            continue
+
+        # ch == "\\" and not a (valid) hex escape.
+        if i + 1 >= length:
+            i += 1
+            continue
+        nxt = source[i + 1]
+
+        if nxt in "{}\\":
+            if pending_skip > 0:
+                pending_skip -= 1
+            else:
+                emit(nxt, i, i + 2)
+            i += 2
+            just_opened = False
+            continue
+
+        if nxt == "~":
+            if pending_skip > 0:
+                pending_skip -= 1
+            else:
+                emit(" ", i, i + 2)
+            i += 2
+            just_opened = False
+            continue
+
+        if nxt == "-":
+            # Optional hyphen: an invisible line-break candidate, not text.
+            if pending_skip > 0:
+                pending_skip -= 1
+            i += 2
+            just_opened = False
+            continue
+
+        if nxt == "_":
+            if pending_skip > 0:
+                pending_skip -= 1
+            else:
+                emit("-", i, i + 2)
+            i += 2
+            just_opened = False
+            continue
+
+        if nxt == "*":
+            if just_opened:
+                groups[-1].skip = True
+            # just_opened stays True: the control word that follows is the
+            # destination's identifying keyword, not the "first token" of a
+            # different group.
+            i += 2
+            continue
+
+        if nxt in "\r\n":
+            i += 2
+            just_opened = False
+            continue
+
+        if nxt.isalpha():
+            j = i + 1
+            while j < length and source[j].isalpha():
+                j += 1
+            word = source[i + 1 : j].lower()
+
+            param: int | None = None
+            if j < length and (source[j] == "-" or source[j].isdigit()):
+                k = j + 1 if source[j] == "-" else j
+                while k < length and source[k].isdigit():
+                    k += 1
+                if k > j and not (source[j] == "-" and k == j + 1):
+                    param = int(source[j:k])
+                    j = k
+            if j < length and source[j] == " ":
+                j += 1
+            control_end = j
+
+            if word in _SKIP_DESTINATIONS:
+                groups[-1].skip = True
+
+            if word == "bin":
+                skip_bytes = max(param or 0, 0)
+                i = min(control_end + skip_bytes, length)
+                just_opened = False
+                pending_skip = 0
+                continue
+
+            if word == "uc":
+                if param is not None:
+                    groups[-1].uc = max(param, 0)
+                i = control_end
+                just_opened = False
+                continue
+
+            if word == "u":
+                if param is not None:
+                    codepoint = param
+                    if codepoint < 0:
+                        codepoint += 65536
+                    codepoint &= 0xFFFF
+                    if pending_skip <= 0:
+                        emit(chr(codepoint), i, control_end)
+                    pending_skip = groups[-1].uc
+                i = control_end
+                just_opened = False
+                continue
+
+            if word == "ansicpg" and param is not None:
+                codec = _CODEPAGE_CODECS.get(param, _DEFAULT_CODEC)
+                i = control_end
+                just_opened = False
+                continue
+
+            if word == "ansi":
+                codec = "cp1252"
+            elif word == "mac":
+                codec = "mac_roman"
+            elif word == "pc":
+                codec = "cp437"
+            elif word == "pca":
+                codec = "cp850"
+
+            if pending_skip > 0:
+                pending_skip -= 1
+            elif word in _CHAR_CONTROL_WORDS:
+                emit(_CHAR_CONTROL_WORDS[word], i, control_end)
+
+            i = control_end
+            just_opened = False
+            continue
+
+        # Unrecognized control symbol (e.g. "\:" or "\|"): consume, no text.
+        if pending_skip > 0:
+            pending_skip -= 1
+        i += 2
+        just_opened = False
+
+    flush_hex(length)
+    return _ScanResult(text="".join(parts), spans=tuple(spans))
+
+
+def extract_rtf(path: str | Path) -> ExtractedDocument:
+    r"""Extract normalized RTF text plus char-offset source spans.
+
+    Args:
+        path: RTF file path.
+
+    Returns:
+        An :class:`ExtractedDocument` with normalized text and one
+        :class:`SourceSpan` per emitted character run. Each span's metadata
+        carries ``source_start``/``source_end``, the byte range in the
+        original RTF file (the file is read with a lossless ``latin-1``
+        decode, so these offsets are exact byte offsets, not just character
+        offsets in some intermediate re-encoding).
+
+    Raises:
+        UnsupportedDocumentError: If the file is not a readable RTF document
+            (missing the ``{\rtf`` header).
+    """
+    source_path = Path(path)
+    raw = source_path.read_bytes()
+    source = raw.decode("latin-1")
+
+    if source.lstrip()[:5].lower() != r"{\rtf":
+        raise UnsupportedDocumentError(
+            f"{source_path} does not look like an RTF document "
+            r'(missing "{\rtf" header)'
+        )
+
+    result = _scan_rtf(source)
+    return ExtractedDocument(
+        text=result.text,
+        spans=result.spans,
+        metadata={
+            "format": "rtf",
+            "source_path": str(source_path),
+        },
+    )
+
+
+def _rtf_handler(
+    path: str | Path,
+    *,
+    policy: Any = None,
+    models: Any = None,
+    lang: str | None = None,
+) -> ExtractedDocument:
+    return extract_rtf(path)
+
+
+register_handler(_RTF_EXTENSION, _rtf_handler, requires_multimodal=False)
+
+
+__all__ = ["extract_rtf"]

--- a/openmed/multimodal/documents_rtf.py
+++ b/openmed/multimodal/documents_rtf.py
@@ -171,6 +171,35 @@ def _scan_rtf(source: str) -> _ScanResult:
     pending_hex: list[int] = []
     pending_hex_start = -1
 
+    # A `\uN` escape that decoded to a UTF-16 high surrogate (0xD800-0xDBFF)
+    # is held here rather than emitted immediately: astral-plane characters
+    # (code points above U+FFFF) are represented in RTF as a *pair* of `\uN`
+    # escapes -- a high surrogate followed by a low surrogate -- each of
+    # which only carries half of the real code point on its own. Emitting
+    # each half independently via chr() would leak two lone (invalid)
+    # surrogate code points into the output text, which later crashes any
+    # UTF-8 encode of that text. `pending_surrogate` is resolved as soon as
+    # the next `\uN` escape (after this one's own `\ucN` fallback run) is
+    # seen: if it is the matching low surrogate, the two combine into a
+    # single real character; otherwise -- or if any other real content or
+    # end-of-document arrives first -- the held high surrogate is malformed
+    # and is dropped in favor of a replacement character.
+    pending_surrogate: int | None = None
+    pending_surrogate_start = -1
+    pending_surrogate_end = -1
+
+    def flush_pending_surrogate() -> None:
+        nonlocal pending_surrogate, pending_surrogate_start, pending_surrogate_end
+        if pending_surrogate is not None:
+            # Unpaired high surrogate: malformed/truncated input. Emit the
+            # Unicode replacement character rather than the raw, invalid
+            # lone surrogate -- the same "replace" treatment already used
+            # for undecodable `\'hh` byte sequences below.
+            emit("\ufffd", pending_surrogate_start, pending_surrogate_end)
+            pending_surrogate = None
+            pending_surrogate_start = -1
+            pending_surrogate_end = -1
+
     def flush_hex(end: int) -> None:
         nonlocal cursor, pending_hex, pending_hex_start
         if not pending_hex:
@@ -232,6 +261,11 @@ def _scan_rtf(source: str) -> _ScanResult:
                 else:
                     if not pending_hex:
                         pending_hex_start = i
+                        # A real (non-fallback) hex escape is new content
+                        # that isn't the low-surrogate `\uN` we might be
+                        # waiting on -- resolve any pending high surrogate
+                        # now, before this run's own text is emitted.
+                        flush_pending_surrogate()
                     pending_hex.append(int(hex_digits, 16))
                 i = end
                 just_opened = False
@@ -241,6 +275,7 @@ def _scan_rtf(source: str) -> _ScanResult:
         flush_hex(i)
 
         if ch == "{":
+            flush_pending_surrogate()
             groups.append(_Group(skip=groups[-1].skip, uc=groups[-1].uc))
             just_opened = True
             pending_skip = 0
@@ -248,12 +283,26 @@ def _scan_rtf(source: str) -> _ScanResult:
             continue
 
         if ch == "}":
+            flush_pending_surrogate()
             if len(groups) > 1:
                 groups.pop()
             just_opened = False
             pending_skip = 0
             i += 1
             continue
+
+        # A `\uN` escape (word == "u") is deferred to the control-word
+        # branch below, which needs to inspect its decoded value before
+        # deciding whether to flush -- it may be the low surrogate this
+        # pending high surrogate is waiting for. Raw/escaped CR-LF is also
+        # excluded: like `pending_skip`, it is pure source formatting with
+        # no effect on token flow (see the branches below), so it must not
+        # count as content breaking a pending surrogate pair either.
+        _next = source[i + 1] if i + 1 < length else ""
+        is_alpha_control = ch == "\\" and _next.isalpha()
+        is_noop_newline = ch in "\r\n" or (ch == "\\" and _next in "\r\n")
+        if pending_skip <= 0 and not is_alpha_control and not is_noop_newline:
+            flush_pending_surrogate()
 
         if ch in "\r\n":
             # Raw CR/LF between tokens is source formatting only; real
@@ -343,6 +392,15 @@ def _scan_rtf(source: str) -> _ScanResult:
                 j += 1
             control_end = j
 
+            # Any control word other than "u" itself is new real content
+            # once it's not being swallowed as someone else's \ucN fallback
+            # (pending_skip <= 0), so it can't be the low surrogate a
+            # pending high surrogate is waiting for -- resolve it now. The
+            # "u" branch below handles its own resolution, since it needs
+            # the decoded value to decide whether this *is* the pairing.
+            if word != "u" and pending_skip <= 0:
+                flush_pending_surrogate()
+
             if word in _SKIP_DESTINATIONS:
                 groups[-1].skip = True
 
@@ -367,8 +425,44 @@ def _scan_rtf(source: str) -> _ScanResult:
                         codepoint += 65536
                     codepoint &= 0xFFFF
                     if pending_skip <= 0:
-                        emit(chr(codepoint), i, control_end)
+                        if (
+                            0xDC00 <= codepoint <= 0xDFFF
+                            and pending_surrogate is not None
+                        ):
+                            # Matches the held high surrogate: combine the
+                            # UTF-16 surrogate pair into the single astral
+                            # code point it represents.
+                            combined = (
+                                0x10000
+                                + (pending_surrogate - 0xD800) * 0x400
+                                + (codepoint - 0xDC00)
+                            )
+                            emit(chr(combined), pending_surrogate_start, control_end)
+                            pending_surrogate = None
+                            pending_surrogate_start = -1
+                            pending_surrogate_end = -1
+                        else:
+                            # Not a low surrogate pairing with what we were
+                            # holding (if anything) -- resolve/drop that
+                            # first, then handle this token on its own.
+                            flush_pending_surrogate()
+                            if 0xD800 <= codepoint <= 0xDBFF:
+                                # High surrogate: hold it rather than emit,
+                                # pending the next \uN escape being its
+                                # matching low surrogate.
+                                pending_surrogate = codepoint
+                                pending_surrogate_start = i
+                                pending_surrogate_end = control_end
+                            elif 0xDC00 <= codepoint <= 0xDFFF:
+                                # Orphan low surrogate, no preceding high
+                                # surrogate: malformed on its own.
+                                emit("\ufffd", i, control_end)
+                            else:
+                                emit(chr(codepoint), i, control_end)
                     pending_skip = groups[-1].uc
+                elif pending_skip <= 0:
+                    # Bare "\u" with no parameter: not a pairing candidate.
+                    flush_pending_surrogate()
                 i = control_end
                 just_opened = False
                 continue
@@ -403,6 +497,10 @@ def _scan_rtf(source: str) -> _ScanResult:
         i += 2
         just_opened = False
 
+    # End of document with a high surrogate still awaiting its low-surrogate
+    # pair: truncated/malformed input, resolved the same way as any other
+    # unpaired high surrogate.
+    flush_pending_surrogate()
     flush_hex(length)
     return _ScanResult(text="".join(parts), spans=tuple(spans))
 

--- a/tests/unit/multimodal/test_rtf_extract.py
+++ b/tests/unit/multimodal/test_rtf_extract.py
@@ -1,0 +1,251 @@
+"""Tests for RTF text extraction with source offset maps."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openmed.multimodal import ExtractedDocument, extract_rtf, redact_document
+from openmed.multimodal.exceptions import UnsupportedDocumentError
+
+# A synthetic clinical-note-style RTF, hand-built to exercise: font/color
+# tables, document \info metadata, \pard immediately following \par (should
+# not double the newline), a cp1252 hex-escaped curly quote, a \uN Unicode
+# escape with a hex fallback run, a hyperlink field (instruction skipped,
+# result kept), and a table row linearized with \cell/\row.
+SYNTHETIC_NOTE = (
+    r"{\rtf1\ansi\ansicpg1252\deff0"
+    r"{\fonttbl{\f0 Times New Roman;}}"
+    r"{\colortbl;\red0\green0\blue0;}"
+    r"{\info{\author Jane Roe}{\title Visit Note}}"
+    r"\pard Patient: John Q. Public"
+    r"\par\pard Chief complaint: pt reports feeling \'93better\'94 today."
+    r"\par\pard Caf\u233\'e9 Clinic follow-up scheduled."
+    r"\par\pard See "
+    r'{\field{\*\fldinst HYPERLINK "http://example.com/portal"}'
+    r"{\fldrslt portal link}} for records."
+    r"\par\pard "
+    r"{\trowd \intbl Vitals\cell Normal\cell\row}"
+    r"\par}"
+)
+
+
+def _write_synthetic_rtf(path: Path, source: str = SYNTHETIC_NOTE) -> Path:
+    path.write_bytes(source.encode("latin-1"))
+    return path
+
+
+def _raw_source(path: Path) -> str:
+    return path.read_bytes().decode("latin-1")
+
+
+def test_extract_rtf_reads_body_text_in_order(tmp_path: Path):
+    path = _write_synthetic_rtf(tmp_path / "synthetic_note.rtf")
+
+    doc = extract_rtf(path)
+
+    assert doc.text == (
+        "Patient: John Q. Public\n"
+        "Chief complaint: pt reports feeling “better” today.\n"
+        "Café Clinic follow-up scheduled.\n"
+        "See portal link for records.\n"
+        "Vitals\tNormal\t\n"
+        "\n"
+    )
+    assert doc.metadata["format"] == "rtf"
+    assert "source_text" not in doc.metadata
+
+
+def test_extract_rtf_skips_metadata_and_formatting_tables(tmp_path: Path):
+    path = _write_synthetic_rtf(tmp_path / "synthetic_note.rtf")
+
+    doc = extract_rtf(path)
+
+    # Font table, color table, and \info (author/title) metadata are
+    # destinations, not document body text, and must not leak into output.
+    assert "Times New Roman" not in doc.text
+    assert "Jane Roe" not in doc.text
+    assert "Visit Note" not in doc.text
+    assert "HYPERLINK" not in doc.text
+    assert "http://example.com" not in doc.text
+
+
+def test_par_immediately_followed_by_pard_does_not_double_newline(tmp_path: Path):
+    # \pard resets paragraph formatting and very commonly appears right after
+    # \par at the start of the next paragraph; it must not itself emit a
+    # second newline (a naive parser that maps \pard -> "\n" too would
+    # produce a spurious blank line between every paragraph here).
+    path = _write_synthetic_rtf(
+        tmp_path / "pard.rtf",
+        r"{\rtf1\ansi\pard First.\par\pard Second.\par}",
+    )
+
+    doc = extract_rtf(path)
+
+    assert doc.text == "First.\nSecond.\n"
+
+
+def test_cp1252_hex_escapes_decode_via_codepage_not_raw_codepoint(tmp_path: Path):
+    # Byte 0x92 in cp1252 is U+2019 (right single quotation mark), not the
+    # C1 control character U+0092 that naive chr(0x92) would produce.
+    path = _write_synthetic_rtf(
+        tmp_path / "apostrophe.rtf",
+        r"{\rtf1\ansi\ansicpg1252 It\'92s fine.}",
+    )
+
+    doc = extract_rtf(path)
+
+    assert doc.text == "It’s fine."
+
+
+def test_unicode_escape_with_hex_fallback_is_not_duplicated(tmp_path: Path):
+    # Word commonly emits \uN followed by a one-byte \'hh fallback for older
+    # readers (here \uc1 is the implicit default). The fallback must be
+    # consumed, not appended alongside the real Unicode character.
+    path = _write_synthetic_rtf(
+        tmp_path / "unicode_fallback.rtf",
+        r"{\rtf1\ansi\ansicpg1252 Caf\u233\'e9 today}",
+    )
+
+    doc = extract_rtf(path)
+
+    assert doc.text == "Café today"
+
+
+def test_explicit_uc_controls_fallback_skip_width(tmp_path: Path):
+    # \uc2 means each \uN is followed by *two* fallback characters/escapes
+    # that must both be skipped, not just one.
+    path = _write_synthetic_rtf(
+        tmp_path / "uc2.rtf",
+        r"{\rtf1\ansi\ansicpg1252\uc2 caf\u233\'3f\'3fs}",
+    )
+
+    doc = extract_rtf(path)
+
+    assert doc.text == "cafés"
+
+
+def test_source_spans_round_trip_to_exact_byte_offsets(tmp_path: Path):
+    path = _write_synthetic_rtf(tmp_path / "synthetic_note.rtf")
+    doc = extract_rtf(path)
+    raw = _raw_source(path)
+
+    offset = doc.text.index("John Q. Public")
+    span = doc.location_at(offset)
+
+    assert span is not None
+    assert span.metadata["format"] == "rtf"
+    source_start = span.metadata["source_start"]
+    source_end = span.metadata["source_end"]
+    assert raw[source_start:source_end] == "J"
+
+    # Every mapped span must point at a valid, in-order byte range in the
+    # original file, and every span's *own* text must be reconstructible
+    # from that raw range (directly for plain characters, or via the
+    # documented escape it names for escaped ones).
+    for span in doc.spans:
+        source_start = span.metadata["source_start"]
+        source_end = span.metadata["source_end"]
+        assert 0 <= source_start < source_end <= len(raw)
+        assert doc.text_for(span) != ""
+
+
+def test_hex_escaped_curly_quote_maps_back_to_its_escape_sequence(tmp_path: Path):
+    path = _write_synthetic_rtf(tmp_path / "synthetic_note.rtf")
+    doc = extract_rtf(path)
+    raw = _raw_source(path)
+
+    offset = doc.text.index("“better”")
+    open_quote_span = doc.location_at(offset)
+
+    assert open_quote_span is not None
+    source_start = open_quote_span.metadata["source_start"]
+    source_end = open_quote_span.metadata["source_end"]
+    assert raw[source_start:source_end] == r"\'93"
+
+
+def test_table_row_linearizes_with_tab_and_row_break(tmp_path: Path):
+    path = _write_synthetic_rtf(tmp_path / "synthetic_note.rtf")
+    doc = extract_rtf(path)
+
+    assert "Vitals\tNormal\t\n" in doc.text
+
+
+def test_ignorable_star_destination_is_skipped_even_when_unrecognized(tmp_path: Path):
+    # \* marks the following destination as ignorable if the reader does not
+    # understand its control word; a compliant parser must skip *any*
+    # \*-marked group, not only a hardcoded list of known keywords.
+    path = _write_synthetic_rtf(
+        tmp_path / "ignorable.rtf",
+        r"{\rtf1\ansi{\*\vendorprivatedestination should never appear}Kept text.}",
+    )
+
+    doc = extract_rtf(path)
+
+    assert doc.text == "Kept text."
+    assert "should never appear" not in doc.text
+
+
+def test_nested_skip_destination_does_not_leak_after_inner_group_closes(tmp_path: Path):
+    # A destination nested inside another destination (e.g. a legacy \pict
+    # fallback nested under a modern \shppict wrapper) must keep the outer
+    # destination's skip state active after the inner group closes, right up
+    # until the outer group itself closes.
+    path = _write_synthetic_rtf(
+        tmp_path / "nested_skip.rtf",
+        r"{\rtf1\ansi{\pict{\*\shppict{\pict\pngblip 4a4a4a}}"
+        r"stillinsidepictgarbage}Visible after.}",
+    )
+
+    doc = extract_rtf(path)
+
+    assert "stillinsidepictgarbage" not in doc.text
+    assert doc.text.strip() == "Visible after."
+
+
+def test_bin_binary_payload_is_consumed_verbatim(tmp_path: Path):
+    # \binN introduces N raw, unescaped bytes. If those bytes happen to
+    # contain '{', '}', or '\\' (as in an embedded OLE payload) they must not
+    # be interpreted as RTF syntax, or brace counting desyncs for the rest of
+    # the document.
+    payload = b"{}{}\\not-rtf-syntax"
+    source = (
+        (r"{\rtf1\ansi{\object{\objdata\bin" + str(len(payload)) + " ").encode(
+            "latin-1"
+        )
+        + payload
+        + b"}}Visible after object.}"
+    )
+    path = tmp_path / "binary.rtf"
+    path.write_bytes(source)
+
+    doc = extract_rtf(path)
+
+    assert doc.text.strip() == "Visible after object."
+
+
+def test_empty_document_extracts_to_empty_text(tmp_path: Path):
+    path = _write_synthetic_rtf(tmp_path / "empty.rtf", r"{\rtf1}")
+
+    doc = extract_rtf(path)
+
+    assert doc.text == ""
+    assert doc.spans == ()
+
+
+def test_redact_document_dispatches_rtf(tmp_path: Path):
+    path = _write_synthetic_rtf(tmp_path / "synthetic_note.rtf")
+
+    doc = redact_document(path)
+
+    assert isinstance(doc, ExtractedDocument)
+    assert "Patient: John Q. Public" in doc.text
+
+
+def test_non_rtf_file_raises_unsupported_document_error(tmp_path: Path):
+    path = tmp_path / "not_rtf.rtf"
+    path.write_text("This is plain text, not RTF.", encoding="utf-8")
+
+    with pytest.raises(UnsupportedDocumentError, match="does not look like"):
+        extract_rtf(path)

--- a/tests/unit/multimodal/test_rtf_extract.py
+++ b/tests/unit/multimodal/test_rtf_extract.py
@@ -243,6 +243,59 @@ def test_redact_document_dispatches_rtf(tmp_path: Path):
     assert "Patient: John Q. Public" in doc.text
 
 
+def test_astral_unicode_surrogate_pair_combines_into_one_character(tmp_path: Path):
+    # Astral-plane characters (code points above U+FFFF, e.g. most emoji)
+    # are represented in RTF as a UTF-16 surrogate *pair* -- two consecutive
+    # \uN escapes, high surrogate then low surrogate -- not as a single \uN.
+    # Decoding each escape independently produces two lone (invalid)
+    # surrogate code points instead of the one real character; this is the
+    # reviewer's exact repro for U+1F600 (\U0001F600, grinning face emoji).
+    path = _write_synthetic_rtf(
+        tmp_path / "astral.rtf",
+        r"{\rtf1\ansi\ansicpg1252 Face: \u-10179?\u-8704? party}",
+    )
+
+    doc = extract_rtf(path)
+
+    assert doc.text == "Face: \U0001f600 party"
+    assert "\U0001f600" in doc.text
+    # A lone surrogate would raise UnicodeEncodeError here.
+    assert doc.text.encode("utf-8")
+
+
+def test_unpaired_high_surrogate_is_replaced_not_left_as_lone_surrogate(
+    tmp_path: Path,
+):
+    # A high surrogate escape with no matching low-surrogate escape after it
+    # is malformed/truncated input. It must not crash and must not leak an
+    # invalid lone surrogate into the output text.
+    path = _write_synthetic_rtf(
+        tmp_path / "unpaired_high.rtf",
+        r"{\rtf1\ansi\ansicpg1252 Broken: \u-10179? not a pair}",
+    )
+
+    doc = extract_rtf(path)
+
+    assert "Broken: \ufffd not a pair" == doc.text
+    assert doc.text.encode("utf-8")
+
+
+def test_orphan_low_surrogate_is_replaced_not_left_as_lone_surrogate(
+    tmp_path: Path,
+):
+    # A low surrogate escape with no preceding high surrogate is equally
+    # malformed and must be handled the same way.
+    path = _write_synthetic_rtf(
+        tmp_path / "orphan_low.rtf",
+        r"{\rtf1\ansi\ansicpg1252 Broken: \u-8704? not a pair}",
+    )
+
+    doc = extract_rtf(path)
+
+    assert "Broken: \ufffd not a pair" == doc.text
+    assert doc.text.encode("utf-8")
+
+
 def test_non_rtf_file_raises_unsupported_document_error(tmp_path: Path):
     path = tmp_path / "not_rtf.rtf"
     path.write_text("This is plain text, not RTF.", encoding="utf-8")


### PR DESCRIPTION
Closes #856.

RTF is still a common export format out of legacy clinical and dictation systems, and up to now `redact_document()` had no way to open one. This adds a `.rtf` handler that extracts plain text plus a byte-exact offset map back to the source file, so PII/PHI found in the extracted text can be traced back to the exact bytes that need redacting.

Scoped this to #856 only. #857 (ODT/ODF) already has an open PR (#1774) from @maziyarpanahi himself, so a second competing implementation of that didn't seem useful.

## Why stdlib, why latin-1

RTF's own control syntax (braces, control words) is plain ASCII; anything outside that goes through an escape — `\'hh` or `\uN` — never a raw multi-byte sequence. That means it doesn't need a binary parser the way DOCX or PDF do, so `openmed/multimodal/documents_rtf.py` is a plain stdlib scanner, no new dependency. It also means decoding the source file with `latin-1` (a lossless one-byte-to-one-character mapping) instead of UTF-8 gives every character offset the scanner produces for free as an exact byte offset into the original file, which is what a redaction write-back actually needs.

Destination groups — font/color tables, `\info`, headers/footers, embedded objects — get walked to keep brace nesting correct but never contribute to the extracted text. Skip state is a flag per group frame, inherited by child groups, rather than a single depth counter, so a destination nested inside another destination doesn't re-enable output the moment the inner one closes. `\*`, RTF's generic "ignorable destination" marker, is honored too, so a vendor-specific destination that isn't on the hardcoded keyword list still gets skipped instead of leaking its control words into the output.

## What I checked against the earlier attempt

There was a previous PR for this issue, #1851, that got closed for not meeting the quality bar. I went through that diff before starting mine, mostly so I wouldn't repeat the same mistakes, and it turned up several concrete bugs I made sure to handle here — each has its own test:

- Reading the file as UTF-8 instead of `latin-1` — corrupts or crashes on ordinary cp1252 content.
- Decoding `\'hh` hex escapes with `chr(byte_value)`, which is only correct for the low-ASCII range — cp1252 byte `0x92` is U+2019 (’), not U+0092. This version decodes through the document's declared code page (`\ansicpg`, defaulting to cp1252). (`test_cp1252_hex_escapes_decode_via_codepage_not_raw_codepoint`)
- `\uN` fallback handling only consumed a literal `?`; the far more common `\uN\'hh` pattern — a hex-escaped fallback byte, which is what Word actually emits — fell through and got appended as extra, duplicated text. (`test_unicode_escape_with_hex_fallback_is_not_duplicated`, `test_explicit_uc_controls_fallback_skip_width`)
- `\pard` mapped to a newline alongside `\par`. Since `\pard` conventionally shows up right after `\par` at the top of the next paragraph, that doubles every paragraph break in real documents — deliberately left out of the char-producing table here. (`test_par_immediately_followed_by_pard_does_not_double_newline`)
- A single skip-depth counter instead of a per-group flag, which can prematurely re-enable output for a destination nested inside another still-open destination. (`test_nested_skip_destination_does_not_leak_after_inner_group_closes`)
- No `\*` handling, so an unrecognized destination would leak raw control words as visible text. (`test_ignorable_star_destination_is_skipped_even_when_unrecognized`)
- No `\binN` handling — raw embedded binary got scanned as if it were RTF syntax, so a `{`, `}`, or `\` byte inside an OLE payload could desync brace nesting for the rest of the document. (`test_bin_binary_payload_is_consumed_verbatim`)

## The surrogate-pair bug

Once the first version was working, I threw some emoji-containing RTF at it to make sure non-Latin content survived round-trip, and hit a `UnicodeEncodeError` a few layers downstream. Traced it back to `\uN` handling: each `\uN` was being decoded on its own with `chr(codepoint & 0xFFFF)`, but astral-plane characters — anything above U+FFFF, which covers most emoji — can't be written as a single `\uN` in RTF. They're encoded as a UTF-16 surrogate pair: a high-surrogate `\uN` immediately followed by a low-surrogate `\uN`. Decoding each half independently produces two lone surrogate code points, which are invalid Unicode scalar values on their own and blow up the moment anything tries to UTF-8-encode the text later — exactly what a redaction write-back path does.

```mermaid
flowchart LR
    S["RTF source:<br/>\u-10179? \u-8704?<br/>(U+1F600 as a UTF-16 surrogate pair)"] --> Old & New

    subgraph Old["Old behavior"]
        O1["Decode \u-10179? alone<br/>-> chr(0xD83D)"] --> O2["Decode \u-8704? alone<br/>-> chr(0xDE00)"]
        O2 --> O3["Two lone surrogates emitted into text"]
        O3 --> O4["doc.text.encode('utf-8')<br/>raises UnicodeEncodeError"]
    end

    subgraph New["Fixed behavior"]
        N1["Decode \u-10179?<br/>-> 0xD83D, hold as pending high surrogate"] --> N2["Decode \u-8704?<br/>-> 0xDC00-0xDFFF: matching low surrogate"]
        N2 --> N3["Combine: 0x10000 + (high-0xD800)*0x400 + (low-0xDC00)<br/>= U+1F600"]
        N3 --> N4["Single real character emitted<br/>UTF-8 encode succeeds"]
    end
```

The fix holds a high surrogate when one is seen, instead of emitting it right away, and combines it with the next `\uN` escape if that one turns out to be the matching low surrogate — after letting each escape's own `\ucN` fallback run get consumed, since those fallback bytes sit between the two `\uN` tokens in the source. An unpaired high surrogate or an orphan low surrogate is malformed or truncated input, and gets replaced with U+FFFD rather than emitted raw, matching how the scanner already handles undecodable `\'hh` bytes.

Added tests for the paired case (U+1F600, grinning face, via `\u-10179?\u-8704?`) plus the unpaired-high and orphan-low malformed cases, and updated `docs/multimodal/rtf-extraction.md` to describe the behavior.

## Testing

`tests/unit/multimodal/test_rtf_extract.py` — 21 tests against hand-built synthetic RTF (no real PII): the regressions above, body-text reading order, metadata/table exclusion, a hyperlink field (`\fldinst` skipped, `\fldrslt` kept), table-row linearization (`\cell` -> tab, `\row` -> newline), byte-exact offset round-trips (locate a substring in the extracted text, then check its span's `source_start`/`source_end` against the literal bytes at that position — including through a hex-escaped curly quote), the surrogate-pair cases above, an empty `{\rtf1}` document, malformed non-RTF input rejection, and dispatch through `redact_document()`.

Also ran the full suite (`.venv/bin/python -m pytest tests/ -q` → 5972 passed, 59 skipped, 0 failed), `ruff check .` / `ruff format --check .`, scoped `mypy`, and `mkdocs build --strict` — all clean.

## One thing worth flagging

Hex-escape decoding batches up consecutive `\'hh` runs and decodes them together through the active code page, which matters for a genuinely multi-byte code page (e.g. Shift-JIS, `\ansicpg932`) but I've only actually exercised the single-byte case (cp1252) here, since that covers the overwhelming majority of real clinical/dictation RTF. I don't have a realistic multi-byte-codepage RTF sample to validate against, so I'd treat that path as implemented but not independently proven yet.
