### PR TITLE
feat: record and gate multimodal dependency licenses (OM-092, closes #257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged; opt-in spans are normalized to OpenMed's exact contiguous-offset
   contract, with explicit errors for missing dependencies, unknown backends,
   and conflicting preconstructed segmenters (#1848).
+- Added a verified dependency-license record for the `[multimodal]` and `[ocr-paddle]`
+  extras (`openmed/multimodal/_licenses.py`) carrying the SPDX identifier, source URL, and verification date for each pinned distribution, plus the Tesseract system-binary license and the TCIA per-collection dataset caveat. A new test gate reuses the permissive-only license policy to fail when a pinned dependency is unrecorded, has drifted from `pyproject.toml`, is not permissive, or is imported in-process contrary to invariant I2. pydicom is confirmed MIT, replacing the previous "license unverified" caveat (#257).
 
 ### Fixed
 

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -174,6 +174,7 @@ classification:
     - hl7v2-deidentification.md
     - compliance.md
     - compliance/api-deprecation-policy.md
+    - compliance/multimodal-dependency-licenses.md
     - compliance/africa-malabo-baseline.md
     - compliance/north-africa-pdpl-0908-checklist.md
     - compliance/africa-data-residency-guide.md

--- a/docs/compliance/multimodal-dependency-licenses.md
+++ b/docs/compliance/multimodal-dependency-licenses.md
@@ -1,0 +1,110 @@
+# Multimodal dependency licenses
+
+The `[multimodal]` and `[ocr-paddle]` extras pull document, image, and DICOM
+ingestion libraries into the OpenMed process. Invariant I2 requires that
+everything running in-process is permissively licensed, and that GPL,
+source-available, or proprietary tools are reached only through an
+out-of-process bridge in `openmed/interop/bridges/`.
+
+This page is the human-readable view of the license record. The authoritative,
+machine-checkable copy is `openmed/multimodal/_licenses.py`, enforced by
+`tests/unit/multimodal/test_multimodal_licenses.py`. Adding a dependency to
+either extra without recording its license fails the test suite.
+
+Licenses below were read from each project's PyPI metadata and verified on
+**2026-08-03**.
+
+## Python dependencies
+
+| Distribution | SPDX | Source |
+| --- | --- | --- |
+| easyocr | `Apache-2.0` | [PyPI](https://pypi.org/project/easyocr/) |
+| markdown-it-py | `MIT` | [PyPI](https://pypi.org/project/markdown-it-py/) |
+| numpy | `BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0` | [PyPI](https://pypi.org/project/numpy/) |
+| onnx | `Apache-2.0` | [PyPI](https://pypi.org/project/onnx/) |
+| paddleocr | `Apache-2.0` | [PyPI](https://pypi.org/project/paddleocr/) |
+| pdfplumber | `MIT` | [PyPI](https://pypi.org/project/pdfplumber/) |
+| piexif | `MIT` | [PyPI](https://pypi.org/project/piexif/) |
+| pikepdf | `MPL-2.0` | [PyPI](https://pypi.org/project/pikepdf/) |
+| pillow | `MIT-CMU` | [PyPI](https://pypi.org/project/pillow/) |
+| pydicom | `MIT` | [PyPI](https://pypi.org/project/pydicom/) |
+| pytesseract | `Apache-2.0` | [PyPI](https://pypi.org/project/pytesseract/) |
+| python-docx | `MIT` | [PyPI](https://pypi.org/project/python-docx/) |
+| python-doctr | `Apache-2.0` | [PyPI](https://pypi.org/project/python-doctr/) |
+
+`paddleocr` is pinned by the `ocr-paddle` extra; every other entry is pinned by
+`multimodal`. The split is a packaging decision because paddlepaddle is heavy and platform-sensitive.
+
+Every entry is on the permissive allow-list in
+`scripts/release/check_license_policy.py`, so all of them may be imported
+in-process. None of the multimodal extras currently requires a subprocess
+bridge.
+
+### Entries that need a note
+
+**pydicom — MIT, verified.** Earlier roadmap revisions (sec 2.2c, 5.8, 4.6)
+carried a "license unverified — confirm before bundling" caveat against
+pydicom and the deid library. That caveat is resolved: pydicom publishes MIT
+and is safe to bundle in-process. The record supersedes the roadmap note.
+
+**pikepdf — MPL-2.0.** The one weak-copyleft entry. MPL-2.0 obligations attach at *file* scope: distributing a modified pikepdf source file requires
+publishing that file's source, but importing pikepdf from OpenMed code imposes no obligation on OpenMed's own sources. The repository license policy lists `MPL-2.0` as allowed for this reason. If OpenMed ever vendors or patches pikepdf source, the modified files must be published under MPL-2.0.
+
+**pillow — MIT-CMU.** Pillow publishes `MIT-CMU`, the current SPDX identifier
+for the HPND-style license it has always carried. The OM-036 reviewed-license
+table spells the same license `HPND`. Both are permissive and both pass the
+gate; the tests compare policy outcomes rather than license strings so the two
+spellings do not conflict.
+
+**numpy — multi-license expression.** The expression covers vendored components. Every term is permissive; none is copyleft.
+
+## OCR system binaries
+
+`pytesseract` is a thin wrapper: it shells out to a Tesseract binary the user
+installs through a system package manager. That binary is not in the Python
+dependency graph, so the pyproject-driven gate cannot see it and its license is
+recorded separately.
+
+| Binary | SPDX | Engine | Source |
+| --- | --- | --- | --- |
+| Tesseract OCR | `Apache-2.0` | `tesseract` | [LICENSE](https://github.com/tesseract-ocr/tesseract/blob/main/LICENSE) |
+
+OpenMed does not redistribute the Tesseract binary. Users obtain it themselves
+(`brew install tesseract`, `apt-get install tesseract-ocr`), so no bundling
+obligation arises; the license is recorded for downstream users who package
+OpenMed together with its OCR runtime.
+
+## Dataset caveat: TCIA collections
+
+The Cancer Imaging Archive is the most likely source a contributor reaches for
+when testing the DICOM path, and its terms do **not** follow pydicom's license.
+
+TCIA licenses data **per collection, not archive-wide**. Individual collections
+range from CC BY through to restricted terms requiring explicit permission. No
+TCIA collection may be committed as a test fixture or bundled with OpenMed
+without checking that specific collection's license first. Use synthetic DICOM
+fixtures instead, consistent with the repository rule that committed golden
+data must be synthetic.
+
+See [TCIA data usage policies](https://www.cancerimagingarchive.net/data-usage-policies-and-restrictions/).
+
+## Scope
+
+This page covers the `[multimodal]` and `[ocr-paddle]` extras only. The
+repository-wide dependency license gate is OM-036
+(`scripts/release/check_license_policy.py`), which audits every non-dev extra
+and runs in CI. SBOM and supply-chain scanning are tracked separately.
+
+## Re-verifying
+
+Re-check a license against upstream metadata with:
+
+```bash
+curl -s https://pypi.org/pypi/pydicom/json \
+  | python3 -c "import json,sys; i=json.load(sys.stdin)['info']; \
+print(i.get('license_expression') or i.get('license'), \
+[c for c in i['classifiers'] if c.startswith('License')])"
+```
+
+When a license changes, update the SPDX value **and** the `verified_on` date in
+`openmed/multimodal/_licenses.py`, then update the table above.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
       - HL7 v2 De-identification: hl7v2-deidentification.md
       - Compliance Posture: compliance.md
       - Public API Deprecation Policy: compliance/api-deprecation-policy.md
+      - Multimodal Dependency Licenses: compliance/multimodal-dependency-licenses.md
       - Pan-African Malabo Baseline: compliance/africa-malabo-baseline.md
       - Egypt PDPL & Morocco Law 09-08: compliance/north-africa-pdpl-0908-checklist.md
       - Africa Data-Residency Guide: compliance/africa-data-residency-guide.md

--- a/openmed/multimodal/_licenses.py
+++ b/openmed/multimodal/_licenses.py
@@ -1,0 +1,253 @@
+"""Verified license record for dependencies"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = [
+    "DependencyLicense",
+    "SystemBinaryLicense",
+    "MULTIMODAL_EXTRAS",
+    "MULTIMODAL_DEPENDENCY_LICENSES",
+    "SYSTEM_BINARY_LICENSES",
+    "TCIA_COLLECTION_CAVEAT",
+    "normalize_distribution",
+    "license_for",
+    "recorded_distributions",
+]
+
+# Optional-dependency groups in pyproject.toml that this record covers.
+MULTIMODAL_EXTRAS = ("multimodal", "ocr-paddle")
+
+_NORMALIZE_RE = re.compile(r"[-_.]+")
+
+
+@dataclass(frozen=True)
+class DependencyLicense:
+    """A verified license for one distribution pinned by a multimodal extra.
+
+    Attributes:
+        distribution: PEP 503 normalized distribution name on PyPI.
+        spdx: SPDX license expression as published by the project.
+        source_url: Where the license was read from during verification.
+        verified_on: ISO-8601 date the license was last confirmed.
+        in_process: Whether OpenMed imports the package into its own process.
+            Permissive-only packages may; anything else must go through
+            :mod:`openmed.interop.bridges` to preserve invariant I2.
+        note: Optional clarification, used where the SPDX identifier alone is
+            misleading or where policy needs an explicit rationale.
+    """
+
+    distribution: str
+    spdx: str
+    source_url: str
+    verified_on: str
+    in_process: bool = True
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class SystemBinaryLicense:
+    """A verified license for a non-PyPI system binary an OCR engine shells to.
+
+    Attributes:
+        name: Human-readable binary or project name.
+        spdx: SPDX license expression for the binary.
+        source_url: Where the license was read from during verification.
+        verified_on: ISO-8601 date the license was last confirmed.
+        engine: OpenMed OCR engine name that invokes the binary.
+        note: Why the binary is outside the Python dependency graph.
+    """
+
+    name: str
+    spdx: str
+    source_url: str
+    verified_on: str
+    engine: str
+    note: str = ""
+
+
+# Verified against the PyPI project metadata for each distribution on the date
+# recorded below. Keep this tuple sorted by distribution name.
+MULTIMODAL_DEPENDENCY_LICENSES: tuple[DependencyLicense, ...] = (
+    DependencyLicense(
+        distribution="easyocr",
+        spdx="Apache-2.0",
+        source_url="https://pypi.org/project/easyocr/",
+        verified_on="2026-08-03",
+    ),
+    DependencyLicense(
+        distribution="markdown-it-py",
+        spdx="MIT",
+        source_url="https://pypi.org/project/markdown-it-py/",
+        verified_on="2026-08-03",
+    ),
+    DependencyLicense(
+        distribution="numpy",
+        spdx="BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0",
+        source_url="https://pypi.org/project/numpy/",
+        verified_on="2026-08-03",
+        note=(
+            "Multi-license expression covering vendored components; every "
+            "term is permissive and none is copyleft."
+        ),
+    ),
+    DependencyLicense(
+        distribution="onnx",
+        spdx="Apache-2.0",
+        source_url="https://pypi.org/project/onnx/",
+        verified_on="2026-08-03",
+    ),
+    DependencyLicense(
+        distribution="paddleocr",
+        spdx="Apache-2.0",
+        source_url="https://pypi.org/project/paddleocr/",
+        verified_on="2026-08-03",
+        note=(
+            "Split into its own extra because paddlepaddle is heavy and "
+            "platform-sensitive, not for licensing reasons."
+        ),
+    ),
+    DependencyLicense(
+        distribution="pdfplumber",
+        spdx="MIT",
+        source_url="https://pypi.org/project/pdfplumber/",
+        verified_on="2026-08-03",
+    ),
+    DependencyLicense(
+        distribution="piexif",
+        spdx="MIT",
+        source_url="https://pypi.org/project/piexif/",
+        verified_on="2026-08-03",
+    ),
+    DependencyLicense(
+        distribution="pikepdf",
+        spdx="MPL-2.0",
+        source_url="https://pypi.org/project/pikepdf/",
+        verified_on="2026-08-03",
+        note=(
+            "Weak copyleft at file scope. Permitted in-process by the "
+            "repository license policy, which lists MPL-2.0 as allowed: "
+            "obligations attach to modified pikepdf source files, not to "
+            "OpenMed code that merely imports it. Contributing patches back "
+            "to pikepdf itself would trigger MPL disclosure for those files."
+        ),
+    ),
+    DependencyLicense(
+        distribution="pillow",
+        spdx="MIT-CMU",
+        source_url="https://pypi.org/project/pillow/",
+        verified_on="2026-08-03",
+        note=(
+            "Pillow publishes MIT-CMU, the current SPDX identifier for the "
+            "HPND-style license it has always used. Permissive either way."
+        ),
+    ),
+    DependencyLicense(
+        distribution="pydicom",
+        spdx="MIT",
+        source_url="https://pypi.org/project/pydicom/",
+        verified_on="2026-08-03",
+        note=(
+            "Supersedes the roadmap's 'license unverified - confirm before "
+            "bundling' caveat (sec 2.2c/5.8/4.6). Confirmed MIT; safe to "
+            "bundle in-process."
+        ),
+    ),
+    DependencyLicense(
+        distribution="pytesseract",
+        spdx="Apache-2.0",
+        source_url="https://pypi.org/project/pytesseract/",
+        verified_on="2026-08-03",
+        note=(
+            "Wrapper only. The Tesseract binary it drives is licensed "
+            "separately; see SYSTEM_BINARY_LICENSES."
+        ),
+    ),
+    DependencyLicense(
+        distribution="python-docx",
+        spdx="MIT",
+        source_url="https://pypi.org/project/python-docx/",
+        verified_on="2026-08-03",
+    ),
+    DependencyLicense(
+        distribution="python-doctr",
+        spdx="Apache-2.0",
+        source_url="https://pypi.org/project/python-doctr/",
+        verified_on="2026-08-03",
+    ),
+)
+
+# OCR engines shell out to binaries the user installs themselves. These are not
+# in the Python dependency graph, so the pyproject-driven gate cannot see them.
+SYSTEM_BINARY_LICENSES: tuple[SystemBinaryLicense, ...] = (
+    SystemBinaryLicense(
+        name="Tesseract OCR",
+        spdx="Apache-2.0",
+        source_url="https://github.com/tesseract-ocr/tesseract/blob/main/LICENSE",
+        verified_on="2026-08-03",
+        engine="tesseract",
+        note=(
+            "Installed by the user via a system package manager and invoked "
+            "as a subprocess by pytesseract. Not redistributed by OpenMed."
+        ),
+    ),
+)
+
+# DICOM corpora are data, not dependencies, and their terms do not follow the
+# pydicom license. Recorded here because the DICOM path is the most likely
+# place for a contributor to reach for public imaging data.
+TCIA_COLLECTION_CAVEAT = (
+    "The Cancer Imaging Archive (TCIA) licenses data per collection, not "
+    "archive-wide. Individual collections range from CC BY to restricted "
+    "terms requiring explicit permission, so no TCIA collection may be "
+    "committed as a test fixture or bundled with OpenMed without checking "
+    "that specific collection's license. Use synthetic DICOM fixtures "
+    "instead. See https://www.cancerimagingarchive.net/data-usage-policies-"
+    "and-restrictions/"
+)
+
+
+def normalize_distribution(name: str) -> str:
+    """Normalize a distribution name according to PEP 503.
+
+    Args:
+        name: Raw distribution name, e.g. ``"Pillow"`` or ``"python_docx"``.
+
+    Returns:
+        The normalized name, e.g. ``"pillow"`` or ``"python-docx"``.
+    """
+
+    return _NORMALIZE_RE.sub("-", name).lower()
+
+
+def recorded_distributions() -> frozenset[str]:
+    """Return the normalized distribution names covered by this record.
+
+    Returns:
+        Every distribution name in :data:`MULTIMODAL_DEPENDENCY_LICENSES`.
+    """
+
+    return frozenset(
+        normalize_distribution(entry.distribution)
+        for entry in MULTIMODAL_DEPENDENCY_LICENSES
+    )
+
+
+def license_for(name: str) -> DependencyLicense | None:
+    """Look up the verified license record for a distribution.
+
+    Args:
+        name: Distribution name, normalized or not.
+
+    Returns:
+        The matching :class:`DependencyLicense`, or ``None`` when the
+        distribution is not pinned by a multimodal extra.
+    """
+
+    normalized = normalize_distribution(name)
+    for entry in MULTIMODAL_DEPENDENCY_LICENSES:
+        if normalize_distribution(entry.distribution) == normalized:
+            return entry
+    return None

--- a/tests/unit/multimodal/test_multimodal_licenses.py
+++ b/tests/unit/multimodal/test_multimodal_licenses.py
@@ -1,0 +1,252 @@
+"""License policy tests for dependencies"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from openmed.multimodal._licenses import (
+    MULTIMODAL_DEPENDENCY_LICENSES,
+    MULTIMODAL_EXTRAS,
+    SYSTEM_BINARY_LICENSES,
+    TCIA_COLLECTION_CAVEAT,
+    license_for,
+    normalize_distribution,
+    recorded_distributions,
+)
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised by Python 3.10 CI
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parents[3]
+PYPROJECT = ROOT / "pyproject.toml"
+MULTIMODAL_PACKAGE = ROOT / "openmed" / "multimodal"
+POLICY_SCRIPT = ROOT / "scripts" / "release" / "check_license_policy.py"
+
+ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+MODULE_TO_DISTRIBUTION = {
+    "PIL": "pillow",
+    "docx": "python-docx",
+    "doctr": "python-doctr",
+    "easyocr": "easyocr",
+    "markdown_it": "markdown-it-py",
+    "numpy": "numpy",
+    "onnx": "onnx",
+    "paddleocr": "paddleocr",
+    "pdfplumber": "pdfplumber",
+    "piexif": "piexif",
+    "pikepdf": "pikepdf",
+    "pydicom": "pydicom",
+    "pytesseract": "pytesseract",
+}
+
+
+def _load_policy():
+    """Load the OM-036 license gate as a module, without importing scripts/."""
+    spec = importlib.util.spec_from_file_location("check_license_policy", POLICY_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+policy = _load_policy()
+
+
+def _pinned_distributions() -> set[str]:
+    """Return the normalized distributions pinned by any multimodal extra."""
+    with PYPROJECT.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+
+    optional = pyproject["project"]["optional-dependencies"]
+    return {
+        policy.dependency_name(str(requirement))
+        for extra in MULTIMODAL_EXTRAS
+        for requirement in optional[extra]
+    }
+
+
+def _statically_imported_modules() -> set[str]:
+    """Return top-level modules imported at module scope across the package."""
+    modules: set[str] = set()
+    for path in sorted(MULTIMODAL_PACKAGE.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                modules.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                modules.add(node.module.split(".")[0])
+    return modules
+
+
+def test_every_pinned_dependency_has_a_license_record():
+    """A dependency added to a multimodal extra must be licensed-audited."""
+    missing = sorted(_pinned_distributions() - recorded_distributions())
+
+    assert not missing, (
+        f"Dependencies pinned by {list(MULTIMODAL_EXTRAS)} with no entry in "
+        f"openmed/multimodal/_licenses.py: {missing}"
+    )
+
+
+def test_record_has_no_entries_for_unpinned_dependencies():
+    """The record must not drift ahead of pyproject.toml."""
+    stale = sorted(recorded_distributions() - _pinned_distributions())
+
+    assert not stale, (
+        f"Entries in openmed/multimodal/_licenses.py that no multimodal extra "
+        f"pins any more: {stale}"
+    )
+
+
+@pytest.mark.parametrize(
+    "entry", MULTIMODAL_DEPENDENCY_LICENSES, ids=lambda e: e.distribution
+)
+def test_recorded_license_is_on_the_permissive_allow_list(entry):
+    allowed, reason = policy.is_allowed_license(entry.distribution, entry.spdx)
+
+    assert allowed, f"{entry.distribution} ({entry.spdx}) is not permissive: {reason}"
+
+
+@pytest.mark.parametrize(
+    "entry", MULTIMODAL_DEPENDENCY_LICENSES, ids=lambda e: e.distribution
+)
+def test_recorded_license_agrees_with_the_repository_gate(entry):
+    """The record and the OM-036 table must not reach opposite verdicts.
+
+    They are allowed to spell a license differently -- Pillow publishes
+    MIT-CMU where the gate's table says HPND -- so this compares policy
+    outcomes rather than strings.
+    """
+    distribution = normalize_distribution(entry.distribution)
+    gate_license = policy.resolve_license(distribution)
+    if not gate_license:
+        pytest.skip(f"{distribution} has no reviewed license in the OM-036 table")
+
+    gate_allowed, _ = policy.is_allowed_license(distribution, gate_license)
+    record_allowed, _ = policy.is_allowed_license(distribution, entry.spdx)
+
+    assert gate_allowed == record_allowed, (
+        f"{distribution}: record says {entry.spdx} (allowed={record_allowed}) "
+        f"but the OM-036 gate says {gate_license} (allowed={gate_allowed})"
+    )
+
+
+def test_a_non_permissive_dependency_would_fail_the_gate():
+    """Guard against the allow-list silently accepting everything."""
+    allowed, reason = policy.is_allowed_license("example-copyleft", "GPL-3.0-only")
+
+    assert allowed is False
+    assert "not allowed" in reason
+
+
+# --- Provenance: every claim is traceable and dated --------------------------
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [*MULTIMODAL_DEPENDENCY_LICENSES, *SYSTEM_BINARY_LICENSES],
+    ids=lambda e: getattr(e, "distribution", None) or e.name,
+)
+def test_every_record_carries_spdx_source_and_verification_date(entry):
+    label = getattr(entry, "distribution", None) or entry.name
+
+    assert entry.spdx.strip(), f"{label} has no SPDX identifier"
+    assert entry.source_url.startswith("https://"), f"{label} has no https source URL"
+    assert ISO_DATE_RE.match(entry.verified_on), (
+        f"{label} verification date {entry.verified_on!r} is not ISO-8601"
+    )
+
+
+def test_pydicom_is_recorded_as_verified_mit():
+    """OM-092: replaces the roadmap's 'license unverified' caveat."""
+    entry = license_for("pydicom")
+
+    assert entry is not None, "pydicom must carry an explicit license record"
+    assert entry.spdx == "MIT"
+    assert entry.source_url.startswith("https://")
+    assert ISO_DATE_RE.match(entry.verified_on)
+
+
+# --- Invariant I2: nothing non-permissive runs in-process --------------------
+
+
+def test_no_non_permissive_dependency_is_marked_in_process():
+    offenders = [
+        entry.distribution
+        for entry in MULTIMODAL_DEPENDENCY_LICENSES
+        if entry.in_process
+        and not policy.is_allowed_license(entry.distribution, entry.spdx)[0]
+    ]
+
+    assert not offenders, (
+        f"Invariant I2: non-permissive dependencies imported in-process by the "
+        f"multimodal package must move to openmed/interop/bridges: {offenders}"
+    )
+
+
+def test_multimodal_package_only_imports_recorded_permissive_distributions():
+    """Any third-party import in the package must trace to a permissive record."""
+    third_party = {
+        module
+        for module in _statically_imported_modules()
+        if module not in sys.stdlib_module_names
+        and module != "openmed"
+        and not module.startswith("_")
+    }
+
+    unrecorded = sorted(third_party - set(MODULE_TO_DISTRIBUTION))
+    assert not unrecorded, (
+        f"Third-party modules imported by openmed/multimodal with no known "
+        f"distribution mapping: {unrecorded}. Add them to the license record."
+    )
+
+    for module in sorted(third_party):
+        entry = license_for(MODULE_TO_DISTRIBUTION[module])
+        assert entry is not None, (
+            f"{module} maps to {MODULE_TO_DISTRIBUTION[module]}, which has no "
+            f"license record"
+        )
+        allowed, reason = policy.is_allowed_license(entry.distribution, entry.spdx)
+        assert allowed, (
+            f"Invariant I2: {module} ({entry.spdx}) is imported in-process by "
+            f"the multimodal package but is not permissive: {reason}"
+        )
+
+
+def test_module_to_distribution_map_only_names_recorded_distributions():
+    """Keep the test's module map from drifting away from the record."""
+    unknown = sorted(
+        distribution
+        for distribution in MODULE_TO_DISTRIBUTION.values()
+        if license_for(distribution) is None
+    )
+
+    assert not unknown, f"Module map names unrecorded distributions: {unknown}"
+
+
+# --- OCR system binaries and dataset caveats ---------------------------------
+
+
+def test_tesseract_system_binary_license_is_documented():
+    tesseract = next(
+        (entry for entry in SYSTEM_BINARY_LICENSES if entry.engine == "tesseract"),
+        None,
+    )
+
+    assert tesseract is not None, "The Tesseract binary license must be recorded"
+    assert tesseract.spdx == "Apache-2.0"
+
+
+def test_tcia_per_collection_caveat_is_recorded():
+    assert "per collection" in TCIA_COLLECTION_CAVEAT
+    assert "cancerimagingarchive.net" in TCIA_COLLECTION_CAVEAT


### PR DESCRIPTION
# Pull Request

## Description
Store a verified, machine-checkable license for every pinned dependency , so invariant I2 is enforced by tests. Each record carries the SPDX identifier, the source the license was read from, and the date it was verified. pydicom is confirmed MIT, replacing the roadmap's "license unverified.

The test gate reuses the existing permissive-only license policy in `scripts/release/check_license_policy.py` rather than restating which licenses are acceptable, so there is one source of truth for the allow-list.

Note on scope: `paddleocr` is covered even though `pyproject.toml` pins it under `[ocr-paddle]` rather than `[multimodal]`. The issue names it explicitly, and the split is a packaging decision (paddlepaddle is heavy and
platform-sensitive), not a licensing one. Auditing `[multimodal]` literally would have left a named dependency ungated.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- `openmed/multimodal/_licenses.py`: new license record with SPDX identifier,
  source URL, and verification date per pinned distribution; the Tesseract
  system-binary license (Apache-2.0), which sits outside the Python dependency
  graph; and the TCIA per-collection dataset caveat
- `tests/unit/multimodal/test_multimodal_licenses.py`: gate that fails when a
  pinned dependency has no record, when the record drifts ahead of
  `pyproject.toml`, when a recorded license is not on the permissive
  allow-list, or when the package statically imports an unrecorded third-party
  module (invariant I2)
- `docs/compliance/multimodal-dependency-licenses.md`: human-readable table
  with per-entry notes and re-verification instructions
- `mkdocs.yml` / `docs/brand/system/publication.yml`: register the new page in
  the nav and the publication manifest
- `CHANGELOG.md`: entry under Unreleased → Added

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

`.venv/bin/python -m pytest tests/ -q` → **10105 passed, 83 skipped, 1 xfailed, 1 failed**

The single failure is
`tests/unit/release/test_api_surface_diff.py::test_real_migration_guide_covers_every_detected_break`,
which is pre-existing and unrelated to this PR. Verified by running it in a
clean worktree at `2a9cd110` (current master, none of this branch's code),
where it fails identically.

No models or inference paths are touched, so the third box does not apply.

Test teeth were verified by mutation: flipping pydicom to GPL-3.0-only fails 4
tests, adding an unrecorded dependency to an extra fails the drift test, and
adding an unrecorded third-party import to the package fails the I2 test.

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

No Swift or `swift/OpenMedKit` files are touched, so that box does not apply.
`make type-check` also passes.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

This PR records the licenses of dependencies that are already pinned. It adds
none, and does not move any dependency between extras.

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #257
Related to #260 (training-data license tracking with a redistribution gate)

## Screenshots/Examples
Not applicable: no UI change. 