### PR TITLE
Add validated clinical section detection orchestration

### DIFF
--- a/openmed/clinical/sections/__init__.py
+++ b/openmed/clinical/sections/__init__.py
@@ -14,6 +14,7 @@ from .detect import (
     parse_section_lists,
     section_label_from_loinc,
     validate_section_spans,
+    validate_sections,
 )
 from .doctype import (
     DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE,
@@ -41,5 +42,6 @@ __all__ = [
     "parse_section_lists",
     "segment_history_family",
     "section_label_from_loinc",
+    "validate_sections",
     "validate_section_spans",
 ]

--- a/openmed/clinical/sections/detect.py
+++ b/openmed/clinical/sections/detect.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any
@@ -88,20 +88,59 @@ class _HeaderHit:
     language: str
 
 
+@dataclass(frozen=True)
+class _SectionCandidate:
+    span: SectionSpan
+    header_start: int
+    header_end: int
+    registration_order: int
+
+    @property
+    def header_length(self) -> int:
+        return self.header_end - self.header_start
+
+
+_SectionSegmenter = Callable[[str, str | None], tuple[SectionSpan, ...]]
+
+
 def detect_sections(
     text: str,
     *,
     language: str | None = None,
     include_unsectioned: bool = True,
 ) -> tuple[SectionSpan, ...]:
-    """Segment *text* into canonical clinical section spans.
+    """Run registered segmenters and assemble canonical section spans.
 
-    Headers are matched at line starts using language-pack section lexicons.
-    Colon/full-width-colon headers, standalone headers, and underlined headers
-    are supported without whitespace assumptions around CJK or RTL scripts.
-    Returned ``label`` values are canonical section keys, so downstream section
-    priors can consume them directly.
+    Candidate headers from the language-pack lexicon and focused section-family
+    segmenters are merged deterministically. Overlapping header matches prefer
+    the longest match, then the earliest section start, then registration order
+    for an exact tie. Returned spans are sorted and, by default, ``unsectioned``
+    spans fill any uncovered ranges so the result covers all of *text*.
     """
+
+    if not text:
+        validate_sections(text, ())
+        return ()
+
+    candidates = _section_candidates(text, language)
+    result = _assemble_sections(
+        text,
+        _resolve_overlapping_headers(candidates),
+        language=language,
+        include_unsectioned=include_unsectioned,
+    )
+    if include_unsectioned:
+        validate_sections(text, result)
+    else:
+        _validate_section_spans(text, result, require_coverage=False)
+    return result
+
+
+def _segment_lexicon_sections(
+    text: str,
+    language: str | None,
+) -> tuple[SectionSpan, ...]:
+    """Return sections detected from the multilingual header lexicon."""
 
     if not text:
         return ()
@@ -113,29 +152,21 @@ def detect_sections(
         for hit in _line_header_hits(line, _next_line(lines, index), language)
     )
     if not hits:
-        unsectioned_result = (
-            (
-                _section_dict(
-                    label=UNSECTIONED_SECTION,
-                    start=0,
-                    end=len(text),
-                    language=language,
-                ),
-            )
-            if include_unsectioned and text
-            else ()
+        result = (
+            _section_dict(
+                label=UNSECTIONED_SECTION,
+                start=0,
+                end=len(text),
+                language=language,
+            ),
         )
-        _validate_section_spans(
-            text,
-            unsectioned_result,
-            require_coverage=include_unsectioned,
-        )
-        return unsectioned_result
+        validate_sections(text, result)
+        return result
 
     sections: list[SectionSpan] = []
     cursor = 0
     for index, hit in enumerate(hits):
-        if include_unsectioned and cursor < hit.start:
+        if cursor < hit.start:
             sections.append(
                 _section_dict(
                     label=UNSECTIONED_SECTION,
@@ -160,7 +191,7 @@ def detect_sections(
             )
         cursor = section_end
 
-    if include_unsectioned and cursor < len(text):
+    if cursor < len(text):
         sections.append(
             _section_dict(
                 label=UNSECTIONED_SECTION,
@@ -170,15 +201,212 @@ def detect_sections(
             )
         )
     result = tuple(section for section in sections if section["start"] < section["end"])
-    _validate_section_spans(
-        text,
-        result,
-        require_coverage=include_unsectioned,
-    )
+    validate_sections(text, result)
     return result
 
 
-def validate_section_spans(
+def _segment_history_sections(
+    text: str,
+    language: str | None,
+) -> tuple[SectionSpan, ...]:
+    """Adapt the focused history-family segmenter to the registry contract."""
+
+    del language
+    from .history import segment_history_family
+
+    return segment_history_family(text)
+
+
+_REGISTERED_SECTION_SEGMENTERS: tuple[_SectionSegmenter, ...] = (
+    _segment_lexicon_sections,
+    _segment_history_sections,
+)
+
+
+def _section_candidates(
+    text: str,
+    language: str | None,
+) -> tuple[_SectionCandidate, ...]:
+    candidates: list[_SectionCandidate] = []
+    registration_order = 0
+    for segmenter in _REGISTERED_SECTION_SEGMENTERS:
+        for index, raw_span in enumerate(segmenter(text, language)):
+            if not isinstance(raw_span, Mapping):
+                raise ValueError(
+                    f"registered section segmenter span {index} must be a mapping"
+                )
+            label = raw_span.get("label")
+            if not isinstance(label, str) or not label.strip():
+                raise ValueError(
+                    f"registered section segmenter span {index} requires a label"
+                )
+            start = _section_offset(raw_span, "start", index)
+            end = _section_offset(raw_span, "end", index)
+            if start < 0 or start > len(text) or end < 0 or end > len(text):
+                raise ValueError(
+                    f"registered section segmenter span {index} has invalid offsets"
+                )
+            if end <= start:
+                raise ValueError(
+                    f"registered section segmenter span {index} has invalid offsets"
+                )
+            if label == UNSECTIONED_SECTION:
+                continue
+
+            metadata = {
+                key: value
+                for key, value in raw_span.items()
+                if isinstance(key, str) and key not in {"label", "start", "end"}
+            }
+            span = SectionSpan(label=label, start=start, end=end, **metadata)
+            header_start, header_end = _candidate_header_bounds(text, span)
+            candidates.append(
+                _SectionCandidate(
+                    span=span,
+                    header_start=header_start,
+                    header_end=header_end,
+                    registration_order=registration_order,
+                )
+            )
+            registration_order += 1
+    return tuple(candidates)
+
+
+def _candidate_header_bounds(
+    text: str,
+    span: Mapping[str, Any],
+) -> tuple[int, int]:
+    start = int(span["start"])
+    end = int(span["end"])
+    raw_header_start = span.get("header_start")
+    raw_header_end = span.get("header_end")
+    if raw_header_start is not None or raw_header_end is not None:
+        if (
+            not isinstance(raw_header_start, int)
+            or isinstance(raw_header_start, bool)
+            or not isinstance(raw_header_end, int)
+            or isinstance(raw_header_end, bool)
+            or not start <= raw_header_start < raw_header_end <= end
+        ):
+            raise ValueError("section candidate has invalid header offsets")
+        return raw_header_start, raw_header_end
+
+    line_end = text.find("\n", start, end)
+    if line_end == -1:
+        line_end = end
+    content_end = line_end - int(line_end > start and text[line_end - 1] == "\r")
+    content, content_start = _strip_line_prefix(text[start:content_end], start)
+    delimiter_index = _first_delimiter_index(content)
+    header = (
+        content[:delimiter_index].strip() if delimiter_index > 0 else content.strip()
+    )
+    if not header:
+        return start, start + 1
+    header_start = content_start + content.find(header)
+    return header_start, header_start + len(header)
+
+
+def _resolve_overlapping_headers(
+    candidates: Iterable[_SectionCandidate],
+) -> tuple[_SectionCandidate, ...]:
+    selected: list[_SectionCandidate] = []
+    precedence = sorted(
+        candidates,
+        key=lambda candidate: (
+            -candidate.header_length,
+            candidate.span.start,
+            candidate.registration_order,
+        ),
+    )
+    for candidate in precedence:
+        if any(_candidate_headers_overlap(candidate, other) for other in selected):
+            continue
+        selected.append(candidate)
+    return tuple(
+        sorted(
+            selected,
+            key=lambda candidate: (
+                candidate.span.start,
+                candidate.registration_order,
+            ),
+        )
+    )
+
+
+def _candidate_headers_overlap(
+    left: _SectionCandidate,
+    right: _SectionCandidate,
+) -> bool:
+    return left.span.start == right.span.start or (
+        left.header_start < right.header_end and right.header_start < left.header_end
+    )
+
+
+def _assemble_sections(
+    text: str,
+    candidates: tuple[_SectionCandidate, ...],
+    *,
+    language: str | None,
+    include_unsectioned: bool,
+) -> tuple[SectionSpan, ...]:
+    if not candidates:
+        if not include_unsectioned:
+            return ()
+        return (
+            _section_dict(
+                label=UNSECTIONED_SECTION,
+                start=0,
+                end=len(text),
+                language=language,
+            ),
+        )
+
+    sections: list[SectionSpan] = []
+    cursor = 0
+    for index, candidate in enumerate(candidates):
+        start = candidate.span.start
+        if include_unsectioned and cursor < start:
+            sections.append(
+                _section_dict(
+                    label=UNSECTIONED_SECTION,
+                    start=cursor,
+                    end=start,
+                    language=language,
+                )
+            )
+        next_start = (
+            candidates[index + 1].span.start
+            if index + 1 < len(candidates)
+            else len(text)
+        )
+        end = min(candidate.span.end, next_start)
+        metadata = {
+            key: value
+            for key, value in candidate.span.items()
+            if key not in {"label", "start", "end"}
+        }
+        sections.append(
+            SectionSpan(
+                label=candidate.span.label,
+                start=start,
+                end=end,
+                **metadata,
+            )
+        )
+        cursor = end
+    if include_unsectioned and cursor < len(text):
+        sections.append(
+            _section_dict(
+                label=UNSECTIONED_SECTION,
+                start=cursor,
+                end=len(text),
+                language=language,
+            )
+        )
+    return tuple(sections)
+
+
+def validate_sections(
     text: str,
     spans: Iterable[Mapping[str, Any]],
 ) -> None:
@@ -194,6 +422,15 @@ def validate_section_spans(
     """
 
     _validate_section_spans(text, spans, require_coverage=True)
+
+
+def validate_section_spans(
+    text: str,
+    spans: Iterable[Mapping[str, Any]],
+) -> None:
+    """Backward-compatible alias for :func:`validate_sections`."""
+
+    validate_sections(text, spans)
 
 
 def list_section_label(section: str | Mapping[str, Any]) -> str | None:
@@ -345,7 +582,7 @@ def _validate_section_spans(
             raise ValueError(f"section span {index} requires a non-empty label")
         start = _section_offset(span, "start", index)
         end = _section_offset(span, "end", index)
-        if start < 0 or end > len(text):
+        if start < 0 or start > len(text) or end < 0 or end > len(text):
             raise ValueError(f"section span {index} is outside document bounds")
         if end <= start:
             raise ValueError(f"section span {index} must have positive length")
@@ -357,7 +594,7 @@ def _validate_section_spans(
             raise ValueError(
                 f"section spans overlap at offsets {start} to {previous_end}"
             )
-        elif start > previous_end:
+        elif require_coverage and start > previous_end:
             raise ValueError(
                 f"section spans leave a gap from {previous_end} to {start}"
             )

--- a/tests/unit/clinical/test_detect_sections.py
+++ b/tests/unit/clinical/test_detect_sections.py
@@ -1,0 +1,243 @@
+"""Synthetic offline tests for clinical section orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+import openmed.clinical.sections.detect as section_detection
+from openmed.clinical.sections import (
+    UNSECTIONED_SECTION,
+    SectionSpan,
+    detect_sections,
+    validate_sections,
+)
+
+
+@dataclass(frozen=True)
+class _GoldSection:
+    family: str
+    span: SectionSpan
+
+
+@dataclass(frozen=True)
+class _MultiFamilyFixture:
+    name: str
+    text: str
+    gold: tuple[_GoldSection, ...]
+
+
+def _fixture(
+    name: str,
+    *sections: tuple[str, str, str],
+) -> _MultiFamilyFixture:
+    text = "".join(fragment for _, _, fragment in sections)
+    cursor = 0
+    gold: list[_GoldSection] = []
+    for family, label, fragment in sections:
+        end = cursor + len(fragment)
+        gold.append(
+            _GoldSection(
+                family=family,
+                span=SectionSpan(label=label, start=cursor, end=end),
+            )
+        )
+        cursor = end
+    return _MultiFamilyFixture(name=name, text=text, gold=tuple(gold))
+
+
+MULTI_FAMILY_FIXTURES = (
+    _fixture(
+        "outpatient_follow_up",
+        ("none", UNSECTIONED_SECTION, "Synthetic follow-up note.\n"),
+        ("history", "history_of_present_illness", "HPI: Dry cough today.\n"),
+        ("list", "medications", "MEDICATIONS: Saline spray as directed.\n"),
+        ("assessment", "assessment_and_plan", "A/P: Continue supportive care."),
+    ),
+    _fixture(
+        "mixed_intake_and_imaging",
+        ("intake", "chief_complaint", "CC: Mild congestion.\n"),
+        ("history", "family_history", "FH: Noncontributory.\n"),
+        ("list", "allergies", "ALLERGIES: No known allergies.\n"),
+        ("radiology", "findings", "FINDINGS: Clear lungs.\n"),
+        ("radiology", "impression", "IMPRESSION: No acute finding."),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    MULTI_FAMILY_FIXTURES,
+    ids=lambda case: case.name,
+)
+def test_detect_sections_assembles_total_cover_with_high_gold_coverage(
+    case: _MultiFamilyFixture,
+) -> None:
+    predicted = detect_sections(case.text)
+    gold_spans = tuple(entry.span for entry in case.gold)
+    families = {entry.family for entry in case.gold if entry.family != "none"}
+
+    assert len(families) >= 3
+    assert predicted[0].start == 0
+    assert predicted[-1].end == len(case.text)
+    assert all(left.end == right.start for left, right in zip(predicted, predicted[1:]))
+    validate_sections(case.text, predicted)
+
+    correct_characters = 0
+    for offset in range(len(case.text)):
+        predicted_label = next(
+            span.label for span in predicted if span.start <= offset < span.end
+        )
+        gold_label = next(
+            span.label for span in gold_spans if span.start <= offset < span.end
+        )
+        correct_characters += int(predicted_label == gold_label)
+    assert correct_characters / len(case.text) >= 0.88
+
+
+@pytest.mark.parametrize(
+    ("first", "second", "expected_label"),
+    (
+        (
+            SectionSpan(
+                label="short_header",
+                start=0,
+                end=24,
+                header_start=0,
+                header_end=3,
+            ),
+            SectionSpan(
+                label="long_header",
+                start=0,
+                end=24,
+                header_start=0,
+                header_end=4,
+            ),
+            "long_header",
+        ),
+        (
+            SectionSpan(
+                label="later_header",
+                start=1,
+                end=24,
+                header_start=1,
+                header_end=5,
+            ),
+            SectionSpan(
+                label="earlier_header",
+                start=0,
+                end=24,
+                header_start=0,
+                header_end=4,
+            ),
+            "earlier_header",
+        ),
+    ),
+)
+def test_overlap_resolution_is_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+    first: SectionSpan,
+    second: SectionSpan,
+    expected_label: str,
+) -> None:
+    text = "HPI: Synthetic overlap.\n"
+
+    def first_segmenter(
+        source: str,
+        language: str | None,
+    ) -> tuple[SectionSpan, ...]:
+        del source, language
+        return (first,)
+
+    def second_segmenter(
+        source: str,
+        language: str | None,
+    ) -> tuple[SectionSpan, ...]:
+        del source, language
+        return (second,)
+
+    monkeypatch.setattr(
+        section_detection,
+        "_REGISTERED_SECTION_SEGMENTERS",
+        (first_segmenter, second_segmenter),
+    )
+
+    results = tuple(detect_sections(text) for _ in range(5))
+
+    assert all(result == results[0] for result in results)
+    assert [span.label for span in results[0]] == [expected_label]
+
+
+def test_detect_sections_fills_internal_candidate_gaps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    text = "HPI:x....PLAN:y"
+    plan_start = text.index("PLAN")
+
+    def partial_segmenter(
+        source: str,
+        language: str | None,
+    ) -> tuple[SectionSpan, ...]:
+        del source, language
+        return (
+            SectionSpan(
+                label="history_of_present_illness",
+                start=0,
+                end=5,
+                header_start=0,
+                header_end=3,
+            ),
+            SectionSpan(
+                label="plan",
+                start=plan_start,
+                end=len(text),
+                header_start=plan_start,
+                header_end=plan_start + 4,
+            ),
+        )
+
+    monkeypatch.setattr(
+        section_detection,
+        "_REGISTERED_SECTION_SEGMENTERS",
+        (partial_segmenter,),
+    )
+
+    sections = detect_sections(text)
+
+    assert [span.label for span in sections] == [
+        "history_of_present_illness",
+        UNSECTIONED_SECTION,
+        "plan",
+    ]
+    assert text[sections[1].start : sections[1].end] == "...."
+    validate_sections(text, sections)
+
+
+@pytest.mark.parametrize(
+    ("spans", "message"),
+    (
+        ((SectionSpan(label="history", start=-1, end=2),), "outside"),
+        ((SectionSpan(label="history", start=0, end=5),), "outside"),
+        (
+            (
+                SectionSpan(label="history", start=0, end=2),
+                SectionSpan(label="plan", start=3, end=4),
+            ),
+            "gap",
+        ),
+        (
+            (
+                SectionSpan(label="history", start=0, end=3),
+                SectionSpan(label="plan", start=2, end=4),
+            ),
+            "overlap",
+        ),
+    ),
+)
+def test_validate_sections_rejects_invalid_covers(
+    spans: tuple[SectionSpan, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        validate_sections("abcd", spans)


### PR DESCRIPTION
# Pull Request

## Description
Adds a single clinical section detection entry point that combines the existing multilingual header detector with focused family segmenters. Candidate headers are resolved deterministically, uncovered ranges become `unsectioned` spans, and every default result is validated as a total contiguous cover.

## Type of Change
- [x] New feature
- [x] Code refactoring
- [x] Test addition/improvement

## Changes Made
- Register and run the multilingual lexicon detector and history-family segmenter through one orchestrator.
- Resolve overlapping header matches by longest match, earliest start, and stable registration order for exact ties.
- Add `validate_sections` while preserving the existing validator entry point.
- Add synthetic multi-family gold maps, gap assembly, overlap determinism, coverage, and validation-error checks.

## Testing
- [x] New orchestrator unit checks pass: 9 passed.
- [x] Existing section contract, multilingual, and history-family regression checks pass: 39 passed.
- [x] Changed-file lint, format, and whitespace checks pass.

## Documentation
- [x] Public entry points include docstrings.
- [x] No changelog update is required for this additive unreleased API.

## Code Quality
- [x] Changed files pass the repository lint and format policy.
- [x] Self-review completed.
- [x] No new warnings observed.

## Dependencies
- [x] No new dependencies.

## Checklist
- [x] Contributing and repository guidelines followed.
- [x] Commit is focused and descriptive.

## Related Issues
Closes #1822

## Screenshots/Examples
Not applicable; this change has no user-interface surface.