### PR TITLE
Package Android R8 consumer rules

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -52,6 +52,21 @@ baseline for on-device inference work because it preserves broad device support
 while keeping runtime, storage, and execution APIs modern enough for the planned
 local-first pipeline.
 
+## R8 And ProGuard
+
+The OpenMedKit AAR includes consumer rules for its ONNX Runtime and DJL native
+bindings, service-loaded tokenizer providers, and model-catalog boundary. R8 and
+ProGuard apply these rules automatically when a consuming application enables
+shrinking or obfuscation; consumers do not need additional OpenMedKit keep rules.
+
+The release packaging check builds the AAR and verifies that every rule from
+`openmedkit/consumer-rules.pro` is present in its packaged `proguard.txt`:
+
+```bash
+cd android
+./gradlew :openmedkit:verifyReleaseConsumerRules
+```
+
 ## Optional Maven Central Publishing
 
 JitPack is the public installation path documented above. The separate, optional

--- a/android/openmedkit/build.gradle.kts
+++ b/android/openmedkit/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.zip.ZipFile
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -23,6 +25,8 @@ val generatedCatalogAssetsDir = layout.buildDirectory.dir("generated/assets/open
 val generatedCatalogAsset = generatedCatalogAssetsDir.map {
     it.file("openmed_model_catalog.jsonl")
 }
+val consumerRulesFile = layout.projectDirectory.file("consumer-rules.pro")
+val releaseAar = layout.buildDirectory.file("outputs/aar/${project.name}-release.aar")
 val centralStagingRepository = layout.buildDirectory.dir("central-staging")
 val centralPortalBundle = layout.buildDirectory.dir("central-portal")
 val pythonExecutable = providers.gradleProperty("openmedPython")
@@ -65,6 +69,7 @@ android {
         // runtime and filesystem APIs without forcing recent-only devices.
         minSdk = 26
         targetSdk = 33
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     compileOptions {
@@ -108,8 +113,44 @@ tasks.matching { it.name.endsWith("Assets") }.configureEach {
     dependsOn(generateAndroidModelCatalog)
 }
 
+val verifyReleaseConsumerRules by tasks.registering {
+    group = "verification"
+    description = "Verifies that the release AAR packages every consumer rule."
+    dependsOn("bundleReleaseAar")
+    inputs.file(consumerRulesFile)
+    inputs.file(releaseAar)
+
+    doLast {
+        val aarFile = releaseAar.get().asFile
+        if (!aarFile.isFile) {
+            throw GradleException("Release AAR does not exist: ${aarFile.path}")
+        }
+
+        val packagedRules = ZipFile(aarFile).use { archive ->
+            val entry = archive.getEntry("proguard.txt")
+                ?: throw GradleException("Release AAR does not contain proguard.txt")
+            archive.getInputStream(entry).bufferedReader().use { reader ->
+                reader.readLines()
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() && !it.startsWith("#") }
+                    .toSet()
+            }
+        }
+        val requiredRules = consumerRulesFile.asFile.readLines()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("#") }
+        val missingRules = requiredRules.filterNot(packagedRules::contains)
+        if (missingRules.isNotEmpty()) {
+            throw GradleException(
+                "Release AAR is missing consumer rules: ${missingRules.joinToString()}",
+            )
+        }
+    }
+}
+
 tasks.matching { it.name.startsWith("test") }.configureEach {
     dependsOn(generateAndroidModelCatalog)
+    dependsOn(verifyReleaseConsumerRules)
 }
 
 val verifyReleasePublicationVersion by tasks.registering {

--- a/android/openmedkit/consumer-rules.pro
+++ b/android/openmedkit/consumer-rules.pro
@@ -1,0 +1,20 @@
+# ONNX Runtime resolves Java classes and members from JNI.
+# See https://onnxruntime.ai/docs/build/android.html#proguard-rules-for-r8-minimization-android-app-builds-to-work
+-keep class ai.onnxruntime.** { *; }
+
+# DJL discovers these providers through META-INF/services.
+-keep class ai.djl.engine.rust.RsEngineProvider { public <init>(); }
+-keep class ai.djl.huggingface.zoo.HfZooProvider { public <init>(); }
+-keep class ai.djl.engine.rust.zoo.RsZooProvider { public <init>(); }
+
+# DJL's tokenizer Java surface binds to libdjl_tokenizer.so through JNI.
+-keep class ai.djl.huggingface.tokenizers.jni.** { *; }
+
+# Keep the OpenMedKit inference seam available to reflective integrations.
+-keep class com.openmed.openmedkit.** implements com.openmed.openmedkit.OnnxTokenClassifier { *; }
+-keep class com.openmed.openmedkit.onnx.OnnxTokenClassifier { public <init>(...); }
+
+# kotlinx.serialization ships generated-serializer rules. OpenMedKit parses the
+# catalog through JsonElement, so only its public catalog boundary needs keeping.
+-keep class com.openmed.openmedkit.catalog.ModelCatalog { public *; }
+-keep class com.openmed.openmedkit.catalog.ModelCatalogEntry { public *; }


### PR DESCRIPTION
OpenMedKit now ships and verifies its own R8 rules, so release-only shrinker crashes are not the vibe. Closes #584.