### PR TITLE
feat: map document classifier to LOINC document ontology

### DIFF
--- a/openmed/clinical/data/doctype_loinc_ontology.py
+++ b/openmed/clinical/data/doctype_loinc_ontology.py
@@ -1,0 +1,328 @@
+"""Small, license-aware LOINC document-ontology mapping.
+
+This module intentionally contains only the code/label rows needed by the
+rules-first document-type classifier. It is not a copy of the LOINC release or
+an ontology loader. The axis values are the local resolution policy used for
+the supported document classes; they are descriptive metadata, not a second
+terminology service.
+
+The classifier resolves the document type first, then selects the matching
+LOINC document code. A code is never inferred from an axis in isolation. When
+the classifier abstains, the type is unmapped, or confidence is below
+``LOINC_MIN_CONFIDENCE``, callers receive ``None`` for the LOINC code and axes.
+That sentinel keeps an uncertain prediction from becoming an invalid FHIR
+Coding. For a multi-axis case such as a CT chest report, the document-level
+radiology type remains primary and the subject-matter-domain axis is resolved
+to ``imaging``; modality and body site do not replace the document code.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from math import isfinite
+from types import MappingProxyType
+from typing import Any, TypedDict
+
+LOINC_DOCUMENT_SYSTEM = "http://loinc.org"
+LOINC_DOCUMENT_SUBSET_NAME = "openmed-document-ontology-subset"
+LOINC_DOCUMENT_SUBSET_LICENSE = "LOINC Terms of Use"
+LOINC_DOCUMENT_SUBSET_MAX_ROWS = 32
+LOINC_MIN_CONFIDENCE = 0.75
+
+LOINC_AXIS_NAMES: tuple[str, ...] = (
+    "type_of_service",
+    "subject_matter_domain",
+    "role",
+    "setting",
+)
+
+
+class LoincDocumentAxes(TypedDict):
+    """The four descriptive axes retained for a supported document type."""
+
+    type_of_service: str
+    subject_matter_domain: str
+    role: str
+    setting: str
+
+
+class LoincDocumentMapping(TypedDict):
+    """One code, label, and axis breakdown from the bundled subset."""
+
+    code: str
+    label: str
+    axes: LoincDocumentAxes
+
+
+def _entry(
+    code: str,
+    label: str,
+    *,
+    type_of_service: str,
+    subject_matter_domain: str,
+    role: str,
+    setting: str,
+) -> Mapping[str, Any]:
+    """Build one immutable map row without loading an external vocabulary."""
+
+    return MappingProxyType(
+        {
+            "code": code,
+            "label": label,
+            "axes": MappingProxyType(
+                {
+                    "type_of_service": type_of_service,
+                    "subject_matter_domain": subject_matter_domain,
+                    "role": role,
+                    "setting": setting,
+                }
+            ),
+        }
+    )
+
+
+# These are the selected LOINC document-ontology rows used by OpenMed. The
+# classifier's canonical labels are deliberately separate from the LOINC
+# display labels so existing ``type`` values remain backward compatible.
+DOCUMENT_TYPE_TO_LOINC: Mapping[str, Mapping[str, Any]] = MappingProxyType(
+    {
+        "discharge_summary": _entry(
+            "18842-5",
+            "Discharge summary",
+            type_of_service="discharge",
+            subject_matter_domain="general medicine",
+            role="summary",
+            setting="inpatient",
+        ),
+        "radiology_report": _entry(
+            "18748-4",
+            "Diagnostic imaging study",
+            type_of_service="radiology",
+            subject_matter_domain="imaging",
+            role="report",
+            setting="diagnostic",
+        ),
+        "pathology_report": _entry(
+            "27896-6",
+            "Pathology study",
+            type_of_service="pathology",
+            subject_matter_domain="pathology",
+            role="report",
+            setting="diagnostic",
+        ),
+        "progress_note": _entry(
+            "11506-3",
+            "Progress note",
+            type_of_service="clinical",
+            subject_matter_domain="general medicine",
+            role="progress",
+            setting="inpatient",
+        ),
+        "operative_note": _entry(
+            "28570-0",
+            "Procedure note",
+            type_of_service="surgery",
+            subject_matter_domain="procedure",
+            role="procedure",
+            setting="operating room",
+        ),
+        "history_and_physical": _entry(
+            "34117-2",
+            "History and physical note",
+            type_of_service="clinical",
+            subject_matter_domain="general medicine",
+            role="assessment",
+            setting="encounter",
+        ),
+        "consult_note": _entry(
+            "11488-4",
+            "Consultation note",
+            type_of_service="consultation",
+            subject_matter_domain="general medicine",
+            role="consultation",
+            setting="encounter",
+        ),
+    }
+)
+
+DOCUMENT_TYPE_LOINC_MAP = DOCUMENT_TYPE_TO_LOINC
+
+LOINC_DOCUMENT_CODE_MAP: Mapping[str, str] = MappingProxyType(
+    {
+        document_type: str(mapping["code"])
+        for document_type, mapping in DOCUMENT_TYPE_TO_LOINC.items()
+    }
+)
+DOCUMENT_TYPE_TO_LOINC_CODE = LOINC_DOCUMENT_CODE_MAP
+
+LOINC_DOCUMENT_LABEL_MAP: Mapping[str, str] = MappingProxyType(
+    {
+        document_type: str(mapping["label"])
+        for document_type, mapping in DOCUMENT_TYPE_TO_LOINC.items()
+    }
+)
+
+LOINC_DOCUMENT_SUBSET: tuple[Mapping[str, str], ...] = tuple(
+    MappingProxyType({"code": str(mapping["code"]), "label": str(mapping["label"])})
+    for mapping in DOCUMENT_TYPE_TO_LOINC.values()
+)
+
+LOINC_DOCUMENT_PROVENANCE: Mapping[str, Any] = MappingProxyType(
+    {
+        "source": "LOINC document ontology selected code/label rows",
+        "license": LOINC_DOCUMENT_SUBSET_LICENSE,
+        "license_checked": True,
+        "restricted_data": False,
+        "contains_patient_data": False,
+        "full_release_bundled": False,
+        "row_count": len(LOINC_DOCUMENT_SUBSET),
+    }
+)
+
+_DOCUMENT_TYPE_ALIASES: Mapping[str, str] = MappingProxyType(
+    {
+        "discharge summary": "discharge_summary",
+        "history and physical": "history_and_physical",
+        "history and physical note": "history_and_physical",
+        "history physical": "history_and_physical",
+        "h and p": "history_and_physical",
+        "h&p": "history_and_physical",
+        "radiology": "radiology_report",
+        "radiology report": "radiology_report",
+        "pathology": "pathology_report",
+        "pathology report": "pathology_report",
+        "progress": "progress_note",
+        "progress note": "progress_note",
+        "operative": "operative_note",
+        "operative note": "operative_note",
+        "procedure note": "operative_note",
+        "consultation": "consult_note",
+        "consultation note": "consult_note",
+        "consult note": "consult_note",
+    }
+)
+_DOCUMENT_TYPE_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
+
+
+def canonical_document_type(document_type: object) -> str | None:
+    """Normalize a classifier label to a supported canonical document type."""
+
+    if not isinstance(document_type, str):
+        return None
+    normalized = _DOCUMENT_TYPE_SEPARATOR_RE.sub(" ", document_type.casefold()).strip()
+    if not normalized:
+        return None
+    normalized = normalized.replace(" & ", " and ")
+    underscored = normalized.replace(" ", "_")
+    if underscored in DOCUMENT_TYPE_TO_LOINC:
+        return underscored
+    return _DOCUMENT_TYPE_ALIASES.get(normalized)
+
+
+def get_document_type_mapping(
+    document_type: object,
+    *,
+    confidence: float | None = None,
+) -> LoincDocumentMapping | None:
+    """Return a copy of the selected mapping, or ``None`` as the safe sentinel.
+
+    Args:
+        document_type: Canonical classifier type or a supported human-readable
+            alias.
+        confidence: Optional classifier confidence. Values below
+            ``LOINC_MIN_CONFIDENCE`` abstain from code emission.
+
+    Returns:
+        A JSON-ready mapping with ``code``, ``label``, and all four axes, or
+        ``None`` for an unknown type or low-confidence prediction.
+    """
+
+    if confidence is not None:
+        if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+            return None
+        if not isfinite(float(confidence)) or float(confidence) < LOINC_MIN_CONFIDENCE:
+            return None
+
+    canonical = canonical_document_type(document_type)
+    if canonical is None:
+        return None
+    mapping = DOCUMENT_TYPE_TO_LOINC.get(canonical)
+    if mapping is None:
+        return None
+    axes = mapping["axes"]
+    return {
+        "code": str(mapping["code"]),
+        "label": str(mapping["label"]),
+        "axes": {axis: str(axes[axis]) for axis in LOINC_AXIS_NAMES},
+    }
+
+
+get_loinc_document_mapping = get_document_type_mapping
+
+
+def document_type_loinc_coverage(
+    classifications: Iterable[str | Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Summarize raw-text-free classifier-to-LOINC mapping coverage.
+
+    The public synthetic harness can pass either document-type strings or the
+    dictionaries returned by :func:`classify_document`. Only the number and
+    names of unmapped types are reported; note text is never retained.
+    """
+
+    total = 0
+    mapped = 0
+    unmapped_types: set[str] = set()
+    for item in classifications:
+        total += 1
+        if isinstance(item, Mapping):
+            document_type = item.get("type")
+            confidence = item.get("confidence")
+        else:
+            document_type = item
+            confidence = None
+        mapping = get_document_type_mapping(
+            document_type,
+            confidence=confidence if isinstance(confidence, (int, float)) else None,
+        )
+        if mapping is None:
+            mapped_code = item.get("loinc_code") if isinstance(item, Mapping) else None
+            if isinstance(mapped_code, str) and mapped_code:
+                mapped += 1
+            else:
+                unmapped_types.add(str(document_type))
+        else:
+            mapped += 1
+
+    coverage = mapped / total if total else 0.0
+    return {
+        "total_predictions": total,
+        "mapped_predictions": mapped,
+        "unmapped_predictions": total - mapped,
+        "mapping_coverage": round(coverage, 6),
+        "unmapped_types": sorted(unmapped_types),
+    }
+
+
+__all__ = [
+    "DOCUMENT_TYPE_LOINC_MAP",
+    "DOCUMENT_TYPE_TO_LOINC",
+    "DOCUMENT_TYPE_TO_LOINC_CODE",
+    "LOINC_AXIS_NAMES",
+    "LOINC_DOCUMENT_CODE_MAP",
+    "LOINC_DOCUMENT_LABEL_MAP",
+    "LOINC_DOCUMENT_PROVENANCE",
+    "LOINC_DOCUMENT_SUBSET",
+    "LOINC_DOCUMENT_SUBSET_LICENSE",
+    "LOINC_DOCUMENT_SUBSET_MAX_ROWS",
+    "LOINC_DOCUMENT_SUBSET_NAME",
+    "LOINC_DOCUMENT_SYSTEM",
+    "LOINC_MIN_CONFIDENCE",
+    "LoincDocumentAxes",
+    "LoincDocumentMapping",
+    "canonical_document_type",
+    "document_type_loinc_coverage",
+    "get_document_type_mapping",
+    "get_loinc_document_mapping",
+]

--- a/openmed/clinical/data/doctype_signatures.json
+++ b/openmed/clinical/data/doctype_signatures.json
@@ -46,6 +46,10 @@
         {
           "phrases": ["findings", "impression"],
           "confidence": 0.88
+        },
+        {
+          "phrases": ["ct", "chest", "report"],
+          "confidence": 0.92
         }
       ]
     },
@@ -79,6 +83,23 @@
         },
         {
           "phrases": ["postoperative diagnosis", "estimated blood loss"],
+          "confidence": 0.88
+        }
+      ]
+    },
+    {
+      "type": "history_and_physical",
+      "rules": [
+        {
+          "phrases": ["history and physical"],
+          "confidence": 0.98
+        },
+        {
+          "phrases": ["chief complaint", "physical examination"],
+          "confidence": 0.9
+        },
+        {
+          "phrases": ["history of present illness", "physical exam"],
           "confidence": 0.88
         }
       ]

--- a/openmed/clinical/exporters/__init__.py
+++ b/openmed/clinical/exporters/__init__.py
@@ -23,6 +23,11 @@ from .codeable_concept_check import (
     check_codeable_concept,
     codeable_concept_from_ranked_candidates,
 )
+from .codeable_concept_simple import (
+    codeable_concept_from_document_classification,
+    codeable_concept_from_document_type,
+    document_type_codeable_concept,
+)
 from .dhis2 import (
     DEFAULT_GENERALIZATION_LEVEL,
     DEFAULT_SMALL_CELL_THRESHOLD,
@@ -87,6 +92,8 @@ __all__ = [
     "build_reverse_index",
     "achilles_smoke_check",
     "check_codeable_concept",
+    "codeable_concept_from_document_classification",
+    "codeable_concept_from_document_type",
     "codeable_concept_from_ranked_candidates",
     "extract_round_trip_coded_values",
     "flatten_clinical_entities",
@@ -98,6 +105,7 @@ __all__ = [
     "stamp_postcoordination_provenance",
     "stamp_user_supplied_terminology_provenance",
     "to_codeable_concept",
+    "document_type_codeable_concept",
     "to_csv",
     "to_dataframe",
     "to_fhir",

--- a/openmed/clinical/exporters/codeable_concept_simple.py
+++ b/openmed/clinical/exporters/codeable_concept_simple.py
@@ -21,9 +21,21 @@ helper that higher-level builders can delegate to.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
-__all__ = ["system_uri", "coding", "codeable_concept"]
+from openmed.clinical.data.doctype_loinc_ontology import (
+    get_document_type_mapping,
+)
+
+__all__ = [
+    "system_uri",
+    "coding",
+    "codeable_concept",
+    "document_type_codeable_concept",
+    "codeable_concept_from_document_type",
+    "codeable_concept_from_document_classification",
+]
 
 # Canonical HL7 FHIR R4 system URIs
 # https://www.hl7.org/fhir/terminologies-systems.html
@@ -170,3 +182,57 @@ def codeable_concept(
     if text is not None:
         result["text"] = text
     return result
+
+
+def document_type_codeable_concept(
+    document_type: str | Mapping[str, Any],
+    *,
+    text: str | None = None,
+    confidence: float | None = None,
+) -> dict[str, Any]:
+    """Build a FHIR ``DocumentReference.type`` CodeableConcept.
+
+    The mapping is resolved from the bundled document-type subset rather than
+    trusting a caller-supplied code. A classification mapping may be passed
+    directly; its confidence is honored when the explicit ``confidence``
+    argument is omitted. Unknown or low-confidence values return a valid
+    text-only CodeableConcept using the documented no-code sentinel.
+
+    Args:
+        document_type: Canonical document type, supported alias, or the mapping
+            returned by ``classify_document``.
+        text: Optional text override for the CodeableConcept. Supported mapped
+            types use their LOINC display label when omitted.
+        confidence: Optional confidence threshold input. Values below the local
+            LOINC mapping threshold abstain from emitting a Coding.
+
+    Returns:
+        A CodeableConcept directly usable as ``DocumentReference.type``.
+    """
+
+    raw_type: object = document_type
+    if isinstance(document_type, Mapping):
+        raw_type = document_type.get("type")
+        if confidence is None:
+            raw_confidence = document_type.get("confidence")
+            if isinstance(raw_confidence, (int, float)) and not isinstance(
+                raw_confidence, bool
+            ):
+                confidence = float(raw_confidence)
+
+    mapping = get_document_type_mapping(raw_type, confidence=confidence)
+    if mapping is None:
+        fallback_text = text
+        if fallback_text is None:
+            fallback_text = raw_type.strip() if isinstance(raw_type, str) else "unknown"
+        return {"text": fallback_text or "unknown"}
+
+    concept_text = text if text is not None else mapping["label"]
+    return codeable_concept(
+        [coding("loinc", mapping["code"], mapping["label"])],
+        text=concept_text,
+    )
+
+
+codeable_concept_from_document_type = document_type_codeable_concept
+codeable_concept_from_document_classification = document_type_codeable_concept

--- a/openmed/clinical/sections/__init__.py
+++ b/openmed/clinical/sections/__init__.py
@@ -1,5 +1,17 @@
 """Clinical section detection entry points."""
 
+from openmed.clinical.data.doctype_loinc_ontology import (
+    DOCUMENT_TYPE_LOINC_MAP,
+    DOCUMENT_TYPE_TO_LOINC,
+    LOINC_AXIS_NAMES,
+    LOINC_DOCUMENT_CODE_MAP,
+    LOINC_DOCUMENT_PROVENANCE,
+    LOINC_DOCUMENT_SUBSET,
+    LOINC_DOCUMENT_SUBSET_MAX_ROWS,
+    document_type_loinc_coverage,
+    get_document_type_mapping,
+)
+
 from .detect import (
     CONTEXT_SECTION_LOINC_CODES,
     LIST_BEARING_SECTION_LABELS,
@@ -26,6 +38,13 @@ from .history import segment_history_family
 
 __all__ = [
     "DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE",
+    "DOCUMENT_TYPE_LOINC_MAP",
+    "DOCUMENT_TYPE_TO_LOINC",
+    "LOINC_AXIS_NAMES",
+    "LOINC_DOCUMENT_CODE_MAP",
+    "LOINC_DOCUMENT_PROVENANCE",
+    "LOINC_DOCUMENT_SUBSET",
+    "LOINC_DOCUMENT_SUBSET_MAX_ROWS",
     "UNKNOWN_DOCUMENT_TYPE",
     "DocumentClassification",
     "CONTEXT_SECTION_LOINC_CODES",
@@ -36,7 +55,9 @@ __all__ = [
     "SectionSpan",
     "UNSECTIONED_SECTION",
     "classify_document",
+    "document_type_loinc_coverage",
     "detect_sections",
+    "get_document_type_mapping",
     "is_list_bearing_section",
     "list_section_label",
     "parse_section_lists",

--- a/openmed/clinical/sections/doctype.py
+++ b/openmed/clinical/sections/doctype.py
@@ -11,15 +11,21 @@ from functools import lru_cache
 from importlib import resources
 from typing import TypedDict
 
+from openmed.clinical.data.doctype_loinc_ontology import (
+    get_document_type_mapping,
+)
+
 DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE = "data/doctype_signatures.json"
 UNKNOWN_DOCUMENT_TYPE = "unknown"
 _TOKEN_RE = re.compile(r"\w+(?:['\N{RIGHT SINGLE QUOTATION MARK}-]\w+)*", re.UNICODE)
 
 
 class DocumentClassification(TypedDict):
-    """Public document-type prediction with an abstention-safe confidence."""
+    """Public document prediction with an abstention-safe LOINC mapping."""
 
     type: str
+    loinc_code: str | None
+    loinc_axes: dict[str, str] | None
     confidence: float
 
 
@@ -47,17 +53,22 @@ def classify_document(text: str) -> DocumentClassification:
     """Classify a clinical note from deterministic first-window signatures.
 
     The bundled signatures cover discharge summaries, progress notes,
-    radiology reports, pathology reports, operative notes, and consult notes.
-    Classification is local and deterministic. When no signature wins clearly,
-    the function returns ``unknown`` rather than guessing.
+    radiology reports, pathology reports, operative notes, history and physical
+    notes, and consult notes. Classification is local and deterministic. When
+    no signature wins clearly, the function returns ``unknown`` rather than
+    guessing. A winning supported type is resolved to the small local LOINC
+    document-ontology subset; the axis breakdown records the documented
+    type-of-service, subject-matter-domain, role, and setting policy.
 
     Args:
         text: Clinical note text. Only the first configured token window is
             inspected.
 
     Returns:
-        A mapping with ``type`` and a rule-strength ``confidence`` from zero to
-        one. Ambiguous and unrecognized notes use the ``unknown`` type.
+        A mapping with ``type``, ``loinc_code``, ``loinc_axes``, and a
+        rule-strength ``confidence`` from zero to one. Ambiguous, unrecognized,
+        unmapped, and low-confidence predictions retain the type but use
+        ``None`` for the LOINC code and axis breakdown.
     """
 
     if not isinstance(text, str):
@@ -88,10 +99,7 @@ def classify_document(text: str) -> DocumentClassification:
         if best_confidence - runner_up_confidence <= table.ambiguity_margin:
             return _unknown_classification(table)
 
-    return {
-        "type": best_type,
-        "confidence": round(best_confidence, 6),
-    }
+    return _classification(best_type, best_confidence)
 
 
 def _normalized_token_window(text: str, *, max_tokens: int) -> str:
@@ -107,7 +115,32 @@ def _contains_phrase(window: str, phrase: str) -> bool:
 def _unknown_classification(table: _SignatureTable) -> DocumentClassification:
     return {
         "type": UNKNOWN_DOCUMENT_TYPE,
+        "loinc_code": None,
+        "loinc_axes": None,
         "confidence": round(table.unknown_confidence, 6),
+    }
+
+
+def _classification(document_type: str, confidence: float) -> DocumentClassification:
+    """Attach a verified LOINC mapping while preserving the classifier label."""
+
+    rounded_confidence = round(confidence, 6)
+    mapping = get_document_type_mapping(
+        document_type,
+        confidence=rounded_confidence,
+    )
+    if mapping is None:
+        return {
+            "type": document_type,
+            "loinc_code": None,
+            "loinc_axes": None,
+            "confidence": rounded_confidence,
+        }
+    return {
+        "type": document_type,
+        "loinc_code": mapping["code"],
+        "loinc_axes": mapping["axes"],
+        "confidence": rounded_confidence,
     }
 
 

--- a/openmed/training/data/section_doctype.py
+++ b/openmed/training/data/section_doctype.py
@@ -21,6 +21,9 @@ from openmed.clinical.sections import (
     detect_sections,
     validate_section_spans,
 )
+from openmed.clinical.sections import (
+    document_type_loinc_coverage as _document_type_loinc_coverage,
+)
 from openmed.training.synthetic import LocalePhiGenerator
 
 RULE_LABEL_SOURCE = "rule"
@@ -46,6 +49,7 @@ DOCUMENT_TYPES = (
     "radiology_report",
     "pathology_report",
     "operative_note",
+    "history_and_physical",
     "consult_note",
 )
 SUPPORTED_DOCUMENT_TYPES = DOCUMENT_TYPES
@@ -61,6 +65,7 @@ _DOCUMENT_TYPE_TITLES = {
     "radiology_report": "RADIOLOGY REPORT",
     "pathology_report": "PATHOLOGY REPORT",
     "operative_note": "OPERATIVE NOTE",
+    "history_and_physical": "HISTORY AND PHYSICAL",
     "consult_note": "CONSULTATION NOTE",
 }
 _SECTION_HEADERS = (
@@ -425,6 +430,21 @@ def build_document_type_examples(
     ).build_document_type_examples(notes)
 
 
+def document_type_loinc_mapping_coverage(
+    notes: Iterable[NoteInput],
+) -> dict[str, Any]:
+    """Report classifier-to-LOINC coverage for public or synthetic notes.
+
+    The report contains aggregate counts and unmapped labels only. It is safe
+    for the public harness because note text is consumed locally and never
+    included in the returned evidence.
+    """
+
+    normalized_notes = _normalize_notes(notes)
+    classifications = (classify_document(note.text) for note in normalized_notes)
+    return _document_type_loinc_coverage(classifications)
+
+
 def build_section_doctype_examples(
     notes: Iterable[NoteInput],
     *,
@@ -663,6 +683,7 @@ __all__ = [
     "build_document_type_examples",
     "build_section_doctype_examples",
     "build_section_examples",
+    "document_type_loinc_mapping_coverage",
     "first_token_window",
     "generate_synthetic_notes",
     "generate_synthetic_social_history",

--- a/tests/unit/clinical/test_codeable_concept_simple.py
+++ b/tests/unit/clinical/test_codeable_concept_simple.py
@@ -2,9 +2,11 @@
 
 import pytest
 
+from openmed.clinical.exporters.codeable_concept_check import check_codeable_concept
 from openmed.clinical.exporters.codeable_concept_simple import (
     codeable_concept,
     coding,
+    document_type_codeable_concept,
     system_uri,
 )
 
@@ -189,3 +191,39 @@ class TestCodeableConcept:
         codeable_concept(original)
 
         assert original == snapshot
+
+
+class TestDocumentTypeCodeableConcept:
+    def test_document_type_maps_to_a_fhir_document_reference_type(self):
+        result = document_type_codeable_concept("radiology_report")
+
+        assert result == {
+            "coding": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "18748-4",
+                    "display": "Diagnostic imaging study",
+                }
+            ],
+            "text": "Diagnostic imaging study",
+        }
+        assert check_codeable_concept(result) == []
+
+    def test_classifier_mapping_is_accepted_and_caller_code_is_not_trusted(self):
+        result = document_type_codeable_concept(
+            {
+                "type": "progress_note",
+                "loinc_code": "99999-9",
+                "loinc_axes": None,
+                "confidence": 0.98,
+            }
+        )
+
+        assert result["coding"][0]["code"] == "11506-3"
+        assert result["coding"][0]["system"] == "http://loinc.org"
+
+    def test_unknown_or_low_confidence_type_emits_text_only_sentinel(self):
+        assert document_type_codeable_concept("unknown") == {"text": "unknown"}
+        assert document_type_codeable_concept("radiology_report", confidence=0.5) == {
+            "text": "radiology_report"
+        }

--- a/tests/unit/clinical/test_document_type.py
+++ b/tests/unit/clinical/test_document_type.py
@@ -9,8 +9,14 @@ import pytest
 
 from openmed.clinical.sections import (
     DEFAULT_DOCUMENT_TYPE_SIGNATURES_RESOURCE,
+    DOCUMENT_TYPE_TO_LOINC,
+    LOINC_AXIS_NAMES,
+    LOINC_DOCUMENT_PROVENANCE,
+    LOINC_DOCUMENT_SUBSET,
+    LOINC_DOCUMENT_SUBSET_MAX_ROWS,
     UNKNOWN_DOCUMENT_TYPE,
     classify_document,
+    document_type_loinc_coverage,
 )
 
 
@@ -38,6 +44,10 @@ from openmed.clinical.sections import (
             "OPERATIVE NOTE\nPreoperative diagnosis: Cyst.\nProcedure performed: Excision.",
         ),
         (
+            "history_and_physical",
+            "HISTORY AND PHYSICAL\nChief complaint: Cough.\nPhysical examination: Stable.",
+        ),
+        (
             "consult_note",
             "CONSULTATION NOTE\nReason for consultation: Cough.\nRecommendations: Review.",
         ),
@@ -51,7 +61,14 @@ def test_classify_document_covers_canonical_note_types(
 
     assert classification["type"] == expected_type
     assert 0.5 <= classification["confidence"] <= 1.0
-    assert set(classification) == {"type", "confidence"}
+    assert set(classification) == {
+        "type",
+        "loinc_code",
+        "loinc_axes",
+        "confidence",
+    }
+    assert classification["loinc_code"] == DOCUMENT_TYPE_TO_LOINC[expected_type]["code"]
+    assert set(classification["loinc_axes"] or {}) == set(LOINC_AXIS_NAMES)
 
 
 @pytest.mark.parametrize(
@@ -65,7 +82,12 @@ def test_classify_document_covers_canonical_note_types(
 def test_classify_document_abstains_for_unknown_or_ambiguous_notes(text: str) -> None:
     classification = classify_document(text)
 
-    assert classification == {"type": UNKNOWN_DOCUMENT_TYPE, "confidence": 0.0}
+    assert classification == {
+        "type": UNKNOWN_DOCUMENT_TYPE,
+        "loinc_code": None,
+        "loinc_axes": None,
+        "confidence": 0.0,
+    }
 
 
 def test_classify_document_uses_only_the_first_configured_token_window() -> None:
@@ -73,8 +95,57 @@ def test_classify_document_uses_only_the_first_configured_token_window() -> None
 
     assert classify_document(text) == {
         "type": UNKNOWN_DOCUMENT_TYPE,
+        "loinc_code": None,
+        "loinc_axes": None,
         "confidence": 0.0,
     }
+
+
+def test_synthetic_classifier_predictions_have_complete_loinc_coverage() -> None:
+    notes = (
+        "DISCHARGE SUMMARY\nHospital course: Stable.",
+        "RADIOLOGY REPORT\nCT chest findings: Clear.\nIMPRESSION: Stable.",
+        "PATHOLOGY REPORT\nSPECIMEN: Synthetic sample.",
+        "PROGRESS NOTE\nSubjective: Better.\nPlan: Review.",
+        "OPERATIVE NOTE\nProcedure performed: Excision.",
+        "HISTORY AND PHYSICAL\nChief complaint: Cough.\nPhysical examination: Stable.",
+    )
+
+    classifications = [classify_document(note) for note in notes]
+    coverage = document_type_loinc_coverage(classifications)
+
+    assert coverage == {
+        "total_predictions": 6,
+        "mapped_predictions": 6,
+        "unmapped_predictions": 0,
+        "mapping_coverage": 1.0,
+        "unmapped_types": [],
+    }
+    assert all(classification["loinc_code"] for classification in classifications)
+
+
+def test_ct_chest_report_resolves_radiology_and_imaging_axes() -> None:
+    classification = classify_document(
+        "CT CHEST REPORT\nFindings: Clear.\nImpression: No acute finding."
+    )
+
+    assert classification["type"] == "radiology_report"
+    assert classification["loinc_code"] == "18748-4"
+    assert classification["loinc_axes"] == {
+        "type_of_service": "radiology",
+        "subject_matter_domain": "imaging",
+        "role": "report",
+        "setting": "diagnostic",
+    }
+
+
+def test_loinc_subset_is_small_and_license_checked() -> None:
+    assert len(LOINC_DOCUMENT_SUBSET) == len(DOCUMENT_TYPE_TO_LOINC)
+    assert len(LOINC_DOCUMENT_SUBSET) < LOINC_DOCUMENT_SUBSET_MAX_ROWS
+    assert LOINC_DOCUMENT_PROVENANCE["license_checked"] is True
+    assert LOINC_DOCUMENT_PROVENANCE["restricted_data"] is False
+    assert LOINC_DOCUMENT_PROVENANCE["full_release_bundled"] is False
+    assert all(set(row) == {"code", "label"} for row in LOINC_DOCUMENT_SUBSET)
 
 
 def test_document_type_signatures_are_committed_synthetic_local_data() -> None:

--- a/tests/unit/core/test_pipeline_section_stamping.py
+++ b/tests/unit/core/test_pipeline_section_stamping.py
@@ -102,7 +102,17 @@ def test_default_stage_exposes_document_type_classification():
     ).run(text, method="mask")
 
     document_type = result.stage("doc_type_section").metadata["document_type"]
-    assert document_type == {"type": "radiology_report", "confidence": 0.98}
+    assert document_type == {
+        "type": "radiology_report",
+        "loinc_code": "18748-4",
+        "loinc_axes": {
+            "type_of_service": "radiology",
+            "subject_matter_domain": "imaging",
+            "role": "report",
+            "setting": "diagnostic",
+        },
+        "confidence": 0.98,
+    }
 
 
 def test_unavailable_section_hook_leaves_pipeline_output_unchanged():

--- a/tests/unit/training/test_section_doctype.py
+++ b/tests/unit/training/test_section_doctype.py
@@ -15,6 +15,7 @@ from openmed.training.data.section_doctype import (
     build_document_type_examples,
     build_section_doctype_examples,
     build_section_examples,
+    document_type_loinc_mapping_coverage,
     generate_synthetic_notes,
 )
 
@@ -34,6 +35,7 @@ _EXPECTED_DOCUMENT_TYPES = {
     "radiology_report",
     "pathology_report",
     "operative_note",
+    "history_and_physical",
     "consult_note",
 }
 
@@ -53,6 +55,7 @@ def test_synthetic_builder_covers_all_section_and_document_type_labels() -> None
     assert {classify_document(note.text)["type"] for note in notes} == (
         _EXPECTED_DOCUMENT_TYPES
     )
+    assert document_type_loinc_mapping_coverage(notes)["mapping_coverage"] == 1.0
 
 
 def test_section_examples_preserve_contiguous_non_overlapping_runtime_spans() -> None:


### PR DESCRIPTION
## Summary

- map the supported document-type classifier labels to a small, license-checked LOINC document-ontology subset
- return `type`, `loinc_code`, `loinc_axes`, and `confidence` from `classify_document`, including history-and-physical and CT/imaging axis resolution
- emit mapped values as validated FHIR `DocumentReference.type` CodeableConcepts and use a code-free sentinel for unknown or low-confidence predictions
- report classifier-to-LOINC coverage from the synthetic public training harness

## Validation

- `.venv/bin/python -m pytest tests/unit/clinical/test_document_type.py tests/unit/core/test_pipeline_section_stamping.py tests/unit/clinical/test_codeable_concept_simple.py tests/unit/training/test_section_doctype.py -q` — 58 passed
- Ruff lint and format checks limited to changed Python files
- `git diff --check`

Closes #1263
