### PR TITLE
feat(eval): gate ONNX and WebGPU export variants in release checks

### DIFF
--- a/openmed/eval/quant_delta.py
+++ b/openmed/eval/quant_delta.py
@@ -504,6 +504,282 @@ def evaluate_coreml_span_parity(
     )
 
 
+EXPORT_VARIANT_FORMAT_PREFIXES = ("onnx", "webgpu")
+_EXPORT_TIER_FIT_KEYS = ("p50_ms", "p95_ms", "ram_mb")
+
+
+@dataclass(frozen=True)
+class ExportVariantParityResult:
+    """Per-variant release evidence for one ONNX or WebGPU export."""
+
+    format: str
+    runtime: str
+    quantized: bool
+    passed: bool
+    tier: str
+    tier_fit_passed: bool
+    reason: str
+    quant_delta: QuantRecallDeltaResult | None = None
+    tier_budget: Mapping[str, float] | None = None
+    tier_violations: Mapping[str, Any] = field(default_factory=dict)
+    source: str = "computed"
+
+    @property
+    def blocking_format(self) -> str | None:
+        return None if self.passed else self.format
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "format": self.format,
+            "runtime": self.runtime,
+            "quantized": self.quantized,
+            "passed": self.passed,
+            "tier": self.tier,
+            "tier_fit_passed": self.tier_fit_passed,
+            "reason": self.reason,
+            "quant_delta": (
+                self.quant_delta.to_dict() if self.quant_delta is not None else None
+            ),
+            "tier_budget": (
+                dict(self.tier_budget) if self.tier_budget is not None else None
+            ),
+            "tier_violations": dict(self.tier_violations),
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True)
+class ExportVariantGateResult:
+    """Aggregate ONNX/WebGPU export-variant release-gate evidence."""
+
+    passed: bool
+    parent_format: str
+    reason: str
+    variant_results: tuple[ExportVariantParityResult, ...] = ()
+    missing_required: tuple[str, ...] = ()
+    evaluated_formats: tuple[str, ...] = ()
+
+    @property
+    def blocked_formats(self) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                {result.format for result in self.variant_results if not result.passed}
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "parent_format": self.parent_format,
+            "reason": self.reason,
+            "variant_results": [result.to_dict() for result in self.variant_results],
+            "missing_required": list(self.missing_required),
+            "evaluated_formats": list(self.evaluated_formats),
+            "blocked_formats": list(self.blocked_formats),
+        }
+
+
+def evaluate_export_variant_gate(
+    *,
+    variants: Sequence[Mapping[str, Any]],
+    tier_budgets: Mapping[str, Mapping[str, float]],
+    parent_recall: Mapping[str, Any] | None = None,
+    parent_format: str = "",
+    required_variants: Sequence[str] = (),
+    tier_aliases: Mapping[str, str] | None = None,
+) -> ExportVariantGateResult:
+    """Evaluate declared ONNX and WebGPU export variants against G4 and G5.
+
+    Each variant is gated for quantized recall delta against the floating-point
+    parent where applicable (G4) and for target-device tier fit (G5). A variant
+    is blocked without affecting sibling variants that pass. Missing recall or
+    tier-fit evidence fails the variant closed. ``required_variants`` that are
+    absent from the manifest are reported so the gate can fail closed on a
+    declared-but-missing export.
+    """
+
+    results: list[ExportVariantParityResult] = []
+    evaluated: set[str] = set()
+    for variant in variants:
+        if not isinstance(variant, Mapping):
+            continue
+        raw_format = str(variant.get("format") or variant.get("name") or "").strip()
+        runtime = _export_runtime(raw_format)
+        if runtime == "unknown":
+            continue
+        evaluated.add(_normalise_dimension(raw_format))
+        results.append(
+            _evaluate_export_variant(
+                variant=variant,
+                format_name=raw_format,
+                runtime=runtime,
+                parent_recall=parent_recall,
+                tier_budgets=tier_budgets,
+                tier_aliases=tier_aliases,
+            )
+        )
+
+    missing_required = tuple(
+        str(item)
+        for item in required_variants
+        if _normalise_dimension(str(item)) not in evaluated
+    )
+    evaluated_formats = tuple(sorted(result.format for result in results))
+
+    if not results:
+        reason = "no ONNX/WebGPU export variants declared"
+        passed = False
+    elif missing_required:
+        reason = "required export variant missing: " + ", ".join(missing_required)
+        passed = False
+    elif all(result.passed for result in results):
+        reason = "ok"
+        passed = True
+    else:
+        blocked = ", ".join(result.format for result in results if not result.passed)
+        reason = "export variant blocked: " + blocked
+        passed = False
+
+    return ExportVariantGateResult(
+        passed=passed,
+        parent_format=str(parent_format or ""),
+        reason=reason,
+        variant_results=tuple(results),
+        missing_required=missing_required,
+        evaluated_formats=evaluated_formats,
+    )
+
+
+def _evaluate_export_variant(
+    *,
+    variant: Mapping[str, Any],
+    format_name: str,
+    runtime: str,
+    parent_recall: Mapping[str, Any] | None,
+    tier_budgets: Mapping[str, Mapping[str, float]],
+    tier_aliases: Mapping[str, str] | None,
+) -> ExportVariantParityResult:
+    quantized = is_quantized_format(format_name)
+    candidate_recall = _mapping_or_empty(
+        variant.get("recall") or variant.get("per_label_recall")
+    )
+    if quantized:
+        quant_delta = evaluate_quant_recall_delta(
+            format_name=format_name,
+            candidate_recall=candidate_recall,
+            parent_recall=parent_recall,
+            precomputed_delta=variant.get("quant_recall_delta"),
+        )
+        quant_passed = quant_delta.passed
+        if quant_delta.source == "missing_evidence":
+            quant_reason = "quantized export requires recall-delta evidence"
+        elif not quant_passed:
+            quant_reason = "quantized recall delta exceeds limit"
+        else:
+            quant_reason = ""
+    else:
+        quant_delta = evaluate_quant_recall_delta(
+            format_name=format_name,
+            candidate_recall=candidate_recall,
+        )
+        quant_passed = True
+        quant_reason = ""
+
+    tier = str(variant.get("tier") or "")
+    tier_passed, tier_budget, tier_violations, tier_reason = _export_tier_fit(
+        variant=variant,
+        tier=tier,
+        tier_budgets=tier_budgets,
+        tier_aliases=tier_aliases,
+    )
+
+    passed = quant_passed and tier_passed
+    reasons = [reason for reason in (quant_reason, tier_reason) if reason]
+    reason = "ok" if passed else "; ".join(reasons) or "export variant blocked"
+    return ExportVariantParityResult(
+        format=format_name,
+        runtime=runtime,
+        quantized=quantized,
+        passed=passed,
+        tier=tier,
+        tier_fit_passed=tier_passed,
+        reason=reason,
+        quant_delta=quant_delta,
+        tier_budget=tier_budget,
+        tier_violations=tier_violations,
+    )
+
+
+def _export_tier_fit(
+    *,
+    variant: Mapping[str, Any],
+    tier: str,
+    tier_budgets: Mapping[str, Mapping[str, float]],
+    tier_aliases: Mapping[str, str] | None,
+) -> tuple[bool, Mapping[str, float] | None, dict[str, Any], str]:
+    normalized_tier = _normalise_dimension(tier)
+    if tier_aliases:
+        normalized_tier = tier_aliases.get(normalized_tier, normalized_tier)
+    budget = tier_budgets.get(normalized_tier)
+    if budget is None:
+        return False, None, {"tier": tier}, "unknown target device tier"
+
+    observed: dict[str, float] = {}
+    missing: list[str] = []
+    for key in _EXPORT_TIER_FIT_KEYS:
+        value = _optional_float(_export_metric(variant, key))
+        if value is None:
+            missing.append(key)
+        else:
+            observed[key] = value
+    if missing:
+        return (
+            False,
+            dict(budget),
+            {"missing": missing},
+            "tier-fit latency/RAM evidence required",
+        )
+
+    violations = {
+        key: {"observed": observed[key], "limit": float(budget[key])}
+        for key in budget
+        if observed.get(key) is not None and observed[key] > float(budget[key])
+    }
+    if violations:
+        return False, dict(budget), violations, "tier latency or RAM budget exceeded"
+    return True, dict(budget), {}, ""
+
+
+def _export_metric(variant: Mapping[str, Any], key: str) -> Any:
+    if key in ("p50_ms", "p95_ms"):
+        latency = variant.get("latency")
+        latency_map = latency if isinstance(latency, Mapping) else {}
+        return variant.get(key, latency_map.get(key))
+    if key == "ram_mb":
+        resources = variant.get("resources")
+        resource_map = resources if isinstance(resources, Mapping) else {}
+        return variant.get(
+            "ram_mb",
+            variant.get(
+                "peak_rss_mib",
+                resource_map.get("peak_rss_mib", resource_map.get("ram_mb")),
+            ),
+        )
+    return variant.get(key)
+
+
+def _export_runtime(format_name: str) -> str:
+    normalized = _normalise_dimension(format_name)
+    for prefix in EXPORT_VARIANT_FORMAT_PREFIXES:
+        if normalized.startswith(prefix):
+            return prefix
+    return "unknown"
+
+
+def _mapping_or_empty(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
 def is_quantized_format(format_name: str) -> bool:
     return limit_for_format(format_name) is not None
 
@@ -887,7 +1163,10 @@ __all__ = [
     "COREML_RECALL_DELTA_LIMIT",
     "DEFAULT_SPECULATIVE_KL_LIMIT",
     "DEFAULT_SPECULATIVE_SPEEDUP_LIMIT",
+    "EXPORT_VARIANT_FORMAT_PREFIXES",
     "CoreMLSpanParityResult",
+    "ExportVariantGateResult",
+    "ExportVariantParityResult",
     "G1_G2_LABELS",
     "INT4_RECALL_DELTA_LIMIT",
     "INT8_RECALL_DELTA_LIMIT",
@@ -895,6 +1174,7 @@ __all__ = [
     "QuantRecallDeltaResult",
     "SpeculativeRedactionParityResult",
     "evaluate_coreml_span_parity",
+    "evaluate_export_variant_gate",
     "evaluate_onnx_logit_parity",
     "evaluate_quant_recall_delta",
     "evaluate_speculative_redaction_parity",

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -50,6 +50,7 @@ from openmed.eval.quant_delta import (
     INT4_RECALL_DELTA_LIMIT,
     INT8_RECALL_DELTA_LIMIT,
     QuantRecallDeltaResult,
+    evaluate_export_variant_gate,
     evaluate_quant_recall_delta,
 )
 from openmed.eval.report import BenchmarkReport
@@ -60,6 +61,7 @@ FLAKINESS_GATE = "flakiness"
 SURROGATE_QUALITY_GATE = "surrogate_quality"
 GROUNDING_ACCURACY_GATE = "grounding_accuracy"
 CROSS_SCRIPT_GATE = "cross_script"
+EXPORT_VARIANT_GATE = "export_variants"
 I18N_THROUGHPUT_GATE = "i18n_throughput"
 I18N_THROUGHPUT_REGRESSION_THRESHOLD = 0.20
 I18N_THROUGHPUT_BASELINE_FAMILY = "i18n-throughput"
@@ -771,6 +773,9 @@ class ReleaseGate:
         ):
             checks.append(_coreml_ane_residency_check(coreml_manifest, metadata))
             checks.append(_coreml_variant_parity_check(coreml_manifest, metadata))
+        export_manifest = _export_variant_manifest(metadata)
+        if export_manifest:
+            checks.extend(_export_variant_checks(export_manifest, metrics, metadata))
         checks.append(_zero_shot_language_leakage_check(metrics, metadata))
         federated_check = _federated_boundary_check(metrics, metadata)
         if federated_check is not None:
@@ -2294,6 +2299,113 @@ def _coreml_variant_parity_check(
         },
         blocking_format=next(iter(failures), missing[0] if missing else None),
     )
+
+
+def _export_variant_manifest(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    inline = _mapping(
+        metadata.get("export_variant_manifest")
+        or metadata.get("export_conversion_manifest")
+        or metadata.get("onnx_webgpu_manifest")
+        or metadata.get("export_manifest")
+    )
+    if inline:
+        return inline
+
+    variants = metadata.get("export_variants")
+    if isinstance(variants, Sequence) and not isinstance(variants, (str, bytes)):
+        manifest: dict[str, Any] = {"variants": list(variants)}
+        required = metadata.get("required_export_variants")
+        if isinstance(required, Sequence) and not isinstance(required, (str, bytes)):
+            manifest["required_variants"] = list(required)
+        return manifest
+
+    manifest_path = _optional_path(
+        _first_value(
+            metadata.get("export_variant_manifest_path"),
+            metadata.get("export_manifest_path"),
+        )
+    )
+    if manifest_path is None or not manifest_path.exists():
+        return {}
+    try:
+        with manifest_path.open("r", encoding="utf-8") as handle:
+            loaded = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    return _mapping(loaded)
+
+
+def _export_variant_checks(
+    manifest: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+) -> list[GateCheck]:
+    variants_raw = manifest.get("variants")
+    variants = (
+        [_mapping(item) for item in variants_raw if isinstance(item, Mapping)]
+        if isinstance(variants_raw, Sequence)
+        and not isinstance(variants_raw, (str, bytes))
+        else []
+    )
+
+    parent_recall = _first_mapping(
+        manifest.get("parent_recall"),
+        manifest.get("fp_parent_per_label_recall"),
+    ) or _quant_parent_recall(metrics, metadata)
+
+    required = manifest.get("required_variants") or metadata.get(
+        "required_export_variants"
+    )
+    required_variants = (
+        [str(item) for item in required]
+        if isinstance(required, Sequence) and not isinstance(required, (str, bytes))
+        else []
+    )
+
+    result = evaluate_export_variant_gate(
+        variants=variants,
+        tier_budgets=_TIER_BUDGETS,
+        parent_recall=parent_recall or None,
+        parent_format=str(manifest.get("parent_format") or ""),
+        required_variants=required_variants,
+        tier_aliases=_TIER_ALIASES,
+    )
+
+    coverage_passed = bool(result.variant_results) and not result.missing_required
+    if not result.variant_results:
+        coverage_reason = "no ONNX/WebGPU export variants declared"
+    elif result.missing_required:
+        coverage_reason = "required export variant missing"
+    else:
+        coverage_reason = "ok"
+
+    checks: list[GateCheck] = [
+        GateCheck(
+            EXPORT_VARIANT_GATE,
+            coverage_passed,
+            reason=coverage_reason,
+            details={
+                "parent_format": result.parent_format,
+                "evaluated_formats": list(result.evaluated_formats),
+                "missing_required": list(result.missing_required),
+                "blocked_formats": list(result.blocked_formats),
+            },
+            blocking_format=(
+                result.missing_required[0] if result.missing_required else None
+            ),
+        )
+    ]
+    for variant in result.variant_results:
+        checks.append(
+            GateCheck(
+                f"{EXPORT_VARIANT_GATE}:{variant.format}",
+                variant.passed,
+                reason=variant.reason,
+                details=variant.to_dict(),
+                blocking_format=variant.blocking_format,
+            )
+        )
+    return checks
 
 
 def _g5_check(
@@ -4391,6 +4503,7 @@ __all__ = [
     "G9_RELAXED_RE_F1_FLOOR",
     "FLAKINESS_GATE",
     "SURROGATE_QUALITY_GATE",
+    "EXPORT_VARIANT_GATE",
     "GROUNDING_ACCURACY_GATE",
     "GROUNDING_TOP1_FLOOR",
     "GROUNDING_TOP5_FLOOR",

--- a/tests/unit/eval/test_quant_delta.py
+++ b/tests/unit/eval/test_quant_delta.py
@@ -4,11 +4,140 @@ import pytest
 
 from openmed.eval.quant_delta import (
     evaluate_coreml_span_parity,
+    evaluate_export_variant_gate,
     evaluate_onnx_logit_parity,
     evaluate_quant_recall_delta,
     evaluate_speculative_redaction_parity,
     token_frequency_kl,
 )
+
+_EXPORT_TIER_BUDGETS = {
+    "tiny": {"ram_mb": 350.0, "p50_ms": 60.0, "p95_ms": 150.0},
+    "base": {"ram_mb": 900.0, "p50_ms": 150.0, "p95_ms": 400.0},
+}
+_EXPORT_PARENT_RECALL = {
+    "PERSON": 0.995,
+    "DATE": 0.995,
+    "ID_NUM": 0.995,
+}
+
+
+def _export_variant(
+    fmt: str,
+    tier: str,
+    *,
+    recall: dict[str, float] | None = None,
+    p50_ms: float = 40.0,
+    p95_ms: float = 120.0,
+    ram_mb: float = 300.0,
+    **overrides: object,
+) -> dict[str, object]:
+    variant: dict[str, object] = {
+        "format": fmt,
+        "tier": tier,
+        "p50_ms": p50_ms,
+        "p95_ms": p95_ms,
+        "ram_mb": ram_mb,
+    }
+    if recall is not None:
+        variant["recall"] = recall
+    variant.update(overrides)
+    return variant
+
+
+def _passing_export_variants() -> list[dict[str, object]]:
+    return [
+        _export_variant("onnx", "base", p50_ms=90.0, p95_ms=280.0, ram_mb=700.0),
+        _export_variant(
+            "onnx-int8",
+            "tiny",
+            recall={"PERSON": 0.992, "DATE": 0.993, "ID_NUM": 0.994},
+        ),
+        _export_variant("webgpu", "base", p50_ms=90.0, p95_ms=280.0, ram_mb=700.0),
+    ]
+
+
+def test_export_variant_gate_releases_passing_onnx_and_webgpu() -> None:
+    result = evaluate_export_variant_gate(
+        variants=_passing_export_variants(),
+        tier_budgets=_EXPORT_TIER_BUDGETS,
+        parent_recall=_EXPORT_PARENT_RECALL,
+        required_variants=["onnx", "onnx-int8", "webgpu"],
+    )
+
+    assert result.passed is True
+    assert result.blocked_formats == ()
+    assert result.missing_required == ()
+    assert set(result.evaluated_formats) == {"onnx", "onnx-int8", "webgpu"}
+
+
+def test_export_variant_gate_blocks_degraded_onnx_int8_only() -> None:
+    variants = _passing_export_variants()
+    variants[1]["recall"] = {"PERSON": 0.985, "DATE": 0.993, "ID_NUM": 0.994}
+
+    result = evaluate_export_variant_gate(
+        variants=variants,
+        tier_budgets=_EXPORT_TIER_BUDGETS,
+        parent_recall=_EXPORT_PARENT_RECALL,
+        required_variants=["onnx", "onnx-int8", "webgpu"],
+    )
+
+    assert result.passed is False
+    assert result.blocked_formats == ("onnx-int8",)
+    passing = {r.format for r in result.variant_results if r.passed}
+    assert passing == {"onnx", "webgpu"}
+
+
+def test_export_variant_gate_blocks_webgpu_tier_budget_breach() -> None:
+    variants = _passing_export_variants()
+    variants[2]["p95_ms"] = 500.0
+
+    result = evaluate_export_variant_gate(
+        variants=variants,
+        tier_budgets=_EXPORT_TIER_BUDGETS,
+        parent_recall=_EXPORT_PARENT_RECALL,
+    )
+
+    assert result.passed is False
+    assert result.blocked_formats == ("webgpu",)
+    webgpu = next(r for r in result.variant_results if r.format == "webgpu")
+    assert webgpu.tier_fit_passed is False
+    assert "p95_ms" in webgpu.tier_violations
+
+
+def test_export_variant_gate_fails_closed_on_missing_tier_evidence() -> None:
+    variants = [
+        {
+            "format": "onnx-int8",
+            "tier": "tiny",
+            "recall": {"PERSON": 0.992},
+        }
+    ]
+
+    result = evaluate_export_variant_gate(
+        variants=variants,
+        tier_budgets=_EXPORT_TIER_BUDGETS,
+        parent_recall=_EXPORT_PARENT_RECALL,
+    )
+
+    assert result.passed is False
+    assert result.blocked_formats == ("onnx-int8",)
+
+
+def test_export_variant_gate_fails_closed_on_missing_required_variant() -> None:
+    variants = [
+        _export_variant("onnx", "base", p50_ms=90.0, p95_ms=280.0, ram_mb=700.0)
+    ]
+
+    result = evaluate_export_variant_gate(
+        variants=variants,
+        tier_budgets=_EXPORT_TIER_BUDGETS,
+        parent_recall=_EXPORT_PARENT_RECALL,
+        required_variants=["onnx", "webgpu"],
+    )
+
+    assert result.passed is False
+    assert result.missing_required == ("webgpu",)
 
 
 def test_int8_delta_below_half_point_passes() -> None:

--- a/tests/unit/eval/test_release_gates.py
+++ b/tests/unit/eval/test_release_gates.py
@@ -1356,6 +1356,108 @@ def test_default_manifest_count_includes_published_android_onnx_fleet() -> None:
     assert len(rows) + derived_count >= 2_000
 
 
+def _export_variant_manifest() -> dict[str, object]:
+    return {
+        "parent_format": "pytorch",
+        "parent_recall": {"PERSON": 0.995, "DATE": 0.995, "ID_NUM": 0.995},
+        "required_variants": ["onnx", "onnx-int8", "webgpu"],
+        "variants": [
+            {
+                "format": "onnx",
+                "tier": "base",
+                "p50_ms": 90.0,
+                "p95_ms": 280.0,
+                "ram_mb": 700.0,
+            },
+            {
+                "format": "onnx-int8",
+                "tier": "tiny",
+                "recall": {"PERSON": 0.992, "DATE": 0.993, "ID_NUM": 0.994},
+                "p50_ms": 40.0,
+                "p95_ms": 120.0,
+                "ram_mb": 300.0,
+            },
+            {
+                "format": "webgpu",
+                "tier": "base",
+                "p50_ms": 90.0,
+                "p95_ms": 280.0,
+                "ram_mb": 700.0,
+            },
+        ],
+    }
+
+
+def test_export_variant_gate_releases_passing_onnx_and_webgpu(
+    tmp_path: Path,
+) -> None:
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metadata_updates={
+                "export_variant_manifest": _export_variant_manifest(),
+            },
+        ),
+        _baseline(),
+    )
+
+    assert result.decision == RELEASABLE
+    assert result.blocked_formats == ()
+    assert _check(result, "export_variants").passed is True
+    assert _check(result, "export_variants:onnx-int8").passed is True
+    assert _check(result, "export_variants:webgpu").passed is True
+
+
+def test_export_variant_gate_blocks_degraded_variant_and_reports_format(
+    tmp_path: Path,
+) -> None:
+    manifest = _export_variant_manifest()
+    manifest["variants"][1]["recall"] = {
+        "PERSON": 0.985,
+        "DATE": 0.993,
+        "ID_NUM": 0.994,
+    }
+
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metadata_updates={"export_variant_manifest": manifest},
+        ),
+        _baseline(),
+    )
+
+    blocked = _check(result, "export_variants:onnx-int8")
+    assert result.decision == QUARANTINED
+    assert blocked.passed is False
+    assert blocked.blocking_format == "onnx-int8"
+    assert result.blocked_formats == ("onnx-int8",)
+    # Unrelated passing variants stay releasable within the same report.
+    assert _check(result, "export_variants:onnx").passed is True
+    assert _check(result, "export_variants:webgpu").passed is True
+
+
+def test_export_variant_gate_fails_closed_when_required_variant_missing(
+    tmp_path: Path,
+) -> None:
+    manifest = _export_variant_manifest()
+    manifest["variants"] = [
+        variant for variant in manifest["variants"] if variant["format"] != "webgpu"
+    ]
+
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metadata_updates={"export_variant_manifest": manifest},
+        ),
+        _baseline(),
+    )
+
+    coverage = _check(result, "export_variants")
+    assert result.decision == QUARANTINED
+    assert coverage.passed is False
+    assert coverage.details["missing_required"] == ["webgpu"]
+
+
 def _coreml_manifest() -> dict[str, object]:
     parity_pass = {
         "passed": True,


### PR DESCRIPTION
## Summary

Adds a release-check gate over **ONNX and WebGPU export variants**, reusing the existing G4 quant-recall-delta and G5 tier-fit machinery rather than building any export engine. Each declared variant is represented in gate input (a manifest) and gate output (a per-variant `GateCheck`), so a failing or missing variant is blocked with a named format while sibling variants that pass stay releasable.

- **`openmed/eval/quant_delta.py`** — `evaluate_export_variant_gate()` + `ExportVariantGateResult` / `ExportVariantParityResult`: per-variant G4 (reusing `evaluate_quant_recall_delta`) applied to quantized variants + G5 tier-fit applied to all; fails closed on missing recall or tier-fit evidence; blocks only the offending variant.
- **`openmed/eval/release_gates.py`** — wires it in: an `EXPORT_VARIANT_GATE`, `_export_variant_manifest()` (reads inline / `export_variants` / a manifest path), and `_export_variant_checks()` emitting one coverage check plus one `export_variants:<fmt>` check per variant. The call is **conditional on a manifest being present**, mirroring the CoreML trigger — so every existing report is unchanged.
- **`tests/unit/eval/test_quant_delta.py`** + **`tests/unit/eval/test_release_gates.py`** — 8 tests (pass, block-degraded-int8-only, tier-budget breach, missing-tier fail-closed, missing-required fail-closed, plus integration through `ReleaseGate.evaluate`).

Stdlib only; the gate reads manifest/metadata and never loads a runtime. No dependency. `Closes #381`.

## Export surface

Confirmed present in-repo (`openmed/onnx/*` convert/quantize/transformersjs; `quant_delta.py` recall-delta + logit-parity; the `release_gates.py` framework), so this builds the real gate over that surface rather than a placeholder. It mirrors the merged `_coreml_variant_parity_check` precedent (manifest-of-variants → per-variant `GateCheck` with `blocking_format`).

## Design / judgment calls

- **One `GateCheck` per variant** (`export_variants:onnx-int8`, …) plus a coverage check — so each variant's `blocking_format` flows independently into `GateReport.blocked_formats`, satisfying "identify the blocked format without blocking unrelated passing formats."
- **Triggered only when a manifest is present** (not on a top-level format prefix) — guarantees zero impact on existing reports/fixtures.
- **G4 only for quantized variants** (`onnx-int8`, `webgpu-int8`, …), **G5 tier-fit for all** — matching "where applicable."
- **Tier budgets injected** from `release_gates` into the evaluator to avoid a circular import (dependency injection).

## Deviations from the issue's letter

- **The issue names no paths/keys.** I introduced the metadata contract `export_variant_manifest` (aliases `export_conversion_manifest` / `onnx_webgpu_manifest` / `export_manifest`; also a bare `export_variants` list or a `*_manifest_path`), matching the CoreML `coreml_conversion_manifest` convention.

## Independent review

An independent adversarial pass returned a clean **APPROVE**, all behaviors reproduced via live probes:

- **Fail-closed**: NaN/null recall, a quantized variant missing recall, `parent_recall=None`, an unknown tier, missing/NaN latency, a garbage precomputed delta, an empty/missing manifest, and a required variant absent — every one QUARANTINED. Boundary: recall delta exactly at the 0.005 limit blocks; 0.0049 passes; tier p95 exactly at budget passes, +0.001 blocks.
- **Isolation**: a degraded `onnx-int8` blocks only itself; sibling `onnx`/`webgpu` stay `passed` with `blocking_format=None`. Degraded-and-missing → `blocked_formats=('onnx-int8','webgpu')`, passing `onnx` released. No leak, no over-block.
- **No regression**: a no-manifest report stays `RELEASABLE` with 0 export checks; detection keys don't collide with existing metadata; the diff only *adds* tests.
- **No hard runtime dep, no circular import** — both confirmed.

Disclosed (cosmetic, out of scope): non-canonical quant names (e.g. `onnx-q8`) follow the project-wide `limit_for_format` naming convention and would skip G4 (pre-existing assumption); duplicate manifest entries produce two identically-named checks (harmless, fail-closed still holds).

## Data provenance

All recall/latency/RAM values are hand-picked algorithmic synthetic values; no real model data or PHI.

## Verification

- `test_quant_delta` + `test_release_gates`: 68 passed. Gate-adjacent regression suite: 109 passed. `directid_contract` + `packaging_typed` + `api_surface_diff` + `public_api_docstrings`: 35 passed.
- `pre-commit` on the 4 changed files: all hooks green.
- No dependency added; `pyproject.toml` / `uv.lock` untouched.
- Base `maziyarpanahi/openmed:master`; `git rev-list --count HEAD..upstream/master` = 0.

## Relationship

Models, Training &amp; Release Engine batch; independent branch, clean to master. Extends the existing release-gate framework.
