### PR TITLE
Add path-filtered CJK and Indic fixture CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,42 @@ on:
 jobs:
   repo-policy:
     runs-on: ubuntu-latest
+    outputs:
+      run-i18n-cjk-indic: ${{ steps.i18n_changes.outputs.should_run }}
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
         python-version: "3.11"
+
+    - name: Detect CJK and Indic test changes
+      id: i18n_changes
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        if [[ "$EVENT_NAME" != "pull_request" ]]; then
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+        elif git diff --quiet "$BASE_SHA" HEAD -- \
+          openmed/core/pii_i18n.py \
+          openmed/core/script_detect.py \
+          openmed/core/decoding \
+          openmed/interop/zh.py \
+          openmed/interop/indic.py \
+          tests/unit/core/test_script_detect.py \
+          tests/unit/test_pii_i18n.py \
+          tests/unit/interop/test_language_adapters.py \
+          tests/unit/interop/test_i18n_cjk_indic_fixtures.py \
+          tests/fixtures/i18n; then
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          echo "No CJK or Indic test paths changed."
+        else
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Enforce repo file policy
       run: |
@@ -285,8 +314,59 @@ jobs:
       run: |
         pytest tests/unit/interop/test_spacy_component.py -q
 
+  i18n-cjk-indic:
+    needs: [repo-policy, lint]
+    if: needs.repo-policy.outputs.run-i18n-cjk-indic == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.11"
+
+    - name: Cache pip packages
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-i18n-cjk-indic-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-i18n-cjk-indic-
+          ${{ runner.os }}-pip-
+
+    - name: Install CJK and Indic test dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev,zh,indic]"
+
+    - name: Run CJK and Indic fixture tests
+      run: |
+        pytest tests/unit -q -k "i18n or script_detect or cjk or indic"
+
+    - name: Trust-CI no-raw-PHI logging guard
+      run: |
+        pytest tests/unit/test_no_raw_text_logging.py -q
+
   build:
-    needs: [repo-policy, lint, test, security, spacy-integration]
+    needs:
+    - repo-policy
+    - lint
+    - test
+    - security
+    - spacy-integration
+    - i18n-cjk-indic
+    if: >-
+      always() &&
+      needs.repo-policy.result == 'success' &&
+      needs.lint.result == 'success' &&
+      needs.test.result == 'success' &&
+      needs.security.result == 'success' &&
+      needs.spacy-integration.result == 'success' &&
+      (
+        needs.i18n-cjk-indic.result == 'success' ||
+        needs.i18n-cjk-indic.result == 'skipped'
+      )
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7

--- a/tests/fixtures/i18n/hi.json
+++ b/tests/fixtures/i18n/hi.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "locale": "hi-IN",
+  "language": "hi",
+  "synthetic": true,
+  "contains_real_phi": false,
+  "provenance": "Invented name and seeded checksum-valid test identifier; no patient source was used.",
+  "text": "रोगी काव्या नवल, आधार 246778325484।",
+  "expected_script": "Devanagari",
+  "expected_segments": [
+    {"start": 0, "end": 35, "script": "Devanagari"}
+  ],
+  "expected_entities": [
+    {"label": "national_id", "start": 22, "end": 34, "text": "246778325484"}
+  ],
+  "expected_tokens": [
+    {"start": 0, "end": 4, "text": "रोगी"},
+    {"start": 5, "end": 11, "text": "काव्या"},
+    {"start": 12, "end": 15, "text": "नवल"},
+    {"start": 15, "end": 16, "text": ","},
+    {"start": 17, "end": 21, "text": "आधार"},
+    {"start": 22, "end": 34, "text": "246778325484"},
+    {"start": 34, "end": 35, "text": "।"}
+  ]
+}

--- a/tests/fixtures/i18n/hinglish.json
+++ b/tests/fixtures/i18n/hinglish.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "locale": "hi-Latn-IN",
+  "language": "hi",
+  "synthetic": true,
+  "contains_real_phi": false,
+  "provenance": "Invented code-mixed note and seeded checksum-valid test identifier; no patient source was used.",
+  "text": "Patient ka naam Kavya Nawal hai; आधार 246778325484.",
+  "expected_script": "Latin",
+  "expected_segments": [
+    {"start": 0, "end": 33, "script": "Latin"},
+    {"start": 33, "end": 51, "script": "Devanagari"}
+  ],
+  "expected_entities": [
+    {"label": "national_id", "start": 38, "end": 50, "text": "246778325484"}
+  ],
+  "expected_tokens": [
+    {"start": 0, "end": 7, "text": "Patient"},
+    {"start": 8, "end": 10, "text": "ka"},
+    {"start": 11, "end": 15, "text": "naam"},
+    {"start": 16, "end": 21, "text": "Kavya"},
+    {"start": 22, "end": 27, "text": "Nawal"},
+    {"start": 28, "end": 31, "text": "hai"},
+    {"start": 31, "end": 32, "text": ";"},
+    {"start": 33, "end": 37, "text": "आधार"},
+    {"start": 38, "end": 50, "text": "246778325484"},
+    {"start": 50, "end": 51, "text": "."}
+  ]
+}

--- a/tests/fixtures/i18n/ta.json
+++ b/tests/fixtures/i18n/ta.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "locale": "ta-IN",
+  "language": "ta",
+  "synthetic": true,
+  "contains_real_phi": false,
+  "provenance": "Invented name and seeded checksum-valid test identifier; no patient source was used.",
+  "text": "நோயாளி யாழினி அருள், ஆதார் Aadhaar 246778325484.",
+  "expected_script": "Tamil",
+  "expected_segments": [
+    {"start": 0, "end": 27, "script": "Tamil"},
+    {"start": 27, "end": 48, "script": "Latin"}
+  ],
+  "expected_entities": [
+    {"label": "national_id", "start": 35, "end": 47, "text": "246778325484"}
+  ],
+  "expected_tokens": [
+    {"start": 0, "end": 6, "text": "நோயாளி"},
+    {"start": 7, "end": 13, "text": "யாழினி"},
+    {"start": 14, "end": 19, "text": "அருள்"},
+    {"start": 19, "end": 20, "text": ","},
+    {"start": 21, "end": 26, "text": "ஆதார்"},
+    {"start": 27, "end": 34, "text": "Aadhaar"},
+    {"start": 35, "end": 47, "text": "246778325484"},
+    {"start": 47, "end": 48, "text": "."}
+  ]
+}

--- a/tests/fixtures/i18n/zh-Hans.json
+++ b/tests/fixtures/i18n/zh-Hans.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "locale": "zh-Hans",
+  "language": "zh",
+  "synthetic": true,
+  "contains_real_phi": false,
+  "provenance": "Invented name and fabricated example phone created for deterministic fixture testing.",
+  "text": "患者林星河，手机号13800138000。",
+  "expected_script": "Han",
+  "expected_variant": "simplified",
+  "expected_segments": [
+    {"start": 0, "end": 21, "script": "Han"}
+  ],
+  "expected_entities": [
+    {"label": "person", "start": 2, "end": 5, "text": "林星河"},
+    {"label": "phone_number", "start": 9, "end": 20, "text": "13800138000"}
+  ],
+  "expected_tokens": [
+    {"start": 0, "end": 2, "text": "患者"},
+    {"start": 2, "end": 3, "text": "林"},
+    {"start": 3, "end": 5, "text": "星河"},
+    {"start": 5, "end": 6, "text": "，"},
+    {"start": 6, "end": 9, "text": "手机号"},
+    {"start": 9, "end": 20, "text": "13800138000"},
+    {"start": 20, "end": 21, "text": "。"}
+  ]
+}

--- a/tests/fixtures/i18n/zh-Hant.json
+++ b/tests/fixtures/i18n/zh-Hant.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "locale": "zh-Hant",
+  "language": "zh",
+  "synthetic": true,
+  "contains_real_phi": false,
+  "provenance": "OpenCC conversion of the paired invented Simplified Chinese fixture and fabricated example phone.",
+  "text": "患者林星河，手機號13800138000。",
+  "expected_script": "Han",
+  "expected_variant": "traditional",
+  "expected_segments": [
+    {"start": 0, "end": 21, "script": "Han"}
+  ],
+  "expected_entities": [
+    {"label": "person", "start": 2, "end": 5, "text": "林星河"},
+    {"label": "phone_number", "start": 9, "end": 20, "text": "13800138000"}
+  ],
+  "expected_tokens": [
+    {"start": 0, "end": 2, "text": "患者"},
+    {"start": 2, "end": 3, "text": "林"},
+    {"start": 3, "end": 5, "text": "星河"},
+    {"start": 5, "end": 6, "text": "，"},
+    {"start": 6, "end": 9, "text": "手機號"},
+    {"start": 9, "end": 20, "text": "13800138000"},
+    {"start": 20, "end": 21, "text": "。"}
+  ]
+}

--- a/tests/unit/interop/test_i18n_cjk_indic_fixtures.py
+++ b/tests/unit/interop/test_i18n_cjk_indic_fixtures.py
@@ -1,0 +1,99 @@
+"""Synthetic span-level coverage for the optional CJK and Indic adapters."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.core.safety_sweep import safety_sweep
+from openmed.core.script_detect import (
+    detect_chinese_script,
+    detect_script,
+    segment_by_script,
+)
+from openmed.interop import indic, zh
+
+_FIXTURE_DIR = Path(__file__).parents[2] / "fixtures" / "i18n"
+_FIXTURE_NAMES = ("zh-Hans.json", "zh-Hant.json", "hi.json", "ta.json", "hinglish.json")
+_FIXTURE_PATHS = tuple(_FIXTURE_DIR / name for name in _FIXTURE_NAMES)
+
+
+def _load_fixture(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _token_spans(text: str, tokens: tuple[str, ...]) -> list[dict[str, object]]:
+    spans: list[dict[str, object]] = []
+    cursor = 0
+    for token in tokens:
+        start = text.index(token, cursor)
+        end = start + len(token)
+        spans.append({"start": start, "end": end, "text": token})
+        cursor = end
+    return spans
+
+
+@pytest.mark.parametrize("path", _FIXTURE_PATHS, ids=lambda path: path.stem)
+def test_i18n_fixtures_have_exact_script_and_entity_spans(path: Path) -> None:
+    fixture = _load_fixture(path)
+    text = str(fixture["text"])
+
+    assert fixture["schema_version"] == 1
+    assert fixture["synthetic"] is True
+    assert fixture["contains_real_phi"] is False
+    assert detect_script(text) == fixture["expected_script"]
+    assert [
+        {"start": start, "end": end, "script": script}
+        for start, end, script in segment_by_script(text)
+    ] == fixture["expected_segments"]
+
+    entities = safety_sweep(text, [], lang=str(fixture["language"]))
+    assert [
+        {
+            "label": entity.label,
+            "start": entity.start,
+            "end": entity.end,
+            "text": entity.text,
+        }
+        for entity in entities
+    ] == fixture["expected_entities"]
+
+    for span in [*fixture["expected_segments"], *fixture["expected_entities"]]:
+        assert 0 <= span["start"] < span["end"] <= len(text)
+    for entity in fixture["expected_entities"]:
+        assert text[entity["start"] : entity["end"]] == entity["text"]
+
+
+@pytest.mark.parametrize("path", _FIXTURE_PATHS, ids=lambda path: path.stem)
+def test_optional_language_adapters_match_fixture_token_spans(path: Path) -> None:
+    fixture = _load_fixture(path)
+    text = str(fixture["text"])
+    language = str(fixture["language"])
+    tokens = (
+        zh.segment(text)
+        if language == "zh"
+        else indic.segment(
+            text,
+            language=language,
+        )
+    )
+
+    assert _token_spans(text, tokens) == fixture["expected_tokens"]
+
+
+def test_opencc_round_trips_simplified_and_traditional_fixtures() -> None:
+    simplified = _load_fixture(_FIXTURE_DIR / "zh-Hans.json")
+    traditional = _load_fixture(_FIXTURE_DIR / "zh-Hant.json")
+
+    assert (
+        zh.convert_script(str(simplified["text"]), config="s2t") == traditional["text"]
+    )
+    assert (
+        zh.convert_script(str(traditional["text"]), config="t2s") == simplified["text"]
+    )
+    assert detect_chinese_script(str(simplified["text"])).variant.value == "simplified"
+    assert (
+        detect_chinese_script(str(traditional["text"])).variant.value == "traditional"
+    )

--- a/tests/unit/interop/test_i18n_cjk_indic_fixtures.py
+++ b/tests/unit/interop/test_i18n_cjk_indic_fixtures.py
@@ -71,6 +71,7 @@ def test_optional_language_adapters_match_fixture_token_spans(path: Path) -> Non
     fixture = _load_fixture(path)
     text = str(fixture["text"])
     language = str(fixture["language"])
+    pytest.importorskip("jieba" if language == "zh" else "indicnlp")
     tokens = (
         zh.segment(text)
         if language == "zh"
@@ -84,6 +85,7 @@ def test_optional_language_adapters_match_fixture_token_spans(path: Path) -> Non
 
 
 def test_opencc_round_trips_simplified_and_traditional_fixtures() -> None:
+    pytest.importorskip("opencc")
     simplified = _load_fixture(_FIXTURE_DIR / "zh-Hans.json")
     traditional = _load_fixture(_FIXTURE_DIR / "zh-Hant.json")
 

--- a/tests/unit/interop/test_language_adapters.py
+++ b/tests/unit/interop/test_language_adapters.py
@@ -45,7 +45,10 @@ def test_zh_segment_missing_extra_raises_actionable_error(monkeypatch):
 
 
 def test_indic_segment_missing_extra_raises_actionable_error(monkeypatch):
-    monkeypatch.setitem(sys.modules, "indicnlp", None)
+    def missing_dependency(name: str):
+        raise ImportError(name)
+
+    monkeypatch.setattr(indic, "_import_module", missing_dependency)
 
     with pytest.raises(ImportError, match=r"pip install openmed\[indic\]"):
         indic.segment("रोगी रवि")


### PR DESCRIPTION
## Description

Adds a path-filtered Python 3.11 CI job for the optional Chinese and Indic language stacks. The job installs the existing `zh` and `indic` extras, runs the focused multilingual unit selection and no-raw-PHI logging guard, and lets the build proceed when the language job is intentionally skipped for unrelated pull requests.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Added changed-path detection for CJK/Indic core, decoding, adapters, tests, and fixture paths.
- Added synthetic Simplified Chinese, Traditional Chinese, Hindi, Tamil, and Hinglish fixtures with exact script, entity, and token spans.
- Exercised the real optional adapters, including an OpenCC round trip, and made the existing missing-Indic-extra test independent of module import order.

## Testing

- [x] I have added tests that prove the change works
- [x] New and existing unit tests pass locally with my changes
- [x] The exact focused CI selection passes: 1,269 passed, 7 skipped in 10.73 seconds
- [x] The full suite passes: 7,757 passed, 52 skipped
- [x] The unchanged no-raw-PHI logging guard and hardcoded-secret checks pass

## Documentation

No documentation update is needed; this change affects CI configuration and synthetic test fixtures only.

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I performed a self-review of my own code
- [x] Workflow syntax, action-reference policy, and repository policy checks pass
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies; the job installs the existing `zh` and `indic` extras

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] I have organized the commit appropriately

## Related Issues

Closes #1523

## Screenshots/Examples

Not applicable.