### PR TITLE
Document multilingual ConText lexicon contributions

### DIFF
--- a/docs/clinical/context-and-extraction.md
+++ b/docs/clinical/context-and-extraction.md
@@ -74,6 +74,123 @@ for name, (span, modifiers) in examples.items():
     print(assertion.to_dict())
 ```
 
+## Multilingual Cue Lexicons
+
+The public resolvers and `scan_context_cues()` accept a `language` argument.
+The registry normalizes a BCP-47-like value to its primary language subtag, so
+`es-MX` selects the `es` pack. An unknown code falls back to English for
+backward compatibility. A registered non-English pack is otherwise isolated:
+missing cues keep the default recent, certain, and affirmed axes rather than
+borrowing English cues.
+
+The shipped `en`, `es`, `fr`, `de`, `zh`, and `hi` packs live in
+`openmed/clinical/lexicons/context_cues.py`. They are compact,
+OpenMed-authored surface-form tables distributed with the repository under
+Apache-2.0. They are not verbatim exports of a publication's supplementary
+lexicon, a terminology system, or a clinical corpus.
+
+### Research Lineage And Pack Provenance
+
+The publications below establish the method and the review practices that
+informed the OpenMed implementation. A citation is not permission to copy a
+paper's corpus or lexical asset. Treat a source as methodological background
+unless its terms have a clear, permissive redistribution license that is
+compatible with Apache-2.0.
+
+| Source | Influence on OpenMed | Data boundary |
+| --- | --- | --- |
+| [Chapman et al., *A Simple Algorithm for Identifying Negated Findings and Diseases in Discharge Summaries*](https://doi.org/10.1006/jbin.2001.1029) | NegEx's compact true-negation, pseudo-negation, and bounded-scope design. | No discharge-summary sentence or source trigger file is bundled. |
+| [Harkema et al., *ConText: An Algorithm for Determining Negation, Experiencer, and Temporal Status from Clinical Reports*](https://pmc.ncbi.nlm.nih.gov/articles/PMC2757457/) | ConText-style contextual axes, directional cues, and termination boundaries. | No evaluation report or annotated condition is bundled. |
+| [Chapman et al., *Extending the NegEx Lexicon for Multiple Languages*](https://pmc.ncbi.nlm.nih.gov/articles/PMC3923890/) | The multilingual translation workflow and the need for clinician or linguist review, especially for French and German variation. | The published OWL/RDF lexicon and its source corpora were not imported. |
+| [Velupillai et al., *Cue-based assertion classification for Swedish clinical text—developing a lexicon for pyConTextSwe*](https://pmc.ncbi.nlm.nih.gov/articles/PMC4104142/) | The practice of testing language-specific cues, inflections, uncertainty, and error-driven refinements independently. | Swedish is not a shipped pack, and no pyConTextSwe cue or clinical sentence was copied. |
+
+The English pack migrated the pre-registry OpenMed tuples to preserve existing
+behavior. The Spanish, French, German, Chinese, and Hindi packs are
+OpenMed-maintained baselines authored as small lists of common surface forms.
+The multilingual publications above informed their structure and review
+criteria; they are not a claim that every shipped phrase occurs in those
+resources. Chinese and Hindi entries in particular are OpenMed-authored
+applications of the published cue-and-scope method, not translations imported
+from those publications. Their committed evaluation evidence is the synthetic
+fixture described below, not a restricted clinical corpus.
+
+### Lexicon Fields
+
+`ClinicalCueLexicon` has the following contribution contract:
+
+| Field | Meaning and review requirement |
+| --- | --- |
+| `language` | Primary language code used as the registry key. Region or script subtags passed by callers normalize to this primary code. |
+| `negation` | True-negation cues that can change `affirmed` to `negated`. Keep phrases that only look negative in `pseudo_negation`. |
+| `pseudo_negation` | Longer phrases masked before true-negation matching, such as an inability to exclude a finding. Test each one as affirmed and, when appropriate, uncertain. |
+| `historical` | Cues that move temporality from its default `recent` value to `historical`. |
+| `hypothetical` | Conditional or future-contingent cues. A hypothetical cue takes precedence over a historical cue. |
+| `recent` | Explicit current or acute cues. The resolver also returns `recent` when no temporal cue matches. |
+| `uncertainty` | Hedging, speculation, or conditional cues that change `certain` to `uncertain`. If a phrase affects multiple axes, include and test it in every relevant tuple. |
+| `backward` | Exact normalized cue strings that scope to a target on their left. Every entry must also appear in an axis tuple so the scanner can discover and categorize it. All other discovered cues scope forward. |
+| `scope_terminators` | Language-specific boundaries used to trim the direct resolver's context window and validate explicit modifier hits. Sentence punctuation is also a boundary. |
+| `conjunction_terminators` | Same-sentence blockers used by `scan_context_cues()` between a cue and target, such as the local equivalents of “but” or “however.” |
+| `token_boundaries` | When `true`, cue matching requires Unicode word boundaries. Set to `false` only when the script or orthography needs substring matching, then add negative tests for accidental matches inside longer text. |
+
+### Scope Direction
+
+`scan_context_cues()` emits offset-bearing modifier hits for historical,
+hypothetical, uncertainty, and negation cues. A cue before a target scopes
+forward; a cue listed in `backward` must occur after the target and scopes to
+the left. Cue and target must remain in the same sentence, and a localized
+`conjunction_terminators` match between them stops the hit.
+
+The resolver path also accepts a span carrying full context and offsets. It
+trims that context at punctuation and `scope_terminators`, then evaluates each
+axis. Pseudo-negation is masked before true negation cues are counted; an even
+number of true negation cues is treated as affirmed so double negation is
+deterministic. These mechanical rules need language-specific minimal pairs and
+must remain advisory annotations rather than clinical decisions.
+
+### Adding A Language Pack
+
+1. Establish provenance before editing. Record the source URL or DOI, license,
+   authoring or translation method, and the language/domain review performed.
+   If a lexical source does not state permissive redistribution terms, use it
+   only to understand the method and author new entries independently.
+2. Add the `ClinicalCueLexicon` constant and its registry entry in
+   `openmed/clinical/lexicons/context_cues.py`. Adding a pack must not require
+   edits to resolver or scanner logic.
+3. Extend `openmed/eval/golden/fixtures/context_multilingual.jsonl`. Update the
+   metadata language list and add uniquely named synthetic minimal pairs for
+   affirmed, negated, historical, hypothetical/uncertain, pseudo-negation, and
+   double-negation behavior. Both the metadata row and every case must retain
+   `"synthetic": true`, and each target string must occur unambiguously in its
+   sentence.
+4. Extend the focused tests in
+   `tests/unit/clinical/test_context_multilingual.py` for forward and backward
+   scope, a localized conjunction terminator, token-boundary behavior, and the
+   per-axis fixture results. The tests and eval must run fully offline.
+
+## Language-Pack Review Checklist
+
+- [ ] The PR identifies each lexical or methodological source and its license;
+      copied material is Apache-2.0-compatible and attribution requirements are
+      preserved.
+- [ ] No raw PHI, real clinical sentence, DUA-gated corpus, proprietary or
+      source-available list, or gated terminology asset appears in code,
+      fixtures, logs, or test artifacts.
+- [ ] A fluent reviewer has checked meaning, spelling, diacritics, inflection,
+      common abbreviations, and whether cues are plausible in the intended
+      clinical register.
+- [ ] True negation, pseudo-negation, uncertainty, and intentional cross-axis
+      overlaps are separated correctly; every `backward` cue also belongs to an
+      axis tuple.
+- [ ] Forward and backward direction, sentence/clause termination, and the
+      `token_boundaries` choice have positive and negative regression cases.
+- [ ] The JSONL cases are fabricated minimal pairs, carry `"synthetic": true`,
+      contain no identifiers, and cover affirmed, negated, historical,
+      hypothetical, uncertain, pseudo-negation, and double-negation outcomes.
+- [ ] The existing English cases and every registered language still meet the
+      focused multilingual context gates without network access.
+- [ ] The change is confined to the lexicon, fixture, focused tests, and this
+      guidance; resolver logic is unchanged.
+
 ## Scope And Section Priors
 
 Modifier hits should be scoped before they reach the axis resolvers. A cue only

--- a/tests/unit/clinical/test_context_multilingual.py
+++ b/tests/unit/clinical/test_context_multilingual.py
@@ -35,6 +35,12 @@ from openmed.eval.harness import (
 
 FORBIDDEN_FIXTURE_MARKERS = ("cpt", "dua", "i2b2", "mimic", "n2c2", "snomed", "umls")
 REQUIRED_LANGUAGES = {"en", "es", "fr", "de", "zh", "hi"}
+CONTEXT_GUIDE = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "clinical"
+    / "context-and-extraction.md"
+)
 
 
 def test_context_multilingual_fixture_is_synthetic_and_complete() -> None:
@@ -53,6 +59,25 @@ def test_context_multilingual_fixture_is_synthetic_and_complete() -> None:
     )
     for marker in FORBIDDEN_FIXTURE_MARKERS:
         assert re.search(rf"(?<![a-z0-9]){marker}(?![a-z0-9])", fixture_text) is None
+
+
+def test_multilingual_context_docs_cover_safe_contribution_contract() -> None:
+    guide = CONTEXT_GUIDE.read_text(encoding="utf-8")
+    normalized_guide = re.sub(r"\s+", " ", guide)
+
+    for field in ClinicalCueLexicon.__dataclass_fields__:
+        assert f"`{field}`" in guide
+
+    for requirement in (
+        "Extending the NegEx Lexicon for Multiple Languages",
+        "pyConTextSwe",
+        "## Language-Pack Review Checklist",
+        "context_multilingual.jsonl",
+        '"synthetic": true',
+        "No raw PHI",
+        "must not require edits to resolver or scanner logic",
+    ):
+        assert requirement in normalized_guide
 
 
 def test_resolvers_accept_language_without_breaking_english_defaults() -> None:


### PR DESCRIPTION
## Description
Documents the provenance and safe contribution contract for multilingual ConText cue packs. The guide now distinguishes research lineage from redistribution permission, defines every lexicon field and scope direction, and requires synthetic offline fixtures for language-pack reviews.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added provenance notes for NegEx, ConText, multilingual NegEx, and pyConTextSwe research lineage without importing external lexical or corpus data.
- Documented all `ClinicalCueLexicon` fields, forward/backward scope, terminators, boundary handling, and registry fallback behavior.
- Added a synthetic-only language-pack workflow and review checklist with a focused documentation contract test.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `.venv/bin/python -m pytest tests/unit/clinical/test_context_multilingual.py::test_context_multilingual_fixture_is_synthetic_and_complete tests/unit/clinical/test_context_multilingual.py::test_multilingual_context_docs_cover_safe_contribution_contract -q`
- `.venv/bin/ruff check tests/unit/clinical/test_context_multilingual.py`
- `.venv/bin/ruff format --check tests/unit/clinical/test_context_multilingual.py`
- `pre-commit run --files docs/clinical/context-and-extraction.md tests/unit/clinical/test_context_multilingual.py`

## Documentation
- [x] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1216
Related to #1199

## Screenshots/Examples
Not applicable; this is documentation and a focused documentation contract test.