### PR TITLE
Enforce protected write-token publishing policy

### DIFF
--- a/.github/workflows/convert-models.yml
+++ b/.github/workflows/convert-models.yml
@@ -157,6 +157,15 @@ jobs:
       url: https://huggingface.co/OpenMed
 
     steps:
+    - name: Require HF write token before publish
+      env:
+        HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+      run: |
+        if [ -z "${HF_WRITE_TOKEN:-}" ]; then
+          echo "::error title=Missing HF_WRITE_TOKEN::Configure HF_WRITE_TOKEN in the hf-publish protected environment before enabling publish."
+          exit 1
+        fi
+
     - uses: actions/checkout@v7
 
     - name: Set up Python
@@ -168,15 +177,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[hf]"
-
-    - name: Require HF write token before publish
-      env:
-        HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
-      run: |
-        if [ -z "${HF_WRITE_TOKEN:-}" ]; then
-          echo "::error title=Missing HF_WRITE_TOKEN::Configure HF_WRITE_TOKEN in the hf-publish protected environment before enabling publish."
-          exit 1
-        fi
 
     - name: Download MLX model
       if: contains(github.event.inputs.formats, 'mlx')

--- a/tests/unit/test_convert_workflow_hf_token.py
+++ b/tests/unit/test_convert_workflow_hf_token.py
@@ -19,8 +19,9 @@ def test_convert_workflow_uses_protected_hf_publish_environment():
     assert "HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}" in workflow
 
 
-def test_convert_workflow_fails_publish_job_when_hf_token_is_missing():
+def test_convert_workflow_fails_publish_job_before_setup_when_hf_token_is_missing():
     workflow = CONVERT_WORKFLOW.read_text(encoding="utf-8")
+    publish_job = workflow.split("  publish-hf:", maxsplit=1)[1]
 
     assert "Require HF write token before publish" in workflow
     assert 'if [ -z "${HF_WRITE_TOKEN:-}" ]; then' in workflow
@@ -28,6 +29,14 @@ def test_convert_workflow_fails_publish_job_when_hf_token_is_missing():
     assert "exit 1" in workflow
     assert re.search(r"hf_[A-Za-z0-9]{20,}", workflow) is None
     assert 'echo "$HF_WRITE_TOKEN' not in workflow
+    guard_position = publish_job.index(
+        "    - name: Require HF write token before publish"
+    )
+    assert guard_position < publish_job.index("    - uses: actions/checkout")
+    assert guard_position < publish_job.index("    - name: Set up Python")
+    assert guard_position < publish_job.index(
+        "    - name: Install publish dependencies"
+    )
 
 
 def test_convert_workflow_publishes_downloaded_conversion_artifacts():


### PR DESCRIPTION
## Summary

- Move the required write-token check to the first step of the protected publish job.
- Avoid checkout, runtime setup, and dependency installation when the environment secret is missing.
- Strengthen the focused regression test so the guard cannot drift behind setup work.

## Why

The protected publish job previously checked its required credential only after setup and dependency installation. Missing credentials should stop the job immediately with the existing clear error and without exposing a secret value.

## Validation

- Focused credential-policy tests
- Python lint and format checks on the modified test
- Workflow lint on the modified workflow

Closes #1990