### PR TITLE
Add rules-first clinical section detection

### DIFF
--- a/openmed/clinical/data/section_headers.yaml
+++ b/openmed/clinical/data/section_headers.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+provenance:
+  task: OM-086
+  source: OpenMed curated deterministic clinical section header lexicon.
+  license: Apache-2.0 repository asset.
+  restricted_data: false
+  synthetic: true
+sections:
+  history_of_present_illness:
+    - History of Present Illness
+    - Present Illness
+    - HPI
+  past_medical_history:
+    - Past Medical History
+    - Medical History
+    - Past History
+    - PMH
+  medications:
+    - Medications
+    - Current Medications
+    - Home Medications
+    - Medication List
+    - Meds
+  allergies:
+    - Allergies
+    - Drug Allergies
+    - Allergy List
+    - Known Allergies
+  social_history:
+    - Social History
+    - Social Hx
+    - Soc Hx
+    - SH
+  assessment_and_plan:
+    - Assessment/Plan
+    - Assessment and Plan
+    - A/P
+  findings:
+    - Findings
+    - Observations
+  impression:
+    - Impression
+    - Conclusion
+  chief_complaint:
+    - Chief Complaint
+    - CC
+  review_of_systems:
+    - Review of Systems
+    - ROS
+  history:
+    - History
+  family_history:
+    - Family History
+    - Family Medical History
+    - FH
+  assessment:
+    - Assessment
+  plan:
+    - Plan

--- a/openmed/clinical/lexicons/__init__.py
+++ b/openmed/clinical/lexicons/__init__.py
@@ -8,9 +8,11 @@ from .context_cues import (
     register_clinical_cue_lexicon,
 )
 from .section_headers import (
+    DEFAULT_SECTION_HEADERS_RESOURCE,
     SectionLexicon,
     available_section_languages,
     get_section_lexicon,
+    load_section_headers,
     normalize_section_header,
     normalized_section_header_aliases,
     register_section_lexicon,
@@ -20,12 +22,14 @@ from .section_headers import (
 
 __all__ = [
     "ClinicalCueLexicon",
+    "DEFAULT_SECTION_HEADERS_RESOURCE",
     "SectionLexicon",
     "available_clinical_cue_languages",
     "available_section_languages",
     "clinical_context_lexicon_stats",
     "get_clinical_cue_lexicon",
     "get_section_lexicon",
+    "load_section_headers",
     "normalize_section_header",
     "normalized_section_header_aliases",
     "register_clinical_cue_lexicon",

--- a/openmed/clinical/lexicons/section_headers.py
+++ b/openmed/clinical/lexicons/section_headers.py
@@ -10,6 +10,26 @@ from __future__ import annotations
 import unicodedata
 from collections.abc import Mapping
 from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_SECTION_HEADERS_RESOURCE = "data/section_headers.yaml"
+_SECTION_HEADERS_PACKAGE = "openmed.clinical"
+_REQUIRED_ENGLISH_SECTION_LABELS = frozenset(
+    {
+        "allergies",
+        "assessment_and_plan",
+        "findings",
+        "history_of_present_illness",
+        "impression",
+        "medications",
+        "past_medical_history",
+        "social_history",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -21,36 +41,73 @@ class SectionLexicon:
     token_boundaries: bool = True
 
 
+def load_section_headers(path: str | Path | None = None) -> dict[str, tuple[str, ...]]:
+    """Load and validate the committed English section-header lexicon.
+
+    Args:
+        path: Optional YAML path used by callers that validate a replacement
+            lexicon. The packaged synthetic lexicon is used when omitted.
+
+    Returns:
+        Canonical section labels mapped to their recognized header forms.
+    """
+
+    if path is None:
+        resource = resources.files(_SECTION_HEADERS_PACKAGE).joinpath(
+            DEFAULT_SECTION_HEADERS_RESOURCE
+        )
+        payload = yaml.safe_load(resource.read_text(encoding="utf-8"))
+    else:
+        payload = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    return _validate_section_headers_payload(payload)
+
+
+def _validate_section_headers_payload(payload: Any) -> dict[str, tuple[str, ...]]:
+    if not isinstance(payload, Mapping) or payload.get("schema_version") != 1:
+        raise ValueError("section header lexicon requires schema_version 1")
+
+    provenance = payload.get("provenance")
+    if (
+        not isinstance(provenance, Mapping)
+        or not provenance.get("source")
+        or provenance.get("restricted_data") is not False
+    ):
+        raise ValueError(
+            "section header lexicon requires local unrestricted provenance"
+        )
+
+    raw_sections = payload.get("sections")
+    if not isinstance(raw_sections, Mapping):
+        raise ValueError("section header lexicon requires a sections mapping")
+
+    sections: dict[str, tuple[str, ...]] = {}
+    for raw_label, raw_headers in raw_sections.items():
+        if not isinstance(raw_label, str) or not raw_label.strip():
+            raise ValueError("section labels require header lists")
+        label = raw_label.strip()
+        if not isinstance(raw_headers, list) or any(
+            not isinstance(header, str) or not header.strip() for header in raw_headers
+        ):
+            raise ValueError(f"section {label!r} requires non-empty string headers")
+        headers = tuple(header.strip() for header in raw_headers)
+        if not headers:
+            raise ValueError(f"section {label!r} must include headers")
+        if len(headers) != len(set(headers)):
+            raise ValueError(f"section {label!r} headers must be unique")
+        sections[label] = headers
+
+    missing = _REQUIRED_ENGLISH_SECTION_LABELS.difference(sections)
+    if missing:
+        raise ValueError(
+            "section header lexicon is missing canonical labels: "
+            + ", ".join(sorted(missing))
+        )
+    return sections
+
+
 ENGLISH_SECTION_LEXICON = SectionLexicon(
     language="en",
-    sections={
-        "past_medical_history": (
-            "Past Medical History",
-            "PMH",
-            "Medical History",
-        ),
-        "history": ("History",),
-        "family_history": (
-            "Family History",
-            "Family Medical History",
-            "FH",
-        ),
-        "social_history": (
-            "Social History",
-            "Social Hx",
-            "SH",
-        ),
-        "history_of_present_illness": (
-            "History of Present Illness",
-            "HPI",
-        ),
-        "assessment": (
-            "Assessment",
-            "Impression",
-            "Assessment and Plan",
-        ),
-        "plan": ("Plan",),
-    },
+    sections=load_section_headers(),
 )
 
 SPANISH_SECTION_LEXICON = SectionLexicon(
@@ -246,9 +303,9 @@ def section_header_aliases(language: str | None = None) -> dict[str, str]:
     for code in languages:
         lexicon = get_section_lexicon(code)
         for canonical, headers in lexicon.sections.items():
-            aliases[canonical] = canonical
+            aliases.setdefault(canonical, canonical)
             for header in headers:
-                aliases[header] = canonical
+                aliases.setdefault(header, canonical)
     return aliases
 
 
@@ -292,9 +349,11 @@ for _lexicon in (
 
 
 __all__ = [
+    "DEFAULT_SECTION_HEADERS_RESOURCE",
     "SectionLexicon",
     "available_section_languages",
     "get_section_lexicon",
+    "load_section_headers",
     "normalize_section_header",
     "normalized_section_header_aliases",
     "register_section_lexicon",

--- a/openmed/clinical/sections/__init__.py
+++ b/openmed/clinical/sections/__init__.py
@@ -1,6 +1,11 @@
 """Clinical section detection entry points."""
 
-from .detect import UNSECTIONED_SECTION, detect_sections
+from .detect import (
+    UNSECTIONED_SECTION,
+    SectionSpan,
+    detect_sections,
+    validate_section_spans,
+)
 from .doctype import (
     DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE,
     UNKNOWN_DOCUMENT_TYPE,
@@ -12,7 +17,9 @@ __all__ = [
     "DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE",
     "UNKNOWN_DOCUMENT_TYPE",
     "DocumentClassification",
+    "SectionSpan",
     "UNSECTIONED_SECTION",
     "classify_document",
     "detect_sections",
+    "validate_section_spans",
 ]

--- a/openmed/clinical/sections/detect.py
+++ b/openmed/clinical/sections/detect.py
@@ -18,6 +18,36 @@ _UNDERLINE_CHARS = frozenset("-_=~")
 _BULLET_PREFIXES = ("-", "*", "•")
 
 
+class SectionSpan(dict[str, Any]):
+    """A JSON-ready canonical half-open clinical section range.
+
+    ``SectionSpan`` remains a dictionary so existing pipeline and service
+    consumers can serialize it directly, while its required fields are also
+    available as attributes for a small typed span contract.
+    """
+
+    def __init__(self, label: str, start: int, end: int, **metadata: Any) -> None:
+        super().__init__(label=label, start=int(start), end=int(end), **metadata)
+
+    @property
+    def label(self) -> str:
+        """Return the canonical section label."""
+
+        return str(self["label"])
+
+    @property
+    def start(self) -> int:
+        """Return the inclusive section start offset."""
+
+        return int(self["start"])
+
+    @property
+    def end(self) -> int:
+        """Return the exclusive section end offset."""
+
+        return int(self["end"])
+
+
 @dataclass(frozen=True)
 class _Line:
     text: str
@@ -43,7 +73,7 @@ def detect_sections(
     *,
     language: str | None = None,
     include_unsectioned: bool = True,
-) -> tuple[dict[str, Any], ...]:
+) -> tuple[SectionSpan, ...]:
     """Segment *text* into canonical clinical section spans.
 
     Headers are matched at line starts using language-pack section lexicons.
@@ -63,7 +93,7 @@ def detect_sections(
         for hit in _line_header_hits(line, _next_line(lines, index), language)
     )
     if not hits:
-        return (
+        unsectioned_result = (
             (
                 _section_dict(
                     label=UNSECTIONED_SECTION,
@@ -75,8 +105,14 @@ def detect_sections(
             if include_unsectioned and text
             else ()
         )
+        _validate_section_spans(
+            text,
+            unsectioned_result,
+            require_coverage=include_unsectioned,
+        )
+        return unsectioned_result
 
-    sections: list[dict[str, Any]] = []
+    sections: list[SectionSpan] = []
     cursor = 0
     for index, hit in enumerate(hits):
         if include_unsectioned and cursor < hit.start:
@@ -113,7 +149,79 @@ def detect_sections(
                 language=language,
             )
         )
-    return tuple(section for section in sections if section["start"] < section["end"])
+    result = tuple(section for section in sections if section["start"] < section["end"])
+    _validate_section_spans(
+        text,
+        result,
+        require_coverage=include_unsectioned,
+    )
+    return result
+
+
+def validate_section_spans(
+    text: str,
+    spans: Iterable[Mapping[str, Any]],
+) -> None:
+    """Assert that section spans form a complete partition of ``text``.
+
+    Spans use half-open character offsets. Each span must have a non-empty
+    canonical label, remain within the document, and begin exactly where the
+    previous span ends. An empty document is valid only with no spans.
+
+    Raises:
+        ValueError: If a span is malformed, out of bounds, empty, overlapping,
+            or leaves any document characters uncovered.
+    """
+
+    _validate_section_spans(text, spans, require_coverage=True)
+
+
+def _validate_section_spans(
+    text: str,
+    spans: Iterable[Mapping[str, Any]],
+    *,
+    require_coverage: bool,
+) -> None:
+    previous_end: int | None = None
+    for index, span in enumerate(spans):
+        if not isinstance(span, Mapping):
+            raise ValueError(f"section span {index} must be a mapping")
+        label = span.get("label")
+        if not isinstance(label, str) or not label.strip():
+            raise ValueError(f"section span {index} requires a non-empty label")
+        start = _section_offset(span, "start", index)
+        end = _section_offset(span, "end", index)
+        if start < 0 or end > len(text):
+            raise ValueError(f"section span {index} is outside document bounds")
+        if end <= start:
+            raise ValueError(f"section span {index} must have positive length")
+
+        if previous_end is None:
+            if require_coverage and start != 0:
+                raise ValueError(f"section spans leave a gap from 0 to {start}")
+        elif start < previous_end:
+            raise ValueError(
+                f"section spans overlap at offsets {start} to {previous_end}"
+            )
+        elif start > previous_end:
+            raise ValueError(
+                f"section spans leave a gap from {previous_end} to {start}"
+            )
+        previous_end = end
+
+    if require_coverage:
+        covered_end = previous_end if previous_end is not None else 0
+        if covered_end != len(text):
+            raise ValueError(
+                f"section spans leave a gap from {covered_end} to {len(text)}"
+            )
+
+
+def _section_offset(span: Mapping[str, Any], key: str, index: int) -> int:
+    value = span.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"section span {index} requires an integer {key}")
+    return value
 
 
 def _iter_lines(text: str) -> Iterable[_Line]:
@@ -282,12 +390,12 @@ def _section_dict(
     header_start: int | None = None,
     header_end: int | None = None,
     content_start: int | None = None,
-) -> dict[str, Any]:
-    section: dict[str, Any] = {
-        "label": label,
-        "start": int(start),
-        "end": int(end),
-    }
+) -> SectionSpan:
+    section = SectionSpan(
+        label=label,
+        start=int(start),
+        end=int(end),
+    )
     if header is not None:
         section.update(
             {
@@ -308,4 +416,9 @@ def _section_dict(
     return section
 
 
-__all__ = ["UNSECTIONED_SECTION", "detect_sections"]
+__all__ = [
+    "SectionSpan",
+    "UNSECTIONED_SECTION",
+    "detect_sections",
+    "validate_section_spans",
+]

--- a/tests/unit/clinical/test_sections.py
+++ b/tests/unit/clinical/test_sections.py
@@ -1,0 +1,126 @@
+"""Synthetic offline tests for rules-first clinical section detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.clinical import canonical_section_label
+from openmed.clinical.lexicons import load_section_headers
+from openmed.clinical.sections import (
+    UNSECTIONED_SECTION,
+    SectionSpan,
+    detect_sections,
+    validate_section_spans,
+)
+
+CANONICAL_SECTION_LABELS = {
+    "history_of_present_illness",
+    "past_medical_history",
+    "medications",
+    "allergies",
+    "social_history",
+    "assessment_and_plan",
+    "findings",
+    "impression",
+}
+
+
+def test_section_header_resource_covers_canonical_labels_and_synonyms() -> None:
+    headers = load_section_headers()
+
+    assert CANONICAL_SECTION_LABELS <= headers.keys()
+    assert "HPI" in headers["history_of_present_illness"]
+    assert "PMH" in headers["past_medical_history"]
+    assert "Soc Hx" in headers["social_history"]
+    assert "A/P" in headers["assessment_and_plan"]
+    assert "CC" in headers["chief_complaint"]
+    assert "ROS" in headers["review_of_systems"]
+
+
+def test_detect_sections_covers_canonical_note_sections_without_offset_gaps() -> None:
+    text = (
+        "Synthetic note preamble.\n"
+        "HPI: Dry cough today.\n"
+        "PMH\nChildhood asthma.\n"
+        "MEDICATIONS: Albuterol as directed.\n"
+        "ALLERGIES\nNo known allergies.\n"
+        "Soc Hx: Never smoked.\n"
+        "A/P\nSupportive care.\n"
+        "FINDINGS: Clear lungs.\n"
+        "IMPRESSION\nNo acute finding."
+    )
+
+    sections = detect_sections(text)
+
+    assert [section["label"] for section in sections] == [
+        UNSECTIONED_SECTION,
+        "history_of_present_illness",
+        "past_medical_history",
+        "medications",
+        "allergies",
+        "social_history",
+        "assessment_and_plan",
+        "findings",
+        "impression",
+    ]
+    assert sections[0]["start"] == 0
+    assert sections[-1]["end"] == len(text)
+    assert all(isinstance(section, SectionSpan) for section in sections)
+    assert sections[1].label == "history_of_present_illness"
+    assert (sections[1].start, sections[1].end) == (
+        sections[1]["start"],
+        sections[1]["end"],
+    )
+    assert all(
+        left["end"] == right["start"] for left, right in zip(sections, sections[1:])
+    )
+    assert "".join(text[span["start"] : span["end"]] for span in sections) == text
+    validate_section_spans(text, sections)
+
+
+def test_section_synonyms_normalize_to_canonical_labels() -> None:
+    text = "CC: Cough.\nROS: No fever.\nSoc Hx: Never smoked.\nA/P: Supportive care."
+
+    assert [section["label"] for section in detect_sections(text)] == [
+        "chief_complaint",
+        "review_of_systems",
+        "social_history",
+        "assessment_and_plan",
+    ]
+    assert canonical_section_label("Impression") == "impression"
+
+
+def test_headerless_note_returns_one_unsectioned_preamble_span() -> None:
+    text = "Synthetic narrative without a recognized clinical header."
+
+    assert detect_sections(text) == (
+        SectionSpan(label=UNSECTIONED_SECTION, start=0, end=len(text)),
+    )
+
+
+@pytest.mark.parametrize(
+    ("spans", "message"),
+    (
+        (
+            (
+                SectionSpan(label="history", start=0, end=4),
+                SectionSpan(label="plan", start=5, end=8),
+            ),
+            "gap",
+        ),
+        (
+            (
+                SectionSpan(label="history", start=0, end=5),
+                SectionSpan(label="plan", start=4, end=8),
+            ),
+            "overlap",
+        ),
+        ((SectionSpan(label="history", start=0, end=4),), "gap"),
+    ),
+)
+def test_section_span_validator_rejects_gaps_and_overlaps(
+    spans: tuple[SectionSpan, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        validate_section_spans("abcdefgh", spans)


### PR DESCRIPTION
## Description

Adds deterministic clinical section segmentation with canonical half-open spans, strict whole-document coverage validation, and a committed unrestricted English header lexicon. The implementation extends the existing multilingual sections package so current pipeline and service consumers keep JSON-ready mapping behavior.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made

- Add a SectionSpan contract with mapping and attribute access plus a validator for gaps, overlaps, invalid offsets, and incomplete coverage.
- Add canonical HPI, PMH, medications, allergies, social history, assessment/plan, findings, and impression headers with common abbreviations.
- Preserve multilingual detection and stable language-agnostic canonical alias precedence.
- Add synthetic offline coverage for labeled notes, synonym normalization, headerless preambles, and invalid span layouts.

## Testing

- [x] Focused detector, multilingual, context, and pipeline regression tests pass: 29 passed.
- [x] Changed-file formatting, lint, type, YAML, security, and secret checks pass.
- [x] Tested colon-delimited, standalone, and uppercase header layouts with synthetic inputs.

## Documentation

- [x] Public APIs include docstrings.
- [x] The committed lexicon records unrestricted synthetic provenance.
- [ ] CHANGELOG updates are deferred to the release process.

## Code Quality

- [x] Performed a self-review.
- [x] The focused validation produces no new warnings.

## Dependencies

- [x] No new dependencies.

## Checklist

- [x] Read the contributing guidelines.
- [x] The commit has a clear, focused message.
- [x] The branch contains only this issue scope.

## Related Issues

Closes #251

## Screenshots/Examples

Not applicable; this change has no visual interface.