### PR TITLE
Render the MCP server from the tool registry with annotations and structured output

### DIFF
--- a/openmed/mcp/server.py
+++ b/openmed/mcp/server.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import asdict
-from typing import Any, Callable, Dict, Optional
+from inspect import Signature
+from typing import Annotated, Any, Callable, Dict, Optional
 
 import openmed
 from openmed.core.model_registry import ModelInfo
@@ -18,6 +21,8 @@ from openmed.core.pii_i18n import (
 )
 from openmed.mcp.tool_registry import (
     TOOL_REGISTRY,
+    ToolSchemaValidationError,
+    ToolSpec,
     render_mcp_tool,
     render_tool_registry_document,
     validate_registered_tool_output,
@@ -105,6 +110,141 @@ def _model_info_to_dict(key: str, model: ModelInfo) -> Dict[str, Any]:
 
 def _json_resource(payload: Any) -> str:
     return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def _error_envelope(error: BaseException) -> Dict[str, Any]:
+    """Return a PHI-safe structured tool error without echoing input or output."""
+
+    error_module = error.__class__.__module__
+    if isinstance(error, ToolSchemaValidationError):
+        code = "invalid_result"
+        message = "The tool returned an invalid structured result."
+    elif isinstance(error, KeyError):
+        code = "unknown_tool"
+        message = "The requested tool is not available."
+    elif isinstance(error, (TypeError, ValueError)) or error_module.startswith(
+        ("jsonschema", "pydantic")
+    ):
+        code = "invalid_arguments"
+        message = "The tool arguments are invalid."
+    else:
+        code = "execution_error"
+        message = "The tool could not complete the request."
+    return {"error": {"code": code, "message": message}, "is_error": True}
+
+
+def _call_tool_result(payload: Dict[str, Any], *, is_error: bool) -> Any:
+    """Return structured content plus a JSON text fallback for older clients."""
+
+    from mcp.types import CallToolResult, TextContent
+
+    return CallToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text=json.dumps(payload, sort_keys=True),
+            )
+        ],
+        structuredContent=payload,
+        isError=is_error,
+    )
+
+
+def _mcp_return_annotation(spec: ToolSpec) -> Any:
+    """Build a typed result annotation from the registry's output contract."""
+
+    try:
+        from mcp.types import CallToolResult
+        from pydantic import ConfigDict, RootModel
+    except ImportError:
+        return Dict[str, Any]
+
+    model_name = "".join(part.title() for part in spec.name.split("_")) + "Result"
+    output_model = type(
+        model_name,
+        (RootModel[Dict[str, Any]],),
+        {
+            "model_config": ConfigDict(
+                json_schema_extra=spec.mcp_output_schema(),
+            )
+        },
+    )
+    return Annotated[CallToolResult, output_model]
+
+
+def _render_structured_mcp_tool(
+    spec: ToolSpec,
+    handler: Callable[..., Dict[str, Any]],
+) -> Callable[..., Any]:
+    """Render one registry tool with structured success and error results."""
+
+    registry_tool = render_mcp_tool(spec, handler)
+    return_annotation = _mcp_return_annotation(spec)
+
+    def _tool(*args: Any, **kwargs: Any) -> Any:
+        try:
+            payload = registry_tool(*args, **kwargs)
+        except Exception as error:
+            return _call_tool_result(_error_envelope(error), is_error=True)
+        return _call_tool_result(payload, is_error=False)
+
+    _tool.__name__ = registry_tool.__name__
+    _tool.__doc__ = spec.description
+    _tool.__signature__ = Signature(  # type: ignore[attr-defined]
+        parameters=tuple(spec.signature.parameters.values()),
+        return_annotation=return_annotation,
+    )
+    _tool.__annotations__ = dict(registry_tool.__annotations__)
+    _tool.__annotations__["return"] = return_annotation
+    return _tool
+
+
+def _mcp_annotations(spec: ToolSpec) -> Any:
+    """Return SDK annotations when available, or the equivalent plain mapping."""
+
+    payload = spec.annotations()
+    try:
+        from mcp.types import ToolAnnotations
+    except ImportError:
+        return payload
+    return ToolAnnotations(**payload)
+
+
+def _synchronize_registered_schemas(server: Any, spec: ToolSpec) -> None:
+    """Make FastMCP advertise the registry schemas verbatim."""
+
+    manager = getattr(server, "_tool_manager", None)
+    if manager is None:
+        return
+    registered = manager.get_tool(spec.name)
+    if registered is None:
+        return
+    registered.parameters = deepcopy(dict(spec.input_schema))
+    registered.fn_metadata.output_schema = spec.mcp_output_schema()
+    registered.__dict__.pop("output_schema", None)
+
+
+def _structured_fastmcp(base_class: Any) -> Any:
+    """Return a FastMCP class that envelopes malformed calls without logging data."""
+
+    from jsonschema import validate
+
+    class _OpenMedFastMCP(base_class):
+        async def call_tool(
+            self,
+            name: str,
+            arguments: Dict[str, Any],
+        ) -> Any:
+            try:
+                tool = self._tool_manager.get_tool(name)
+                if tool is None:
+                    raise KeyError(name)
+                validate(instance=arguments, schema=tool.parameters)
+                return await super().call_tool(name, arguments)
+            except Exception as error:
+                return _call_tool_result(_error_envelope(error), is_error=True)
+
+    return _OpenMedFastMCP
 
 
 def openmed_analyze_text(
@@ -336,6 +476,21 @@ def openmed_loaded_models(
     return validate_registered_tool_output("openmed_loaded_models", response)
 
 
+def openmed_health(
+    *,
+    runtime_provider: Optional[RuntimeProvider] = None,
+) -> Dict[str, Any]:
+    """Return a PHI-free MCP health summary."""
+
+    loaded = _runtime(runtime_provider).loaded_models()
+    models = loaded.get("models")
+    loaded_model_count = len(models) if isinstance(models, Mapping) else 0
+    return {
+        "version": openmed.__version__,
+        "loaded_model_count": loaded_model_count,
+    }
+
+
 def openmed_unload_model(
     model_name: Optional[str] = None,
     all_models: bool = False,
@@ -477,10 +632,20 @@ def _register_tools(
 ) -> None:
     handlers = build_mcp_tool_handlers(runtime_provider)
     for spec in TOOL_REGISTRY.latest_specs():
-        server.tool(name=spec.name)(render_mcp_tool(spec, handlers[spec.name]))
+        server.tool(
+            name=spec.name,
+            title=spec.title,
+            description=spec.description,
+            annotations=_mcp_annotations(spec),
+            structured_output=True,
+        )(_render_structured_mcp_tool(spec, handlers[spec.name]))
+        _synchronize_registered_schemas(server, spec)
 
 
-def _register_resources(server: Any) -> None:
+def _register_resources(
+    server: Any,
+    runtime_provider: Optional[RuntimeProvider] = None,
+) -> None:
     @server.resource(
         "openmed://models",
         name="OpenMed model registry",
@@ -521,6 +686,14 @@ def _register_resources(server: Any) -> None:
     def _tool_registry_resource() -> str:
         return _json_resource(render_tool_registry_document())
 
+    @server.resource(
+        "openmed://health",
+        name="OpenMed health",
+        mime_type="application/json",
+    )
+    def _health_resource() -> str:
+        return _json_resource(openmed_health(runtime_provider=runtime_provider))
+
 
 def _register_prompts(server: Any) -> None:
     @server.prompt(name="openmed-clinical-ner")
@@ -556,7 +729,7 @@ def create_mcp_server(
     streamable_http_path: str = "/mcp",
 ) -> Any:
     """Create a FastMCP server exposing OpenMed tools, resources, and prompts."""
-    FastMCP = _load_fastmcp()
+    FastMCP = _structured_fastmcp(_load_fastmcp())
     server = FastMCP(
         "OpenMed",
         instructions=MCP_INSTRUCTIONS,
@@ -568,7 +741,7 @@ def create_mcp_server(
         json_response=True,
     )
     _register_tools(server, runtime_provider)
-    _register_resources(server)
+    _register_resources(server, runtime_provider)
     _register_prompts(server)
     return server
 

--- a/openmed/mcp/tool_registry.py
+++ b/openmed/mcp/tool_registry.py
@@ -81,6 +81,11 @@ class ToolSpec:
     version: str = "1.0.0"
     stability: str = "stable"
     parameters: Sequence[ToolParameter] = ()
+    title: str = ""
+    read_only_hint: bool = False
+    destructive_hint: bool = True
+    idempotent_hint: bool = False
+    open_world_hint: bool = True
 
     def __post_init__(self) -> None:
         """Normalize mutable inputs and validate core metadata."""
@@ -92,6 +97,10 @@ class ToolSpec:
             raise ValueError(
                 f"tool spec {self.name!r} stability must be one of {known}"
             )
+        title = self.title.strip()
+        if not title:
+            title = self.name.removeprefix("openmed_").replace("_", " ").title()
+        object.__setattr__(self, "title", title)
         object.__setattr__(self, "input_schema", deepcopy(dict(self.input_schema)))
         object.__setattr__(self, "output_schema", deepcopy(dict(self.output_schema)))
         object.__setattr__(self, "parameters", tuple(self.parameters))
@@ -104,6 +113,44 @@ class ToolSpec:
             [parameter.signature_parameter() for parameter in self.parameters],
             return_annotation=dict[str, Any],
         )
+
+    def annotations(self) -> JsonObject:
+        """Return MCP-compatible behavioral annotations for this tool."""
+
+        return {
+            "title": self.title,
+            "readOnlyHint": self.read_only_hint,
+            "destructiveHint": self.destructive_hint,
+            "idempotentHint": self.idempotent_hint,
+            "openWorldHint": self.open_world_hint,
+        }
+
+    def mcp_output_schema(self) -> JsonSchema:
+        """Return the MCP result schema, including structured failures."""
+
+        return {
+            "type": "object",
+            "anyOf": [
+                deepcopy(dict(self.output_schema)),
+                {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "error": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                "code": {"type": "string"},
+                                "message": {"type": "string"},
+                            },
+                            "required": ["code", "message"],
+                        },
+                        "is_error": {"type": "boolean", "const": True},
+                    },
+                    "required": ["error", "is_error"],
+                },
+            ],
+        }
 
     def document(self) -> JsonObject:
         """Return a machine-readable schema document for this tool."""
@@ -790,23 +837,35 @@ _WORKFLOW_RESULT_OUTPUT = _object(
 def _tool_spec(
     *,
     name: str,
+    title: str,
     description: str,
     parameters: Sequence[ToolParameter],
     output_schema: Mapping[str, Any],
+    read_only_hint: bool,
+    destructive_hint: bool = False,
+    idempotent_hint: bool = True,
+    open_world_hint: bool = False,
 ) -> ToolSpec:
     return ToolSpec(
         name=name,
+        title=title,
         description=description,
         input_schema=input_schema(parameters),
         output_schema=output_schema,
         parameters=parameters,
+        read_only_hint=read_only_hint,
+        destructive_hint=destructive_hint,
+        idempotent_hint=idempotent_hint,
+        open_world_hint=open_world_hint,
     )
 
 
 TOOL_SPECS: tuple[ToolSpec, ...] = (
     _tool_spec(
         name="openmed_analyze_text",
+        title="Analyze Clinical Text",
         description="Run OpenMed named-entity recognition on clinical text.",
+        read_only_hint=True,
         parameters=(
             _TEXT_PARAMETER,
             _MODEL_NAME_PARAMETER,
@@ -828,7 +887,9 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
     ),
     _tool_spec(
         name="openmed_extract_pii",
+        title="Extract PII and PHI",
         description="Extract PII/PHI entities from clinical text.",
+        read_only_hint=True,
         parameters=(
             _TEXT_PARAMETER,
             _PII_MODEL_NAME_PARAMETER,
@@ -842,7 +903,9 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
     ),
     _tool_spec(
         name="openmed_deidentify",
+        title="De-identify Clinical Text",
         description="De-identify text by masking, removing, replacing, hashing, or shifting.",
+        read_only_hint=True,
         parameters=(
             _TEXT_PARAMETER,
             _parameter(
@@ -869,7 +932,9 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
     ),
     _tool_spec(
         name="openmed_list_models",
+        title="List Available Models",
         description="List OpenMed model registry entries.",
+        read_only_hint=True,
         parameters=(
             _parameter("category", _nullable("string"), Optional[str], None),
             _parameter("pii_language", _nullable("string"), Optional[str], None),
@@ -879,19 +944,25 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
     ),
     _tool_spec(
         name="openmed_list_pii_languages",
+        title="List PII Languages",
         description="List supported PII languages and default models.",
+        read_only_hint=True,
         parameters=(),
         output_schema=_LIST_PII_LANGUAGES_OUTPUT,
     ),
     _tool_spec(
         name="openmed_loaded_models",
+        title="List Loaded Models",
         description="Return currently loaded model resources.",
+        read_only_hint=True,
         parameters=(),
         output_schema=_GENERIC_OBJECT_OUTPUT,
     ),
     _tool_spec(
         name="openmed_unload_model",
+        title="Unload Model",
         description="Unload one inactive model, or all inactive models.",
+        read_only_hint=False,
         parameters=(
             _parameter("model_name", _nullable("string"), Optional[str], None),
             _parameter("all_models", _schema("boolean"), bool, False),
@@ -900,10 +971,12 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
     ),
     _tool_spec(
         name="openmed_run_workflow",
+        title="Run Clinical Workflow",
         description=(
             "Run a stateful multi-step OpenMed workflow with server-side "
             "intermediate handles and PHI-safe egress."
         ),
+        read_only_hint=False,
         parameters=(
             _parameter("pipeline", _object(), dict[str, Any]),
             _parameter("session_id", _nullable("string"), Optional[str], None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ integrity = [
 ]
 
 mcp = [
-  "mcp>=1.9",
+  "mcp>=1.27,<2",
 ]
 
 lid = [

--- a/tests/unit/interop/test_tool_schema_sync.py
+++ b/tests/unit/interop/test_tool_schema_sync.py
@@ -68,7 +68,9 @@ def test_mcp_server_registers_exactly_the_registry_tools():
         def __init__(self):
             self.tools = {}
 
-        def tool(self, *, name):
+        def tool(self, *, name, **metadata):
+            del metadata
+
             def _decorator(func):
                 self.tools[name] = func
                 return func

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -1,0 +1,102 @@
+"""Protocol-level tests for registry-rendered MCP tools."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from openmed.mcp.server import create_mcp_server
+from openmed.mcp.tool_registry import TOOL_REGISTRY
+
+
+class _Runtime:
+    def __init__(self, models: dict[str, Any] | None = None) -> None:
+        self._models = models or {}
+
+    def loaded_models(self) -> dict[str, Any]:
+        return {"models": self._models}
+
+
+def _server(runtime: _Runtime | None = None):
+    selected = runtime or _Runtime()
+    return create_mcp_server(runtime_provider=lambda: selected)
+
+
+def test_every_tool_advertises_registry_schemas_and_annotations() -> None:
+    server = _server()
+    advertised = {tool.name: tool for tool in asyncio.run(server.list_tools())}
+
+    assert set(advertised) == {spec.name for spec in TOOL_REGISTRY.latest_specs()}
+    for spec in TOOL_REGISTRY.latest_specs():
+        tool = advertised[spec.name]
+        assert tool.title == spec.title
+        assert tool.inputSchema == spec.input_schema
+        assert tool.outputSchema == spec.mcp_output_schema()
+        assert tool.annotations is not None
+        assert tool.annotations.model_dump(exclude_none=True) == spec.annotations()
+
+
+def test_structured_result_includes_machine_data_and_text_fallback() -> None:
+    result = asyncio.run(
+        _server(_Runtime(models={"model-a": {"active_requests": 0}})).call_tool(
+            "openmed_loaded_models", {}
+        )
+    )
+
+    assert result.isError is False
+    assert result.structuredContent == {"models": {"model-a": {"active_requests": 0}}}
+    assert json.loads(result.content[0].text) == result.structuredContent
+
+
+def test_malformed_call_returns_phi_safe_structured_error_without_logging(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    request_secret = "Patient Jane Secret has MRN-394-PRIVATE"
+    response_secret = "loaded-model-PHI-response-secret"
+    server = _server(_Runtime(models={response_secret: {}}))
+
+    with caplog.at_level(logging.DEBUG):
+        malformed = asyncio.run(
+            server.call_tool(
+                "openmed_deidentify",
+                {"text": request_secret, "method": "unsupported-method"},
+            )
+        )
+        successful = asyncio.run(server.call_tool("openmed_loaded_models", {}))
+
+    assert malformed.isError is True
+    assert malformed.structuredContent == {
+        "error": {
+            "code": "invalid_arguments",
+            "message": "The tool arguments are invalid.",
+        },
+        "is_error": True,
+    }
+    assert json.loads(malformed.content[0].text) == malformed.structuredContent
+    assert successful.isError is False
+    assert response_secret in json.dumps(successful.structuredContent)
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert request_secret not in logged
+    assert response_secret not in logged
+
+
+def test_health_resource_reports_only_version_and_loaded_model_count() -> None:
+    model_names = {
+        "model-one": {"active_requests": 0},
+        "model-two": {"active_requests": 1},
+    }
+    resources = asyncio.run(
+        _server(_Runtime(models=model_names)).read_resource("openmed://health")
+    )
+    payload = json.loads(resources[0].content)
+
+    assert set(payload) == {"loaded_model_count", "version"}
+    assert payload["loaded_model_count"] == 2
+    assert payload["version"]
+    assert not set(model_names) & set(payload)

--- a/tests/unit/mcp/test_tool_registry.py
+++ b/tests/unit/mcp/test_tool_registry.py
@@ -23,11 +23,13 @@ from openmed.mcp.tool_registry import (
 class FakeFastMCP:
     def __init__(self) -> None:
         self.tools: dict[str, Any] = {}
+        self.tool_metadata: dict[str, dict[str, Any]] = {}
         self.resources: dict[str, Any] = {}
 
-    def tool(self, *, name: str):
+    def tool(self, *, name: str, **metadata: Any):
         def _decorator(func):
             self.tools[name] = func
+            self.tool_metadata[name] = metadata
             return func
 
         return _decorator

--- a/tests/unit/mcp/test_workflow.py
+++ b/tests/unit/mcp/test_workflow.py
@@ -384,7 +384,8 @@ def test_workflow_tool_is_registered_and_schema_validated():
         def __init__(self) -> None:
             self.tools: list[str] = []
 
-        def tool(self, *, name: str):
+        def tool(self, *, name: str, **metadata: Any):
+            del metadata
             self.tools.append(name)
 
             def decorator(func):

--- a/uv.lock
+++ b/uv.lock
@@ -5448,7 +5448,7 @@ requires-dist = [
     { name = "llama-index-core", marker = "extra == 'agents'", specifier = ">=0.10,<1" },
     { name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.10,<1" },
     { name = "markdown-it-py", marker = "extra == 'multimodal'", specifier = ">=3.0,<5" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.9" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.27,<2" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6" },
     { name = "mkdocs-git-revision-date-localized-plugin", marker = "extra == 'docs'", specifier = ">=1.2.6" },
     { name = "mkdocs-llmstxt", marker = "extra == 'docs'", specifier = ">=0.5.0,<1" },


### PR DESCRIPTION
## Description

Closes #1786.

Renders the MCP surface from the canonical registry with human-readable titles, behavioral annotations, registry-exact input schemas, typed structured outputs, and backward-compatible JSON text content. Malformed calls now return PHI-safe structured error envelopes, and a new health resource reports only the package version and loaded-model count.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Extended the canonical tool specs with titles and read-only, destructive, idempotent, and open-world hints for every registered tool.
- Registered FastMCP tools with registry-exact input schemas and typed output schemas that cover both successful results and structured errors.
- Added JSON text fallbacks for older clients while preserving `structuredContent` for schema-aware clients.
- Converted argument, validation, and execution failures into PHI-safe `{error, is_error}` envelopes without logging request or response text.
- Added `openmed://health`, returning only the OpenMed version and loaded-model count.
- Constrained the optional MCP SDK dependency to the compatible stable v1 range used by this implementation.

## Testing

- [x] I have added tests that prove the change is effective
- [x] New and existing unit tests pass locally with these changes

Commands run:

- `make format`
- `make lint`
- `make format-check`
- `.venv/bin/pre-commit run --files openmed/mcp/server.py openmed/mcp/tool_registry.py pyproject.toml tests/unit/interop/test_tool_schema_sync.py tests/unit/mcp/test_mcp_server.py tests/unit/mcp/test_tool_registry.py tests/unit/mcp/test_workflow.py uv.lock`
- `.venv/bin/python -m pytest tests/ -q` — 8115 passed, 78 skipped

## Documentation

- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

No user-facing documentation or changelog change is required; the protocol behavior is described by the advertised schemas, annotations, and tests.

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies

- [ ] I have not changed dependency constraints
- [x] I constrained the existing optional MCP SDK dependency to `>=1.27,<2` so structured-output behavior stays on the compatible stable v1 API.

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] The branch is based on the latest `origin/master`
- [x] No assignees or reviewers were added

## Related Issues

Closes #1786

## Screenshots/Examples

Not applicable.
