### PR TITLE
feat(eval): add per-family Model-Steward target-leakage config

### DIFF
--- a/gates/target_leakage.yaml
+++ b/gates/target_leakage.yaml
@@ -1,0 +1,72 @@
+# Per-family Model-Steward target-leakage config (roadmap section 7.4 / 6.4).
+#
+# Signed floors keyed by (family, tier, format). The ReleaseGate harness
+# (OM-031b) reads this file to obtain each family's enforced leakage floor.
+# Entries may omit any ceiling; omitted values inherit from `defaults` below.
+# All values are synthetic and algorithmically seeded, not measured releases.
+schema_version: 1
+steward_owner: "model-stewardship-council"
+defaults:
+  target_leakage_rate: 0.005
+  residual_leakage_ceiling: 0.005
+  over_redaction_ceiling: 0.02
+entries:
+  # DirectID (P0): direct identifiers must never leak (G3 critical == 0).
+  directid::small::pytorch:
+    family: DirectID
+    tier: small
+    format: pytorch
+    target_leakage_rate: 0.0
+    residual_leakage_ceiling: 0.005
+    over_redaction_ceiling: 0.02
+    steward_owner: "model-stewardship-council"
+  directid::base::pytorch:
+    family: DirectID
+    tier: base
+    format: pytorch
+    target_leakage_rate: 0.0
+    residual_leakage_ceiling: 0.005
+    over_redaction_ceiling: 0.02
+    steward_owner: "model-stewardship-council"
+  directid::small::mlx-fp:
+    family: DirectID
+    tier: small
+    format: mlx-fp
+    target_leakage_rate: 0.0
+    residual_leakage_ceiling: 0.005
+    over_redaction_ceiling: 0.02
+    steward_owner: "model-stewardship-council"
+  # ClinicalPrivacy (P0): clinical PHI carries the same critical-zero floor.
+  clinicalprivacy::small::pytorch:
+    family: ClinicalPrivacy
+    tier: small
+    format: pytorch
+    target_leakage_rate: 0.0
+    residual_leakage_ceiling: 0.005
+    over_redaction_ceiling: 0.02
+    steward_owner: "model-stewardship-council"
+  clinicalprivacy::base::pytorch:
+    family: ClinicalPrivacy
+    tier: base
+    format: pytorch
+    target_leakage_rate: 0.0
+    residual_leakage_ceiling: 0.005
+    over_redaction_ceiling: 0.02
+    steward_owner: "model-stewardship-council"
+  # Multilingual PII (P1): non-Latin scripts share the critical-zero floor.
+  multilingual-pii::small::pytorch:
+    family: multilingual-pii
+    tier: small
+    format: pytorch
+    target_leakage_rate: 0.0
+    residual_leakage_ceiling: 0.005
+    over_redaction_ceiling: 0.02
+    steward_owner: "model-stewardship-council"
+  multilingual-pii::base::pytorch:
+    family: multilingual-pii
+    tier: base
+    format: pytorch
+    target_leakage_rate: 0.0
+    residual_leakage_ceiling: 0.005
+    over_redaction_ceiling: 0.02
+    steward_owner: "model-stewardship-council"

--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -438,6 +438,20 @@ from openmed.eval.surrogate_quality import (
     evaluate_surrogate_record,
     load_surrogate_quality_records,
 )
+from openmed.eval.target_leakage import (
+    DEFAULT_OVER_REDACTION_CEILING,
+    DEFAULT_RESIDUAL_LEAKAGE_CEILING,
+    DEFAULT_TARGET_LEAKAGE_RATE,
+    TARGET_LEAKAGE_PATH,
+    TARGET_LEAKAGE_SCHEMA_VERSION,
+    LeakageTargets,
+    TargetLeakageConfigError,
+    TargetLeakageMiss,
+    get_targets,
+    load_target_leakage_config,
+    target_leakage_key,
+    validate_target_leakage_config,
+)
 from openmed.eval.threshold_sweep import (
     ThresholdSweepPoint,
     ThresholdSweepReport,
@@ -836,4 +850,16 @@ __all__ = [
     "GATED",
     "RECOVERED",
     "REGRESSION_TRACKER_SCHEMA_VERSION",
+    "DEFAULT_OVER_REDACTION_CEILING",
+    "DEFAULT_RESIDUAL_LEAKAGE_CEILING",
+    "DEFAULT_TARGET_LEAKAGE_RATE",
+    "LeakageTargets",
+    "TARGET_LEAKAGE_PATH",
+    "TARGET_LEAKAGE_SCHEMA_VERSION",
+    "TargetLeakageConfigError",
+    "TargetLeakageMiss",
+    "get_targets",
+    "load_target_leakage_config",
+    "target_leakage_key",
+    "validate_target_leakage_config",
 ]

--- a/openmed/eval/target_leakage.py
+++ b/openmed/eval/target_leakage.py
@@ -60,6 +60,35 @@ class TargetLeakageConfigError(ValueError):
     """Raised when the target-leakage config is malformed."""
 
 
+class _StrictLeakageLoader(yaml.SafeLoader):
+    """SafeLoader that rejects duplicate mapping keys.
+
+    A duplicate key would let a later, laxer floor silently override an
+    earlier stricter one (e.g. a signed ``0.0`` downgraded to ``0.9``), so the
+    loader treats it as a malformed config rather than taking the last value.
+    """
+
+
+def _construct_mapping_no_duplicates(
+    loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise TargetLeakageConfigError(
+                f"target-leakage config has a duplicate key: {key!r}"
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_StrictLeakageLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_no_duplicates,
+)
+
+
 class TargetLeakageMiss(LookupError):
     """Raised when a requested ``(family, tier, format)`` is unconfigured."""
 
@@ -109,7 +138,14 @@ def load_target_leakage_config(
 
     config_path = Path(path)
     with config_path.open("r", encoding="utf-8") as handle:
-        payload = yaml.safe_load(handle)
+        try:
+            payload = yaml.load(handle, Loader=_StrictLeakageLoader)
+        except TargetLeakageConfigError:
+            raise
+        except yaml.YAMLError as exc:
+            raise TargetLeakageConfigError(
+                f"target-leakage config is not valid YAML: {exc}"
+            ) from exc
     if not isinstance(payload, Mapping):
         raise TargetLeakageConfigError("target-leakage config must be a mapping")
     validate_target_leakage_config(payload)

--- a/openmed/eval/target_leakage.py
+++ b/openmed/eval/target_leakage.py
@@ -1,0 +1,277 @@
+"""Per-family Model-Steward target-leakage config and reader.
+
+The Model Steward signs off on each manifest family's target leakage rate,
+keyed by ``(family, tier, format)``. The committed, versioned config lives at
+``gates/target_leakage.yaml`` and is the single source of truth that the
+ReleaseGate harness reads to obtain the per-family leakage floor it must
+enforce. This module loads and validates that config and exposes
+:func:`get_targets` as the reader the harness consumes.
+
+The config schema is intentionally small and versioned:
+
+```
+schema_version: 1
+steward_owner: "model-stewardship-council"
+defaults:
+  target_leakage_rate: 0.005
+  residual_leakage_ceiling: 0.005
+  over_redaction_ceiling: 0.02
+entries:
+  directid::small::pytorch:
+    family: DirectID
+    tier: small
+    format: pytorch
+    target_leakage_rate: 0.0
+    residual_leakage_ceiling: 0.005
+    over_redaction_ceiling: 0.02
+    steward_owner: "model-stewardship-council"
+```
+
+Each entry may omit any of the three ceilings; omitted values fall back first
+to the config ``defaults`` block and then to the module-level defaults, so the
+steward only records the numbers that deviate from the sane baseline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+TARGET_LEAKAGE_SCHEMA_VERSION = 1
+TARGET_LEAKAGE_PATH = (
+    Path(__file__).resolve().parents[2] / "gates" / "target_leakage.yaml"
+)
+
+DEFAULT_TARGET_LEAKAGE_RATE = 0.005
+DEFAULT_RESIDUAL_LEAKAGE_CEILING = 0.005
+DEFAULT_OVER_REDACTION_CEILING = 0.02
+
+_CEILING_FIELDS = (
+    "target_leakage_rate",
+    "residual_leakage_ceiling",
+    "over_redaction_ceiling",
+)
+
+
+class TargetLeakageConfigError(ValueError):
+    """Raised when the target-leakage config is malformed."""
+
+
+class TargetLeakageMiss(LookupError):
+    """Raised when a requested ``(family, tier, format)`` is unconfigured."""
+
+
+@dataclass(frozen=True)
+class LeakageTargets:
+    """Signed per-family leakage floors for one ``(family, tier, format)``."""
+
+    family: str
+    tier: str | None
+    format: str
+    target_leakage_rate: float
+    residual_leakage_ceiling: float
+    over_redaction_ceiling: float
+    steward_owner: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain JSON-serialisable mapping of the leakage floors."""
+
+        return {
+            "family": self.family,
+            "tier": self.tier,
+            "format": self.format,
+            "target_leakage_rate": float(self.target_leakage_rate),
+            "residual_leakage_ceiling": float(self.residual_leakage_ceiling),
+            "over_redaction_ceiling": float(self.over_redaction_ceiling),
+            "steward_owner": self.steward_owner,
+        }
+
+
+def target_leakage_key(family: str, tier: str | None, format_name: str) -> str:
+    """Return the stable config key for ``(family, tier, format)``."""
+
+    return "::".join(
+        (
+            _normalise_key_part(family),
+            _normalise_key_part(tier or "none"),
+            _normalise_key_part(format_name),
+        )
+    )
+
+
+def load_target_leakage_config(
+    path: str | Path = TARGET_LEAKAGE_PATH,
+) -> dict[str, Any]:
+    """Load and validate the committed target-leakage config document."""
+
+    config_path = Path(path)
+    with config_path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle)
+    if not isinstance(payload, Mapping):
+        raise TargetLeakageConfigError("target-leakage config must be a mapping")
+    validate_target_leakage_config(payload)
+    return dict(payload)
+
+
+def get_targets(
+    family: str,
+    tier: str | None,
+    format_name: str,
+    *,
+    path: str | Path = TARGET_LEAKAGE_PATH,
+    config: Mapping[str, Any] | None = None,
+) -> LeakageTargets:
+    """Return the signed leakage floors for ``(family, tier, format)``.
+
+    Omitted per-entry ceilings inherit from the config ``defaults`` block and
+    then the module-level defaults. A ``(family, tier, format)`` with no entry
+    raises :class:`TargetLeakageMiss` naming the unconfigured key.
+    """
+
+    payload = dict(config) if config is not None else load_target_leakage_config(path)
+    validate_target_leakage_config(payload)
+
+    key = target_leakage_key(family, tier, format_name)
+    entries = payload.get("entries") or {}
+    entry = entries.get(key)
+    if entry is None:
+        raise TargetLeakageMiss(
+            f"No Model-Steward target-leakage config for key: {key}. "
+            "Add a signed entry to gates/target_leakage.yaml."
+        )
+
+    defaults = _resolve_defaults(payload)
+    steward_owner = str(
+        entry.get("steward_owner", payload.get("steward_owner", "unassigned"))
+    )
+    return LeakageTargets(
+        family=str(entry["family"]),
+        tier=None if entry.get("tier") is None else str(entry["tier"]),
+        format=str(entry["format"]),
+        target_leakage_rate=_pick_ceiling(entry, defaults, "target_leakage_rate"),
+        residual_leakage_ceiling=_pick_ceiling(
+            entry, defaults, "residual_leakage_ceiling"
+        ),
+        over_redaction_ceiling=_pick_ceiling(entry, defaults, "over_redaction_ceiling"),
+        steward_owner=steward_owner,
+    )
+
+
+def validate_target_leakage_config(config: Mapping[str, Any]) -> None:
+    """Validate the documented target-leakage config schema."""
+
+    if not isinstance(config, Mapping):
+        raise TargetLeakageConfigError("target-leakage config must be a mapping")
+    if config.get("schema_version") != TARGET_LEAKAGE_SCHEMA_VERSION:
+        raise TargetLeakageConfigError(
+            f"target-leakage schema_version must be {TARGET_LEAKAGE_SCHEMA_VERSION}"
+        )
+    steward_owner = config.get("steward_owner")
+    if not isinstance(steward_owner, str) or not steward_owner.strip():
+        raise TargetLeakageConfigError(
+            "target-leakage config requires a non-empty steward_owner"
+        )
+
+    defaults = config.get("defaults")
+    if defaults is not None:
+        if not isinstance(defaults, Mapping):
+            raise TargetLeakageConfigError("target-leakage defaults must be a mapping")
+        for field_name in _CEILING_FIELDS:
+            if field_name in defaults:
+                _validate_rate(defaults[field_name], f"defaults.{field_name}")
+
+    entries = config.get("entries")
+    if not isinstance(entries, Mapping):
+        raise TargetLeakageConfigError("target-leakage entries must be a mapping")
+    for key, entry in entries.items():
+        _validate_entry(str(key), entry)
+
+
+def _validate_entry(key: str, entry: Any) -> None:
+    if not isinstance(entry, Mapping):
+        raise TargetLeakageConfigError(f"entry {key!r} must be a mapping")
+
+    for required in ("family", "format"):
+        if not entry.get(required) or not isinstance(entry[required], str):
+            raise TargetLeakageConfigError(
+                f"entry {key!r} requires a non-empty {required}"
+            )
+    if entry.get("tier") is not None and not isinstance(entry["tier"], str):
+        raise TargetLeakageConfigError(f"entry {key!r} tier must be a string or null")
+
+    expected_key = target_leakage_key(
+        entry["family"], entry.get("tier"), entry["format"]
+    )
+    if expected_key != key:
+        raise TargetLeakageConfigError(
+            f"entry {key!r} does not match its (family, tier, format) dimensions "
+            f"(expected key {expected_key!r})"
+        )
+
+    for field_name in _CEILING_FIELDS:
+        if field_name in entry:
+            _validate_rate(entry[field_name], f"{key}.{field_name}")
+
+    if "steward_owner" in entry and (
+        not isinstance(entry["steward_owner"], str)
+        or not entry["steward_owner"].strip()
+    ):
+        raise TargetLeakageConfigError(
+            f"entry {key!r} steward_owner must be a non-empty string"
+        )
+
+
+def _validate_rate(value: Any, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TargetLeakageConfigError(f"{field_name} must be a number in 0..1")
+    result = float(value)
+    if not 0.0 <= result <= 1.0:
+        raise TargetLeakageConfigError(f"{field_name} must be between 0.0 and 1.0")
+    return result
+
+
+def _resolve_defaults(config: Mapping[str, Any]) -> dict[str, float]:
+    module_defaults = {
+        "target_leakage_rate": DEFAULT_TARGET_LEAKAGE_RATE,
+        "residual_leakage_ceiling": DEFAULT_RESIDUAL_LEAKAGE_CEILING,
+        "over_redaction_ceiling": DEFAULT_OVER_REDACTION_CEILING,
+    }
+    configured = config.get("defaults")
+    if isinstance(configured, Mapping):
+        for field_name in _CEILING_FIELDS:
+            if field_name in configured:
+                module_defaults[field_name] = float(configured[field_name])
+    return module_defaults
+
+
+def _pick_ceiling(
+    entry: Mapping[str, Any],
+    defaults: Mapping[str, float],
+    field_name: str,
+) -> float:
+    if field_name in entry:
+        return float(entry[field_name])
+    return float(defaults[field_name])
+
+
+def _normalise_key_part(value: str) -> str:
+    return str(value).strip().lower().replace("_", "-") or "none"
+
+
+__all__ = [
+    "DEFAULT_OVER_REDACTION_CEILING",
+    "DEFAULT_RESIDUAL_LEAKAGE_CEILING",
+    "DEFAULT_TARGET_LEAKAGE_RATE",
+    "LeakageTargets",
+    "TARGET_LEAKAGE_PATH",
+    "TARGET_LEAKAGE_SCHEMA_VERSION",
+    "TargetLeakageConfigError",
+    "TargetLeakageMiss",
+    "get_targets",
+    "load_target_leakage_config",
+    "target_leakage_key",
+    "validate_target_leakage_config",
+]

--- a/tests/unit/eval/test_target_leakage.py
+++ b/tests/unit/eval/test_target_leakage.py
@@ -1,0 +1,190 @@
+"""Tests for the per-family Model-Steward target-leakage config and reader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from openmed.eval.target_leakage import (
+    DEFAULT_OVER_REDACTION_CEILING,
+    DEFAULT_RESIDUAL_LEAKAGE_CEILING,
+    DEFAULT_TARGET_LEAKAGE_RATE,
+    TARGET_LEAKAGE_PATH,
+    TARGET_LEAKAGE_SCHEMA_VERSION,
+    LeakageTargets,
+    TargetLeakageConfigError,
+    TargetLeakageMiss,
+    get_targets,
+    load_target_leakage_config,
+    target_leakage_key,
+    validate_target_leakage_config,
+)
+
+SEEDED_FAMILIES = ("DirectID", "ClinicalPrivacy", "multilingual-pii")
+
+
+def _synthetic_config(
+    *,
+    rate: float = 0.0,
+    residual: float = 0.004,
+    over_redaction: float = 0.03,
+) -> dict:
+    """Build a small algorithmic config exercising every schema field."""
+
+    entries = {}
+    for index, family in enumerate(SEEDED_FAMILIES):
+        # Vary the numbers algorithmically so lookups can be told apart.
+        key = target_leakage_key(family, "small", "pytorch")
+        entries[key] = {
+            "family": family,
+            "tier": "small",
+            "format": "pytorch",
+            "target_leakage_rate": rate,
+            "residual_leakage_ceiling": round(residual + index * 0.001, 6),
+            "over_redaction_ceiling": round(over_redaction + index * 0.005, 6),
+            "steward_owner": f"steward-{index}",
+        }
+    # One entry that omits ceilings to exercise default inheritance.
+    inherit_key = target_leakage_key("DirectID", "base", "onnx")
+    entries[inherit_key] = {
+        "family": "DirectID",
+        "tier": "base",
+        "format": "onnx",
+    }
+    return {
+        "schema_version": TARGET_LEAKAGE_SCHEMA_VERSION,
+        "steward_owner": "synthetic-council",
+        "defaults": {
+            "target_leakage_rate": 0.005,
+            "residual_leakage_ceiling": 0.005,
+            "over_redaction_ceiling": 0.02,
+        },
+        "entries": entries,
+    }
+
+
+def test_key_is_normalised_across_case_and_separators():
+    assert target_leakage_key("DirectID", "Small", "PyTorch") == (
+        "directid::small::pytorch"
+    )
+    assert target_leakage_key("multilingual_pii", None, "onnx") == (
+        "multilingual-pii::none::onnx"
+    )
+
+
+def test_loader_returns_configured_targets_per_family_tier_format():
+    config = _synthetic_config()
+
+    for index, family in enumerate(SEEDED_FAMILIES):
+        targets = get_targets(family, "small", "pytorch", config=config)
+        assert isinstance(targets, LeakageTargets)
+        assert targets.family == family
+        assert targets.target_leakage_rate == 0.0
+        assert targets.residual_leakage_ceiling == round(0.004 + index * 0.001, 6)
+        assert targets.over_redaction_ceiling == round(0.03 + index * 0.005, 6)
+        assert targets.steward_owner == f"steward-{index}"
+
+
+def test_omitted_ceilings_inherit_config_defaults():
+    config = _synthetic_config()
+
+    targets = get_targets("DirectID", "base", "onnx", config=config)
+
+    assert targets.target_leakage_rate == 0.005
+    assert targets.residual_leakage_ceiling == 0.005
+    assert targets.over_redaction_ceiling == 0.02
+    # steward_owner falls back to the config-level owner when unset.
+    assert targets.steward_owner == "synthetic-council"
+
+
+def test_missing_family_lookup_raises_clear_error():
+    config = _synthetic_config()
+
+    with pytest.raises(TargetLeakageMiss) as excinfo:
+        get_targets("UnknownFamily", "small", "pytorch", config=config)
+
+    message = str(excinfo.value)
+    assert "unknownfamily::small::pytorch" in message
+    assert "gates/target_leakage.yaml" in message
+
+
+def test_schema_rejects_out_of_range_leakage_rate():
+    config = _synthetic_config()
+    key = target_leakage_key("DirectID", "small", "pytorch")
+    config["entries"][key]["target_leakage_rate"] = 1.5
+
+    with pytest.raises(TargetLeakageConfigError) as excinfo:
+        validate_target_leakage_config(config)
+    assert "target_leakage_rate" in str(excinfo.value)
+
+
+def test_schema_rejects_mismatched_key():
+    config = _synthetic_config()
+    entry = {
+        "family": "DirectID",
+        "tier": "small",
+        "format": "pytorch",
+    }
+    config["entries"]["not-the-right-key"] = entry
+
+    with pytest.raises(TargetLeakageConfigError) as excinfo:
+        validate_target_leakage_config(config)
+    assert "does not match" in str(excinfo.value)
+
+
+def test_schema_requires_steward_owner():
+    config = _synthetic_config()
+    config.pop("steward_owner")
+
+    with pytest.raises(TargetLeakageConfigError):
+        validate_target_leakage_config(config)
+
+
+def test_load_and_write_roundtrip_from_disk(tmp_path: Path):
+    config = _synthetic_config()
+    path = tmp_path / "target_leakage.yaml"
+    path.write_text(yaml.safe_dump(config, sort_keys=True), encoding="utf-8")
+
+    loaded = load_target_leakage_config(path)
+    targets = get_targets("ClinicalPrivacy", "small", "pytorch", path=path)
+
+    assert loaded["schema_version"] == TARGET_LEAKAGE_SCHEMA_VERSION
+    assert targets.family == "ClinicalPrivacy"
+
+
+def test_committed_config_is_present_and_seeds_p0_p1_families():
+    assert TARGET_LEAKAGE_PATH.exists()
+    config = load_target_leakage_config()
+
+    seeded = {entry["family"] for entry in config["entries"].values()}
+    assert {"DirectID", "ClinicalPrivacy", "multilingual-pii"} <= seeded
+
+    # Section 6.4: direct-identifier families carry a critical-zero floor.
+    directid = get_targets("DirectID", "small", "pytorch")
+    assert directid.target_leakage_rate == 0.0
+    assert directid.residual_leakage_ceiling <= 0.005
+
+
+def test_module_defaults_match_section_six_four_numbers():
+    assert DEFAULT_RESIDUAL_LEAKAGE_CEILING == 0.005
+    assert DEFAULT_TARGET_LEAKAGE_RATE == 0.005
+    assert 0.0 <= DEFAULT_OVER_REDACTION_CEILING <= 1.0
+
+
+def test_leakage_targets_to_dict_is_serialisable():
+    config = _synthetic_config()
+    targets = get_targets("DirectID", "small", "pytorch", config=config)
+
+    payload = targets.to_dict()
+    assert payload["family"] == "DirectID"
+    assert set(payload) == {
+        "family",
+        "tier",
+        "format",
+        "target_leakage_rate",
+        "residual_leakage_ceiling",
+        "over_redaction_ceiling",
+        "steward_owner",
+    }


### PR DESCRIPTION
## Summary

Adds the per-family Model-Steward target-leakage config — a committed, versioned source of truth for each model family's signed leakage floors, plus a reader the release-gate harness consumes.

- **`gates/target_leakage.yaml`** — committed, versioned config keyed by `family::tier::format`; each entry holds `target_leakage_rate`, `residual_leakage_ceiling`, `over_redaction_ceiling`, and `steward_owner`, over a top-level `schema_version` + `defaults` block. Seeded (synthetically) for DirectID, ClinicalPrivacy, and multilingual-pii at the roadmap §6.4 numbers (critical target leakage 0, residual ≤ 0.5%).
- **`openmed/eval/target_leakage.py`** — loader + `get_targets(family, tier, format)` returning a frozen `LeakageTargets`; schema validation, key normalization, default inheritance, and the typed `TargetLeakageConfigError` / `TargetLeakageMiss`.
- **`openmed/eval/__init__.py`** — re-exports the new symbols (the surface the OM-031b ReleaseGate harness imports).
- **`tests/unit/eval/test_target_leakage.py`** — 11 tests over algorithmic synthetic fixtures.

Mirrors the existing `openmed/core/baseline.py` store (also keyed by family/tier/format) for structure, key-normalization, and error shape. No dependency added (`pyyaml` already present). `Closes #259`.

## Deviations from the issue's letter

- **`openmed/eval/__init__.py` added** (a 4th file the issue's list omits) to export the reader — required for the OM-031b harness to `from openmed.eval import get_targets`, matching how the sibling `ModelStewardConfig` is already exported.
- **Config schema was unspecified in the issue** — I mirrored the closest merged analog (`core/baseline.py`).

## Judgment calls

- **Attached to** `openmed/eval/release_gates.py`, which already holds the *consumer* (`ModelStewardConfig.target_for(family)`, `_g3_check` critical-leakage-zero, `RESIDUAL_LEAKAGE_SOFT_CEILING = 0.005`) — the config's defaults are coherent with that existing ceiling.
- **`get_targets`** raises `TargetLeakageMiss` on an unconfigured (family,tier,format) key but *inherits* omitted ceilings from the config `defaults` then module defaults — satisfying both "sane defaults" and "clear error for an unconfigured family."

## Independent review

An independent adversarial pass validated the schema (out-of-range rates, string ceilings, `bool`-excluded, missing/wrong `schema_version`, missing fields, dimension mismatch all raise; boundaries 0.0/1.0 accepted), normalization symmetry (no wrong-entry resolution), default inheritance, frozen immutability, determinism, and consumer coherence. It found and **fixed two real defects** (`a260a212`):

- **[Med] Malformed YAML leaked a raw `yaml.YAMLError`** instead of the typed `TargetLeakageConfigError` — now caught and wrapped.
- **[Med, privacy-relevant] A duplicate config key silently downgraded a signed floor** — `yaml.safe_load` kept the last value, so a family listed twice (`0.0` then `0.9`) silently relaxed a critical-zero leakage floor with no error. Now a strict loader rejects any duplicate key with the typed error. (`check-yaml` guards commit-time; this closes the *runtime* loader gap for any config the harness loads.)

Verdict **APPROVE-WITH-NITS**. Disclosed out-of-scope: `ModelStewardConfig` is keyed by family only and the `LeakageTargets`→`ModelStewardConfig` wiring adapter is OM-031b's job (per the issue's "Out of scope").

## Data provenance

All seeded families/floors are synthetic and algorithmically chosen; no real model measurements.

## Verification

- `test_target_leakage` (11) + `test_release_gates` (49) + `public_api_docstrings` + `packaging_typed` + `api_surface_diff`: **87 passed**. Loader probes: all malformed/duplicate/empty/list cases raise the typed error post-fix.
- `pre-commit` on changed files: all hooks green (incl. `check-yaml` on the committed config).
- No dependency added; `pyproject.toml` / `uv.lock` untouched.
- Base `maziyarpanahi/openmed:master`; `git rev-list --count HEAD..upstream/master` = 0.

## Relationship

Models, Training &amp; Release Engine batch; independent branch, clean to master.
