### PR TITLE
feat: add clinical PHI SHIELD benchmark evidence

### DIFF
--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -18,6 +18,35 @@ provision licensed assets outside the repository and pass an explicit local
 path to `load_cmeee`. Missing paths and repository-internal real-data paths fail
 with license-boundary guidance.
 
+## Clinical PHI flagship SHIELD comparison
+
+The `OpenMed/OpenMed-ClinicalPrivacy-tier0` SHIELD report is comparison
+evidence, not a high-recall release gate. Its explicit
+`metrics.shield_comparison` block contains aggregate recall, leakage, and exact
+span scores plus recall and leakage for every SHIELD-mapped canonical label.
+G1a, G2, and G3 certification remains a separate release-gate workflow.
+
+The flagship runner requires a checkpoint manifest and a stable link to that
+manifest. The report binds that checkpoint row to the committed clinical-PHI
+dataset manifest, the public SHIELD corpus coordinates, the normalized fixture
+set, and the eval code. It stores hashes instead of raw fixture identifiers and
+does not vendor SHIELD rows.
+
+```bash
+openmed benchmark pii \
+  --suite shield \
+  --models OpenMed/OpenMed-ClinicalPrivacy-tier0 \
+  --checkpoint-manifest models.jsonl \
+  --checkpoint-manifest-ref \
+    models.jsonl#OpenMed/OpenMed-ClinicalPrivacy-tier0 \
+  --output clinical-privacy-shield.report.json
+```
+
+The checkpoint input may be a JSON object, a list of model rows, or JSONL. Its
+flagship row must identify `OpenMed/OpenMed-ClinicalPrivacy-tier0`; when a
+`reproducibility_hash` is present, it must be a lowercase `sha256:` digest.
+Offline tests use only synthetic SHIELD-shaped rows.
+
 ## Metric Bundle
 
 | Metric | Path | Gating? | Description |

--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -1988,6 +1988,23 @@ def _add_benchmark_command(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Use the approved-access full SHIELD corpus instead of the public sample.",
     )
+    pii_parser.add_argument(
+        "--checkpoint-manifest",
+        type=Path,
+        default=None,
+        help=(
+            "Checkpoint JSON or JSONL for the named clinical PHI flagship. "
+            "This enables manifest-linked SHIELD comparison evidence."
+        ),
+    )
+    pii_parser.add_argument(
+        "--checkpoint-manifest-ref",
+        default=None,
+        help=(
+            "Stable repository or publication link to --checkpoint-manifest, "
+            "recorded in the BenchmarkReport."
+        ),
+    )
     pii_parser.set_defaults(handler=_handle_benchmark_pii)
 
     clinical_parser = benchmark_sub.add_parser(
@@ -4227,8 +4244,14 @@ def _handle_benchmark_pii(args: argparse.Namespace) -> int:
     if args.attack == "reid":
         return _handle_benchmark_pii_reid(args)
 
+    from openmed.eval.datasets import CLINICAL_PRIVACY_MODEL_ID
     from openmed.eval.harness import run_benchmark
-    from openmed.eval.suites import SHIELD, load_suite_fixtures, suite_metadata
+    from openmed.eval.suites import (
+        SHIELD,
+        load_suite_fixtures,
+        run_clinical_phi_shield_benchmark,
+        suite_metadata,
+    )
 
     try:
         models = _parse_model_args(args.models or [])
@@ -4242,6 +4265,39 @@ def _handle_benchmark_pii(args: argparse.Namespace) -> int:
         )
 
     suite = str(args.suite or SHIELD)
+    if args.checkpoint_manifest_ref and args.checkpoint_manifest is None:
+        raise CliError(
+            "--checkpoint-manifest-ref requires --checkpoint-manifest.",
+            code="invalid_argument",
+            exit_code=EXIT_USAGE,
+        )
+    if args.checkpoint_manifest is not None:
+        if suite != SHIELD:
+            raise CliError(
+                "--checkpoint-manifest is supported only for the SHIELD suite.",
+                code="invalid_argument",
+                exit_code=EXIT_USAGE,
+            )
+        if args.full_shield:
+            raise CliError(
+                "The clinical PHI flagship report uses the public SHIELD sample; "
+                "do not combine --checkpoint-manifest with --full-shield.",
+                code="invalid_argument",
+                exit_code=EXIT_USAGE,
+            )
+        if len(models) != 1 or models[0] != CLINICAL_PRIVACY_MODEL_ID:
+            raise CliError(
+                "--checkpoint-manifest requires exactly the named model "
+                f"{CLINICAL_PRIVACY_MODEL_ID!r}.",
+                code="invalid_argument",
+                exit_code=EXIT_USAGE,
+            )
+        if not args.checkpoint_manifest_ref:
+            raise CliError(
+                "--checkpoint-manifest-ref is required for reproducible evidence.",
+                code="invalid_argument",
+                exit_code=EXIT_USAGE,
+            )
     try:
         if suite == SHIELD:
             use_sample = not bool(args.full_shield)
@@ -4261,16 +4317,33 @@ def _handle_benchmark_pii(args: argparse.Namespace) -> int:
     metadata.setdefault("benchmark_domain", "pii")
     metadata.setdefault("source_suite", suite)
 
-    reports = [
-        run_benchmark(
-            fixtures,
-            suite=suite,
-            model_name=model,
-            device=args.device,
-            metadata=metadata,
-        )
-        for model in models
-    ]
+    if args.checkpoint_manifest is not None:
+        try:
+            reports = [
+                run_clinical_phi_shield_benchmark(
+                    fixtures,
+                    checkpoint_manifest=args.checkpoint_manifest,
+                    checkpoint_manifest_ref=args.checkpoint_manifest_ref,
+                    device=args.device,
+                )
+            ]
+        except ValueError as exc:
+            raise CliError(
+                f"Invalid clinical PHI checkpoint evidence: {exc}",
+                code="invalid_argument",
+                exit_code=EXIT_USAGE,
+            ) from exc
+    else:
+        reports = [
+            run_benchmark(
+                fixtures,
+                suite=suite,
+                model_name=model,
+                device=args.device,
+                metadata=metadata,
+            )
+            for model in models
+        ]
     if len(reports) == 1:
         payload: Any = reports[0].to_dict()
     else:

--- a/openmed/eval/suites/__init__.py
+++ b/openmed/eval/suites/__init__.py
@@ -192,6 +192,7 @@ from openmed.eval.suites.relations import (
 from openmed.eval.suites.shield import (
     SHIELD,
     load_shield_fixtures,
+    run_clinical_phi_shield_benchmark,
     shield_suite_metadata,
 )
 
@@ -483,6 +484,7 @@ __all__ = [
     "load_masakhaner_fixtures",
     "drugprot_suite_metadata",
     "load_shield_fixtures",
+    "run_clinical_phi_shield_benchmark",
     "shield_suite_metadata",
     "load_policy_compliance_fixtures",
     "policy_compliance_metadata",

--- a/openmed/eval/suites/shield.py
+++ b/openmed/eval/suites/shield.py
@@ -7,12 +7,15 @@ No corpus rows are stored in this repository.
 from __future__ import annotations
 
 import json
+import re
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
 from urllib.parse import quote
 from urllib.request import urlopen
 
+from openmed.core.audit import stable_hash
 from openmed.core.labels import (
     AGE,
     CANONICAL_LABELS,
@@ -24,8 +27,14 @@ from openmed.core.labels import (
     PHONE,
     URL,
 )
-from openmed.eval.harness import BenchmarkFixture
+from openmed.eval.cache import eval_code_hash, hash_fixture_set
+from openmed.eval.harness import (
+    BenchmarkFixture,
+    ModelRunner,
+    run_benchmark,
+)
 from openmed.eval.metrics import EvalSpan
+from openmed.eval.report import BenchmarkReport
 
 SHIELD = "shield"
 CORPUS_ROLE = "comparison"
@@ -55,6 +64,9 @@ SHIELD_LABEL_TO_CANONICAL: dict[str, str] = {
 }
 
 RowsLoader = Callable[[str, str, str], list[Mapping[str, Any]]]
+CheckpointManifest = Mapping[str, Any] | str | Path
+_SAFE_MANIFEST_REF = re.compile(r"[A-Za-z0-9._~:/?#@!$&()*+,;=%-]{1,2048}")
+_SAFE_SOURCE_REVISION = re.compile(r"[A-Za-z0-9._~:/@+-]{1,256}")
 
 
 @dataclass(frozen=True)
@@ -190,6 +202,119 @@ def fixtures_from_rows(
     return fixtures
 
 
+def run_clinical_phi_shield_benchmark(
+    fixtures: Sequence[BenchmarkFixture],
+    *,
+    checkpoint_manifest: CheckpointManifest,
+    checkpoint_manifest_ref: str,
+    device: str = "cpu",
+    runner: ModelRunner | None = None,
+    generated_at: str | None = None,
+) -> BenchmarkReport:
+    """Benchmark the named clinical-PHI flagship as SHIELD comparison evidence.
+
+    The checkpoint manifest may be one JSON object, a list of model-manifest
+    rows, or a JSONL model manifest. ``checkpoint_manifest_ref`` is the stable
+    repository or publication link recorded in the report. Corpus text and raw
+    fixture identifiers are never copied into the resulting metadata.
+
+    Args:
+        fixtures: Public-sample SHIELD fixtures loaded by reference. Tests may
+            supply synthetic SHIELD-shaped rows through :func:`fixtures_from_rows`.
+        checkpoint_manifest: Checkpoint metadata or a path containing it.
+        checkpoint_manifest_ref: Stable link to the committed or published
+            checkpoint manifest.
+        device: Device label recorded in the benchmark report.
+        runner: Optional model runner; defaults to the standard eval runner.
+        generated_at: Optional caller-supplied report timestamp.
+
+    Returns:
+        A ``BenchmarkReport`` with explicit aggregate and per-label SHIELD
+        comparison metrics plus reproducibility metadata.
+
+    Raises:
+        ValueError: If the checkpoint or fixtures do not identify the named
+            flagship and public SHIELD comparison source.
+    """
+
+    from openmed.eval.datasets.clinical_phi import (
+        CLINICAL_PHI_MANIFEST_ID,
+        CLINICAL_PHI_MANIFEST_REF,
+        CLINICAL_PRIVACY_MODEL_ID,
+        clinical_phi_manifest_hash,
+        load_clinical_phi_manifest,
+    )
+
+    if not fixtures:
+        raise ValueError("clinical PHI SHIELD benchmark requires fixtures")
+    _validate_public_sample_fixtures(fixtures)
+    manifest_ref = _validate_manifest_ref(checkpoint_manifest_ref)
+    checkpoint = _checkpoint_manifest_row(
+        checkpoint_manifest,
+        model_id=CLINICAL_PRIVACY_MODEL_ID,
+    )
+    checkpoint_metadata = _checkpoint_metadata(
+        checkpoint,
+        manifest_ref=manifest_ref,
+        model_id=CLINICAL_PRIVACY_MODEL_ID,
+    )
+
+    dataset_manifest = load_clinical_phi_manifest()
+    public_source = dataset_manifest.source("shield_public_sample")
+    metadata = shield_suite_metadata()
+    metadata.update(
+        {
+            "benchmark_domain": "clinical_phi",
+            "checkpoint_manifest": checkpoint_metadata,
+            "comparison_evidence_only": True,
+            "dataset_manifest": {
+                "manifest_hash": clinical_phi_manifest_hash(dataset_manifest),
+                "manifest_id": CLINICAL_PHI_MANIFEST_ID,
+                "manifest_ref": CLINICAL_PHI_MANIFEST_REF,
+            },
+            "fixture_ids": [
+                _sha256_value(stable_hash({"fixture_id": fixture.fixture_id}))
+                for fixture in fixtures
+            ],
+            "public_corpus_reference": {
+                "dataset": public_source.dataset,
+                "license_id": public_source.license_id,
+                "loader_ref": public_source.loader_ref,
+                "redistribution": public_source.redistribution,
+                "source_id": public_source.source_id,
+                "source_url": public_source.source_url,
+                "split": public_source.split,
+            },
+            "reproducibility": {
+                "eval_code_hash": _sha256_value(
+                    eval_code_hash(
+                        (
+                            "openmed.eval.harness",
+                            "openmed.eval.metrics",
+                            "openmed.eval.suites.shield",
+                        )
+                    )
+                ),
+                "fixture_set_hash": _sha256_value(hash_fixture_set(fixtures)),
+                "runner_ref": ("openmed.eval.suites:run_clinical_phi_shield_benchmark"),
+            },
+        }
+    )
+
+    report = run_benchmark(
+        fixtures,
+        suite=SHIELD,
+        model_name=CLINICAL_PRIVACY_MODEL_ID,
+        device=device,
+        runner=runner,
+        generated_at=generated_at,
+        metadata=metadata,
+    )
+    metrics = dict(report.metrics)
+    metrics["shield_comparison"] = _shield_comparison_metrics(metrics)
+    return replace(report, metrics=metrics)
+
+
 def _span_from_row(row: Mapping[str, Any], *, text: str) -> EvalSpan:
     raw_label = str(row.get("span_label", ""))
     canonical_label = map_shield_label(raw_label)
@@ -211,6 +336,157 @@ def _span_from_row(row: Mapping[str, Any], *, text: str) -> EvalSpan:
             "span_id": str(row.get("span_id") or ""),
         },
     )
+
+
+def _checkpoint_manifest_row(
+    checkpoint_manifest: CheckpointManifest,
+    *,
+    model_id: str,
+) -> Mapping[str, Any]:
+    if isinstance(checkpoint_manifest, Mapping):
+        payload: Any = checkpoint_manifest
+    else:
+        path = Path(checkpoint_manifest)
+        try:
+            contents = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ValueError(f"failed to read checkpoint manifest: {path}") from exc
+        try:
+            payload = json.loads(contents)
+        except json.JSONDecodeError:
+            try:
+                payload = [
+                    json.loads(line) for line in contents.splitlines() if line.strip()
+                ]
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"checkpoint manifest is not valid JSON or JSONL: {path}"
+                ) from exc
+
+    if isinstance(payload, Mapping):
+        nested = payload.get("models") or payload.get("checkpoints")
+        rows: Sequence[Any] = (
+            nested
+            if isinstance(nested, Sequence) and not isinstance(nested, (str, bytes))
+            else (payload,)
+        )
+    elif isinstance(payload, Sequence) and not isinstance(payload, (str, bytes)):
+        rows = payload
+    else:
+        raise ValueError("checkpoint manifest must contain model metadata")
+
+    matches = [
+        row
+        for row in rows
+        if isinstance(row, Mapping)
+        and str(row.get("model_id") or row.get("repo_id") or "") == model_id
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            "checkpoint manifest must contain exactly one "
+            f"{model_id!r} row; found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _checkpoint_metadata(
+    checkpoint: Mapping[str, Any],
+    *,
+    manifest_ref: str,
+    model_id: str,
+) -> dict[str, str]:
+    metadata = {
+        "manifest_content_hash": _sha256_value(stable_hash(checkpoint)),
+        "manifest_ref": manifest_ref,
+        "model_id": model_id,
+    }
+    reproducibility_hash = checkpoint.get("reproducibility_hash")
+    if reproducibility_hash is not None:
+        value = str(reproducibility_hash)
+        if not _is_sha256(value):
+            raise ValueError(
+                "checkpoint reproducibility_hash must be sha256:<64 lowercase hex>"
+            )
+        metadata["reproducibility_hash"] = value
+
+    provenance = checkpoint.get("provenance")
+    source_revision = checkpoint.get("source_revision")
+    if source_revision is None and isinstance(provenance, Mapping):
+        source_revision = provenance.get("source_revision")
+    if source_revision is not None:
+        revision = str(source_revision)
+        if _SAFE_SOURCE_REVISION.fullmatch(revision) is None:
+            raise ValueError("checkpoint source_revision must be a safe revision id")
+        metadata["source_revision"] = revision
+    return metadata
+
+
+def _shield_comparison_metrics(metrics: Mapping[str, Any]) -> dict[str, Any]:
+    recall = metrics.get("recall_slices")
+    leakage = metrics.get("leakage")
+    exact = metrics.get("exact_span_f1")
+    if not all(isinstance(value, Mapping) for value in (recall, leakage, exact)):
+        raise ValueError(
+            "SHIELD benchmark lacks required recall, leakage, or F1 metrics"
+        )
+
+    labels = sorted(set(SHIELD_LABEL_TO_CANONICAL.values()))
+    recall_by_label = recall.get("by_label")
+    leakage_by_label = leakage.get("by_label")
+    if not isinstance(recall_by_label, Mapping) or not isinstance(
+        leakage_by_label, Mapping
+    ):
+        raise ValueError("SHIELD benchmark lacks per-label recall or leakage")
+
+    return {
+        "aggregate": {
+            "exact_span_f1": float(exact["f1"]),
+            "exact_span_precision": float(exact["precision"]),
+            "exact_span_recall": float(exact["recall"]),
+            "leakage": float(leakage["overall"]),
+            "recall": float(recall["overall"]),
+        },
+        "by_label": {
+            label: {
+                "leakage": float(leakage_by_label[label]),
+                "recall": float(recall_by_label[label]),
+            }
+            for label in labels
+        },
+        "evidence_role": "comparison",
+        "high_recall_release_gate": False,
+    }
+
+
+def _validate_public_sample_fixtures(fixtures: Sequence[BenchmarkFixture]) -> None:
+    for fixture in fixtures:
+        repository = str(fixture.metadata.get("repository") or "")
+        variant = str(fixture.metadata.get("variant") or "")
+        if repository != PUBLIC_SAMPLE_REPOSITORY or variant != "public_sample":
+            raise ValueError(
+                "clinical PHI SHIELD benchmark requires public-sample fixtures"
+            )
+
+
+def _validate_manifest_ref(value: str) -> str:
+    reference = str(value).strip()
+    if _SAFE_MANIFEST_REF.fullmatch(reference) is None:
+        raise ValueError("checkpoint_manifest_ref must be a safe repository link")
+    return reference
+
+
+def _is_sha256(value: str) -> bool:
+    prefix = "sha256:"
+    digest = value.removeprefix(prefix)
+    return (
+        value.startswith(prefix)
+        and len(digest) == 64
+        and all(character in "0123456789abcdef" for character in digest)
+    )
+
+
+def _sha256_value(value: str) -> str:
+    return value if value.startswith("sha256:") else f"sha256:{value}"
 
 
 def _load_dataset_rows(
@@ -308,4 +584,5 @@ __all__ = [
     "shield_suite_metadata",
     "load_shield_fixtures",
     "fixtures_from_rows",
+    "run_clinical_phi_shield_benchmark",
 ]

--- a/tests/unit/eval/test_shield_suite.py
+++ b/tests/unit/eval/test_shield_suite.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import re
+from pathlib import Path
 from typing import Mapping
 
 import pytest
@@ -18,8 +20,19 @@ from openmed.core.labels import (
     PHONE,
     URL,
 )
+from openmed.eval.datasets import (
+    CLINICAL_PHI_MANIFEST_ID,
+    CLINICAL_PHI_MANIFEST_REF,
+    CLINICAL_PRIVACY_MODEL_ID,
+    clinical_phi_manifest_hash,
+)
 from openmed.eval.harness import run_benchmark
-from openmed.eval.suites import SHIELD, load_suite_fixtures, suite_metadata
+from openmed.eval.suites import (
+    SHIELD,
+    load_suite_fixtures,
+    run_clinical_phi_shield_benchmark,
+    suite_metadata,
+)
 from openmed.eval.suites.shield import (
     IS_HIGH_RECALL_GATE_TARGET,
     PUBLIC_SAMPLE_NOTES_CONFIG,
@@ -145,6 +158,99 @@ def test_shield_report_contains_per_label_leakage_and_recall() -> None:
     assert data["metrics"]["recall_slices"]["by_label"][PHONE] == 0.0
 
 
+def test_clinical_phi_flagship_report_binds_comparison_evidence() -> None:
+    note, spans = _synthetic_shield_rows()
+    fixture = fixtures_from_rows([note], spans)[0]
+    checkpoint = _synthetic_checkpoint_manifest()
+
+    def runner(fixture, model_name, device):
+        assert model_name == CLINICAL_PRIVACY_MODEL_ID
+        assert device == "cpu"
+        return [
+            {"start": span.start, "end": span.end, "label": span.label}
+            for span in fixture.gold_spans
+            if span.label in {PERSON, AGE}
+        ]
+
+    report = run_clinical_phi_shield_benchmark(
+        [fixture],
+        checkpoint_manifest=checkpoint,
+        checkpoint_manifest_ref=("models.jsonl#OpenMed/OpenMed-ClinicalPrivacy-tier0"),
+        runner=runner,
+        generated_at="2026-08-01T00:00:00Z",
+    )
+
+    data = report.to_dict()
+    comparison = data["metrics"]["shield_comparison"]
+    assert data["model_name"] == CLINICAL_PRIVACY_MODEL_ID
+    assert comparison["evidence_role"] == "comparison"
+    assert comparison["high_recall_release_gate"] is False
+    assert (
+        comparison["aggregate"]["recall"] == data["metrics"]["recall_slices"]["overall"]
+    )
+    assert comparison["aggregate"]["leakage"] == data["metrics"]["leakage"]["overall"]
+    assert comparison["by_label"][PERSON] == {
+        "leakage": 0.0,
+        "recall": 1.0,
+    }
+    assert comparison["by_label"][PHONE] == {
+        "leakage": 1.0,
+        "recall": 0.0,
+    }
+
+    metadata = data["metadata"]
+    assert metadata["comparison_evidence_only"] is True
+    assert metadata["gate_target"] is False
+    assert metadata["checkpoint_manifest"]["model_id"] == (CLINICAL_PRIVACY_MODEL_ID)
+    assert (
+        metadata["checkpoint_manifest"]["reproducibility_hash"]
+        == (checkpoint["reproducibility_hash"])
+    )
+    assert metadata["checkpoint_manifest"]["source_revision"] == "a" * 40
+    assert re.fullmatch(
+        r"sha256:[0-9a-f]{64}",
+        metadata["checkpoint_manifest"]["manifest_content_hash"],
+    )
+    assert metadata["dataset_manifest"] == {
+        "manifest_hash": clinical_phi_manifest_hash(),
+        "manifest_id": CLINICAL_PHI_MANIFEST_ID,
+        "manifest_ref": CLINICAL_PHI_MANIFEST_REF,
+    }
+    assert metadata["public_corpus_reference"]["source_url"].endswith(
+        PUBLIC_SAMPLE_REPOSITORY
+    )
+    assert metadata["public_corpus_reference"]["redistribution"] == ("reference-only")
+    assert metadata["fixture_ids"] != ["note-x"]
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", metadata["fixture_ids"][0])
+    assert re.fullmatch(
+        r"sha256:[0-9a-f]{64}",
+        metadata["reproducibility"]["fixture_set_hash"],
+    )
+    assert re.fullmatch(
+        r"sha256:[0-9a-f]{64}",
+        metadata["reproducibility"]["eval_code_hash"],
+    )
+    serialized = json.dumps(data, sort_keys=True)
+    for raw_value in ("note-x", "John Doe", "MRN-98765", "555-0123", "123 Main St"):
+        assert raw_value not in serialized
+
+
+def test_clinical_phi_flagship_report_rejects_other_checkpoint() -> None:
+    note, spans = _synthetic_shield_rows()
+    fixture = fixtures_from_rows([note], spans)[0]
+
+    with pytest.raises(ValueError, match="exactly one"):
+        run_clinical_phi_shield_benchmark(
+            [fixture],
+            checkpoint_manifest={
+                "repo_id": "OpenMed/another-model",
+                "reproducibility_hash": "sha256:" + "0" * 64,
+            },
+            checkpoint_manifest_ref="models.jsonl#OpenMed/another-model",
+            runner=lambda fixture, model_name, device: (),
+        )
+
+
 def test_cli_benchmark_pii_emits_shield_benchmark_report(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -180,6 +286,76 @@ def test_cli_benchmark_pii_emits_shield_benchmark_report(
     assert output["metadata"]["license"] == VERIFIED_LICENSE
     assert output["metrics"]["leakage"]["by_label"][PERSON] == 0.0
     assert output["metrics"]["recall_slices"]["by_label"][PERSON] == 1.0
+
+
+def test_cli_benchmark_pii_emits_manifest_linked_flagship_report(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    from openmed.cli import main_module
+    from openmed.eval import harness, suites
+
+    note, spans = _synthetic_shield_rows()
+    fixtures = fixtures_from_rows([note], spans)
+    checkpoint_path = tmp_path / "checkpoint.jsonl"
+    checkpoint_path.write_text(
+        "\n".join(
+            (
+                json.dumps({"repo_id": "OpenMed/unrelated-model"}),
+                json.dumps(_synthetic_checkpoint_manifest()),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        suites,
+        "load_shield_fixtures",
+        lambda **kwargs: fixtures,
+    )
+    monkeypatch.setattr(
+        harness,
+        "default_model_runner",
+        lambda fixture, model_name, device: [
+            {"start": span.start, "end": span.end, "label": span.label}
+            for span in fixture.gold_spans
+        ],
+    )
+
+    result = main_module.main(
+        [
+            "benchmark",
+            "pii",
+            "--suite",
+            "shield",
+            "--models",
+            CLINICAL_PRIVACY_MODEL_ID,
+            "--checkpoint-manifest",
+            str(checkpoint_path),
+            "--checkpoint-manifest-ref",
+            "models.jsonl#OpenMed/OpenMed-ClinicalPrivacy-tier0",
+        ]
+    )
+
+    assert result == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["model_name"] == CLINICAL_PRIVACY_MODEL_ID
+    assert output["metadata"]["checkpoint_manifest"]["manifest_ref"].startswith(
+        "models.jsonl#"
+    )
+    assert output["metrics"]["shield_comparison"]["aggregate"]["recall"] == 1.0
+    assert output["metrics"]["shield_comparison"]["high_recall_release_gate"] is False
+
+
+def _synthetic_checkpoint_manifest() -> dict[str, object]:
+    return {
+        "repo_id": CLINICAL_PRIVACY_MODEL_ID,
+        "family": "ClinicalPrivacy",
+        "reproducibility_hash": "sha256:" + "1" * 64,
+        "provenance": {"source_revision": "a" * 40},
+    }
 
 
 def _synthetic_shield_rows() -> tuple[dict[str, object], list[dict[str, object]]]:


### PR DESCRIPTION
# Pull Request

## Description
Adds a manifest-linked SHIELD comparison path for the named clinical PHI flagship. The report exposes aggregate and per-label recall/leakage, binds results to checkpoint, dataset, corpus, fixture-set, and eval-code evidence, hashes fixture identifiers, and explicitly remains outside the high-recall release gate.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing behavior)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Add a flagship-specific SHIELD runner with explicit comparison metrics and reproducibility metadata.
- Add CLI checkpoint-manifest inputs and validate the named model/public-corpus boundary.
- Add synthetic offline tests and usage documentation without vendoring corpus rows or persisting raw identifiers.

## Testing
- [x] Added tests that prove the feature works.
- [x] Focused unit and API-surface tests pass locally.
- [x] Tested JSON, JSONL, model-validation, CLI, metadata-hygiene, aggregate, and per-label paths.

Commands run:
- `.venv/bin/python -m pytest tests/unit/eval/test_shield_suite.py -q`
- `.venv/bin/python -m pytest tests/unit/test_public_api_docstrings.py -q`
- `.venv/bin/python -m pytest tests/unit/release/test_public_api_compat.py -q`
- `.venv/bin/ruff check openmed/cli/main.py openmed/eval/suites/shield.py openmed/eval/suites/__init__.py tests/unit/eval/test_shield_suite.py`
- `.venv/bin/ruff format --check openmed/cli/main.py openmed/eval/suites/shield.py openmed/eval/suites/__init__.py tests/unit/eval/test_shield_suite.py`
- `.venv/bin/pre-commit run --files docs/eval-harness.md openmed/cli/main.py openmed/eval/suites/__init__.py openmed/eval/suites/shield.py tests/unit/eval/test_shield_suite.py`

## Documentation
- [x] Updated the eval-harness documentation.
- [x] Added docstrings for the new public API.
- [ ] CHANGELOG update is not required for this scoped feature PR.

## Code Quality
- [x] Ran formatter, lint, security, and secret checks on changed files.
- [x] Performed a self-review.
- [x] The changes generate no new warnings.

## Dependencies
- [x] No new dependencies.

## Checklist
- [x] Read the contributing and repository guidelines.
- [x] Commit message is clear and scoped.
- [x] The branch contains one focused commit.

## Related Issues
Closes #385

## Screenshots/Examples
Not applicable; this changes benchmark evidence and CLI output rather than a visual surface.
