### PR TITLE
Complete OMOP CDM vocabulary-aware loading

### DIFF
--- a/docs/clinical/concept-grounding.md
+++ b/docs/clinical/concept-grounding.md
@@ -111,6 +111,27 @@ restricted UMLS, SNOMED, or CPT vocabulary data paths.
 
 ## Run incremental OMOP loads
 
+Use a caller-supplied Athena export and optional Usagi mapping when source spans
+still need standard-concept and domain resolution. The router's decision is
+authoritative, so an unverified `concept_id` carried by an input span cannot
+bypass the local vocabulary lookup:
+
+```python
+from openmed.interop.omop import VocabularyRouter, load_grounded_jsonl
+
+router = VocabularyRouter.from_athena(
+    "/local/athena-export",
+    "/local/usagi-mapping.csv",
+    vocabulary_version="caller-supplied-release",
+)
+tables = load_grounded_jsonl("grounded.jsonl", vocabulary_router=router)
+```
+
+Mapped target and source concepts are copied from the supplied Athena index into
+the loader-owned CONCEPT subset. Each SOURCE_TO_CONCEPT_MAP row retains its
+source code, source concept, target concept, target vocabulary, and vocabulary
+version. A missing match remains source-only with target `concept_id=0`.
+
 The OMOP writers use idempotent append mode by default. A rerun with the same
 deterministic rows does not create duplicates and does not remove data already
 in the target. Use replace-by-note mode when the incoming batch is the complete,

--- a/openmed/interop/omop/cdm_loader.py
+++ b/openmed/interop/omop/cdm_loader.py
@@ -27,6 +27,26 @@ LoadMode = Literal["append", "replace_by_note"]
 OmopDomain = Literal["Condition", "Drug", "Measurement", "Procedure", "Observation"]
 WriterKind = Literal["duckdb", "sqlite", "parquet"]
 
+
+class _VocabularyMapping(Protocol):
+    domain: OmopDomain | None
+    source_code: str
+    source_concept_id: int
+    source_code_description: str | None
+    source_vocabulary_id: str
+    target_concept_id: int
+    target_vocabulary_id: str
+    standard_concept: str | None
+
+    def to_source_to_concept_map_row(self) -> dict[str, Any]: ...
+
+
+class _VocabularyRouter(Protocol):
+    def route_span(self, span: Any) -> _VocabularyMapping: ...
+
+    def concept_record(self, concept_id: int) -> Mapping[str, Any] | None: ...
+
+
 _MISSING = object()
 
 _TABLE_ORDER: tuple[str, ...] = (
@@ -621,6 +641,7 @@ def load_grounded_notes(
     notes: Iterable[Any],
     *,
     vocabulary_version: str | None = None,
+    vocabulary_router: _VocabularyRouter | None = None,
     mode: LoadMode = "append",
 ) -> OmopCdmTables:
     """Build OMOP CDM tables from grounded clinical note records.
@@ -631,6 +652,9 @@ def load_grounded_notes(
             produce NOTE_NLP rows.
         vocabulary_version: Optional user-supplied vocabulary version string
             recorded in SOURCE_TO_CONCEPT_MAP rows.
+        vocabulary_router: Optional router backed by caller-supplied Athena and
+            Usagi artifacts. When provided, its standard-concept and domain
+            decisions are authoritative over concept fields in each span.
         mode: Load mode. ``append`` preserves existing rows and remains the
             default. ``replace_by_note`` marks each incoming source note hash
             as authoritative when the rows are persisted by a writer.
@@ -728,6 +752,7 @@ def load_grounded_notes(
                 note_text=note_text,
                 source_note_hash=source_note_hash,
                 vocabulary_version=vocabulary_version or "",
+                vocabulary_router=vocabulary_router,
             )
             if rejection is not None:
                 rejections.append(rejection)
@@ -755,6 +780,7 @@ def load_grounded_jsonl(
     path: str | Path,
     *,
     vocabulary_version: str | None = None,
+    vocabulary_router: _VocabularyRouter | None = None,
     mode: LoadMode = "append",
 ) -> OmopCdmTables:
     """Load grounded note records from JSONL into in-memory OMOP tables."""
@@ -772,6 +798,7 @@ def load_grounded_jsonl(
     return load_grounded_notes(
         records,
         vocabulary_version=vocabulary_version,
+        vocabulary_router=vocabulary_router,
         mode=mode,
     )
 
@@ -1126,8 +1153,12 @@ def _load_entity(
     note_text: str,
     source_note_hash: str,
     vocabulary_version: str,
+    vocabulary_router: _VocabularyRouter | None,
 ) -> RejectedSpan | None:
-    domain = _entity_domain(entity)
+    mapping = (
+        vocabulary_router.route_span(entity) if vocabulary_router is not None else None
+    )
+    domain = mapping.domain if mapping is not None else _entity_domain(entity)
     start = _optional_int(_first_value(_entity_sources(entity), ("start",)))
     end = _optional_int(_first_value(_entity_sources(entity), ("end",)))
 
@@ -1156,7 +1187,12 @@ def _load_entity(
             domain=domain,
         )
 
-    concept = _entity_concept(entity, domain)
+    concept = _entity_concept(
+        entity,
+        domain,
+        mapping=mapping,
+        vocabulary_router=vocabulary_router,
+    )
     _add_concept_row(table_rows, concept)
 
     lexical_variant = _entity_text(entity) or note_text[start:end]
@@ -1214,6 +1250,12 @@ def _load_entity(
             "idempotent_key": idempotent_key,
         },
     )
+    provenance = _entity_provenance(
+        concept,
+        mapping=mapping,
+        lexical_variant=lexical_variant,
+        vocabulary_version=vocabulary_version,
+    )
     _upsert_row(
         table_rows,
         "source_to_concept_map",
@@ -1222,16 +1264,7 @@ def _load_entity(
                 "source_to_concept_map",
                 idempotent_key,
             ),
-            "source_code": concept["concept_code"],
-            "source_concept_id": int(concept["source_concept_id"]),
-            "source_vocabulary_id": concept["vocabulary_id"],
-            "source_code_description": lexical_variant,
-            "target_concept_id": int(concept["concept_id"]),
-            "target_vocabulary_id": concept["vocabulary_id"],
-            "valid_start_date": None,
-            "valid_end_date": None,
-            "invalid_reason": None if int(concept["concept_id"]) else "UNMAPPED",
-            "vocabulary_version": vocabulary_version,
+            **provenance,
             "source_note_hash": source_note_hash,
             "note_nlp_id": note_nlp_id,
         },
@@ -1239,7 +1272,69 @@ def _load_entity(
     return None
 
 
-def _entity_concept(entity: Any, domain: OmopDomain) -> dict[str, Any]:
+def _entity_concept(
+    entity: Any,
+    domain: OmopDomain,
+    *,
+    mapping: _VocabularyMapping | None,
+    vocabulary_router: _VocabularyRouter | None,
+) -> dict[str, Any]:
+    if mapping is not None:
+        target_id = int(mapping.target_concept_id)
+        source_id = int(mapping.source_concept_id)
+        target_record = (
+            vocabulary_router.concept_record(target_id)
+            if vocabulary_router is not None and target_id
+            else None
+        )
+        source_record = (
+            vocabulary_router.concept_record(source_id)
+            if vocabulary_router is not None and source_id
+            else None
+        )
+        return {
+            "concept_id": target_id,
+            "source_concept_id": source_id,
+            "concept_name": _concept_value(
+                target_record,
+                "concept_name",
+                UNMAPPED_CONCEPT_NAME if not target_id else f"Concept {target_id}",
+            ),
+            "domain_id": _concept_value(target_record, "domain_id", domain),
+            "vocabulary_id": _concept_value(
+                target_record,
+                "vocabulary_id",
+                (mapping.target_vocabulary_id if target_id else UNMAPPED_VOCABULARY_ID),
+            ),
+            "concept_class_id": _concept_value(target_record, "concept_class_id", ""),
+            "standard_concept": (
+                _concept_value(
+                    target_record, "standard_concept", mapping.standard_concept
+                )
+                if target_id
+                else None
+            ),
+            "concept_code": _concept_value(target_record, "concept_code", ""),
+            "source_concept_name": _concept_value(
+                source_record,
+                "concept_name",
+                mapping.source_code_description or mapping.source_code,
+            ),
+            "source_domain_id": _concept_value(source_record, "domain_id", domain),
+            "source_vocabulary_id": _concept_value(
+                source_record, "vocabulary_id", mapping.source_vocabulary_id
+            ),
+            "source_concept_class_id": _concept_value(
+                source_record, "concept_class_id", ""
+            ),
+            "source_standard_concept": _concept_value(
+                source_record, "standard_concept", None
+            ),
+            "source_concept_code": _concept_value(
+                source_record, "concept_code", mapping.source_code
+            ),
+        }
+
     concept_id = _optional_int(
         _first_value(_entity_sources(entity), _CONCEPT_ID_FIELDS)
     )
@@ -1279,34 +1374,95 @@ def _add_concept_row(
     concept: Mapping[str, Any],
 ) -> None:
     concept_id = int(concept["concept_id"])
+    target_concept = (
+        _unmapped_concept_row() if concept_id == UNMAPPED_CONCEPT_ID else concept
+    )
+    target_vocabulary_id = target_concept.get("vocabulary_id")
+    if target_vocabulary_id is None:
+        target_vocabulary_id = (
+            UNMAPPED_VOCABULARY_ID if concept_id == UNMAPPED_CONCEPT_ID else ""
+        )
     _upsert_row(
         table_rows,
         "concept",
         {
             "concept_id": concept_id,
-            "concept_name": concept.get("concept_name") or UNMAPPED_CONCEPT_NAME,
-            "domain_id": concept.get("domain_id") or "",
-            "vocabulary_id": concept.get("vocabulary_id") or UNMAPPED_VOCABULARY_ID,
-            "concept_class_id": concept.get("concept_class_id") or "",
-            "standard_concept": concept.get("standard_concept"),
-            "concept_code": concept.get("concept_code") or "",
+            "concept_name": target_concept.get("concept_name") or UNMAPPED_CONCEPT_NAME,
+            "domain_id": target_concept.get("domain_id") or "",
+            "vocabulary_id": target_vocabulary_id,
+            "concept_class_id": target_concept.get("concept_class_id") or "",
+            "standard_concept": target_concept.get("standard_concept"),
+            "concept_code": target_concept.get("concept_code") or "",
         },
     )
-    source_concept_id = int(concept.get("source_concept_id") or concept_id)
-    if source_concept_id != concept_id:
+    raw_source_concept_id = concept.get("source_concept_id")
+    source_concept_id = (
+        concept_id if raw_source_concept_id is None else int(raw_source_concept_id)
+    )
+    if source_concept_id not in {UNMAPPED_CONCEPT_ID, concept_id}:
         _upsert_row(
             table_rows,
             "concept",
             {
                 "concept_id": source_concept_id,
-                "concept_name": concept.get("concept_name") or "",
-                "domain_id": concept.get("domain_id") or "",
-                "vocabulary_id": concept.get("vocabulary_id") or "",
-                "concept_class_id": concept.get("concept_class_id") or "",
-                "standard_concept": concept.get("standard_concept"),
-                "concept_code": concept.get("concept_code") or "",
+                "concept_name": concept.get("source_concept_name")
+                or concept.get("concept_name")
+                or "",
+                "domain_id": concept.get("source_domain_id")
+                or concept.get("domain_id")
+                or "",
+                "vocabulary_id": concept.get("source_vocabulary_id")
+                or concept.get("vocabulary_id")
+                or "",
+                "concept_class_id": concept.get("source_concept_class_id")
+                or concept.get("concept_class_id")
+                or "",
+                "standard_concept": concept.get(
+                    "source_standard_concept", concept.get("standard_concept")
+                ),
+                "concept_code": concept.get("source_concept_code")
+                or concept.get("concept_code")
+                or "",
             },
         )
+
+
+def _entity_provenance(
+    concept: Mapping[str, Any],
+    *,
+    mapping: _VocabularyMapping | None,
+    lexical_variant: str,
+    vocabulary_version: str,
+) -> dict[str, Any]:
+    if mapping is not None:
+        provenance = mapping.to_source_to_concept_map_row()
+        if provenance["vocabulary_version"] is None:
+            provenance["vocabulary_version"] = vocabulary_version
+        return provenance
+    concept_id = int(concept["concept_id"])
+    return {
+        "source_code": concept["concept_code"],
+        "source_concept_id": int(concept["source_concept_id"]),
+        "source_vocabulary_id": concept["vocabulary_id"],
+        "source_code_description": lexical_variant,
+        "target_concept_id": concept_id,
+        "target_vocabulary_id": concept["vocabulary_id"],
+        "valid_start_date": None,
+        "valid_end_date": None,
+        "invalid_reason": None if concept_id else "UNMAPPED",
+        "vocabulary_version": vocabulary_version,
+    }
+
+
+def _concept_value(
+    record: Mapping[str, Any] | None,
+    field_name: str,
+    fallback: Any,
+) -> Any:
+    if record is None:
+        return fallback
+    value = record.get(field_name)
+    return fallback if value is None or value == "" else value
 
 
 def _unmapped_concept_row() -> dict[str, Any]:

--- a/openmed/interop/omop/vocab_router.py
+++ b/openmed/interop/omop/vocab_router.py
@@ -263,6 +263,12 @@ class VocabularyRouter:
 
         return tuple(self.route_span(span) for span in spans)
 
+    def concept_record(self, concept_id: int) -> Mapping[str, Any] | None:
+        """Return a copy of a caller-supplied Athena concept record by ID."""
+
+        record = self._by_concept_id.get(int(concept_id))
+        return dict(record) if record is not None else None
+
     def _source_record(self, source_vocab: str, code: str) -> Mapping[str, Any] | None:
         if not code:
             return None

--- a/tests/unit/interop/test_omop_cdm_loader.py
+++ b/tests/unit/interop/test_omop_cdm_loader.py
@@ -14,6 +14,7 @@ from openmed.interop.omop import (
     UNMAPPED_CONCEPT_ID,
     OmopCdmTables,
     OmopLoadSummary,
+    VocabularyRouter,
     emit_postgres_ddl,
     load_grounded_jsonl,
     load_grounded_notes,
@@ -32,6 +33,14 @@ NOTE_TEXT = (
 )
 TARGET_NOTE_HASH = "1" * 64
 PRESERVED_NOTE_HASH = "2" * 64
+
+_ROUTED_CONCEPTS = {
+    "COND-1": (9_101, 201826, "Condition"),
+    "DRUG-1": (9_102, 1112807, "Drug"),
+    "MEAS-1": (9_103, 3004410, "Measurement"),
+    "PROC-1": (9_104, 4017990, "Procedure"),
+    "OBS-1": (9_105, 40766527, "Observation"),
+}
 
 
 def _entity(
@@ -98,6 +107,38 @@ def _fixture_notes() -> list[dict[str, Any]]:
             ],
         }
     ]
+
+
+def _vocabulary_router() -> VocabularyRouter:
+    target_records = {}
+    source_records = {}
+    usagi = {}
+    for source_code, (source_id, target_id, domain) in _ROUTED_CONCEPTS.items():
+        target_code = f"TARGET-{source_code}"
+        target_records[target_code] = {
+            "concept_id": target_id,
+            "concept_name": f"Standard {source_code}",
+            "domain_id": domain,
+            "vocabulary_id": "SYNTHETIC",
+            "concept_class_id": "Standard",
+            "standard_concept": "S",
+            "concept_code": target_code,
+        }
+        source_records[source_code] = {
+            "concept_id": source_id,
+            "concept_name": f"Source {source_code}",
+            "domain_id": domain,
+            "vocabulary_id": "LOCAL",
+            "concept_class_id": "Source",
+            "standard_concept": None,
+            "concept_code": source_code,
+        }
+        usagi[f"LOCAL:{source_code}"] = target_id
+    return VocabularyRouter(
+        {"SYNTHETIC": target_records, "LOCAL": source_records},
+        usagi,
+        vocabulary_version="SYNTHETIC 2026-01",
+    )
 
 
 def _replacement_fixture_notes(*, include_stale_span: bool) -> list[dict[str, Any]]:
@@ -209,6 +250,115 @@ def test_load_grounded_notes_builds_valid_duckdb_omop_tables() -> None:
         WHERE source_code = 'SRC-UNMAPPED'
         """
     ).fetchall() == [(UNMAPPED_CONCEPT_ID, "UNMAPPED")]
+
+
+def test_vocabulary_router_drives_end_to_end_cdm_load(tmp_path: Path) -> None:
+    notes = _fixture_notes()
+    invented_ids = set()
+    for index, entity in enumerate(notes[0]["entities"][:5], start=1):
+        invented_id = 8_000_000 + index
+        entity["concept_id"] = invented_id
+        invented_ids.add(invented_id)
+    jsonl = tmp_path / "routed-grounded.jsonl"
+    jsonl.write_text(json.dumps(notes[0]) + "\n", encoding="utf-8")
+
+    tables = load_grounded_jsonl(
+        jsonl,
+        vocabulary_router=_vocabulary_router(),
+    )
+
+    expected_counts = dict(_expected_counts())
+    expected_counts["concept"] = 11
+    assert tables.row_counts == expected_counts
+    assert validate_omop_tables(tables) == ()
+
+    concepts = {row["concept_id"]: row for row in tables.table("concept")}
+    assert invented_ids.isdisjoint(concepts)
+    assert concepts[UNMAPPED_CONCEPT_ID]["concept_code"] == ""
+    assert concepts[UNMAPPED_CONCEPT_ID]["domain_id"] == ""
+    for source_code, (source_id, target_id, domain) in _ROUTED_CONCEPTS.items():
+        assert concepts[source_id] == {
+            "concept_id": source_id,
+            "concept_name": f"Source {source_code}",
+            "domain_id": domain,
+            "vocabulary_id": "LOCAL",
+            "concept_class_id": "Source",
+            "standard_concept": None,
+            "concept_code": source_code,
+        }
+        assert concepts[target_id]["concept_code"] == f"TARGET-{source_code}"
+        assert concepts[target_id]["standard_concept"] == "S"
+
+    provenance = {
+        row["source_code"]: row for row in tables.table("source_to_concept_map")
+    }
+    for source_code, (source_id, target_id, _domain) in _ROUTED_CONCEPTS.items():
+        row = provenance[source_code]
+        assert row["source_concept_id"] == source_id
+        assert row["source_vocabulary_id"] == "LOCAL"
+        assert row["target_concept_id"] == target_id
+        assert row["target_vocabulary_id"] == "SYNTHETIC"
+        assert row["vocabulary_version"] == "SYNTHETIC 2026-01"
+    assert provenance["SRC-UNMAPPED"]["target_concept_id"] == UNMAPPED_CONCEPT_ID
+    assert provenance["SRC-UNMAPPED"]["target_vocabulary_id"] == "UNMAPPED"
+    assert provenance["SRC-UNMAPPED"]["invalid_reason"] == "UNMAPPED"
+
+    con = write_omop_duckdb(tables)
+    first_counts = _table_counts_from_duckdb(con)
+    write_omop_duckdb(tables, con)
+    assert _table_counts_from_duckdb(con) == first_counts == expected_counts
+    assert validate_omop_database(con) == ()
+
+
+def test_vocabulary_router_does_not_mislabel_unknown_target_metadata() -> None:
+    note_text = "Synthetic source finding."
+    source_code = "SRC-ABSENT"
+    router = VocabularyRouter(
+        {
+            "LOCAL": {
+                source_code: {
+                    "concept_id": 9_999,
+                    "concept_name": "Synthetic source concept",
+                    "domain_id": "Condition",
+                    "vocabulary_id": "LOCAL",
+                    "concept_class_id": "Source",
+                    "standard_concept": None,
+                    "concept_code": source_code,
+                }
+            }
+        },
+        {f"LOCAL:{source_code}": 8_888},
+    )
+
+    tables = load_grounded_notes(
+        [
+            {
+                "document_id": "synthetic-note",
+                "person_id": "synthetic-person",
+                "note_text": note_text,
+                "entities": [
+                    {
+                        "text": "source finding",
+                        "start": note_text.index("source finding"),
+                        "end": note_text.index("source finding")
+                        + len("source finding"),
+                        "code": source_code,
+                        "vocabulary_id": "LOCAL",
+                        "domain_id": "Condition",
+                    }
+                ],
+            }
+        ],
+        vocabulary_router=router,
+    )
+
+    target = next(row for row in tables.table("concept") if row["concept_id"] == 8_888)
+    provenance = tables.table("source_to_concept_map")[0]
+    assert target["concept_name"] == "Concept 8888"
+    assert target["concept_code"] == ""
+    assert target["vocabulary_id"] == ""
+    assert provenance["target_vocabulary_id"] == ""
+    assert validate_omop_tables(tables) == ()
 
 
 def test_postgres_ddl_is_stable_and_covers_loader_owned_tables() -> None:


### PR DESCRIPTION
# Pull Request

## Description
Completes the canonical OMOP CDM ETL path by wiring the existing caller-supplied Athena/Usagi vocabulary router into grounded-note loading. Previously the router and loader were separate surfaces, so routed domain decisions and source-to-standard provenance were not carried into loader-owned CDM tables.

The router is authoritative when supplied: unverified input concept IDs cannot bypass vocabulary resolution, exact source and target concept metadata is persisted when available, unknown target metadata stays explicitly unknown, and unmatched terms remain source-only at concept ID 0. The JSONL loader exposes the same integration while preserving the existing pre-grounded path.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Added optional vocabulary-router integration to in-memory and JSONL OMOP loads.
- Persisted caller-supplied source/target concept rows and complete SOURCE_TO_CONCEPT_MAP provenance without fabricating concept IDs.
- Kept the canonical concept-0 row stable and documented local Athena/Usagi loading.
- Added a synthetic end-to-end regression covering all five routed domains, DuckDB constraints, idempotent reruns, unmapped terms, and unknown target metadata.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Focused existing unit tests pass locally with my changes
- [x] I have tested this change with different synthetic inputs

Validation performed:
- Loader and vocabulary-router regression files: 23 passed.
- Command, service, and lazy-adapter regression files: 17 passed with one pre-existing dependency deprecation warning.
- Changed-file lint, formatting, security, secret, whitespace, and merge-conflict checks: passed.

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new public functions
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious behavior
- [x] My changes generate no new warnings

Validation was intentionally limited to changed files and focused regression files; broad testing remains owned by CI.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have organized the commit appropriately

## Related Issues
Closes #1249

## Screenshots/Examples
Not applicable.
