### PR TITLE
Fix deterministic safety sweep recall accounting

### DIFF
--- a/openmed/core/pii.py
+++ b/openmed/core/pii.py
@@ -1495,7 +1495,7 @@ def _apply_safety_sweep_to_result(
         safety_sweep,
     )
 
-    before_count = len(pii_result.entities)
+    before_entity_ids = {id(entity) for entity in pii_result.entities}
     entities = safety_sweep(
         text,
         pii_result.entities,
@@ -1503,7 +1503,14 @@ def _apply_safety_sweep_to_result(
         locale=locale,
         patterns=patterns,
     )
-    added_count = len(entities) - before_count
+    # Overlap resolution may remove model spans, so a list-length delta does
+    # not measure the sweep's independent recall contribution.
+    added_count = sum(
+        id(entity) not in before_entity_ids
+        and (getattr(entity, "metadata", None) or {}).get("source")
+        == SAFETY_SWEEP_SOURCE
+        for entity in entities
+    )
 
     metadata = dict(getattr(pii_result, "metadata", None) or {})
     metadata["safety_sweep"] = {

--- a/tests/unit/core/test_safety_sweep.py
+++ b/tests/unit/core/test_safety_sweep.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from openmed.core.anonymizer.providers import clinical_ids
 from openmed.core.labels import ID_SUBTYPE_NPI
-from openmed.core.pii import deidentify
+from openmed.core.pii import _apply_safety_sweep_to_result, deidentify
 from openmed.core.pii_entity_merger import PIIPattern
 from openmed.core.quality_gates import detect_overlapping_entities
 from openmed.core.safety_sweep import (
@@ -171,6 +171,29 @@ def test_safety_sweep_resolves_overlapping_existing_spans():
 
     assert detect_overlapping_entities(entities) == []
     assert [entity.label for entity in entities] == ["SSN"]
+
+
+def test_safety_sweep_counts_added_spans_independently_of_overlap_resolution():
+    text = "Patient SSN 123-45-6789. Email jane.patient@example.com."
+    broad = _entity_for(text, "Patient SSN 123-45-6789", label="OTHER")
+    sensitive = _entity_for(text, "123-45-6789", label="SSN")
+    pii_result = PredictionResult(
+        text=text,
+        entities=[broad, sensitive],
+        model_name="stub",
+        timestamp=datetime.now().isoformat(),
+    )
+
+    swept_result, added_count = _apply_safety_sweep_to_result(
+        text,
+        pii_result,
+        lang="en",
+    )
+
+    assert added_count == 1
+    assert swept_result.metadata["safety_sweep"]["spans_added"] == 1
+    assert "email" in _swept_by_label(swept_result.entities)
+    assert detect_overlapping_entities(swept_result.entities) == []
 
 
 @patch("openmed.core.pii.extract_pii")


### PR DESCRIPTION
## Description

Closes #1976.

Completes deterministic post-ML safety-sweep accounting by measuring retained sweep-origin spans directly. Model-overlap resolution can reduce the total span count while the sweep recovers a missed identifier; the audit metric now records that independent recall contribution accurately.

## Type of Change

- [x] Bug fix
- [x] Test addition/improvement

## Changes Made

- Count newly retained safety-sweep spans by provenance instead of using a total list-length delta.
- Add a regression covering overlapping model spans plus an independently recovered email.
- Preserve non-overlapping final spans and correct per-run recall metadata.

## Testing

- [x] Explicit deterministic safety-sweep unit test file passes (13 tests).
- [x] Targeted pipeline-ordering and audit-provenance cases pass (2 tests).
- [x] Changed-file lint, format, security, and repository hygiene checks pass.

## Documentation

- [x] Not required; this corrects existing metadata accounting without changing the public API.

## Dependencies

- [x] No new dependencies.

## Checklist

- [x] The commit is focused and descriptive.
- [x] The change was self-reviewed.
- [x] No raw identifier values are added to audit artifacts.