### PR TITLE
Fix BOM-prefixed structured risk CLI input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `openmed risk discover`, `risk assess`, and `risk anonymize` handling
+  of UTF-8 BOM-prefixed CSV and TSV schemas so the first column is classified
+  consistently, and added bounded validation causes to structured-release CLI
+  errors instead of replacing actionable `TypeError` and `ValueError` details
+  with a generic schema mismatch.
+
 ## [2.0.0] - 2026-07-28
 
 OpenMed 2.0 expands the local-first privacy, clinical extraction, evaluation,

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -227,6 +227,26 @@ def _merged_column_args(
     return tuple(dict.fromkeys((*comma_separated, *literal_columns)))
 
 
+def _release_error_message(summary: str, exc: TypeError | ValueError) -> str:
+    """Attach a bounded, single-line release validation cause."""
+
+    rendered = []
+    for character in str(exc):
+        category = unicodedata.category(character)
+        if character in "\r\n\t":
+            rendered.append(" ")
+        elif category.startswith("C") or category in {"Zl", "Zp"}:
+            rendered.append(f"\\u{ord(character):04x}")
+        else:
+            rendered.append(character)
+    detail = " ".join("".join(rendered).split())
+    if not detail:
+        detail = "No additional validation detail was provided."
+    if len(detail) > 1_000:
+        detail = detail[:997] + "..."
+    return f"{summary} Cause ({type(exc).__name__}): {detail}"
+
+
 def _role_override_arg(value: str) -> tuple[str, tuple[str, ...]]:
     if "=" not in value:
         raise argparse.ArgumentTypeError(
@@ -2787,7 +2807,10 @@ def _handle_risk_assess(args: argparse.Namespace) -> int:
         assessment = assess_release(records, policy)
     except (TypeError, ValueError) as exc:
         raise CliError(
-            "The structured release policy does not match the input schema.",
+            _release_error_message(
+                "The structured release policy does not match the input schema.",
+                exc,
+            ),
             code="invalid_release_config",
             exit_code=EXIT_USAGE,
         ) from exc
@@ -3063,7 +3086,10 @@ def _handle_risk_anonymize(args: argparse.Namespace) -> int:
         assess_release(records, policy)
     except (TypeError, ValueError) as exc:
         raise CliError(
-            "The structured release policy does not match the input schema.",
+            _release_error_message(
+                "The structured release policy does not match the input schema.",
+                exc,
+            ),
             code="invalid_release_config",
             exit_code=EXIT_USAGE,
         ) from exc
@@ -3136,7 +3162,16 @@ def _handle_risk_anonymize(args: argparse.Namespace) -> int:
             code="release_backup_cleanup_failed",
             exit_code=EXIT_ERROR,
         ) from exc
-    except (ImportError, OSError, TypeError, ValueError) as exc:
+    except (TypeError, ValueError) as exc:
+        raise CliError(
+            _release_error_message(
+                "Failed to anonymize and validate the structured release.",
+                exc,
+            ),
+            code="release_anonymization_failed",
+            exit_code=EXIT_ERROR,
+        ) from exc
+    except (ImportError, OSError) as exc:
         raise CliError(
             "Failed to anonymize and validate the structured release.",
             code="release_anonymization_failed",
@@ -3216,7 +3251,10 @@ def _validated_release_policy(args: argparse.Namespace):
         return _release_policy_from_args(args)
     except (TypeError, ValueError) as exc:
         raise CliError(
-            "The structured release policy is invalid.",
+            _release_error_message(
+                "The structured release policy is invalid.",
+                exc,
+            ),
             code="invalid_release_policy",
             exit_code=EXIT_USAGE,
         ) from exc

--- a/openmed/structured/qi_detect.py
+++ b/openmed/structured/qi_detect.py
@@ -453,7 +453,7 @@ def _read_delimited_sample(
 ) -> _TableSample:
     rows: list[dict[str, Any]] = []
     complete = True
-    with path.open("r", encoding="utf-8", newline="") as handle:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
         try:
             reader = csv.DictReader(handle, delimiter=delimiter, strict=True)
             if reader.fieldnames is None:

--- a/openmed/structured/table_io.py
+++ b/openmed/structured/table_io.py
@@ -77,7 +77,7 @@ def write_table(
 
 
 def _read_delimited(path: Path, *, delimiter: str) -> list[dict[str, Any]]:
-    with path.open("r", encoding="utf-8", newline="") as handle:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
         try:
             reader = csv.DictReader(handle, delimiter=delimiter, strict=True)
             if reader.fieldnames is None:

--- a/tests/unit/cli/test_risk_release_cli.py
+++ b/tests/unit/cli/test_risk_release_cli.py
@@ -62,6 +62,14 @@ def _write_csv(path: Path, rows=ROWS) -> Path:
     return path
 
 
+def _write_bom_csv(path: Path, rows=ROWS) -> Path:
+    with path.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+    return path
+
+
 def _policy_args() -> list[str]:
     return [
         "--qi",
@@ -429,6 +437,65 @@ def test_risk_assess_repeatable_flags_support_literal_schema_names(
     assert "Île-de-France" not in rendered
 
 
+def test_risk_assess_accepts_bom_prefixed_seven_column_csv(tmp_path: Path) -> None:
+    rows = [
+        {**row, "encounter_id": f"encounter-{index}"}
+        for index, row in enumerate(ROWS, start=1)
+    ]
+    source = _write_bom_csv(tmp_path / "bom-source.csv", rows)
+    output = tmp_path / "assessment.json"
+
+    code = main_module.main(
+        [
+            "risk",
+            "assess",
+            str(source),
+            "--output",
+            str(output),
+            "--qi",
+            "age,zip,visit_date",
+            "--sensitive",
+            "disease",
+            "--direct-id",
+            "full_name,encounter_id",
+            "--privacy-unit",
+            "patient_id",
+            "--k",
+            "2",
+            "--l",
+            "2",
+            "--t",
+            "0",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["meets_policy"] is True
+    assert payload["privacy_unit_count"] == len(ROWS)
+
+
+def test_risk_discover_strips_bom_from_csv_schema(tmp_path: Path) -> None:
+    source = _write_bom_csv(tmp_path / "bom-source.csv")
+    output = tmp_path / "discovery.json"
+
+    code = main_module.main(
+        [
+            "risk",
+            "discover",
+            str(source),
+            "--output",
+            str(output),
+            "--full-scan",
+        ]
+    )
+
+    assert code == 0
+    serialized = output.read_text(encoding="utf-8")
+    assert '"patient_id"' in serialized
+    assert "\\ufeffpatient_id" not in serialized
+
+
 def test_risk_population_assess_writes_aggregate_safe_evidence(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -637,6 +704,56 @@ def test_risk_anonymize_writes_validated_release_and_expert_evidence(
     )
     assert verify_code == 0
     assert "verification: PASS" in capsys.readouterr().out
+
+
+def test_risk_anonymize_accepts_bom_with_repeatable_policy_columns(
+    tmp_path: Path,
+) -> None:
+    rows = [
+        {**row, "encounter_id": f"encounter-{index}"}
+        for index, row in enumerate(ROWS, start=1)
+    ]
+    source = _write_bom_csv(tmp_path / "bom-source.csv", rows)
+    release = tmp_path / "release.jsonl"
+    evidence = tmp_path / "evidence.json"
+    policy_args = [
+        "--qi-column",
+        "age",
+        "--qi-column",
+        "zip",
+        "--qi-column",
+        "visit_date",
+        "--sensitive-column",
+        "disease",
+        "--direct-id-column",
+        "full_name",
+        "--direct-id-column",
+        "encounter_id",
+        "--privacy-unit",
+        "patient_id",
+        "--k",
+        "2",
+        "--l",
+        "2",
+        "--t",
+        "0",
+    ]
+
+    code = main_module.main(
+        _anonymize_args(
+            source,
+            release,
+            evidence,
+            policy_args=policy_args,
+        )
+    )
+
+    assert code == 0
+    released = read_table(release)
+    assert len(released) == len(ROWS)
+    assert all("patient_id" not in row for row in released)
+    assert all("encounter_id" not in row for row in released)
+    assert all("full_name" not in row for row in released)
 
 
 def test_other_release_context_requires_reviewed_assumptions_notes(
@@ -1415,7 +1532,72 @@ def test_invalid_release_policy_is_usage_error(
     )
 
     assert code == 2
-    assert "policy is invalid" in capsys.readouterr().err
+    error = capsys.readouterr().err
+    assert "policy is invalid" in error
+    assert "Cause (ValueError):" in error
+    assert "quasi_identifiers cannot overlap non_sensitive_attributes" in error
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("command", ["assess", "anonymize"])
+def test_release_config_error_surfaces_safe_value_error_cause(
+    command: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rows = [
+        {**row, "encounter_id": f"encounter-{index}"}
+        for index, row in enumerate(ROWS, start=1)
+    ]
+    source = _write_csv(tmp_path / "source.csv", rows)
+    output = tmp_path / "output.json"
+    policy_args = [
+        "--qi-column",
+        "age,zip,visit_date",
+        "--sensitive-column",
+        "disease",
+        "--direct-id-column",
+        "full_name,encounter_id",
+        "--privacy-unit",
+        "patient_id",
+        "--k",
+        "2",
+        "--l",
+        "2",
+        "--t",
+        "0",
+    ]
+    if command == "assess":
+        args = [
+            "risk",
+            "assess",
+            str(source),
+            "--output",
+            str(output),
+            *policy_args,
+        ]
+    else:
+        args = _anonymize_args(
+            source,
+            tmp_path / "release.jsonl",
+            tmp_path / "evidence.json",
+            policy_args=policy_args,
+        )
+    args.append("--json")
+
+    code = main_module.main(args)
+
+    assert code == 2
+    payload = json.loads(capsys.readouterr().out)
+    message = payload["error"]["message"]
+    assert payload["error"]["code"] == "invalid_release_config"
+    assert "Cause (ValueError):" in message
+    assert "Declared policy columns are absent from the table" in message
+    assert "age,zip,visit_date" in message
+    assert "full_name,encounter_id" in message
+    for row in rows:
+        for value in row.values():
+            assert value not in message
     assert not output.exists()
 
 

--- a/tests/unit/structured/test_qi_detect.py
+++ b/tests/unit/structured/test_qi_detect.py
@@ -113,6 +113,20 @@ def test_scan_table_surfaces_planted_singleton_qi_set(tmp_path: Path) -> None:
     )
 
 
+def test_scan_table_strips_utf8_byte_order_mark(tmp_path: Path) -> None:
+    csv_path = _write_csv(tmp_path / "bom.csv", ROWS)
+    csv_path.write_text(
+        "\ufeff" + csv_path.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    manifest = scan_table(csv_path)
+
+    assert "record_id" in manifest["columns"]
+    assert "\ufeffrecord_id" not in manifest["columns"]
+    assert "\ufeff" not in json.dumps(manifest, ensure_ascii=False)
+
+
 def test_detected_qi_class_sizes_match_explicit_kanon_report(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/structured/test_table_io.py
+++ b/tests/unit/structured/test_table_io.py
@@ -37,6 +37,24 @@ def test_table_io_round_trip_supported_text_formats(
         assert restored == ROWS
 
 
+@pytest.mark.parametrize(
+    ("suffix", "delimiter"),
+    [(".csv", ","), (".tsv", "\t")],
+)
+def test_delimited_reader_strips_utf8_byte_order_mark(
+    tmp_path: Path,
+    suffix: str,
+    delimiter: str,
+) -> None:
+    path = tmp_path / f"bom{suffix}"
+    path.write_text(
+        f"\ufeffpatient_id{delimiter}age\npatient-1{delimiter}30\n",
+        encoding="utf-8",
+    )
+
+    assert read_table(path) == [{"patient_id": "patient-1", "age": "30"}]
+
+
 def test_table_writer_refuses_overwrite_by_default(tmp_path: Path) -> None:
     path = tmp_path / "release.jsonl"
     write_table(path, ROWS)


### PR DESCRIPTION
# Pull Request

## Description
Fixes a v2.0.0 structured-risk CLI failure on UTF-8 BOM-prefixed CSV and TSV
inputs. The same seven-column policy worked through `assess_release()` on clean
in-memory rows, while `risk discover` accepted the file and `risk assess` /
`risk anonymize` returned only `invalid_release_config`.

The BOM was retained as an invisible control character on the first header.
Discovery therefore classified a different schema label, and the release
engine correctly rejected the invalid label. The CLI then hid that `ValueError`
behind a generic schema-mismatch message.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Decode delimited structured inputs with `utf-8-sig` in both complete table
  reads and bounded QI discovery, stripping only an initial UTF-8 BOM while
  preserving normal UTF-8 behavior.
- Surface bounded, single-line `TypeError` and `ValueError` causes for
  structured release policy, schema, and anonymization failures without
  changing the stable JSON error-envelope keys.
- Add seven-column CLI regressions for both comma-list flags and correctly
  repeated literal `--*-column` flags, plus table I/O and discovery coverage.
- Document the correction under `Unreleased`.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Validation performed:
- `uv run --extra dev pytest -q tests/unit` — 8663 passed, 43 skipped
- Structured table, QI discovery, and risk CLI files — 161 passed
- Release engine, expert evidence, and CLI JSON envelope files — 120 passed
- `uv run --extra dev make format`
- `uv run --extra dev make lint`
- `uv run --extra dev make format-check`
- Touched-file pre-commit hooks, including Ruff, Bandit, and secret detection
- Manual v2 seven-column reproduction: BOM-prefixed `risk assess` reaches the
  expected policy verdict, `risk anonymize` succeeds with validated evidence,
  and invalid combined literal-column usage exposes the actual missing-column
  cause

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift` (not applicable; no Swift changes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
No linked issue.

## Screenshots/Examples
Before:

```json
{"error":{"code":"invalid_release_config","message":"The structured release policy does not match the input schema."},"ok":false}
```

After an invalid combined literal-column argument:

```text
The structured release policy does not match the input schema. Cause (ValueError): Declared policy columns are absent from the table: [...]
```

Correct comma-list arguments and correctly repeated literal-column arguments
now both work on BOM-prefixed delimited input.
