### PR TITLE
fix: bind recovery helper to workflow revision

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -90,7 +90,14 @@ jobs:
         id: release_metadata
         env:
           RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
+          WORKFLOW_REVISION: ${{ github.workflow_sha }}
         run: |
+          WORKFLOW_CHANGELOG="$RUNNER_TEMP/openmed-changelog.py"
+          git show \
+            "${WORKFLOW_REVISION}:scripts/release/changelog.py" \
+            > "$WORKFLOW_CHANGELOG"
+          test -s "$WORKFLOW_CHANGELOG"
+
           release_version_args=()
           if [ -n "${RELEASE_TAG:-}" ] && [[ "$RELEASE_TAG" == v* ]]; then
             RELEASE_COMMIT=$(git rev-list -n 1 "$RELEASE_TAG")
@@ -110,7 +117,8 @@ jobs:
             RANGE="$RANGE_END"
           fi
 
-          python scripts/release/changelog.py \
+          python "$WORKFLOW_CHANGELOG" \
+            --repo "$GITHUB_WORKSPACE" \
             --range "$RANGE" \
             --current-version "$BASE_VERSION" \
             "${release_version_args[@]}" \

--- a/tests/unit/release/test_provenance_workflow.py
+++ b/tests/unit/release/test_provenance_workflow.py
@@ -66,6 +66,10 @@ def test_reusable_provenance_workflow_attests_and_verifies_distributions():
     assert "release-source.json" in content
     assert "--release-version" in content
     assert "computed next version $COMPUTED_VERSION" not in content
+    assert "WORKFLOW_REVISION: ${{ github.workflow_sha }}" in content
+    assert '"${WORKFLOW_REVISION}:scripts/release/changelog.py"' in content
+    assert '--repo "$GITHUB_WORKSPACE"' in content
+    assert "python scripts/release/changelog.py" not in content
 
 
 def test_publish_workflow_blocks_pypi_upload_on_provenance_verification():

--- a/tests/unit/test_publish_workflow_version.py
+++ b/tests/unit/test_publish_workflow_version.py
@@ -143,7 +143,8 @@ def test_publish_workflow_keeps_release_gates():
     assert "id-token: write" in provenance_workflow
     assert "python scripts/release/check_repo_policy.py" in provenance_workflow
     assert "Compute release metadata" in provenance_workflow
-    assert "python scripts/release/changelog.py" in provenance_workflow
+    assert 'python "$WORKFLOW_CHANGELOG"' in provenance_workflow
+    assert '"${WORKFLOW_REVISION}:scripts/release/changelog.py"' in provenance_workflow
     assert "--release-version" in provenance_workflow
     assert "steps.release_metadata.outputs.next_version" not in provenance_workflow
     assert "Verify version matches tag" in provenance_workflow


### PR DESCRIPTION
## Description
Fixes the v2.0.0 recovery dispatch failure caused by running the immutable tag’s older changelog helper with a newer workflow argument. Recovery now loads the helper from the same trusted revision as the workflow while all release analysis and package builds remain anchored to the immutable tag checkout.

Failed recovery run: https://github.com/maziyarpanahi/openmed/actions/runs/30406167162

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test addition/improvement

## Changes Made
- Source the metadata helper from `github.workflow_sha`.
- Pass the immutable tag checkout through `--repo`.
- Add regression coverage forbidding the stale tag-helper path.

## Testing
- [x] 33 focused publication, provenance, and changelog tests pass.
- [x] Actionlint passes.
- [x] Scoped pre-commit hooks pass.
- [x] Repository policy and whitespace checks pass.

## Documentation
- [x] Existing recovery documentation remains accurate.

## Code Quality
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Dependencies
- [x] I have not added any new dependencies.

## Checklist
- [x] My commits have clear, descriptive messages.
- [x] Each changed file is committed separately.

## Related Issues
Release recovery follow-up for v2.0.0.