### PR TITLE
Add model download and cache management CLI

### DIFF
--- a/openmed/cli/main.py
+++ b/openmed/cli/main.py
@@ -13,6 +13,7 @@ import tempfile
 import unicodedata
 from collections import Counter
 from collections.abc import Mapping as MappingABC
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence
 
@@ -30,7 +31,13 @@ from ..core.config import (
     save_profile,
     set_config,
 )
-from ..core.hf_hub import get_remote_model_size_mb, list_cached_models
+from ..core.hf_hub import (
+    clear_cached_model,
+    get_remote_model_size_mb,
+    list_cached_models,
+    prefetch_model,
+    resolve_repo_id,
+)
 from ..core.manifest_diff import ManifestDiff, diff_manifests
 from ..core.model_card import render_model_card
 from ..core.model_integrity import ModelIntegrityError, verify_cached_models
@@ -1602,6 +1609,55 @@ def _add_export_command(subparsers: argparse._SubParsersAction) -> None:
 def _add_models_command(subparsers: argparse._SubParsersAction) -> None:
     models_parser = subparsers.add_parser("models", help="Discover OpenMed models.")
     models_sub = models_parser.add_subparsers(dest="models_command")
+
+    models_cache = models_sub.add_parser(
+        "cache",
+        help="Download, inspect, or clear cached OpenMed models.",
+    )
+    models_cache_sub = models_cache.add_subparsers(dest="models_cache_command")
+
+    models_cache_download = models_cache_sub.add_parser(
+        "download",
+        help="Download an OpenMed model into the local Hugging Face cache.",
+    )
+    models_cache_download.add_argument(
+        "repo_id",
+        help="Registry alias or Hugging Face repository id to download.",
+    )
+    models_cache_download.add_argument(
+        "--revision",
+        default=None,
+        help="Optional branch, tag, or commit to download.",
+    )
+    models_cache_download.add_argument(
+        "--allow-patterns",
+        action="append",
+        default=None,
+        metavar="PATTERN",
+        help="Only download files matching PATTERN; repeat for multiple patterns.",
+    )
+    models_cache_download.set_defaults(handler=_handle_models_cache_download)
+
+    models_cache_list = models_cache_sub.add_parser(
+        "list",
+        help="List OpenMed models in the local Hugging Face cache.",
+    )
+    models_cache_list.set_defaults(handler=_handle_models_cache_list)
+
+    models_cache_clear = models_cache_sub.add_parser(
+        "clear",
+        help="Remove one OpenMed model from the local Hugging Face cache.",
+    )
+    models_cache_clear.add_argument(
+        "repo_id",
+        help="Registry alias or Hugging Face repository id to remove.",
+    )
+    models_cache_clear.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm deletion of the selected model cache.",
+    )
+    models_cache_clear.set_defaults(handler=_handle_models_cache_clear)
 
     models_pull = models_sub.add_parser(
         "pull",
@@ -5358,6 +5414,138 @@ def _format_param_count(param_count: int | None) -> str:
     if param_count is None:
         return "unknown"
     return f"{param_count:,}"
+
+
+def _format_models_cache_last_used(value: Any) -> str:
+    if (
+        value is None
+        or isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+    ):
+        return "never" if value is None else "unknown"
+
+    try:
+        return datetime.fromtimestamp(value, tz=timezone.utc).isoformat(
+            timespec="seconds"
+        )
+    except (OverflowError, OSError, ValueError):
+        return "unknown"
+
+
+def _models_cache_payload(cached_models: Sequence[Any]) -> dict[str, Any]:
+    models = []
+    for cached in cached_models:
+        size_on_disk = cached.size_on_disk
+        models.append(
+            {
+                "repo_id": cached.repo_id,
+                "size_bytes": size_on_disk,
+                "size_mb": round(size_on_disk / 1_000_000, 3),
+                "last_accessed": cached.last_accessed,
+                "last_used": _format_models_cache_last_used(cached.last_accessed),
+            }
+        )
+    return {"count": len(models), "models": models}
+
+
+def _format_models_cache_table(payload: Mapping[str, Any]) -> str:
+    rows = [
+        {
+            "repo_id": str(model["repo_id"]),
+            "size_mb": f"{float(model['size_mb']):.3f} MB",
+            "last_used": str(model["last_used"]),
+        }
+        for model in payload["models"]
+    ]
+    if not rows:
+        return "No cached OpenMed models.\n"
+
+    columns = (
+        ("repo_id", "repo_id"),
+        ("size_mb", "size_mb"),
+        ("last_used", "last_used"),
+    )
+    widths = {
+        key: max(len(header), *(len(row[key]) for row in rows))
+        for key, header in columns
+    }
+    lines = [
+        "  ".join(header.ljust(widths[key]) for key, header in columns),
+        "  ".join("-" * widths[key] for key, _header in columns),
+        *[
+            "  ".join(row[key].ljust(widths[key]) for key, _header in columns)
+            for row in rows
+        ],
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _handle_models_cache_download(args: argparse.Namespace) -> int:
+    config = _load_and_apply_config(args)
+    try:
+        repo_id = resolve_repo_id(args.repo_id)
+        path = prefetch_model(
+            repo_id,
+            revision=args.revision,
+            allow_patterns=args.allow_patterns,
+            config=config,
+        )
+    except (ImportError, OfflineModeError, OSError, ValueError) as exc:
+        raise CliError(
+            f"Failed to download model {args.repo_id}: {exc}",
+            code="download_failed",
+            exit_code=EXIT_ERROR,
+        ) from exc
+
+    path_text = str(path)
+    return emit(
+        args,
+        {"repo_id": repo_id, "path": path_text},
+        human=f"Model ready: {path_text}",
+    )
+
+
+def _handle_models_cache_list(args: argparse.Namespace) -> int:
+    try:
+        cached_models = sorted(
+            list_cached_models(),
+            key=lambda cached: cached.repo_id,
+        )
+    except (ImportError, OSError, ValueError) as exc:
+        raise CliError(
+            f"Failed to list model cache: {exc}",
+            code="cache_list_failed",
+            exit_code=EXIT_ERROR,
+        ) from exc
+
+    payload = _models_cache_payload(cached_models)
+    return emit(args, payload, human=_format_models_cache_table(payload))
+
+
+def _handle_models_cache_clear(args: argparse.Namespace) -> int:
+    if not args.yes:
+        raise CliError(
+            f"Refusing to clear {args.repo_id} without --yes confirmation.",
+            code="confirmation_required",
+            exit_code=EXIT_USAGE,
+        )
+
+    try:
+        repo_id = resolve_repo_id(args.repo_id)
+        removed = clear_cached_model(repo_id)
+    except (ImportError, OSError, ValueError) as exc:
+        raise CliError(
+            f"Failed to clear model cache {args.repo_id}: {exc}",
+            code="cache_clear_failed",
+            exit_code=EXIT_ERROR,
+        ) from exc
+
+    if removed:
+        human = f"Cleared model cache: {repo_id}"
+    else:
+        human = f"No cached model found: {repo_id}"
+    return emit(args, {"repo_id": repo_id, "removed": removed}, human=human)
 
 
 def _handle_models_list(args: argparse.Namespace) -> int:

--- a/tests/unit/cli/test_models_cache_cli.py
+++ b/tests/unit/cli/test_models_cache_cli.py
@@ -1,0 +1,179 @@
+"""Tests for the ``openmed models cache`` commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openmed.cli import main_module
+from openmed.core.hf_hub import CachedModel
+from openmed.core.offline import OfflineModeError
+
+
+def test_models_cache_list_prints_repo_sizes_and_last_used(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        main_module,
+        "list_cached_models",
+        lambda: [
+            CachedModel(
+                repo_id="OpenMed/unit-model",
+                size_on_disk=12_345_678,
+                last_accessed=1_700_000_000.0,
+                path=tmp_path / "unit-model",
+            )
+        ],
+    )
+
+    result = main_module.main(["models", "cache", "list"])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "repo_id" in captured.out
+    assert "size_mb" in captured.out
+    assert "last_used" in captured.out
+    assert "OpenMed/unit-model" in captured.out
+    assert "12.346 MB" in captured.out
+    assert "2023-11-14T22:13:20+00:00" in captured.out
+    assert captured.err == ""
+
+
+def test_models_cache_list_json_is_scriptable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        main_module,
+        "list_cached_models",
+        lambda: [
+            CachedModel(
+                repo_id="OpenMed/unit-model",
+                size_on_disk=2_000_000,
+                last_accessed=None,
+                path=tmp_path / "unit-model",
+            )
+        ],
+    )
+
+    result = main_module.main(["models", "cache", "list", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 0
+    assert payload["ok"] is True
+    assert payload["command"] == "models cache list"
+    assert payload["data"]["models"] == [
+        {
+            "last_accessed": None,
+            "last_used": "never",
+            "repo_id": "OpenMed/unit-model",
+            "size_bytes": 2_000_000,
+            "size_mb": 2.0,
+        }
+    ]
+
+
+def test_models_cache_download_resolves_repo_and_returns_local_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: dict[str, Any] = {}
+
+    def fake_prefetch(repo_id: str, **kwargs: Any) -> str:
+        calls["repo_id"] = repo_id
+        calls.update(kwargs)
+        return "/synthetic/hf-cache/snapshot"
+
+    monkeypatch.setattr(main_module, "prefetch_model", fake_prefetch)
+
+    result = main_module.main(
+        [
+            "models",
+            "cache",
+            "download",
+            "disease_detection_tiny",
+            "--revision",
+            "synthetic-revision",
+            "--allow-patterns",
+            "*.json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert calls["repo_id"] == "OpenMed/OpenMed-NER-DiseaseDetect-TinyMed-135M"
+    assert calls["revision"] == "synthetic-revision"
+    assert calls["allow_patterns"] == ["*.json"]
+    assert calls["config"] is not None
+    assert "Model ready: /synthetic/hf-cache/snapshot" in captured.out
+    assert captured.err == ""
+
+
+def test_models_cache_download_reports_offline_cache_miss(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("OPENMED_OFFLINE", "1")
+
+    def fail_prefetch(*_args: Any, **_kwargs: Any) -> str:
+        raise OfflineModeError(
+            "OpenMed/unit-model is not available in the local cache and offline "
+            "mode blocks the download."
+        )
+
+    monkeypatch.setattr(main_module, "prefetch_model", fail_prefetch)
+
+    result = main_module.main(["models", "cache", "download", "OpenMed/unit-model"])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "not available in the local cache" in captured.err
+    assert "offline mode blocks the download" in captured.err
+    assert captured.out == ""
+
+
+def test_models_cache_clear_requires_confirmation_without_deleting(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_clear(*_args: Any, **_kwargs: Any) -> bool:
+        pytest.fail("cache clear was called without --yes")
+
+    monkeypatch.setattr(main_module, "clear_cached_model", fail_clear)
+
+    result = main_module.main(["models", "cache", "clear", "OpenMed/unit-model"])
+    captured = capsys.readouterr()
+
+    assert result == 2
+    assert "without --yes confirmation" in captured.err
+    assert captured.out == ""
+
+
+def test_models_cache_clear_with_confirmation_targets_resolved_repo(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: dict[str, Any] = {}
+
+    def fake_clear(repo_id: str, **kwargs: Any) -> bool:
+        calls["repo_id"] = repo_id
+        calls.update(kwargs)
+        return True
+
+    monkeypatch.setattr(main_module, "clear_cached_model", fake_clear)
+
+    result = main_module.main(
+        ["models", "cache", "clear", "OpenMed/unit-model", "--yes"]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert calls == {"repo_id": "OpenMed/unit-model"}
+    assert "Cleared model cache: OpenMed/unit-model" in captured.out
+    assert captured.err == ""


### PR DESCRIPTION
## Summary

Adds `openmed models cache` with download, list, and confirmation-gated clear commands. The CLI resolves registry aliases, reuses the existing Hugging Face cache helpers, reports cached model size and last-use metadata, and preserves clear offline-cache errors.

## Validation

- `.venv/bin/python -m pytest tests/unit/cli/test_models_cache_cli.py -q` (6 passed)
- `.venv/bin/ruff check openmed/cli/main.py tests/unit/cli/test_models_cache_cli.py`
- `.venv/bin/ruff format --check openmed/cli/main.py tests/unit/cli/test_models_cache_cli.py`
- `git diff --check`

Closes #543
