### PR TITLE
Preserve additive label policy spine coverage

### DIFF
--- a/tests/unit/core/test_labels_policy_spine.py
+++ b/tests/unit/core/test_labels_policy_spine.py
@@ -40,9 +40,65 @@ ALLOWED_SYSTEM_HINTS = set(CLINICAL_SYSTEM_HINTS) | {
     CHINESE_ICD_10,
 }
 
+POLICY_SPINE_BASELINE_LABELS = frozenset(
+    {
+        "PERSON",
+        "FIRST_NAME",
+        "LAST_NAME",
+        "MIDDLE_NAME",
+        "PREFIX",
+        "USERNAME",
+        "EMAIL",
+        "PHONE",
+        "URL",
+        "LOCATION",
+        "STREET_ADDRESS",
+        "BUILDING_NUMBER",
+        "ZIPCODE",
+        "GPS_COORDINATES",
+        "ORDINAL_DIRECTION",
+        "DATE",
+        "DATE_OF_BIRTH",
+        "TIME",
+        "AGE",
+        "ID_NUM",
+        "SSN",
+        "ACCOUNT_NUMBER",
+        "PASSWORD",
+        "PIN",
+        "API_KEY",
+        "CREDIT_CARD",
+        "CREDIT_CARD_ISSUER",
+        "CVV",
+        "IBAN",
+        "BIC",
+        "AMOUNT",
+        "CURRENCY",
+        "BITCOIN_ADDRESS",
+        "ETHEREUM_ADDRESS",
+        "LITECOIN_ADDRESS",
+        "MASKED_NUMBER",
+        "GENDER",
+        "ETHNICITY",
+        "EYE_COLOR",
+        "HEIGHT",
+        "ORGANIZATION",
+        "JOB_TITLE",
+        "JOB_DEPARTMENT",
+        "OCCUPATION",
+        "IP_ADDRESS",
+        "MAC_ADDRESS",
+        "USER_AGENT",
+        "VIN",
+        "VEHICLE_REGISTRATION",
+        "IMEI",
+    }
+)
+
 
 def test_metadata_tables_cover_canonical_labels_exactly():
-    assert len(CANONICAL_LABELS) == 114
+    assert len(POLICY_SPINE_BASELINE_LABELS) == 50
+    assert POLICY_SPINE_BASELINE_LABELS <= CANONICAL_LABELS
     assert set(LABEL_METADATA) == CANONICAL_LABELS
     assert set(LABEL_TO_HIPAA) == CANONICAL_LABELS
 


### PR DESCRIPTION
## Summary

- preserve the original 50-label policy-spine baseline explicitly
- keep exhaustive metadata and HIPAA mapping checks tied to every current canonical label
- allow future additive label growth without weakening baseline compatibility

## Validation

- policy-spine regressions: 7 passed
- legacy import, normalization, and accessor regressions: 3 passed
- public accessor import smoke check passed
- changed-file lint and format checks passed

Closes #1978