### PR TITLE
Add clinical document type classification

### DIFF
--- a/openmed/clinical/data/doctype_signatures.json
+++ b/openmed/clinical/data/doctype_signatures.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "provenance": {
+    "source": "OpenMed synthetic clinical note-type signatures",
+    "license": "Apache-2.0",
+    "restricted_data": false,
+    "synthetic": true
+  },
+  "max_tokens": 256,
+  "ambiguity_margin": 0.05,
+  "unknown_confidence": 0.0,
+  "document_types": [
+    {
+      "type": "discharge_summary",
+      "rules": [
+        {
+          "phrases": ["discharge summary"],
+          "confidence": 0.98
+        },
+        {
+          "phrases": ["hospital course", "discharge diagnoses"],
+          "confidence": 0.9
+        }
+      ]
+    },
+    {
+      "type": "progress_note",
+      "rules": [
+        {
+          "phrases": ["progress note"],
+          "confidence": 0.98
+        },
+        {
+          "phrases": ["subjective", "objective", "assessment", "plan"],
+          "confidence": 0.9
+        }
+      ]
+    },
+    {
+      "type": "radiology_report",
+      "rules": [
+        {
+          "phrases": ["radiology report"],
+          "confidence": 0.98
+        },
+        {
+          "phrases": ["findings", "impression"],
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "type": "pathology_report",
+      "rules": [
+        {
+          "phrases": ["pathology report"],
+          "confidence": 0.98
+        },
+        {
+          "phrases": ["specimen", "microscopic description"],
+          "confidence": 0.9
+        },
+        {
+          "phrases": ["final diagnosis", "gross description"],
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "type": "operative_note",
+      "rules": [
+        {
+          "phrases": ["operative note"],
+          "confidence": 0.98
+        },
+        {
+          "phrases": ["preoperative diagnosis", "procedure performed"],
+          "confidence": 0.92
+        },
+        {
+          "phrases": ["postoperative diagnosis", "estimated blood loss"],
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "type": "consult_note",
+      "rules": [
+        {
+          "phrases": ["consultation note"],
+          "confidence": 0.98
+        },
+        {
+          "phrases": ["consult note"],
+          "confidence": 0.98
+        },
+        {
+          "phrases": ["reason for consultation", "recommendations"],
+          "confidence": 0.9
+        }
+      ]
+    }
+  ]
+}

--- a/openmed/clinical/sections/__init__.py
+++ b/openmed/clinical/sections/__init__.py
@@ -1,5 +1,18 @@
 """Clinical section detection entry points."""
 
 from .detect import UNSECTIONED_SECTION, detect_sections
+from .doctype import (
+    DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE,
+    UNKNOWN_DOCUMENT_TYPE,
+    DocumentClassification,
+    classify_document,
+)
 
-__all__ = ["UNSECTIONED_SECTION", "detect_sections"]
+__all__ = [
+    "DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE",
+    "UNKNOWN_DOCUMENT_TYPE",
+    "DocumentClassification",
+    "UNSECTIONED_SECTION",
+    "classify_document",
+    "detect_sections",
+]

--- a/openmed/clinical/sections/doctype.py
+++ b/openmed/clinical/sections/doctype.py
@@ -1,0 +1,233 @@
+"""Deterministic, rules-first clinical document-type classification."""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+from typing import TypedDict
+
+DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE = "data/doctype_signatures.json"
+UNKNOWN_DOCUMENT_TYPE = "unknown"
+_TOKEN_RE = re.compile(r"\w+(?:['\N{RIGHT SINGLE QUOTATION MARK}-]\w+)*", re.UNICODE)
+
+
+class DocumentClassification(TypedDict):
+    """Public document-type prediction with an abstention-safe confidence."""
+
+    type: str
+    confidence: float
+
+
+@dataclass(frozen=True)
+class _SignatureRule:
+    phrases: tuple[str, ...]
+    confidence: float
+
+
+@dataclass(frozen=True)
+class _DocumentTypeRules:
+    document_type: str
+    rules: tuple[_SignatureRule, ...]
+
+
+@dataclass(frozen=True)
+class _SignatureTable:
+    max_tokens: int
+    ambiguity_margin: float
+    unknown_confidence: float
+    document_types: tuple[_DocumentTypeRules, ...]
+
+
+def classify_document(text: str) -> DocumentClassification:
+    """Classify a clinical note from deterministic first-window signatures.
+
+    The bundled signatures cover discharge summaries, progress notes,
+    radiology reports, pathology reports, operative notes, and consult notes.
+    Classification is local and deterministic. When no signature wins clearly,
+    the function returns ``unknown`` rather than guessing.
+
+    Args:
+        text: Clinical note text. Only the first configured token window is
+            inspected.
+
+    Returns:
+        A mapping with ``type`` and a rule-strength ``confidence`` from zero to
+        one. Ambiguous and unrecognized notes use the ``unknown`` type.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+
+    table = _load_signature_table()
+    window = _normalized_token_window(text, max_tokens=table.max_tokens)
+    if not window:
+        return _unknown_classification(table)
+
+    matches: list[tuple[float, str]] = []
+    for document_type in table.document_types:
+        matched_confidences = [
+            rule.confidence
+            for rule in document_type.rules
+            if all(_contains_phrase(window, phrase) for phrase in rule.phrases)
+        ]
+        if matched_confidences:
+            matches.append((max(matched_confidences), document_type.document_type))
+
+    if not matches:
+        return _unknown_classification(table)
+
+    matches.sort(key=lambda item: (-item[0], item[1]))
+    best_confidence, best_type = matches[0]
+    if len(matches) > 1:
+        runner_up_confidence = matches[1][0]
+        if best_confidence - runner_up_confidence <= table.ambiguity_margin:
+            return _unknown_classification(table)
+
+    return {
+        "type": best_type,
+        "confidence": round(best_confidence, 6),
+    }
+
+
+def _normalized_token_window(text: str, *, max_tokens: int) -> str:
+    normalized = unicodedata.normalize("NFKC", text).casefold()
+    tokens = _TOKEN_RE.findall(normalized)
+    return " ".join(tokens[:max_tokens])
+
+
+def _contains_phrase(window: str, phrase: str) -> bool:
+    return f" {phrase} " in f" {window} "
+
+
+def _unknown_classification(table: _SignatureTable) -> DocumentClassification:
+    return {
+        "type": UNKNOWN_DOCUMENT_TYPE,
+        "confidence": round(table.unknown_confidence, 6),
+    }
+
+
+@lru_cache(maxsize=1)
+def _load_signature_table() -> _SignatureTable:
+    resource = resources.files("openmed.clinical").joinpath(
+        DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE
+    )
+    with resource.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return _validate_signature_table(payload)
+
+
+def _validate_signature_table(payload: object) -> _SignatureTable:
+    if not isinstance(payload, Mapping):
+        raise ValueError("document type signature table must be a JSON object")
+    if payload.get("schema_version") != 1:
+        raise ValueError("document type signature schema_version must be 1")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise ValueError("document type signatures require provenance metadata")
+    if provenance.get("restricted_data") is not False:
+        raise ValueError("document type signatures must not use restricted data")
+    if provenance.get("synthetic") is not True:
+        raise ValueError("document type signatures must declare synthetic=true")
+
+    max_tokens = payload.get("max_tokens")
+    if (
+        not isinstance(max_tokens, int)
+        or isinstance(max_tokens, bool)
+        or max_tokens < 1
+    ):
+        raise ValueError("document type max_tokens must be a positive integer")
+    ambiguity_margin = _probability(
+        payload.get("ambiguity_margin"), field="ambiguity_margin", maximum=0.99
+    )
+    unknown_confidence = _probability(
+        payload.get("unknown_confidence"), field="unknown_confidence"
+    )
+
+    raw_document_types = payload.get("document_types")
+    if not isinstance(raw_document_types, list) or len(raw_document_types) < 6:
+        raise ValueError("document type signatures must cover at least six types")
+
+    document_types: list[_DocumentTypeRules] = []
+    seen_types: set[str] = set()
+    for raw_document_type in raw_document_types:
+        document_type = _validate_document_type(raw_document_type)
+        if document_type.document_type in seen_types:
+            raise ValueError(f"duplicate document type {document_type.document_type!r}")
+        seen_types.add(document_type.document_type)
+        document_types.append(document_type)
+
+    return _SignatureTable(
+        max_tokens=max_tokens,
+        ambiguity_margin=ambiguity_margin,
+        unknown_confidence=unknown_confidence,
+        document_types=tuple(document_types),
+    )
+
+
+def _validate_document_type(raw: object) -> _DocumentTypeRules:
+    if not isinstance(raw, Mapping):
+        raise ValueError("each document type signature must be an object")
+    document_type = raw.get("type")
+    if not isinstance(document_type, str) or not document_type.strip():
+        raise ValueError("document type names must be non-empty strings")
+    document_type = document_type.strip()
+    if document_type == UNKNOWN_DOCUMENT_TYPE:
+        raise ValueError("unknown is reserved for classifier abstention")
+
+    raw_rules = raw.get("rules")
+    if not isinstance(raw_rules, list) or not raw_rules:
+        raise ValueError(f"document type {document_type!r} requires rules")
+    rules = tuple(
+        _validate_signature_rule(rule, document_type=document_type)
+        for rule in raw_rules
+    )
+    return _DocumentTypeRules(document_type=document_type, rules=rules)
+
+
+def _validate_signature_rule(raw: object, *, document_type: str) -> _SignatureRule:
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"rules for {document_type!r} must be objects")
+    raw_phrases = raw.get("phrases")
+    if not isinstance(raw_phrases, list) or not raw_phrases:
+        raise ValueError(f"rules for {document_type!r} require phrases")
+    phrases = tuple(
+        normalized
+        for phrase in raw_phrases
+        if isinstance(phrase, str)
+        and (normalized := _normalized_token_window(phrase, max_tokens=32))
+    )
+    if len(phrases) != len(raw_phrases):
+        raise ValueError(f"rules for {document_type!r} contain invalid phrases")
+    confidence = _probability(raw.get("confidence"), field="confidence", minimum=0.01)
+    return _SignatureRule(phrases=phrases, confidence=confidence)
+
+
+def _probability(
+    raw: object,
+    *,
+    field: str,
+    minimum: float = 0.0,
+    maximum: float = 1.0,
+) -> float:
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise ValueError(f"document type {field} must be numeric")
+    value = float(raw)
+    if not minimum <= value <= maximum:
+        raise ValueError(
+            f"document type {field} must be between {minimum} and {maximum}"
+        )
+    return value
+
+
+__all__ = [
+    "DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE",
+    "UNKNOWN_DOCUMENT_TYPE",
+    "DocumentClassification",
+    "classify_document",
+]

--- a/openmed/core/pipeline.py
+++ b/openmed/core/pipeline.py
@@ -1122,6 +1122,7 @@ class Pipeline:
 
         if hasattr(sections, "detect_sections"):
             return {
+                "document_type": sections.classify_document(text),
                 "section_hook": "detect_sections",
                 "sections": sections.detect_sections(text, language=language),
                 "section_detection": {

--- a/tests/unit/clinical/test_document_type.py
+++ b/tests/unit/clinical/test_document_type.py
@@ -1,0 +1,94 @@
+"""Synthetic offline tests for clinical document-type classification."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+
+import pytest
+
+from openmed.clinical.sections import (
+    DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE,
+    UNKNOWN_DOCUMENT_TYPE,
+    classify_document,
+)
+
+
+@pytest.mark.parametrize(
+    ("expected_type", "text"),
+    (
+        (
+            "discharge_summary",
+            "DISCHARGE SUMMARY\nHospital course: Stable.\nDischarge diagnoses: Cough.",
+        ),
+        (
+            "progress_note",
+            "PROGRESS NOTE\nSubjective: Better.\nAssessment: Stable.\nPlan: Review.",
+        ),
+        (
+            "radiology_report",
+            "RADIOLOGY REPORT\nFINDINGS: Clear.\nIMPRESSION: No acute finding.",
+        ),
+        (
+            "pathology_report",
+            "PATHOLOGY REPORT\nSPECIMEN: Synthetic sample.\nMICROSCOPIC DESCRIPTION: Benign.",
+        ),
+        (
+            "operative_note",
+            "OPERATIVE NOTE\nPreoperative diagnosis: Cyst.\nProcedure performed: Excision.",
+        ),
+        (
+            "consult_note",
+            "CONSULTATION NOTE\nReason for consultation: Cough.\nRecommendations: Review.",
+        ),
+    ),
+)
+def test_classify_document_covers_canonical_note_types(
+    expected_type: str,
+    text: str,
+) -> None:
+    classification = classify_document(text)
+
+    assert classification["type"] == expected_type
+    assert 0.5 <= classification["confidence"] <= 1.0
+    assert set(classification) == {"type", "confidence"}
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "",
+        "Brief synthetic clinical narrative without a note-type signature.",
+        "RADIOLOGY REPORT\nPATHOLOGY REPORT\nSynthetic mixed template.",
+    ),
+)
+def test_classify_document_abstains_for_unknown_or_ambiguous_notes(text: str) -> None:
+    classification = classify_document(text)
+
+    assert classification == {"type": UNKNOWN_DOCUMENT_TYPE, "confidence": 0.0}
+
+
+def test_classify_document_uses_only_the_first_configured_token_window() -> None:
+    text = " ".join(["synthetic"] * 256 + ["DISCHARGE", "SUMMARY"])
+
+    assert classify_document(text) == {
+        "type": UNKNOWN_DOCUMENT_TYPE,
+        "confidence": 0.0,
+    }
+
+
+def test_document_type_signatures_are_committed_synthetic_local_data() -> None:
+    resource = resources.files("openmed.clinical").joinpath(
+        DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE
+    )
+    payload = json.loads(resource.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == 1
+    assert payload["provenance"] == {
+        "source": "OpenMed synthetic clinical note-type signatures",
+        "license": "Apache-2.0",
+        "restricted_data": False,
+        "synthetic": True,
+    }
+    assert len(payload["document_types"]) >= 6
+    assert all(entry["rules"] for entry in payload["document_types"])

--- a/tests/unit/core/test_pipeline_section_stamping.py
+++ b/tests/unit/core/test_pipeline_section_stamping.py
@@ -93,6 +93,18 @@ def test_default_section_detector_exposes_canonical_sections_to_pipeline():
     ]
 
 
+def test_default_stage_exposes_document_type_classification():
+    text = "RADIOLOGY REPORT\nFINDINGS: Clear.\nIMPRESSION: No acute finding."
+
+    result = Pipeline(
+        model_detector=_model_detector(),
+        use_safety_sweep=False,
+    ).run(text, method="mask")
+
+    document_type = result.stage("doc_type_section").metadata["document_type"]
+    assert document_type == {"type": "radiology_report", "confidence": 0.98}
+
+
 def test_unavailable_section_hook_leaves_pipeline_output_unchanged():
     text = "Patient John Doe visited."
 


### PR DESCRIPTION
# Pull Request

## Description
Adds deterministic first-window clinical document-type classification to the existing section-detection stage. This supplies the missing routing metadata for clinical notes while preserving the section spans and section-stamped downstream artifacts already present on the main branch.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test addition/improvement

## Changes Made
- Added a committed synthetic, permissively licensed signature table for discharge summaries, progress notes, radiology reports, pathology reports, operative notes, and consult notes.
- Added a local classifier that validates its signature data, limits inspection to the first configured token window, and abstains with an unknown result for missing or ambiguous evidence.
- Exposed document classification through the clinical sections package and the existing document-type/section pipeline stage.
- Added synthetic tests for all six note types, abstention behavior, token-window bounds, data provenance, and pipeline metadata.

## Testing
- [x] 13 focused changed-behavior and regression tests passed.
- [x] Changed-file lint and format checks passed.
- [x] Changed-file safety, secret, whitespace, and structural hooks passed.

## Documentation
- [x] Public API docstrings were added.
- [ ] Changelog update was not required.

## Dependencies
- [x] No dependencies were added.

## Checklist
- [x] The change is scoped to the requested clinical document metadata behavior.
- [x] The commit is current with the target branch.
- [x] The implementation uses synthetic offline data only.

## Related Issues
Closes #151

## Screenshots/Examples
Not applicable.