### PR TITLE
Ship an MCP-enabled container image and compose service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,13 @@ __pycache__/
 *.py[cod]
 .pytest_cache/
 .ruff_cache/
+.mypy_cache/
+.hypothesis/
+.build/
+**/.build/
+.c*/
 .coverage
+coverage.xml
 
 dist/
 build/

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,23 @@
+FROM python:3.11-slim@sha256:e031123e3d85762b141ad1cbc56452ba69c6e722ebf2f042cc0dc86c47c0d8b3
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    OPENMED_PROFILE=prod \
+    OPENMED_SERVICE_KEEP_ALIVE=10m
+
+WORKDIR /app
+
+COPY . /app
+
+RUN python -m pip install --no-cache-dir --upgrade \
+        "pip==26.1.2" \
+        "setuptools==83.0.0" \
+        "wheel==0.47.0" \
+        "jaraco.context==6.1.2" \
+    && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
+    && pip install --no-cache-dir ".[hf,mcp,service]"
+
+EXPOSE 8081
+
+ENTRYPOINT ["openmed-mcp"]
+CMD ["--transport", "stdio"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,5 +13,38 @@ services:
     volumes:
       - hf-cache:/root/.cache/huggingface
 
+  mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile.mcp
+    command:
+      - --transport
+      - streamable-http
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8081"
+      - --streamable-http-path
+      - /mcp
+    ports:
+      - "127.0.0.1:${OPENMED_MCP_PORT:-8081}:8081"
+    environment:
+      OPENMED_PROFILE: ${OPENMED_PROFILE:-prod}
+      OPENMED_CACHE_DIR: ${OPENMED_CACHE_DIR:-/root/.cache/huggingface/openmed}
+      OPENMED_SERVICE_KEEP_ALIVE: ${OPENMED_SERVICE_KEEP_ALIVE:-10m}
+      HF_TOKEN: ${HF_TOKEN:-}
+    volumes:
+      - hf-cache:/root/.cache/huggingface
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import socket; socket.create_connection(("127.0.0.1", 8081), 3).close()
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+
 volumes:
   hf-cache:

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -24,6 +24,69 @@ uv sync --extra mcp
 uv run openmed-mcp --version
 ```
 
+## Run in a container
+
+Build the dedicated MCP image from a checkout:
+
+```bash
+docker build -f Dockerfile.mcp -t openmed-mcp:local .
+```
+
+The image defaults to stdio. Keep stdin attached with `-i` and do not allocate
+a TTY, because MCP protocol messages use stdin and stdout:
+
+```bash
+docker run -i --rm \
+  -v openmed-hf-cache:/root/.cache/huggingface \
+  openmed-mcp:local
+```
+
+A command-map client can launch that container directly:
+
+```json
+{
+  "mcpServers": {
+    "openmed-container": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-v",
+        "openmed-hf-cache:/root/.cache/huggingface",
+        "openmed-mcp:local"
+      ]
+    }
+  }
+}
+```
+
+For a local Streamable HTTP endpoint, override the image's default command.
+The server must listen on all container interfaces, while the published port
+remains limited to host loopback:
+
+```bash
+docker run --rm \
+  -p 127.0.0.1:8081:8081 \
+  -v openmed-hf-cache:/root/.cache/huggingface \
+  openmed-mcp:local \
+  --transport streamable-http \
+  --host 0.0.0.0 \
+  --port 8081 \
+  --streamable-http-path /mcp
+```
+
+The equivalent Compose service includes the same loopback port binding, a
+listener health check, and a persistent model cache:
+
+```bash
+docker compose up --build mcp
+```
+
+Connect remote-style local clients to `http://127.0.0.1:8081/mcp`. Set
+`OPENMED_MCP_PORT` before starting Compose to select a different host port;
+the container endpoint remains on port `8081`.
+
 ## Local stdio connections
 
 Stdio is the recommended transport when the MCP client and OpenMed run on the

--- a/tests/unit/mcp/test_mcp_container.py
+++ b/tests/unit/mcp/test_mcp_container.py
@@ -1,0 +1,84 @@
+"""Smoke coverage for the OpenMed MCP container surfaces."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+REST_DOCKERFILE = BASE_DIR / "Dockerfile"
+MCP_DOCKERFILE = BASE_DIR / "Dockerfile.mcp"
+COMPOSE_FILE = BASE_DIR / "docker-compose.yml"
+CLIENT_DOCS = BASE_DIR / "docs" / "mcp-clients.md"
+
+
+def _json_instruction(contents: str, instruction: str) -> list[str]:
+    prefix = f"{instruction} "
+    line = next(line for line in contents.splitlines() if line.startswith(prefix))
+    value = json.loads(line.removeprefix(prefix))
+    assert isinstance(value, list)
+    return value
+
+
+def _load_compose() -> dict[str, Any]:
+    payload = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_mcp_image_defaults_to_stdio_and_supports_http_override() -> None:
+    dockerfile = MCP_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert 'pip install --no-cache-dir ".[hf,mcp,service]"' in dockerfile
+    assert "EXPOSE 8081" in dockerfile
+    assert _json_instruction(dockerfile, "ENTRYPOINT") == ["openmed-mcp"]
+    assert _json_instruction(dockerfile, "CMD") == ["--transport", "stdio"]
+
+
+def test_rest_image_command_remains_unchanged() -> None:
+    dockerfile = REST_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "EXPOSE 8080" in dockerfile
+    assert _json_instruction(dockerfile, "CMD") == [
+        "uvicorn",
+        "openmed.service.app:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8080",
+    ]
+
+
+def test_compose_declares_healthy_mcp_service_with_persistent_cache() -> None:
+    compose = _load_compose()
+    mcp = compose["services"]["mcp"]
+
+    assert mcp["build"] == {"context": ".", "dockerfile": "Dockerfile.mcp"}
+    assert mcp["command"] == [
+        "--transport",
+        "streamable-http",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8081",
+        "--streamable-http-path",
+        "/mcp",
+    ]
+    assert "127.0.0.1:${OPENMED_MCP_PORT:-8081}:8081" in mcp["ports"]
+    assert "hf-cache:/root/.cache/huggingface" in mcp["volumes"]
+    assert "hf-cache" in compose["volumes"]
+    assert mcp["healthcheck"]["test"][:2] == ["CMD", "python"]
+
+
+def test_container_client_commands_are_documented() -> None:
+    docs = CLIENT_DOCS.read_text(encoding="utf-8")
+
+    assert "docker build -f Dockerfile.mcp -t openmed-mcp:local ." in docs
+    assert '"command": "docker"' in docs
+    assert "docker run -i --rm" in docs
+    assert "--transport streamable-http" in docs
+    assert "docker compose up --build mcp" in docs
+    assert "http://127.0.0.1:8081/mcp" in docs


### PR DESCRIPTION
# Pull Request

## Description

Adds a dedicated MCP container image that defaults to stdio, supports a Streamable HTTP command override, and integrates with Compose through a loopback-only published port, listener health check, and persistent model cache. The existing REST image and command remain unchanged.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add `Dockerfile.mcp` with the MCP console entry point and stdio default.
- Add a Streamable HTTP `mcp` Compose service with health and cache persistence.
- Document container command-map, direct HTTP, and Compose client setup.
- Add smoke coverage for both image commands, the REST compatibility contract, Compose wiring, and documentation.
- Exclude local build caches and hidden development state from container build contexts.

## Testing

- [x] Full test suite passes: `.venv/bin/python -m pytest tests/ -q` - 7750 passed, 52 skipped.
- [x] Canonical formatting and lint checks pass.
- [x] Strict documentation build passes.
- [x] Scoped pre-commit checks pass.
- [x] MCP image builds and returns valid initialize responses over stdio and Streamable HTTP.
- [x] Compose service reaches healthy state with a persistent named cache volume.
- [x] Existing REST image builds and returns a healthy `/health` response.

## Documentation

- [x] Container stdio and Streamable HTTP client configurations are documented.
- [ ] Changelog update is not required for this scoped feature PR.

## Dependencies

- [x] No project dependencies were added.

## Checklist

- [x] The change is focused on the requested issue.
- [x] The branch is based on the latest `master`.
- [x] The commit has the repository-owner identity and no additional attribution.
- [x] No assignees or reviewers were added.

## Related Issues

Closes #1740

## Screenshots/Examples

Not applicable; this is a container and documentation change validated by live protocol smoke checks.
