### PR TITLE
feat: enable /assign for merged contributors

### DIFF
--- a/.github/scripts/trusted_self_assign.py
+++ b/.github/scripts/trusted_self_assign.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Self-assign trusted contributors who comment ``/assign`` on an issue."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+COMMAND = "/assign"
+MIN_MERGED_PULL_REQUESTS = 1
+GITHUB_API_VERSION = "2026-03-10"
+GITHUB_API_URL = "https://api.github.com"
+LOGIN_PATTERN = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?")
+REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+
+
+class EventPayloadError(RuntimeError):
+    """Raised when a relevant event has an unsafe or malformed payload."""
+
+
+class GitHubResponseError(RuntimeError):
+    """Raised when GitHub returns an unusable response."""
+
+
+@dataclass(frozen=True)
+class AssignmentRequest:
+    """Validated self-assignment request extracted from an issue event."""
+
+    issue_number: int
+    login: str
+    existing_assignees: frozenset[str]
+
+
+class AssignmentClient(Protocol):
+    """GitHub operations required by the self-assignment handler."""
+
+    def merged_pull_request_count(self, repository: str, login: str) -> int:
+        """Return the number of merged pull requests authored by ``login``."""
+
+    def add_assignee(self, repository: str, issue_number: int, login: str) -> None:
+        """Add ``login`` to the issue's current assignees."""
+
+    def add_comment(self, repository: str, issue_number: int, body: str) -> None:
+        """Post an issue comment."""
+
+
+class GitHubClient:
+    """Small REST client for the GitHub operations used by this workflow."""
+
+    def __init__(self, token: str, api_url: str = GITHUB_API_URL) -> None:
+        if not token:
+            raise ValueError("GITHUB_TOKEN must not be empty")
+        self._token = token
+        self._api_url = api_url.rstrip("/")
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: dict[str, str] | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        url = f"{self._api_url}{path}"
+        if query:
+            url = f"{url}?{urlencode(query)}"
+
+        data = None
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+
+        request = Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self._token}",
+                "Content-Type": "application/json",
+                "User-Agent": "openmed-trusted-self-assign",
+                "X-GitHub-Api-Version": GITHUB_API_VERSION,
+            },
+        )
+        try:
+            with urlopen(request, timeout=30) as response:  # noqa: S310
+                raw_body = response.read()
+        except HTTPError as error:
+            response_body = error.read().decode("utf-8", errors="replace")[:500]
+            raise GitHubResponseError(
+                f"GitHub API {method} {path} returned HTTP {error.code}: "
+                f"{response_body}"
+            ) from error
+        except URLError as error:
+            raise GitHubResponseError(
+                f"GitHub API {method} {path} could not be reached: {error.reason}"
+            ) from error
+
+        if not raw_body:
+            return {}
+        try:
+            parsed = json.loads(raw_body)
+        except json.JSONDecodeError as error:
+            raise GitHubResponseError(
+                f"GitHub API {method} {path} returned invalid JSON"
+            ) from error
+        if not isinstance(parsed, dict):
+            raise GitHubResponseError(
+                f"GitHub API {method} {path} returned a non-object response"
+            )
+        return parsed
+
+    def merged_pull_request_count(self, repository: str, login: str) -> int:
+        """Return a complete merged-PR count for ``login`` or fail closed."""
+
+        query = f"repo:{repository} is:pr is:merged author:{login}"
+        result = self._request_json(
+            "GET",
+            "/search/issues",
+            query={"q": query, "per_page": "1"},
+        )
+        if result.get("incomplete_results") is not False:
+            raise GitHubResponseError(
+                "GitHub returned incomplete merged pull request search results"
+            )
+
+        total_count = result.get("total_count")
+        if (
+            isinstance(total_count, bool)
+            or not isinstance(total_count, int)
+            or total_count < 0
+        ):
+            raise GitHubResponseError(
+                "GitHub returned an invalid merged pull request count"
+            )
+        return total_count
+
+    def add_assignee(self, repository: str, issue_number: int, login: str) -> None:
+        """Add ``login`` without replacing the issue's existing assignees."""
+
+        self._request_json(
+            "POST",
+            f"/repos/{repository}/issues/{issue_number}/assignees",
+            payload={"assignees": [login]},
+        )
+
+    def add_comment(self, repository: str, issue_number: int, body: str) -> None:
+        """Post an issue comment explaining an ineligible request."""
+
+        self._request_json(
+            "POST",
+            f"/repos/{repository}/issues/{issue_number}/comments",
+            payload={"body": body},
+        )
+
+
+def parse_assignment_request(event: dict[str, Any]) -> AssignmentRequest | None:
+    """Return a validated request, or ``None`` for events that must be ignored."""
+
+    if event.get("action") != "created":
+        return None
+
+    issue = event.get("issue")
+    comment = event.get("comment")
+    if not isinstance(issue, dict) or not isinstance(comment, dict):
+        return None
+    if "pull_request" in issue or issue.get("state") != "open":
+        return None
+    if comment.get("body") != COMMAND:
+        return None
+
+    user = comment.get("user")
+    if not isinstance(user, dict):
+        raise EventPayloadError("Relevant comment is missing its user")
+    login = user.get("login")
+    user_type = user.get("type")
+    if user_type == "Bot" or (
+        isinstance(login, str) and login.casefold().endswith("[bot]")
+    ):
+        return None
+    if not isinstance(login, str) or LOGIN_PATTERN.fullmatch(login) is None:
+        raise EventPayloadError("Relevant comment has an invalid GitHub login")
+
+    issue_number = issue.get("number")
+    if (
+        isinstance(issue_number, bool)
+        or not isinstance(issue_number, int)
+        or issue_number < 1
+    ):
+        raise EventPayloadError("Relevant comment has an invalid issue number")
+
+    assignees = issue.get("assignees", [])
+    if not isinstance(assignees, list):
+        raise EventPayloadError("Relevant issue has an invalid assignee list")
+    existing_assignees: set[str] = set()
+    for assignee in assignees:
+        if not isinstance(assignee, dict) or not isinstance(assignee.get("login"), str):
+            raise EventPayloadError("Relevant issue has an invalid assignee")
+        existing_assignees.add(assignee["login"].casefold())
+
+    return AssignmentRequest(
+        issue_number=issue_number,
+        login=login,
+        existing_assignees=frozenset(existing_assignees),
+    )
+
+
+def process_event(
+    event: dict[str, Any], repository: str, client: AssignmentClient
+) -> str:
+    """Process one issue-comment event and return a machine-readable outcome."""
+
+    if REPOSITORY_PATTERN.fullmatch(repository) is None:
+        raise EventPayloadError("GITHUB_REPOSITORY has an invalid value")
+
+    assignment = parse_assignment_request(event)
+    if assignment is None:
+        return "ignored"
+    if assignment.login.casefold() in assignment.existing_assignees:
+        return "already-assigned"
+
+    merged_count = client.merged_pull_request_count(repository, assignment.login)
+    if merged_count < MIN_MERGED_PULL_REQUESTS:
+        client.add_comment(
+            repository,
+            assignment.issue_number,
+            (
+                f"@{assignment.login}, automatic `/assign` self-assignment is "
+                "available after at least one pull request has been merged into "
+                "this repository. Please ask a maintainer to assign you for now."
+            ),
+        )
+        return "ineligible"
+
+    client.add_assignee(repository, assignment.issue_number, assignment.login)
+    return "assigned"
+
+
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"{name} must be set")
+    return value
+
+
+def main() -> int:
+    """Load the workflow event and run the self-assignment handler."""
+
+    event_path = Path(_required_environment("GITHUB_EVENT_PATH"))
+    event = json.loads(event_path.read_text(encoding="utf-8"))
+    if not isinstance(event, dict):
+        raise EventPayloadError("GITHUB_EVENT_PATH must contain a JSON object")
+
+    client = GitHubClient(_required_environment("GITHUB_TOKEN"))
+    outcome = process_event(
+        event,
+        _required_environment("GITHUB_REPOSITORY"),
+        client,
+    )
+    print(f"Trusted self-assignment outcome: {outcome}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/trusted-contributor-self-assign.yml
+++ b/.github/workflows/trusted-contributor-self-assign.yml
@@ -1,0 +1,31 @@
+name: Trusted contributor self-assignment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  self-assign:
+    if: >-
+      github.event.issue.pull_request == null &&
+      github.event.issue.state == 'open' &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.comment.body == '/assign'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Verify contributor and assign issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/trusted_self_assign.py

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -13,7 +13,14 @@ Browse the [issues page](https://github.com/maziyarpanahi/openmed/issues) and fi
 
 ### Claiming an issue
 
-Comment on the issue to let the maintainers know you're working on it. A short "I'd like to take this" is enough — no formal assignment is required.
+Trusted contributors can self-assign an open issue by posting a comment whose
+entire content is `/assign`. You are eligible as soon as you have at least one
+pull request merged into this repository. The command works only on open issue
+conversations; it ignores pull request conversations, bots, and comments that
+contain any other text.
+
+If you do not have a merged pull request yet, comment on the issue to ask a
+maintainer before starting work. A short "I'd like to take this" is enough.
 
 If the issue does not match the available templates, open a new item from the
 [issue forms](https://github.com/maziyarpanahi/openmed/issues/new/choose) and

--- a/tests/unit/release/test_trusted_self_assign.py
+++ b/tests/unit/release/test_trusted_self_assign.py
@@ -1,0 +1,260 @@
+"""Tests for trusted-contributor issue self-assignment."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / ".github" / "scripts" / "trusted_self_assign.py"
+
+spec = importlib.util.spec_from_file_location("trusted_self_assign", SCRIPT)
+assert spec is not None
+trusted_self_assign = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = trusted_self_assign
+spec.loader.exec_module(trusted_self_assign)
+
+
+class FakeClient:
+    """Record calls made by the event processor."""
+
+    def __init__(self, merged_count: int = 1) -> None:
+        self.merged_count = merged_count
+        self.merged_queries: list[tuple[str, str]] = []
+        self.assignments: list[tuple[str, int, str]] = []
+        self.comments: list[tuple[str, int, str]] = []
+
+    def merged_pull_request_count(self, repository: str, login: str) -> int:
+        self.merged_queries.append((repository, login))
+        return self.merged_count
+
+    def add_assignee(self, repository: str, issue_number: int, login: str) -> None:
+        self.assignments.append((repository, issue_number, login))
+
+    def add_comment(self, repository: str, issue_number: int, body: str) -> None:
+        self.comments.append((repository, issue_number, body))
+
+
+def issue_comment_event(
+    *,
+    action: str = "created",
+    body: str = "/assign",
+    state: str = "open",
+    login: str = "merged-user",
+    user_type: str = "User",
+    assignees: list[str] | None = None,
+    pull_request: bool = False,
+) -> dict[str, Any]:
+    """Build a minimal issue-comment event payload."""
+
+    issue: dict[str, Any] = {
+        "number": 42,
+        "state": state,
+        "assignees": [{"login": assignee} for assignee in (assignees or [])],
+    }
+    if pull_request:
+        issue["pull_request"] = {
+            "url": "https://api.github.com/repos/maziyarpanahi/openmed/pulls/42"
+        }
+    return {
+        "action": action,
+        "issue": issue,
+        "comment": {
+            "body": body,
+            "user": {"login": login, "type": user_type},
+        },
+    }
+
+
+def test_parse_assignment_request_accepts_exact_open_issue_command():
+    request = trusted_self_assign.parse_assignment_request(issue_comment_event())
+
+    assert request == trusted_self_assign.AssignmentRequest(
+        issue_number=42,
+        login="merged-user",
+        existing_assignees=frozenset(),
+    )
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        issue_comment_event(action="edited"),
+        issue_comment_event(body=" /assign"),
+        issue_comment_event(body="/assign\n"),
+        issue_comment_event(body="/assign please"),
+        issue_comment_event(state="closed"),
+        issue_comment_event(pull_request=True),
+        issue_comment_event(user_type="Bot"),
+        issue_comment_event(login="dependabot[bot]"),
+    ],
+)
+def test_parse_assignment_request_ignores_unsupported_events(event):
+    assert trusted_self_assign.parse_assignment_request(event) is None
+
+
+def test_parse_assignment_request_rejects_invalid_relevant_login():
+    event = issue_comment_event(login="bad login")
+
+    with pytest.raises(
+        trusted_self_assign.EventPayloadError,
+        match="invalid GitHub login",
+    ):
+        trusted_self_assign.parse_assignment_request(event)
+
+
+def test_process_event_assigns_author_with_one_merged_pull_request():
+    client = FakeClient(merged_count=1)
+
+    outcome = trusted_self_assign.process_event(
+        issue_comment_event(), "maziyarpanahi/openmed", client
+    )
+
+    assert outcome == "assigned"
+    assert client.merged_queries == [("maziyarpanahi/openmed", "merged-user")]
+    assert client.assignments == [("maziyarpanahi/openmed", 42, "merged-user")]
+    assert client.comments == []
+
+
+def test_process_event_rejects_author_without_a_merged_pull_request():
+    client = FakeClient(merged_count=0)
+
+    outcome = trusted_self_assign.process_event(
+        issue_comment_event(), "maziyarpanahi/openmed", client
+    )
+
+    assert outcome == "ineligible"
+    assert client.assignments == []
+    assert len(client.comments) == 1
+    assert "after at least one pull request has been merged" in client.comments[0][2]
+    assert "ask a maintainer" in client.comments[0][2]
+
+
+def test_process_event_adds_user_without_replacing_existing_assignees():
+    client = FakeClient()
+    event = issue_comment_event(assignees=["current-owner"])
+
+    outcome = trusted_self_assign.process_event(event, "maziyarpanahi/openmed", client)
+
+    assert outcome == "assigned"
+    assert client.assignments == [("maziyarpanahi/openmed", 42, "merged-user")]
+
+
+def test_process_event_is_idempotent_for_existing_assignee():
+    client = FakeClient()
+    event = issue_comment_event(assignees=["MERGED-USER"])
+
+    outcome = trusted_self_assign.process_event(event, "maziyarpanahi/openmed", client)
+
+    assert outcome == "already-assigned"
+    assert client.merged_queries == []
+    assert client.assignments == []
+    assert client.comments == []
+
+
+def test_process_event_rejects_invalid_repository():
+    with pytest.raises(
+        trusted_self_assign.EventPayloadError,
+        match="GITHUB_REPOSITORY",
+    ):
+        trusted_self_assign.process_event(
+            issue_comment_event(), "maziyarpanahi/openmed other:repo", FakeClient()
+        )
+
+
+def test_client_uses_scoped_merged_pull_request_search(monkeypatch):
+    client = trusted_self_assign.GitHubClient("test-token")
+    calls: list[tuple[str, str, dict[str, str] | None, Any]] = []
+
+    def fake_request(
+        method: str,
+        path: str,
+        *,
+        query: dict[str, str] | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        calls.append((method, path, query, payload))
+        return {"total_count": 1, "incomplete_results": False, "items": []}
+
+    monkeypatch.setattr(client, "_request_json", fake_request)
+
+    assert client.merged_pull_request_count("maziyarpanahi/openmed", "merged-user") == 1
+    assert calls == [
+        (
+            "GET",
+            "/search/issues",
+            {
+                "q": ("repo:maziyarpanahi/openmed is:pr is:merged author:merged-user"),
+                "per_page": "1",
+            },
+            None,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"total_count": 1, "incomplete_results": True},
+        {"total_count": 1},
+        {"total_count": True, "incomplete_results": False},
+        {"total_count": -1, "incomplete_results": False},
+        {"total_count": "1", "incomplete_results": False},
+    ],
+)
+def test_client_fails_closed_on_incomplete_or_invalid_search(monkeypatch, response):
+    client = trusted_self_assign.GitHubClient("test-token")
+    monkeypatch.setattr(
+        client,
+        "_request_json",
+        lambda *args, **kwargs: response,
+    )
+
+    with pytest.raises(trusted_self_assign.GitHubResponseError):
+        client.merged_pull_request_count("maziyarpanahi/openmed", "merged-user")
+
+
+def test_client_posts_additive_assignee_payload(monkeypatch):
+    client = trusted_self_assign.GitHubClient("test-token")
+    calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    def fake_request(
+        method: str,
+        path: str,
+        *,
+        query: dict[str, str] | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        del query
+        calls.append((method, path, payload))
+        return {}
+
+    monkeypatch.setattr(client, "_request_json", fake_request)
+
+    client.add_assignee("maziyarpanahi/openmed", 42, "merged-user")
+
+    assert calls == [
+        (
+            "POST",
+            "/repos/maziyarpanahi/openmed/issues/42/assignees",
+            {"assignees": ["merged-user"]},
+        )
+    ]
+
+
+def test_workflow_has_least_privilege_and_exact_command_gate():
+    workflow = (
+        ROOT / ".github" / "workflows" / "trusted-contributor-self-assign.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "issue_comment:" in workflow
+    assert "contents: read" in workflow
+    assert "issues: write" in workflow
+    assert "pull-requests: read" in workflow
+    assert "github.event.comment.body == '/assign'" in workflow
+    assert "persist-credentials: false" in workflow


### PR DESCRIPTION
## Description

Adds an issue-comment workflow that lets contributors self-assign an open issue by commenting `/assign` after they have at least one pull request merged into OpenMed.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Add a least-privilege `issue_comment` workflow with an exact `/assign` gate.
- Verify eligibility through a complete repository-scoped merged-PR search and fail closed when GitHub search is incomplete.
- Preserve existing assignees, make repeat commands idempotent, reject bots/PR comments/closed issues, and explain ineligible requests.
- Document the one-merged-PR rule in contributor onboarding.

## Testing

- [x] Focused tests on Python 3.10 and 3.12: 23 passed on each version.
- [x] Full suite: 11,558 passed, 101 skipped, 1 xfailed.
- [x] `make format`, `make lint`, and `make format-check`.
- [x] `actionlint .github/workflows/*.yml`.
- [x] GitHub Action reference and repository policy checks.
- [x] Scoped pre-commit hooks.
- [x] Strict documentation build.
- [x] Wheel and sdist build plus wheel license-policy audit.

## Documentation

- [x] Updated `docs/onboarding.md`.
- [ ] Updated `CHANGELOG.md` (not needed for contributor automation).

## Code Quality

- [x] Performed a self-review of the exact staged diff.
- [x] No new warnings introduced.

## Dependencies

- [x] No new dependencies. The handler uses only the Python standard library.

## Related Issues

Direct maintainer request; no linked issue.

## Screenshots/Examples

Not applicable; this is repository automation.