### PR TITLE
feat: expose FHIR bundle, re-identification risk, signed audit and model-search as agent tools

### DIFF
--- a/openmed/interop/function_tools.py
+++ b/openmed/interop/function_tools.py
@@ -111,6 +111,21 @@ def _tool_handler(
             **kwargs,
             runtime_provider=runtime_provider,
         ),
+        "openmed_fhir_bundle": lambda **kwargs: mcp_server.openmed_fhir_bundle(
+            **kwargs
+        ),
+        "openmed_risk_report": lambda **kwargs: mcp_server.openmed_risk_report(
+            **kwargs
+        ),
+        "openmed_signed_audit_report": (
+            lambda **kwargs: mcp_server.openmed_signed_audit_report(
+                **kwargs,
+                runtime_provider=runtime_provider,
+            )
+        ),
+        "openmed_search_models": lambda **kwargs: mcp_server.openmed_search_models(
+            **kwargs
+        ),
     }
     try:
         return handlers[name]

--- a/openmed/interop/tools.json
+++ b/openmed/interop/tools.json
@@ -612,6 +612,97 @@
       "version": "1.0.0"
     },
     {
+      "description": "Assemble FHIR resources into a R4 bundle. ",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "bundle_type": {
+            "default": "transaction",
+            "enum": [
+              "transaction",
+              "batch",
+              "collection"
+            ],
+            "type": "string"
+          },
+          "doc_id": {
+            "default": "openmed-document",
+            "type": "string"
+          },
+          "resources": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "resourceType": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "resourceType"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "resources"
+        ],
+        "type": "object"
+      },
+      "name": "openmed_fhir_bundle",
+      "output_schema": {
+        "additionalProperties": true,
+        "properties": {
+          "entry": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "fullUrl": {
+                  "type": "string"
+                },
+                "request": {
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "resource": {
+                  "additionalProperties": true,
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "fullUrl",
+                "resource"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "resourceType": {
+            "enum": [
+              "Bundle"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "resourceType",
+          "type",
+          "entry"
+        ],
+        "type": "object"
+      },
+      "stability": "stable",
+      "version": "1.0.0"
+    },
+    {
       "description": "List OpenMed model registry entries.",
       "input_schema": {
         "additionalProperties": false,
@@ -784,6 +875,166 @@
       "version": "1.0.0"
     },
     {
+      "description": "Reidentification risk for de-identified text",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "aux": {
+            "default": null,
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "deidentified": {},
+          "original": {
+            "default": null,
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "deidentified"
+        ],
+        "type": "object"
+      },
+      "name": "openmed_risk_report",
+      "output_schema": {
+        "additionalProperties": true,
+        "properties": {
+          "k_min": {
+            "type": "integer"
+          },
+          "leakage_rate": {
+            "type": "number"
+          },
+          "quasi_identifiers": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "category": {
+                  "type": "string"
+                },
+                "end": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "normalized_value": {
+                  "type": "string"
+                },
+                "record_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "record_index": {
+                  "type": "integer"
+                },
+                "section": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "source": {
+                  "type": "string"
+                },
+                "start": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "record_index",
+                "record_id",
+                "category",
+                "value",
+                "normalized_value",
+                "source",
+                "start",
+                "end",
+                "section"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "reid_rate": {
+            "type": "number"
+          },
+          "singleton_records": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "effective_k": {
+                  "type": "integer"
+                },
+                "quasi_identifier_key": {
+                  "items": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "category": {
+                        "type": "string"
+                      },
+                      "values": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "category",
+                      "values"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "record_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "record_index": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "record_index",
+                "record_id",
+                "effective_k",
+                "quasi_identifier_key"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "leakage_rate",
+          "reid_rate",
+          "k_min",
+          "singleton_records",
+          "quasi_identifiers"
+        ],
+        "type": "object"
+      },
+      "stability": "stable",
+      "version": "1.0.0"
+    },
+    {
       "description": "Run a stateful multi-step OpenMed workflow with server-side intermediate handles and PHI-safe egress.",
       "input_schema": {
         "additionalProperties": false,
@@ -922,6 +1173,389 @@
           "final_output",
           "outputs",
           "trace"
+        ],
+        "type": "object"
+      },
+      "stability": "stable",
+      "version": "1.0.0"
+    },
+    {
+      "description": "Search OpenMed models from the canonical manifest by category, license, size and language.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "language": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "license": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "default": 50,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_size_mb": {
+            "default": null,
+            "minimum": 0.0,
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "name": "openmed_search_models",
+      "output_schema": {
+        "additionalProperties": true,
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "models": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "category": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "display_name": {
+                  "type": "string"
+                },
+                "entity_types": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "key": {
+                  "type": "string"
+                },
+                "model_id": {
+                  "type": "string"
+                },
+                "size_category": {
+                  "type": "string"
+                },
+                "size_mb": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "specialization": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "model_id",
+                "display_name",
+                "category",
+                "specialization",
+                "description",
+                "entity_types",
+                "size_category",
+                "size_mb"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "returned": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "count",
+          "returned",
+          "models"
+        ],
+        "type": "object"
+      },
+      "stability": "stable",
+      "version": "1.0.0"
+    },
+    {
+      "description": "Run deidentification with auditing set as True and return a signed audit report",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence_threshold": {
+            "default": 0.7,
+            "description": "Minimum confidence score for de-identification.",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "type": "number"
+          },
+          "keep_alive": {
+            "default": null,
+            "description": "Optional model keep-alive duration for the service runtime.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "key_id": {
+            "default": "release",
+            "type": "string"
+          },
+          "lang": {
+            "default": "en",
+            "description": "PII language code.",
+            "enum": [
+              "am",
+              "ar",
+              "as",
+              "bn",
+              "cs",
+              "da",
+              "de",
+              "el",
+              "en",
+              "es",
+              "fr",
+              "gu",
+              "he",
+              "hi",
+              "id",
+              "it",
+              "ja",
+              "kn",
+              "ko",
+              "ml",
+              "mr",
+              "nl",
+              "no",
+              "or",
+              "pa",
+              "pt",
+              "ro",
+              "ru",
+              "sv",
+              "sw",
+              "ta",
+              "te",
+              "th",
+              "tr",
+              "uk",
+              "xh",
+              "zh",
+              "zu"
+            ],
+            "type": "string"
+          },
+          "method": {
+            "default": "mask",
+            "enum": [
+              "hash",
+              "mask",
+              "remove",
+              "replace",
+              "shift_dates"
+            ],
+            "type": "string"
+          },
+          "model_name": {
+            "default": "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1",
+            "description": "PII model registry key, local model path, or model identifier.",
+            "type": "string"
+          },
+          "signing_key": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "text": {
+            "description": "Clinical text to process.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "name": "openmed_signed_audit_report",
+      "output_schema": {
+        "additionalProperties": true,
+        "properties": {
+          "deidentified_text_hash": {
+            "type": "string"
+          },
+          "detectors": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "document_length": {
+            "type": "integer"
+          },
+          "input_hash": {
+            "type": "string"
+          },
+          "manifest_hash": {
+            "type": "string"
+          },
+          "openmed_version": {
+            "type": "string"
+          },
+          "policy": {
+            "type": "string"
+          },
+          "repro_hash": {
+            "type": "string"
+          },
+          "residual_risk": {
+            "additionalProperties": true,
+            "properties": {},
+            "required": [],
+            "type": "object"
+          },
+          "resolved_profile": {
+            "additionalProperties": true,
+            "properties": {},
+            "required": [],
+            "type": "object"
+          },
+          "safety_sweep": {
+            "additionalProperties": true,
+            "properties": {},
+            "required": [],
+            "type": "object"
+          },
+          "signature": {
+            "additionalProperties": true,
+            "properties": {
+              "algorithm": {
+                "type": "string"
+              },
+              "key_id": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "key_id",
+              "algorithm",
+              "value"
+            ],
+            "type": "object"
+          },
+          "spans": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "action": {
+                  "type": "string"
+                },
+                "canonical_label": {
+                  "type": "string"
+                },
+                "confidence": {
+                  "type": "number"
+                },
+                "context": {
+                  "additionalProperties": true,
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                },
+                "end": {
+                  "type": "integer"
+                },
+                "evidence": {
+                  "additionalProperties": true,
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "sources": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "start": {
+                  "type": "integer"
+                },
+                "surrogate": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "text_hash": {
+                  "type": "string"
+                },
+                "threshold": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "start",
+                "end",
+                "label",
+                "canonical_label",
+                "sources",
+                "confidence",
+                "threshold",
+                "action",
+                "surrogate",
+                "text_hash"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "thresholds": {
+            "additionalProperties": true,
+            "properties": {},
+            "required": [],
+            "type": "object"
+          }
+        },
+        "required": [
+          "policy",
+          "spans",
+          "openmed_version",
+          "manifest_hash",
+          "document_length",
+          "input_hash",
+          "deidentified_text_hash",
+          "repro_hash",
+          "signature"
         ],
         "type": "object"
       },

--- a/openmed/mcp/server.py
+++ b/openmed/mcp/server.py
@@ -12,6 +12,8 @@ from inspect import Signature
 from typing import Annotated, Any, Callable, Dict, Optional
 
 import openmed
+from openmed.clinical.exporters.fhir import to_bundle
+from openmed.risk.reid import risk_report
 from openmed.core.model_registry import ModelInfo
 from openmed.core.pii_i18n import (
     DEFAULT_PII_MODELS,
@@ -476,6 +478,98 @@ def openmed_loaded_models(
     return validate_registered_tool_output("openmed_loaded_models", response)
 
 
+def openmed_fhir_bundle(
+    resources: list[Dict[str, Any]],
+    doc_id: str = "openmed-document",
+    bundle_type: str = "transaction",
+) -> Dict[str, Any]:
+    """Assemble FHIR resources into a R4 bundle."""
+    bundle = to_bundle(resources, doc_id=doc_id, bundle_type=bundle_type)
+    return validate_registered_tool_output("openmed_fhir_bundle", bundle)
+
+
+def openmed_risk_report(
+    deidentified: Any,
+    original: Optional[Any] = None,
+    aux: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """residual re-identification risk for de-identified records."""
+    response = risk_report(deidentified, original, aux)
+    return validate_registered_tool_output("openmed_risk_report", response)
+
+
+def openmed_signed_audit_report(
+    text: str,
+    method: str = "mask",
+    model_name: str = DEFAULT_PII_MODELS["en"],
+    confidence_threshold: float = 0.7,
+    lang: str = "en",
+    signing_key: Optional[str] = None,
+    key_id: str = "release",
+    keep_alive: Optional[str] = None,
+    *,
+    runtime_provider: Optional[RuntimeProvider] = None,
+) -> Dict[str, Any]:
+    """returns a signed PHI-sage audit report"""
+    if not signing_key:
+        raise ValueError("A signing key is required")
+    runtime = _runtime(runtime_provider)
+
+    def operation() -> Dict[str, Any]:
+        report = openmed.deidentify(
+            text,
+            method=method,
+            model_name=model_name,
+            confidence_threshold=confidence_threshold,
+            config=runtime.config,
+            lang=lang,
+            loader=runtime.get_loader(),
+            audit=True,
+        )
+        report.sign(signing_key, key_id=key_id)
+        return report.to_dict()
+
+    response = _run_model_request(runtime, model_name, keep_alive, operation)
+    return validate_registered_tool_output("openmed_signed_audit_report", response)
+
+
+def openmed_search_models(
+    category: Optional[str] = None,
+    language: Optional[str] = None,
+    max_size_mb: Optional[float] = None,
+    license: Optional[str] = None,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """search openmed model by category, language, size, license"""
+    models = openmed.get_all_models()
+
+    def _matches(model: ModelInfo) -> bool:
+        if category and category.strip().lower() != model.category.strip().lower():
+            return False
+        if language:
+            languages = {str(code).strip().lower() for code in model.languages}
+            if language.strip().lower() not in languages:
+                return False
+        if max_size_mb is not None:
+            size_mb = model.size_mb
+            if size_mb is None or size_mb > max_size_mb:
+                return False
+        if license:
+            declared = (model.license or "").strip().lower()
+            if license.strip().lower() not in declared:
+                return False
+        return True
+
+    matched = sorted((key, model) for key, model in models.items() if _matches(model))
+    limited = matched[: max(limit, 0)]
+    response = {
+        "count": len(matched),
+        "returned": len(limited),
+        "models": [_model_info_to_dict(key, model) for key, model in limited],
+    }
+    return validate_registered_tool_output("openmed_search_models", response)
+
+
 def openmed_health(
     *,
     runtime_provider: Optional[RuntimeProvider] = None,
@@ -618,6 +712,15 @@ def build_mcp_tool_handlers(
             **kwargs,
             runtime_provider=runtime_provider,
         ),
+        "openmed_fhir_bundle": lambda **kwargs: openmed_fhir_bundle(**kwargs),
+        "openmed_risk_report": lambda **kwargs: openmed_risk_report(**kwargs),
+        "openmed_signed_audit_report": (
+            lambda **kwargs: openmed_signed_audit_report(
+                **kwargs,
+                runtime_provider=runtime_provider,
+            )
+        ),
+        "openmed_search_models": lambda **kwargs: openmed_search_models(**kwargs),
     }
 
 

--- a/openmed/mcp/server.py
+++ b/openmed/mcp/server.py
@@ -13,7 +13,6 @@ from typing import Annotated, Any, Callable, Dict, Optional
 
 import openmed
 from openmed.clinical.exporters.fhir import to_bundle
-from openmed.risk.reid import risk_report
 from openmed.core.model_registry import ModelInfo
 from openmed.core.pii_i18n import (
     DEFAULT_PII_MODELS,
@@ -30,6 +29,7 @@ from openmed.mcp.tool_registry import (
     validate_registered_tool_output,
 )
 from openmed.mcp.workflow import WorkflowRunner, builtin_workflow_step_executors
+from openmed.risk.reid import risk_report
 from openmed.service.runtime import ServiceRuntime
 from openmed.utils.validation import validate_model_name
 

--- a/openmed/mcp/tool_registry.py
+++ b/openmed/mcp/tool_registry.py
@@ -1218,7 +1218,7 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
     _tool_spec(
         name="openmed_search_models",
         title="Search Available Models",
-        description="Search OpenMed models from the canonical manifest by category, " \
+        description="Search OpenMed models from the canonical manifest by category, "
         "license, size and language.",
         read_only_hint=True,
         destructive_hint=False,

--- a/openmed/mcp/tool_registry.py
+++ b/openmed/mcp/tool_registry.py
@@ -832,6 +832,153 @@ _WORKFLOW_RESULT_OUTPUT = _object(
         "trace",
     ),
 )
+_FHIR_RESOURCE_SCHEMA = _object(
+    properties={"resourceType": _schema("string")},
+    required=("resourceType",),
+    additional=True,
+)
+_FHIR_BUNDLE_ENTRY_OUTPUT = _object(
+    properties={
+        "fullUrl": _schema("string"),
+        "resource": _object(),
+        "request": _nullable("object"),
+    },
+    required=("fullUrl", "resource"),
+)
+_FHIR_BUNDLE_OUTPUT = _object(
+    properties={
+        "resourceType": _schema("string", enum=["Bundle"]),
+        "type": _schema("string"),
+        "entry": _array(_FHIR_BUNDLE_ENTRY_OUTPUT),
+    },
+    required=("resourceType", "type", "entry"),
+)
+_QUASI_IDENTIFIER_OUTPUT = _object(
+    properties={
+        "record_index": _schema("integer"),
+        "record_id": _nullable("string"),
+        "category": _schema("string"),
+        "value": _schema("string"),
+        "normalized_value": _schema("string"),
+        "source": _schema("string"),
+        "start": _nullable("integer"),
+        "end": _nullable("integer"),
+        "section": _nullable("string"),
+    },
+    required=(
+        "record_index",
+        "record_id",
+        "category",
+        "value",
+        "normalized_value",
+        "source",
+        "start",
+        "end",
+        "section",
+    ),
+)
+_QUASI_IDENTIFIER_KEY_OUTPUT = _object(
+    properties={
+        "category": _schema("string"),
+        "values": _array(_schema("string")),
+    },
+    required=("category", "values"),
+)
+_SINGLETON_RECORD_OUTPUT = _object(
+    properties={
+        "record_index": _schema("integer"),
+        "record_id": _nullable("string"),
+        "effective_k": _schema("integer"),
+        "quasi_identifier_key": _array(_QUASI_IDENTIFIER_KEY_OUTPUT),
+    },
+    required=(
+        "record_index",
+        "record_id",
+        "effective_k",
+        "quasi_identifier_key",
+    ),
+)
+_RISK_REPORT_OUTPUT = _object(
+    properties={
+        "leakage_rate": _schema("number"),
+        "reid_rate": _schema("number"),
+        "k_min": _schema("integer"),
+        "singleton_records": _array(_SINGLETON_RECORD_OUTPUT),
+        "quasi_identifiers": _array(_QUASI_IDENTIFIER_OUTPUT),
+    },
+    required=(
+        "leakage_rate",
+        "reid_rate",
+        "k_min",
+        "singleton_records",
+        "quasi_identifiers",
+    ),
+)
+_AUDIT_SPAN_OUTPUT = _object(
+    properties={
+        "start": _schema("integer"),
+        "end": _schema("integer"),
+        "label": _schema("string"),
+        "canonical_label": _schema("string"),
+        "sources": _array(_schema("string")),
+        "confidence": _schema("number"),
+        "threshold": _schema("number"),
+        "action": _schema("string"),
+        "surrogate": _nullable("string"),
+        "text_hash": _schema("string"),
+        "evidence": _object(),
+        "context": _object(),
+    },
+    required=(
+        "start",
+        "end",
+        "label",
+        "canonical_label",
+        "sources",
+        "confidence",
+        "threshold",
+        "action",
+        "surrogate",
+        "text_hash",
+    ),
+)
+_AUDIT_SIGNATURE_OUTPUT = _object(
+    properties={
+        "key_id": _schema("string"),
+        "algorithm": _schema("string"),
+        "value": _schema("string"),
+    },
+    required=("key_id", "algorithm", "value"),
+)
+_SIGNED_AUDIT_REPORT_OUTPUT = _object(
+    properties={
+        "policy": _schema("string"),
+        "resolved_profile": _object(),
+        "detectors": _array(_object()),
+        "safety_sweep": _object(),
+        "spans": _array(_AUDIT_SPAN_OUTPUT),
+        "thresholds": _object(),
+        "residual_risk": _object(),
+        "openmed_version": _schema("string"),
+        "manifest_hash": _schema("string"),
+        "document_length": _schema("integer"),
+        "input_hash": _schema("string"),
+        "deidentified_text_hash": _schema("string"),
+        "repro_hash": _schema("string"),
+        "signature": _AUDIT_SIGNATURE_OUTPUT,
+    },
+    required=(
+        "policy",
+        "spans",
+        "openmed_version",
+        "manifest_hash",
+        "document_length",
+        "input_hash",
+        "deidentified_text_hash",
+        "repro_hash",
+        "signature",
+    ),
+)
 
 
 def _tool_spec(
@@ -984,8 +1131,128 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         ),
         output_schema=_WORKFLOW_RESULT_OUTPUT,
     ),
+    _tool_spec(
+        name="openmed_fhir_bundle",
+        title="Assemble FHIR Bundle",
+        description="Assemble FHIR resources into a R4 bundle. ",
+        read_only_hint=True,
+        destructive_hint=False,
+        open_world_hint=False,
+        parameters=(
+            _parameter(
+                "resources", _array(_FHIR_RESOURCE_SCHEMA), list[dict[str, Any]]
+            ),
+            _parameter("doc_id", _schema("string"), str, "openmed-document"),
+            _parameter(
+                "bundle_type",
+                _schema(
+                    "string",
+                    enum=["transaction", "batch", "collection"],
+                ),
+                str,
+                "transaction",
+            ),
+        ),
+        output_schema=_FHIR_BUNDLE_OUTPUT,
+    ),
+    _tool_spec(
+        name="openmed_risk_report",
+        title="Score Re-identification Risk",
+        description="Reidentification risk for de-identified text",
+        read_only_hint=True,
+        destructive_hint=False,
+        open_world_hint=False,
+        parameters=(
+            _parameter(
+                "deidentified",
+                {},
+                Any,
+            ),
+            _parameter(
+                "original",
+                _nullable("object"),
+                Optional[Any],
+                None,
+            ),
+            _parameter(
+                "aux",
+                _nullable("object"),
+                Optional[Any],
+                None,
+            ),
+        ),
+        output_schema=_RISK_REPORT_OUTPUT,
+    ),
+    _tool_spec(
+        name="openmed_signed_audit_report",
+        title="Generate Signed Audit Report",
+        description="Run deidentification with auditing set as True and return a signed audit report",
+        read_only_hint=True,
+        destructive_hint=False,
+        open_world_hint=False,
+        parameters=(
+            _TEXT_PARAMETER,
+            _parameter(
+                "method",
+                _schema(
+                    "string",
+                    enum=["hash", "mask", "remove", "replace", "shift_dates"],
+                ),
+                str,
+                "mask",
+            ),
+            _PII_MODEL_NAME_PARAMETER,
+            _DEID_CONFIDENCE_PARAMETER,
+            _LANG_PARAMETER,
+            _parameter(
+                "signing_key",
+                _nullable("string"),
+                Optional[str],
+                None,
+            ),
+            _parameter("key_id", _schema("string"), str, "release"),
+            _KEEP_ALIVE_PARAMETER,
+        ),
+        output_schema=_SIGNED_AUDIT_REPORT_OUTPUT,
+    ),
+    _tool_spec(
+        name="openmed_search_models",
+        title="Search Available Models",
+        description="Search OpenMed models from the canonical manifest by category, " \
+        "license, size and language.",
+        read_only_hint=True,
+        destructive_hint=False,
+        open_world_hint=False,
+        parameters=(
+            _parameter(
+                "category",
+                _nullable("string"),
+                Optional[str],
+                None,
+            ),
+            _parameter(
+                "language",
+                _nullable("string"),
+                Optional[str],
+                None,
+            ),
+            _parameter(
+                "max_size_mb",
+                _nullable("number", minimum=0.0),
+                Optional[float],
+                None,
+            ),
+            _parameter(
+                "license",
+                _nullable("string"),
+                Optional[str],
+                None,
+            ),
+            _parameter("limit", _schema("integer", minimum=0), int, 50),
+        ),
+        output_schema=_LIST_MODELS_OUTPUT,
+    ),
 )
-
 TOOL_REGISTRY = ToolRegistry(TOOL_SPECS)
 
 __all__ = [

--- a/tests/unit/mcp/test_tool_registry.py
+++ b/tests/unit/mcp/test_tool_registry.py
@@ -7,6 +7,17 @@ from typing import Any
 
 import pytest
 
+import openmed
+from openmed.core.audit import (
+    AuditReport,
+    AuditSignature,
+    AuditSpan,
+    DetectorInfo,
+    hash_text,
+    recompute_repro_hash,
+    stable_hash,
+    verify_repro_hash,
+)
 from openmed.interop import adapter_tool_definitions, langchain, presidio
 from openmed.mcp import server as mcp_server
 from openmed.mcp.tool_registry import (
@@ -150,6 +161,227 @@ def test_registry_supports_multiple_versions_side_by_side() -> None:
         "1.0.0",
         "2.0.0",
     ]
+
+#Issue #1741
+NEW_TOOLS={
+    "openmed_fhir_bundle",
+    "openmed_risk_report",
+    "openmed_signed_audit_report",
+    "openmed_search_models"
+}
+
+def test_new_tools_have_correct_annotations() -> None:
+    for tool in NEW_TOOLS:
+        annotations = TOOL_REGISTRY.get(tool).annotations()
+        assert annotations["readOnlyHint"] is True
+        assert annotations["destructiveHint"] is False
+        assert annotations["openWorldHint"] is False
+
+#openmed_fhir_bundle specific tests.
+def test_fhir_bundle_assembles_a_valid_bundle() -> None:
+    bundle = mcp_server.openmed_fhir_bundle(
+        resources=[
+            {
+                "resourceType": "Patient", 
+                "id": "patient-1"
+            },
+            {
+                "resourceType": "Observation",
+                "id": "obs-1",
+                "status": "final",
+                "subject": {"reference": "Patient/patient-1"},
+            }
+        ],
+        doc_id="doc-1",
+    )
+    assert bundle["resourceType"] == "Bundle"
+    assert bundle["type"] == 'transaction'
+    assert len(bundle["entry"]) == 2
+    patient_full_url = bundle["entry"][0]["fullUrl"]
+    subject = bundle["entry"][1]["resource"]["subject"]["reference"]
+    assert subject == patient_full_url
+
+def test_fhir_bundle_raises_value_error_without_resource_type() -> None:
+    with pytest.raises(ValueError):
+        mcp_server.openmed_fhir_bundle(resources=[{"id": "patient-1"}])
+
+
+#openmed_risk_report specific tests
+def _span(text, label, value, *, section="assessment"):
+    start = text.index(value)
+    return {
+        "label": label,
+        "start": start,
+        "end": start + len(value),
+        "metadata": {"section": section},
+    }
+
+def test_risk_report_is_schema_valid() -> None:
+    text = (
+        "Assessment: 94-year-old seen at North Clinic on 2024-02-03 "
+        "with [RARE_CONDITION]."
+    )
+    report = mcp_server.openmed_risk_report(
+        deidentified={
+            "doc_id": "note-1",
+            "text": text,
+            "entities": [
+                _span(text, "AGE", "94-year-old"),
+                _span(text, "ORGANIZATION", "North Clinic"),
+                _span(text, "DATE", "2024-02-03"),
+                _span(text, "RARE_CONDITION", "[RARE_CONDITION]"),
+            ],
+        }
+    )
+
+    assert set(report) == {
+        "leakage_rate",
+        "reid_rate",
+        "k_min",
+        "singleton_records",
+        "quasi_identifiers",
+    }
+    assert report["k_min"] == 1
+    assert report["singleton_records"][0]["record_id"] == "note-1"
+    categories = {qi["category"] for qi in report["quasi_identifiers"]}
+    assert categories == {"age", "provider_institution", "date", "rare_condition"}
+    age_qi = next(qi for qi in report["quasi_identifiers"] if qi["category"] == "age")
+    assert age_qi["value"] == "94-year-old"
+    assert age_qi["start"] == text.index("94-year-old")
+    assert age_qi["section"] == "assessment"
+
+
+def test_risk_report_output_is_phi_safe() -> None:
+    text = (
+        "Assessment: 94-year-old seen at North Clinic on 2024-02-03 "
+        "with [RARE_CONDITION]."
+    )
+    report = mcp_server.openmed_risk_report(
+        deidentified={
+            "doc_id": "note-1",
+            "text": text,
+            "entities": [
+                _span(text, "AGE", "94-year-old"),
+                _span(text, "ORGANIZATION", "North Clinic"),
+                _span(text, "DATE", "2024-02-03"),
+                _span(text, "RARE_CONDITION", "[RARE_CONDITION]"),
+            ],
+        }
+    )
+    serialized = json.dumps(report)
+    assert text not in serialized
+    for quasi_identifier in report["quasi_identifiers"]:
+        assert quasi_identifier["value"] != text
+        assert len(quasi_identifier["value"]) < len(text)
+    
+
+#openmed_signed_audit_report specific tests
+class _StubRuntime:
+    config = None
+    def get_loader(self):
+        return None
+    def run_model_request(self, model_name, keep_alive, operation):
+       del model_name, keep_alive
+       return operation()
+
+    
+def _sample_audit_report(text: str) -> AuditReport:
+    text = "Patient John Doe called 555-1234."
+    return AuditReport(
+        policy="hipaa_safe_harbor",
+        resolved_profile={
+            "method": "mask",
+            "confidence_threshold": 0.7,
+            "language": "en",
+        },
+        detectors=[
+            DetectorInfo(
+                source="ml",
+                model_id="unit-test-model",
+                model_format="transformers",
+            )
+        ],
+        safety_sweep={
+            "source": "safety_sweep",
+            "patterns_version": "safety-sweep-v1",
+            "spans_added": 0,
+        },
+        spans=[
+            AuditSpan(
+                start=8,
+                end=16,
+                label="NAME",
+                canonical_label="PERSON",
+                sources=["ml"],
+                confidence=0.95,
+                threshold=0.7,
+                action="mask",
+                surrogate="[NAME]",
+                text_hash=hash_text("John Doe"),
+                evidence={"raw_label": "NAME", "model_id": "unit-test-model"},
+                context={"before": "Patient ", "after": " called 555-1234."},
+            )
+        ],
+        thresholds={"PERSON": 0.7},
+        residual_risk={
+            "projected_leakage": 0.05,
+            "risk_report_record_score": 0.0,
+            "risk_report": {
+                "leakage_rate": 0.0,
+                "reid_rate": 0.0,
+                "k_min": 0,
+                "singleton_records": [],
+                "quasi_identifiers": [],
+            },
+        },
+        openmed_version="2.0.0",
+        manifest_hash="sha256:manifest",
+        document_length=len(text),
+        input_hash=hash_text(text),
+        deidentified_text_hash=hash_text("Patient [NAME] called [PHONE]."),
+    )
+
+
+def test_signed_audit_report_is_schema_valid_and_signed(monkeypatch) -> None:
+    text = "John Doe visited the clinic."
+
+    def fake_deidentify(*args, **kwargs):
+        assert kwargs.get("audit") is True
+        return _sample_audit_report(text)
+
+    monkeypatch.setattr(openmed, "deidentify", fake_deidentify)
+
+    report = mcp_server.openmed_signed_audit_report(
+        text=text,
+        signing_key="unit-test-key",
+        runtime_provider=_StubRuntime,
+    )
+
+    assert report["signature"]["key_id"] == "release"
+    assert report["signature"]["algorithm"]
+    assert report["signature"]["value"]
+    assert len(report["spans"]) == 1
+
+
+def test_signed_audit_report_output_is_phi_safe(monkeypatch) -> None:
+    text = "John Doe visited the clinic."
+    monkeypatch.setattr(
+        openmed, "deidentify", lambda *a, **k: _sample_audit_report(text)
+    )
+
+    report = mcp_server.openmed_signed_audit_report(
+        text=text,
+        signing_key="unit-test-key",
+        runtime_provider=_StubRuntime,
+    )
+
+    serialized = json.dumps(report)
+    assert "John Doe" not in serialized
+    for span in report["spans"]:
+        assert set(span) >= {"start", "end", "label", "text_hash"}
+        assert isinstance(span["start"], int)
+        assert isinstance(span["end"], int)
+        assert isinstance(span["text_hash"], str) and span["text_hash"]
 
 
 def _replace_spec(

--- a/tests/unit/mcp/test_tool_registry.py
+++ b/tests/unit/mcp/test_tool_registry.py
@@ -162,13 +162,15 @@ def test_registry_supports_multiple_versions_side_by_side() -> None:
         "2.0.0",
     ]
 
-#Issue #1741
-NEW_TOOLS={
+
+# Issue #1741
+NEW_TOOLS = {
     "openmed_fhir_bundle",
     "openmed_risk_report",
     "openmed_signed_audit_report",
-    "openmed_search_models"
+    "openmed_search_models",
 }
+
 
 def test_new_tools_have_correct_annotations() -> None:
     for tool in NEW_TOOLS:
@@ -177,36 +179,35 @@ def test_new_tools_have_correct_annotations() -> None:
         assert annotations["destructiveHint"] is False
         assert annotations["openWorldHint"] is False
 
-#openmed_fhir_bundle specific tests.
+
+# openmed_fhir_bundle specific tests.
 def test_fhir_bundle_assembles_a_valid_bundle() -> None:
     bundle = mcp_server.openmed_fhir_bundle(
         resources=[
-            {
-                "resourceType": "Patient", 
-                "id": "patient-1"
-            },
+            {"resourceType": "Patient", "id": "patient-1"},
             {
                 "resourceType": "Observation",
                 "id": "obs-1",
                 "status": "final",
                 "subject": {"reference": "Patient/patient-1"},
-            }
+            },
         ],
         doc_id="doc-1",
     )
     assert bundle["resourceType"] == "Bundle"
-    assert bundle["type"] == 'transaction'
+    assert bundle["type"] == "transaction"
     assert len(bundle["entry"]) == 2
     patient_full_url = bundle["entry"][0]["fullUrl"]
     subject = bundle["entry"][1]["resource"]["subject"]["reference"]
     assert subject == patient_full_url
+
 
 def test_fhir_bundle_raises_value_error_without_resource_type() -> None:
     with pytest.raises(ValueError):
         mcp_server.openmed_fhir_bundle(resources=[{"id": "patient-1"}])
 
 
-#openmed_risk_report specific tests
+# openmed_risk_report specific tests
 def _span(text, label, value, *, section="assessment"):
     start = text.index(value)
     return {
@@ -215,6 +216,7 @@ def _span(text, label, value, *, section="assessment"):
         "end": start + len(value),
         "metadata": {"section": section},
     }
+
 
 def test_risk_report_is_schema_valid() -> None:
     text = (
@@ -273,18 +275,20 @@ def test_risk_report_output_is_phi_safe() -> None:
     for quasi_identifier in report["quasi_identifiers"]:
         assert quasi_identifier["value"] != text
         assert len(quasi_identifier["value"]) < len(text)
-    
 
-#openmed_signed_audit_report specific tests
+
+# openmed_signed_audit_report specific tests
 class _StubRuntime:
     config = None
+
     def get_loader(self):
         return None
-    def run_model_request(self, model_name, keep_alive, operation):
-       del model_name, keep_alive
-       return operation()
 
-    
+    def run_model_request(self, model_name, keep_alive, operation):
+        del model_name, keep_alive
+        return operation()
+
+
 def _sample_audit_report(text: str) -> AuditReport:
     text = "Patient John Doe called 555-1234."
     return AuditReport(


### PR DESCRIPTION
# Pull Request

## Description
Registers FHIR Bundle assembly, re-identification risk scoring, signed audit reporting,
and model search/recommendation as canonical registry tools (closes #1741), so they flow
automatically to the MCP server and every framework adapter alongside the existing core
tool set.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Added registry entries for `openmed_fhir_bundle` , `openmed_risk_report`
  , `openmed_signed_audit_report` , and `openmed_search_models`.
- All four tools carry `readOnlyHint=True`, `destructiveHint=False`, `openWorldHint=False`
  annotations, consistent with the rest of the registry.
- Wired into the MCP server automatically via `TOOL_REGISTRY`.
- Regenerated `openmed/interop/tools.json` from the registry.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages

## Related Issues
Closes #1741
