### PR TITLE
fix: recover failed package publication

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: python-package-distributions
+      release-tag:
+        description: Immutable vX.Y.Z tag to build during a recovery dispatch.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -25,6 +30,38 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ inputs.release-tag || github.ref }}
+
+      - name: Verify release source ref
+        if: inputs.release-tag != '' || github.ref_type == 'tag'
+        env:
+          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must match vX.Y.Z: $RELEASE_TAG"
+            exit 1
+          fi
+          TAG_COMMIT=$(git rev-list -n 1 "$RELEASE_TAG")
+          CHECKED_OUT_COMMIT=$(git rev-parse HEAD)
+          if [ "$CHECKED_OUT_COMMIT" != "$TAG_COMMIT" ]; then
+            echo "Checked-out commit $CHECKED_OUT_COMMIT != $RELEASE_TAG commit $TAG_COMMIT"
+            exit 1
+          fi
+          python3 - "$RELEASE_TAG" "$TAG_COMMIT" <<'PY'
+          import json
+          import os
+          import sys
+
+          payload = {
+              "release_commit": sys.argv[2],
+              "release_tag": sys.argv[1],
+              "workflow_ref": os.environ["GITHUB_REF"],
+              "workflow_sha": os.environ["GITHUB_SHA"],
+          }
+          with open("release-source.json", "w", encoding="utf-8") as handle:
+              json.dump(payload, handle, indent=2, sort_keys=True)
+              handle.write("\n")
+          PY
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -51,11 +88,15 @@ jobs:
 
       - name: Compute release metadata
         id: release_metadata
+        env:
+          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
         run: |
-          if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
-            RELEASE_COMMIT=$(git rev-list -n 1 "$GITHUB_REF_NAME")
+          release_version_args=()
+          if [ -n "${RELEASE_TAG:-}" ] && [[ "$RELEASE_TAG" == v* ]]; then
+            RELEASE_COMMIT=$(git rev-list -n 1 "$RELEASE_TAG")
             PREVIOUS_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' "${RELEASE_COMMIT}^" 2>/dev/null || true)
             RANGE_END="$RELEASE_COMMIT"
+            release_version_args=(--release-version "${RELEASE_TAG#v}")
           else
             PREVIOUS_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)
             RANGE_END="HEAD"
@@ -72,20 +113,18 @@ jobs:
           python scripts/release/changelog.py \
             --range "$RANGE" \
             --current-version "$BASE_VERSION" \
+            "${release_version_args[@]}" \
             --github-output
 
       - name: Verify version matches tag
-        if: github.ref_type == 'tag'
+        if: inputs.release-tag != '' || github.ref_type == 'tag'
+        env:
+          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
         run: |
           VERSION=$(python -c "import pathlib, re; content = pathlib.Path('openmed/__about__.py').read_text(); print(re.search(r'__version__\\s*=\\s*\"([^\"]+)\"', content).group(1))")
-          TAG=${GITHUB_REF#refs/tags/v}
-          COMPUTED_VERSION="${{ steps.release_metadata.outputs.next_version }}"
-          if [ "$VERSION" != "$TAG" ]; then
-            echo "Version mismatch: package version $VERSION != tag version $TAG"
-            exit 1
-          fi
-          if [ "$COMPUTED_VERSION" != "$TAG" ]; then
-            echo "Version mismatch: computed next version $COMPUTED_VERSION != tag version $TAG"
+          TAG_VERSION=${RELEASE_TAG#v}
+          if [ "$VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: package version $VERSION != tag version $TAG_VERSION"
             exit 1
           fi
 
@@ -199,6 +238,7 @@ jobs:
           name: release-provenance
           path: |
             release-artifact-digests.txt
+            release-source.json
             provenance-bundles/*.json
             provenance-verification/*.json
           if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,28 @@
-# Tags matching v* build and publish OpenMed to PyPI and npm.
+# Tags matching v* build and publish OpenMed to PyPI and npm. A guarded manual
+# dispatch can recover an existing immutable tag after a workflow-only failure.
 name: Publish OpenMed Packages
 
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing immutable vX.Y.Z tag to publish.
+        required: true
+        type: string
+
+concurrency:
+  group: publish-openmed-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   provenance:
     name: Build, attest, and verify distributions
     uses: ./.github/workflows/provenance.yml
+    with:
+      release-tag: ${{ inputs.tag || github.ref_name }}
     permissions:
       contents: read
       id-token: write
@@ -23,6 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -32,10 +47,12 @@ jobs:
           package-manager-cache: false
 
       - name: Verify release versions agree
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           PYTHON_VERSION=$(python3 -c "import pathlib, re; content = pathlib.Path('openmed/__about__.py').read_text(); print(re.search(r'__version__\\s*=\\s*\"([^\"]+)\"', content).group(1))")
           NPM_VERSION=$(node -p "require('./js/openmedkit-web/package.json').version")
-          TAG_VERSION=${GITHUB_REF_NAME#v}
+          TAG_VERSION=${RELEASE_TAG#v}
           if [ "$PYTHON_VERSION" != "$TAG_VERSION" ]; then
             echo "Version mismatch: Python $PYTHON_VERSION != tag $TAG_VERSION"
             exit 1
@@ -64,7 +81,10 @@ jobs:
   publish:
     name: Publish distributions
     needs: [provenance, npm-verify]
-    if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    if: >-
+      (github.event_name == 'push' && github.ref_type == 'tag' &&
+       startsWith(github.ref_name, 'v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -88,7 +108,10 @@ jobs:
   npm-publish:
     name: Publish npm package
     needs: [provenance, npm-verify]
-    if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    if: >-
+      (github.event_name == 'push' && github.ref_type == 'tag' &&
+       startsWith(github.ref_name, 'v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
     environment:
       name: npm
@@ -99,6 +122,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -214,6 +239,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}  # this job does not check out the repo
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
           PROVENANCE_OUTCOME: ${{ steps.provenance-evidence.outcome }}
           SIGN_OUTCOME: ${{ steps.sign-distributions.outcome }}
         shell: bash
@@ -225,7 +251,8 @@ jobs:
           if [ "$PROVENANCE_OUTCOME" = "success" ]; then
             for candidate in \
               release-provenance/provenance-bundles/python-distributions.intoto.json \
-              release-provenance/release-artifact-digests.txt; do
+              release-provenance/release-artifact-digests.txt \
+              release-provenance/release-source.json; do
               if [ ! -s "$candidate" ]; then
                 echo "Expected provenance evidence is missing or empty: $candidate" >&2
                 exit 1
@@ -248,9 +275,9 @@ jobs:
           printf 'Attaching release evidence:\n'
           printf -- '- %s\n' "${assets[@]}"
 
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" --generate-notes || true
-          gh release upload "$GITHUB_REF_NAME" "${assets[@]}" --clobber
+          gh release create "$RELEASE_TAG" \
+            --title "$RELEASE_TAG" --generate-notes || true
+          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
 
   sbom:
     name: Generate release SBOM
@@ -263,6 +290,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -294,11 +322,12 @@ jobs:
           if-no-files-found: warn
 
       - name: Attach SBOM to the tagged GitHub release
-        if: github.ref_type == 'tag' && hashFiles('sbom.cdx.json') != ''
+        if: hashFiles('sbom.cdx.json') != ''
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          gh release upload "$GITHUB_REF_NAME" sbom.cdx.json --clobber \
-            || gh release create "$GITHUB_REF_NAME" sbom.cdx.json \
-                 --title "$GITHUB_REF_NAME" --generate-notes
+          gh release upload "$RELEASE_TAG" sbom.cdx.json --clobber \
+            || gh release create "$RELEASE_TAG" sbom.cdx.json \
+                 --title "$RELEASE_TAG" --generate-notes

--- a/docs/release/trusted-publishing.md
+++ b/docs/release/trusted-publishing.md
@@ -3,7 +3,9 @@
 OpenMed publishes the `openmed` wheel and source distribution from the
 tag-driven `.github/workflows/publish.yml` workflow. The same workflow validates
 and publishes the `openmed` npm package for browsers and Node.js. Both packages
-must match the release tag before either registry upload begins.
+must match the release tag before either registry upload begins. A guarded
+manual dispatch exists only to recover an existing immutable tag after a
+workflow-only failure.
 
 The current PyPI path uses the project-scoped `PYPI_API_TOKEN` GitHub secret.
 The npm path uses the short-lived `NPM_ACCESS_TOKEN` secret from the GitHub
@@ -17,7 +19,11 @@ this repository, workflow file, and GitHub environment.
 
 The only PyPI publishing workflow is `.github/workflows/publish.yml`.
 
-- It runs from `push` events for `v*` tags only.
+- It runs automatically from `push` events for `v*` tags.
+- A maintainer may manually dispatch it with an existing `vX.Y.Z` tag to
+  recover a failed tag run. The workflow checks out that exact tag, verifies
+  the checked-out commit against the tag, and repeats every build and
+  verification gate before publishing.
 - It does not run from `pull_request` or forked pull request events.
 - The reusable provenance job in `.github/workflows/provenance.yml` builds and
   checks the distributions, generates SLSA provenance, and verifies the
@@ -36,8 +42,14 @@ The only PyPI publishing workflow is `.github/workflows/publish.yml`.
 - The evidence job runs after the publish job, so it cannot gate the PyPI
   upload on GitHub OIDC or Sigstore availability. Signing is best effort, but
   evidence that is produced must verify against the `publish.yml` workflow
-  identity and the release commit before it is attached to the release, or the
-  evidence job fails.
+  identity and triggering workflow revision before it is attached to the
+  release, or the evidence job fails. The attached `release-source.json`
+  separately records the exact immutable tag commit that was checked out,
+  including during a recovery dispatch from `master`.
+- Conventional commits determine the minimum safe version bump. The tag may
+  intentionally select a larger minor or major version, but it must be newer
+  than the previous tag, meet or exceed that minimum, and exactly match both
+  package manifests.
 
 Do not add a second PyPI publishing workflow. Do not add `hatch publish` or
 Twine upload commands back to release CI.
@@ -131,6 +143,18 @@ pushed.
 After the tagged publish succeeds, verify the PyPI release page lists the
 uploaded wheel and source distribution. For the repository-level SLSA
 provenance check, see [SLSA Build Provenance](../supply-chain/provenance.md).
+
+If an immutable tag run fails before either registry upload, fix and merge the
+workflow guard first, then recover the existing tag through the same production
+workflow:
+
+```bash
+gh workflow run publish.yml --ref master -f tag=vX.Y.Z
+```
+
+Do not delete, move, or recreate the tag. Do not use the recovery dispatch when
+either registry already contains the version without first determining whether
+the other publish can be safely resumed.
 
 ## Token Handling
 

--- a/scripts/release/changelog.py
+++ b/scripts/release/changelog.py
@@ -17,6 +17,7 @@ ROOT = Path(__file__).resolve().parents[2]
 ABOUT_FILE = ROOT / "openmed" / "__about__.py"
 
 VERSION_PATTERN = re.compile(r'__version__\s*=\s*"([^"]+)"')
+SEMVER_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 CONVENTIONAL_PATTERN = re.compile(
     r"^(?P<type>[A-Za-z][A-Za-z0-9-]*)"
     r"(?:\((?P<scope>[^)]+)\))?"
@@ -142,6 +143,39 @@ def bump_version(current_version: str, bump: str) -> str:
     if bump == "patch":
         return f"{major}.{minor}.{patch + 1}"
     raise ValueError(f"Unknown SemVer bump {bump!r}")
+
+
+def parse_semver(version: str) -> tuple[int, int, int]:
+    """Parse a stable SemVer version into a comparable tuple."""
+    match = SEMVER_PATTERN.fullmatch(version)
+    if not match:
+        raise ValueError(f"Expected SemVer version X.Y.Z, got {version!r}")
+    return tuple(int(part) for part in match.groups())
+
+
+def validate_release_version(
+    current_version: str,
+    minimum_version: str,
+    release_version: str,
+) -> None:
+    """Require a release to advance and meet the computed minimum bump.
+
+    Conventional commits provide the minimum safe bump. Release owners may
+    intentionally choose a larger minor or major version.
+    """
+    current = parse_semver(current_version)
+    minimum = parse_semver(minimum_version)
+    release = parse_semver(release_version)
+
+    if release <= current:
+        raise ValueError(
+            f"Release version {release_version} must be newer than {current_version}"
+        )
+    if release < minimum:
+        raise ValueError(
+            f"Release version {release_version} is below the computed minimum "
+            f"{minimum_version}"
+        )
 
 
 def changelog_section_for(commit: ConventionalCommit) -> str | None:
@@ -281,6 +315,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Base SemVer version. Defaults to the latest v* tag, then openmed/__about__.py.",
     )
     parser.add_argument(
+        "--release-version",
+        help=(
+            "Validate an explicit release version against the computed minimum. "
+            "Larger intentional minor or major versions are accepted."
+        ),
+    )
+    parser.add_argument(
         "--date",
         default=date.today().isoformat(),
         help="Release date for the rendered changelog section.",
@@ -315,6 +356,16 @@ def main(argv: list[str] | None = None) -> int:
 
     commits = read_commits(repo, range_spec)
     notes = build_release_notes(current_version, commits, args.date)
+    if args.release_version:
+        try:
+            validate_release_version(
+                current_version,
+                notes.next_version,
+                args.release_version,
+            )
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
 
     payload = {
         "bump": notes.bump,

--- a/tests/unit/release/test_changelog.py
+++ b/tests/unit/release/test_changelog.py
@@ -6,6 +6,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[3]
 CHANGELOG_SCRIPT = ROOT / "scripts" / "release" / "changelog.py"
 
@@ -99,6 +101,30 @@ def test_bang_subject_computes_major_bump():
 
     assert notes.bump == "major"
     assert notes.next_version == "2.0.0"
+
+
+def test_release_version_accepts_intentional_major_bump_above_minimum():
+    release_changelog.validate_release_version("1.9.1", "1.10.0", "2.0.0")
+
+
+@pytest.mark.parametrize(
+    ("current_version", "minimum_version", "release_version"),
+    [
+        ("1.9.1", "1.10.0", "1.9.2"),
+        ("1.9.1", "1.9.2", "1.9.1"),
+    ],
+)
+def test_release_version_rejects_stale_or_insufficient_bump(
+    current_version,
+    minimum_version,
+    release_version,
+):
+    with pytest.raises(ValueError):
+        release_changelog.validate_release_version(
+            current_version,
+            minimum_version,
+            release_version,
+        )
 
 
 def test_writes_github_outputs(tmp_path):

--- a/tests/unit/release/test_provenance_workflow.py
+++ b/tests/unit/release/test_provenance_workflow.py
@@ -30,6 +30,12 @@ def test_reusable_provenance_workflow_attests_and_verifies_distributions():
     job = jobs["python-distributions"]
 
     assert workflow["on"]["workflow_call"]["inputs"]["distribution-artifact-name"]
+    assert workflow["on"]["workflow_call"]["inputs"]["release-tag"] == {
+        "description": "Immutable vX.Y.Z tag to build during a recovery dispatch.",
+        "required": "false",
+        "type": "string",
+        "default": "",
+    }
     assert job["name"] == "Build, attest, and verify Python distributions"
     assert job["permissions"] == {
         "contents": "read",
@@ -51,6 +57,15 @@ def test_reusable_provenance_workflow_attests_and_verifies_distributions():
     assert '--source-digest "$GITHUB_SHA"' in content
     assert '--source-ref "$GITHUB_REF"' in content
     assert "actions/upload-artifact@v7" in content
+    assert "Verify release source ref" in content
+    assert "Checked-out commit $CHECKED_OUT_COMMIT" in content
+    assert '"release_commit": sys.argv[2]' in content
+    assert '"release_tag": sys.argv[1]' in content
+    assert '"workflow_ref": os.environ["GITHUB_REF"]' in content
+    assert '"workflow_sha": os.environ["GITHUB_SHA"]' in content
+    assert "release-source.json" in content
+    assert "--release-version" in content
+    assert "computed next version $COMPUTED_VERSION" not in content
 
 
 def test_publish_workflow_blocks_pypi_upload_on_provenance_verification():
@@ -62,6 +77,7 @@ def test_publish_workflow_blocks_pypi_upload_on_provenance_verification():
     npm_publish = jobs["npm-publish"]
 
     assert provenance["uses"] == "./.github/workflows/provenance.yml"
+    assert provenance["with"]["release-tag"] == ("${{ inputs.tag || github.ref_name }}")
     assert provenance["permissions"] == {
         "contents": "read",
         "id-token": "write",
@@ -134,8 +150,9 @@ def test_evidence_job_attaches_provenance_and_signatures_to_the_release():
         in content
     )
     assert "release-provenance/release-artifact-digests.txt" in content
+    assert "release-provenance/release-source.json" in content
     assert "assets+=(sigstore-bundles/*.sigstore.json)" in content
-    assert 'gh release upload "$GITHUB_REF_NAME" "${assets[@]}" --clobber' in content
+    assert 'gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber' in content
 
     # A partially successful signing run leaves unverified bundles on disk, so
     # signatures are only attached when the whole signing step succeeded.

--- a/tests/unit/test_publish_workflow_version.py
+++ b/tests/unit/test_publish_workflow_version.py
@@ -117,8 +117,16 @@ def test_publish_workflow_keeps_release_gates():
     )
 
     assert "tags:\n      - 'v*'" in publish_workflow
-    assert "workflow_dispatch:" not in publish_workflow
+    assert workflow["on"]["workflow_dispatch"]["inputs"]["tag"] == {
+        "description": "Existing immutable vX.Y.Z tag to publish.",
+        "required": "true",
+        "type": "string",
+    }
     assert "pull_request:" not in publish_workflow
+    assert workflow["concurrency"] == {
+        "group": "publish-openmed-${{ inputs.tag || github.ref_name }}",
+        "cancel-in-progress": "false",
+    }
     assert "uses: ./.github/workflows/provenance.yml" in publish_workflow
     assert "pypa/gh-action-pypi-publish@v1.14.1" in publish_workflow
     assert "HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}" not in publish_workflow
@@ -136,8 +144,10 @@ def test_publish_workflow_keeps_release_gates():
     assert "python scripts/release/check_repo_policy.py" in provenance_workflow
     assert "Compute release metadata" in provenance_workflow
     assert "python scripts/release/changelog.py" in provenance_workflow
-    assert "steps.release_metadata.outputs.next_version" in provenance_workflow
+    assert "--release-version" in provenance_workflow
+    assert "steps.release_metadata.outputs.next_version" not in provenance_workflow
     assert "Verify version matches tag" in provenance_workflow
+    assert "Verify release source ref" in provenance_workflow
     assert "twine check dist/*" in provenance_workflow
 
 
@@ -154,6 +164,7 @@ def test_publish_workflow_verifies_and_publishes_npm_package():
     )
 
     assert npm_verify["permissions"] == {"contents": "read"}
+    assert npm_verify["steps"][0]["with"]["ref"] == ("${{ inputs.tag || github.ref }}")
     assert "actions/setup-node@v7" in content
     assert "node-version: '24'" in content
     assert "package-manager-cache: false" in content
@@ -175,6 +186,7 @@ def test_publish_workflow_verifies_and_publishes_npm_package():
         "npm publish --ignore-scripts --access public --provenance"
     )
     assert publish_step["env"]["NODE_AUTH_TOKEN"] == ("${{ secrets.NPM_ACCESS_TOKEN }}")
+    assert npm_publish["steps"][0]["with"]["ref"] == ("${{ inputs.tag || github.ref }}")
     assert sbom["needs"] == ["publish", "npm-publish"]
 
 


### PR DESCRIPTION
## Description
Fix the v2.0.0 package publication gate that rejected an intentional major-version jump, and add a guarded recovery dispatch for the existing immutable tag.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made
- Treat Conventional Commit version inference as the minimum safe bump, allowing an intentional larger minor or major version.
- Pin recovery builds to an existing `vX.Y.Z` tag and record the tag commit separately from the triggering workflow revision.
- Add a required tag input and per-release concurrency to the sole PyPI/npm production workflow.

## Testing
- [x] Added regression coverage for the v1.9.1 to v2.0.0 major-version jump.
- [x] 33 focused release workflow/version tests pass.
- [x] Full suite: 8,870 passed in the sandbox; all 31 sandbox/host-capability reruns pass outside it.
- [x] npm audit, test, and pack dry-run pass; wheel/sdist build and Twine checks pass.
- [x] `actionlint`, strict MkDocs, scoped pre-commit, and GitHub Actions reference policy pass.

## Documentation
- [x] Updated the registry publishing runbook.
- [x] Added docstrings to the new version validation helpers.
- [ ] CHANGELOG.md is unchanged because this is post-release workflow recovery.

## Code Quality
- [x] Ruff check and format-check pass for changed Python files.
- [x] Performed a self-review.
- [x] Changes generate no new warnings.

## Dependencies
- [x] No new dependencies.

## Checklist
- [x] Read the contributing guidelines.
- [x] Commits are clear, descriptive, and one file each.

## Related Issues
No linked issue.

## Screenshots/Examples
The failed v2.0.0 run computed `1.10.0` as the minimum recommended bump. The repaired gate accepts the intentional `2.0.0` release while continuing to reject `1.9.2` as below that minimum.