### PR TITLE
Gate relation regressions against pinned baselines

### DIFF
--- a/gates/baseline.json
+++ b/gates/baseline.json
@@ -77,5 +77,34 @@
       "updated_at": "2026-04-14T00:00:00+00:00"
     }
   },
+  "relation_golden": {
+    "entries": {
+      "relation::asserted-absent": {
+        "family": "Relation",
+        "fixture_hash": "sha256:eefd1e98cb6026cb843cd8f0dfcc084825f3323de4e9ff98efc8f62677578187",
+        "key": "relation::asserted-absent",
+        "relation_type": "ASSERTED_ABSENT",
+        "strict_f1": 1.0,
+        "tolerance": 0.01
+      },
+      "relation::temporally-before": {
+        "family": "Relation",
+        "fixture_hash": "sha256:eefd1e98cb6026cb843cd8f0dfcc084825f3323de4e9ff98efc8f62677578187",
+        "key": "relation::temporally-before",
+        "relation_type": "TEMPORALLY_BEFORE",
+        "strict_f1": 1.0,
+        "tolerance": 0.01
+      },
+      "relation::treats": {
+        "family": "Relation",
+        "fixture_hash": "sha256:eefd1e98cb6026cb843cd8f0dfcc084825f3323de4e9ff98efc8f62677578187",
+        "key": "relation::treats",
+        "relation_type": "TREATS",
+        "strict_f1": 1.0,
+        "tolerance": 0.01
+      }
+    },
+    "schema_version": 1
+  },
   "schema_version": 1
 }

--- a/openmed/core/baseline.py
+++ b/openmed/core/baseline.py
@@ -19,6 +19,10 @@ The baseline JSON schema is intentionally small and versioned:
   }
 }
 ```
+
+Relation-golden baselines are stored in an optional ``relation_golden``
+section. Its entries are keyed only by model family and normalized relation
+type so export formats share the same semantic regression threshold.
 """
 
 from __future__ import annotations
@@ -31,6 +35,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 BASELINE_SCHEMA_VERSION = 1
+RELATION_GOLDEN_SCHEMA_VERSION = 1
 BASELINE_PATH = Path(__file__).resolve().parents[2] / "gates" / "baseline.json"
 _SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -52,6 +57,17 @@ def baseline_key(family: str, tier: str | None, format_name: str) -> str:
             _normalise_key_part(family),
             _normalise_key_part(tier or "none"),
             _normalise_key_part(format_name),
+        )
+    )
+
+
+def relation_baseline_key(family: str, relation_type: str) -> str:
+    """Return the stable key for a model-family relation baseline."""
+
+    return "::".join(
+        (
+            _normalise_key_part(family),
+            _normalise_key_part(relation_type),
         )
     )
 
@@ -188,6 +204,10 @@ def validate_baseline_store(store: Mapping[str, Any]) -> None:
     for key, entry in entries.items():
         _validate_entry(str(key), entry)
 
+    relation_golden = store.get("relation_golden")
+    if relation_golden is not None:
+        _validate_relation_golden(relation_golden)
+
 
 def _validate_entry(key: str, entry: Any) -> None:
     if not isinstance(entry, Mapping):
@@ -227,6 +247,68 @@ def _validate_entry(key: str, entry: Any) -> None:
             raise BaselineError(f"baseline entry {key!r} released must be YYYY-MM-DD")
 
 
+def _validate_relation_golden(value: Any) -> None:
+    if not isinstance(value, Mapping):
+        raise BaselineError("relation_golden must be a JSON object")
+    if value.get("schema_version") != RELATION_GOLDEN_SCHEMA_VERSION:
+        raise BaselineError(
+            f"relation_golden schema_version must be {RELATION_GOLDEN_SCHEMA_VERSION}"
+        )
+    entries = value.get("entries")
+    if not isinstance(entries, Mapping):
+        raise BaselineError("relation_golden entries must be a JSON object")
+
+    for key, entry in entries.items():
+        _validate_relation_entry(str(key), entry)
+
+
+def _validate_relation_entry(key: str, entry: Any) -> None:
+    if not isinstance(entry, Mapping):
+        raise BaselineError(f"relation baseline entry {key!r} must be a JSON object")
+
+    required = {
+        "key",
+        "family",
+        "relation_type",
+        "strict_f1",
+        "tolerance",
+        "fixture_hash",
+    }
+    missing = sorted(required - set(entry))
+    if missing:
+        raise BaselineError(
+            f"relation baseline entry {key!r} missing fields: {missing}"
+        )
+    if entry["key"] != key:
+        raise BaselineError(f"relation baseline entry {key!r} has mismatched key")
+    expected_key = relation_baseline_key(entry["family"], entry["relation_type"])
+    if expected_key != key:
+        raise BaselineError(
+            f"relation baseline entry {key!r} does not match its dimensions"
+        )
+    if not isinstance(entry["family"], str) or not entry["family"].strip():
+        raise BaselineError(f"relation baseline entry {key!r} family must be non-empty")
+    if (
+        not isinstance(entry["relation_type"], str)
+        or not entry["relation_type"].strip()
+    ):
+        raise BaselineError(
+            f"relation baseline entry {key!r} relation_type must be non-empty"
+        )
+    for field in ("strict_f1", "tolerance"):
+        metric = entry[field]
+        if (
+            isinstance(metric, bool)
+            or not isinstance(metric, (int, float))
+            or not 0.0 <= float(metric) <= 1.0
+        ):
+            raise BaselineError(
+                f"relation baseline entry {key!r} {field} must be between 0 and 1"
+            )
+    if not _SHA256_RE.fullmatch(str(entry["fixture_hash"])):
+        raise BaselineError(f"relation baseline entry {key!r} has invalid fixture_hash")
+
+
 def _normalise_key_part(value: str) -> str:
     return str(value).strip().lower().replace("_", "-") or "none"
 
@@ -238,12 +320,14 @@ def _jsonable(value: Any) -> Any:
 __all__ = [
     "BASELINE_PATH",
     "BASELINE_SCHEMA_VERSION",
+    "RELATION_GOLDEN_SCHEMA_VERSION",
     "BaselineError",
     "BaselineMiss",
     "baseline_key",
     "get_baseline",
     "load_baseline_store",
     "require_baseline",
+    "relation_baseline_key",
     "update_baseline_entry",
     "validate_baseline_store",
     "write_baseline_store",

--- a/openmed/eval/release_gates.py
+++ b/openmed/eval/release_gates.py
@@ -85,6 +85,8 @@ G7_RECALL_DROP_LIMIT = 0.002
 G11_CRITICAL_RECALL_FLOOR = 0.999
 G9_STRICT_RE_F1_FLOOR = 0.850
 G9_RELAXED_RE_F1_FLOOR = 0.900
+RELATION_GOLDEN_REGRESSION_GATE = "relation_golden_regression"
+RELATION_GOLDEN_TRAP_KINDS = ("assertion", "temporal")
 G13_STRICT_ENTITY_F1_FLOOR = 0.900
 G13_STRICT_RELATION_F1_FLOOR = 0.850
 G13_UNCERTAINTY_ACCURACY_FLOOR = 0.950
@@ -793,6 +795,24 @@ class ReleaseGate:
         checks.append(_g8_check(metadata))
         checks.append(_surrogate_quality_release_check(metrics, metadata))
         checks.append(_g9_relation_extraction_check(metrics, metadata))
+        relation_baseline = baseline
+        if relation_baseline is None and _relation_golden_gate_is_applicable(
+            metrics, metadata
+        ):
+            try:
+                relation_baseline = baseline_store.load_baseline_store(
+                    self.baseline_path
+                )
+            except OSError:
+                relation_baseline = {}
+        checks.append(
+            evaluate_relation_golden_regression_gate(
+                metrics,
+                relation_baseline or {},
+                family=identity["family"],
+                metadata=metadata,
+            )
+        )
         checks.append(_g13_radiology_entity_relation_check(metrics, metadata))
         coreml_manifest = _coreml_conversion_manifest(metadata)
         if coreml_manifest or _normalise_dimension(identity["format"]).startswith(
@@ -3352,6 +3372,303 @@ def _relation_type_summary(value: Any) -> dict[str, Any]:
     return summary
 
 
+def evaluate_relation_golden_regression_gate(
+    metrics: Mapping[str, Any],
+    baseline: Mapping[str, Any],
+    *,
+    family: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> GateCheck:
+    """Gate per-type strict relation F1 and zero-tolerance trap leaks.
+
+    Candidate evidence uses ``relation_golden.by_type`` with the same strict
+    metric payload produced by :func:`compute_relation_metrics`, plus integer
+    ``trap_leaks`` counts for ``assertion`` and ``temporal``. Baselines come
+    from the committed ``relation_golden`` baseline-store section.
+    """
+
+    metadata = metadata or {}
+    evidence = _relation_golden_evidence(metrics, metadata)
+    required = _relation_golden_gate_required(metadata)
+    if not evidence:
+        return GateCheck(
+            RELATION_GOLDEN_REGRESSION_GATE,
+            not required,
+            reason=(
+                "relation golden evidence is required" if required else "not applicable"
+            ),
+            details={"family": family, "required": required},
+        )
+
+    candidate_f1, invalid_candidates = _candidate_relation_strict_f1(evidence)
+    family_baselines, invalid_baselines = _relation_golden_baselines(
+        baseline, family=family
+    )
+    comparisons: dict[str, Any] = {}
+    missing_baselines: list[str] = []
+    missing_candidates: list[str] = []
+    regressions: dict[str, Any] = {}
+
+    relation_types = sorted(
+        set(candidate_f1)
+        | set(invalid_candidates)
+        | set(family_baselines)
+        | set(invalid_baselines)
+    )
+    for relation_type in relation_types:
+        candidate = candidate_f1.get(relation_type)
+        pinned = family_baselines.get(relation_type)
+        if pinned is None:
+            if relation_type in candidate_f1 or relation_type in invalid_candidates:
+                missing_baselines.append(relation_type)
+            continue
+        if candidate is None:
+            if relation_type not in invalid_candidates:
+                missing_candidates.append(relation_type)
+            continue
+
+        baseline_f1 = float(pinned["strict_f1"])
+        tolerance = float(pinned["tolerance"])
+        minimum = max(0.0, baseline_f1 - tolerance)
+        drop = baseline_f1 - candidate
+        comparison = {
+            "baseline": baseline_f1,
+            "baseline_key": pinned["key"],
+            "candidate": candidate,
+            "drop": drop,
+            "fixture_hash": pinned["fixture_hash"],
+            "minimum": minimum,
+            "tolerance": tolerance,
+        }
+        comparisons[relation_type] = comparison
+        if candidate + 1e-12 < minimum:
+            regressions[relation_type] = comparison
+
+    trap_leaks, invalid_traps = _relation_trap_leaks(evidence, metadata)
+    missing_traps = [
+        kind
+        for kind in RELATION_GOLDEN_TRAP_KINDS
+        if kind not in trap_leaks and kind not in invalid_traps
+    ]
+    leaked_traps = {kind: count for kind, count in trap_leaks.items() if count > 0}
+
+    violations: dict[str, Any] = {}
+    if missing_baselines:
+        violations["missing_baselines"] = missing_baselines
+    if invalid_baselines:
+        violations["invalid_baselines"] = invalid_baselines
+    if missing_candidates:
+        violations["missing_candidate_relation_types"] = missing_candidates
+    if invalid_candidates:
+        violations["invalid_candidate_strict_f1"] = invalid_candidates
+    if regressions:
+        violations["strict_f1_regressions"] = regressions
+    if missing_traps:
+        violations["missing_trap_leak_counts"] = missing_traps
+    if invalid_traps:
+        violations["invalid_trap_leak_counts"] = invalid_traps
+    if leaked_traps:
+        violations["trap_leaks"] = leaked_traps
+
+    passed = not violations
+    if passed:
+        reason = "ok"
+    elif leaked_traps:
+        reason = "zero-tolerance assertion or temporal trap leak"
+    elif missing_baselines or invalid_baselines:
+        reason = "relation golden baseline is missing or invalid"
+    elif regressions:
+        reason = "strict relation F1 regressed beyond pinned tolerance"
+    else:
+        reason = "relation golden evidence is incomplete or invalid"
+
+    return GateCheck(
+        RELATION_GOLDEN_REGRESSION_GATE,
+        passed,
+        reason=reason,
+        details={
+            "comparisons": comparisons,
+            "family": family,
+            "required": required,
+            "trap_leaks": trap_leaks,
+            "trap_tolerance": {kind: 0 for kind in RELATION_GOLDEN_TRAP_KINDS},
+            "violations": violations,
+        },
+    )
+
+
+def _relation_golden_gate_required(metadata: Mapping[str, Any]) -> bool:
+    return bool(
+        metadata.get("relation_golden_required")
+        or metadata.get("relation_golden_regression_required")
+    )
+
+
+def _relation_golden_gate_is_applicable(
+    metrics: Mapping[str, Any], metadata: Mapping[str, Any]
+) -> bool:
+    return bool(_relation_golden_evidence(metrics, metadata)) or (
+        _relation_golden_gate_required(metadata)
+    )
+
+
+def _relation_golden_evidence(
+    metrics: Mapping[str, Any], metadata: Mapping[str, Any]
+) -> dict[str, Any]:
+    explicit = _first_mapping(
+        metrics.get("relation_golden"),
+        metrics.get("relation_golden_regression"),
+        metadata.get("relation_golden"),
+        metadata.get("relation_golden_regression"),
+    )
+    if explicit:
+        return explicit
+
+    relation_evidence = _relation_extraction_evidence(metrics, metadata)
+    if relation_evidence and any(
+        key in relation_evidence for key in ("by_type", "trap_leaks", "traps")
+    ):
+        return relation_evidence
+    if _relation_golden_gate_required(metadata) and isinstance(
+        metrics.get("by_type"), Mapping
+    ):
+        return dict(metrics)
+    return {}
+
+
+def _candidate_relation_strict_f1(
+    evidence: Mapping[str, Any],
+) -> tuple[dict[str, float], dict[str, str]]:
+    nested_metrics = _mapping(evidence.get("metrics"))
+    by_type = _first_mapping(
+        evidence.get("by_type"),
+        evidence.get("per_relation_type"),
+        nested_metrics.get("by_type"),
+        nested_metrics.get("per_relation_type"),
+    )
+    values: dict[str, float] = {}
+    invalid: dict[str, str] = {}
+    if not by_type:
+        invalid["*"] = "missing by_type relation metrics"
+        return values, invalid
+
+    for raw_type, raw_metric in sorted(by_type.items(), key=lambda item: str(item[0])):
+        relation_type = _canonical_relation_type(raw_type)
+        if not relation_type:
+            invalid[str(raw_type)] = "relation type is empty"
+            continue
+        if relation_type in values or relation_type in invalid:
+            invalid[relation_type] = "duplicate normalized relation type"
+            values.pop(relation_type, None)
+            continue
+
+        metric = _mapping(raw_metric)
+        strict = _first_value(metric.get("strict"), metric.get("strict_f1"))
+        if isinstance(strict, Mapping):
+            raw_f1 = _first_value(strict.get("f1"), strict.get("point"))
+        else:
+            raw_f1 = strict
+        parsed = _strict_probability(raw_f1)
+        if parsed is None:
+            invalid[relation_type] = "strict F1 must be between 0 and 1"
+            continue
+        values[relation_type] = parsed
+    return values, invalid
+
+
+def _relation_golden_baselines(
+    baseline: Mapping[str, Any], *, family: str
+) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    section = _mapping(baseline.get("relation_golden"))
+    entries = _mapping(section.get("entries"))
+    normalized_family = _normalise_dimension(family)
+    values: dict[str, dict[str, Any]] = {}
+    invalid: dict[str, str] = {}
+    for raw_key, raw_entry in sorted(entries.items(), key=lambda item: str(item[0])):
+        entry = _mapping(raw_entry)
+        if _normalise_dimension(str(entry.get("family") or "")) != normalized_family:
+            continue
+        relation_type = _canonical_relation_type(entry.get("relation_type"))
+        key = str(raw_key)
+        if not relation_type:
+            invalid[key] = "relation type is empty"
+            continue
+        expected_key = baseline_store.relation_baseline_key(family, relation_type)
+        strict_f1 = _strict_probability(entry.get("strict_f1"))
+        tolerance = _strict_probability(entry.get("tolerance"))
+        if entry.get("key") != key or key != expected_key:
+            invalid[relation_type] = "baseline key does not match family and type"
+        elif strict_f1 is None:
+            invalid[relation_type] = "baseline strict F1 must be between 0 and 1"
+        elif tolerance is None:
+            invalid[relation_type] = "baseline tolerance must be between 0 and 1"
+        elif relation_type in values:
+            invalid[relation_type] = "duplicate normalized relation baseline"
+            values.pop(relation_type, None)
+        else:
+            values[relation_type] = {
+                "fixture_hash": str(entry.get("fixture_hash") or ""),
+                "key": key,
+                "strict_f1": strict_f1,
+                "tolerance": tolerance,
+            }
+    return values, invalid
+
+
+def _relation_trap_leaks(
+    evidence: Mapping[str, Any], metadata: Mapping[str, Any]
+) -> tuple[dict[str, int], dict[str, str]]:
+    nested_metrics = _mapping(evidence.get("metrics"))
+    nested_metadata = _mapping(evidence.get("metadata"))
+    trap_leaks = _first_mapping(
+        evidence.get("trap_leaks"),
+        nested_metrics.get("trap_leaks"),
+        nested_metadata.get("trap_leaks"),
+        metadata.get("relation_trap_leaks"),
+    )
+    if not trap_leaks:
+        traps = _first_mapping(
+            evidence.get("traps"),
+            nested_metadata.get("traps"),
+            metadata.get("relation_traps"),
+        )
+        trap_leaks = _mapping(traps.get("by_kind"))
+
+    values: dict[str, int] = {}
+    invalid: dict[str, str] = {}
+    for kind in RELATION_GOLDEN_TRAP_KINDS:
+        if kind not in trap_leaks:
+            continue
+        count = _relation_trap_leak_count(trap_leaks[kind])
+        if count is None:
+            invalid[kind] = "trap leak count must be a non-negative integer"
+        else:
+            values[kind] = count
+    return values, invalid
+
+
+def _relation_trap_leak_count(value: Any) -> int | None:
+    direct = _strict_nonnegative_int(value)
+    if direct is not None:
+        return direct
+    payload = _mapping(value)
+    for field in ("leak_count", "leaked_count", "failure_count"):
+        if field in payload:
+            return _strict_nonnegative_int(payload[field])
+    for field in ("leaked_relation_ids", "leaks"):
+        leaked = payload.get(field)
+        if isinstance(leaked, Sequence) and not isinstance(
+            leaked, (str, bytes, bytearray)
+        ):
+            return len(leaked)
+    return None
+
+
+def _canonical_relation_type(value: Any) -> str:
+    normalized = _normalise_dimension(str(value or ""))
+    return normalized.upper().replace("-", "_")
+
+
 def evaluate_radiology_entity_relation_gate(
     metrics: Mapping[str, Any],
     metadata: Mapping[str, Any] | None = None,
@@ -5622,6 +5939,8 @@ __all__ = [
     "G15_E2E_FACT_F1_FLOOR",
     "G9_STRICT_RE_F1_FLOOR",
     "G9_RELAXED_RE_F1_FLOOR",
+    "RELATION_GOLDEN_REGRESSION_GATE",
+    "RELATION_GOLDEN_TRAP_KINDS",
     "FLAKINESS_GATE",
     "SURROGATE_QUALITY_GATE",
     "EXPORT_VARIANT_GATE",
@@ -5645,6 +5964,7 @@ __all__ = [
     "evaluate_end_to_end_pipeline_gate",
     "evaluate_federated_boundary_gate",
     "evaluate_radiology_entity_relation_gate",
+    "evaluate_relation_golden_regression_gate",
     "evaluate_grounding_accuracy_gate",
     "evaluate_surrogate_quality_gate",
     "format_preview",

--- a/tests/unit/core/test_baseline.py
+++ b/tests/unit/core/test_baseline.py
@@ -11,10 +11,12 @@ import pytest
 from openmed.core.baseline import (
     BASELINE_PATH,
     BASELINE_SCHEMA_VERSION,
+    BaselineError,
     BaselineMiss,
     baseline_key,
     get_baseline,
     load_baseline_store,
+    relation_baseline_key,
     require_baseline,
     update_baseline_entry,
     validate_baseline_store,
@@ -98,6 +100,11 @@ def test_committed_baseline_store_validates_schema() -> None:
     validate_baseline_store(store)
     assert store["schema_version"] == BASELINE_SCHEMA_VERSION
     assert get_baseline("PII", "Small", "mlx-fp", store=store) is not None
+    assert sorted(store["relation_golden"]["entries"]) == [
+        "relation::asserted-absent",
+        "relation::temporally-before",
+        "relation::treats",
+    ]
 
 
 def test_update_baseline_entry_preserves_other_keys(tmp_path: Path) -> None:
@@ -166,6 +173,33 @@ def test_reproducibility_hash_is_deterministic_for_fixed_inputs() -> None:
 def test_baseline_key_uses_family_tier_format_dimensions() -> None:
     assert baseline_key("PII", "Small", "MLX_FP") == "pii::small::mlx-fp"
     assert baseline_key("General", None, "coreml") == "general::none::coreml"
+
+
+def test_relation_baseline_key_uses_family_and_relation_type_dimensions() -> None:
+    assert (
+        relation_baseline_key("Relation", "TEMPORALLY_BEFORE")
+        == "relation::temporally-before"
+    )
+
+
+def test_relation_baseline_schema_rejects_mismatched_dimensions() -> None:
+    store = _store()
+    store["relation_golden"] = {
+        "entries": {
+            "relation::treats": {
+                "family": "Relation",
+                "fixture_hash": "sha256:" + "a" * 64,
+                "key": "relation::treats",
+                "relation_type": "CAUSES",
+                "strict_f1": 1.0,
+                "tolerance": 0.01,
+            }
+        },
+        "schema_version": 1,
+    }
+
+    with pytest.raises(BaselineError, match="does not match its dimensions"):
+        validate_baseline_store(store)
 
 
 def test_publish_artifact_updates_manifest_and_baseline(

--- a/tests/unit/eval/test_release_gates.py
+++ b/tests/unit/eval/test_release_gates.py
@@ -11,6 +11,7 @@ from openmed.compliance import (
     build_release_expert_review_evidence,
 )
 from openmed.core.audit import stable_hash
+from openmed.core.baseline import relation_baseline_key
 from openmed.eval import release_gates
 from openmed.eval.metrics import (
     compute_metrics_bundle,
@@ -322,6 +323,53 @@ def _relation_metric(*, strict_lower: float, relaxed_lower: float) -> dict[str, 
     }
 
 
+def _relation_golden_metric(
+    *,
+    strict_by_type: dict[str, float] | None = None,
+    assertion_leaks: int = 0,
+    temporal_leaks: int = 0,
+) -> dict[str, object]:
+    strict_by_type = strict_by_type or {
+        "ASSERTED_ABSENT": 1.0,
+        "TEMPORALLY_BEFORE": 1.0,
+        "TREATS": 1.0,
+    }
+    return {
+        "relation_golden": {
+            "by_type": {
+                relation_type: {"strict": {"f1": strict_f1}}
+                for relation_type, strict_f1 in strict_by_type.items()
+            },
+            "trap_leaks": {
+                "assertion": assertion_leaks,
+                "temporal": temporal_leaks,
+            },
+        }
+    }
+
+
+def _relation_golden_baseline_store() -> dict[str, object]:
+    fixture_hash = (
+        "sha256:eefd1e98cb6026cb843cd8f0dfcc084825f3323de4e9ff98efc8f62677578187"
+    )
+    entries: dict[str, object] = {}
+    for relation_type in ("ASSERTED_ABSENT", "TEMPORALLY_BEFORE", "TREATS"):
+        key = relation_baseline_key("Relation", relation_type)
+        entries[key] = {
+            "family": "Relation",
+            "fixture_hash": fixture_hash,
+            "key": key,
+            "relation_type": relation_type,
+            "strict_f1": 1.0,
+            "tolerance": 0.01,
+        }
+    return {
+        "entries": {},
+        "relation_golden": {"entries": entries, "schema_version": 1},
+        "schema_version": 1,
+    }
+
+
 def test_release_gate_passes_and_emits_signed_section_64_report(
     tmp_path: Path,
     monkeypatch,
@@ -531,6 +579,122 @@ def test_g9_relation_gate_passes_at_configured_lower_ci_floor(
     assert check.details["per_relation_type"]["INHIBITOR"]["strict_f1"] == (
         release_gates.G9_STRICT_RE_F1_FLOOR
     )
+
+
+def test_relation_golden_gate_passes_at_pinned_tolerance_and_is_signed(
+    tmp_path: Path,
+) -> None:
+    metrics = _relation_golden_metric(
+        strict_by_type={
+            "ASSERTED_ABSENT": 0.99,
+            "TEMPORALLY_BEFORE": 0.99,
+            "TREATS": 0.99,
+        }
+    )
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metadata_updates={
+                "family": "Relation",
+                "relation_golden_regression_required": True,
+            },
+            metric_updates=metrics,
+        )
+    )
+
+    check = _check(result, release_gates.RELATION_GOLDEN_REGRESSION_GATE)
+    assert result.decision == RELEASABLE
+    assert result.verify(SIGNING_KEY)
+    assert check.passed is True
+    assert check.details["comparisons"]["TREATS"]["minimum"] == 0.99
+    assert check.details["trap_tolerance"] == {"assertion": 0, "temporal": 0}
+
+    restored = GateReport.from_json(result.to_json())
+    restored_check = _check(restored, release_gates.RELATION_GOLDEN_REGRESSION_GATE)
+    assert restored.verify(SIGNING_KEY)
+    assert restored_check.details == check.details
+
+
+def test_relation_golden_gate_quarantines_strict_f1_regression(
+    tmp_path: Path,
+) -> None:
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metadata_updates={
+                "family": "Relation",
+                "relation_golden_regression_required": True,
+            },
+            metric_updates=_relation_golden_metric(
+                strict_by_type={
+                    "ASSERTED_ABSENT": 1.0,
+                    "TEMPORALLY_BEFORE": 1.0,
+                    "TREATS": 0.989,
+                }
+            ),
+        ),
+        _relation_golden_baseline_store(),
+    )
+
+    check = _check(result, release_gates.RELATION_GOLDEN_REGRESSION_GATE)
+    regression = check.details["violations"]["strict_f1_regressions"]["TREATS"]
+    assert result.decision == QUARANTINED
+    assert result.verify(SIGNING_KEY)
+    assert check.passed is False
+    assert regression["candidate"] == 0.989
+    assert regression["minimum"] == 0.99
+
+
+def test_relation_golden_gate_quarantines_missing_type_baseline(
+    tmp_path: Path,
+) -> None:
+    baseline = _relation_golden_baseline_store()
+    del baseline["relation_golden"]["entries"]["relation::treats"]
+
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metadata_updates={
+                "family": "Relation",
+                "relation_golden_regression_required": True,
+            },
+            metric_updates=_relation_golden_metric(),
+        ),
+        baseline,
+    )
+
+    check = _check(result, release_gates.RELATION_GOLDEN_REGRESSION_GATE)
+    assert result.decision == QUARANTINED
+    assert result.verify(SIGNING_KEY)
+    assert check.passed is False
+    assert check.details["violations"]["missing_baselines"] == ["TREATS"]
+
+
+@pytest.mark.parametrize("trap_kind", release_gates.RELATION_GOLDEN_TRAP_KINDS)
+def test_relation_golden_gate_hard_fails_on_any_trap_leak(
+    tmp_path: Path,
+    trap_kind: str,
+) -> None:
+    trap_counts = {"assertion_leaks": 0, "temporal_leaks": 0}
+    trap_counts[f"{trap_kind}_leaks"] = 1
+    result = _gate().evaluate(
+        _report(
+            tmp_path,
+            metadata_updates={
+                "family": "Relation",
+                "relation_golden_regression_required": True,
+            },
+            metric_updates=_relation_golden_metric(**trap_counts),
+        ),
+        _relation_golden_baseline_store(),
+    )
+
+    check = _check(result, release_gates.RELATION_GOLDEN_REGRESSION_GATE)
+    assert result.decision == QUARANTINED
+    assert result.verify(SIGNING_KEY)
+    assert check.passed is False
+    assert check.reason == "zero-tolerance assertion or temporal trap leak"
+    assert check.details["violations"]["trap_leaks"] == {trap_kind: 1}
 
 
 def test_gate_report_from_json_rejects_malformed_payload() -> None:


### PR DESCRIPTION
## Description

Adds fail-closed relation golden-regression enforcement to the signed release-gate report. Strict F1 is compared per model family and relation type against pinned baselines, while assertion and temporal trap leaks have exactly-zero tolerance.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test addition/improvement

## Changes Made

- Add and validate relation golden baselines keyed by model family and normalized relation type.
- Quarantine missing baselines and strict-F1 drops beyond each pinned tolerance.
- Hard-fail assertion or temporal trap leaks and sign the detailed comparison into the existing gate report.
- Keep relation runner, scorecard, and model-card wiring outside this child issue.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run:

- `.venv/bin/python -m pytest -q tests/unit/eval/test_release_gates.py` — 79 passed
- `.venv/bin/python -m pytest -q tests/unit/core/test_baseline.py` — 8 passed
- `uv run ruff check openmed/core/baseline.py openmed/eval/release_gates.py tests/unit/core/test_baseline.py tests/unit/eval/test_release_gates.py`
- `uv run ruff format --check openmed/core/baseline.py openmed/eval/release_gates.py tests/unit/core/test_baseline.py tests/unit/eval/test_release_gates.py`
- `.venv/bin/pre-commit run --files gates/baseline.json openmed/core/baseline.py openmed/eval/release_gates.py tests/unit/core/test_baseline.py tests/unit/eval/test_release_gates.py`

## Documentation

- [x] Public baseline schema and gate docstrings are updated
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran repository Ruff format, lint, and format-check equivalents limited to changed files
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #1209

## Screenshots/Examples

Not applicable; this change has no UI surface.
