### PR TITLE
docs: add FHIR and OMOP interoperability guide

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -188,6 +188,7 @@ classification:
     - compliance/consent-data-use-tags.md
     - compliance/breach-notification-runbook.md
     - compliance/templates/breach-report-template.md
+    - guides/fhir-omop-interoperability.md
     - fhir-interop.md
     - dhis2-export.md
     - openmrs-adapter.md

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -85,6 +85,7 @@ content-security policy blocks the optional inline styling.
 | `examples/dbt-deidentify/` | Demonstrates the v1.8 warehouse transformation package for table redaction macros and redacted staging models. |
 | `examples/spark-streaming/` | Demonstrates Spark structured-streaming de-identification against synthetic records. |
 | `examples/first_five_minutes_redact_extract_fhir.py` | Walks through synthetic redaction, deterministic clinical extraction, and FHIR Bundle assembly. |
+| `examples/interop_fhir_export.py` | Exports synthetic grounded spans through the public `to_fhir()` facade, smoke-checks the transaction Bundle, and prints JSON; see the [FHIR and OMOP interoperability guide](./guides/fhir-omop-interoperability.md). |
 | `examples/datasets_walkthrough.py` | Loads one bundled synthetic golden fixture and runs the public `extract_pii`/`deidentify` API with offline-first model handling. |
 | `scripts/smoke_gliner.py` | Runs a bounded set of GLiNER models/texts to confirm zero-shot dependencies are installed before releasing. |
 | `tests/run-tests.sh` | Convenience runner that stitches together unit, integration, and smoke tests; extend it to include docs builds and API smoke checks. |

--- a/docs/guides/fhir-omop-interoperability.md
+++ b/docs/guides/fhir-omop-interoperability.md
@@ -1,0 +1,205 @@
+# FHIR and OMOP Interoperability
+
+This guide connects OpenMed's clinical grounding output to its FHIR R4 and
+OMOP interoperability helpers. The complete local flow is:
+
+```text
+grounded spans -> FHIR resources -> transaction Bundle -> profile checks
+                                                   -> $de-identify
+                                                   -> bulk NDJSON de-identification
+             \-> Athena/Usagi routing -> OMOP CDM tables
+```
+
+All examples below use fabricated clinical data. OpenMed does not bundle
+Athena, UMLS, SNOMED CT, CPT, or other restricted vocabulary content.
+
+## Run the self-contained example
+
+The runnable
+[`examples/interop_fhir_export.py`](https://github.com/maziyarpanahi/openmed/blob/master/examples/interop_fhir_export.py)
+script constructs three `GroundedSpan` objects, exports them through the public
+`to_fhir()` facade, performs a dependency-free Bundle smoke check, and prints
+JSON. It does not download models or contact a terminology service.
+
+```bash
+uv run python examples/interop_fhir_export.py > /tmp/openmed-bundle.json
+```
+
+The same API accepts grounded spans from a real extraction pipeline:
+
+```python
+from openmed.clinical.exporters import to_fhir
+
+bundle = to_fhir(
+    grounded_spans,
+    document_id="stable-document-id",
+    subject_reference="Patient/patient-123",
+)
+```
+
+`to_fhir()` maps supported canonical labels to `Condition`,
+`MedicationStatement`, `Observation`, or `Procedure`. For an iterable it calls
+the Bundle assembler, which assigns deterministic `urn:uuid` full URLs,
+rewrites internal references, and adds transaction request blocks. Treat
+grounding as advisory: review coding and assertion context before clinical or
+billing use.
+
+## Validate base R4 and declared profiles
+
+The example's smoke check confirms the output contract without adding a FHIR
+runtime dependency. It is deliberately not a complete R4 validator. Before
+sending a Bundle to another system, run the HL7 validator or the receiving
+server's validator against FHIR R4 (`4.0.1`).
+
+OpenMed also provides `check_bundle()` for predictable, offline checks against
+a local npm-package-style implementation guide snapshot:
+
+```python
+from openmed.clinical.exporters.fhir import check_bundle
+
+for entry in bundle["entry"]:
+    resource = entry["resource"]
+    resource.setdefault("meta", {}).setdefault("profile", []).append(
+        f"http://hl7.org/fhir/StructureDefinition/{resource['resourceType']}"
+    )
+
+outcome = check_bundle(bundle, "/opt/fhir/packages/hl7.fhir.r4.core")
+errors = [
+    issue
+    for issue in outcome["issue"]
+    if issue["severity"] in {"fatal", "error"}
+]
+if errors:
+    raise ValueError("FHIR profile check failed")
+```
+
+The checker evaluates only profiles explicitly listed in each resource's
+`meta.profile`. Declare the correct base or implementation-guide canonical URL
+when building the resource; otherwise there is no profile constraint to check.
+The checker covers cardinality, fixed and pattern values, locally enumerable
+bindings, and selected slices. It does not execute FHIRPath invariants, fetch
+packages, or call remote terminology servers.
+
+## Check US Core locally
+
+Download the US Core package through your normal FHIR package workflow and
+keep it outside the repository. Add the appropriate US Core canonical URL to
+each exported resource's `meta.profile`, populate every required US Core field,
+then run the same checker:
+
+```python
+from openmed.clinical.exporters.fhir import check_bundle
+
+us_core_outcome = check_bundle(
+    bundle,
+    "/opt/fhir/packages/hl7.fhir.us.core",
+)
+```
+
+Use the US Core version required by the receiving system. A base-R4-valid
+resource is not automatically US Core conformant. See
+[WHO SMART Guidelines Profile Checks](../fhir-smart-guidelines.md) for package
+layout, supported constraints, post-de-identification comparison, and safe
+`OperationOutcome` handling.
+
+## Bind terminology with Athena and Usagi
+
+Load a caller-supplied Athena export and, optionally, an approved Usagi mapping
+to route source codes to standard OMOP concepts. The router preserves mapping
+status and vocabulary provenance; it uses concept ID `0` instead of fabricating
+a match when a term is unresolved.
+
+```python
+from openmed.interop.athena import load_athena_vocab, load_usagi_mapping
+from openmed.interop.omop import VocabularyRouter
+
+vocabulary = load_athena_vocab(
+    "/secure/athena-export",
+    vocabulary_ids={"ICD10CM", "RxNorm", "LOINC"},
+)
+usagi = load_usagi_mapping("/secure/mappings/usagi.csv")
+router = VocabularyRouter(
+    vocabulary,
+    usagi,
+    vocabulary_version="2026-02-01",
+)
+
+mapping = router.route(
+    "E11.9",
+    source_vocabulary_id="ICD10CM",
+    domain_hint="Condition",
+    source_code_description="Type 2 diabetes mellitus without complications",
+)
+print(mapping.to_dict())
+```
+
+The FHIR exporter reads the selected `Candidate` on each `GroundedSpan` and
+emits its coding system, code, display, score provenance, and vocabulary
+version. The OMOP path uses the Athena/Usagi router to resolve standard concept
+IDs and CDM domains. These are two projections of the same reviewed grounding
+result; do not infer an OMOP concept ID from a FHIR code without terminology
+resolution.
+
+## Run the FHIR `$de-identify` operation
+
+Wrap the Bundle in an R4 `Parameters` resource and call the local operation:
+
+```python
+from openmed.interop.fhir_operations import de_identify
+
+result = de_identify(
+    {
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "bundle", "resource": bundle},
+            {"name": "policy", "valueString": "hipaa_safe_harbor"},
+            {"name": "method", "valueCode": "mask"},
+        ],
+    }
+)
+```
+
+The returned `Parameters` contains the de-identified Bundle, the applied policy
+and method, and a PHI-free `OperationOutcome` manifest of changed element paths.
+Run profile checks again after de-identification. Passing the original Bundle
+as `original_bundle` lets `check_bundle()` distinguish pre-existing failures
+from failures introduced by removal or masking.
+
+## De-identify FHIR Bulk NDJSON
+
+FHIR Bulk Data uses one resource per NDJSON line. Process it as a stream so raw
+resources are not materialized as a second complete file:
+
+```python
+from openmed.interop.fhir_bulk import deidentify_ndjson
+
+summary = deidentify_ndjson(
+    "/secure/incoming/Patient.ndjson",
+    "/secure/outgoing/Patient.ndjson",
+    policy="hipaa_safe_harbor",
+    method="mask",
+)
+print(
+    summary.resources_deidentified,
+    summary.error_count,
+    summary.output_sha256,
+)
+```
+
+Malformed lines are skipped and recorded by line number without copying their
+content into errors. Protect the input path as PHI, review nonzero error counts,
+and validate the de-identified output before release. For streams arriving over
+a trusted transport, use `deidentify_ndjson_stream()` or
+`deidentify_ndjson_async()` to avoid persisting raw input.
+
+## Operational checklist
+
+1. Use stable document IDs and synthetic data in tests.
+2. Review grounding and terminology mappings before export.
+3. Validate base R4, then the exact receiving profile version.
+4. De-identify locally and re-run profile checks on the transformed Bundle.
+5. Keep Athena and restricted terminology artifacts caller-supplied.
+6. Treat raw Bundles and input NDJSON as PHI until policy checks pass.
+
+For the lower-level Bundle and `OperationOutcome` APIs, see
+[FHIR Interop Helpers](../fhir-interop.md).

--- a/examples/interop_fhir_export.py
+++ b/examples/interop_fhir_export.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Export synthetic grounded clinical spans as a FHIR R4 Bundle."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from openmed.clinical.exporters import to_fhir
+from openmed.clinical.grounding import Candidate, GroundedSpan
+
+_FHIR_RESOURCE_TYPES = frozenset(
+    {"Condition", "MedicationStatement", "Observation", "Procedure"}
+)
+
+
+def _span(
+    text: str,
+    start: int,
+    label: str,
+    system: str,
+    code: str,
+    *,
+    display: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> GroundedSpan:
+    """Build one deterministic synthetic grounding result."""
+    return GroundedSpan(
+        text=text,
+        start=start,
+        end=start + len(text),
+        canonical_label=label,
+        candidates=(
+            Candidate(
+                system=system,
+                code=code,
+                display=display,
+                score=1.0,
+                source="synthetic-example",
+                matched_alias=display,
+                match_kind="exact",
+            ),
+        ),
+        metadata=metadata or {},
+    )
+
+
+def example_spans() -> tuple[GroundedSpan, ...]:
+    """Return fabricated spans with representative clinical codings."""
+    return (
+        _span(
+            "type 2 diabetes",
+            0,
+            "CONDITION",
+            "ICD10CM",
+            "E11.9",
+            display="Type 2 diabetes mellitus without complications",
+        ),
+        _span(
+            "metformin 500 mg tablet",
+            24,
+            "MEDICATION",
+            "RXNORM",
+            "860975",
+            display="Metformin hydrochloride 500 MG oral tablet",
+        ),
+        _span(
+            "glucose 130 mg/dL",
+            55,
+            "LAB_TEST",
+            "LOINC",
+            "2345-7",
+            display="Glucose [Mass/volume] in Serum or Plasma",
+            metadata={"value": 130, "unit": "mg/dL"},
+        ),
+    )
+
+
+def validate_example_bundle_shape(bundle: Mapping[str, Any]) -> None:
+    """Fail fast when the example did not produce its expected R4 shape.
+
+    This is a dependency-free smoke check for the example's transaction Bundle,
+    not a replacement for full FHIR profile validation.
+    """
+    if bundle.get("resourceType") != "Bundle":
+        raise ValueError("expected a FHIR Bundle")
+    if bundle.get("type") != "transaction":
+        raise ValueError("expected a FHIR transaction Bundle")
+
+    entries = bundle.get("entry")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("expected a non-empty Bundle.entry list")
+
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"Bundle.entry[{index}] must be an object")
+        if not str(entry.get("fullUrl", "")).startswith("urn:uuid:"):
+            raise ValueError(f"Bundle.entry[{index}].fullUrl must be a UUID URN")
+
+        resource = entry.get("resource")
+        if not isinstance(resource, Mapping):
+            raise ValueError(f"Bundle.entry[{index}].resource must be an object")
+        resource_type = resource.get("resourceType")
+        if resource_type not in _FHIR_RESOURCE_TYPES:
+            raise ValueError(
+                f"Bundle.entry[{index}] has unsupported resourceType {resource_type!r}"
+            )
+
+        request = entry.get("request")
+        if not isinstance(request, Mapping):
+            raise ValueError(f"Bundle.entry[{index}].request must be an object")
+        if request.get("method") != "POST" or request.get("url") != resource_type:
+            raise ValueError(f"Bundle.entry[{index}].request is inconsistent")
+
+
+def build_bundle() -> dict[str, Any]:
+    """Export and smoke-check the fabricated spans."""
+    bundle = to_fhir(
+        example_spans(),
+        document_id="synthetic-interop-example",
+        subject_reference="Patient/synthetic-patient",
+    )
+    if bundle is None:
+        raise RuntimeError("FHIR export unexpectedly returned no Bundle")
+    validate_example_bundle_shape(bundle)
+    return bundle
+
+
+def main() -> dict[str, Any]:
+    """Print the synthetic FHIR Bundle as JSON and return it."""
+    bundle = build_bundle()
+    print(json.dumps(bundle, indent=2, sort_keys=True))
+    return bundle
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
       - Consent and Data-Use Tags: compliance/consent-data-use-tags.md
       - Breach Notification Runbook: compliance/breach-notification-runbook.md
       - Breach Report Template: compliance/templates/breach-report-template.md
+      - FHIR and OMOP Interoperability: guides/fhir-omop-interoperability.md
       - FHIR Interop Helpers: fhir-interop.md
       - De-identified DHIS2 Export: dhis2-export.md
       - OpenMRS Adapter: openmrs-adapter.md

--- a/tests/unit/examples/test_interop_fhir_export_example.py
+++ b/tests/unit/examples/test_interop_fhir_export_example.py
@@ -1,0 +1,34 @@
+"""Smoke test for the synthetic FHIR interoperability example."""
+
+from __future__ import annotations
+
+import json
+
+from examples import interop_fhir_export as example
+
+
+def test_interop_fhir_export_runs_end_to_end(capsys) -> None:
+    bundle = example.main()
+
+    printed = json.loads(capsys.readouterr().out)
+    assert printed == bundle
+    example.validate_example_bundle_shape(bundle)
+
+    assert bundle["resourceType"] == "Bundle"
+    assert bundle["type"] == "transaction"
+    resources = [entry["resource"] for entry in bundle["entry"]]
+    assert [resource["resourceType"] for resource in resources] == [
+        "Condition",
+        "MedicationStatement",
+        "Observation",
+    ]
+    assert resources[2]["valueQuantity"] == {
+        "value": 130,
+        "unit": "mg/dL",
+        "system": "http://unitsofmeasure.org",
+        "code": "mg/dL",
+    }
+    assert all(
+        resource["subject"]["reference"] == "Patient/synthetic-patient"
+        for resource in resources
+    )


### PR DESCRIPTION
FHIR/OMOP interop finally has docs and a runnable example, so the whole flow is no longer just lore. Closes #2349.