### PR TITLE
feat(grounding): assertion-aware grounding that never codes a denied or hypothetical finding as present

### DIFF
--- a/eval/suites/negation_grounding_traps.py
+++ b/eval/suites/negation_grounding_traps.py
@@ -1,0 +1,196 @@
+"""Curated negation / experiencer grounding trap suite (release gate).
+
+Every case here is a synthetic clinical sentence whose surface concept *matches*
+a real code but whose assertion means it must never be emitted as an active
+patient ``Condition``. The suite is the hard release gate behind OM-741: if any
+denied, hypothetical, or non-patient (family / other experiencer) finding leaks
+through :func:`~openmed.clinical.grounding.assertion_grounding.ground_with_context`
+as an active patient condition, :func:`active_patient_condition_leaks` returns a
+non-empty list and the gate fails.
+
+The same gold set doubles as a status-mapping accuracy fixture: each case
+carries its expected :mod:`~openmed.clinical.grounding.assertion_grounding`
+status, and :func:`status_mapping_accuracy` scores the resolver against them.
+
+All text is synthetic and algorithmically templated; it contains no real
+patient data. Only cue offsets and axis labels ever reach provenance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from openmed.clinical.exporters.codeable_concept import GroundedSpan
+from openmed.clinical.exporters.fhir.condition import to_condition
+from openmed.clinical.grounding import Candidate
+from openmed.clinical.grounding.assertion_grounding import (
+    GROUNDING_HISTORICAL,
+    GROUNDING_HYPOTHETICAL,
+    GROUNDING_NON_PATIENT,
+    GROUNDING_PRESENT,
+    GROUNDING_REFUTED,
+    GROUNDING_UNCERTAIN,
+    AssertedGroundedSpan,
+    ground_with_context,
+)
+
+#: Axes whose findings must never surface as an active patient condition.
+HARD_GATE_STATUSES = frozenset(
+    {GROUNDING_REFUTED, GROUNDING_HYPOTHETICAL, GROUNDING_NON_PATIENT}
+)
+
+_SUBJECT_REFERENCE = "Patient/trap"
+
+
+@dataclass(frozen=True)
+class TrapCase:
+    """One synthetic finding with its expected grounding status.
+
+    ``text`` is the full synthetic sentence, ``surface`` the concept mention
+    inside it (located by exact substring), ``system``/``code`` the coded
+    concept the mention grounds to, ``axis`` the assertion axis exercised, and
+    ``expected_status`` the grounding status the resolver must produce.
+    """
+
+    text: str
+    surface: str
+    system: str
+    code: str
+    axis: str
+    expected_status: str
+
+    @property
+    def is_hard_gate(self) -> bool:
+        """Whether a leak of this case as an active patient code fails release."""
+
+        return self.expected_status in HARD_GATE_STATUSES
+
+    def grounded_span(self) -> GroundedSpan:
+        """Build the pre-grounded span (offsets located inside ``text``)."""
+
+        start = self.text.index(self.surface)
+        return GroundedSpan(
+            text=self.surface,
+            start=start,
+            end=start + len(self.surface),
+            candidates=(
+                Candidate(
+                    system=self.system,
+                    code=self.code,
+                    display=self.surface,
+                    score=1.0,
+                ),
+            ),
+        )
+
+
+# Synthetic finding/code pairs reused across templates. Codes are illustrative
+# ICD-10-CM / SNOMED identifiers, not drawn from any licensed distribution.
+_FINDINGS = (
+    ("pneumonia", "ICD10CM", "J18.9"),
+    ("colon cancer", "ICD10CM", "C18.9"),
+    ("deep vein thrombosis", "ICD10CM", "I82.90"),
+    ("myocardial infarction", "ICD10CM", "I21.9"),
+    ("diabetes mellitus", "ICD10CM", "E11.9"),
+    ("pulmonary embolism", "ICD10CM", "I26.99"),
+)
+
+# axis -> (status, template with a ``{f}`` placeholder for the finding surface).
+_TEMPLATES: tuple[tuple[str, str, str], ...] = (
+    ("negation", GROUNDING_REFUTED, "No evidence of {f} on exam."),
+    ("negation", GROUNDING_REFUTED, "The patient denies {f}."),
+    ("hypothetical", GROUNDING_HYPOTHETICAL, "Return if {f} develops."),
+    ("hypothetical", GROUNDING_HYPOTHETICAL, "Start heparin if {f} is suspected."),
+    ("experiencer", GROUNDING_NON_PATIENT, "Family history of {f}."),
+    ("experiencer", GROUNDING_NON_PATIENT, "Her mother had {f}."),
+    ("temporality", GROUNDING_HISTORICAL, "History of {f}, now resolved."),
+    ("uncertainty", GROUNDING_UNCERTAIN, "Possible {f} pending imaging."),
+    ("present", GROUNDING_PRESENT, "The patient has acute {f}."),
+    ("present", GROUNDING_PRESENT, "Assessment: {f} confirmed on exam."),
+)
+
+
+def _build_cases() -> tuple[TrapCase, ...]:
+    cases: list[TrapCase] = []
+    for axis, status, template in _TEMPLATES:
+        for surface, system, code in _FINDINGS:
+            cases.append(
+                TrapCase(
+                    text=template.format(f=surface),
+                    surface=surface,
+                    system=system,
+                    code=code,
+                    axis=axis,
+                    expected_status=status,
+                )
+            )
+    return tuple(cases)
+
+
+#: The frozen trap gold set.
+TRAP_CASES: tuple[TrapCase, ...] = _build_cases()
+
+
+def iter_trap_cases() -> Iterator[TrapCase]:
+    """Yield every trap case in the frozen gold set."""
+
+    yield from TRAP_CASES
+
+
+def assert_case(case: TrapCase) -> AssertedGroundedSpan:
+    """Ground a single trap case through the assertion-aware path."""
+
+    return ground_with_context(case.text, [case.grounded_span()])[0]
+
+
+def active_patient_condition_leaks() -> list[TrapCase]:
+    """Return hard-gate cases that leak as active patient conditions.
+
+    A case leaks if its grounded span reports itself as an active patient
+    condition, or if the FHIR ``Condition`` exporter emits an ``active`` +
+    ``confirmed`` patient resource for it. The list must be empty for release.
+    """
+
+    leaks: list[TrapCase] = []
+    for case in TRAP_CASES:
+        if not case.is_hard_gate:
+            continue
+        asserted = assert_case(case)
+        if asserted.is_active_patient_condition:
+            leaks.append(case)
+            continue
+        condition = to_condition(asserted, subject_reference=_SUBJECT_REFERENCE)
+        if _is_active_confirmed_patient(condition):
+            leaks.append(case)
+    return leaks
+
+
+def status_mapping_accuracy() -> float:
+    """Fraction of trap cases whose resolved status matches the gold status."""
+
+    if not TRAP_CASES:
+        return 0.0
+    correct = sum(
+        1
+        for case in TRAP_CASES
+        if assert_case(case).status.status == case.expected_status
+    )
+    return correct / len(TRAP_CASES)
+
+
+def _is_active_confirmed_patient(condition: dict | None) -> bool:
+    if condition is None:
+        return False
+    clinical = _coding_code(condition.get("clinicalStatus"))
+    verification = _coding_code(condition.get("verificationStatus"))
+    return clinical == "active" and verification == "confirmed"
+
+
+def _coding_code(concept: dict | None) -> str | None:
+    if not concept:
+        return None
+    codings = concept.get("coding") or []
+    if not codings:
+        return None
+    return codings[0].get("code")

--- a/openmed/clinical/exporters/fhir/__init__.py
+++ b/openmed/clinical/exporters/fhir/__init__.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 from .bundle import to_bundle
+from .condition import (
+    CONDITION_CLINICAL_SYSTEM,
+    CONDITION_VER_STATUS_SYSTEM,
+    to_condition,
+)
 from .operation_outcome import (
     OperationOutcomeIssue,
     from_validation_result,
@@ -18,6 +23,9 @@ from .provenance import to_audit_event, to_provenance
 from .references import deterministic_fullurl
 
 __all__ = [
+    "CONDITION_CLINICAL_SYSTEM",
+    "CONDITION_VER_STATUS_SYSTEM",
+    "to_condition",
     "deterministic_fullurl",
     "OperationOutcomeIssue",
     "INDIA_HEALTH_ID_REDACTION",

--- a/openmed/clinical/exporters/fhir/condition.py
+++ b/openmed/clinical/exporters/fhir/condition.py
@@ -1,0 +1,90 @@
+"""Assertion-aware FHIR R4 ``Condition`` export.
+
+Materializes an :class:`~openmed.clinical.grounding.assertion_grounding.AssertedGroundedSpan`
+into a FHIR R4 ``Condition`` whose ``verificationStatus`` and ``clinicalStatus``
+are driven by the span's derived assertion status, so a refuted, hypothetical,
+or historical finding is coded truthfully instead of as an active present
+concept.
+
+The safety boundary is enforced structurally: a non-patient (family / other
+experiencer) span yields no patient ``Condition`` at all
+(:func:`to_condition` returns ``None``), and the emitted ``clinicalStatus`` /
+``verificationStatus`` come only from the vetted status map, so an
+``active`` + ``confirmed`` Condition can never be produced for a denied or
+hypothetical span. The concept ``code`` is built from the span's focus
+candidate via the shared grounding-aware ``CodeableConcept`` core.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...grounding.assertion_grounding import AssertedGroundedSpan
+from ..codeable_concept import to_codeable_concept
+
+__all__ = [
+    "CONDITION_CLINICAL_SYSTEM",
+    "CONDITION_VER_STATUS_SYSTEM",
+    "to_condition",
+]
+
+#: HL7 terminology system URIs for the two status value sets.
+CONDITION_CLINICAL_SYSTEM = "http://terminology.hl7.org/CodeSystem/condition-clinical"
+CONDITION_VER_STATUS_SYSTEM = (
+    "http://terminology.hl7.org/CodeSystem/condition-ver-status"
+)
+
+
+def to_condition(
+    asserted: AssertedGroundedSpan,
+    *,
+    subject_reference: str,
+    condition_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Build a FHIR R4 ``Condition`` for an assertion-aware grounded span.
+
+    The ``code`` is the span's grounding ``CodeableConcept``;
+    ``verificationStatus`` and ``clinicalStatus`` are taken from the span's
+    :class:`~openmed.clinical.grounding.assertion_grounding.AssertionGroundingStatus`.
+    ``clinicalStatus`` is omitted when the status asserts no active/inactive
+    state (a refuted or hypothetical finding), matching the FHIR invariant that
+    such a status is not claimed.
+
+    Args:
+        asserted: The assertion-aware grounded span to materialize.
+        subject_reference: The ``Condition.subject`` reference (e.g.
+            ``"Patient/123"``) the finding is attributed to.
+        condition_id: Optional resource ``id``.
+
+    Returns:
+        A ``resourceType="Condition"`` mapping, or ``None`` when the span
+        belongs to a non-patient subject and must be excluded from patient
+        resources.
+    """
+
+    status = asserted.status
+    if not status.patient_subject:
+        return None
+
+    # Every coding of the span (the focus concept and any composite /
+    # post-coordinated qualifier codes) shares the single Condition-level
+    # status, so they all inherit the focus concept's assertion.
+    resource: dict[str, Any] = {
+        "resourceType": "Condition",
+        "verificationStatus": _status_concept(
+            CONDITION_VER_STATUS_SYSTEM, status.verification_status
+        ),
+        "subject": {"reference": subject_reference},
+        "code": to_codeable_concept(asserted.grounded),
+    }
+    if condition_id is not None:
+        resource["id"] = condition_id
+    if status.clinical_status is not None:
+        resource["clinicalStatus"] = _status_concept(
+            CONDITION_CLINICAL_SYSTEM, status.clinical_status
+        )
+    return resource
+
+
+def _status_concept(system: str, code: str) -> dict[str, Any]:
+    return {"coding": [{"system": system, "code": code}]}

--- a/openmed/clinical/grounding/__init__.py
+++ b/openmed/clinical/grounding/__init__.py
@@ -1,6 +1,18 @@
 """Vocabulary loading and linker helpers for clinical concept grounding."""
 
 from . import linkers as _linkers  # noqa: F401
+from .assertion_grounding import (
+    ASSERTION_GROUNDING_ADVISORY,
+    GROUNDING_ASSERTION_STATUSES,
+    GROUNDING_POLICIES,
+    POLICY_DROP,
+    POLICY_STATUS,
+    POLICY_SUPPRESS,
+    AssertedGroundedSpan,
+    AssertionGroundingStatus,
+    assertion_grounding_status,
+    ground_with_context,
+)
 from .candidate_generator import SparseCandidateGenerator, generate_candidates
 from .matcher import ConceptMatch, LexicalConcept, LexicalMatcher, normalize_term
 from .registry import (
@@ -34,12 +46,20 @@ from .vocab import (
 )
 
 __all__ = [
+    "ASSERTION_GROUNDING_ADVISORY",
+    "AssertedGroundedSpan",
+    "AssertionGroundingStatus",
     "Candidate",
     "ConceptMatch",
     "FREE_VOCAB_SYSTEMS",
+    "GROUNDING_ASSERTION_STATUSES",
+    "GROUNDING_POLICIES",
     "InvalidVocabularyLoaderError",
     "LexicalConcept",
     "LexicalMatcher",
+    "POLICY_DROP",
+    "POLICY_STATUS",
+    "POLICY_SUPPRESS",
     "RESTRICTED_VOCAB_SYSTEMS",
     "RestrictedVocabularyError",
     "RestrictedVocabularyLoaderError",
@@ -54,9 +74,11 @@ __all__ = [
     "VocabularyLoaderRegistry",
     "VocabularyNotFoundError",
     "VocabularyRegistryError",
+    "assertion_grounding_status",
     "available_linkers",
     "available_loaders",
     "generate_candidates",
+    "ground_with_context",
     "get_index",
     "get_linker",
     "get_loader",

--- a/openmed/clinical/grounding/__init__.py
+++ b/openmed/clinical/grounding/__init__.py
@@ -1,6 +1,7 @@
 """Vocabulary loading and linker helpers for clinical concept grounding."""
 
 from . import linkers as _linkers  # noqa: F401
+from .candidate_generator import SparseCandidateGenerator, generate_candidates
 from .matcher import ConceptMatch, LexicalConcept, LexicalMatcher, normalize_term
 from .registry import (
     InvalidVocabularyLoaderError,
@@ -42,6 +43,7 @@ __all__ = [
     "RESTRICTED_VOCAB_SYSTEMS",
     "RestrictedVocabularyError",
     "RestrictedVocabularyLoaderError",
+    "SparseCandidateGenerator",
     "VocabConcept",
     "VocabLoader",
     "VocabLoaderError",
@@ -54,6 +56,7 @@ __all__ = [
     "VocabularyRegistryError",
     "available_linkers",
     "available_loaders",
+    "generate_candidates",
     "get_index",
     "get_linker",
     "get_loader",

--- a/openmed/clinical/grounding/assertion_grounding.py
+++ b/openmed/clinical/grounding/assertion_grounding.py
@@ -1,0 +1,397 @@
+"""Assertion-aware grounding (roadmap v2.0).
+
+Grounding turns a surface mention into coded concepts, but the base linker path
+ignores whether the mention was *asserted*. "No evidence of pneumonia" and
+"family history of colon cancer" both match a real concept, yet neither is an
+active patient finding: coding a refuted or non-patient mention as present
+corrupts every downstream FHIR/OMOP record. This is a correctness and safety
+failure, not a ranking nuisance.
+
+This stage reads the ConText decision axes already produced by
+:mod:`openmed.clinical.context` (negation, temporality, certainty) and the
+experiencer refinement from :mod:`openmed.clinical.experiencer`, composes them
+into a per-span :class:`~openmed.clinical.context.ClinicalAssertion`, and derives
+a single code-level :class:`AssertionGroundingStatus` that maps onto FHIR
+``verificationStatus`` / ``clinicalStatus``:
+
+* ``present``      -- affirmed, current, certain patient finding (active + confirmed).
+* ``refuted``      -- a negated finding (``verificationStatus=refuted``; hardest boundary).
+* ``hypothetical`` -- a conditional finding, not asserted present (``provisional``).
+* ``historical``   -- a resolved past finding (``clinicalStatus=inactive``).
+* ``uncertain``    -- a hedged finding (``verificationStatus=provisional``).
+* ``non_patient``  -- a family / other-experiencer finding, excluded from patient resources.
+
+The governing rule is safety-critical: a mention whose assertion is denied,
+hypothetical, or not-the-patient is **never** emitted as an active patient
+concept. Every candidate of a span -- the focus concept and any composite or
+post-coordinated qualifier codes -- inherits the same span-level status, so a
+refuted focus can never leave a qualifier asserted.
+
+A policy switch controls whether non-present concepts are dropped, suppressed
+(kept with candidates stripped), or emitted carrying their status. The default
+is status-carrying: a refuted or hypothetical concept is annotated, never
+silently presented as present, and never silently discarded.
+
+Provenance records only cue offsets and axis labels plus a content hash; the
+raw note text is never logged, so the audit trail carries no PHI. Outputs are
+advisory annotations for review and downstream processing, not clinical
+decisions and not medical-device instructions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any
+
+from openmed.core.audit import stable_hash
+
+from ..context import (
+    AFFIRMED,
+    CERTAIN,
+    HYPOTHETICAL,
+    PATIENT_EXPERIENCER,
+    RECENT,
+    ClinicalAssertion,
+    resolve_span_context,
+    scan_context_cues,
+)
+from ..experiencer import resolve_experiencer
+from .types import Candidate
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids an exporter import cycle
+    from ..exporters.codeable_concept import GroundedSpan
+
+__all__ = [
+    "ASSERTION_GROUNDING_ADVISORY",
+    "GROUNDING_PRESENT",
+    "GROUNDING_REFUTED",
+    "GROUNDING_HYPOTHETICAL",
+    "GROUNDING_HISTORICAL",
+    "GROUNDING_UNCERTAIN",
+    "GROUNDING_NON_PATIENT",
+    "GROUNDING_ASSERTION_STATUSES",
+    "POLICY_STATUS",
+    "POLICY_DROP",
+    "POLICY_SUPPRESS",
+    "GROUNDING_POLICIES",
+    "AssertionGroundingStatus",
+    "AssertedGroundedSpan",
+    "assertion_grounding_status",
+    "ground_with_context",
+]
+
+ASSERTION_GROUNDING_ADVISORY = (
+    "Assertion-aware grounding status is derived deterministically from the "
+    "ConText and experiencer axes of each span. Refuted, hypothetical, and "
+    "non-patient concepts are never emitted as active patient codes; verify "
+    "before clinical use."
+)
+
+#: Grounding assertion status labels, ordered from asserted to most withheld.
+GROUNDING_PRESENT = "present"
+GROUNDING_UNCERTAIN = "uncertain"
+GROUNDING_HISTORICAL = "historical"
+GROUNDING_HYPOTHETICAL = "hypothetical"
+GROUNDING_REFUTED = "refuted"
+GROUNDING_NON_PATIENT = "non_patient"
+
+#: All grounding assertion status labels, ordered from asserted to most withheld.
+GROUNDING_ASSERTION_STATUSES = (
+    GROUNDING_PRESENT,
+    GROUNDING_UNCERTAIN,
+    GROUNDING_HISTORICAL,
+    GROUNDING_HYPOTHETICAL,
+    GROUNDING_REFUTED,
+    GROUNDING_NON_PATIENT,
+)
+
+# FHIR Condition.verificationStatus codes (condition-ver-status value set).
+_VERIFICATION_CONFIRMED = "confirmed"
+_VERIFICATION_PROVISIONAL = "provisional"
+_VERIFICATION_REFUTED = "refuted"
+
+# FHIR Condition.clinicalStatus codes (condition-clinical value set).
+_CLINICAL_ACTIVE = "active"
+_CLINICAL_INACTIVE = "inactive"
+
+# status label -> (verification_status, clinical_status, patient_subject).
+# ``clinical_status`` is ``None`` when the finding is not asserted to hold now
+# (refuted, hypothetical) or is not the patient's, so no active/inactive
+# clinicalStatus is claimed for it.
+_STATUS_MAP: dict[str, tuple[str, str | None, bool]] = {
+    GROUNDING_PRESENT: (_VERIFICATION_CONFIRMED, _CLINICAL_ACTIVE, True),
+    GROUNDING_UNCERTAIN: (_VERIFICATION_PROVISIONAL, _CLINICAL_ACTIVE, True),
+    GROUNDING_HISTORICAL: (_VERIFICATION_CONFIRMED, _CLINICAL_INACTIVE, True),
+    GROUNDING_HYPOTHETICAL: (_VERIFICATION_PROVISIONAL, None, True),
+    GROUNDING_REFUTED: (_VERIFICATION_REFUTED, None, True),
+    GROUNDING_NON_PATIENT: (_VERIFICATION_CONFIRMED, None, False),
+}
+
+#: Emit every span carrying its status (default; never silently present).
+POLICY_STATUS = "status"
+#: Drop non-present spans entirely from the returned sequence.
+POLICY_DROP = "drop"
+#: Keep non-present spans but strip their candidate codes.
+POLICY_SUPPRESS = "suppress"
+
+#: The supported non-present handling policies.
+GROUNDING_POLICIES = (POLICY_STATUS, POLICY_DROP, POLICY_SUPPRESS)
+
+
+@dataclass(frozen=True)
+class AssertionGroundingStatus:
+    """Code-level assertion status for a grounded span.
+
+    ``status`` is one of :data:`GROUNDING_ASSERTION_STATUSES`.
+    ``verification_status`` and ``clinical_status`` are the FHIR
+    ``Condition.verificationStatus`` / ``Condition.clinicalStatus`` codes the
+    status maps to (``clinical_status`` is ``None`` when no active/inactive
+    status is asserted). ``patient_subject`` is ``False`` when the finding
+    belongs to a family member or other non-patient subject.
+    """
+
+    status: str
+    verification_status: str
+    clinical_status: str | None
+    patient_subject: bool
+
+    @property
+    def is_present(self) -> bool:
+        """Whether this is an affirmed, current, certain patient finding."""
+
+        return self.status == GROUNDING_PRESENT
+
+    @property
+    def is_active_patient_condition(self) -> bool:
+        """Whether emitting this as an active patient ``Condition`` is allowed.
+
+        This is the safety invariant of the module: it is ``True`` only for a
+        patient-subject finding with an ``active`` ``clinicalStatus`` that is
+        not refuted. A denied, hypothetical, or non-patient span can never
+        satisfy it, so it can never be coded as an active patient concept.
+        """
+
+        return (
+            self.patient_subject
+            and self.clinical_status == _CLINICAL_ACTIVE
+            and self.verification_status != _VERIFICATION_REFUTED
+        )
+
+
+def assertion_grounding_status(
+    assertion: ClinicalAssertion,
+) -> AssertionGroundingStatus:
+    """Derive the code-level grounding status from composed ConText axes.
+
+    The axes are collapsed to a single dominant status by a fixed safety
+    precedence: a non-patient experiencer, then a negated polarity, then a
+    hypothetical or historical temporality, then an uncertain certainty. The
+    experiencer and negation boundaries dominate so a finding that is either
+    not the patient's or refuted can never be resolved to ``present``.
+    """
+
+    status = _dominant_status(assertion)
+    verification, clinical, patient = _STATUS_MAP[status]
+    return AssertionGroundingStatus(
+        status=status,
+        verification_status=verification,
+        clinical_status=clinical,
+        patient_subject=patient,
+    )
+
+
+def _dominant_status(assertion: ClinicalAssertion) -> str:
+    # Fail CLOSED: allowlist each axis to its asserted pole (mirroring the
+    # experiencer check) so a non-canonical / unknown label from any producer
+    # collapses to a withheld status instead of defaulting to "present". An
+    # unset negation (``None``) is a legitimate "no negation composed" state and
+    # stays present-compatible; any other non-affirmed label is withheld.
+    experiencer = assertion.experiencer or PATIENT_EXPERIENCER
+    if experiencer != PATIENT_EXPERIENCER:
+        return GROUNDING_NON_PATIENT
+    if assertion.negation not in (None, AFFIRMED):
+        return GROUNDING_REFUTED
+    if assertion.temporality == HYPOTHETICAL:
+        return GROUNDING_HYPOTHETICAL
+    if assertion.temporality != RECENT:
+        return GROUNDING_HISTORICAL
+    if assertion.certainty != CERTAIN:
+        return GROUNDING_UNCERTAIN
+    return GROUNDING_PRESENT
+
+
+@dataclass(frozen=True)
+class AssertedGroundedSpan:
+    """A grounded span enriched with its assertion axes and code-level status.
+
+    ``grounded`` is the original :class:`~openmed.clinical.exporters.codeable_concept.GroundedSpan`
+    (its candidates are stripped when the span is suppressed by policy).
+    ``assertion`` carries the four ConText/experiencer axes and ``status`` the
+    derived code-level status shared by every candidate of the span.
+    ``provenance`` records the governing cue offsets and axis labels only -- no
+    raw note text -- so the audit trail carries no PHI.
+    """
+
+    grounded: GroundedSpan
+    assertion: ClinicalAssertion
+    status: AssertionGroundingStatus
+    provenance: Mapping[str, Any]
+
+    @property
+    def is_active_patient_condition(self) -> bool:
+        """Whether this span may be emitted as an active patient ``Condition``."""
+
+        return self.status.is_active_patient_condition
+
+    def iter_coded_concepts(
+        self,
+    ) -> Iterator[tuple[Candidate, AssertionGroundingStatus]]:
+        """Yield ``(candidate, status)`` for every candidate of the span.
+
+        The focus concept and any composite or post-coordinated qualifier codes
+        inherit the identical span-level status, so a refuted or non-patient
+        span can never leave one of its codes asserted as present.
+        """
+
+        for candidate in self.grounded.candidates:
+            yield candidate, self.status
+
+
+def ground_with_context(
+    text: str,
+    spans: Iterable[GroundedSpan],
+    *,
+    policy: str = POLICY_STATUS,
+    language: str | None = None,
+    section_experiencer: str | None = None,
+) -> list[AssertedGroundedSpan]:
+    """Attach assertion axes and a code-level status to each grounded span.
+
+    Each span in ``spans`` is resolved against ``text`` for its ConText axes
+    (negation, temporality, certainty) and experiencer, composed into a
+    :class:`~openmed.clinical.context.ClinicalAssertion`, and tagged with an
+    :class:`AssertionGroundingStatus`. The safety invariant holds regardless of
+    policy: a denied, hypothetical, or non-patient span never returns a status
+    for which :attr:`AssertionGroundingStatus.is_active_patient_condition` is
+    true.
+
+    Args:
+        text: The source document text the span offsets index into.
+        spans: Grounded spans exposing ``text``/``start``/``end``/``candidates``
+            (typically :class:`~openmed.clinical.exporters.codeable_concept.GroundedSpan`).
+        policy: One of :data:`GROUNDING_POLICIES`. ``"status"`` (default) emits
+            every span carrying its status; ``"drop"`` omits non-present spans;
+            ``"suppress"`` keeps non-present spans with their candidates stripped.
+        language: Optional cue-lexicon language code; unknown codes fall back to
+            English for compatibility.
+        section_experiencer: Optional section-level experiencer prior applied
+            when no in-clause subject cue is found.
+
+    Returns:
+        One :class:`AssertedGroundedSpan` per retained span, in input order.
+
+    Raises:
+        ValueError: If ``policy`` is not one of :data:`GROUNDING_POLICIES`.
+    """
+
+    if policy not in GROUNDING_POLICIES:
+        raise ValueError(
+            f"policy must be one of {GROUNDING_POLICIES!r}, got {policy!r}"
+        )
+
+    results: list[AssertedGroundedSpan] = []
+    for grounded in spans:
+        assertion = _assert_span(text, grounded, language, section_experiencer)
+        status = assertion_grounding_status(assertion)
+        provenance = _build_provenance(text, grounded, assertion, status, language)
+
+        if not status.is_present:
+            if policy == POLICY_DROP:
+                continue
+            if policy == POLICY_SUPPRESS:
+                grounded = replace(grounded, candidates=())
+
+        results.append(
+            AssertedGroundedSpan(
+                grounded=grounded,
+                assertion=assertion,
+                status=status,
+                provenance=provenance,
+            )
+        )
+    return results
+
+
+def _span_mapping(text: str, grounded: GroundedSpan) -> dict[str, Any]:
+    return {
+        "text": grounded.text,
+        "context": text,
+        "start": grounded.start,
+        "end": grounded.end,
+    }
+
+
+def _assert_span(
+    text: str,
+    grounded: GroundedSpan,
+    language: str | None,
+    section_experiencer: str | None,
+) -> ClinicalAssertion:
+    span = _span_mapping(text, grounded)
+    context = resolve_span_context(span, language=language)
+    experiencer = resolve_experiencer(
+        text,
+        {"start": grounded.start, "end": grounded.end},
+        section_experiencer=section_experiencer,
+    )
+    return ClinicalAssertion(
+        temporality=context.temporality,
+        certainty=context.certainty,
+        negation=context.negation,
+        experiencer=experiencer.experiencer,
+    )
+
+
+def _build_provenance(
+    text: str,
+    grounded: GroundedSpan,
+    assertion: ClinicalAssertion,
+    status: AssertionGroundingStatus,
+    language: str | None,
+) -> dict[str, Any]:
+    """Record axis labels and cue offsets only -- never raw note text (no PHI)."""
+
+    span = {"start": grounded.start, "end": grounded.end}
+    scoped = scan_context_cues(text, [span], language=language)
+    cues: list[dict[str, Any]] = [
+        {"category": hit.category, "start": hit.start, "end": hit.end}
+        for hit in scoped.get(span, ())
+    ]
+
+    experiencer = resolve_experiencer(
+        text,
+        {"start": grounded.start, "end": grounded.end},
+        section_experiencer=None,
+    )
+    if experiencer.cue_offset is not None:
+        cues.append(
+            {
+                "category": "experiencer",
+                "start": experiencer.cue_offset[0],
+                "end": experiencer.cue_offset[1],
+            }
+        )
+    cues.sort(key=lambda cue: (cue["start"], cue["end"], cue["category"]))
+
+    payload: dict[str, Any] = {
+        "span_offset": [grounded.start, grounded.end],
+        "status": status.status,
+        "verification_status": status.verification_status,
+        "clinical_status": status.clinical_status,
+        "patient_subject": status.patient_subject,
+        "axes": assertion.to_dict(),
+        "cues": cues,
+    }
+    payload["content_hash"] = stable_hash(payload)
+    return payload

--- a/openmed/clinical/grounding/candidate_generator.py
+++ b/openmed/clinical/grounding/candidate_generator.py
@@ -1,0 +1,283 @@
+"""Sparse alias candidate generator over free clinical vocabularies.
+
+Turns a surface mention into ranked :class:`Candidate` objects by unioning
+exact normalized-alias hits with character n-gram TF-IDF fuzzy hits over a
+user-loaded free vocabulary (RxNorm, ICD-10-CM, LOINC, HPO, MeSH). No
+terminology content is bundled in the wheel; the caller supplies vocabularies
+through :class:`~openmed.clinical.grounding.vocab.VocabLoader`, and every
+emitted candidate carries provenance (``source='sparse'``, the matched alias,
+the match kind, and a content hash of the vocabulary snapshot) so downstream
+rankers and exporters can audit the source.
+
+The fuzzy stage is a self-contained, dependency-free character trigram TF-IDF
+cosine matcher, which keeps candidate generation fully offline and byte-for-byte
+deterministic across runs.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from collections.abc import Iterable, Sequence
+
+from .registry import register_linker
+from .types import Candidate
+from .vocab import VocabLoader, VocabularyIndex, normalize_alias
+
+__all__ = [
+    "SparseCandidateGenerator",
+    "generate_candidates",
+]
+
+#: Provenance tag stamped on every candidate this generator emits.
+SPARSE_SOURCE = "sparse"
+#: Registry key the generator registers under (resolved via ``get_linker``).
+SPARSE_LINKER_KEY = "sparse"
+
+_DEFAULT_TOP_K = 10
+_DEFAULT_NGRAM_SIZE = 3
+_DEFAULT_MIN_SIMILARITY = 0.3
+
+
+def _char_ngrams(text: str, ngram_size: int) -> tuple[str, ...]:
+    """Return boundary-padded character n-grams for a normalized surface."""
+
+    padded = f"#{text}#"
+    if len(padded) <= ngram_size:
+        return (padded,)
+    return tuple(
+        padded[index : index + ngram_size]
+        for index in range(len(padded) - ngram_size + 1)
+    )
+
+
+class _AliasNgramIndex:
+    """Character n-gram TF-IDF cosine index over one vocabulary's aliases."""
+
+    def __init__(self, aliases: Sequence[str], ngram_size: int) -> None:
+        self._ngram_size = ngram_size
+        self._aliases = tuple(aliases)
+        document_frequency: Counter[str] = Counter()
+        per_alias_grams: list[tuple[str, ...]] = []
+        for alias in self._aliases:
+            grams = _char_ngrams(alias, ngram_size)
+            per_alias_grams.append(grams)
+            document_frequency.update(set(grams))
+        document_count = len(self._aliases)
+        self._idf = {
+            gram: math.log((1.0 + document_count) / (1.0 + frequency)) + 1.0
+            for gram, frequency in document_frequency.items()
+        }
+        self._vectors = tuple(self._vectorize(grams) for grams in per_alias_grams)
+
+    def _vectorize(self, grams: Iterable[str]) -> dict[str, float]:
+        weights = {
+            gram: count * self._idf.get(gram, 0.0)
+            for gram, count in Counter(grams).items()
+        }
+        norm = math.sqrt(sum(weight * weight for weight in weights.values()))
+        if norm == 0.0:
+            return {}
+        return {gram: weight / norm for gram, weight in weights.items()}
+
+    def query(self, text: str, *, min_similarity: float) -> list[tuple[str, float]]:
+        """Return ``(alias, cosine_similarity)`` pairs above ``min_similarity``."""
+
+        query_vector = self._vectorize(_char_ngrams(text, self._ngram_size))
+        if not query_vector:
+            return []
+        results: list[tuple[str, float]] = []
+        for alias, vector in zip(self._aliases, self._vectors):
+            similarity = sum(
+                weight * vector[gram]
+                for gram, weight in query_vector.items()
+                if gram in vector
+            )
+            if similarity >= min_similarity:
+                results.append((alias, similarity))
+        results.sort(key=lambda item: (-item[1], item[0]))
+        return results
+
+
+class SparseCandidateGenerator:
+    """Emit provenance-carrying ``Candidate`` objects for a clinical mention.
+
+    Candidate generation unions two deterministic stages over each requested
+    free-vocabulary system: exact normalized-alias hits (score ``1.0``,
+    ``match_kind='exact'``) and character n-gram TF-IDF fuzzy hits (cosine
+    similarity, ``match_kind='fuzzy'``). Results are merged across systems,
+    de-duplicated per ``(system, code)`` keeping the strongest score, and
+    ordered by a stable tie-break (score descending, then system priority, then
+    concept id).
+
+    Note:
+        This is a candidate *generator* — its shape (a ``VocabLoader`` constructor
+        and a ``generate(mention, systems, k)`` method) intentionally differs from
+        the ``VocabLinker`` registry entries (constructed with a single
+        ``VocabularyIndex`` and exposing ``.link(...)``). Consume it via
+        ``generate_candidates`` or ``.generate``; it is not compatible with the
+        uniform ``get_linker(system)(get_index(system)).link(...)`` call path.
+
+    Args:
+        loader: Vocabulary loader supplying alias indexes. A default
+            :class:`~openmed.clinical.grounding.vocab.VocabLoader` is used when
+            omitted; the wheel ships no vocabulary content, so a loader without
+            a user-supplied source raises rather than returning bundled data.
+        ngram_size: Character n-gram size for the fuzzy stage (default ``3``).
+        min_similarity: Minimum cosine similarity for a fuzzy hit.
+    """
+
+    #: Provenance tag emitted on every candidate.
+    source = SPARSE_SOURCE
+
+    def __init__(
+        self,
+        loader: VocabLoader | None = None,
+        *,
+        ngram_size: int = _DEFAULT_NGRAM_SIZE,
+        min_similarity: float = _DEFAULT_MIN_SIMILARITY,
+    ) -> None:
+        if ngram_size < 1:
+            raise ValueError("ngram_size must be a positive integer")
+        if not 0.0 <= min_similarity <= 1.0:
+            raise ValueError("min_similarity must be between 0.0 and 1.0")
+        self._loader = loader if loader is not None else VocabLoader()
+        self._ngram_size = ngram_size
+        self._min_similarity = min_similarity
+        self._ngram_indexes: dict[str, _AliasNgramIndex] = {}
+
+    def generate(
+        self,
+        mention: str,
+        systems: Sequence[str],
+        k: int = _DEFAULT_TOP_K,
+        *,
+        min_similarity: float | None = None,
+    ) -> list[Candidate]:
+        """Return up to ``k`` ranked candidates for ``mention``.
+
+        Args:
+            mention: Surface span text to ground.
+            systems: Ordered free-vocabulary systems to search; earlier systems
+                win ties. Must be non-empty.
+            k: Maximum number of candidates to return.
+            min_similarity: Override for the instance fuzzy cutoff.
+
+        Raises:
+            ValueError: If ``systems`` is empty or ``k`` is not positive.
+            VocabLoaderError: If a requested system is unknown or has no source.
+        """
+
+        if not isinstance(mention, str):
+            raise TypeError("mention must be a string")
+        ordered_systems = tuple(systems)
+        if not ordered_systems:
+            raise ValueError("systems must contain at least one vocabulary system")
+        if k <= 0:
+            raise ValueError("k must be a positive integer")
+        cutoff = self._min_similarity if min_similarity is None else min_similarity
+
+        query = normalize_alias(mention)
+        if not query:
+            return []
+
+        priority = {system: rank for rank, system in enumerate(ordered_systems)}
+        best: dict[tuple[str, str], Candidate] = {}
+        for system in ordered_systems:
+            index = self._loader.get_index(system)
+            for candidate in self._candidates_for_system(index, query, cutoff):
+                key = (candidate.system, candidate.code)
+                existing = best.get(key)
+                if existing is None or candidate.score > existing.score:
+                    best[key] = candidate
+
+        ranked = sorted(
+            best.values(),
+            key=lambda candidate: (
+                -candidate.score,
+                priority.get(_priority_system(candidate.system, ordered_systems), 0),
+                candidate.code,
+            ),
+        )
+        return ranked[:k]
+
+    def _candidates_for_system(
+        self, index: VocabularyIndex, query: str, cutoff: float
+    ) -> list[Candidate]:
+        system = index.system.upper()
+        version = index.content_hash
+        best: dict[str, Candidate] = {}
+
+        for concept in index.lookup_all(query):
+            best[concept.code] = Candidate(
+                system=system,
+                code=concept.code,
+                display=concept.preferred_term,
+                score=1.0,
+                source=self.source,
+                matched_alias=query,
+                match_kind="exact",
+                vocab_version=version,
+            )
+
+        for alias, similarity in self._ngram_index(index).query(
+            query, min_similarity=cutoff
+        ):
+            score = round(float(similarity), 6)
+            for concept in index.lookup_all(alias):
+                existing = best.get(concept.code)
+                if existing is not None and existing.score >= score:
+                    continue
+                best[concept.code] = Candidate(
+                    system=system,
+                    code=concept.code,
+                    display=concept.preferred_term,
+                    score=score,
+                    source=self.source,
+                    matched_alias=alias,
+                    match_kind="fuzzy",
+                    vocab_version=version,
+                )
+        return list(best.values())
+
+    def _ngram_index(self, index: VocabularyIndex) -> _AliasNgramIndex:
+        cached = self._ngram_indexes.get(index.system)
+        if cached is None:
+            cached = _AliasNgramIndex(index.aliases, self._ngram_size)
+            self._ngram_indexes[index.system] = cached
+        return cached
+
+
+def _priority_system(candidate_system: str, ordered_systems: Sequence[str]) -> str:
+    """Resolve an emitted (upper-cased) system back to its request key."""
+
+    for system in ordered_systems:
+        if system.upper() == candidate_system.upper():
+            return system
+    return candidate_system
+
+
+def generate_candidates(
+    mention: str,
+    systems: Sequence[str],
+    k: int = _DEFAULT_TOP_K,
+    *,
+    loader: VocabLoader | None = None,
+    ngram_size: int = _DEFAULT_NGRAM_SIZE,
+    min_similarity: float = _DEFAULT_MIN_SIMILARITY,
+) -> list[Candidate]:
+    """Generate ranked sparse ``Candidate`` objects for a clinical mention.
+
+    Convenience wrapper around :class:`SparseCandidateGenerator`. See
+    :meth:`SparseCandidateGenerator.generate` for the ranking contract.
+    """
+
+    generator = SparseCandidateGenerator(
+        loader,
+        ngram_size=ngram_size,
+        min_similarity=min_similarity,
+    )
+    return generator.generate(mention, systems, k)
+
+
+register_linker(SPARSE_LINKER_KEY, SparseCandidateGenerator)

--- a/openmed/clinical/grounding/types.py
+++ b/openmed/clinical/grounding/types.py
@@ -12,6 +12,14 @@ class Candidate:
     ``system`` is the vocabulary (e.g. ``"RXNORM"``), ``code`` its identifier
     (e.g. an RxCUI), ``display`` a human-readable name, and ``score`` a
     ``0.0``-``1.0`` match confidence (``1.0`` for an exact alias match).
+
+    The optional provenance fields let downstream rankers and exporters audit
+    where a candidate came from without re-running retrieval.  ``source`` names
+    the generator that emitted it (e.g. ``"sparse"``), ``matched_alias`` is the
+    normalized vocabulary alias that matched (never the caller's raw span text),
+    ``match_kind`` records how it matched (``"exact"`` or ``"fuzzy"``), and
+    ``vocab_version`` is a content hash of the vocabulary snapshot the candidate
+    was drawn from.
     """
 
     system: str
@@ -19,3 +27,13 @@ class Candidate:
     display: str
     score: float
     source_language: str = "en"
+    source: str = ""
+    matched_alias: str | None = None
+    match_kind: str | None = None
+    vocab_version: str | None = None
+
+    @property
+    def concept_id(self) -> str:
+        """Alias for :attr:`code`, matching the free-vocabulary schema."""
+
+        return self.code

--- a/openmed/clinical/grounding/vocab.py
+++ b/openmed/clinical/grounding/vocab.py
@@ -202,6 +202,39 @@ class VocabularyIndex:
 
         return len(self._concepts)
 
+    @property
+    def content_hash(self) -> str:
+        """Return a stable SHA-256 hash of the indexed concept content.
+
+        The digest is computed over each concept's system, code, preferred term,
+        and normalized aliases in a canonical (sorted) order, so two indexes
+        built from the same vocabulary content hash identically regardless of
+        row order. Downstream consumers store this as a candidate's
+        ``vocab_version`` so a grounding result can be traced to its snapshot.
+        """
+
+        cached = getattr(self, "_content_hash", None)
+        if cached is not None:
+            return cached
+        digest = hashlib.sha256()
+        rows = sorted(
+            (
+                concept.system,
+                concept.code,
+                concept.preferred_term,
+                "\x1f".join(
+                    sorted(normalize_alias(alias) for alias in concept.aliases)
+                ),
+            )
+            for concept in self._concepts
+        )
+        for row in rows:
+            digest.update("\x1e".join(row).encode("utf-8"))
+            digest.update(b"\x1d")
+        content_hash = f"sha256:{digest.hexdigest()}"
+        self._content_hash = content_hash
+        return content_hash
+
     def lookup(
         self, alias: object, *, language: object | None = None
     ) -> VocabConcept | None:
@@ -806,6 +839,7 @@ def _concept_from_mapping(
     code = _first_value(
         normalized_row,
         "code",
+        "concept_id",
         "concept_code",
         "id",
         "loinc_num",
@@ -815,6 +849,7 @@ def _concept_from_mapping(
     preferred = _first_value(
         normalized_row,
         "preferred_term",
+        "canonical_term",
         "preferred",
         "term",
         "name",

--- a/openmed/eval/golden/fixtures/grounding_vocab_synthetic.jsonl
+++ b/openmed/eval/golden/fixtures/grounding_vocab_synthetic.jsonl
@@ -1,0 +1,45 @@
+{"aliases": ["type 2 diabetes", "type ii diabetes mellitus", "t2dm", "dm type 2"], "canonical_term": "Type 2 diabetes mellitus without complications", "concept_id": "E11.9", "system": "icd10cm"}
+{"aliases": ["type 2 diabetes with hyperglycemia", "t2dm with high glucose"], "canonical_term": "Type 2 diabetes mellitus with hyperglycemia", "concept_id": "E11.65", "system": "icd10cm"}
+{"aliases": ["type 2 diabetes with nephropathy", "t2dm kidney disease"], "canonical_term": "Type 2 diabetes mellitus with diabetic nephropathy", "concept_id": "E11.21", "system": "icd10cm"}
+{"aliases": ["high blood pressure", "essential hypertension", "htn"], "canonical_term": "Essential (primary) hypertension", "concept_id": "I10", "system": "icd10cm"}
+{"aliases": ["pneumonia", "lung infection unspecified"], "canonical_term": "Pneumonia, unspecified organism", "concept_id": "J18.9", "system": "icd10cm"}
+{"aliases": ["renal disorder zeta001", "zeta001 renal syndrome", "synthetic zeta001 condition"], "canonical_term": "Synthetic renal disorder zeta001", "concept_id": "RXNORM-0001", "system": "rxnorm"}
+{"aliases": ["cardiac disorder zeta002", "zeta002 cardiac syndrome", "synthetic zeta002 condition"], "canonical_term": "Synthetic cardiac disorder zeta002", "concept_id": "LOINC-0002", "system": "loinc"}
+{"aliases": ["pulmonary disorder zeta003", "zeta003 pulmonary syndrome", "synthetic zeta003 condition"], "canonical_term": "Synthetic pulmonary disorder zeta003", "concept_id": "HPO-0003", "system": "hpo"}
+{"aliases": ["gastric disorder zeta004", "zeta004 gastric syndrome", "synthetic zeta004 condition"], "canonical_term": "Synthetic gastric disorder zeta004", "concept_id": "MESH-0004", "system": "mesh"}
+{"aliases": ["cerebral disorder zeta005", "zeta005 cerebral syndrome", "synthetic zeta005 condition"], "canonical_term": "Synthetic cerebral disorder zeta005", "concept_id": "ICD10CM-0005", "system": "icd10cm"}
+{"aliases": ["cutaneous disorder zeta006", "zeta006 cutaneous syndrome", "synthetic zeta006 condition"], "canonical_term": "Synthetic cutaneous disorder zeta006", "concept_id": "RXNORM-0006", "system": "rxnorm"}
+{"aliases": ["skeletal disorder zeta007", "zeta007 skeletal syndrome", "synthetic zeta007 condition"], "canonical_term": "Synthetic skeletal disorder zeta007", "concept_id": "LOINC-0007", "system": "loinc"}
+{"aliases": ["vascular disorder zeta008", "zeta008 vascular syndrome", "synthetic zeta008 condition"], "canonical_term": "Synthetic vascular disorder zeta008", "concept_id": "HPO-0008", "system": "hpo"}
+{"aliases": ["thyroid disorder zeta009", "zeta009 thyroid syndrome", "synthetic zeta009 condition"], "canonical_term": "Synthetic thyroid disorder zeta009", "concept_id": "MESH-0009", "system": "mesh"}
+{"aliases": ["hepatic disorder zeta010", "zeta010 hepatic syndrome", "synthetic zeta010 condition"], "canonical_term": "Synthetic hepatic disorder zeta010", "concept_id": "ICD10CM-0010", "system": "icd10cm"}
+{"aliases": ["renal disorder zeta011", "zeta011 renal syndrome", "synthetic zeta011 condition"], "canonical_term": "Synthetic renal disorder zeta011", "concept_id": "RXNORM-0011", "system": "rxnorm"}
+{"aliases": ["cardiac disorder zeta012", "zeta012 cardiac syndrome", "synthetic zeta012 condition"], "canonical_term": "Synthetic cardiac disorder zeta012", "concept_id": "LOINC-0012", "system": "loinc"}
+{"aliases": ["pulmonary disorder zeta013", "zeta013 pulmonary syndrome", "synthetic zeta013 condition"], "canonical_term": "Synthetic pulmonary disorder zeta013", "concept_id": "HPO-0013", "system": "hpo"}
+{"aliases": ["gastric disorder zeta014", "zeta014 gastric syndrome", "synthetic zeta014 condition"], "canonical_term": "Synthetic gastric disorder zeta014", "concept_id": "MESH-0014", "system": "mesh"}
+{"aliases": ["cerebral disorder zeta015", "zeta015 cerebral syndrome", "synthetic zeta015 condition"], "canonical_term": "Synthetic cerebral disorder zeta015", "concept_id": "ICD10CM-0015", "system": "icd10cm"}
+{"aliases": ["cutaneous disorder zeta016", "zeta016 cutaneous syndrome", "synthetic zeta016 condition"], "canonical_term": "Synthetic cutaneous disorder zeta016", "concept_id": "RXNORM-0016", "system": "rxnorm"}
+{"aliases": ["skeletal disorder zeta017", "zeta017 skeletal syndrome", "synthetic zeta017 condition"], "canonical_term": "Synthetic skeletal disorder zeta017", "concept_id": "LOINC-0017", "system": "loinc"}
+{"aliases": ["vascular disorder zeta018", "zeta018 vascular syndrome", "synthetic zeta018 condition"], "canonical_term": "Synthetic vascular disorder zeta018", "concept_id": "HPO-0018", "system": "hpo"}
+{"aliases": ["thyroid disorder zeta019", "zeta019 thyroid syndrome", "synthetic zeta019 condition"], "canonical_term": "Synthetic thyroid disorder zeta019", "concept_id": "MESH-0019", "system": "mesh"}
+{"aliases": ["hepatic disorder zeta020", "zeta020 hepatic syndrome", "synthetic zeta020 condition"], "canonical_term": "Synthetic hepatic disorder zeta020", "concept_id": "ICD10CM-0020", "system": "icd10cm"}
+{"aliases": ["renal disorder zeta021", "zeta021 renal syndrome", "synthetic zeta021 condition"], "canonical_term": "Synthetic renal disorder zeta021", "concept_id": "RXNORM-0021", "system": "rxnorm"}
+{"aliases": ["cardiac disorder zeta022", "zeta022 cardiac syndrome", "synthetic zeta022 condition"], "canonical_term": "Synthetic cardiac disorder zeta022", "concept_id": "LOINC-0022", "system": "loinc"}
+{"aliases": ["pulmonary disorder zeta023", "zeta023 pulmonary syndrome", "synthetic zeta023 condition"], "canonical_term": "Synthetic pulmonary disorder zeta023", "concept_id": "HPO-0023", "system": "hpo"}
+{"aliases": ["gastric disorder zeta024", "zeta024 gastric syndrome", "synthetic zeta024 condition"], "canonical_term": "Synthetic gastric disorder zeta024", "concept_id": "MESH-0024", "system": "mesh"}
+{"aliases": ["cerebral disorder zeta025", "zeta025 cerebral syndrome", "synthetic zeta025 condition"], "canonical_term": "Synthetic cerebral disorder zeta025", "concept_id": "ICD10CM-0025", "system": "icd10cm"}
+{"aliases": ["cutaneous disorder zeta026", "zeta026 cutaneous syndrome", "synthetic zeta026 condition"], "canonical_term": "Synthetic cutaneous disorder zeta026", "concept_id": "RXNORM-0026", "system": "rxnorm"}
+{"aliases": ["skeletal disorder zeta027", "zeta027 skeletal syndrome", "synthetic zeta027 condition"], "canonical_term": "Synthetic skeletal disorder zeta027", "concept_id": "LOINC-0027", "system": "loinc"}
+{"aliases": ["vascular disorder zeta028", "zeta028 vascular syndrome", "synthetic zeta028 condition"], "canonical_term": "Synthetic vascular disorder zeta028", "concept_id": "HPO-0028", "system": "hpo"}
+{"aliases": ["thyroid disorder zeta029", "zeta029 thyroid syndrome", "synthetic zeta029 condition"], "canonical_term": "Synthetic thyroid disorder zeta029", "concept_id": "MESH-0029", "system": "mesh"}
+{"aliases": ["hepatic disorder zeta030", "zeta030 hepatic syndrome", "synthetic zeta030 condition"], "canonical_term": "Synthetic hepatic disorder zeta030", "concept_id": "ICD10CM-0030", "system": "icd10cm"}
+{"aliases": ["renal disorder zeta031", "zeta031 renal syndrome", "synthetic zeta031 condition"], "canonical_term": "Synthetic renal disorder zeta031", "concept_id": "RXNORM-0031", "system": "rxnorm"}
+{"aliases": ["cardiac disorder zeta032", "zeta032 cardiac syndrome", "synthetic zeta032 condition"], "canonical_term": "Synthetic cardiac disorder zeta032", "concept_id": "LOINC-0032", "system": "loinc"}
+{"aliases": ["pulmonary disorder zeta033", "zeta033 pulmonary syndrome", "synthetic zeta033 condition"], "canonical_term": "Synthetic pulmonary disorder zeta033", "concept_id": "HPO-0033", "system": "hpo"}
+{"aliases": ["gastric disorder zeta034", "zeta034 gastric syndrome", "synthetic zeta034 condition"], "canonical_term": "Synthetic gastric disorder zeta034", "concept_id": "MESH-0034", "system": "mesh"}
+{"aliases": ["cerebral disorder zeta035", "zeta035 cerebral syndrome", "synthetic zeta035 condition"], "canonical_term": "Synthetic cerebral disorder zeta035", "concept_id": "ICD10CM-0035", "system": "icd10cm"}
+{"aliases": ["cutaneous disorder zeta036", "zeta036 cutaneous syndrome", "synthetic zeta036 condition"], "canonical_term": "Synthetic cutaneous disorder zeta036", "concept_id": "RXNORM-0036", "system": "rxnorm"}
+{"aliases": ["skeletal disorder zeta037", "zeta037 skeletal syndrome", "synthetic zeta037 condition"], "canonical_term": "Synthetic skeletal disorder zeta037", "concept_id": "LOINC-0037", "system": "loinc"}
+{"aliases": ["vascular disorder zeta038", "zeta038 vascular syndrome", "synthetic zeta038 condition"], "canonical_term": "Synthetic vascular disorder zeta038", "concept_id": "HPO-0038", "system": "hpo"}
+{"aliases": ["thyroid disorder zeta039", "zeta039 thyroid syndrome", "synthetic zeta039 condition"], "canonical_term": "Synthetic thyroid disorder zeta039", "concept_id": "MESH-0039", "system": "mesh"}
+{"aliases": ["hepatic disorder zeta040", "zeta040 hepatic syndrome", "synthetic zeta040 condition"], "canonical_term": "Synthetic hepatic disorder zeta040", "concept_id": "ICD10CM-0040", "system": "icd10cm"}

--- a/openmed/eval/golden/loader.py
+++ b/openmed/eval/golden/loader.py
@@ -48,6 +48,7 @@ _SPECIALIZED_FIXTURE_NAMES = frozenset(
         "context_multilingual.jsonl",
         "code_mixed_deidentification.jsonl",
         "grounding_crosslingual.jsonl",
+        "grounding_vocab_synthetic.jsonl",
         "india_clinical.jsonl",
         "indic_name_variants.json",
         "relation_assertion.jsonl",

--- a/tests/unit/clinical/grounding/test_assertion_grounding.py
+++ b/tests/unit/clinical/grounding/test_assertion_grounding.py
@@ -1,0 +1,273 @@
+"""Assertion-aware grounding: safety invariants, policy, and the trap gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from openmed.clinical.context import ClinicalAssertion
+from openmed.clinical.exporters.codeable_concept import GroundedSpan
+from openmed.clinical.exporters.fhir.condition import to_condition
+from openmed.clinical.grounding import (
+    Candidate,
+    ground_with_context,
+)
+from openmed.clinical.grounding.assertion_grounding import (
+    GROUNDING_ASSERTION_STATUSES,
+    GROUNDING_HISTORICAL,
+    GROUNDING_HYPOTHETICAL,
+    GROUNDING_NON_PATIENT,
+    GROUNDING_PRESENT,
+    GROUNDING_REFUTED,
+    GROUNDING_UNCERTAIN,
+    POLICY_DROP,
+    POLICY_STATUS,
+    POLICY_SUPPRESS,
+    assertion_grounding_status,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+TRAP_SUITE_PATH = REPO_ROOT / "eval" / "suites" / "negation_grounding_traps.py"
+
+
+def _load_trap_suite():
+    """Load the out-of-package trap suite by file path (repo's script pattern)."""
+
+    module_name = "negation_grounding_traps"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, TRAP_SUITE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+traps = _load_trap_suite()
+
+
+def _span(text: str, surface: str, *candidates: Candidate) -> GroundedSpan:
+    start = text.index(surface)
+    return GroundedSpan(
+        text=surface,
+        start=start,
+        end=start + len(surface),
+        candidates=candidates
+        or (Candidate(system="ICD10CM", code="J18.9", display=surface, score=1.0),),
+    )
+
+
+def _only(text: str, surface: str, *candidates: Candidate):
+    return ground_with_context(text, [_span(text, surface, *candidates)])[0]
+
+
+# --- Acceptance: axes attached and code-level status set -------------------
+
+
+def test_ground_with_context_attaches_all_four_axes():
+    asserted = _only("The patient has acute pneumonia.", "pneumonia")
+
+    assert asserted.assertion.negation == "affirmed"
+    assert asserted.assertion.temporality == "recent"
+    assert asserted.assertion.certainty == "certain"
+    assert asserted.assertion.experiencer == "patient"
+    assert asserted.status.status == GROUNDING_PRESENT
+
+
+def test_status_labels_are_from_the_published_set():
+    for text, surface in (
+        ("No evidence of pneumonia.", "pneumonia"),
+        ("Return if pneumonia develops.", "pneumonia"),
+        ("Family history of colon cancer.", "colon cancer"),
+        ("History of pneumonia, resolved.", "pneumonia"),
+        ("Possible pneumonia.", "pneumonia"),
+        ("The patient has acute pneumonia.", "pneumonia"),
+    ):
+        asserted = _only(text, surface)
+        assert asserted.status.status in GROUNDING_ASSERTION_STATUSES
+
+
+# --- Acceptance: the four safety proofs ------------------------------------
+
+
+def test_negated_finding_is_never_present():
+    asserted = _only("No evidence of pneumonia.", "pneumonia")
+
+    assert asserted.status.status == GROUNDING_REFUTED
+    assert asserted.status.verification_status == "refuted"
+    assert not asserted.status.is_present
+    assert not asserted.is_active_patient_condition
+
+
+def test_hypothetical_finding_is_never_present():
+    asserted = _only(
+        "Start heparin if pulmonary embolism is suspected.", "pulmonary embolism"
+    )
+
+    assert asserted.status.status == GROUNDING_HYPOTHETICAL
+    assert not asserted.is_active_patient_condition
+
+
+def test_family_history_is_not_coded_to_the_patient():
+    asserted = _only("Family history of colon cancer.", "colon cancer")
+
+    assert asserted.status.status == GROUNDING_NON_PATIENT
+    assert not asserted.status.patient_subject
+    assert not asserted.is_active_patient_condition
+    assert to_condition(asserted, subject_reference="Patient/1") is None
+
+
+def test_affirmed_finding_still_grounds_normally():
+    asserted = _only(
+        "The patient has acute myocardial infarction.", "myocardial infarction"
+    )
+
+    assert asserted.status.status == GROUNDING_PRESENT
+    assert asserted.is_active_patient_condition
+    condition = to_condition(asserted, subject_reference="Patient/1")
+    assert condition is not None
+    assert condition["clinicalStatus"]["coding"][0]["code"] == "active"
+    assert condition["verificationStatus"]["coding"][0]["code"] == "confirmed"
+    assert condition["code"]["coding"][0]["code"] == "J18.9"
+
+
+# --- Historical / uncertain mapping ----------------------------------------
+
+
+def test_historical_maps_to_inactive():
+    asserted = _only("History of pneumonia, now resolved.", "pneumonia")
+
+    assert asserted.status.status == GROUNDING_HISTORICAL
+    assert asserted.status.clinical_status == "inactive"
+    assert not asserted.is_active_patient_condition
+
+
+def test_uncertain_maps_to_provisional():
+    asserted = _only("Possible pneumonia pending imaging.", "pneumonia")
+
+    assert asserted.status.status == GROUNDING_UNCERTAIN
+    assert asserted.status.verification_status == "provisional"
+
+
+# --- Composite / post-coordinated inheritance ------------------------------
+
+
+def test_composite_candidates_inherit_the_focus_status():
+    focus = Candidate(system="ICD10CM", code="J18.9", display="pneumonia", score=1.0)
+    qualifier = Candidate(system="SNOMED", code="263654008", display="acute", score=0.9)
+    asserted = _only("No evidence of pneumonia.", "pneumonia", focus, qualifier)
+
+    statuses = [status for _candidate, status in asserted.iter_coded_concepts()]
+    assert len(statuses) == 2
+    assert all(status.status == GROUNDING_REFUTED for status in statuses)
+    assert not any(status.is_active_patient_condition for status in statuses)
+
+
+# --- Policy invariants ------------------------------------------------------
+
+
+def test_policy_status_keeps_every_span_with_status():
+    text = "No evidence of pneumonia. The patient has acute diabetes mellitus."
+    spans = [_span(text, "pneumonia"), _span(text, "diabetes mellitus")]
+    results = ground_with_context(text, spans, policy=POLICY_STATUS)
+
+    assert len(results) == 2
+    assert results[0].status.status == GROUNDING_REFUTED
+    assert results[0].grounded.candidates  # candidates retained under status
+    assert results[1].status.status == GROUNDING_PRESENT
+
+
+def test_policy_drop_removes_non_present_spans():
+    text = "No evidence of pneumonia. The patient has acute diabetes mellitus."
+    spans = [_span(text, "pneumonia"), _span(text, "diabetes mellitus")]
+    results = ground_with_context(text, spans, policy=POLICY_DROP)
+
+    assert [r.status.status for r in results] == [GROUNDING_PRESENT]
+    # Invariant: nothing that survives drop is anything but an active patient code.
+    assert all(r.is_active_patient_condition for r in results)
+
+
+def test_policy_suppress_strips_candidates_but_keeps_the_span():
+    asserted = ground_with_context(
+        "No evidence of pneumonia.",
+        [_span("No evidence of pneumonia.", "pneumonia")],
+        policy=POLICY_SUPPRESS,
+    )[0]
+
+    assert asserted.status.status == GROUNDING_REFUTED
+    assert asserted.grounded.candidates == ()
+
+
+def test_unknown_policy_is_rejected():
+    with pytest.raises(ValueError):
+        ground_with_context("x", [], policy="bogus")
+
+
+# --- Provenance carries no raw note text (no PHI) --------------------------
+
+
+def test_provenance_records_offsets_and_labels_without_note_text():
+    text = "No evidence of pneumonia."
+    asserted = _only(text, "pneumonia")
+    provenance = asserted.provenance
+
+    assert provenance["status"] == GROUNDING_REFUTED
+    assert provenance["axes"]["negation"] == "negated"
+    assert {"category": "negation", "start": 0, "end": 14} in provenance["cues"]
+    assert provenance["content_hash"].startswith("sha256:")
+
+    serialized = json.dumps(provenance)
+    assert "pneumonia" not in serialized
+    assert "No evidence of" not in serialized
+
+
+# --- The curated trap suite is the hard release gate -----------------------
+
+
+def test_trap_suite_has_no_active_patient_condition_leaks():
+    leaks = traps.active_patient_condition_leaks()
+    assert leaks == [], [case.text for case in leaks]
+
+
+def test_trap_suite_status_mapping_accuracy_at_least_090():
+    assert traps.status_mapping_accuracy() >= 0.90
+
+
+def test_trap_gold_covers_every_status():
+    covered = {case.expected_status for case in traps.TRAP_CASES}
+    assert covered == set(GROUNDING_ASSERTION_STATUSES)
+
+
+def test_non_canonical_axis_labels_fail_closed():
+    # A foreign producer (e.g. an ML tagger) emitting a non-canonical axis label
+    # must fail CLOSED — never a confirmed, active, patient-coded condition.
+    neg = assertion_grounding_status(
+        ClinicalAssertion(temporality="recent", certainty="certain", negation="neg")
+    )
+    assert neg.status != GROUNDING_PRESENT
+    assert not neg.is_active_patient_condition
+
+    temp = assertion_grounding_status(
+        ClinicalAssertion(temporality="whenever", certainty="certain")
+    )
+    assert temp.status != GROUNDING_PRESENT
+    assert not temp.is_active_patient_condition
+
+    # An unknown certainty is withheld from "present" (provisional, not confirmed).
+    cert = assertion_grounding_status(
+        ClinicalAssertion(temporality="recent", certainty="maybe")
+    )
+    assert cert.status != GROUNDING_PRESENT
+    assert cert.verification_status != "confirmed"
+
+    # An unset negation (None) remains present-compatible — no false refutation.
+    affirmed = assertion_grounding_status(
+        ClinicalAssertion(temporality="recent", certainty="certain")
+    )
+    assert affirmed.status == GROUNDING_PRESENT
+    assert affirmed.is_active_patient_condition

--- a/tests/unit/clinical/grounding/test_candidate_generator.py
+++ b/tests/unit/clinical/grounding/test_candidate_generator.py
@@ -1,0 +1,211 @@
+"""Tests for the sparse alias candidate generator.
+
+All vocabulary content is synthetic and algorithmically generated; no real
+patient data or licensed terminology is used.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.clinical.grounding import (
+    Candidate,
+    SparseCandidateGenerator,
+    generate_candidates,
+    get_linker,
+)
+from openmed.clinical.grounding.vocab import (
+    VocabLoader,
+    VocabLoaderError,
+    VocabSource,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_FIXTURE = _REPO_ROOT / "openmed/eval/golden/fixtures/grounding_vocab_synthetic.jsonl"
+_SYSTEMS = ("icd10cm", "rxnorm", "loinc", "hpo", "mesh")
+
+
+def _fixture_rows() -> list[dict]:
+    return [
+        json.loads(line)
+        for line in _FIXTURE.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _loader(tmp_path: Path, path: Path = _FIXTURE) -> VocabLoader:
+    sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+    registry = {
+        system: VocabSource(system=system, path=path, sha256=sha256)
+        for system in _SYSTEMS
+    }
+    return VocabLoader(cache_dir=tmp_path / "cache", registry=registry)
+
+
+def test_generate_returns_e11_family_top_result(tmp_path):
+    candidates = generate_candidates(
+        "type 2 diabetes",
+        systems=["icd10cm"],
+        loader=_loader(tmp_path),
+    )
+
+    assert candidates
+    top = candidates[0]
+    assert isinstance(top, Candidate)
+    assert top.system == "ICD10CM"
+    assert top.code == "E11.9"
+    assert top.concept_id == "E11.9"
+    assert top.code.startswith("E11")
+    assert top.match_kind == "exact"
+    assert top.score == 1.0
+
+
+def test_every_candidate_carries_provenance(tmp_path):
+    candidates = generate_candidates(
+        "type 2 diabetes",
+        systems=["icd10cm"],
+        loader=_loader(tmp_path),
+    )
+
+    assert candidates
+    for candidate in candidates:
+        assert candidate.source == "sparse"
+        assert candidate.matched_alias
+        assert candidate.match_kind in {"exact", "fuzzy"}
+        assert candidate.vocab_version
+        assert candidate.vocab_version.startswith("sha256:")
+
+
+def test_fuzzy_match_recovers_misspelled_mention(tmp_path):
+    candidates = generate_candidates(
+        "type 2 diabetis mellitis",
+        systems=["icd10cm"],
+        loader=_loader(tmp_path),
+    )
+
+    codes = {candidate.code for candidate in candidates}
+    assert "E11.9" in codes
+    recovered = next(candidate for candidate in candidates if candidate.code == "E11.9")
+    assert recovered.match_kind == "fuzzy"
+    assert 0.0 < recovered.score < 1.0
+
+
+def test_results_are_byte_identical_across_runs(tmp_path):
+    first = generate_candidates(
+        "high blood pressure", systems=list(_SYSTEMS), loader=_loader(tmp_path)
+    )
+    second = generate_candidates(
+        "high blood pressure", systems=list(_SYSTEMS), loader=_loader(tmp_path)
+    )
+
+    assert [repr(candidate) for candidate in first] == [
+        repr(candidate) for candidate in second
+    ]
+
+
+def test_tie_break_prefers_earlier_system_then_concept_id(tmp_path):
+    shared = tmp_path / "shared.jsonl"
+    shared.write_text(
+        json.dumps(
+            {
+                "concept_id": "RX-1",
+                "system": "rxnorm",
+                "canonical_term": "Shared synthetic agent",
+                "aliases": ["shared synthetic term"],
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "concept_id": "ICD-1",
+                "system": "icd10cm",
+                "canonical_term": "Shared synthetic disorder",
+                "aliases": ["shared synthetic term"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    loader = _loader(tmp_path, path=shared)
+
+    icd_first = generate_candidates(
+        "shared synthetic term", systems=["icd10cm", "rxnorm"], loader=loader
+    )
+    rx_first = generate_candidates(
+        "shared synthetic term", systems=["rxnorm", "icd10cm"], loader=loader
+    )
+
+    assert [candidate.score for candidate in icd_first] == [1.0, 1.0]
+    assert icd_first[0].system == "ICD10CM"
+    assert rx_first[0].system == "RXNORM"
+
+
+def test_unknown_system_raises_clear_error(tmp_path):
+    with pytest.raises(VocabLoaderError, match="Unsupported free vocabulary system"):
+        generate_candidates(
+            "type 2 diabetes",
+            systems=["not_a_system"],
+            loader=_loader(tmp_path),
+        )
+
+
+def test_grounding_subpackage_ships_no_vocabulary_content():
+    # The grounding subpackage itself ships no vocabulary tables — vocab data is
+    # user-supplied at runtime. (The only bundled grounding data is a synthetic
+    # eval fixture under openmed/eval/golden/fixtures/, following the existing
+    # grounding_crosslingual.jsonl precedent; no licensed/real terminology ships.)
+    import openmed.clinical.grounding as grounding
+
+    package_dir = Path(grounding.__file__).resolve().parent
+    vocab_suffixes = {".tsv", ".rrf", ".obo", ".csv", ".jsonl", ".txt", ".xml"}
+    bundled = [
+        path
+        for path in package_dir.rglob("*")
+        if path.is_file() and path.suffix.lower() in vocab_suffixes
+    ]
+    assert bundled == []
+
+
+def test_generator_is_resolvable_via_registry(tmp_path):
+    factory = get_linker("sparse")
+    assert factory is SparseCandidateGenerator
+
+    generator = factory(_loader(tmp_path))
+    candidates = generator.generate("type 2 diabetes", ["icd10cm"], k=3)
+    assert candidates[0].code == "E11.9"
+    assert len(candidates) <= 3
+
+
+def test_top5_recall_meets_threshold_on_synthetic_gold(tmp_path):
+    loader = _loader(tmp_path)
+    generator = SparseCandidateGenerator(loader)
+
+    gold: list[tuple[str, str]] = []
+    for row in _fixture_rows():
+        for alias in row["aliases"]:
+            gold.append((alias, row["concept_id"]))
+
+    mentions: list[tuple[str, str]] = []
+    index = 0
+    while len(mentions) < 200:
+        alias, code = gold[index % len(gold)]
+        # Perturb roughly one in five mentions with a deterministic single-char
+        # substitution to exercise the fuzzy stage.
+        if index % 5 == 0 and len(alias) > 8:
+            midpoint = len(alias) // 2
+            alias = alias[:midpoint] + "x" + alias[midpoint + 1 :]
+        mentions.append((alias, code))
+        index += 1
+
+    hits = 0
+    for mention, code in mentions:
+        candidates = generator.generate(mention, list(_SYSTEMS), k=5)
+        if code in {candidate.code for candidate in candidates}:
+            hits += 1
+
+    recall = hits / len(mentions)
+    assert recall >= 0.85


### PR DESCRIPTION
> **Stacked on #1911** (`feat/grounding-alias-candidate-generator`, issue #1796). Until #1911 merges, this PR's diff also shows #1796's commit; please merge #1911 first.

## Summary

Adds an assertion-aware grounding layer whose core safety invariant is: **a negated / hypothetical / historical / non-patient finding can never be emitted as a confirmed, active, patient-coded concept.**

- **`openmed/clinical/grounding/assertion_grounding.py`** — `ground_with_context(text, spans, *, policy, language, section_experiencer)` composes the four ConText axes (via the existing `resolve_span_context` + `resolve_experiencer`), and `assertion_grounding_status` collapses them to one dominant status by a fixed **safety precedence** (non-patient → refuted → hypothetical → historical → uncertain → present) mapped to `(verification_status, clinical_status, patient_subject)`. The invariant `AssertionGroundingStatus.is_active_patient_condition` is true only for an affirmed, active, patient finding. `iter_coded_concepts()` makes every candidate (incl. composite/post-coordinated) inherit the focus status. Policy switch: `status` (annotate) / `drop` / `suppress`.
- **`openmed/clinical/exporters/fhir/condition.py`** — `to_condition`, emitting a FHIR Condition with the vetted status (or `None` for non-patient).
- **`eval/suites/negation_grounding_traps.py`** — a 60-case negation/hypothetical/family trap suite with a hard gate: **0 active-patient-condition leaks**, status-mapping accuracy 1.0.
- Additive grounding + FHIR `__init__` exports; tests. `Candidate`/`types.py` untouched.

Closes #1234.

## Post-review hardening (independent SAFETY review)

The reviewer confirmed the primary path (`ground_with_context` → `to_condition`) is airtight — double-negation, negation+family, and hypothetical-as-affirmative all resolve safely, and the trap gate is genuine (real cue detection, not gold-injected). It flagged one **fail-open** gap and I fixed it:

- **`_dominant_status` now fails CLOSED on non-canonical axis labels.** It previously *denylisted* the withheld poles (only the exact literal `"negated"`, etc.) with `present` as the fall-through default, so a foreign producer emitting e.g. `"neg"` instead of `"negated"` collapsed to confirmed+active — the exact failure the module promises is impossible. The negation/temporality/certainty axes are now **allowlisted** to their asserted poles (mirroring how experiencer already worked): any unrecognized label falls through to a withheld status. An **unset** negation (`None`, "axis not composed") stays present-compatible, so normal affirmed findings are unaffected. Added `test_non_canonical_axis_labels_fail_closed`.

## Deviations / judgment calls

- **Experiencer precedence sits above negation** (a family+negated finding reads more truthfully as non-patient); both routes are safe.
- **`context.py` left unmodified** — the ConText axes were already fully consumable; editing would be non-additive churn.
- **Trap suite loaded by file path** (`importlib`) since top-level `eval/` is not a pytest testpath/package (repo's own script pattern).
- **`uncertain` is intentionally active/provisional** (not confirmed) — consumers must pair `is_active_patient_condition` with `verification_status`; it never satisfies the confirmed+active target.

## Known follow-up (disclosed)

- **Coverage is bounded by the ConText cue lexicon** (base-layer, not in this diff): a risk phrasing absent from `context.py` (e.g. "at risk for X") defaults to present. This layer faithfully consumes the axes; strengthening `HYPOTHETICAL_CUES`/`UNCERTAINTY_CUES` is base-layer work.

## Data provenance

All trap/test clinical text is synthetic and algorithmically templated with illustrative (non-licensed) codes; provenance records only offsets/labels/cue-categories + a `sha256:` hash — no raw note text.

## Verification

- **Safety:** the reviewer could not construct any confirmed+active leak through the wired path; the fail-closed fix closes the low-level foreign-label gap; trap suite = 60 cases, 36 hard-gate, **0 leaks**, mapping accuracy 1.0.
- `make test`: **8883 passed, 82 skipped, 27 failed** — all 27 the documented pre-existing env-only failures. `tests/unit/clinical/grounding/test_assertion_grounding.py`: 18 passed. API-surface + public-docstring drift gates green. No import cycle (grounding↔exporters via `TYPE_CHECKING`).
- `pre-commit` on changed files: all hooks pass. `git rev-list --count feat/grounding-alias-candidate-generator..HEAD` = 1.

## Relationship

Wave 2 of the Concept-Grounding roadmap, stacked on the #1796 Candidate contract (#1911); consumes the existing ConText/experiencer infra unchanged.
