### PR TITLE
Wire discovered plugins into runtime registries

### DIFF
--- a/openmed/core/detector_plugins.py
+++ b/openmed/core/detector_plugins.py
@@ -54,6 +54,7 @@ import logging
 import re
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from importlib import import_module
 from threading import RLock
 from typing import Any, Callable
 
@@ -216,7 +217,7 @@ def register_detector(spec: DetectorSpec) -> DetectorSpec:
         raise TypeError("register_detector expects a DetectorSpec")
 
     with _DISCOVERY_LOCK:
-        DETECTOR_REGISTRY.setdefault(spec.stage, {})[spec.name] = spec
+        DETECTOR_REGISTRY.setdefault(spec.stage, {})[detector_provenance(spec)] = spec
     return spec
 
 
@@ -391,7 +392,7 @@ def iter_detector_capabilities(
 
 
 def discover_detectors() -> None:
-    """Discover ``openmed.detectors`` entry points once."""
+    """Discover legacy detectors and validated SDK recognizers once."""
 
     global _DISCOVERY_COMPLETE
 
@@ -407,7 +408,7 @@ def discover_detectors() -> None:
             "Failed to enumerate OpenMed detector plugins: %s",
             exc.__class__.__name__,
         )
-        return
+        entry_points = ()
 
     for entry_point in entry_points:
         entry_name = str(getattr(entry_point, "name", "<unknown>"))
@@ -422,11 +423,111 @@ def discover_detectors() -> None:
                 exc.__class__.__name__,
             )
 
+    discover_recognizer_plugins()
+
+
+def discover_recognizer_plugins(
+    *,
+    allow_network_egress: bool = False,
+    allow_non_permissive_licenses: bool = False,
+    opt_in_plugins: Sequence[str] = (),
+) -> tuple[DetectorSpec, ...]:
+    """Discover validated SDK recognizers and register detector adapters.
+
+    The SDK registry owns compatibility and policy validation. This runtime
+    bridge forwards explicit opt-ins and only adapts registrations the SDK has
+    accepted. Importing this module does not import or discover SDK plugins.
+
+    Args:
+        allow_network_egress: Allow SDK plugins declaring network access.
+        allow_non_permissive_licenses: Allow restricted plugin licenses.
+        opt_in_plugins: Plugin or qualified component ids explicitly enabled.
+
+    Returns:
+        Detector specs registered for accepted recognizer components.
+    """
+
+    try:
+        registrations = _iter_sdk_plugins(
+            "recognizer",
+            allow_network_egress=allow_network_egress,
+            allow_non_permissive_licenses=allow_non_permissive_licenses,
+            opt_in_plugins=opt_in_plugins,
+        )
+    except Exception as exc:  # pragma: no cover - defensive SDK boundary
+        logger.warning(
+            "Failed to discover OpenMed SDK recognizers: %s",
+            exc.__class__.__name__,
+        )
+        return ()
+    return register_plugin_recognizers(registrations)
+
+
+def register_plugin_recognizers(
+    registrations: Iterable[Any],
+) -> tuple[DetectorSpec, ...]:
+    """Adapt accepted SDK recognizer registrations to detector specs.
+
+    Args:
+        registrations: Validated ``PluginRegistration`` objects from the SDK.
+
+    Returns:
+        Detector specs registered with the privacy pipeline.
+    """
+
+    registered: list[DetectorSpec] = []
+    for registration in registrations:
+        try:
+            metadata = registration.metadata
+            if metadata.kind != "recognizer":
+                continue
+            runtime_metadata = metadata.metadata
+            stage = str(runtime_metadata.get("stage") or "fast_pii")
+            spec = DetectorSpec(
+                name=metadata.component_id,
+                stage=stage,
+                languages=metadata.languages,
+                detect=registration.component.recognize,
+                provenance_prefix=f"plugin:{metadata.plugin_id}",
+                covered_labels=metadata.labels,
+            )
+            register_detector(spec)
+        except Exception as exc:
+            qualified_id = _safe_registration_id(registration)
+            logger.warning(
+                "Failed to wire OpenMed SDK recognizer %s: %s",
+                qualified_id,
+                exc.__class__.__name__,
+            )
+            continue
+        registered.append(spec)
+    return tuple(registered)
+
 
 def detector_provenance(spec: DetectorSpec) -> str:
     """Return the detector provenance string recorded on plugin spans."""
 
     return f"{spec.provenance_prefix}:{spec.name}"
+
+
+def _iter_sdk_plugins(kind: str, **policy: Any) -> tuple[Any, ...]:
+    """Return SDK registrations without importing the SDK during bare imports."""
+
+    try:
+        registry = import_module("openmed.plugins.registry")
+    except ModuleNotFoundError as exc:
+        if exc.name in {"openmed.plugins.protocols", "openmed.plugins.registry"}:
+            return ()
+        raise
+    return tuple(registry.iter_plugins(kind, **policy))
+
+
+def _safe_registration_id(registration: Any) -> str:
+    try:
+        value = registration.metadata.qualified_id
+    except Exception:
+        return "<unknown>"
+    return value if isinstance(value, str) and value else "<unknown>"
 
 
 def _entry_points_for_group(group: str) -> Sequence[Any]:
@@ -538,7 +639,9 @@ __all__ = [
     "detect_indian_identifiers",
     "detector_provenance",
     "discover_detectors",
+    "discover_recognizer_plugins",
     "iter_detector_capabilities",
     "iter_detectors",
     "register_detector",
+    "register_plugin_recognizers",
 ]

--- a/openmed/interop/__init__.py
+++ b/openmed/interop/__init__.py
@@ -8,10 +8,15 @@ optional third-party detector dependencies.
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from importlib import import_module
+from threading import RLock
 from types import ModuleType
 from typing import Any, Final
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -22,6 +27,24 @@ class AdapterSpec:
     module: str
     extra: str
     description: str
+    kind: str = "builtin"
+    plugin_id: str = ""
+    component_id: str = ""
+    loaded_by_policy_opt_in: bool = False
+
+    @property
+    def is_plugin(self) -> bool:
+        """Return whether this spec represents a third-party SDK component."""
+
+        return bool(self.plugin_id and self.component_id)
+
+    @property
+    def qualified_id(self) -> str:
+        """Return stable plugin provenance or the built-in adapter name."""
+
+        if self.is_plugin:
+            return f"{self.plugin_id}:{self.component_id}"
+        return self.name
 
 
 _ADAPTERS: Final[dict[str, AdapterSpec]] = {
@@ -177,6 +200,9 @@ _ADAPTERS: Final[dict[str, AdapterSpec]] = {
     ),
 }
 
+_PLUGIN_ADAPTERS: dict[str, tuple[AdapterSpec, Any]] = {}
+_PLUGIN_ADAPTER_LOCK = RLock()
+
 _GATEWAY_EXPORTS: Final[dict[str, str]] = {
     "PrivacyGateway": "PrivacyGateway",
     "PrivacyGatewayConfig": "PrivacyGatewayConfig",
@@ -189,14 +215,39 @@ _TOOL_EXPORTS: Final[frozenset[str]] = frozenset(
 )
 
 
-def available_adapters() -> tuple[str, ...]:
-    """Return registered adapter names without importing adapter modules."""
+def available_adapters(
+    *,
+    include_plugins: bool = False,
+    allow_network_egress: bool = False,
+    allow_non_permissive_licenses: bool = False,
+    opt_in_plugins: Sequence[str] = (),
+) -> tuple[str, ...]:
+    """Return registered adapter and exporter names.
 
-    return tuple(sorted(_ADAPTERS))
+    Built-in listing remains dependency-light. Set ``include_plugins`` to run
+    explicit SDK discovery before returning first- and third-party names.
+    """
+
+    if include_plugins:
+        discover_plugin_adapters(
+            allow_network_egress=allow_network_egress,
+            allow_non_permissive_licenses=allow_non_permissive_licenses,
+            opt_in_plugins=opt_in_plugins,
+        )
+
+    with _PLUGIN_ADAPTER_LOCK:
+        plugin_names = tuple(_PLUGIN_ADAPTERS)
+    return tuple(sorted((*_ADAPTERS, *plugin_names)))
 
 
 def adapter_spec(name: str) -> AdapterSpec:
     """Return registry metadata for *name* without importing the adapter."""
+
+    plugin_name = str(name or "").strip()
+    with _PLUGIN_ADAPTER_LOCK:
+        plugin_entry = _PLUGIN_ADAPTERS.get(plugin_name)
+    if plugin_entry is not None:
+        return plugin_entry[0]
 
     key = _normalize_adapter_name(name)
     try:
@@ -206,8 +257,14 @@ def adapter_spec(name: str) -> AdapterSpec:
         raise KeyError(f"unknown interop adapter {name!r}; available: {known}") from exc
 
 
-def get_adapter(name: str) -> ModuleType:
-    """Import and return an adapter module by name."""
+def get_adapter(name: str) -> ModuleType | Any:
+    """Return a built-in adapter module or registered plugin component."""
+
+    plugin_name = str(name or "").strip()
+    with _PLUGIN_ADAPTER_LOCK:
+        plugin_entry = _PLUGIN_ADAPTERS.get(plugin_name)
+    if plugin_entry is not None:
+        return plugin_entry[1]
 
     spec = adapter_spec(name)
     module = import_module(spec.module)
@@ -215,6 +272,82 @@ def get_adapter(name: str) -> ModuleType:
     if ensure_registered is not None:
         ensure_registered()
     return module
+
+
+def discover_plugin_adapters(
+    *,
+    allow_network_egress: bool = False,
+    allow_non_permissive_licenses: bool = False,
+    opt_in_plugins: Sequence[str] = (),
+) -> tuple[AdapterSpec, ...]:
+    """Discover accepted SDK exporters and interop adapters.
+
+    Policy-restricted components are returned by the SDK only when the caller
+    supplies an explicit component opt-in or broad policy flag.
+
+    Args:
+        allow_network_egress: Allow SDK plugins declaring network access.
+        allow_non_permissive_licenses: Allow restricted plugin licenses.
+        opt_in_plugins: Plugin or qualified component ids explicitly enabled.
+
+    Returns:
+        Newly registered plugin adapter metadata.
+    """
+
+    try:
+        registrations = _iter_sdk_plugins(
+            allow_network_egress=allow_network_egress,
+            allow_non_permissive_licenses=allow_non_permissive_licenses,
+            opt_in_plugins=opt_in_plugins,
+        )
+    except Exception as exc:  # pragma: no cover - defensive SDK boundary
+        logger.warning(
+            "Failed to discover OpenMed SDK interop plugins: %s",
+            exc.__class__.__name__,
+        )
+        return ()
+    return register_plugin_adapters(registrations)
+
+
+def register_plugin_adapters(
+    registrations: Iterable[Any],
+) -> tuple[AdapterSpec, ...]:
+    """Register validated SDK exporters and interop adapter components."""
+
+    registered: list[AdapterSpec] = []
+    for registration in registrations:
+        try:
+            metadata = registration.metadata
+            if metadata.kind not in {"exporter", "interop_adapter"}:
+                continue
+            name = metadata.qualified_id
+            spec = AdapterSpec(
+                name=name,
+                module="",
+                extra="",
+                description=metadata.description or metadata.name or name,
+                kind=metadata.kind,
+                plugin_id=metadata.plugin_id,
+                component_id=metadata.component_id,
+                loaded_by_policy_opt_in=registration.loaded_by_policy_opt_in,
+            )
+            with _PLUGIN_ADAPTER_LOCK:
+                existing = _PLUGIN_ADAPTERS.get(name)
+                if existing is None:
+                    _PLUGIN_ADAPTERS[name] = (spec, registration.component)
+                elif existing[0] != spec:
+                    raise ValueError(
+                        "plugin adapter metadata changed after registration"
+                    )
+        except Exception as exc:
+            logger.warning(
+                "Failed to wire OpenMed SDK interop component %s: %s",
+                _safe_registration_id(registration),
+                exc.__class__.__name__,
+            )
+            continue
+        registered.append(spec)
+    return tuple(registered)
 
 
 def adapter_tool_definitions(name: str) -> tuple[dict[str, Any], ...]:
@@ -262,6 +395,31 @@ def _normalize_adapter_name(name: str) -> str:
     return str(name or "").strip().lower().replace("-", "_")
 
 
+def _iter_sdk_plugins(**policy: Any) -> tuple[Any, ...]:
+    """Return SDK registrations without importing plugins at module import."""
+
+    try:
+        registry = import_module("openmed.plugins.registry")
+    except ModuleNotFoundError as exc:
+        if exc.name in {"openmed.plugins.protocols", "openmed.plugins.registry"}:
+            return ()
+        raise
+    return tuple(registry.iter_plugins(None, **policy))
+
+
+def _safe_registration_id(registration: Any) -> str:
+    try:
+        value = registration.metadata.qualified_id
+    except Exception:
+        return "<unknown>"
+    return value if isinstance(value, str) and value else "<unknown>"
+
+
+def _reset_plugin_adapters_for_tests() -> None:
+    with _PLUGIN_ADAPTER_LOCK:
+        _PLUGIN_ADAPTERS.clear()
+
+
 def __getattr__(name: str) -> Any:
     if name in _ADAPTERS:
         return get_adapter(name)
@@ -287,12 +445,14 @@ __all__ = [
     "adapter_spec",
     "assert_redacted",
     "available_adapters",
+    "discover_plugin_adapters",
     "gateway",
     "get_adapter",
     "get_langchain_tools",
     "get_llamaindex_tools",
     "get_tool",
     "list_tools",
+    "register_plugin_adapters",
     "restore_text",
     "to_function_tools",
     "to_tool_use_tools",

--- a/openmed/interop/function_tools.py
+++ b/openmed/interop/function_tools.py
@@ -140,6 +140,10 @@ def _tool_handler(
     }
     try:
         return handlers[name]
+    except KeyError:
+        pass
+    try:
+        return TOOL_REGISTRY.handler(name)
     except KeyError as exc:
         raise KeyError(f"unknown OpenMed tool {name!r}") from exc
 

--- a/openmed/mcp/server.py
+++ b/openmed/mcp/server.py
@@ -1388,7 +1388,7 @@ def build_mcp_tool_handlers(
     of registered tool names matches the canonical registry specs.
     """
 
-    return {
+    handlers: dict[str, Callable[..., Dict[str, Any]]] = {
         "openmed_analyze_text": lambda **kwargs: openmed_analyze_text(
             **kwargs,
             runtime_provider=runtime_provider,
@@ -1436,6 +1436,8 @@ def build_mcp_tool_handlers(
         ),
         "openmed_search_models": lambda **kwargs: openmed_search_models(**kwargs),
     }
+    handlers.update(TOOL_REGISTRY.registered_handlers())
+    return handlers
 
 
 # Canonical set of MCP-exposed tool names, kept in sync with TOOL_REGISTRY by

--- a/openmed/mcp/tool_registry.py
+++ b/openmed/mcp/tool_registry.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from importlib import import_module
 from inspect import Parameter, Signature
+from threading import RLock
 from typing import Any, Optional
 
 from openmed.core.labels import CANONICAL_LABELS
@@ -19,6 +22,8 @@ from openmed.core.schemas import load_schema
 
 JsonSchema = dict[str, Any]
 JsonObject = dict[str, Any]
+
+logger = logging.getLogger(__name__)
 
 _SEMVER_RE = re.compile(
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
@@ -97,6 +102,8 @@ class ToolSpec:
     destructive_hint: bool = True
     idempotent_hint: bool = False
     open_world_hint: bool = True
+    plugin_id: str = ""
+    plugin_component_id: str = ""
 
     def __post_init__(self) -> None:
         """Normalize mutable inputs and validate core metadata."""
@@ -107,6 +114,11 @@ class ToolSpec:
             known = ", ".join(sorted(_STABILITY_VALUES))
             raise ValueError(
                 f"tool spec {self.name!r} stability must be one of {known}"
+            )
+        if bool(self.plugin_id) != bool(self.plugin_component_id):
+            raise ValueError(
+                f"tool spec {self.name!r} plugin provenance must include "
+                "plugin_id and plugin_component_id"
             )
         title = self.title.strip()
         if not title:
@@ -166,7 +178,7 @@ class ToolSpec:
     def document(self) -> JsonObject:
         """Return a machine-readable schema document for this tool."""
 
-        return {
+        payload: JsonObject = {
             "name": self.name,
             "description": self.description,
             "version": self.version,
@@ -174,6 +186,37 @@ class ToolSpec:
             "input_schema": deepcopy(dict(self.input_schema)),
             "output_schema": deepcopy(dict(self.output_schema)),
         }
+        if self.plugin_id:
+            payload["plugin"] = {
+                "plugin_id": self.plugin_id,
+                "component_id": self.plugin_component_id,
+                "qualified_id": f"{self.plugin_id}:{self.plugin_component_id}",
+            }
+        return payload
+
+
+@dataclass(frozen=True)
+class PluginTool:
+    """One plugin-owned MCP tool specification and executable handler.
+
+    Validated SDK components expose a ``openmed_tools`` attribute or zero-arg
+    method returning one or more of these declarations. The runtime attaches
+    stable plugin provenance to the supplied :class:`ToolSpec` before adding it
+    alongside first-party tools.
+
+    Args:
+        spec: Versioned schemas and user-facing metadata for the tool.
+        handler: Callable returning an object matching ``spec.output_schema``.
+    """
+
+    spec: ToolSpec
+    handler: Callable[..., Mapping[str, Any]]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.spec, ToolSpec):
+            raise TypeError("PluginTool.spec must be a ToolSpec")
+        if not callable(self.handler):
+            raise TypeError("PluginTool.handler must be callable")
 
 
 @dataclass(frozen=True)
@@ -270,21 +313,38 @@ class ToolRegistry:
         self,
         specs: Iterable[ToolSpec] = (),
         workflows: Iterable[WorkflowSpec] = (),
+        *,
+        plugin_loader: Callable[["ToolRegistry"], Any] | None = None,
     ) -> None:
         self._specs: dict[tuple[str, str], ToolSpec] = {}
         self._workflows: dict[tuple[str, str], WorkflowSpec] = {}
+        self._handlers: dict[tuple[str, str], Callable[..., Mapping[str, Any]]] = {}
+        self._plugin_loader = plugin_loader
+        self._plugin_loader_started = False
+        self._plugin_loader_lock = RLock()
         for spec in specs:
             self.register(spec)
         for workflow in workflows:
             self.register_workflow(workflow)
 
-    def register(self, spec: ToolSpec) -> None:
+    def register(
+        self,
+        spec: ToolSpec,
+        *,
+        handler: Callable[..., Mapping[str, Any]] | None = None,
+    ) -> None:
         """Register one tool spec version."""
 
+        if not isinstance(spec, ToolSpec):
+            raise TypeError("register expects a ToolSpec")
+        if handler is not None and not callable(handler):
+            raise TypeError("tool handler must be callable")
         key = (spec.name, spec.version)
         if key in self._specs:
             raise ValueError(f"duplicate tool spec {spec.name!r} {spec.version!r}")
         self._specs[key] = spec
+        if handler is not None:
+            self._handlers[key] = handler
 
     def register_workflow(self, spec: WorkflowSpec) -> None:
         """Register one discoverable workflow spec version."""
@@ -303,6 +363,7 @@ class ToolRegistry:
     def get(self, name: str, version: str | None = None) -> ToolSpec:
         """Return one spec by name and optional version."""
 
+        self._ensure_runtime_plugins()
         if version is not None:
             try:
                 return self._specs[(name, version)]
@@ -317,12 +378,14 @@ class ToolRegistry:
     def latest_specs(self) -> tuple[ToolSpec, ...]:
         """Return the latest version of each registered tool, sorted by name."""
 
+        self._ensure_runtime_plugins()
         names = sorted({name for name, _version in self._specs})
         return tuple(self.get(name) for name in names)
 
     def all_specs(self) -> tuple[ToolSpec, ...]:
         """Return all registered specs sorted by name and semantic version."""
 
+        self._ensure_runtime_plugins()
         return tuple(
             sorted(
                 self._specs.values(),
@@ -333,6 +396,7 @@ class ToolRegistry:
     def get_workflow(self, name: str, version: str | None = None) -> WorkflowSpec:
         """Return one workflow spec by name and optional version."""
 
+        self._ensure_runtime_plugins()
         if version is not None:
             try:
                 return self._workflows[(name, version)]
@@ -347,6 +411,7 @@ class ToolRegistry:
     def workflow_specs(self) -> tuple[WorkflowSpec, ...]:
         """Return all workflow specs sorted by name and semantic version."""
 
+        self._ensure_runtime_plugins()
         return tuple(
             sorted(
                 self._workflows.values(),
@@ -357,11 +422,167 @@ class ToolRegistry:
     def document(self) -> JsonObject:
         """Return the generated machine-readable registry document."""
 
+        self._ensure_runtime_plugins()
         return {
             "schema_version": "1.1.0",
             "tools": [spec.document() for spec in self.all_specs()],
             "workflows": [spec.document() for spec in self.workflow_specs()],
         }
+
+    def handler(
+        self,
+        name: str,
+        version: str | None = None,
+    ) -> Callable[..., Mapping[str, Any]]:
+        """Return a plugin-owned handler by tool name and optional version."""
+
+        spec = self.get(name, version)
+        try:
+            return self._handlers[(spec.name, spec.version)]
+        except KeyError as exc:
+            raise KeyError(f"tool spec {spec.name!r} has no registry handler") from exc
+
+    def registered_handlers(self) -> dict[str, Callable[..., Mapping[str, Any]]]:
+        """Return handlers for the latest plugin-owned tool versions."""
+
+        self._ensure_runtime_plugins()
+        handlers: dict[str, Callable[..., Mapping[str, Any]]] = {}
+        for spec in self.latest_specs():
+            handler = self._handlers.get((spec.name, spec.version))
+            if handler is not None:
+                handlers[spec.name] = handler
+        return handlers
+
+    def _ensure_runtime_plugins(self) -> None:
+        loader = self._plugin_loader
+        if loader is None or self._plugin_loader_started:
+            return
+        with self._plugin_loader_lock:
+            if self._plugin_loader_started:
+                return
+            self._plugin_loader_started = True
+            try:
+                loader(self)
+            except Exception as exc:  # pragma: no cover - defensive plugin boundary
+                logger.warning(
+                    "Failed to wire OpenMed SDK tools: %s",
+                    exc.__class__.__name__,
+                )
+
+
+def discover_plugin_tools(
+    *,
+    registry: ToolRegistry | None = None,
+    allow_network_egress: bool = False,
+    allow_non_permissive_licenses: bool = False,
+    opt_in_plugins: Sequence[str] = (),
+) -> tuple[ToolSpec, ...]:
+    """Discover validated SDK components and register their MCP tools.
+
+    The SDK registry performs protocol and policy validation before this bridge
+    inspects a component's optional ``openmed_tools`` declarations.
+
+    Args:
+        registry: Target tool registry. Defaults to :data:`TOOL_REGISTRY`.
+        allow_network_egress: Allow SDK plugins declaring network access.
+        allow_non_permissive_licenses: Allow restricted plugin licenses.
+        opt_in_plugins: Plugin or qualified component ids explicitly enabled.
+
+    Returns:
+        Tool specs registered from accepted plugin components.
+    """
+
+    try:
+        registrations = _iter_sdk_plugins(
+            allow_network_egress=allow_network_egress,
+            allow_non_permissive_licenses=allow_non_permissive_licenses,
+            opt_in_plugins=opt_in_plugins,
+        )
+    except Exception as exc:  # pragma: no cover - defensive SDK boundary
+        logger.warning(
+            "Failed to discover OpenMed SDK tools: %s",
+            exc.__class__.__name__,
+        )
+        return ()
+    target = registry if registry is not None else TOOL_REGISTRY
+    return register_plugin_tools(registrations, registry=target)
+
+
+def register_plugin_tools(
+    registrations: Iterable[Any],
+    *,
+    registry: ToolRegistry,
+) -> tuple[ToolSpec, ...]:
+    """Register tools exposed by validated SDK component registrations."""
+
+    registered: list[ToolSpec] = []
+    for registration in registrations:
+        try:
+            declarations = _plugin_tool_declarations(registration.component)
+            metadata = registration.metadata
+            for declaration in declarations:
+                spec = replace(
+                    declaration.spec,
+                    plugin_id=metadata.plugin_id,
+                    plugin_component_id=metadata.component_id,
+                )
+                key = (spec.name, spec.version)
+                with registry._plugin_loader_lock:
+                    existing = registry._specs.get(key)
+                    if existing is None:
+                        registry.register(spec, handler=declaration.handler)
+                    elif existing != spec:
+                        raise ValueError(
+                            f"plugin tool conflicts with registered tool {spec.name!r}"
+                        )
+                registered.append(spec)
+        except Exception as exc:
+            logger.warning(
+                "Failed to wire OpenMed SDK tools for %s: %s",
+                _safe_registration_id(registration),
+                exc.__class__.__name__,
+            )
+    return tuple(registered)
+
+
+def _plugin_tool_declarations(component: Any) -> tuple[PluginTool, ...]:
+    value = getattr(component, "openmed_tools", ())
+    if callable(value) and not isinstance(value, PluginTool):
+        value = value()
+    if isinstance(value, PluginTool):
+        return (value,)
+    if value is None:
+        return ()
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes, Mapping)):
+        declarations = tuple(value)
+        if any(not isinstance(item, PluginTool) for item in declarations):
+            raise TypeError("openmed_tools must contain PluginTool declarations")
+        return declarations
+    raise TypeError("openmed_tools must be a PluginTool or iterable of PluginTool")
+
+
+def _iter_sdk_plugins(**policy: Any) -> tuple[Any, ...]:
+    """Return SDK registrations without importing plugins at module import."""
+
+    try:
+        plugin_registry = import_module("openmed.plugins.registry")
+    except ModuleNotFoundError as exc:
+        if exc.name in {"openmed.plugins.protocols", "openmed.plugins.registry"}:
+            return ()
+        raise
+    return tuple(plugin_registry.iter_plugins(None, **policy))
+
+
+def _safe_registration_id(registration: Any) -> str:
+    try:
+        value = registration.metadata.qualified_id
+    except Exception:
+        return "<unknown>"
+    return value if isinstance(value, str) and value else "<unknown>"
+
+
+def _default_plugin_tool_loader(registry: ToolRegistry) -> None:
+    discover_plugin_tools(registry=registry)
 
 
 def input_schema(parameters: Sequence[ToolParameter]) -> JsonSchema:
@@ -1821,6 +2042,7 @@ CLINICAL_WORKFLOW_SPEC = WorkflowSpec(
 TOOL_REGISTRY = ToolRegistry(
     TOOL_SPECS,
     workflows=(CLINICAL_WORKFLOW_SPEC,),
+    plugin_loader=_default_plugin_tool_loader,
 )
 
 __all__ = [
@@ -1829,6 +2051,7 @@ __all__ = [
     "CLINICAL_WORKFLOW_SPEC",
     "TOOL_REGISTRY",
     "TOOL_SPECS",
+    "PluginTool",
     "ToolCompatibilityError",
     "ToolParameter",
     "ToolRegistry",
@@ -1837,6 +2060,7 @@ __all__ = [
     "WorkflowArtifactSpec",
     "WorkflowSpec",
     "check_tool_registry_compatibility",
+    "discover_plugin_tools",
     "input_schema",
     "invoke_tool",
     "render_adapter_tool_definitions",
@@ -1844,6 +2068,7 @@ __all__ = [
     "render_mcp_tool",
     "render_presidio_tool_definitions",
     "render_tool_registry_document",
+    "register_plugin_tools",
     "validate_registered_tool_output",
     "validate_registered_workflow_artifact",
     "validate_tool_output",

--- a/tests/unit/core/test_detector_plugins.py
+++ b/tests/unit/core/test_detector_plugins.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
@@ -135,6 +136,56 @@ def test_fake_entry_point_is_discovered_once_without_explicit_registration(
         "fake_clinical"
     ]
     assert calls == 1
+
+
+def test_sdk_recognizer_participates_in_pipeline_arbitration(monkeypatch):
+    marker = "OPENMED_SYNTHETIC_PERSON"
+
+    class SyntheticRecognizer:
+        def recognize(self, text: str, **kwargs):
+            del kwargs
+            return (_plugin_span(text, marker),)
+
+    metadata = SimpleNamespace(
+        plugin_id="synthetic-runtime-plugin",
+        component_id="marker-recognizer",
+        qualified_id="synthetic-runtime-plugin:marker-recognizer",
+        kind="recognizer",
+        labels=("PERSON",),
+        languages=("en",),
+        metadata={},
+    )
+    registration = SimpleNamespace(
+        metadata=metadata,
+        component=SyntheticRecognizer(),
+        loaded_by_policy_opt_in=False,
+    )
+
+    monkeypatch.setattr(
+        detector_plugins.importlib_metadata,
+        "entry_points",
+        lambda *, group=None: (),
+    )
+    monkeypatch.setattr(
+        detector_plugins,
+        "_iter_sdk_plugins",
+        lambda kind, **policy: (registration,),
+    )
+
+    result = Pipeline(
+        model_detector=lambda text, **kwargs: _empty_prediction(
+            text,
+            kwargs["model_name"],
+        ),
+        use_safety_sweep=False,
+    ).run(f"Synthetic fixture {marker}", method="mask")
+
+    arbitration_span = result.stage("span_arbitration").spans[0]
+    assert arbitration_span.canonical_label == "PERSON"
+    assert (
+        arbitration_span.detector == "plugin:synthetic-runtime-plugin:marker-recognizer"
+    )
+    assert result.redacted_text == "Synthetic fixture [PERSON]"
 
 
 def test_broken_entry_point_logs_warning_and_pipeline_continues(

--- a/tests/unit/interop/test_core_does_not_import_adapters.py
+++ b/tests/unit/interop/test_core_does_not_import_adapters.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 
 import pytest
+
+import openmed.interop as interop
 
 OPTIONAL_ADAPTER_MODULE_PREFIXES = (
     "duckdb",
@@ -28,6 +31,13 @@ OPTIONAL_ADAPTER_MODULE_PREFIXES = (
     "scrubadub",
     "spacy",
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime_plugin_adapters():
+    interop._reset_plugin_adapters_for_tests()
+    yield
+    interop._reset_plugin_adapters_for_tests()
 
 
 def _clear_optional_adapter_modules() -> None:
@@ -111,6 +121,77 @@ def test_import_interop_registry_does_not_import_optional_adapter_dependencies()
     assert adapter_spec("zh").extra == "zh"
     assert "openmed.interop.icd11_api" not in sys.modules
     assert not any(_is_optional_adapter_module(name) for name in sys.modules)
+
+
+def test_sdk_adapters_and_exporters_share_registry_with_explicit_policy_opt_in(
+    monkeypatch,
+):
+    class SyntheticAdapter:
+        def to_openmed_spans(self, payload, **kwargs):
+            del payload, kwargs
+            return ()
+
+        def from_openmed_spans(self, spans, **kwargs):
+            del spans, kwargs
+            return {"schema": "synthetic-adapter.v1"}
+
+    class SyntheticExporter:
+        def export(self, spans, **kwargs):
+            del spans, kwargs
+            return {"schema": "synthetic-exporter.v1"}
+
+    def registration(component_id, kind, component, *, opted_in=False):
+        metadata = SimpleNamespace(
+            plugin_id="synthetic-interop-plugin",
+            component_id=component_id,
+            qualified_id=f"synthetic-interop-plugin:{component_id}",
+            kind=kind,
+            name=f"Synthetic {kind}",
+            description=f"Offline synthetic {kind}",
+        )
+        return SimpleNamespace(
+            metadata=metadata,
+            component=component,
+            loaded_by_policy_opt_in=opted_in,
+        )
+
+    adapter = registration(
+        "record-adapter",
+        "interop_adapter",
+        SyntheticAdapter(),
+    )
+    restricted_exporter = registration(
+        "restricted-exporter",
+        "exporter",
+        SyntheticExporter(),
+        opted_in=True,
+    )
+
+    def fake_iter_sdk_plugins(**policy):
+        registrations = [adapter]
+        if "synthetic-interop-plugin:restricted-exporter" in policy["opt_in_plugins"]:
+            registrations.append(restricted_exporter)
+        return tuple(registrations)
+
+    monkeypatch.setattr(interop, "_iter_sdk_plugins", fake_iter_sdk_plugins)
+
+    default_specs = interop.discover_plugin_adapters()
+    assert [spec.qualified_id for spec in default_specs] == [
+        "synthetic-interop-plugin:record-adapter"
+    ]
+    assert "synthetic-interop-plugin:restricted-exporter" not in (
+        interop.available_adapters()
+    )
+
+    interop.discover_plugin_adapters(
+        opt_in_plugins=("synthetic-interop-plugin:restricted-exporter",)
+    )
+
+    exporter_name = "synthetic-interop-plugin:restricted-exporter"
+    assert exporter_name in interop.available_adapters()
+    assert interop.adapter_spec(exporter_name).kind == "exporter"
+    assert interop.adapter_spec(exporter_name).loaded_by_policy_opt_in is True
+    assert interop.get_adapter(exporter_name) is restricted_exporter.component
 
 
 def test_presidio_adapter_missing_extra_raises_clear_import_error(monkeypatch):

--- a/tests/unit/mcp/test_tool_registry.py
+++ b/tests/unit/mcp/test_tool_registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 from copy import deepcopy
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -23,12 +24,14 @@ from openmed.mcp import server as mcp_server
 from openmed.mcp.tool_registry import (
     CLINICAL_STAGE_ORDER,
     TOOL_REGISTRY,
+    PluginTool,
     ToolCompatibilityError,
     ToolRegistry,
     ToolSchemaValidationError,
     ToolSpec,
     check_tool_registry_compatibility,
     invoke_tool,
+    register_plugin_tools,
     validate_registered_tool_output,
 )
 
@@ -189,6 +192,68 @@ def test_registry_supports_multiple_versions_side_by_side() -> None:
         "1.0.0",
         "2.0.0",
     ]
+
+
+def test_valid_plugin_tool_is_lazily_registered_with_stable_metadata() -> None:
+    tool = PluginTool(
+        spec=ToolSpec(
+            name="synthetic_plugin_status",
+            title="Synthetic Plugin Status",
+            description="Return deterministic synthetic plugin status.",
+            version="1.2.0",
+            stability="stable",
+            input_schema={
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {},
+                "required": [],
+            },
+            output_schema={
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {"status": {"type": "string"}},
+                "required": ["status"],
+            },
+            read_only_hint=True,
+            destructive_hint=False,
+            idempotent_hint=True,
+            open_world_hint=False,
+        ),
+        handler=lambda: {"status": "synthetic-ok"},
+    )
+
+    class ToolBearingComponent:
+        openmed_tools = (tool,)
+
+    metadata = SimpleNamespace(
+        plugin_id="synthetic-tool-plugin",
+        component_id="status-component",
+        qualified_id="synthetic-tool-plugin:status-component",
+    )
+    registration = SimpleNamespace(
+        metadata=metadata,
+        component=ToolBearingComponent(),
+        loaded_by_policy_opt_in=False,
+    )
+    registry = ToolRegistry(
+        plugin_loader=lambda target: register_plugin_tools(
+            (registration,),
+            registry=target,
+        )
+    )
+
+    assert [spec.name for spec in registry.latest_specs()] == [
+        "synthetic_plugin_status"
+    ]
+    spec = registry.get("synthetic_plugin_status")
+    assert spec.version == "1.2.0"
+    assert spec.stability == "stable"
+    assert spec.document()["plugin"] == {
+        "plugin_id": "synthetic-tool-plugin",
+        "component_id": "status-component",
+        "qualified_id": "synthetic-tool-plugin:status-component",
+    }
+    assert invoke_tool(spec, registry.handler(spec.name)) == {"status": "synthetic-ok"}
 
 
 @pytest.mark.parametrize("tool_name", sorted(CLINICAL_TOOL_NAMES))


### PR DESCRIPTION
# Pull Request

## Description
Wires SDK-validated plugin components into the runtime surfaces where recognizers, interop adapters, exporters, and MCP tools are consumed. Discovery stays lazy so a bare `import openmed` does not enumerate entry points or import optional plugin dependencies.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Adapted validated SDK recognizers into detector specs so their spans pass through the existing pipeline arbitration and privacy-safe provenance handling.
- Added lazy exporter and interop-adapter registration to the existing interop registry, with SDK policy flags forwarded for explicit opt-in.
- Added typed plugin-owned MCP tool declarations, stable plugin provenance in registry documents, and handler routing across MCP and framework tool surfaces.
- Kept all runtime bridges compatible with the pending core SDK registry contract in #1324 without including that sibling's implementation.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Relevant unit tests pass locally with my changes
- [x] I have tested this change with different plugin inputs

Commands and checks run:
- `.venv/bin/python -m pytest tests/unit/core/test_detector_plugins.py tests/unit/interop/test_core_does_not_import_adapters.py tests/unit/mcp/test_tool_registry.py tests/unit/interop/test_tool_schema_sync.py -q` (39 passed)
- Ruff format, Ruff check, and Ruff format-check on the eight changed files
- `.venv/bin/pre-commit run --files <eight changed files>`
- Disposable compatibility merge with `feature/v21-child-1324` plus an offline editable install of the shipped example plugin; installed entry-point recognizer arbitration and exporter registration passed

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

User-facing SDK stability documentation remains scoped to #1327.

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented the runtime discovery boundaries where behavior is non-obvious
- [x] My changes generate no new warnings

Validation was intentionally limited to changed files and explicit test files.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1326

Parent epic: #1283

## Screenshots/Examples
Not applicable; this change adds Python runtime registry wiring and synthetic offline tests.
