### PR TITLE
Add zero-shot family-transfer adapter routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added offline family-transfer adapter routing that prefers installed target
+  adapters, falls back to compatible donor adapters with scored provenance,
+  and returns explicit unsupported or unavailable routing failures (#1331).
 - Completed clinical temporal timeline composition with DCT/TIMEX anchors on
   every ordered event, transitively reduced public TLINK graphs, metric-ready
   edge keys, and retained/pruned privacy-safe decision provenance (#1253).

--- a/openmed/training/adapters/__init__.py
+++ b/openmed/training/adapters/__init__.py
@@ -16,10 +16,16 @@ from .config import (
     normalize_language_code,
 )
 from .family_transfer import (
+    FamilyAdapterFallback,
+    FamilyAdapterRoute,
+    FamilyTransferAdapterUnavailableError,
+    FamilyTransferRouter,
+    UnsupportedFamilyTransferLanguageError,
     adapter_metadata_for,
     donor_languages_for,
     primary_donor_for,
     resolve_family_transfer,
+    route_family_adapter,
 )
 
 __all__ = [
@@ -30,14 +36,20 @@ __all__ = [
     "DEFAULT_TRANSFER_GRAPH",
     "PERMISSIVE_ADAPTER_LICENSES",
     "AdapterMetadata",
+    "FamilyAdapterFallback",
+    "FamilyAdapterRoute",
     "FamilyTransferConfig",
+    "FamilyTransferAdapterUnavailableError",
     "FamilyTransferResolution",
+    "FamilyTransferRouter",
     "LanguageFamily",
     "TransferEdge",
+    "UnsupportedFamilyTransferLanguageError",
     "adapter_metadata_for",
     "donor_languages_for",
     "get_family_transfer_config",
     "normalize_language_code",
     "primary_donor_for",
     "resolve_family_transfer",
+    "route_family_adapter",
 ]

--- a/openmed/training/adapters/family_transfer.py
+++ b/openmed/training/adapters/family_transfer.py
@@ -2,12 +2,204 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
 from .config import (
     DEFAULT_FAMILY_TRANSFER_CONFIG,
     AdapterMetadata,
     FamilyTransferConfig,
     FamilyTransferResolution,
+    TransferEdge,
+    normalize_language_code,
 )
+
+
+class UnsupportedFamilyTransferLanguageError(ValueError):
+    """Raised when adapter routing is requested for an unknown language."""
+
+
+class FamilyTransferAdapterUnavailableError(LookupError):
+    """Raised when neither a target nor compatible donor adapter is available."""
+
+
+@dataclass(frozen=True, slots=True)
+class FamilyAdapterFallback:
+    """Scored provenance for a zero-shot donor-adapter selection.
+
+    ``score`` is routing metadata, not runtime confidence. It uses the transfer
+    edge's expected F1 floor when configured; otherwise it is a deterministic
+    reciprocal-rank score derived from donor priority. ``provenance`` records
+    which source supplied that score.
+    """
+
+    donor: str
+    target: str
+    score: float
+    provenance: str
+
+
+@dataclass(frozen=True, slots=True)
+class FamilyAdapterRoute:
+    """Resolved backbone and adapter metadata for a requested language."""
+
+    target_language: str
+    adapter_language: str
+    family_id: str
+    backbone_model_id: str
+    adapter: AdapterMetadata
+    mode: str
+    fallback: FamilyAdapterFallback | None = None
+
+
+class FamilyTransferRouter:
+    """Resolve target adapters or zero-shot family donors without network I/O."""
+
+    def __init__(
+        self,
+        available_adapters: Mapping[str, AdapterMetadata],
+        *,
+        config: FamilyTransferConfig = DEFAULT_FAMILY_TRANSFER_CONFIG,
+    ) -> None:
+        """Create an adapter router from an offline availability snapshot.
+
+        Args:
+            available_adapters: Installed adapter metadata keyed by the
+                adapter's language. Keys may include region or script suffixes.
+            config: Validated family taxonomy and ordered donor graph.
+
+        Raises:
+            TypeError: If the catalog is not a mapping or contains non-adapter
+                metadata.
+            ValueError: If catalog keys normalize to the same language.
+        """
+
+        if not isinstance(available_adapters, Mapping):
+            raise TypeError("available_adapters must be a mapping")
+        if not isinstance(config, FamilyTransferConfig):
+            raise TypeError("config must be a FamilyTransferConfig")
+
+        adapters: dict[str, AdapterMetadata] = {}
+        for raw_language, adapter in available_adapters.items():
+            language = normalize_language_code(raw_language)
+            if language in adapters:
+                raise ValueError(
+                    f"available_adapters contains duplicate language {language!r}"
+                )
+            if not isinstance(adapter, AdapterMetadata):
+                raise TypeError(
+                    "available_adapters values must be AdapterMetadata records"
+                )
+            adapters[language] = adapter
+
+        self._available_adapters = MappingProxyType(adapters)
+        self._config = config
+
+    @property
+    def available_languages(self) -> tuple[str, ...]:
+        """Return normalized languages with installed adapters."""
+
+        return tuple(sorted(self._available_adapters))
+
+    def route(self, language: str) -> FamilyAdapterRoute:
+        """Resolve a request to a target adapter or scored donor fallback.
+
+        Args:
+            language: Requested target language, optionally region-qualified.
+
+        Returns:
+            Backbone and adapter metadata for direct or zero-shot inference.
+
+        Raises:
+            UnsupportedFamilyTransferLanguageError: If the target is outside
+                the configured taxonomy.
+            FamilyTransferAdapterUnavailableError: If no direct or compatible
+                donor adapter is installed.
+        """
+
+        resolution = self._config.resolve(language)
+        if resolution is None:
+            normalized = normalize_language_code(language)
+            raise UnsupportedFamilyTransferLanguageError(
+                f"unsupported family-transfer language {normalized!r}"
+            )
+
+        target_adapter = self._available_adapters.get(resolution.language)
+        if target_adapter is not None:
+            return FamilyAdapterRoute(
+                target_language=resolution.language,
+                adapter_language=resolution.language,
+                family_id=resolution.family.family_id,
+                backbone_model_id=target_adapter.backbone_model_id,
+                adapter=target_adapter,
+                mode="target_adapter",
+            )
+
+        for edge in resolution.donor_edges:
+            donor_adapter = self._available_adapters.get(edge.donor_language)
+            if donor_adapter is None:
+                continue
+            if donor_adapter.backbone_model_id != edge.adapter.backbone_model_id:
+                continue
+            fallback = _fallback_metadata(edge, donor_adapter)
+            return FamilyAdapterRoute(
+                target_language=resolution.language,
+                adapter_language=edge.donor_language,
+                family_id=resolution.family.family_id,
+                backbone_model_id=donor_adapter.backbone_model_id,
+                adapter=donor_adapter,
+                mode="zero_shot_fallback",
+                fallback=fallback,
+            )
+
+        donors = tuple(edge.donor_language for edge in resolution.donor_edges)
+        raise FamilyTransferAdapterUnavailableError(
+            f"no target or compatible donor adapter is available for "
+            f"{resolution.language!r}; configured donors: {donors!r}"
+        )
+
+
+def _fallback_metadata(
+    edge: TransferEdge,
+    donor_adapter: AdapterMetadata,
+) -> FamilyAdapterFallback:
+    if edge.expected_f1_floor is not None:
+        score = edge.expected_f1_floor
+        score_source = "configured expected_f1_floor"
+    else:
+        score = 1.0 / (edge.priority + 1)
+        score_source = f"reciprocal rank for donor priority {edge.priority}"
+    provenance = (
+        f"{edge.adapter.provenance} Donor adapter provenance: "
+        f"{donor_adapter.provenance}. Routing score source: {score_source}."
+    )
+    return FamilyAdapterFallback(
+        donor=edge.donor_language,
+        target=edge.target_language,
+        score=score,
+        provenance=provenance,
+    )
+
+
+def route_family_adapter(
+    language: str,
+    available_adapters: Mapping[str, AdapterMetadata],
+    *,
+    config: FamilyTransferConfig = DEFAULT_FAMILY_TRANSFER_CONFIG,
+) -> FamilyAdapterRoute:
+    """Resolve one offline target request through :class:`FamilyTransferRouter`.
+
+    Args:
+        language: Requested target language.
+        available_adapters: Installed adapters keyed by language.
+        config: Validated family taxonomy and donor graph.
+
+    Returns:
+        Direct target-adapter or scored zero-shot donor route.
+    """
+
+    return FamilyTransferRouter(available_adapters, config=config).route(language)
 
 
 def resolve_family_transfer(
@@ -52,8 +244,14 @@ def adapter_metadata_for(
 
 
 __all__ = [
+    "FamilyAdapterFallback",
+    "FamilyAdapterRoute",
+    "FamilyTransferAdapterUnavailableError",
+    "FamilyTransferRouter",
+    "UnsupportedFamilyTransferLanguageError",
     "adapter_metadata_for",
     "donor_languages_for",
     "primary_donor_for",
     "resolve_family_transfer",
+    "route_family_adapter",
 ]

--- a/tests/unit/training/test_family_transfer.py
+++ b/tests/unit/training/test_family_transfer.py
@@ -11,13 +11,17 @@ from openmed.training.adapters import (
     DEFAULT_LANGUAGE_FAMILIES,
     PERMISSIVE_ADAPTER_LICENSES,
     AdapterMetadata,
+    FamilyTransferAdapterUnavailableError,
     FamilyTransferConfig,
+    FamilyTransferRouter,
     TransferEdge,
+    UnsupportedFamilyTransferLanguageError,
     adapter_metadata_for,
     donor_languages_for,
     get_family_transfer_config,
     primary_donor_for,
     resolve_family_transfer,
+    route_family_adapter,
 )
 
 
@@ -41,6 +45,13 @@ def _edge(
             provenance="Synthetic offline unit-test adapter metadata",
         ),
         priority=priority,
+    )
+
+
+def _available_adapter(language: str) -> AdapterMetadata:
+    return AdapterMetadata(
+        adapter_id=f"synthetic-offline/{language}-adapter",
+        provenance=f"Synthetic offline {language} adapter fixture",
     )
 
 
@@ -125,6 +136,71 @@ def test_registry_route_without_donor_stays_native() -> None:
     assert route.donor_language is None
     assert route.adapter_id is None
     assert route.mode == "native"
+
+
+def test_family_router_prefers_an_available_target_adapter() -> None:
+    telugu_adapter = _available_adapter("te")
+    hindi_adapter = _available_adapter("hi")
+
+    route = route_family_adapter(
+        "te-IN",
+        {"te": telugu_adapter, "hi": hindi_adapter},
+    )
+
+    assert route.target_language == "te"
+    assert route.adapter_language == "te"
+    assert route.family_id == "indic"
+    assert route.backbone_model_id == telugu_adapter.backbone_model_id
+    assert route.adapter is telugu_adapter
+    assert route.mode == "target_adapter"
+    assert route.fallback is None
+
+
+def test_family_router_falls_back_from_telugu_to_hindi_with_scored_metadata() -> None:
+    hindi_adapter = _available_adapter("hi")
+
+    route = FamilyTransferRouter({"hi-IN": hindi_adapter}).route("te")
+
+    assert route.target_language == "te"
+    assert route.adapter_language == "hi"
+    assert route.backbone_model_id == hindi_adapter.backbone_model_id
+    assert route.adapter is hindi_adapter
+    assert route.mode == "zero_shot_fallback"
+    assert route.fallback is not None
+    assert route.fallback.donor == "hi"
+    assert route.fallback.target == "te"
+    assert route.fallback.score == pytest.approx(0.80)
+    assert "hi-to-te" in route.fallback.provenance
+    assert hindi_adapter.provenance in route.fallback.provenance
+    assert "configured expected_f1_floor" in route.fallback.provenance
+
+
+def test_family_router_keeps_donor_language_on_its_direct_adapter() -> None:
+    hindi_adapter = _available_adapter("hi")
+
+    route = FamilyTransferRouter({"hi": hindi_adapter}).route("hi-IN")
+
+    assert route.target_language == "hi"
+    assert route.adapter_language == "hi"
+    assert route.adapter is hindi_adapter
+    assert route.mode == "target_adapter"
+    assert route.fallback is None
+
+
+def test_family_router_rejects_unsupported_and_unavailable_targets() -> None:
+    router = FamilyTransferRouter({})
+
+    with pytest.raises(
+        UnsupportedFamilyTransferLanguageError,
+        match="unsupported family-transfer language 'xx'",
+    ):
+        router.route("xx")
+
+    with pytest.raises(
+        FamilyTransferAdapterUnavailableError,
+        match="no target or compatible donor adapter.*'te'",
+    ):
+        router.route("te")
 
 
 def test_transfer_config_rejects_missing_donor_family() -> None:


### PR DESCRIPTION
## Description

Adds an offline family-transfer adapter router that resolves language requests
to a backbone plus installed adapter metadata. Direct target adapters take
precedence; when absent, compatible donor adapters are selected through the
committed transfer graph with scored, source-described fallback provenance.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made

- Added immutable direct and zero-shot adapter route result types.
- Added explicit unsupported-language and adapter-unavailable failures.
- Preserved direct routing for installed donor-language adapters.
- Exported the routing API and documented the change in the changelog.

## Testing

- [x] Added synthetic offline tests for target selection, Telugu-to-Hindi
  fallback, donor routing, and failure modes.
- [x] Ran `.venv/bin/python -m pytest
  tests/unit/training/test_family_transfer.py -q` (16 passed).
- [x] Ran changed-file pre-commit hooks, Ruff lint/format checks, Bandit, secret
  scanning, and `git diff --check`.

## Documentation

- [x] Added Google-style docstrings to the new public API.
- [x] Updated `CHANGELOG.md`.

## Code Quality

- [x] Performed a self-review.
- [x] Added no network calls, telemetry, raw PHI, or non-synthetic fixtures.
- [x] Changed no dependencies.

## Dependencies

- [x] No new dependencies.

## Related Issues

Closes #1331

## Screenshots/Examples

Not applicable; this is a metadata-routing API.
