### PR TITLE
fix: resolve ruff F-errors — unused imports, variables, and operator style

### DIFF
--- a/openmed/core/pii_i18n.py
+++ b/openmed/core/pii_i18n.py
@@ -23,11 +23,9 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date
 from importlib import resources
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 from .anonymizer.providers.clinical_ids import (
-    gstin_check_char,
-    pan_check_letter,
     validate_abha,
     validate_australian_medicare,
     validate_australian_tfn,
@@ -47,11 +45,9 @@ from .lang_id_codemix import (
     token_language_runs,
 )
 from .language_pack_catalog import (
-    DEFAULT_MODEL_PLACEHOLDER_LANGUAGES,
     DEFAULT_PII_MODELS,
     NATIONAL_ID_ONLY_LANGUAGES,
     SUPPORTED_LANGUAGES,
-    USER_SUPPLIED_MODEL_LANGUAGES,
 )
 from .locale_formats import LOCALE_PII_FORMATS, LocalePIIFormat
 

--- a/openmed/eval/coverage.py
+++ b/openmed/eval/coverage.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Callable
 
 from openmed.core.decoding.spans import iter_grapheme_clusters
 from openmed.core.labels import CANONICAL_LABELS

--- a/openmed/eval/datasets/multilingual_ner.py
+++ b/openmed/eval/datasets/multilingual_ner.py
@@ -26,7 +26,6 @@ from openmed.core.labels import (
     LAB_TEST,
     LOCATION,
     MEDICATION,
-    MICROORGANISM,
     ORGANIZATION,
     OTHER,
     PERSON,

--- a/openmed/eval/relation_metrics.py
+++ b/openmed/eval/relation_metrics.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from dataclasses import dataclass, field, replace
 from math import isfinite
 from typing import Any, Iterable, Mapping, Sequence

--- a/openmed/eval/suites/multimodal_dicom.py
+++ b/openmed/eval/suites/multimodal_dicom.py
@@ -838,7 +838,7 @@ def _write_pixel_dicom(
     *,
     uid_entropy: str,
 ) -> Path:
-    pydicom = _import_pydicom()
+    _import_pydicom()
     from pydicom.dataset import FileDataset, FileMetaDataset
     from pydicom.uid import CTImageStorage, ExplicitVRLittleEndian, generate_uid
 

--- a/openmed/integrations/log_redactor.py
+++ b/openmed/integrations/log_redactor.py
@@ -286,7 +286,7 @@ def _iter_ndjson_events(input_stream: Iterable[str]) -> Iterator[dict[str, Any]]
             continue
         try:
             event = json.loads(line)
-        except json.JSONDecodeError as exc:
+        except json.JSONDecodeError:
             raise LogRedactorError(
                 f"invalid JSON object at input line {line_number}"
             ) from None

--- a/openmed/processing/advanced_ner.py
+++ b/openmed/processing/advanced_ner.py
@@ -684,7 +684,7 @@ class AdvancedNERProcessor:
         if use_smart_grouping and pipeline_output:
             # Check if we have token-level data (no aggregation_strategy used)
             first_item = pipeline_output[0]
-            if "entity" in first_item and not "entity_group" in first_item:
+            if "entity" in first_item and "entity_group" not in first_item:
                 entities = self.smart_group_entities(pipeline_output, text)
             else:
                 # Already grouped, convert to EntitySpan format


### PR DESCRIPTION
## Summary

Resolves several ruff static-analysis warnings (F-errors and E713) across 7 files. These are genuine code-quality issues — not re-export false positives.

## Changes

| File | Fix | Category |
|------|-----|----------|
| `processing/advanced_ner.py` | `not "entity_group" in` → `"entity_group" not in` | E713 — operator style |
| `integrations/log_redactor.py` | Remove unused `as exc` in `except JSONDecodeError` | F841 — unused variable |
| `eval/suites/multimodal_dicom.py` | `pydicom = _import_pydicom()` → `_import_pydicom()` | F841 — unused variable |
| `core/pii_i18n.py` | Remove unused `typing.Set` import | F401 — unused import |
| `core/pii_i18n.py` | Remove unused `gstin_check_char`, `pan_check_letter` imports | F401 — unused import |
| `core/pii_i18n.py` | Remove unused `DEFAULT_MODEL_PLACEHOLDER_LANGUAGES`, `USER_SUPPLIED_MODEL_LANGUAGES` imports | F401 — unused import |
| `eval/coverage.py` | Remove unused `typing.Any` import | F401 — unused import |
| `eval/datasets/multilingual_ner.py` | Remove unused `MICROORGANISM` import | F401 — unused import |
| `eval/relation_metrics.py` | Remove unused `collections.defaultdict` import | F401 — unused import |

## Verification

```
$ ruff check openmed/processing/advanced_ner.py openmed/integrations/log_redactor.py openmed/eval/suites/multimodal_dicom.py openmed/core/pii_i18n.py openmed/eval/coverage.py openmed/eval/datasets/multilingual_ner.py openmed/eval/relation_metrics.py --select=F
All checks passed!
```

Remaining F401 warnings are in `__init__.py` re-export files (intentional public API surface) and are not addressed here.