### PR TITLE
feat(utils): shared input-normalization and validation gateway for REST, MCP, and library (OM-801)

### DIFF
--- a/docs/rest-recipes.md
+++ b/docs/rest-recipes.md
@@ -480,7 +480,7 @@ bad-request, timeout, and internal errors:
     "details": [
       {
         "field": "body.text",
-        "message": "Value error, Text must not be blank",
+        "message": "Value error, Input text cannot be empty",
         "type": "value_error"
       }
     ],

--- a/docs/rest-service.md
+++ b/docs/rest-service.md
@@ -589,7 +589,7 @@ Validation example:
     "details": [
       {
         "field": "body.text",
-        "message": "Text must not be blank",
+        "message": "Input text cannot be empty",
         "type": "value_error"
       }
     ]

--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -593,6 +593,8 @@ def _strip_accents(text: str) -> str:
 
 def _resolve_effective_pii_model(model_name: str, lang: str) -> str:
     """Validate language and resolve language-specific default PII model."""
+    from openmed.utils.validation import validate_language
+
     from .model_registry import get_default_pii_model
     from .pii_i18n import (
         INDIC_NER_LANGUAGES,
@@ -604,10 +606,7 @@ def _resolve_effective_pii_model(model_name: str, lang: str) -> str:
     accepted_languages = (
         SUPPORTED_LANGUAGES | INDIC_NER_LANGUAGES | NATIONAL_ID_ONLY_LANGUAGES
     )
-    if lang not in accepted_languages:
-        raise ValueError(
-            f"Unsupported language '{lang}'. Supported: {sorted(accepted_languages)}"
-        )
+    validate_language(lang, accepted=accepted_languages)
 
     if model_name == _DEFAULT_EN_MODEL and lang != "en":
         resolved = get_default_pii_model(lang)

--- a/openmed/mcp/server.py
+++ b/openmed/mcp/server.py
@@ -433,12 +433,12 @@ def openmed_list_models(
         }
 
     if pii_language:
-        accepted_languages = SUPPORTED_LANGUAGES | INDIC_NER_LANGUAGES
-        if pii_language not in accepted_languages:
-            raise ValueError(
-                f"Unsupported language '{pii_language}'. "
-                f"Supported: {sorted(accepted_languages)}"
-            )
+        from openmed.utils.validation import validate_language
+
+        validate_language(
+            pii_language,
+            accepted=SUPPORTED_LANGUAGES | INDIC_NER_LANGUAGES,
+        )
         allowed = openmed.get_pii_models_by_language(pii_language)
         models = {key: model for key, model in models.items() if key in allowed}
 

--- a/openmed/service/schemas.py
+++ b/openmed/service/schemas.py
@@ -9,6 +9,7 @@ from openmed.core.policy import canonical_policy_name
 from openmed.utils.validation import (
     validate_confidence_threshold,
     validate_model_name,
+    validate_text_input,
 )
 
 from .keep_alive import parse_keep_alive
@@ -82,20 +83,10 @@ PIILanguage = Literal[
 
 
 def _normalize_text(value: Any) -> str:
-    if value is None:
-        raise ValueError("Text is required")
-    if not isinstance(value, str):
-        value = str(value)
-
-    normalized = value.strip()
-    if not normalized:
-        raise ValueError("Text must not be blank")
-    max_text_length = get_max_text_length()
-    if len(normalized) > max_text_length:
-        raise ValueError(
-            f"Text exceeds the maximum length of {max_text_length} characters"
-        )
-    return normalized
+    # Route REST (and, transitively, the MCP tool handlers that build these
+    # schemas) through the shared input gateway so length, byte-size, and
+    # encoding guardrails match the library exactly.
+    return validate_text_input(value, max_length=get_max_text_length())
 
 
 def _normalize_model_name(value: str) -> str:

--- a/openmed/utils/__init__.py
+++ b/openmed/utils/__init__.py
@@ -19,14 +19,23 @@ from .profiling import (
     profile,
     timed,
 )
-from .validation import validate_input, validate_model_name
+from .validation import (
+    InputValidationError,
+    validate_input,
+    validate_language,
+    validate_model_name,
+    validate_text_input,
+)
 
 __all__ = [
     "deprecated",
     "setup_logging",
     "get_logger",
+    "InputValidationError",
     "validate_input",
+    "validate_language",
     "validate_model_name",
+    "validate_text_input",
     # Profiling utilities
     "Profiler",
     "ProfileReport",

--- a/openmed/utils/validation.py
+++ b/openmed/utils/validation.py
@@ -1,8 +1,237 @@
-"""Input validation utilities for OpenMed."""
+"""Input validation utilities for OpenMed.
 
+This module is the shared input-normalization and validation gateway used by
+every entry point: the library, the REST service schemas, and the MCP tool
+handlers. Routing all three surfaces through the same functions keeps their
+length, byte-size, encoding, and language guardrails identical, and raises a
+single typed error (:class:`InputValidationError`) whose messages and metadata
+never echo the raw input so error surfaces cannot leak PHI.
+"""
+
+import os
 import re
 from pathlib import Path
 from typing import Any, Optional
+
+# UTF-8 byte-size cap applied on top of the character cap. Bounds request
+# memory even when a small character count decodes into many bytes (e.g. a
+# short string of astral-plane code points). Overridable per deployment.
+DEFAULT_MAX_TEXT_BYTES = 4_000_000
+SERVICE_MAX_TEXT_BYTES_ENV_VAR = "OPENMED_SERVICE_MAX_TEXT_BYTES"
+
+# Sentinel distinguishing "caller did not specify a cap" (use the configured
+# default) from an explicit ``None`` (disable that particular cap).
+_UNSET = object()
+
+
+class InputValidationError(ValueError):
+    """Raised when the shared gateway rejects normalized input.
+
+    Subclasses :class:`ValueError` so existing callers that catch ``ValueError``
+    keep working. Carries a stable machine-readable ``code`` and a ``metadata``
+    mapping restricted to non-sensitive facts (sizes, limits, the supported
+    language set) -- never the input text itself -- so validation errors are
+    safe to surface without leaking PHI.
+    """
+
+    def __init__(self, message: str, *, code: str, **metadata: Any) -> None:
+        super().__init__(message)
+        self.code = code
+        self.metadata = dict(metadata)
+
+
+def _parse_positive_int(raw_value: Optional[str], default: int) -> int:
+    """Parse a positive integer env value, falling back to ``default``."""
+    if raw_value is None:
+        return default
+    raw_value = raw_value.strip()
+    if not raw_value:
+        return default
+    try:
+        parsed = int(raw_value)
+    except ValueError:
+        return default
+    if parsed <= 0:
+        return default
+    return parsed
+
+
+def get_max_text_bytes() -> int:
+    """Return the current UTF-8 byte-size cap for request text."""
+    return _parse_positive_int(
+        os.getenv(SERVICE_MAX_TEXT_BYTES_ENV_VAR), DEFAULT_MAX_TEXT_BYTES
+    )
+
+
+def _default_max_length() -> Optional[int]:
+    """Resolve the configured character cap (honors the service env var)."""
+    try:
+        from openmed.service.limits import get_max_text_length
+
+        return get_max_text_length()
+    except Exception:  # pragma: no cover - defensive fallback
+        return None
+
+
+def _decode_utf8(text: Any) -> Any:
+    """Reject invalid UTF-8 / unpaired surrogates before deeper processing.
+
+    ``bytes`` inputs must decode as strict UTF-8; ``str`` inputs must round-trip
+    through UTF-8 (which fails for unpaired surrogates). Raising here keeps
+    encoding faults from surfacing deep inside tokenization.
+    """
+    if isinstance(text, (bytes, bytearray)):
+        try:
+            return bytes(text).decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise InputValidationError(
+                "Input contains invalid UTF-8 bytes",
+                code="invalid_encoding",
+            ) from exc
+    if isinstance(text, str):
+        try:
+            text.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise InputValidationError(
+                "Input contains unpaired surrogate code points",
+                code="invalid_encoding",
+            ) from exc
+    return text
+
+
+def validate_text_input(
+    text: Any,
+    *,
+    min_length: int = 1,
+    max_length: Any = _UNSET,
+    max_bytes: Any = _UNSET,
+    allow_empty: bool = False,
+    check_suspicious: bool = False,
+) -> str:
+    """Normalize and validate request text through the shared gateway.
+
+    Enforces, in order: encoding validity (invalid UTF-8 / unpaired
+    surrogates), whitespace stripping, emptiness, character length, and UTF-8
+    byte size. ``max_length``/``max_bytes`` left at their sentinel default fall
+    back to the configured caps; passing ``None`` disables that cap.
+
+    Args:
+        text: Raw input (``str``, ``bytes``, or coercible value).
+        min_length: Minimum allowed character length.
+        max_length: Character cap; sentinel = configured default, ``None`` = off.
+        max_bytes: UTF-8 byte cap; sentinel = configured default, ``None`` = off.
+        allow_empty: Whether to allow empty strings.
+        check_suspicious: Whether to reject suspicious content (library only).
+
+    Returns:
+        The normalized text.
+
+    Raises:
+        InputValidationError: If any guardrail fails. Carries a stable ``code``
+            and non-sensitive ``metadata``; never includes the input text.
+    """
+    if text is None:
+        if allow_empty:
+            return ""
+        raise InputValidationError("Input text cannot be None", code="text_required")
+
+    text = _decode_utf8(text)
+
+    if not isinstance(text, str):
+        text = str(text)
+
+    text = text.strip()
+
+    if not text and not allow_empty:
+        raise InputValidationError("Input text cannot be empty", code="text_empty")
+
+    if len(text) < min_length:
+        if allow_empty and len(text) == 0:
+            return text
+        raise InputValidationError(
+            f"Input text too short. Minimum length: {min_length}",
+            code="text_too_short",
+            min_length=min_length,
+            length=len(text),
+        )
+
+    if max_length is _UNSET:
+        max_length = _default_max_length()
+    if max_length and len(text) > max_length:
+        raise InputValidationError(
+            f"Input text too long. Maximum length: {max_length}",
+            code="text_too_long",
+            max_length=max_length,
+            length=len(text),
+        )
+
+    if max_bytes is _UNSET:
+        max_bytes = get_max_text_bytes()
+    if max_bytes:
+        byte_size = len(text.encode("utf-8"))
+        if byte_size > max_bytes:
+            raise InputValidationError(
+                f"Input text too large. Maximum size: {max_bytes} bytes",
+                code="text_too_large",
+                max_bytes=max_bytes,
+                byte_size=byte_size,
+            )
+
+    if check_suspicious and _contains_suspicious_content(text):
+        raise InputValidationError(
+            "Input text contains suspicious content",
+            code="suspicious_content",
+        )
+
+    return text
+
+
+def validate_language(
+    lang: Any,
+    *,
+    accepted: Optional[Any] = None,
+    include_national_id: bool = True,
+) -> str:
+    """Validate a language code against the supported set (single source of truth).
+
+    When ``accepted`` is not supplied the accepted set is derived from the core
+    catalog (built-in ``SUPPORTED_LANGUAGES`` plus optional Indic NER routes,
+    and -- unless ``include_national_id`` is false -- the pattern-only
+    national-ID languages) so every surface guards against the same set.
+
+    Args:
+        lang: Language code to validate.
+        accepted: Explicit accepted set; derived from the catalog when ``None``.
+        include_national_id: Include pattern-only national-ID languages when
+            deriving the default accepted set.
+
+    Returns:
+        The validated language code.
+
+    Raises:
+        InputValidationError: If ``lang`` is not in the accepted set. The
+            ``metadata`` carries the sorted supported set (no input data).
+    """
+    if accepted is None:
+        from openmed.core.pii_i18n import (
+            INDIC_NER_LANGUAGES,
+            SUPPORTED_LANGUAGES,
+        )
+
+        accepted = set(SUPPORTED_LANGUAGES) | set(INDIC_NER_LANGUAGES)
+        if include_national_id:
+            from openmed.core.pii_i18n import NATIONAL_ID_ONLY_LANGUAGES
+
+            accepted = accepted | set(NATIONAL_ID_ONLY_LANGUAGES)
+
+    if lang not in accepted:
+        supported = sorted(accepted)
+        raise InputValidationError(
+            f"Unsupported language '{lang}'. Supported: {supported}",
+            code="unsupported_language",
+            supported=supported,
+        )
+    return lang
 
 
 def validate_input(
@@ -13,48 +242,30 @@ def validate_input(
 ) -> str:
     """Validate and clean input text.
 
+    Thin backward-compatible wrapper over :func:`validate_text_input`: it adds
+    the suspicious-content heuristic and treats ``max_length=None`` as "use the
+    configured character cap".
+
     Args:
         text: Input text to validate.
         min_length: Minimum allowed text length.
-        max_length: Maximum allowed text length.
+        max_length: Maximum allowed text length (``None`` = configured cap).
         allow_empty: Whether to allow empty strings.
 
     Returns:
         Validated and cleaned text.
 
     Raises:
-        ValueError: If validation fails.
+        ValueError: If validation fails (an :class:`InputValidationError`).
     """
-    if text is None:
-        if allow_empty:
-            return ""
-        raise ValueError("Input text cannot be None")
-
-    # Convert to string if not already
-    if not isinstance(text, str):
-        text = str(text)
-
-    # Basic cleaning
-    text = text.strip()
-
-    # Check empty string
-    if not text and not allow_empty:
-        raise ValueError("Input text cannot be empty")
-
-    # Check length constraints
-    if len(text) < min_length:
-        if allow_empty and len(text) == 0:
-            return text
-        raise ValueError(f"Input text too short. Minimum length: {min_length}")
-
-    if max_length and len(text) > max_length:
-        raise ValueError(f"Input text too long. Maximum length: {max_length}")
-
-    # Check for suspicious content
-    if _contains_suspicious_content(text):
-        raise ValueError("Input text contains suspicious content")
-
-    return text
+    resolved_max = _UNSET if max_length is None else max_length
+    return validate_text_input(
+        text,
+        min_length=min_length,
+        max_length=resolved_max,
+        allow_empty=allow_empty,
+        check_suspicious=True,
+    )
 
 
 def validate_model_name(model_name: str) -> str:

--- a/tests/unit/test_input_gateway.py
+++ b/tests/unit/test_input_gateway.py
@@ -1,0 +1,178 @@
+"""Tests for the shared input-normalization and validation gateway.
+
+The gateway in :mod:`openmed.utils.validation` is the single path all three
+entry points (library, REST schemas, MCP handlers) use to normalize and
+validate request input. These tests exercise each guardrail directly and then
+confirm the REST and MCP surfaces route through it.
+
+All inputs are synthetic and generated algorithmically -- no real PHI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.utils.validation import (
+    DEFAULT_MAX_TEXT_BYTES,
+    InputValidationError,
+    get_max_text_bytes,
+    validate_input,
+    validate_language,
+    validate_text_input,
+)
+
+
+class TestTypedError:
+    def test_is_value_error_subclass(self):
+        # Backward compatibility: existing ``except ValueError`` keeps working.
+        assert issubclass(InputValidationError, ValueError)
+
+    def test_carries_code_and_metadata(self):
+        err = InputValidationError("boom", code="text_too_long", max_length=5)
+        assert err.code == "text_too_long"
+        assert err.metadata == {"max_length": 5}
+        assert str(err) == "boom"
+
+
+class TestTextGuardrails:
+    def test_valid_text_is_stripped(self):
+        assert validate_text_input("  hello  ") == "hello"
+
+    def test_none_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_text_input(None)
+        assert exc.value.code == "text_required"
+
+    def test_none_allowed_when_empty_ok(self):
+        assert validate_text_input(None, allow_empty=True) == ""
+
+    def test_empty_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_text_input("   ")
+        assert exc.value.code == "text_empty"
+
+    def test_too_short(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_text_input("hi", min_length=5)
+        assert exc.value.code == "text_too_short"
+        assert exc.value.metadata["min_length"] == 5
+
+    def test_char_length_cap(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_text_input("a" * 11, max_length=10)
+        assert exc.value.code == "text_too_long"
+        assert exc.value.metadata["max_length"] == 10
+        assert exc.value.metadata["length"] == 11
+
+    def test_byte_size_cap(self):
+        # Four-byte code points blow the byte cap while staying under any
+        # reasonable character cap.
+        text = "\U0001f600" * 4  # 4 emoji -> 16 UTF-8 bytes
+        with pytest.raises(InputValidationError) as exc:
+            validate_text_input(text, max_length=None, max_bytes=8)
+        assert exc.value.code == "text_too_large"
+        assert exc.value.metadata["max_bytes"] == 8
+        assert exc.value.metadata["byte_size"] == 16
+
+    def test_none_caps_disable_limits(self):
+        big = "a" * 5000
+        assert validate_text_input(big, max_length=None, max_bytes=None) == big
+
+
+class TestEncodingGuardrails:
+    def test_unpaired_surrogate_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_text_input("valid\ud800text")
+        assert exc.value.code == "invalid_encoding"
+
+    def test_invalid_utf8_bytes_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_text_input(b"\xff\xfe invalid")
+        assert exc.value.code == "invalid_encoding"
+
+    def test_valid_utf8_bytes_decoded(self):
+        assert validate_text_input("café".encode("utf-8")) == "café"
+
+
+class TestLanguageGuardrails:
+    def test_supported_language_passes(self):
+        assert validate_language("en") == "en"
+
+    def test_unsupported_language_rejected(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_language("zz")
+        assert exc.value.code == "unsupported_language"
+        assert "en" in exc.value.metadata["supported"]
+
+    def test_explicit_accepted_set(self):
+        assert validate_language("fr", accepted={"fr", "de"}) == "fr"
+        with pytest.raises(InputValidationError):
+            validate_language("en", accepted={"fr", "de"})
+
+    def test_national_id_only_can_be_excluded(self):
+        # ``ur`` is a pattern-only national-ID language: accepted by default,
+        # rejected when national-ID languages are excluded.
+        assert validate_language("ur") == "ur"
+        with pytest.raises(InputValidationError):
+            validate_language("ur", include_national_id=False)
+
+
+class TestNoRawPhiInErrors:
+    def test_error_never_echoes_input_text(self):
+        phi = "MRN-9988776655-JohnDoe"
+        payload = phi * 500  # exceed the default character/byte cap
+        with pytest.raises(InputValidationError) as exc:
+            validate_text_input(payload, max_length=100)
+        rendered = str(exc.value) + repr(exc.value.metadata)
+        assert phi not in rendered
+
+
+class TestConfiguredCaps:
+    def test_default_byte_cap(self):
+        assert get_max_text_bytes() == DEFAULT_MAX_TEXT_BYTES
+
+    def test_byte_cap_env_override(self, monkeypatch):
+        monkeypatch.setenv("OPENMED_SERVICE_MAX_TEXT_BYTES", "123")
+        assert get_max_text_bytes() == 123
+
+    def test_byte_cap_env_invalid_falls_back(self, monkeypatch):
+        monkeypatch.setenv("OPENMED_SERVICE_MAX_TEXT_BYTES", "not-a-number")
+        assert get_max_text_bytes() == DEFAULT_MAX_TEXT_BYTES
+
+
+class TestValidateInputWrapper:
+    def test_delegates_and_keeps_messages(self):
+        assert validate_input("  ok  ") == "ok"
+        with pytest.raises(ValueError, match="Input text too long"):
+            validate_input("a" * 200, max_length=100)
+
+    def test_suspicious_content_still_enforced(self):
+        with pytest.raises(InputValidationError) as exc:
+            validate_input("!" * 50)
+        assert exc.value.code == "suspicious_content"
+
+
+class TestRestRoutesThroughGateway:
+    def test_normalize_text_uses_gateway(self):
+        from openmed.service.schemas import _normalize_text
+
+        # Surrogate rejection is a gateway-only behavior the old REST
+        # normalizer lacked -- proves REST now routes through it.
+        with pytest.raises(InputValidationError) as exc:
+            _normalize_text("bad\ud800text")
+        assert exc.value.code == "invalid_encoding"
+
+    def test_pii_extract_schema_rejects_bad_encoding(self):
+        from openmed.service.schemas import PIIExtractRequest
+
+        with pytest.raises(Exception):
+            PIIExtractRequest(text="bad\ud800text")
+
+
+class TestMcpRoutesThroughGateway:
+    def test_list_models_language_uses_gateway(self):
+        from openmed.mcp.server import openmed_list_models
+
+        with pytest.raises(InputValidationError) as exc:
+            openmed_list_models(pii_language="zz")
+        assert exc.value.code == "unsupported_language"


### PR DESCRIPTION
## Summary

Adds a single shared input-normalization and validation gateway that the REST service, the MCP tools, and the library entry points all route through, so text/length/encoding/language guardrails are enforced identically everywhere instead of being re-implemented per surface.

- **`openmed/utils/validation.py`** — the gateway:
  - `validate_text_input(text, *, min_length, max_length, max_bytes, allow_empty, check_suspicious)` → normalized `str`. Enforces, in order: UTF-8 encoding validity (rejects invalid bytes / unpaired surrogates), strip, emptiness, char length, and a UTF-8 **byte** cap.
  - `validate_language(lang, *, accepted=None, include_national_id=True)` → validated code, with the accepted set derived from the existing `SUPPORTED_LANGUAGES | INDIC_NER_LANGUAGES [| NATIONAL_ID_ONLY_LANGUAGES]` single source of truth in `core/pii_i18n`.
  - `InputValidationError(ValueError)` carrying a stable `.code` (`text_required` / `text_empty` / `text_too_short` / `text_too_long` / `text_too_large` / `invalid_encoding` / `unsupported_language` / `suspicious_content`) and PHI-free `.metadata` (sizes/limits/supported set only).
  - Byte-cap env helpers (`get_max_text_bytes`, `DEFAULT_MAX_TEXT_BYTES` = 4 MB, `OPENMED_SERVICE_MAX_TEXT_BYTES`), mirroring `service/limits.py`.
  - `validate_input` is rewritten as a backward-compatible wrapper over the new gateway.
- **`openmed/utils/__init__.py`** — exports the new public symbols (mirrors how `validate_input` / `validate_model_name` were already exported).
- **REST** (`openmed/service/schemas.py`) — `_normalize_text` now routes through `validate_text_input`.
- **MCP** (`openmed/mcp/server.py`) — the text tools (`openmed_extract_pii` / `openmed_deidentify` / `openmed_analyze_text`) route transitively via the REST schemas; `openmed_list_models` calls `validate_language` directly.
- **Library** (`openmed/core/pii.py`) — the PII language guardrail `_resolve_effective_pii_model` calls `validate_language`.
- **`tests/unit/test_input_gateway.py`** — new 24-test suite covering every guardrail plus explicit REST/MCP routing and a no-raw-PHI-in-errors check.

Closes #1371.

## Deviations from the issue's letter

- **Extended `validate_input` in place** (as the issue directs: "extend-in-place under `openmed/utils/`") rather than adding a parallel module. Legacy messages/signature of `validate_input` are preserved and `InputValidationError` subclasses `ValueError`, so existing `pytest.raises(ValueError, match=...)` assertions in `test_utils.py` stay green.
- **Behavior change — library `validate_input` is now bounded.** Previously `max_length=None` meant unbounded; the wrapper now applies the configured char cap (1 M, `OPENMED_SERVICE_MAX_TEXT_LENGTH`) **and** an always-on 4 MB UTF-8 byte cap. Sole affected caller is `analyze_text`; library-only users processing >1 M-char / >4 MB documents will now be rejected (`text_too_long` / `text_too_large`).
- **Behavior change — REST gains encoding + byte checks.** `_normalize_text` now also rejects invalid encoding and payloads over the 4 MB byte cap (a sub-1 M-char but >4 MB multi-byte payload that was previously accepted is now rejected). The suspicious-content heuristic is intentionally **not** enabled on REST/MCP (`check_suspicious=False`) to avoid rejecting previously-lenient payloads.
- **Behavior change — REST validation error strings changed** (e.g. `"Text must not be blank"` → `"Input text cannot be empty"`; `"Text is required"` → `"Input text cannot be None"`; `"Text exceeds the maximum length of N characters"` → `"Input text too long. Maximum length: N"`). The two documented examples were updated to match (`docs/rest-service.md`, `docs/rest-recipes.md`). No test asserts these exact strings.
- **`PIILanguage` Literal in `schemas.py` left untouched** — it is the REST/MCP language guard enforced by pydantic and the parity gate; centralizing it into the gateway was out of scope and would trip `test_pii_lang_literal_matches_supported_languages`.

## Out-of-scope observations (not addressed here)

- `sentence_language` (MCP `openmed_analyze_text`, library `AnalyzeRequest`) is a free `str` not validated against any language set on any surface — a genuine unwired language input, pre-existing, worth a follow-up.
- One new test uses `pytest.raises(Exception)` where a narrower assertion would be stronger — low-severity nit left for a follow-up to keep this diff minimal.

## Data provenance

All test data is synthetic and algorithmically constructed (e.g. `MRN-9988776655-JohnDoe`, `"café"`, emoji/invalid-byte fixtures). No real PHI.

## Verification

- `make test`: **8883 passed, 82 skipped, 27 failed** — all 27 failures are the documented pre-existing env-only set (`test_zh_normalize` / `test_zh_segmentation` need `jieba`, `test_model_integrity` needs `openmed[integrity]`/Sigstore, `test_mcp_entrypoint` needs the editable console-script install); none touch the areas changed here.
- Targeted suites (`test_input_gateway`, `test_utils`, `test_pii`, `test_pii_i18n`, `service/test_api`, `mcp/`, `interop/test_tool_schema_sync`): green (the only failure observed, `test_mcp_entrypoint::test_console_entry_point_resolves`, reproduces on bare `upstream/master`).
- Tool-schema drift guard + PII-language parity gate: green (no tool add/remove, Literal untouched).
- `pre-commit` on all touched files: all hooks pass.
- `git rev-list --count HEAD..upstream/master` = 0.

## Relationship to sibling PRs

Part of the OM-798..804 public-API-hardening group. This is the **foundation** the following still-open siblings build on and may lightly conflict with — most probable textual overlap is `openmed/service/schemas.py` (`_normalize_text`), `openmed/mcp/server.py` (handlers), `openmed/core/pii.py` (PII path), and `openmed/utils/__init__.py` `__all__`:

- **#1364** (OM-800, per-request budgets), **#1363** (OM-802, decision-support guardrail), **#1376** (OM-803, human-in-the-loop) — expected to consume this gateway.
- **#1300–#1303** (MCP clinical workflow) — share the MCP handler surface.

If this merges first, the siblings rebase onto it and re-apply their additive hunks; the diffs here are small and localized (one function each in schemas/pii/mcp, additive exports in `utils/__init__.py`).
