### PR TITLE
docs: add export format support matrix

### DIFF
--- a/docs/coreml-export.md
+++ b/docs/coreml-export.md
@@ -3,7 +3,9 @@
 Use CoreML when you need a bundled Apple model package for Swift, iOS, or
 macOS app integration. If you want the shared OpenMed MLX artifact path, see
 the [MLX backend](mlx-backend.md) and
-[OpenMedKit Swift guide](swift-openmedkit.md).
+[OpenMedKit Swift guide](swift-openmedkit.md). For the cross-backend view
+of which architectures reach which runtimes, see the
+[Export Format Support Matrix](export-matrix.md).
 
 The CoreML converter is a local packaging path for Hugging Face
 token-classification checkpoints. After model download, conversion runs

--- a/docs/export-gguf.md
+++ b/docs/export-gguf.md
@@ -3,7 +3,9 @@
 OpenMed exports local encoder backbones to GGUF for embedding inference in
 llama.cpp-compatible runtimes. The export is intended for dense grounding and
 retrieval models such as SapBERT. It produces both an F16 artifact and a Q8_0
-artifact from the same local checkpoint.
+artifact from the same local checkpoint. For the cross-backend view of which
+architectures reach GGUF versus the token-classification export paths, see the
+[Export Format Support Matrix](export-matrix.md).
 
 Token-classification checkpoints are intentionally rejected. llama.cpp supports
 the BERT-family encoder embedding path, but it does not expose the classifier

--- a/docs/export-matrix.md
+++ b/docs/export-matrix.md
@@ -1,0 +1,82 @@
+# Export Format Support Matrix
+
+Which combinations of architecture family, export backend, and precision tier
+does OpenMed actually support today? This page is the single answer, kept
+honest against the code by a coherence test in
+`tests/unit/test_export_matrix.py`.
+
+Use it before you plan a conversion so you know up front whether your
+architecture reaches your target runtime.
+
+## Support levels
+
+- ✅ **Supported** — a first-class path with a documented converter, unit
+  tests, and (where relevant) a certification gate.
+- ⚠️ **Partial / conditional** — path exists but has a documented restriction
+  (for example a family allowlist, or "certified only when recall holds").
+- ❌ **Not supported** — no converter, or explicitly rejected by the backend.
+
+The matrix rows are the Hugging Face model-type strings and OpenMed family
+names most contributors search for. The **MLX aliases** column lists the
+token-classification aliases understood by
+`openmed.mlx.models._SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES` (or the MLX
+custom-family set). The coherence test asserts every entry in that allowlist
+appears here as a backtick-wrapped alias, so the matrix cannot drift silently
+when a new family is added to the code.
+
+## Matrix
+
+| Family | MLX aliases | MLX fp | MLX INT8 | MLX INT4 | CoreML fp16 | CoreML INT8 | ONNX (default) | ONNX Android | Transformers.js | GGUF (embedding) |
+|---|---|---|---|---|---|---|---|---|---|---|
+| BERT | `bert` | ✅ | ✅ | ⚠️ INT4-if-recall-holds | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ backbone only (see limitations) |
+| DistilBERT | `distilbert` | ✅ (via bert) | ✅ | ⚠️ INT4-if-recall-holds | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ backbone only |
+| Electra | `electra` | ✅ (via bert) | ✅ | ⚠️ INT4-if-recall-holds | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ backbone only |
+| RoBERTa | `roberta` | ✅ (via bert) | ✅ | ⚠️ INT4-if-recall-holds | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ backbone only |
+| XLM-RoBERTa | `xlm-roberta`, `xlm_roberta` | ✅ (via bert) | ✅ | ⚠️ INT4-if-recall-holds | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ backbone only |
+| DeBERTa-v2 | `deberta`, `deberta-v2` | ✅ | ✅ | ⚠️ INT4-if-recall-holds | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ backbone only |
+| ModernBERT | — | ❌ family not in MLX allowlist | ❌ | ❌ | ❌ family not in CoreML allowlist | ❌ | ⚠️ upstream ONNX support required | ⚠️ same as ONNX (default) | ⚠️ same as ONNX (default) | ❌ |
+| Longformer | — | ❌ family not in MLX allowlist | ❌ | ❌ | ❌ family not in CoreML allowlist | ❌ | ⚠️ upstream ONNX support required | ⚠️ same as ONNX (default) | ⚠️ same as ONNX (default) | ❌ |
+| OpenAI Privacy Filter | `openai-privacy-filter`, `privacy-filter`, `privacy-filter-nemotron`, `nemotron-privacy-filter`, `privacy-filter-multilingual`, `multilingual-privacy-filter` | ✅ | ✅ | ⚠️ INT4-if-recall-holds | ❌ family not in CoreML allowlist | ❌ | ❌ no ONNX converter path today | ❌ | ❌ | ❌ |
+| GLiNER (span) | `gliner-uni-encoder-span` | ✅ (MLX custom family) | ✅ | ⚠️ INT4-if-recall-holds | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| GLiClass | `gliclass-uni-encoder` | ✅ (MLX custom family) | ✅ | ⚠️ INT4-if-recall-holds | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| GLiNER (token-relex) | `gliner-uni-encoder-token-relex` | ✅ (MLX custom family) | ✅ | ⚠️ INT4-if-recall-holds | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+## Known limitations
+
+The cells above encode a handful of load-bearing constraints; the source of
+truth is the backend code, but the essentials are:
+
+- **GGUF is embedding-only.** `openmed.gguf.convert` deliberately rejects
+  token-classification heads: llama.cpp can run the BERT-family encoder
+  embedding path but does not expose the token classifier head required to
+  produce OpenMed entity labels. Export the encoder backbone (for example a
+  checkpoint whose `config.json` names `BertModel` rather than
+  `BertForTokenClassification`) instead. See
+  [GGUF Embedding Export](export-gguf.md).
+- **CoreML is token-classification-only and enforces a family allowlist.**
+  `openmed.coreml.convert.SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES` accepts
+  `bert`, `distilbert`, `electra`, `roberta`, `xlm-roberta`, and `deberta-v2`.
+  Any other architecture fails before tracing with an error that lists the
+  supported families. See [CoreML Packaging](coreml-export.md).
+- **MLX enforces a family allowlist.** The MLX dispatcher resolves architectures
+  through `_SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES` (BERT-family and
+  DeBERTa-v2) plus the MLX-custom set (`gliner-uni-encoder-span`,
+  `gliclass-uni-encoder`, `gliner-uni-encoder-token-relex`) and the privacy
+  filter family. Architectures outside the allowlist raise a clear
+  "unsupported family" error rather than falling through silently. See
+  [MLX Backend](mlx-backend.md).
+- **INT4 is certified only when recall holds.** `openmed.mlx.convert`
+  will emit an INT4 artifact for any allowlisted family, but the artifact is
+  marked `certified: false` in `recall_delta.json` when the measured per-label
+  recall delta exceeds the INT4 limit. Release gates block over-budget INT4
+  formats. See [MLX Quantized Export Certification](export-mlx-quant.md).
+
+## See also
+
+- [MLX Backend](mlx-backend.md)
+- [MLX Quantized Export Certification](export-mlx-quant.md)
+- [CoreML Packaging](coreml-export.md)
+- [ONNX and WebGPU Export](export-onnx-webgpu.md)
+- [Android ONNX Export](export-onnx-android.md)
+- [Transformers.js Export](export-transformersjs.md)
+- [GGUF Embedding Export](export-gguf.md)

--- a/docs/export-mlx-quant.md
+++ b/docs/export-mlx-quant.md
@@ -2,7 +2,9 @@
 
 OpenMed MLX exports can emit INT4 artifacts, but an INT4 artifact is only
 marked certified when it holds recall against its full-precision parent on the
-same synthetic or approved eval fixtures.
+same synthetic or approved eval fixtures. For which architectures reach the
+MLX INT4/INT8/fp paths in the first place, see the
+[Export Format Support Matrix](export-matrix.md).
 
 ## INT4 Export
 

--- a/docs/export-onnx-webgpu.md
+++ b/docs/export-onnx-webgpu.md
@@ -7,6 +7,10 @@ token-classification checkpoint or local model directory into:
 - an fp16 ONNX graph intended for WebGPU
 - an optional Transformers.js bundle for browser pipelines
 
+For the cross-backend view of which architectures reach ONNX (default,
+Android, or Transformers.js), see the
+[Export Format Support Matrix](export-matrix.md).
+
 Android uses a separate, fixed-opset profile documented in
 [Android ONNX Export](./export-onnx-android.md).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
       - WHO SMART Guidelines Profiles: fhir-smart-guidelines.md
       - ICD-11 Offline Grounding: icd11-grounding.md
   - Apple Silicon & Mobile:
+      - Export Format Support Matrix: export-matrix.md
       - MLX Backend: mlx-backend.md
       - Torch MPS Performance: performance-mps.md
       - MLX Quantized Export: export-mlx-quant.md

--- a/tests/unit/test_export_matrix.py
+++ b/tests/unit/test_export_matrix.py
@@ -1,0 +1,68 @@
+"""Coherence guard for ``docs/export-matrix.md``.
+
+Every alias in the MLX
+``openmed.mlx.models._SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES`` allowlist
+must appear as a backtick-wrapped token in the matrix so the doc stays honest
+as backends are added. The matrix must also capture the two canonical
+limitations the docs promise to state verbatim (GGUF is embedding-only; CoreML
+is token-classification-only) and be reachable from the primary export docs.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from openmed.mlx.models import _SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "export-matrix.md"
+MKDOCS = ROOT / "mkdocs.yml"
+LINKING_DOCS = (
+    ROOT / "docs" / "coreml-export.md",
+    ROOT / "docs" / "export-mlx-quant.md",
+    ROOT / "docs" / "export-onnx-webgpu.md",
+    ROOT / "docs" / "export-gguf.md",
+)
+
+_BACKTICK = re.compile(r"`([^`]+)`")
+
+
+def _backtick_tokens(text: str) -> set[str]:
+    return {match.strip() for match in _BACKTICK.findall(text)}
+
+
+def test_matrix_mentions_every_mlx_allowlist_family() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    tokens = _backtick_tokens(text)
+    missing = set(_SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES) - tokens
+    assert not missing, (
+        "docs/export-matrix.md must mention every MLX-supported family alias "
+        f"as a backtick-wrapped token; missing: {sorted(missing)}"
+    )
+
+
+def test_matrix_documents_canonical_limitations() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    lowered = text.lower()
+
+    assert "gguf" in lowered and "embedding" in lowered, (
+        "matrix must document the GGUF-embedding-only limitation"
+    )
+    assert "coreml" in lowered and "token-classification" in lowered, (
+        "matrix must document the CoreML-token-classification-only limitation"
+    )
+    assert "int4" in lowered, "matrix must reference the INT4 recall gate"
+    assert "allowlist" in lowered, "matrix must reference the MLX family allowlist"
+
+
+def test_matrix_is_in_mkdocs_nav_and_cross_linked() -> None:
+    nav = MKDOCS.read_text(encoding="utf-8")
+    assert "export-matrix.md" in nav, (
+        "docs/export-matrix.md must be listed in mkdocs.yml nav"
+    )
+    for path in LINKING_DOCS:
+        text = path.read_text(encoding="utf-8")
+        assert "export-matrix.md" in text, (
+            f"{path.relative_to(ROOT)} should link to the export matrix"
+        )


### PR DESCRIPTION
## Description

Add a single-page cross-backend view of which architecture families reach
which OpenMed export backends, kept honest by a coherence test against
`openmed.mlx.models._SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES`.

Contributors currently have to piece the support story together from
`openmed/mlx/models/__init__.py`, `openmed/coreml/convert.py`,
`openmed/gguf/convert.py`, and the individual export docs. `docs/export-matrix.md`
consolidates that into one architecture-by-format table plus the four
canonical limitations (GGUF is embedding-only, CoreML enforces its
token-classification family allowlist, MLX enforces its family allowlist,
INT4 is certified only when recall holds).

## Type of Change

- [x] Documentation update
- [x] Test addition/improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- `docs/export-matrix.md` — new architecture-by-format matrix (BERT,
  DistilBERT, Electra, RoBERTa, XLM-RoBERTa, DeBERTa-v2, ModernBERT,
  Longformer, OpenAI Privacy Filter, and the three MLX GLiNER/GLiClass
  custom families) across MLX fp/INT8/INT4, CoreML fp16/INT8, ONNX
  default & Android, Transformers.js, and GGUF. Each cell records
  supported / partial / unsupported plus the reason.
- `tests/unit/test_export_matrix.py` — 3 coherence tests:
  - every alias in the MLX allowlist appears in the matrix
  - the GGUF-embedding-only, CoreML-token-classification-only, MLX
    family allowlist, and INT4 recall-gate limitations are documented
  - the page is in `mkdocs.yml` nav and cross-linked from the primary
    export docs
- `mkdocs.yml` — nav entry under "Apple Silicon & Mobile".
- `docs/coreml-export.md`, `docs/export-mlx-quant.md`,
  `docs/export-onnx-webgpu.md`, `docs/export-gguf.md` — one-sentence
  cross-link so readers can jump to the matrix from any backend page.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Commands run against the branch (macOS, Python 3.11, extras
`[dev,cli,hf,mlx,coreml,onnx,docs]`):

- `pytest tests/unit/test_export_matrix.py -v` → **3 passed**
- `pytest tests/ -q` → **8913 passed, 55 skipped, 1 failed**
- `make lint` → pass
- `make format-check` → pass (1057 files)
- `uvx pre-commit run --files <all changed>` → all hooks pass
  (check-yaml, ruff-check, ruff-format, gitleaks, trailing-whitespace,
  EOF, mixed-line-ending)
- `mkdocs build --strict` → pass (exit 0)

**Pre-existing failure disclosure:** the one failing test
(`tests/integration/test_sentence_detection_real.py::test_sentence_detection_filters_placeholders`)
reproduces on clean `master` with the same error — an HF 401 when the
suite tries to download `OpenMed/OpenMed-NER-OncologyDetect-SuperMedical-355M`
without an auth token. The skip helper's `unavailable_markers` tuple
does not match the current transformers error string, so the test
raises instead of skipping. **Not caused by this branch**; happy to
file a separate issue if useful.

## Documentation

- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes (N/A — no
  new public API)
- [ ] I have updated the CHANGELOG.md (see note below)

CHANGELOG: happy to add an `### Added` entry under `[Unreleased]` for
the new docs page if you prefer — left it out for now since recent
docs-only PRs merged without CHANGELOG entries.

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes — N/A (no Swift changes)
- [x] I have performed a self-review of my own code (two senior-review
  passes locally: pass 1 unified GGUF cell wording across BERT-family
  rows; pass 2 corrected an inverted "coherence test asserts…"
  sentence to match what the test actually verifies)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately (single commit)

## Related Issues

Closes #311