### PR TITLE
Harden synthetic golden fixture validation

### DIFF
--- a/openmed/eval/golden/README.md
+++ b/openmed/eval/golden/README.md
@@ -52,11 +52,11 @@ Required fields:
   it must note that the synthetic set is an assistive safety probe, not
   clinical ground truth.
 
-The package loader validates offsets, canonical labels, synthetic markers,
-expected output, hard-negative candidate metadata, critical-finding disclaimers,
-and language coverage. The JSON and JSONL files are also compatible with
-`openmed.eval.harness.load_fixtures`; golden-specific expected output remains
-available through each fixture's metadata.
+The package loader validates unique fixture IDs, offsets, canonical labels,
+synthetic markers, expected output, hard-negative candidate metadata,
+critical-finding disclaimers, and language coverage. The JSON and JSONL files
+are also compatible with `openmed.eval.harness.load_fixtures`; golden-specific
+expected output remains available through each fixture's metadata.
 
 ## Temporal TLINK Fixtures
 

--- a/openmed/eval/golden/loader.py
+++ b/openmed/eval/golden/loader.py
@@ -208,6 +208,7 @@ def list_fixture_paths(path: str | Path | None = None) -> tuple[Path, ...]:
 def load_golden_fixtures(path: str | Path | None = None) -> list[GoldenFixture]:
     """Load and validate all golden fixtures under *path*."""
     fixtures: list[GoldenFixture] = []
+    fixture_paths: dict[str, Path] = {}
     for fixture_path in list_fixture_paths(path):
         if fixture_path.suffix.lower() == ".jsonl":
             rows = [
@@ -215,20 +216,28 @@ def load_golden_fixtures(path: str | Path | None = None) -> list[GoldenFixture]:
                 for line in fixture_path.read_text(encoding="utf-8").splitlines()
                 if line.strip()
             ]
-            fixtures.extend(GoldenFixture.from_mapping(row) for row in rows)
-            continue
+        else:
+            raw = json.loads(fixture_path.read_text(encoding="utf-8"))
+            if not isinstance(raw, Mapping):
+                raise ValueError(f"{fixture_path} must contain a mapping")
+            if raw.get("version") != _FIXTURE_VERSION:
+                raise ValueError(f"{fixture_path} has unsupported fixture version")
+            if raw.get("synthetic") is not True:
+                raise ValueError(f"{fixture_path} must be marked synthetic")
+            rows = raw.get("fixtures")
+            if not isinstance(rows, list):
+                raise ValueError(f"{fixture_path} must contain a fixtures list")
 
-        raw = json.loads(fixture_path.read_text(encoding="utf-8"))
-        if not isinstance(raw, Mapping):
-            raise ValueError(f"{fixture_path} must contain a mapping")
-        if raw.get("version") != _FIXTURE_VERSION:
-            raise ValueError(f"{fixture_path} has unsupported fixture version")
-        if raw.get("synthetic") is not True:
-            raise ValueError(f"{fixture_path} must be marked synthetic")
-        rows = raw.get("fixtures")
-        if not isinstance(rows, list):
-            raise ValueError(f"{fixture_path} must contain a fixtures list")
-        fixtures.extend(GoldenFixture.from_mapping(row) for row in rows)
+        for row in rows:
+            fixture = GoldenFixture.from_mapping(row)
+            first_path = fixture_paths.get(fixture.fixture_id)
+            if first_path is not None:
+                raise ValueError(
+                    f"duplicate golden fixture id {fixture.fixture_id!r}: "
+                    f"{first_path} and {fixture_path}"
+                )
+            fixture_paths[fixture.fixture_id] = fixture_path
+            fixtures.append(fixture)
     return fixtures
 
 

--- a/tests/unit/eval/test_golden_fixtures.py
+++ b/tests/unit/eval/test_golden_fixtures.py
@@ -6,6 +6,8 @@ import json
 from datetime import date
 from pathlib import Path
 
+import pytest
+
 from openmed.core.decoding.spans import (
     is_grapheme_boundary,
     iter_grapheme_clusters,
@@ -169,6 +171,23 @@ def test_golden_fixtures_parse_offsets_expected_output_and_round_trip():
 
         mapping = fixture.to_mapping()
         assert GoldenFixture.from_mapping(mapping).to_mapping() == mapping
+
+
+def test_golden_loader_rejects_duplicate_fixture_ids(tmp_path):
+    fixture = _one("date_arithmetic").to_mapping()
+    fixture_pack = {
+        "fixtures": [fixture],
+        "synthetic": True,
+        "version": 1,
+    }
+    for filename in ("first.json", "second.json"):
+        (tmp_path / filename).write_text(
+            json.dumps(fixture_pack),
+            encoding="utf-8",
+        )
+
+    with pytest.raises(ValueError, match="duplicate golden fixture id"):
+        load_golden_fixtures(tmp_path)
 
 
 def test_golden_json_files_are_harness_loadable():


### PR DESCRIPTION
## Description

Completes the canonical synthetic golden-fixture work by making fixture IDs
unambiguous across the full package. The loader now rejects duplicate IDs across
JSON and JSONL sources and reports both defining paths, preventing benchmark
rows from silently colliding.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test addition/improvement
- [x] Documentation update

## Changes Made

- Validate fixture ID uniqueness while loading the complete golden pack.
- Add a synthetic offline regression test for duplicate IDs across fixture files.
- Document the uniqueness invariant in the golden fixture format guide.

## Testing

- [x] `.venv/bin/python -m pytest tests/unit/eval/test_golden_fixtures.py -q` (39 passed)
- [x] `.venv/bin/ruff check openmed/eval/golden/loader.py tests/unit/eval/test_golden_fixtures.py`
- [x] `.venv/bin/ruff format --check openmed/eval/golden/loader.py tests/unit/eval/test_golden_fixtures.py`
- [x] `.venv/bin/pre-commit run --files openmed/eval/golden/loader.py tests/unit/eval/test_golden_fixtures.py openmed/eval/golden/README.md`

## Documentation

- [x] Updated the golden fixture README.
- [x] No changelog entry is needed for this internal validation hardening.

## Dependencies

- [x] No new dependencies.

## Related Issues

Closes #1992

## Screenshots/Examples

Not applicable; there are no UI changes.
