### PR TITLE
Align overlap resolution with canonical label risk policy

### DIFF
--- a/openmed/core/quality_gates.py
+++ b/openmed/core/quality_gates.py
@@ -15,7 +15,7 @@ import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, List, Mapping, Sequence, Tuple, TypeVar
 
-from .labels import normalize_label
+from .labels import normalize_label, risk_level_for
 
 if TYPE_CHECKING:
     from openmed.processing.outputs import EntityPrediction
@@ -35,36 +35,9 @@ _RISK_LEVEL_RANKS = {
     "severe": 4,
 }
 
-_HIGH_RISK_LABEL_RANKS = {
-    "PERSON": 2,
-    "FIRST_NAME": 2,
-    "LAST_NAME": 2,
-    "MIDDLE_NAME": 2,
-    "USERNAME": 2,
-    "EMAIL": 2,
-    "PHONE": 2,
-    "STREET_ADDRESS": 2,
-    "GPS_COORDINATES": 2,
-    "DATE_OF_BIRTH": 3,
-    "ID_NUM": 3,
-    "SSN": 4,
-    "ACCOUNT_NUMBER": 3,
-    "PASSWORD": 4,
-    "PIN": 4,
-    "API_KEY": 4,
-    "CREDIT_CARD": 4,
-    "CVV": 4,
-    "IBAN": 3,
-    "BIC": 3,
-    "BITCOIN_ADDRESS": 3,
-    "ETHEREUM_ADDRESS": 3,
-    "LITECOIN_ADDRESS": 3,
-    "IP_ADDRESS": 3,
-    "MAC_ADDRESS": 3,
-    "VIN": 3,
-    "VEHICLE_REGISTRATION": 3,
-    "IMEI": 3,
-}
+_CRITICAL_LABELS = frozenset(
+    {"SSN", "PASSWORD", "PIN", "API_KEY", "CREDIT_CARD", "CVV"}
+)
 
 
 class SpanValidationWarning(UserWarning):
@@ -193,10 +166,10 @@ def _entity_risk_rank(entity: Any) -> int:
         _risk_rank_from_value(metadata.get("risk")),
         _risk_rank_from_value(metadata.get("severity")),
     )
-    label_rank = _HIGH_RISK_LABEL_RANKS.get(
-        normalize_label(_entity_label(entity)),
-        0,
-    )
+    label = normalize_label(_entity_label(entity))
+    label_rank = _risk_rank_from_value(risk_level_for(label))
+    if label in _CRITICAL_LABELS:
+        label_rank = _RISK_LEVEL_RANKS["critical"]
     return max(metadata_rank, label_rank)
 
 

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -258,6 +258,29 @@ class TestResolveOverlappingEntities:
         _assert_no_overlaps(resolved)
         assert [entity.label for entity in resolved] == ["SSN"]
 
+    def test_prefers_canonical_high_risk_label_over_longer_low_risk_span(self):
+        entities = [
+            _ent(
+                "synthetic URL example.test",
+                label="OTHER",
+                start=0,
+                end=26,
+                confidence=0.99,
+            ),
+            _ent(
+                "example.test",
+                label="URL",
+                start=14,
+                end=26,
+                confidence=0.10,
+            ),
+        ]
+
+        resolved = resolve_overlapping_entities(entities)
+
+        _assert_no_overlaps(resolved)
+        assert [entity.label for entity in resolved] == ["URL"]
+
     def test_partial_overlap_prefers_longest_span_within_same_risk_tier(self):
         entities = [
             _ent("Alpha", label="OTHER", start=0, end=5, confidence=0.95),


### PR DESCRIPTION
## Description

Aligns deterministic entity-overlap resolution with the canonical label risk policy. The resolver's private label table predated newer high-risk labels, allowing a longer low-risk span to displace labels such as `URL`; the resolver now derives every canonical label's rank from the shared taxonomy while retaining explicit critical-label precedence.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test addition/improvement

## Changes Made

- Use the canonical label taxonomy for overlap risk ranking.
- Retain the critical override for credential and financial-identifier labels.
- Add a synthetic regression proving a canonical high-risk label wins over a longer, higher-confidence low-risk overlap.
- Preserve warn-only span validation and the documented risk, length, confidence, and position precedence.

## Testing

- [x] Focused quality-gate unit test file passed.
- [x] Focused safety-sweep and de-identification overlap cases passed.
- [x] Changed-file lint, format, security, and repository checks passed.

## Documentation

The existing resolver docstring already documents the precedence; no user-facing documentation change is required.

## Dependencies

- [x] No new dependencies.

## Related Issues

Closes #1980
