### PR TITLE
feat(grounding): sparse alias candidate generator with provenance-carrying Candidate contract

### DIFF
--- a/openmed/clinical/grounding/__init__.py
+++ b/openmed/clinical/grounding/__init__.py
@@ -1,6 +1,7 @@
 """Vocabulary loading and linker helpers for clinical concept grounding."""
 
 from . import linkers as _linkers  # noqa: F401
+from .candidate_generator import SparseCandidateGenerator, generate_candidates
 from .matcher import ConceptMatch, LexicalConcept, LexicalMatcher, normalize_term
 from .registry import (
     InvalidVocabularyLoaderError,
@@ -42,6 +43,7 @@ __all__ = [
     "RESTRICTED_VOCAB_SYSTEMS",
     "RestrictedVocabularyError",
     "RestrictedVocabularyLoaderError",
+    "SparseCandidateGenerator",
     "VocabConcept",
     "VocabLoader",
     "VocabLoaderError",
@@ -54,6 +56,7 @@ __all__ = [
     "VocabularyRegistryError",
     "available_linkers",
     "available_loaders",
+    "generate_candidates",
     "get_index",
     "get_linker",
     "get_loader",

--- a/openmed/clinical/grounding/candidate_generator.py
+++ b/openmed/clinical/grounding/candidate_generator.py
@@ -1,0 +1,283 @@
+"""Sparse alias candidate generator over free clinical vocabularies.
+
+Turns a surface mention into ranked :class:`Candidate` objects by unioning
+exact normalized-alias hits with character n-gram TF-IDF fuzzy hits over a
+user-loaded free vocabulary (RxNorm, ICD-10-CM, LOINC, HPO, MeSH). No
+terminology content is bundled in the wheel; the caller supplies vocabularies
+through :class:`~openmed.clinical.grounding.vocab.VocabLoader`, and every
+emitted candidate carries provenance (``source='sparse'``, the matched alias,
+the match kind, and a content hash of the vocabulary snapshot) so downstream
+rankers and exporters can audit the source.
+
+The fuzzy stage is a self-contained, dependency-free character trigram TF-IDF
+cosine matcher, which keeps candidate generation fully offline and byte-for-byte
+deterministic across runs.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from collections.abc import Iterable, Sequence
+
+from .registry import register_linker
+from .types import Candidate
+from .vocab import VocabLoader, VocabularyIndex, normalize_alias
+
+__all__ = [
+    "SparseCandidateGenerator",
+    "generate_candidates",
+]
+
+#: Provenance tag stamped on every candidate this generator emits.
+SPARSE_SOURCE = "sparse"
+#: Registry key the generator registers under (resolved via ``get_linker``).
+SPARSE_LINKER_KEY = "sparse"
+
+_DEFAULT_TOP_K = 10
+_DEFAULT_NGRAM_SIZE = 3
+_DEFAULT_MIN_SIMILARITY = 0.3
+
+
+def _char_ngrams(text: str, ngram_size: int) -> tuple[str, ...]:
+    """Return boundary-padded character n-grams for a normalized surface."""
+
+    padded = f"#{text}#"
+    if len(padded) <= ngram_size:
+        return (padded,)
+    return tuple(
+        padded[index : index + ngram_size]
+        for index in range(len(padded) - ngram_size + 1)
+    )
+
+
+class _AliasNgramIndex:
+    """Character n-gram TF-IDF cosine index over one vocabulary's aliases."""
+
+    def __init__(self, aliases: Sequence[str], ngram_size: int) -> None:
+        self._ngram_size = ngram_size
+        self._aliases = tuple(aliases)
+        document_frequency: Counter[str] = Counter()
+        per_alias_grams: list[tuple[str, ...]] = []
+        for alias in self._aliases:
+            grams = _char_ngrams(alias, ngram_size)
+            per_alias_grams.append(grams)
+            document_frequency.update(set(grams))
+        document_count = len(self._aliases)
+        self._idf = {
+            gram: math.log((1.0 + document_count) / (1.0 + frequency)) + 1.0
+            for gram, frequency in document_frequency.items()
+        }
+        self._vectors = tuple(self._vectorize(grams) for grams in per_alias_grams)
+
+    def _vectorize(self, grams: Iterable[str]) -> dict[str, float]:
+        weights = {
+            gram: count * self._idf.get(gram, 0.0)
+            for gram, count in Counter(grams).items()
+        }
+        norm = math.sqrt(sum(weight * weight for weight in weights.values()))
+        if norm == 0.0:
+            return {}
+        return {gram: weight / norm for gram, weight in weights.items()}
+
+    def query(self, text: str, *, min_similarity: float) -> list[tuple[str, float]]:
+        """Return ``(alias, cosine_similarity)`` pairs above ``min_similarity``."""
+
+        query_vector = self._vectorize(_char_ngrams(text, self._ngram_size))
+        if not query_vector:
+            return []
+        results: list[tuple[str, float]] = []
+        for alias, vector in zip(self._aliases, self._vectors):
+            similarity = sum(
+                weight * vector[gram]
+                for gram, weight in query_vector.items()
+                if gram in vector
+            )
+            if similarity >= min_similarity:
+                results.append((alias, similarity))
+        results.sort(key=lambda item: (-item[1], item[0]))
+        return results
+
+
+class SparseCandidateGenerator:
+    """Emit provenance-carrying ``Candidate`` objects for a clinical mention.
+
+    Candidate generation unions two deterministic stages over each requested
+    free-vocabulary system: exact normalized-alias hits (score ``1.0``,
+    ``match_kind='exact'``) and character n-gram TF-IDF fuzzy hits (cosine
+    similarity, ``match_kind='fuzzy'``). Results are merged across systems,
+    de-duplicated per ``(system, code)`` keeping the strongest score, and
+    ordered by a stable tie-break (score descending, then system priority, then
+    concept id).
+
+    Note:
+        This is a candidate *generator* — its shape (a ``VocabLoader`` constructor
+        and a ``generate(mention, systems, k)`` method) intentionally differs from
+        the ``VocabLinker`` registry entries (constructed with a single
+        ``VocabularyIndex`` and exposing ``.link(...)``). Consume it via
+        ``generate_candidates`` or ``.generate``; it is not compatible with the
+        uniform ``get_linker(system)(get_index(system)).link(...)`` call path.
+
+    Args:
+        loader: Vocabulary loader supplying alias indexes. A default
+            :class:`~openmed.clinical.grounding.vocab.VocabLoader` is used when
+            omitted; the wheel ships no vocabulary content, so a loader without
+            a user-supplied source raises rather than returning bundled data.
+        ngram_size: Character n-gram size for the fuzzy stage (default ``3``).
+        min_similarity: Minimum cosine similarity for a fuzzy hit.
+    """
+
+    #: Provenance tag emitted on every candidate.
+    source = SPARSE_SOURCE
+
+    def __init__(
+        self,
+        loader: VocabLoader | None = None,
+        *,
+        ngram_size: int = _DEFAULT_NGRAM_SIZE,
+        min_similarity: float = _DEFAULT_MIN_SIMILARITY,
+    ) -> None:
+        if ngram_size < 1:
+            raise ValueError("ngram_size must be a positive integer")
+        if not 0.0 <= min_similarity <= 1.0:
+            raise ValueError("min_similarity must be between 0.0 and 1.0")
+        self._loader = loader if loader is not None else VocabLoader()
+        self._ngram_size = ngram_size
+        self._min_similarity = min_similarity
+        self._ngram_indexes: dict[str, _AliasNgramIndex] = {}
+
+    def generate(
+        self,
+        mention: str,
+        systems: Sequence[str],
+        k: int = _DEFAULT_TOP_K,
+        *,
+        min_similarity: float | None = None,
+    ) -> list[Candidate]:
+        """Return up to ``k`` ranked candidates for ``mention``.
+
+        Args:
+            mention: Surface span text to ground.
+            systems: Ordered free-vocabulary systems to search; earlier systems
+                win ties. Must be non-empty.
+            k: Maximum number of candidates to return.
+            min_similarity: Override for the instance fuzzy cutoff.
+
+        Raises:
+            ValueError: If ``systems`` is empty or ``k`` is not positive.
+            VocabLoaderError: If a requested system is unknown or has no source.
+        """
+
+        if not isinstance(mention, str):
+            raise TypeError("mention must be a string")
+        ordered_systems = tuple(systems)
+        if not ordered_systems:
+            raise ValueError("systems must contain at least one vocabulary system")
+        if k <= 0:
+            raise ValueError("k must be a positive integer")
+        cutoff = self._min_similarity if min_similarity is None else min_similarity
+
+        query = normalize_alias(mention)
+        if not query:
+            return []
+
+        priority = {system: rank for rank, system in enumerate(ordered_systems)}
+        best: dict[tuple[str, str], Candidate] = {}
+        for system in ordered_systems:
+            index = self._loader.get_index(system)
+            for candidate in self._candidates_for_system(index, query, cutoff):
+                key = (candidate.system, candidate.code)
+                existing = best.get(key)
+                if existing is None or candidate.score > existing.score:
+                    best[key] = candidate
+
+        ranked = sorted(
+            best.values(),
+            key=lambda candidate: (
+                -candidate.score,
+                priority.get(_priority_system(candidate.system, ordered_systems), 0),
+                candidate.code,
+            ),
+        )
+        return ranked[:k]
+
+    def _candidates_for_system(
+        self, index: VocabularyIndex, query: str, cutoff: float
+    ) -> list[Candidate]:
+        system = index.system.upper()
+        version = index.content_hash
+        best: dict[str, Candidate] = {}
+
+        for concept in index.lookup_all(query):
+            best[concept.code] = Candidate(
+                system=system,
+                code=concept.code,
+                display=concept.preferred_term,
+                score=1.0,
+                source=self.source,
+                matched_alias=query,
+                match_kind="exact",
+                vocab_version=version,
+            )
+
+        for alias, similarity in self._ngram_index(index).query(
+            query, min_similarity=cutoff
+        ):
+            score = round(float(similarity), 6)
+            for concept in index.lookup_all(alias):
+                existing = best.get(concept.code)
+                if existing is not None and existing.score >= score:
+                    continue
+                best[concept.code] = Candidate(
+                    system=system,
+                    code=concept.code,
+                    display=concept.preferred_term,
+                    score=score,
+                    source=self.source,
+                    matched_alias=alias,
+                    match_kind="fuzzy",
+                    vocab_version=version,
+                )
+        return list(best.values())
+
+    def _ngram_index(self, index: VocabularyIndex) -> _AliasNgramIndex:
+        cached = self._ngram_indexes.get(index.system)
+        if cached is None:
+            cached = _AliasNgramIndex(index.aliases, self._ngram_size)
+            self._ngram_indexes[index.system] = cached
+        return cached
+
+
+def _priority_system(candidate_system: str, ordered_systems: Sequence[str]) -> str:
+    """Resolve an emitted (upper-cased) system back to its request key."""
+
+    for system in ordered_systems:
+        if system.upper() == candidate_system.upper():
+            return system
+    return candidate_system
+
+
+def generate_candidates(
+    mention: str,
+    systems: Sequence[str],
+    k: int = _DEFAULT_TOP_K,
+    *,
+    loader: VocabLoader | None = None,
+    ngram_size: int = _DEFAULT_NGRAM_SIZE,
+    min_similarity: float = _DEFAULT_MIN_SIMILARITY,
+) -> list[Candidate]:
+    """Generate ranked sparse ``Candidate`` objects for a clinical mention.
+
+    Convenience wrapper around :class:`SparseCandidateGenerator`. See
+    :meth:`SparseCandidateGenerator.generate` for the ranking contract.
+    """
+
+    generator = SparseCandidateGenerator(
+        loader,
+        ngram_size=ngram_size,
+        min_similarity=min_similarity,
+    )
+    return generator.generate(mention, systems, k)
+
+
+register_linker(SPARSE_LINKER_KEY, SparseCandidateGenerator)

--- a/openmed/clinical/grounding/types.py
+++ b/openmed/clinical/grounding/types.py
@@ -12,6 +12,14 @@ class Candidate:
     ``system`` is the vocabulary (e.g. ``"RXNORM"``), ``code`` its identifier
     (e.g. an RxCUI), ``display`` a human-readable name, and ``score`` a
     ``0.0``-``1.0`` match confidence (``1.0`` for an exact alias match).
+
+    The optional provenance fields let downstream rankers and exporters audit
+    where a candidate came from without re-running retrieval.  ``source`` names
+    the generator that emitted it (e.g. ``"sparse"``), ``matched_alias`` is the
+    normalized vocabulary alias that matched (never the caller's raw span text),
+    ``match_kind`` records how it matched (``"exact"`` or ``"fuzzy"``), and
+    ``vocab_version`` is a content hash of the vocabulary snapshot the candidate
+    was drawn from.
     """
 
     system: str
@@ -19,3 +27,13 @@ class Candidate:
     display: str
     score: float
     source_language: str = "en"
+    source: str = ""
+    matched_alias: str | None = None
+    match_kind: str | None = None
+    vocab_version: str | None = None
+
+    @property
+    def concept_id(self) -> str:
+        """Alias for :attr:`code`, matching the free-vocabulary schema."""
+
+        return self.code

--- a/openmed/clinical/grounding/vocab.py
+++ b/openmed/clinical/grounding/vocab.py
@@ -202,6 +202,39 @@ class VocabularyIndex:
 
         return len(self._concepts)
 
+    @property
+    def content_hash(self) -> str:
+        """Return a stable SHA-256 hash of the indexed concept content.
+
+        The digest is computed over each concept's system, code, preferred term,
+        and normalized aliases in a canonical (sorted) order, so two indexes
+        built from the same vocabulary content hash identically regardless of
+        row order. Downstream consumers store this as a candidate's
+        ``vocab_version`` so a grounding result can be traced to its snapshot.
+        """
+
+        cached = getattr(self, "_content_hash", None)
+        if cached is not None:
+            return cached
+        digest = hashlib.sha256()
+        rows = sorted(
+            (
+                concept.system,
+                concept.code,
+                concept.preferred_term,
+                "\x1f".join(
+                    sorted(normalize_alias(alias) for alias in concept.aliases)
+                ),
+            )
+            for concept in self._concepts
+        )
+        for row in rows:
+            digest.update("\x1e".join(row).encode("utf-8"))
+            digest.update(b"\x1d")
+        content_hash = f"sha256:{digest.hexdigest()}"
+        self._content_hash = content_hash
+        return content_hash
+
     def lookup(
         self, alias: object, *, language: object | None = None
     ) -> VocabConcept | None:
@@ -806,6 +839,7 @@ def _concept_from_mapping(
     code = _first_value(
         normalized_row,
         "code",
+        "concept_id",
         "concept_code",
         "id",
         "loinc_num",
@@ -815,6 +849,7 @@ def _concept_from_mapping(
     preferred = _first_value(
         normalized_row,
         "preferred_term",
+        "canonical_term",
         "preferred",
         "term",
         "name",

--- a/openmed/eval/golden/fixtures/grounding_vocab_synthetic.jsonl
+++ b/openmed/eval/golden/fixtures/grounding_vocab_synthetic.jsonl
@@ -1,0 +1,45 @@
+{"aliases": ["type 2 diabetes", "type ii diabetes mellitus", "t2dm", "dm type 2"], "canonical_term": "Type 2 diabetes mellitus without complications", "concept_id": "E11.9", "system": "icd10cm"}
+{"aliases": ["type 2 diabetes with hyperglycemia", "t2dm with high glucose"], "canonical_term": "Type 2 diabetes mellitus with hyperglycemia", "concept_id": "E11.65", "system": "icd10cm"}
+{"aliases": ["type 2 diabetes with nephropathy", "t2dm kidney disease"], "canonical_term": "Type 2 diabetes mellitus with diabetic nephropathy", "concept_id": "E11.21", "system": "icd10cm"}
+{"aliases": ["high blood pressure", "essential hypertension", "htn"], "canonical_term": "Essential (primary) hypertension", "concept_id": "I10", "system": "icd10cm"}
+{"aliases": ["pneumonia", "lung infection unspecified"], "canonical_term": "Pneumonia, unspecified organism", "concept_id": "J18.9", "system": "icd10cm"}
+{"aliases": ["renal disorder zeta001", "zeta001 renal syndrome", "synthetic zeta001 condition"], "canonical_term": "Synthetic renal disorder zeta001", "concept_id": "RXNORM-0001", "system": "rxnorm"}
+{"aliases": ["cardiac disorder zeta002", "zeta002 cardiac syndrome", "synthetic zeta002 condition"], "canonical_term": "Synthetic cardiac disorder zeta002", "concept_id": "LOINC-0002", "system": "loinc"}
+{"aliases": ["pulmonary disorder zeta003", "zeta003 pulmonary syndrome", "synthetic zeta003 condition"], "canonical_term": "Synthetic pulmonary disorder zeta003", "concept_id": "HPO-0003", "system": "hpo"}
+{"aliases": ["gastric disorder zeta004", "zeta004 gastric syndrome", "synthetic zeta004 condition"], "canonical_term": "Synthetic gastric disorder zeta004", "concept_id": "MESH-0004", "system": "mesh"}
+{"aliases": ["cerebral disorder zeta005", "zeta005 cerebral syndrome", "synthetic zeta005 condition"], "canonical_term": "Synthetic cerebral disorder zeta005", "concept_id": "ICD10CM-0005", "system": "icd10cm"}
+{"aliases": ["cutaneous disorder zeta006", "zeta006 cutaneous syndrome", "synthetic zeta006 condition"], "canonical_term": "Synthetic cutaneous disorder zeta006", "concept_id": "RXNORM-0006", "system": "rxnorm"}
+{"aliases": ["skeletal disorder zeta007", "zeta007 skeletal syndrome", "synthetic zeta007 condition"], "canonical_term": "Synthetic skeletal disorder zeta007", "concept_id": "LOINC-0007", "system": "loinc"}
+{"aliases": ["vascular disorder zeta008", "zeta008 vascular syndrome", "synthetic zeta008 condition"], "canonical_term": "Synthetic vascular disorder zeta008", "concept_id": "HPO-0008", "system": "hpo"}
+{"aliases": ["thyroid disorder zeta009", "zeta009 thyroid syndrome", "synthetic zeta009 condition"], "canonical_term": "Synthetic thyroid disorder zeta009", "concept_id": "MESH-0009", "system": "mesh"}
+{"aliases": ["hepatic disorder zeta010", "zeta010 hepatic syndrome", "synthetic zeta010 condition"], "canonical_term": "Synthetic hepatic disorder zeta010", "concept_id": "ICD10CM-0010", "system": "icd10cm"}
+{"aliases": ["renal disorder zeta011", "zeta011 renal syndrome", "synthetic zeta011 condition"], "canonical_term": "Synthetic renal disorder zeta011", "concept_id": "RXNORM-0011", "system": "rxnorm"}
+{"aliases": ["cardiac disorder zeta012", "zeta012 cardiac syndrome", "synthetic zeta012 condition"], "canonical_term": "Synthetic cardiac disorder zeta012", "concept_id": "LOINC-0012", "system": "loinc"}
+{"aliases": ["pulmonary disorder zeta013", "zeta013 pulmonary syndrome", "synthetic zeta013 condition"], "canonical_term": "Synthetic pulmonary disorder zeta013", "concept_id": "HPO-0013", "system": "hpo"}
+{"aliases": ["gastric disorder zeta014", "zeta014 gastric syndrome", "synthetic zeta014 condition"], "canonical_term": "Synthetic gastric disorder zeta014", "concept_id": "MESH-0014", "system": "mesh"}
+{"aliases": ["cerebral disorder zeta015", "zeta015 cerebral syndrome", "synthetic zeta015 condition"], "canonical_term": "Synthetic cerebral disorder zeta015", "concept_id": "ICD10CM-0015", "system": "icd10cm"}
+{"aliases": ["cutaneous disorder zeta016", "zeta016 cutaneous syndrome", "synthetic zeta016 condition"], "canonical_term": "Synthetic cutaneous disorder zeta016", "concept_id": "RXNORM-0016", "system": "rxnorm"}
+{"aliases": ["skeletal disorder zeta017", "zeta017 skeletal syndrome", "synthetic zeta017 condition"], "canonical_term": "Synthetic skeletal disorder zeta017", "concept_id": "LOINC-0017", "system": "loinc"}
+{"aliases": ["vascular disorder zeta018", "zeta018 vascular syndrome", "synthetic zeta018 condition"], "canonical_term": "Synthetic vascular disorder zeta018", "concept_id": "HPO-0018", "system": "hpo"}
+{"aliases": ["thyroid disorder zeta019", "zeta019 thyroid syndrome", "synthetic zeta019 condition"], "canonical_term": "Synthetic thyroid disorder zeta019", "concept_id": "MESH-0019", "system": "mesh"}
+{"aliases": ["hepatic disorder zeta020", "zeta020 hepatic syndrome", "synthetic zeta020 condition"], "canonical_term": "Synthetic hepatic disorder zeta020", "concept_id": "ICD10CM-0020", "system": "icd10cm"}
+{"aliases": ["renal disorder zeta021", "zeta021 renal syndrome", "synthetic zeta021 condition"], "canonical_term": "Synthetic renal disorder zeta021", "concept_id": "RXNORM-0021", "system": "rxnorm"}
+{"aliases": ["cardiac disorder zeta022", "zeta022 cardiac syndrome", "synthetic zeta022 condition"], "canonical_term": "Synthetic cardiac disorder zeta022", "concept_id": "LOINC-0022", "system": "loinc"}
+{"aliases": ["pulmonary disorder zeta023", "zeta023 pulmonary syndrome", "synthetic zeta023 condition"], "canonical_term": "Synthetic pulmonary disorder zeta023", "concept_id": "HPO-0023", "system": "hpo"}
+{"aliases": ["gastric disorder zeta024", "zeta024 gastric syndrome", "synthetic zeta024 condition"], "canonical_term": "Synthetic gastric disorder zeta024", "concept_id": "MESH-0024", "system": "mesh"}
+{"aliases": ["cerebral disorder zeta025", "zeta025 cerebral syndrome", "synthetic zeta025 condition"], "canonical_term": "Synthetic cerebral disorder zeta025", "concept_id": "ICD10CM-0025", "system": "icd10cm"}
+{"aliases": ["cutaneous disorder zeta026", "zeta026 cutaneous syndrome", "synthetic zeta026 condition"], "canonical_term": "Synthetic cutaneous disorder zeta026", "concept_id": "RXNORM-0026", "system": "rxnorm"}
+{"aliases": ["skeletal disorder zeta027", "zeta027 skeletal syndrome", "synthetic zeta027 condition"], "canonical_term": "Synthetic skeletal disorder zeta027", "concept_id": "LOINC-0027", "system": "loinc"}
+{"aliases": ["vascular disorder zeta028", "zeta028 vascular syndrome", "synthetic zeta028 condition"], "canonical_term": "Synthetic vascular disorder zeta028", "concept_id": "HPO-0028", "system": "hpo"}
+{"aliases": ["thyroid disorder zeta029", "zeta029 thyroid syndrome", "synthetic zeta029 condition"], "canonical_term": "Synthetic thyroid disorder zeta029", "concept_id": "MESH-0029", "system": "mesh"}
+{"aliases": ["hepatic disorder zeta030", "zeta030 hepatic syndrome", "synthetic zeta030 condition"], "canonical_term": "Synthetic hepatic disorder zeta030", "concept_id": "ICD10CM-0030", "system": "icd10cm"}
+{"aliases": ["renal disorder zeta031", "zeta031 renal syndrome", "synthetic zeta031 condition"], "canonical_term": "Synthetic renal disorder zeta031", "concept_id": "RXNORM-0031", "system": "rxnorm"}
+{"aliases": ["cardiac disorder zeta032", "zeta032 cardiac syndrome", "synthetic zeta032 condition"], "canonical_term": "Synthetic cardiac disorder zeta032", "concept_id": "LOINC-0032", "system": "loinc"}
+{"aliases": ["pulmonary disorder zeta033", "zeta033 pulmonary syndrome", "synthetic zeta033 condition"], "canonical_term": "Synthetic pulmonary disorder zeta033", "concept_id": "HPO-0033", "system": "hpo"}
+{"aliases": ["gastric disorder zeta034", "zeta034 gastric syndrome", "synthetic zeta034 condition"], "canonical_term": "Synthetic gastric disorder zeta034", "concept_id": "MESH-0034", "system": "mesh"}
+{"aliases": ["cerebral disorder zeta035", "zeta035 cerebral syndrome", "synthetic zeta035 condition"], "canonical_term": "Synthetic cerebral disorder zeta035", "concept_id": "ICD10CM-0035", "system": "icd10cm"}
+{"aliases": ["cutaneous disorder zeta036", "zeta036 cutaneous syndrome", "synthetic zeta036 condition"], "canonical_term": "Synthetic cutaneous disorder zeta036", "concept_id": "RXNORM-0036", "system": "rxnorm"}
+{"aliases": ["skeletal disorder zeta037", "zeta037 skeletal syndrome", "synthetic zeta037 condition"], "canonical_term": "Synthetic skeletal disorder zeta037", "concept_id": "LOINC-0037", "system": "loinc"}
+{"aliases": ["vascular disorder zeta038", "zeta038 vascular syndrome", "synthetic zeta038 condition"], "canonical_term": "Synthetic vascular disorder zeta038", "concept_id": "HPO-0038", "system": "hpo"}
+{"aliases": ["thyroid disorder zeta039", "zeta039 thyroid syndrome", "synthetic zeta039 condition"], "canonical_term": "Synthetic thyroid disorder zeta039", "concept_id": "MESH-0039", "system": "mesh"}
+{"aliases": ["hepatic disorder zeta040", "zeta040 hepatic syndrome", "synthetic zeta040 condition"], "canonical_term": "Synthetic hepatic disorder zeta040", "concept_id": "ICD10CM-0040", "system": "icd10cm"}

--- a/openmed/eval/golden/loader.py
+++ b/openmed/eval/golden/loader.py
@@ -48,6 +48,7 @@ _SPECIALIZED_FIXTURE_NAMES = frozenset(
         "context_multilingual.jsonl",
         "code_mixed_deidentification.jsonl",
         "grounding_crosslingual.jsonl",
+        "grounding_vocab_synthetic.jsonl",
         "india_clinical.jsonl",
         "indic_name_variants.json",
         "relation_assertion.jsonl",

--- a/tests/unit/clinical/grounding/test_candidate_generator.py
+++ b/tests/unit/clinical/grounding/test_candidate_generator.py
@@ -1,0 +1,211 @@
+"""Tests for the sparse alias candidate generator.
+
+All vocabulary content is synthetic and algorithmically generated; no real
+patient data or licensed terminology is used.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.clinical.grounding import (
+    Candidate,
+    SparseCandidateGenerator,
+    generate_candidates,
+    get_linker,
+)
+from openmed.clinical.grounding.vocab import (
+    VocabLoader,
+    VocabLoaderError,
+    VocabSource,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_FIXTURE = _REPO_ROOT / "openmed/eval/golden/fixtures/grounding_vocab_synthetic.jsonl"
+_SYSTEMS = ("icd10cm", "rxnorm", "loinc", "hpo", "mesh")
+
+
+def _fixture_rows() -> list[dict]:
+    return [
+        json.loads(line)
+        for line in _FIXTURE.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _loader(tmp_path: Path, path: Path = _FIXTURE) -> VocabLoader:
+    sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+    registry = {
+        system: VocabSource(system=system, path=path, sha256=sha256)
+        for system in _SYSTEMS
+    }
+    return VocabLoader(cache_dir=tmp_path / "cache", registry=registry)
+
+
+def test_generate_returns_e11_family_top_result(tmp_path):
+    candidates = generate_candidates(
+        "type 2 diabetes",
+        systems=["icd10cm"],
+        loader=_loader(tmp_path),
+    )
+
+    assert candidates
+    top = candidates[0]
+    assert isinstance(top, Candidate)
+    assert top.system == "ICD10CM"
+    assert top.code == "E11.9"
+    assert top.concept_id == "E11.9"
+    assert top.code.startswith("E11")
+    assert top.match_kind == "exact"
+    assert top.score == 1.0
+
+
+def test_every_candidate_carries_provenance(tmp_path):
+    candidates = generate_candidates(
+        "type 2 diabetes",
+        systems=["icd10cm"],
+        loader=_loader(tmp_path),
+    )
+
+    assert candidates
+    for candidate in candidates:
+        assert candidate.source == "sparse"
+        assert candidate.matched_alias
+        assert candidate.match_kind in {"exact", "fuzzy"}
+        assert candidate.vocab_version
+        assert candidate.vocab_version.startswith("sha256:")
+
+
+def test_fuzzy_match_recovers_misspelled_mention(tmp_path):
+    candidates = generate_candidates(
+        "type 2 diabetis mellitis",
+        systems=["icd10cm"],
+        loader=_loader(tmp_path),
+    )
+
+    codes = {candidate.code for candidate in candidates}
+    assert "E11.9" in codes
+    recovered = next(candidate for candidate in candidates if candidate.code == "E11.9")
+    assert recovered.match_kind == "fuzzy"
+    assert 0.0 < recovered.score < 1.0
+
+
+def test_results_are_byte_identical_across_runs(tmp_path):
+    first = generate_candidates(
+        "high blood pressure", systems=list(_SYSTEMS), loader=_loader(tmp_path)
+    )
+    second = generate_candidates(
+        "high blood pressure", systems=list(_SYSTEMS), loader=_loader(tmp_path)
+    )
+
+    assert [repr(candidate) for candidate in first] == [
+        repr(candidate) for candidate in second
+    ]
+
+
+def test_tie_break_prefers_earlier_system_then_concept_id(tmp_path):
+    shared = tmp_path / "shared.jsonl"
+    shared.write_text(
+        json.dumps(
+            {
+                "concept_id": "RX-1",
+                "system": "rxnorm",
+                "canonical_term": "Shared synthetic agent",
+                "aliases": ["shared synthetic term"],
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "concept_id": "ICD-1",
+                "system": "icd10cm",
+                "canonical_term": "Shared synthetic disorder",
+                "aliases": ["shared synthetic term"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    loader = _loader(tmp_path, path=shared)
+
+    icd_first = generate_candidates(
+        "shared synthetic term", systems=["icd10cm", "rxnorm"], loader=loader
+    )
+    rx_first = generate_candidates(
+        "shared synthetic term", systems=["rxnorm", "icd10cm"], loader=loader
+    )
+
+    assert [candidate.score for candidate in icd_first] == [1.0, 1.0]
+    assert icd_first[0].system == "ICD10CM"
+    assert rx_first[0].system == "RXNORM"
+
+
+def test_unknown_system_raises_clear_error(tmp_path):
+    with pytest.raises(VocabLoaderError, match="Unsupported free vocabulary system"):
+        generate_candidates(
+            "type 2 diabetes",
+            systems=["not_a_system"],
+            loader=_loader(tmp_path),
+        )
+
+
+def test_grounding_subpackage_ships_no_vocabulary_content():
+    # The grounding subpackage itself ships no vocabulary tables — vocab data is
+    # user-supplied at runtime. (The only bundled grounding data is a synthetic
+    # eval fixture under openmed/eval/golden/fixtures/, following the existing
+    # grounding_crosslingual.jsonl precedent; no licensed/real terminology ships.)
+    import openmed.clinical.grounding as grounding
+
+    package_dir = Path(grounding.__file__).resolve().parent
+    vocab_suffixes = {".tsv", ".rrf", ".obo", ".csv", ".jsonl", ".txt", ".xml"}
+    bundled = [
+        path
+        for path in package_dir.rglob("*")
+        if path.is_file() and path.suffix.lower() in vocab_suffixes
+    ]
+    assert bundled == []
+
+
+def test_generator_is_resolvable_via_registry(tmp_path):
+    factory = get_linker("sparse")
+    assert factory is SparseCandidateGenerator
+
+    generator = factory(_loader(tmp_path))
+    candidates = generator.generate("type 2 diabetes", ["icd10cm"], k=3)
+    assert candidates[0].code == "E11.9"
+    assert len(candidates) <= 3
+
+
+def test_top5_recall_meets_threshold_on_synthetic_gold(tmp_path):
+    loader = _loader(tmp_path)
+    generator = SparseCandidateGenerator(loader)
+
+    gold: list[tuple[str, str]] = []
+    for row in _fixture_rows():
+        for alias in row["aliases"]:
+            gold.append((alias, row["concept_id"]))
+
+    mentions: list[tuple[str, str]] = []
+    index = 0
+    while len(mentions) < 200:
+        alias, code = gold[index % len(gold)]
+        # Perturb roughly one in five mentions with a deterministic single-char
+        # substitution to exercise the fuzzy stage.
+        if index % 5 == 0 and len(alias) > 8:
+            midpoint = len(alias) // 2
+            alias = alias[:midpoint] + "x" + alias[midpoint + 1 :]
+        mentions.append((alias, code))
+        index += 1
+
+    hits = 0
+    for mention, code in mentions:
+        candidates = generator.generate(mention, list(_SYSTEMS), k=5)
+        if code in {candidate.code for candidate in candidates}:
+            hits += 1
+
+    recall = hits / len(mentions)
+    assert recall >= 0.85


### PR DESCRIPTION
## Summary

Adds a deterministic, offline sparse alias candidate generator over the free clinical vocabularies, and extends the grounding `Candidate` type with provenance so downstream retrieval/ranking can trace and rank candidates. This is the foundation the rest of the grounding roadmap builds on.

- **`openmed/clinical/grounding/types.py`** — extends `Candidate` **additively** with `source=""`, `matched_alias=None`, `match_kind=None`, `vocab_version=None` (all defaulted, appended after the existing five fields) and a read-only `concept_id` property returning `code`. Positional construction and existing consumers are unchanged.
- **`openmed/clinical/grounding/candidate_generator.py`** — `SparseCandidateGenerator` + `generate_candidates(mention, systems, k=10, *, loader=None, ngram_size=3, min_similarity=0.3) -> list[Candidate]`. Unions exact normalized-alias hits (score 1.0) with character-trigram TF-IDF fuzzy hits, dedups per `(system, code)` keeping the best score, and orders by `(-score, system_priority_rank, code)`. Pure-Python (no `rapidfuzz`) for byte-identical determinism. Registered via `register_linker("sparse", ...)`.
- **`openmed/clinical/grounding/vocab.py`** — recognizes `concept_id`/`canonical_term` alias-table keys; adds `VocabularyIndex.content_hash -> "sha256:<hex>"` used as the `vocab_version` provenance key.
- Grounding `__init__` exports; a synthetic 45-concept alias fixture; unit tests.

Closes #1796.

## Deviations / judgment calls

- **Kept `code`; did not rename to `concept_id`.** The merged `Candidate` already uses `code` and is imported by 4 linkers, the FHIR exporter, `medication_sig`, and `icd11_api`; renaming would be a breaking change. Added a `concept_id` read-only property satisfying the schema wording without breakage.
- **Provenance fields are additive with defaults**, so all existing `Candidate(...)` sites and equality/determinism tests are untouched.
- **Did not edit `registry.py`.** Every existing linker self-registers by calling `register_linker` from its own module; the generator follows that idiom, and `get_linker("sparse")` resolves it (no name collision with `hpo`/`icd10cm`/`rxnorm`).
- **Fuzzy matching is self-authored char-trigram TF-IDF**, not the optional `rapidfuzz` path — guarantees cross-run byte-identity without the optional `grounding` extra.
- **Emits `system` UPPERCASE** to match the existing `Candidate.system` convention (`RXNORM`/`ICD10CM`).

## Post-review hardening (independent review pass)

- **Renamed the bundled-content test** from `test_wheel_ships_no_vocabulary_content` to `test_grounding_subpackage_ships_no_vocabulary_content`, with a comment clarifying its true scope: it asserts the grounding *subpackage* ships no vocabulary tables. The only bundled grounding data is the **synthetic** eval fixture under `openmed/eval/golden/fixtures/` (following the existing `grounding_crosslingual.jsonl` precedent) — **no licensed/real terminology is bundled**.
- **Documented the generator's registry-shape divergence:** `SparseCandidateGenerator` (a `VocabLoader`-constructed `.generate(...)`) intentionally differs from the `VocabLinker` entries (`(vocab).link(...)`). Its docstring now states it must be consumed via `generate_candidates`/`.generate`, not the uniform `get_linker(system)(get_index(system)).link(...)` path.

## Out-of-scope / follow-ups

- **Registry uniformity:** whether to give the generator a `.link`-compatible adapter or move it to a separate registry is a design decision left for a follow-up (documented in the meantime).
- **`content_hash` currently hashes concept aliases but not `language_aliases`** — to be addressed by the language-aware alias work (#1799) that owns that space.
- The recall test is a **smoke test** (mentions drawn from the alias list ± a deterministic perturbation), demonstrating the pipeline runs deterministically (measured top-5 recall 1.0); it is not a real-world retrieval benchmark.

## Data provenance

All fixture/test data is synthetic and algorithmically generated (`zeta0NN` placeholders plus common ICD-10 codes with generic lay aliases). No licensed terminology tables.

## Verification

- `make test`: **8866 passed, 82 skipped, 27 failed** — all 27 are the documented pre-existing env-only failures (zh jieba/opencc, model_integrity, mcp_entrypoint); none touch grounding/eval.
- `tests/unit/clinical/grounding` + `tests/unit/eval`: 931 passed, 5 skipped; `Candidate`-consuming suites (linkers, codeable-concept determinism, medication_sig/fhir, icd11): all green.
- `_SPECIALIZED_FIXTURE_NAMES` gate edit (so `load_golden_fixtures()` doesn't parse the vocab fixture as a PII gold row) verified via `test_fixture_coverage`.
- `pre-commit` on changed files: all hooks pass. `git rev-list --count HEAD..upstream/master` = 0.

## Relationship

Foundation of the Concept-Grounding-&-Terminology roadmap: the `Candidate` contract and `generate_candidates`/`SparseCandidateGenerator` here are consumed by the offline HNSW index (#1797), language-aware alias space (#1799), reranker (#1798), and ranking stage (#1233).
