### PR TITLE
Complete the CLI and MCP packaging contract

### DIFF
--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -135,6 +135,11 @@ def _lazy_api():
 
 Handler = Callable[[argparse.Namespace], int]
 
+
+class _UnavailableCommandError(NotImplementedError):
+    """Signal that a recovered CLI command has no current implementation."""
+
+
 COMPLIANCE_CAVEAT = (
     "No de-identification tool can guarantee compliance or zero residual risk. "
     "Validate locally before any production or clinical use."
@@ -333,6 +338,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_deid_command(subparsers)
     _add_redact_dataset_command(subparsers)
     _add_pii_command(subparsers)
+    _add_tui_command(subparsers)
     _add_audit_command(subparsers)
     _add_compliance_command(subparsers)
     _add_risk_command(subparsers)
@@ -558,6 +564,27 @@ def _add_batch_command(subparsers: argparse._SubParsersAction) -> None:
         help="Commit progress after this many items (default: 10).",
     )
     batch_parser.set_defaults(handler=_handle_batch)
+
+
+def _add_tui_command(subparsers: argparse._SubParsersAction) -> None:
+    """Restore the historical TUI command without reviving its removed backend."""
+
+    tui_parser = subparsers.add_parser(
+        "tui",
+        help="Launch the historical interactive terminal UI.",
+    )
+    tui_parser.add_argument(
+        "--model",
+        default=None,
+        help="Model registry key or Hugging Face identifier.",
+    )
+    tui_parser.add_argument(
+        "--confidence-threshold",
+        type=_unit_interval_float,
+        default=0.5,
+        help="Minimum confidence score for predictions (default: 0.5).",
+    )
+    tui_parser.set_defaults(handler=_handle_tui)
 
 
 def _add_deid_command(subparsers: argparse._SubParsersAction) -> None:
@@ -2266,6 +2293,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     try:
         return handler(args)
+    except _UnavailableCommandError as exc:
+        error = CliError(
+            str(exc),
+            code="not_implemented",
+            exit_code=EXIT_ERROR,
+        )
+        return emit_error(args, error)
     except CliError as exc:
         return emit_error(args, exc)
     except Exception as exc:
@@ -2454,6 +2488,13 @@ def _handle_batch(args: argparse.Namespace) -> int:
 
     emit(args, payload, human=human)
     return 0 if result.failed_items == 0 else 1
+
+
+def _handle_tui(args: argparse.Namespace) -> int:
+    raise _UnavailableCommandError(
+        "The historical OpenMed TUI is not implemented because its backend "
+        "was removed; use 'openmed --help' for supported commands."
+    )
 
 
 def _handle_redact_dataset(args: argparse.Namespace) -> int:

--- a/tests/unit/cli/test_cli_smoke.py
+++ b/tests/unit/cli/test_cli_smoke.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from importlib import metadata
 from pathlib import Path
 
 import pytest
@@ -81,11 +82,28 @@ def test_argparse_cli_without_command_prints_help(
     assert "Command-line utilities for OpenMed" in capsys.readouterr().out
 
 
-def test_tui_command_is_not_registered() -> None:
-    result = _run_module("openmed.cli.main", "tui")
+def test_tui_entry_is_a_clear_not_implemented_stub() -> None:
+    args = main_module.build_parser().parse_args(
+        [
+            "tui",
+            "--model",
+            "synthetic-model",
+            "--confidence-threshold",
+            "0.6",
+        ]
+    )
 
-    assert result.returncode == 2
-    assert "invalid choice: 'tui'" in result.stderr
+    with pytest.raises(NotImplementedError, match="backend was removed"):
+        args.handler(args)
+
+
+def test_tui_entry_reports_the_stub_at_the_console_boundary(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = main_module.main(["tui"])
+
+    assert result == 1
+    assert "TUI is not implemented" in capsys.readouterr().err
 
 
 def test_typer_surface_is_importable() -> None:
@@ -114,3 +132,14 @@ def test_console_script_is_declared() -> None:
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["scripts"]["openmed"] == "openmed.cli:main"
+
+
+def test_console_script_resolves_to_tracked_cli_package() -> None:
+    entry_point = next(
+        item
+        for item in metadata.entry_points(group="console_scripts")
+        if item.name == "openmed"
+    )
+
+    assert entry_point.value == "openmed.cli:main"
+    assert entry_point.load() is cli_entry


### PR DESCRIPTION
## Description

Closes #1973.

Completes the tracked CLI and MCP packaging contract by restoring the historical `openmed tui` command as an explicitly bounded not-implemented stub. The repository already contains the recovered source packages, console metadata, and wheel inclusion; this adds the missing command contract and regression coverage without reviving removed backend code.

## Type of Change

- [x] Bug fix
- [x] Test addition/improvement

## Changes Made

- Restore the historical TUI parser surface with its model and confidence options.
- Report the removed backend through a clear, stable not-implemented error.
- Verify the installed `openmed` entry point resolves to the tracked CLI package.

## Testing

- [x] Focused CLI smoke checks passed.
- [x] CLI help-contract checks passed.
- [x] Repository policy checks passed.
- [x] Changed-file lint and format checks passed.
- [x] Editable-install commands and offline wheel contents verified.

## Documentation

- [x] No documentation change is required; the command help and error are self-describing.

## Dependencies

- [x] No new dependencies.

## Checklist

- [x] The commit is focused and self-reviewed.
- [x] The branch is current with `master`.
- [x] The change uses synthetic offline validation only.