### PR TITLE
docs: highlight Agent Skills in v2 release notes

### DIFF
--- a/docs/release/v2.0.0.md
+++ b/docs/release/v2.0.0.md
@@ -27,9 +27,14 @@ commit ledger is recorded in `CHANGELOG.md`.
 - **Interoperability:** OpenMRS, DHIS2, OpenHIM, community health forms, WHO
   SMART profiles, PySpark, Prefect, scrubadub, LlamaIndex, scispaCy, QuickUMLS,
   and offline ICD-11 integration points.
-- **On-device and agent tooling:** watchOS and visionOS OpenMedKit targets,
+- **Agent Skills for healthcare workflows:** 72 portable Agent Skills across
+  14 categories teach Claude Code, OpenAI Codex, OpenCode, and compatible
+  agents to assemble local de-identification, clinical NER, FHIR export,
+  evaluation, compliance, and deployment workflows. A safe one-command
+  installer preserves existing user-owned entries.
+- **On-device and MCP tooling:** watchOS and visionOS OpenMedKit targets,
   grapheme-safe Swift spans, Android span models, typed MCP tools, an MCP
-  container, WebGPU and GGUF guidance, repository skills, and LLM-ready docs.
+  container, WebGPU and GGUF guidance, and LLM-ready docs.
 - **Release safety:** multilingual golden fixtures, throughput and latency
   budgets, parser fuzzing, adversarial-PHI tests, signed evidence, API
   compatibility output, and a fail-closed release-readiness decision.
@@ -37,6 +42,62 @@ commit ledger is recorded in `CHANGELOG.md`.
   source revision, use the valid SPDX `ICU` identifier, and carry the complete
   ICU notice inside Python distributions and every standalone converted-model
   bundle.
+
+## Agent Skills: from a prompt to a local pipeline
+
+OpenMed 2.0 ships a catalog of
+[72 portable Agent Skills](https://github.com/maziyarpanahi/openmed/tree/v2.0.0/skills)
+for building healthcare workflows with Claude Code, OpenAI Codex, OpenCode,
+and compatible agents. The catalog covers de-identification, clinical entity
+extraction, FHIR and OMOP handoffs, evaluation, compliance, document intake,
+analytics, and deployment. The multi-agent onboarding from
+[#1866](https://github.com/maziyarpanahi/openmed/pull/1866) installs every
+skill in one command and safely preserves existing files, directories, and
+unrelated symlinks.
+
+```bash
+git clone https://github.com/maziyarpanahi/openmed
+cd openmed
+./install-skills.sh
+```
+
+Or target one client:
+
+```bash
+./install-skills.sh claude     # ~/.claude/skills/
+./install-skills.sh codex      # ~/.codex/skills/
+./install-skills.sh opencode   # ~/.config/opencode/skills/
+./install-skills.sh agents     # ~/.agents/skills/
+```
+
+Then ask the agent for a concrete local workflow using synthetic input:
+
+> Build a local OpenMed pipeline that de-identifies a synthetic discharge note
+> and extracts medication entities. Keep the example synthetic.
+
+The agent can combine the `deidentifying-clinical-text` and
+`extracting-clinical-entities` skills into runnable OpenMed code:
+
+```python
+import openmed
+
+note = (
+    "Synthetic patient Jane Example (MRN 12345), seen 2024-03-02, "
+    "started on metformin 500mg BID."
+)
+deid = openmed.deidentify(
+    note,
+    method="mask",
+    policy="hipaa_safe_harbor",
+)
+meds = openmed.analyze_text(
+    deid.deidentified_text,
+    model_name="pharma_detection_superclinical",
+)
+```
+
+After the one-time model download, inference runs locally. Keep real PHI out
+of cloud-hosted agent prompts, logs, and copied examples.
 
 ## Compatibility
 

--- a/tests/fuzz/test_deidentify_fuzz.py
+++ b/tests/fuzz/test_deidentify_fuzz.py
@@ -733,6 +733,7 @@ def test_deidentify_long_input_preserves_offsets_and_never_leaks(doc):
         )
 
 
+@settings(deadline=None)
 @given(case=chunk_boundary_documents())
 def test_streaming_chunk_boundary_matches_single_pass(case):
     """A boundary inside an identifier is buffered and redacted as one span."""


### PR DESCRIPTION
## Description

Promotes the Agent Skills catalog to a first-class OpenMed 2.0 highlight and
adds a practical prompt-to-local-pipeline example to the versioned release
page. This follows up on #1866 and mirrors the corrected public v2.0.0 release
announcement. It also removes an unrelated wall-clock deadline from the
streaming correctness fuzz test after the first exact-head run exposed a
Windows/Python 3.12 timing flake.

## Type of Change

- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Highlight the 72 portable Agent Skills across 14 healthcare workflow categories.
- Document the safe one-command installer and its Claude Code, OpenAI Codex,
  OpenCode, and cross-client targets.
- Add a synthetic de-identification and medication-extraction example with a
  clear local-inference and PHI boundary.
- Disable Hypothesis timing enforcement for the streaming chunk-boundary
  correctness test; its data and span invariants remain unchanged.

## Testing

- [x] `.venv/bin/pre-commit run --files docs/release/v2.0.0.md`
- [x] `.venv/bin/mkdocs build --strict --site-dir /tmp/openmed-v2-skills-docs`
- [x] `uv run --extra dev pytest tests/fuzz/test_deidentify_fuzz.py::test_streaming_chunk_boundary_matches_single_pass -q`
- [x] `.venv/bin/pre-commit run --files tests/fuzz/test_deidentify_fuzz.py`

## Documentation

- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Related to #1866

## Screenshots/Examples

The release page now includes the exact synthetic prompt and generated local
Python pipeline shown in the Agent Skills catalog.
