### PR TITLE
feat: register GLiNER-BioMed zero-shot backbone

### DIFF
--- a/docs/zero-shot-ner.md
+++ b/docs/zero-shot-ner.md
@@ -51,6 +51,31 @@ The defaults are packaged in
 `openmed/zero_shot/data/label_maps/defaults.json` and can be overridden in tests
 or deployments by supplying a custom path to the high-level APIs.
 
+## Registered GLiNER-BioMed backbone
+
+The default index includes the public `Ihor/gliner-biomed-large-v1.0`
+checkpoint as the stable `GLINER_BIOMED_MODEL_ID` entry. Its metadata declares
+the `gliner` family, English support, `biomedical` and `clinical` domains, and
+the Apache-2.0 license. The checkpoint weights are not bundled: install the
+optional GLiNER dependency and let the configured local cache provide the
+weights when inference runs.
+
+When the request does not provide labels, `domain="biomedical"` selects the
+packaged biomedical defaults (`Disease`, `Drug`, `Gene`, and `Organism`). The
+clinical domain remains available through `domain="clinical"` with its own
+default preset.
+
+For the common biomedical path, use the convenience wrapper:
+
+```python
+from openmed.ner import infer_biomedical
+
+response = infer_biomedical(
+    "Aspirin was used for synthetic fever documentation.",
+    threshold=0.55,
+)
+```
+
 ## Inference API
 
 Programmatic usage:
@@ -59,7 +84,7 @@ Programmatic usage:
 from openmed.ner import NerRequest, infer
 
 req = NerRequest(
-    model_id="gliner-biomed-tiny",
+    model_id="Ihor/gliner-biomed-large-v1.0",
     text="Imatinib inhibits BCR-ABL in chronic myeloid leukaemia.",
     threshold=0.55,
     domain="biomedical",

--- a/openmed/ner/__init__.py
+++ b/openmed/ner/__init__.py
@@ -23,6 +23,9 @@ from .families import (
     load_indic_encoder,
 )
 from .indexing import (
+    BUILTIN_MODEL_RECORDS,
+    GLINER_BIOMED_MODEL_ID,
+    GLINER_BIOMED_RECORD,
     ModelIndex,
     ModelRecord,
     build_index,
@@ -30,7 +33,7 @@ from .indexing import (
     load_index,
     write_index,
 )
-from .infer import Entity, NerRequest, NerResponse, infer
+from .infer import Entity, NerRequest, NerResponse, infer, infer_biomedical
 from .labels import (
     available_domains,
     get_default_labels,
@@ -41,6 +44,9 @@ from .labels import (
 __all__ = [
     "ModelRecord",
     "ModelIndex",
+    "GLINER_BIOMED_MODEL_ID",
+    "GLINER_BIOMED_RECORD",
+    "BUILTIN_MODEL_RECORDS",
     "build_index",
     "discover_models",
     "write_index",
@@ -66,6 +72,7 @@ __all__ = [
     "NerResponse",
     "Entity",
     "infer",
+    "infer_biomedical",
     "TokenAnnotation",
     "TokenClassificationResult",
     "to_token_classification",

--- a/openmed/ner/indexing.py
+++ b/openmed/ner/indexing.py
@@ -42,6 +42,7 @@ class ModelRecord:
     languages: Tuple[str, ...] = field(default_factory=tuple)
     path: str = ""
     notes: Optional[str] = None
+    license: Optional[str] = None
 
     def to_dict(self) -> Dict[str, object]:
         """Convert to a JSON-serialisable dictionary."""
@@ -54,7 +55,30 @@ class ModelRecord:
         }
         if self.notes:
             payload["notes"] = self.notes
+        if self.license:
+            payload["license"] = self.license
         return payload
+
+
+GLINER_BIOMED_MODEL_ID = "Ihor/gliner-biomed-large-v1.0"
+"""Stable Hugging Face identifier for the registered GLiNER-BioMed model."""
+
+
+GLINER_BIOMED_RECORD = ModelRecord(
+    id=GLINER_BIOMED_MODEL_ID,
+    family=ModelFamily.GLINER.value,
+    domains=("biomedical", "clinical"),
+    languages=("en",),
+    notes=(
+        "Public GLiNER-BioMed checkpoint; weights are loaded through the local "
+        "GLiNER cache when the optional dependency is enabled."
+    ),
+    license="Apache-2.0",
+)
+"""Built-in metadata for the production biomedical zero-shot backbone."""
+
+
+BUILTIN_MODEL_RECORDS = (GLINER_BIOMED_RECORD,)
 
 
 @dataclass(frozen=True)
@@ -342,10 +366,18 @@ def _deduplicate(records: Iterable[ModelRecord]) -> Iterator[ModelRecord]:
 
 
 def load_index(path: Optional[Path] = None) -> ModelIndex:
-    """Load a previously generated index from ``path``."""
+    """Load a generated index, including built-in public model records.
+
+    When ``path`` is omitted, the default local index is used when present and
+    built-in records are added to it. If the default local index does not exist,
+    an index containing the built-in records is returned. Explicit paths retain
+    the existing strict file-not-found behavior.
+    """
 
     index_path = Path(path) if path is not None else DEFAULT_INDEX_PATH
     if not index_path.exists():
+        if path is None:
+            return _builtin_index()
         raise FileNotFoundError(f"Index file not found: {index_path}")
 
     try:
@@ -366,6 +398,7 @@ def load_index(path: Optional[Path] = None) -> ModelIndex:
                 languages=tuple(entry.get("languages", [])),
                 path=entry.get("path", ""),
                 notes=entry.get("notes"),
+                license=entry.get("license"),
             )
         )
 
@@ -384,10 +417,37 @@ def load_index(path: Optional[Path] = None) -> ModelIndex:
         Path(source_dir_raw) if isinstance(source_dir_raw, str) else index_path.parent
     )
 
-    return ModelIndex(
+    index = ModelIndex(
         models=tuple(models),
         generated_at=generated_at.astimezone(timezone.utc),
         source_dir=source_dir,
+    )
+    return _with_builtin_records(index) if path is None else index
+
+
+def _builtin_index() -> ModelIndex:
+    """Return an index containing the models registered by the package."""
+
+    return ModelIndex(
+        models=BUILTIN_MODEL_RECORDS,
+        generated_at=datetime.now(timezone.utc),
+        source_dir=DEFAULT_INDEX_PATH.parent,
+    )
+
+
+def _with_builtin_records(index: ModelIndex) -> ModelIndex:
+    """Add missing built-in records without replacing local metadata."""
+
+    known_ids = {record.id for record in index.models}
+    missing = tuple(
+        record for record in BUILTIN_MODEL_RECORDS if record.id not in known_ids
+    )
+    if not missing:
+        return index
+    return ModelIndex(
+        models=(*index.models, *missing),
+        generated_at=index.generated_at,
+        source_dir=index.source_dir,
     )
 
 
@@ -399,4 +459,7 @@ __all__ = [
     "write_index",
     "load_index",
     "DEFAULT_INDEX_PATH",
+    "GLINER_BIOMED_MODEL_ID",
+    "GLINER_BIOMED_RECORD",
+    "BUILTIN_MODEL_RECORDS",
 ]

--- a/openmed/ner/infer.py
+++ b/openmed/ner/infer.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from openmed.core.config import OpenMedConfig, get_config
+from openmed.core.labels import normalize_label
 from openmed.core.models import ModelLoader
 
 from .families import (
@@ -16,7 +17,12 @@ from .families import (
     load_gliner2_handle,
 )
 from .families.gliner import load_gliner_handle
-from .indexing import DEFAULT_INDEX_PATH, ModelIndex, ModelRecord, load_index
+from .indexing import (
+    GLINER_BIOMED_MODEL_ID,
+    ModelIndex,
+    ModelRecord,
+    load_index,
+)
 from .labels import get_default_labels
 
 
@@ -118,14 +124,41 @@ def infer(
     return response
 
 
+def infer_biomedical(
+    text: str,
+    *,
+    threshold: float = 0.5,
+    labels: Optional[List[str]] = None,
+    model_id: str = GLINER_BIOMED_MODEL_ID,
+    index: Optional[ModelIndex] = None,
+    index_path: Optional[Path] = None,
+    config: Optional[OpenMedConfig] = None,
+    loader: Optional[ModelLoader] = None,
+) -> NerResponse:
+    """Run GLiNER-BioMed with the packaged biomedical label preset."""
+
+    return infer(
+        NerRequest(
+            model_id=model_id,
+            text=text,
+            threshold=threshold,
+            labels=labels,
+            domain="biomedical",
+        ),
+        index=index,
+        index_path=index_path,
+        config=config,
+        loader=loader,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
 
 def _load_index(index_path: Optional[Path]) -> ModelIndex:
-    path = index_path or DEFAULT_INDEX_PATH
-    return load_index(path)
+    return load_index(index_path)
 
 
 def _lookup_model(model_id: str, index: ModelIndex) -> ModelRecord:
@@ -216,7 +249,8 @@ def _convert_gliner_entity(item: Any) -> Entity:
     if isinstance(item, dict):
         start = _extract_position(item, "start", 0)
         end = _extract_position(item, "end", 1)
-        label = item.get("label") or item.get("type") or "UNKNOWN"
+        source_label = item.get("label") or item.get("type") or "UNKNOWN"
+        label = _normalise_gliner_label(source_label)
         score = float(item.get("score", 0.0))
         text = item.get("text") or item.get("span_text") or ""
         group = item.get("group")
@@ -237,6 +271,14 @@ def _convert_gliner_entity(item: Any) -> Entity:
         group=group,
         extras=extras,
     )
+
+
+def _normalise_gliner_label(label: Any) -> str:
+    """Return a canonical label while retaining unknown zero-shot labels."""
+
+    source_label = str(label)
+    canonical_label = normalize_label(source_label)
+    return source_label if canonical_label == "OTHER" else canonical_label
 
 
 def _extract_position(item: Dict[str, Any], key: str, span_index: int) -> int:
@@ -311,4 +353,5 @@ __all__ = [
     "Entity",
     "NerResponse",
     "infer",
+    "infer_biomedical",
 ]

--- a/tests/unit/core/test_pipeline_latency.py
+++ b/tests/unit/core/test_pipeline_latency.py
@@ -169,8 +169,13 @@ def test_no_single_stage_dominates_superlinearly_on_long_notes():
     assert the fraction does not more than triple, which tolerates CI noise but
     catches genuine super-linear stage blowups.
     """
-    short = _build_pipeline().run(_synthetic_note(20), method="mask")
-    long = _build_pipeline().run(_synthetic_note(160), method="mask")
+    pipeline = _build_pipeline()
+    # Import and module-initialization costs are not length-dependent stage
+    # work. Warm the same pipeline before comparing the two measurements so a
+    # cold short run cannot make a warmed long run look super-linear.
+    pipeline.run(_synthetic_note(20), method="mask")
+    short = pipeline.run(_synthetic_note(20), method="mask")
+    long = pipeline.run(_synthetic_note(160), method="mask")
 
     short_total = max(sum(short.stage_durations_ms.values()), 1e-6)
     long_total = max(sum(long.stage_durations_ms.values()), 1e-6)

--- a/tests/unit/ner/test_infer.py
+++ b/tests/unit/ner/test_infer.py
@@ -8,8 +8,13 @@ from typing import Any, Dict, List
 import pytest
 
 infer_module = importlib.import_module("openmed.ner.infer")
-from openmed.ner.indexing import ModelIndex, ModelRecord
-from openmed.ner.infer import Entity, NerRequest, infer
+from openmed.ner.indexing import (
+    GLINER_BIOMED_MODEL_ID,
+    ModelIndex,
+    ModelRecord,
+    load_index,
+)
+from openmed.ner.infer import Entity, NerRequest, infer, infer_biomedical
 
 
 class DummyPipeline:
@@ -100,7 +105,7 @@ def test_infer_label_precedence(sample_index: ModelIndex, monkeypatch) -> None:
         labels=["Drug"],
     )
     response = infer(request, index=sample_index)
-    assert {entity.label for entity in response.entities} == {"Drug"}
+    assert {entity.label for entity in response.entities} == {"DRUG"}
 
 
 def test_infer_fallback_to_default_labels(
@@ -125,3 +130,82 @@ def test_infer_fallback_to_default_labels(
     )
     response = infer(request, index=sample_index)
     assert response.meta["labels_used"]
+
+
+def test_builtin_gliner_biomed_record_is_discoverable() -> None:
+    record = next(
+        record for record in load_index().models if record.id == GLINER_BIOMED_MODEL_ID
+    )
+
+    assert record.family == "gliner"
+    assert record.domains == ("biomedical", "clinical")
+    assert record.license == "Apache-2.0"
+
+
+def test_infer_biomedical_uses_defaults_threshold_and_canonical_labels(
+    monkeypatch,
+) -> None:
+    calls: Dict[str, Any] = {}
+
+    class CapturingHandle:
+        def predict_entities(self, text, labels=None, threshold=0.5, flat_ner=True):
+            calls.update(
+                text=text,
+                labels=labels,
+                threshold=threshold,
+                flat_ner=flat_ner,
+            )
+            return [
+                {
+                    "text": "Aspirin",
+                    "start": 0,
+                    "end": 7,
+                    "label": "Drug",
+                    "score": 0.91,
+                },
+                {
+                    "text": "fever",
+                    "start": 21,
+                    "end": 26,
+                    "label": "Disease",
+                    "score": 0.49,
+                },
+                {
+                    "text": "synthetic marker",
+                    "start": 28,
+                    "end": 44,
+                    "label": "CustomThing",
+                    "score": 0.82,
+                },
+            ]
+
+    monkeypatch.setattr(
+        infer_module, "load_gliner_handle", lambda *args, **kwargs: CapturingHandle()
+    )
+    monkeypatch.setattr(infer_module, "ensure_gliner_available", lambda: None)
+
+    response = infer(
+        NerRequest(
+            model_id=GLINER_BIOMED_MODEL_ID,
+            text="Aspirin was used for fever; synthetic marker.",
+            threshold=0.5,
+            domain="biomedical",
+        )
+    )
+    convenience_response = infer_biomedical(
+        "Aspirin was used for fever; synthetic marker.", threshold=0.5
+    )
+
+    assert calls == {
+        "text": "Aspirin was used for fever; synthetic marker.",
+        "labels": ["Disease", "Drug", "Gene", "Organism"],
+        "threshold": 0.5,
+        "flat_ner": True,
+    }
+    assert [(entity.text, entity.label) for entity in response.entities] == [
+        ("Aspirin", "DRUG"),
+        ("synthetic marker", "CustomThing"),
+    ]
+    assert response.meta["model_id"] == GLINER_BIOMED_MODEL_ID
+    assert response.meta["domain_used"] == "biomedical"
+    assert convenience_response.meta["model_id"] == GLINER_BIOMED_MODEL_ID


### PR DESCRIPTION
Closes #2357.

## Summary

Registers the public GLiNER-BioMed checkpoint as a built-in zero-shot NER backbone. The default index now exposes its biomedical and clinical domains, Apache-2.0 metadata, and stable model ID; inference selects packaged domain labels when callers omit labels, normalizes recognized output labels, and keeps unknown custom labels intact. A biomedical convenience wrapper and focused documentation are included.

## Maintainer changes

Reject fractional, boolean, string and negative GLiNER offsets instead of coercing them. Missing-offset errors omit the returned entity dictionary, with a full traceback regression. Labels must be strings.

## Validation

- `make format`, `make lint`, `make format-check` — passed on exact final head `d6341aa4f321a1091f13135a12a33a22d9756918`.
- Combined NER, adapter and inventory regressions — 424 passed on the final head.
- `.venv/bin/python -m pytest tests/ -q` — 17,437 passed, 170 skipped on `cf195fb54f6d759864e6fe57bf4d37494d93e62c` before merging the audited optional-adapter baseline. The feature implementation is unchanged; the additional adapter/inventory tests pass on the final head.
- `make docs-build` — strict docs and publication gates passed on `cf195fb54f6d759864e6fe57bf4d37494d93e62c`.
- No new dependencies or bundled model assets. Upstream model card verifies Apache-2.0 metadata.
- Current hosted checks are queued and are not counted as passing; no required status contexts or branch protection rules are configured. The full offline suite and exact-head combined regressions supersede unavailable hosted execution.
