### PR TITLE
fix: replace assert statements with proper error handling in production code

### DIFF
--- a/openmed/clinical/exporters/dhis2.py
+++ b/openmed/clinical/exporters/dhis2.py
@@ -309,13 +309,15 @@ class _ManifestState:
             self.transformed_paths = set()
 
     def changed(self, path: str) -> None:
-        assert self.transformed_paths is not None
+        if self.transformed_paths is None:
+            self.transformed_paths = set()
         self.transformed_paths.add(path)
 
     def to_manifest(self, config: DHIS2ExportConfig) -> dict[str, Any]:
         """Build a deterministic manifest containing metadata and counts only."""
 
-        assert self.transformed_paths is not None
+        if self.transformed_paths is None:
+            self.transformed_paths = set()
         return {
             "schema_version": 1,
             "exporter": "dhis2",

--- a/openmed/core/africa_context.py
+++ b/openmed/core/africa_context.py
@@ -42,7 +42,8 @@ def rendered_pattern_entries() -> tuple[Mapping[str, Any], ...]:
 
     payload = load_africa_context_data()
     term_sets = payload["term_sets"]
-    assert isinstance(term_sets, Mapping)
+    if not isinstance(term_sets, Mapping):
+        raise TypeError(f"term_sets must be a Mapping, got {type(term_sets).__name__}")
 
     entries: list[Mapping[str, Any]] = []
     for index, raw_entry in enumerate(payload["patterns"]):
@@ -101,7 +102,8 @@ def profile_defaults_for(profile_name: str) -> Mapping[str, Mapping[str, str]]:
     """Return configured context-action defaults for an African profile."""
 
     defaults = load_africa_context_data()["african_profile_defaults"]
-    assert isinstance(defaults, Mapping)
+    if not isinstance(defaults, Mapping):
+        raise TypeError(f"african_profile_defaults must be a Mapping, got {type(defaults).__name__}")
     value = defaults.get(str(profile_name), {})
     if not isinstance(value, Mapping):
         raise ValueError(

--- a/openmed/interop/scispacy_linker.py
+++ b/openmed/interop/scispacy_linker.py
@@ -34,7 +34,8 @@ def to_canonical(linked: Any) -> list[dict[str, Any]]:
         candidates = _candidate_records(span)
         if candidates is _MISSING:
             raise ScispaCyLinkerResourceError(_resource_message())
-        assert isinstance(candidates, list)
+        if not isinstance(candidates, list):
+            raise TypeError(f"candidates must be a list, got {type(candidates).__name__}")
 
         output: dict[str, Any] = {}
         text = _value(span, ("text", "ngram"))

--- a/openmed/processing/legacy_encoding.py
+++ b/openmed/processing/legacy_encoding.py
@@ -565,7 +565,8 @@ def convert_legacy_encoding(
     if raw is None:
         if encoding in {"iscii", "legacy-font"}:
             raise ValueError("legacy conversion requires bytes or Latin-1 text")
-        assert isinstance(data, str)
+        if not isinstance(data, str):
+            raise TypeError(f"expected str, got {type(data).__name__}")
         return _unicode_identity(data)
 
     detected: LegacyEncoding


### PR DESCRIPTION
## Problem

Assert statements in production code are stripped under `python -O` (optimized mode), which can lead to silent None dereferences and type errors. This is a correctness and reliability issue for deployments that run with optimization flags.

## Changes

Replace `assert` statements with proper error handling:

### `processing/legacy_encoding.py`
- `assert isinstance(data, str)` → `if not isinstance(data, str): raise TypeError(...)`

### `core/africa_context.py`
- `assert isinstance(term_sets, Mapping)` → `if not isinstance(term_sets, Mapping): raise TypeError(...)`
- `assert isinstance(defaults, Mapping)` → `if not isinstance(defaults, Mapping): raise TypeError(...)`

### `interop/scispacy_linker.py`
- `assert isinstance(candidates, list)` → `if not isinstance(candidates, list): raise TypeError(...)`

### `clinical/exporters/dhis2.py`
- `assert self.transformed_paths is not None` → `if self.transformed_paths is None: self.transformed_paths = set()`

## Testing

All 92 existing tests pass:
```
tests/unit/processing/test_legacy_encoding.py .........................  [ 27%]
tests/unit/core/test_africa_context_safety_sweep.py .................... [ 48%]
.................                                                        [ 67%]
tests/unit/interop/test_scispacy_linker_adapter.py ........              [ 76%]
tests/unit/clinical/test_dhis2_exporter.py ......................        [100%]
```