### PR TITLE
Detect and suppress boilerplate and copy-forward note spans

### DIFF
--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -35,6 +35,17 @@ from .assertion_graph import (
     ReconciledAssertion,
     reconcile_assertions,
 )
+from .boilerplate import (
+    BOILERPLATE_DETECTOR_VERSION,
+    COPY_FORWARD_DETECTOR_VERSION,
+    DEFAULT_BOILERPLATE_TEMPLATE_RESOURCE,
+    BoilerplateSpan,
+    BoilerplateTemplate,
+    CopyForwardSpan,
+    detect_boilerplate,
+    detect_copy_forward,
+    load_boilerplate_template_corpus,
+)
 from .cancer_staging import (
     TNM_STAGING_ADVISORY,
     TnmBasis,
@@ -465,6 +476,15 @@ __all__ = [
     "AxisProvenance",
     "ReconciledAssertion",
     "reconcile_assertions",
+    "BOILERPLATE_DETECTOR_VERSION",
+    "COPY_FORWARD_DETECTOR_VERSION",
+    "DEFAULT_BOILERPLATE_TEMPLATE_RESOURCE",
+    "BoilerplateSpan",
+    "BoilerplateTemplate",
+    "CopyForwardSpan",
+    "detect_boilerplate",
+    "detect_copy_forward",
+    "load_boilerplate_template_corpus",
     "INDIA_CLINICAL_NER_DISCLAIMER",
     "AbnormalFlag",
     "LabValueAttributeMention",

--- a/openmed/clinical/boilerplate.py
+++ b/openmed/clinical/boilerplate.py
@@ -1,0 +1,721 @@
+"""Deterministic span annotations for clinical boilerplate and copy-forward text.
+
+The detectors in this module are local, rules-first, and non-destructive. They
+return half-open offsets into the original text and never remove or rewrite the
+note. The bundled phrase table is synthetic and contains no restricted note
+corpus material.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+DEFAULT_BOILERPLATE_TEMPLATE_RESOURCE = "data/boilerplate_templates.json"
+BOILERPLATE_DETECTOR_VERSION = "openmed-boilerplate-v1"
+COPY_FORWARD_DETECTOR_VERSION = "openmed-copy-forward-v1"
+
+_BOILERPLATE_TYPE = "boilerplate"
+_COPY_FORWARD_TYPE = "copy_forward"
+_ALLOWED_TEMPLATE_SOURCE_TYPES = frozenset({"synthetic", "public_domain"})
+_TOKEN_RE = re.compile(r"[^\W_]+(?:['\N{RIGHT SINGLE QUOTATION MARK}-][^\W_]+)*")
+_CHECKBOX_RE = re.compile(
+    r"^(?:[-*\N{BULLET}]\s*)?(?:\[[ xX\N{CHECK MARK}\N{HEAVY CHECK MARK}-]\]|"
+    r"[\N{BALLOT BOX}\N{BALLOT BOX WITH CHECK}\N{BALLOT BOX WITH X}])\s+\S"
+)
+_DOT_PHRASE_RE = re.compile(r"^\.[A-Za-z][\w.-]{2,}(?:\s|$)")
+_PLACEHOLDER_RE = re.compile(
+    r"(?:\*{3,}|_{3,}|\{\{[^\r\n]{0,80}\}\}|<<[^\r\n]{0,80}>>|"
+    r"\[(?:insert|select|choose|enter)[^\]\r\n]{0,80}\])",
+    re.IGNORECASE,
+)
+_MAX_SHINGLE_OCCURRENCES = 64
+_MAX_COPY_FORWARD_TOKENS = 100_000
+
+
+@dataclass(frozen=True)
+class BoilerplateTemplate:
+    """One validated entry from the bundled unrestricted template corpus."""
+
+    template_id: str
+    text: str
+    source_type: str
+
+
+@dataclass(frozen=True)
+class BoilerplateSpan:
+    """One non-destructive boilerplate annotation over original note offsets."""
+
+    start: int
+    end: int
+    score: float
+    provenance: Mapping[str, Any]
+    type: str = field(default=_BOILERPLATE_TYPE, init=False)
+
+    def __post_init__(self) -> None:
+        _validate_annotation_fields(self.start, self.end, self.score)
+        object.__setattr__(self, "provenance", dict(self.provenance))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-ready annotation mapping."""
+
+        return {
+            "type": self.type,
+            "start": self.start,
+            "end": self.end,
+            "score": self.score,
+            "provenance": dict(self.provenance),
+        }
+
+
+@dataclass(frozen=True)
+class CopyForwardSpan:
+    """One copied span with a caller-safe source reference and source offsets."""
+
+    start: int
+    end: int
+    copied_from: str
+    source_start: int
+    source_end: int
+    score: float
+    provenance: Mapping[str, Any]
+    type: str = field(default=_COPY_FORWARD_TYPE, init=False)
+
+    def __post_init__(self) -> None:
+        _validate_annotation_fields(self.start, self.end, self.score)
+        if not isinstance(self.copied_from, str) or not self.copied_from.strip():
+            raise ValueError("copied_from must be a non-empty source reference")
+        if (
+            isinstance(self.source_start, bool)
+            or isinstance(self.source_end, bool)
+            or not isinstance(self.source_start, int)
+            or not isinstance(self.source_end, int)
+        ):
+            raise TypeError("source offsets must be integers")
+        if self.source_start < 0 or self.source_end <= self.source_start:
+            raise ValueError("source offsets must satisfy 0 <= start < end")
+        object.__setattr__(self, "copied_from", self.copied_from.strip())
+        object.__setattr__(self, "provenance", dict(self.provenance))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-ready annotation mapping."""
+
+        return {
+            "type": self.type,
+            "start": self.start,
+            "end": self.end,
+            "copied_from": self.copied_from,
+            "source_start": self.source_start,
+            "source_end": self.source_end,
+            "score": self.score,
+            "provenance": dict(self.provenance),
+        }
+
+
+@dataclass(frozen=True)
+class _Token:
+    normalized: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class _BoilerplateCandidate:
+    start: int
+    end: int
+    score: float
+    rule_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _CopyCandidate:
+    start: int
+    end: int
+    source_reference: str
+    source_start: int
+    source_end: int
+    matched_tokens: int
+    match_kind: str
+
+
+def detect_boilerplate(text: str) -> tuple[BoilerplateSpan, ...]:
+    """Annotate template, checkbox, dot-phrase, and placeholder scaffolding.
+
+    Matching uses the committed synthetic phrase corpus plus conservative line
+    structure rules. Returned spans use half-open offsets into ``text`` and the
+    input string is never changed.
+
+    Args:
+        text: Clinical note text to annotate.
+
+    Returns:
+        Deterministically ordered boilerplate annotations with rule provenance.
+
+    Raises:
+        TypeError: If ``text`` is not a string.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    if not text:
+        return ()
+
+    templates = load_boilerplate_template_corpus()
+    template_tokens = tuple(
+        (template, tuple(token.normalized for token in _tokens(template.text)))
+        for template in templates
+    )
+    candidates: list[_BoilerplateCandidate] = []
+
+    for line_start, line_end in _content_lines(text):
+        surface = text[line_start:line_end]
+        stripped = surface.strip()
+        if not stripped:
+            continue
+        content_start = line_start + len(surface) - len(surface.lstrip())
+        content_end = line_end - (len(surface) - len(surface.rstrip()))
+        line_tokens = _tokens(text, start=content_start, end=content_end)
+        normalized_line = tuple(token.normalized for token in line_tokens)
+
+        for template, normalized_template in template_tokens:
+            for token_start in _subsequence_starts(
+                normalized_line, normalized_template
+            ):
+                if len(normalized_line) == len(normalized_template):
+                    match_start, match_end = content_start, content_end
+                else:
+                    match_start = line_tokens[token_start].start
+                    match_end = line_tokens[
+                        token_start + len(normalized_template) - 1
+                    ].end
+                    terminal = template.text.rstrip()[-1:]
+                    if (
+                        terminal in ".!?"
+                        and text[match_end : match_end + 1] == terminal
+                    ):
+                        match_end += 1
+                candidates.append(
+                    _BoilerplateCandidate(
+                        start=match_start,
+                        end=match_end,
+                        score=0.98,
+                        rule_ids=(f"template:{template.template_id}",),
+                    )
+                )
+
+        structural_rules: list[tuple[str, float]] = []
+        if _CHECKBOX_RE.search(stripped):
+            structural_rules.append(("structure:checkbox", 0.94))
+        if _DOT_PHRASE_RE.search(stripped):
+            structural_rules.append(("structure:dot_phrase", 0.96))
+        if _PLACEHOLDER_RE.search(stripped):
+            structural_rules.append(("structure:placeholder", 0.92))
+        if structural_rules:
+            candidates.append(
+                _BoilerplateCandidate(
+                    start=content_start,
+                    end=content_end,
+                    score=max(score for _, score in structural_rules),
+                    rule_ids=tuple(rule_id for rule_id, _ in structural_rules),
+                )
+            )
+
+    return tuple(
+        BoilerplateSpan(
+            start=candidate.start,
+            end=candidate.end,
+            score=candidate.score,
+            provenance={
+                "detector": BOILERPLATE_DETECTOR_VERSION,
+                "corpus_version": _template_corpus_version(),
+                "rule_ids": candidate.rule_ids,
+            },
+        )
+        for candidate in _merge_boilerplate_candidates(candidates)
+    )
+
+
+def detect_copy_forward(
+    text: str,
+    *,
+    source_documents: Mapping[str, str]
+    | Sequence[Mapping[str, Any] | tuple[str, str]]
+    | None = None,
+    document_id: str | None = None,
+    shingle_size: int = 5,
+    min_tokens: int = 8,
+) -> tuple[CopyForwardSpan, ...]:
+    """Detect intra-note and caller-supplied cross-note copied token runs.
+
+    Text is normalized with NFKC and case folding before word shingles are
+    compared. Punctuation and whitespace changes therefore preserve a match,
+    while returned spans still index the original note. Cross-document inputs
+    are references supplied directly by the caller; this function performs no
+    patient linking, storage, or network access.
+
+    Args:
+        text: Current clinical note text.
+        source_documents: Optional prior documents, either a mapping from source
+            reference to text, or a sequence of ``(reference, text)`` pairs or
+            mappings with ``doc_id`` and ``text`` fields.
+        document_id: Optional source reference used for intra-document matches.
+        shingle_size: Number of normalized word tokens per shingle.
+        min_tokens: Minimum contiguous copied token count to annotate.
+
+    Returns:
+        Non-overlapping copy-forward spans ordered by current-note offset.
+
+    Raises:
+        TypeError: If text or source documents have unsupported types.
+        ValueError: If identifiers or detector options are invalid.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    if document_id is not None and (
+        not isinstance(document_id, str) or not document_id.strip()
+    ):
+        raise ValueError("document_id must be a non-empty string when provided")
+    _validate_copy_options(shingle_size=shingle_size, min_tokens=min_tokens)
+
+    current_tokens = _tokens(text)
+    _validate_token_budget(current_tokens, label="current document")
+    if len(current_tokens) < min_tokens:
+        return ()
+
+    candidates = _matching_copy_candidates(
+        text,
+        current_tokens,
+        text,
+        current_tokens,
+        source_reference=document_id.strip() if document_id else "current_document",
+        match_kind="intra_document",
+        shingle_size=shingle_size,
+        min_tokens=min_tokens,
+        same_document=True,
+    )
+    for source_reference, source_text in _coerce_source_documents(source_documents):
+        source_tokens = _tokens(source_text)
+        _validate_token_budget(
+            source_tokens, label=f"source document {source_reference!r}"
+        )
+        if len(source_tokens) < min_tokens:
+            continue
+        candidates.extend(
+            _matching_copy_candidates(
+                text,
+                current_tokens,
+                source_text,
+                source_tokens,
+                source_reference=source_reference,
+                match_kind="cross_document",
+                shingle_size=shingle_size,
+                min_tokens=min_tokens,
+                same_document=False,
+            )
+        )
+
+    selected = _select_non_overlapping_copy_candidates(candidates)
+    return tuple(
+        CopyForwardSpan(
+            start=candidate.start,
+            end=candidate.end,
+            copied_from=candidate.source_reference,
+            source_start=candidate.source_start,
+            source_end=candidate.source_end,
+            score=1.0,
+            provenance={
+                "detector": COPY_FORWARD_DETECTOR_VERSION,
+                "match_kind": candidate.match_kind,
+                "normalization": "nfkc_casefold_word_shingles",
+                "shingle_size": shingle_size,
+                "matched_tokens": candidate.matched_tokens,
+            },
+        )
+        for candidate in selected
+    )
+
+
+@lru_cache(maxsize=1)
+def load_boilerplate_template_corpus() -> tuple[BoilerplateTemplate, ...]:
+    """Load and validate the bundled synthetic/public template phrase corpus."""
+
+    payload = _load_template_payload()
+    raw_templates = payload.get("templates")
+    if not isinstance(raw_templates, list) or not raw_templates:
+        raise ValueError("boilerplate template corpus requires template entries")
+
+    templates: list[BoilerplateTemplate] = []
+    seen_ids: set[str] = set()
+    for raw_template in raw_templates:
+        if not isinstance(raw_template, Mapping):
+            raise ValueError("boilerplate template entries must be objects")
+        template_id = raw_template.get("id")
+        text = raw_template.get("text")
+        source_type = raw_template.get("source_type")
+        if not isinstance(template_id, str) or not template_id.strip():
+            raise ValueError("boilerplate templates require non-empty ids")
+        if template_id in seen_ids:
+            raise ValueError(f"duplicate boilerplate template id {template_id!r}")
+        if not isinstance(text, str) or len(_tokens(text)) < 4:
+            raise ValueError(
+                f"boilerplate template {template_id!r} requires at least four tokens"
+            )
+        if source_type not in _ALLOWED_TEMPLATE_SOURCE_TYPES:
+            raise ValueError(
+                f"boilerplate template {template_id!r} has a restricted source type"
+            )
+        seen_ids.add(template_id)
+        templates.append(
+            BoilerplateTemplate(
+                template_id=template_id,
+                text=text,
+                source_type=str(source_type),
+            )
+        )
+    return tuple(templates)
+
+
+def _load_template_payload() -> dict[str, Any]:
+    resource = resources.files("openmed.clinical").joinpath(
+        DEFAULT_BOILERPLATE_TEMPLATE_RESOURCE
+    )
+    payload = json.loads(resource.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        raise ValueError("boilerplate template corpus requires schema_version 1")
+    provenance = payload.get("provenance")
+    if (
+        not isinstance(provenance, Mapping)
+        or provenance.get("restricted_data") is not False
+        or provenance.get("synthetic") is not True
+        or not provenance.get("source")
+        or not provenance.get("license")
+    ):
+        raise ValueError(
+            "boilerplate template corpus requires unrestricted synthetic provenance"
+        )
+    corpus_version = payload.get("corpus_version")
+    if not isinstance(corpus_version, str) or not corpus_version.strip():
+        raise ValueError("boilerplate template corpus requires corpus_version")
+    return payload
+
+
+@lru_cache(maxsize=1)
+def _template_corpus_version() -> str:
+    return str(_load_template_payload()["corpus_version"])
+
+
+def _validate_annotation_fields(start: int, end: int, score: float) -> None:
+    if (
+        isinstance(start, bool)
+        or isinstance(end, bool)
+        or not isinstance(start, int)
+        or not isinstance(end, int)
+    ):
+        raise TypeError("annotation offsets must be integers")
+    if start < 0 or end <= start:
+        raise ValueError("annotation offsets must satisfy 0 <= start < end")
+    if (
+        isinstance(score, bool)
+        or not isinstance(score, (int, float))
+        or not math.isfinite(score)
+        or not 0.0 <= score <= 1.0
+    ):
+        raise ValueError("annotation score must be between 0.0 and 1.0")
+
+
+def _content_lines(text: str) -> tuple[tuple[int, int], ...]:
+    lines: list[tuple[int, int]] = []
+    cursor = 0
+    for raw_line in text.splitlines(keepends=True):
+        content_end = cursor + len(raw_line.rstrip("\r\n"))
+        lines.append((cursor, content_end))
+        cursor += len(raw_line)
+    if not lines and text:
+        lines.append((0, len(text)))
+    return tuple(lines)
+
+
+def _normalize_token(surface: str) -> str:
+    return unicodedata.normalize("NFKC", surface).casefold()
+
+
+def _tokens(text: str, *, start: int = 0, end: int | None = None) -> tuple[_Token, ...]:
+    safe_end = len(text) if end is None else end
+    return tuple(
+        _Token(
+            normalized=_normalize_token(match.group(0)),
+            start=match.start(),
+            end=match.end(),
+        )
+        for match in _TOKEN_RE.finditer(text, start, safe_end)
+    )
+
+
+def _subsequence_starts(
+    sequence: tuple[str, ...],
+    subsequence: tuple[str, ...],
+) -> tuple[int, ...]:
+    if not subsequence or len(subsequence) > len(sequence):
+        return ()
+    width = len(subsequence)
+    return tuple(
+        index
+        for index in range(len(sequence) - width + 1)
+        if sequence[index : index + width] == subsequence
+    )
+
+
+def _merge_boilerplate_candidates(
+    candidates: Sequence[_BoilerplateCandidate],
+) -> tuple[_BoilerplateCandidate, ...]:
+    if not candidates:
+        return ()
+    ordered = sorted(candidates, key=lambda item: (item.start, item.end, item.rule_ids))
+    merged: list[_BoilerplateCandidate] = []
+    for candidate in ordered:
+        if not merged or candidate.start >= merged[-1].end:
+            merged.append(candidate)
+            continue
+        previous = merged[-1]
+        merged[-1] = _BoilerplateCandidate(
+            start=min(previous.start, candidate.start),
+            end=max(previous.end, candidate.end),
+            score=max(previous.score, candidate.score),
+            rule_ids=tuple(sorted(set((*previous.rule_ids, *candidate.rule_ids)))),
+        )
+    return tuple(merged)
+
+
+def _validate_copy_options(*, shingle_size: int, min_tokens: int) -> None:
+    for name, value in (("shingle_size", shingle_size), ("min_tokens", min_tokens)):
+        if isinstance(value, bool) or not isinstance(value, int) or value < 2:
+            raise ValueError(f"{name} must be an integer of at least 2")
+    if min_tokens < shingle_size:
+        raise ValueError("min_tokens must be greater than or equal to shingle_size")
+
+
+def _validate_token_budget(tokens: Sequence[_Token], *, label: str) -> None:
+    if len(tokens) > _MAX_COPY_FORWARD_TOKENS:
+        raise ValueError(f"{label} exceeds the copy-forward token budget")
+
+
+def _coerce_source_documents(
+    source_documents: Mapping[str, str]
+    | Sequence[Mapping[str, Any] | tuple[str, str]]
+    | None,
+) -> tuple[tuple[str, str], ...]:
+    if source_documents is None:
+        return ()
+
+    raw_items: Sequence[tuple[Any, Any] | Mapping[str, Any]]
+    if isinstance(source_documents, Mapping):
+        if "doc_id" in source_documents and "text" in source_documents:
+            raw_items = (source_documents,)
+        else:
+            raw_items = tuple(source_documents.items())
+    elif isinstance(source_documents, Sequence) and not isinstance(
+        source_documents, (str, bytes)
+    ):
+        raw_items = source_documents
+    else:
+        raise TypeError("source_documents must be a mapping or sequence")
+
+    documents: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for index, raw_item in enumerate(raw_items):
+        if isinstance(raw_item, Mapping):
+            source_reference = raw_item.get("doc_id")
+            source_text = raw_item.get("text")
+        elif isinstance(raw_item, tuple) and len(raw_item) == 2:
+            source_reference, source_text = raw_item
+        else:
+            raise TypeError(
+                f"source document at index {index} must provide a reference and text"
+            )
+        if not isinstance(source_reference, str) or not source_reference.strip():
+            raise ValueError(
+                f"source document at index {index} requires a non-empty reference"
+            )
+        source_reference = source_reference.strip()
+        if source_reference in seen:
+            raise ValueError(
+                f"duplicate source document reference {source_reference!r}"
+            )
+        if not isinstance(source_text, str):
+            raise TypeError(
+                f"source document {source_reference!r} text must be a string"
+            )
+        seen.add(source_reference)
+        documents.append((source_reference, source_text))
+    return tuple(sorted(documents, key=lambda item: item[0]))
+
+
+def _shingles(
+    text: str,
+    tokens: Sequence[_Token],
+    size: int,
+) -> tuple[tuple[str, ...] | None, ...]:
+    return tuple(
+        (
+            None
+            if "\n" in text[tokens[index].start : tokens[index + size - 1].end]
+            or "\r" in text[tokens[index].start : tokens[index + size - 1].end]
+            else tuple(token.normalized for token in tokens[index : index + size])
+        )
+        for index in range(len(tokens) - size + 1)
+    )
+
+
+def _shingle_index(
+    shingles: Sequence[tuple[str, ...] | None],
+) -> dict[tuple[str, ...], tuple[int, ...]]:
+    mutable: dict[tuple[str, ...], list[int]] = {}
+    for index, shingle in enumerate(shingles):
+        if shingle is None:
+            continue
+        positions = mutable.setdefault(shingle, [])
+        if len(positions) <= _MAX_SHINGLE_OCCURRENCES:
+            positions.append(index)
+    return {
+        shingle: tuple(positions)
+        for shingle, positions in mutable.items()
+        if len(positions) <= _MAX_SHINGLE_OCCURRENCES
+    }
+
+
+def _matching_copy_candidates(
+    current_text: str,
+    current_tokens: Sequence[_Token],
+    source_text: str,
+    source_tokens: Sequence[_Token],
+    *,
+    source_reference: str,
+    match_kind: str,
+    shingle_size: int,
+    min_tokens: int,
+    same_document: bool,
+) -> list[_CopyCandidate]:
+    current_shingles = _shingles(current_text, current_tokens, shingle_size)
+    source_shingles = _shingles(source_text, source_tokens, shingle_size)
+    source_index = _shingle_index(source_shingles)
+    positions_by_diagonal: dict[int, set[int]] = {}
+
+    for current_index, shingle in enumerate(current_shingles):
+        if shingle is None:
+            continue
+        for source_index_value in source_index.get(shingle, ()):
+            if same_document and source_index_value + shingle_size > current_index:
+                continue
+            diagonal = source_index_value - current_index
+            positions_by_diagonal.setdefault(diagonal, set()).add(current_index)
+
+    candidates: list[_CopyCandidate] = []
+    for diagonal, positions in sorted(positions_by_diagonal.items()):
+        ordered_positions = sorted(positions)
+        if not ordered_positions:
+            continue
+        run_start = ordered_positions[0]
+        previous = run_start
+        for current_index in (*ordered_positions[1:], -1):
+            if current_index == previous + 1:
+                previous = current_index
+                continue
+            shingle_count = previous - run_start + 1
+            matched_tokens = shingle_count + shingle_size - 1
+            if matched_tokens >= min_tokens:
+                source_token_start = run_start + diagonal
+                source_token_end = source_token_start + matched_tokens
+                current_token_end = run_start + matched_tokens
+                start, end = _expand_line_span(
+                    current_text,
+                    current_tokens[run_start].start,
+                    current_tokens[current_token_end - 1].end,
+                )
+                source_start, source_end = _expand_line_span(
+                    source_text,
+                    source_tokens[source_token_start].start,
+                    source_tokens[source_token_end - 1].end,
+                )
+                candidates.append(
+                    _CopyCandidate(
+                        start=start,
+                        end=end,
+                        source_reference=source_reference,
+                        source_start=source_start,
+                        source_end=source_end,
+                        matched_tokens=matched_tokens,
+                        match_kind=match_kind,
+                    )
+                )
+            if current_index == -1:
+                break
+            run_start = current_index
+            previous = current_index
+    return candidates
+
+
+def _expand_line_span(text: str, start: int, end: int) -> tuple[int, int]:
+    line_start = max(text.rfind("\n", 0, start), text.rfind("\r", 0, start)) + 1
+    line_breaks = tuple(
+        position
+        for separator in ("\n", "\r")
+        if (position := text.find(separator, end)) != -1
+    )
+    line_end = min(line_breaks) if line_breaks else len(text)
+    prefix = text[line_start:start]
+    suffix = text[end:line_end]
+    if not prefix.strip() and not suffix.strip(" \t\r.,;:!?()[]{}"):
+        return line_start + len(prefix) - len(prefix.lstrip()), line_end - len(
+            text[line_start:line_end]
+        ) + len(text[line_start:line_end].rstrip())
+    return start, end
+
+
+def _select_non_overlapping_copy_candidates(
+    candidates: Sequence[_CopyCandidate],
+) -> tuple[_CopyCandidate, ...]:
+    selected: list[_CopyCandidate] = []
+    ranked = sorted(
+        candidates,
+        key=lambda item: (
+            -item.matched_tokens,
+            -(item.end - item.start),
+            item.start,
+            item.source_reference,
+            item.source_start,
+        ),
+    )
+    for candidate in ranked:
+        if any(
+            candidate.start < existing.end and existing.start < candidate.end
+            for existing in selected
+        ):
+            continue
+        selected.append(candidate)
+    return tuple(
+        sorted(
+            selected,
+            key=lambda item: (item.start, item.end, item.source_reference),
+        )
+    )
+
+
+__all__ = [
+    "BOILERPLATE_DETECTOR_VERSION",
+    "COPY_FORWARD_DETECTOR_VERSION",
+    "DEFAULT_BOILERPLATE_TEMPLATE_RESOURCE",
+    "BoilerplateSpan",
+    "BoilerplateTemplate",
+    "CopyForwardSpan",
+    "detect_boilerplate",
+    "detect_copy_forward",
+    "load_boilerplate_template_corpus",
+]

--- a/openmed/clinical/data/boilerplate_templates.json
+++ b/openmed/clinical/data/boilerplate_templates.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "corpus_version": "openmed-synthetic-boilerplate-v1",
+  "provenance": {
+    "source": "OpenMed synthetic clinical template phrases",
+    "license": "Apache-2.0",
+    "restricted_data": false,
+    "synthetic": true
+  },
+  "templates": [
+    {
+      "id": "constitutional-normal-exam",
+      "source_type": "synthetic",
+      "text": "Constitutional: well developed, well nourished, and in no acute distress."
+    },
+    {
+      "id": "head-normal-exam",
+      "source_type": "synthetic",
+      "text": "Head: normocephalic and atraumatic."
+    },
+    {
+      "id": "eyes-normal-exam",
+      "source_type": "synthetic",
+      "text": "Eyes: pupils equal, round, and reactive to light."
+    },
+    {
+      "id": "cardiovascular-normal-exam",
+      "source_type": "synthetic",
+      "text": "Cardiovascular: regular rate and rhythm without murmurs, rubs, or gallops."
+    },
+    {
+      "id": "respiratory-normal-exam",
+      "source_type": "synthetic",
+      "text": "Respiratory: clear to auscultation bilaterally without wheezes, rales, or rhonchi."
+    },
+    {
+      "id": "abdomen-normal-exam",
+      "source_type": "synthetic",
+      "text": "Abdomen: soft, non-tender, and non-distended with bowel sounds present."
+    },
+    {
+      "id": "extremities-normal-exam",
+      "source_type": "synthetic",
+      "text": "Extremities: no clubbing, cyanosis, or edema."
+    },
+    {
+      "id": "neurologic-normal-exam",
+      "source_type": "synthetic",
+      "text": "Neurologic: alert and oriented with cranial nerves grossly intact."
+    },
+    {
+      "id": "review-of-systems-catchall",
+      "source_type": "synthetic",
+      "text": "Review of systems is otherwise negative except as documented above."
+    },
+    {
+      "id": "chart-review-attestation",
+      "source_type": "synthetic",
+      "text": "The patient was seen and examined and the chart was reviewed."
+    },
+    {
+      "id": "consent-attestation",
+      "source_type": "synthetic",
+      "text": "Risks, benefits, and alternatives were discussed with the patient."
+    }
+  ]
+}

--- a/openmed/clinical/summary_card.py
+++ b/openmed/clinical/summary_card.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 ENTITY_CATEGORY_LABELS = ("problems", "medications", "labs", "procedures", "other")
@@ -34,6 +34,7 @@ _CATEGORY_FIELD_NAMES = (
 )
 _ENTITY_CONTAINER_NAMES = ("entities", "clinical_entities", "spans")
 _SECTION_CONTAINER_NAMES = ("sections", "clinical_sections")
+_BOILERPLATE_CONTAINER_NAMES = ("boilerplate_spans", "content_annotations")
 _CODING_CONTAINER_NAMES = (
     "coding",
     "codings",
@@ -106,6 +107,7 @@ class ClinicalSummaryCard:
     uncoded_entities: int = 0
     distinct_codes: int = 0
     section_count: int = 0
+    suppression_provenance: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         for field_name in (
@@ -118,6 +120,11 @@ class ClinicalSummaryCard:
                 raise TypeError(f"{field_name} must be an integer count")
             if value < 0:
                 raise ValueError(f"{field_name} must be non-negative")
+        object.__setattr__(
+            self,
+            "suppression_provenance",
+            _validated_suppression_provenance(self.suppression_provenance),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Return a deterministic, JSON-compatible card representation."""
@@ -137,6 +144,10 @@ class ClinicalSummaryCard:
             },
             "section_count": self.section_count,
         }
+        if self.suppression_provenance:
+            payload["provenance"] = {
+                "boilerplate_suppression": dict(self.suppression_provenance)
+            }
         _assert_card_payload_is_log_safe(payload)
         return payload
 
@@ -149,6 +160,9 @@ class ClinicalSummaryCard:
 def build_summary_card(
     entities: object | None = None,
     sections: object | None = None,
+    *,
+    boilerplate_spans: object | None = None,
+    suppress_boilerplate: bool = False,
 ) -> ClinicalSummaryCard:
     """Build a PHI-free summary card from clinical entities and sections.
 
@@ -162,6 +176,12 @@ def build_summary_card(
             field is also accepted.
         sections: Optional sequence of detected sections, or a section metadata
             mapping with a ``sections`` or ``clinical_sections`` field.
+        boilerplate_spans: Optional boilerplate/copy-forward annotations with
+            half-open ``start``/``end`` offsets. A document mapping may instead
+            provide ``boilerplate_spans`` or ``content_annotations``.
+        suppress_boilerplate: Drop entities fully contained by a flagged span
+            before aggregating counts. The card then includes fixed, PHI-free
+            suppression provenance. Defaults to ``False``.
 
     Returns:
         A :class:`ClinicalSummaryCard` containing only aggregate counts.
@@ -171,16 +191,30 @@ def build_summary_card(
     if isinstance(entities, Mapping):
         if sections is None:
             sections = _first_field_value(entities, _SECTION_CONTAINER_NAMES)
+        if boilerplate_spans is None:
+            boilerplate_spans = _first_field_value(
+                entities, _BOILERPLATE_CONTAINER_NAMES
+            )
         nested_entities = _first_field_value(entities, _ENTITY_CONTAINER_NAMES)
         if nested_entities is not None:
             entity_source = nested_entities
+
+    # Keep the general processing package out of the clinical import path. The
+    # suppression helper is needed only when a card is actually built.
+    from openmed.processing.text import apply_boilerplate_suppression
+
+    suppression = apply_boilerplate_suppression(
+        tuple(_iter_items(entity_source)),
+        tuple(_iter_items(boilerplate_spans)),
+        suppress_boilerplate=suppress_boilerplate,
+    )
 
     category_counts = dict.fromkeys(ENTITY_CATEGORY_LABELS, 0)
     coded_entities = 0
     uncoded_entities = 0
     distinct_codes: set[tuple[str, str]] = set()
 
-    for entity in _iter_items(entity_source):
+    for entity in suppression.records:
         category = _category_for_entity(entity)
         category_counts[category] += 1
 
@@ -201,6 +235,7 @@ def build_summary_card(
         uncoded_entities=uncoded_entities,
         distinct_codes=len(distinct_codes),
         section_count=_count_sections(sections),
+        suppression_provenance=(suppression.provenance if suppress_boilerplate else {}),
     )
 
 
@@ -330,7 +365,10 @@ def _field_value(source: object, field_name: str) -> object | None:
 
 
 def _assert_card_payload_is_log_safe(payload: Mapping[str, Any]) -> None:
-    if tuple(payload.keys()) != _TOP_LEVEL_KEYS:
+    expected_keys = _TOP_LEVEL_KEYS + (
+        ("provenance",) if "provenance" in payload else ()
+    )
+    if tuple(payload.keys()) != expected_keys:
         raise ValueError("summary card payload keys must be fixed")
 
     entity_counts = payload["entity_counts"]
@@ -353,6 +391,45 @@ def _assert_card_payload_is_log_safe(payload: Mapping[str, Any]) -> None:
     ):
         if isinstance(value, bool) or not isinstance(value, int):
             raise ValueError(f"summary card field {label!r} must be an integer count")
+
+    if "provenance" in payload:
+        provenance = payload["provenance"]
+        if not isinstance(provenance, Mapping) or tuple(provenance) != (
+            "boilerplate_suppression",
+        ):
+            raise ValueError("summary card provenance keys must be fixed")
+        _validated_suppression_provenance(provenance["boilerplate_suppression"])
+
+
+def _validated_suppression_provenance(value: object) -> dict[str, Any]:
+    if not value:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError("suppression_provenance must be a mapping")
+    expected_keys = (
+        "enabled",
+        "policy",
+        "input_entity_count",
+        "retained_entity_count",
+        "suppressed_entity_count",
+        "annotation_count",
+    )
+    if tuple(value) != expected_keys:
+        raise ValueError("suppression provenance keys must be fixed")
+    if not isinstance(value["enabled"], bool):
+        raise ValueError("suppression provenance enabled must be a boolean")
+    if value["policy"] != "drop_fully_contained":
+        raise ValueError("suppression provenance policy is unsupported")
+    for key in expected_keys[2:]:
+        count = value[key]
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise ValueError(f"suppression provenance {key} must be non-negative")
+    if (
+        value["input_entity_count"]
+        != value["retained_entity_count"] + value["suppressed_entity_count"]
+    ):
+        raise ValueError("suppression provenance entity counts must balance")
+    return dict(value)
 
 
 __all__ = [

--- a/openmed/processing/__init__.py
+++ b/openmed/processing/__init__.py
@@ -71,9 +71,11 @@ from .pulsar_connector import PulsarClientPair, create_pulsar_clients
 from .sentences import SentenceSpan, segment_chinese_text, segment_text
 from .text import (
     INDIC_SCRIPTS,
+    BoilerplateSuppressionResult,
     IndicNormalization,
     IndicNormalizer,
     TextProcessor,
+    apply_boilerplate_suppression,
     normalize_indic_text,
     postprocess_text,
     preprocess_text,
@@ -144,6 +146,8 @@ from .zh_segmentation import (
 
 __all__ = [
     "TextProcessor",
+    "BoilerplateSuppressionResult",
+    "apply_boilerplate_suppression",
     "INDIC_SCRIPTS",
     "IndicNormalization",
     "IndicNormalizer",

--- a/openmed/processing/text.py
+++ b/openmed/processing/text.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import unicodedata
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
@@ -1172,6 +1172,164 @@ class TextProcessor:
             entities[key] = list(set(entities[key]))
 
         return entities
+
+
+@dataclass(frozen=True)
+class BoilerplateSuppressionResult:
+    """Clinical records retained after optional annotation-based suppression.
+
+    ``provenance`` contains counts and a fixed policy name only. It never
+    includes entity text, annotation source identifiers, or source surfaces.
+    """
+
+    records: tuple[object, ...]
+    provenance: Mapping[str, object]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "provenance", dict(self.provenance))
+
+
+def apply_boilerplate_suppression(
+    records: Iterable[object],
+    annotations: Iterable[object] = (),
+    *,
+    suppress_boilerplate: bool = False,
+) -> BoilerplateSuppressionResult:
+    """Drop records fully contained by boilerplate/copy-forward annotations.
+
+    Suppression is opt-in and conservative. Records without valid offsets, or
+    records that only partially overlap an annotation, are retained. The
+    original records and annotations are never mutated.
+
+    Args:
+        records: Extracted entity mappings or objects with ``start``/``end``,
+            ``start_char``/``end_char``, or an ``offset``/``offsets`` pair.
+        annotations: Boilerplate or copy-forward span mappings/objects.
+        suppress_boilerplate: Whether to apply the drop policy. Defaults to
+            ``False`` so existing extraction behavior remains unchanged.
+
+    Returns:
+        Retained records and PHI-free aggregate suppression provenance.
+
+    Raises:
+        TypeError: If either input is a string/bytes value or suppression is
+            not a boolean.
+        ValueError: If a relevant annotation has malformed offsets.
+    """
+
+    if not isinstance(suppress_boilerplate, bool):
+        raise TypeError("suppress_boilerplate must be a boolean")
+    materialized_records = _materialize_suppression_items(records, label="records")
+    materialized_annotations = _materialize_suppression_items(
+        annotations, label="annotations"
+    )
+    flagged_spans = tuple(
+        span
+        for annotation in materialized_annotations
+        if (span := _suppression_annotation_span(annotation)) is not None
+    )
+
+    retained: list[object] = []
+    suppressed_count = 0
+    for record in materialized_records:
+        record_span = _record_span(record)
+        suppress = (
+            suppress_boilerplate
+            and record_span is not None
+            and any(
+                annotation_start <= record_span[0] and record_span[1] <= annotation_end
+                for annotation_start, annotation_end in flagged_spans
+            )
+        )
+        if suppress:
+            suppressed_count += 1
+        else:
+            retained.append(record)
+
+    provenance: dict[str, object] = {
+        "enabled": suppress_boilerplate,
+        "policy": "drop_fully_contained",
+        "input_entity_count": len(materialized_records),
+        "retained_entity_count": len(retained),
+        "suppressed_entity_count": suppressed_count,
+        "annotation_count": len(flagged_spans),
+    }
+    return BoilerplateSuppressionResult(
+        records=tuple(retained),
+        provenance=provenance,
+    )
+
+
+def _materialize_suppression_items(
+    values: Iterable[object],
+    *,
+    label: str,
+) -> tuple[object, ...]:
+    if isinstance(values, (str, bytes)):
+        raise TypeError(f"{label} must be an iterable of records")
+    try:
+        return tuple(values)
+    except TypeError:
+        raise TypeError(f"{label} must be an iterable of records") from None
+
+
+def _suppression_annotation_span(annotation: object) -> tuple[int, int] | None:
+    annotation_type = _suppression_field(annotation, "type")
+    if annotation_type not in {"boilerplate", "copy_forward"}:
+        return None
+    start = _suppression_field(annotation, "start")
+    end = _suppression_field(annotation, "end")
+    if (
+        isinstance(start, bool)
+        or isinstance(end, bool)
+        or not isinstance(start, int)
+        or not isinstance(end, int)
+        or start < 0
+        or end <= start
+    ):
+        raise ValueError("suppression annotations require valid integer offsets")
+    return start, end
+
+
+def _record_span(record: object) -> tuple[int, int] | None:
+    for start_key, end_key in (
+        ("start", "end"),
+        ("start_char", "end_char"),
+        ("start_offset", "end_offset"),
+    ):
+        start = _suppression_field(record, start_key)
+        end = _suppression_field(record, end_key)
+        if start is not None or end is not None:
+            return _validated_record_span(start, end)
+
+    for pair_key in ("offset", "offsets"):
+        pair = _suppression_field(record, pair_key)
+        if pair is not None:
+            if not isinstance(pair, Sequence) or isinstance(pair, (str, bytes)):
+                return None
+            if len(pair) != 2:
+                return None
+            return _validated_record_span(pair[0], pair[1])
+    return None
+
+
+def _validated_record_span(start: object, end: object) -> tuple[int, int] | None:
+    if (
+        isinstance(start, bool)
+        or isinstance(end, bool)
+        or not isinstance(start, int)
+        or not isinstance(end, int)
+        or start < 0
+        or end < start
+    ):
+        return None
+    return start, end
+
+
+def _suppression_field(source: object, field_name: str) -> object | None:
+    if isinstance(source, Mapping):
+        return source.get(field_name)
+    return getattr(source, field_name, None)
 
 
 def preprocess_text(

--- a/tests/fixtures/clinical/boilerplate_copy_forward.json
+++ b/tests/fixtures/clinical/boilerplate_copy_forward.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": 1,
+  "provenance": {
+    "source": "OpenMed synthetic boilerplate and copy-forward evaluation cases",
+    "license": "Apache-2.0",
+    "restricted_data": false,
+    "synthetic": true
+  },
+  "boilerplate_cases": [
+    {
+      "case_id": "normal-exam-template",
+      "text": "Assessment: Synthetic cough is improving today.\nConstitutional: well developed, well nourished, and in no acute distress.\nPlan: Continue supportive care.\n",
+      "gold_surfaces": [
+        {
+          "surface": "Constitutional: well developed, well nourished, and in no acute distress.",
+          "occurrence": 0
+        }
+      ]
+    },
+    {
+      "case_id": "checkbox-scaffold",
+      "text": "Review of systems\n[ ] Replace this synthetic checkbox item before signing\nCurrent concern: intermittent cough.\n",
+      "gold_surfaces": [
+        {
+          "surface": "[ ] Replace this synthetic checkbox item before signing",
+          "occurrence": 0
+        }
+      ]
+    },
+    {
+      "case_id": "dot-phrase-scaffold",
+      "text": "History: Synthetic symptoms began today.\n.NORMAL_EXAM\nPlan: Review tomorrow.\n",
+      "gold_surfaces": [
+        {
+          "surface": ".NORMAL_EXAM",
+          "occurrence": 0
+        }
+      ]
+    },
+    {
+      "case_id": "placeholder-scaffold",
+      "text": "Family history: {{ enter synthetic family details }}\nAssessment: No family details supplied.\n",
+      "gold_surfaces": [
+        {
+          "surface": "Family history: {{ enter synthetic family details }}",
+          "occurrence": 0
+        }
+      ]
+    },
+    {
+      "case_id": "patient-specific-clean-line",
+      "text": "Assessment: A new synthetic cough began after today's exercise.\nPlan: Reassess the newly reported symptom tomorrow.\n",
+      "gold_surfaces": []
+    }
+  ],
+  "copy_forward_cases": [
+    {
+      "case_id": "cross-document-exact",
+      "document_id": "current-a",
+      "source_documents": {
+        "prior-a": "Prior assessment:\nSynthetic cough improved after oral fluids and quiet rest overnight.\nPrior plan: review as needed.\n"
+      },
+      "text": "Current assessment:\nSynthetic cough improved after oral fluids and quiet rest overnight.\nNew plan: review tomorrow.\n",
+      "gold_surfaces": [
+        {
+          "surface": "Synthetic cough improved after oral fluids and quiet rest overnight.",
+          "occurrence": 0
+        }
+      ]
+    },
+    {
+      "case_id": "cross-document-normalized",
+      "document_id": "current-b",
+      "source_documents": {
+        "prior-b": "CARDIOPULMONARY: Synthetic examination showed steady rhythm, clear breath sounds, and comfortable effort."
+      },
+      "text": "cardiopulmonary - synthetic examination showed steady rhythm clear breath sounds AND comfortable effort!",
+      "gold_surfaces": [
+        {
+          "surface": "cardiopulmonary - synthetic examination showed steady rhythm clear breath sounds AND comfortable effort!",
+          "occurrence": 0
+        }
+      ]
+    },
+    {
+      "case_id": "intra-document-repeat",
+      "document_id": "current-c",
+      "source_documents": {},
+      "text": "Assessment:\nSynthetic abdominal discomfort improved with hydration and gentle activity today.\nPlan: Continue observation.\nSynthetic abdominal discomfort improved with hydration and gentle activity today.\n",
+      "gold_surfaces": [
+        {
+          "surface": "Synthetic abdominal discomfort improved with hydration and gentle activity today.",
+          "occurrence": 1
+        }
+      ]
+    },
+    {
+      "case_id": "copy-forward-clean-note",
+      "document_id": "current-d",
+      "source_documents": {
+        "prior-d": "Synthetic ankle stiffness resolved after rest and elevation yesterday."
+      },
+      "text": "A newly reported synthetic headache began during today's exercise session.",
+      "gold_surfaces": []
+    }
+  ]
+}

--- a/tests/unit/clinical/test_boilerplate.py
+++ b/tests/unit/clinical/test_boilerplate.py
@@ -1,0 +1,264 @@
+"""Synthetic offline tests for boilerplate and copy-forward span annotations."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from pathlib import Path
+
+import pytest
+
+from openmed.clinical import (
+    DEFAULT_BOILERPLATE_TEMPLATE_RESOURCE,
+    BoilerplateSpan,
+    CopyForwardSpan,
+    build_summary_card,
+    detect_boilerplate,
+    detect_copy_forward,
+    load_boilerplate_template_corpus,
+)
+from openmed.processing import apply_boilerplate_suppression
+
+_FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "clinical"
+    / "boilerplate_copy_forward.json"
+)
+
+
+def _load_fixture() -> dict:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _gold_offsets(text: str, gold_surfaces: list[dict]) -> set[tuple[int, int]]:
+    offsets: set[tuple[int, int]] = set()
+    for item in gold_surfaces:
+        surface = item["surface"]
+        start = -1
+        for _ in range(item["occurrence"] + 1):
+            start = text.find(surface, start + 1)
+        assert start >= 0
+        offsets.add((start, start + len(surface)))
+    return offsets
+
+
+def _exact_span_metrics(
+    gold: set[tuple[str, int, int]],
+    predicted: set[tuple[str, int, int]],
+) -> dict[str, float]:
+    true_positive = len(gold & predicted)
+    precision = true_positive / len(predicted) if predicted else float(not gold)
+    recall = true_positive / len(gold) if gold else float(not predicted)
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return {"precision": precision, "recall": recall, "f1": f1}
+
+
+def test_detect_boilerplate_returns_offset_aligned_non_destructive_spans() -> None:
+    text = (
+        "Assessment: Synthetic cough is improving today.\n"
+        "  Constitutional: well developed, well nourished, and in no acute distress.  \n"
+    )
+    original = text[:]
+
+    spans = detect_boilerplate(text)
+
+    assert text == original
+    assert spans == detect_boilerplate(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert isinstance(span, BoilerplateSpan)
+    assert span.type == "boilerplate"
+    assert text[span.start : span.end] == (
+        "Constitutional: well developed, well nourished, and in no acute distress."
+    )
+    assert span.provenance["detector"] == "openmed-boilerplate-v1"
+    assert span.to_dict()["provenance"]["rule_ids"] == (
+        "template:constitutional-normal-exam",
+    )
+
+
+def test_copy_forward_spans_include_cross_and_intra_source_provenance() -> None:
+    repeated = "Synthetic abdominal discomfort improved with hydration and gentle activity today."
+    text = f"Assessment:\n{repeated}\nPlan:\n{repeated}\n"
+    source = (
+        "Synthetic respiratory symptoms improved after hydration and quiet rest today."
+    )
+    current = f"Assessment:\n{source}\n"
+
+    intra = detect_copy_forward(text, document_id="current-note")
+    cross = detect_copy_forward(
+        current,
+        source_documents={"prior-note": source},
+        document_id="current-note",
+    )
+
+    assert len(intra) == 1
+    assert isinstance(intra[0], CopyForwardSpan)
+    assert intra[0].type == "copy_forward"
+    assert intra[0].copied_from == "current-note"
+    assert intra[0].provenance["match_kind"] == "intra_document"
+    assert text[intra[0].start : intra[0].end] == repeated
+    assert len(cross) == 1
+    assert cross[0].copied_from == "prior-note"
+    assert cross[0].provenance["match_kind"] == "cross_document"
+    assert current[cross[0].start : cross[0].end] == source
+
+
+def test_synthetic_detection_fixture_meets_span_f1_gates() -> None:
+    fixture = _load_fixture()
+    boilerplate_gold: set[tuple[str, int, int]] = set()
+    boilerplate_predicted: set[tuple[str, int, int]] = set()
+    for case in fixture["boilerplate_cases"]:
+        boilerplate_gold.update(
+            (case["case_id"], start, end)
+            for start, end in _gold_offsets(case["text"], case["gold_surfaces"])
+        )
+        boilerplate_predicted.update(
+            (case["case_id"], span.start, span.end)
+            for span in detect_boilerplate(case["text"])
+        )
+
+    copy_gold: set[tuple[str, int, int]] = set()
+    copy_predicted: set[tuple[str, int, int]] = set()
+    for case in fixture["copy_forward_cases"]:
+        copy_gold.update(
+            (case["case_id"], start, end)
+            for start, end in _gold_offsets(case["text"], case["gold_surfaces"])
+        )
+        copy_predicted.update(
+            (case["case_id"], span.start, span.end)
+            for span in detect_copy_forward(
+                case["text"],
+                source_documents=case["source_documents"],
+                document_id=case["document_id"],
+            )
+        )
+
+    boilerplate_metrics = _exact_span_metrics(boilerplate_gold, boilerplate_predicted)
+    copy_metrics = _exact_span_metrics(copy_gold, copy_predicted)
+    assert boilerplate_metrics["precision"] >= 0.85
+    assert boilerplate_metrics["recall"] >= 0.85
+    assert boilerplate_metrics["f1"] >= 0.85
+    assert copy_metrics["precision"] >= 0.80
+    assert copy_metrics["recall"] >= 0.80
+    assert copy_metrics["f1"] >= 0.80
+
+
+def test_suppression_drops_only_fully_flagged_entities_and_records_provenance() -> None:
+    text = (
+        "Assessment: new synthetic cough.\n"
+        "Constitutional: well developed, well nourished, and in no acute distress.\n"
+    )
+    annotations = detect_boilerplate(text)
+    boilerplate_start = text.index("no acute distress")
+    current_start = text.index("new synthetic cough")
+    entities = [
+        {
+            "category": "problem",
+            "start": boilerplate_start,
+            "end": boilerplate_start + len("no acute distress"),
+        },
+        {
+            "category": "problem",
+            "start": current_start,
+            "end": current_start + len("new synthetic cough"),
+        },
+        {
+            "category": "medication",
+            "start": annotations[0].end - 4,
+            "end": annotations[0].end + 1,
+        },
+    ]
+    original_entities = [dict(entity) for entity in entities]
+
+    disabled = apply_boilerplate_suppression(entities, annotations)
+    enabled = apply_boilerplate_suppression(
+        entities, annotations, suppress_boilerplate=True
+    )
+    card = build_summary_card(
+        entities,
+        boilerplate_spans=annotations,
+        suppress_boilerplate=True,
+    )
+    document_card = build_summary_card(
+        {"clinical_entities": entities, "boilerplate_spans": annotations},
+        suppress_boilerplate=True,
+    )
+    copy_suppression = apply_boilerplate_suppression(
+        [{"category": "lab", "offsets": (4, 9)}],
+        [{"type": "copy_forward", "start": 3, "end": 10}],
+        suppress_boilerplate=True,
+    )
+
+    assert len(disabled.records) == 3
+    assert len(enabled.records) == 2
+    assert entities == original_entities
+    assert copy_suppression.records == ()
+    assert copy_suppression.provenance["suppressed_entity_count"] == 1
+    assert enabled.provenance == {
+        "enabled": True,
+        "policy": "drop_fully_contained",
+        "input_entity_count": 3,
+        "retained_entity_count": 2,
+        "suppressed_entity_count": 1,
+        "annotation_count": 1,
+    }
+    assert card.to_dict() == {
+        "entity_counts": {
+            "problems": 1,
+            "medications": 1,
+            "labs": 0,
+            "procedures": 0,
+            "other": 0,
+        },
+        "coding_counts": {
+            "coded_entities": 0,
+            "uncoded_entities": 2,
+            "distinct_codes": 0,
+        },
+        "section_count": 0,
+        "provenance": {"boilerplate_suppression": enabled.provenance},
+    }
+    assert document_card == card
+
+
+def test_template_and_evaluation_data_are_synthetic_and_unrestricted() -> None:
+    resource = resources.files("openmed.clinical").joinpath(
+        DEFAULT_BOILERPLATE_TEMPLATE_RESOURCE
+    )
+    corpus = json.loads(resource.read_text(encoding="utf-8"))
+    fixture = _load_fixture()
+
+    expected_provenance = {
+        "source": "OpenMed synthetic clinical template phrases",
+        "license": "Apache-2.0",
+        "restricted_data": False,
+        "synthetic": True,
+    }
+    assert corpus["provenance"] == expected_provenance
+    assert fixture["provenance"]["restricted_data"] is False
+    assert fixture["provenance"]["synthetic"] is True
+    assert {entry["source_type"] for entry in corpus["templates"]} <= {
+        "synthetic",
+        "public_domain",
+    }
+    assert len(load_boilerplate_template_corpus()) == len(corpus["templates"])
+    corpus_text = json.dumps(corpus, sort_keys=True).casefold()
+    for restricted_source in ("mimic", "i2b2", "n2c2", '"source_type": "dua"'):
+        assert restricted_source not in corpus_text
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    (
+        ({"shingle_size": 1}, "shingle_size"),
+        ({"shingle_size": 9, "min_tokens": 8}, "min_tokens"),
+        ({"document_id": ""}, "document_id"),
+    ),
+)
+def test_copy_forward_rejects_invalid_options(kwargs: dict, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        detect_copy_forward(
+            "Synthetic text with enough words for validation.", **kwargs
+        )


### PR DESCRIPTION
## Description

Adds deterministic, local span annotations for clinical template boilerplate and copy-forward text so downstream extraction can avoid stale or non-patient-specific findings without modifying source notes.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/improvement

## Changes Made

- Added offset-aligned boilerplate annotations for synthetic canned phrases, checkbox scaffolds, dot phrases, and placeholders.
- Added intra-document and caller-supplied cross-document normalized word-shingle matching with source references and provenance.
- Added opt-in suppression for fully contained entities, including PHI-free aggregate provenance in clinical summary cards.
- Added an unrestricted synthetic template corpus and synthetic exact-span evaluation cases with boilerplate and copy-forward F1 gates.

## Testing

- [x] Added focused tests proving annotation offsets, provenance, deterministic behavior, suppression, and corpus restrictions.
- [x] `tests/unit/clinical/test_boilerplate.py` — 8 passed.
- [x] `tests/unit/clinical/test_summary_card.py` — 4 passed.
- [x] Changed-file lint and format checks pass.

## Documentation

- [x] Added docstrings to new public functions and classes.
- [ ] Changelog update is not required for this scoped feature branch.

## Code Quality

- [x] Performed a self-review of the complete diff.
- [x] Added no new dependencies.
- [x] Source notes remain unchanged and no raw clinical text enters suppression provenance.

## Related Issues

Closes #1265

## Screenshots/Examples

Not applicable; this change adds Python annotation and filtering APIs.
