### PR TITLE
Add MCP clinical workflow contracts and stage-order validation

### DIFF
--- a/openmed/interop/function_tools.py
+++ b/openmed/interop/function_tools.py
@@ -111,6 +111,14 @@ def _tool_handler(
             **kwargs,
             runtime_provider=runtime_provider,
         ),
+        "openmed_ground": lambda **kwargs: mcp_server.openmed_ground(**kwargs),
+        "openmed_export_fhir": lambda **kwargs: mcp_server.openmed_export_fhir(
+            **kwargs
+        ),
+        "openmed_risk_score": lambda **kwargs: mcp_server.openmed_risk_score(**kwargs),
+        "openmed_clinical_pipeline": (
+            lambda **kwargs: mcp_server.openmed_clinical_pipeline(**kwargs)
+        ),
         "openmed_fhir_bundle": lambda **kwargs: mcp_server.openmed_fhir_bundle(
             **kwargs
         ),

--- a/openmed/interop/tools.json
+++ b/openmed/interop/tools.json
@@ -157,6 +157,449 @@
       "version": "1.0.0"
     },
     {
+      "description": "Plan and validate declarative clinical stages without silently reordering them.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "allow_external_llm": {
+            "default": false,
+            "description": "Reserve external LLM routing through the privacy gateway.",
+            "type": "boolean"
+          },
+          "options": {
+            "default": null,
+            "description": "Execution options reserved for later pipeline handlers.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "session_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "spans": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "action": {
+                      "enum": [
+                        "keep",
+                        "redact",
+                        "replace",
+                        "mask",
+                        "hash",
+                        "format_preserve"
+                      ],
+                      "type": "string"
+                    },
+                    "canonical_label": {
+                      "enum": [
+                        "ABNORMAL_FLAG",
+                        "ACCOUNT_NUMBER",
+                        "ADMINISTRATION_ROUTE",
+                        "AGE",
+                        "AIRWAY_MANAGEMENT",
+                        "AMOUNT",
+                        "ANESTHESIA_TYPE",
+                        "ANESTHETIC_AGENT",
+                        "ANTIBIOTIC",
+                        "API_KEY",
+                        "ASA_CLASS",
+                        "BIC",
+                        "BITCOIN_ADDRESS",
+                        "BODY_SITE",
+                        "BUILDING_NUMBER",
+                        "CARE_INTERVENTION",
+                        "CKD_STAGE",
+                        "CLINICAL_SIGNIFICANCE",
+                        "CONDITION",
+                        "CREDIT_CARD",
+                        "CREDIT_CARD_ISSUER",
+                        "CURRENCY",
+                        "CVV",
+                        "DATE",
+                        "DATE_OF_BIRTH",
+                        "DEVELOPMENTAL_MILESTONE",
+                        "DEVICE",
+                        "DIALYSIS_MODALITY",
+                        "DIET_TYPE",
+                        "DOSAGE",
+                        "DOSE_NUMBER",
+                        "DURATION",
+                        "DYSPNEA_GRADE",
+                        "EMAIL",
+                        "ENDOSCOPIC_FINDING",
+                        "ETHEREUM_ADDRESS",
+                        "ETHNICITY",
+                        "EYE_COLOR",
+                        "FEEDING_ROUTE",
+                        "FIRST_NAME",
+                        "FORM",
+                        "FREQUENCY",
+                        "GENDER",
+                        "GENE_SYMBOL",
+                        "GI_SCORE",
+                        "GI_SYMPTOM",
+                        "GLYCEMIC_MEASURE",
+                        "GPS_COORDINATES",
+                        "GROWTH_PARAMETER",
+                        "GROWTH_PERCENTILE",
+                        "HEIGHT",
+                        "HORMONE_LEVEL",
+                        "IBAN",
+                        "ID_NUM",
+                        "IMEI",
+                        "INDICATION",
+                        "INSULIN_REGIMEN",
+                        "INTAKE_OUTPUT",
+                        "IP_ADDRESS",
+                        "JOB_DEPARTMENT",
+                        "JOB_TITLE",
+                        "LAB_TEST",
+                        "LAB_VALUE",
+                        "LAST_NAME",
+                        "LINE_DRAIN_TUBE",
+                        "LITECOIN_ADDRESS",
+                        "LOCATION",
+                        "MAC_ADDRESS",
+                        "MASKED_NUMBER",
+                        "MEDICATION",
+                        "MICROORGANISM",
+                        "MIDDLE_NAME",
+                        "NURSING_RISK_SCORE",
+                        "NUTRITIONAL_STATUS",
+                        "NUTRITION_TARGET",
+                        "OCCUPATION",
+                        "ORDINAL_DIRECTION",
+                        "ORGANIZATION",
+                        "OTHER",
+                        "OXYGEN_SUPPORT",
+                        "PASSWORD",
+                        "PERSON",
+                        "PHONE",
+                        "PIN",
+                        "POLYP_DESCRIPTOR",
+                        "PREFIX",
+                        "PROBLEM",
+                        "PROCEDURE",
+                        "PROTEIN_CHANGE",
+                        "REFERENCE_RANGE",
+                        "RENAL_FUNCTION_MEASURE",
+                        "RESPIRATORY_FINDING",
+                        "ROUTE",
+                        "SEVERITY",
+                        "SPIROMETRY_MEASURE",
+                        "SSN",
+                        "STREET_ADDRESS",
+                        "STRENGTH",
+                        "SUSCEPTIBILITY",
+                        "THYROID_MEASURE",
+                        "TIME",
+                        "UNIT",
+                        "URINE_FINDING",
+                        "URL",
+                        "USERNAME",
+                        "USER_AGENT",
+                        "VACCINE_LOT",
+                        "VACCINE_NAME",
+                        "VACCINE_SERIES",
+                        "VARIANT_DESCRIPTOR",
+                        "VEHICLE_REGISTRATION",
+                        "VIN",
+                        "ZIPCODE",
+                        "ZYGOSITY"
+                      ],
+                      "type": "string"
+                    },
+                    "detector": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "doc_id": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "end": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "entity_type": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "evidence": {
+                      "type": "object"
+                    },
+                    "metadata": {
+                      "type": "object"
+                    },
+                    "policy_label": {
+                      "enum": [
+                        "DIRECT_IDENTIFIER",
+                        "QUASI_IDENTIFIER",
+                        "SENSITIVE_ATTRIBUTE",
+                        "CLINICAL_CONCEPT"
+                      ],
+                      "type": "string"
+                    },
+                    "regulatory_tags": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "replacement": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "reversible_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "schema_version": {
+                      "const": 1,
+                      "type": "integer"
+                    },
+                    "score": {
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "section": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "start": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "text_hash": {
+                      "pattern": "^hmac-sha256:[0-9a-f]{64}$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "doc_id",
+                    "start",
+                    "end",
+                    "text_hash",
+                    "entity_type",
+                    "canonical_label",
+                    "policy_label",
+                    "regulatory_tags",
+                    "score",
+                    "detector",
+                    "evidence",
+                    "action",
+                    "replacement",
+                    "reversible_id",
+                    "section",
+                    "metadata"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional canonical OpenMedSpan artifacts."
+          },
+          "stages": {
+            "description": "Clinical workflow stages in canonical order: detect, context, sections, relations, ground, export, risk.",
+            "items": {
+              "enum": [
+                "detect",
+                "context",
+                "sections",
+                "relations",
+                "ground",
+                "export",
+                "risk"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "text": {
+            "default": null,
+            "description": "Optional clinical text reserved for later pipeline execution.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workflow_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "stages"
+        ],
+        "type": "object"
+      },
+      "name": "openmed_clinical_pipeline",
+      "output_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "artifacts": {
+            "additionalProperties": true,
+            "properties": {},
+            "required": [],
+            "type": "object"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "details": {
+                    "additionalProperties": true,
+                    "properties": {},
+                    "required": [],
+                    "type": "object"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "stage": {
+                    "enum": [
+                      "detect",
+                      "context",
+                      "sections",
+                      "relations",
+                      "ground",
+                      "export",
+                      "risk",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "code",
+                  "message",
+                  "stage",
+                  "details"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "final_output": {},
+          "schema_version": {
+            "enum": [
+              "openmed.clinical_pipeline.v1"
+            ],
+            "type": "string"
+          },
+          "stages": {
+            "items": {
+              "enum": [
+                "detect",
+                "context",
+                "sections",
+                "relations",
+                "ground",
+                "export",
+                "risk"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "planned",
+              "completed",
+              "rejected",
+              "failed"
+            ],
+            "type": "string"
+          },
+          "trace": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "stage": {
+                  "enum": [
+                    "detect",
+                    "context",
+                    "sections",
+                    "relations",
+                    "ground",
+                    "export",
+                    "risk"
+                  ],
+                  "type": "string"
+                },
+                "status": {
+                  "enum": [
+                    "planned",
+                    "completed"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "stage",
+                "status"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "status",
+          "stages",
+          "artifacts",
+          "final_output",
+          "error",
+          "trace"
+        ],
+        "type": "object"
+      },
+      "stability": "stable",
+      "version": "1.0.0"
+    },
+    {
       "description": "De-identify text by masking, removing, replacing, hashing, or shifting.",
       "input_schema": {
         "additionalProperties": false,
@@ -437,6 +880,608 @@
       "version": "1.0.0"
     },
     {
+      "description": "Export canonical OpenMedSpan artifacts to a FHIR Bundle.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "bundle_type": {
+            "default": "collection",
+            "enum": [
+              "collection",
+              "transaction",
+              "batch"
+            ],
+            "type": "string"
+          },
+          "doc_id": {
+            "default": "workflow",
+            "type": "string"
+          },
+          "resources": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional prebuilt standalone FHIR resources."
+          },
+          "spans": {
+            "description": "Canonical, text-free OpenMedSpan artifacts to process.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "action": {
+                  "enum": [
+                    "keep",
+                    "redact",
+                    "replace",
+                    "mask",
+                    "hash",
+                    "format_preserve"
+                  ],
+                  "type": "string"
+                },
+                "canonical_label": {
+                  "enum": [
+                    "ABNORMAL_FLAG",
+                    "ACCOUNT_NUMBER",
+                    "ADMINISTRATION_ROUTE",
+                    "AGE",
+                    "AIRWAY_MANAGEMENT",
+                    "AMOUNT",
+                    "ANESTHESIA_TYPE",
+                    "ANESTHETIC_AGENT",
+                    "ANTIBIOTIC",
+                    "API_KEY",
+                    "ASA_CLASS",
+                    "BIC",
+                    "BITCOIN_ADDRESS",
+                    "BODY_SITE",
+                    "BUILDING_NUMBER",
+                    "CARE_INTERVENTION",
+                    "CKD_STAGE",
+                    "CLINICAL_SIGNIFICANCE",
+                    "CONDITION",
+                    "CREDIT_CARD",
+                    "CREDIT_CARD_ISSUER",
+                    "CURRENCY",
+                    "CVV",
+                    "DATE",
+                    "DATE_OF_BIRTH",
+                    "DEVELOPMENTAL_MILESTONE",
+                    "DEVICE",
+                    "DIALYSIS_MODALITY",
+                    "DIET_TYPE",
+                    "DOSAGE",
+                    "DOSE_NUMBER",
+                    "DURATION",
+                    "DYSPNEA_GRADE",
+                    "EMAIL",
+                    "ENDOSCOPIC_FINDING",
+                    "ETHEREUM_ADDRESS",
+                    "ETHNICITY",
+                    "EYE_COLOR",
+                    "FEEDING_ROUTE",
+                    "FIRST_NAME",
+                    "FORM",
+                    "FREQUENCY",
+                    "GENDER",
+                    "GENE_SYMBOL",
+                    "GI_SCORE",
+                    "GI_SYMPTOM",
+                    "GLYCEMIC_MEASURE",
+                    "GPS_COORDINATES",
+                    "GROWTH_PARAMETER",
+                    "GROWTH_PERCENTILE",
+                    "HEIGHT",
+                    "HORMONE_LEVEL",
+                    "IBAN",
+                    "ID_NUM",
+                    "IMEI",
+                    "INDICATION",
+                    "INSULIN_REGIMEN",
+                    "INTAKE_OUTPUT",
+                    "IP_ADDRESS",
+                    "JOB_DEPARTMENT",
+                    "JOB_TITLE",
+                    "LAB_TEST",
+                    "LAB_VALUE",
+                    "LAST_NAME",
+                    "LINE_DRAIN_TUBE",
+                    "LITECOIN_ADDRESS",
+                    "LOCATION",
+                    "MAC_ADDRESS",
+                    "MASKED_NUMBER",
+                    "MEDICATION",
+                    "MICROORGANISM",
+                    "MIDDLE_NAME",
+                    "NURSING_RISK_SCORE",
+                    "NUTRITIONAL_STATUS",
+                    "NUTRITION_TARGET",
+                    "OCCUPATION",
+                    "ORDINAL_DIRECTION",
+                    "ORGANIZATION",
+                    "OTHER",
+                    "OXYGEN_SUPPORT",
+                    "PASSWORD",
+                    "PERSON",
+                    "PHONE",
+                    "PIN",
+                    "POLYP_DESCRIPTOR",
+                    "PREFIX",
+                    "PROBLEM",
+                    "PROCEDURE",
+                    "PROTEIN_CHANGE",
+                    "REFERENCE_RANGE",
+                    "RENAL_FUNCTION_MEASURE",
+                    "RESPIRATORY_FINDING",
+                    "ROUTE",
+                    "SEVERITY",
+                    "SPIROMETRY_MEASURE",
+                    "SSN",
+                    "STREET_ADDRESS",
+                    "STRENGTH",
+                    "SUSCEPTIBILITY",
+                    "THYROID_MEASURE",
+                    "TIME",
+                    "UNIT",
+                    "URINE_FINDING",
+                    "URL",
+                    "USERNAME",
+                    "USER_AGENT",
+                    "VACCINE_LOT",
+                    "VACCINE_NAME",
+                    "VACCINE_SERIES",
+                    "VARIANT_DESCRIPTOR",
+                    "VEHICLE_REGISTRATION",
+                    "VIN",
+                    "ZIPCODE",
+                    "ZYGOSITY"
+                  ],
+                  "type": "string"
+                },
+                "detector": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "doc_id": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "end": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "entity_type": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "object"
+                },
+                "metadata": {
+                  "type": "object"
+                },
+                "policy_label": {
+                  "enum": [
+                    "DIRECT_IDENTIFIER",
+                    "QUASI_IDENTIFIER",
+                    "SENSITIVE_ATTRIBUTE",
+                    "CLINICAL_CONCEPT"
+                  ],
+                  "type": "string"
+                },
+                "regulatory_tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "replacement": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "reversible_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "schema_version": {
+                  "const": 1,
+                  "type": "integer"
+                },
+                "score": {
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "section": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "start": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "text_hash": {
+                  "pattern": "^hmac-sha256:[0-9a-f]{64}$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "schema_version",
+                "doc_id",
+                "start",
+                "end",
+                "text_hash",
+                "entity_type",
+                "canonical_label",
+                "policy_label",
+                "regulatory_tags",
+                "score",
+                "detector",
+                "evidence",
+                "action",
+                "replacement",
+                "reversible_id",
+                "section",
+                "metadata"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "spans"
+        ],
+        "type": "object"
+      },
+      "name": "openmed_export_fhir",
+      "output_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "bundle": {
+            "additionalProperties": true,
+            "properties": {},
+            "required": [],
+            "type": "object"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "details": {
+                    "additionalProperties": true,
+                    "properties": {},
+                    "required": [],
+                    "type": "object"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "stage": {
+                    "enum": [
+                      "detect",
+                      "context",
+                      "sections",
+                      "relations",
+                      "ground",
+                      "export",
+                      "risk",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "code",
+                  "message",
+                  "stage",
+                  "details"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resource_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "schema_version": {
+            "enum": [
+              "openmed.export_fhir.v1"
+            ],
+            "type": "string"
+          },
+          "spans": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "action": {
+                  "enum": [
+                    "keep",
+                    "redact",
+                    "replace",
+                    "mask",
+                    "hash",
+                    "format_preserve"
+                  ],
+                  "type": "string"
+                },
+                "canonical_label": {
+                  "enum": [
+                    "ABNORMAL_FLAG",
+                    "ACCOUNT_NUMBER",
+                    "ADMINISTRATION_ROUTE",
+                    "AGE",
+                    "AIRWAY_MANAGEMENT",
+                    "AMOUNT",
+                    "ANESTHESIA_TYPE",
+                    "ANESTHETIC_AGENT",
+                    "ANTIBIOTIC",
+                    "API_KEY",
+                    "ASA_CLASS",
+                    "BIC",
+                    "BITCOIN_ADDRESS",
+                    "BODY_SITE",
+                    "BUILDING_NUMBER",
+                    "CARE_INTERVENTION",
+                    "CKD_STAGE",
+                    "CLINICAL_SIGNIFICANCE",
+                    "CONDITION",
+                    "CREDIT_CARD",
+                    "CREDIT_CARD_ISSUER",
+                    "CURRENCY",
+                    "CVV",
+                    "DATE",
+                    "DATE_OF_BIRTH",
+                    "DEVELOPMENTAL_MILESTONE",
+                    "DEVICE",
+                    "DIALYSIS_MODALITY",
+                    "DIET_TYPE",
+                    "DOSAGE",
+                    "DOSE_NUMBER",
+                    "DURATION",
+                    "DYSPNEA_GRADE",
+                    "EMAIL",
+                    "ENDOSCOPIC_FINDING",
+                    "ETHEREUM_ADDRESS",
+                    "ETHNICITY",
+                    "EYE_COLOR",
+                    "FEEDING_ROUTE",
+                    "FIRST_NAME",
+                    "FORM",
+                    "FREQUENCY",
+                    "GENDER",
+                    "GENE_SYMBOL",
+                    "GI_SCORE",
+                    "GI_SYMPTOM",
+                    "GLYCEMIC_MEASURE",
+                    "GPS_COORDINATES",
+                    "GROWTH_PARAMETER",
+                    "GROWTH_PERCENTILE",
+                    "HEIGHT",
+                    "HORMONE_LEVEL",
+                    "IBAN",
+                    "ID_NUM",
+                    "IMEI",
+                    "INDICATION",
+                    "INSULIN_REGIMEN",
+                    "INTAKE_OUTPUT",
+                    "IP_ADDRESS",
+                    "JOB_DEPARTMENT",
+                    "JOB_TITLE",
+                    "LAB_TEST",
+                    "LAB_VALUE",
+                    "LAST_NAME",
+                    "LINE_DRAIN_TUBE",
+                    "LITECOIN_ADDRESS",
+                    "LOCATION",
+                    "MAC_ADDRESS",
+                    "MASKED_NUMBER",
+                    "MEDICATION",
+                    "MICROORGANISM",
+                    "MIDDLE_NAME",
+                    "NURSING_RISK_SCORE",
+                    "NUTRITIONAL_STATUS",
+                    "NUTRITION_TARGET",
+                    "OCCUPATION",
+                    "ORDINAL_DIRECTION",
+                    "ORGANIZATION",
+                    "OTHER",
+                    "OXYGEN_SUPPORT",
+                    "PASSWORD",
+                    "PERSON",
+                    "PHONE",
+                    "PIN",
+                    "POLYP_DESCRIPTOR",
+                    "PREFIX",
+                    "PROBLEM",
+                    "PROCEDURE",
+                    "PROTEIN_CHANGE",
+                    "REFERENCE_RANGE",
+                    "RENAL_FUNCTION_MEASURE",
+                    "RESPIRATORY_FINDING",
+                    "ROUTE",
+                    "SEVERITY",
+                    "SPIROMETRY_MEASURE",
+                    "SSN",
+                    "STREET_ADDRESS",
+                    "STRENGTH",
+                    "SUSCEPTIBILITY",
+                    "THYROID_MEASURE",
+                    "TIME",
+                    "UNIT",
+                    "URINE_FINDING",
+                    "URL",
+                    "USERNAME",
+                    "USER_AGENT",
+                    "VACCINE_LOT",
+                    "VACCINE_NAME",
+                    "VACCINE_SERIES",
+                    "VARIANT_DESCRIPTOR",
+                    "VEHICLE_REGISTRATION",
+                    "VIN",
+                    "ZIPCODE",
+                    "ZYGOSITY"
+                  ],
+                  "type": "string"
+                },
+                "detector": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "doc_id": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "end": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "entity_type": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "object"
+                },
+                "metadata": {
+                  "type": "object"
+                },
+                "policy_label": {
+                  "enum": [
+                    "DIRECT_IDENTIFIER",
+                    "QUASI_IDENTIFIER",
+                    "SENSITIVE_ATTRIBUTE",
+                    "CLINICAL_CONCEPT"
+                  ],
+                  "type": "string"
+                },
+                "regulatory_tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "replacement": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "reversible_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "schema_version": {
+                  "const": 1,
+                  "type": "integer"
+                },
+                "score": {
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "section": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "start": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "text_hash": {
+                  "pattern": "^hmac-sha256:[0-9a-f]{64}$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "schema_version",
+                "doc_id",
+                "start",
+                "end",
+                "text_hash",
+                "entity_type",
+                "canonical_label",
+                "policy_label",
+                "regulatory_tags",
+                "score",
+                "detector",
+                "evidence",
+                "action",
+                "replacement",
+                "reversible_id",
+                "section",
+                "metadata"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "completed",
+              "failed",
+              "unimplemented"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema_version",
+          "status",
+          "spans",
+          "bundle",
+          "resource_count",
+          "error"
+        ],
+        "type": "object"
+      },
+      "stability": "stable",
+      "version": "1.0.0"
+    },
+    {
       "description": "Extract PII/PHI entities from clinical text.",
       "input_schema": {
         "additionalProperties": false,
@@ -696,6 +1741,601 @@
           "resourceType",
           "type",
           "entry"
+        ],
+        "type": "object"
+      },
+      "stability": "stable",
+      "version": "1.0.0"
+    },
+    {
+      "description": "Ground canonical OpenMedSpan artifacts to clinical coding systems.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "allow_external_llm": {
+            "default": false,
+            "description": "Reserve privacy-gateway-mediated external LLM grounding.",
+            "type": "boolean"
+          },
+          "max_candidates": {
+            "default": 5,
+            "description": "Maximum grounding candidates per span.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "spans": {
+            "description": "Canonical, text-free OpenMedSpan artifacts to process.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "action": {
+                  "enum": [
+                    "keep",
+                    "redact",
+                    "replace",
+                    "mask",
+                    "hash",
+                    "format_preserve"
+                  ],
+                  "type": "string"
+                },
+                "canonical_label": {
+                  "enum": [
+                    "ABNORMAL_FLAG",
+                    "ACCOUNT_NUMBER",
+                    "ADMINISTRATION_ROUTE",
+                    "AGE",
+                    "AIRWAY_MANAGEMENT",
+                    "AMOUNT",
+                    "ANESTHESIA_TYPE",
+                    "ANESTHETIC_AGENT",
+                    "ANTIBIOTIC",
+                    "API_KEY",
+                    "ASA_CLASS",
+                    "BIC",
+                    "BITCOIN_ADDRESS",
+                    "BODY_SITE",
+                    "BUILDING_NUMBER",
+                    "CARE_INTERVENTION",
+                    "CKD_STAGE",
+                    "CLINICAL_SIGNIFICANCE",
+                    "CONDITION",
+                    "CREDIT_CARD",
+                    "CREDIT_CARD_ISSUER",
+                    "CURRENCY",
+                    "CVV",
+                    "DATE",
+                    "DATE_OF_BIRTH",
+                    "DEVELOPMENTAL_MILESTONE",
+                    "DEVICE",
+                    "DIALYSIS_MODALITY",
+                    "DIET_TYPE",
+                    "DOSAGE",
+                    "DOSE_NUMBER",
+                    "DURATION",
+                    "DYSPNEA_GRADE",
+                    "EMAIL",
+                    "ENDOSCOPIC_FINDING",
+                    "ETHEREUM_ADDRESS",
+                    "ETHNICITY",
+                    "EYE_COLOR",
+                    "FEEDING_ROUTE",
+                    "FIRST_NAME",
+                    "FORM",
+                    "FREQUENCY",
+                    "GENDER",
+                    "GENE_SYMBOL",
+                    "GI_SCORE",
+                    "GI_SYMPTOM",
+                    "GLYCEMIC_MEASURE",
+                    "GPS_COORDINATES",
+                    "GROWTH_PARAMETER",
+                    "GROWTH_PERCENTILE",
+                    "HEIGHT",
+                    "HORMONE_LEVEL",
+                    "IBAN",
+                    "ID_NUM",
+                    "IMEI",
+                    "INDICATION",
+                    "INSULIN_REGIMEN",
+                    "INTAKE_OUTPUT",
+                    "IP_ADDRESS",
+                    "JOB_DEPARTMENT",
+                    "JOB_TITLE",
+                    "LAB_TEST",
+                    "LAB_VALUE",
+                    "LAST_NAME",
+                    "LINE_DRAIN_TUBE",
+                    "LITECOIN_ADDRESS",
+                    "LOCATION",
+                    "MAC_ADDRESS",
+                    "MASKED_NUMBER",
+                    "MEDICATION",
+                    "MICROORGANISM",
+                    "MIDDLE_NAME",
+                    "NURSING_RISK_SCORE",
+                    "NUTRITIONAL_STATUS",
+                    "NUTRITION_TARGET",
+                    "OCCUPATION",
+                    "ORDINAL_DIRECTION",
+                    "ORGANIZATION",
+                    "OTHER",
+                    "OXYGEN_SUPPORT",
+                    "PASSWORD",
+                    "PERSON",
+                    "PHONE",
+                    "PIN",
+                    "POLYP_DESCRIPTOR",
+                    "PREFIX",
+                    "PROBLEM",
+                    "PROCEDURE",
+                    "PROTEIN_CHANGE",
+                    "REFERENCE_RANGE",
+                    "RENAL_FUNCTION_MEASURE",
+                    "RESPIRATORY_FINDING",
+                    "ROUTE",
+                    "SEVERITY",
+                    "SPIROMETRY_MEASURE",
+                    "SSN",
+                    "STREET_ADDRESS",
+                    "STRENGTH",
+                    "SUSCEPTIBILITY",
+                    "THYROID_MEASURE",
+                    "TIME",
+                    "UNIT",
+                    "URINE_FINDING",
+                    "URL",
+                    "USERNAME",
+                    "USER_AGENT",
+                    "VACCINE_LOT",
+                    "VACCINE_NAME",
+                    "VACCINE_SERIES",
+                    "VARIANT_DESCRIPTOR",
+                    "VEHICLE_REGISTRATION",
+                    "VIN",
+                    "ZIPCODE",
+                    "ZYGOSITY"
+                  ],
+                  "type": "string"
+                },
+                "detector": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "doc_id": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "end": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "entity_type": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "object"
+                },
+                "metadata": {
+                  "type": "object"
+                },
+                "policy_label": {
+                  "enum": [
+                    "DIRECT_IDENTIFIER",
+                    "QUASI_IDENTIFIER",
+                    "SENSITIVE_ATTRIBUTE",
+                    "CLINICAL_CONCEPT"
+                  ],
+                  "type": "string"
+                },
+                "regulatory_tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "replacement": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "reversible_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "schema_version": {
+                  "const": 1,
+                  "type": "integer"
+                },
+                "score": {
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "section": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "start": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "text_hash": {
+                  "pattern": "^hmac-sha256:[0-9a-f]{64}$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "schema_version",
+                "doc_id",
+                "start",
+                "end",
+                "text_hash",
+                "entity_type",
+                "canonical_label",
+                "policy_label",
+                "regulatory_tags",
+                "score",
+                "detector",
+                "evidence",
+                "action",
+                "replacement",
+                "reversible_id",
+                "section",
+                "metadata"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "vocabularies": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional grounding vocabularies to constrain."
+          }
+        },
+        "required": [
+          "spans"
+        ],
+        "type": "object"
+      },
+      "name": "openmed_ground",
+      "output_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "error": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "details": {
+                    "additionalProperties": true,
+                    "properties": {},
+                    "required": [],
+                    "type": "object"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "stage": {
+                    "enum": [
+                      "detect",
+                      "context",
+                      "sections",
+                      "relations",
+                      "ground",
+                      "export",
+                      "risk",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "code",
+                  "message",
+                  "stage",
+                  "details"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "grounded_concepts": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "schema_version": {
+            "enum": [
+              "openmed.ground.v1"
+            ],
+            "type": "string"
+          },
+          "spans": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "action": {
+                  "enum": [
+                    "keep",
+                    "redact",
+                    "replace",
+                    "mask",
+                    "hash",
+                    "format_preserve"
+                  ],
+                  "type": "string"
+                },
+                "canonical_label": {
+                  "enum": [
+                    "ABNORMAL_FLAG",
+                    "ACCOUNT_NUMBER",
+                    "ADMINISTRATION_ROUTE",
+                    "AGE",
+                    "AIRWAY_MANAGEMENT",
+                    "AMOUNT",
+                    "ANESTHESIA_TYPE",
+                    "ANESTHETIC_AGENT",
+                    "ANTIBIOTIC",
+                    "API_KEY",
+                    "ASA_CLASS",
+                    "BIC",
+                    "BITCOIN_ADDRESS",
+                    "BODY_SITE",
+                    "BUILDING_NUMBER",
+                    "CARE_INTERVENTION",
+                    "CKD_STAGE",
+                    "CLINICAL_SIGNIFICANCE",
+                    "CONDITION",
+                    "CREDIT_CARD",
+                    "CREDIT_CARD_ISSUER",
+                    "CURRENCY",
+                    "CVV",
+                    "DATE",
+                    "DATE_OF_BIRTH",
+                    "DEVELOPMENTAL_MILESTONE",
+                    "DEVICE",
+                    "DIALYSIS_MODALITY",
+                    "DIET_TYPE",
+                    "DOSAGE",
+                    "DOSE_NUMBER",
+                    "DURATION",
+                    "DYSPNEA_GRADE",
+                    "EMAIL",
+                    "ENDOSCOPIC_FINDING",
+                    "ETHEREUM_ADDRESS",
+                    "ETHNICITY",
+                    "EYE_COLOR",
+                    "FEEDING_ROUTE",
+                    "FIRST_NAME",
+                    "FORM",
+                    "FREQUENCY",
+                    "GENDER",
+                    "GENE_SYMBOL",
+                    "GI_SCORE",
+                    "GI_SYMPTOM",
+                    "GLYCEMIC_MEASURE",
+                    "GPS_COORDINATES",
+                    "GROWTH_PARAMETER",
+                    "GROWTH_PERCENTILE",
+                    "HEIGHT",
+                    "HORMONE_LEVEL",
+                    "IBAN",
+                    "ID_NUM",
+                    "IMEI",
+                    "INDICATION",
+                    "INSULIN_REGIMEN",
+                    "INTAKE_OUTPUT",
+                    "IP_ADDRESS",
+                    "JOB_DEPARTMENT",
+                    "JOB_TITLE",
+                    "LAB_TEST",
+                    "LAB_VALUE",
+                    "LAST_NAME",
+                    "LINE_DRAIN_TUBE",
+                    "LITECOIN_ADDRESS",
+                    "LOCATION",
+                    "MAC_ADDRESS",
+                    "MASKED_NUMBER",
+                    "MEDICATION",
+                    "MICROORGANISM",
+                    "MIDDLE_NAME",
+                    "NURSING_RISK_SCORE",
+                    "NUTRITIONAL_STATUS",
+                    "NUTRITION_TARGET",
+                    "OCCUPATION",
+                    "ORDINAL_DIRECTION",
+                    "ORGANIZATION",
+                    "OTHER",
+                    "OXYGEN_SUPPORT",
+                    "PASSWORD",
+                    "PERSON",
+                    "PHONE",
+                    "PIN",
+                    "POLYP_DESCRIPTOR",
+                    "PREFIX",
+                    "PROBLEM",
+                    "PROCEDURE",
+                    "PROTEIN_CHANGE",
+                    "REFERENCE_RANGE",
+                    "RENAL_FUNCTION_MEASURE",
+                    "RESPIRATORY_FINDING",
+                    "ROUTE",
+                    "SEVERITY",
+                    "SPIROMETRY_MEASURE",
+                    "SSN",
+                    "STREET_ADDRESS",
+                    "STRENGTH",
+                    "SUSCEPTIBILITY",
+                    "THYROID_MEASURE",
+                    "TIME",
+                    "UNIT",
+                    "URINE_FINDING",
+                    "URL",
+                    "USERNAME",
+                    "USER_AGENT",
+                    "VACCINE_LOT",
+                    "VACCINE_NAME",
+                    "VACCINE_SERIES",
+                    "VARIANT_DESCRIPTOR",
+                    "VEHICLE_REGISTRATION",
+                    "VIN",
+                    "ZIPCODE",
+                    "ZYGOSITY"
+                  ],
+                  "type": "string"
+                },
+                "detector": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "doc_id": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "end": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "entity_type": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "object"
+                },
+                "metadata": {
+                  "type": "object"
+                },
+                "policy_label": {
+                  "enum": [
+                    "DIRECT_IDENTIFIER",
+                    "QUASI_IDENTIFIER",
+                    "SENSITIVE_ATTRIBUTE",
+                    "CLINICAL_CONCEPT"
+                  ],
+                  "type": "string"
+                },
+                "regulatory_tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "replacement": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "reversible_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "schema_version": {
+                  "const": 1,
+                  "type": "integer"
+                },
+                "score": {
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "section": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "start": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "text_hash": {
+                  "pattern": "^hmac-sha256:[0-9a-f]{64}$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "schema_version",
+                "doc_id",
+                "start",
+                "end",
+                "text_hash",
+                "entity_type",
+                "canonical_label",
+                "policy_label",
+                "regulatory_tags",
+                "score",
+                "detector",
+                "evidence",
+                "action",
+                "replacement",
+                "reversible_id",
+                "section",
+                "metadata"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "completed",
+              "failed",
+              "unimplemented"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema_version",
+          "status",
+          "spans",
+          "grounded_concepts",
+          "error"
         ],
         "type": "object"
       },
@@ -1028,6 +2668,613 @@
           "k_min",
           "singleton_records",
           "quasi_identifiers"
+        ],
+        "type": "object"
+      },
+      "stability": "stable",
+      "version": "1.0.0"
+    },
+    {
+      "description": "Score residual re-identification risk over de-identified clinical artifacts.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "deidentified_text": {
+            "default": null,
+            "description": "Optional de-identified text for residual-risk scoring.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "quasi_identifiers": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional quasi-identifier field names."
+          },
+          "records": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional structured records for residual-risk scoring."
+          },
+          "spans": {
+            "description": "Canonical, text-free OpenMedSpan artifacts to process.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "action": {
+                  "enum": [
+                    "keep",
+                    "redact",
+                    "replace",
+                    "mask",
+                    "hash",
+                    "format_preserve"
+                  ],
+                  "type": "string"
+                },
+                "canonical_label": {
+                  "enum": [
+                    "ABNORMAL_FLAG",
+                    "ACCOUNT_NUMBER",
+                    "ADMINISTRATION_ROUTE",
+                    "AGE",
+                    "AIRWAY_MANAGEMENT",
+                    "AMOUNT",
+                    "ANESTHESIA_TYPE",
+                    "ANESTHETIC_AGENT",
+                    "ANTIBIOTIC",
+                    "API_KEY",
+                    "ASA_CLASS",
+                    "BIC",
+                    "BITCOIN_ADDRESS",
+                    "BODY_SITE",
+                    "BUILDING_NUMBER",
+                    "CARE_INTERVENTION",
+                    "CKD_STAGE",
+                    "CLINICAL_SIGNIFICANCE",
+                    "CONDITION",
+                    "CREDIT_CARD",
+                    "CREDIT_CARD_ISSUER",
+                    "CURRENCY",
+                    "CVV",
+                    "DATE",
+                    "DATE_OF_BIRTH",
+                    "DEVELOPMENTAL_MILESTONE",
+                    "DEVICE",
+                    "DIALYSIS_MODALITY",
+                    "DIET_TYPE",
+                    "DOSAGE",
+                    "DOSE_NUMBER",
+                    "DURATION",
+                    "DYSPNEA_GRADE",
+                    "EMAIL",
+                    "ENDOSCOPIC_FINDING",
+                    "ETHEREUM_ADDRESS",
+                    "ETHNICITY",
+                    "EYE_COLOR",
+                    "FEEDING_ROUTE",
+                    "FIRST_NAME",
+                    "FORM",
+                    "FREQUENCY",
+                    "GENDER",
+                    "GENE_SYMBOL",
+                    "GI_SCORE",
+                    "GI_SYMPTOM",
+                    "GLYCEMIC_MEASURE",
+                    "GPS_COORDINATES",
+                    "GROWTH_PARAMETER",
+                    "GROWTH_PERCENTILE",
+                    "HEIGHT",
+                    "HORMONE_LEVEL",
+                    "IBAN",
+                    "ID_NUM",
+                    "IMEI",
+                    "INDICATION",
+                    "INSULIN_REGIMEN",
+                    "INTAKE_OUTPUT",
+                    "IP_ADDRESS",
+                    "JOB_DEPARTMENT",
+                    "JOB_TITLE",
+                    "LAB_TEST",
+                    "LAB_VALUE",
+                    "LAST_NAME",
+                    "LINE_DRAIN_TUBE",
+                    "LITECOIN_ADDRESS",
+                    "LOCATION",
+                    "MAC_ADDRESS",
+                    "MASKED_NUMBER",
+                    "MEDICATION",
+                    "MICROORGANISM",
+                    "MIDDLE_NAME",
+                    "NURSING_RISK_SCORE",
+                    "NUTRITIONAL_STATUS",
+                    "NUTRITION_TARGET",
+                    "OCCUPATION",
+                    "ORDINAL_DIRECTION",
+                    "ORGANIZATION",
+                    "OTHER",
+                    "OXYGEN_SUPPORT",
+                    "PASSWORD",
+                    "PERSON",
+                    "PHONE",
+                    "PIN",
+                    "POLYP_DESCRIPTOR",
+                    "PREFIX",
+                    "PROBLEM",
+                    "PROCEDURE",
+                    "PROTEIN_CHANGE",
+                    "REFERENCE_RANGE",
+                    "RENAL_FUNCTION_MEASURE",
+                    "RESPIRATORY_FINDING",
+                    "ROUTE",
+                    "SEVERITY",
+                    "SPIROMETRY_MEASURE",
+                    "SSN",
+                    "STREET_ADDRESS",
+                    "STRENGTH",
+                    "SUSCEPTIBILITY",
+                    "THYROID_MEASURE",
+                    "TIME",
+                    "UNIT",
+                    "URINE_FINDING",
+                    "URL",
+                    "USERNAME",
+                    "USER_AGENT",
+                    "VACCINE_LOT",
+                    "VACCINE_NAME",
+                    "VACCINE_SERIES",
+                    "VARIANT_DESCRIPTOR",
+                    "VEHICLE_REGISTRATION",
+                    "VIN",
+                    "ZIPCODE",
+                    "ZYGOSITY"
+                  ],
+                  "type": "string"
+                },
+                "detector": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "doc_id": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "end": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "entity_type": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "object"
+                },
+                "metadata": {
+                  "type": "object"
+                },
+                "policy_label": {
+                  "enum": [
+                    "DIRECT_IDENTIFIER",
+                    "QUASI_IDENTIFIER",
+                    "SENSITIVE_ATTRIBUTE",
+                    "CLINICAL_CONCEPT"
+                  ],
+                  "type": "string"
+                },
+                "regulatory_tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "replacement": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "reversible_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "schema_version": {
+                  "const": 1,
+                  "type": "integer"
+                },
+                "score": {
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "section": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "start": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "text_hash": {
+                  "pattern": "^hmac-sha256:[0-9a-f]{64}$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "schema_version",
+                "doc_id",
+                "start",
+                "end",
+                "text_hash",
+                "entity_type",
+                "canonical_label",
+                "policy_label",
+                "regulatory_tags",
+                "score",
+                "detector",
+                "evidence",
+                "action",
+                "replacement",
+                "reversible_id",
+                "section",
+                "metadata"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "spans"
+        ],
+        "type": "object"
+      },
+      "name": "openmed_risk_score",
+      "output_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "error": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "details": {
+                    "additionalProperties": true,
+                    "properties": {},
+                    "required": [],
+                    "type": "object"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "stage": {
+                    "enum": [
+                      "detect",
+                      "context",
+                      "sections",
+                      "relations",
+                      "ground",
+                      "export",
+                      "risk",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "code",
+                  "message",
+                  "stage",
+                  "details"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "risk_report": {
+            "additionalProperties": true,
+            "properties": {},
+            "required": [],
+            "type": "object"
+          },
+          "schema_version": {
+            "enum": [
+              "openmed.risk_score.v1"
+            ],
+            "type": "string"
+          },
+          "spans": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "action": {
+                  "enum": [
+                    "keep",
+                    "redact",
+                    "replace",
+                    "mask",
+                    "hash",
+                    "format_preserve"
+                  ],
+                  "type": "string"
+                },
+                "canonical_label": {
+                  "enum": [
+                    "ABNORMAL_FLAG",
+                    "ACCOUNT_NUMBER",
+                    "ADMINISTRATION_ROUTE",
+                    "AGE",
+                    "AIRWAY_MANAGEMENT",
+                    "AMOUNT",
+                    "ANESTHESIA_TYPE",
+                    "ANESTHETIC_AGENT",
+                    "ANTIBIOTIC",
+                    "API_KEY",
+                    "ASA_CLASS",
+                    "BIC",
+                    "BITCOIN_ADDRESS",
+                    "BODY_SITE",
+                    "BUILDING_NUMBER",
+                    "CARE_INTERVENTION",
+                    "CKD_STAGE",
+                    "CLINICAL_SIGNIFICANCE",
+                    "CONDITION",
+                    "CREDIT_CARD",
+                    "CREDIT_CARD_ISSUER",
+                    "CURRENCY",
+                    "CVV",
+                    "DATE",
+                    "DATE_OF_BIRTH",
+                    "DEVELOPMENTAL_MILESTONE",
+                    "DEVICE",
+                    "DIALYSIS_MODALITY",
+                    "DIET_TYPE",
+                    "DOSAGE",
+                    "DOSE_NUMBER",
+                    "DURATION",
+                    "DYSPNEA_GRADE",
+                    "EMAIL",
+                    "ENDOSCOPIC_FINDING",
+                    "ETHEREUM_ADDRESS",
+                    "ETHNICITY",
+                    "EYE_COLOR",
+                    "FEEDING_ROUTE",
+                    "FIRST_NAME",
+                    "FORM",
+                    "FREQUENCY",
+                    "GENDER",
+                    "GENE_SYMBOL",
+                    "GI_SCORE",
+                    "GI_SYMPTOM",
+                    "GLYCEMIC_MEASURE",
+                    "GPS_COORDINATES",
+                    "GROWTH_PARAMETER",
+                    "GROWTH_PERCENTILE",
+                    "HEIGHT",
+                    "HORMONE_LEVEL",
+                    "IBAN",
+                    "ID_NUM",
+                    "IMEI",
+                    "INDICATION",
+                    "INSULIN_REGIMEN",
+                    "INTAKE_OUTPUT",
+                    "IP_ADDRESS",
+                    "JOB_DEPARTMENT",
+                    "JOB_TITLE",
+                    "LAB_TEST",
+                    "LAB_VALUE",
+                    "LAST_NAME",
+                    "LINE_DRAIN_TUBE",
+                    "LITECOIN_ADDRESS",
+                    "LOCATION",
+                    "MAC_ADDRESS",
+                    "MASKED_NUMBER",
+                    "MEDICATION",
+                    "MICROORGANISM",
+                    "MIDDLE_NAME",
+                    "NURSING_RISK_SCORE",
+                    "NUTRITIONAL_STATUS",
+                    "NUTRITION_TARGET",
+                    "OCCUPATION",
+                    "ORDINAL_DIRECTION",
+                    "ORGANIZATION",
+                    "OTHER",
+                    "OXYGEN_SUPPORT",
+                    "PASSWORD",
+                    "PERSON",
+                    "PHONE",
+                    "PIN",
+                    "POLYP_DESCRIPTOR",
+                    "PREFIX",
+                    "PROBLEM",
+                    "PROCEDURE",
+                    "PROTEIN_CHANGE",
+                    "REFERENCE_RANGE",
+                    "RENAL_FUNCTION_MEASURE",
+                    "RESPIRATORY_FINDING",
+                    "ROUTE",
+                    "SEVERITY",
+                    "SPIROMETRY_MEASURE",
+                    "SSN",
+                    "STREET_ADDRESS",
+                    "STRENGTH",
+                    "SUSCEPTIBILITY",
+                    "THYROID_MEASURE",
+                    "TIME",
+                    "UNIT",
+                    "URINE_FINDING",
+                    "URL",
+                    "USERNAME",
+                    "USER_AGENT",
+                    "VACCINE_LOT",
+                    "VACCINE_NAME",
+                    "VACCINE_SERIES",
+                    "VARIANT_DESCRIPTOR",
+                    "VEHICLE_REGISTRATION",
+                    "VIN",
+                    "ZIPCODE",
+                    "ZYGOSITY"
+                  ],
+                  "type": "string"
+                },
+                "detector": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "doc_id": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "end": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "entity_type": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "object"
+                },
+                "metadata": {
+                  "type": "object"
+                },
+                "policy_label": {
+                  "enum": [
+                    "DIRECT_IDENTIFIER",
+                    "QUASI_IDENTIFIER",
+                    "SENSITIVE_ATTRIBUTE",
+                    "CLINICAL_CONCEPT"
+                  ],
+                  "type": "string"
+                },
+                "regulatory_tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "replacement": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "reversible_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "schema_version": {
+                  "const": 1,
+                  "type": "integer"
+                },
+                "score": {
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "section": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "start": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "text_hash": {
+                  "pattern": "^hmac-sha256:[0-9a-f]{64}$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "schema_version",
+                "doc_id",
+                "start",
+                "end",
+                "text_hash",
+                "entity_type",
+                "canonical_label",
+                "policy_label",
+                "regulatory_tags",
+                "score",
+                "detector",
+                "evidence",
+                "action",
+                "replacement",
+                "reversible_id",
+                "section",
+                "metadata"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "completed",
+              "failed",
+              "unimplemented"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema_version",
+          "status",
+          "spans",
+          "risk_report",
+          "error"
         ],
         "type": "object"
       },

--- a/openmed/mcp/server.py
+++ b/openmed/mcp/server.py
@@ -28,7 +28,11 @@ from openmed.mcp.tool_registry import (
     render_tool_registry_document,
     validate_registered_tool_output,
 )
-from openmed.mcp.workflow import WorkflowRunner, builtin_workflow_step_executors
+from openmed.mcp.workflow import (
+    WorkflowRunner,
+    builtin_workflow_step_executors,
+    plan_clinical_pipeline,
+)
 from openmed.risk.reid import risk_report
 from openmed.service.runtime import ServiceRuntime
 from openmed.utils.gateway import normalize_text, validate_language
@@ -637,6 +641,89 @@ def openmed_run_workflow(
     return validate_registered_tool_output("openmed_run_workflow", response)
 
 
+def openmed_ground(
+    spans: list[Dict[str, Any]],
+    vocabularies: Optional[list[str]] = None,
+    max_candidates: int = 5,
+    allow_external_llm: bool = False,
+) -> Dict[str, Any]:
+    """Return the registered grounding contract until its handler lands."""
+
+    del vocabularies, max_candidates, allow_external_llm
+    response = {
+        "schema_version": "openmed.ground.v1",
+        "status": "unimplemented",
+        "spans": deepcopy(spans),
+        "grounded_concepts": [],
+        "error": _pending_clinical_contract_error("ground"),
+    }
+    return validate_registered_tool_output("openmed_ground", response)
+
+
+def openmed_export_fhir(
+    spans: list[Dict[str, Any]],
+    resources: Optional[list[Dict[str, Any]]] = None,
+    doc_id: str = "workflow",
+    bundle_type: str = "collection",
+) -> Dict[str, Any]:
+    """Return the registered FHIR export contract until its handler lands."""
+
+    del resources, doc_id, bundle_type
+    response = {
+        "schema_version": "openmed.export_fhir.v1",
+        "status": "unimplemented",
+        "spans": deepcopy(spans),
+        "bundle": {},
+        "resource_count": 0,
+        "error": _pending_clinical_contract_error("export"),
+    }
+    return validate_registered_tool_output("openmed_export_fhir", response)
+
+
+def openmed_risk_score(
+    spans: list[Dict[str, Any]],
+    deidentified_text: Optional[str] = None,
+    records: Optional[list[Dict[str, Any]]] = None,
+    quasi_identifiers: Optional[list[str]] = None,
+) -> Dict[str, Any]:
+    """Return the registered risk-score contract until its handler lands."""
+
+    del deidentified_text, records, quasi_identifiers
+    response = {
+        "schema_version": "openmed.risk_score.v1",
+        "status": "unimplemented",
+        "spans": deepcopy(spans),
+        "risk_report": {},
+        "error": _pending_clinical_contract_error("risk"),
+    }
+    return validate_registered_tool_output("openmed_risk_score", response)
+
+
+def openmed_clinical_pipeline(
+    stages: list[str],
+    text: Optional[str] = None,
+    spans: Optional[list[Dict[str, Any]]] = None,
+    options: Optional[Dict[str, Any]] = None,
+    allow_external_llm: bool = False,
+    session_id: Optional[str] = None,
+    workflow_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Plan and validate the registered clinical pipeline contract."""
+
+    del text, spans, options, allow_external_llm, session_id, workflow_id
+    response = plan_clinical_pipeline(stages)
+    return validate_registered_tool_output("openmed_clinical_pipeline", response)
+
+
+def _pending_clinical_contract_error(stage: str) -> Dict[str, Any]:
+    return {
+        "code": "handler_pending",
+        "message": "This clinical tool contract has no runtime handler yet.",
+        "stage": stage,
+        "details": {"implemented": False},
+    }
+
+
 def _workflow_step_executors(
     runtime_provider: Optional[RuntimeProvider],
 ) -> Dict[str, Callable[..., Any]]:
@@ -728,6 +815,12 @@ def build_mcp_tool_handlers(
         "openmed_run_workflow": lambda **kwargs: openmed_run_workflow(
             **kwargs,
             runtime_provider=runtime_provider,
+        ),
+        "openmed_ground": lambda **kwargs: openmed_ground(**kwargs),
+        "openmed_export_fhir": lambda **kwargs: openmed_export_fhir(**kwargs),
+        "openmed_risk_score": lambda **kwargs: openmed_risk_score(**kwargs),
+        "openmed_clinical_pipeline": (
+            lambda **kwargs: openmed_clinical_pipeline(**kwargs)
         ),
         "openmed_fhir_bundle": lambda **kwargs: openmed_fhir_bundle(**kwargs),
         "openmed_risk_report": lambda **kwargs: openmed_risk_report(**kwargs),

--- a/openmed/mcp/tool_registry.py
+++ b/openmed/mcp/tool_registry.py
@@ -9,11 +9,13 @@ from dataclasses import dataclass
 from inspect import Parameter, Signature
 from typing import Any, Optional
 
+from openmed.core.labels import CANONICAL_LABELS
 from openmed.core.pii_i18n import (
     DEFAULT_PII_MODELS,
     INDIC_NER_LANGUAGES,
     SUPPORTED_LANGUAGES,
 )
+from openmed.core.schemas import load_schema
 
 JsonSchema = dict[str, Any]
 JsonObject = dict[str, Any]
@@ -23,6 +25,15 @@ _SEMVER_RE = re.compile(
     r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
 )
 _STABILITY_VALUES = frozenset({"experimental", "stable", "deprecated"})
+CLINICAL_STAGE_ORDER = (
+    "detect",
+    "context",
+    "sections",
+    "relations",
+    "ground",
+    "export",
+    "risk",
+)
 
 
 class ToolSchemaValidationError(ValueError):
@@ -580,6 +591,16 @@ def _array(items: Mapping[str, Any]) -> JsonSchema:
     return {"type": "array", "items": dict(items)}
 
 
+def _openmed_span_schema() -> JsonSchema:
+    """Return the canonical span schema for a nested tool contract."""
+
+    schema = load_schema("span")
+    for metadata_key in ("$id", "$schema", "schema_version", "title"):
+        schema.pop(metadata_key, None)
+    schema["properties"]["canonical_label"]["enum"] = sorted(CANONICAL_LABELS)
+    return schema
+
+
 def _parameter(
     name: str,
     schema: Mapping[str, Any],
@@ -831,6 +852,133 @@ _WORKFLOW_RESULT_OUTPUT = _object(
         "outputs",
         "trace",
     ),
+)
+_OPENMED_SPAN_OUTPUT = _openmed_span_schema()
+_CLINICAL_STAGE_SCHEMA = _schema(
+    "string",
+    enum=list(CLINICAL_STAGE_ORDER),
+)
+_CLINICAL_CONTRACT_ERROR_OUTPUT = _object(
+    properties={
+        "code": _schema("string"),
+        "message": _schema("string"),
+        "stage": _nullable(
+            "string",
+            enum=[*CLINICAL_STAGE_ORDER, None],
+        ),
+        "details": _object(),
+    },
+    required=("code", "message", "stage", "details"),
+    additional=False,
+)
+_CLINICAL_ERROR_OR_NULL = {"anyOf": [_CLINICAL_CONTRACT_ERROR_OUTPUT, _schema("null")]}
+_CLINICAL_TRACE_OUTPUT = _object(
+    properties={
+        "stage": _CLINICAL_STAGE_SCHEMA,
+        "status": _schema("string", enum=["planned", "completed"]),
+    },
+    required=("stage", "status"),
+    additional=False,
+)
+_GROUND_OUTPUT = _object(
+    properties={
+        "schema_version": _schema("string", enum=["openmed.ground.v1"]),
+        "status": _schema(
+            "string",
+            enum=["completed", "failed", "unimplemented"],
+        ),
+        "spans": _array(_OPENMED_SPAN_OUTPUT),
+        "grounded_concepts": _array(_object()),
+        "error": _CLINICAL_ERROR_OR_NULL,
+    },
+    required=("schema_version", "status", "spans", "grounded_concepts", "error"),
+    additional=False,
+)
+_EXPORT_FHIR_OUTPUT = _object(
+    properties={
+        "schema_version": _schema("string", enum=["openmed.export_fhir.v1"]),
+        "status": _schema(
+            "string",
+            enum=["completed", "failed", "unimplemented"],
+        ),
+        "spans": _array(_OPENMED_SPAN_OUTPUT),
+        "bundle": _object(),
+        "resource_count": _schema("integer", minimum=0),
+        "error": _CLINICAL_ERROR_OR_NULL,
+    },
+    required=(
+        "schema_version",
+        "status",
+        "spans",
+        "bundle",
+        "resource_count",
+        "error",
+    ),
+    additional=False,
+)
+_RISK_SCORE_OUTPUT = _object(
+    properties={
+        "schema_version": _schema("string", enum=["openmed.risk_score.v1"]),
+        "status": _schema(
+            "string",
+            enum=["completed", "failed", "unimplemented"],
+        ),
+        "spans": _array(_OPENMED_SPAN_OUTPUT),
+        "risk_report": _object(),
+        "error": _CLINICAL_ERROR_OR_NULL,
+    },
+    required=("schema_version", "status", "spans", "risk_report", "error"),
+    additional=False,
+)
+_CLINICAL_PIPELINE_OUTPUT = _object(
+    properties={
+        "schema_version": _schema(
+            "string",
+            enum=["openmed.clinical_pipeline.v1"],
+        ),
+        "status": _schema(
+            "string",
+            enum=["planned", "completed", "rejected", "failed"],
+        ),
+        "stages": _array(_CLINICAL_STAGE_SCHEMA),
+        "artifacts": _object(),
+        "final_output": {},
+        "error": _CLINICAL_ERROR_OR_NULL,
+        "trace": _array(_CLINICAL_TRACE_OUTPUT),
+    },
+    required=(
+        "schema_version",
+        "status",
+        "stages",
+        "artifacts",
+        "final_output",
+        "error",
+        "trace",
+    ),
+    additional=False,
+)
+_SPAN_ARRAY_OR_NULL = {"anyOf": [_array(_OPENMED_SPAN_OUTPUT), _schema("null")]}
+_STRING_ARRAY_OR_NULL = {"anyOf": [_array(_schema("string")), _schema("null")]}
+_OBJECT_ARRAY_OR_NULL = {"anyOf": [_array(_object()), _schema("null")]}
+_CLINICAL_STAGES_PARAMETER = _parameter(
+    "stages",
+    {
+        "type": "array",
+        "items": _CLINICAL_STAGE_SCHEMA,
+        "minItems": 1,
+        "uniqueItems": True,
+    },
+    list[str],
+    description=(
+        "Clinical workflow stages in canonical order: detect, context, sections, "
+        "relations, ground, export, risk."
+    ),
+)
+_CLINICAL_SPANS_PARAMETER = _parameter(
+    "spans",
+    _array(_OPENMED_SPAN_OUTPUT),
+    list[dict[str, Any]],
+    description="Canonical, text-free OpenMedSpan artifacts to process.",
 )
 _FHIR_RESOURCE_SCHEMA = _object(
     properties={"resourceType": _schema("string")},
@@ -1132,6 +1280,142 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         output_schema=_WORKFLOW_RESULT_OUTPUT,
     ),
     _tool_spec(
+        name="openmed_ground",
+        title="Ground Clinical Spans",
+        description=(
+            "Ground canonical OpenMedSpan artifacts to clinical coding systems."
+        ),
+        read_only_hint=True,
+        open_world_hint=True,
+        parameters=(
+            _CLINICAL_SPANS_PARAMETER,
+            _parameter(
+                "vocabularies",
+                _STRING_ARRAY_OR_NULL,
+                Optional[list[str]],
+                None,
+                "Optional grounding vocabularies to constrain.",
+            ),
+            _parameter(
+                "max_candidates",
+                _schema("integer", minimum=1),
+                int,
+                5,
+                "Maximum grounding candidates per span.",
+            ),
+            _parameter(
+                "allow_external_llm",
+                _schema("boolean"),
+                bool,
+                False,
+                "Reserve privacy-gateway-mediated external LLM grounding.",
+            ),
+        ),
+        output_schema=_GROUND_OUTPUT,
+    ),
+    _tool_spec(
+        name="openmed_export_fhir",
+        title="Export Clinical Spans to FHIR",
+        description="Export canonical OpenMedSpan artifacts to a FHIR Bundle.",
+        read_only_hint=True,
+        parameters=(
+            _CLINICAL_SPANS_PARAMETER,
+            _parameter(
+                "resources",
+                _OBJECT_ARRAY_OR_NULL,
+                Optional[list[dict[str, Any]]],
+                None,
+                "Optional prebuilt standalone FHIR resources.",
+            ),
+            _parameter("doc_id", _schema("string"), str, "workflow"),
+            _parameter(
+                "bundle_type",
+                _schema("string", enum=["collection", "transaction", "batch"]),
+                str,
+                "collection",
+            ),
+        ),
+        output_schema=_EXPORT_FHIR_OUTPUT,
+    ),
+    _tool_spec(
+        name="openmed_risk_score",
+        title="Score Clinical Re-identification Risk",
+        description=(
+            "Score residual re-identification risk over de-identified clinical "
+            "artifacts."
+        ),
+        read_only_hint=True,
+        parameters=(
+            _CLINICAL_SPANS_PARAMETER,
+            _parameter(
+                "deidentified_text",
+                _nullable("string"),
+                Optional[str],
+                None,
+                "Optional de-identified text for residual-risk scoring.",
+            ),
+            _parameter(
+                "records",
+                _OBJECT_ARRAY_OR_NULL,
+                Optional[list[dict[str, Any]]],
+                None,
+                "Optional structured records for residual-risk scoring.",
+            ),
+            _parameter(
+                "quasi_identifiers",
+                _STRING_ARRAY_OR_NULL,
+                Optional[list[str]],
+                None,
+                "Optional quasi-identifier field names.",
+            ),
+        ),
+        output_schema=_RISK_SCORE_OUTPUT,
+    ),
+    _tool_spec(
+        name="openmed_clinical_pipeline",
+        title="Plan Clinical Pipeline",
+        description=(
+            "Plan and validate declarative clinical stages without silently "
+            "reordering them."
+        ),
+        read_only_hint=True,
+        open_world_hint=True,
+        parameters=(
+            _CLINICAL_STAGES_PARAMETER,
+            _parameter(
+                "text",
+                _nullable("string"),
+                Optional[str],
+                None,
+                "Optional clinical text reserved for later pipeline execution.",
+            ),
+            _parameter(
+                "spans",
+                _SPAN_ARRAY_OR_NULL,
+                Optional[list[dict[str, Any]]],
+                None,
+                "Optional canonical OpenMedSpan artifacts.",
+            ),
+            _parameter(
+                "options",
+                _nullable("object"),
+                Optional[dict[str, Any]],
+                None,
+                "Execution options reserved for later pipeline handlers.",
+            ),
+            _parameter(
+                "allow_external_llm",
+                _schema("boolean"),
+                bool,
+                False,
+                "Reserve external LLM routing through the privacy gateway.",
+            ),
+            _parameter("session_id", _nullable("string"), Optional[str], None),
+            _parameter("workflow_id", _nullable("string"), Optional[str], None),
+        ),
+        output_schema=_CLINICAL_PIPELINE_OUTPUT,
+    ),
+    _tool_spec(
         name="openmed_fhir_bundle",
         title="Assemble FHIR Bundle",
         description="Assemble FHIR resources into a R4 bundle. ",
@@ -1256,6 +1540,7 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
 TOOL_REGISTRY = ToolRegistry(TOOL_SPECS)
 
 __all__ = [
+    "CLINICAL_STAGE_ORDER",
     "TOOL_REGISTRY",
     "TOOL_SPECS",
     "ToolCompatibilityError",

--- a/openmed/mcp/workflow.py
+++ b/openmed/mcp/workflow.py
@@ -8,13 +8,14 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Callable, Mapping, MutableMapping, Optional
+from typing import Any, Callable, Mapping, MutableMapping, Optional, Sequence
 
 from openmed.clinical.exporters.codeable_concept_simple import (
     codeable_concept,
     coding,
 )
 from openmed.clinical.exporters.fhir import to_bundle
+from openmed.mcp.tool_registry import CLINICAL_STAGE_ORDER
 
 WorkflowStepExecutor = Callable[..., Any]
 StringDeidentifier = Callable[[str], str]
@@ -30,6 +31,202 @@ class WorkflowValidationError(WorkflowError):
 
 class TransientWorkflowError(WorkflowError):
     """Raised by step adapters to signal a retryable transient failure."""
+
+
+CLINICAL_PIPELINE_SCHEMA_VERSION = "openmed.clinical_pipeline.v1"
+_CLINICAL_STAGE_INDEX = {
+    stage: index for index, stage in enumerate(CLINICAL_STAGE_ORDER)
+}
+
+
+class ClinicalStageOrderError(WorkflowValidationError):
+    """Describe an invalid clinical stage declaration without echoing input."""
+
+    def __init__(
+        self,
+        *,
+        code: str,
+        message: str,
+        stages: Sequence[str] = (),
+        stage: str | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.stages = tuple(stages)
+        error_details: dict[str, Any] = {
+            "allowed_order": list(CLINICAL_STAGE_ORDER),
+        }
+        if details:
+            error_details.update(dict(details))
+        self.error = {
+            "code": code,
+            "message": message,
+            "stage": stage,
+            "details": error_details,
+        }
+
+
+def validate_clinical_stage_order(stages: Sequence[Any]) -> tuple[str, ...]:
+    """Validate and normalize a declared clinical pipeline stage sequence.
+
+    Intermediate stages may be omitted, but declared stages must retain their
+    relative order from :data:`CLINICAL_STAGE_ORDER`. Unknown, duplicate, or
+    reordered stages are rejected deterministically rather than rearranged.
+
+    Args:
+        stages: Declared pipeline stage names.
+
+    Returns:
+        The normalized stage names as a tuple.
+
+    Raises:
+        ClinicalStageOrderError: If the declaration is empty or invalid.
+    """
+
+    if isinstance(stages, (str, bytes, bytearray)) or not isinstance(stages, Sequence):
+        raise ClinicalStageOrderError(
+            code="invalid_stage_list",
+            message="Clinical pipeline stages must be a non-empty sequence.",
+            details={"received_type": type(stages).__name__},
+        )
+    if not stages:
+        raise ClinicalStageOrderError(
+            code="invalid_stage_list",
+            message="Clinical pipeline stages must be a non-empty sequence.",
+            details={"declared_count": 0},
+        )
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    previous_stage: str | None = None
+    previous_index = -1
+    for declared_index, raw_stage in enumerate(stages):
+        if not isinstance(raw_stage, str):
+            raise ClinicalStageOrderError(
+                code="unknown_stage",
+                message="Clinical pipeline contains an unknown stage.",
+                stages=normalized,
+                details={"declared_index": declared_index},
+            )
+
+        stage = raw_stage.strip().lower()
+        if stage not in _CLINICAL_STAGE_INDEX:
+            raise ClinicalStageOrderError(
+                code="unknown_stage",
+                message="Clinical pipeline contains an unknown stage.",
+                stages=normalized,
+                details={"declared_index": declared_index},
+            )
+        if stage in seen:
+            raise ClinicalStageOrderError(
+                code="duplicate_stage",
+                message="Clinical pipeline stages must be unique.",
+                stages=(*normalized, stage),
+                stage=stage,
+                details={"declared_index": declared_index},
+            )
+
+        stage_index = _CLINICAL_STAGE_INDEX[stage]
+        if stage_index < previous_index:
+            raise ClinicalStageOrderError(
+                code="invalid_stage_order",
+                message="Clinical pipeline stages are not in canonical order.",
+                stages=(*normalized, stage),
+                stage=stage,
+                details={
+                    "declared_index": declared_index,
+                    "previous_stage": previous_stage,
+                },
+            )
+
+        normalized.append(stage)
+        seen.add(stage)
+        previous_stage = stage
+        previous_index = stage_index
+
+    return tuple(normalized)
+
+
+def plan_clinical_pipeline(
+    stages: Sequence[Any],
+    *,
+    stage_callbacks: Mapping[str, Callable[[], Any]] | None = None,
+) -> dict[str, Any]:
+    """Validate a clinical stage plan before invoking any supplied callback.
+
+    The MCP contract uses this function without callbacks as a pure planner.
+    Callback support lets later execution layers reuse the same validate-first
+    boundary and makes the no-work-on-rejection guarantee directly testable.
+
+    Args:
+        stages: Declared pipeline stage names.
+        stage_callbacks: Optional zero-argument callbacks keyed by stage name.
+
+    Returns:
+        A schema-versioned, machine-readable plan or rejection payload.
+    """
+
+    try:
+        normalized_stages = validate_clinical_stage_order(stages)
+    except ClinicalStageOrderError as exc:
+        return _clinical_pipeline_payload(
+            status="rejected",
+            stages=exc.stages,
+            error=exc.error,
+        )
+
+    if stage_callbacks is None:
+        return _clinical_pipeline_payload(
+            status="planned",
+            stages=normalized_stages,
+            trace=[
+                {"stage": stage, "status": "planned"} for stage in normalized_stages
+            ],
+        )
+
+    callbacks = dict(stage_callbacks)
+    artifacts: dict[str, Any] = {}
+    trace: list[dict[str, str]] = []
+    for stage in normalized_stages:
+        callback = callbacks.get(stage)
+        if callback is None:
+            trace.append({"stage": stage, "status": "planned"})
+            continue
+        artifacts[stage] = callback()
+        trace.append({"stage": stage, "status": "completed"})
+
+    status = "completed" if len(artifacts) == len(normalized_stages) else "planned"
+    return _clinical_pipeline_payload(
+        status=status,
+        stages=normalized_stages,
+        artifacts=artifacts,
+        trace=trace,
+    )
+
+
+def _clinical_pipeline_payload(
+    *,
+    status: str,
+    stages: Sequence[str],
+    artifacts: Mapping[str, Any] | None = None,
+    error: Mapping[str, Any] | None = None,
+    trace: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    artifacts_payload = copy.deepcopy(dict(artifacts or {}))
+    final_output: Any = None
+    for stage in reversed(tuple(stages)):
+        if stage in artifacts_payload:
+            final_output = copy.deepcopy(artifacts_payload[stage])
+            break
+    return {
+        "schema_version": CLINICAL_PIPELINE_SCHEMA_VERSION,
+        "status": status,
+        "stages": list(stages),
+        "artifacts": artifacts_payload,
+        "final_output": final_output,
+        "error": copy.deepcopy(dict(error)) if error is not None else None,
+        "trace": [copy.deepcopy(dict(item)) for item in trace],
+    }
 
 
 @dataclass

--- a/tests/unit/mcp/test_tool_registry.py
+++ b/tests/unit/mcp/test_tool_registry.py
@@ -21,6 +21,7 @@ from openmed.core.audit import (
 from openmed.interop import adapter_tool_definitions, langchain, presidio
 from openmed.mcp import server as mcp_server
 from openmed.mcp.tool_registry import (
+    CLINICAL_STAGE_ORDER,
     TOOL_REGISTRY,
     ToolCompatibilityError,
     ToolRegistry,
@@ -28,7 +29,34 @@ from openmed.mcp.tool_registry import (
     ToolSpec,
     check_tool_registry_compatibility,
     invoke_tool,
+    validate_registered_tool_output,
 )
+
+CLINICAL_TOOL_NAMES = {
+    "openmed_clinical_pipeline",
+    "openmed_export_fhir",
+    "openmed_ground",
+    "openmed_risk_score",
+}
+SYNTHETIC_CLINICAL_SPAN = {
+    "schema_version": 1,
+    "doc_id": "synthetic-note-001",
+    "start": 0,
+    "end": 7,
+    "text_hash": f"hmac-sha256:{'0' * 64}",
+    "entity_type": "SYNTHETIC_CONCEPT",
+    "canonical_label": "CONDITION",
+    "policy_label": "CLINICAL_CONCEPT",
+    "regulatory_tags": [],
+    "score": 0.9,
+    "detector": "synthetic-test-detector",
+    "evidence": {"synthetic": True},
+    "action": "keep",
+    "replacement": None,
+    "reversible_id": None,
+    "section": "assessment",
+    "metadata": {"synthetic": True},
+}
 
 
 class FakeFastMCP:
@@ -161,6 +189,50 @@ def test_registry_supports_multiple_versions_side_by_side() -> None:
         "1.0.0",
         "2.0.0",
     ]
+
+
+@pytest.mark.parametrize("tool_name", sorted(CLINICAL_TOOL_NAMES))
+def test_clinical_tool_contracts_are_versioned(tool_name: str) -> None:
+    spec = TOOL_REGISTRY.get(tool_name)
+
+    assert spec.version == "1.0.0"
+    assert spec.document()["input_schema"] == spec.input_schema
+    assert spec.document()["output_schema"] == spec.output_schema
+    assert spec.input_schema["required"]
+    assert spec.output_schema["required"]
+
+
+@pytest.mark.parametrize("tool_name", sorted(CLINICAL_TOOL_NAMES))
+def test_clinical_tool_contracts_use_compatibility_gate(tool_name: str) -> None:
+    spec = TOOL_REGISTRY.get(tool_name)
+    input_schema = deepcopy(dict(spec.input_schema))
+    required_parameter = input_schema["required"][0]
+    input_schema["properties"][required_parameter]["type"] = "string"
+    broken = _replace_spec(spec, input_schema=input_schema)
+
+    with pytest.raises(ToolCompatibilityError, match="without version bump"):
+        check_tool_registry_compatibility([spec], [broken])
+
+
+def test_clinical_contract_handlers_return_registered_output_shapes() -> None:
+    span = deepcopy(SYNTHETIC_CLINICAL_SPAN)
+    handlers = mcp_server.build_mcp_tool_handlers(None)
+    invocations = {
+        "openmed_ground": {"spans": [span]},
+        "openmed_export_fhir": {"spans": [span]},
+        "openmed_risk_score": {"spans": [span]},
+        "openmed_clinical_pipeline": {
+            "stages": ["detect", "context", "ground", "risk"]
+        },
+    }
+
+    for tool_name, arguments in invocations.items():
+        payload = handlers[tool_name](**arguments)
+        assert validate_registered_tool_output(tool_name, payload) == payload
+
+    pipeline = handlers["openmed_clinical_pipeline"](stages=list(CLINICAL_STAGE_ORDER))
+    assert pipeline["status"] == "planned"
+    assert pipeline["stages"] == list(CLINICAL_STAGE_ORDER)
 
 
 # Issue #1741

--- a/tests/unit/mcp/test_workflow.py
+++ b/tests/unit/mcp/test_workflow.py
@@ -10,15 +10,19 @@ import pytest
 
 from openmed.mcp.server import _register_tools
 from openmed.mcp.tool_registry import (
+    CLINICAL_STAGE_ORDER,
     TOOL_REGISTRY,
     ToolSchemaValidationError,
     validate_registered_tool_output,
 )
 from openmed.mcp.workflow import (
+    ClinicalStageOrderError,
     TransientWorkflowError,
     WorkflowRunner,
     WorkflowStateStore,
     builtin_workflow_step_executors,
+    plan_clinical_pipeline,
+    validate_clinical_stage_order,
 )
 
 PHI_NOTE = "Patient Jane Doe called 555-1212 about diabetes."
@@ -397,3 +401,66 @@ def test_workflow_tool_is_registered_and_schema_validated():
     _register_tools(fake_server, runtime_provider=None)
 
     assert "openmed_run_workflow" in fake_server.tools
+
+
+def test_clinical_stage_order_accepts_canonical_subsequences() -> None:
+    stages = [" Detect ", "sections", "ground", "risk"]
+
+    normalized = validate_clinical_stage_order(stages)
+    plan = plan_clinical_pipeline(stages)
+
+    assert normalized == ("detect", "sections", "ground", "risk")
+    assert plan["status"] == "planned"
+    assert plan["stages"] == list(normalized)
+    assert [item["status"] for item in plan["trace"]] == ["planned"] * 4
+    assert validate_registered_tool_output("openmed_clinical_pipeline", plan) == plan
+
+
+def test_invalid_clinical_stage_order_returns_error_without_work() -> None:
+    calls: Counter[str] = Counter()
+
+    def record(stage: str) -> dict[str, str]:
+        calls[stage] += 1
+        return {"stage": stage}
+
+    callbacks = {
+        stage: (lambda stage=stage: record(stage)) for stage in CLINICAL_STAGE_ORDER
+    }
+
+    plan = plan_clinical_pipeline(
+        ["detect", "risk", "ground"],
+        stage_callbacks=callbacks,
+    )
+
+    assert plan["status"] == "rejected"
+    assert plan["stages"] == ["detect", "risk", "ground"]
+    assert plan["error"] == {
+        "code": "invalid_stage_order",
+        "message": "Clinical pipeline stages are not in canonical order.",
+        "stage": "ground",
+        "details": {
+            "allowed_order": list(CLINICAL_STAGE_ORDER),
+            "declared_index": 2,
+            "previous_stage": "risk",
+        },
+    }
+    assert calls == {}
+    assert plan["artifacts"] == {}
+    assert plan["trace"] == []
+    assert validate_registered_tool_output("openmed_clinical_pipeline", plan) == plan
+
+
+def test_unknown_clinical_stage_error_does_not_echo_input() -> None:
+    private_marker = "SYNTHETIC-PRIVATE-MARKER"
+
+    with pytest.raises(ClinicalStageOrderError) as exc_info:
+        validate_clinical_stage_order(["detect", private_marker])
+
+    plan = plan_clinical_pipeline(["detect", private_marker])
+    serialized = json.dumps(plan, sort_keys=True)
+
+    assert exc_info.value.error["code"] == "unknown_stage"
+    assert plan["status"] == "rejected"
+    assert plan["stages"] == ["detect"]
+    assert private_marker not in serialized
+    assert validate_registered_tool_output("openmed_clinical_pipeline", plan) == plan


### PR DESCRIPTION
## Description
Adds the first OM-754 child slice: versioned MCP contracts for clinical grounding, FHIR export, residual-risk scoring, and a declarative clinical pipeline planner. The planner validates the canonical stage order before any supplied stage callback can run and returns schema-valid structured rejections without echoing arbitrary invalid input.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Registered `openmed_ground`, `openmed_export_fhir`, `openmed_risk_score`, and `openmed_clinical_pipeline` with versioned input/output schemas built on text-free canonical `OpenMedSpan` artifacts.
- Added deterministic validation for `detect -> context -> sections -> relations -> ground -> export -> risk`, including structured errors and validate-before-callback behavior.
- Kept standalone runtime execution out of scope by exposing schema-valid handler-pending responses, and regenerated the shared adapter registry bundle.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:
- `.venv/bin/python -m pytest tests/unit/mcp/test_tool_registry.py tests/unit/mcp/test_workflow.py tests/unit/mcp/test_mcp_server.py tests/unit/interop/test_tool_schema_sync.py tests/unit/interop/test_framework_adapters.py -q` (47 passed, 1 skipped)
- `uv run ruff check openmed/interop/function_tools.py openmed/mcp/server.py openmed/mcp/tool_registry.py openmed/mcp/workflow.py tests/unit/mcp/test_tool_registry.py tests/unit/mcp/test_workflow.py`
- `uv run ruff format --check openmed/interop/function_tools.py openmed/mcp/server.py openmed/mcp/tool_registry.py openmed/mcp/workflow.py tests/unit/mcp/test_tool_registry.py tests/unit/mcp/test_workflow.py`
- `pre-commit run --files openmed/interop/function_tools.py openmed/mcp/server.py openmed/mcp/tool_registry.py openmed/mcp/workflow.py tests/unit/mcp/test_tool_registry.py tests/unit/mcp/test_workflow.py openmed/interop/tools.json`
- `git diff --check`

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

Documentation and the MCP prompt/resource remain in the later epic slice.

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Scoped Ruff and pre-commit commands were used because this child task requires changed-file-only validation.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1300
Related to #1251

## Screenshots/Examples
Not applicable; this is a schema and validation change.
