### PR TITLE
Add a high-level extract_clinical_entities helper over NER families

### DIFF
--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     )
     from .core.results import AnalyzeResult
     from .processing import BatchProcessor
+    from .processing.advanced_ner import extract_clinical_entities
     from .processing.sentences import SentenceSpan
 
 _LAZY_IMPORTS = {
@@ -165,6 +166,7 @@ _LAZY_IMPORTS = {
     "redact_dataset": ".processing",
     "sentence_utils": ".processing",
     "AdvancedNERProcessor": ".processing.advanced_ner",
+    "extract_clinical_entities": ".processing.advanced_ner",
     "StreamingReplayResult": ".processing.advanced_ner",
     "StreamingTokenClassifier": ".processing.advanced_ner",
     "create_advanced_processor": ".processing.advanced_ner",
@@ -856,6 +858,7 @@ __all__ = [
     "process_batch",
     "redact_dataset",
     "AdvancedNERProcessor",
+    "extract_clinical_entities",
     "StreamingReplayResult",
     "StreamingTokenClassifier",
     "create_advanced_processor",

--- a/openmed/processing/advanced_ner.py
+++ b/openmed/processing/advanced_ner.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import logging
 import re
 import time
-from collections.abc import AsyncIterable, Awaitable, Callable, Iterable, Sequence
+from collections.abc import (
+    AsyncIterable,
+    Awaitable,
+    Callable,
+    Iterable,
+    Mapping,
+    Sequence,
+)
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
@@ -15,6 +22,13 @@ from openmed.core.decoding import (
     coerce_token_classification_spans,
     reconcile_stream_spans,
 )
+from openmed.core.labels import normalize_label
+from openmed.core.model_registry import (
+    get_models_by_category,
+    get_recommended_models,
+)
+from openmed.core.models import ModelLoader
+from openmed.core.offline import OFFLINE_ENV_VAR, OfflineModeError, is_local_only
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +74,269 @@ class EntitySpan:
 
 
 TokenClassifier = Callable[[str], Sequence[object] | Any]
+
+
+_CLINICAL_DOMAIN_CATEGORIES = {
+    "anatomy": "Anatomy",
+    "blood": "Hematology",
+    "chemical": "Chemical",
+    "disease": "Disease",
+    "drug": "Pharmaceutical",
+    "genome": "Genomics",
+    "genomics": "Genomics",
+    "hematology": "Hematology",
+    "medical": "Medical",
+    "medication": "Pharmaceutical",
+    "oncology": "Oncology",
+    "pathology": "Pathology",
+    "pharma": "Pharmaceutical",
+    "pharmaceutical": "Pharmaceutical",
+    "protein": "Protein",
+    "species": "Species",
+}
+_CLINICAL_TIER_TARGET_SIZES = {
+    "fast": "Tiny",
+    "balanced": "Medium",
+    "accurate": "Large",
+}
+_CLINICAL_TIER_PREFERENCE_TOKENS = {
+    "fast": ("tinymed", "small"),
+    "balanced": ("supermedical", "bioclinical", "electramed", "superclinical"),
+    "accurate": ("superclinical", "supermedical"),
+}
+
+
+def _normalize_clinical_domain(domain: str) -> str:
+    """Resolve a user-facing clinical domain to a registry category."""
+
+    if not isinstance(domain, str):
+        raise TypeError("domain must be a string")
+    key = domain.strip().casefold().replace("_", "-").replace(" ", "-")
+    category = _CLINICAL_DOMAIN_CATEGORIES.get(key)
+    if category is None:
+        supported = ", ".join(sorted(_CLINICAL_DOMAIN_CATEGORIES))
+        raise ValueError(
+            f"unsupported clinical domain {domain!r}; expected one of: {supported}"
+        )
+    return category
+
+
+def _normalize_clinical_tier(tier: str) -> str:
+    """Validate and normalize a clinical model tier."""
+
+    if not isinstance(tier, str):
+        raise TypeError("tier must be a string")
+    normalized = tier.strip().casefold()
+    if normalized not in _CLINICAL_TIER_TARGET_SIZES:
+        supported = ", ".join(sorted(_CLINICAL_TIER_TARGET_SIZES))
+        raise ValueError(f"unsupported clinical tier {tier!r}; expected: {supported}")
+    return normalized
+
+
+def _registry_model_id(model: object) -> str | None:
+    """Return a usable repository id from a registry model object."""
+
+    model_id = getattr(model, "model_id", None)
+    if not isinstance(model_id, str) or not model_id.strip():
+        return None
+    return model_id.strip()
+
+
+def _is_token_classification_model(model: object) -> bool:
+    """Return whether a registry entry can back the helper's pipeline."""
+
+    model_id = _registry_model_id(model)
+    if model_id is None or model_id.casefold().endswith("-mlx"):
+        return False
+    task = getattr(model, "task", "token-classification")
+    return task is None or str(task).casefold() in {
+        "",
+        "unknown",
+        "token-classification",
+        "token_classification",
+    }
+
+
+def _resolve_clinical_model(domain: str, tier: str) -> str:
+    """Select a deterministic registry model for a clinical domain and tier."""
+
+    category_models = [
+        model
+        for model in get_models_by_category(domain)
+        if _is_token_classification_model(model)
+    ]
+    recommended_models = [
+        model
+        for model in get_recommended_models(tier)
+        if _is_token_classification_model(model)
+        and str(getattr(model, "category", "")).casefold() == domain.casefold()
+    ]
+    if recommended_models:
+        recommended_id = _registry_model_id(recommended_models[0])
+        if recommended_id is not None:
+            return recommended_id
+
+    if not category_models:
+        raise LookupError(f"no token-classification models are registered for {domain}")
+
+    target_size = _CLINICAL_TIER_TARGET_SIZES[tier]
+    sized_models = [
+        model
+        for model in category_models
+        if getattr(model, "size_category", None) == target_size
+        or getattr(model, "tier", None) == target_size
+    ]
+    candidates = sized_models or category_models
+    preference_tokens = _CLINICAL_TIER_PREFERENCE_TOKENS[tier]
+
+    def sort_key(model: object) -> tuple[int, int, str]:
+        model_id = _registry_model_id(model) or ""
+        lowered_id = model_id.casefold()
+        token_rank = next(
+            (
+                index
+                for index, token in enumerate(preference_tokens)
+                if token in lowered_id
+            ),
+            len(preference_tokens),
+        )
+        param_count = getattr(model, "param_count", None)
+        parameter_order = int(param_count) if isinstance(param_count, int) else 0
+        if tier == "accurate":
+            parameter_order = -parameter_order
+        return token_rank, parameter_order, lowered_id
+
+    selected = sorted(candidates, key=sort_key)[0]
+    selected_id = _registry_model_id(selected)
+    if selected_id is None:  # pragma: no cover - filtered above
+        raise LookupError(f"no usable model is registered for {domain}")
+    return selected_id
+
+
+def _iter_prediction_mappings(value: object) -> Iterable[Mapping[str, Any]]:
+    """Flatten common token-classification output shapes into mappings."""
+
+    if isinstance(value, EntitySpan):
+        yield value.to_dict()
+        return
+    if isinstance(value, Mapping):
+        nested = value.get("entities")
+        if nested is not None and not any(
+            key in value for key in ("text", "word", "label", "entity", "entity_group")
+        ):
+            yield from _iter_prediction_mappings(nested)
+        else:
+            yield value
+        return
+    if isinstance(value, (str, bytes)):
+        return
+    if isinstance(value, Iterable):
+        for item in value:
+            yield from _iter_prediction_mappings(item)
+
+
+def _clinical_span_from_prediction(
+    prediction: Mapping[str, Any], source_text: str
+) -> EntitySpan | None:
+    """Convert one model prediction into a canonical, offset-safe span."""
+
+    raw_text = prediction.get("text", prediction.get("word"))
+    span_text = str(raw_text) if raw_text is not None else ""
+    try:
+        start_value = prediction.get("start")
+        end_value = prediction.get("end")
+        if start_value is None or end_value is None:
+            if not span_text:
+                return None
+            start_value = source_text.find(span_text)
+            end_value = start_value + len(span_text)
+        start = int(start_value)
+        end = int(end_value)
+        if not span_text and 0 <= start <= end <= len(source_text):
+            span_text = source_text[start:end]
+        score_value = prediction.get("score", prediction.get("confidence", 1.0))
+        score = float(1.0 if score_value is None else score_value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+    if not (0 <= start < end <= len(source_text)):
+        return None
+    raw_label = prediction.get("label")
+    if raw_label in (None, ""):
+        raw_label = prediction.get("entity_group", prediction.get("entity", ""))
+    return EntitySpan(
+        text=span_text or source_text[start:end],
+        label=normalize_label(str(raw_label)),
+        start=start,
+        end=end,
+        score=score,
+    )
+
+
+def extract_clinical_entities(
+    text: str,
+    domain: str = "disease",
+    tier: str = "balanced",
+    model_id: str | None = None,
+) -> List[EntitySpan]:
+    """Extract canonical biomedical entity spans with a registry-selected model.
+
+    Args:
+        text: Clinical text to classify.
+        domain: Registry domain, such as ``"disease"`` or ``"oncology"``.
+        tier: Model size preference: ``"fast"``, ``"balanced"``, or
+            ``"accurate"``.
+        model_id: Optional registry key, repository id, or local model path.
+
+    Returns:
+        A list of :class:`EntitySpan` values with canonical labels and source
+        character offsets.
+
+    Raises:
+        OfflineModeError: If offline mode is active and the selected model is
+            not available in the local cache.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    normalized_domain = _normalize_clinical_domain(domain)
+    normalized_tier = _normalize_clinical_tier(tier)
+    if model_id is not None:
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise ValueError("model_id must be a non-empty string or None")
+        selected_model_id = model_id.strip()
+    else:
+        selected_model_id = _resolve_clinical_model(
+            normalized_domain,
+            normalized_tier,
+        )
+
+    if not text:
+        return []
+
+    loader: Any = None
+    try:
+        loader = ModelLoader()
+        classifier = loader.create_pipeline(
+            selected_model_id,
+            task="token-classification",
+            aggregation_strategy="simple",
+        )
+        predictions = classifier(text)
+    except Exception as exc:
+        if is_local_only(getattr(loader, "config", None)):
+            raise OfflineModeError(
+                f"Clinical model {selected_model_id!r} is not available in the "
+                f"local cache; {OFFLINE_ENV_VAR}/local_only=True blocks loading. "
+                f"Cache the model before offline use or unset {OFFLINE_ENV_VAR}."
+            ) from exc
+        raise
+
+    return [
+        span
+        for prediction in _iter_prediction_mappings(predictions)
+        if (span := _clinical_span_from_prediction(prediction, text)) is not None
+    ]
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_extract_clinical_entities.py
+++ b/tests/unit/test_extract_clinical_entities.py
@@ -1,0 +1,129 @@
+"""Focused tests for the high-level clinical NER helper."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openmed.core.offline import OfflineModeError
+from openmed.processing import advanced_ner
+
+
+class _FakeLoader:
+    instances = []
+    predictions = [
+        {
+            "entity_group": "B-disease",
+            "score": 0.93,
+            "start": 16,
+            "end": 24,
+            "word": "diabetes",
+        }
+    ]
+
+    def __init__(self):
+        self.config = SimpleNamespace(local_only=False)
+        self.calls = []
+        self.instances.append(self)
+
+    def create_pipeline(self, model_name, **kwargs):
+        self.calls.append((model_name, kwargs))
+
+        def classify(_text):
+            return list(self.predictions)
+
+        return classify
+
+
+def test_top_level_import_is_stable():
+    from openmed import extract_clinical_entities
+
+    assert extract_clinical_entities is advanced_ner.extract_clinical_entities
+
+
+def test_domain_resolution_selects_registry_model_and_canonicalizes_spans(monkeypatch):
+    model = SimpleNamespace(
+        model_id="OpenMed/synthetic-disease-model",
+        category="Disease",
+        task="token-classification",
+        size_category="Medium",
+        param_count=125_000_000,
+    )
+    category_calls = []
+    recommendation_calls = []
+
+    def fake_category(category):
+        category_calls.append(category)
+        return [model]
+
+    def fake_recommendations(tier):
+        recommendation_calls.append(tier)
+        return [model]
+
+    _FakeLoader.instances.clear()
+    monkeypatch.setattr(advanced_ner, "ModelLoader", _FakeLoader)
+    monkeypatch.setattr(advanced_ner, "get_models_by_category", fake_category)
+    monkeypatch.setattr(advanced_ner, "get_recommended_models", fake_recommendations)
+
+    spans = advanced_ner.extract_clinical_entities(
+        "Synthetic note: diabetes",
+        domain="disease",
+    )
+
+    assert category_calls == ["Disease"]
+    assert recommendation_calls == ["balanced"]
+    assert _FakeLoader.instances[0].calls == [
+        (
+            "OpenMed/synthetic-disease-model",
+            {"task": "token-classification", "aggregation_strategy": "simple"},
+        )
+    ]
+    assert [span.to_dict() for span in spans] == [
+        {
+            "text": "diabetes",
+            "label": "DISEASE",
+            "start": 16,
+            "end": 24,
+            "score": 0.93,
+        }
+    ]
+
+
+def test_model_id_override_does_not_require_registry_resolution(monkeypatch):
+    _FakeLoader.instances.clear()
+    monkeypatch.setattr(advanced_ner, "ModelLoader", _FakeLoader)
+    monkeypatch.setattr(
+        advanced_ner,
+        "get_models_by_category",
+        lambda _category: pytest.fail("registry should not be used for an override"),
+    )
+    monkeypatch.setattr(
+        advanced_ner,
+        "get_recommended_models",
+        lambda _tier: pytest.fail("registry should not be used for an override"),
+    )
+
+    spans = advanced_ner.extract_clinical_entities(
+        "Synthetic note: diabetes",
+        model_id="/tmp/synthetic-clinical-model",
+    )
+
+    assert _FakeLoader.instances[0].calls[0][0] == "/tmp/synthetic-clinical-model"
+    assert spans[0].label == "DISEASE"
+
+
+def test_offline_uncached_model_has_actionable_error(monkeypatch):
+    class UncachedLoader:
+        def __init__(self):
+            self.config = SimpleNamespace(local_only=False)
+
+        def create_pipeline(self, _model_name, **_kwargs):
+            raise FileNotFoundError("synthetic model is not cached")
+
+    monkeypatch.setenv("OPENMED_OFFLINE", "1")
+    monkeypatch.setattr(advanced_ner, "ModelLoader", UncachedLoader)
+
+    with pytest.raises(OfflineModeError, match="local cache"):
+        advanced_ner.extract_clinical_entities(
+            "Synthetic note: diabetes",
+            model_id="OpenMed/synthetic-uncached-model",
+        )


### PR DESCRIPTION
## Description

Adds the top-level `extract_clinical_entities` helper to choose a biomedical NER model by domain/tier, accept an explicit local/model override, and return canonical source spans. Offline cache failures remain distinct from inference failures.

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Test addition/improvement

## Maintainer changes

- Require integral in-range offsets and bounded finite confidence rather than silently coercing malformed model output.
- Return text from the original source offsets and reject ambiguous repeated mentions when offsets are absent.
- Add ten synthetic malformed-output and span-integrity regression cases.

## Validation

- `make format`, `make lint`, `make format-check` passed on exact final head `969efb5783484747ddcbe407319beed1a9e3780b`.
- Combined clinical extraction, Portuguese registry, canonical labels and NER tests: 827 passed, 11 skipped on the final head.
- `.venv/bin/python -m pytest tests/ -q`: 17,465 passed, 170 skipped on `e5fc1910683b60f02eafe48c2221cb6f5690f5af`, before merging the audited Portuguese registry baseline. The helper implementation is unchanged, with combined regressions passing on the final head.
- Current hosted checks are queued and are not counted as passing; no required check contexts or branch protection rules are configured. Full local validation and exact-head combined regressions supersede unavailable hosted execution.

## Documentation and dependencies

Public docstrings describe model selection, canonical spans and offline behavior. No new dependencies, model assets or datasets are bundled.

## Related Issues

Closes #2354
