### PR TITLE
feat: add per-language ID and date trap golden fixtures

### DIFF
--- a/openmed/eval/golden/fixtures/per_language_date_traps.json
+++ b/openmed/eval/golden/fixtures/per_language_date_traps.json
@@ -1,0 +1,416 @@
+{
+  "version": 1,
+  "synthetic": true,
+  "fixtures": [
+    {
+      "id": "golden-per-language-date-trap-en",
+      "language": "en",
+      "text": "Synthetic chart: visit on 03/14/2026, follow-up on 07/20/2026, final review on 11/05/2026.",
+      "gold_spans": [
+        {
+          "start": 26,
+          "end": 36,
+          "label": "DATE",
+          "text": "03/14/2026"
+        },
+        {
+          "start": 51,
+          "end": 61,
+          "label": "DATE",
+          "text": "07/20/2026"
+        },
+        {
+          "start": 79,
+          "end": 89,
+          "label": "DATE",
+          "text": "11/05/2026"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "en_US",
+        "expected_output": {
+          "method": "mask",
+          "text": "Synthetic chart: visit on [DATE], follow-up on [DATE], final review on [DATE]."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-fr",
+      "language": "fr",
+      "text": "Dossier synthétique: visite le 14/03/2026, suivi le 20/07/2026, revue finale le 05/11/2026.",
+      "gold_spans": [
+        {
+          "start": 31,
+          "end": 41,
+          "label": "DATE",
+          "text": "14/03/2026"
+        },
+        {
+          "start": 52,
+          "end": 62,
+          "label": "DATE",
+          "text": "20/07/2026"
+        },
+        {
+          "start": 80,
+          "end": 90,
+          "label": "DATE",
+          "text": "05/11/2026"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "fr_FR",
+        "expected_output": {
+          "method": "mask",
+          "text": "Dossier synthétique: visite le [DATE], suivi le [DATE], revue finale le [DATE]."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-de",
+      "language": "de",
+      "text": "Synthetische Akte: Besuch am 14.03.2026, Nachuntersuchung am 20.07.2026, Abschluss am 05.11.2026.",
+      "gold_spans": [
+        {
+          "start": 29,
+          "end": 39,
+          "label": "DATE",
+          "text": "14.03.2026"
+        },
+        {
+          "start": 61,
+          "end": 71,
+          "label": "DATE",
+          "text": "20.07.2026"
+        },
+        {
+          "start": 86,
+          "end": 96,
+          "label": "DATE",
+          "text": "05.11.2026"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "de_DE",
+        "expected_output": {
+          "method": "mask",
+          "text": "Synthetische Akte: Besuch am [DATE], Nachuntersuchung am [DATE], Abschluss am [DATE]."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-it",
+      "language": "it",
+      "text": "Cartella sintetica: visita il 14/03/2026, follow-up il 20/07/2026, revisione finale il 05/11/2026.",
+      "gold_spans": [
+        {
+          "start": 30,
+          "end": 40,
+          "label": "DATE",
+          "text": "14/03/2026"
+        },
+        {
+          "start": 55,
+          "end": 65,
+          "label": "DATE",
+          "text": "20/07/2026"
+        },
+        {
+          "start": 87,
+          "end": 97,
+          "label": "DATE",
+          "text": "05/11/2026"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "it_IT",
+        "expected_output": {
+          "method": "mask",
+          "text": "Cartella sintetica: visita il [DATE], follow-up il [DATE], revisione finale il [DATE]."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-es",
+      "language": "es",
+      "text": "Nota sintética: visita el 14/03/2026, seguimiento el 20/07/2026, revisión final el 05/11/2026.",
+      "gold_spans": [
+        {
+          "start": 26,
+          "end": 36,
+          "label": "DATE",
+          "text": "14/03/2026"
+        },
+        {
+          "start": 53,
+          "end": 63,
+          "label": "DATE",
+          "text": "20/07/2026"
+        },
+        {
+          "start": 83,
+          "end": 93,
+          "label": "DATE",
+          "text": "05/11/2026"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "es_ES",
+        "expected_output": {
+          "method": "mask",
+          "text": "Nota sintética: visita el [DATE], seguimiento el [DATE], revisión final el [DATE]."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-nl",
+      "language": "nl",
+      "text": "Synthetisch dossier: bezoek op 14-03-2026, follow-up op 20-07-2026, eindbeoordeling op 05-11-2026.",
+      "gold_spans": [
+        {
+          "start": 31,
+          "end": 41,
+          "label": "DATE",
+          "text": "14-03-2026"
+        },
+        {
+          "start": 56,
+          "end": 66,
+          "label": "DATE",
+          "text": "20-07-2026"
+        },
+        {
+          "start": 87,
+          "end": 97,
+          "label": "DATE",
+          "text": "05-11-2026"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "nl_NL",
+        "expected_output": {
+          "method": "mask",
+          "text": "Synthetisch dossier: bezoek op [DATE], follow-up op [DATE], eindbeoordeling op [DATE]."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-hi",
+      "language": "hi",
+      "text": "सिंथेटिक चार्ट: दौरा 14/03/2026 को, फॉलो-अप 20/07/2026 को, अंतिम समीक्षा 05/11/2026 को।",
+      "gold_spans": [
+        {
+          "start": 21,
+          "end": 31,
+          "label": "DATE",
+          "text": "14/03/2026"
+        },
+        {
+          "start": 44,
+          "end": 54,
+          "label": "DATE",
+          "text": "20/07/2026"
+        },
+        {
+          "start": 73,
+          "end": 83,
+          "label": "DATE",
+          "text": "05/11/2026"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "hi_IN",
+        "expected_output": {
+          "method": "mask",
+          "text": "सिंथेटिक चार्ट: दौरा [DATE] को, फॉलो-अप [DATE] को, अंतिम समीक्षा [DATE] को।"
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-te",
+      "language": "te",
+      "text": "కృత్రిమ చార్ట్: సందర్శన 14/03/2026 న, ఫాలో-అప్ 20/07/2026 న, అంతిమ సమీక్ష 05/11/2026 న.",
+      "gold_spans": [
+        {
+          "start": 24,
+          "end": 34,
+          "label": "DATE",
+          "text": "14/03/2026"
+        },
+        {
+          "start": 47,
+          "end": 57,
+          "label": "DATE",
+          "text": "20/07/2026"
+        },
+        {
+          "start": 74,
+          "end": 84,
+          "label": "DATE",
+          "text": "05/11/2026"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "en_IN",
+        "expected_output": {
+          "method": "mask",
+          "text": "కృత్రిమ చార్ట్: సందర్శన [DATE] న, ఫాలో-అప్ [DATE] న, అంతిమ సమీక్ష [DATE] న."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-pt",
+      "language": "pt",
+      "text": "Nota sintética: visita em 14/03/2026, retorno em 20/07/2026, revisão final em 05/11/2026.",
+      "gold_spans": [
+        {
+          "start": 26,
+          "end": 36,
+          "label": "DATE",
+          "text": "14/03/2026"
+        },
+        {
+          "start": 49,
+          "end": 59,
+          "label": "DATE",
+          "text": "20/07/2026"
+        },
+        {
+          "start": 78,
+          "end": 88,
+          "label": "DATE",
+          "text": "05/11/2026"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "pt_BR",
+        "expected_output": {
+          "method": "mask",
+          "text": "Nota sintética: visita em [DATE], retorno em [DATE], revisão final em [DATE]."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-ar",
+      "language": "ar",
+      "text": "ملاحظة اصطناعية: زيارة في ١٤/٠٣/٢٠٢٦، متابعة في ٢٠/٠٧/٢٠٢٦، مراجعة نهائية في ٠٥/١١/٢٠٢٦.",
+      "gold_spans": [
+        {
+          "start": 26,
+          "end": 36,
+          "label": "DATE",
+          "text": "١٤/٠٣/٢٠٢٦"
+        },
+        {
+          "start": 48,
+          "end": 58,
+          "label": "DATE",
+          "text": "٢٠/٠٧/٢٠٢٦"
+        },
+        {
+          "start": 77,
+          "end": 87,
+          "label": "DATE",
+          "text": "٠٥/١١/٢٠٢٦"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "ar_EG",
+        "expected_output": {
+          "method": "mask",
+          "text": "ملاحظة اصطناعية: زيارة في [DATE]، متابعة في [DATE]، مراجعة نهائية في [DATE]."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-ja",
+      "language": "ja",
+      "text": "合成メモ: 初診 2026年3月14日、再診 2026-07-20、最終確認 2026年11月5日。",
+      "gold_spans": [
+        {
+          "start": 9,
+          "end": 19,
+          "label": "DATE",
+          "text": "2026年3月14日"
+        },
+        {
+          "start": 23,
+          "end": 33,
+          "label": "DATE",
+          "text": "2026-07-20"
+        },
+        {
+          "start": 39,
+          "end": 49,
+          "label": "DATE",
+          "text": "2026年11月5日"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "ja_JP",
+        "expected_output": {
+          "method": "mask",
+          "text": "合成メモ: 初診 [DATE]、再診 [DATE]、最終確認 [DATE]。"
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-date-trap-tr",
+      "language": "tr",
+      "text": "Sentetik not: ziyaret 14.03.2026, kontrol 20.07.2026, son değerlendirme 05.11.2026.",
+      "gold_spans": [
+        {
+          "start": 22,
+          "end": 32,
+          "label": "DATE",
+          "text": "14.03.2026"
+        },
+        {
+          "start": 42,
+          "end": 52,
+          "label": "DATE",
+          "text": "20.07.2026"
+        },
+        {
+          "start": 72,
+          "end": 82,
+          "label": "DATE",
+          "text": "05.11.2026"
+        }
+      ],
+      "metadata": {
+        "category": "multilingual",
+        "synthetic": true,
+        "locale": "tr_TR",
+        "expected_output": {
+          "method": "mask",
+          "text": "Sentetik not: ziyaret [DATE], kontrol [DATE], son değerlendirme [DATE]."
+        }
+      }
+    }
+  ],
+  "notice": "Synthetic-only golden fixtures for evals; no DUA data and no real PHI.",
+  "suite": "golden"
+}

--- a/openmed/eval/golden/fixtures/per_language_id_traps.json
+++ b/openmed/eval/golden/fixtures/per_language_id_traps.json
@@ -355,7 +355,7 @@
     {
       "id": "golden-per-language-id-trap-ja",
       "language": "ja",
-      "text": "合成メモ: マイナンバー 1234 5678 9012 有効、1234 5678 901 無効（桁数不足）テスト患者。",
+      "text": "合成メモ: マイナンバー 1234 5678 9012 有効、1234/5678/9012 無効（形式不正）テスト患者。",
       "gold_spans": [
         {
           "start": 13,
@@ -375,15 +375,15 @@
         "hard_negatives": [
           {
             "start": 31,
-            "end": 44,
-            "text": "1234 5678 901",
+            "end": 45,
+            "text": "1234/5678/9012",
             "identifier_type": "my_number",
             "reason": "format_mismatch"
           }
         ],
         "expected_output": {
           "method": "mask",
-          "text": "合成メモ: マイナンバー [ID_NUM] 有効、1234 5678 901 無効（桁数不足）テスト患者。"
+          "text": "合成メモ: マイナンバー [ID_NUM] 有効、1234/5678/9012 無効（形式不正）テスト患者。"
         }
       }
     },

--- a/openmed/eval/golden/fixtures/per_language_id_traps.json
+++ b/openmed/eval/golden/fixtures/per_language_id_traps.json
@@ -374,8 +374,8 @@
         "locale": "ja_JP",
         "hard_negatives": [
           {
-            "start": 13,
-            "end": 26,
+            "start": 31,
+            "end": 44,
             "text": "1234 5678 901",
             "identifier_type": "my_number",
             "reason": "format_mismatch"

--- a/openmed/eval/golden/fixtures/per_language_id_traps.json
+++ b/openmed/eval/golden/fixtures/per_language_id_traps.json
@@ -1,0 +1,428 @@
+{
+  "version": 1,
+  "synthetic": true,
+  "fixtures": [
+    {
+      "id": "golden-per-language-id-trap-en",
+      "language": "en",
+      "text": "Synthetic record: valid SSN 123-45-6789, invalid SSN 000-00-0000 for test patient.",
+      "gold_spans": [
+        {
+          "start": 28,
+          "end": 39,
+          "label": "SSN",
+          "text": "123-45-6789",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "ssn"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "en_US",
+        "hard_negatives": [
+          {
+            "start": 53,
+            "end": 64,
+            "text": "000-00-0000",
+            "identifier_type": "ssn",
+            "reason": "fails_checksum"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "Synthetic record: valid SSN [SSN], invalid SSN 000-00-0000 for test patient."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-fr",
+      "language": "fr",
+      "text": "Dossier synthétique: NIR valide 242108708540372, NIR invalide 242108708540373 pour patient fictif.",
+      "gold_spans": [
+        {
+          "start": 32,
+          "end": 47,
+          "label": "ID_NUM",
+          "text": "242108708540372",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "nir"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "fr_FR",
+        "hard_negatives": [
+          {
+            "start": 62,
+            "end": 77,
+            "text": "242108708540373",
+            "identifier_type": "nir",
+            "reason": "fails_checksum"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "Dossier synthétique: NIR valide [ID_NUM], NIR invalide 242108708540373 pour patient fictif."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-de",
+      "language": "de",
+      "text": "Synthetische Akte: Steuer-ID 38449725069 gültig, 12345678901 ungültig für Testperson.",
+      "gold_spans": [
+        {
+          "start": 29,
+          "end": 40,
+          "label": "ID_NUM",
+          "text": "38449725069",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "steuer_id"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "de_DE",
+        "hard_negatives": [
+          {
+            "start": 49,
+            "end": 60,
+            "text": "12345678901",
+            "identifier_type": "steuer_id",
+            "reason": "fails_structure"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "Synthetische Akte: Steuer-ID [ID_NUM] gültig, 12345678901 ungültig für Testperson."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-it",
+      "language": "it",
+      "text": "Cartella sintetica: codice fiscale MNCPNL59L71E221W valido, MNCPNL59L71E2210 invalido per paziente fittizio.",
+      "gold_spans": [
+        {
+          "start": 35,
+          "end": 51,
+          "label": "ID_NUM",
+          "text": "MNCPNL59L71E221W",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "codice_fiscale"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "it_IT",
+        "hard_negatives": [
+          {
+            "start": 60,
+            "end": 76,
+            "text": "MNCPNL59L71E2210",
+            "identifier_type": "codice_fiscale",
+            "reason": "fails_structure"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "Cartella sintetica: codice fiscale [ID_NUM] valido, MNCPNL59L71E2210 invalido per paziente fittizio."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-es",
+      "language": "es",
+      "text": "Nota sintética: DNI 12345678Z válido, DNI 12345678X inválido para paciente ficticio.",
+      "gold_spans": [
+        {
+          "start": 20,
+          "end": 29,
+          "label": "ID_NUM",
+          "text": "12345678Z",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "dni"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "es_ES",
+        "hard_negatives": [
+          {
+            "start": 42,
+            "end": 51,
+            "text": "12345678X",
+            "identifier_type": "dni",
+            "reason": "fails_checksum"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "Nota sintética: DNI [ID_NUM] válido, DNI 12345678X inválido para paciente ficticio."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-nl",
+      "language": "nl",
+      "text": "Synthetisch dossier: BSN 456378923 geldig, BSN 456378924 ongeldig voor testpatiënt.",
+      "gold_spans": [
+        {
+          "start": 25,
+          "end": 34,
+          "label": "ID_NUM",
+          "text": "456378923",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "bsn"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "nl_NL",
+        "hard_negatives": [
+          {
+            "start": 47,
+            "end": 56,
+            "text": "456378924",
+            "identifier_type": "bsn",
+            "reason": "fails_checksum"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "Synthetisch dossier: BSN [ID_NUM] geldig, BSN 456378924 ongeldig voor testpatiënt."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-hi",
+      "language": "hi",
+      "text": "सिंथेटिक नोट: आधार 659676687472 मान्य, आधार 659676687473 अमान्य परीक्षण रोगी के लिए।",
+      "gold_spans": [
+        {
+          "start": 19,
+          "end": 31,
+          "label": "ID_NUM",
+          "text": "659676687472",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "aadhaar"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "hi_IN",
+        "hard_negatives": [
+          {
+            "start": 44,
+            "end": 56,
+            "text": "659676687473",
+            "identifier_type": "aadhaar",
+            "reason": "fails_verhoeff"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "सिंथेटिक नोट: आधार [ID_NUM] मान्य, आधार 659676687473 अमान्य परीक्षण रोगी के लिए।"
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-te",
+      "language": "te",
+      "text": "కృత్రిమ గమనిక: ఆధార్ 691256223921 చెల్లుబాటు, ఆధార్ 691256223922 చెల్లని పరీక్ష రోగి కోసం.",
+      "gold_spans": [
+        {
+          "start": 21,
+          "end": 33,
+          "label": "ID_NUM",
+          "text": "691256223921",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "aadhaar"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "en_IN",
+        "hard_negatives": [
+          {
+            "start": 52,
+            "end": 64,
+            "text": "691256223922",
+            "identifier_type": "aadhaar",
+            "reason": "fails_verhoeff"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "కృత్రిమ గమనిక: ఆధార్ [ID_NUM] చెల్లుబాటు, ఆధార్ 691256223922 చెల్లని పరీక్ష రోగి కోసం."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-pt",
+      "language": "pt",
+      "text": "Nota sintética: CPF 456.378.921-64 válido, CPF 456.378.921-65 inválido para paciente fictício.",
+      "gold_spans": [
+        {
+          "start": 20,
+          "end": 34,
+          "label": "ID_NUM",
+          "text": "456.378.921-64",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "cpf"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "pt_BR",
+        "hard_negatives": [
+          {
+            "start": 47,
+            "end": 61,
+            "text": "456.378.921-65",
+            "identifier_type": "cpf",
+            "reason": "fails_checksum"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "Nota sintética: CPF [ID_NUM] válido, CPF 456.378.921-65 inválido para paciente fictício."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-ar",
+      "language": "ar",
+      "text": "ملاحظة اصطناعية: رقم قومي 29801011234567 صالح، رقم قومي 29813011234567 غير صالح للمريض التجريبي.",
+      "gold_spans": [
+        {
+          "start": 26,
+          "end": 40,
+          "label": "ID_NUM",
+          "text": "29801011234567",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "egyptian_national_id"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "ar_EG",
+        "hard_negatives": [
+          {
+            "start": 56,
+            "end": 70,
+            "text": "29813011234567",
+            "identifier_type": "egyptian_national_id",
+            "reason": "fails_structure"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "ملاحظة اصطناعية: رقم قومي [ID_NUM] صالح، رقم قومي 29813011234567 غير صالح للمريض التجريبي."
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-ja",
+      "language": "ja",
+      "text": "合成メモ: マイナンバー 1234 5678 9012 有効、1234 5678 901 無効（桁数不足）テスト患者。",
+      "gold_spans": [
+        {
+          "start": 13,
+          "end": 27,
+          "label": "ID_NUM",
+          "text": "1234 5678 9012",
+          "metadata": {
+            "checksum_status": "not_validated",
+            "identifier_type": "my_number"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "ja_JP",
+        "hard_negatives": [
+          {
+            "start": 13,
+            "end": 26,
+            "text": "1234 5678 901",
+            "identifier_type": "my_number",
+            "reason": "format_mismatch"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "合成メモ: マイナンバー [ID_NUM] 有効、1234 5678 901 無効（桁数不足）テスト患者。"
+        }
+      }
+    },
+    {
+      "id": "golden-per-language-id-trap-tr",
+      "language": "tr",
+      "text": "Sentetik not: TCKN 13198785260 geçerli, TCKN 13198785261 geçersiz test hastası için.",
+      "gold_spans": [
+        {
+          "start": 19,
+          "end": 30,
+          "label": "ID_NUM",
+          "text": "13198785260",
+          "metadata": {
+            "checksum_status": "valid",
+            "identifier_type": "tckn"
+          }
+        }
+      ],
+      "metadata": {
+        "category": "checksum_ids",
+        "synthetic": true,
+        "locale": "tr_TR",
+        "hard_negatives": [
+          {
+            "start": 45,
+            "end": 56,
+            "text": "13198785261",
+            "identifier_type": "tckn",
+            "reason": "fails_checksum"
+          }
+        ],
+        "expected_output": {
+          "method": "mask",
+          "text": "Sentetik not: TCKN [ID_NUM] geçerli, TCKN 13198785261 geçersiz test hastası için."
+        }
+      }
+    }
+  ],
+  "notice": "Synthetic-only golden fixtures for evals; no DUA data and no real PHI.",
+  "suite": "golden"
+}

--- a/tests/unit/eval/test_golden_fixtures.py
+++ b/tests/unit/eval/test_golden_fixtures.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-import re
 import unicodedata
+from collections.abc import Callable
 from datetime import date
 from pathlib import Path
 
@@ -1552,11 +1552,14 @@ def test_date_arithmetic_fixture_preserves_intervals_after_shift_dates():
         assert shifted in fixture.expected_output["text"]
 
 
-WIRED_LANGUAGES = frozenset(
+# OM-120 freezes the 12-language baseline named in issue #285. The live
+# language registry now includes later packs, so deriving this historical
+# acceptance set from SUPPORTED_LANGUAGES would silently expand the task.
+OM_120_WIRED_LANGUAGES = frozenset(
     {"en", "fr", "de", "it", "es", "nl", "hi", "te", "pt", "ar", "ja", "tr"}
 )
 
-_ID_TRAP_VALIDATORS: dict[str, tuple] = {
+_ID_TRAP_VALIDATORS: dict[str, tuple[Callable[[str], bool], ...]] = {
     "en": (validate_ssn,),
     "fr": (validate_french_nir,),
     "de": (validate_german_steuer_id,),
@@ -1587,12 +1590,19 @@ def _date_trap_fixtures() -> list[GoldenFixture]:
     ]
 
 
+def _mask_gold_spans(fixture: GoldenFixture) -> str:
+    masked = fixture.text
+    for span in sorted(fixture.gold_spans, key=lambda item: item.start, reverse=True):
+        masked = masked[: span.start] + f"[{span.label}]" + masked[span.end :]
+    return masked
+
+
 def test_per_language_id_traps_cover_all_wired_languages():
     fixtures = _id_trap_fixtures()
     languages = {fixture.language for fixture in fixtures}
 
-    assert languages == WIRED_LANGUAGES
-    assert len(fixtures) == len(WIRED_LANGUAGES)
+    assert languages == OM_120_WIRED_LANGUAGES
+    assert len(fixtures) == len(OM_120_WIRED_LANGUAGES)
 
     for fixture in fixtures:
         assert fixture.category == "checksum_ids"
@@ -1611,15 +1621,15 @@ def test_per_language_id_traps_cover_all_wired_languages():
                 f"overlaps gold span [{span.start}:{span.end}]"
             )
         assert fixture.expected_output["method"] == "mask"
-        assert fixture.expected_output["text"]
+        assert fixture.expected_output["text"] == _mask_gold_spans(fixture)
 
 
 def test_per_language_date_traps_cover_all_wired_languages():
     fixtures = _date_trap_fixtures()
     languages = {fixture.language for fixture in fixtures}
 
-    assert languages == WIRED_LANGUAGES
-    assert len(fixtures) == len(WIRED_LANGUAGES)
+    assert languages == OM_120_WIRED_LANGUAGES
+    assert len(fixtures) == len(OM_120_WIRED_LANGUAGES)
 
     for fixture in fixtures:
         assert fixture.category == "multilingual"
@@ -1628,6 +1638,7 @@ def test_per_language_date_traps_cover_all_wired_languages():
         assert len(date_spans) == 3
         assert fixture.expected_output["method"] == "mask"
         assert fixture.expected_output["text"].count("[DATE]") == 3
+        assert fixture.expected_output["text"] == _mask_gold_spans(fixture)
 
 
 def test_per_language_id_traps_invalid_ids_fail_validators():
@@ -1664,27 +1675,36 @@ def test_per_language_traps_recover_through_language_patterns():
     regressions where a language pack's regex stops matching native formats.
     """
     for fixture in [*_id_trap_fixtures(), *_date_trap_fixtures()]:
-        patterns = get_patterns_for_language(fixture.language)
+        units = find_semantic_units(
+            fixture.text,
+            get_patterns_for_language(fixture.language),
+        )
+        recovered = {
+            (
+                start,
+                end,
+                normalize_label(entity_type, fixture.language),
+                fixture.text[start:end],
+            )
+            for start, end, entity_type, _score, _pattern, validated in units
+            if validated
+        }
         for span in fixture.gold_spans:
-            recovered = False
-            for pattern in patterns:
-                for match in re.finditer(pattern.pattern, fixture.text, pattern.flags):
-                    if match.start() != span.start or match.group(0) != span.text:
-                        continue
-                    if normalize_label(pattern.entity_type) != span.label:
-                        continue
-                    if pattern.validator is not None and not pattern.validator(
-                        match.group(0)
-                    ):
-                        continue
-                    recovered = True
-                    break
-                if recovered:
-                    break
-            assert recovered, (
+            assert (span.start, span.end, span.label, span.text) in recovered, (
                 f"{fixture.fixture_id}: span {span.text!r} ({span.label}) "
                 f"at [{span.start}:{span.end}] not recovered by "
                 f"{fixture.language} patterns"
+            )
+
+        for hard_negative in fixture.metadata.get("hard_negatives", []):
+            assert not any(
+                start < hard_negative["end"]
+                and end > hard_negative["start"]
+                and validated
+                for start, end, _entity_type, _score, _pattern, validated in units
+            ), (
+                f"{fixture.fixture_id}: hard negative {hard_negative['text']!r} "
+                "was accepted by a production pattern"
             )
 
 

--- a/tests/unit/eval/test_golden_fixtures.py
+++ b/tests/unit/eval/test_golden_fixtures.py
@@ -1605,6 +1605,11 @@ def test_per_language_id_traps_cover_all_wired_languages():
         assert "start" in hn and "end" in hn
         assert "text" in hn and "identifier_type" in hn and "reason" in hn
         assert fixture.text[hn["start"] : hn["end"]] == hn["text"]
+        for span in fixture.gold_spans:
+            assert not (hn["start"] < span.end and span.start < hn["end"]), (
+                f"{fixture.fixture_id}: hard negative [{hn['start']}:{hn['end']}] "
+                f"overlaps gold span [{span.start}:{span.end}]"
+            )
         assert fixture.expected_output["method"] == "mask"
         assert fixture.expected_output["text"]
 

--- a/tests/unit/eval/test_golden_fixtures.py
+++ b/tests/unit/eval/test_golden_fixtures.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import unicodedata
 from datetime import date
 from pathlib import Path
@@ -16,12 +17,17 @@ from openmed.core.decoding.spans import (
 from openmed.core.labels import CANONICAL_LABELS, normalize_label
 from openmed.core.language_pack import LanguagePack, get_language_pack
 from openmed.core.language_router import LanguageRouter
-from openmed.core.pii_entity_merger import find_semantic_units, validate_luhn
+from openmed.core.pii_entity_merger import (
+    find_semantic_units,
+    validate_luhn,
+    validate_ssn,
+)
 from openmed.core.pii_i18n import (
     INDIC_NER_LANGUAGES,
     LANGUAGE_PII_PATTERNS,
     NATIONAL_ID_ONLY_LANGUAGES,
     SUPPORTED_LANGUAGES,
+    get_patterns_for_language,
     normalize_bengali_assamese_digits,
     normalize_odia_digits,
     validate_aadhaar,
@@ -30,8 +36,13 @@ from openmed.core.pii_i18n import (
     validate_assamese_indian_phone,
     validate_czechoslovak_rodne_cislo,
     validate_danish_cpr,
+    validate_dutch_bsn,
+    validate_egyptian_national_id,
+    validate_french_nir,
+    validate_german_steuer_id,
     validate_hungarian_taj,
     validate_israeli_teudat_zehut,
+    validate_italian_codice_fiscale,
     validate_latvian_personas_kods,
     validate_maharashtra_pin,
     validate_malaysian_mykad,
@@ -44,8 +55,10 @@ from openmed.core.pii_i18n import (
     validate_philsys_psn,
     validate_portuguese_cpf,
     validate_romanian_cnp,
+    validate_spanish_dni,
     validate_tamil_aadhaar,
     validate_tamil_nadu_puducherry_pin,
+    validate_turkish_tckn,
     validate_vietnamese_cccd,
 )
 from openmed.eval import harness
@@ -1537,6 +1550,137 @@ def test_date_arithmetic_fixture_preserves_intervals_after_shift_dates():
     for original, shifted in zip(original_dates, shifted_dates):
         assert original in fixture.text
         assert shifted in fixture.expected_output["text"]
+
+
+WIRED_LANGUAGES = frozenset(
+    {"en", "fr", "de", "it", "es", "nl", "hi", "te", "pt", "ar", "ja", "tr"}
+)
+
+_ID_TRAP_VALIDATORS: dict[str, tuple] = {
+    "en": (validate_ssn,),
+    "fr": (validate_french_nir,),
+    "de": (validate_german_steuer_id,),
+    "it": (validate_italian_codice_fiscale,),
+    "es": (validate_spanish_dni,),
+    "nl": (validate_dutch_bsn,),
+    "hi": (validate_aadhaar,),
+    "te": (validate_aadhaar,),
+    "pt": (validate_portuguese_cpf,),
+    "ar": (validate_egyptian_national_id,),
+    "tr": (validate_turkish_tckn,),
+}
+
+
+def _id_trap_fixtures() -> list[GoldenFixture]:
+    return [
+        fixture
+        for fixture in load_golden_fixtures()
+        if fixture.fixture_id.startswith("golden-per-language-id-trap-")
+    ]
+
+
+def _date_trap_fixtures() -> list[GoldenFixture]:
+    return [
+        fixture
+        for fixture in load_golden_fixtures()
+        if fixture.fixture_id.startswith("golden-per-language-date-trap-")
+    ]
+
+
+def test_per_language_id_traps_cover_all_wired_languages():
+    fixtures = _id_trap_fixtures()
+    languages = {fixture.language for fixture in fixtures}
+
+    assert languages == WIRED_LANGUAGES
+    assert len(fixtures) == len(WIRED_LANGUAGES)
+
+    for fixture in fixtures:
+        assert fixture.category == "checksum_ids"
+        assert fixture.metadata["synthetic"] is True
+        assert len(fixture.gold_spans) >= 1
+        assert fixture.gold_spans[0].label in CANONICAL_LABELS
+        hard_negatives = fixture.metadata.get("hard_negatives", [])
+        assert len(hard_negatives) == 1
+        hn = hard_negatives[0]
+        assert "start" in hn and "end" in hn
+        assert "text" in hn and "identifier_type" in hn and "reason" in hn
+        assert fixture.text[hn["start"] : hn["end"]] == hn["text"]
+        assert fixture.expected_output["method"] == "mask"
+        assert fixture.expected_output["text"]
+
+
+def test_per_language_date_traps_cover_all_wired_languages():
+    fixtures = _date_trap_fixtures()
+    languages = {fixture.language for fixture in fixtures}
+
+    assert languages == WIRED_LANGUAGES
+    assert len(fixtures) == len(WIRED_LANGUAGES)
+
+    for fixture in fixtures:
+        assert fixture.category == "multilingual"
+        assert fixture.metadata["synthetic"] is True
+        date_spans = [span for span in fixture.gold_spans if span.label == "DATE"]
+        assert len(date_spans) == 3
+        assert fixture.expected_output["method"] == "mask"
+        assert fixture.expected_output["text"].count("[DATE]") == 3
+
+
+def test_per_language_id_traps_invalid_ids_fail_validators():
+    """Valid IDs pass their language's checksum validator; invalid hard
+    negatives fail it.  For ``ja`` there is no My Number checksum validator
+    in the repository, so the fixture explicitly uses
+    ``checksum_status="not_validated"`` with a ``format_mismatch`` hard
+    negative instead of a checksum failure.
+    """
+    for fixture in _id_trap_fixtures():
+        lang = fixture.language
+        valid_span = fixture.gold_spans[0]
+        valid_id = valid_span.text
+        hn = fixture.metadata["hard_negatives"][0]
+        invalid_id = hn["text"]
+
+        if lang == "ja":
+            assert valid_span.metadata["checksum_status"] == "not_validated"
+            assert hn["reason"] == "format_mismatch"
+            continue
+
+        validators = _ID_TRAP_VALIDATORS[lang]
+        assert any(v(valid_id) for v in validators), (
+            f"{lang}: valid ID {valid_id!r} should pass at least one validator"
+        )
+        assert all(not v(invalid_id) for v in validators), (
+            f"{lang}: invalid ID {invalid_id!r} should fail all validators"
+        )
+
+
+def test_per_language_traps_recover_through_language_patterns():
+    """Every gold span in the per-language trap fixtures is recovered by the
+    language's PII patterns at the exact recorded offset.  This catches
+    regressions where a language pack's regex stops matching native formats.
+    """
+    for fixture in [*_id_trap_fixtures(), *_date_trap_fixtures()]:
+        patterns = get_patterns_for_language(fixture.language)
+        for span in fixture.gold_spans:
+            recovered = False
+            for pattern in patterns:
+                for match in re.finditer(pattern.pattern, fixture.text, pattern.flags):
+                    if match.start() != span.start or match.group(0) != span.text:
+                        continue
+                    if normalize_label(pattern.entity_type) != span.label:
+                        continue
+                    if pattern.validator is not None and not pattern.validator(
+                        match.group(0)
+                    ):
+                        continue
+                    recovered = True
+                    break
+                if recovered:
+                    break
+            assert recovered, (
+                f"{fixture.fixture_id}: span {span.text!r} ({span.label}) "
+                f"at [{span.start}:{span.end}] not recovered by "
+                f"{fixture.language} patterns"
+            )
 
 
 def _one(category: str) -> GoldenFixture:


### PR DESCRIPTION
## Summary

- Adds one synthetic national-ID-trap fixture per wired language (en, fr, de, it, es, nl, hi, te, pt, ar, ja, tr) under `openmed/eval/golden/fixtures/per_language_id_traps.json`, each containing a valid identifier with a gold span and an invalid checksum/structure variant recorded as a hard negative with explicit offsets.
- Adds one synthetic native-date-format fixture per wired language under `openmed/eval/golden/fixtures/per_language_date_traps.json`, each containing three locale-specific dates (e.g. pt-BR DD/MM/YYYY, de DD.MM.YYYY, ar Eastern-Arabic numerals, ja native-kanji + Western) with gold spans and masked expected output.
- Adds four regression tests to `tests/unit/eval/test_golden_fixtures.py` asserting per-language coverage, valid/invalid validator semantics, and that every gold span is recovered by the production language patterns at the exact recorded offset.
- Reuses the existing golden fixture format and loader; no loader modification, no new validator implementation.

Closes #285 — Expand the multilingual golden regression fixtures with per-language ID and date traps

## What was changed and why

OM-019 committed one multilingual golden fixture per wired language, enough to assert each language has coverage but not enough to catch per-language regressions on locale-specific identifiers and date formats. A regression in one language's surrogate or date handling could pass undetected because the golden suite under-exercised each locale's national-ID checksum types and native date formats.

This PR extends `openmed/eval/golden/fixtures/` with two new fixture files that give each of the 12 wired languages its own ID-trap and date-trap coverage, using the existing golden fixture format and loader.

### ID traps (`per_language_id_traps.json`)

- Category: `checksum_ids` (matches existing `checksum_ids.json` precedent).
- 12 fixtures, one per wired language.
- Each fixture contains one valid identifier as a gold span with `checksum_status` and `identifier_type` metadata, plus one invalid variant as a `hard_negatives` entry with explicit `start`/`end` offsets, `text`, `identifier_type`, and `reason`.
- Identifier types follow existing repository mappings: en→SSN, fr→NIR, de→Steuer-ID, it→codice fiscale, es→DNI, nl→BSN, hi/te→Aadhaar, pt→CPF, ar→Egyptian national ID, tr→TCKN.
- Invalid variants differ in the way appropriate to each validator: checksum failure (en, fr, es, nl, pt, tr), Verhoeff failure (hi, te), structure failure (de digit-frequency rule, it check-character position, ar invalid month).
- Expected post-action output uses `method: "mask"` with the valid identifier replaced by its canonical label.

### Japanese My Number limitation

Because the repository has no My Number checksum validator, the Japanese fixture uses `checksum_status: "not_validated"` for the valid span and a `format_mismatch` hard negative (valid 12-digit form vs unsupported slash-separated form) rather than pretending a format mismatch is equivalent to a checksum failure. The test explicitly asserts `checksum_status == "not_validated"` and `reason == "format_mismatch"` and skips the validator check for `ja`.

The Japanese hard-negative offsets were corrected after initial review: the malformed occurrence is at `[31:45]`, disjoint from the valid gold span at `[13:27]`. The ID-trap coverage test enforces that every hard-negative span is disjoint from every gold span in the same fixture.

### Date traps (`per_language_date_traps.json`)

- Category: `multilingual`.
- 12 fixtures, one per wired language.
- Each fixture contains exactly three native-format dates as gold spans, with expected output masking each as `[DATE]`.
- Native formats exercised: en MM/DD/YYYY, fr/it/es/pt DD/MM/YYYY, de/tr DD.MM.YYYY, nl DD-MM-YYYY, ar Eastern-Arabic numerals (١٤/٠٣/٢٠٢٦), ja native kanji format (2026年3月14日) alongside Western ISO (2026-07-20).
- hi and te use DD/MM/YYYY, consistent with existing `i18n/hi.jsonl` and `i18n/te.jsonl` locale conventions.

## Regression tests

Four tests added to `tests/unit/eval/test_golden_fixtures.py`:

1. **`test_per_language_id_traps_cover_all_wired_languages`** — asserts all 12 wired languages are present, category is `checksum_ids`, fixtures are synthetic, each has at least one gold span with a canonical label, exactly one hard negative with valid offsets disjoint from all gold spans, and masked expected output.

2. **`test_per_language_date_traps_cover_all_wired_languages`** — asserts all 12 languages present, category is `multilingual`, exactly three DATE gold spans per fixture, and exactly three `[DATE]` masks in expected output.

3. **`test_per_language_id_traps_invalid_ids_fail_validators`** — independently runs each language's production validator against the fixture's valid and invalid identifiers. Asserts the valid ID passes at least one validator and the invalid ID fails all validators. Handles `ja` separately by asserting `not_validated` status and `format_mismatch` reason without invoking a checksum validator.

4. **`test_per_language_traps_recover_through_language_patterns`** — runs the production semantic matcher for each fixture, verifies every gold span is recovered at the exact recorded offset, and verifies every hard negative remains unaccepted under all PII labels. This catches both missed detections and cross-label false positives.

## Verification

- `pytest tests/unit/eval/test_golden_fixtures.py -q`: 48 passed.
- `pytest tests/ -q`: 11702 passed, 103 skipped, 1 xfailed, 1 failed.
- The single full-suite failure (`test_license_policy.py`) is pre-existing and unrelated to OM-120; the identical Dagster license-resolution failure was independently reproduced on untouched `origin/master`.
- `ruff format --check`: clean.
- `ruff check`: clean.
- The Japanese hard-negative correction was verified: valid gold span `[13:27]`, malformed hard negative `[31:45]`, no overlap and no accepted production match.
- The hard-negative regression was verified to reject values accepted under any production PII label, not only their intended national-ID validator.

## Change type

- [x] test
- [x] eval fixtures