### PR TITLE
African deployment reference: facility EMR to national HMIS synthetic demo

### DIFF
--- a/docs/deploy/africa-reference-deployment.md
+++ b/docs/deploy/africa-reference-deployment.md
@@ -1,0 +1,183 @@
+# African facility EMR to national HMIS reference
+
+This reference demonstrates a common African health-data path without using a
+real patient corpus: a facility-local OpenMRS-compatible EMR is read through
+FHIR2, OpenMed removes seeded identifiers on the facility machine, precise
+geography is reduced to a district organisation unit, and reviewable DHIS2
+aggregate and Tracker payloads are emitted for an HMIS hand-off.
+
+The default workflow is fully synthetic, deterministic, and offline. It starts
+a recorded-response fixture for both legacy REST and FHIR2 endpoints on an
+ephemeral loopback port, exercises both adapter paths, and builds the
+transaction Bundle from FHIR2 resources. It does not require Java, Docker,
+credentials, model downloads, or internet access.
+
+!!! danger "The raw stage stays inside the facility boundary"
+
+    `01-raw-openmrs.json` deliberately contains synthetic names, MSISDNs,
+    national identifiers, and GPS coordinates. It exists so implementers can
+    inspect the input to the privacy boundary. Never substitute real patient
+    data in this reference or move the raw stage to a national reporting
+    system.
+
+## Facility-edge architecture
+
+```mermaid
+flowchart LR
+    A["KenyaEMR / UgandaEMR-style OpenMRS<br/>facility LAN"]
+    B["Raw FHIR2 pull<br/>facility storage only"]
+    C["OpenMed adapter<br/>exact synthetic de-identification"]
+    D{"No-PHI gate"}
+    E["FHIR transaction Bundle<br/>de-identified"]
+    F["DHIS2 exporter<br/>ICD-11 codes + geo policy"]
+    G{"No-PHI + district-only gates"}
+    H["DHIS2 aggregate / Tracker<br/>national HMIS hand-off"]
+
+    A --> B --> C --> D
+    D -->|pass| E --> F --> G
+    G -->|pass| H
+    D -->|fail closed| X["No egress"]
+    G -->|fail closed| X
+```
+
+The de-identification and geography policy run before any national-system
+handoff. Only district-level `orgUnit` values can cross the final boundary.
+Facility UIDs and `geometry`, `latitude`, and `longitude` fields fail the demo's
+release gate.
+
+## Run the offline reference
+
+From a development checkout with the OpenMRS extra or development dependencies
+installed:
+
+```bash
+.venv/bin/python examples/africa-openmrs-dhis2/run_demo.py \
+  --output-dir /tmp/openmed-africa-reference \
+  --seed 875 \
+  --patient-count 50
+```
+
+The command prints counts only. It never prints payload content or seeded
+identifiers. The output directory contains:
+
+| Stage | Artifact | Boundary |
+| --- | --- | --- |
+| 1 | `01-raw-openmrs.json` | Facility-only synthetic raw pull |
+| 2 | `02-deidentified-fhir-bundle.json` | Valid FHIR transaction Bundle |
+| 3 | `03-openmrs-deidentification-manifest.json` | PHI-free path and count summary |
+| 4 | `04-dhis2-aggregate.json` | District-generalised aggregate import body |
+| 5 | `05-dhis2-tracker.json` | District-generalised Tracker import body |
+| 6 | `06-dhis2-export-manifest.json` | PHI-free DHIS2 transformation summary |
+| 7 | `07-demo-manifest.json` | Stable hashes for every prior stage |
+
+The fictional Mtoni district contains three facilities and 50 patients by
+default. Each patient has a seeded name, MSISDN, national identifier, and GPS
+coordinate. Observations use ICD-11-style codes from the WHO MMS namespace.
+Two executions with the same seed and patient count produce byte-identical
+artifacts, including the manifests.
+
+Use `--page-size` to exercise fixture pagination without changing the artifacts:
+
+```bash
+.venv/bin/python examples/africa-openmrs-dhis2/run_demo.py \
+  --output-dir /tmp/openmed-africa-reference-paged \
+  --seed 875 \
+  --patient-count 50 \
+  --page-size 7
+```
+
+The smoke coverage in `tests/unit/examples/test_africa_reference_demo.py`
+executes this fixture path, validates the FHIR transaction shape, runs the
+DHIS2 aggregate and Tracker schema checkers, scans every egress artifact and
+console output for all seeded identifiers, checks district-only geography, and
+compares two complete runs byte for byte.
+
+## Mapping to KenyaEMR and UgandaEMR-style deployments
+
+The fixture uses the same integration boundaries an implementer should map in
+an OpenMRS distribution:
+
+1. Confirm the deployment's OpenMRS context path and enabled FHIR2 R4 module.
+   KenyaEMR and UgandaEMR configurations differ by release and local
+   customisation, so enumerate Patient, Encounter, and Observation search
+   capabilities rather than assuming identical profiles.
+2. Run the OpenMRS adapter on a facility-controlled machine or server. Keep
+   credentials and the raw pull inside the facility LAN.
+3. Replace the exact synthetic redactor with a reviewed OpenMed privacy policy
+   for the deployment's languages and identifier formats. Measure
+   direct-identifier recall before enabling an egress route.
+4. Map the shipped ICD-11-style example codes and fictional DHIS2 UIDs to the
+   ministry's reviewed metadata. Never infer national data-element or program
+   UIDs.
+5. Export through `openmed.clinical.exporters.DHIS2Exporter`. Supply a local
+   organisation-unit snapshot and set the permitted district level for the
+   target hierarchy.
+6. Review the FHIR and DHIS2 manifests, then hand only the gated aggregate and
+   Tracker files to facility-controlled transport tooling.
+
+An OpenHIM mediator can sit between the facility and the HIE when that is part
+of the national architecture. It is intentionally not included in this chain;
+see [OpenHIM De-identification Mediator](openhim-mediator.md) for the separate
+deployment surface.
+
+## Facility hardware guidance
+
+The fixture itself is lightweight and runs on a developer laptop or modest
+facility PC. For a facility deployment, start with local operational
+requirements rather than national-server sizing:
+
+| Component | Practical starting point | Why |
+| --- | --- | --- |
+| OpenMed edge worker | 4 modern CPU cores, 8 GB RAM, encrypted SSD | Batch FHIR processing, policy checks, and local artifacts |
+| Combined EMR and edge host | 8 CPU cores, 16 GB RAM, encrypted SSD | Leaves headroom for OpenMRS, its database, and privacy jobs |
+| Storage | Capacity for the EMR plus two staged batches and logs that contain no raw PHI | Supports review and retry without uncontrolled copies |
+| Power and network | UPS, tested shutdown, local LAN operation, queued outbound transfer | Keeps de-identification available during intermittent power or WAN service |
+
+Treat these as a pilot baseline, not a production guarantee. Benchmark with the
+facility's record volume, concurrency, language policy, retention rules, and
+OpenMRS distribution. Keep database backups encrypted and test restoration
+without copying real records into lower-trust environments.
+
+## Optional live container profile
+
+The offline fixture is the supported CI path. For an isolated demo lab,
+`docker-compose.yml` also carries a `live` profile with real OpenMRS Reference
+Application and DHIS2 Core containers:
+
+```bash
+docker compose \
+  -f examples/africa-openmrs-dhis2/docker-compose.yml \
+  --profile live \
+  up -d
+```
+
+OpenMRS is bound to `127.0.0.1:8080` and DHIS2 to `127.0.0.1:8081` by default.
+The containers are demo-grade, start with local-only example passwords, and are
+not a hardened deployment. Load only the generated fictional recording and
+reviewed fictional DHIS2 metadata before testing live API round-trips. The
+fixture command does not upload anything to either service; use the existing
+OpenMRS adapter and DHIS2 import endpoints only after the synthetic metadata is
+present.
+
+Stop the optional stack and remove its demo volumes when finished:
+
+```bash
+docker compose \
+  -f examples/africa-openmrs-dhis2/docker-compose.yml \
+  --profile live \
+  down --volumes
+```
+
+CI never starts this profile. A live deployment needs separate secret
+management, TLS, backups, network policy, observability, upgrade planning,
+distribution-specific validation, and ministry metadata governance.
+
+## Safety checklist
+
+- Use only the bundled generator or another demonstrably synthetic corpus.
+- Keep the raw OpenMRS pull and credentials inside the facility boundary.
+- Fail closed if any seeded identifier appears in an egress artifact or log.
+- Permit only district-level organisation units in national HMIS payloads.
+- Review ICD-11 and DHIS2 metadata mappings with the clinical and HMIS owners.
+- Do not treat this example as medical-device logic or an automated clinical
+  decision system.

--- a/examples/africa-openmrs-dhis2/docker-compose.yml
+++ b/examples/africa-openmrs-dhis2/docker-compose.yml
@@ -1,0 +1,89 @@
+# Optional demo-grade servers. The offline fixture workflow does not use this
+# file, and CI must never enable the "live" profile.
+services:
+  openmrs-db:
+    profiles: [live]
+    image: mariadb:10.11.7
+    command: >-
+      mysqld --character-set-server=utf8mb4
+      --collation-server=utf8mb4_general_ci
+    environment:
+      MYSQL_DATABASE: openmrs
+      MYSQL_USER: openmrs
+      MYSQL_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs-demo-only}
+      MYSQL_ROOT_PASSWORD: ${OPENMRS_DB_ROOT_PASSWORD:-openmrs-root-demo-only}
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          mariadb-admin ping -h 127.0.0.1 -uopenmrs
+          -p$${MYSQL_PASSWORD}
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    volumes:
+      - openmrs-db-data:/var/lib/mysql
+
+  openmrs:
+    profiles: [live]
+    image: openmrs/openmrs-reference-application-3-backend:3.7.1
+    depends_on:
+      openmrs-db:
+        condition: service_healthy
+    environment:
+      OMRS_CONFIG_MODULE_WEB_ADMIN: "true"
+      OMRS_CONFIG_AUTO_UPDATE_DATABASE: "true"
+      OMRS_CONFIG_CREATE_TABLES: "true"
+      OMRS_CONFIG_CONNECTION_SERVER: openmrs-db
+      OMRS_CONFIG_CONNECTION_DATABASE: openmrs
+      OMRS_CONFIG_CONNECTION_USERNAME: openmrs
+      OMRS_CONFIG_CONNECTION_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs-demo-only}
+    healthcheck:
+      test:
+        - CMD
+        - curl
+        - --fail
+        - http://localhost:8080/openmrs
+      interval: 10s
+      timeout: 5s
+      retries: 60
+    ports:
+      - "127.0.0.1:${OPENMRS_DEMO_PORT:-8080}:8080"
+    volumes:
+      - openmrs-app-data:/openmrs/data
+
+  dhis2-db:
+    profiles: [live]
+    image: ghcr.io/baosystems/postgis:16-3.5
+    environment:
+      POSTGRES_DB: dhis2
+      POSTGRES_USER: dhis2
+      POSTGRES_PASSWORD: ${DHIS2_DB_PASSWORD:-dhis2-demo-only}
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready --username=dhis2 --dbname=dhis2
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    volumes:
+      - dhis2-db-data:/var/lib/postgresql/data
+
+  dhis2:
+    profiles: [live]
+    image: dhis2/core:2.43.0.1
+    depends_on:
+      dhis2-db:
+        condition: service_healthy
+    environment:
+      DB_HOSTNAME: dhis2-db
+      DB_NAME: dhis2
+      DB_USERNAME: dhis2
+      DB_PASSWORD: ${DHIS2_DB_PASSWORD:-dhis2-demo-only}
+    ports:
+      - "127.0.0.1:${DHIS2_DEMO_PORT:-8081}:8080"
+
+volumes:
+  openmrs-app-data: {}
+  openmrs-db-data: {}
+  dhis2-db-data: {}

--- a/examples/africa-openmrs-dhis2/fixture_server.py
+++ b/examples/africa-openmrs-dhis2/fixture_server.py
@@ -1,0 +1,178 @@
+"""Loopback-only recorded OpenMRS FHIR2 response server for the demo."""
+
+from __future__ import annotations
+
+import copy
+import json
+import threading
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+_FHIR_TYPES = frozenset({"Patient", "Encounter", "Observation"})
+_REST_TYPES = frozenset({"patient", "encounter", "obs"})
+
+
+@contextmanager
+def openmrs_fixture_server(
+    fhir_resources: Mapping[str, Sequence[Mapping[str, Any]]],
+    rest_resources: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> Iterator[str]:
+    """Serve deterministic OpenMRS REST and FHIR2 pages on loopback."""
+
+    fhir_recording = {
+        resource_type: tuple(copy.deepcopy(list(items)))
+        for resource_type, items in fhir_resources.items()
+    }
+    rest_recording = {
+        resource_type: tuple(copy.deepcopy(list(items)))
+        for resource_type, items in rest_resources.items()
+    }
+    handler = _handler_for(fhir_recording, rest_recording)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(
+        target=server.serve_forever,
+        name="openmrs-fixture",
+        daemon=True,
+    )
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}/openmrs"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _handler_for(
+    fhir_recording: Mapping[str, Sequence[Mapping[str, Any]]],
+    rest_recording: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> type[BaseHTTPRequestHandler]:
+    class FixtureHandler(BaseHTTPRequestHandler):
+        server_version = "OpenMRSFixture/1.0"
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlsplit(self.path)
+            fhir_prefix = "/openmrs/ws/fhir2/R4/"
+            rest_prefix = "/openmrs/ws/rest/v1/"
+            if parsed.path.startswith(fhir_prefix):
+                resource_type = parsed.path.removeprefix(fhir_prefix)
+                if resource_type not in _FHIR_TYPES:
+                    self._json(404, {"error": "unsupported_resource"})
+                    return
+                self._fhir_search(
+                    parsed.path,
+                    parse_qs(parsed.query),
+                    resource_type,
+                )
+                return
+            if parsed.path.startswith(rest_prefix):
+                resource_type = parsed.path.removeprefix(rest_prefix)
+                if resource_type not in _REST_TYPES:
+                    self._json(404, {"error": "unsupported_resource"})
+                    return
+                self._rest_search(parse_qs(parsed.query), resource_type)
+                return
+            self._json(404, {"error": "not_found"})
+
+        def _fhir_search(
+            self,
+            path: str,
+            query: Mapping[str, list[str]],
+            resource_type: str,
+        ) -> None:
+            page_size = _positive_int(query.get("_count", ["25"])[0], default=25)
+            page = _positive_int(query.get("page", ["1"])[0], default=1)
+            resources = list(fhir_recording.get(resource_type, ()))
+            start = (page - 1) * page_size
+            selected = resources[start : start + page_size]
+            base_url = (
+                f"http://{self.server.server_address[0]}:"
+                f"{self.server.server_address[1]}"
+            )
+            search_url = f"{base_url}{path}"
+            bundle: dict[str, Any] = {
+                "resourceType": "Bundle",
+                "type": "searchset",
+                "total": len(resources),
+                "entry": [
+                    {
+                        "fullUrl": f"{search_url}/{resource['id']}",
+                        "resource": resource,
+                    }
+                    for resource in selected
+                ],
+                "link": [
+                    {
+                        "relation": "self",
+                        "url": f"{search_url}?{urlencode({'_count': page_size, 'page': page})}",
+                    }
+                ],
+            }
+            if start + page_size < len(resources):
+                bundle["link"].append(
+                    {
+                        "relation": "next",
+                        "url": (
+                            f"{search_url}?"
+                            f"{urlencode({'_count': page_size, 'page': page + 1})}"
+                        ),
+                    }
+                )
+            self._json(200, bundle)
+
+        def _rest_search(
+            self,
+            query: Mapping[str, list[str]],
+            resource_type: str,
+        ) -> None:
+            page_size = _positive_int(query.get("limit", ["25"])[0], default=25)
+            start = _nonnegative_int(
+                query.get("startIndex", ["0"])[0],
+                default=0,
+            )
+            resources = list(rest_recording.get(resource_type, ()))
+            self._json(
+                200,
+                {
+                    "results": resources[start : start + page_size],
+                    "startIndex": start,
+                },
+            )
+
+        def _json(self, status: int, payload: Mapping[str, Any]) -> None:
+            body = json.dumps(
+                payload,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/fhir+json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *args: object) -> None:
+            return
+
+    return FixtureHandler
+
+
+def _positive_int(value: str, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _nonnegative_int(value: str, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed >= 0 else default

--- a/examples/africa-openmrs-dhis2/fixtures/README.md
+++ b/examples/africa-openmrs-dhis2/fixtures/README.md
@@ -1,0 +1,19 @@
+# Synthetic fixture boundary
+
+The fixture demo generates a deterministic, fictional OpenMRS FHIR2 recording
+in memory and serves it only on an ephemeral `127.0.0.1` port. The committed
+organisation-unit snapshot represents one fictional country, province,
+district, and three facilities. No Java service, internet access, credentials,
+or real patient corpus is used.
+
+Regenerate an inspectable recording from the repository root:
+
+```bash
+python examples/africa-openmrs-dhis2/synthetic_data.py \
+  --seed 875 \
+  --patient-count 50 \
+  --output /tmp/openmed-africa-recording.json
+```
+
+The resulting file intentionally contains synthetic PHI and must remain inside
+the facility-side test boundary. It is not a DHIS2 export artifact.

--- a/examples/africa-openmrs-dhis2/fixtures/organisation_units.json
+++ b/examples/africa-openmrs-dhis2/fixtures/organisation_units.json
@@ -1,0 +1,43 @@
+{
+  "organisationUnits": [
+    {
+      "id": "ouCountryFiction",
+      "level": 1
+    },
+    {
+      "id": "ouProvinceLake",
+      "level": 2,
+      "parent": {
+        "id": "ouCountryFiction"
+      }
+    },
+    {
+      "id": "ouDistrictMtoni",
+      "level": 3,
+      "parent": {
+        "id": "ouProvinceLake"
+      }
+    },
+    {
+      "id": "ouFacilityKijani",
+      "level": 4,
+      "parent": {
+        "id": "ouDistrictMtoni"
+      }
+    },
+    {
+      "id": "ouFacilityMawingu",
+      "level": 4,
+      "parent": {
+        "id": "ouDistrictMtoni"
+      }
+    },
+    {
+      "id": "ouFacilityTumaini",
+      "level": 4,
+      "parent": {
+        "id": "ouDistrictMtoni"
+      }
+    }
+  ]
+}

--- a/examples/africa-openmrs-dhis2/run_demo.py
+++ b/examples/africa-openmrs-dhis2/run_demo.py
@@ -1,0 +1,448 @@
+"""Run the offline facility-EMR to national-HMIS synthetic reference demo."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fixture_server import openmrs_fixture_server
+from synthetic_data import (
+    DEFAULT_PATIENT_COUNT,
+    DEFAULT_SEED,
+    DISTRICT_ORG_UNIT,
+    SyntheticDataset,
+    generate_dataset,
+)
+
+from openmed.clinical.exporters import DHIS2ExportConfig, export_dhis2
+from openmed.interop import assert_redacted
+from openmed.interop.openmrs import (
+    DeidentifiedResource,
+    OpenMRSAdapter,
+    OpenMRSClient,
+    OpenMRSConfig,
+    manifest_paths,
+)
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+ORG_UNITS_FIXTURE = EXAMPLE_DIR / "fixtures" / "organisation_units.json"
+ARTIFACT_NAMES = (
+    "01-raw-openmrs.json",
+    "02-deidentified-fhir-bundle.json",
+    "03-openmrs-deidentification-manifest.json",
+    "04-dhis2-aggregate.json",
+    "05-dhis2-tracker.json",
+    "06-dhis2-export-manifest.json",
+    "07-demo-manifest.json",
+)
+
+
+@dataclass(frozen=True)
+class _RedactionResult:
+    deidentified_text: str
+
+
+class ExactSyntheticRedactor:
+    """Replace the complete, known synthetic identifier inventory."""
+
+    def __init__(self, mapping: dict[str, str]) -> None:
+        replacements: dict[str, str] = {}
+        for replacement, original in mapping.items():
+            replacements.setdefault(original, replacement)
+        self._replacements = tuple(
+            sorted(
+                replacements.items(),
+                key=lambda item: (-len(item[0]), item[0]),
+            )
+        )
+
+    def __call__(self, text: str, **_: Any) -> _RedactionResult:
+        transformed = text
+        for original, replacement in self._replacements:
+            transformed = transformed.replace(original, replacement)
+        return _RedactionResult(deidentified_text=transformed)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the documented fixture-mode command-line interface."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("africa-reference-output"),
+        help="directory for inspectable stage artifacts",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help="fixed synthetic-data seed",
+    )
+    parser.add_argument(
+        "--patient-count",
+        type=int,
+        default=DEFAULT_PATIENT_COUNT,
+        help="number of fictional patients",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=17,
+        help="fixture-server FHIR search page size",
+    )
+    return parser
+
+
+def run_demo(
+    output_dir: Path,
+    *,
+    seed: int = DEFAULT_SEED,
+    patient_count: int = DEFAULT_PATIENT_COUNT,
+    page_size: int = 17,
+) -> dict[str, Path]:
+    """Execute every fixture-backed stage and return the artifact paths."""
+
+    if page_size < 1:
+        raise ValueError("page_size must be greater than zero")
+
+    dataset = generate_dataset(seed=seed, patient_count=patient_count)
+    phi_mapping = dataset.phi_mapping()
+    redactor = ExactSyntheticRedactor(phi_mapping)
+    fhir_fixture_resources = dataset.fhir_resources()
+    rest_fixture_resources = dataset.rest_resources()
+
+    with openmrs_fixture_server(
+        fhir_fixture_resources,
+        rest_fixture_resources,
+    ) as base_url:
+        with OpenMRSClient(
+            OpenMRSConfig(
+                base_url=base_url,
+                page_size=page_size,
+                max_retries=0,
+            )
+        ) as client:
+            raw_resources = {
+                "fhir2": {
+                    resource_type: list(client.pull_fhir(resource_type))
+                    for resource_type in ("Patient", "Encounter", "Observation")
+                },
+                "rest": {
+                    resource_type: list(client.pull_rest(resource_type))
+                    for resource_type in ("patient", "encounter", "obs")
+                },
+            }
+            adapter = OpenMRSAdapter(client, deidentifier=redactor)
+            deidentified_fhir_records = tuple(
+                record
+                for resource_type in ("Patient", "Encounter", "Observation")
+                for record in adapter.pull_fhir(resource_type)
+            )
+            deidentified_rest_records = tuple(
+                record
+                for resource_type in ("encounter", "obs")
+                for record in adapter.pull_rest(resource_type)
+            )
+            deidentified_records = deidentified_fhir_records + deidentified_rest_records
+            fhir_bundle = adapter.export_bundle(
+                deidentified_fhir_records,
+                doc_id=f"africa-reference-{seed}",
+            )
+
+    for record in deidentified_records:
+        assert_redacted(_canonical_json(record.resource), phi_mapping)
+    _validate_transaction_bundle(fhir_bundle, expected_entries=patient_count * 3)
+    openmrs_manifest = _openmrs_manifest(deidentified_records, dataset)
+    aggregate_source, tracker_source = _build_dhis2_sources(
+        dataset,
+        deidentified_records,
+    )
+    dhis2_result = export_dhis2(
+        aggregate_source,
+        tracker_source,
+        ORG_UNITS_FIXTURE,
+        config=DHIS2ExportConfig(
+            generalization_level=3,
+            small_cell_threshold=5,
+            date_mode="coarsen",
+            period_granularity="month",
+        ),
+        text_redactor=redactor,
+    )
+    _assert_district_only(dhis2_result.combined_payload, dataset)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = {
+        ARTIFACT_NAMES[0]: output_dir / ARTIFACT_NAMES[0],
+        ARTIFACT_NAMES[1]: output_dir / ARTIFACT_NAMES[1],
+        ARTIFACT_NAMES[2]: output_dir / ARTIFACT_NAMES[2],
+        ARTIFACT_NAMES[3]: output_dir / ARTIFACT_NAMES[3],
+        ARTIFACT_NAMES[4]: output_dir / ARTIFACT_NAMES[4],
+        ARTIFACT_NAMES[5]: output_dir / ARTIFACT_NAMES[5],
+        ARTIFACT_NAMES[6]: output_dir / ARTIFACT_NAMES[6],
+    }
+    _write_json(
+        artifacts[ARTIFACT_NAMES[0]],
+        {
+            "fixture": "fictional-mtoni-district",
+            "seed": seed,
+            "resources": raw_resources,
+        },
+    )
+    _write_json(artifacts[ARTIFACT_NAMES[1]], fhir_bundle)
+    _write_json(artifacts[ARTIFACT_NAMES[2]], openmrs_manifest)
+    _write_json(artifacts[ARTIFACT_NAMES[3]], dhis2_result.aggregate_payload)
+    _write_json(artifacts[ARTIFACT_NAMES[4]], dhis2_result.tracker_payload)
+    _write_json(artifacts[ARTIFACT_NAMES[5]], dhis2_result.manifest)
+
+    boundary_paths = tuple(
+        artifacts[name]
+        for name in (
+            ARTIFACT_NAMES[1],
+            ARTIFACT_NAMES[2],
+            ARTIFACT_NAMES[3],
+            ARTIFACT_NAMES[4],
+            ARTIFACT_NAMES[5],
+        )
+    )
+    for path in boundary_paths:
+        assert_redacted(path.read_text(encoding="utf-8"), phi_mapping)
+
+    demo_manifest = {
+        "schema_version": 1,
+        "mode": "fixture",
+        "seed": seed,
+        "patient_count": patient_count,
+        "district_org_unit": dataset.district_uid,
+        "privacy_boundary": "de-identification-before-egress",
+        "artifacts": [
+            {
+                "name": path.name,
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+            for path in artifacts.values()
+            if path.name != ARTIFACT_NAMES[6]
+        ],
+    }
+    _write_json(artifacts[ARTIFACT_NAMES[6]], demo_manifest)
+    assert_redacted(
+        artifacts[ARTIFACT_NAMES[6]].read_text(encoding="utf-8"),
+        phi_mapping,
+    )
+
+    console_output = (
+        "Fixture demo complete: "
+        f"{patient_count} synthetic patients, "
+        f"{len(fhir_bundle['entry'])} de-identified FHIR resources, "
+        f"district org unit {DISTRICT_ORG_UNIT}, "
+        f"{len(artifacts)} stage artifacts."
+    )
+    assert_redacted(console_output, phi_mapping)
+    print(console_output)
+    return artifacts
+
+
+def _openmrs_manifest(
+    records: tuple[DeidentifiedResource, ...],
+    dataset: SyntheticDataset,
+) -> dict[str, Any]:
+    counts = Counter(f"{record.api}:{record.resource_name}" for record in records)
+    transformed_paths = sorted(
+        {path for record in records for path in manifest_paths(record.manifest)}
+    )
+    return {
+        "schema_version": 1,
+        "adapter": "openmrs-fhir2",
+        "fixture_seed": dataset.seed,
+        "resource_counts": dict(sorted(counts.items())),
+        "transformed_resource_count": sum(
+            bool(manifest_paths(record.manifest)) for record in records
+        ),
+        "transformed_paths": transformed_paths,
+    }
+
+
+def _build_dhis2_sources(
+    dataset: SyntheticDataset,
+    records: tuple[DeidentifiedResource, ...],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    deidentified_patients = {
+        record.resource["id"]: record.resource
+        for record in records
+        if record.resource_name == "Patient"
+    }
+    counts = Counter(
+        (
+            patient.facility_uid,
+            patient.encounter_date[:7].replace("-", ""),
+            patient.diagnosis_code,
+        )
+        for patient in dataset.patients
+    )
+    data_value_sets: list[dict[str, Any]] = []
+    for facility in dataset.facilities:
+        periods = sorted(
+            period for facility_uid, period, _ in counts if facility_uid == facility.uid
+        )
+        for period in dict.fromkeys(periods):
+            data_values = [
+                {
+                    "dataElement": f"icd11-{diagnosis_code}",
+                    "value": str(count),
+                }
+                for (
+                    facility_uid,
+                    value_period,
+                    diagnosis_code,
+                ), count in sorted(counts.items())
+                if facility_uid == facility.uid and value_period == period
+            ]
+            data_value_sets.append(
+                {
+                    "dataSet": "dsMtoniIcd11Monthly",
+                    "period": period,
+                    "orgUnit": facility.uid,
+                    "completeDate": f"{period[:4]}-{period[4:]}-28",
+                    "dataValues": data_values,
+                }
+            )
+
+    tracked_entities: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    for patient in dataset.patients:
+        fhir_patient = deidentified_patients[patient.patient_id]
+        display_name = fhir_patient["name"][0]["text"]
+        national_id = fhir_patient["identifier"][0]["value"]
+        tracked_entity = f"tei-{patient.index:03d}"
+        tracked_entities.append(
+            {
+                "trackedEntity": tracked_entity,
+                "trackedEntityType": "tetSyntheticPatient",
+                "orgUnit": patient.facility_uid,
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [patient.longitude, patient.latitude],
+                },
+                "latitude": patient.latitude,
+                "longitude": patient.longitude,
+                "attributes": [
+                    {
+                        "attribute": "attrDisplayName",
+                        "value": display_name,
+                    },
+                    {
+                        "attribute": "attrNationalIdentifier",
+                        "value": national_id,
+                    },
+                ],
+            }
+        )
+        events.append(
+            {
+                "event": f"event-{patient.index:03d}",
+                "program": "programIcd11Surveillance",
+                "programStage": "stageDiagnosis",
+                "trackedEntity": tracked_entity,
+                "orgUnit": patient.facility_uid,
+                "occurredAt": f"{patient.encounter_date}T08:15:00Z",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [patient.longitude, patient.latitude],
+                },
+                "dataValues": [
+                    {
+                        "dataElement": "deIcd11Diagnosis",
+                        "value": patient.diagnosis_code,
+                    }
+                ],
+                "notes": [
+                    {"value": (f"Facility-coded synthetic case for {display_name}")}
+                ],
+            }
+        )
+
+    return (
+        {"dataValueSets": data_value_sets},
+        {"trackedEntities": tracked_entities, "events": events},
+    )
+
+
+def _validate_transaction_bundle(bundle: Any, *, expected_entries: int) -> None:
+    if not isinstance(bundle, dict):
+        raise ValueError("FHIR export must be a JSON object")
+    if bundle.get("resourceType") != "Bundle" or bundle.get("type") != "transaction":
+        raise ValueError("FHIR export must be a transaction Bundle")
+    entries = bundle.get("entry")
+    if not isinstance(entries, list) or len(entries) != expected_entries:
+        raise ValueError("FHIR transaction Bundle has an unexpected entry count")
+    for entry in entries:
+        if not isinstance(entry, dict) or not isinstance(entry.get("resource"), dict):
+            raise ValueError("FHIR transaction entry lacks a resource")
+        request = entry.get("request")
+        if not isinstance(request, dict) or request.get("method") != "POST":
+            raise ValueError("FHIR transaction entry lacks a POST request")
+
+
+def _assert_district_only(payload: dict[str, Any], dataset: SyntheticDataset) -> None:
+    serialized = _canonical_json(payload)
+    for facility in dataset.facilities:
+        if facility.uid in serialized:
+            raise ValueError("facility org unit survived district generalization")
+    for key in ('"geometry"', '"latitude"', '"longitude"'):
+        if key in serialized:
+            raise ValueError("precise geography survived DHIS2 export")
+    org_units = _collect_key(payload, "orgUnit")
+    if not org_units or set(org_units) != {dataset.district_uid}:
+        raise ValueError("DHIS2 export must reference only the district org unit")
+
+
+def _collect_key(value: Any, target: str) -> list[Any]:
+    found: list[Any] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key == target:
+                found.append(child)
+            else:
+                found.extend(_collect_key(child, target))
+    elif isinstance(value, list):
+        for child in value:
+            found.extend(_collect_key(child, target))
+    return found
+
+
+def _canonical_json(value: Any) -> str:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(_canonical_json(value), encoding="utf-8")
+
+
+def main() -> None:
+    """Run the documented fixture-backed command."""
+
+    args = build_parser().parse_args()
+    run_demo(
+        args.output_dir,
+        seed=args.seed,
+        patient_count=args.patient_count,
+        page_size=args.page_size,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/africa-openmrs-dhis2/synthetic_data.py
+++ b/examples/africa-openmrs-dhis2/synthetic_data.py
@@ -1,0 +1,368 @@
+"""Deterministic synthetic data for the African OpenMRS-to-DHIS2 demo.
+
+Every person, identifier, phone number, and coordinate emitted here is
+fictional. The generator intentionally includes values that must be removed at
+the facility boundary so the demo can prove its privacy gates are effective.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SEED = 875
+DEFAULT_PATIENT_COUNT = 50
+DISTRICT_ORG_UNIT = "ouDistrictMtoni"
+ICD11_SYSTEM = "http://id.who.int/icd/release/11/mms"
+
+_GIVEN_NAMES = (
+    "Amina",
+    "Amara",
+    "Chidi",
+    "Fatuma",
+    "Imani",
+    "Kato",
+    "Lerato",
+    "Musa",
+    "Nia",
+    "Odhiambo",
+    "Sade",
+    "Thabo",
+)
+_DIAGNOSES = (
+    ("1A00", "Cholera"),
+    ("5A11", "Type 2 diabetes mellitus"),
+    ("BA00", "Essential hypertension"),
+)
+
+
+@dataclass(frozen=True)
+class Facility:
+    """One fictional facility inside the synthetic district."""
+
+    uid: str
+    name: str
+    latitude: float
+    longitude: float
+
+
+@dataclass(frozen=True)
+class SyntheticPatient:
+    """One fictional patient and the local identifiers seeded for redaction."""
+
+    index: int
+    patient_id: str
+    encounter_id: str
+    observation_id: str
+    given_name: str
+    family_name: str
+    msisdn: str
+    national_id: str
+    latitude: float
+    longitude: float
+    facility_uid: str
+    diagnosis_code: str
+    diagnosis_display: str
+    encounter_date: str
+
+    @property
+    def full_name(self) -> str:
+        """Return the deliberately identifying display name."""
+
+        return f"{self.given_name} {self.family_name}"
+
+    @property
+    def gps(self) -> str:
+        """Return the deliberately identifying coordinate pair."""
+
+        return f"{self.latitude:.5f}, {self.longitude:.5f}"
+
+
+@dataclass(frozen=True)
+class SyntheticDataset:
+    """A reproducible fictional district health system."""
+
+    seed: int
+    district_uid: str
+    facilities: tuple[Facility, ...]
+    patients: tuple[SyntheticPatient, ...]
+
+    def phi_mapping(self) -> dict[str, str]:
+        """Return replacement-token to original-value mappings for leak gates."""
+
+        mapping: dict[str, str] = {}
+        for patient in self.patients:
+            suffix = f"{patient.index:03d}"
+            mapping[f"[FULL_NAME_{suffix}]"] = patient.full_name
+            mapping[f"[GIVEN_NAME_{suffix}]"] = patient.given_name
+            mapping[f"[FAMILY_NAME_{suffix}]"] = patient.family_name
+            mapping[f"[MSISDN_{suffix}]"] = patient.msisdn
+            mapping[f"[NATIONAL_ID_{suffix}]"] = patient.national_id
+            mapping[f"[GPS_{suffix}]"] = patient.gps
+            mapping[f"[LATITUDE_{suffix}]"] = f"{patient.latitude:.5f}"
+            mapping[f"[LONGITUDE_{suffix}]"] = f"{patient.longitude:.5f}"
+        return mapping
+
+    def fhir_resources(self) -> dict[str, list[dict[str, Any]]]:
+        """Build the OpenMRS FHIR2 fixture recording for this dataset."""
+
+        resources: dict[str, list[dict[str, Any]]] = {
+            "Patient": [],
+            "Encounter": [],
+            "Observation": [],
+        }
+        for patient in self.patients:
+            resources["Patient"].append(_patient_resource(patient))
+            resources["Encounter"].append(_encounter_resource(patient))
+            resources["Observation"].append(_observation_resource(patient))
+        return resources
+
+    def rest_resources(self) -> dict[str, list[dict[str, Any]]]:
+        """Build the matching OpenMRS legacy REST fixture recording."""
+
+        resources: dict[str, list[dict[str, Any]]] = {
+            "patient": [],
+            "encounter": [],
+            "obs": [],
+        }
+        for patient in self.patients:
+            resources["patient"].append(_rest_patient_resource(patient))
+            resources["encounter"].append(_rest_encounter_resource(patient))
+            resources["obs"].append(_rest_observation_resource(patient))
+        return resources
+
+    def recording(self) -> dict[str, Any]:
+        """Return a JSON-serializable recorded-response fixture."""
+
+        return {
+            "fixture": "fictional-mtoni-district",
+            "seed": self.seed,
+            "districtOrgUnit": self.district_uid,
+            "fhir2": self.fhir_resources(),
+            "rest": self.rest_resources(),
+        }
+
+
+def generate_dataset(
+    *,
+    seed: int = DEFAULT_SEED,
+    patient_count: int = DEFAULT_PATIENT_COUNT,
+) -> SyntheticDataset:
+    """Generate one district, three facilities, and synthetic patient records."""
+
+    if patient_count < 1:
+        raise ValueError("patient_count must be greater than zero")
+
+    facilities = (
+        Facility("ouFacilityKijani", "Kijani Health Centre", -0.31230, 32.58120),
+        Facility("ouFacilityMawingu", "Mawingu District Clinic", -0.28710, 32.60640),
+        Facility("ouFacilityTumaini", "Tumaini Community Hospital", -0.33580, 32.62510),
+    )
+    rng = random.Random(seed)
+    first_day = date(2026, 1, 5)
+    patients: list[SyntheticPatient] = []
+    for offset in range(patient_count):
+        index = offset + 1
+        facility = facilities[offset % len(facilities)]
+        diagnosis_code, diagnosis_display = _DIAGNOSES[rng.randrange(len(_DIAGNOSES))]
+        patients.append(
+            SyntheticPatient(
+                index=index,
+                patient_id=f"patient-{index:03d}",
+                encounter_id=f"encounter-{index:03d}",
+                observation_id=f"observation-{index:03d}",
+                given_name=_GIVEN_NAMES[offset % len(_GIVEN_NAMES)],
+                family_name=f"Fiction{index:03d}",
+                msisdn=f"+256 700 {index // 1000:03d} {index % 1000:03d}",
+                national_id=f"CF-{seed:04d}-{index:06d}",
+                latitude=facility.latitude + rng.uniform(-0.008, 0.008),
+                longitude=facility.longitude + rng.uniform(-0.008, 0.008),
+                facility_uid=facility.uid,
+                diagnosis_code=diagnosis_code,
+                diagnosis_display=diagnosis_display,
+                encounter_date=(first_day + timedelta(days=offset)).isoformat(),
+            )
+        )
+
+    return SyntheticDataset(
+        seed=seed,
+        district_uid=DISTRICT_ORG_UNIT,
+        facilities=facilities,
+        patients=tuple(patients),
+    )
+
+
+def _patient_resource(patient: SyntheticPatient) -> dict[str, Any]:
+    return {
+        "resourceType": "Patient",
+        "id": patient.patient_id,
+        "active": True,
+        "identifier": [
+            {
+                "system": "https://fictional.example.org/national-id",
+                "value": patient.national_id,
+            }
+        ],
+        "name": [
+            {
+                "use": "official",
+                "text": patient.full_name,
+                "family": patient.family_name,
+                "given": [patient.given_name],
+            }
+        ],
+        "telecom": [{"system": "phone", "value": patient.msisdn, "use": "mobile"}],
+        "address": [{"district": "Mtoni", "country": "Fictional Republic"}],
+        "extension": [
+            {
+                "url": "https://fictional.example.org/fhir/StructureDefinition/gps",
+                "valueString": patient.gps,
+            }
+        ],
+    }
+
+
+def _encounter_resource(patient: SyntheticPatient) -> dict[str, Any]:
+    return {
+        "resourceType": "Encounter",
+        "id": patient.encounter_id,
+        "status": "finished",
+        "class": {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+            "code": "AMB",
+            "display": "ambulatory",
+        },
+        "subject": {"reference": f"Patient/{patient.patient_id}"},
+        "serviceProvider": {"reference": f"Organization/{patient.facility_uid}"},
+        "period": {
+            "start": f"{patient.encounter_date}T08:00:00Z",
+            "end": f"{patient.encounter_date}T08:30:00Z",
+        },
+        "reasonCode": [
+            {
+                "coding": [
+                    {
+                        "system": ICD11_SYSTEM,
+                        "code": patient.diagnosis_code,
+                        "display": patient.diagnosis_display,
+                    }
+                ]
+            }
+        ],
+    }
+
+
+def _observation_resource(patient: SyntheticPatient) -> dict[str, Any]:
+    return {
+        "resourceType": "Observation",
+        "id": patient.observation_id,
+        "status": "final",
+        "code": {
+            "coding": [
+                {
+                    "system": ICD11_SYSTEM,
+                    "code": patient.diagnosis_code,
+                    "display": patient.diagnosis_display,
+                }
+            ]
+        },
+        "subject": {"reference": f"Patient/{patient.patient_id}"},
+        "encounter": {"reference": f"Encounter/{patient.encounter_id}"},
+        "effectiveDateTime": f"{patient.encounter_date}T08:15:00Z",
+        "valueString": (
+            f"{patient.full_name}; phone {patient.msisdn}; national ID "
+            f"{patient.national_id}; home GPS {patient.gps}."
+        ),
+    }
+
+
+def _rest_patient_resource(patient: SyntheticPatient) -> dict[str, Any]:
+    return {
+        "uuid": patient.patient_id,
+        "display": patient.full_name,
+        "identifiers": [
+            {
+                "identifier": patient.national_id,
+                "identifierType": {"display": "Fictional national identifier"},
+            }
+        ],
+        "person": {
+            "display": patient.full_name,
+            "names": [
+                {
+                    "givenName": patient.given_name,
+                    "familyName": patient.family_name,
+                }
+            ],
+        },
+    }
+
+
+def _rest_encounter_resource(patient: SyntheticPatient) -> dict[str, Any]:
+    return {
+        "uuid": patient.encounter_id,
+        "patient": {"uuid": patient.patient_id},
+        "encounterDatetime": f"{patient.encounter_date}T08:00:00.000+0000",
+        "encounterType": {"uuid": "encounter-type-outpatient"},
+        "encounterNotes": [
+            f"{patient.full_name} attended the fictional outpatient clinic.",
+            f"Local contact {patient.msisdn}; home GPS {patient.gps}.",
+        ],
+    }
+
+
+def _rest_observation_resource(patient: SyntheticPatient) -> dict[str, Any]:
+    return {
+        "uuid": patient.observation_id,
+        "person": {"uuid": patient.patient_id},
+        "encounter": {"uuid": patient.encounter_id},
+        "obsDatetime": f"{patient.encounter_date}T08:15:00.000+0000",
+        "concept": {
+            "uuid": f"icd11-{patient.diagnosis_code}",
+            "display": patient.diagnosis_display,
+        },
+        "value": (
+            f"ICD-11 {patient.diagnosis_code} recorded for "
+            f"{patient.full_name} at {patient.gps}."
+        ),
+        "comment": (f"Contact {patient.msisdn}; national ID {patient.national_id}."),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument(
+        "--patient-count",
+        type=int,
+        default=DEFAULT_PATIENT_COUNT,
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> None:
+    """Write a deterministic synthetic OpenMRS fixture recording."""
+
+    args = _parser().parse_args()
+    dataset = generate_dataset(seed=args.seed, patient_count=args.patient_count)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(
+            dataset.recording(),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
       - REST Authentication: serving/authentication.md
       - Helm Deployment: deploy/helm.md
       - OpenHIM De-identification Mediator: deploy/openhim-mediator.md
+      - African Facility-to-HMIS Reference: deploy/africa-reference-deployment.md
       - Multi-Arch Containers: deploy/multi-arch.md
       - ModelLoader & Pipelines: model-loader.md
       - Model Registry: model-registry.md

--- a/tests/unit/examples/test_africa_reference_demo.py
+++ b/tests/unit/examples/test_africa_reference_demo.py
@@ -1,0 +1,204 @@
+"""End-to-end safety coverage for the African OpenMRS-to-DHIS2 reference."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from openmed.interop import assert_redacted
+from tests.unit.clinical.fixtures.dhis2.schema_checker import (
+    validate_aggregate_payload,
+    validate_tracker_payload,
+)
+
+ROOT = Path(__file__).parents[3]
+EXAMPLE = ROOT / "examples" / "africa-openmrs-dhis2"
+RUN_DEMO = EXAMPLE / "run_demo.py"
+DOCS = ROOT / "docs" / "deploy" / "africa-reference-deployment.md"
+COMPOSE = EXAMPLE / "docker-compose.yml"
+DISTRICT_UID = "ouDistrictMtoni"
+ARTIFACT_NAMES = (
+    "01-raw-openmrs.json",
+    "02-deidentified-fhir-bundle.json",
+    "03-openmrs-deidentification-manifest.json",
+    "04-dhis2-aggregate.json",
+    "05-dhis2-tracker.json",
+    "06-dhis2-export-manifest.json",
+    "07-demo-manifest.json",
+)
+
+
+def _run_demo(output_dir: Path, *, page_size: int = 17) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(RUN_DEMO),
+            "--output-dir",
+            str(output_dir),
+            "--seed",
+            "875",
+            "--patient-count",
+            "50",
+            "--page-size",
+            str(page_size),
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _load(output_dir: Path, name: str) -> Any:
+    return json.loads((output_dir / name).read_text(encoding="utf-8"))
+
+
+def _seeded_phi(raw: dict[str, Any]) -> dict[str, str]:
+    originals: list[str] = []
+    for patient in raw["resources"]["fhir2"]["Patient"]:
+        name = patient["name"][0]
+        originals.extend(
+            [
+                name["text"],
+                name["family"],
+                *name["given"],
+                patient["identifier"][0]["value"],
+                patient["telecom"][0]["value"],
+                patient["extension"][0]["valueString"],
+            ]
+        )
+        originals.extend(
+            part.strip() for part in patient["extension"][0]["valueString"].split(",")
+        )
+    return {
+        f"[SEEDED_IDENTIFIER_{index:04d}]": original
+        for index, original in enumerate(dict.fromkeys(originals), start=1)
+    }
+
+
+def _collect_key(value: Any, target: str) -> list[Any]:
+    found: list[Any] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key == target:
+                found.append(child)
+            else:
+                found.extend(_collect_key(child, target))
+    elif isinstance(value, list):
+        for child in value:
+            found.extend(_collect_key(child, target))
+    return found
+
+
+def test_fixture_demo_round_trip_is_valid_private_and_district_only(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "run"
+    process = _run_demo(output_dir)
+    assert process.stderr == ""
+    assert "50 synthetic patients" in process.stdout
+    assert all((output_dir / name).is_file() for name in ARTIFACT_NAMES)
+
+    raw = _load(output_dir, ARTIFACT_NAMES[0])
+    assert raw["seed"] == 875
+    assert {
+        resource_type: len(resources)
+        for resource_type, resources in raw["resources"]["fhir2"].items()
+    } == {"Encounter": 50, "Observation": 50, "Patient": 50}
+    assert {
+        resource_type: len(resources)
+        for resource_type, resources in raw["resources"]["rest"].items()
+    } == {"encounter": 50, "obs": 50, "patient": 50}
+    phi_mapping = _seeded_phi(raw)
+    assert len(phi_mapping) >= 250
+
+    bundle = _load(output_dir, ARTIFACT_NAMES[1])
+    assert bundle["resourceType"] == "Bundle"
+    assert bundle["type"] == "transaction"
+    assert len(bundle["entry"]) == 150
+    assert Counter(entry["resource"]["resourceType"] for entry in bundle["entry"]) == {
+        "Patient": 50,
+        "Encounter": 50,
+        "Observation": 50,
+    }
+    assert all(entry["request"]["method"] == "POST" for entry in bundle["entry"])
+    assert all(entry["fullUrl"].startswith("urn:uuid:") for entry in bundle["entry"])
+
+    openmrs_manifest = _load(output_dir, ARTIFACT_NAMES[2])
+    assert openmrs_manifest["resource_counts"] == {
+        "fhir2:Encounter": 50,
+        "fhir2:Observation": 50,
+        "fhir2:Patient": 50,
+        "rest:encounter": 50,
+        "rest:obs": 50,
+    }
+
+    aggregate = _load(output_dir, ARTIFACT_NAMES[3])
+    tracker = _load(output_dir, ARTIFACT_NAMES[4])
+    validate_aggregate_payload(aggregate)
+    validate_tracker_payload(tracker)
+    combined = {"aggregate": aggregate, "tracker": tracker}
+    assert set(_collect_key(combined, "orgUnit")) == {DISTRICT_UID}
+
+    serialized_dhis2 = json.dumps(combined, ensure_ascii=False, sort_keys=True)
+    org_units = json.loads(
+        (EXAMPLE / "fixtures" / "organisation_units.json").read_text(encoding="utf-8")
+    )["organisationUnits"]
+    facility_uids = {org_unit["id"] for org_unit in org_units if org_unit["level"] == 4}
+    assert not any(facility_uid in serialized_dhis2 for facility_uid in facility_uids)
+    assert '"geometry"' not in serialized_dhis2
+    assert '"latitude"' not in serialized_dhis2
+    assert '"longitude"' not in serialized_dhis2
+
+    for name in ARTIFACT_NAMES[1:]:
+        assert_redacted(
+            (output_dir / name).read_text(encoding="utf-8"),
+            phi_mapping,
+        )
+    assert_redacted(process.stdout, phi_mapping)
+
+
+def test_same_seed_produces_byte_identical_stage_artifacts(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _run_demo(first, page_size=7)
+    _run_demo(second, page_size=19)
+
+    assert {name: (first / name).read_bytes() for name in ARTIFACT_NAMES} == {
+        name: (second / name).read_bytes() for name in ARTIFACT_NAMES
+    }
+
+
+def test_documented_walkthrough_matches_the_cli_surface() -> None:
+    help_result = subprocess.run(
+        [sys.executable, str(RUN_DEMO), "--help"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    docs = DOCS.read_text(encoding="utf-8")
+    for flag in ("--output-dir", "--seed", "--patient-count", "--page-size"):
+        assert flag in help_result.stdout
+        assert flag in docs
+    assert ".venv/bin/python examples/africa-openmrs-dhis2/run_demo.py" in docs
+    assert "tests/unit/examples/test_africa_reference_demo.py" in docs
+
+
+def test_optional_live_compose_profile_is_explicit_and_loopback_only() -> None:
+    compose = yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+    assert compose["services"]
+    for service in compose["services"].values():
+        assert service["profiles"] == ["live"]
+        for port in service.get("ports", []):
+            assert port.startswith("127.0.0.1:")
+
+    docs = DOCS.read_text(encoding="utf-8")
+    assert "--profile live" in docs
+    assert "CI never starts this profile" in docs


### PR DESCRIPTION
# Pull Request

## Description
Adds a fully synthetic, offline facility-to-HMIS reference that exercises OpenMRS REST and FHIR2 pulls, facility-side de-identification, ICD-11-style coding, district-only DHIS2 aggregate and Tracker export, and deterministic inspectable artifacts. This gives implementers a runnable privacy-boundary demonstration without requiring Java services, network access, credentials, or real patient data.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added a fixed-seed fictional district generator with three facilities, 50 patients, seeded names, MSISDNs, national identifiers, GPS coordinates, and ICD-11-style observations.
- Added a loopback-only OpenMRS REST/FHIR2 fixture server and end-to-end runner that writes raw, de-identified FHIR, DHIS2, and manifest stages with fail-closed PHI and geography gates.
- Added the optional `live` Compose profile, facility-edge architecture and hardware guidance, KenyaEMR/UgandaEMR-style mapping notes, CLI-verified documentation, and full smoke/reproducibility coverage.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Validated with:
- `.venv/bin/python -m pytest tests/ -q` — 7,750 passed, 52 skipped
- Focused OpenMRS, DHIS2, and example coverage — 41 passed
- `make format`, `make lint`, and `make format-check`
- `.venv/bin/mkdocs build --strict`
- `docker compose -f examples/africa-openmrs-dhis2/docker-compose.yml --profile live config`

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1452

## Screenshots/Examples

Fixture-mode console output contains counts only:

```text
Fixture demo complete: 50 synthetic patients, 150 de-identified FHIR resources, district org unit ouDistrictMtoni, 7 stage artifacts.
```
