### PR TITLE
feat(eval): add adversarial-perturbation robustness suite (homoglyph, zero-width, combining, bidi)

### DIFF
--- a/openmed/eval/__init__.py
+++ b/openmed/eval/__init__.py
@@ -4,6 +4,19 @@ Intended contents include harness.py, metrics.py, suites/, golden/, report.py,
 calibrate.py, and release_gates.py.
 """
 
+from openmed.eval.adversarial_perturbations import (
+    DEFAULT_ADVERSARIAL_PERTURBATION_PROBABILITY,
+    DEFAULT_ADVERSARIAL_PERTURBATIONS,
+    DEFAULT_LEAKAGE_DELTA_BUDGET,
+    AdversarialPerturbationGateError,
+    AdversarialPerturbationReport,
+    AdversarialPerturbationVariant,
+    adversarial_perturbation_report,
+    bidi_control_wrapping_perturbation,
+    combining_mark_injection_perturbation,
+    homoglyph_substitution_perturbation,
+    zero_width_injection_perturbation,
+)
 from openmed.eval.attacks.linkage import (
     LinkageAttackResult,
     LongitudinalLinkageAttackResult,
@@ -527,6 +540,17 @@ from openmed.eval.utility import (
 )
 
 __all__ = [
+    "DEFAULT_ADVERSARIAL_PERTURBATIONS",
+    "DEFAULT_ADVERSARIAL_PERTURBATION_PROBABILITY",
+    "DEFAULT_LEAKAGE_DELTA_BUDGET",
+    "AdversarialPerturbationGateError",
+    "AdversarialPerturbationReport",
+    "AdversarialPerturbationVariant",
+    "adversarial_perturbation_report",
+    "bidi_control_wrapping_perturbation",
+    "combining_mark_injection_perturbation",
+    "homoglyph_substitution_perturbation",
+    "zero_width_injection_perturbation",
     "DEFAULT_MIXED_SCRIPT_DETECTION_FLOOR",
     "MIXED_SCRIPT_LEAKAGE_CEILING",
     "ABSTENTION_ROUTE_ACCEPT",

--- a/openmed/eval/adversarial_perturbations.py
+++ b/openmed/eval/adversarial_perturbations.py
@@ -1,0 +1,473 @@
+"""Adversarial Unicode-evasion robustness suite.
+
+The typo/OCR/casing robustness suite (``openmed.eval.robustness``) covers
+natural perturbations. This module adds deterministic *adversarial* Unicode
+evasions an attacker uses to slip identifiers past a detector: homoglyph
+substitution, zero-width/invisible character insertion, combining-mark
+injection, and bidi-control wrapping.
+
+Every operator is seedable and produces byte-identical output across runs and
+processes. The suite generates perturbed variants of synthetic fixtures, scores
+the PHI-leakage delta against the clean baseline per operator (and per label),
+and enforces a fail-closed leakage-delta budget. It runs entirely offline over
+in-memory fixtures with no external assets.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from openmed.eval.harness import BenchmarkFixture, ModelRunner, default_model_runner
+from openmed.eval.metrics import EvalSpan, LeakageMetrics, compute_leakage_rate
+from openmed.eval.robustness import (
+    Edit,
+    Perturbation,
+    _perturb_fixture,
+    _resolve_model_runner,
+    _resolve_suite,
+    _run_predictions,
+    _select_positions,
+)
+
+FixturePerturber = Callable[[BenchmarkFixture, random.Random], BenchmarkFixture]
+PerturbationLike = str | Perturbation
+
+DEFAULT_ADVERSARIAL_PERTURBATION_PROBABILITY = 0.5
+DEFAULT_LEAKAGE_DELTA_BUDGET = 0.0
+
+# Curated Latin -> confusable maps built in-code (Greek/Cyrillic look-alikes).
+_HOMOGLYPH_SUBSTITUTIONS: Mapping[str, str] = {
+    "A": "\u0391",  # Greek capital alpha
+    "B": "\u0392",  # Greek capital beta
+    "C": "\u0421",  # Cyrillic capital es
+    "E": "\u0395",  # Greek capital epsilon
+    "H": "\u0397",  # Greek capital eta
+    "I": "\u0399",  # Greek capital iota
+    "K": "\u039a",  # Greek capital kappa
+    "M": "\u039c",  # Greek capital mu
+    "N": "\u039d",  # Greek capital nu
+    "O": "\u039f",  # Greek capital omicron
+    "P": "\u03a1",  # Greek capital rho
+    "T": "\u03a4",  # Greek capital tau
+    "X": "\u03a7",  # Greek capital chi
+    "a": "\u0430",  # Cyrillic small a
+    "c": "\u0441",  # Cyrillic small es
+    "e": "\u0435",  # Cyrillic small ie
+    "i": "\u0456",  # Cyrillic small dotless i
+    "o": "\u03bf",  # Greek small omicron
+    "p": "\u0440",  # Cyrillic small er
+    "x": "\u0445",  # Cyrillic small ha
+}
+# Zero-width / invisible code points inserted between visible characters.
+_ZERO_WIDTH_CHARS: tuple[str, ...] = (
+    "\u200b",  # zero-width space
+    "\u200c",  # zero-width non-joiner
+    "\u200d",  # zero-width joiner
+    "\u2060",  # word joiner
+    "\ufeff",  # zero-width no-break space
+)
+# Combining marks appended to a base character to split its cluster.
+_COMBINING_MARKS: tuple[str, ...] = (
+    "\u0301",  # combining acute accent
+    "\u0323",  # combining dot below
+    "\u0308",  # combining diaeresis
+    "\u0331",  # combining macron below
+)
+# Bidi-control (prefix, suffix) wrappers applied around a span.
+_BIDI_WRAPPERS: tuple[tuple[str, str], ...] = (
+    ("\u202e", "\u202c"),  # RLO ... PDF
+    ("\u202d", "\u202c"),  # LRO ... PDF
+    ("\u2067", "\u2069"),  # RLI ... PDI
+    ("\u2066", "\u2069"),  # LRI ... PDI
+)
+
+
+@dataclass(frozen=True)
+class AdversarialPerturbationVariant:
+    """Leakage and leakage-delta record for one adversarial operator."""
+
+    name: str
+    leakage: LeakageMetrics
+    delta_overall: float
+    delta_by_label: Mapping[str, float]
+    flagged: bool
+    flagged_labels: tuple[str, ...]
+    seed: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-ready variant payload keyed by operator and label."""
+        return {
+            "delta_by_label": dict(sorted(self.delta_by_label.items())),
+            "delta_overall": self.delta_overall,
+            "flagged": self.flagged,
+            "flagged_labels": list(self.flagged_labels),
+            "leakage": self.leakage.to_dict(),
+            "seed": self.seed,
+        }
+
+
+class AdversarialPerturbationGateError(RuntimeError):
+    """Raised when an operator raises leakage above the configured budget."""
+
+
+@dataclass(frozen=True)
+class AdversarialPerturbationReport:
+    """Clean-vs-perturbed leakage report with a fail-closed delta gate."""
+
+    model_name: str
+    suite: str
+    device: str
+    seed: int
+    leakage_delta_budget: float
+    clean: LeakageMetrics
+    variants: tuple[AdversarialPerturbationVariant, ...]
+    violations: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        """Return whether every operator stayed within the leakage budget."""
+        return not self.violations
+
+    def variant(self, name: str) -> AdversarialPerturbationVariant:
+        """Return the named operator variant."""
+        for variant in self.variants:
+            if variant.name == name:
+                return variant
+        raise KeyError(name)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-ready robustness-degradation report payload."""
+        return {
+            "clean": self.clean.to_dict(),
+            "device": self.device,
+            "leakage_delta_budget": self.leakage_delta_budget,
+            "model_name": self.model_name,
+            "passed": self.passed,
+            "seed": self.seed,
+            "suite": self.suite,
+            "variants": {variant.name: variant.to_dict() for variant in self.variants},
+            "violations": list(self.violations),
+        }
+
+
+def homoglyph_substitution_perturbation(
+    *,
+    probability: float = DEFAULT_ADVERSARIAL_PERTURBATION_PROBABILITY,
+    name: str = "homoglyph_substitution",
+) -> Perturbation:
+    """Return a deterministic Latin-to-confusable homoglyph perturbation."""
+
+    def apply(fixture: BenchmarkFixture, rng: random.Random) -> BenchmarkFixture:
+        text = fixture.text
+        edits: list[Edit] = []
+        for span in fixture.gold_spans:
+            positions = [
+                index
+                for index in range(span.start, span.end)
+                if text[index] in _HOMOGLYPH_SUBSTITUTIONS
+            ]
+            edits.extend(
+                (index, index + 1, _HOMOGLYPH_SUBSTITUTIONS[text[index]])
+                for index in _select_positions(positions, probability, rng)
+            )
+        return _perturb_fixture(fixture, edits)
+
+    return Perturbation(name=name, apply=apply)
+
+
+def zero_width_injection_perturbation(
+    *,
+    probability: float = DEFAULT_ADVERSARIAL_PERTURBATION_PROBABILITY,
+    name: str = "zero_width_injection",
+) -> Perturbation:
+    """Return a deterministic zero-width/invisible-character perturbation."""
+
+    def apply(fixture: BenchmarkFixture, rng: random.Random) -> BenchmarkFixture:
+        text = fixture.text
+        edits: list[Edit] = []
+        for span in fixture.gold_spans:
+            positions = [
+                index
+                for index in range(span.start, span.end - 1)
+                if text[index].isalnum() and text[index + 1].isalnum()
+            ]
+            for index in _select_positions(positions, probability, rng):
+                invisible = _ZERO_WIDTH_CHARS[rng.randrange(len(_ZERO_WIDTH_CHARS))]
+                edits.append((index, index + 1, f"{text[index]}{invisible}"))
+        return _perturb_fixture(fixture, edits)
+
+    return Perturbation(name=name, apply=apply)
+
+
+def combining_mark_injection_perturbation(
+    *,
+    probability: float = DEFAULT_ADVERSARIAL_PERTURBATION_PROBABILITY,
+    name: str = "combining_mark_injection",
+) -> Perturbation:
+    """Return a deterministic combining-mark splitting perturbation."""
+
+    def apply(fixture: BenchmarkFixture, rng: random.Random) -> BenchmarkFixture:
+        text = fixture.text
+        edits: list[Edit] = []
+        for span in fixture.gold_spans:
+            positions = [
+                index for index in range(span.start, span.end) if text[index].isalpha()
+            ]
+            for index in _select_positions(positions, probability, rng):
+                mark = _COMBINING_MARKS[rng.randrange(len(_COMBINING_MARKS))]
+                edits.append((index, index + 1, f"{text[index]}{mark}"))
+        return _perturb_fixture(fixture, edits)
+
+    return Perturbation(name=name, apply=apply)
+
+
+def bidi_control_wrapping_perturbation(
+    *,
+    name: str = "bidi_control_wrapping",
+) -> Perturbation:
+    """Return a deterministic bidi-control wrapping perturbation.
+
+    Each gold span is wrapped in a seed-chosen bidirectional override pair
+    (for example RLO ... PDF), a byte-level evasion that leaves the rendered
+    glyphs unchanged while corrupting the underlying identifier.
+    """
+
+    def apply(fixture: BenchmarkFixture, rng: random.Random) -> BenchmarkFixture:
+        text = fixture.text
+        edits: list[Edit] = []
+        for span in fixture.gold_spans:
+            if span.end <= span.start:
+                continue
+            prefix, suffix = _BIDI_WRAPPERS[rng.randrange(len(_BIDI_WRAPPERS))]
+            first = span.start
+            last = span.end - 1
+            if first == last:
+                edits.append((first, first + 1, f"{prefix}{text[first]}{suffix}"))
+                continue
+            edits.append((first, first + 1, f"{prefix}{text[first]}"))
+            edits.append((last, last + 1, f"{text[last]}{suffix}"))
+        return _perturb_fixture(fixture, edits)
+
+    return Perturbation(name=name, apply=apply)
+
+
+DEFAULT_ADVERSARIAL_PERTURBATIONS: tuple[Perturbation, ...] = (
+    homoglyph_substitution_perturbation(),
+    zero_width_injection_perturbation(),
+    combining_mark_injection_perturbation(),
+    bidi_control_wrapping_perturbation(),
+)
+
+
+def adversarial_perturbation_report(
+    model: str | ModelRunner,
+    suite: str | Path | Iterable[BenchmarkFixture],
+    perturbations: (
+        PerturbationLike
+        | Sequence[PerturbationLike]
+        | Mapping[str, PerturbationLike]
+        | None
+    ) = None,
+    seed: int = 0,
+    *,
+    suite_name: str | None = None,
+    device: str = "cpu",
+    runner: ModelRunner | None = None,
+    leakage_delta_budget: float = DEFAULT_LEAKAGE_DELTA_BUDGET,
+    raise_on_violation: bool = False,
+) -> AdversarialPerturbationReport:
+    """Score per-operator PHI-leakage deltas under adversarial Unicode evasions.
+
+    Args:
+        model: Model name, or a benchmark runner callable. When a callable is
+            supplied and ``runner`` is omitted, it is used as the runner.
+        suite: Fixture path, named suite, or an iterable of benchmark fixtures.
+        perturbations: Operator names or objects. ``None`` uses the default
+            homoglyph, zero-width, combining-mark, and bidi-control operators.
+        seed: Base seed making each operator reproducible.
+        suite_name: Optional report suite name for iterable fixture inputs.
+        device: Device label passed through to leakage scoring.
+        runner: Optional injected model runner.
+        leakage_delta_budget: Maximum tolerated increase in overall leakage per
+            operator. An operator whose leakage delta exceeds this budget is
+            flagged and recorded as a gate violation (fail-closed at ``0.0``).
+        raise_on_violation: When true, raise instead of returning a failing
+            report.
+
+    Returns:
+        A clean-baseline leakage report plus one variant per operator with the
+        leakage delta keyed by operator and label and a fail-closed gate.
+    """
+    if leakage_delta_budget < 0.0:
+        raise ValueError("leakage_delta_budget must be non-negative")
+
+    fixtures, resolved_suite_name = _resolve_suite(suite, suite_name=suite_name)
+    model_name, model_runner = _resolve_model_runner(model, runner)
+    base_runner = model_runner or default_model_runner
+
+    clean = _suite_leakage(fixtures, base_runner, model_name, device)
+
+    variants: list[AdversarialPerturbationVariant] = []
+    violations: list[str] = []
+    for index, perturbation in enumerate(_resolve_perturbations(perturbations)):
+        variant_seed = seed + index
+        rng = random.Random(variant_seed)
+        perturbed = [perturbation(fixture, rng) for fixture in fixtures]
+        leakage = _suite_leakage(perturbed, base_runner, model_name, device)
+        delta_overall = leakage.overall - clean.overall
+        delta_by_label = _leakage_delta_by_label(clean, leakage)
+        flagged_labels = tuple(
+            label
+            for label, delta in sorted(delta_by_label.items())
+            if delta > leakage_delta_budget
+        )
+        flagged = delta_overall > leakage_delta_budget
+        if flagged:
+            violations.append(perturbation.name)
+        variants.append(
+            AdversarialPerturbationVariant(
+                name=perturbation.name,
+                leakage=leakage,
+                delta_overall=delta_overall,
+                delta_by_label=delta_by_label,
+                flagged=flagged,
+                flagged_labels=flagged_labels,
+                seed=variant_seed,
+            )
+        )
+
+    report = AdversarialPerturbationReport(
+        model_name=model_name,
+        suite=resolved_suite_name,
+        device=device,
+        seed=seed,
+        leakage_delta_budget=leakage_delta_budget,
+        clean=clean,
+        variants=tuple(variants),
+        violations=tuple(violations),
+    )
+    if raise_on_violation and not report.passed:
+        joined = ", ".join(report.violations)
+        raise AdversarialPerturbationGateError(
+            f"adversarial-perturbation leakage gate failed: {joined}"
+        )
+    return report
+
+
+def _suite_leakage(
+    fixtures: Sequence[BenchmarkFixture],
+    runner: ModelRunner,
+    model_name: str,
+    device: str,
+) -> LeakageMetrics:
+    """Aggregate gold/predicted spans across a suite and score leakage."""
+    gold: list[EvalSpan] = []
+    predicted: list[EvalSpan] = []
+    document_offset = 0
+    for fixture in fixtures:
+        for span in fixture.gold_spans:
+            gold.append(
+                replace(
+                    span,
+                    start=document_offset + span.start,
+                    end=document_offset + span.end,
+                )
+            )
+        for prediction in _run_predictions(fixture, runner, model_name, device):
+            predicted.append(
+                replace(
+                    prediction,
+                    start=document_offset + prediction.start,
+                    end=document_offset + prediction.end,
+                )
+            )
+        document_offset += len(fixture.text) + 1
+    return compute_leakage_rate(gold, predicted, default_device=device)
+
+
+def _leakage_delta_by_label(
+    clean: LeakageMetrics,
+    perturbed: LeakageMetrics,
+) -> dict[str, float]:
+    """Return per-label leakage deltas over labels observed in either run.
+
+    ``LeakageMetrics.by_label`` enumerates the full canonical label set with a
+    zero rate for absent labels; the report is keyed only on labels that carry
+    gold PHI graphemes in the clean or perturbed suite.
+    """
+    labels = {
+        label
+        for counts in (clean.total_chars_by_label, perturbed.total_chars_by_label)
+        for label, total in counts.items()
+        if total > 0
+    }
+    return {
+        label: perturbed.by_label.get(label, 0.0) - clean.by_label.get(label, 0.0)
+        for label in sorted(labels)
+    }
+
+
+def _resolve_perturbations(
+    perturbations: (
+        PerturbationLike
+        | Sequence[PerturbationLike]
+        | Mapping[str, PerturbationLike]
+        | None
+    ),
+) -> tuple[Perturbation, ...]:
+    if perturbations is None:
+        return DEFAULT_ADVERSARIAL_PERTURBATIONS
+    if isinstance(perturbations, (str, Perturbation)):
+        return (_coerce_perturbation(perturbations),)
+    if isinstance(perturbations, Mapping):
+        return tuple(
+            _coerce_perturbation(perturbation, name=name)
+            for name, perturbation in perturbations.items()
+        )
+    return tuple(_coerce_perturbation(perturbation) for perturbation in perturbations)
+
+
+def _coerce_perturbation(
+    perturbation: str | Perturbation,
+    *,
+    name: str | None = None,
+) -> Perturbation:
+    if isinstance(perturbation, Perturbation):
+        if name is not None and name != perturbation.name:
+            return Perturbation(name=name, apply=perturbation.apply)
+        return perturbation
+    key = perturbation.lower().replace("-", "_")
+    aliases = {
+        "bidi": "bidi_control_wrapping",
+        "combining": "combining_mark_injection",
+        "combining_mark": "combining_mark_injection",
+        "homoglyph": "homoglyph_substitution",
+        "zero_width": "zero_width_injection",
+        "zerowidth": "zero_width_injection",
+    }
+    key = aliases.get(key, key)
+    for candidate in DEFAULT_ADVERSARIAL_PERTURBATIONS:
+        if candidate.name == key:
+            if name is not None and name != candidate.name:
+                return Perturbation(name=name, apply=candidate.apply)
+            return candidate
+    raise ValueError(f"unknown adversarial perturbation: {perturbation!r}")
+
+
+__all__ = [
+    "DEFAULT_ADVERSARIAL_PERTURBATIONS",
+    "DEFAULT_ADVERSARIAL_PERTURBATION_PROBABILITY",
+    "DEFAULT_LEAKAGE_DELTA_BUDGET",
+    "AdversarialPerturbationGateError",
+    "AdversarialPerturbationReport",
+    "AdversarialPerturbationVariant",
+    "adversarial_perturbation_report",
+    "bidi_control_wrapping_perturbation",
+    "combining_mark_injection_perturbation",
+    "homoglyph_substitution_perturbation",
+    "zero_width_injection_perturbation",
+]

--- a/openmed/eval/adversarial_perturbations.py
+++ b/openmed/eval/adversarial_perturbations.py
@@ -97,6 +97,7 @@ class AdversarialPerturbationVariant:
     flagged: bool
     flagged_labels: tuple[str, ...]
     seed: int
+    perturbed_documents: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-ready variant payload keyed by operator and label."""
@@ -106,6 +107,7 @@ class AdversarialPerturbationVariant:
             "flagged": self.flagged,
             "flagged_labels": list(self.flagged_labels),
             "leakage": self.leakage.to_dict(),
+            "perturbed_documents": self.perturbed_documents,
             "seed": self.seed,
         }
 
@@ -317,6 +319,11 @@ def adversarial_perturbation_report(
         variant_seed = seed + index
         rng = random.Random(variant_seed)
         perturbed = [perturbation(fixture, rng) for fixture in fixtures]
+        perturbed_documents = sum(
+            1
+            for original, variant in zip(fixtures, perturbed)
+            if variant.text != original.text
+        )
         leakage = _suite_leakage(perturbed, base_runner, model_name, device)
         delta_overall = leakage.overall - clean.overall
         delta_by_label = _leakage_delta_by_label(clean, leakage)
@@ -337,6 +344,7 @@ def adversarial_perturbation_report(
                 flagged=flagged,
                 flagged_labels=flagged_labels,
                 seed=variant_seed,
+                perturbed_documents=perturbed_documents,
             )
         )
 

--- a/tests/unit/eval/test_adversarial_perturbations.py
+++ b/tests/unit/eval/test_adversarial_perturbations.py
@@ -1,0 +1,231 @@
+"""Tests for the adversarial Unicode-evasion perturbation suite."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import socket
+import subprocess
+import sys
+
+import pytest
+
+from openmed.eval.adversarial_perturbations import (
+    DEFAULT_ADVERSARIAL_PERTURBATIONS,
+    AdversarialPerturbationGateError,
+    adversarial_perturbation_report,
+    bidi_control_wrapping_perturbation,
+    combining_mark_injection_perturbation,
+    homoglyph_substitution_perturbation,
+    zero_width_injection_perturbation,
+)
+from openmed.eval.harness import BenchmarkFixture
+
+_ALL_OPERATORS = [
+    homoglyph_substitution_perturbation(probability=1.0),
+    zero_width_injection_perturbation(probability=1.0),
+    combining_mark_injection_perturbation(probability=1.0),
+    bidi_control_wrapping_perturbation(),
+]
+
+
+def _fixture() -> BenchmarkFixture:
+    return BenchmarkFixture.from_mapping(
+        {
+            "id": "note-1",
+            "text": "Patient John Doe has MRN A1001 today.",
+            "language": "en",
+            "gold_spans": [
+                {"start": 8, "end": 16, "label": "PERSON"},
+                {"start": 25, "end": 30, "label": "ID_NUM"},
+            ],
+        }
+    )
+
+
+def _naive_runner(fixture, model_name, device):
+    """Detector that only matches the pristine (unperturbed) surfaces."""
+    assert device == "cpu"
+    out = []
+    for value, label in (("John Doe", "PERSON"), ("A1001", "ID_NUM")):
+        start = fixture.text.find(value)
+        if start >= 0:
+            out.append({"start": start, "end": start + len(value), "label": label})
+    return out
+
+
+def _oracle_runner(fixture, model_name, device):
+    """Detector that recovers every gold span regardless of perturbation."""
+    return [
+        {"start": span.start, "end": span.end, "label": span.label}
+        for span in fixture.gold_spans
+    ]
+
+
+@pytest.mark.parametrize("operator", _ALL_OPERATORS)
+def test_operators_are_seeded_and_reproject_spans_without_drift(operator):
+    fixture = _fixture()
+
+    first = operator(fixture, random.Random(17))
+    second = operator(fixture, random.Random(17))
+
+    assert first.text == second.text
+    assert first.gold_spans == second.gold_spans
+    assert first.text != fixture.text
+    for span in first.gold_spans:
+        assert span.text == first.text[span.start : span.end]
+        assert span.end > span.start
+
+
+@pytest.mark.parametrize("operator", _ALL_OPERATORS)
+def test_operators_actually_perturb_each_gold_span(operator):
+    fixture = _fixture()
+
+    perturbed = operator(fixture, random.Random(3))
+
+    # Every gold identifier surface is corrupted at the byte level.
+    for clean_span, dirty_span in zip(fixture.gold_spans, perturbed.gold_spans):
+        assert dirty_span.text != clean_span.text
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "homoglyph_substitution",
+        "zero_width_injection",
+        "combining_mark_injection",
+        "bidi_control_wrapping",
+    ],
+)
+def test_operators_are_byte_identical_across_processes(name):
+    fixture = _fixture()
+    operator = next(p for p in DEFAULT_ADVERSARIAL_PERTURBATIONS if p.name == name)
+    in_process = operator(fixture, random.Random(99)).text
+
+    def _subprocess_text(hashseed: str) -> str:
+        env = dict(os.environ)
+        env["PYTHONHASHSEED"] = hashseed
+        snippet = (
+            "import random, json;"
+            "from openmed.eval.harness import BenchmarkFixture;"
+            "from openmed.eval.adversarial_perturbations import"
+            " DEFAULT_ADVERSARIAL_PERTURBATIONS as P;"
+            "fx=BenchmarkFixture.from_mapping("
+            "{'id':'note-1','text':'Patient John Doe has MRN A1001 today.',"
+            "'language':'en','gold_spans':["
+            "{'start':8,'end':16,'label':'PERSON'},"
+            "{'start':25,'end':30,'label':'ID_NUM'}]});"
+            f"op=next(p for p in P if p.name=={name!r});"
+            "print(json.dumps(op(fx, random.Random(99)).text))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", snippet],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        return json.loads(result.stdout)
+
+    # Hash randomization must not perturb the deterministic output.
+    assert _subprocess_text("0") == in_process
+    assert _subprocess_text("123456") == in_process
+
+
+def test_report_flags_over_budget_operators_against_clean_baseline():
+    report = adversarial_perturbation_report(
+        "exact",
+        [_fixture()],
+        runner=_naive_runner,
+        suite_name="synthetic",
+    )
+
+    assert report.clean.overall == pytest.approx(0.0)
+    assert not report.passed
+    # Every operator evades the pristine-surface detector and raises leakage.
+    assert set(report.violations) == {
+        "bidi_control_wrapping",
+        "combining_mark_injection",
+        "homoglyph_substitution",
+        "zero_width_injection",
+    }
+    for variant in report.variants:
+        assert variant.flagged
+        assert variant.delta_overall > 0.0
+        # Report is keyed by operator and label.
+        assert set(variant.flagged_labels) == {"ID_NUM", "PERSON"}
+        assert set(variant.delta_by_label) == {"ID_NUM", "PERSON"}
+        assert all(delta >= 0.0 for delta in variant.delta_by_label.values())
+
+
+def test_report_passes_when_detector_recovers_perturbed_spans():
+    report = adversarial_perturbation_report(
+        "exact",
+        [_fixture()],
+        runner=_oracle_runner,
+    )
+
+    assert report.passed
+    assert not report.violations
+    for variant in report.variants:
+        assert not variant.flagged
+        assert variant.flagged_labels == ()
+        assert variant.delta_overall == pytest.approx(0.0)
+        assert variant.leakage.overall == pytest.approx(0.0)
+
+
+def test_report_tolerates_deltas_within_configured_budget():
+    report = adversarial_perturbation_report(
+        "exact",
+        [_fixture()],
+        runner=_naive_runner,
+        leakage_delta_budget=1.0,
+    )
+
+    # A budget of 1.0 admits full-leakage deltas, so nothing is flagged.
+    assert report.passed
+    assert not report.violations
+
+
+def test_gate_raises_on_violation():
+    with pytest.raises(
+        AdversarialPerturbationGateError,
+        match="adversarial-perturbation leakage gate failed",
+    ):
+        adversarial_perturbation_report(
+            "exact",
+            [_fixture()],
+            runner=_naive_runner,
+            raise_on_violation=True,
+        )
+
+
+def test_report_is_offline_and_serializes_without_raw_phi(monkeypatch):
+    def _no_network(*args, **kwargs):
+        raise AssertionError("adversarial-perturbation suite must run offline")
+
+    monkeypatch.setattr(socket, "socket", _no_network)
+
+    report = adversarial_perturbation_report(
+        "exact",
+        [_fixture()],
+        runner=_naive_runner,
+        suite_name="synthetic",
+    )
+
+    payload = json.dumps(report.to_dict(), sort_keys=True)
+    assert "John Doe" not in payload
+    assert "A1001" not in payload
+    assert report.to_dict()["variants"]["homoglyph_substitution"]["flagged"] is True
+    assert report.to_dict()["leakage_delta_budget"] == 0.0
+
+
+def test_negative_budget_is_rejected():
+    with pytest.raises(ValueError, match="non-negative"):
+        adversarial_perturbation_report(
+            "exact",
+            [_fixture()],
+            runner=_naive_runner,
+            leakage_delta_budget=-0.1,
+        )

--- a/tests/unit/eval/test_adversarial_perturbations.py
+++ b/tests/unit/eval/test_adversarial_perturbations.py
@@ -221,6 +221,44 @@ def test_report_is_offline_and_serializes_without_raw_phi(monkeypatch):
     assert report.to_dict()["leakage_delta_budget"] == 0.0
 
 
+def test_variant_records_operator_coverage_to_expose_noop_operators():
+    # A gold span of pure digits has no homoglyph-map or alphabetic characters,
+    # so those operators cannot perturb it. The report must make that visible
+    # instead of reporting a falsely-clean, indistinguishable pass.
+    numeric = BenchmarkFixture.from_mapping(
+        {
+            "id": "note-2",
+            "text": "MRN is 40071 today.",
+            "language": "en",
+            "gold_spans": [{"start": 7, "end": 12, "label": "ID_NUM"}],
+        }
+    )
+
+    def _find_numeric(fixture, model_name, device):
+        start = fixture.text.find("40071")
+        if start < 0:
+            return []
+        return [{"start": start, "end": start + 5, "label": "ID_NUM"}]
+
+    report = adversarial_perturbation_report(
+        "exact",
+        [numeric],
+        runner=_find_numeric,
+        suite_name="synthetic",
+    )
+
+    # Homoglyph/combining cannot touch pure digits -> zero coverage, still "clean".
+    assert report.variant("homoglyph_substitution").perturbed_documents == 0
+    assert report.variant("combining_mark_injection").perturbed_documents == 0
+    assert not report.variant("homoglyph_substitution").flagged
+    # Zero-width and bidi still perturb adjacent digits.
+    assert report.variant("zero_width_injection").perturbed_documents == 1
+    assert report.variant("bidi_control_wrapping").perturbed_documents == 1
+    payload = report.to_dict()["variants"]
+    assert payload["homoglyph_substitution"]["perturbed_documents"] == 0
+    assert payload["zero_width_injection"]["perturbed_documents"] == 1
+
+
 def test_negative_budget_is_rejected():
     with pytest.raises(ValueError, match="non-negative"):
         adversarial_perturbation_report(


### PR DESCRIPTION
## Summary
Adds a standalone adversarial-perturbation robustness suite that extends the existing `openmed/eval/robustness.py` (OM-232) with deliberate Unicode evasions attackers use to slip identifiers past detectors: **homoglyph substitution**, **zero-width/invisible-character insertion**, **combining-mark injection**, and **bidi-control wrapping**. Each operator produces seeded-deterministic perturbations of synthetic fixtures, scores per-operator leakage delta vs. a clean baseline, and exposes a fail-closed leakage-delta gate. Runs fully offline.

Closes #885.

## Scope (mirrors the issue)
- Perturbation operators for homoglyph substitution, zero-width/invisible insertion, combining-mark injection, and bidi-control wrapping.
- Perturbed variants of synthetic fixtures with per-operator leakage delta vs. clean baseline.
- Robustness-degradation report keyed by operator and label, with a fail-closed leakage-delta budget gate (`DEFAULT_LEAKAGE_DELTA_BUDGET = 0.0` — any leakage increase flags).

## Deviations from the issue's letter (with evidence)
- **Extra file — `openmed/eval/__init__.py`** (issue listed 2 files). Package-export of the new public symbols, following the module's established export convention (the closest merged analog touched `__init__.py` identically). No auto-enrolling gate forces further files: `test_public_api_docstrings.py` scans only top-level `openmed.__all__`, `test_packaging_typed.py` walks a hardcoded `TYPED_MODULES` tuple, and there is no eval-`__all__`/exact-count/doc-drift test.
- **Reuses `robustness.py` private helpers** (offset projection, leakage scoring, `Perturbation`/`Edit`) rather than reinventing — guarantees leakage is scored identically to OM-232 and keeps vetted offset code single-sourced.
- **Curated Unicode maps use `\uXXXX` escapes, not literal glyphs** — the bandit `B613` trojansource hook rejects literal bidi controls; also matches `robustness.py`'s convention.
- **`bidi_control_wrapping` is a genuinely new operator**; the other three promote internal adversarial-search operations into first-class, seedable, individually-scored suite operators per the issue scope.

## Independent adversarial review
A separate reviewer attacked cross-process determinism, gate sign/direction, PHI-in-report, and offset integrity — all held (insertion operators reuse `_apply_edits`, which **raises** on any span drift, so a miscount can't silently mis-score). One **MEDIUM** fixed: no-op operators on numeric-only PHI (homoglyph/combining can't touch digits) previously emitted a silently-clean pass; now each operator reports a `perturbed_documents` coverage count so a zero-coverage attack is detectable in the audit artifact. Verdict semantics were intentionally left unchanged (the delta contract is correct; flagging zero-coverage as a violation would be a contract change for the maintainer to decide).

## Data provenance
All synthetic and algorithmic. Fixtures are in-code objects with invented names/IDs; homoglyph/zero-width/combining/bidi tables are small curated Unicode maps built in-code. No real PHI, no external assets, no network/file I/O (an offline test blocks `socket`).

## Verification
- New suite: **19 tests** pass (determinism within-process and byte-identical across subprocesses under differing `PYTHONHASHSEED`; each operator perturbs; gate flags an over-budget operator and passes a clean one; offline; no raw PHI in serialized report).
- Full `tests/unit/eval`: **1004 passed, 5 skipped** (skips pre-existing optional-dep), post-rebase onto current `master`.
- `pre-commit` on changed files: all hooks pass.

## Sibling PRs / rebase
Independent on `master`. Shares only the additive `openmed/eval/__init__.py` export block with siblings #1274 (OM-776) and #1279 (OM-781) from the same Eval/Benchmarks/Gates P1 batch — the three export blocks are in different regions and rebased cleanly over the just-merged #1935. I will rebase as siblings merge.
