### PR TITLE
Dosing-range sanity checker flagging out-of-range extracted doses for clinician review

### DIFF
--- a/openmed/clinical/__init__.py
+++ b/openmed/clinical/__init__.py
@@ -170,6 +170,14 @@ from .document_linking import (
     EntityOccurrence,
     link_documents,
 )
+from .dosing_check import (
+    DOSE_RANGE_ADVISORY,
+    DOSE_RANGE_DATA_NOTICE,
+    DoseRange,
+    DoseRangeTableError,
+    DoseRangeTableSource,
+    check_dose_ranges,
+)
 from .drug_interactions import find_interactions
 from .events import (
     ASSISTIVE_EVENT_DISCLAIMER,
@@ -245,8 +253,10 @@ from .lexicons import (
     split_measurement_text,
 )
 from .medication_sig import (
+    DOSE_NORMALIZATION_ADVISORY,
     MEDICATION_CANDIDATES,
     MEDICATION_SIG_ADVISORY,
+    DoseNormalization,
     DurationNormalization,
     FrequencyNormalization,
     MedicationCandidate,
@@ -254,6 +264,7 @@ from .medication_sig import (
     MedicationGrounder,
     MedicationSigAttributeType,
     filter_medication_candidates,
+    normalize_dose,
     normalize_duration,
     normalize_frequency,
     normalize_medication_attribute,
@@ -631,6 +642,12 @@ __all__ = [
     "build_guarded_suggestion",
     "guarded_suggestion",
     "validate_guarded_suggestion",
+    "DOSE_RANGE_ADVISORY",
+    "DOSE_RANGE_DATA_NOTICE",
+    "DoseRange",
+    "DoseRangeTableError",
+    "DoseRangeTableSource",
+    "check_dose_ranges",
     "find_interactions",
     "COREFERENCE_FEATURES",
     "COREFERENCE_RESOLUTION_ADVISORY",
@@ -757,6 +774,8 @@ __all__ = [
     "problem_mentions_from_grounded_terms",
     "FrequencyNormalization",
     "DurationNormalization",
+    "DoseNormalization",
+    "DOSE_NORMALIZATION_ADVISORY",
     "MEDICATION_CANDIDATES",
     "MEDICATION_SIG_ADVISORY",
     "MedicationCandidate",
@@ -764,6 +783,7 @@ __all__ = [
     "MedicationGrounder",
     "MedicationSigAttributeType",
     "filter_medication_candidates",
+    "normalize_dose",
     "normalize_frequency",
     "normalize_duration",
     "normalize_medication_attribute",

--- a/openmed/clinical/dosing_check.py
+++ b/openmed/clinical/dosing_check.py
@@ -1,0 +1,627 @@
+"""Offline dose-range checks over caller-supplied reference data.
+
+This module deliberately ships no dosing guidance. A caller supplies a local
+reference-range table keyed by drug and route, and the checker compares already
+extracted dose amounts after deterministic unit normalization. An out-of-range
+value becomes a guarded clinician-review advisory; it is never corrected,
+capped, or replaced with a recommendation. Missing references and incompatible
+units are explicit ``not_checked`` notes rather than implicit passes.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from os import PathLike
+from pathlib import Path
+from typing import Any, TypeAlias, TypedDict
+
+from .decision_support import GuardedSuggestion, SourceSpan, build_guarded_suggestion
+from .lexicons.clinical_norm import split_measurement_text
+from .medication_sig import DoseNormalization, normalize_dose
+
+DOSE_RANGE_ADVISORY = (
+    "Dose-range comparison is a clinician-review advisory based only on a "
+    "caller-supplied reference range; it does not correct, cap, or recommend a "
+    "dose."
+)
+
+DOSE_RANGE_DATA_NOTICE = (
+    "OpenMed includes no production dosing guidance. Callers must supply a "
+    "local, license-cleared reference-range table and remain responsible for "
+    "its scope, currency, and permitted use."
+)
+
+DoseRangeTableSource: TypeAlias = (
+    Mapping[Any, Any] | Sequence[Mapping[str, Any]] | str | PathLike[str] | None
+)
+
+
+class DoseRange(TypedDict, total=False):
+    """A caller-supplied dose range row."""
+
+    low: object
+    high: object
+    low_inclusive: bool
+    high_inclusive: bool
+    unit: str
+
+
+class DoseRangeTableError(ValueError):
+    """Raised when a caller-supplied dose-range table is malformed."""
+
+
+@dataclass(frozen=True)
+class _Bound:
+    value: object
+    unit: str | None
+    canonical_value: float
+    canonical_unit: str | None
+    dimension: dict[str, int]
+
+
+@dataclass(frozen=True)
+class _ReferenceRange:
+    drug: str
+    route: str
+    low: _Bound | None
+    high: _Bound | None
+    low_inclusive: bool
+    high_inclusive: bool
+
+
+@dataclass(frozen=True)
+class _DoseRecord:
+    index: int
+    drug: str | None
+    route: str | None
+    value: object
+    unit: object | None
+    source_spans: tuple[SourceSpan, ...]
+
+
+def check_dose_ranges(
+    doses: Iterable[Any] | Mapping[str, Any],
+    reference_ranges: DoseRangeTableSource,
+    *,
+    language: object | None = None,
+) -> list[GuardedSuggestion]:
+    """Flag extracted doses outside caller-supplied drug/route ranges.
+
+    Args:
+        doses: Dose-like mappings or objects. Each item should expose a drug
+            name, route, and dose amount/unit. ``dose``, ``amount``, ``value``,
+            or a normalized-dose mapping are accepted. ``start``/``end`` or
+            ``source_spans`` values are used for traceability; deterministic
+            synthetic offsets are used when callers do not provide spans.
+        reference_ranges: A local mapping, sequence of rows, or local JSON path
+            containing caller-owned ranges. The canonical mapping shape is
+            ``{"ranges": {"drug": {"route": {"low": ..., "high": ...,
+            "unit": "mg"}}}}``. No URL or network source is accepted.
+        language: Optional source-language code for localized numbers and unit
+            aliases.
+
+    Returns:
+        ``GuardedSuggestion`` values for above/below-range doses and explicit
+        ``not_checked`` notes. In-range doses produce no suggestion.
+
+    Note:
+        A returned flag is an assistive review signal only. This function never
+        changes an extracted amount and never emits a replacement dose.
+
+    Raises:
+        DoseRangeTableError: If the supplied table cannot be loaded or contains
+            an invalid range row.
+        TypeError: If ``doses`` is not an iterable of dose-like values.
+    """
+
+    if isinstance(doses, (str, bytes)) or doses is None:
+        raise TypeError("doses must be an iterable of dose-like values")
+    if isinstance(doses, Mapping):
+        dose_values = [doses]
+    else:
+        try:
+            dose_values = list(doses)
+        except TypeError as exc:
+            raise TypeError("doses must be an iterable of dose-like values") from exc
+
+    ranges = _load_reference_ranges(reference_ranges, language=language)
+    records = _dose_records(dose_values)
+    suggestions: list[GuardedSuggestion] = []
+
+    for record in records:
+        reference = _find_reference(ranges, record.drug, record.route)
+        if reference is None:
+            suggestions.append(
+                _not_checked_note(
+                    record,
+                    "no reference range supplied, not checked",
+                    reason="missing_reference_range",
+                )
+            )
+            continue
+
+        normalized = normalize_dose(
+            record.value,
+            record.unit,
+            language=language,
+        )
+        if not normalized["recognized"]:
+            note = (
+                "unit mismatch, not checked"
+                if normalized.get("unit") is not None
+                else "dose could not be normalized, not checked"
+            )
+            suggestions.append(
+                _not_checked_note(
+                    record,
+                    note,
+                    reason="dose_normalization_failed",
+                )
+            )
+            continue
+
+        comparison = _compare_to_reference(normalized, reference)
+        if comparison is None:
+            suggestions.append(
+                _not_checked_note(
+                    record,
+                    "unit mismatch, not checked",
+                    reason="incompatible_units",
+                )
+            )
+            continue
+
+        bound_side, bound = comparison
+        if bound_side is not None and bound is not None:
+            suggestions.append(
+                _range_flag(
+                    record,
+                    normalized,
+                    reference,
+                    bound_side,
+                    bound,
+                )
+            )
+
+    return suggestions
+
+
+def _dose_records(values: Sequence[Any]) -> list[_DoseRecord]:
+    records: list[_DoseRecord] = []
+    cursor = 0
+    for index, value in enumerate(values):
+        drug = _text_or_none(
+            _field(
+                value,
+                "drug",
+                "drug_name",
+                "medication",
+                "medication_name",
+                "name",
+            )
+        )
+        route = _text_or_none(
+            _field(value, "route", "administration_route", "admin_route")
+        )
+        dose_value, dose_unit, sig_route = _dose_input(value)
+        if route is None:
+            route = sig_route
+        display = drug or f"dose at index {index}"
+        source_spans = _source_spans(value)
+        if not source_spans:
+            end = cursor + max(len(display), 1)
+            source_spans = (SourceSpan(start=cursor, end=end, label=f"dose[{index}]"),)
+            cursor = end + 1
+        records.append(
+            _DoseRecord(
+                index=index,
+                drug=drug,
+                route=route,
+                value=dose_value,
+                unit=dose_unit,
+                source_spans=source_spans,
+            )
+        )
+    return records
+
+
+def _dose_input(value: Any) -> tuple[object, object | None, str | None]:
+    normalized = _field(value, "normalized_dose", "dose_normalized")
+    raw_dose = normalized
+    if raw_dose is None:
+        raw_dose = _field(value, "dose", "amount", "value", "magnitude")
+    explicit_unit = _field(value, "unit", "units", "dose_unit", "dose_units")
+
+    if raw_dose is None:
+        sig = _field(value, "sig", "instructions", "dose_sig")
+        if isinstance(sig, str):
+            parsed = _parse_sig_fields(sig)
+            raw_dose = parsed[0]
+            explicit_unit = parsed[1]
+            return raw_dose, explicit_unit, parsed[2]
+
+    if isinstance(raw_dose, Mapping):
+        nested_value = _field(
+            raw_dose,
+            "value",
+            "amount",
+            "dose",
+            "magnitude",
+        )
+        nested_unit = _field(
+            raw_dose,
+            "unit",
+            "units",
+            "dose_unit",
+            "dose_units",
+        )
+        if nested_value is not None:
+            raw_dose = nested_value
+        if nested_unit is not None:
+            explicit_unit = nested_unit
+
+    if raw_dose is None:
+        raw_dose = value
+    return raw_dose, explicit_unit, None
+
+
+def _parse_sig_fields(sig: str) -> tuple[object, object | None, str | None]:
+    from .sig_parser import parse_sig
+
+    parsed = parse_sig(sig)
+    return parsed["dose"], parsed["unit"], parsed["route"]
+
+
+def _source_spans(value: Any) -> tuple[SourceSpan, ...]:
+    raw_spans = _field(value, "source_spans", "source_span")
+    if raw_spans is not None:
+        if isinstance(raw_spans, (SourceSpan, Mapping)):
+            candidates = (raw_spans,)
+        elif isinstance(raw_spans, Iterable) and not isinstance(
+            raw_spans, (str, bytes)
+        ):
+            candidates = tuple(raw_spans)
+        else:
+            candidates = (raw_spans,)
+        return tuple(SourceSpan.from_obj(span) for span in candidates)
+
+    start = _field(value, "start", "source_start")
+    end = _field(value, "end", "source_end")
+    if type(start) is int and type(end) is int and 0 <= start < end:
+        return (SourceSpan(start=start, end=end),)
+    return ()
+
+
+def _not_checked_note(
+    record: _DoseRecord,
+    note: str,
+    *,
+    reason: str,
+) -> GuardedSuggestion:
+    return build_guarded_suggestion(
+        {
+            "kind": "dose_range_note",
+            "status": "not_checked",
+            "drug": record.drug,
+            "route": record.route,
+            "note": note,
+            "review": "clinician_review_required",
+        },
+        record.source_spans,
+        1.0,
+        provenance={
+            "producer": "openmed.clinical.dosing_check",
+            "reason": reason,
+            "reference_data": "caller_supplied",
+        },
+    )
+
+
+def _range_flag(
+    record: _DoseRecord,
+    normalized: DoseNormalization,
+    reference: _ReferenceRange,
+    bound_side: str,
+    bound: _Bound,
+) -> GuardedSuggestion:
+    observed_value = normalized["value"]
+    observed_unit = normalized["unit"]
+    reference_bound = bound.value
+    return build_guarded_suggestion(
+        {
+            "kind": "dose_range_flag",
+            "status": "above_range" if bound_side == "high" else "below_range",
+            "direction": "above" if bound_side == "high" else "below",
+            "drug": record.drug,
+            "route": record.route,
+            "observed_value": observed_value,
+            "observed_unit": observed_unit,
+            "reference_bound": reference_bound,
+            "reference_bound_unit": bound.unit,
+            "bound": bound_side,
+            "reference_range": {
+                "low": reference.low.value if reference.low is not None else None,
+                "high": (reference.high.value if reference.high is not None else None),
+                "low_inclusive": reference.low_inclusive,
+                "high_inclusive": reference.high_inclusive,
+            },
+            "advisory": DOSE_RANGE_ADVISORY,
+            "review": "clinician_review_required",
+        },
+        record.source_spans,
+        1.0,
+        provenance={
+            "producer": "openmed.clinical.dosing_check",
+            "comparison": "dimension_checked_unit_normalization",
+            "reference_data": "caller_supplied",
+            "bound": bound_side,
+        },
+    )
+
+
+def _compare_to_reference(
+    normalized: DoseNormalization,
+    reference: _ReferenceRange,
+) -> tuple[str | None, _Bound | None] | None:
+    observed = normalized.get("canonical_value")
+    if observed is None:
+        return None
+    dimension = dict(normalized.get("dimension", {}))
+    for bound in (reference.low, reference.high):
+        if bound is not None and bound.dimension != dimension:
+            return None
+
+    if reference.low is not None:
+        low = reference.low
+        below = observed < low.canonical_value
+        if observed == low.canonical_value and not reference.low_inclusive:
+            below = True
+        if below:
+            return "low", low
+
+    if reference.high is not None:
+        high = reference.high
+        above = observed > high.canonical_value
+        if observed == high.canonical_value and not reference.high_inclusive:
+            above = True
+        if above:
+            return "high", high
+
+    return None, None
+
+
+def _load_reference_ranges(
+    source: DoseRangeTableSource,
+    *,
+    language: object | None,
+) -> dict[tuple[str, str], _ReferenceRange]:
+    payload: Any = source
+    if source is None:
+        return {}
+    if isinstance(source, (str, PathLike)):
+        path_text = str(source)
+        if "://" in path_text:
+            raise DoseRangeTableError(
+                "reference_ranges must be a local mapping or file path, not a URL"
+            )
+        path = Path(source)
+        try:
+            with path.open(encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise DoseRangeTableError(
+                f"could not load local dose-range table {path}"
+            ) from exc
+
+    rows = _range_rows(payload)
+    ranges: dict[tuple[str, str], _ReferenceRange] = {}
+    for index, row in enumerate(rows):
+        reference = _parse_reference_range(row, index=index, language=language)
+        key = (reference.drug, reference.route)
+        existing = ranges.get(key)
+        if existing is not None and existing != reference:
+            raise DoseRangeTableError(
+                f"dose-range table contains conflicting records for {key!r}"
+            )
+        ranges[key] = reference
+    return ranges
+
+
+def _range_rows(payload: Any) -> list[Mapping[str, Any]]:
+    if isinstance(payload, Mapping):
+        nested = payload.get("ranges", payload.get("reference_ranges"))
+        if nested is not None:
+            return _range_rows(nested)
+        if _has_range_fields(payload):
+            return [payload]
+
+        rows: list[Mapping[str, Any]] = []
+        for drug, route_values in payload.items():
+            if drug in {"metadata", "schema_version"}:
+                continue
+            if isinstance(drug, (tuple, list)) and len(drug) == 2:
+                if isinstance(route_values, Mapping):
+                    row = dict(route_values)
+                    row.setdefault("drug", drug[0])
+                    row.setdefault("route", drug[1])
+                    rows.append(row)
+                continue
+            if not isinstance(route_values, Mapping):
+                continue
+            if _has_range_fields(route_values):
+                row = dict(route_values)
+                row.setdefault("drug", drug)
+                rows.append(row)
+                continue
+            for route, range_value in route_values.items():
+                if not isinstance(range_value, Mapping):
+                    continue
+                row = dict(range_value)
+                row.setdefault("drug", drug)
+                row.setdefault("route", route)
+                rows.append(row)
+        return rows
+
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes)):
+        return [row for row in payload if isinstance(row, Mapping)]
+    raise DoseRangeTableError("dose-range table must be a mapping or row sequence")
+
+
+def _parse_reference_range(
+    row: Mapping[str, Any],
+    *,
+    index: int,
+    language: object | None,
+) -> _ReferenceRange:
+    drug = _normalize_key(
+        _field(row, "drug", "drug_name", "medication", "medication_name", "name")
+    )
+    route = _normalize_key(_field(row, "route", "administration_route", "admin_route"))
+    if not drug or not route:
+        raise DoseRangeTableError(
+            f"dose-range row {index} requires both drug and route keys"
+        )
+
+    nested = _field(row, "range", "reference_range", "bounds")
+    range_row: Mapping[str, Any] = nested if isinstance(nested, Mapping) else row
+    low_raw = _field(range_row, "low", "minimum", "min", "lower")
+    high_raw = _field(range_row, "high", "maximum", "max", "upper")
+    if low_raw is None and high_raw is None:
+        raise DoseRangeTableError(
+            f"dose-range row {index} must supply a low or high bound"
+        )
+
+    row_unit = _field(range_row, "unit", "units", "dose_unit", "dose_units")
+    if row_unit is None and range_row is not row:
+        row_unit = _field(row, "unit", "units", "dose_unit", "dose_units")
+    low = _normalize_bound(low_raw, row_unit, language=language)
+    high = _normalize_bound(high_raw, row_unit, language=language)
+    if low_raw is not None and low is None:
+        raise DoseRangeTableError(f"dose-range row {index} has an invalid low bound")
+    if high_raw is not None and high is None:
+        raise DoseRangeTableError(f"dose-range row {index} has an invalid high bound")
+    if low is None and high is None:
+        raise DoseRangeTableError(f"dose-range row {index} has no usable bounds")
+    if low is not None and high is not None and low.dimension != high.dimension:
+        raise DoseRangeTableError(
+            f"dose-range row {index} contains incompatible bound units"
+        )
+
+    return _ReferenceRange(
+        drug=drug,
+        route=route,
+        low=low,
+        high=high,
+        low_inclusive=_bool_or_default(_field(range_row, "low_inclusive"), True),
+        high_inclusive=_bool_or_default(_field(range_row, "high_inclusive"), True),
+    )
+
+
+def _normalize_bound(
+    raw: object,
+    unit: object | None,
+    *,
+    language: object | None,
+) -> _Bound | None:
+    bound_value = raw
+    bound_unit = unit
+    if isinstance(raw, Mapping):
+        bound_value = _field(raw, "value", "amount", "dose", "magnitude")
+        nested_unit = _field(raw, "unit", "units", "dose_unit", "dose_units")
+        if nested_unit is not None:
+            bound_unit = nested_unit
+    elif bound_unit is None and isinstance(raw, str):
+        measurement = split_measurement_text(raw)
+        if measurement is not None:
+            bound_value, bound_unit = measurement
+
+    normalized = normalize_dose(bound_value, bound_unit, language=language)
+    canonical_value = normalized.get("canonical_value")
+    if not normalized["recognized"] or canonical_value is None:
+        return None
+    return _Bound(
+        value=normalized["value"],
+        unit=normalized["unit"],
+        canonical_value=canonical_value,
+        canonical_unit=normalized["canonical_unit"],
+        dimension=dict(normalized["dimension"]),
+    )
+
+
+def _find_reference(
+    ranges: Mapping[tuple[str, str], _ReferenceRange],
+    drug: str | None,
+    route: str | None,
+) -> _ReferenceRange | None:
+    normalized_drug = _normalize_key(drug)
+    normalized_route = _normalize_key(route)
+    if not normalized_drug or not normalized_route:
+        return None
+    return ranges.get((normalized_drug, normalized_route)) or ranges.get(
+        (normalized_drug, "*")
+    )
+
+
+def _has_range_fields(value: Mapping[Any, Any]) -> bool:
+    return any(
+        key in value
+        for key in (
+            "low",
+            "high",
+            "minimum",
+            "maximum",
+            "min",
+            "max",
+            "lower",
+            "upper",
+            "range",
+            "reference_range",
+            "bounds",
+        )
+    )
+
+
+def _field(value: Any, *names: str, default: object | None = None) -> object | None:
+    if isinstance(value, Mapping):
+        for name in names:
+            if name in value:
+                return value[name]
+        return default
+    for name in names:
+        candidate = getattr(value, name, None)
+        if candidate is not None:
+            return candidate
+    return default
+
+
+def _text_or_none(value: object | None) -> str | None:
+    if isinstance(value, Mapping):
+        value = _field(value, "name", "text", "display", "value")
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_key(value: object | None) -> str:
+    text = _text_or_none(value)
+    if text is None:
+        return ""
+    return re.sub(r"\s+", " ", text.casefold()).strip()
+
+
+def _bool_or_default(value: object | None, default: bool) -> bool:
+    return value if isinstance(value, bool) else default
+
+
+__all__ = [
+    "DOSE_RANGE_ADVISORY",
+    "DOSE_RANGE_DATA_NOTICE",
+    "DoseRange",
+    "DoseRangeTableError",
+    "DoseRangeTableSource",
+    "check_dose_ranges",
+]

--- a/openmed/clinical/medication_sig.py
+++ b/openmed/clinical/medication_sig.py
@@ -12,11 +12,13 @@ from .lexicons.clinical_norm import (
     localized_duration_text,
     localized_frequency_text,
     parse_locale_number,
+    split_measurement_text,
 )
+from .units import parse_measurement
 
 FrequencyPeriodUnit = Literal["h", "d", "wk"]
 DurationUnit = Literal["d", "wk"]
-MedicationSigAttributeType = Literal["frequency", "duration"]
+MedicationSigAttributeType = Literal["dose", "frequency", "duration"]
 Number = int | float
 MEDICATION_CANDIDATES = "medication_candidates"
 MedicationGrounder = Callable[[str], Sequence[Candidate]]
@@ -45,6 +47,21 @@ class DurationNormalization(TypedDict):
     unit: DurationUnit | None
     days: Number | None
     cue: str | None
+
+
+class DoseNormalization(TypedDict):
+    """Structured medication dose amount and unit normalization result."""
+
+    raw: object
+    recognized: bool
+    confidence: float
+    value: Number | None
+    unit: str | None
+    canonical_value: float | None
+    canonical_unit: str | None
+    dimension: dict[str, int]
+    reason: str
+    advisory: str
 
 
 class _FrequencyCue(TypedDict, total=False):
@@ -94,6 +111,12 @@ MEDICATION_SIG_ADVISORY = (
     "Medication sig normalization is deterministic support tooling and is not "
     "a substitute for clinician review; PRN/as-needed cues are flagged without "
     "implying a scheduled numeric frequency."
+)
+
+DOSE_NORMALIZATION_ADVISORY = (
+    "Medication dose normalization is deterministic support tooling and is not "
+    "a substitute for clinician review; it does not determine whether a dose "
+    "is appropriate."
 )
 
 # Provenance: these are common Latin prescription sig abbreviations and plain
@@ -457,6 +480,88 @@ def normalize_duration(
     return _empty_duration(text)
 
 
+def normalize_dose(
+    value: object,
+    unit: object | None = None,
+    *,
+    language: object | None = None,
+) -> DoseNormalization:
+    """Normalize a medication dose amount into a dimension-checked unit.
+
+    ``value`` may be a numeric amount with a separate ``unit``, a measurement
+    string such as ``"500 mg"``, or a mapping/object exposing an amount and a
+    unit. The original amount and unit are preserved for review output while
+    ``canonical_value`` and ``canonical_unit`` are suitable for comparison.
+    Unitless numeric values remain dimensionless so callers can use the helper
+    for synthetic or count-based inputs; a supplied unit is still required for
+    dimensional comparison with a ranged dose.
+
+    Args:
+        value: Dose amount, measurement string, or dose-like mapping/object.
+        unit: Optional unit when ``value`` is a numeric amount.
+        language: Optional source-language code for localized numbers and units.
+
+    Returns:
+        A deterministic mapping with ``recognized=False`` when the amount or
+        unit cannot be normalized. The mapping never recommends or changes a
+        dose.
+    """
+
+    raw = value
+    value, unit = _dose_parts(value, unit)
+    numeric_value = parse_locale_number(value, language=language)
+    if numeric_value is None:
+        return _empty_dose(raw, reason="dose amount is not finite numeric")
+
+    if unit is None or (isinstance(unit, str) and not unit.strip()):
+        cleaned_value = _clean_number(numeric_value)
+        return {
+            "raw": raw,
+            "recognized": True,
+            "confidence": 1.0,
+            "value": cleaned_value,
+            "unit": None,
+            "canonical_value": numeric_value,
+            "canonical_unit": None,
+            "dimension": {},
+            "reason": "",
+            "advisory": DOSE_NORMALIZATION_ADVISORY,
+        }
+
+    normalized_unit = str(unit).strip()
+    measurement = parse_measurement(
+        numeric_value,
+        normalized_unit,
+        language=language,
+    )
+    if measurement["status"] != "ok":
+        return {
+            "raw": raw,
+            "recognized": False,
+            "confidence": 0.0,
+            "value": _clean_number(numeric_value),
+            "unit": normalized_unit,
+            "canonical_value": None,
+            "canonical_unit": None,
+            "dimension": dict(measurement.get("dimension", {})),
+            "reason": measurement.get("reason", "dose unit could not be normalized"),
+            "advisory": DOSE_NORMALIZATION_ADVISORY,
+        }
+
+    return {
+        "raw": raw,
+        "recognized": True,
+        "confidence": 1.0,
+        "value": _clean_number(numeric_value),
+        "unit": normalized_unit,
+        "canonical_value": measurement["canonical_magnitude"],
+        "canonical_unit": measurement["canonical_unit"],
+        "dimension": dict(measurement["dimension"]),
+        "reason": "",
+        "advisory": DOSE_NORMALIZATION_ADVISORY,
+    }
+
+
 def normalize_medication_attribute(
     attribute_type: MedicationSigAttributeType | str,
     text: object,
@@ -475,6 +580,8 @@ def normalize_medication_attribute(
         attribute types without deterministic sig normalization.
     """
 
+    if attribute_type == "dose":
+        return normalize_dose(text, language=language)
     if attribute_type == "frequency":
         return normalize_frequency(text, language=language)
     if attribute_type == "duration":
@@ -559,6 +666,55 @@ def _looks_like_observation_abbreviation(
 
 def _empty_frequency(raw: object) -> FrequencyNormalization:
     return _frequency_result(raw, recognized=False, confidence=0.0)
+
+
+def _empty_dose(raw: object, *, reason: str) -> DoseNormalization:
+    return {
+        "raw": raw,
+        "recognized": False,
+        "confidence": 0.0,
+        "value": None,
+        "unit": None,
+        "canonical_value": None,
+        "canonical_unit": None,
+        "dimension": {},
+        "reason": reason,
+        "advisory": DOSE_NORMALIZATION_ADVISORY,
+    }
+
+
+def _dose_parts(value: object, unit: object | None) -> tuple[object, object | None]:
+    if unit is not None:
+        if isinstance(value, str):
+            parts = split_measurement_text(value)
+            if parts is not None:
+                return parts[0], unit
+        return value, unit
+
+    nested = _entity_field(
+        value,
+        "value",
+        "amount",
+        "dose",
+        "magnitude",
+        default=None,
+    )
+    nested_unit = _entity_field(
+        value,
+        "unit",
+        "units",
+        "dose_unit",
+        "dose_units",
+        default=None,
+    )
+    if nested is not None and nested is not value:
+        return nested, nested_unit
+
+    if isinstance(value, str):
+        parts = split_measurement_text(value)
+        if parts is not None:
+            return parts[0], parts[1]
+    return value, None
 
 
 def _frequency_result(
@@ -682,8 +838,10 @@ def _frequency_per_day(period: Number, unit: FrequencyPeriodUnit) -> float:
 
 
 __all__ = [
+    "DOSE_NORMALIZATION_ADVISORY",
     "DurationNormalization",
     "DurationUnit",
+    "DoseNormalization",
     "FrequencyNormalization",
     "FrequencyPeriodUnit",
     "MEDICATION_CANDIDATES",
@@ -693,6 +851,7 @@ __all__ = [
     "MedicationGrounder",
     "MedicationSigAttributeType",
     "filter_medication_candidates",
+    "normalize_dose",
     "normalize_medication_attribute",
     "normalize_duration",
     "normalize_frequency",

--- a/tests/fixtures/clinical/synthetic_dose_ranges.json
+++ b/tests/fixtures/clinical/synthetic_dose_ranges.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "synthetic": true,
+    "clinical_use": false,
+    "notice": "Synthetic fixture only; production dose ranges are user-supplied and are not bundled by OpenMed."
+  },
+  "ranges": {
+    "synthetic medication alpha": {
+      "oral": {
+        "low": 100,
+        "high": 500,
+        "unit": "mg"
+      }
+    }
+  }
+}

--- a/tests/unit/clinical/test_dosing_check.py
+++ b/tests/unit/clinical/test_dosing_check.py
@@ -1,0 +1,128 @@
+"""Focused tests for caller-supplied, advisory dose-range checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.clinical import (
+    CLINICAL_DECISION_SUPPORT_DISCLAIMER,
+    DOSE_RANGE_ADVISORY,
+    GuardedSuggestion,
+    check_dose_ranges,
+    normalize_dose,
+)
+
+FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "clinical"
+    / "synthetic_dose_ranges.json"
+)
+
+
+def _dose(
+    value: object,
+    unit: str = "mg",
+    *,
+    drug: str = "Synthetic Medication Alpha",
+    route: str = "oral",
+    start: int = 10,
+    end: int = 24,
+) -> dict[str, object]:
+    return {
+        "drug": drug,
+        "route": route,
+        "dose": value,
+        "unit": unit,
+        "start": start,
+        "end": end,
+    }
+
+
+def test_synthetic_fixture_documents_user_supplied_production_ranges() -> None:
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    assert payload["metadata"]["synthetic"] is True
+    assert payload["metadata"]["clinical_use"] is False
+    assert "production" in payload["metadata"]["notice"]
+    assert "user-supplied" in payload["metadata"]["notice"]
+
+
+def test_over_range_dose_returns_guarded_review_flag_with_exceeded_bound() -> None:
+    flags = check_dose_ranges([_dose(1000)], FIXTURE)
+
+    assert len(flags) == 1
+    flag = flags[0]
+    assert isinstance(flag, GuardedSuggestion)
+    assert flag.disclaimer == CLINICAL_DECISION_SUPPORT_DISCLAIMER
+    assert flag.requires_clinician_review is True
+    assert flag.autonomous_decision is False
+    assert [(span.start, span.end) for span in flag.source_spans] == [(10, 24)]
+
+    suggestion = flag.suggestion
+    assert suggestion["kind"] == "dose_range_flag"
+    assert suggestion["status"] == "above_range"
+    assert suggestion["observed_value"] == 1000
+    assert suggestion["observed_unit"] == "mg"
+    assert suggestion["reference_bound"] == 500
+    assert suggestion["reference_bound_unit"] == "mg"
+    assert suggestion["bound"] == "high"
+    assert suggestion["advisory"] == DOSE_RANGE_ADVISORY
+    assert "corrected_dose" not in suggestion
+    assert "recommended_dose" not in suggestion
+
+
+def test_below_range_dose_identifies_the_lower_bound() -> None:
+    flags = check_dose_ranges([_dose(50)], FIXTURE)
+
+    assert len(flags) == 1
+    assert flags[0].suggestion["status"] == "below_range"
+    assert flags[0].suggestion["reference_bound"] == 100
+    assert flags[0].suggestion["bound"] == "low"
+
+
+def test_in_range_dose_produces_no_flag() -> None:
+    assert check_dose_ranges([_dose(250)], FIXTURE) == []
+
+
+def test_unit_conversion_is_dimension_checked_before_comparison() -> None:
+    normalized = normalize_dose(1, "g")
+    assert normalized["recognized"] is True
+    assert normalized["canonical_value"] == pytest.approx(1.0)
+    assert normalized["canonical_unit"] == "g"
+
+    flags = check_dose_ranges([_dose(0.25, "g")], FIXTURE)
+    assert flags == []
+
+
+def test_incompatible_unit_returns_not_checked_note_never_false_flag() -> None:
+    notes = check_dose_ranges([_dose(250, "mL")], FIXTURE)
+
+    assert len(notes) == 1
+    note = notes[0]
+    assert note.suggestion["kind"] == "dose_range_note"
+    assert note.suggestion["status"] == "not_checked"
+    assert note.suggestion["note"] == "unit mismatch, not checked"
+    assert "dose_range_flag" not in note.suggestion["kind"]
+
+
+def test_missing_reference_returns_not_checked_note_not_implicit_pass() -> None:
+    notes = check_dose_ranges(
+        [_dose(250, drug="Synthetic Medication Without Range")],
+        FIXTURE,
+    )
+
+    assert len(notes) == 1
+    assert notes[0].suggestion["status"] == "not_checked"
+    assert notes[0].suggestion["note"] == ("no reference range supplied, not checked")
+
+
+def test_nested_mapping_reference_table_is_supported() -> None:
+    table = {
+        "Synthetic Medication Alpha": {"oral": {"low": 100, "high": 500, "unit": "mg"}}
+    }
+
+    assert check_dose_ranges([_dose(250)], table) == []


### PR DESCRIPTION
Closes #1833.

Adds an offline dosing-range sanity checker that normalizes extracted dose units, compares them only with caller-supplied drug/route ranges, and emits guarded clinician-review advisories for above- or below-range values. Missing ranges and incompatible units produce explicit not-checked notes; no production dosing data, dose correction, capping, or recommendation is included. A synthetic fixture and focused regression tests cover the acceptance criteria.

Checks:
- `.venv/bin/python -m pytest tests/unit/clinical/test_dosing_check.py -q`
- `.venv/bin/python -m pytest tests/unit/clinical/test_medication_sig.py -q`
- `.venv/bin/python -m pytest tests/unit/clinical/test_decision_support.py -q`
- `.venv/bin/python -m pytest tests/unit/clinical/test_drug_interactions.py -q`
- `.venv/bin/ruff format --check openmed/clinical/__init__.py openmed/clinical/dosing_check.py openmed/clinical/medication_sig.py tests/unit/clinical/test_dosing_check.py`
- `.venv/bin/ruff check openmed/clinical/__init__.py openmed/clinical/dosing_check.py openmed/clinical/medication_sig.py tests/unit/clinical/test_dosing_check.py`
