### PR TITLE
fix: load pulled models in offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed offline Hugging Face pipeline loading so `openmed models pull` caches
+  are resolved without passing `local_files_only` twice through Transformers,
+  including fallback component loading from the standard Hub cache (#1983).
 - Fixed the PySpark batch de-identification adapter so
   `make_deidentify_udf()` supplies concrete pandas `Series` annotations during
   UDF construction instead of failing with an unsupported `Any` signature

--- a/openmed/core/models.py
+++ b/openmed/core/models.py
@@ -178,6 +178,7 @@ class ModelLoader:
             model_name,
             full_model_name,
             local_only=bool(requested_local_loading.get("local_files_only")),
+            revision=kwargs.get("revision"),
         )
 
         try:
@@ -376,6 +377,7 @@ class ModelLoader:
             model_name,
             full_model_name,
             local_only=bool(requested_local_loading.get("local_files_only")),
+            revision=kwargs.get("revision"),
         )
 
         model_kwargs: Dict[str, Any] = {}
@@ -395,10 +397,12 @@ class ModelLoader:
             )
             pipeline_load_kwargs = dict(kwargs)
             model_kwargs = dict(pipeline_load_kwargs.pop("model_kwargs", {}) or {})
-            # Transformers forwards loader options through ``model_kwargs``;
-            # top-level extras are sent to the instantiated pipeline instead.
+            # Cached-only loading is enforced by resolving a local snapshot plus
+            # the socket guard below. Do not forward ``local_files_only`` here:
+            # Transformers 5 supplies the same keyword internally and otherwise
+            # passes it twice to AutoConfig.from_pretrained().
             pipeline_load_kwargs.pop("local_files_only", None)
-            model_kwargs.update(local_loading_kwargs)
+            model_kwargs.pop("local_files_only", None)
             cache_dir = pipeline_load_kwargs.pop("cache_dir", None)
             if cache_dir is None and local_loading_kwargs.get("local_files_only"):
                 cache_dir = getattr(self.config, "cache_dir", None)
@@ -421,7 +425,7 @@ class ModelLoader:
             pipeline_kwargs.update(pipeline_load_kwargs)
             self._apply_attention_pipeline_kwargs(pipeline_kwargs)
 
-            effective_local_only = bool(model_kwargs.get("local_files_only"))
+            effective_local_only = bool(local_loading_kwargs.get("local_files_only"))
             with network_blocked_if_offline(
                 self.config,
                 local_only=effective_local_only,
@@ -436,9 +440,9 @@ class ModelLoader:
             logger.error("Failed to create pipeline for %s: %s", full_model_name, e)
             # Fall back to loading model components manually
             fallback_load_kwargs = {
-                key: model_kwargs[key]
+                key: local_loading_kwargs[key]
                 for key in ("local_files_only",)
-                if key in model_kwargs
+                if key in local_loading_kwargs
             }
             with network_blocked_if_offline(
                 self.config,
@@ -687,18 +691,56 @@ class ModelLoader:
         resolved_model_name: str,
         *,
         local_only: bool,
+        revision: Optional[str] = None,
     ) -> str:
         """Resolve and verify cached artifacts before model construction."""
         registry_info = get_model_info(requested_model_name) or get_model_info(
             resolved_model_name
         )
-        return prepare_model_reference(
+        prepared_reference = prepare_model_reference(
             resolved_model_name,
             registry_info=registry_info,
             cache_dir=str(self.config.cache_dir),
             local_only=local_only,
             token=getattr(self.config, "hf_token", None),
         )
+        if not local_only or self._as_existing_local_path(prepared_reference):
+            return prepared_reference
+
+        cached_snapshot = self._find_cached_hf_snapshot(
+            prepared_reference,
+            revision=revision,
+        )
+        return cached_snapshot or prepared_reference
+
+    def _find_cached_hf_snapshot(
+        self,
+        model_name: str,
+        *,
+        revision: Optional[str] = None,
+    ) -> Optional[str]:
+        """Find a Hub snapshot without network access in known cache roots."""
+        from .hf_hub import _import_snapshot_download
+
+        snapshot_download, local_entry_not_found = _import_snapshot_download()
+        configured_cache = getattr(self.config, "cache_dir", None)
+        cache_candidates = (
+            str(configured_cache) if configured_cache is not None else None,
+            None,
+        )
+        for cache_dir in cache_candidates:
+            download_kwargs: Dict[str, Any] = {
+                "repo_id": model_name,
+                "revision": revision,
+                "local_files_only": True,
+            }
+            if cache_dir is not None:
+                download_kwargs["cache_dir"] = cache_dir
+            try:
+                return str(snapshot_download(**download_kwargs))
+            except local_entry_not_found:
+                continue
+        return None
 
     def _as_existing_local_path(self, model_name: str) -> Optional[Path]:
         """Return a filesystem path when ``model_name`` points to local files."""
@@ -725,6 +767,10 @@ class ModelLoader:
             return {"local_files_only": True}
         if kwargs and "local_files_only" in kwargs:
             return {"local_files_only": kwargs["local_files_only"]}
+        if kwargs and isinstance(kwargs.get("model_kwargs"), Mapping):
+            model_kwargs = kwargs["model_kwargs"]
+            if "local_files_only" in model_kwargs:
+                return {"local_files_only": model_kwargs["local_files_only"]}
         if self._as_existing_local_path(model_name) is not None:
             return {"local_files_only": True}
         return {}

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -179,7 +179,7 @@ class TestModelLoader:
         kwargs = mock_pipeline.call_args.kwargs
         assert kwargs["model"] == str(model_dir)
         assert "local_files_only" not in kwargs
-        assert kwargs["model_kwargs"]["local_files_only"] is True
+        assert "local_files_only" not in kwargs["model_kwargs"]
         assert kwargs["model_kwargs"]["cache_dir"] == loader.config.cache_dir
 
     @patch("openmed.core.models.HF_AVAILABLE", True)

--- a/tests/unit/test_offline_mode.py
+++ b/tests/unit/test_offline_mode.py
@@ -62,7 +62,7 @@ def test_local_only_hf_pipeline_uses_cached_files(mock_pipeline, monkeypatch):
 
     pipeline_kwargs = mock_pipeline.call_args.kwargs
     assert "local_files_only" not in pipeline_kwargs
-    assert pipeline_kwargs["model_kwargs"]["local_files_only"] is True
+    assert "local_files_only" not in pipeline_kwargs["model_kwargs"]
     assert pipeline_kwargs["model_kwargs"]["cache_dir"] == loader.config.cache_dir
 
 
@@ -81,7 +81,86 @@ def test_local_only_config_cannot_be_disabled_by_pipeline_kwarg(
 
     pipeline_kwargs = mock_pipeline.call_args.kwargs
     assert "local_files_only" not in pipeline_kwargs
-    assert pipeline_kwargs["model_kwargs"]["local_files_only"] is True
+    assert "local_files_only" not in pipeline_kwargs["model_kwargs"]
+
+
+@patch("openmed.core.models.HF_AVAILABLE", True)
+@patch("openmed.core.backends._module_available", lambda _: True)
+@patch("openmed.core.models.pipeline")
+def test_nested_local_only_pipeline_kwarg_is_enforced_without_forwarding_collision(
+    mock_pipeline,
+    monkeypatch,
+):
+    _clear_offline_env(monkeypatch)
+
+    from openmed.core.models import ModelLoader
+
+    loader = ModelLoader(OpenMedConfig(backend="hf"))
+    with patch.object(
+        loader,
+        "_prepare_model_reference",
+        return_value="/cached/local-pii",
+    ) as mock_prepare:
+        loader.create_pipeline(
+            "OpenMed/local-pii",
+            model_kwargs={"local_files_only": True},
+        )
+
+    assert mock_prepare.call_args.kwargs["local_only"] is True
+    pipeline_kwargs = mock_pipeline.call_args.kwargs
+    assert "local_files_only" not in pipeline_kwargs
+    assert "local_files_only" not in pipeline_kwargs["model_kwargs"]
+
+
+@patch("openmed.core.models.prepare_model_reference")
+@patch("openmed.core.hf_hub._import_snapshot_download")
+def test_local_only_model_uses_snapshot_from_standard_hf_cache(
+    mock_import_snapshot_download,
+    mock_prepare_model_reference,
+    tmp_path,
+    monkeypatch,
+):
+    _clear_offline_env(monkeypatch)
+    model_id = "OpenMed/local-pii"
+    snapshot = tmp_path / "hf-cache" / "snapshot"
+    snapshot.mkdir(parents=True)
+    calls = []
+
+    class LocalEntryNotFoundError(Exception):
+        pass
+
+    def fake_snapshot_download(**kwargs):
+        calls.append(kwargs)
+        if "cache_dir" in kwargs:
+            raise LocalEntryNotFoundError
+        return str(snapshot)
+
+    mock_prepare_model_reference.return_value = model_id
+    mock_import_snapshot_download.return_value = (
+        fake_snapshot_download,
+        LocalEntryNotFoundError,
+    )
+
+    from openmed.core.models import ModelLoader
+
+    loader = ModelLoader(OpenMedConfig(local_only=True, backend="hf"))
+
+    assert loader._prepare_model_reference(model_id, model_id, local_only=True) == str(
+        snapshot
+    )
+    assert calls == [
+        {
+            "repo_id": model_id,
+            "revision": None,
+            "local_files_only": True,
+            "cache_dir": loader.config.cache_dir,
+        },
+        {
+            "repo_id": model_id,
+            "revision": None,
+            "local_files_only": True,
+        },
+    ]
 
 
 @patch("openmed.core.models.HF_AVAILABLE", True)


### PR DESCRIPTION
## Description
Fixes offline Hugging Face loading for models fetched by `openmed models pull`. OpenMed now resolves cached Hub snapshots before constructing a Transformers pipeline, avoids forwarding a duplicate `local_files_only` keyword, and preserves cache-only fallback component loading.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Resolve offline model references from the configured OpenMed cache and the standard Hugging Face Hub cache.
- Keep `local_files_only` out of high-level Transformers pipeline kwargs while retaining the local snapshot and socket guard.
- Preserve local-only component fallback behavior and nested caller options.
- Add regression coverage and an Unreleased changelog entry.

## Testing
- [x] Added tests that prove the fix is effective.
- [x] New and existing unit tests pass locally with the change.
- [x] Tested the reported offline CLI flow with a completed cached Portuguese model.
- `49 passed` in the focused model/offline suite.
- `9764 passed, 75 skipped, 1 xfailed` in the final frozen full-suite run, deselecting only the pre-existing migration-guide check whose 481-symbol result is identical on `origin/master`.
- Real offline CLI de-identification exited 0 with `OpenMed/OpenMed-PII-Portuguese-LiteClinical-Small-66M-v1`.
- Direct offline fallback component loading returned `DistilBertForTokenClassification` and `BertTokenizer` from the same standard Hub cache.

## Documentation
- [x] Updated `CHANGELOG.md`.
- [x] No new public API documentation is required.

## Code Quality
- [x] Ran `make format`, `make lint`, and `make format-check`.
- [x] Ran scoped mypy checks.
- [x] Ran pre-commit on every changed file.
- [x] Performed a self-review.
- [x] Changes generate no new warnings.

## Dependencies
- [x] No new dependencies.

## Checklist
- [x] Read the contributing guidelines.
- [x] Commit has a clear, descriptive message.
- [x] Commit is focused on the reported defect.

## Related Issues
Closes #1983

## Screenshots/Examples
Not applicable.