### PR TITLE
Add ModernBERT support to MLX token classification export

### DIFF
--- a/openmed/mlx/convert.py
+++ b/openmed/mlx/convert.py
@@ -110,6 +110,16 @@ _ELECTRA_KEY_REPLACEMENTS: list[Tuple[str, str]] = [
     ("classifier.", "classifier."),
 ]
 
+_MODERNBERT_KEY_REPLACEMENTS: list[Tuple[str, str]] = [
+    # Current Transformers checkpoints use ``model`` as the base-model
+    # prefix. Keep that prefix because the MLX implementation mirrors the
+    # token-classification module layout.
+    ("modernbert.", "model."),
+    # Accept the older BERT-style names used by early ModernBERT exports.
+    ("model.embeddings.word_embeddings.", "model.embeddings.tok_embeddings."),
+    ("model.encoder.layer.", "model.layers."),
+]
+
 _OPF_MODEL_TYPES = {
     "openai-privacy-filter",
     "privacy-filter",
@@ -317,6 +327,10 @@ def _infer_source_model_type(key: str, model_type: str | None) -> str:
         return "roberta"
     if key.startswith("electra."):
         return "electra"
+    if key.startswith("model.embeddings.tok_embeddings.") or key.startswith(
+        "model.layers."
+    ):
+        return "modernbert"
     return "bert"
 
 
@@ -333,6 +347,8 @@ def remap_key(key: str, model_type: str | None = None) -> str:
         replacements = _ROBERTA_KEY_REPLACEMENTS + _BERT_KEY_REPLACEMENTS
     elif source_model_type == "electra":
         replacements = _ELECTRA_KEY_REPLACEMENTS
+    elif resolved_model_type == "modernbert":
+        replacements = _MODERNBERT_KEY_REPLACEMENTS
     else:
         replacements = _BERT_KEY_REPLACEMENTS
 

--- a/openmed/mlx/models/__init__.py
+++ b/openmed/mlx/models/__init__.py
@@ -28,6 +28,7 @@ _SUPPORTED_TOKEN_CLASSIFICATION_MODEL_TYPES = {
     "xlm_roberta": "bert",
     "deberta": "deberta-v2",
     "deberta-v2": "deberta-v2",
+    "modernbert": "modernbert",
 }
 
 _CUSTOM_FAMILIES = {
@@ -191,7 +192,10 @@ def normalize_model_config(
             normalized.get("attention_probs_dropout_prob", 0.1),
         ),
     )
-    normalized.setdefault("layer_norm_eps", normalized.get("layer_norm_eps", 1e-12))
+    normalized.setdefault(
+        "layer_norm_eps",
+        normalized.get("norm_eps", normalized.get("layer_norm_eps", 1e-12)),
+    )
 
     if source_model_type == "distilbert":
         normalized.setdefault("type_vocab_size", 0)
@@ -201,6 +205,35 @@ def normalize_model_config(
         normalized.setdefault(
             "_mlx_position_offset", int(normalized.get("pad_token_id", 1)) + 1
         )
+    elif source_model_type == "modernbert":
+        normalized.setdefault("hidden_act", normalized.get("hidden_activation", "gelu"))
+        normalized.setdefault(
+            "embedding_dropout", normalized.get("embedding_dropout", 0.0)
+        )
+        normalized.setdefault("mlp_dropout", normalized.get("mlp_dropout", 0.0))
+        normalized.setdefault(
+            "classifier_dropout", normalized.get("classifier_dropout", 0.0)
+        )
+        normalized.setdefault("norm_bias", normalized.get("norm_bias", False))
+        normalized.setdefault("attention_bias", normalized.get("attention_bias", False))
+        normalized.setdefault("mlp_bias", normalized.get("mlp_bias", False))
+        normalized.setdefault(
+            "global_attn_every_n_layers",
+            normalized.get("global_attn_every_n_layers", 3),
+        )
+        normalized.setdefault("local_attention", normalized.get("local_attention", 128))
+        normalized.setdefault(
+            "global_rope_theta",
+            normalized.get(
+                "global_rope_theta",
+                normalized.get("rope_theta", 160000.0),
+            ),
+        )
+        normalized.setdefault(
+            "local_rope_theta",
+            normalized.get("local_rope_theta", 10000.0),
+        )
+        normalized.setdefault("_mlx_position_offset", 0)
     elif family == "openai-privacy-filter":
         normalized.setdefault("num_experts", normalized.get("num_local_experts", 128))
         normalized.setdefault(
@@ -261,6 +294,14 @@ def build_model(
         from openmed.mlx.models.deberta_v2_tc import DebertaV2ForTokenClassification
 
         return DebertaV2ForTokenClassification(config)
+
+    if (
+        family == "modernbert"
+        and resolve_artifact_task(config, manifest=manifest) == "token-classification"
+    ):
+        from openmed.mlx.models.modernbert_tc import ModernBertForTokenClassification
+
+        return ModernBertForTokenClassification(config)
 
     if family == "openai-privacy-filter":
         from openmed.mlx.models.privacy_filter import (

--- a/openmed/mlx/models/modernbert_tc.py
+++ b/openmed/mlx/models/modernbert_tc.py
@@ -1,0 +1,389 @@
+"""ModernBERT token classification implemented in Apple MLX.
+
+The implementation mirrors the inference path of Hugging Face
+``ModernBertForTokenClassification`` for converted checkpoints. ModernBERT
+uses rotary positions, alternating global and sliding-window attention, and a
+gated MLP rather than the absolute-position BERT block.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+try:
+    import mlx.core as mx
+    import mlx.nn as nn
+except ImportError:
+    raise ImportError(
+        "MLX is required for this module. Install with: pip install openmed[mlx]"
+    )
+
+
+class _Identity(nn.Module):
+    """Parameter-free identity layer used by ModernBERT's first block."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x
+
+
+class _LayerNorm(nn.Module):
+    """LayerNorm with the optional bias used by ModernBERT checkpoints."""
+
+    def __init__(self, dimensions: int, eps: float, bias: bool) -> None:
+        super().__init__()
+        self.weight = mx.ones((dimensions,))
+        self.use_bias = bool(bias)
+        if self.use_bias:
+            self.bias = mx.zeros((dimensions,))
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        mean = mx.mean(x, axis=-1, keepdims=True)
+        centered = x - mean
+        normalized = centered * mx.rsqrt(
+            mx.mean(centered * centered, axis=-1, keepdims=True) + self.eps
+        )
+        normalized = normalized * self.weight
+        if self.use_bias:
+            normalized = normalized + self.bias
+        return normalized
+
+
+def _activation(x: mx.array, name: str) -> mx.array:
+    """Apply a Hugging Face-compatible ModernBERT activation."""
+    normalized = str(name).lower().replace("-", "_")
+    if normalized in {"gelu", "gelu_exact"}:
+        return nn.gelu(x)
+    if normalized in {"gelu_new", "gelu_fast", "gelu_pytorch_tanh"}:
+        return (
+            0.5
+            * x
+            * (1.0 + mx.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * x * x * x)))
+        )
+    if normalized in {"silu", "swish"}:
+        return nn.silu(x)
+    if normalized == "relu":
+        return nn.relu(x)
+    raise ValueError(f"Unsupported ModernBERT activation: {name!r}")
+
+
+def _rotate_half(x: mx.array) -> mx.array:
+    """Rotate the first and second halves of the head dimension."""
+    half = x.shape[-1] // 2
+    return mx.concatenate((-x[..., half:], x[..., :half]), axis=-1)
+
+
+class ModernBertRotaryEmbedding(nn.Module):
+    """Generate the non-interleaved rotary embeddings used by ModernBERT."""
+
+    def __init__(self, dimension: int, base: float) -> None:
+        super().__init__()
+        self.dimension = dimension
+        self.base = float(base)
+
+    def __call__(
+        self,
+        x: mx.array,
+        position_ids: Optional[mx.array] = None,
+    ) -> tuple[mx.array, mx.array]:
+        """Return cosine and sine tensors broadcastable over attention heads."""
+        seq_len = x.shape[-3]
+        if position_ids is None:
+            position_ids = mx.arange(seq_len, dtype=mx.float32)[None, :]
+        else:
+            position_ids = position_ids.astype(mx.float32)
+
+        exponent = mx.arange(
+            0,
+            self.dimension,
+            2,
+            dtype=mx.float32,
+        ) / float(self.dimension)
+        inv_freq = mx.exp(-mx.log(mx.array(self.base, dtype=mx.float32)) * exponent)
+        freqs = position_ids[..., None] * inv_freq
+        embedding = mx.concatenate((freqs, freqs), axis=-1)
+        return mx.cos(embedding).astype(x.dtype), mx.sin(embedding).astype(x.dtype)
+
+
+class ModernBertEmbeddings(nn.Module):
+    """Token embeddings followed by ModernBERT's input normalization."""
+
+    def __init__(self, config: dict) -> None:
+        super().__init__()
+        self.tok_embeddings = nn.Embedding(
+            config["vocab_size"],
+            config["hidden_size"],
+        )
+        self.norm = _LayerNorm(
+            config["hidden_size"],
+            eps=config.get("layer_norm_eps", 1e-5),
+            bias=config.get("norm_bias", False),
+        )
+        self.drop = nn.Dropout(p=float(config.get("embedding_dropout", 0.0)))
+
+    def __call__(self, input_ids: mx.array) -> mx.array:
+        return self.drop(self.norm(self.tok_embeddings(input_ids)))
+
+
+class ModernBertMLP(nn.Module):
+    """Gated ModernBERT feed-forward block."""
+
+    def __init__(self, config: dict) -> None:
+        super().__init__()
+        hidden_size = config["hidden_size"]
+        intermediate_size = config["intermediate_size"]
+        bias = bool(config.get("mlp_bias", False))
+        self.Wi = nn.Linear(hidden_size, intermediate_size * 2, bias=bias)
+        self.Wo = nn.Linear(intermediate_size, hidden_size, bias=bias)
+        self.activation = config.get(
+            "hidden_act",
+            config.get("hidden_activation", "gelu"),
+        )
+        self.drop = nn.Dropout(p=float(config.get("mlp_dropout", 0.0)))
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        projected = self.Wi(hidden_states)
+        split = projected.shape[-1] // 2
+        input_states = projected[..., :split]
+        gate_states = projected[..., split:]
+        activated = _activation(input_states, self.activation) * gate_states
+        return self.Wo(self.drop(activated))
+
+
+class ModernBertAttention(nn.Module):
+    """Multi-head rotary self-attention with optional local masking."""
+
+    def __init__(self, config: dict, layer_id: int) -> None:
+        super().__init__()
+        hidden_size = config["hidden_size"]
+        self.num_heads = int(config["num_attention_heads"])
+        self.head_dim = hidden_size // self.num_heads
+        if self.head_dim * self.num_heads != hidden_size:
+            raise ValueError(
+                "ModernBERT hidden_size must be divisible by num_attention_heads"
+            )
+
+        attention_bias = bool(config.get("attention_bias", False))
+        self.Wqkv = nn.Linear(hidden_size, hidden_size * 3, bias=attention_bias)
+        self.Wo = nn.Linear(hidden_size, hidden_size, bias=attention_bias)
+        self.attention_dropout = float(config.get("attention_dropout", 0.0))
+        self.drop = nn.Dropout(p=self.attention_dropout)
+        self.out_drop = nn.Dropout(p=self.attention_dropout)
+
+        global_every = max(1, int(config.get("global_attn_every_n_layers", 3)))
+        is_local = layer_id % global_every != 0
+        if is_local:
+            local_window = int(config.get("local_attention", 128))
+            self.local_radius = max(0, local_window // 2)
+            rope_theta = config.get("local_rope_theta") or config.get(
+                "global_rope_theta", 160000.0
+            )
+        else:
+            self.local_radius = None
+            rope_theta = config.get("global_rope_theta") or 160000.0
+        self.rotary_emb = ModernBertRotaryEmbedding(self.head_dim, rope_theta)
+
+    def _attention_mask(
+        self,
+        attention_mask: Optional[mx.array],
+        sequence_length: int,
+        dtype: Any,
+    ) -> Optional[mx.array]:
+        if attention_mask is None and self.local_radius is None:
+            return None
+
+        negative = mx.array(mx.finfo(dtype).min, dtype=dtype)
+        if attention_mask is None:
+            mask = mx.zeros((1, 1, 1, sequence_length), dtype=dtype)
+        else:
+            valid = attention_mask > 0
+            mask = mx.where(
+                valid[:, None, None, :],
+                mx.array(0.0, dtype=dtype),
+                negative,
+            )
+
+        if self.local_radius is not None:
+            positions = mx.arange(sequence_length, dtype=mx.int32)
+            distance = mx.abs(positions[:, None] - positions[None, :])
+            local = distance <= self.local_radius
+            mask = mx.where(local[None, None, :, :], mask, negative)
+        return mask
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: Optional[mx.array] = None,
+        position_ids: Optional[mx.array] = None,
+    ) -> mx.array:
+        batch_size, sequence_length, _ = hidden_states.shape
+        qkv = self.Wqkv(hidden_states).reshape(
+            batch_size,
+            sequence_length,
+            3,
+            self.num_heads,
+            self.head_dim,
+        )
+        qkv = qkv.transpose(0, 3, 2, 1, 4)
+        query, key, value = qkv[:, :, 0], qkv[:, :, 1], qkv[:, :, 2]
+
+        cos, sin = self.rotary_emb(query, position_ids=position_ids)
+        cos = cos[:, None, :, :]
+        sin = sin[:, None, :, :]
+        query = query * cos + _rotate_half(query) * sin
+        key = key * cos + _rotate_half(key) * sin
+
+        scale = self.head_dim**-0.5
+        scores = (query @ key.transpose(0, 1, 3, 2)) * scale
+        mask = self._attention_mask(
+            attention_mask,
+            sequence_length,
+            scores.dtype,
+        )
+        if mask is not None:
+            scores = scores + mask
+
+        weights = mx.softmax(scores.astype(mx.float32), axis=-1).astype(scores.dtype)
+        weights = self.drop(weights)
+        output = (
+            (weights @ value)
+            .transpose(0, 2, 1, 3)
+            .reshape(
+                batch_size,
+                sequence_length,
+                self.num_heads * self.head_dim,
+            )
+        )
+        return self.out_drop(self.Wo(output))
+
+
+class ModernBertEncoderLayer(nn.Module):
+    """One ModernBERT pre-normalized residual encoder block."""
+
+    def __init__(self, config: dict, layer_id: int) -> None:
+        super().__init__()
+        hidden_size = config["hidden_size"]
+        eps = config.get("layer_norm_eps", 1e-5)
+        self.attn_norm = (
+            _Identity()
+            if layer_id == 0
+            else _LayerNorm(hidden_size, eps=eps, bias=config.get("norm_bias", False))
+        )
+        self.attn = ModernBertAttention(config, layer_id)
+        self.mlp_norm = _LayerNorm(
+            hidden_size,
+            eps=eps,
+            bias=config.get("norm_bias", False),
+        )
+        self.mlp = ModernBertMLP(config)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: Optional[mx.array] = None,
+        position_ids: Optional[mx.array] = None,
+    ) -> mx.array:
+        hidden_states = hidden_states + self.attn(
+            self.attn_norm(hidden_states),
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+        return hidden_states + self.mlp(self.mlp_norm(hidden_states))
+
+
+class ModernBertModel(nn.Module):
+    """ModernBERT encoder without the token-classification head."""
+
+    def __init__(self, config: dict) -> None:
+        super().__init__()
+        self.embeddings = ModernBertEmbeddings(config)
+        self.layers = [
+            ModernBertEncoderLayer(config, layer_id)
+            for layer_id in range(int(config["num_hidden_layers"]))
+        ]
+        self.final_norm = _LayerNorm(
+            config["hidden_size"],
+            eps=config.get("layer_norm_eps", 1e-5),
+            bias=config.get("norm_bias", False),
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: Optional[mx.array] = None,
+        position_ids: Optional[mx.array] = None,
+    ) -> mx.array:
+        sequence_length = input_ids.shape[1]
+        if attention_mask is None:
+            attention_mask = mx.ones(input_ids.shape, dtype=mx.float32)
+        if position_ids is None:
+            position_ids = mx.arange(sequence_length, dtype=mx.int32)[None, :]
+
+        hidden_states = self.embeddings(input_ids)
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+            )
+        return self.final_norm(hidden_states)
+
+
+class ModernBertPredictionHead(nn.Module):
+    """Token-classification projection head used by ModernBERT."""
+
+    def __init__(self, config: dict) -> None:
+        super().__init__()
+        hidden_size = config["hidden_size"]
+        self.dense = nn.Linear(
+            hidden_size,
+            hidden_size,
+            bias=bool(config.get("classifier_bias", False)),
+        )
+        self.activation = config.get(
+            "classifier_activation",
+            config.get("hidden_act", "gelu"),
+        )
+        self.norm = _LayerNorm(
+            hidden_size,
+            eps=config.get("layer_norm_eps", 1e-5),
+            bias=config.get("norm_bias", False),
+        )
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        return self.norm(_activation(self.dense(hidden_states), self.activation))
+
+
+class ModernBertForTokenClassification(nn.Module):
+    """ModernBERT with a token-classification head.
+
+    Output shape is ``(batch, sequence_length, num_labels)``.
+    """
+
+    def __init__(self, config: dict) -> None:
+        super().__init__()
+        self.model = ModernBertModel(config)
+        self.head = ModernBertPredictionHead(config)
+        self.drop = nn.Dropout(p=float(config.get("classifier_dropout", 0.0)))
+        self.classifier = nn.Linear(config["hidden_size"], config["num_labels"])
+        self.config = config
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        token_type_ids: Optional[mx.array] = None,
+        attention_mask: Optional[mx.array] = None,
+        position_ids: Optional[mx.array] = None,
+    ) -> mx.array:
+        del token_type_ids
+        hidden_states = self.model(
+            input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+        hidden_states = self.drop(self.head(hidden_states))
+        return self.classifier(hidden_states)

--- a/tests/unit/mlx/test_mlx_architecture_coverage.py
+++ b/tests/unit/mlx/test_mlx_architecture_coverage.py
@@ -1,0 +1,159 @@
+"""Offline coverage for the ModernBERT MLX architecture path."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from openmed.mlx.convert import remap_key
+
+
+def _available(module_name: str) -> bool:
+    """Return whether an optional backend can be imported in this process."""
+    try:
+        __import__(module_name)
+    except Exception:
+        return False
+    return True
+
+
+_MLX_AVAILABLE = _available("mlx.core")
+_TORCH_AVAILABLE = _available("torch")
+_TRANSFORMERS_AVAILABLE = _available("transformers")
+
+
+def _tiny_config() -> dict:
+    return {
+        "model_type": "modernbert",
+        "vocab_size": 64,
+        "pad_token_id": 0,
+        "hidden_size": 32,
+        "intermediate_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_labels": 3,
+        "max_position_embeddings": 32,
+        "norm_eps": 1e-5,
+        "norm_bias": True,
+        "attention_bias": True,
+        "attention_dropout": 0.0,
+        "global_attn_every_n_layers": 2,
+        "local_attention": 8,
+        "global_rope_theta": 160000.0,
+        "local_rope_theta": 10000.0,
+        "embedding_dropout": 0.0,
+        "mlp_bias": True,
+        "mlp_dropout": 0.0,
+        "classifier_dropout": 0.0,
+        "classifier_bias": False,
+        "classifier_activation": "gelu",
+        "hidden_activation": "gelu",
+    }
+
+
+def test_modernbert_dispatch_and_key_remapping() -> None:
+    from openmed.mlx.models import normalize_model_config, resolve_model_type
+
+    config = _tiny_config()
+    assert resolve_model_type(config) == "modernbert"
+    assert (
+        resolve_model_type({"architectures": ["ModernBertForTokenClassification"]})
+        == "modernbert"
+    )
+    normalized = normalize_model_config(config)
+    assert normalized["_mlx_family"] == "modernbert"
+    assert normalized["layer_norm_eps"] == pytest.approx(1e-5)
+
+    assert (
+        remap_key("model.layers.0.attn.Wqkv.weight", "modernbert")
+        == "model.layers.0.attn.Wqkv.weight"
+    )
+    assert (
+        remap_key("model.embeddings.word_embeddings.weight", "modernbert")
+        == "model.embeddings.tok_embeddings.weight"
+    )
+
+
+@pytest.mark.skipif(not _MLX_AVAILABLE, reason="requires MLX")
+def test_modernbert_fp_and_int8_logits_keep_token_shape(tmp_path) -> None:
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+
+    from openmed.mlx.convert import save_mlx_model
+    from openmed.mlx.models import build_model, load_model
+
+    config = _tiny_config()
+    config["_mlx_model_type"] = "modernbert"
+    config["_mlx_task"] = "token-classification"
+    model = build_model(config)
+    weights = dict(tree_flatten(model.parameters()))
+
+    fp_artifact = save_mlx_model(weights, config, tmp_path / "fp")
+    fp_model = load_model(fp_artifact)
+    input_ids = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+    mask = mx.ones(input_ids.shape, dtype=mx.float32)
+    fp_logits = fp_model(input_ids, attention_mask=mask)
+    mx.eval(fp_logits)
+    assert tuple(fp_logits.shape) == (1, 5, config["num_labels"])
+
+    int8_artifact = save_mlx_model(
+        weights,
+        config,
+        tmp_path / "int8",
+        quantize_bits=8,
+        quantize_group_size=32,
+    )
+    int8_model = load_model(int8_artifact)
+    int8_logits = int8_model(input_ids, attention_mask=mask)
+    mx.eval(int8_logits)
+    assert tuple(int8_logits.shape) == tuple(fp_logits.shape)
+
+
+@pytest.mark.skipif(
+    not (_MLX_AVAILABLE and _TORCH_AVAILABLE and _TRANSFORMERS_AVAILABLE),
+    reason="requires MLX, PyTorch, and Transformers",
+)
+def test_modernbert_mlx_logits_match_pytorch_reference() -> None:
+    import mlx.core as mx
+    import torch
+    from transformers import ModernBertConfig, ModernBertForTokenClassification
+
+    from openmed.mlx.models import build_model
+
+    torch.manual_seed(7)
+    torch_config = ModernBertConfig(
+        **_tiny_config(),
+        reference_compile=False,
+    )
+    torch_config.num_labels = 3
+    torch_config._attn_implementation = "eager"
+    reference = ModernBertForTokenClassification(torch_config)
+    reference.eval()
+
+    input_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7]], dtype=torch.long)
+    attention_mask = torch.tensor(
+        [[1, 1, 1, 1, 1, 1, 0]],
+        dtype=torch.bool,
+    )
+    with torch.no_grad():
+        expected = reference(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+        ).logits.numpy()
+
+    weights = {
+        remap_key(key, "modernbert"): mx.array(value.detach().cpu().numpy())
+        for key, value in reference.state_dict().items()
+    }
+    mlx_config = torch_config.to_dict()
+    mlx_config["num_labels"] = torch_config.num_labels
+    mlx_model = build_model(mlx_config)
+    mlx_model.load_weights(list(weights.items()))
+    mlx_model.eval()
+    actual = mlx_model(
+        mx.array(input_ids.numpy(), dtype=mx.int32),
+        attention_mask=mx.array(attention_mask.numpy(), dtype=mx.float32),
+    )
+    mx.eval(actual)
+
+    np.testing.assert_allclose(np.asarray(actual), expected, rtol=3e-4, atol=3e-4)


### PR DESCRIPTION
## Summary

- Add ModernBERT token-classification support to the MLX backend, including rotary attention, alternating global/local windows, gated MLP blocks, and the classification head.
- Wire ModernBERT configuration and Hugging Face weight-key dispatch for MLX-fp and MLX-8bit artifacts.
- Add synthetic offline coverage for architecture dispatch, PyTorch/MLX logit parity, and INT8 output shape preservation.

## Validation

- `tests/unit/mlx/test_mlx_architecture_coverage.py` — 3 passed on the arm64 MLX environment.
- `tests/unit/mlx/test_mlx_convert.py` — 34 passed, 2 skipped.
- Ruff lint and format checks pass for all changed files.

Closes #2345
