### PR TITLE
Wire Portuguese (PT-BR) NER family detection into the registry and catalog

### DIFF
--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -84,6 +84,7 @@ _LAZY_IMPORTS = {
     "get_model_info": ".core.model_registry",
     "get_model_suggestions": ".core.model_registry",
     "get_models_by_category": ".core.model_registry",
+    "get_ner_models_by_language": ".core.model_registry",
     "get_pii_models_by_language": ".core.model_registry",
     "list_model_categories": ".core.model_registry",
     "ModelQuery": ".core.model_search",
@@ -874,6 +875,7 @@ __all__ = [
     "get_all_models",
     "list_model_categories",
     "get_model_suggestions",
+    "get_ner_models_by_language",
     "get_pii_models_by_language",
     "get_default_pii_model",
     # Hugging Face Hub model-pull helpers

--- a/openmed/core/labels.py
+++ b/openmed/core/labels.py
@@ -1565,6 +1565,9 @@ _ALIAS_MAP: Final[Mapping[str, str]] = {
     "proteinfamilyorgroup": PROTEIN,
     "proteinfamiliyorgroup": PROTEIN,
     "proteinvariant": PROTEIN,
+    # Portuguese biomedical NER family labels.
+    "doenca": DISEASE,
+    "anatomia": ANATOMY,
     "dna": DNA,
     "rna": RNA,
     "anatomy": ANATOMY,

--- a/openmed/core/model_registry.py
+++ b/openmed/core/model_registry.py
@@ -635,12 +635,49 @@ def _clean_model_tokens(tokens: Iterable[str]) -> List[str]:
     return cleaned
 
 
+_PORTUGUESE_NER_LANGUAGE_TOKENS = frozenset(
+    {"portuguese", "brazil", "brazilian", "pt", "ptbr", "br"}
+)
+_PORTUGUESE_NER_CATEGORY_TOKENS = {
+    "Hematology": frozenset({"bloodcancerdetect", "hematology", "hematologia"}),
+    "Disease": frozenset({"diseasedetect", "disease", "doenca"}),
+    "Pharmaceutical": frozenset(
+        {"pharmadetect", "pharmaceutical", "drug", "medicamento"}
+    ),
+    "Oncology": frozenset({"oncologydetect", "oncology", "cancer"}),
+    "Anatomy": frozenset({"anatomydetect", "anatomy", "anatomia"}),
+    "Genomics": frozenset({"genomedetect", "genomicdetect", "dnadetect", "genomics"}),
+    "Chemical": frozenset({"chemicaldetect", "chemical", "chem", "quimica", "quimico"}),
+    "Species": frozenset({"speciesdetect", "organismdetect", "species", "organism"}),
+    "Protein": frozenset({"proteindetect", "protein", "proteina"}),
+    "Pathology": frozenset({"pathologydetect", "pathology", "patologia"}),
+}
+
+
+def _portuguese_ner_category_from_row(row: Dict[str, Any]) -> Optional[str]:
+    """Return the inferred category for a Portuguese NER repository, if any."""
+    if str(row.get("family") or "").casefold() != "ner":
+        return None
+
+    tokens = {token.casefold() for token in _split_repo_tokens(row.get("repo_id", ""))}
+    if not tokens.intersection(_PORTUGUESE_NER_LANGUAGE_TOKENS):
+        return None
+
+    for category, family_tokens in _PORTUGUESE_NER_CATEGORY_TOKENS.items():
+        if tokens.intersection(family_tokens):
+            return category
+    return None
+
+
 def _category_from_row(row: Dict[str, Any]) -> str:
     repo = row.get("repo_id", "").lower()
     family = str(row.get("family") or "").lower()
 
     if family == "pii" or "pii" in repo or "privacy-filter" in repo:
         return "Privacy"
+    portuguese_category = _portuguese_ner_category_from_row(row)
+    if portuguese_category is not None:
+        return portuguese_category
     if "bloodcancerdetect" in repo or "hematology" in repo or "leukemia" in repo:
         return "Hematology"
     if "diseasedetect" in repo:
@@ -677,7 +714,7 @@ def _display_name_from_row(row: Dict[str, Any]) -> str:
 
 
 def _specialization_from_row(row: Dict[str, Any], category: str) -> str:
-    languages = row.get("languages") or []
+    languages = _languages_from_row(row)
     language = ""
     if len(languages) == 1 and languages[0] != "en":
         language = f"{languages[0].upper()} "
@@ -752,8 +789,16 @@ def _size_category(row: Dict[str, Any]) -> str:
     return "Unknown"
 
 
+def _languages_from_row(row: Dict[str, Any]) -> List[str]:
+    """Return manifest languages, inferring Portuguese for tagged NER repos."""
+    if _portuguese_ner_category_from_row(row) is not None:
+        return ["pt"]
+    return list(row.get("languages") or [])
+
+
 def _model_info_from_row(row: Dict[str, Any]) -> ModelInfo:
     category = _category_from_row(row)
+    languages = _languages_from_row(row)
     return ModelInfo(
         model_id=row["repo_id"],
         display_name=_display_name_from_row(row),
@@ -765,7 +810,7 @@ def _model_info_from_row(row: Dict[str, Any]) -> ModelInfo:
         recommended_confidence=_recommended_confidence(category),
         family=str(row.get("family") or "Unknown"),
         task=str(row.get("task") or "unknown"),
-        languages=list(row.get("languages") or []),
+        languages=languages,
         tier=row.get("tier"),
         param_count=row.get("param_count"),
         architecture=row.get("architecture"),
@@ -1613,6 +1658,21 @@ def get_pii_models_by_language(lang: str) -> Dict[str, ModelInfo]:
     language_models.update(optional_indic)
     language_models.update(_configured_indic_encoder_pii_models(lang))
     return language_models
+
+
+def get_ner_models_by_language(lang: str) -> Dict[str, ModelInfo]:
+    """Return non-privacy NER models whose manifest language matches ``lang``."""
+    normalized_lang = str(lang).strip().casefold()
+    if not normalized_lang:
+        return {}
+    return {
+        key: info
+        for key, info in OPENMED_MODELS.items()
+        if info.category != "Privacy"
+        and info.family.casefold() == "ner"
+        and normalized_lang
+        in {language.casefold() for language in (info.languages or [])}
+    }
 
 
 def _configured_indic_pii_model(lang: str) -> Dict[str, ModelInfo]:

--- a/tests/unit/test_model_registry_multilingual.py
+++ b/tests/unit/test_model_registry_multilingual.py
@@ -3,11 +3,14 @@
 import pytest
 
 from openmed.core import model_registry
+from openmed.core.labels import ANATOMY, DISEASE, normalize_label
 from openmed.core.model_registry import (
     CATEGORIES,
     OPENMED_MODELS,
     ModelInfo,
+    build_registry,
     get_default_pii_model,
+    get_ner_models_by_language,
     get_pii_models_by_language,
     load_manifest_rows,
 )
@@ -24,6 +27,22 @@ from openmed.core.pii_i18n import (
 MULTILINGUAL_DEFAULT_LANGUAGES = {"as", "he", "id", "mr", "or", "ro", "th"}
 V2_REGISTRY_LANGUAGES = {"bn", "ta", "zh"}
 OPTIONAL_ONLY_LANGUAGES = INDIC_NER_LANGUAGES - SUPPORTED_LANGUAGES
+
+PT_ANATOMY_NER_MANIFEST_ROW = {
+    "repo_id": "OpenMed/OpenMed-NER-AnatomyDetect-Portuguese-Base-110M",
+    "family": "NER",
+    "task": "token-classification",
+    "tier": "Base",
+    "param_count": 110_000_000,
+    "canonical_labels": ["ANATOMY"],
+}
+EN_ANATOMY_NER_MANIFEST_ROW = {
+    "repo_id": "OpenMed/OpenMed-NER-AnatomyDetect-BioClinical-108M",
+    "family": "NER",
+    "task": "token-classification",
+    "languages": ["en"],
+    "canonical_labels": ["ANATOMY"],
+}
 
 
 class TestRegistryCompleteness:
@@ -234,3 +253,43 @@ class TestHelperFunctions:
         assert model_registry.get_pii_models_by_language("hi") == {
             "pii_hi_supported": supported
         }
+
+
+class TestPortugueseNerRegistry:
+    """Verify Portuguese NER rows are classified and language-filterable."""
+
+    def test_portuguese_anatomy_row_gets_category_and_language(self):
+        registry = build_registry([PT_ANATOMY_NER_MANIFEST_ROW])
+        info = next(iter(registry.values()))
+
+        assert info.category == "Anatomy"
+        assert info.languages == ["pt"]
+
+    def test_ner_models_by_language_excludes_english_models(self, monkeypatch):
+        registry = build_registry(
+            [PT_ANATOMY_NER_MANIFEST_ROW, EN_ANATOMY_NER_MANIFEST_ROW]
+        )
+        monkeypatch.setattr(model_registry, "OPENMED_MODELS", registry)
+
+        portuguese_models = get_ner_models_by_language("pt")
+
+        assert [info.model_id for info in portuguese_models.values()] == [
+            PT_ANATOMY_NER_MANIFEST_ROW["repo_id"]
+        ]
+        assert get_ner_models_by_language("pt")
+        assert not any(
+            info.model_id == EN_ANATOMY_NER_MANIFEST_ROW["repo_id"]
+            for info in portuguese_models.values()
+        )
+
+    def test_ner_language_helper_is_a_top_level_export(self):
+        import openmed
+
+        assert openmed.get_ner_models_by_language is get_ner_models_by_language
+
+    @pytest.mark.parametrize(
+        ("label", "expected"),
+        (("DOENCA", DISEASE), ("ANATOMIA", ANATOMY)),
+    )
+    def test_portuguese_family_labels_normalize(self, label, expected):
+        assert normalize_label(label, lang="pt") == expected


### PR DESCRIPTION
Closes #2355.

Adds Portuguese NER registry wiring that infers the `pt` language for Portuguese/Brazil-tagged NER repository rows, exposes a language-filtered NER catalog helper, and normalizes Portuguese biomedical family labels to canonical taxonomy names. The synthetic multilingual registry coverage verifies PT anatomy discovery while excluding English-only NER models.

Focused checks: Ruff format/check and targeted pytest nodes for Portuguese registry discovery, top-level export, label normalization, and nearest registry/label regressions.