### PR TITLE
Add linking-confidence calibration and a code->span review report

### DIFF
--- a/openmed/clinical/grounding/__init__.py
+++ b/openmed/clinical/grounding/__init__.py
@@ -158,7 +158,7 @@ from .snapshot_cache import (
     snapshot_path,
     store_snapshot,
 )
-from .types import Candidate, GroundedSpan
+from .types import GROUNDING_CONFIDENCE_BANDS, Candidate, GroundedSpan
 from .vocab import (
     FREE_VOCAB_SYSTEMS,
     RESTRICTED_VOCAB_SYSTEMS,
@@ -206,6 +206,7 @@ __all__ = [
     "FREE_VOCAB_SYSTEMS",
     "GROUNDING_ASSERTION_STATUSES",
     "GROUNDING_ASSIST_ONLY_ADVISORY",
+    "GROUNDING_CONFIDENCE_BANDS",
     "GROUNDING_METHODS",
     "GROUNDING_POLICIES",
     "GroundingAlternative",

--- a/openmed/clinical/grounding/calibrate.py
+++ b/openmed/clinical/grounding/calibrate.py
@@ -1,0 +1,457 @@
+"""Calibrate clinical grounding scores for human review.
+
+Grounding linkers emit matcher scores, not probabilities. This module fits an
+independent isotonic score-to-confidence mapping for each vocabulary and adds
+an explicit ``accept``/``uncertain`` band to :class:`GroundedSpan` values.
+
+This is deliberately separate from PII detection calibration. PII calibration
+maps detector scores to redaction decisions; grounding calibration maps a
+vocabulary-linker score to the probability that the selected code is correct.
+Neither calibration path makes an autonomous clinical decision.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from .calibration import (
+    GroundingCalibrator,
+    coerce_grounding_calibration_records,
+)
+from .calibration import (
+    fit_grounding_calibrator as _fit_grounding_calibrator,
+)
+from .types import GROUNDING_CONFIDENCE_BANDS, GroundedSpan
+
+CALIBRATION_SCHEMA_VERSION = 1
+DEFAULT_ACCEPT_THRESHOLD = 0.80
+ACCEPT_BAND = "accept"
+UNCERTAIN_BAND = "uncertain"
+GROUNDING_CALIBRATION_ADVISORY = (
+    "Grounding confidence is an assistive code-linking signal. It is distinct "
+    "from PII detection calibration and requires human verification."
+)
+
+
+@dataclass(frozen=True)
+class CalibratedGroundingScore:
+    """One raw grounding score after calibration and band assignment."""
+
+    vocabulary: str
+    raw_score: float
+    calibrated_confidence: float
+    threshold: float
+    band: str
+
+    @property
+    def accepted(self) -> bool:
+        """Return whether the score is in the configured accept band."""
+
+        return self.band == ACCEPT_BAND
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-ready score record without source text."""
+
+        return {
+            "vocabulary": self.vocabulary,
+            "raw_score": self.raw_score,
+            "calibrated_confidence": self.calibrated_confidence,
+            "threshold": self.threshold,
+            "band": self.band,
+            "accepted": self.accepted,
+        }
+
+
+@dataclass(frozen=True)
+class GroundingConfidenceCalibrator:
+    """Per-vocabulary grounding calibrator with configurable review bands.
+
+    ``model`` contains the fitted isotonic curves. ``threshold`` is the default
+    accept threshold and ``thresholds`` optionally overrides it per vocabulary.
+    Thresholds are applied to calibrated confidence, never to raw matcher
+    scores.
+    """
+
+    model: GroundingCalibrator
+    threshold: float = DEFAULT_ACCEPT_THRESHOLD
+    thresholds: Mapping[str, float] = field(default_factory=dict)
+    label: str = "*"
+    schema_version: int = CALIBRATION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.model, GroundingCalibrator):
+            raise TypeError("model must be a GroundingCalibrator")
+        default_threshold = _bounded_probability(self.threshold, "threshold")
+        normalized_thresholds = {
+            _normalize_vocabulary(vocabulary): _bounded_probability(
+                value,
+                f"threshold for {vocabulary}",
+            )
+            for vocabulary, value in (self.thresholds or {}).items()
+        }
+        label = str(self.label or "*").strip() or "*"
+        object.__setattr__(self, "threshold", default_threshold)
+        object.__setattr__(self, "thresholds", normalized_thresholds)
+        object.__setattr__(self, "label", label)
+
+    def predict(
+        self,
+        vocabulary: str | None = None,
+        score: float | None = None,
+        *,
+        system: str | None = None,
+        label: str | None = None,
+    ) -> float:
+        """Return calibrated confidence for one vocabulary score.
+
+        ``system`` is accepted as an alias for ``vocabulary`` so the method can
+        be used directly with :class:`~openmed.clinical.grounding.Candidate`.
+        """
+
+        vocabulary = _resolve_vocabulary(vocabulary, system)
+        if score is None:
+            raise TypeError("score is required")
+        return self.model.predict(
+            system=vocabulary,
+            label=label or self.label,
+            score=_bounded_probability(score, "score"),
+        )
+
+    def confidence(
+        self,
+        vocabulary: str | None = None,
+        score: float | None = None,
+        *,
+        system: str | None = None,
+        label: str | None = None,
+    ) -> float:
+        """Alias for :meth:`predict` using the issue's confidence terminology."""
+
+        return self.predict(
+            vocabulary,
+            score,
+            system=system,
+            label=label,
+        )
+
+    def threshold_for(
+        self,
+        vocabulary: str | None = None,
+        *,
+        system: str | None = None,
+        threshold: float | None = None,
+    ) -> float:
+        """Return the explicit, per-vocabulary, or default threshold."""
+
+        if threshold is not None:
+            return _bounded_probability(threshold, "threshold")
+        resolved = _resolve_vocabulary(vocabulary, system)
+        return self.thresholds.get(resolved, self.threshold)
+
+    def band_for(
+        self,
+        vocabulary: str,
+        confidence: float,
+        *,
+        threshold: float | None = None,
+    ) -> str:
+        """Classify calibrated confidence as ``accept`` or ``uncertain``."""
+
+        bounded_confidence = _bounded_probability(
+            confidence,
+            "calibrated_confidence",
+        )
+        configured_threshold = self.threshold_for(
+            vocabulary,
+            threshold=threshold,
+        )
+        return (
+            ACCEPT_BAND
+            if bounded_confidence >= configured_threshold
+            else UNCERTAIN_BAND
+        )
+
+    def classify(
+        self,
+        vocabulary: str,
+        score: float,
+        *,
+        label: str | None = None,
+        threshold: float | None = None,
+    ) -> CalibratedGroundingScore:
+        """Calibrate and classify one raw grounding score."""
+
+        confidence = self.predict(vocabulary, score, label=label)
+        configured_threshold = self.threshold_for(
+            vocabulary,
+            threshold=threshold,
+        )
+        return CalibratedGroundingScore(
+            vocabulary=_normalize_vocabulary(vocabulary),
+            raw_score=_bounded_probability(score, "score"),
+            calibrated_confidence=confidence,
+            threshold=configured_threshold,
+            band=self.band_for(
+                vocabulary,
+                confidence,
+                threshold=configured_threshold,
+            ),
+        )
+
+    def apply(
+        self,
+        grounded_span: GroundedSpan,
+        *,
+        label: str | None = None,
+        threshold: float | None = None,
+    ) -> GroundedSpan:
+        """Attach per-candidate confidence metadata to a grounded span.
+
+        The selected candidates remain intact, including uncertain candidates,
+        so a review report can show the link that needs human adjudication.
+        Existing ``abstained`` state is preserved; this layer only adds a
+        confidence band.
+        """
+
+        if not isinstance(grounded_span, GroundedSpan):
+            raise TypeError("grounded_span must be a GroundedSpan")
+        candidates = tuple(grounded_span.candidates)
+        if not candidates:
+            return replace(
+                grounded_span,
+                calibrated_score=None,
+                calibrated_confidence=None,
+                confidence_band=None,
+            )
+
+        candidate_scores = []
+        resolved_label = label or grounded_span.canonical_label or self.label
+        for candidate in candidates:
+            calibrated = self.classify(
+                candidate.system,
+                candidate.score,
+                label=resolved_label,
+                threshold=threshold,
+            )
+            candidate_scores.append(
+                {
+                    "system": candidate.system,
+                    "code": candidate.code,
+                    "display": candidate.display,
+                    **calibrated.to_dict(),
+                }
+            )
+
+        top = candidate_scores[0]
+        calibration = {
+            "schema_version": self.schema_version,
+            "vocabulary": top["vocabulary"],
+            "raw_score": top["raw_score"],
+            "calibrated_confidence": top["calibrated_confidence"],
+            "threshold": top["threshold"],
+            "band": top["band"],
+            "candidates": candidate_scores,
+            "advisory": GROUNDING_CALIBRATION_ADVISORY,
+        }
+        provenance = _merge_calibration_mapping(
+            grounded_span.provenance,
+            calibration,
+        )
+        metadata = _merge_calibration_mapping(
+            grounded_span.metadata,
+            calibration,
+            key="grounding_confidence_calibration",
+        )
+        return replace(
+            grounded_span,
+            calibrated_score=top["calibrated_confidence"],
+            calibrated_confidence=top["calibrated_confidence"],
+            confidence_band=top["band"],
+            provenance=provenance,
+            metadata=metadata,
+        )
+
+    def apply_many(
+        self,
+        grounded_spans: Iterable[GroundedSpan],
+        *,
+        label: str | None = None,
+        threshold: float | None = None,
+    ) -> tuple[GroundedSpan, ...]:
+        """Apply this calibrator deterministically to a sequence of spans."""
+
+        return tuple(
+            self.apply(span, label=label, threshold=threshold)
+            for span in grounded_spans
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic, source-text-free calibrator artifact."""
+
+        return {
+            "schema_version": self.schema_version,
+            "threshold": self.threshold,
+            "thresholds": dict(sorted(self.thresholds.items())),
+            "label": self.label,
+            "model": self.model.to_dict(),
+            "advisory": GROUNDING_CALIBRATION_ADVISORY,
+        }
+
+
+def fit_grounding_confidence_calibrator(
+    scores: Sequence[Any],
+    gold: Sequence[Any] | None = None,
+    *,
+    labels: Sequence[str] | None = None,
+    systems: Sequence[str] | None = None,
+    threshold: float = DEFAULT_ACCEPT_THRESHOLD,
+    thresholds: Mapping[str, float] | None = None,
+    label: str = "*",
+) -> GroundingConfidenceCalibrator:
+    """Fit a per-vocabulary isotonic score-to-confidence calibrator.
+
+    ``scores`` and ``gold`` use the same synthetic, offline record shapes as
+    :func:`openmed.clinical.grounding.calibration.fit_grounding_calibrator`.
+    The fitted model is intentionally vocabulary-specific and never consumes
+    PII detector scores or PII labels.
+    """
+
+    model = _fit_grounding_calibrator(
+        scores,
+        gold,
+        labels=labels,
+        systems=systems,
+    )
+    return GroundingConfidenceCalibrator(
+        model=model,
+        threshold=threshold,
+        thresholds={} if thresholds is None else thresholds,
+        label=label,
+    )
+
+
+def calibrate_grounding_scores(
+    scores: Sequence[Any],
+    calibrator: GroundingConfidenceCalibrator,
+    *,
+    labels: Sequence[str] | None = None,
+    systems: Sequence[str] | None = None,
+) -> tuple[float, ...]:
+    """Map labeled score-shaped inputs to bounded calibrated confidences."""
+
+    records = coerce_grounding_calibration_records(
+        scores,
+        [False for _ in scores],
+        labels=labels,
+        systems=systems,
+    )
+    return tuple(
+        calibrator.predict(
+            vocabulary=record.system,
+            score=record.score,
+            label=record.label,
+        )
+        for record in records
+    )
+
+
+def apply_grounding_calibration(
+    grounded_span: GroundedSpan,
+    calibrator: GroundingConfidenceCalibrator,
+    *,
+    label: str | None = None,
+    threshold: float | None = None,
+) -> GroundedSpan:
+    """Apply a fitted confidence calibrator to one grounded span."""
+
+    return calibrator.apply(
+        grounded_span,
+        label=label,
+        threshold=threshold,
+    )
+
+
+def calibrate_grounded_span(
+    grounded_span: GroundedSpan,
+    calibrator: GroundingConfidenceCalibrator,
+    *,
+    label: str | None = None,
+    threshold: float | None = None,
+) -> GroundedSpan:
+    """Compatibility alias for :func:`apply_grounding_calibration`."""
+
+    return apply_grounding_calibration(
+        grounded_span,
+        calibrator,
+        label=label,
+        threshold=threshold,
+    )
+
+
+def fit_calibrator(*args: Any, **kwargs: Any) -> GroundingConfidenceCalibrator:
+    """Short alias for :func:`fit_grounding_confidence_calibrator`."""
+
+    return fit_grounding_confidence_calibrator(*args, **kwargs)
+
+
+# The task's public module is named ``calibrate.py`` while the older grounding
+# coverage/report implementation remains in ``calibration.py``. Keep the
+# obvious function name available in both paths without duplicating the model.
+fit_grounding_calibrator = fit_grounding_confidence_calibrator
+
+
+def _merge_calibration_mapping(
+    value: Any,
+    calibration: Mapping[str, Any],
+    *,
+    key: str = "grounding_calibration",
+) -> dict[str, Any]:
+    merged = dict(value) if isinstance(value, Mapping) else {}
+    existing = merged.get(key)
+    nested = dict(existing) if isinstance(existing, Mapping) else {}
+    nested.update(calibration)
+    merged[key] = nested
+    return merged
+
+
+def _resolve_vocabulary(
+    vocabulary: str | None,
+    system: str | None,
+) -> str:
+    if vocabulary is not None and system is not None:
+        if _normalize_vocabulary(vocabulary) != _normalize_vocabulary(system):
+            raise ValueError("vocabulary and system must identify the same system")
+    return _normalize_vocabulary(vocabulary if vocabulary is not None else system)
+
+
+def _normalize_vocabulary(value: Any) -> str:
+    text = str(value or "GROUNDING").strip()
+    return text.upper() if text else "GROUNDING"
+
+
+def _bounded_probability(value: Any, name: str) -> float:
+    probability = float(value)
+    if not math.isfinite(probability) or not 0.0 <= probability <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1]")
+    return probability
+
+
+__all__ = [
+    "ACCEPT_BAND",
+    "CALIBRATION_SCHEMA_VERSION",
+    "DEFAULT_ACCEPT_THRESHOLD",
+    "GROUNDING_CALIBRATION_ADVISORY",
+    "GROUNDING_CONFIDENCE_BANDS",
+    "UNCERTAIN_BAND",
+    "CalibratedGroundingScore",
+    "GroundingConfidenceCalibrator",
+    "apply_grounding_calibration",
+    "calibrate_grounded_span",
+    "calibrate_grounding_scores",
+    "fit_calibrator",
+    "fit_grounding_calibrator",
+    "fit_grounding_confidence_calibrator",
+]

--- a/openmed/clinical/grounding/review_report.py
+++ b/openmed/clinical/grounding/review_report.py
@@ -1,0 +1,497 @@
+"""Human-reviewable code-to-span reports for grounded clinical concepts.
+
+The report is intentionally built from already-redacted grounding spans. It
+contains only the span surface supplied by the caller, offsets, terminology
+metadata, and confidence fields; it never receives or stores the surrounding
+source document. The reverse index is the same canonical URI/code index used by
+the FHIR CodeableConcept exporter.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from openmed.clinical.exporters.codeable_concept import (
+    SYSTEM_URI,
+    build_reverse_index,
+    to_codeable_concept,
+)
+
+from .calibrate import (
+    ACCEPT_BAND,
+    DEFAULT_ACCEPT_THRESHOLD,
+    UNCERTAIN_BAND,
+    GroundingConfidenceCalibrator,
+)
+from .calibration import GroundingCalibrator
+from .types import GROUNDING_CONFIDENCE_BANDS, Candidate, GroundedSpan
+
+REVIEW_REPORT_SCHEMA_VERSION = 1
+GROUNDING_REVIEW_REPORT_ARTIFACT = "openmed.grounding.review_report"
+GROUNDING_REVIEW_REPORT_ADVISORY = (
+    "Grounding assignments are assistive outputs and require human verification; "
+    "this report is not a clinical decision or coding authorization."
+)
+
+
+@dataclass(frozen=True)
+class GroundingReviewEntry:
+    """One assigned code paired with its source span and confidence."""
+
+    span_text: str
+    start: int
+    end: int
+    system: str
+    code: str
+    display: str
+    raw_score: float
+    calibrated_confidence: float | None
+    band: str
+    system_uri: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.span_text, str):
+            raise TypeError("review span text must be a string")
+        if type(self.start) is not int or self.start < 0:
+            raise ValueError("review span start must be a non-negative integer")
+        if type(self.end) is not int or self.end < self.start:
+            raise ValueError("review span end must be at or after start")
+        raw_score = _bounded_probability(self.raw_score, "raw_score")
+        calibrated = (
+            None
+            if self.calibrated_confidence is None
+            else _bounded_probability(
+                self.calibrated_confidence,
+                "calibrated_confidence",
+            )
+        )
+        band = str(self.band).strip().lower()
+        if band not in GROUNDING_CONFIDENCE_BANDS:
+            raise ValueError("band must be 'accept' or 'uncertain'")
+        if not self.system or not self.code:
+            raise ValueError("review entries require a system and code")
+        object.__setattr__(self, "raw_score", raw_score)
+        object.__setattr__(self, "calibrated_confidence", calibrated)
+        object.__setattr__(self, "band", band)
+        if self.system_uri is None:
+            object.__setattr__(self, "system_uri", _system_uri(self.system))
+
+    @property
+    def source_text(self) -> str:
+        """Alias for the already-redacted span surface."""
+
+        return self.span_text
+
+    @property
+    def source_span(self) -> str:
+        """Alias matching the terminology used by the issue."""
+
+        return self.span_text
+
+    @property
+    def confidence(self) -> float | None:
+        """Alias for the calibrated confidence value."""
+
+        return self.calibrated_confidence
+
+    @property
+    def accepted(self) -> bool:
+        """Return whether the link is in the accept band."""
+
+        return self.band == ACCEPT_BAND
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a flat, JSON-ready review entry."""
+
+        return {
+            "span_text": self.span_text,
+            "source_span": self.span_text,
+            "start": self.start,
+            "end": self.end,
+            "offsets": [self.start, self.end],
+            "system": self.system,
+            "system_uri": self.system_uri,
+            "code": self.code,
+            "display": self.display,
+            "raw_score": self.raw_score,
+            "calibrated_confidence": self.calibrated_confidence,
+            "band": self.band,
+            "accepted": self.accepted,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "GroundingReviewEntry":
+        """Build an entry from :meth:`to_dict` output."""
+
+        offsets = payload.get("offsets") or ()
+        start = payload.get("start", offsets[0] if len(offsets) > 0 else None)
+        end = payload.get("end", offsets[1] if len(offsets) > 1 else None)
+        if start is None or end is None:
+            raise ValueError("review entry requires start and end offsets")
+        return cls(
+            span_text=str(payload.get("span_text", payload.get("source_span", ""))),
+            start=int(start),
+            end=int(end),
+            system=str(payload["system"]),
+            code=str(payload["code"]),
+            display=str(payload.get("display", "")),
+            raw_score=float(payload["raw_score"]),
+            calibrated_confidence=(
+                None
+                if payload.get("calibrated_confidence") is None
+                else float(payload["calibrated_confidence"])
+            ),
+            band=str(payload["band"]),
+            system_uri=(
+                None
+                if payload.get("system_uri") is None
+                else str(payload["system_uri"])
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class GroundingReviewReport:
+    """Deterministic JSON and Markdown artifact for grounding review."""
+
+    entries: tuple[GroundingReviewEntry, ...]
+    reverse_index: Mapping[tuple[str, str], tuple[tuple[int, int], ...]] = field(
+        default_factory=dict
+    )
+    generated_at: str | None = None
+    schema_version: int = REVIEW_REPORT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        entries = tuple(self.entries)
+        if any(not isinstance(entry, GroundingReviewEntry) for entry in entries):
+            raise TypeError("entries must contain GroundingReviewEntry values")
+        index = {
+            (str(system), str(code)): tuple(
+                (int(start), int(end)) for start, end in offsets
+            )
+            for (system, code), offsets in self.reverse_index.items()
+        }
+        object.__setattr__(self, "entries", entries)
+        object.__setattr__(self, "reverse_index", index)
+
+    def __len__(self) -> int:
+        """Return the number of assigned-code entries."""
+
+        return len(self.entries)
+
+    def __iter__(self):
+        """Iterate over assigned-code entries."""
+
+        return iter(self.entries)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the report payload with a JSON-safe reverse index."""
+
+        return {
+            "schema_version": self.schema_version,
+            "artifact_type": GROUNDING_REVIEW_REPORT_ARTIFACT,
+            "generated_at": self.generated_at,
+            "entry_count": len(self.entries),
+            "entries": [entry.to_dict() for entry in self.entries],
+            "reverse_index": [
+                {
+                    "system_uri": system,
+                    "code": code,
+                    "offsets": [list(offset) for offset in offsets],
+                }
+                for (system, code), offsets in sorted(self.reverse_index.items())
+            ],
+            "advisory": GROUNDING_REVIEW_REPORT_ADVISORY,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "GroundingReviewReport":
+        """Build a report from :meth:`to_dict` output."""
+
+        raw_index = payload.get("reverse_index", ())
+        index: dict[tuple[str, str], tuple[tuple[int, int], ...]] = {}
+        if isinstance(raw_index, Mapping):
+            for key, offsets in raw_index.items():
+                system, separator, code = str(key).partition("|")
+                if not separator:
+                    continue
+                index[(system, code)] = tuple(tuple(offset) for offset in offsets)
+        else:
+            for row in raw_index:
+                if not isinstance(row, Mapping):
+                    continue
+                key = (str(row["system_uri"]), str(row["code"]))
+                index[key] = tuple(tuple(offset) for offset in row["offsets"])
+        return cls(
+            entries=tuple(
+                GroundingReviewEntry.from_dict(entry)
+                for entry in payload.get("entries", ())
+            ),
+            reverse_index=index,
+            generated_at=payload.get("generated_at"),
+            schema_version=int(
+                payload.get("schema_version", REVIEW_REPORT_SCHEMA_VERSION)
+            ),
+        )
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Serialize the report as deterministic JSON."""
+
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            indent=indent,
+            sort_keys=True,
+        )
+
+    def write_json(self, path: str | Path, *, indent: int = 2) -> Path:
+        """Write deterministic JSON to *path*."""
+
+        output_path = Path(path)
+        output_path.write_text(self.to_json(indent=indent) + "\n", encoding="utf-8")
+        return output_path
+
+    def to_markdown(self) -> str:
+        """Serialize the report as a reviewer-friendly Markdown table."""
+
+        lines = [
+            "# Grounding Review Report",
+            "",
+            GROUNDING_REVIEW_REPORT_ADVISORY,
+            "",
+            "| Source span | Offsets | System | Code | Display | Raw score | "
+            "Calibrated confidence | Band |",
+            "|---|---|---|---|---|---:|---:|---|",
+        ]
+        for entry in self.entries:
+            confidence = (
+                "—"
+                if entry.calibrated_confidence is None
+                else f"{entry.calibrated_confidence:.6f}"
+            )
+            lines.append(
+                "| "
+                + " | ".join(
+                    (
+                        _markdown_cell(entry.span_text),
+                        f"{entry.start}:{entry.end}",
+                        _markdown_cell(entry.system),
+                        _markdown_cell(entry.code),
+                        _markdown_cell(entry.display),
+                        f"{entry.raw_score:.6f}",
+                        confidence,
+                        entry.band,
+                    )
+                )
+                + " |"
+            )
+        return "\n".join(lines) + "\n"
+
+    def write_markdown(self, path: str | Path) -> Path:
+        """Write the Markdown report to *path*."""
+
+        output_path = Path(path)
+        output_path.write_text(self.to_markdown(), encoding="utf-8")
+        return output_path
+
+
+def build_review_report(
+    grounded_spans: Iterable[GroundedSpan],
+    calibrator: GroundingConfidenceCalibrator | GroundingCalibrator | None = None,
+    *,
+    threshold: float | None = None,
+    label: str | None = None,
+    include_uncertain: bool = True,
+    generated_at: str | None = None,
+) -> GroundingReviewReport:
+    """Build a code-to-span report from already-redacted grounded spans.
+
+    ``calibrator`` is optional when spans were calibrated before report
+    construction. When supplied, every assigned candidate is calibrated so
+    multi-vocabulary spans receive the correct vocabulary-specific confidence.
+    Uncertain links are retained by default for human review.
+    """
+
+    spans = tuple(grounded_spans)
+    review_spans = tuple(span for span in spans if not span.abstained)
+    reverse_index_raw = build_reverse_index(review_spans)
+    reverse_index = {key: tuple(offsets) for key, offsets in reverse_index_raw.items()}
+    confidence_calibrator = _as_confidence_calibrator(calibrator, threshold)
+    entries: list[GroundingReviewEntry] = []
+
+    for span in review_spans:
+        if not span.candidates:
+            continue
+        concept = to_codeable_concept(span)
+        candidates_by_key = {
+            (_system_uri(candidate.system), candidate.code): candidate
+            for candidate in span.candidates
+        }
+        for coding in concept.get("coding", ()):
+            key = (str(coding["system"]), str(coding["code"]))
+            candidate = candidates_by_key[key]
+            confidence, band = _candidate_confidence(
+                span,
+                candidate,
+                confidence_calibrator,
+                label=label,
+                threshold=threshold,
+            )
+            if not include_uncertain and band == UNCERTAIN_BAND:
+                continue
+            entries.append(
+                GroundingReviewEntry(
+                    span_text=span.text,
+                    start=span.start,
+                    end=span.end,
+                    system=candidate.system,
+                    system_uri=key[0],
+                    code=candidate.code,
+                    display=candidate.display,
+                    raw_score=float(candidate.score),
+                    calibrated_confidence=confidence,
+                    band=band,
+                )
+            )
+
+    return GroundingReviewReport(
+        entries=tuple(entries),
+        reverse_index=reverse_index,
+        generated_at=generated_at,
+    )
+
+
+def build_grounding_review_report(*args: Any, **kwargs: Any) -> GroundingReviewReport:
+    """Explicitly named alias for :func:`build_review_report`."""
+
+    return build_review_report(*args, **kwargs)
+
+
+def build_code_span_review_report(
+    *args: Any,
+    **kwargs: Any,
+) -> GroundingReviewReport:
+    """Alias naming the report's code-to-span review purpose."""
+
+    return build_review_report(*args, **kwargs)
+
+
+def _as_confidence_calibrator(
+    calibrator: GroundingConfidenceCalibrator | GroundingCalibrator | None,
+    threshold: float | None,
+) -> GroundingConfidenceCalibrator | None:
+    if isinstance(calibrator, GroundingConfidenceCalibrator):
+        return calibrator
+    if isinstance(calibrator, GroundingCalibrator):
+        return GroundingConfidenceCalibrator(
+            model=calibrator,
+            threshold=(DEFAULT_ACCEPT_THRESHOLD if threshold is None else threshold),
+        )
+    if calibrator is not None:
+        raise TypeError("calibrator must be a grounding calibrator")
+    return None
+
+
+def _candidate_confidence(
+    span: GroundedSpan,
+    candidate: Candidate,
+    calibrator: GroundingConfidenceCalibrator | None,
+    *,
+    label: str | None,
+    threshold: float | None,
+) -> tuple[float | None, str]:
+    if calibrator is not None:
+        result = calibrator.classify(
+            candidate.system,
+            candidate.score,
+            label=label or span.canonical_label,
+            threshold=threshold,
+        )
+        return result.calibrated_confidence, result.band
+
+    metadata_result = _metadata_candidate_result(span, candidate)
+    if metadata_result is not None:
+        confidence = metadata_result.get("calibrated_confidence")
+        band = metadata_result.get("band")
+        if confidence is not None and band in GROUNDING_CONFIDENCE_BANDS:
+            return float(confidence), str(band)
+
+    is_top_candidate = span.candidates and candidate == span.candidates[0]
+    if is_top_candidate and span.calibrated_confidence is not None:
+        confidence = float(span.calibrated_confidence)
+        band = span.confidence_band
+        if band in GROUNDING_CONFIDENCE_BANDS:
+            return confidence, band
+        return confidence, _band_from_values(confidence, DEFAULT_ACCEPT_THRESHOLD)
+
+    # An uncalibrated span can still be rendered for review, but the raw score
+    # is explicitly marked as the provisional confidence fallback.
+    raw_score = float(candidate.score)
+    return raw_score, _band_from_values(raw_score, DEFAULT_ACCEPT_THRESHOLD)
+
+
+def _metadata_candidate_result(
+    span: GroundedSpan,
+    candidate: Candidate,
+) -> Mapping[str, Any] | None:
+    calibration = span.metadata.get("grounding_confidence_calibration")
+    if not isinstance(calibration, Mapping):
+        return None
+    candidates = calibration.get("candidates")
+    if not isinstance(candidates, Iterable) or isinstance(candidates, (str, bytes)):
+        return None
+    system_uri = _system_uri(candidate.system)
+    for row in candidates:
+        if not isinstance(row, Mapping):
+            continue
+        row_system = str(row.get("system", ""))
+        if str(row.get("code", "")) == candidate.code and (
+            row_system == candidate.system or row_system == system_uri
+        ):
+            return row
+    return None
+
+
+def _system_uri(system: str) -> str:
+    try:
+        return SYSTEM_URI[str(system).upper()]
+    except KeyError:
+        raise ValueError(f"unknown grounding system {system!r}") from None
+
+
+def _band_from_values(confidence: float, threshold: float) -> str:
+    bounded_confidence = _bounded_probability(confidence, "confidence")
+    bounded_threshold = _bounded_probability(threshold, "threshold")
+    return ACCEPT_BAND if bounded_confidence >= bounded_threshold else UNCERTAIN_BAND
+
+
+def _bounded_probability(value: Any, name: str) -> float:
+    probability = float(value)
+    if not math.isfinite(probability) or not 0.0 <= probability <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1]")
+    return probability
+
+
+def _markdown_cell(value: Any) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+review_report = build_review_report
+
+
+__all__ = [
+    "GROUNDING_REVIEW_REPORT_ADVISORY",
+    "GROUNDING_REVIEW_REPORT_ARTIFACT",
+    "REVIEW_REPORT_SCHEMA_VERSION",
+    "GroundingReviewEntry",
+    "GroundingReviewReport",
+    "build_code_span_review_report",
+    "build_grounding_review_report",
+    "build_review_report",
+    "review_report",
+]

--- a/openmed/clinical/grounding/types.py
+++ b/openmed/clinical/grounding/types.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from openmed.clinical.context import ClinicalAssertion, ClinicalContextResult
 
 
+GROUNDING_CONFIDENCE_BANDS = frozenset(("accept", "uncertain"))
+
+
 @dataclass(frozen=True)
 class Candidate:
     """A ranked grounding candidate: a coded concept for a clinical span.
@@ -75,6 +78,8 @@ class GroundedSpan:
         end: Exclusive character offset in the source document.
         candidates: At most one selected candidate per requested system.
         calibrated_score: Optional post-calibration probability.
+        calibrated_confidence: Optional post-calibration linking confidence.
+        confidence_band: Optional ``"accept"`` or ``"uncertain"`` band.
         abstained: Whether calibrated grounding withheld the selected codes.
         provenance: Optional grounding-calibration provenance.
         canonical_label: Optional canonical clinical label such as
@@ -101,6 +106,8 @@ class GroundedSpan:
     assertion: ClinicalAssertion | ClinicalContextResult | None = None
     source_language: str = "en"
     metadata: Mapping[str, Any] = field(default_factory=dict, compare=False)
+    calibrated_confidence: float | None = None
+    confidence_band: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.text, str):
@@ -120,9 +127,44 @@ class GroundedSpan:
             raise TypeError("grounded span metadata must be a mapping")
         if not isinstance(self.provenance, Mapping):
             raise TypeError("grounded span provenance must be a mapping")
+        calibrated_score = _optional_probability(
+            self.calibrated_score,
+            "calibrated_score",
+        )
+        calibrated_confidence = _optional_probability(
+            self.calibrated_confidence,
+            "calibrated_confidence",
+        )
+        if (
+            calibrated_score is not None
+            and calibrated_confidence is not None
+            and calibrated_score != calibrated_confidence
+        ):
+            raise ValueError(
+                "calibrated_score and calibrated_confidence must agree when both "
+                "are provided"
+            )
+        if calibrated_score is None:
+            calibrated_score = calibrated_confidence
+        if calibrated_confidence is None:
+            calibrated_confidence = calibrated_score
+        confidence_band = self.confidence_band
+        if confidence_band is not None:
+            confidence_band = str(confidence_band).strip().lower()
+            if confidence_band not in GROUNDING_CONFIDENCE_BANDS:
+                raise ValueError("confidence_band must be 'accept' or 'uncertain'")
         object.__setattr__(self, "candidates", candidates)
         object.__setattr__(self, "provenance", dict(self.provenance))
         object.__setattr__(self, "metadata", dict(self.metadata))
+        object.__setattr__(self, "calibrated_score", calibrated_score)
+        object.__setattr__(self, "calibrated_confidence", calibrated_confidence)
+        object.__setattr__(self, "confidence_band", confidence_band)
+
+    @property
+    def band(self) -> str | None:
+        """Alias for the explicit calibrated linking-confidence band."""
+
+        return self.confidence_band
 
     @property
     def codes(self) -> dict[str, str]:
@@ -164,6 +206,8 @@ class GroundedSpan:
             "codes": self.codes,
             "score": self.score,
             "calibrated_score": self.calibrated_score,
+            "calibrated_confidence": self.calibrated_confidence,
+            "confidence_band": self.confidence_band,
             "abstained": self.abstained,
             "provenance": dict(self.provenance),
             "canonical_label": self.canonical_label,
@@ -172,3 +216,14 @@ class GroundedSpan:
             "candidates": [candidate.to_dict() for candidate in self.candidates],
             "metadata": dict(self.metadata),
         }
+
+
+def _optional_probability(value: Any, name: str) -> float | None:
+    """Validate an optional probability without importing calibration helpers."""
+
+    if value is None:
+        return None
+    probability = float(value)
+    if not math.isfinite(probability) or not 0.0 <= probability <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1]")
+    return probability

--- a/tests/unit/clinical/test_grounding_calibrate.py
+++ b/tests/unit/clinical/test_grounding_calibrate.py
@@ -1,0 +1,97 @@
+"""Focused tests for grounding confidence calibration and review reports."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.clinical.grounding import Candidate, GroundedSpan
+from openmed.clinical.grounding.calibrate import (
+    ACCEPT_BAND,
+    UNCERTAIN_BAND,
+    apply_grounding_calibration,
+    fit_grounding_confidence_calibrator,
+)
+from openmed.clinical.grounding.review_report import build_review_report
+
+
+def _calibrator():
+    rows = [
+        {"system": "RXNORM", "score": 0.10, "correct": False},
+        {"system": "RXNORM", "score": 0.25, "correct": False},
+        {"system": "RXNORM", "score": 0.75, "correct": True},
+        {"system": "RXNORM", "score": 0.95, "correct": True},
+        {"system": "LOINC", "score": 0.10, "correct": False},
+        {"system": "LOINC", "score": 0.40, "correct": True},
+        {"system": "LOINC", "score": 0.90, "correct": True},
+    ]
+    return fit_grounding_confidence_calibrator(rows, threshold=0.70)
+
+
+def test_per_vocabulary_confidence_is_bounded_and_monotonic() -> None:
+    calibrator = _calibrator()
+
+    confidences = tuple(
+        calibrator.predict("RXNORM", score) for score in (0.10, 0.25, 0.50, 0.75, 0.95)
+    )
+
+    assert all(0.0 <= confidence <= 1.0 for confidence in confidences)
+    assert confidences == tuple(sorted(confidences))
+    assert calibrator.predict("RXNORM", 0.75) > calibrator.predict("LOINC", 0.10)
+
+
+def test_low_score_link_carries_an_uncertain_band() -> None:
+    calibrator = _calibrator()
+    span = GroundedSpan(
+        text="mzx-alpha",
+        start=12,
+        end=21,
+        candidates=(Candidate("RXNORM", "SYN-001", "Synthetic medicine", 0.25),),
+    )
+
+    calibrated = apply_grounding_calibration(span, calibrator)
+
+    assert calibrated.calibrated_confidence == pytest.approx(0.0)
+    assert calibrated.calibrated_score == calibrated.calibrated_confidence
+    assert calibrated.confidence_band == UNCERTAIN_BAND
+    assert calibrated.band == UNCERTAIN_BAND
+    assert calibrated.abstained is False
+    assert calibrated.provenance["grounding_calibration"]["band"] == UNCERTAIN_BAND
+
+
+def test_review_report_pairs_each_code_with_source_offsets_and_serializes() -> None:
+    calibrator = _calibrator()
+    span = GroundedSpan(
+        text="mzx-beta",
+        start=30,
+        end=38,
+        candidates=(Candidate("RXNORM", "SYN-002", "Synthetic medicine", 0.95),),
+    )
+    calibrated = apply_grounding_calibration(span, calibrator)
+
+    report = build_review_report(
+        [calibrated],
+        generated_at="2026-08-09T00:00:00Z",
+    )
+
+    assert len(report.entries) == 1
+    entry = report.entries[0]
+    assert entry.span_text == "mzx-beta"
+    assert (entry.start, entry.end) == (30, 38)
+    assert entry.system == "RXNORM"
+    assert entry.system_uri == "http://www.nlm.nih.gov/research/umls/rxnorm"
+    assert entry.code == "SYN-002"
+    assert entry.raw_score == pytest.approx(0.95)
+    assert entry.calibrated_confidence == pytest.approx(1.0)
+    assert entry.band == ACCEPT_BAND
+    assert report.reverse_index[(entry.system_uri, entry.code)] == ((30, 38),)
+
+    payload = json.loads(report.to_json())
+    assert payload["artifact_type"] == "openmed.grounding.review_report"
+    assert payload["entries"][0]["offsets"] == [30, 38]
+    assert payload["entries"][0]["calibrated_confidence"] == pytest.approx(1.0)
+    markdown = report.to_markdown()
+    assert "Grounding Review Report" in markdown
+    assert "mzx-beta" in markdown
+    assert "accept" in markdown


### PR DESCRIPTION
Closes #2361.

Adds per-vocabulary isotonic grounding confidence calibration with configurable accept/uncertain bands on GroundedSpan, plus deterministic JSON and Markdown code-to-span review reports built from the existing reverse index. The report preserves source offsets and already-redacted span text so reviewers can audit raw scores, calibrated confidence, and band assignments. Grounding calibration remains separate from PII detection calibration.

Validation:
- Focused grounding and export regression tests: 47 passed.
- Changed-file lint and formatting checks passed.