### PR TITLE
Build exact Chinese character-to-word offset mapping

### DIFF
--- a/openmed/core/decoding/__init__.py
+++ b/openmed/core/decoding/__init__.py
@@ -17,6 +17,7 @@ from .graph import (
     edge_f1,
 )
 from .spans import (
+    CjkOffsetMap,
     IndicSpanRefinement,
     TokenClassificationSpan,
     TokenClassificationStreamEvent,
@@ -25,10 +26,12 @@ from .spans import (
     is_indic_text,
     iter_grapheme_cluster_spans,
     iter_grapheme_clusters,
+    project_word_spans_to_char_spans,
     reconcile_stream_spans,
     refine_indic_name_span,
     refine_privacy_filter_span,
     remap_normalized_span,
+    snap_char_span_to_word_boundaries,
     snap_span_to_grapheme_boundaries,
     snap_span_to_graphemes,
     stable_span_id,
@@ -50,6 +53,7 @@ from .viterbi import (
 )
 
 __all__ = [
+    "CjkOffsetMap",
     "EdgeCardinality",
     "EdgeDecisionTrace",
     "GraphExplainReport",
@@ -73,11 +77,13 @@ __all__ = [
     "iter_grapheme_clusters",
     "labels_to_char_spans",
     "labels_to_token_spans",
+    "project_word_spans_to_char_spans",
     "reconcile_stream_spans",
     "refine_indic_name_span",
     "remap_normalized_span",
     "refine_privacy_filter_span",
     "resolve_viterbi_biases",
+    "snap_char_span_to_word_boundaries",
     "snap_span_to_grapheme_boundaries",
     "snap_span_to_graphemes",
     "stable_span_key",

--- a/openmed/core/decoding/spans.py
+++ b/openmed/core/decoding/spans.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import hashlib
 import re
 import unicodedata
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
 from typing import Any, Final
 
@@ -75,6 +75,186 @@ _PREPEND_RANGES: Final = (
     (0x11D46, 0x11D46),
     (0x11F02, 0x11F02),
 )
+
+
+@dataclass(frozen=True, init=False)
+class CjkOffsetMap:
+    """Bidirectional word and source code-point offsets for segmented CJK text.
+
+    ``char_to_word[i]`` contains the word-token index covering source code
+    point ``text[i]``, or ``None`` for inter-token Unicode whitespace.
+    ``word_to_char[j]`` contains the exact source ``[start, end)`` span for
+    word token ``j``. The source must already be NFC-normalized; no hidden
+    normalization or UTF-8 byte conversion is performed.
+
+    Args:
+        text: Original NFC-normalized source text.
+        word_tokens: Monotonic span tokens whose offsets index ``text``.
+    """
+
+    text: str
+    word_tokens: tuple[Any, ...]
+    char_to_word: tuple[int | None, ...]
+    word_to_char: tuple[tuple[int, int], ...]
+
+    def __init__(self, text: str, word_tokens: Sequence[Any]) -> None:
+        """Build and validate lookup tables over Python string offsets."""
+        if not isinstance(text, str):
+            raise TypeError("text must be a string")
+        if not unicodedata.is_normalized("NFC", text):
+            raise ValueError("text must be NFC-normalized before offset mapping")
+
+        tokens = tuple(word_tokens)
+        char_to_word: list[int | None] = [None] * len(text)
+        word_to_char: list[tuple[int, int]] = []
+        cursor = 0
+
+        for word_index, token in enumerate(tokens):
+            start = getattr(token, "start", None)
+            end = getattr(token, "end", None)
+            token_text = getattr(token, "text", None)
+            if (
+                isinstance(start, bool)
+                or isinstance(end, bool)
+                or not isinstance(start, int)
+                or not isinstance(end, int)
+            ):
+                raise TypeError("word-token offsets must be integers")
+            if start < cursor:
+                raise ValueError("word tokens must be monotonic and non-overlapping")
+            if not 0 <= start < end <= len(text):
+                raise ValueError("word-token span falls outside the source text")
+            if any(not character.isspace() for character in text[cursor:start]):
+                raise ValueError(
+                    "word tokens leave non-whitespace source text uncovered"
+                )
+            if not isinstance(token_text, str) or text[start:end] != token_text:
+                raise ValueError("word-token text does not match its source span")
+
+            word_to_char.append((start, end))
+            for char_index in range(start, end):
+                char_to_word[char_index] = word_index
+            cursor = end
+
+        if any(not character.isspace() for character in text[cursor:]):
+            raise ValueError("word tokens leave trailing non-whitespace text uncovered")
+
+        object.__setattr__(self, "text", text)
+        object.__setattr__(self, "word_tokens", tokens)
+        object.__setattr__(self, "char_to_word", tuple(char_to_word))
+        object.__setattr__(self, "word_to_char", tuple(word_to_char))
+
+    def word_index_for_char(self, index: int) -> int | None:
+        """Return the word covering one source code point, if any."""
+        if not 0 <= index < len(self.text):
+            raise IndexError("character index falls outside the source text")
+        return self.char_to_word[index]
+
+    def char_span_for_word(self, index: int) -> tuple[int, int]:
+        """Return the exact source span for one word-token index."""
+        if not 0 <= index < len(self.word_to_char):
+            raise IndexError("word index falls outside the token sequence")
+        return self.word_to_char[index]
+
+    def word_position_for_char(self, index: int) -> tuple[int, int] | None:
+        """Return ``(word_index, code_point_in_word)`` for a source index.
+
+        The within-word coordinate retains enough information for an exact
+        char-to-word-to-char round trip instead of collapsing every character
+        in a multi-code-point word onto its first boundary.
+        """
+        word_index = self.word_index_for_char(index)
+        if word_index is None:
+            return None
+        return word_index, index - self.word_to_char[word_index][0]
+
+    def char_for_word_position(self, word_index: int, position: int) -> int:
+        """Map a within-word code-point coordinate back to source text."""
+        start, end = self.char_span_for_word(word_index)
+        if not 0 <= position < end - start:
+            raise IndexError("within-word position falls outside the word token")
+        return start + position
+
+
+def project_word_spans_to_char_spans(
+    word_spans: Iterable[tuple[int, int]],
+    offset_map: CjkOffsetMap,
+) -> list[tuple[int, int]]:
+    """Project half-open word-index spans onto exact source code points.
+
+    Empty word spans stay empty at the corresponding word boundary. Non-empty
+    spans include the complete first and last word and therefore cannot emit a
+    partial Han word.
+    """
+    projected: list[tuple[int, int]] = []
+    word_count = len(offset_map.word_to_char)
+
+    for word_start, word_end in word_spans:
+        if (
+            isinstance(word_start, bool)
+            or isinstance(word_end, bool)
+            or not isinstance(word_start, int)
+            or not isinstance(word_end, int)
+        ):
+            raise TypeError("word-span offsets must be integers")
+        if not 0 <= word_start <= word_end <= word_count:
+            raise ValueError("word span must satisfy 0 <= start <= end <= word count")
+        if word_start == word_end:
+            if word_start < word_count:
+                anchor = offset_map.word_to_char[word_start][0]
+            elif word_count:
+                anchor = offset_map.word_to_char[-1][1]
+            else:
+                anchor = 0
+            projected.append((anchor, anchor))
+            continue
+
+        projected.append(
+            (
+                offset_map.word_to_char[word_start][0],
+                offset_map.word_to_char[word_end - 1][1],
+            )
+        )
+    return projected
+
+
+def snap_char_span_to_word_boundaries(
+    start: int,
+    end: int,
+    offset_map: CjkOffsetMap,
+) -> tuple[int, int]:
+    """Snap a source span outward to every segmented word it intersects.
+
+    A span that intersects no word (for example, a standalone U+3000
+    full-width space) is returned unchanged so whitespace is never promoted
+    into a redactable word.
+    """
+    if (
+        isinstance(start, bool)
+        or isinstance(end, bool)
+        or not isinstance(start, int)
+        or not isinstance(end, int)
+    ):
+        raise TypeError("character-span offsets must be integers")
+    if not 0 <= start <= end <= len(offset_map.text):
+        raise ValueError("span must satisfy 0 <= start <= end <= len(text)")
+    if start == end:
+        return start, end
+
+    intersecting_words = {
+        word_index
+        for word_index in offset_map.char_to_word[start:end]
+        if word_index is not None
+    }
+    if not intersecting_words:
+        return start, end
+
+    first_word = min(intersecting_words)
+    last_word = max(intersecting_words)
+    return (
+        offset_map.word_to_char[first_word][0],
+        offset_map.word_to_char[last_word][1],
+    )
 
 
 def iter_grapheme_cluster_spans(text: str) -> Iterator[tuple[int, int]]:
@@ -189,10 +369,13 @@ def snap_span_to_graphemes(start: int, end: int, text: str) -> tuple[int, int]:
 
 
 def trim_span_whitespace(start: int, end: int, text: str) -> tuple[int, int]:
-    """Strip whole whitespace clusters from ``text[start:end]``.
+    """Strip whole Unicode whitespace clusters from ``text[start:end]``.
 
     Input boundaries are first snapped outward, so the returned ``[start, end)``
     offsets never bisect a combining sequence, Indic aksara, or emoji sequence.
+    Full-width U+3000 spaces are trimmed only at the edges; interior spaces and
+    Han characters remain untouched. A zero-width joiner is never considered
+    whitespace by itself.
     """
     start, end = snap_span_to_grapheme_boundaries(start, end, text)
     if start == end:
@@ -413,6 +596,8 @@ def refine_privacy_filter_span(
     Latin or neutral script runs and shrink to it. The Latin-only trailing
     ``" and"`` / ``" or"`` heuristic is disabled for spans containing CJK
     or other scripts. Every returned boundary is snapped to a whole grapheme.
+    All inputs and outputs are Python code-point offsets into the same source
+    string; this function never performs byte-based offset arithmetic.
     """
     start, end = trim_span_whitespace(start, end, text)
     span_text = text[start:end]
@@ -893,15 +1078,18 @@ def stable_span_key(span: Any) -> tuple[int, int, str, str]:
 
 
 __all__ = [
+    "CjkOffsetMap",
     "IndicSpanRefinement",
     "TokenClassificationSpan",
     "TokenClassificationStreamEvent",
     "coerce_token_classification_spans",
     "iter_grapheme_cluster_spans",
+    "project_word_spans_to_char_spans",
     "reconcile_stream_spans",
     "refine_indic_name_span",
     "remap_normalized_span",
     "refine_privacy_filter_span",
+    "snap_char_span_to_word_boundaries",
     "stable_span_id",
     "stable_span_key",
     "snap_span_to_grapheme_boundaries",

--- a/openmed/processing/tokenization.py
+++ b/openmed/processing/tokenization.py
@@ -26,6 +26,7 @@ from typing import (
 )
 
 from openmed.core.decoding.spans import (
+    CjkOffsetMap,
     is_grapheme_boundary,
     is_indic_text,
     iter_grapheme_clusters,
@@ -648,6 +649,8 @@ def _reject_dictionary(
 
 @dataclass(frozen=True)
 class SpanToken:
+    """A token whose half-open offsets index Python source code points."""
+
     text: str
     start: int
     end: int
@@ -1366,6 +1369,51 @@ def remap_predictions_to_tokens(
         i = j
 
     return remapped
+
+
+def remap_predictions_to_chinese_words(
+    predictions: List[Dict[str, Any]],
+    text: str,
+    word_tokens: List[SpanToken],
+) -> List[Dict[str, Any]]:
+    """Remap subword predictions onto whole segmented Chinese words.
+
+    ``text`` must be the original NFC-normalized string used by the segmenter,
+    and every prediction offset must be a Python code-point offset into that
+    same string. Partial overlaps expand to whole words. Adjacent words with
+    the same label may merge, but Unicode whitespace (including U+3000) is
+    never bridged into the resulting redaction span.
+
+    Args:
+        predictions: Token-classifier predictions with ``start`` and ``end``.
+        text: Original NFC-normalized source text.
+        word_tokens: Chinese segmentation tokens over ``text``.
+
+    Returns:
+        OutputFormatter-compatible prediction dictionaries on word boundaries.
+    """
+    CjkOffsetMap(text, word_tokens)
+    for prediction in predictions:
+        start = prediction.get("start")
+        end = prediction.get("end")
+        if (
+            isinstance(start, bool)
+            or isinstance(end, bool)
+            or not isinstance(start, int)
+            or not isinstance(end, int)
+        ):
+            continue
+        if not 0 <= start <= end <= len(text):
+            raise ValueError(
+                "prediction offsets must index the NFC-normalized source text"
+            )
+
+    return remap_predictions_to_tokens(
+        predictions,
+        text,
+        word_tokens,
+        gap=0,
+    )
 
 
 def _is_reasonable_length(

--- a/tests/unit/core/test_cjk_offset_mapping.py
+++ b/tests/unit/core/test_cjk_offset_mapping.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import unicodedata
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from openmed.core.decoding import (
+    CjkOffsetMap,
+    project_word_spans_to_char_spans,
+    refine_privacy_filter_span,
+    snap_char_span_to_word_boundaries,
+    trim_span_whitespace,
+)
+from openmed.processing.tokenization import (
+    SpanToken,
+    remap_predictions_to_chinese_words,
+)
+
+
+def _tokens_from_parts(parts: list[str]) -> tuple[str, list[SpanToken]]:
+    text = "".join(parts)
+    tokens: list[SpanToken] = []
+    cursor = 0
+    for part in parts:
+        end = cursor + len(part)
+        if part and not part.isspace():
+            tokens.append(SpanToken(part, cursor, end))
+        cursor = end
+    return text, tokens
+
+
+def test_name_projection_covers_exact_chinese_code_points() -> None:
+    text, tokens = _tokens_from_parts(["患者", "王芳", "入院"])
+    offset_map = CjkOffsetMap(text, tokens)
+
+    assert project_word_spans_to_char_spans([(1, 2)], offset_map) == [(2, 4)]
+    start, end = project_word_spans_to_char_spans([(1, 2)], offset_map)[0]
+    assert text[start:end] == "王芳"
+    assert (start, end) == (text.index("王芳"), text.index("王芳") + 2)
+
+
+def test_partial_han_prediction_snaps_to_whole_word() -> None:
+    text, tokens = _tokens_from_parts(["患者", "心房颤动", "入院"])
+    offset_map = CjkOffsetMap(text, tokens)
+    partial_start = text.index("心房")
+    partial_end = partial_start + len("心房")
+
+    assert snap_char_span_to_word_boundaries(
+        partial_start,
+        partial_end,
+        offset_map,
+    ) == (text.index("心房颤动"), text.index("心房颤动") + len("心房颤动"))
+
+
+def test_multibyte_name_offsets_follow_python_slicing_not_utf8_bytes() -> None:
+    text, tokens = _tokens_from_parts(["李雷", " ", "said", " ", "hello"])
+    offset_map = CjkOffsetMap(text, tokens)
+
+    assert offset_map.word_to_char[0] == (0, 2)
+    assert project_word_spans_to_char_spans([(0, 1)], offset_map) == [(0, 2)]
+    assert text[slice(*offset_map.word_to_char[0])] == "李雷"
+    assert len("李雷".encode("utf-8")) == 6
+
+
+def test_full_width_space_is_a_gap_not_a_redactable_word() -> None:
+    text, tokens = _tokens_from_parts(["王芳", "\u3000", "心房颤动"])
+    offset_map = CjkOffsetMap(text, tokens)
+
+    assert offset_map.char_to_word[2] is None
+    assert snap_char_span_to_word_boundaries(2, 3, offset_map) == (2, 3)
+    assert trim_span_whitespace(0, len(text), text) == (0, len(text))
+    assert refine_privacy_filter_span(
+        "private_person",
+        0,
+        len(text),
+        text,
+    ) == (0, len(text))
+
+
+def test_unicode_edge_spaces_trim_without_dropping_joined_han_text() -> None:
+    text = "\u3000王\u200d芳\u3000"
+
+    assert trim_span_whitespace(0, len(text), text) == (1, len(text) - 1)
+    assert text[slice(*trim_span_whitespace(0, len(text), text))] == "王\u200d芳"
+
+
+def test_chinese_remap_expands_partial_subword_prediction() -> None:
+    text, tokens = _tokens_from_parts(["患者", "心房颤动", "入院"])
+    start = text.index("心房")
+    predictions = [
+        {
+            "start": start,
+            "end": start + len("心房"),
+            "entity": "B-CONDITION",
+            "score": 0.95,
+        }
+    ]
+
+    remapped = remap_predictions_to_chinese_words(predictions, text, tokens)
+
+    assert remapped == [
+        {
+            "start": text.index("心房颤动"),
+            "end": text.index("心房颤动") + len("心房颤动"),
+            "score": 0.95,
+            "entity_group": "CONDITION",
+            "word": "心房颤动",
+            "metadata": {},
+        }
+    ]
+
+
+def test_chinese_remap_does_not_merge_across_full_width_space() -> None:
+    text, tokens = _tokens_from_parts(["王芳", "\u3000", "李雷"])
+    predictions = [
+        {"start": 0, "end": 2, "entity_group": "NAME", "score": 0.9},
+        {"start": 3, "end": 5, "entity_group": "NAME", "score": 0.8},
+    ]
+
+    remapped = remap_predictions_to_chinese_words(predictions, text, tokens)
+
+    assert [(item["word"], item["start"], item["end"]) for item in remapped] == [
+        ("王芳", 0, 2),
+        ("李雷", 3, 5),
+    ]
+
+
+def test_offset_map_rejects_non_nfc_source_and_invalid_tokens() -> None:
+    decomposed = "e\u0301患者"
+    assert unicodedata.normalize("NFC", decomposed) != decomposed
+    with pytest.raises(ValueError, match="NFC-normalized"):
+        CjkOffsetMap(decomposed, [SpanToken(decomposed, 0, len(decomposed))])
+
+    with pytest.raises(ValueError, match="does not match"):
+        CjkOffsetMap("王芳", [SpanToken("李雷", 0, 2)])
+
+
+_TOKEN_PARTS = st.sampled_from(
+    [
+        "患者",
+        "王芳",
+        "李雷",
+        "心房颤动",
+        "入院",
+        "A",
+        "Latin",
+        "B2",
+        "Ａ",
+        "１２",
+    ]
+)
+_SPACE_PARTS = st.sampled_from([" ", "\u3000"])
+
+
+@pytest.mark.fuzz
+@settings(max_examples=2000, deadline=None)
+@given(
+    st.lists(
+        st.one_of(_TOKEN_PARTS, _SPACE_PARTS),
+        min_size=1,
+        max_size=20,
+    )
+)
+def test_mixed_code_point_word_round_trips_are_exact(parts: list[str]) -> None:
+    text, tokens = _tokens_from_parts(parts)
+    offset_map = CjkOffsetMap(text, tokens)
+
+    for char_index, word_index in enumerate(offset_map.char_to_word):
+        if word_index is None:
+            assert text[char_index].isspace()
+            continue
+        word_position = offset_map.word_position_for_char(char_index)
+        assert word_position is not None
+        assert offset_map.char_for_word_position(*word_position) == char_index
+        word_start, word_end = offset_map.char_span_for_word(word_index)
+        assert text[word_start:word_end] == tokens[word_index].text


### PR DESCRIPTION
## Description

Adds validated character-to-word offset mapping for segmented Chinese text so partial model or rule predictions expand to exact whole-word code-point spans in the original NFC-normalized source. This prevents one-character drift from leaking part of a name or over-redacting adjacent clinical text.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made

- Added `CjkOffsetMap` with validated character-to-word and word-to-character lookup tables.
- Added word-span projection and character-span snapping helpers that preserve exact Python string offsets.
- Added a Chinese prediction remap path that expands partial subword predictions to whole segmented words without bridging Unicode whitespace.
- Documented and enforced NFC source and code-point offset invariants, including full-width space and zero-width joiner behavior.
- Added a 2,000-example mixed Han, Latin, and full-width property test plus targeted regression coverage.

## Testing

- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with mixed-script and multibyte inputs

Validation completed:

- `.venv/bin/python -m pytest tests/ -q` — 7,746 passed, 52 skipped
- `make format`
- `make lint`
- `make format-check`
- `make type-check`

## Documentation

- [x] I have added docstrings to new functions/classes
- [x] The public offset invariant is documented in the affected APIs

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] The branch is rebased on the latest `master`

## Related Issues

Closes #1466

## Screenshots/Examples

Not applicable; this change affects offset mapping and prediction remapping APIs.
