### PR TITLE
Add longitudinal linkage risk dashboard panel

### DIFF
--- a/docs/reidentification-risk.md
+++ b/docs/reidentification-risk.md
@@ -197,6 +197,115 @@ not serialize profile keys, cell values, privacy-unit identifiers, or source
 paths. The integrity digest detects mutation; use an external signature when
 authenticity or provenance matters.
 
+### Longitudinal cross-document linkage
+
+`longitudinal_risk_report()` measures whether stable evidence can cluster two
+or more de-identified notes back to the same privacy unit. Run it only after
+free text and structured fields have passed direct-identifier de-identification.
+Each input note needs a stable source-side patient key and may provide age,
+rare-condition, and surrogate evidence in its fields or audit spans. The key is
+converted to an HMAC-SHA256 patient pseudonym before it enters the report; note
+identifiers and evidence values are also HMAC digests. Supply an installation-
+specific HMAC key through a secret-management channel and do not publish it.
+
+The current estimator deliberately uses a conservative patient-level bound. A
+patient with fewer than two notes, or without a stable attack fingerprint, has
+a bound of `0.0`. A patient with reusable surrogate evidence, an age trajectory,
+or rare-attribute evidence has a bound of `1.0`. The report's
+`linkage_success_upper_bound` is the maximum patient bound, so adding documents
+cannot lower it. This is a safety upper bound, not a calibrated probability or
+the observed success rate of a particular attacker.
+
+```python
+from openmed.risk import longitudinal_risk_report
+
+linkage_report = longitudinal_risk_report(
+    deidentified_notes,
+    hmac_key=longitudinal_hmac_key,
+    patient_key_fields=("patient_id",),
+)
+```
+
+The report schema is versioned independently of the dashboard:
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Currently `1`. Consumers must reject unknown versions. |
+| `patient_count`, `document_count` | Number of pseudonymous patients and de-identified notes assessed. |
+| `linkage_success_upper_bound` | Maximum conservative patient-level bound. |
+| `mean_patient_linkage_upper_bound` | Arithmetic mean of the patient bounds. |
+| `linkable_patient_count` | Patients whose bound is greater than zero. |
+| `residual_direct_identifier_leakage` | Fraction of notes with detected residual direct identifiers. |
+| `residual_direct_identifier_leakage_count` | Total residual direct-identifier findings. |
+| `patient_risks` | Per-patient hashed breakdown used to validate the aggregate values. |
+| `high_risk_patients` | Rows tied at the nonzero maximum bound. Empty when the maximum is zero. |
+
+Each `patient_risks` row contains `patient_pseudonym`, document, evidence, and
+direct-identifier counts, its linkage bound, aggregate stable-surrogate, age,
+rare-attribute, and category counts, a hashed attack fingerprint, and hashed
+evidence references. Evidence references contain a note index, note and value
+digests, and optional start/end offsets and section metadata. They never contain
+the evidence value. The dashboard and signed gate apply a narrower allowlist:
+only digests, offsets, counts, and scores are retained; category, source,
+section, and any unknown fields are discarded.
+
+Add the panel to either existing HTML dashboard with the optional
+`longitudinal` argument. The aggregate release dashboard is the appropriate
+choice for expert-review handoff:
+
+```python
+from pathlib import Path
+
+from openmed.risk import render_release_assessment_dashboard
+
+dashboard_html = render_release_assessment_dashboard(
+    release_assessment,
+    longitudinal=linkage_report,
+)
+Path("longitudinal-release-dashboard.html").write_text(
+    dashboard_html,
+    encoding="utf-8",
+)
+```
+
+The panel shows corpus counts and upper bounds, then the highest-risk cohort and
+its hashed evidence. It validates every displayed digest, integer, offset, and
+probability and ignores all other input fields. Omitting `longitudinal` preserves
+the previous dashboard output.
+
+For release, first run the focused check, then attach the same report to the
+complete benchmark evidence under `metrics.longitudinal_linkage_risk` and use
+the normal signed release gate. The default linkage ceiling is zero; a caller
+may choose another ceiling only under a documented release policy.
+
+```python
+from openmed.eval import ReleaseGate, evaluate_cross_document_linkage_gate
+
+linkage_check = evaluate_cross_document_linkage_gate(
+    linkage_report,
+    ceiling=approved_linkage_ceiling,
+)
+if not linkage_check.passed:
+    raise RuntimeError(linkage_check.reason)
+
+benchmark_payload = benchmark_report.to_dict()
+benchmark_payload["metrics"]["longitudinal_linkage_risk"] = linkage_report
+signed_verdict = ReleaseGate(
+    cross_document_linkage_ceiling=approved_linkage_ceiling,
+    signing_key=release_signing_key,
+).evaluate(benchmark_payload, baseline_evidence)
+if not signed_verdict.verify(release_signing_key):
+    raise RuntimeError("Release-gate signature verification failed")
+```
+
+A passing bound means only that no modeled fingerprint exceeded the configured
+ceiling in the supplied corpus. It does not model cross-institution linkage,
+unknown auxiliary data, errors in the patient key, or attacks using signals the
+extractor did not capture. An empty highest-risk cohort is not proof of zero
+re-identification risk. Keep the report and dashboard under the same release-
+governance controls as other hashed evidence, because stable digests can still
+support correlation.
+
 ## Run the synthetic example
 
 The repository includes a fully offline walkthrough with fabricated patients:

--- a/openmed/risk/dashboard.py
+++ b/openmed/risk/dashboard.py
@@ -171,6 +171,7 @@ def render_risk_dashboard(
     risk: Mapping[str, Any],
     *,
     kanon: Mapping[str, Any] | None = None,
+    longitudinal: Mapping[str, Any] | None = None,
     title: str | None = None,
 ) -> str:
     """Render a local-sensitive, self-contained diagnostic dashboard.
@@ -185,6 +186,9 @@ def render_risk_dashboard(
         risk: Mapping returned by :func:`openmed.risk.risk_report`.
         kanon: Optional mapping returned by :func:`openmed.risk.kanon_report`
             or :func:`openmed.risk.enforce_kanon`.
+        longitudinal: Optional mapping returned by
+            :func:`openmed.risk.longitudinal_risk_report`. Its panel renders
+            only validated hashes, offsets, counts, and scores.
         title: Optional document and page title. Defaults to a stable title.
 
     Returns:
@@ -200,6 +204,8 @@ def render_risk_dashboard(
     ]
     if kanon is not None:
         body.append(_render_kanon(kanon))
+    if longitudinal is not None:
+        body.append(_render_longitudinal_linkage(longitudinal))
 
     return _render_document(document_title, body)
 
@@ -219,6 +225,7 @@ def write_risk_dashboard(
 def render_release_assessment_dashboard(
     assessment: ReleaseAssessment | AnonymizationResult | Mapping[str, Any],
     *,
+    longitudinal: Mapping[str, Any] | None = None,
     title: str | None = None,
 ) -> str:
     """Render only allow-listed aggregate release evidence.
@@ -228,6 +235,9 @@ def render_release_assessment_dashboard(
             :class:`AnonymizationResult`, or the mapping returned by
             ``to_dict()`` / ``to_safe_dict()`` on those objects. Detailed
             ``risk_report`` and ``kanon_report`` mappings are rejected.
+        longitudinal: Optional mapping returned by
+            :func:`openmed.risk.longitudinal_risk_report`. Its panel renders
+            only validated hashes, offsets, counts, and scores.
         title: Optional document and page title.
 
     Returns:
@@ -245,6 +255,8 @@ def render_release_assessment_dashboard(
         body.append(_render_release_assessment(payload, section_id="assessment"))
     else:
         body.extend(_render_anonymization_summary(payload))
+    if longitudinal is not None:
+        body.append(_render_longitudinal_linkage(longitudinal))
     return _render_document(document_title, body)
 
 
@@ -252,13 +264,18 @@ def write_release_assessment_dashboard(
     assessment: ReleaseAssessment | AnonymizationResult | Mapping[str, Any],
     path: str | Path,
     *,
+    longitudinal: Mapping[str, Any] | None = None,
     title: str | None = None,
 ) -> Path:
     """Write an aggregate release-evidence dashboard and return its path."""
 
     output_path = Path(path)
     output_path.write_text(
-        render_release_assessment_dashboard(assessment, title=title),
+        render_release_assessment_dashboard(
+            assessment,
+            longitudinal=longitudinal,
+            title=title,
+        ),
         encoding="utf-8",
     )
     return output_path
@@ -535,6 +552,295 @@ def _render_safe_generalization_levels(value: Any) -> list[str]:
         "<h2>Selected Generalization</h2>",
         _table(["Attribute", "Level", "Loss"], rows),
     ]
+
+
+def _render_longitudinal_linkage(report: Mapping[str, Any]) -> str:
+    validated = _safe_longitudinal_report(report)
+    if validated is None:
+        return "\n".join(
+            [
+                '<section aria-labelledby="longitudinal-linkage-risk">',
+                '<h2 id="longitudinal-linkage-risk">Longitudinal Linkage Risk</h2>',
+                (
+                    '<p class="empty">Longitudinal linkage evidence is '
+                    "unavailable or malformed.</p>"
+                ),
+                "</section>",
+            ]
+        )
+
+    patients = validated["patients"]
+    highest_bound = validated["linkage_success_upper_bound"]
+    highest_risk = [
+        patient
+        for patient in patients
+        if highest_bound > 0.0
+        and math.isclose(
+            patient["linkage_upper_bound"],
+            highest_bound,
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        )
+    ]
+
+    sections = [
+        '<section aria-labelledby="longitudinal-linkage-risk">',
+        '<h2 id="longitudinal-linkage-risk">Longitudinal Linkage Risk</h2>',
+        (
+            '<p class="subtle">The maximum is a conservative patient-level '
+            "upper bound, not an observed attack-success rate.</p>"
+        ),
+        '<div class="metric-grid">',
+        _metric("Patients", _format_count(validated["patient_count"])),
+        _metric("Documents", _format_count(validated["document_count"])),
+        _metric(
+            "Linkable patients",
+            _format_count(validated["linkable_patient_count"]),
+        ),
+        _metric(
+            "Maximum linkage bound",
+            _format_rate(validated["linkage_success_upper_bound"]),
+        ),
+        _metric(
+            "Mean patient bound",
+            _format_rate(validated["mean_patient_linkage_upper_bound"]),
+        ),
+        _metric(
+            "Affected document rate",
+            _format_rate(validated["residual_direct_identifier_leakage"]),
+        ),
+        _metric(
+            "Residual direct identifiers",
+            _format_count(validated["residual_direct_identifier_leakage_count"]),
+        ),
+        "</div>",
+        "<h2>Highest-Risk Cohort</h2>",
+    ]
+    if highest_risk:
+        sections.append(
+            _table(
+                [
+                    "Patient hash",
+                    "Documents",
+                    "Evidence items",
+                    "Direct identifiers",
+                    "Upper bound",
+                ],
+                [
+                    [
+                        patient["patient_hash"],
+                        str(patient["document_count"]),
+                        str(patient["evidence_count"]),
+                        str(patient["direct_identifier_count"]),
+                        _format_rate(patient["linkage_upper_bound"]),
+                    ]
+                    for patient in highest_risk
+                ],
+            )
+        )
+    else:
+        sections.append('<p class="empty">No linkable patient cohort reported.</p>')
+
+    evidence_rows = [
+        [
+            patient["patient_hash"],
+            str(item["note_index"]),
+            item["note_hash"],
+            item["value_hash"],
+            _format_count(item.get("start")),
+            _format_count(item.get("end")),
+        ]
+        for patient in highest_risk
+        for item in patient["evidence"]
+    ]
+    if evidence_rows:
+        sections.extend(
+            [
+                "<h2>Highest-Risk Hashed Evidence</h2>",
+                _table(
+                    [
+                        "Patient hash",
+                        "Note index",
+                        "Note hash",
+                        "Value hash",
+                        "Start",
+                        "End",
+                    ],
+                    evidence_rows,
+                ),
+            ]
+        )
+    sections.append("</section>")
+    return "\n".join(sections)
+
+
+def _safe_longitudinal_report(report: Mapping[str, Any]) -> dict[str, Any] | None:
+    schema_version = _nonnegative_int(report.get("schema_version"))
+    patient_count = _nonnegative_int(report.get("patient_count"))
+    document_count = _nonnegative_int(report.get("document_count"))
+    linkable_patient_count = _nonnegative_int(report.get("linkable_patient_count"))
+    upper_bound = _probability(report.get("linkage_success_upper_bound"))
+    mean_bound = _probability(report.get("mean_patient_linkage_upper_bound"))
+    direct_leakage = _probability(report.get("residual_direct_identifier_leakage"))
+    direct_leakage_count = _nonnegative_int(
+        report.get("residual_direct_identifier_leakage_count")
+    )
+    patients = _safe_longitudinal_patients(report.get("patient_risks"))
+    if (
+        schema_version != 1
+        or patient_count is None
+        or document_count is None
+        or linkable_patient_count is None
+        or upper_bound is None
+        or mean_bound is None
+        or direct_leakage is None
+        or direct_leakage_count is None
+        or patients is None
+    ):
+        return None
+
+    patient_bounds = [patient["linkage_upper_bound"] for patient in patients]
+    patient_hashes = [patient["patient_hash"] for patient in patients]
+    expected_upper_bound = max(patient_bounds, default=0.0)
+    expected_mean_bound = sum(patient_bounds) / patient_count if patient_count else 0.0
+    if (
+        len(patients) != patient_count
+        or len(set(patient_hashes)) != patient_count
+        or sum(patient["document_count"] for patient in patients) != document_count
+        or sum(patient["direct_identifier_count"] for patient in patients)
+        != direct_leakage_count
+        or sum(bound > 0.0 for bound in patient_bounds) != linkable_patient_count
+        or not math.isclose(
+            upper_bound,
+            expected_upper_bound,
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        )
+        or not math.isclose(
+            mean_bound,
+            expected_mean_bound,
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        )
+        or (direct_leakage_count == 0 and direct_leakage != 0.0)
+        or (direct_leakage_count > 0 and direct_leakage <= 0.0)
+    ):
+        return None
+    return {
+        "patient_count": patient_count,
+        "document_count": document_count,
+        "linkable_patient_count": linkable_patient_count,
+        "linkage_success_upper_bound": upper_bound,
+        "mean_patient_linkage_upper_bound": mean_bound,
+        "residual_direct_identifier_leakage": direct_leakage,
+        "residual_direct_identifier_leakage_count": direct_leakage_count,
+        "patients": patients,
+    }
+
+
+def _safe_longitudinal_patients(value: Any) -> list[dict[str, Any]] | None:
+    patients = []
+    for item in _as_sequence(value):
+        if not isinstance(item, Mapping):
+            return None
+        patient_hash = _safe_digest(item.get("patient_pseudonym"))
+        document_count = _nonnegative_int(item.get("document_count"))
+        evidence_count = _nonnegative_int(item.get("evidence_count"))
+        direct_identifier_count = _nonnegative_int(item.get("direct_identifier_count"))
+        linkage_upper_bound = _probability(item.get("linkage_upper_bound"))
+        evidence = _safe_longitudinal_evidence(item.get("evidence"))
+        if (
+            patient_hash is None
+            or document_count is None
+            or document_count < 1
+            or evidence_count is None
+            or direct_identifier_count is None
+            or linkage_upper_bound is None
+            or evidence is None
+            or evidence_count != len(evidence)
+        ):
+            return None
+        patients.append(
+            {
+                "patient_hash": patient_hash,
+                "document_count": document_count,
+                "evidence_count": evidence_count,
+                "direct_identifier_count": direct_identifier_count,
+                "linkage_upper_bound": linkage_upper_bound,
+                "evidence": evidence,
+            }
+        )
+    patients.sort(key=lambda patient: patient["patient_hash"])
+    return patients
+
+
+def _safe_longitudinal_evidence(value: Any) -> list[dict[str, Any]] | None:
+    evidence = []
+    for item in _as_sequence(value):
+        if not isinstance(item, Mapping):
+            return None
+        note_index = _nonnegative_int(item.get("note_index"))
+        note_hash = _safe_digest(item.get("note_hash"))
+        value_hash = _safe_digest(item.get("value_hash"))
+        raw_start = item.get("start")
+        raw_end = item.get("end")
+        start = _nonnegative_int(raw_start)
+        end = _nonnegative_int(raw_end)
+        if (
+            note_index is None
+            or note_hash is None
+            or value_hash is None
+            or (raw_start is not None and start is None)
+            or (raw_end is not None and end is None)
+            or (start is not None and end is not None and end < start)
+        ):
+            return None
+        safe_item = {
+            "note_index": note_index,
+            "note_hash": note_hash,
+            "value_hash": value_hash,
+        }
+        if start is not None:
+            safe_item["start"] = start
+        if end is not None:
+            safe_item["end"] = end
+        evidence.append(safe_item)
+    evidence.sort(
+        key=lambda item: (
+            item["note_index"],
+            item["note_hash"],
+            item["value_hash"],
+            item.get("start", -1),
+            item.get("end", -1),
+        )
+    )
+    return evidence
+
+
+def _safe_digest(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    prefix, separator, digest = value.partition(":")
+    if separator != ":" or prefix not in {"sha256", "hmac-sha256"}:
+        return None
+    if len(digest) != 64:
+        return None
+    try:
+        int(digest, 16)
+    except ValueError:
+        return None
+    return value
+
+
+def _nonnegative_int(value: Any) -> int | None:
+    return value if type(value) is int and value >= 0 else None
+
+
+def _probability(value: Any) -> float | None:
+    if type(value) not in {int, float}:
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) and 0.0 <= parsed <= 1.0 else None
 
 
 def _safe_metadata_strings(value: Any) -> list[str]:

--- a/tests/unit/risk/test_risk_dashboard.py
+++ b/tests/unit/risk/test_risk_dashboard.py
@@ -14,6 +14,7 @@ from openmed.risk import (
     assess_release,
     enforce_kanon,
     kanon_report,
+    longitudinal_risk_report,
     render_release_assessment_dashboard,
     render_risk_dashboard,
     risk_report,
@@ -98,6 +99,34 @@ def _release_policy() -> AnonymityPolicy:
         privacy_unit="patient_id",
         target_k=2,
     )
+
+
+def _sample_longitudinal_risk() -> dict[str, object]:
+    report = longitudinal_risk_report(
+        [
+            {
+                "patient_id": "synthetic-subject-001",
+                "record_id": f"synthetic-note-{index}",
+                "text": "Synthetic follow-up note.",
+                "audit_spans": [
+                    {
+                        "canonical_label": "SYNTHETIC_SURROGATE",
+                        "surrogate": "synthetic-surrogate-a",
+                        "start": 0,
+                        "end": 9,
+                    }
+                ],
+            }
+            for index in (1, 2)
+        ],
+        hmac_key="synthetic-dashboard-key",
+    )
+    report["raw_note"] = "raw-top-level-canary"
+    report["patient_risks"][0]["raw_patient_key"] = "raw-patient-canary"
+    report["patient_risks"][0]["evidence"][0]["source"] = "raw-source-canary"
+    report["patient_risks"][0]["evidence"][0]["category"] = "raw-category-canary"
+    report["patient_risks"][0]["evidence"][0]["section"] = "raw-section-canary"
+    return report
 
 
 def test_render_risk_dashboard_returns_self_contained_html_document():
@@ -278,6 +307,69 @@ def test_release_assessment_dashboard_renders_only_allowlisted_aggregates():
     _assert_balanced_html(html)
 
 
+def test_release_dashboard_adds_privacy_safe_longitudinal_linkage_panel():
+    longitudinal = _sample_longitudinal_risk()
+    high_risk = longitudinal["patient_risks"][0]
+
+    html = render_release_assessment_dashboard(
+        assess_release(_release_rows(), _release_policy()),
+        longitudinal=longitudinal,
+    )
+
+    assert "Longitudinal Linkage Risk" in html
+    assert "Highest-Risk Cohort" in html
+    assert "Maximum linkage bound" in html
+    assert "100.0%" in html
+    assert high_risk["patient_pseudonym"] in html
+    assert high_risk["evidence"][0]["note_hash"] in html
+    assert high_risk["evidence"][0]["value_hash"] in html
+    assert ">0</td>" in html
+    assert ">9</td>" in html
+    for canary in (
+        "synthetic-subject-001",
+        "synthetic-note-1",
+        "synthetic-surrogate-a",
+        "raw-top-level-canary",
+        "raw-patient-canary",
+        "raw-source-canary",
+        "raw-category-canary",
+        "raw-section-canary",
+    ):
+        assert canary not in html
+    _assert_balanced_html(html)
+
+
+def test_legacy_dashboard_output_is_unchanged_when_longitudinal_is_omitted():
+    risk = _sample_risk()
+
+    default_html = render_risk_dashboard(risk)
+    explicit_html = render_risk_dashboard(risk, longitudinal=None)
+    longitudinal_html = render_risk_dashboard(
+        risk,
+        longitudinal=_sample_longitudinal_risk(),
+    )
+
+    assert explicit_html == default_html
+    assert "Longitudinal Linkage Risk" not in default_html
+    assert "Longitudinal Linkage Risk" in longitudinal_html
+
+
+def test_longitudinal_panel_fails_closed_without_echoing_malformed_values():
+    longitudinal = _sample_longitudinal_risk()
+    longitudinal["patient_count"] = "raw-numeric-field-canary"
+    longitudinal["patient_risks"][0]["patient_pseudonym"] = "raw-hash-canary"
+
+    html = render_release_assessment_dashboard(
+        assess_release(_release_rows(), _release_policy()),
+        longitudinal=longitudinal,
+    )
+
+    assert "Longitudinal linkage evidence is unavailable or malformed" in html
+    assert "raw-numeric-field-canary" not in html
+    assert "raw-hash-canary" not in html
+    assert "Highest-Risk Cohort" not in html
+
+
 def test_anonymization_dashboard_never_traverses_sensitive_records():
     result = anonymize_release(_release_rows(), _release_policy())
     assert any(
@@ -440,10 +532,16 @@ def test_write_release_assessment_dashboard_writes_safe_balanced_html(tmp_path):
     result = anonymize_release(_release_rows(), _release_policy())
     path = tmp_path / "release-assessment.html"
 
-    returned = write_release_assessment_dashboard(result, path)
+    returned = write_release_assessment_dashboard(
+        result,
+        path,
+        longitudinal=_sample_longitudinal_risk(),
+    )
 
     assert returned == path
     html = path.read_text(encoding="utf-8")
     assert "Aggregate evidence only" in html
+    assert "Longitudinal Linkage Risk" in html
     assert "raw-qi-value-canary" not in html
+    assert "raw-patient-canary" not in html
     _assert_balanced_html(html)


### PR DESCRIPTION
# Pull Request

## Description
Adds an opt-in longitudinal linkage-risk panel to the existing local and aggregate HTML dashboards. The panel validates the versioned risk report, summarizes conservative upper bounds, and shows the highest-risk cohort using only digests, offsets, counts, and scores. Malformed evidence fails closed without echoing untrusted values.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added a deterministic longitudinal linkage panel shared by the local diagnostic and aggregate release dashboards.
- Added strict schema, digest, count, offset, probability, and aggregate-consistency validation with privacy-safe failure output.
- Documented report inputs, conservative-bound semantics, schema fields, dashboard usage, signed release workflow, and limitations.

## Testing
- [x] Added tests that prove the panel renders privacy-safe evidence and rejects malformed values.
- [x] Ran four explicit changed-behavior cases in `tests/unit/risk/test_risk_dashboard.py` (`4 passed`).
- [x] Covered linked and omitted longitudinal inputs plus aggregate-dashboard file output.

## Documentation
- [x] Updated the structured re-identification risk guide.
- [x] Updated public API docstrings for the optional longitudinal input.
- [ ] CHANGELOG updated; not required for this focused child feature.

## Code Quality
- [ ] Broad Make targets were not run; validation was intentionally limited to changed files.
- [x] Ran changed-file Ruff lint and format checks.
- [x] Ran changed-file pre-commit hooks, including Bandit and secret scanning.
- [x] Ran `git diff --check` and performed a focused self-review.
- [x] Changes generate no new warnings.

## Dependencies
- [x] No new dependencies.

## Checklist
- [x] Read the repository guidelines.
- [x] Commit has a clear, focused message.
- [x] Change remains within the dashboard-and-documentation child issue boundary.

## Related Issues
Closes #1041

## Screenshots/Examples
No static screenshot is included; targeted tests validate the self-contained HTML structure and privacy-safe rendered evidence.
