### PR TITLE
Preserve prediction spans in re-identification risk reports

### DIFF
--- a/openmed/risk/reid.py
+++ b/openmed/risk/reid.py
@@ -295,13 +295,14 @@ def risk_report(
 ) -> dict[str, Any]:
     """Score residual re-identification risk for text or table records.
 
-    Inputs may be a string, a prediction-result-like mapping with ``text`` and
-    span dictionaries, a row mapping, a sequence of records, or a
-    DataFrame-like object exposing ``to_dict("records")``. Existing OpenMed
-    span offsets are preferred: when a span provides ``start`` and ``end``,
-    the quasi-identifier value is sliced from the source text and its section
-    metadata is carried into the report. Regex and column-name extraction are
-    deliberately small hooks until grounding-driven QI classification lands.
+    Inputs may be a string, a prediction result exposing ``to_dict()``, a
+    prediction-result-like mapping with ``text`` and span dictionaries, a row
+    mapping, a sequence of records, or a DataFrame-like object exposing
+    ``to_dict("records")``. Existing OpenMed span offsets are preferred: when a
+    span provides ``start`` and ``end``, the quasi-identifier value is sliced
+    from the source text and its section metadata is carried into the report.
+    Regex and column-name extraction are deliberately small hooks until
+    grounding-driven QI classification lands.
     ``quasi_identifier_fields`` selects an exact tabular key for equivalence
     classes. This keeps arbitrary-schema table scans byte-compatible with the
     keys emitted for singleton records while preserving scalar types.
@@ -878,6 +879,10 @@ def _coerce_records(data: Any, *, source: str) -> list[_Record]:
     dataframe_records = _maybe_dataframe_records(data)
     if dataframe_records is not None:
         data = dataframe_records
+    else:
+        mapping_record = _maybe_mapping_record(data)
+        if mapping_record is not None:
+            data = mapping_record
 
     if isinstance(data, str):
         return [_Record(0, None, data, {}, (), source)]
@@ -918,6 +923,17 @@ def _maybe_dataframe_records(data: Any) -> list[Mapping[str, Any]] | None:
     if isinstance(records, list) and all(isinstance(item, Mapping) for item in records):
         return records
     return None
+
+
+def _maybe_mapping_record(data: Any) -> Mapping[str, Any] | None:
+    to_dict = getattr(data, "to_dict", None)
+    if to_dict is None or isinstance(data, Mapping):
+        return None
+    try:
+        record = to_dict()
+    except TypeError:
+        return None
+    return record if isinstance(record, Mapping) else None
 
 
 def _first_container(data: Mapping[str, Any]) -> Any | None:

--- a/tests/unit/risk/test_reid.py
+++ b/tests/unit/risk/test_reid.py
@@ -1,5 +1,6 @@
 """Tests for residual re-identification risk reports."""
 
+from openmed.processing.outputs import EntityPrediction, PredictionResult
 from openmed.risk import risk_report
 
 
@@ -47,6 +48,42 @@ def test_risk_report_exports_documented_shape_and_uses_span_offsets():
     assert age_qi["value"] == "94-year-old"
     assert age_qi["start"] == text.index("94-year-old")
     assert age_qi["section"] == "assessment"
+
+
+def test_risk_report_accepts_prediction_results_with_span_offsets():
+    text = "Assessment: 94-year-old seen at North Clinic."
+    start = text.index("94-year-old")
+    result = PredictionResult(
+        text=text,
+        entities=[
+            EntityPrediction(
+                text="94-year-old",
+                label="AGE",
+                confidence=1.0,
+                start=start,
+                end=start + len("94-year-old"),
+                metadata={"section": "assessment"},
+            )
+        ],
+        model_name="synthetic-offset-model",
+        timestamp="2026-01-01T00:00:00",
+    )
+
+    report = risk_report(result)
+
+    assert report["k_min"] == 1
+    age_qi = next(qi for qi in report["quasi_identifiers"] if qi["category"] == "age")
+    assert age_qi == {
+        "record_index": 0,
+        "record_id": None,
+        "category": "age",
+        "value": "94-year-old",
+        "normalized_value": "94",
+        "source": "span",
+        "start": start,
+        "end": start + len("94-year-old"),
+        "section": "assessment",
+    }
 
 
 def test_table_equivalence_classes_flag_singleton_and_compute_k_min():
@@ -110,6 +147,9 @@ def test_aux_linkage_attack_scores_nonzero_and_anonymized_records_score_zero():
     report = risk_report(deidentified, aux=aux)
 
     assert report["reid_rate"] > 0
+
+    original_report = risk_report(deidentified, original=aux)
+    assert original_report["reid_rate"] > 0
 
     anonymized_report = risk_report(
         [


### PR DESCRIPTION
## Description
Completes the canonical re-identification risk report delivery for text and table records. Prediction-result objects are now coerced through their structured mappings so quasi-identifiers retain authoritative span offsets and section metadata instead of being derived from object representations.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test addition/improvement

## Changes Made
- Accept structured prediction-result objects alongside mappings, strings, tables, and record sequences.
- Preserve span-grounded quasi-identifier values, offsets, and section provenance.
- Exercise linkage attacks against both an original corpus and a synthetic auxiliary table.

## Testing
- [x] Focused risk-report unit tests pass locally (5 passed).
- [x] Changed-file lint, formatting, security, and repository-policy checks pass.

## Documentation
- [x] Updated the public input-contract docstring.

## Code Quality
- [x] Performed a self-review of the scoped diff.
- [x] Changes generate no new warnings.

## Dependencies
- [x] No new dependencies added.

## Checklist
- [x] Read the contributing guidelines.
- [x] Commit has a clear, descriptive message.

## Related Issues
Closes #1977

## Screenshots/Examples
Not applicable; this change affects the Python risk-report API.