### PR TITLE
docs: clarify NER entity grouping

### DIFF
--- a/docs/analyze-text.md
+++ b/docs/analyze-text.md
@@ -16,7 +16,7 @@ result = analyze_text(
     output_format="dict",
     include_confidence=True,
     confidence_threshold=0.55,
-    group_entities=True,
+    group_entities=False,
     metadata={"source": "clinic-note-42"},
 )
 print(result.model)
@@ -32,10 +32,53 @@ payload = result.to_dict()
 - `aggregation_strategy`: forwarded to the HF pipeline. `simple` (default) yields grouped tokens; `None` keeps raw tokens.
 - `output_format`: `"dict"` (default, returns `AnalyzeResult`), `"json"`, `"html"`, or `"csv"`.
 - `include_confidence` & `confidence_threshold`: control the final payload; defaults keep all scores.
-- `group_entities`: merge adjacent spans of the same label after formatting.
+- `group_entities`: merge nearby spans of the same label after formatting.
+  Leave this `False` when `aggregation_strategy="simple"` should preserve the
+  model's separate BIO entities, especially for diagnosis or medication lists.
 - `formatter_kwargs`: forwarded to `openmed.processing.format_predictions`.
 - Sentence options (`sentence_detection`, `sentence_language`, `sentence_clean`, `sentence_segmenter`) wrap pySBD so each
   prediction carries the sentence span; disable them if latency matters more than helper metadata.
+
+### Preserve diagnosis-list boundaries
+
+`aggregation_strategy="simple"` already combines the subword tokens belonging
+to each BIO entity. Enabling `group_entities` adds a second, label-only merge;
+it can join distinct same-label items separated by a small gap, including
+comma-separated diagnoses.
+
+Medical-token remapping is useful when a model splits clinical terms poorly,
+but it can also coalesce adjacent same-label spans. Disable both optional merge
+layers when the model's original BIO boundaries are the desired output:
+
+```python
+from openmed import OpenMedConfig, analyze_text
+
+text = (
+    "Diagnoses: hypertension, diabetic peripheral neuropathy, "
+    "urinary incontinence"
+)
+result = analyze_text(
+    text,
+    model_name="OpenMed/OpenMed-NER-DiseaseDetect-SuperClinical-434M-mlx",
+    config=OpenMedConfig(
+        backend="mlx",
+        use_medical_tokenizer=False,
+    ),
+    aggregation_strategy="simple",
+    confidence_threshold=0.7,
+    group_entities=False,
+)
+
+print([entity.text for entity in result.entities])
+# ['hypertension', 'diabetic peripheral neuropathy', 'urinary incontinence']
+```
+
+When the source is a structured problem list, retain its item boundaries and
+analyze each item separately or preserve one item per line. Do not split an
+unpunctuated clinical phrase on whitespace: valid diagnoses such as
+`diabetic peripheral neuropathy` and `urinary incontinence` are multiword
+entities. If the original list structure is unavailable, use a caller-supplied
+terminology linker or grounder to validate any attempted split.
 
 ## Chunking & truncation
 

--- a/docs/batch-processing.md
+++ b/docs/batch-processing.md
@@ -31,7 +31,7 @@ processor = BatchProcessor(
     model_name="disease_detection_superclinical",
     batch_size=16,
     confidence_threshold=0.5,
-    group_entities=True,
+    group_entities=False,  # preserve separate BIO entities in diagnosis lists
     continue_on_error=True,  # Don't stop on individual failures
 )
 

--- a/docs/output-formatting.md
+++ b/docs/output-formatting.md
@@ -90,6 +90,13 @@ print(formatted.entities[0].to_dict())
 print(formatted.to_dict())
 ```
 
+`group_entities=True` deliberately performs a second merge after any model
+aggregation. It ignores BIO `B-` versus `I-` boundaries and can therefore join
+distinct same-label list items separated by a small gap, such as
+`hypertension, diabetes`. Keep it disabled when exact diagnosis or medication
+list boundaries matter; use it only when intentionally repairing fragmented
+spans.
+
 ### HTML output
 
 ```python

--- a/examples/clinical_ner_families.py
+++ b/examples/clinical_ner_families.py
@@ -155,7 +155,7 @@ def run_family_extraction(
                     text,
                     model_name=model.model_id,
                     confidence_threshold=model.recommended_confidence,
-                    group_entities=True,
+                    group_entities=False,
                 )
         except Exception as exc:
             print(f"{selection.family}: model unavailable offline ({exc})")

--- a/tests/unit/test_examples_smoke.py
+++ b/tests/unit/test_examples_smoke.py
@@ -85,7 +85,7 @@ def test_clinical_ner_families_uses_mocked_analyzer_without_network(
     clinical_ner_families.run_family_extraction(analyzer=fake_analyzer)
 
     assert len(calls) == 3
-    assert all(call["group_entities"] is True for call in calls)
+    assert all(call["group_entities"] is False for call in calls)
     assert all(call["model_name"].startswith("OpenMed/") for call in calls)
     assert "HF_HUB_OFFLINE" not in os.environ
     assert "TRANSFORMERS_OFFLINE" not in os.environ


### PR DESCRIPTION
# Pull Request

## Description

Clarify how to preserve separate BIO entities when extracting diagnosis or
medication lists.

The reported DiseaseDetect output was reproducible:
`aggregation_strategy="simple"` correctly produced separate BIO entities, but
`group_entities=True` performed a second label-only merge and joined
comma-separated diagnoses. The default medical-token remapping could similarly
coalesce adjacent same-label entities in an unpunctuated list.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Document `aggregation_strategy="simple"`, `group_entities=False`, and
  `use_medical_tokenizer=False` as the precision-oriented configuration for
  preserving model BIO boundaries.
- Explain why unpunctuated problem lists must retain source structure or use
  terminology grounding instead of whitespace splitting.
- Stop the canonical batch and clinical-family examples from enabling the
  redundant formatter merge.
- Update the focused example smoke test.

## Testing

- [x] `uv run --extra dev pytest tests/unit/test_examples_smoke.py -q` — 48 passed
- [x] `uv run --extra docs mkdocs build --strict`
- [x] `uv run --extra dev pre-commit run --files docs/analyze-text.md docs/batch-processing.md docs/output-formatting.md examples/clinical_ner_families.py tests/unit/test_examples_smoke.py`
- [x] Reproduced both reported disease-list patterns with the cached MLX model and verified that the documented configuration returns three separate diagnoses.

## Documentation

- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Related to #1856

## Screenshots/Examples

With formatter grouping and medical-token remapping disabled, the reported list
resolves to `hypertension`, `diabetic peripheral neuropathy`, and
`urinary incontinence` as separate `DISEASE` spans.
