### PR TITLE
Keep skipped model publishes idempotent

### DIFF
--- a/openmed/core/hf_publish.py
+++ b/openmed/core/hf_publish.py
@@ -347,43 +347,44 @@ def publish_artifact(
             commit_message=f"Publish {format_name} artifact",
         )
 
-    if manifest_path is not None:
-        append_manifest_row(manifest_path, row)
-    if baseline_path is not None:
-        update_baseline_entry(
-            baseline_path,
-            family=str(row["family"]),
-            tier=row.get("tier"),
-            format_name=str(row["formats"][0]),
-            metrics=baseline_metrics
-            if baseline_metrics is not None
-            else row["benchmark"],
-            reproducibility_hash=str(row["reproducibility_hash"]),
-            repo_id=str(row["repo_id"]),
-            source_model_id=source_model_id,
-            released=str(row["released"]) if row.get("released") else None,
-            git_sha=resolved_git_sha,
-            metadata={
-                "architecture": row.get("architecture"),
-                "base_model": row.get("base_model"),
-                "task": row.get("task"),
-            },
-        )
-    if any((benchmarks_dir, leaderboard_dir, status_output_path)):
-        if manifest_path is None or baseline_path is None:
-            raise HfPublishError(
-                "manifest and baseline paths are required to refresh status outputs"
+    if not skipped:
+        if manifest_path is not None:
+            append_manifest_row(manifest_path, row)
+        if baseline_path is not None:
+            update_baseline_entry(
+                baseline_path,
+                family=str(row["family"]),
+                tier=row.get("tier"),
+                format_name=str(row["formats"][0]),
+                metrics=baseline_metrics
+                if baseline_metrics is not None
+                else row["benchmark"],
+                reproducibility_hash=str(row["reproducibility_hash"]),
+                repo_id=str(row["repo_id"]),
+                source_model_id=source_model_id,
+                released=str(row["released"]) if row.get("released") else None,
+                git_sha=resolved_git_sha,
+                metadata={
+                    "architecture": row.get("architecture"),
+                    "base_model": row.get("base_model"),
+                    "task": row.get("task"),
+                },
             )
-        _refresh_status_outputs(
-            manifest_path=manifest_path,
-            baseline_path=baseline_path,
-            benchmark_report_paths=benchmark_report_paths or [],
-            benchmarks_dir=benchmarks_dir,
-            leaderboard_dir=leaderboard_dir,
-            status_output_path=status_output_path,
-            smoke_status=smoke_status,
-            smoke_failure_reason=smoke_failure_reason,
-        )
+        if any((benchmarks_dir, leaderboard_dir, status_output_path)):
+            if manifest_path is None or baseline_path is None:
+                raise HfPublishError(
+                    "manifest and baseline paths are required to refresh status outputs"
+                )
+            _refresh_status_outputs(
+                manifest_path=manifest_path,
+                baseline_path=baseline_path,
+                benchmark_report_paths=benchmark_report_paths or [],
+                benchmarks_dir=benchmarks_dir,
+                leaderboard_dir=leaderboard_dir,
+                status_output_path=status_output_path,
+                smoke_status=smoke_status,
+                smoke_failure_reason=smoke_failure_reason,
+            )
 
     return PublishResult(
         repo_id=repo_id,

--- a/tests/unit/mlx/test_hf_publish.py
+++ b/tests/unit/mlx/test_hf_publish.py
@@ -142,6 +142,14 @@ def test_manifest_row_can_record_multiple_runtime_formats(tmp_path):
 
 def test_publish_artifact_skips_existing_repo_without_upload(tmp_path, monkeypatch):
     artifact = _write_mlx_artifact(tmp_path)
+    manifest = tmp_path / "models.jsonl"
+    baseline = tmp_path / "baseline.json"
+    existing_manifest = (
+        '{"repo_id":"OpenMed/test-model-v1-coreml",'
+        '"formats":["coreml"],'
+        '"reproducibility_hash":"sha256:published"}\n'
+    )
+    manifest.write_text(existing_manifest, encoding="utf-8")
     fake_api = FakeApi(exists=True)
     monkeypatch.setenv("HF_WRITE_TOKEN", "secret-token")
 
@@ -149,6 +157,8 @@ def test_publish_artifact_skips_existing_repo_without_upload(tmp_path, monkeypat
         artifact_dir=artifact,
         source_model_id="OpenMed/test-model",
         format_name="coreml",
+        manifest_path=manifest,
+        baseline_path=baseline,
         api=fake_api,
     )
 
@@ -157,6 +167,8 @@ def test_publish_artifact_skips_existing_repo_without_upload(tmp_path, monkeypat
     assert fake_api.uploaded == []
     assert (artifact / "README.md").exists()
     assert result.repo_id == "OpenMed/test-model-v1-coreml"
+    assert manifest.read_text(encoding="utf-8") == existing_manifest
+    assert not baseline.exists()
 
 
 def test_publish_artifact_blocks_stale_gate_card_before_hf_write(


### PR DESCRIPTION
## Description

Makes model-publication retries metadata-safe. When a target repository already exists and the upload is skipped, the local manifest, release baseline, and generated status surfaces now remain unchanged instead of recording a reproducibility hash for bytes that were never uploaded. Successful uploads continue to emit and refresh the publication metadata required by the conversion pipeline.

## Type of Change

- [x] Bug fix (non-breaking change)
- [x] Test addition/improvement

## Changes Made

- Guard manifest, baseline, and status updates behind an actual artifact upload.
- Preserve existing publication metadata during idempotent skip-existing retries.
- Extend offline mocked-client coverage for unchanged manifest and baseline behavior.

## Testing

- [x] 23 focused publication, workflow-policy, baseline, and status tests passed.
- [x] Changed-file lint and format checks passed.
- [x] Synthetic offline fixtures only; no live publication was performed.

## Documentation

- [x] No documentation update is required for this behavioral correction.
- [x] Existing public API documentation remains accurate.

## Code Quality

- [x] Self-review completed.
- [x] No new warnings or dependencies introduced.

## Related Issues

Closes #1981