### PR TITLE
Bundle v2.2 grounding calibration and section context

### DIFF
--- a/openmed/clinical/grounding/__init__.py
+++ b/openmed/clinical/grounding/__init__.py
@@ -135,6 +135,14 @@ from .registry import (
 )
 from .restricted import RESTRICTED_SYSTEM_URIS, UserKeyVocabularyLoader
 from .retrieval import TwoStageRetriever, retrieve_candidates
+from .section_context import (
+    DEFAULT_SECTION_CONTEXT_CONFIG,
+    DEFAULT_SECTION_CONTEXT_RULES,
+    SECTION_CONTEXT_RULES,
+    SectionContextConfig,
+    SectionContextRule,
+    apply_section_context,
+)
 from .snapshot_cache import (
     DEFAULT_CACHE_ENV,
     DEFAULT_GROUNDING_CACHE_ENV,
@@ -196,6 +204,8 @@ __all__ = [
     "DenseCandidateGenerator",
     "DEFAULT_TTY_PRIORITY",
     "DEFAULT_GROUNDING_SYSTEMS",
+    "DEFAULT_SECTION_CONTEXT_CONFIG",
+    "DEFAULT_SECTION_CONTEXT_RULES",
     "ECLConstraint",
     "ECLResolver",
     "ECLValidationError",
@@ -266,6 +276,9 @@ __all__ = [
     "RxNormLoaderError",
     "RxNormVocabularyLoader",
     "SnomedExpression",
+    "SECTION_CONTEXT_RULES",
+    "SectionContextConfig",
+    "SectionContextRule",
     "TwoStageRetriever",
     "UserKeyVocabularyLoader",
     "VocabConcept",
@@ -279,6 +292,7 @@ __all__ = [
     "VocabularyNotFoundError",
     "VocabularyRegistryError",
     "assertion_grounding_status",
+    "apply_section_context",
     "available_linkers",
     "available_loaders",
     "build_index",

--- a/openmed/clinical/grounding/calibration.py
+++ b/openmed/clinical/grounding/calibration.py
@@ -13,7 +13,9 @@ from openmed.eval.metrics import expected_calibration_error, reliability_bins
 
 SCHEMA_VERSION = 1
 GROUNDING_CALIBRATION_ARTIFACT = "openmed.grounding.calibration.report"
+GROUNDING_CALIBRATION_CONFIG = "openmed.grounding.calibrator"
 DEFAULT_GROUNDING_LABEL = "*"
+DEFAULT_GROUNDING_REVIEW_THRESHOLD = 0.50
 DEFAULT_MIN_GROUNDING_ACCURACY = 0.85
 DEFAULT_MIN_GROUNDING_COVERAGE = 0.70
 DEFAULT_RELIABILITY_BINS = 10
@@ -129,12 +131,28 @@ class GroundingCalibrator:
         """Return a JSON-ready fitted calibrator payload."""
 
         return {
+            "schema_version": SCHEMA_VERSION,
             "groups": [
                 group.to_dict()
                 for _, group in sorted(self.groups.items(), key=lambda item: item[0])
             ],
             "fallback": self.fallback.to_dict(),
         }
+
+    def to_config(self) -> dict[str, Any]:
+        """Return versioned, JSON-ready parameters for local persistence."""
+
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "artifact_type": GROUNDING_CALIBRATION_CONFIG,
+            **self.to_dict(),
+        }
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> "GroundingCalibrator":
+        """Restore a calibrator from a versioned local configuration."""
+
+        return _calibrator_from_config(config)
 
 
 @dataclass(frozen=True)
@@ -306,12 +324,12 @@ def coerce_grounding_calibration_records(
         record_system = (
             score_item.system
             if isinstance(score_item, GroundingCalibrationRecord)
-            else None
+            else _object_value(score_item, "system", "system_uri", "vocabulary")
         )
         record_label = (
             score_item.label
             if isinstance(score_item, GroundingCalibrationRecord)
-            else None
+            else _object_value(score_item, "label", "entity_type", "kind")
         )
 
         score = _score_from_item(score_item)
@@ -623,6 +641,90 @@ def apply_grounding_abstention(
     )
 
 
+def apply_concept_match_calibration(
+    matches: Sequence[Any],
+    calibrator: GroundingCalibrator,
+    *,
+    review_threshold: float | Mapping[str, Any] | None = None,
+    threshold: float | Mapping[str, Any] | None = None,
+    label: str = DEFAULT_GROUNDING_LABEL,
+    labels: Sequence[str] | None = None,
+    systems: Sequence[str] | None = None,
+) -> tuple[Any, ...]:
+    """Attach calibrated confidence and review state to lexical matches.
+
+    ``matches`` must contain :class:`~openmed.clinical.grounding.matcher.ConceptMatch`
+    instances.  The raw lexical score is preserved, while the returned
+    immutable match carries a probability from the fitted per-vocabulary map.
+    A match whose probability is strictly below its configured threshold is
+    marked ``review_required``; it is never silently removed.
+
+    Thresholds may be a single value or a mapping keyed by the same vocabulary
+    identifier used during fitting.  This operation is deterministic and uses
+    no network or model-training path.
+    """
+
+    from .matcher import ConceptMatch
+
+    if not isinstance(calibrator, GroundingCalibrator):
+        raise TypeError("calibrator must be a GroundingCalibrator")
+    items = tuple(matches)
+    if labels is not None and len(labels) != len(items):
+        raise ValueError("labels must have the same length as matches")
+    if systems is not None and len(systems) != len(items):
+        raise ValueError("systems must have the same length as matches")
+    if review_threshold is not None and threshold is not None:
+        raise ValueError("provide only one of review_threshold or threshold")
+    selected_threshold = review_threshold if review_threshold is not None else threshold
+    if selected_threshold is None:
+        thresholds: Mapping[str, Any] = {"*": DEFAULT_GROUNDING_REVIEW_THRESHOLD}
+    elif isinstance(selected_threshold, Mapping):
+        thresholds = selected_threshold
+    else:
+        thresholds = {"*": selected_threshold}
+
+    calibrated: list[ConceptMatch] = []
+    for index, match in enumerate(items):
+        if not isinstance(match, ConceptMatch):
+            raise TypeError("matches must contain ConceptMatch objects")
+        system = systems[index] if systems is not None else _match_system(match)
+        match_label = (
+            labels[index] if labels is not None else _match_label(match, label)
+        )
+        probability = calibrator.predict(
+            system=system,
+            label=match_label,
+            score=match.score,
+        )
+        match_threshold = _threshold_for_system(system, thresholds)
+        review_required = probability < match_threshold
+        calibration = dict(match.calibration)
+        calibration.update(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "artifact_type": GROUNDING_CALIBRATION_CONFIG,
+                "system": _normalize_system(system),
+                "label": _normalize_label(match_label),
+                "raw_score": match.score,
+                "calibrated_confidence": probability,
+                "review_threshold": match_threshold,
+                "review_required": review_required,
+            }
+        )
+        calibrated.append(
+            replace(
+                match,
+                calibrated_confidence=probability,
+                review_required=review_required,
+                calibration=calibration,
+            )
+        )
+    return tuple(calibrated)
+
+
+calibrate_concept_matches = apply_concept_match_calibration
+
+
 def _vocabulary_reports(
     records: Sequence[GroundingCalibrationRecord],
     probabilities: Sequence[float],
@@ -790,7 +892,10 @@ def _score_from_item(item: Any) -> float:
         if value is None:
             raise ValueError("grounding score mapping requires score")
         return _bounded_probability(value, "score")
-    return _bounded_probability(item, "score")
+    value = _object_value(item, "score", "confidence", "similarity", "probability")
+    if value is None:
+        return _bounded_probability(item, "score")
+    return _bounded_probability(value, "score")
 
 
 def _correct_from_items(score_item: Any, gold_item: Any) -> bool:
@@ -806,7 +911,7 @@ def _correct_from_items(score_item: Any, gold_item: Any) -> bool:
             if value is not None:
                 return _bool_from_value(value)
             predicted_code = _first_value(
-                getattr(score_item, "code", None),
+                _object_value(score_item, "code", "concept_id"),
                 score_item.get("code") if isinstance(score_item, Mapping) else None,
                 score_item.get("predicted_code")
                 if isinstance(score_item, Mapping)
@@ -839,6 +944,16 @@ def _correct_from_items(score_item: Any, gold_item: Any) -> bool:
         )
         if value is not None:
             return _bool_from_value(value)
+    value = _object_value(
+        score_item,
+        "correct",
+        "is_correct",
+        "matched",
+        "accurate",
+        "target",
+    )
+    if value is not None:
+        return _bool_from_value(value)
     raise ValueError("grounding calibration requires correctness labels")
 
 
@@ -848,6 +963,8 @@ def _weight_from_items(score_item: Any, gold_item: Any) -> float:
         value = score_item.weight
     elif isinstance(score_item, Mapping):
         value = _first_value(score_item.get("weight"), score_item.get("span_weight"))
+    else:
+        value = _object_value(score_item, "weight", "span_weight")
     if value is None and isinstance(gold_item, Mapping):
         value = _first_value(gold_item.get("weight"), gold_item.get("span_weight"))
     if value is None:
@@ -865,13 +982,25 @@ def _metadata_from_items(score_item: Any, gold_item: Any) -> dict[str, Any]:
             metadata.update(dict(item.metadata))
         elif isinstance(item, Mapping) and isinstance(item.get("metadata"), Mapping):
             metadata.update(dict(item["metadata"]))
+        else:
+            raw_metadata = _object_value(item, "metadata")
+            if isinstance(raw_metadata, Mapping):
+                metadata.update(dict(raw_metadata))
+            match_type = _object_value(item, "match_type")
+            if match_type is not None:
+                metadata.setdefault("match_type", str(match_type))
     return metadata
 
 
 def _threshold_for_system(system: str, operating_points: Mapping[str, Any]) -> float:
-    value = operating_points.get(system)
-    if value is None:
-        value = operating_points.get(system.lower(), operating_points.get("*"))
+    normalized_system = _normalize_system(system)
+    value = _first_value(
+        operating_points.get(system),
+        operating_points.get(normalized_system),
+        operating_points.get(str(system).lower()),
+        operating_points.get(str(system).upper()),
+        operating_points.get("*"),
+    )
     if isinstance(value, GroundingOperatingPoint):
         return value.threshold
     if isinstance(value, Mapping):
@@ -881,6 +1010,35 @@ def _threshold_for_system(system: str, operating_points: Mapping[str, Any]) -> f
     if threshold is None:
         raise ValueError(f"missing grounding operating point for {system}")
     return _bounded_probability(threshold, "threshold")
+
+
+def _match_system(match: Any) -> str:
+    metadata = _object_value(match, "metadata")
+    if not isinstance(metadata, Mapping):
+        metadata = {}
+    return str(
+        _first_value(
+            metadata.get("calibration_system"),
+            metadata.get("vocabulary"),
+            metadata.get("system"),
+            _object_value(match, "system_uri", "system"),
+        )
+    )
+
+
+def _match_label(match: Any, default: str) -> str:
+    metadata = _object_value(match, "metadata")
+    if not isinstance(metadata, Mapping):
+        metadata = {}
+    return str(
+        _first_value(
+            metadata.get("calibration_label"),
+            metadata.get("label"),
+            metadata.get("entity_type"),
+            metadata.get("kind"),
+            default,
+        )
+    )
 
 
 def _merge_grounding_provenance(
@@ -927,6 +1085,17 @@ def _first_value(*values: Any) -> Any:
     return None
 
 
+def _object_value(item: Any, *names: str) -> Any:
+    for name in names:
+        if isinstance(item, Mapping):
+            value = item.get(name)
+        else:
+            value = getattr(item, name, None)
+        if value is not None:
+            return value
+    return None
+
+
 def _first_text(
     *mappings: Mapping[str, Any],
     keys: Sequence[str],
@@ -959,6 +1128,87 @@ def _optional_float(value: Any) -> float | None:
     return number if math.isfinite(number) else None
 
 
+def _calibrator_from_config(config: Mapping[str, Any]) -> GroundingCalibrator:
+    if not isinstance(config, Mapping):
+        raise TypeError("grounding calibration config must be a mapping")
+    if config.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(
+            "unsupported grounding calibration config schema_version: "
+            f"{config.get('schema_version')!r}"
+        )
+    artifact_type = config.get("artifact_type")
+    if artifact_type is not None and artifact_type not in {
+        GROUNDING_CALIBRATION_CONFIG,
+        GROUNDING_CALIBRATION_ARTIFACT,
+    }:
+        raise ValueError(
+            "grounding calibration config artifact_type must be "
+            f"{GROUNDING_CALIBRATION_CONFIG!r}"
+        )
+
+    payload = config.get("calibrator", config)
+    if not isinstance(payload, Mapping):
+        raise ValueError("grounding calibration config calibrator must be a mapping")
+    raw_groups = payload.get("groups")
+    if not isinstance(raw_groups, Sequence) or isinstance(raw_groups, (str, bytes)):
+        raise ValueError("grounding calibration config groups must be a sequence")
+
+    groups: dict[tuple[str, str], GroundingCalibrationGroup] = {}
+    for raw_group in raw_groups:
+        group = _group_from_config(raw_group)
+        key = (group.system, group.label)
+        if key in groups:
+            raise ValueError(f"duplicate grounding calibration group {key!r}")
+        groups[key] = group
+
+    fallback_payload = payload.get("fallback")
+    if not isinstance(fallback_payload, Mapping):
+        raise ValueError("grounding calibration config requires a fallback group")
+    fallback = _group_from_config(fallback_payload)
+    return GroundingCalibrator(groups=groups, fallback=fallback)
+
+
+def _group_from_config(payload: Any) -> GroundingCalibrationGroup:
+    if not isinstance(payload, Mapping):
+        raise ValueError("grounding calibration group must be a mapping")
+    raw_knots = payload.get("knots")
+    if not isinstance(raw_knots, Sequence) or isinstance(raw_knots, (str, bytes)):
+        raise ValueError("grounding calibration group knots must be a sequence")
+
+    knots: list[tuple[float, float]] = []
+    previous_score = -1.0
+    previous_probability = -1.0
+    for raw_knot in raw_knots:
+        if not isinstance(raw_knot, Mapping):
+            raise ValueError("grounding calibration knots must be mappings")
+        score = _bounded_probability(raw_knot.get("max_score"), "max_score")
+        probability = _bounded_probability(
+            raw_knot.get("probability"),
+            "probability",
+        )
+        if score < previous_score or probability < previous_probability:
+            raise ValueError("grounding calibration knots must be monotonic")
+        knots.append((score, probability))
+        previous_score = score
+        previous_probability = probability
+
+    sample_count = int(payload.get("sample_count", 0))
+    positive_count = int(payload.get("positive_count", 0))
+    total_weight = float(payload.get("total_weight", 0.0))
+    if sample_count < 0 or positive_count < 0 or positive_count > sample_count:
+        raise ValueError("grounding calibration group counts are invalid")
+    if not math.isfinite(total_weight) or total_weight < 0.0:
+        raise ValueError("grounding calibration group total_weight is invalid")
+    return GroundingCalibrationGroup(
+        system=_normalize_system(payload.get("system")),
+        label=_normalize_label(payload.get("label")),
+        knots=tuple(knots),
+        sample_count=sample_count,
+        positive_count=positive_count,
+        total_weight=total_weight,
+    )
+
+
 def _utc_now() -> str:
     return (
         datetime.now(timezone.utc)
@@ -972,16 +1222,20 @@ def _utc_now() -> str:
 
 __all__ = [
     "DEFAULT_GROUNDING_LABEL",
+    "DEFAULT_GROUNDING_REVIEW_THRESHOLD",
     "DEFAULT_MIN_GROUNDING_ACCURACY",
     "DEFAULT_MIN_GROUNDING_COVERAGE",
     "DEFAULT_RELIABILITY_BINS",
     "GROUNDING_CALIBRATION_ARTIFACT",
+    "GROUNDING_CALIBRATION_CONFIG",
     "GroundingCalibrationGroup",
     "GroundingCalibrationRecord",
     "GroundingCalibrationResult",
     "GroundingCalibrator",
     "GroundingOperatingPoint",
+    "apply_concept_match_calibration",
     "apply_grounding_abstention",
+    "calibrate_concept_matches",
     "calibrate_grounding",
     "coerce_grounding_calibration_records",
     "coverage_accuracy_curve",

--- a/openmed/clinical/grounding/matcher.py
+++ b/openmed/clinical/grounding/matcher.py
@@ -80,7 +80,8 @@ class ConceptMatch:
     ``match_type`` records whether the original term matched exactly, only
     after normalization, or through an abbreviation.  ``matched_term`` is the
     vocabulary term, not the caller's query, so match results do not duplicate
-    arbitrary source text.
+    arbitrary source text.  Optional section fields are populated by the
+    section-context layer and remain separate from vocabulary metadata.
     """
 
     system_uri: str
@@ -93,6 +94,10 @@ class ConceptMatch:
     calibrated_confidence: float | None = None
     review_required: bool = False
     calibration: Mapping[str, object] = field(default_factory=dict, hash=False)
+    section: str | None = None
+    experiencer: str | None = None
+    section_bias: float = 0.0
+    context_score: float | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "system_uri", _validate_system_uri(self.system_uri))
@@ -124,6 +129,23 @@ class ConceptMatch:
         if not isinstance(self.calibration, Mapping):
             raise TypeError("calibration must be a mapping")
         object.__setattr__(self, "calibration", dict(self.calibration))
+        if self.section is not None and (
+            not isinstance(self.section, str) or not self.section.strip()
+        ):
+            raise ValueError("section must be non-empty when provided")
+        if self.experiencer is not None and (
+            not isinstance(self.experiencer, str) or not self.experiencer.strip()
+        ):
+            raise ValueError("experiencer must be non-empty when provided")
+        section_bias = float(self.section_bias)
+        if not math.isfinite(section_bias):
+            raise ValueError("section_bias must be finite")
+        object.__setattr__(self, "section_bias", section_bias)
+        if self.context_score is not None:
+            context_score = float(self.context_score)
+            if not math.isfinite(context_score):
+                raise ValueError("context_score must be finite when provided")
+            object.__setattr__(self, "context_score", context_score)
 
     @property
     def key(self) -> tuple[str, str]:
@@ -170,6 +192,12 @@ class ConceptMatch:
             "review_required": self.review_required,
             "calibration": dict(self.calibration),
         }
+
+    @property
+    def ranking_score(self) -> float:
+        """Return the context-adjusted score used for deterministic ordering."""
+
+        return self.score if self.context_score is None else self.context_score
 
 
 @dataclass(frozen=True)
@@ -260,6 +288,9 @@ class LexicalMatcher:
         review_threshold: float | Mapping[str, Any] | None = None,
         threshold: float | Mapping[str, Any] | None = None,
         label: str = "*",
+        sections: object | None = None,
+        experiencer: str | None = None,
+        section_rules: Mapping[str, object] | None = None,
     ) -> tuple[ConceptMatch, ...]:
         """Return deterministically ranked concepts for ``query``.
 
@@ -269,7 +300,9 @@ class LexicalMatcher:
         selected matches also carry a calibrated confidence and a review flag.
 
         Calibration is opt-in and consumes a caller-fitted, local calibrator;
-        lookup never fits parameters or accesses a network resource.
+        lookup never fits parameters or accesses a network resource. When
+        ``sections`` or ``experiencer`` is provided, section context is applied
+        before ``limit`` is enforced.
         """
 
         if not isinstance(query, str):
@@ -305,16 +338,27 @@ class LexicalMatcher:
             "abbreviation",
         )
 
-        matches = sorted(
-            best.values(),
-            key=lambda match: (
-                -match.score,
-                match.system_uri,
-                match.code,
-                match.display,
-                order_by_key[match.key],
-            ),
+        matches = tuple(
+            sorted(
+                best.values(),
+                key=lambda match: (
+                    -match.score,
+                    match.system_uri,
+                    match.code,
+                    match.display,
+                    order_by_key[match.key],
+                ),
+            )
         )
+        if sections is not None or experiencer is not None:
+            from .section_context import apply_section_context
+
+            matches = apply_section_context(
+                matches,
+                sections,
+                experiencer,
+                rules=section_rules,
+            )
         if limit is not None:
             matches = matches[:limit]
         if calibrator is None:
@@ -343,6 +387,9 @@ class LexicalMatcher:
         review_threshold: float | Mapping[str, Any] | None = None,
         threshold: float | Mapping[str, Any] | None = None,
         label: str = "*",
+        sections: object | None = None,
+        experiencer: str | None = None,
+        section_rules: Mapping[str, object] | None = None,
     ) -> tuple[ConceptMatch, ...]:
         """Alias for :meth:`lookup`."""
 
@@ -353,6 +400,9 @@ class LexicalMatcher:
             review_threshold=review_threshold,
             threshold=threshold,
             label=label,
+            sections=sections,
+            experiencer=experiencer,
+            section_rules=section_rules,
         )
 
     def _build_abbreviation_index(

--- a/openmed/clinical/grounding/matcher.py
+++ b/openmed/clinical/grounding/matcher.py
@@ -191,6 +191,10 @@ class ConceptMatch:
             "calibrated_confidence": self.calibrated_confidence,
             "review_required": self.review_required,
             "calibration": dict(self.calibration),
+            "section": self.section,
+            "experiencer": self.experiencer,
+            "section_bias": self.section_bias,
+            "context_score": self.context_score,
         }
 
     @property

--- a/openmed/clinical/grounding/matcher.py
+++ b/openmed/clinical/grounding/matcher.py
@@ -13,7 +13,7 @@ import unicodedata
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Literal, TypeAlias
+from typing import Any, Literal, TypeAlias
 
 __all__ = [
     "AbbreviationMap",
@@ -90,6 +90,9 @@ class ConceptMatch:
     match_type: MatchType
     matched_term: str
     metadata: Mapping[str, object] = field(default_factory=dict, hash=False)
+    calibrated_confidence: float | None = None
+    review_required: bool = False
+    calibration: Mapping[str, object] = field(default_factory=dict, hash=False)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "system_uri", _validate_system_uri(self.system_uri))
@@ -109,12 +112,64 @@ class ConceptMatch:
         if not isinstance(self.metadata, Mapping):
             raise TypeError("metadata must be a mapping")
         object.__setattr__(self, "metadata", dict(self.metadata))
+        if self.calibrated_confidence is not None:
+            confidence = float(self.calibrated_confidence)
+            if not math.isfinite(confidence) or not 0.0 <= confidence <= 1.0:
+                raise ValueError(
+                    "calibrated_confidence must be finite and between 0.0 and 1.0"
+                )
+            object.__setattr__(self, "calibrated_confidence", confidence)
+        if not isinstance(self.review_required, bool):
+            raise TypeError("review_required must be a boolean")
+        if not isinstance(self.calibration, Mapping):
+            raise TypeError("calibration must be a mapping")
+        object.__setattr__(self, "calibration", dict(self.calibration))
 
     @property
     def key(self) -> tuple[str, str]:
         """Return the stable vocabulary URI and code identity."""
 
         return (self.system_uri, self.code)
+
+    @property
+    def calibrated_score(self) -> float | None:
+        """Return the calibrated confidence using the grounding span name."""
+
+        return self.calibrated_confidence
+
+    @property
+    def abstained(self) -> bool:
+        """Return whether this match was withheld pending review."""
+
+        return self.review_required
+
+    @property
+    def abstain(self) -> bool:
+        """Return the short-form abstention flag for this match."""
+
+        return self.review_required
+
+    @property
+    def needs_review(self) -> bool:
+        """Return whether this match requires human review."""
+
+        return self.review_required
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-ready match including optional calibration metadata."""
+
+        return {
+            "system_uri": self.system_uri,
+            "code": self.code,
+            "display": self.display,
+            "score": self.score,
+            "match_type": self.match_type,
+            "matched_term": self.matched_term,
+            "metadata": dict(self.metadata),
+            "calibrated_confidence": self.calibrated_confidence,
+            "review_required": self.review_required,
+            "calibration": dict(self.calibration),
+        }
 
 
 @dataclass(frozen=True)
@@ -197,13 +252,24 @@ class LexicalMatcher:
         return self._concept_count
 
     def lookup(
-        self, query: str, *, limit: int | None = None
+        self,
+        query: str,
+        *,
+        limit: int | None = None,
+        calibrator: Any | None = None,
+        review_threshold: float | Mapping[str, Any] | None = None,
+        threshold: float | Mapping[str, Any] | None = None,
+        label: str = "*",
     ) -> tuple[ConceptMatch, ...]:
         """Return deterministically ranked concepts for ``query``.
 
         Exact matches rank ahead of normalized matches, which rank ahead of
         abbreviation matches.  A concept reachable through multiple terms is
-        returned once at its best score.
+        returned once at its best score.  When ``calibrator`` is supplied, the
+        selected matches also carry a calibrated confidence and a review flag.
+
+        Calibration is opt-in and consumes a caller-fitted, local calibrator;
+        lookup never fits parameters or accesses a network resource.
         """
 
         if not isinstance(query, str):
@@ -212,6 +278,8 @@ class LexicalMatcher:
             not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0
         ):
             raise ValueError("limit must be a positive integer or None")
+        if review_threshold is not None and threshold is not None:
+            raise ValueError("provide only one of review_threshold or threshold")
         normalized_query = normalize_term(query)
         if not normalized_query:
             return ()
@@ -249,14 +317,43 @@ class LexicalMatcher:
         )
         if limit is not None:
             matches = matches[:limit]
-        return tuple(matches)
+        if calibrator is None:
+            if review_threshold is not None or threshold is not None:
+                raise ValueError("a calibrator is required for review thresholds")
+            return tuple(matches)
+
+        from .calibration import apply_concept_match_calibration
+
+        selected_threshold = (
+            review_threshold if review_threshold is not None else threshold
+        )
+        return apply_concept_match_calibration(
+            tuple(matches),
+            calibrator,
+            review_threshold=selected_threshold,
+            label=label,
+        )
 
     def match(
-        self, query: str, *, limit: int | None = None
+        self,
+        query: str,
+        *,
+        limit: int | None = None,
+        calibrator: Any | None = None,
+        review_threshold: float | Mapping[str, Any] | None = None,
+        threshold: float | Mapping[str, Any] | None = None,
+        label: str = "*",
     ) -> tuple[ConceptMatch, ...]:
         """Alias for :meth:`lookup`."""
 
-        return self.lookup(query, limit=limit)
+        return self.lookup(
+            query,
+            limit=limit,
+            calibrator=calibrator,
+            review_threshold=review_threshold,
+            threshold=threshold,
+            label=label,
+        )
 
     def _build_abbreviation_index(
         self, abbreviations: AbbreviationMap

--- a/openmed/clinical/grounding/section_context.py
+++ b/openmed/clinical/grounding/section_context.py
@@ -1,0 +1,595 @@
+"""Offline section priors for lexical grounding candidates.
+
+Section context is an advisory grounding signal.  It uses semantic-type
+metadata supplied by the caller's vocabulary snapshot to remove implausible
+matches, adjust deterministic ranking, and preserve the section and
+experiencer that governed the result.  No terminology is downloaded and no
+source span text is copied into the returned metadata.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import unicodedata
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from types import MappingProxyType
+from typing import TypeAlias
+
+from ..context import canonical_section_label
+from .matcher import ConceptMatch
+
+__all__ = [
+    "DEFAULT_SECTION_CONTEXT_CONFIG",
+    "DEFAULT_SECTION_CONTEXT_RULES",
+    "SECTION_CONTEXT_RULES",
+    "SectionContextConfig",
+    "SectionContextRule",
+    "apply_section_context",
+]
+
+
+_PATIENT = "patient"
+_SECTION_FIELDS = (
+    "section",
+    "section_label",
+    "section_name",
+    "canonical_section",
+    "canonical_label",
+    "label",
+    "name",
+)
+_SEMANTIC_TYPE_FIELDS = (
+    "semantic_type",
+    "semantic_types",
+    "semanticType",
+    "semanticTypes",
+    "concept_type",
+    "concept_types",
+    "kind",
+    "type",
+    "types",
+    "category",
+    "domain",
+)
+_VALUE_SPLIT_RE = re.compile(r"[,|;]")
+
+
+def _normalize_key(value: object, *, name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} values must be strings")
+    normalized = unicodedata.normalize("NFKC", value).casefold().strip()
+    normalized = re.sub(r"[^\w]+", "_", normalized, flags=re.UNICODE)
+    normalized = normalized.strip("_")
+    if not normalized:
+        raise ValueError(f"{name} values must not be empty")
+    return normalized
+
+
+def _normalize_section(value: object) -> str | None:
+    text = _section_text(value)
+    if text is None:
+        return None
+    canonical = canonical_section_label(text)
+    if canonical:
+        return canonical
+    return _normalize_key(text, name="section")
+
+
+def _section_text(value: object) -> str | None:
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    if isinstance(value, Mapping):
+        for field_name in _SECTION_FIELDS:
+            candidate = value.get(field_name)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+        return None
+    for field_name in _SECTION_FIELDS:
+        candidate = getattr(value, field_name, None)
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return None
+
+
+def _normalize_semantic_type(value: object) -> str:
+    return _normalize_key(value, name="semantic type")
+
+
+def _normalize_experiencer(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("experiencer must be a non-empty string when provided")
+    return _normalize_key(value, name="experiencer")
+
+
+@dataclass(frozen=True)
+class SectionContextRule:
+    """Configurable grounding policy for one canonical note section.
+
+    ``semantic_type_biases`` contains additive score adjustments keyed by the
+    semantic type recorded in a concept's metadata.  ``excluded_semantic_types``
+    are hard exclusions for this section.  ``default_bias`` applies to a match
+    whose type has no explicit bias, while ``non_patient_bias`` is applied when
+    the resolved experiencer is not the patient.
+    """
+
+    semantic_type_biases: Mapping[str, float] = field(default_factory=dict)
+    excluded_semantic_types: frozenset[str] = frozenset()
+    default_bias: float = 0.0
+    experiencer: str | None = None
+    non_patient_bias: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.semantic_type_biases, Mapping):
+            raise TypeError("semantic_type_biases must be a mapping")
+        biases: dict[str, float] = {}
+        for raw_type, raw_bias in self.semantic_type_biases.items():
+            semantic_type = _normalize_semantic_type(raw_type)
+            bias = float(raw_bias)
+            if not math.isfinite(bias):
+                raise ValueError("semantic type biases must be finite")
+            biases[semantic_type] = bias
+        object.__setattr__(self, "semantic_type_biases", MappingProxyType(biases))
+
+        excluded = self.excluded_semantic_types
+        if isinstance(excluded, str):
+            excluded_values = (excluded,)
+        else:
+            try:
+                excluded_values = tuple(excluded)
+            except TypeError as exc:
+                raise TypeError(
+                    "excluded_semantic_types must be an iterable of strings"
+                ) from exc
+        object.__setattr__(
+            self,
+            "excluded_semantic_types",
+            frozenset(_normalize_semantic_type(value) for value in excluded_values),
+        )
+
+        for field_name in ("default_bias", "non_patient_bias"):
+            bias = float(getattr(self, field_name))
+            if not math.isfinite(bias):
+                raise ValueError(f"{field_name} must be finite")
+            object.__setattr__(self, field_name, bias)
+        object.__setattr__(
+            self, "experiencer", _normalize_experiencer(self.experiencer)
+        )
+
+    @property
+    def biases(self) -> Mapping[str, float]:
+        """Alias for :attr:`semantic_type_biases` used by policy consumers."""
+
+        return self.semantic_type_biases
+
+    @property
+    def exclusions(self) -> frozenset[str]:
+        """Alias for :attr:`excluded_semantic_types`."""
+
+        return self.excluded_semantic_types
+
+
+SectionContextRuleInput: TypeAlias = SectionContextRule | Mapping[str, object]
+
+
+def _coerce_rule(value: SectionContextRuleInput) -> SectionContextRule:
+    if isinstance(value, SectionContextRule):
+        return value
+    if not isinstance(value, Mapping):
+        raise TypeError("section rules must be SectionContextRule or mappings")
+
+    raw_biases = value.get("semantic_type_biases")
+    if raw_biases is None:
+        raw_biases = value.get("biases", value.get("bias", {}))
+    if isinstance(raw_biases, Sequence) and not isinstance(raw_biases, str):
+        raw_biases = {
+            item: 0.1 for item in raw_biases if isinstance(item, str) and item.strip()
+        }
+    if raw_biases is None:
+        raw_biases = {}
+
+    preferred = value.get("preferred_semantic_types", value.get("preferred_types"))
+    if preferred is not None:
+        if isinstance(preferred, str):
+            preferred_values = (preferred,)
+        else:
+            preferred_values = tuple(preferred)
+        preferred_bias = float(value.get("preferred_bias", 0.1))
+        if not isinstance(raw_biases, Mapping):
+            raise TypeError("section rule biases must be a mapping")
+        raw_biases = {
+            **raw_biases,
+            **{item: preferred_bias for item in preferred_values},
+        }
+
+    raw_exclusions = value.get("excluded_semantic_types")
+    if raw_exclusions is None:
+        raw_exclusions = value.get(
+            "exclusions",
+            value.get("exclude", value.get("excluded_types", ())),
+        )
+    if raw_exclusions is None:
+        raw_exclusions = ()
+    return SectionContextRule(
+        semantic_type_biases=raw_biases,
+        excluded_semantic_types=raw_exclusions,
+        default_bias=value.get("default_bias", 0.0),
+        experiencer=value.get("experiencer"),
+        non_patient_bias=value.get("non_patient_bias", value.get("downrank", 0.0)),
+    )
+
+
+def _compile_rules(
+    rules: Mapping[str, SectionContextRuleInput],
+) -> Mapping[str, SectionContextRule]:
+    if not isinstance(rules, Mapping):
+        raise TypeError("section rules must be a mapping")
+    compiled: dict[str, SectionContextRule] = {}
+    for raw_section, raw_rule in rules.items():
+        section = _normalize_section(raw_section)
+        if section is None:
+            raise ValueError("section rule keys must be non-empty labels")
+        compiled[section] = _coerce_rule(raw_rule)
+    return MappingProxyType(compiled)
+
+
+# This table is intentionally data-shaped: downstream users can replace it with
+# a caller-owned mapping without changing the ranking implementation.
+_DEFAULT_RULE_DATA: Mapping[str, Mapping[str, object]] = {
+    "allergies": {
+        "semantic_type_biases": {
+            "allergen": 0.18,
+            "allergy": 0.18,
+            "substance": 0.08,
+        },
+        "excluded_semantic_types": ("medication", "drug", "pharmaceutical"),
+        "experiencer": "patient",
+    },
+    "medications": {
+        "semantic_type_biases": {
+            "medication": 0.18,
+            "drug": 0.18,
+            "pharmaceutical": 0.15,
+        },
+        "excluded_semantic_types": ("allergen", "allergy"),
+        "experiencer": "patient",
+    },
+    "problem_list": {
+        "semantic_type_biases": {
+            "condition": 0.12,
+            "disease": 0.12,
+            "disorder": 0.12,
+        },
+        "excluded_semantic_types": ("medication", "drug"),
+        "experiencer": "patient",
+    },
+    "assessment": {
+        "semantic_type_biases": {
+            "condition": 0.08,
+            "disease": 0.08,
+            "disorder": 0.08,
+        },
+        "experiencer": "patient",
+    },
+    "family_history": {
+        "semantic_type_biases": {
+            "condition": 0.04,
+            "disease": 0.04,
+            "disorder": 0.04,
+        },
+        "default_bias": -0.12,
+        "non_patient_bias": -0.05,
+        "experiencer": "family",
+    },
+    "social_history": {"experiencer": "patient"},
+}
+
+SECTION_CONTEXT_RULES = _compile_rules(_DEFAULT_RULE_DATA)
+DEFAULT_SECTION_CONTEXT_RULES = SECTION_CONTEXT_RULES
+
+
+@dataclass(frozen=True)
+class SectionContextConfig:
+    """Immutable, validated section-policy configuration."""
+
+    rules: Mapping[str, SectionContextRuleInput] = field(
+        default_factory=lambda: SECTION_CONTEXT_RULES
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "rules", _compile_rules(self.rules))
+
+    def rule_for(self, section: object) -> SectionContextRule | None:
+        """Return the configured rule for ``section``, if one exists."""
+
+        normalized = _normalize_section(section)
+        if normalized is None:
+            return None
+        return self.rules.get(normalized)
+
+
+DEFAULT_SECTION_CONTEXT_CONFIG = SectionContextConfig()
+
+
+@dataclass(frozen=True)
+class _SectionEntry:
+    label: str
+    start: int | None = None
+    end: int | None = None
+    match_key: tuple[str, str] | str | None = None
+
+
+def _offset(value: object, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"section {field_name} must be a non-negative integer")
+    return value
+
+
+def _entry_from_value(
+    value: object,
+    *,
+    match_key: tuple[str, str] | str | None = None,
+) -> _SectionEntry | None:
+    label = _normalize_section(value)
+    if label is None:
+        return None
+    if not isinstance(value, Mapping):
+        return _SectionEntry(label=label, match_key=match_key)
+    start = _offset(value.get("start", value.get("start_char")), "start")
+    end = _offset(value.get("end", value.get("end_char")), "end")
+    if (start is None) != (end is None) or (start is not None and end < start):
+        raise ValueError("section start and end offsets must be an ordered pair")
+    raw_key = value.get("match_key")
+    if raw_key is None and "system" in value and "code" in value:
+        raw_key = (value["system"], value["code"])
+    if raw_key is not None and not isinstance(raw_key, (str, tuple)):
+        raise TypeError("section match_key must be a code or (system, code) pair")
+    return _SectionEntry(
+        label=label,
+        start=start,
+        end=end,
+        match_key=raw_key if raw_key is not None else match_key,
+    )
+
+
+def _coerce_sections(sections: object | None) -> tuple[_SectionEntry, ...]:
+    if sections is None:
+        return ()
+    if isinstance(sections, str):
+        entry = _entry_from_value(sections)
+        return (entry,) if entry is not None else ()
+    if isinstance(sections, Mapping):
+        if _section_text(sections) is not None:
+            entry = _entry_from_value(sections)
+            return (entry,) if entry is not None else ()
+        entries: list[_SectionEntry] = []
+        for raw_key, value in sections.items():
+            key = raw_key if isinstance(raw_key, (str, tuple)) else None
+            entry = _entry_from_value(value, match_key=key)
+            if entry is None and isinstance(raw_key, str):
+                entry = _entry_from_value(raw_key, match_key=key)
+            if entry is not None:
+                entries.append(entry)
+        return tuple(entries)
+    if isinstance(sections, (bytes, bytearray)):
+        raise TypeError("sections must be a label, mapping, or iterable")
+    try:
+        values = tuple(sections)  # type: ignore[arg-type]
+    except TypeError as exc:
+        raise TypeError("sections must be a label, mapping, or iterable") from exc
+    entries = []
+    for value in values:
+        entry = _entry_from_value(value)
+        if entry is not None:
+            entries.append(entry)
+    return tuple(entries)
+
+
+def _match_offsets(match: ConceptMatch) -> tuple[int, int] | None:
+    start = match.metadata.get("start", match.metadata.get("start_char"))
+    end = match.metadata.get("end", match.metadata.get("end_char"))
+    if isinstance(start, int) and not isinstance(start, bool):
+        if isinstance(end, int) and not isinstance(end, bool) and start <= end:
+            return start, end
+    return None
+
+
+def _entry_for_match(
+    match: ConceptMatch,
+    entries: Sequence[_SectionEntry],
+) -> _SectionEntry | None:
+    for entry in entries:
+        if entry.match_key is None:
+            continue
+        if entry.match_key == match.key or entry.match_key == match.code:
+            return entry
+
+    offsets = _match_offsets(match)
+    if offsets is not None:
+        start, end = offsets
+        containing = [
+            entry
+            for entry in entries
+            if entry.start is not None
+            and entry.end is not None
+            and entry.start <= start
+            and end <= entry.end
+        ]
+        if containing:
+            return min(
+                containing, key=lambda entry: (entry.end - entry.start, entry.label)
+            )
+
+    return next(
+        (
+            entry
+            for entry in entries
+            if entry.match_key is None and entry.start is None and entry.end is None
+        ),
+        None,
+    )
+
+
+def _metadata_values(
+    metadata: Mapping[str, object], field_name: str
+) -> tuple[object, ...]:
+    value = metadata.get(field_name)
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return tuple(item for item in _VALUE_SPLIT_RE.split(value) if item.strip())
+    if isinstance(value, Mapping):
+        return ()
+    try:
+        return tuple(value)  # type: ignore[arg-type]
+    except TypeError:
+        return (value,)
+
+
+def _semantic_types(match: ConceptMatch) -> frozenset[str]:
+    values: list[object] = []
+    for field_name in _SEMANTIC_TYPE_FIELDS:
+        values.extend(_metadata_values(match.metadata, field_name))
+    result: set[str] = set()
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            result.add(_normalize_semantic_type(value))
+    return frozenset(result)
+
+
+def _section_bias(
+    match: ConceptMatch,
+    rule: SectionContextRule | None,
+    resolved_experiencer: str | None,
+) -> tuple[float, bool]:
+    if rule is None:
+        return 0.0, False
+    semantic_types = _semantic_types(match)
+    excluded = bool(semantic_types & rule.excluded_semantic_types)
+    matching_biases = [
+        rule.semantic_type_biases[semantic_type]
+        for semantic_type in semantic_types
+        if semantic_type in rule.semantic_type_biases
+    ]
+    bias = max(matching_biases, default=rule.default_bias)
+    if resolved_experiencer is not None and resolved_experiencer != _PATIENT:
+        bias += rule.non_patient_bias
+    return bias, excluded
+
+
+def _sort_key(match: ConceptMatch) -> tuple[float, float, float, str, str, str, str]:
+    context_score = match.context_score
+    if context_score is None:
+        context_score = match.score
+    return (
+        -context_score,
+        -match.score,
+        -match.section_bias,
+        match.system_uri,
+        match.code,
+        match.display,
+        match.matched_term,
+    )
+
+
+def apply_section_context(
+    matches: Iterable[ConceptMatch],
+    sections: object | None,
+    experiencer: str | None = None,
+    *,
+    rules: Mapping[str, SectionContextRuleInput] | SectionContextConfig | None = None,
+    config: SectionContextConfig | None = None,
+    drop_excluded: bool = True,
+) -> tuple[ConceptMatch, ...]:
+    """Apply section-aware semantic-type priors to lexical matches.
+
+    Args:
+        matches: Candidate :class:`ConceptMatch` records with vocabulary
+            metadata such as ``semantic_type`` or ``semantic_types``.
+        sections: A detected section label, or offset-bearing section mappings.
+            When several unscoped labels are supplied, the first recognized label
+            governs the matches; offset-bearing entries are selected per match.
+        experiencer: Optional explicit experiencer.  It overrides a section's
+            configured prior, while an omitted value lets a section rule provide
+            one (for example, ``family_history`` -> ``family``).
+        rules: Optional caller-owned section rule mapping.
+        config: Optional :class:`SectionContextConfig`; mutually exclusive with
+            ``rules``.
+        drop_excluded: Remove candidates whose semantic type is excluded by the
+            governing section.  Set to ``False`` to retain them with provenance.
+
+    Returns:
+        A deterministic tuple of section-enriched matches.  Only canonical
+        section labels, offsets supplied by the caller, concept metadata, and
+        concept identifiers are carried forward; raw query text is not stored.
+    """
+
+    if not isinstance(drop_excluded, bool):
+        raise TypeError("drop_excluded must be a boolean")
+    if config is not None and rules is not None:
+        raise ValueError("pass either config or rules, not both")
+    if isinstance(rules, SectionContextConfig):
+        if config is not None:
+            raise ValueError("pass either config or rules, not both")
+        config = rules
+        rules = None
+    resolved_config = config or (
+        SectionContextConfig(rules)
+        if rules is not None
+        else DEFAULT_SECTION_CONTEXT_CONFIG
+    )
+    resolved_experiencer = _normalize_experiencer(experiencer)
+    entries = _coerce_sections(sections)
+
+    enriched: list[ConceptMatch] = []
+    for match in matches:
+        if not isinstance(match, ConceptMatch):
+            raise TypeError("matches must contain ConceptMatch objects")
+        entry = _entry_for_match(match, entries)
+        section = (
+            entry.label
+            if entry is not None
+            else match.section or _normalize_section(match.metadata)
+        )
+        rule = resolved_config.rule_for(section) if section is not None else None
+        match_experiencer = (
+            resolved_experiencer
+            or (rule.experiencer if rule is not None else None)
+            or match.experiencer
+            or _normalize_experiencer(match.metadata.get("experiencer"))
+        )
+        bias, excluded = _section_bias(match, rule, match_experiencer)
+        if excluded and drop_excluded:
+            continue
+
+        metadata = dict(match.metadata)
+        if section is not None:
+            metadata["section"] = section
+        if match_experiencer is not None:
+            metadata["experiencer"] = match_experiencer
+            metadata["patient_record_eligible"] = match_experiencer == _PATIENT
+            metadata["non_patient"] = match_experiencer != _PATIENT
+        metadata["section_bias"] = bias
+        if excluded:
+            metadata["section_excluded"] = True
+
+        context_score = match.score + bias
+        enriched.append(
+            replace(
+                match,
+                section=section,
+                experiencer=match_experiencer,
+                section_bias=bias,
+                context_score=context_score,
+                metadata=metadata,
+            )
+        )
+
+    enriched.sort(key=_sort_key)
+    return tuple(enriched)

--- a/tests/unit/clinical/grounding/test_calibration.py
+++ b/tests/unit/clinical/grounding/test_calibration.py
@@ -15,12 +15,15 @@ from openmed.clinical.exporters.codeable_concept import (
 from openmed.clinical.grounding import Candidate, grounding_provenance
 from openmed.clinical.grounding.calibration import (
     GroundingCalibrationRecord,
+    GroundingCalibrator,
+    apply_concept_match_calibration,
     apply_grounding_abstention,
     calibrate_grounding,
     evaluate_grounding_coverage_gate,
     fit_grounding_calibrator,
     grounding_calibration_report,
 )
+from openmed.clinical.grounding.matcher import ConceptMatch, LexicalMatcher
 from openmed.eval.metrics import expected_calibration_error, reliability_bins
 from openmed.eval.suites import (
     GROUNDING_CALIBRATION,
@@ -188,3 +191,117 @@ def test_grounding_calibration_suite_reads_local_gold_and_writes_report(
         "offline": True,
         "gold_path": str(gold_path),
     }
+
+
+def test_synthetic_calibration_is_monotonic_comparable_and_improves_raw_ece() -> None:
+    scores: list[dict[str, object]] = []
+    gold: list[bool] = []
+    for system, positives in (("rxnorm", 9), ("hpo", 2)):
+        for index in range(10):
+            scores.append(
+                {
+                    "system": system,
+                    "label": "concept",
+                    "score": 0.80,
+                    "correct": index < positives,
+                }
+            )
+            gold.append(index < positives)
+
+    calibrator = fit_grounding_calibrator(scores)
+    raw_probabilities = [float(row["score"]) for row in scores]
+    calibrated = calibrator.predict_many(scores)
+    raw_ece = expected_calibration_error(
+        reliability_bins(zip(raw_probabilities, gold), n_bins=10)
+    )
+    calibrated_ece = expected_calibration_error(
+        reliability_bins(zip(calibrated, gold), n_bins=10)
+    )
+
+    assert calibrated_ece < raw_ece
+    assert calibrator.predict(system="RXNORM", label="concept", score=0.80) > (
+        calibrator.predict(system="HPO", label="concept", score=0.80)
+    )
+    for system in ("RXNORM", "HPO"):
+        probabilities = [
+            calibrator.predict(system=system, label="concept", score=score)
+            for score in (0.10, 0.80, 1.00)
+        ]
+        assert probabilities == sorted(probabilities)
+
+
+def test_calibrator_config_is_versioned_and_round_trips() -> None:
+    records = [
+        GroundingCalibrationRecord("RXNORM", "DRUG", 0.20, False),
+        GroundingCalibrationRecord("RXNORM", "DRUG", 0.90, True),
+    ]
+    calibrator = fit_grounding_calibrator(records)
+
+    config = calibrator.to_config()
+    restored = GroundingCalibrator.from_config(config)
+
+    assert config["schema_version"] == 1
+    assert config["artifact_type"] == "openmed.grounding.calibrator"
+    assert restored.to_config() == config
+    with pytest.raises(ValueError, match="schema_version"):
+        GroundingCalibrator.from_config({**config, "schema_version": 2})
+
+
+def test_concept_matches_receive_confidence_and_review_state_offline() -> None:
+    system_uri = "https://example.org/fhir/CodeSystem/synthetic-free"
+    training = (
+        ConceptMatch(
+            system_uri=system_uri,
+            code="LOW",
+            display="Low synthetic concept",
+            score=0.20,
+            match_type="normalized",
+            matched_term="low",
+        ),
+        ConceptMatch(
+            system_uri=system_uri,
+            code="HIGH",
+            display="High synthetic concept",
+            score=0.90,
+            match_type="exact",
+            matched_term="high",
+        ),
+    )
+    calibrator = fit_grounding_calibrator(
+        training,
+        [False, True],
+        labels=["concept", "concept"],
+    )
+    matches = (
+        training[0],
+        training[1],
+    )
+
+    calibrated = apply_concept_match_calibration(
+        matches,
+        calibrator,
+        review_threshold=0.75,
+        label="concept",
+    )
+
+    assert calibrated[0].score == pytest.approx(0.20)
+    assert calibrated[0].calibrated_confidence == pytest.approx(0.0)
+    assert calibrated[0].review_required is True
+    assert calibrated[0].needs_review is True
+    assert calibrated[0].abstained is True
+    assert calibrated[1].calibrated_confidence == pytest.approx(1.0)
+    assert calibrated[1].review_required is False
+    assert calibrated[1].calibration["schema_version"] == 1
+
+    matcher = LexicalMatcher(
+        {"High": {"code": "HIGH", "display": "High synthetic concept"}},
+        system_uri=system_uri,
+    )
+    emitted = matcher.lookup(
+        "High",
+        calibrator=calibrator,
+        review_threshold=0.75,
+        label="concept",
+    )
+    assert emitted[0].calibrated_confidence == pytest.approx(1.0)
+    assert emitted[0].review_required is False

--- a/tests/unit/clinical/grounding/test_section_context.py
+++ b/tests/unit/clinical/grounding/test_section_context.py
@@ -1,0 +1,189 @@
+"""Focused tests for section-aware grounding context."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import pytest
+
+from openmed.clinical.grounding import (
+    ConceptMatch,
+    LexicalConcept,
+    LexicalMatcher,
+    SectionContextConfig,
+    apply_section_context,
+)
+
+SYSTEM_URI = "https://example.org/fhir/CodeSystem/synthetic-grounding"
+
+
+def _match(
+    code: str,
+    display: str,
+    semantic_type: str,
+    *,
+    score: float = 1.0,
+) -> ConceptMatch:
+    return ConceptMatch(
+        system_uri=SYSTEM_URI,
+        code=code,
+        display=display,
+        score=score,
+        match_type="exact",
+        matched_term="shared term",
+        metadata={"semantic_type": semantic_type},
+    )
+
+
+def _matcher() -> LexicalMatcher:
+    return LexicalMatcher(
+        {
+            "shared term": [
+                LexicalConcept(
+                    system_uri=SYSTEM_URI,
+                    code="ALLERGEN-1",
+                    display="Synthetic allergen",
+                    metadata={"semantic_type": "allergen"},
+                ),
+                LexicalConcept(
+                    system_uri=SYSTEM_URI,
+                    code="MEDICATION-1",
+                    display="Synthetic medication",
+                    metadata={"semantic_type": "medication"},
+                ),
+            ]
+        }
+    )
+
+
+def test_same_term_is_filtered_to_section_appropriate_concept() -> None:
+    matches = _matcher().lookup("shared term")
+
+    allergies = apply_section_context(matches, ["Allergies"], "patient")
+    medications = apply_section_context(matches, ["Medications"], "patient")
+
+    assert [match.code for match in allergies] == ["ALLERGEN-1"]
+    assert allergies[0].section == "allergies"
+    assert allergies[0].experiencer == "patient"
+    assert [match.code for match in medications] == ["MEDICATION-1"]
+    assert medications[0].section == "medications"
+
+
+def test_family_history_marks_and_downranks_non_patient_concepts() -> None:
+    match = _match("COND-1", "Synthetic family condition", "condition")
+
+    family = apply_section_context((match,), "Family History")
+    patient = apply_section_context((match,), "Assessment", "patient")
+
+    assert family[0].section == "family_history"
+    assert family[0].experiencer == "family"
+    assert family[0].metadata["non_patient"] is True
+    assert family[0].metadata["patient_record_eligible"] is False
+    assert family[0].ranking_score < patient[0].ranking_score
+    assert family[0].context_score is not None
+
+
+def test_section_rules_are_caller_configurable() -> None:
+    rules = SectionContextConfig(
+        {
+            "custom review": {
+                "semantic_type_biases": {"laboratory_test": 0.25},
+                "excluded_semantic_types": ("medication",),
+                "experiencer": "patient",
+            }
+        }
+    )
+    matches = (
+        _match("LAB-1", "Synthetic lab", "laboratory test", score=0.8),
+        _match("MED-1", "Synthetic medication", "medication", score=1.0),
+    )
+
+    result = apply_section_context(matches, "Custom Review", config=rules)
+
+    assert [match.code for match in result] == ["LAB-1"]
+    assert result[0].score == pytest.approx(0.8)
+    assert result[0].ranking_score == pytest.approx(1.05)
+    assert result[0].metadata["section"] == "custom_review"
+
+
+def test_offset_sections_are_selected_per_match_without_copying_source_text() -> None:
+    first = ConceptMatch(
+        system_uri=SYSTEM_URI,
+        code="A",
+        display="Synthetic A",
+        score=1.0,
+        match_type="exact",
+        matched_term="shared term",
+        metadata={"semantic_type": "allergen", "start": 2, "end": 8},
+    )
+    second = ConceptMatch(
+        system_uri=SYSTEM_URI,
+        code="B",
+        display="Synthetic B",
+        score=1.0,
+        match_type="exact",
+        matched_term="shared term",
+        metadata={"semantic_type": "medication", "start": 20, "end": 26},
+    )
+
+    result = apply_section_context(
+        (first, second),
+        (
+            {"label": "Allergies", "start": 0, "end": 10},
+            {"label": "Medications", "start": 10, "end": 30},
+        ),
+    )
+
+    assert [(match.code, match.section) for match in result] == [
+        ("A", "allergies"),
+        ("B", "medications"),
+    ]
+    serialized = asdict(result[0])
+    assert "shared term" not in serialized["metadata"]
+
+
+def test_offset_sections_do_not_claim_matches_outside_their_ranges() -> None:
+    match = ConceptMatch(
+        system_uri=SYSTEM_URI,
+        code="OUTSIDE",
+        display="Synthetic outside concept",
+        score=1.0,
+        match_type="exact",
+        matched_term="shared term",
+        metadata={"semantic_type": "condition", "start": 40, "end": 45},
+    )
+
+    result = apply_section_context(
+        (match,),
+        (
+            {"label": "Allergies", "start": 0, "end": 10},
+            {"label": "Medications", "start": 10, "end": 30},
+        ),
+    )
+
+    assert result[0].section is None
+    assert "section" not in result[0].metadata
+
+
+def test_matcher_applies_context_before_limit() -> None:
+    matches = _matcher().lookup(
+        "shared term",
+        sections="Medications",
+        limit=1,
+    )
+
+    assert [match.code for match in matches] == ["MEDICATION-1"]
+
+
+def test_excluded_matches_can_be_retained_for_audit() -> None:
+    matches = _matcher().lookup("shared term")
+
+    result = apply_section_context(matches, "Allergies", drop_excluded=False)
+
+    by_code = {match.code: match for match in result}
+    assert by_code["MEDICATION-1"].metadata["section_excluded"] is True
+
+
+def test_apply_section_context_rejects_non_match_inputs() -> None:
+    with pytest.raises(TypeError, match="ConceptMatch"):
+        apply_section_context((object(),), "Assessment")

--- a/tests/unit/clinical/grounding/test_section_context.py
+++ b/tests/unit/clinical/grounding/test_section_context.py
@@ -13,6 +13,7 @@ from openmed.clinical.grounding import (
     SectionContextConfig,
     apply_section_context,
 )
+from openmed.clinical.grounding.calibration import fit_grounding_calibrator
 
 SYSTEM_URI = "https://example.org/fhir/CodeSystem/synthetic-grounding"
 
@@ -173,6 +174,31 @@ def test_matcher_applies_context_before_limit() -> None:
     )
 
     assert [match.code for match in matches] == ["MEDICATION-1"]
+
+
+def test_matcher_composes_section_context_and_calibration() -> None:
+    calibrator = fit_grounding_calibrator(
+        (
+            {"system": SYSTEM_URI, "label": "concept", "score": 0.2},
+            {"system": SYSTEM_URI, "label": "concept", "score": 0.9},
+        ),
+        (False, True),
+    )
+
+    match = _matcher().lookup(
+        "shared term",
+        sections="Medications",
+        limit=1,
+        calibrator=calibrator,
+        review_threshold=0.75,
+        label="concept",
+    )[0]
+
+    assert match.code == "MEDICATION-1"
+    assert match.section == "medications"
+    assert match.calibrated_confidence == pytest.approx(1.0)
+    assert match.review_required is False
+    assert match.to_dict()["section"] == "medications"
 
 
 def test_excluded_matches_can_be_retained_for_audit() -> None:


### PR DESCRIPTION
## Included pull requests

- #2233 — Add concept-normalization confidence calibration for grounded codes
- #2234 — Add section-aware grounding context that scopes concept matches by note section

## Issues resolved

Related to #930
Related to #929

## Maintainer integration changes

- Composed section-context ranking with optional confidence calibration before the result limit.
- Included section and experiencer metadata in serialized calibrated matches.
- Added a regression test covering section context and calibration together.

## Validation

- `.venv/bin/python -m pytest tests/unit/clinical/grounding/test_calibration.py tests/unit/clinical/grounding/test_section_context.py -q` — 18 passed.
- `.venv/bin/python -m pytest tests/unit -q` — aggregate release tree: 11,593 passed, 89 skipped.
- `.venv/bin/python -m pytest tests/ -q` — aggregate release tree: 11,710 passed, 96 skipped, 1 xfailed.
- `make format-check`, `make lint`, and `make type-check` — passed on the aggregate release tree.
- The final batch tree is byte-identical to the independently rehearsed grounding tree.