### PR TITLE
Add task-oriented examples cookbook

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -138,6 +138,7 @@ classification:
     - benchmarks/i18n-throughput.md
     - zero-shot-howto.md
     - zero-shot-ner.md
+    - cookbook.md
     - examples.md
     - document-adapter-provenance.md
     - multimodal/epub-extraction.md

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -181,6 +181,7 @@ classification:
     - benchmarks/i18n-throughput.md
     - zero-shot-howto.md
     - zero-shot-ner.md
+    - cookbook.md
     - examples.md
     - examples/notebook-gallery.md
     - document-adapter-provenance.md

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,0 +1,66 @@
+# Cookbook
+
+Start with the task you need to complete, then open the linked script, notebook,
+or recipe. The examples use synthetic data unless their own documentation says
+otherwise. Run scripts from the repository root so their relative paths resolve
+consistently.
+
+## De-identify text and datasets
+
+| Goal | Asset | What it covers |
+| --- | --- | --- |
+| De-identify a CSV column | [Deidentification Cookbook notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Deidentification_Cookbook.ipynb) | A list/CSV recipe that adds de-identified output without changing the source values. |
+| Batch-redact a folder of text files | [Deidentification Cookbook notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Deidentification_Cookbook.ipynb) | `BatchProcessor.process_directory()` over synthetic `.txt` notes with mirrored redacted output. |
+| Explore the complete PII API | [PII Detection Complete Guide notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/PII_Detection_Complete_Guide.ipynb) | PII extraction, de-identification methods, entity review, and output handling. |
+| Process a batch of notes | [pii_batch_processing.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/pii_batch_processing.py) | `BatchProcessor` extraction and deterministic replacement over synthetic notes. |
+| Run the first redaction-to-FHIR flow | [first_five_minutes_redact_extract_fhir.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/first_five_minutes_redact_extract_fhir.py) | Redaction, deterministic clinical extraction, and FHIR Bundle assembly. |
+| Exercise a bundled evaluation fixture | [datasets_walkthrough.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/datasets_walkthrough.py) | Offline-first loading of synthetic fixtures through `extract_pii` and `deidentify`. |
+| Protect retrieval context | [redaction_preserving_retrieval.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/redaction_preserving_retrieval.py) | Redaction before retrieval and controlled use of protected context. |
+| Redact before an external model call | [privacy_gateway_quickstart.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/privacy_gateway_quickstart.py) | A privacy boundary with redaction before egress and safe re-identification afterward. |
+
+## Process documents and messages
+
+| Goal | Asset | What it covers |
+| --- | --- | --- |
+| Redact helpdesk SMS exports | [sms_deid_helpdesk_logs.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/sms_deid_helpdesk_logs.py) | RapidPro JSON and CSV input, contact pseudonyms, coarse timestamps, and bounded batches. |
+| De-identify community health forms | [chw_form_deid.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/chw_form_deid.py) | Local ODK, CommCare, and KoBoToolbox JSON or CSV exports. |
+| Inspect multimodal and document adapters | [v17_multimodal_browser_interop.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/v17_multimodal_browser_interop.py) | OCR contracts, source offsets, chat JSONL, CSV manifests, FHIR, HL7 v2, and browser bundles. |
+| Segment long text into batches | [Sentence Detection and Batching notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Sentence_Detection_Batching.ipynb) | Sentence segmentation, batched inference, and projection back to source paragraphs. |
+
+## Select and compare models
+
+| Goal | Asset | What it covers |
+| --- | --- | --- |
+| Compare PII models and methods | [pii_model_comparison.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/pii_model_comparison.py) | Registry discovery, model-size tradeoffs, shared inputs, and de-identification methods. |
+| Tour zero-shot NER | [Zero-Shot NER Tour notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/ZeroShot_NER_Tour.ipynb) | GLiNER indexing, label defaults, inference, and BIO/BILOU span conversion. |
+| Inspect medical tokenization | [Medical Tokenizer Demo notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Medical_Tokenizer_Demo.ipynb) | Medical-aware tokenization and token-to-source alignment. |
+| Compare tokenizer behavior | [Medical Tokenizer Benchmark notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Medical_Tokenizer_Benchmark.ipynb) | Reproducible tokenizer comparisons over clinical text. |
+
+## Extract clinical entities
+
+| Goal | Asset | What it covers |
+| --- | --- | --- |
+| Run disease, pharmaceutical, and oncology NER | [clinical_ner_families.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/clinical_ner_families.py) | Registry-based family selection, offline defaults, and labeled-span output. |
+| Build a DataFrame extraction flow | [clinical_extraction_dataframe_api.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/clinical_extraction_dataframe_api.py) | Clinical extraction through the tabular API. |
+| Start from a guided notebook | [Getting Started notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/getting_started.ipynb) | Installation, registry exploration, and a first `analyze_text` call. |
+
+## Run multilingual workflows
+
+| Goal | Asset | What it covers |
+| --- | --- | --- |
+| De-identify Chinese, Hindi, and Hinglish notes | [Chinese and Hindi De-identification Tour notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Chinese_Hindi_Deid_Tour.ipynb) | Deterministic de-identification, structured review, UTF-8 output, and leak assertions. |
+| Compare multilingual PII behavior | [Multilingual PII Detection Guide notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Multilingual_PII_Detection_Guide.ipynb) | Language-aware PII detection and de-identification. |
+| Exercise additional language packs | [pii_multilingual_new_languages.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/pii_multilingual_new_languages.py) | Registry entries, locale-specific recognizers, and optional model-backed extraction. |
+
+## Serve and integrate OpenMed
+
+| Goal | Asset | What it covers |
+| --- | --- | --- |
+| Start and call the REST service | [REST API Recipes](rest-recipes.md) | Service startup, health checks, analysis, PII extraction, de-identification, and production safeguards. |
+| Build a local interactive demo | [gradio_deid_app.py](https://github.com/maziyarpanahi/openmed/blob/master/examples/gradio_deid_app.py) | A small Gradio interface for synthetic text and multiple de-identification methods. |
+| Redact warehouse columns with dbt | [dbt de-identification example](https://github.com/maziyarpanahi/openmed/blob/master/examples/dbt-deidentify/README.md) | Redaction macros, synthetic seed data, and a redacted staging model. |
+| Redact a Spark stream | [Spark streaming example](https://github.com/maziyarpanahi/openmed/blob/master/examples/spark-streaming/README.md) | Structured Streaming de-identification over synthetic records. |
+| Add structured log redaction | [log redaction example](https://github.com/maziyarpanahi/openmed/blob/master/examples/log-redaction/README.md) | Logging integration that removes sensitive values before emission. |
+
+For shorter copy-and-paste snippets and feature-specific documentation, see
+[Examples and Copy/Paste Recipes](examples.md).

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,0 +1,95 @@
+# OpenMed Cookbook
+
+Start with the task you need to complete, then open the linked runnable script,
+notebook, or copy-ready recipe. Repository examples use synthetic inputs by
+default; review any optional model download or external-service boundary before
+using the same workflow with real data.
+
+## Pick a task
+
+| Goal | Start here | What it demonstrates |
+| --- | --- | --- |
+| Redact one clinical note | [De-identification cookbook notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Deidentification_Cookbook.ipynb) | Masking, replacement, hashing, and rich notebook rendering. |
+| De-identify a folder or CSV in batches | [Batch processing script](https://github.com/maziyarpanahi/openmed/blob/master/examples/pii_batch_processing.py) | Bounded extraction and de-identification with `BatchProcessor`. |
+| Compare PII models | [Model comparison script](https://github.com/maziyarpanahi/openmed/blob/master/examples/pii_model_comparison.py) | Runs several model choices against shared synthetic text. |
+| Explore clinical NER families | [Clinical NER families script](https://github.com/maziyarpanahi/openmed/blob/master/examples/clinical_ner_families.py) | Biomedical and clinical model-family selection. |
+| Build a REST workflow | [REST recipes](./rest-recipes.md) | Copy-ready health, extraction, de-identification, batch, and streaming requests. |
+| Redact, extract, and assemble FHIR | [First-five-minutes script](https://github.com/maziyarpanahi/openmed/blob/master/examples/first_five_minutes_redact_extract_fhir.py) | A synthetic local redaction-to-FHIR path. |
+| Evaluate a model offline | [Evaluation walkthrough notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/04_eval_walkthrough.ipynb) | Bundled synthetic fixtures and offline evaluation. |
+| Process Chinese, Hindi, or Hinglish | [Multilingual tour notebook](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Chinese_Hindi_Deid_Tour.ipynb) | Script-aware de-identification and zero-leak assertions. |
+| Protect an agent or retrieval pipeline | [Privacy gateway script](https://github.com/maziyarpanahi/openmed/blob/master/examples/privacy_gateway_quickstart.py) | Local redaction before an explicit external boundary. |
+| Review structured-data release risk | [Structured release-risk script](https://github.com/maziyarpanahi/openmed/blob/master/examples/structured_release_risk.py) | Advisory k/l/t policy review and aggregate evidence. |
+
+## Runnable script index
+
+### Privacy and de-identification
+
+| Use when you want to... | Script |
+| --- | --- |
+| Batch extraction or de-identification | [`examples/pii_batch_processing.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/pii_batch_processing.py) |
+| Compare model outputs | [`examples/pii_model_comparison.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/pii_model_comparison.py) |
+| Exercise recently added language support | [`examples/pii_multilingual_new_languages.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/pii_multilingual_new_languages.py) |
+| De-identify a fabricated Chinese note | [`examples/deid_chinese_clinical_note.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/deid_chinese_clinical_note.py) |
+| De-identify fabricated Hindi and Hinglish notes | [`examples/deid_hindi_hinglish_note.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/deid_hindi_hinglish_note.py) |
+| Redact RapidPro-style or CSV helpdesk logs | [`examples/sms_deid_helpdesk_logs.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/sms_deid_helpdesk_logs.py) |
+| Redact ODK, CommCare, or KoBoToolbox exports | [`examples/chw_form_deid.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/chw_form_deid.py) |
+| Try language-agnostic obfuscation | [`examples/obfuscation_demo.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/obfuscation_demo.py) |
+| Compare the unified MLX and PyTorch privacy API | [`examples/privacy_filter_unified.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/privacy_filter_unified.py) |
+| Launch the optional synthetic Gradio demo | [`examples/gradio_deid_app.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/gradio_deid_app.py) |
+| Walk through a bundled synthetic dataset | [`examples/datasets_walkthrough.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/datasets_walkthrough.py) |
+
+### Clinical extraction, grounding, and exchange
+
+| Use when you want to... | Script |
+| --- | --- |
+| Compare clinical and biomedical NER families | [`examples/clinical_ner_families.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/clinical_ner_families.py) |
+| Redact, extract, and build a FHIR Bundle | [`examples/first_five_minutes_redact_extract_fhir.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/first_five_minutes_redact_extract_fhir.py) |
+| Ground a synthetic mention offline | [`examples/offline_grounding.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/offline_grounding.py) |
+| Prepare a local OpenMRS de-identified handoff | [`examples/openmrs_deid_handoff.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/openmrs_deid_handoff.py) |
+| Build a de-identified DHIS2 district export | [`examples/dhis2_district_export.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/dhis2_district_export.py) |
+
+### Models, agents, and local pipelines
+
+| Use when you want to... | Script |
+| --- | --- |
+| Run MLX token classification | [`examples/mlx_token_classification_ner.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/mlx_token_classification_ner.py) |
+| Run MLX GLiNER zero-shot NER | [`examples/mlx_gliner_zero_shot_ner.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/mlx_gliner_zero_shot_ner.py) |
+| Render registry tools for agent frameworks | [`examples/agent_tools_quickstart.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/agent_tools_quickstart.py) |
+| Add a privacy boundary to a graph flow | [`examples/graph_orchestration_privacy.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/graph_orchestration_privacy.py) |
+| Redact before an external model call | [`examples/privacy_gateway_quickstart.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/privacy_gateway_quickstart.py) |
+| Preserve retrieval utility after redaction | [`examples/redaction_preserving_retrieval.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/redaction_preserving_retrieval.py) |
+| Protect a local search pipeline | [`examples/search_pipeline_privacy.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/search_pipeline_privacy.py) |
+
+### Policy, risk, onboarding, and release evidence
+
+| Use when you want to... | Script |
+| --- | --- |
+| Review a structured release | [`examples/structured_release_risk.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/structured_release_risk.py) |
+| Compare a release with a reference population | [`examples/structured_population_risk.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/structured_population_risk.py) |
+| Exercise policy, audit, and release gates | [`examples/v16_policy_audit_release_gates.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/v16_policy_audit_release_gates.py) |
+| Exercise multimodal, interop, and browser exports | [`examples/v17_multimodal_browser_interop.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/v17_multimodal_browser_interop.py) |
+| Warm a mirror-backed cache, then work offline | [`examples/onboarding_china_mirrors.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/onboarding_china_mirrors.py) |
+| Review an India DPDP-aware workflow | [`examples/onboarding_india_dpdp.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/onboarding_india_dpdp.py) |
+
+## Notebook index
+
+| Goal | Notebook or notebook companion |
+| --- | --- |
+| First redaction workflow | [`examples/notebooks/01_quickstart_redaction.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/01_quickstart_redaction.ipynb) |
+| Batch a synthetic dataset | [`examples/notebooks/02_batch_dataset.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/02_batch_dataset.ipynb) |
+| Export a deterministic FHIR Bundle | [`examples/notebooks/03_fhir_export.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/03_fhir_export.ipynb) |
+| Run the offline evaluation walkthrough | [`examples/notebooks/04_eval_walkthrough.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/04_eval_walkthrough.ipynb) |
+| Tour Chinese, Hindi, and Hinglish de-identification | [`examples/notebooks/Chinese_Hindi_Deid_Tour.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Chinese_Hindi_Deid_Tour.ipynb) |
+| Explore masking, replacement, and hashing | [`examples/notebooks/Deidentification_Cookbook.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Deidentification_Cookbook.ipynb) |
+| Follow the original getting-started notebook | [`examples/notebooks/getting_started.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/getting_started.ipynb) |
+| Benchmark the medical tokenizer | [`examples/notebooks/Medical_Tokenizer_Benchmark.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Medical_Tokenizer_Benchmark.ipynb) |
+| Explore medical tokenization interactively | [`examples/notebooks/Medical_Tokenizer_Demo.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Medical_Tokenizer_Demo.ipynb) |
+| Review multilingual PII detection | [`examples/notebooks/Multilingual_PII_Detection_Guide.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Multilingual_PII_Detection_Guide.ipynb) |
+| Follow the complete PII detection guide | [`examples/notebooks/PII_Detection_Complete_Guide.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/PII_Detection_Complete_Guide.ipynb) |
+| Segment and batch sentences | [`examples/notebooks/Sentence_Detection_Batching.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/Sentence_Detection_Batching.ipynb) |
+| Tour zero-shot NER | [`examples/notebooks/ZeroShot_NER_Tour.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/ZeroShot_NER_Tour.ipynb) |
+| Use the clinical extraction DataFrame API | [`examples/notebooks/clinical_extraction_dataframe_api.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/clinical_extraction_dataframe_api.py) |
+
+For narrative snippets and integration-specific examples, continue to
+[Examples & Copy/Paste Recipes](./examples.md) and the
+[Notebook Gallery](./examples/notebook-gallery.md).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,6 +4,9 @@ This page curates the most useful samples already in the repository so you can
 jump straight to runnable notebooks or scripts. The v1.6, v1.7, and v1.8
 examples use synthetic data and are safe to run during release review.
 
+For a task-first map from common goals to the exact runnable asset, see the
+[Cookbook](cookbook.md).
+
 ## Notebooks (`examples/notebooks/`)
 
 | Notebook | Highlights |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,6 +4,10 @@ This page curates the most useful samples already in the repository so you can
 jump straight to runnable notebooks or scripts. The v1.6, v1.7, and v1.8
 examples use synthetic data and are safe to run during release review.
 
+If you already know the outcome you want, use the
+**[Task-oriented Cookbook](./cookbook.md)** to jump directly from that goal to
+the matching script, notebook, or REST recipe.
+
 ## Curated Notebook Gallery
 
 For a guided, end-to-end walkthrough from quickstart redaction to FHIR export and offline evaluation, visit the **[Example Notebooks Gallery](./examples/notebook-gallery.md)**. All gallery notebooks run 100% offline on synthetic fixtures and are verified by continuous integration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - Chinese and Indic Throughput: benchmarks/i18n-throughput.md
       - Zero-shot NER How-to: zero-shot-howto.md
       - Zero-shot Toolkit: zero-shot-ner.md
+      - Cookbook: cookbook.md
       - Examples & Copy/Paste Recipes: examples.md
       - Document Adapter Provenance: document-adapter-provenance.md
       - EPUB Extraction: multimodal/epub-extraction.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
       - Chinese and Indic Throughput: benchmarks/i18n-throughput.md
       - Zero-shot NER How-to: zero-shot-howto.md
       - Zero-shot Toolkit: zero-shot-ner.md
+      - Task-oriented Cookbook: cookbook.md
       - Examples & Copy/Paste Recipes: examples.md
       - Example Notebooks Gallery: examples/notebook-gallery.md
       - Document Adapter Provenance: document-adapter-provenance.md

--- a/tests/unit/test_docs_cookbook_links.py
+++ b/tests/unit/test_docs_cookbook_links.py
@@ -1,0 +1,35 @@
+"""Keep repository example links in the cookbook from going stale."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COOKBOOK = ROOT / "docs" / "cookbook.md"
+MARKDOWN_LINK = re.compile(r"\[[^]]+\]\(([^)\s]+)\)")
+REPOSITORY_BLOB_PREFIX = "https://github.com/maziyarpanahi/openmed/blob/master/"
+
+
+def _linked_example_paths(markdown: str) -> list[Path]:
+    paths: list[Path] = []
+    for target in MARKDOWN_LINK.findall(markdown):
+        target_without_fragment = target.split("#", maxsplit=1)[0]
+        if target_without_fragment.startswith(REPOSITORY_BLOB_PREFIX):
+            relative_path = target_without_fragment.removeprefix(REPOSITORY_BLOB_PREFIX)
+        elif target_without_fragment.startswith("../examples/"):
+            relative_path = target_without_fragment.removeprefix("../")
+        else:
+            continue
+
+        if relative_path.startswith("examples/"):
+            paths.append(Path(relative_path))
+    return paths
+
+
+def test_every_cookbook_example_link_exists() -> None:
+    linked_paths = _linked_example_paths(COOKBOOK.read_text(encoding="utf-8"))
+
+    assert linked_paths, "cookbook must link to at least one repository example"
+    missing = [str(path) for path in linked_paths if not (ROOT / path).is_file()]
+    assert not missing, f"cookbook links to missing example files: {missing}"

--- a/tests/unit/test_docs_cookbook_links.py
+++ b/tests/unit/test_docs_cookbook_links.py
@@ -1,0 +1,53 @@
+"""Regression tests for the task-oriented cookbook index."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COOKBOOK = ROOT / "docs" / "cookbook.md"
+EXAMPLE_LINK = re.compile(
+    r"\(https://github\.com/maziyarpanahi/openmed/blob/master/"
+    r"(?P<path>examples/[^)#?]+)\)"
+)
+
+
+def _linked_example_paths() -> set[str]:
+    content = COOKBOOK.read_text(encoding="utf-8")
+    return {match.group("path") for match in EXAMPLE_LINK.finditer(content)}
+
+
+def test_every_cookbook_example_link_exists() -> None:
+    linked = _linked_example_paths()
+
+    assert linked
+    for relative_path in sorted(linked):
+        path = ROOT / relative_path
+        assert path.is_file(), f"Cookbook example does not exist: {relative_path}"
+
+
+def test_cookbook_indexes_current_scripts_and_notebooks() -> None:
+    top_level_scripts = {
+        path.relative_to(ROOT).as_posix()
+        for path in (ROOT / "examples").glob("*.py")
+        if path.name != "__init__.py"
+    }
+    notebooks = {
+        path.relative_to(ROOT).as_posix()
+        for pattern in ("*.ipynb", "*.py")
+        for path in (ROOT / "examples" / "notebooks").glob(pattern)
+    }
+    expected = top_level_scripts | notebooks
+
+    assert expected <= _linked_example_paths()
+
+
+def test_cookbook_is_navigated_and_cross_linked() -> None:
+    mkdocs = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    examples = (ROOT / "docs" / "examples.md").read_text(encoding="utf-8")
+    cookbook = COOKBOOK.read_text(encoding="utf-8")
+
+    assert "Task-oriented Cookbook: cookbook.md" in mkdocs
+    assert "[Task-oriented Cookbook](./cookbook.md)" in examples
+    assert "[REST recipes](./rest-recipes.md)" in cookbook


### PR DESCRIPTION
## Description

Adds a task-oriented cookbook landing page that indexes every current example script and notebook, groups recipes by workflow, and catches stale links through deterministic tests.

## Type of Change

- [x] Documentation update
- [x] Test addition/improvement

## Testing

Validated at exact head `5b0a4617ae0929f36f3f4647c956c1c5d1764085` against master `7c93a8e0aa4fa6cd652516b5f036acadef6bae41`:

- Cookbook-link and documentation-publication suites: 15 passed.
- Scoped pre-commit, Ruff, format, secret, and diff checks passed.
- Strict documentation validation passed during review; the final master refresh touched only exception-compatibility files.

## Documentation

Adds the cookbook, refreshes the examples index, navigation, and publication metadata.

## Dependencies

No new dependency.

## Related Issues

Closes #478

## Screenshots/Examples

Not applicable; this PR is the documentation index itself.