### PR TITLE
feat(eval): add India DPDP policy coverage evaluation and per-label reporting

### DIFF
--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -225,6 +225,16 @@ from openmed.eval.history import (
     metric_history,
     write_run_ledger,
 )
+from openmed.eval.india_dpdp_coverage import (
+    INDIA_DPDP_COVERAGE,
+    INDIA_DPDP_POLICY,
+    DpdpCoverageGateFailure,
+    DpdpCoverageReport,
+    DpdpLabelCoverage,
+    assert_india_dpdp_coverage_gate,
+    india_dpdp_coverage_metadata,
+    run_india_dpdp_coverage,
+)
 from openmed.eval.leakage_dashboard import (
     DEFAULT_WORST_LABEL_COUNT,
     LEAKAGE_DASHBOARD_ARTIFACT_TYPE,
@@ -479,6 +489,14 @@ __all__ = [
     "BoundaryLeakageResult",
     "BenchmarkRunLedger",
     "BenchmarkRunLedgerEntry",
+    "INDIA_DPDP_COVERAGE",
+    "INDIA_DPDP_POLICY",
+    "DpdpCoverageGateFailure",
+    "DpdpCoverageReport",
+    "DpdpLabelCoverage",
+    "assert_india_dpdp_coverage_gate",
+    "india_dpdp_coverage_metadata",
+    "run_india_dpdp_coverage",
     "CalibrationArtifactPaths",
     "ConformalCalibrationGroup",
     "ConformalCalibrationReport",

--- a/openmed/eval/india_dpdp_coverage.py
+++ b/openmed/eval/india_dpdp_coverage.py
@@ -1,0 +1,285 @@
+"""India DPDP policy-coverage evaluation with per-label reporting.
+
+This suite loads the synthetic OM-677 India clinical de-identification corpus
+and applies the ``india_dpdp_act`` policy profile to every annotated
+identifier. It produces deterministic per-label totals, covered counts,
+coverage rates, and action counts, and enforces a policy gate requiring every
+direct identifier to resolve to ``replace`` with zero ``keep`` actions.
+
+Reports are privacy-safe: they emit counts, canonical labels, offsets, surface
+hashes, and verdicts rather than any raw fixture identifier value.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from openmed.core.labels import normalize_label, policy_label_for
+from openmed.core.policy import PolicyName, PolicyProfile, load_policy
+from openmed.core.safety_sweep import hashed_span_surface
+from openmed.core.schemas.span import ACTION_KEEP
+from openmed.eval.datasets.clinical_phi import (
+    IndiaClinicalPHICorpus,
+    load_india_clinical_phi_corpus,
+)
+
+INDIA_DPDP_COVERAGE = "india_dpdp_coverage"
+INDIA_DPDP_POLICY = PolicyName.INDIA_DPDP_ACT.value
+REPLACE_ACTION = "replace"
+
+
+@dataclass(frozen=True)
+class DpdpLabelCoverage:
+    """Per-label policy-coverage aggregates for the India DPDP suite."""
+
+    label: str
+    policy_label: str
+    direct_identifier: bool
+    total: int
+    covered: int
+    coverage_rate: float
+    action_counts: Mapping[str, int]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic, raw-text-free mapping for this label."""
+
+        return {
+            "label": self.label,
+            "policy_label": self.policy_label,
+            "direct_identifier": self.direct_identifier,
+            "total": self.total,
+            "covered": self.covered,
+            "coverage_rate": self.coverage_rate,
+            "action_counts": {
+                action: int(self.action_counts[action])
+                for action in sorted(self.action_counts)
+            },
+        }
+
+
+@dataclass(frozen=True)
+class DpdpCoverageGateFailure:
+    """Raw-text-free failure emitted by the India DPDP coverage gate."""
+
+    document_id: str
+    label: str
+    identifier_type: str
+    action: str
+    reason: str
+    evidence: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "document_id": self.document_id,
+            "label": self.label,
+            "identifier_type": self.identifier_type,
+            "action": self.action,
+            "reason": self.reason,
+            "evidence": dict(self.evidence),
+        }
+
+
+@dataclass(frozen=True)
+class DpdpCoverageReport:
+    """Deterministic India DPDP policy-coverage report."""
+
+    policy: str
+    policy_schema_version: int
+    document_count: int
+    span_count: int
+    direct_identifier_span_count: int
+    covered_direct_identifier_span_count: int
+    direct_identifier_coverage_rate: float
+    keep_action_count: int
+    per_label: tuple[DpdpLabelCoverage, ...]
+    passed: bool
+    failures: tuple[DpdpCoverageGateFailure, ...] = field(default_factory=tuple)
+
+    def direct_identifier_labels(self) -> tuple[str, ...]:
+        """Return the canonical direct-identifier labels present in the corpus."""
+
+        return tuple(
+            coverage.label for coverage in self.per_label if coverage.direct_identifier
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic, raw-text-free report mapping."""
+
+        return {
+            "suite": INDIA_DPDP_COVERAGE,
+            "policy": self.policy,
+            "policy_schema_version": self.policy_schema_version,
+            "document_count": self.document_count,
+            "span_count": self.span_count,
+            "direct_identifier_span_count": self.direct_identifier_span_count,
+            "covered_direct_identifier_span_count": (
+                self.covered_direct_identifier_span_count
+            ),
+            "direct_identifier_coverage_rate": self.direct_identifier_coverage_rate,
+            "keep_action_count": self.keep_action_count,
+            "direct_identifier_labels": list(self.direct_identifier_labels()),
+            "per_label": [coverage.to_dict() for coverage in self.per_label],
+            "passed": self.passed,
+            "failures": [failure.to_dict() for failure in self.failures],
+        }
+
+
+def run_india_dpdp_coverage(
+    *,
+    policy: PolicyProfile | None = None,
+    corpus: IndiaClinicalPHICorpus | None = None,
+) -> DpdpCoverageReport:
+    """Evaluate India DPDP policy coverage over the synthetic India corpus.
+
+    Args:
+        policy: Optional loaded profile. Defaults to the ``india_dpdp_act``
+            profile. Callers may inject a derived profile to exercise the gate.
+        corpus: Optional preloaded India clinical corpus. Defaults to the
+            committed synthetic OM-677 corpus.
+
+    Returns:
+        A deterministic, raw-text-free per-label coverage report plus gate
+        verdict and failures.
+    """
+
+    active_policy = policy if policy is not None else load_policy(INDIA_DPDP_POLICY)
+    active_corpus = corpus if corpus is not None else load_india_clinical_phi_corpus()
+
+    per_label_total: Counter[str] = Counter()
+    per_label_covered: Counter[str] = Counter()
+    per_label_actions: dict[str, Counter[str]] = {}
+    per_label_direct: dict[str, bool] = {}
+
+    span_count = 0
+    direct_span_count = 0
+    covered_direct_span_count = 0
+    keep_action_count = 0
+    failures: list[DpdpCoverageGateFailure] = []
+
+    for record in active_corpus.records:
+        for span in record.gold_spans:
+            span_count += 1
+            label = normalize_label(span.label, lang=record.language)
+            action = active_policy.action_for(label, lang=record.language)
+            is_direct = bool(span.metadata.get("direct_identifier"))
+            identifier_type = str(span.metadata.get("identifier_type") or "")
+
+            per_label_total[label] += 1
+            per_label_actions.setdefault(label, Counter())[action] += 1
+            per_label_direct[label] = per_label_direct.get(label, False) or is_direct
+            if action != ACTION_KEEP:
+                per_label_covered[label] += 1
+            if action == ACTION_KEEP:
+                keep_action_count += 1
+
+            if is_direct:
+                direct_span_count += 1
+                if action == REPLACE_ACTION:
+                    covered_direct_span_count += 1
+                else:
+                    reason = (
+                        "direct_identifier_keep_action"
+                        if action == ACTION_KEEP
+                        else "direct_identifier_not_replaced"
+                    )
+                    failures.append(
+                        DpdpCoverageGateFailure(
+                            document_id=record.document_id,
+                            label=label,
+                            identifier_type=identifier_type,
+                            action=action,
+                            reason=reason,
+                            evidence=hashed_span_surface(
+                                record.text,
+                                span.start,
+                                span.end,
+                                label=label,
+                            ),
+                        )
+                    )
+
+    per_label = tuple(
+        DpdpLabelCoverage(
+            label=label,
+            policy_label=policy_label_for(label),
+            direct_identifier=per_label_direct[label],
+            total=per_label_total[label],
+            covered=per_label_covered[label],
+            coverage_rate=round(
+                per_label_covered[label] / per_label_total[label]
+                if per_label_total[label]
+                else 0.0,
+                6,
+            ),
+            action_counts=dict(per_label_actions[label]),
+        )
+        for label in sorted(per_label_total)
+    )
+
+    direct_coverage_rate = round(
+        covered_direct_span_count / direct_span_count if direct_span_count else 0.0,
+        6,
+    )
+
+    return DpdpCoverageReport(
+        policy=active_policy.name,
+        policy_schema_version=active_policy.schema_version,
+        document_count=len(active_corpus.records),
+        span_count=span_count,
+        direct_identifier_span_count=direct_span_count,
+        covered_direct_identifier_span_count=covered_direct_span_count,
+        direct_identifier_coverage_rate=direct_coverage_rate,
+        keep_action_count=keep_action_count,
+        per_label=per_label,
+        passed=not failures,
+        failures=tuple(failures),
+    )
+
+
+def assert_india_dpdp_coverage_gate(
+    *,
+    policy: PolicyProfile | None = None,
+    corpus: IndiaClinicalPHICorpus | None = None,
+) -> DpdpCoverageReport:
+    """Return a passing report or raise with raw-text-free diagnostics."""
+
+    report = run_india_dpdp_coverage(policy=policy, corpus=corpus)
+    if not report.passed:
+        offenders = ", ".join(
+            sorted(
+                {
+                    f"{failure.document_id}:{failure.label}"
+                    for failure in report.failures
+                }
+            )
+        )
+        raise AssertionError(
+            f"India DPDP policy-coverage gate failed for direct identifiers: {offenders}"
+        )
+    return report
+
+
+def india_dpdp_coverage_metadata() -> dict[str, Any]:
+    """Return raw-text-free metadata describing the India DPDP coverage suite."""
+
+    return {
+        "suite": INDIA_DPDP_COVERAGE,
+        "policy": INDIA_DPDP_POLICY,
+        "synthetic": True,
+        "required_direct_identifier_coverage": 1.0,
+        "required_keep_actions": 0,
+    }
+
+
+__all__ = [
+    "INDIA_DPDP_COVERAGE",
+    "INDIA_DPDP_POLICY",
+    "DpdpCoverageGateFailure",
+    "DpdpCoverageReport",
+    "DpdpLabelCoverage",
+    "assert_india_dpdp_coverage_gate",
+    "india_dpdp_coverage_metadata",
+    "run_india_dpdp_coverage",
+]

--- a/tests/unit/eval/test_india_dpdp_coverage.py
+++ b/tests/unit/eval/test_india_dpdp_coverage.py
@@ -1,0 +1,126 @@
+"""Tests for the India DPDP policy-coverage evaluation and per-label report."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.core.labels import DIRECT_IDENTIFIER, PERSON, policy_label_for
+from openmed.core.policy import load_policy
+from openmed.core.schemas.span import ACTION_KEEP
+from openmed.eval import (
+    INDIA_DPDP_COVERAGE,
+    INDIA_DPDP_POLICY,
+    assert_india_dpdp_coverage_gate,
+    india_dpdp_coverage_metadata,
+    run_india_dpdp_coverage,
+)
+from openmed.eval.datasets import load_india_clinical_phi_corpus
+
+_EXPECTED_DIRECT_IDENTIFIER_LABELS = ("ID_NUM", "PERSON", "PHONE", "STREET_ADDRESS")
+
+
+def test_coverage_report_is_deterministic_and_covers_every_direct_label() -> None:
+    report = run_india_dpdp_coverage()
+
+    assert report == run_india_dpdp_coverage()
+    assert report.policy == INDIA_DPDP_POLICY
+    assert report.to_dict()["suite"] == INDIA_DPDP_COVERAGE
+
+    corpus = load_india_clinical_phi_corpus()
+    assert report.document_count == len(corpus.records)
+    assert report.span_count == sum(len(record.gold_spans) for record in corpus.records)
+
+    assert report.direct_identifier_labels() == _EXPECTED_DIRECT_IDENTIFIER_LABELS
+    for coverage in report.per_label:
+        assert coverage.policy_label == policy_label_for(coverage.label)
+        assert coverage.total > 0
+        assert 0.0 <= coverage.coverage_rate <= 1.0
+        assert sum(coverage.action_counts.values()) == coverage.total
+        if coverage.direct_identifier:
+            assert coverage.policy_label == DIRECT_IDENTIFIER
+
+
+def test_direct_identifiers_reach_full_replace_coverage_with_zero_keep() -> None:
+    report = run_india_dpdp_coverage()
+
+    assert report.passed is True
+    assert report.failures == ()
+    assert report.direct_identifier_span_count > 0
+    assert (
+        report.covered_direct_identifier_span_count
+        == report.direct_identifier_span_count
+    )
+    assert report.direct_identifier_coverage_rate == 1.0
+    assert report.keep_action_count == 0
+
+    for coverage in report.per_label:
+        if coverage.direct_identifier:
+            assert coverage.action_counts == {"replace": coverage.total}
+            assert coverage.covered == coverage.total
+
+
+def test_assert_gate_returns_passing_report() -> None:
+    report = assert_india_dpdp_coverage_gate()
+
+    assert report.passed is True
+
+
+def test_report_contains_no_raw_fixture_phi_values() -> None:
+    report = run_india_dpdp_coverage()
+    serialized = json.dumps(report.to_dict(), ensure_ascii=False)
+
+    corpus = load_india_clinical_phi_corpus()
+    raw_surfaces = {
+        span.text for record in corpus.records for span in record.gold_spans
+    }
+    assert raw_surfaces
+    for surface in raw_surfaces:
+        assert surface not in serialized
+
+
+def test_keep_regression_fails_gate_with_label_and_document_id() -> None:
+    base = load_policy(INDIA_DPDP_POLICY)
+    leaking = base.derive(actions={**dict(base.actions), PERSON: ACTION_KEEP})
+
+    report = run_india_dpdp_coverage(policy=leaking)
+
+    assert report.passed is False
+    assert report.keep_action_count > 0
+    person_failures = [
+        failure for failure in report.failures if failure.label == PERSON
+    ]
+    assert person_failures
+    assert all(
+        failure.reason == "direct_identifier_keep_action" for failure in person_failures
+    )
+    assert all(failure.action == ACTION_KEEP for failure in person_failures)
+    corpus = load_india_clinical_phi_corpus()
+    expected_documents = {
+        record.document_id
+        for record in corpus.records
+        for span in record.gold_spans
+        if span.label == PERSON
+    }
+    assert {failure.document_id for failure in person_failures} == expected_documents
+
+    for failure in person_failures:
+        evidence = failure.evidence
+        assert set(evidence) >= {"start", "end", "length", "text_hash"}
+        assert str(evidence["text_hash"]).startswith("sha256:")
+
+    with pytest.raises(AssertionError, match="India DPDP policy-coverage gate failed"):
+        assert_india_dpdp_coverage_gate(policy=leaking)
+
+
+def test_metadata_is_raw_text_free_and_declares_requirements() -> None:
+    metadata = india_dpdp_coverage_metadata()
+
+    assert metadata == {
+        "suite": INDIA_DPDP_COVERAGE,
+        "policy": INDIA_DPDP_POLICY,
+        "synthetic": True,
+        "required_direct_identifier_coverage": 1.0,
+        "required_keep_actions": 0,
+    }


### PR DESCRIPTION
## Summary

Adds the **India DPDP policy-coverage** slice of the India clinical de-identification eval suite (OM-677, parent #1503): a deterministic evaluator that applies the `india_dpdp_act` policy profile to every annotated identifier in the synthetic OM-677 India corpus and reports per-label coverage plus a direct-identifier gate.

- **`openmed/eval/india_dpdp_coverage.py`** — `run_india_dpdp_coverage`, `assert_india_dpdp_coverage_gate`, `india_dpdp_coverage_metadata`, and `DpdpCoverageReport` / `DpdpLabelCoverage` / `DpdpCoverageGateFailure`. Per label: total, covered (action ≠ `keep`), coverage rate, and per-action counts. The gate requires every DPDP **direct** identifier (PERSON, ID_NUM, PHONE, STREET_ADDRESS) to resolve to `replace`; ZIPCODE/pincode is a quasi-identifier (`mask`), reported but not gated.
- **`openmed/eval/__init__.py`** — re-exports the new public names (mirrors how `coverage.py` is exposed).
- **`tests/unit/eval/test_india_dpdp_coverage.py`** — 6 tests.

Stdlib only; no dependency. `Closes #1578`.

## Important scope clarification — coverage is policy-mapping, not detection recall

"100% direct-identifier coverage" here means **every gold-annotated direct identifier maps to a `replace` action under `india_dpdp_act`** — it is *not* a measurement of whether the runtime detector *finds* those identifiers. Runtime residual-substring scanning / detection recall is explicitly out of scope for this issue (it belongs to the sibling leakage gate #1579 and the parent suite). This is called out so the metric is not misread as end-to-end protection. (Independent note for the maintainer: the offline `safety_sweep` detector currently misses some Indic-script PERSON names and addresses in the corpus — a detector-capability gap tracked separately, not addressed here.)

## Deviations from the issue's letter

- **Not added to `DEFAULT_SUITES`** — harness registration is out of scope per the issue, and `openmed.eval.suites.DEFAULT_SUITES` is an exact-tuple pinned by `tests/unit/eval/test_metrics.py`; adding it would break that gate. Public names are re-exported from `openmed.eval` (mirrors the `INDIC_ENCODER_RECALL_DELTA` precedent).
- **Consumes the already-committed `india_dpdp_act` profile (#1497)** rather than duplicating it (the issue notes it should not be duplicated).

## Judgment calls

- **DPDP direct-identifier set** derived from the corpus ground truth (`span.metadata["direct_identifier"]`): PERSON / ID_NUM / PHONE / STREET_ADDRESS (all `DIRECT_IDENTIFIER` under `policy_label_for`, all resolve to `replace`); ZIPCODE is `QUASI_IDENTIFIER` (`mask`) — reported, not gated. A test asserts `direct ⇒ policy_label == DIRECT_IDENTIFIER` so the split can't silently drift.
- **Privacy-safety**: failure evidence carries `document_id`, canonical label, offset, and a `sha256:` surface hash — never the raw identifier value (asserted by a test and re-verified in review).

## Independent review

An independent adversarial pass returned a clean **APPROVE**: it serialized a passing report and two failing reports (PERSON→keep, PERSON→mask) and scanned the full JSON at all depths against every raw gold surface (names in Latin/Devanagari/Tamil, Aadhaar/ABHA/PAN/phone/address/pincode) — **0 raw-PHI hits**; the gate bites with the correct reasons (`direct_identifier_keep_action` / `direct_identifier_not_replaced`) naming label + document id; coverage math hand-verified against the 17-span corpus; determinism confirmed; `DEFAULT_SUITES` untouched. It independently surfaced the coverage-vs-recall clarification above.

## Data provenance

All fixtures are the pre-existing synthetic OM-677 corpus (`"synthetic": true`, deterministic fictional personas, no patient/production source), unchanged by this branch.

## Verification

- New suite: 6 passed. Full gate + regression run (`metrics`, `policy_compliance`, `india_clinical_phi_corpus`, `africa_policy_coverage`, `public_api_docstrings`, `packaging_typed`, `api_surface_diff`): 128 passed.
- `pre-commit` on changed files: all hooks green.
- No dependency added; `pyproject.toml` / `uv.lock` untouched.
- Base `maziyarpanahi/openmed:master`; `git rev-list --count HEAD..upstream/master` = 0.

## Relationship

Eval, Benchmarks &amp; Gates batch; independent branch, clean to master. Sibling of #1579 (India residual-PHI leakage gate) — both consume the committed corpus + `india_dpdp_act` policy and share the `openmed/eval` export surface, so whichever merges first, the other takes a trivial export rebase.
