### PR TITLE
feat: add composite concept normalization and re-linking

### DIFF
--- a/openmed/clinical/grounding/__init__.py
+++ b/openmed/clinical/grounding/__init__.py
@@ -15,6 +15,14 @@ from .assertion_grounding import (
     ground_with_context,
 )
 from .candidate_generator import SparseCandidateGenerator, generate_candidates
+from .decompose import (
+    COMPOSITE_GROUNDING_DECISIONS,
+    CompositeChildProvenance,
+    CompositeDecompositionProvenance,
+    CompositeGroundingResult,
+    PostCoordinationRequest,
+    decompose_and_relink,
+)
 from .embeddings import (
     AliasEncoder,
     EncoderUnavailableError,
@@ -83,6 +91,10 @@ __all__ = [
     "AssertionGroundingStatus",
     "Candidate",
     "CandidateRankingStage",
+    "COMPOSITE_GROUNDING_DECISIONS",
+    "CompositeChildProvenance",
+    "CompositeDecompositionProvenance",
+    "CompositeGroundingResult",
     "ConceptMatch",
     "DenseCandidateGenerator",
     "DEFAULT_GROUNDING_SYSTEMS",
@@ -105,6 +117,7 @@ __all__ = [
     "POLICY_DROP",
     "POLICY_STATUS",
     "POLICY_SUPPRESS",
+    "PostCoordinationRequest",
     "RESTRICTED_VOCAB_SYSTEMS",
     "RESTRICTED_SYSTEM_URIS",
     "RankingConfig",
@@ -128,6 +141,7 @@ __all__ = [
     "available_loaders",
     "build_index",
     "build_or_load_index",
+    "decompose_and_relink",
     "generate_candidates",
     "ground",
     "ground_with_context",

--- a/openmed/clinical/grounding/api.py
+++ b/openmed/clinical/grounding/api.py
@@ -8,6 +8,7 @@ from typing import Any
 from openmed.core.labels import normalize_label
 
 from ..context import ClinicalAssertion, RerankContext
+from .decompose import decompose_and_relink
 from .embeddings import AliasEncoder
 from .matcher import LexicalMatcher
 from .ranker import CandidateRankingStage, RankingConfig
@@ -62,6 +63,8 @@ def ground(
     config: RankingConfig | None = None,
     restricted_loaders: Mapping[str, UserKeyVocabularyLoader] | None = None,
     source_language: str | None = None,
+    normalize_composites: bool = False,
+    composite_atomic_terms: Iterable[str] | None = None,
 ) -> list[GroundedSpan]:
     """Ground clinical spans to one selected concept per requested system.
 
@@ -86,9 +89,16 @@ def ground(
         config: Optional ranking configuration.
         restricted_loaders: Explicit user-key-gated local UMLS/SNOMED loaders.
         source_language: Default source language when a span omits one.
+        normalize_composites: Opt in to rules-first composite decomposition and
+            child re-linking before emission. Exact whole-span concepts remain
+            single pre-coordinated results; uncodable proposals are retained as
+            post-coordination abstentions.
+        composite_atomic_terms: Additional atomic multi-word concepts that the
+            opt-in normalizer must never split.
 
     Returns:
-        One :class:`GroundedSpan` per input, including abstentions.
+        Grounded spans, including abstentions. The default returns one per input;
+        the opt-in composite stage may emit one span per linked child.
 
     Raises:
         ValueError: If no systems are requested or a span is malformed.
@@ -97,6 +107,13 @@ def ground(
     """
 
     ordered_systems = _normalize_systems(systems)
+    if not isinstance(normalize_composites, bool):
+        raise TypeError("normalize_composites must be a boolean")
+    if isinstance(composite_atomic_terms, (str, bytes)):
+        raise TypeError("composite_atomic_terms must be an iterable of terms")
+    atomic_terms = (
+        None if composite_atomic_terms is None else tuple(composite_atomic_terms)
+    )
     free_systems = tuple(
         system for system in ordered_systems if system in _FREE_ALIASES
     )
@@ -113,36 +130,60 @@ def ground(
     results: list[GroundedSpan] = []
     for index, raw_span in enumerate(spans):
         span = _coerce_span(raw_span, index=index, default_language=source_language)
-        candidates: list[Candidate] = []
-        if stage is not None:
-            ranked = stage.rank(
-                span.text,
-                free_systems,
-                context=_rerank_context(raw_span, span.assertion),
-                source_language=span.source_language,
-            )
-            candidates.extend(_select_one_per_system(item.candidate for item in ranked))
-        for system in restricted_systems:
-            matcher, gated_loader = gated[system]
-            matches = matcher.lookup(span.text, limit=1)
-            if not matches:
-                continue
-            match = matches[0]
-            candidates.append(
-                Candidate(
-                    system=system.upper(),
-                    code=match.code,
-                    display=match.display,
-                    score=match.score,
-                    source_language=span.source_language,
-                    source="sparse",
-                    matched_alias=match.matched_term,
-                    match_kind=match.match_type,
-                    vocab_version=gated_loader.content_hash,
-                )
-            )
+        rerank_context = _rerank_context(raw_span, span.assertion)
 
-        candidates = _ordered_candidates(candidates, ordered_systems)
+        def link_surface(surface: str) -> list[Candidate]:
+            candidates: list[Candidate] = []
+            if stage is not None:
+                ranked = stage.rank(
+                    surface,
+                    free_systems,
+                    context=rerank_context,
+                    source_language=span.source_language,
+                )
+                candidates.extend(
+                    _select_one_per_system(item.candidate for item in ranked)
+                )
+            for system in restricted_systems:
+                matcher, gated_loader = gated[system]
+                matches = matcher.lookup(surface, limit=1)
+                if not matches:
+                    continue
+                match = matches[0]
+                candidates.append(
+                    Candidate(
+                        system=system.upper(),
+                        code=match.code,
+                        display=match.display,
+                        score=match.score,
+                        source_language=span.source_language,
+                        source="sparse",
+                        matched_alias=match.matched_term,
+                        match_kind=match.match_type,
+                        vocab_version=gated_loader.content_hash,
+                    )
+                )
+            return _ordered_candidates(candidates, ordered_systems)
+
+        if normalize_composites:
+            byte_start = _first_value(raw_span, ("byte_start", "start_byte"))
+            if byte_start is None:
+                byte_start = span.metadata.get("byte_start", span.start)
+            decomposition = decompose_and_relink(
+                span.text,
+                linker=link_surface,
+                start=span.start,
+                byte_start=byte_start,
+                atomic_terms=atomic_terms,
+                canonical_label=span.canonical_label,
+                assertion=span.assertion,
+                source_language=span.source_language,
+                metadata=span.metadata,
+            )
+            results.extend(decomposition.spans)
+            continue
+
+        candidates = link_surface(span.text)
         results.append(
             GroundedSpan(
                 text=span.text,

--- a/openmed/clinical/grounding/decompose.py
+++ b/openmed/clinical/grounding/decompose.py
@@ -1,0 +1,345 @@
+"""Split composite mentions, re-link children, and record safe provenance."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from openmed.clinical.normalization.composite import (
+    CompositeMention,
+    CompositeNormalization,
+    normalize_composite,
+)
+from openmed.core.audit import hash_text
+
+from .provenance import GROUNDING_ASSIST_ONLY_ADVISORY
+from .types import Candidate, GroundedSpan
+
+if TYPE_CHECKING:
+    from openmed.clinical.context import ClinicalAssertion
+
+__all__ = [
+    "COMPOSITE_GROUNDING_DECISIONS",
+    "CompositeChildProvenance",
+    "CompositeDecompositionProvenance",
+    "CompositeGroundingResult",
+    "PostCoordinationRequest",
+    "decompose_and_relink",
+]
+
+COMPOSITE_GROUNDING_DECISIONS = frozenset(
+    {"unchanged", "precoordinated", "multiple", "postcoordination"}
+)
+
+CandidateLinker = Callable[[str], Sequence[Candidate]]
+
+
+@dataclass(frozen=True)
+class CompositeChildProvenance:
+    """PHI-safe provenance for one proposed or emitted child mention."""
+
+    start: int
+    end: int
+    byte_start: int
+    byte_end: int
+    text_hash: str
+    linked: bool
+    codes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the child record without storing its raw surface."""
+
+        return {
+            "start": self.start,
+            "end": self.end,
+            "byte_start": self.byte_start,
+            "byte_end": self.byte_end,
+            "text_hash": self.text_hash,
+            "linked": self.linked,
+            "codes": list(self.codes),
+        }
+
+
+@dataclass(frozen=True)
+class CompositeDecompositionProvenance:
+    """Trace one parent mention to proposed or emitted child coordinates.
+
+    Only offsets, hashes, closed-vocabulary decisions, and terminology codes are
+    retained. Parent and child surfaces are intentionally excluded.
+    """
+
+    parent_start: int
+    parent_end: int
+    parent_byte_start: int
+    parent_byte_end: int
+    parent_text_hash: str
+    strategy: str
+    decision: str
+    children: tuple[CompositeChildProvenance, ...]
+    blocked_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.decision not in COMPOSITE_GROUNDING_DECISIONS:
+            raise ValueError(f"unknown composite decision {self.decision!r}")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-ready record with no raw mention text."""
+
+        return {
+            "parent_start": self.parent_start,
+            "parent_end": self.parent_end,
+            "parent_byte_start": self.parent_byte_start,
+            "parent_byte_end": self.parent_byte_end,
+            "parent_text_hash": self.parent_text_hash,
+            "strategy": self.strategy,
+            "decision": self.decision,
+            "blocked_reason": self.blocked_reason,
+            "children": [child.to_dict() for child in self.children],
+            "advisory": GROUNDING_ASSIST_ONLY_ADVISORY,
+        }
+
+
+@dataclass(frozen=True)
+class PostCoordinationRequest:
+    """Deferred input for a caller-owned post-coordination expression builder.
+
+    This task does not construct terminology expressions. The request preserves
+    the parent and proposed child mentions for that later stage, along with any
+    children that could already be linked and a PHI-safe audit record.
+    """
+
+    parent: CompositeMention
+    children: tuple[CompositeMention, ...]
+    linked_children: tuple[GroundedSpan, ...]
+    reason: str
+    provenance: CompositeDecompositionProvenance
+
+
+@dataclass(frozen=True)
+class CompositeGroundingResult:
+    """Grounding decision for one normalized composite mention."""
+
+    decision: str
+    normalization: CompositeNormalization
+    spans: tuple[GroundedSpan, ...]
+    provenance: CompositeDecompositionProvenance
+    postcoordination: PostCoordinationRequest | None = None
+
+    def __post_init__(self) -> None:
+        if self.decision not in COMPOSITE_GROUNDING_DECISIONS:
+            raise ValueError(f"unknown composite decision {self.decision!r}")
+        if not self.spans:
+            raise ValueError("composite grounding must retain an output span")
+
+
+def decompose_and_relink(
+    mention: str,
+    *,
+    linker: CandidateLinker,
+    start: int = 0,
+    byte_start: int | None = None,
+    atomic_terms: Iterable[str] | None = None,
+    canonical_label: str | None = None,
+    assertion: "ClinicalAssertion | None" = None,
+    source_language: str = "en",
+    metadata: Mapping[str, Any] | None = None,
+) -> CompositeGroundingResult:
+    """Normalize one mention and re-link accepted children through ``linker``.
+
+    An exact whole-span candidate wins as a pre-coordinated concept. Otherwise,
+    a fully linkable decomposition emits one grounded span per child. If a rule
+    proposes a split but any child is uncodable, the parent is emitted as an
+    abstention and a :class:`PostCoordinationRequest` preserves the proposal for
+    a later caller-owned builder. Nothing is dropped.
+
+    Args:
+        mention: Exact source mention surface.
+        linker: Existing candidate generation/ranking stack exposed as a local
+            callable returning ordered candidates for one surface.
+        start: Character-coordinate base in the source document.
+        byte_start: UTF-8 byte-coordinate base; defaults to ``start``.
+        atomic_terms: Optional additional atomic stop-list entries.
+        canonical_label: Optional canonical clinical label inherited by children.
+        assertion: Optional assertion context inherited by children.
+        source_language: Normalized source language inherited by children.
+        metadata: Optional structured caller context inherited by children.
+
+    Returns:
+        The decision, output spans, safe provenance, and optional deferred
+        post-coordination request.
+    """
+
+    linked_by_text: dict[str, tuple[Candidate, ...]] = {}
+
+    def linked(surface: str) -> tuple[Candidate, ...]:
+        cached = linked_by_text.get(surface)
+        if cached is None:
+            candidates = tuple(linker(surface))
+            if any(not isinstance(candidate, Candidate) for candidate in candidates):
+                raise TypeError("linker must return Candidate objects")
+            cached = _one_per_system(candidates)
+            linked_by_text[surface] = cached
+        return cached
+
+    normalization = normalize_composite(
+        mention,
+        start=start,
+        byte_start=byte_start,
+        atomic_terms=atomic_terms,
+        is_linkable=lambda surface: bool(linked(surface)),
+    )
+    parent_candidates = linked(normalization.parent.text)
+    proposal = (
+        normalization.children
+        if normalization.was_split
+        else normalization.proposed_children
+    )
+
+    if proposal and _has_exact_candidate(parent_candidates):
+        decision = "precoordinated"
+        output_mentions = (normalization.parent,)
+        output_candidates = (parent_candidates,)
+    elif normalization.was_split:
+        decision = "multiple"
+        output_mentions = normalization.children
+        output_candidates = tuple(linked(child.text) for child in output_mentions)
+    elif normalization.needs_postcoordination:
+        decision = "postcoordination"
+        output_mentions = (normalization.parent,)
+        # A fuzzy whole-span hit must not coerce a partially uncodable composite
+        # into an unrelated code. The parent is retained as an explicit abstention.
+        output_candidates = ((),)
+    else:
+        decision = "unchanged"
+        output_mentions = (normalization.parent,)
+        output_candidates = (parent_candidates,)
+
+    provenance_mentions = proposal or output_mentions
+    provenance = _decomposition_provenance(
+        normalization,
+        decision=decision,
+        mentions=provenance_mentions,
+        linked=linked,
+    )
+    provenance_payload = (
+        {"composite_decomposition": provenance.to_dict()} if proposal else {}
+    )
+    inherited_metadata = dict(metadata or {})
+    spans = tuple(
+        _grounded_span(
+            child,
+            candidates,
+            provenance=provenance_payload,
+            canonical_label=canonical_label,
+            assertion=assertion,
+            source_language=source_language,
+            metadata=inherited_metadata,
+        )
+        for child, candidates in zip(output_mentions, output_candidates)
+    )
+
+    postcoordination = None
+    if decision == "postcoordination":
+        linked_children = tuple(
+            _grounded_span(
+                child,
+                linked(child.text),
+                provenance=provenance_payload,
+                canonical_label=canonical_label,
+                assertion=assertion,
+                source_language=source_language,
+                metadata=inherited_metadata,
+            )
+            for child in normalization.proposed_children
+        )
+        postcoordination = PostCoordinationRequest(
+            parent=normalization.parent,
+            children=normalization.proposed_children,
+            linked_children=linked_children,
+            reason=normalization.blocked_reason or "uncodable_composite",
+            provenance=provenance,
+        )
+
+    return CompositeGroundingResult(
+        decision=decision,
+        normalization=normalization,
+        spans=spans,
+        provenance=provenance,
+        postcoordination=postcoordination,
+    )
+
+
+def _decomposition_provenance(
+    normalization: CompositeNormalization,
+    *,
+    decision: str,
+    mentions: Sequence[CompositeMention],
+    linked: Callable[[str], tuple[Candidate, ...]],
+) -> CompositeDecompositionProvenance:
+    parent = normalization.parent
+    children = tuple(
+        CompositeChildProvenance(
+            start=child.start,
+            end=child.end,
+            byte_start=child.byte_start,
+            byte_end=child.byte_end,
+            text_hash=hash_text(child.text),
+            linked=bool(linked(child.text)),
+            codes=tuple(
+                f"{candidate.system}:{candidate.code}"
+                for candidate in linked(child.text)
+            ),
+        )
+        for child in mentions
+    )
+    return CompositeDecompositionProvenance(
+        parent_start=parent.start,
+        parent_end=parent.end,
+        parent_byte_start=parent.byte_start,
+        parent_byte_end=parent.byte_end,
+        parent_text_hash=hash_text(parent.text),
+        strategy=normalization.strategy,
+        decision=decision,
+        children=children,
+        blocked_reason=normalization.blocked_reason,
+    )
+
+
+def _grounded_span(
+    mention: CompositeMention,
+    candidates: Sequence[Candidate],
+    *,
+    provenance: Mapping[str, Any],
+    canonical_label: str | None,
+    assertion: "ClinicalAssertion | None",
+    source_language: str,
+    metadata: Mapping[str, Any],
+) -> GroundedSpan:
+    return GroundedSpan(
+        text=mention.text,
+        start=mention.start,
+        end=mention.end,
+        candidates=tuple(candidates),
+        provenance=provenance,
+        canonical_label=canonical_label,
+        assertion=assertion,
+        source_language=source_language,
+        metadata=metadata,
+    )
+
+
+def _one_per_system(candidates: Sequence[Candidate]) -> tuple[Candidate, ...]:
+    selected: list[Candidate] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        system = candidate.system.casefold()
+        if system in seen:
+            continue
+        selected.append(candidate)
+        seen.add(system)
+    return tuple(selected)
+
+
+def _has_exact_candidate(candidates: Sequence[Candidate]) -> bool:
+    return any(candidate.match_kind == "exact" for candidate in candidates)

--- a/openmed/clinical/normalization/__init__.py
+++ b/openmed/clinical/normalization/__init__.py
@@ -40,6 +40,13 @@ from .chinese import (
     load_chinese_terminology_dictionary,
     normalize_chinese_clinical_surface,
 )
+from .composite import (
+    COMPOSITE_SPLIT_STRATEGIES,
+    KNOWN_ATOMIC_COMPOSITES,
+    CompositeMention,
+    CompositeNormalization,
+    normalize_composite,
+)
 from .india import (
     INDIAN_CLINICAL_ABBREVIATIONS,
     INDIAN_CLINICAL_NORMALIZATION_VERSION,
@@ -97,6 +104,9 @@ __all__ = [
     "ChineseTerminologyMatch",
     "ChineseTerminologyPathError",
     "CodeSystemMetadata",
+    "COMPOSITE_SPLIT_STRATEGIES",
+    "CompositeMention",
+    "CompositeNormalization",
     "ConceptNormalizationCache",
     "ConceptNormalizer",
     "EmbeddingBackendStatus",
@@ -119,6 +129,7 @@ __all__ = [
     "IndiaTerminologyKind",
     "IndiaTerminologyLoadResult",
     "IndiaTerminologyLoader",
+    "KNOWN_ATOMIC_COMPOSITES",
     "NormalizationCacheStats",
     "NormalizationEvaluationResult",
     "NormalizationGoldCase",
@@ -141,6 +152,7 @@ __all__ = [
     "make_normalization_cache_key",
     "make_rerank_cache_key",
     "normalize_chinese_clinical_surface",
+    "normalize_composite",
     "rank_candidates",
     "normalize_indian_clinical_abbreviation",
     "normalize_indian_clinical_entities",

--- a/openmed/clinical/normalization/composite.py
+++ b/openmed/clinical/normalization/composite.py
@@ -1,0 +1,354 @@
+"""Rules-first decomposition of composite clinical concept mentions.
+
+The normalizer deliberately uses a small, auditable rule set rather than a
+syntactic parser.  It recognizes coordination, complication phrases, and a
+small modifier/head pattern while retaining both character and UTF-8 byte
+offsets into the original mention.  Callers may supply a linkability predicate;
+when any proposed child is not linkable the split is withheld and exposed as a
+post-coordination proposal instead of silently dropping part of the mention.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+__all__ = [
+    "COMPOSITE_SPLIT_STRATEGIES",
+    "KNOWN_ATOMIC_COMPOSITES",
+    "CompositeMention",
+    "CompositeNormalization",
+    "normalize_composite",
+]
+
+COMPOSITE_SPLIT_STRATEGIES = frozenset(
+    {"atomic", "unsplit", "coordination", "complication", "modifier_head"}
+)
+
+# These are lexical atoms even though their surfaces contain a separator that
+# would otherwise look compositional to the rules below.  The set is intentionally
+# small and caller-extensible; it protects common false-positive shapes without
+# pretending to be a terminology bundle.
+KNOWN_ATOMIC_COMPOSITES: frozenset[str] = frozenset(
+    {
+        "attention deficit and hyperactivity disorder",
+        "bed and breakfast sign",
+        "ear, nose and throat disorder",
+        "hand, foot and mouth disease",
+        "head and neck cancer",
+        "heart and lung transplant status",
+        "migraine with aura",
+        "mother and baby unit",
+        "pain with psychological factors",
+        "salt and pepper retinopathy",
+        "signs and symptoms",
+        "sickle cell disease with crisis",
+    }
+)
+
+_COMPLICATION_RE = re.compile(
+    r"\s+(?:with|complicated\s+by|associated\s+with)\s+",
+    flags=re.IGNORECASE,
+)
+_COORDINATION_RE = re.compile(
+    r"\s*(?:,|;|&|\band\b|\bor\b)\s*",
+    flags=re.IGNORECASE,
+)
+_MODIFIER_HEAD_RE = re.compile(
+    r"\s+(?:acute\s+exacerbation|exacerbation|flare|complication)$",
+    flags=re.IGNORECASE,
+)
+
+LinkabilityCheck = Callable[[str], bool]
+
+
+@dataclass(frozen=True)
+class CompositeMention:
+    """One contiguous sub-mention with source-relative coordinates.
+
+    Args:
+        text: Exact contiguous text copied from the parent mention.
+        start: Inclusive character offset in the caller's source coordinates.
+        end: Exclusive character offset in the caller's source coordinates.
+        byte_start: Inclusive UTF-8 byte offset in the caller's byte coordinates.
+        byte_end: Exclusive UTF-8 byte offset in the caller's byte coordinates.
+    """
+
+    text: str
+    start: int
+    end: int
+    byte_start: int
+    byte_end: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.text, str) or not self.text:
+            raise ValueError("composite mention text must be non-empty")
+        for name, value in (
+            ("start", self.start),
+            ("end", self.end),
+            ("byte_start", self.byte_start),
+            ("byte_end", self.byte_end),
+        ):
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+        if self.end < self.start or self.byte_end < self.byte_start:
+            raise ValueError("composite mention offsets must be ordered")
+        if self.end - self.start != len(self.text):
+            raise ValueError("character offsets must match composite mention text")
+        if self.byte_end - self.byte_start != len(self.text.encode("utf-8")):
+            raise ValueError("byte offsets must match UTF-8 composite mention text")
+
+
+@dataclass(frozen=True)
+class CompositeNormalization:
+    """Result of applying the rules-first composite normalizer.
+
+    ``children`` is the accepted decomposition.  It contains only ``parent``
+    when no rule applies, an atomic stop-list entry matches, or a linkability
+    check blocks a proposed split.  ``proposed_children`` retains the latter
+    proposal so a downstream stage can route it to post-coordination.
+    """
+
+    parent: CompositeMention
+    children: tuple[CompositeMention, ...]
+    strategy: str
+    proposed_children: tuple[CompositeMention, ...] = ()
+    blocked_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.strategy not in COMPOSITE_SPLIT_STRATEGIES:
+            raise ValueError(f"unknown composite split strategy {self.strategy!r}")
+        if not self.children:
+            raise ValueError("composite normalization must retain a child span")
+
+    @property
+    def was_split(self) -> bool:
+        """Return whether the accepted output contains multiple children."""
+
+        return len(self.children) > 1
+
+    @property
+    def needs_postcoordination(self) -> bool:
+        """Return whether an unlinked proposal needs post-coordination."""
+
+        return bool(self.proposed_children and self.blocked_reason)
+
+
+def normalize_composite(
+    mention: str,
+    *,
+    start: int = 0,
+    byte_start: int | None = None,
+    atomic_terms: Iterable[str] | None = None,
+    is_linkable: LinkabilityCheck | None = None,
+) -> CompositeNormalization:
+    """Split one clinical mention into contiguous, offset-bearing children.
+
+    Rules run in conservative order: known lexical atoms, complication phrases,
+    modifier/head suffixes, then coordination.  A supplied ``is_linkable``
+    predicate is evaluated for every proposed child before the split is
+    accepted.  If any child cannot be linked, the function returns the intact
+    parent in ``children`` and keeps the proposal in ``proposed_children`` for a
+    post-coordination builder.
+
+    Args:
+        mention: Exact source surface to normalize.
+        start: Character-coordinate base of ``mention`` in its source document.
+        byte_start: UTF-8 byte-coordinate base. Defaults to ``start`` for
+            backward-compatible ASCII/source-relative use.
+        atomic_terms: Additional known atomic multi-word surfaces.
+        is_linkable: Optional offline predicate used to validate every child.
+
+    Returns:
+        A deterministic normalization result with exact character and byte
+        offsets. No network or terminology lookup occurs unless the caller's
+        predicate performs one.
+
+    Raises:
+        TypeError: If ``mention`` is not a string.
+        ValueError: If the mention is empty or an offset base is invalid.
+    """
+
+    if not isinstance(mention, str):
+        raise TypeError("mention must be a string")
+    if not mention.strip():
+        raise ValueError("mention must contain non-whitespace text")
+    if type(start) is not int or start < 0:
+        raise ValueError("start must be a non-negative integer")
+    resolved_byte_start = start if byte_start is None else byte_start
+    if type(resolved_byte_start) is not int or resolved_byte_start < 0:
+        raise ValueError("byte_start must be a non-negative integer")
+
+    local_start, local_end = _trim_range(mention, 0, len(mention))
+    parent = _span(
+        mention,
+        0,
+        len(mention),
+        char_base=start,
+        byte_base=resolved_byte_start,
+    )
+    known_atomic = set(KNOWN_ATOMIC_COMPOSITES)
+    if atomic_terms is not None:
+        known_atomic.update(_normalize_atomic(term) for term in atomic_terms)
+    if _normalize_atomic(parent.text) in known_atomic:
+        return CompositeNormalization(
+            parent=parent,
+            children=(parent,),
+            strategy="atomic",
+        )
+
+    proposal, strategy = _propose_split(
+        mention,
+        local_start,
+        local_end,
+        char_base=start,
+        byte_base=resolved_byte_start,
+    )
+    if len(proposal) < 2:
+        return CompositeNormalization(
+            parent=parent,
+            children=(parent,),
+            strategy="unsplit",
+        )
+
+    if is_linkable is not None and not all(
+        bool(is_linkable(child.text)) for child in proposal
+    ):
+        return CompositeNormalization(
+            parent=parent,
+            children=(parent,),
+            strategy=strategy,
+            proposed_children=proposal,
+            blocked_reason="unlinked_child",
+        )
+    return CompositeNormalization(
+        parent=parent,
+        children=proposal,
+        strategy=strategy,
+    )
+
+
+def _propose_split(
+    mention: str,
+    local_start: int,
+    local_end: int,
+    *,
+    char_base: int,
+    byte_base: int,
+) -> tuple[tuple[CompositeMention, ...], str]:
+    complication = _split_matches(
+        mention,
+        local_start,
+        local_end,
+        _COMPLICATION_RE,
+        char_base=char_base,
+        byte_base=byte_base,
+    )
+    if len(complication) >= 2:
+        return complication, "complication"
+
+    modifier = _MODIFIER_HEAD_RE.search(mention, local_start, local_end)
+    if modifier is not None and modifier.start() > local_start:
+        spans = _spans_from_ranges(
+            mention,
+            ((local_start, modifier.start()), (modifier.start(), local_end)),
+            char_base=char_base,
+            byte_base=byte_base,
+        )
+        if len(spans) == 2:
+            return spans, "modifier_head"
+
+    coordination = _split_matches(
+        mention,
+        local_start,
+        local_end,
+        _COORDINATION_RE,
+        char_base=char_base,
+        byte_base=byte_base,
+    )
+    if len(coordination) >= 2:
+        return coordination, "coordination"
+    return (), "unsplit"
+
+
+def _split_matches(
+    mention: str,
+    local_start: int,
+    local_end: int,
+    pattern: re.Pattern[str],
+    *,
+    char_base: int,
+    byte_base: int,
+) -> tuple[CompositeMention, ...]:
+    ranges: list[tuple[int, int]] = []
+    cursor = local_start
+    for match in pattern.finditer(mention, local_start, local_end):
+        if match.start() == match.end():
+            continue
+        ranges.append((cursor, match.start()))
+        cursor = match.end()
+    if not ranges:
+        return ()
+    ranges.append((cursor, local_end))
+    return _spans_from_ranges(
+        mention,
+        ranges,
+        char_base=char_base,
+        byte_base=byte_base,
+    )
+
+
+def _spans_from_ranges(
+    mention: str,
+    ranges: Iterable[tuple[int, int]],
+    *,
+    char_base: int,
+    byte_base: int,
+) -> tuple[CompositeMention, ...]:
+    spans: list[CompositeMention] = []
+    for range_start, range_end in ranges:
+        trimmed_start, trimmed_end = _trim_range(mention, range_start, range_end)
+        if trimmed_start >= trimmed_end:
+            return ()
+        spans.append(
+            _span(
+                mention,
+                trimmed_start,
+                trimmed_end,
+                char_base=char_base,
+                byte_base=byte_base,
+            )
+        )
+    return tuple(spans)
+
+
+def _span(
+    mention: str,
+    local_start: int,
+    local_end: int,
+    *,
+    char_base: int,
+    byte_base: int,
+) -> CompositeMention:
+    return CompositeMention(
+        text=mention[local_start:local_end],
+        start=char_base + local_start,
+        end=char_base + local_end,
+        byte_start=byte_base + len(mention[:local_start].encode("utf-8")),
+        byte_end=byte_base + len(mention[:local_end].encode("utf-8")),
+    )
+
+
+def _trim_range(text: str, start: int, end: int) -> tuple[int, int]:
+    while start < end and text[start].isspace():
+        start += 1
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
+def _normalize_atomic(value: object) -> str:
+    text = unicodedata.normalize("NFKC", str(value)).casefold()
+    return re.sub(r"\s+", " ", text).strip()

--- a/openmed/eval/suites/__init__.py
+++ b/openmed/eval/suites/__init__.py
@@ -90,6 +90,13 @@ from openmed.eval.suites.code_mixed_routing import (
     load_code_mixed_routing_fixtures,
     run_code_mixed_routing,
 )
+from openmed.eval.suites.composite_normalization import (
+    COMPOSITE_NORMALIZATION,
+    build_composite_normalization_gold,
+    composite_normalization_metadata,
+    evaluate_composite_normalization,
+    run_composite_normalization,
+)
 from openmed.eval.suites.cross_lingual_grounding import (
     CROSS_LINGUAL_GROUNDING,
     CROSS_LINGUAL_LANGUAGES,

--- a/openmed/eval/suites/composite_normalization.py
+++ b/openmed/eval/suites/composite_normalization.py
@@ -1,0 +1,235 @@
+"""Synthetic offline evaluation for composite normalization and re-linking."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from openmed.clinical.grounding.ranker import CandidateRankingStage, RankingConfig
+from openmed.clinical.grounding.vocab import VocabConcept, VocabularyIndex
+from openmed.clinical.normalization.composite import (
+    KNOWN_ATOMIC_COMPOSITES,
+    normalize_composite,
+)
+
+COMPOSITE_NORMALIZATION = "composite_normalization"
+
+_COMPOSITE_SURFACES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("nausea and vomiting", ("nausea", "vomiting")),
+    ("fever and chills", ("fever", "chills")),
+    ("cough and wheezing", ("cough", "wheezing")),
+    ("headache and dizziness", ("headache", "dizziness")),
+    ("fatigue and weakness", ("fatigue", "weakness")),
+    ("constipation or diarrhea", ("constipation", "diarrhea")),
+    ("rash or pruritus", ("rash", "pruritus")),
+    ("edema and swelling", ("edema", "swelling")),
+    ("tremor and rigidity", ("tremor", "rigidity")),
+    ("dysuria and hematuria", ("dysuria", "hematuria")),
+    ("nausée and vomiting", ("nausée", "vomiting")),
+    ("fatigue, weakness and malaise", ("fatigue", "weakness", "malaise")),
+    ("cough; dyspnea", ("cough", "dyspnea")),
+    ("insomnia & anxiety", ("insomnia", "anxiety")),
+    (
+        "type 2 diabetes with diabetic nephropathy",
+        ("type 2 diabetes", "diabetic nephropathy"),
+    ),
+    (
+        "hypertension with chronic kidney disease",
+        ("hypertension", "chronic kidney disease"),
+    ),
+    ("asthma with bronchospasm", ("asthma", "bronchospasm")),
+    (
+        "pneumonia complicated by pleural effusion",
+        ("pneumonia", "pleural effusion"),
+    ),
+    ("cirrhosis complicated by ascites", ("cirrhosis", "ascites")),
+    ("influenza associated with myalgia", ("influenza", "myalgia")),
+    ("heart failure with pulmonary edema", ("heart failure", "pulmonary edema")),
+    (
+        "dermatitis with secondary infection",
+        ("dermatitis", "secondary infection"),
+    ),
+    ("migraine with photophobia", ("migraine", "photophobia")),
+    (
+        "anemia associated with iron deficiency",
+        ("anemia", "iron deficiency"),
+    ),
+    (
+        "osteoarthritis with joint effusion",
+        ("osteoarthritis", "joint effusion"),
+    ),
+    (
+        "pancreatitis complicated by pseudocyst",
+        ("pancreatitis", "pseudocyst"),
+    ),
+    (
+        "chronic obstructive pulmonary disease exacerbation",
+        ("chronic obstructive pulmonary disease", "exacerbation"),
+    ),
+    ("asthma acute exacerbation", ("asthma", "acute exacerbation")),
+    ("eczema flare", ("eczema", "flare")),
+    ("lupus flare", ("lupus", "flare")),
+    ("heart failure exacerbation", ("heart failure", "exacerbation")),
+    ("ulcer complication", ("ulcer", "complication")),
+    ("diabetes complication", ("diabetes", "complication")),
+    ("arthritis flare", ("arthritis", "flare")),
+    ("bronchitis exacerbation", ("bronchitis", "exacerbation")),
+    ("colitis acute exacerbation", ("colitis", "acute exacerbation")),
+)
+
+
+@dataclass(frozen=True)
+class CompositeNormalizationCase:
+    """One synthetic composite mention with child surfaces and gold codes."""
+
+    mention: str
+    children: tuple[str, ...]
+    gold_codes: tuple[str, ...]
+
+
+class _SyntheticVocabLoader:
+    def __init__(self, index: VocabularyIndex) -> None:
+        self._index = index
+
+    def get_index(self, system: str) -> VocabularyIndex:
+        if system.casefold() != self._index.system:
+            raise ValueError(f"unsupported synthetic system {system!r}")
+        return self._index
+
+
+def build_composite_normalization_gold() -> tuple[CompositeNormalizationCase, ...]:
+    """Return at least 30 deterministic synthetic composite gold cases."""
+
+    terms = sorted({child for _, children in _COMPOSITE_SURFACES for child in children})
+    codes = {term: f"SYN{index:04d}" for index, term in enumerate(terms, start=1)}
+    return tuple(
+        CompositeNormalizationCase(
+            mention=mention,
+            children=children,
+            gold_codes=tuple(codes[child] for child in children),
+        )
+        for mention, children in _COMPOSITE_SURFACES
+    )
+
+
+def composite_normalization_metadata() -> dict[str, Any]:
+    """Return synthetic-data and offline provenance for this suite."""
+
+    return {
+        "suite": COMPOSITE_NORMALIZATION,
+        "source": "synthetic composite clinical surfaces",
+        "redistribution": "safe; no DUA or production terminology",
+        "offline": True,
+    }
+
+
+def evaluate_composite_normalization(
+    cases: Sequence[CompositeNormalizationCase] | None = None,
+) -> dict[str, Any]:
+    """Measure split offsets, top-1 linking, and over/under-split rates.
+
+    Child concepts are loaded into an in-memory synthetic ICD-10-CM-like index
+    and linked through the production candidate generation plus ranking stage.
+    The corpus and vocabulary are constructed locally and never perform network
+    access.
+    """
+
+    gold = tuple(cases) if cases is not None else build_composite_normalization_gold()
+    if len(gold) < 30:
+        raise ValueError("composite normalization gold set must contain >=30 cases")
+    term_codes = _term_code_map(gold)
+    stage = _synthetic_ranking_stage(term_codes)
+
+    concept_total = sum(len(case.children) for case in gold)
+    top1_correct = 0
+    over_split = 0
+    under_split = 0
+    offset_correct = 0
+    offset_total = 0
+
+    def ranked(surface: str):
+        return stage.rank(surface, systems=("icd10cm",))
+
+    for case in gold:
+        normalized = normalize_composite(
+            case.mention,
+            is_linkable=lambda surface: bool(ranked(surface)),
+        )
+        predicted = normalized.children
+        over_split += int(len(predicted) > len(case.children))
+        under_split += int(len(predicted) < len(case.children))
+
+        for index, expected in enumerate(case.children):
+            if index >= len(predicted) or predicted[index].text != expected:
+                continue
+            candidates = ranked(predicted[index].text)
+            if candidates and candidates[0].candidate.code == case.gold_codes[index]:
+                top1_correct += 1
+
+        encoded = case.mention.encode("utf-8")
+        for child in predicted:
+            offset_total += 1
+            byte_surface = encoded[child.byte_start : child.byte_end].decode("utf-8")
+            offset_correct += int(
+                byte_surface == child.text
+                and case.mention[child.start : child.end] == child.text
+            )
+
+    atomic_false_splits = sum(
+        int(normalize_composite(term).was_split)
+        for term in sorted(KNOWN_ATOMIC_COMPOSITES)
+    )
+    case_count = len(gold)
+    return {
+        "suite": COMPOSITE_NORMALIZATION,
+        "case_count": case_count,
+        "concept_count": concept_total,
+        "top1_accuracy": top1_correct / concept_total,
+        "over_split_rate": over_split / case_count,
+        "under_split_rate": under_split / case_count,
+        "offset_accuracy": offset_correct / offset_total if offset_total else 0.0,
+        "atomic_term_count": len(KNOWN_ATOMIC_COMPOSITES),
+        "atomic_false_splits": atomic_false_splits,
+        "metadata": composite_normalization_metadata(),
+    }
+
+
+def run_composite_normalization(
+    *,
+    cases: Sequence[CompositeNormalizationCase] | None = None,
+) -> dict[str, Any]:
+    """Run the synthetic composite-normalization suite and return its report."""
+
+    return evaluate_composite_normalization(cases)
+
+
+def _term_code_map(
+    cases: Sequence[CompositeNormalizationCase],
+) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for case in cases:
+        if len(case.children) != len(case.gold_codes):
+            raise ValueError("composite child surfaces and gold codes must align")
+        for term, code in zip(case.children, case.gold_codes):
+            existing = mapping.setdefault(term, code)
+            if existing != code:
+                raise ValueError(f"conflicting synthetic codes for {term!r}")
+    return mapping
+
+
+def _synthetic_ranking_stage(term_codes: dict[str, str]) -> CandidateRankingStage:
+    concepts = tuple(
+        VocabConcept(
+            system="icd10cm",
+            code=code,
+            preferred_term=term,
+        )
+        for term, code in sorted(term_codes.items())
+    )
+    index = VocabularyIndex("icd10cm", concepts)
+    loader = _SyntheticVocabLoader(index)
+    return CandidateRankingStage(
+        loader,  # type: ignore[arg-type]
+        config=RankingConfig(systems=("icd10cm",)),
+    )

--- a/tests/unit/clinical/normalization/test_composite.py
+++ b/tests/unit/clinical/normalization/test_composite.py
@@ -1,0 +1,249 @@
+"""Focused tests for composite splitting, re-linking, and safe provenance."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from pathlib import Path
+
+from openmed.clinical.grounding import (
+    Candidate,
+    VocabLoader,
+    VocabSource,
+    decompose_and_relink,
+    ground,
+)
+from openmed.clinical.normalization import (
+    KNOWN_ATOMIC_COMPOSITES,
+    normalize_composite,
+)
+from openmed.eval.suites.composite_normalization import (
+    build_composite_normalization_gold,
+    evaluate_composite_normalization,
+)
+
+
+def _candidate(surface: str, code: str) -> Candidate:
+    return Candidate(
+        system="ICD10CM",
+        code=code,
+        display=f"synthetic {code}",
+        score=1.0,
+        source="sparse",
+        matched_alias=surface,
+        match_kind="exact",
+        vocab_version="sha256:synthetic-composite-v1",
+    )
+
+
+def _strict_linker(mapping: dict[str, str]):
+    def link(surface: str) -> tuple[Candidate, ...]:
+        code = mapping.get(surface)
+        return (_candidate(surface, code),) if code is not None else ()
+
+    return link
+
+
+def _loader(tmp_path: Path, rows: list[dict[str, object]]) -> VocabLoader:
+    path = tmp_path / "composite-vocab.jsonl"
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    checksum = hashlib.sha256(path.read_bytes()).hexdigest()
+    return VocabLoader(
+        cache_dir=tmp_path / "cache",
+        registry={
+            "icd10cm": VocabSource(
+                system="icd10cm",
+                path=path,
+                sha256=checksum,
+            )
+        },
+    )
+
+
+def test_normalize_composite_gold_has_byte_accurate_offsets() -> None:
+    cases = build_composite_normalization_gold()
+
+    assert len(cases) >= 30
+    for case in cases:
+        result = normalize_composite(case.mention, is_linkable=lambda _: True)
+        assert tuple(child.text for child in result.children) == case.children
+        encoded = case.mention.encode("utf-8")
+        for child in result.children:
+            assert case.mention[child.start : child.end] == child.text
+            assert (
+                encoded[child.byte_start : child.byte_end].decode("utf-8") == child.text
+            )
+
+
+def test_byte_and_character_bases_are_preserved_independently() -> None:
+    mention = "  nausée and vomiting  "
+    result = normalize_composite(
+        mention,
+        start=100,
+        byte_start=200,
+        is_linkable=lambda _: True,
+    )
+
+    first, second = result.children
+    first_local = mention.index("nausée")
+    second_local = mention.index("vomiting")
+    assert (first.start, first.end) == (100 + first_local, 100 + first_local + 6)
+    assert first.byte_start == 200 + len(mention[:first_local].encode("utf-8"))
+    assert first.byte_end == first.byte_start + len("nausée".encode("utf-8"))
+    assert (second.start, second.end) == (
+        100 + second_local,
+        100 + second_local + len("vomiting"),
+    )
+
+
+def test_known_atomic_multiword_concepts_have_zero_false_splits() -> None:
+    results = [normalize_composite(term) for term in KNOWN_ATOMIC_COMPOSITES]
+
+    assert results
+    assert all(result.strategy == "atomic" for result in results)
+    assert all(not result.was_split for result in results)
+    assert all(result.children == (result.parent,) for result in results)
+
+
+def test_linkability_check_withholds_split_for_uncodable_child() -> None:
+    result = normalize_composite(
+        "asthma with synthetic uncodable qualifier",
+        is_linkable=lambda surface: surface == "asthma",
+    )
+
+    assert not result.was_split
+    assert result.needs_postcoordination
+    assert result.blocked_reason == "unlinked_child"
+    assert tuple(child.text for child in result.proposed_children) == (
+        "asthma",
+        "synthetic uncodable qualifier",
+    )
+
+
+def test_relink_emits_multiple_child_codes_when_whole_span_is_not_exact() -> None:
+    result = decompose_and_relink(
+        "nausea and vomiting",
+        linker=_strict_linker({"nausea": "SYN-NAUSEA", "vomiting": "SYN-VOMITING"}),
+        start=14,
+        byte_start=14,
+    )
+
+    assert result.decision == "multiple"
+    assert [span.text for span in result.spans] == ["nausea", "vomiting"]
+    assert [span.codes for span in result.spans] == [
+        {"icd10cm": "SYN-NAUSEA"},
+        {"icd10cm": "SYN-VOMITING"},
+    ]
+    assert [(span.start, span.end) for span in result.spans] == [(14, 20), (25, 33)]
+    assert result.postcoordination is None
+
+
+def test_exact_whole_span_wins_as_precoordinated_concept() -> None:
+    surface = "type 2 diabetes with diabetic nephropathy"
+    result = decompose_and_relink(
+        surface,
+        linker=_strict_linker(
+            {
+                surface: "SYN-DM-NEPHRO",
+                "type 2 diabetes": "SYN-DM2",
+                "diabetic nephropathy": "SYN-NEPHRO",
+            }
+        ),
+    )
+
+    assert result.decision == "precoordinated"
+    assert len(result.spans) == 1
+    assert result.spans[0].text == surface
+    assert result.spans[0].codes == {"icd10cm": "SYN-DM-NEPHRO"}
+    decomposition = result.spans[0].provenance["composite_decomposition"]
+    assert decomposition["decision"] == "precoordinated"
+    assert len(decomposition["children"]) == 2
+
+
+def test_uncodable_composite_routes_to_postcoordination_without_raw_phi() -> None:
+    surface = "asthma with Patient-Zeta-493 qualifier"
+    result = decompose_and_relink(
+        surface,
+        linker=_strict_linker({"asthma": "SYN-ASTHMA"}),
+        start=7,
+        byte_start=7,
+    )
+
+    assert result.decision == "postcoordination"
+    assert len(result.spans) == 1
+    assert result.spans[0].text == surface
+    assert result.spans[0].candidates == ()
+    assert result.postcoordination is not None
+    assert [span.codes for span in result.postcoordination.linked_children] == [
+        {"icd10cm": "SYN-ASTHMA"},
+        {},
+    ]
+    serialized = json.dumps(result.provenance.to_dict(), sort_keys=True)
+    assert "Patient-Zeta-493" not in serialized
+    assert "asthma" not in serialized
+    assert result.provenance.parent_text_hash
+    assert all(child.text_hash for child in result.provenance.children)
+
+
+def test_ground_facade_composite_stage_is_opt_in_and_reuses_ranking(
+    tmp_path: Path,
+) -> None:
+    loader = _loader(
+        tmp_path,
+        [
+            {
+                "code": "SYN-NAUSEA",
+                "preferred_term": "nausea",
+                "synonyms": [],
+            },
+            {
+                "code": "SYN-VOMITING",
+                "preferred_term": "vomiting",
+                "synonyms": [],
+            },
+        ],
+    )
+    raw_span = {
+        "text": "nausea and vomiting",
+        "start": 5,
+        "end": 24,
+        "label": "condition",
+    }
+
+    default = ground([raw_span], systems=["icd10cm"], loader=loader)
+    normalized = ground(
+        [raw_span],
+        systems=["icd10cm"],
+        loader=loader,
+        normalize_composites=True,
+    )
+
+    assert [span.text for span in default] == ["nausea and vomiting"]
+    assert [span.text for span in normalized] == ["nausea", "vomiting"]
+    assert [span.codes for span in normalized] == [
+        {"icd10cm": "SYN-NAUSEA"},
+        {"icd10cm": "SYN-VOMITING"},
+    ]
+    assert [(span.start, span.end) for span in normalized] == [(5, 11), (16, 24)]
+    assert all(span.canonical_label == "CONDITION" for span in normalized)
+    assert all("composite_decomposition" in span.provenance for span in normalized)
+
+
+def test_synthetic_eval_reports_all_acceptance_metrics_offline(monkeypatch) -> None:
+    def fail_socket(*args, **kwargs):
+        raise AssertionError("network egress attempted")
+
+    monkeypatch.setattr(socket, "socket", fail_socket)
+    report = evaluate_composite_normalization()
+
+    assert report["case_count"] >= 30
+    assert report["top1_accuracy"] >= 0.80
+    assert report["over_split_rate"] == 0.0
+    assert report["under_split_rate"] == 0.0
+    assert report["offset_accuracy"] == 1.0
+    assert report["atomic_false_splits"] == 0
+    assert report["metadata"]["offline"] is True


### PR DESCRIPTION
## Description

Adds an opt-in, rules-first composite clinical concept normalizer that splits coordinated, complication, and modifier/head mentions, then re-links accepted children through the existing candidate generation and ranking stack. Exact whole-span matches remain single pre-coordinated concepts, while partially uncodable decompositions are retained for post-coordination instead of being dropped.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made

- Added contiguous child spans with character and UTF-8 byte offsets, an extensible atomic-term stop-list, and a linkability gate.
- Added multiple-code, pre-coordinated, and deferred post-coordination decisions with parent-to-child provenance containing hashes, offsets, decisions, and codes but no raw mention text.
- Exposed composite normalization through the grounding facade as an opt-in stage and added a 36-case synthetic offline evaluation reporting top-1 accuracy plus over-split and under-split rates.

## Testing

- [x] `.venv/bin/python -m pytest tests/unit/clinical/normalization/test_composite.py tests/unit/clinical/grounding/test_grounding_facade.py -q` — 14 passed
- [x] Ruff lint passed on all eight changed Python files
- [x] Ruff format check passed on all eight changed Python files

## Documentation

- [x] Added Google-style docstrings to new public functions and classes
- [x] No changelog entry required for this scoped, unreleased feature

## Code Quality

- [x] Performed a self-review of the complete patch
- [x] Added comments around conservative split and abstention behavior
- [x] Added no dependencies
- [x] Used only synthetic offline test and evaluation data

## Related Issues

Closes #1260

## Screenshots/Examples

Not applicable; this change adds Python grounding APIs and evaluation coverage.
