### PR TITLE
fix: construct Spark de-identification pandas UDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the PySpark batch de-identification adapter so
+  `make_deidentify_udf()` supplies concrete pandas `Series` annotations during
+  UDF construction instead of failing with an unsupported `Any` signature
+  (#1942).
 - Fixed `openmed risk discover`, `risk assess`, and `risk anonymize` handling
   of UTF-8 BOM-prefixed CSV and TSV schemas so the first column is classified
   consistently, and added bounded validation causes to structured-release CLI

--- a/openmed/interop/spark_udf.py
+++ b/openmed/interop/spark_udf.py
@@ -96,12 +96,19 @@ def make_deidentify_udf(*, policy: str = "hipaa_safe_harbor", **kwargs: Any) -> 
     """
 
     pandas_udf, StringType = _load_pandas_udf()
+    pandas_module = _import_module("pandas")
 
-    @pandas_udf(StringType())
     def _redact(texts: Any) -> Any:
         return _deidentify_series(texts, policy=policy, **kwargs)
 
-    return _redact
+    # PySpark 3.5 infers the pandas UDF type from runtime annotations and
+    # rejects ``Any`` or postponed ``"pd.Series"`` annotations. Keep pandas
+    # lazy while supplying the concrete types before applying the decorator.
+    _redact.__annotations__ = {
+        "texts": pandas_module.Series,
+        "return": pandas_module.Series,
+    }
+    return pandas_udf(StringType())(_redact)
 
 
 def deidentify_columns(

--- a/tests/unit/interop/test_spark_udf.py
+++ b/tests/unit/interop/test_spark_udf.py
@@ -153,6 +153,44 @@ def test_make_deidentify_udf_raises_clear_error_without_pyspark(monkeypatch):
         spark_udf.make_deidentify_udf()
 
 
+def test_make_deidentify_udf_supplies_runtime_pandas_series_annotations(monkeypatch):
+    captured_annotations: dict[str, object] = {}
+
+    class FakeStringType:
+        pass
+
+    def fake_pandas_udf(return_type):
+        assert isinstance(return_type, FakeStringType)
+
+        def decorate(function):
+            captured_annotations.update(function.__annotations__)
+            return function
+
+        return decorate
+
+    monkeypatch.setattr(
+        spark_udf,
+        "_load_pandas_udf",
+        lambda: (fake_pandas_udf, FakeStringType),
+    )
+
+    udf = spark_udf.make_deidentify_udf()
+
+    assert callable(udf)
+    series_annotation = captured_annotations["texts"]
+    assert series_annotation is captured_annotations["return"]
+    assert getattr(series_annotation, "__module__", None) == "pandas.core.series"
+    assert getattr(series_annotation, "__qualname__", None) == "Series"
+
+
+def test_make_deidentify_udf_constructs_real_pandas_udf_when_installed():
+    pytest.importorskip("pyspark")
+
+    udf = spark_udf.make_deidentify_udf(deidentifier=fake_deidentifier)
+
+    assert callable(udf)
+
+
 class _FakeDataFrame:
     def __init__(self, columns: dict[str, str]) -> None:
         self.columns = dict(columns)


### PR DESCRIPTION
## Description

Fixes Spark batch de-identification UDF construction by replacing postponed `Any` runtime annotations with concrete pandas `Series` classes before PySpark decorates the callback. The pandas and PySpark imports remain lazy, so the optional-dependency boundary is preserved.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Supply concrete runtime `pandas.Series` input and return annotations before calling `pandas_udf`.
- Preserve lazy optional imports and the existing worker-side model loading behavior.
- Add annotation-contract and real PySpark construction regression tests.
- Record the fix in the unreleased changelog.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Model coverage is not applicable because the failure and fix occur during UDF construction before model invocation.

Validation:
- Exact Python 3.12.12 / PySpark 3.5.9 / pandas 2.3.3 / PyArrow 21.0.0 reproduction now constructs the UDF successfully.
- `.venv/bin/python -m pytest tests/unit/interop/test_spark_udf.py -q` — 12 passed.
- `PYSPARK_PYTHON=.venv/bin/python PYSPARK_DRIVER_PYTHON=.venv/bin/python .venv/bin/python -m pytest tests/ -q` — 9,097 passed, 78 skipped.
- `make format`, `make lint`, `make format-check` — passed.
- `make type-check` — passed.
- `pre-commit run --files CHANGELOG.md openmed/interop/spark_udf.py tests/unit/interop/test_spark_udf.py` — passed.

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

No public API or documentation usage changes are required; this restores the documented behavior. No new functions or classes were added.

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1942

## Screenshots/Examples

Before: `make_deidentify_udf()` raised `[UNSUPPORTED_SIGNATURE]` during decoration.

After: the same supported runtime returns a callable pandas UDF with concrete `pandas.Series` annotations.