### PR TITLE
feat: integrate v2.2 data-processing adapters

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -191,6 +191,7 @@ classification:
     - integrations/ray-map-batches.md
     - integrations/sqlalchemy.md
     - duckdb-deidentification.md
+    - integrations/distributed-sql-udf.md
     - spark-deidentification.md
     - prefect-integration.md
     - spacy-component.md

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -188,6 +188,7 @@ classification:
     - integrations/lakehouse-redaction.md
     - integrations/dask.md
     - integrations/pandas-on-spark.md
+    - integrations/ray-map-batches.md
     - integrations/sqlalchemy.md
     - duckdb-deidentification.md
     - spark-deidentification.md

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -181,6 +181,7 @@ classification:
     - security/no-raw-phi-logging.md
     - security/tamper-evident-audit-log.md
     - integrations-langchain.md
+    - integrations/arrow-flight.md
     - integrations-haystack.md
     - integrations-llamaindex.md
     - integrations/columnar-redactor.md

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -186,6 +186,7 @@ classification:
     - integrations/columnar-redactor.md
     - integrations/lakehouse-redaction.md
     - integrations/dask.md
+    - integrations/pandas-on-spark.md
     - integrations/sqlalchemy.md
     - duckdb-deidentification.md
     - spark-deidentification.md

--- a/docs/integrations/arrow-flight.md
+++ b/docs/integrations/arrow-flight.md
@@ -1,0 +1,90 @@
+# Arrow Flight De-identification
+
+OpenMed's Arrow Flight integration accepts a stream of Arrow record batches,
+de-identifies one configured string column, and returns each redacted batch as
+soon as it is processed. The service preserves the input schema, row count,
+nulls, and every non-target column. It never materializes the complete stream.
+
+Install the optional columnar dependency:
+
+```bash
+uv pip install -e ".[columnar]"
+```
+
+## Start a Server
+
+```python
+from openmed.integrations.arrow_flight import (
+    ArrowFlightDeidentificationServer,
+)
+
+server = ArrowFlightDeidentificationServer(
+    "grpc://127.0.0.1:8815",
+    batch_size=512,
+)
+server.serve()
+```
+
+`ArrowFlightDeidentificationServer` uses OpenMed's PII model and
+`process_batch(operation="deidentify")` by default. You can set server-wide
+defaults with `text_column=` and `policy=`, or select them per exchange in the
+Flight command descriptor.
+
+## Exchange Record Batches
+
+```python
+import pyarrow as pa
+import pyarrow.flight as flight
+
+from openmed.integrations.arrow_flight import make_deidentify_descriptor
+
+client = flight.connect("grpc://127.0.0.1:8815")
+descriptor = make_deidentify_descriptor(
+    "clinical_note",
+    policy="hipaa_safe_harbor",
+)
+writer, reader = client.do_exchange(descriptor)
+
+schema = pa.schema(
+    [
+        ("record_id", pa.int64()),
+        ("clinical_note", pa.string()),
+        ("status", pa.string()),
+    ]
+)
+writer.begin(schema)
+
+for input_batch in source_batches:
+    writer.write_batch(input_batch)
+    output_batch = reader.read_chunk().data
+    consume(output_batch)
+
+writer.done_writing()
+```
+
+The helper creates a versioned JSON `FlightDescriptor` command. For
+`DoExchange`, the descriptor is the request-metadata channel; its policy takes
+precedence over a server default. Keeping configuration in the descriptor lets
+one server apply different OpenMed policy profiles without mixing raw clinical
+cells into RPC metadata.
+
+## Privacy and Streaming Contract
+
+- Each incoming `RecordBatch` is passed to `process_batch` and returned before
+  the server reads the entire stream.
+- Only the target string column is converted to Python values for redaction.
+  All other Arrow arrays are passed through unchanged.
+- Response batches retain the input schema and number of rows, including null
+  placement.
+- The service does not log raw or redacted cell values. Errors identify only
+  the column and row position.
+- The command descriptor must not contain patient data. It is only for the
+  text-column name, policy name, and descriptor version.
+
+## Authentication and TLS Hooks
+
+The server constructor forwards Arrow Flight's `auth_handler`,
+`tls_certificates`, `verify_client`, `root_certificates`, and `middleware`
+options. These are deployment hooks, not a complete security policy. Production
+operators remain responsible for certificate management, authentication design,
+network isolation, and authorization.

--- a/docs/integrations/distributed-sql-udf.md
+++ b/docs/integrations/distributed-sql-udf.md
@@ -1,0 +1,90 @@
+# Distributed SQL De-identification UDF
+
+OpenMed provides a Python entrypoint for distributed SQL UDF bridges that
+execute code inside worker processes. The SQL function is logically scalar:
+
+```sql
+openmed_deidentify(text VARCHAR, profile VARCHAR) -> VARCHAR
+```
+
+The Python bridge should invoke that function in vectorized mode. Each worker
+keeps one lazy OpenMed model loader and sends row windows through
+`process_batch`, avoiding one model initialization and one inference call per
+row. OpenMed does not ship a compiled engine plugin JAR; provisioning and
+securing the engine-specific Python bridge remains an operator responsibility.
+
+## Registration descriptor
+
+The engine-neutral descriptor is available as
+`OPENMED_DEIDENTIFY_DESCRIPTOR`:
+
+```python
+from openmed.integrations.distributed_sql_udf import (
+    OPENMED_DEIDENTIFY_DESCRIPTOR,
+)
+
+descriptor = OPENMED_DEIDENTIFY_DESCRIPTOR
+```
+
+Its registration fields are:
+
+```yaml
+name: openmed_deidentify
+language: python
+entrypoint: openmed.integrations.distributed_sql_udf:deidentify_batch
+arguments:
+  - name: text
+    sql_type: VARCHAR
+    python_batch: texts
+  - name: profile
+    sql_type: VARCHAR
+    python_batch: profiles
+return_type: VARCHAR
+vectorized: true
+null_handling: called_on_null_input
+default_batch_size: 64
+```
+
+Map the descriptor to the equivalent fields in the engine's Python UDF
+registration system. In particular, configure the bridge to pass arrays of
+`text` and `profile` values to `deidentify_batch`; the returned array aligns
+one-to-one with the input rows. SQL `NULL` stays `NULL`, and an empty string
+stays empty without loading the model.
+
+## Worker lifecycle
+
+For direct integration or an offline registration test, construct the callable
+once during worker setup and reuse it for every vector window:
+
+```python
+from openmed.integrations.distributed_sql_udf import (
+    DistributedSQLDeidentifyUDF,
+    DistributedSQLUDFConfig,
+)
+
+openmed_deidentify = DistributedSQLDeidentifyUDF(
+    config=DistributedSQLUDFConfig(
+        default_profile="hipaa_safe_harbor",
+        batch_size=64,
+    )
+)
+
+redacted = openmed_deidentify(
+    [
+        "Patient Jane Roe has hypertension.",
+        None,
+        "",
+    ],
+    ["hipaa_safe_harbor", None, "hipaa_safe_harbor"],
+)
+```
+
+The module-level `deidentify_batch` entrypoint uses the same process-local
+worker pattern automatically. `deidentify(text, profile)` is also available
+for scalar-only bridges, but a bridge that calls Python once per row cannot
+benefit from vector batching.
+
+Install the OpenMed model artifact on every worker before accepting queries if
+the deployment must remain fully offline. Raw input text is not logged by this
+adapter; engine query logs, failure capture, and spill configuration should be
+reviewed separately so they do not retain PHI.

--- a/docs/integrations/pandas-on-spark.md
+++ b/docs/integrations/pandas-on-spark.md
@@ -1,0 +1,57 @@
+# Pandas-on-Spark De-identification
+
+OpenMed registers pandas-on-Spark DataFrame and Series accessors so existing
+Pandas-style workflows can redact free-text columns without switching to a
+row-at-a-time Spark UDF.
+
+Install the optional Spark extra:
+
+```bash
+pip install "openmed[spark]"
+```
+
+Import the integration once to register the `.deid` accessors:
+
+```python
+import pyspark.pandas as ps
+import openmed.integrations.pandas_on_spark  # registers the accessors
+
+records = ps.DataFrame(
+    {
+        "record_id": ["a", "b"],
+        "clinical_note": [
+            "Patient Jane Roe called 555-0100.",
+            "Follow-up contains no identifiers.",
+        ],
+    }
+)
+
+redacted = records.deid.deidentify(
+    columns="clinical_note",
+    policy="hipaa_safe_harbor",
+)
+print(redacted.to_pandas())
+```
+
+The DataFrame method has the same public signature as the local Pandas
+accessor: pass one column name or a sequence through `columns`, select a
+`method`, and optionally set a policy profile. Extra de-identification options,
+including `model_name`, `confidence_threshold`, and language settings, are
+forwarded to OpenMed's batch processor.
+
+Series use the same distributed path:
+
+```python
+notes = records["clinical_note"].deid.deidentify(
+    policy="strict_no_leak",
+    use_safety_sweep=True,
+)
+```
+
+Under the hood, pandas-on-Spark sends Arrow row groups through a pandas UDF.
+OpenMed calls `process_batch` once for each row group and reuses a worker-local
+model loader, so the model backbone is not loaded once per row. The integration
+does not log source text or emit raw PHI in progress metadata.
+
+This accessor is for the pandas API on Spark. Use the Structured Streaming
+helpers for streaming sinks, or the Dask accessor for Dask DataFrames.

--- a/docs/integrations/ray-map-batches.md
+++ b/docs/integrations/ray-map-batches.md
@@ -1,0 +1,96 @@
+# Ray Data map-batches de-identification
+
+OpenMed provides a stateful `Dataset.map_batches` stage for distributed,
+columnar de-identification. Ray runs the callable class in an actor pool, and
+each actor loads one OpenMed model pipeline in its constructor and reuses that
+pipeline for every batch it processes.
+
+Install OpenMed's model dependencies and Ray Data:
+
+```bash
+pip install "openmed[hf]" "ray[data]"
+```
+
+## Apply the stage
+
+Choose the free-text column explicitly. Non-target columns, null values, batch
+row counts, and the dataset's total row count pass through unchanged.
+
+```python
+import ray
+
+from openmed.integrations.ray_map_batches import map_batches_deidentify
+
+ray.init()
+
+records = ray.data.from_items(
+    [
+        {"record_id": "a", "clinical_note": "Patient Jane Roe called."},
+        {"record_id": "b", "clinical_note": "No identifiers here."},
+    ]
+)
+
+redacted = map_batches_deidentify(
+    records,
+    column="clinical_note",
+    policy_profile="hipaa_safe_harbor",
+    batch_size=256,
+    batch_format="pyarrow",
+    concurrency=4,
+)
+
+redacted.write_parquet("/secure/output/redacted-notes")
+```
+
+The returned dataset is lazy. A terminal operation such as `write_parquet`,
+`materialize`, or `take_all` starts execution.
+
+## Actor pool and batch format
+
+`concurrency=4` creates a fixed pool of four model actors. Use `(minimum,
+maximum)` for an autoscaling pool, or `(minimum, maximum, initial)` to set its
+initial size as well:
+
+```python
+redacted = map_batches_deidentify(
+    records,
+    column="clinical_note",
+    policy_profile="strict_no_leak",
+    batch_size=512,
+    batch_format="pandas",
+    concurrency=(1, 8, 2),
+    num_cpus=2,
+)
+```
+
+Supported batch formats are `"pyarrow"` and `"pandas"`. The stage copies the
+batch before replacing the target column, leaving Ray's zero-copy input buffers
+untouched. `num_cpus`, `num_gpus`, and other Ray worker resource arguments are
+forwarded to `Dataset.map_batches`.
+
+## Use the callable class directly
+
+For custom Ray Data plans, pass `RayDeidentifyBatch` to `map_batches`. A class
+UDF is important here: a function UDF is stateless and would not retain the
+loaded model between calls.
+
+```python
+from ray.data import ActorPoolStrategy
+
+from openmed.integrations.ray_map_batches import RayDeidentifyBatch
+
+redacted = records.map_batches(
+    RayDeidentifyBatch,
+    batch_size=256,
+    batch_format="pyarrow",
+    compute=ActorPoolStrategy(size=4),
+    fn_constructor_kwargs={
+        "column": "clinical_note",
+        "policy_profile": "hipaa_safe_harbor",
+    },
+)
+```
+
+Ray's object store and worker processes temporarily hold the input batches.
+Deploy this stage only on a trusted, access-controlled cluster appropriate for
+the sensitivity of the source data, and write results only to approved storage.

--- a/examples/dataflow/README.md
+++ b/examples/dataflow/README.md
@@ -1,0 +1,56 @@
+# Dataflow bundle processor
+
+OpenMed's Apache Beam transform de-identifies a configured field in bounded
+batches and reuses one resident processor for each worker-side `DoFn` instance.
+It uses `BatchElements` rather than grouping on record content, so PHI and
+quasi-identifiers never become shuffle or partition keys.
+
+Install Apache Beam alongside OpenMed, then run the same graph locally with
+Beam's DirectRunner before submitting it to Dataflow:
+
+```bash
+pip install --upgrade "openmed" "apache-beam>=2.60,<3"
+```
+
+The integration is tested with Python 3.10-3.12. Apache Beam remains a separate
+runtime dependency so it does not enlarge OpenMed's core dependency surface.
+
+```python
+import apache_beam as beam
+
+from openmed.integrations.dataflow_processor import DataflowBatchProcessor
+
+records = [
+    {
+        "record_id": "synthetic-001",
+        "note": "Patient Jane Roe called 555-0101.",
+        "facility": "example-clinic",
+    }
+]
+
+with beam.Pipeline(runner="DirectRunner") as pipeline:
+    outputs = (
+        pipeline
+        | "Create records" >> beam.Create(records)
+        | "De-identify notes"
+        >> DataflowBatchProcessor(
+            text_field="note",
+            policy="hipaa_safe_harbor",
+            batch_size=32,
+        )
+    )
+    cleaned = outputs.cleaned
+    dead_letters = outputs.dead_letter
+```
+
+`cleaned` contains copies with only the configured field replaced.
+`dead_letters` contains `DataflowDeadLetter` values with the original element
+and a PHI-free reason code. Route that collection to a protected sink; do not
+log or publish it. Empty strings pass through unchanged, while `None` elements,
+missing fields, null fields, non-string fields, batch failures, and malformed
+batch results go to the dead-letter output without failing the bundle.
+
+The default processor uses OpenMed's batched de-identification path with one
+resident `BatchProcessor` created during Beam `DoFn.setup()`. Dataflow may create
+multiple `DoFn` instances for parallelism or worker recycling, so model setup is
+once per instance rather than once for the entire job.

--- a/examples/executable-udf/README.md
+++ b/examples/executable-udf/README.md
@@ -1,0 +1,88 @@
+# Executable UDF column redaction
+
+OpenMed can run as a one-column `TabSeparated` transform for ClickHouse-style
+executable user-defined functions. Each input row on stdin produces exactly one
+redacted output row on stdout, in the same order. The adapter buffers rows and
+reuses one model loader across batches; it never writes raw values to logs or
+diagnostics.
+
+Install OpenMed and cache the selected PII model before enabling the function.
+The database host can then run with `OPENMED_OFFLINE=1` so query-time inference
+does not require network access.
+
+## Run the adapter directly
+
+The package installs a dedicated console entrypoint:
+
+```bash
+printf 'Patient Jane Roe called 555-0100\n' \
+  | OPENMED_OFFLINE=1 openmed-executable-udf --batch-size 32
+```
+
+Output is one escaped TSV string per row:
+
+```text
+Patient [NAME] called [PHONE]
+```
+
+Use `--policy`, `--method`, `--model-name`, `--lang`, and
+`--confidence-threshold` to select the same de-identification behavior used by
+the Python API. The default safety sweep stays enabled.
+
+## Register the ClickHouse function
+
+ClickHouse searches direct executable commands under its configured
+`user_scripts_path`. Create `/var/lib/clickhouse/user_scripts/openmed-redact`
+with an absolute path to the environment where OpenMed is installed:
+
+```sh
+#!/bin/sh
+export OPENMED_OFFLINE=1
+exec /opt/openmed/.venv/bin/openmed-executable-udf "$@"
+```
+
+Make the wrapper executable, readable only as appropriate for the ClickHouse
+service account, and test it as that account. Then add
+`/etc/clickhouse-server/openmed_redact_function.xml`:
+
+```xml
+<functions>
+    <function>
+        <type>executable</type>
+        <name>openmed_redact</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>String</type>
+            <name>text</name>
+        </argument>
+        <format>TabSeparated</format>
+        <command>openmed-redact --batch-size 32</command>
+        <execute_direct>true</execute_direct>
+        <send_chunk_header>false</send_chunk_header>
+        <command_read_timeout>120000</command_read_timeout>
+        <command_write_timeout>120000</command_write_timeout>
+        <stderr_reaction>throw</stderr_reaction>
+        <check_exit_code>true</check_exit_code>
+    </function>
+</functions>
+```
+
+Ensure the server's `user_defined_executable_functions_config` pattern matches
+that XML filename, reload the configuration, and confirm the function is
+available before using it:
+
+```sql
+SELECT name, origin
+FROM system.functions
+WHERE name = 'openmed_redact';
+
+SELECT openmed_redact(note_text)
+FROM synthetic_notes;
+```
+
+The adapter expects exactly one non-nullable `String` argument serialized as
+`TabSeparated`. It rejects extra TSV columns and fails the query when batch
+redaction cannot return exactly one valid result for every input row.
+
+See the [ClickHouse executable UDF documentation](https://clickhouse.com/docs/sql-reference/functions/udf#executable-user-defined-functions)
+for server paths, configuration reload behavior, and executable settings.

--- a/examples/search-ingest/README.md
+++ b/examples/search-ingest/README.md
@@ -1,0 +1,72 @@
+# Search-ingest inline redaction sidecar
+
+This example places an OpenMed HTTP processor in front of an
+Elasticsearch/OpenSearch-style indexing path. The processor receives the full
+ingest-document envelope, redacts only configured string fields in `_source`,
+and returns the same envelope for the indexing client or gateway to forward.
+
+All processing stays local after the selected OpenMed model is downloaded. Do
+not enable request-body logging in the sidecar, reverse proxy, or indexing
+gateway because ingest documents can contain PHI.
+
+## Start the processor
+
+Install the service extra and bind to loopback for local development:
+
+```bash
+uv pip install --upgrade "openmed[service]"
+uvicorn openmed.integrations.search_ingest_processor:app \
+  --host 127.0.0.1 --port 8090
+```
+
+Use authenticated TLS between the indexing gateway and sidecar in any remote
+deployment. The example service intentionally does not add a second auth model;
+deploy it on a private network boundary controlled by the gateway.
+
+## Configure a pipeline
+
+[`pipeline.json`](pipeline.json) is a vendor-neutral gateway manifest. It:
+
+1. registers the `openmed-inline-redaction` HTTP processor;
+2. configures the nested `_source` fields and policy profile for that pipeline;
+3. routes `clinical-documents-*` index actions through the processor.
+
+Load or translate this manifest in the indexing client, proxy, or ingest gateway
+that owns the route. Elasticsearch and OpenSearch run their built-in ingest
+processors inside the cluster and do not provide one portable arbitrary-HTTP
+processor definition. Therefore, do not submit this manifest directly to
+`_ingest/pipeline`; doing so would require a cluster-specific plugin, which is
+outside this example's scope.
+
+Field paths are relative to `_source`. Explicit envelope paths such as
+`_source.clinical.note` are also supported. A missing path, a non-string value,
+or an empty string is left unchanged. Each request supplies its pipeline policy,
+so multiple routes can use different OpenMed profiles with the same sidecar.
+
+## Request contract
+
+The pipeline sends the document envelope plus its configured fields and policy:
+
+```bash
+curl --fail-with-body http://127.0.0.1:8090/process \
+  -H 'Content-Type: application/json' \
+  --data-binary @- <<'JSON'
+{
+  "document": {
+    "_index": "clinical-documents-2026",
+    "_id": "synthetic-001",
+    "_source": {
+      "clinical": {"note": "Synthetic patient Jane Roe called 555-0100."},
+      "patient": {"summary": "Synthetic follow-up note."},
+      "status": "open"
+    },
+    "_ingest": {"timestamp": "2026-07-19T00:00:00Z"}
+  },
+  "fields": ["clinical.note", "patient.summary"],
+  "policy": "hipaa_safe_harbor"
+}
+JSON
+```
+
+The response is the modified document itself, not a second wrapper. `_index`,
+`_id`, `_routing`, `_ingest`, and all non-target `_source` values are preserved.

--- a/examples/search-ingest/pipeline.json
+++ b/examples/search-ingest/pipeline.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "processors": [
+    {
+      "id": "openmed-inline-redaction",
+      "type": "http",
+      "request": {
+        "method": "POST",
+        "url": "http://127.0.0.1:8090/process",
+        "timeout_seconds": 30,
+        "body": {
+          "document": "${document}",
+          "fields": [
+            "clinical.note",
+            "patient.summary"
+          ],
+          "policy": "hipaa_safe_harbor"
+        }
+      },
+      "response_document": "$"
+    }
+  ],
+  "pipeline": {
+    "id": "openmed-inline-redaction-v1",
+    "processors": [
+      "openmed-inline-redaction"
+    ]
+  },
+  "routes": [
+    {
+      "index_pattern": "clinical-documents-*",
+      "pipeline": "openmed-inline-redaction-v1"
+    }
+  ]
+}

--- a/examples/stream-processor/README.md
+++ b/examples/stream-processor/README.md
@@ -1,0 +1,52 @@
+# Stream processor record de-identification
+
+OpenMed's framework-neutral stream helpers make record-level de-identification
+easy to place between a source and sink. The map function copies every record,
+redacts only the configured free-text field, and sends text to
+`openmed.processing.process_batch` in bounded micro-batches. Its `open()`
+lifecycle is idempotent, so one resident processor is reused by each parallel
+subtask.
+
+This offline job uses synthetic records and a list-backed sink. It exercises the
+same `open`/`map_batch`/`invoke` lifecycle that a cluster adapter can call, but
+does not require a stream-processing cluster:
+
+```python
+from openmed.integrations.stream_processor import (
+    StreamDeidentifyMapFunction,
+    StreamSink,
+    run_stream_job,
+)
+
+source = [
+    {
+        "event_id": "evt-2",
+        "note": "Patient Jane Roe called 555-0101",
+        "facility": "synthetic-clinic",
+    },
+    {
+        "event_id": "evt-1",  # out-of-order records are safe
+        "note": "Patient Jane Roe called 555-0101",  # duplicates are safe
+        "facility": "synthetic-clinic",
+    },
+]
+
+mapper = StreamDeidentifyMapFunction(
+    text_field="note",
+    policy="hipaa_safe_harbor",
+    batch_size=32,
+)
+redacted_records = []
+sink = StreamSink(redacted_records.append)
+
+written = run_stream_job(source, mapper, sink)
+assert written == 2
+assert source[0]["note"] == "Patient Jane Roe called 555-0101"
+assert redacted_records[0]["facility"] == "synthetic-clinic"
+assert "Jane Roe" not in redacted_records[0]["note"]
+```
+
+For a parallel runtime, construct one `StreamDeidentifyMapFunction` per subtask,
+call `open(runtime_context)` during subtask initialization, pass record groups to
+`map_batch`, and forward each returned record to `StreamSink.invoke`. Do not
+share one map-function instance between concurrent subtasks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
       - Lakehouse Table Redaction: integrations/lakehouse-redaction.md
       - Dask DataFrame De-identification: integrations/dask.md
       - Pandas-on-Spark De-identification: integrations/pandas-on-spark.md
+      - Ray Data Batch De-identification: integrations/ray-map-batches.md
       - SQLAlchemy Write-time Redaction: integrations/sqlalchemy.md
       - DuckDB De-identification UDFs: duckdb-deidentification.md
       - PySpark De-identification UDFs: spark-deidentification.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - No-Raw-PHI Logging: security/no-raw-phi-logging.md
       - Tamper-evident Audit Log: security/tamper-evident-audit-log.md
       - LangChain Redaction Wrapper: integrations-langchain.md
+      - Arrow Flight De-identification: integrations/arrow-flight.md
       - Haystack Redaction Component: integrations-haystack.md
       - LlamaIndex Redaction Postprocessor: integrations-llamaindex.md
       - Columnar Redactor: integrations/columnar-redactor.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
       - Ray Data Batch De-identification: integrations/ray-map-batches.md
       - SQLAlchemy Write-time Redaction: integrations/sqlalchemy.md
       - DuckDB De-identification UDFs: duckdb-deidentification.md
+      - Distributed SQL De-identification UDF: integrations/distributed-sql-udf.md
       - PySpark De-identification UDFs: spark-deidentification.md
       - Prefect Batch De-identification: prefect-integration.md
       - spaCy Pipeline Component: spacy-component.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
       - Columnar Redactor: integrations/columnar-redactor.md
       - Lakehouse Table Redaction: integrations/lakehouse-redaction.md
       - Dask DataFrame De-identification: integrations/dask.md
+      - Pandas-on-Spark De-identification: integrations/pandas-on-spark.md
       - SQLAlchemy Write-time Redaction: integrations/sqlalchemy.md
       - DuckDB De-identification UDFs: duckdb-deidentification.md
       - PySpark De-identification UDFs: spark-deidentification.md

--- a/openmed/integrations/__init__.py
+++ b/openmed/integrations/__init__.py
@@ -43,6 +43,14 @@ from .spark_streaming import (
     deidentify_write_stream,
     write_deidentified_stream,
 )
+from .stream_processor import (
+    DEFAULT_STREAM_BATCH_SIZE,
+    DEFAULT_STREAM_POLICY,
+    DeidentifyMapFunction,
+    StreamDeidentifyMapFunction,
+    StreamSink,
+    run_stream_job,
+)
 
 __all__ = [
     "ColumnarProgress",
@@ -52,6 +60,9 @@ __all__ = [
     "DEFAULT_LOG_REDACTION_MODEL",
     "DEFAULT_BATCH_ID_COLUMN",
     "DEFAULT_SPARK_POLICY",
+    "DEFAULT_STREAM_BATCH_SIZE",
+    "DEFAULT_STREAM_POLICY",
+    "DeidentifyMapFunction",
     "ENTITY_COUNT_ATTRIBUTE",
     "FIELD_COUNT_ATTRIBUTE",
     "LakehouseRedactionProgress",
@@ -62,6 +73,8 @@ __all__ = [
     "SparkDeidentifyColumn",
     "SparkDeidentifySink",
     "SparkDeidentifyStreamBuilder",
+    "StreamDeidentifyMapFunction",
+    "StreamSink",
     "DataflowToolConfig",
     "DataflowToolProcessorError",
     "clear_pipeline_cache",
@@ -76,6 +89,7 @@ __all__ = [
     "redact_log_events",
     "redact_ndjson_lines",
     "redact_ndjson_stream",
+    "run_stream_job",
     "script_processor",
     "write_deidentified_stream",
 ]

--- a/openmed/integrations/__init__.py
+++ b/openmed/integrations/__init__.py
@@ -34,6 +34,14 @@ from .log_redactor import (
     redact_ndjson_lines,
     redact_ndjson_stream,
 )
+from .ray_map_batches import (
+    DEFAULT_RAY_PII_MODEL,
+    ActorPoolConcurrency,
+    BatchFormat,
+    RayDeidentifyBatch,
+    RayMapBatchesDeidentifier,
+    map_batches_deidentify,
+)
 from .spark_streaming import (
     DEFAULT_BATCH_ID_COLUMN,
     DEFAULT_SPARK_POLICY,
@@ -59,10 +67,13 @@ __all__ = [
     "DEFAULT_LOG_MESSAGE_FIELDS",
     "DEFAULT_LOG_REDACTION_MODEL",
     "DEFAULT_BATCH_ID_COLUMN",
+    "DEFAULT_RAY_PII_MODEL",
     "DEFAULT_SPARK_POLICY",
     "DEFAULT_STREAM_BATCH_SIZE",
     "DEFAULT_STREAM_POLICY",
     "DeidentifyMapFunction",
+    "ActorPoolConcurrency",
+    "BatchFormat",
     "ENTITY_COUNT_ATTRIBUTE",
     "FIELD_COUNT_ATTRIBUTE",
     "LakehouseRedactionProgress",
@@ -79,6 +90,9 @@ __all__ = [
     "DataflowToolProcessorError",
     "clear_pipeline_cache",
     "deidentify_write_stream",
+    "RayDeidentifyBatch",
+    "RayMapBatchesDeidentifier",
+    "map_batches_deidentify",
     "process_flow_file",
     "process_json_lines",
     "process_record",

--- a/openmed/integrations/__init__.py
+++ b/openmed/integrations/__init__.py
@@ -19,6 +19,13 @@ from .dataflow_tool_processor import (
     process_record,
     script_processor,
 )
+from .executable_udf import (
+    DEFAULT_EXECUTABLE_UDF_MODEL,
+    ExecutableUDFConfig,
+    ExecutableUDFError,
+    redact_tsv_lines,
+    redact_tsv_stream,
+)
 from .lakehouse_redact import (
     LakehouseRedactionProgress,
     LakehouseRedactionResult,
@@ -63,6 +70,7 @@ from .stream_processor import (
 __all__ = [
     "ColumnarProgress",
     "ColumnarRedactionResult",
+    "DEFAULT_EXECUTABLE_UDF_MODEL",
     "DEFAULT_DATAFLOW_TOOL_MODEL",
     "DEFAULT_LOG_MESSAGE_FIELDS",
     "DEFAULT_LOG_REDACTION_MODEL",
@@ -78,6 +86,8 @@ __all__ = [
     "FIELD_COUNT_ATTRIBUTE",
     "LakehouseRedactionProgress",
     "LakehouseRedactionResult",
+    "ExecutableUDFConfig",
+    "ExecutableUDFError",
     "LogRedactorConfig",
     "LogRedactorError",
     "RECORD_COUNT_ATTRIBUTE",
@@ -104,6 +114,8 @@ __all__ = [
     "redact_ndjson_lines",
     "redact_ndjson_stream",
     "run_stream_job",
+    "redact_tsv_lines",
+    "redact_tsv_stream",
     "script_processor",
     "write_deidentified_stream",
 ]

--- a/openmed/integrations/arrow_flight.py
+++ b/openmed/integrations/arrow_flight.py
@@ -1,0 +1,298 @@
+"""Arrow Flight service for streaming record-batch de-identification.
+
+The service implements ``DoExchange`` so clients can send Arrow record batches
+and receive one redacted batch for every input batch. Only the configured text
+column is materialized for de-identification; the service never materializes
+the complete input stream.
+
+Request configuration is carried in a versioned JSON command descriptor. Raw
+cell values are intentionally never logged or included in service errors.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+try:
+    import pyarrow as pa
+    import pyarrow.flight as flight
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "Arrow Flight de-identification requires pyarrow. Install "
+        "openmed[columnar] or install pyarrow directly."
+    ) from exc
+
+from openmed.processing.batch import process_batch
+
+DEFAULT_ARROW_FLIGHT_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+ARROW_FLIGHT_DESCRIPTOR_VERSION = 1
+
+ProcessBatchCallable = Callable[..., Any]
+
+_PROTECTED_PROCESS_BATCH_OPTIONS = {
+    "batch_size",
+    "ids",
+    "model_name",
+    "operation",
+    "policy",
+    "texts",
+}
+
+
+def make_deidentify_descriptor(
+    text_column: str | None = None,
+    *,
+    policy: str | None = None,
+) -> flight.FlightDescriptor:
+    """Build a command descriptor for a de-identification exchange.
+
+    Args:
+        text_column: Optional string column to redact in every incoming record
+            batch. It may be omitted when the server defines a default.
+        policy: Optional OpenMed de-identification policy profile.
+
+    Returns:
+        A Flight command descriptor containing versioned JSON metadata.
+    """
+    payload: dict[str, Any] = {"version": ARROW_FLIGHT_DESCRIPTOR_VERSION}
+    if text_column is not None:
+        payload["text_column"] = _normalize_required_string(text_column, "text_column")
+    if policy is not None:
+        payload["policy"] = _normalize_required_string(policy, "policy")
+    command = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return flight.FlightDescriptor.for_command(command)
+
+
+class ArrowFlightDeidentificationServer(flight.FlightServerBase):
+    """Stream Arrow record batches through OpenMed de-identification.
+
+    Args:
+        location: Flight listen location. Port ``0`` requests a free local port.
+        text_column: Optional default text column when a descriptor omits it.
+        policy: Optional default de-identification policy profile.
+        model_name: PII model forwarded to :func:`process_batch`.
+        batch_size: Internal OpenMed processing batch size for each Arrow batch.
+        process_batch_options: Additional de-identification options, such as
+            ``method``, ``lang``, or ``use_safety_sweep``.
+        process_batch_fn: Test or embedding seam. Defaults to OpenMed's
+            :func:`process_batch`.
+        auth_handler: Optional Arrow Flight authentication handler.
+        tls_certificates: Optional Flight TLS certificate/key pairs.
+        verify_client: Whether Flight should require client certificates.
+        root_certificates: Optional roots used to verify client certificates.
+        middleware: Optional Arrow Flight server middleware mapping.
+
+    The authentication and TLS arguments are configuration hooks only. This
+    integration does not define an authentication policy or certificate
+    lifecycle.
+    """
+
+    def __init__(
+        self,
+        location: str | tuple[str, int] | flight.Location = "grpc://127.0.0.1:0",
+        *,
+        text_column: str | None = None,
+        policy: str | None = None,
+        model_name: str = DEFAULT_ARROW_FLIGHT_MODEL,
+        batch_size: int = 512,
+        process_batch_options: Mapping[str, Any] | None = None,
+        process_batch_fn: ProcessBatchCallable | None = None,
+        auth_handler: Any = None,
+        tls_certificates: Sequence[tuple[bytes, bytes]] | None = None,
+        verify_client: bool = False,
+        root_certificates: bytes | None = None,
+        middleware: Mapping[str, Any] | None = None,
+    ) -> None:
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        self._text_column = (
+            _normalize_required_string(text_column, "text_column")
+            if text_column is not None
+            else None
+        )
+        self._policy = (
+            _normalize_required_string(policy, "policy") if policy is not None else None
+        )
+        self._model_name = _normalize_required_string(model_name, "model_name")
+        self._batch_size = batch_size
+        self._process_batch_options = dict(process_batch_options or {})
+        protected = sorted(
+            _PROTECTED_PROCESS_BATCH_OPTIONS.intersection(self._process_batch_options)
+        )
+        if protected:
+            joined = ", ".join(protected)
+            raise ValueError(
+                "process_batch_options cannot override managed option(s): " + joined
+            )
+        self._process_batch = process_batch_fn or process_batch
+        super().__init__(
+            location,
+            auth_handler=auth_handler,
+            tls_certificates=tls_certificates,
+            verify_client=verify_client,
+            root_certificates=root_certificates,
+            middleware=dict(middleware) if middleware is not None else None,
+        )
+
+    def do_exchange(
+        self,
+        context: flight.ServerCallContext,
+        descriptor: flight.FlightDescriptor,
+        reader: flight.MetadataRecordBatchReader,
+        writer: flight.MetadataRecordBatchWriter,
+    ) -> None:
+        """Redact each incoming record batch and stream it back immediately."""
+        request = _parse_descriptor(descriptor)
+        text_column = request.get("text_column", self._text_column)
+        if text_column is None:
+            raise ValueError(
+                "A text_column is required in the Flight descriptor or server config"
+            )
+        policy = request["policy"] if "policy" in request else self._policy
+
+        schema = reader.schema
+        column_index = _validate_text_column(schema, text_column)
+        writer.begin(schema)
+
+        for chunk in reader:
+            if context.is_cancelled():
+                break
+            record_batch = chunk.data
+            if record_batch is None:
+                continue
+            redacted = self._redact_record_batch(
+                record_batch,
+                column_index=column_index,
+                text_column=text_column,
+                policy=policy,
+            )
+            if chunk.app_metadata is None:
+                writer.write_batch(redacted)
+            else:
+                writer.write_with_metadata(redacted, chunk.app_metadata)
+
+    def _redact_record_batch(
+        self,
+        record_batch: pa.RecordBatch,
+        *,
+        column_index: int,
+        text_column: str,
+        policy: str | None,
+    ) -> pa.RecordBatch:
+        field = record_batch.schema.field(column_index)
+        values = record_batch.column(column_index).to_pylist()
+        row_indexes = [index for index, value in enumerate(values) if value is not None]
+        if not row_indexes:
+            return record_batch
+
+        texts = [str(values[index]) for index in row_indexes]
+        ids = [f"flight_row_{index}" for index in row_indexes]
+        options = dict(self._process_batch_options)
+        options.update(
+            {
+                "operation": "deidentify",
+                "batch_size": self._batch_size,
+                "policy": policy,
+            }
+        )
+        try:
+            result = self._process_batch(
+                texts,
+                model_name=self._model_name,
+                ids=ids,
+                **options,
+            )
+        except Exception:
+            raise RuntimeError(
+                f"De-identification failed for column {text_column!r}"
+            ) from None
+        items = list(getattr(result, "items", ()) or ())
+        if len(items) != len(row_indexes):
+            raise RuntimeError(
+                "process_batch returned an unexpected number of results for "
+                f"column {text_column!r}"
+            )
+
+        redacted_values = list(values)
+        for row_index, item in zip(row_indexes, items):
+            if getattr(item, "error", None):
+                raise RuntimeError(
+                    "De-identification failed for "
+                    f"column {text_column!r} at row {row_index}"
+                )
+            redacted_values[row_index] = _deidentified_text(
+                getattr(item, "result", item)
+            )
+
+        redacted_array = pa.array(redacted_values, type=field.type)
+        return record_batch.set_column(column_index, field, redacted_array)
+
+
+def _parse_descriptor(descriptor: flight.FlightDescriptor) -> dict[str, Any]:
+    if descriptor.descriptor_type != flight.DescriptorType.CMD:
+        raise ValueError("Arrow Flight de-identification requires a command descriptor")
+    try:
+        payload = json.loads(descriptor.command.decode("utf-8"))
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            "Arrow Flight command descriptor must contain valid UTF-8 JSON"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Arrow Flight command descriptor must contain a JSON object")
+    if payload.get("version") != ARROW_FLIGHT_DESCRIPTOR_VERSION:
+        raise ValueError(
+            "Unsupported Arrow Flight descriptor version; "
+            f"expected {ARROW_FLIGHT_DESCRIPTOR_VERSION}"
+        )
+
+    if set(payload).difference({"version", "text_column", "policy"}):
+        raise ValueError("Arrow Flight command descriptor has unsupported fields")
+
+    request: dict[str, Any] = {}
+    if "text_column" in payload:
+        request["text_column"] = _normalize_required_string(
+            payload["text_column"], "text_column"
+        )
+    if "policy" in payload:
+        request["policy"] = _normalize_required_string(payload["policy"], "policy")
+    return request
+
+
+def _validate_text_column(schema: pa.Schema, text_column: str) -> int:
+    column_index = schema.get_field_index(text_column)
+    if column_index < 0:
+        raise ValueError(f"Text column is missing from the Arrow schema: {text_column}")
+    field_type = schema.field(column_index).type
+    if not (
+        pa.types.is_string(field_type)
+        or pa.types.is_large_string(field_type)
+        or pa.types.is_null(field_type)
+    ):
+        raise ValueError(f"Arrow text column must be string-typed: {text_column}")
+    return column_index
+
+
+def _deidentified_text(result: Any) -> str:
+    if hasattr(result, "deidentified_text"):
+        return str(result.deidentified_text)
+    if isinstance(result, Mapping) and "deidentified_text" in result:
+        return str(result["deidentified_text"])
+    if isinstance(result, str):
+        return result
+    raise TypeError("process_batch results must expose deidentified_text")
+
+
+def _normalize_required_string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+__all__ = [
+    "ARROW_FLIGHT_DESCRIPTOR_VERSION",
+    "DEFAULT_ARROW_FLIGHT_MODEL",
+    "ArrowFlightDeidentificationServer",
+    "make_deidentify_descriptor",
+]

--- a/openmed/integrations/dataflow_processor.py
+++ b/openmed/integrations/dataflow_processor.py
@@ -1,0 +1,340 @@
+"""Apache Beam/Dataflow record de-identification with bundle-scoped setup.
+
+The transform batches records without deriving keys from their contents. This
+keeps PHI and quasi-identifiers out of shuffle keys while allowing one resident
+OpenMed batch processor to be reused by each Beam ``DoFn`` instance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    import apache_beam as beam
+except ImportError as exc:  # pragma: no cover - exercised by packaging users
+    raise ImportError(
+        "Apache Beam is required for the Dataflow integration. "
+        "Install it with `pip install 'apache-beam>=2.60,<3'`."
+    ) from exc
+
+from openmed.core.policy import PolicyName, canonical_policy_name
+
+DEFAULT_DATAFLOW_BATCH_SIZE = 32
+DEFAULT_DATAFLOW_POLICY = "hipaa_safe_harbor"
+CLEANED_TAG = "cleaned"
+DEAD_LETTER_TAG = "dead_letter"
+
+ProcessBatchCallable = Callable[..., Any]
+ProcessorFactory = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class DataflowDeadLetter:
+    """An element that could not be safely de-identified.
+
+    ``reason`` is a stable, PHI-free category. The original ``element`` is
+    retained so callers can route it to a protected dead-letter sink.
+
+    Attributes:
+        element: Original input element.
+        reason: PHI-free failure category.
+    """
+
+    element: Any
+    reason: str
+
+
+@dataclass(frozen=True)
+class _PreparedRecord:
+    original: Any
+    output: dict[str, Any]
+    text: str
+
+
+class _RedactBatchDoFn(beam.DoFn):
+    """Redact one Beam-provided batch with a resident OpenMed processor."""
+
+    def __init__(
+        self,
+        *,
+        text_field: str,
+        policy: str | None,
+        method: str,
+        model_name: str,
+        batch_size: int,
+        processor_factory: ProcessorFactory | None,
+        process_batch_fn: ProcessBatchCallable | None,
+        deidentify_kwargs: Mapping[str, Any],
+    ) -> None:
+        self.text_field = text_field
+        self.policy = policy
+        self.method = method
+        self.model_name = model_name
+        self.batch_size = batch_size
+        self.processor_factory = processor_factory
+        self.configured_process_batch = process_batch_fn
+        self.deidentify_kwargs = dict(deidentify_kwargs)
+        self._process_batch: ProcessBatchCallable | None = None
+        self._forward_options = False
+
+    def setup(self) -> None:
+        """Create one resident processor for this worker-side ``DoFn``."""
+
+        if self.configured_process_batch is not None:
+            self._process_batch = self.configured_process_batch
+            self._forward_options = True
+            return
+
+        factory = self.processor_factory
+        if factory is None:
+            from openmed.processing import BatchProcessor
+
+            factory = BatchProcessor
+
+        processor = factory(**self._processor_options())
+        process_texts = getattr(processor, "process_texts", None)
+        if callable(process_texts):
+            self._process_batch = process_texts
+        elif callable(processor):
+            self._process_batch = processor
+        else:
+            raise TypeError(
+                "processor_factory must return a callable or expose process_texts"
+            )
+
+    def process(self, batch: Sequence[Any]):
+        """Yield cleaned records and tagged dead letters for one input batch."""
+
+        prepared: list[_PreparedRecord] = []
+        for element in batch:
+            try:
+                prepared_record, failure = self._prepare(element)
+            except Exception:
+                prepared_record = None
+                failure = DataflowDeadLetter(element, "invalid_element")
+            if failure is not None:
+                yield beam.pvalue.TaggedOutput(DEAD_LETTER_TAG, failure)
+            elif prepared_record is None:
+                yield dict(element)
+            else:
+                prepared.append(prepared_record)
+
+        if not prepared:
+            return
+
+        try:
+            batch_result = self._run_batch([record.text for record in prepared])
+            items = _batch_items(batch_result)
+        except Exception:
+            for record in prepared:
+                yield beam.pvalue.TaggedOutput(
+                    DEAD_LETTER_TAG,
+                    DataflowDeadLetter(record.original, "processing_error"),
+                )
+            return
+
+        if len(items) != len(prepared):
+            for record in prepared:
+                yield beam.pvalue.TaggedOutput(
+                    DEAD_LETTER_TAG,
+                    DataflowDeadLetter(record.original, "invalid_result_count"),
+                )
+            return
+
+        for record, item in zip(prepared, items):
+            try:
+                redacted_text, reason = _deidentified_text(item)
+            except Exception:
+                redacted_text, reason = "", "invalid_result"
+            if reason is not None:
+                yield beam.pvalue.TaggedOutput(
+                    DEAD_LETTER_TAG,
+                    DataflowDeadLetter(record.original, reason),
+                )
+                continue
+            record.output[self.text_field] = redacted_text
+            yield record.output
+
+    def _prepare(
+        self, element: Any
+    ) -> tuple[_PreparedRecord | None, DataflowDeadLetter | None]:
+        if element is None or not isinstance(element, Mapping):
+            return None, DataflowDeadLetter(element, "invalid_element")
+        if self.text_field not in element:
+            return None, DataflowDeadLetter(element, "missing_text_field")
+
+        value = element[self.text_field]
+        if value is None:
+            return None, DataflowDeadLetter(element, "null_text")
+        if not isinstance(value, str):
+            return None, DataflowDeadLetter(element, "invalid_text_type")
+        if not value:
+            return None, None
+        return _PreparedRecord(element, dict(element), value), None
+
+    def _run_batch(self, texts: list[str]) -> Any:
+        process_batch = self._process_batch
+        if process_batch is None:  # pragma: no cover - Beam lifecycle invariant
+            raise RuntimeError("dataflow processor setup was not called")
+        if self._forward_options:
+            return process_batch(texts, **self._processor_options())
+        return process_batch(texts)
+
+    def _processor_options(self) -> dict[str, Any]:
+        options = {
+            "model_name": self.model_name,
+            "operation": "deidentify",
+            "batch_size": self.batch_size,
+            "continue_on_error": True,
+            "method": self.method,
+            **self.deidentify_kwargs,
+        }
+        if self.policy is not None:
+            options["policy"] = self.policy
+        return options
+
+
+class DataflowBatchProcessor(beam.PTransform):
+    """Batch and de-identify a configured field in Beam record mappings.
+
+    The transform returns a tagged output tuple. Access cleaned records through
+    ``outputs.cleaned`` and invalid records through ``outputs.dead_letter``.
+    Batches are formed with ``BatchElements`` and never use record contents as
+    keys, so PHI and quasi-identifiers are not exposed as partition keys.
+
+    Args:
+        text_field: Mapping field containing text to de-identify.
+        policy: Optional OpenMed policy profile.
+        method: De-identification method forwarded to OpenMed.
+        model_name: Model registry key or artifact identifier.
+        batch_size: Maximum records passed to one batch inference call.
+        processor_factory: Optional factory called once from ``DoFn.setup``.
+            It receives the OpenMed batch processor options and must return a
+            callable or an object exposing ``process_texts``.
+        process_batch_fn: Optional replacement for
+            :func:`openmed.processing.process_batch`, primarily for tests.
+        **deidentify_kwargs: Additional options forwarded to OpenMed.
+    """
+
+    def __init__(
+        self,
+        text_field: str = "text",
+        *,
+        policy: str | PolicyName | None = DEFAULT_DATAFLOW_POLICY,
+        method: str = "mask",
+        model_name: str = "disease_detection_superclinical",
+        batch_size: int = DEFAULT_DATAFLOW_BATCH_SIZE,
+        processor_factory: ProcessorFactory | None = None,
+        process_batch_fn: ProcessBatchCallable | None = None,
+        **deidentify_kwargs: Any,
+    ) -> None:
+        self.text_field = _non_empty_string(text_field, "text_field")
+        self.policy = canonical_policy_name(policy) if policy is not None else None
+        self.method = _non_empty_string(method, "method")
+        self.model_name = _non_empty_string(model_name, "model_name")
+        self.batch_size = _positive_int(batch_size, "batch_size")
+        if processor_factory is not None and not callable(processor_factory):
+            raise TypeError("processor_factory must be callable")
+        if process_batch_fn is not None and not callable(process_batch_fn):
+            raise TypeError("process_batch_fn must be callable")
+        if processor_factory is not None and process_batch_fn is not None:
+            raise ValueError("pass only one of processor_factory or process_batch_fn")
+
+        kwargs = dict(deidentify_kwargs)
+        for reserved in (
+            "batch_size",
+            "continue_on_error",
+            "ids",
+            "method",
+            "model_name",
+            "operation",
+            "policy",
+            "texts",
+        ):
+            if reserved in kwargs:
+                raise ValueError(
+                    f"deidentify kwargs must not include reserved key {reserved!r}"
+                )
+        self.processor_factory = processor_factory
+        self.process_batch_fn = process_batch_fn
+        self.deidentify_kwargs = kwargs
+
+    def expand(self, records):
+        """Apply bundle-friendly batching and record de-identification."""
+
+        batches = records | "Batch records without QI keys" >> beam.BatchElements(
+            min_batch_size=self.batch_size,
+            max_batch_size=self.batch_size,
+        )
+        return batches | "De-identify record batches" >> beam.ParDo(
+            _RedactBatchDoFn(
+                text_field=self.text_field,
+                policy=self.policy,
+                method=self.method,
+                model_name=self.model_name,
+                batch_size=self.batch_size,
+                processor_factory=self.processor_factory,
+                process_batch_fn=self.process_batch_fn,
+                deidentify_kwargs=self.deidentify_kwargs,
+            )
+        ).with_outputs(DEAD_LETTER_TAG, main=CLEANED_TAG)
+
+
+DataflowProcessor = DataflowBatchProcessor
+
+
+def _batch_items(batch_result: Any) -> list[Any]:
+    raw_items = getattr(batch_result, "items", batch_result)
+    try:
+        return list(raw_items)
+    except TypeError as exc:
+        raise TypeError("batch processor returned a non-iterable result") from exc
+
+
+def _deidentified_text(item: Any) -> tuple[str, str | None]:
+    if getattr(item, "success", True) is False:
+        return "", "processing_error"
+
+    result = getattr(item, "result", item)
+    if isinstance(result, str):
+        return result, None
+    if isinstance(result, Mapping):
+        text = result.get("deidentified_text")
+    else:
+        text = getattr(result, "deidentified_text", None)
+    if not isinstance(text, str):
+        return "", "invalid_result"
+    return text, None
+
+
+def _non_empty_string(value: str, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _positive_int(value: int, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        integer = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+    if integer < 1 or integer != value:
+        raise ValueError(f"{name} must be a positive integer")
+    return integer
+
+
+__all__ = [
+    "CLEANED_TAG",
+    "DEAD_LETTER_TAG",
+    "DEFAULT_DATAFLOW_BATCH_SIZE",
+    "DEFAULT_DATAFLOW_POLICY",
+    "DataflowBatchProcessor",
+    "DataflowDeadLetter",
+    "DataflowProcessor",
+    "ProcessBatchCallable",
+    "ProcessorFactory",
+]

--- a/openmed/integrations/distributed_sql_udf.py
+++ b/openmed/integrations/distributed_sql_udf.py
@@ -1,0 +1,324 @@
+"""Vectorized Python UDF entrypoint for distributed SQL engines."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any
+
+from openmed.core.policy import canonical_policy_name
+from openmed.utils.validation import validate_batch_size
+
+DEFAULT_DISTRIBUTED_SQL_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+DEFAULT_DISTRIBUTED_SQL_PROFILE = "hipaa_safe_harbor"
+DEFAULT_DISTRIBUTED_SQL_BATCH_SIZE = 64
+
+_PROFILE_ALIASES = {
+    "hipaa": DEFAULT_DISTRIBUTED_SQL_PROFILE,
+    "safe_harbor": DEFAULT_DISTRIBUTED_SQL_PROFILE,
+}
+_RESERVED_PROCESS_BATCH_KWARGS = frozenset(
+    {
+        "batch_size",
+        "continue_on_error",
+        "loader",
+        "method",
+        "model_name",
+        "operation",
+        "policy",
+    }
+)
+
+ProcessBatch = Callable[..., Any]
+LoaderFactory = Callable[[], Any | None]
+
+
+@dataclass(frozen=True)
+class DistributedSQLUDFConfig:
+    """Runtime settings for a distributed SQL de-identification worker."""
+
+    model_name: str = DEFAULT_DISTRIBUTED_SQL_MODEL
+    default_profile: str = DEFAULT_DISTRIBUTED_SQL_PROFILE
+    batch_size: int = DEFAULT_DISTRIBUTED_SQL_BATCH_SIZE
+    method: str = "mask"
+    confidence_threshold: float = 0.7
+    process_batch_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        model_name = _non_empty_string(self.model_name, "model_name")
+        method = _non_empty_string(self.method, "method")
+        default_profile = _canonical_profile(self.default_profile)
+        batch_size = validate_batch_size(self.batch_size)
+        confidence_threshold = float(self.confidence_threshold)
+        if not 0.0 <= confidence_threshold <= 1.0:
+            raise ValueError("confidence_threshold must be between 0.0 and 1.0")
+
+        process_batch_kwargs = dict(self.process_batch_kwargs)
+        reserved = sorted(_RESERVED_PROCESS_BATCH_KWARGS & process_batch_kwargs.keys())
+        if reserved:
+            names = ", ".join(reserved)
+            raise ValueError(
+                "process_batch_kwargs must not override reserved settings: " + names
+            )
+
+        object.__setattr__(self, "model_name", model_name)
+        object.__setattr__(self, "default_profile", default_profile)
+        object.__setattr__(self, "batch_size", batch_size)
+        object.__setattr__(self, "method", method)
+        object.__setattr__(self, "confidence_threshold", confidence_threshold)
+        object.__setattr__(self, "process_batch_kwargs", process_batch_kwargs)
+
+
+class DistributedSQLDeidentifyUDF:
+    """Process vector windows for one distributed SQL Python worker.
+
+    The object is intended to be constructed once in each worker process. Its
+    model loader is created only when the first non-empty batch arrives and is
+    then forwarded to every :func:`openmed.processing.process_batch` call.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: DistributedSQLUDFConfig | None = None,
+        process_batch_fn: ProcessBatch | None = None,
+        loader_factory: LoaderFactory | None = None,
+    ) -> None:
+        self.config = config or DistributedSQLUDFConfig()
+        self._process_batch_fn = process_batch_fn
+        self._loader_factory = loader_factory
+        self._loader: Any | None = None
+        self._loader_initialized = False
+
+    def __call__(
+        self,
+        texts: Sequence[str | None],
+        profiles: Sequence[str | None] | str | None = None,
+    ) -> list[str | None]:
+        """Return a vector of de-identified SQL cell values."""
+
+        return self.deidentify_batch(texts, profiles)
+
+    def deidentify(
+        self,
+        text: str | None,
+        profile: str | None = None,
+    ) -> str | None:
+        """Return one de-identified value for scalar compatibility."""
+
+        return self.deidentify_batch([text], profile)[0]
+
+    def deidentify_batch(
+        self,
+        texts: Sequence[str | None],
+        profiles: Sequence[str | None] | str | None = None,
+    ) -> list[str | None]:
+        """De-identify a vector while preserving nulls, empties, and row order."""
+
+        if isinstance(texts, (str, bytes)):
+            raise TypeError("texts must be a sequence of SQL cell values")
+
+        values = list(texts)
+        resolved_profiles = self._resolve_profiles(profiles, len(values))
+        output: list[str | None] = [None] * len(values)
+
+        for start in range(0, len(values), self.config.batch_size):
+            stop = min(start + self.config.batch_size, len(values))
+            self._process_window(
+                values,
+                resolved_profiles,
+                output,
+                start=start,
+                stop=stop,
+            )
+
+        return output
+
+    def _process_window(
+        self,
+        values: Sequence[str | None],
+        profiles: Sequence[str | None],
+        output: list[str | None],
+        *,
+        start: int,
+        stop: int,
+    ) -> None:
+        grouped_positions: dict[str, list[int]] = {}
+        for position in range(start, stop):
+            value = values[position]
+            if value is None:
+                output[position] = None
+                continue
+            if not isinstance(value, str):
+                raise TypeError(
+                    "distributed SQL text values must be strings or None; "
+                    f"row {position} is {type(value).__name__}"
+                )
+            if value == "":
+                output[position] = ""
+                continue
+            profile = _canonical_profile(
+                profiles[position] or self.config.default_profile
+            )
+            grouped_positions.setdefault(profile, []).append(position)
+
+        for profile, positions in grouped_positions.items():
+            batch_values = []
+            for position in positions:
+                value = values[position]
+                if not isinstance(value, str) or not value:
+                    raise RuntimeError("invalid internal distributed SQL row state")
+                batch_values.append(value)
+            batch_output = self._run_process_batch(batch_values, profile=profile)
+            for position, redacted in zip(positions, batch_output, strict=True):
+                output[position] = redacted
+
+    def _run_process_batch(
+        self,
+        texts: Sequence[str | None],
+        *,
+        profile: str,
+    ) -> list[str]:
+        process_batch = self._get_process_batch()
+        batch_result = process_batch(
+            list(texts),
+            model_name=self.config.model_name,
+            operation="deidentify",
+            batch_size=self.config.batch_size,
+            loader=self._get_loader(),
+            continue_on_error=False,
+            policy=profile,
+            method=self.config.method,
+            confidence_threshold=self.config.confidence_threshold,
+            **dict(self.config.process_batch_kwargs),
+        )
+        items = list(getattr(batch_result, "items", ()))
+        if len(items) != len(texts):
+            raise RuntimeError(
+                "process_batch returned "
+                f"{len(items)} results for {len(texts)} distributed SQL rows"
+            )
+
+        redacted: list[str] = []
+        for index, item in enumerate(items):
+            if getattr(item, "error", None) is not None:
+                raise RuntimeError(
+                    f"process_batch failed for distributed SQL row {index}"
+                )
+            redacted.append(_result_text(getattr(item, "result", None), index=index))
+        return redacted
+
+    def _resolve_profiles(
+        self,
+        profiles: Sequence[str | None] | str | None,
+        expected: int,
+    ) -> list[str | None]:
+        if profiles is None or isinstance(profiles, str):
+            return [profiles] * expected
+        if isinstance(profiles, bytes):
+            raise TypeError("profiles must be a string or a sequence of profile names")
+
+        values = list(profiles)
+        if len(values) != expected:
+            raise ValueError(
+                f"profiles contains {len(values)} values for {expected} text rows"
+            )
+        return values
+
+    def _get_process_batch(self) -> ProcessBatch:
+        if self._process_batch_fn is None:
+            from openmed.processing import process_batch
+
+            self._process_batch_fn = process_batch
+        return self._process_batch_fn
+
+    def _get_loader(self) -> Any | None:
+        if self._loader_initialized:
+            return self._loader
+
+        self._loader_initialized = True
+        factory = self._loader_factory or _default_loader_factory
+        self._loader = factory()
+        return self._loader
+
+
+OPENMED_DEIDENTIFY_DESCRIPTOR: dict[str, Any] = {
+    "name": "openmed_deidentify",
+    "language": "python",
+    "entrypoint": ("openmed.integrations.distributed_sql_udf:deidentify_batch"),
+    "arguments": [
+        {"name": "text", "sql_type": "VARCHAR", "python_batch": "texts"},
+        {"name": "profile", "sql_type": "VARCHAR", "python_batch": "profiles"},
+    ],
+    "return_type": "VARCHAR",
+    "vectorized": True,
+    "null_handling": "called_on_null_input",
+    "default_batch_size": DEFAULT_DISTRIBUTED_SQL_BATCH_SIZE,
+}
+
+
+@lru_cache(maxsize=1)
+def _default_worker() -> DistributedSQLDeidentifyUDF:
+    """Return the process-local worker used by module-level entrypoints."""
+
+    return DistributedSQLDeidentifyUDF()
+
+
+def deidentify(
+    text: str | None,
+    profile: str | None = None,
+) -> str | None:
+    """De-identify one logical SQL scalar value with the process-local worker."""
+
+    return _default_worker().deidentify(text, profile)
+
+
+def deidentify_batch(
+    texts: Sequence[str | None],
+    profiles: Sequence[str | None] | str | None = None,
+) -> list[str | None]:
+    """De-identify a vector window with the process-local worker."""
+
+    return _default_worker().deidentify_batch(texts, profiles)
+
+
+def _default_loader_factory() -> Any:
+    from openmed.core import ModelLoader
+
+    return ModelLoader()
+
+
+def _canonical_profile(profile: str) -> str:
+    normalized = _non_empty_string(profile, "profile").lower().replace("-", "_")
+    return canonical_policy_name(_PROFILE_ALIASES.get(normalized, normalized))
+
+
+def _non_empty_string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+def _result_text(result: Any, *, index: int) -> str:
+    if isinstance(result, str):
+        return result
+    value = getattr(result, "deidentified_text", None)
+    if isinstance(value, str):
+        return value
+    raise TypeError(
+        "process_batch result for distributed SQL row "
+        f"{index} must be a string or expose deidentified_text"
+    )
+
+
+__all__ = [
+    "DEFAULT_DISTRIBUTED_SQL_BATCH_SIZE",
+    "DEFAULT_DISTRIBUTED_SQL_MODEL",
+    "DEFAULT_DISTRIBUTED_SQL_PROFILE",
+    "DistributedSQLDeidentifyUDF",
+    "DistributedSQLUDFConfig",
+    "OPENMED_DEIDENTIFY_DESCRIPTOR",
+    "deidentify",
+    "deidentify_batch",
+]

--- a/openmed/integrations/executable_udf.py
+++ b/openmed/integrations/executable_udf.py
@@ -1,0 +1,403 @@
+"""Executable UDF adapter for streaming column redaction over stdin/stdout.
+
+The adapter implements a one-column ClickHouse ``TabSeparated`` transform:
+each input row contains one escaped string value and each output row contains
+the corresponding redacted value. Input rows are buffered into bounded batches
+before they are passed to :func:`openmed.processing.batch.process_batch`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, TextIO
+
+from openmed.core import ModelLoader
+from openmed.core.pii_i18n import DEFAULT_PII_MODELS
+from openmed.processing.batch import process_batch
+
+DEFAULT_EXECUTABLE_UDF_MODEL = DEFAULT_PII_MODELS["en"]
+
+_TSV_DECODE_ESCAPES = {
+    "0": "\0",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "\\": "\\",
+    "'": "'",
+}
+_TSV_ENCODE_ESCAPES = {
+    "\\": "\\\\",
+    "\0": "\\0",
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+}
+
+
+class ExecutableUDFError(RuntimeError):
+    """Raised when an executable UDF batch cannot be redacted safely."""
+
+
+@dataclass(frozen=True)
+class ExecutableUDFConfig:
+    """Configuration for the executable UDF stream.
+
+    Args:
+        batch_size: Maximum number of rows passed to one batch call.
+        model_name: PII model passed to batch de-identification.
+        method: De-identification method.
+        confidence_threshold: Minimum confidence for PII detection.
+        deidentify_kwargs: Extra keyword arguments forwarded to batch
+            de-identification.
+    """
+
+    batch_size: int = 32
+    model_name: str = DEFAULT_EXECUTABLE_UDF_MODEL
+    method: str = "mask"
+    confidence_threshold: float | None = 0.7
+    deidentify_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.batch_size < 1:
+            raise ValueError("batch_size must be positive")
+
+
+def redact_tsv_lines(
+    lines: Iterable[str],
+    *,
+    batch_size: int = 32,
+    model_name: str = DEFAULT_EXECUTABLE_UDF_MODEL,
+    method: str = "mask",
+    confidence_threshold: float | None = 0.7,
+    config: Any | None = None,
+    loader: Any | None = None,
+    **deidentify_kwargs: Any,
+) -> Iterator[str]:
+    """Yield redacted one-column TabSeparated rows.
+
+    A single shared model loader is reused for every buffered batch so a model
+    is not reloaded as the stream advances. Blank values are emitted as blank
+    output rows without calling the model; no input rows are skipped.
+
+    Args:
+        lines: Iterable containing one ClickHouse TabSeparated string per row.
+        batch_size: Maximum number of rows passed to one batch call.
+        model_name: PII model passed to batch de-identification.
+        method: De-identification method.
+        confidence_threshold: Minimum confidence for PII detection.
+        config: Optional OpenMed configuration.
+        loader: Optional shared model loader. A loader is created once when
+            omitted.
+        **deidentify_kwargs: Extra keyword arguments forwarded to batch
+            de-identification.
+
+    Yields:
+        Escaped redacted values with exactly one trailing newline per row.
+
+    Raises:
+        ExecutableUDFError: If input is not one-column TSV or batch redaction
+            fails, returns the wrong cardinality, or returns invalid results.
+    """
+
+    udf_config = ExecutableUDFConfig(
+        batch_size=batch_size,
+        model_name=model_name,
+        method=method,
+        confidence_threshold=confidence_threshold,
+        deidentify_kwargs=deidentify_kwargs,
+    )
+    shared_loader = loader if loader is not None else ModelLoader(config)
+    batch: list[str] = []
+
+    for line_number, raw_line in enumerate(lines, start=1):
+        batch.append(_parse_tsv_row(raw_line, line_number=line_number))
+        if len(batch) >= udf_config.batch_size:
+            yield from _redact_batch(
+                batch,
+                udf_config,
+                config=config,
+                loader=shared_loader,
+            )
+            batch = []
+
+    if batch:
+        yield from _redact_batch(
+            batch,
+            udf_config,
+            config=config,
+            loader=shared_loader,
+        )
+
+
+def redact_tsv_stream(
+    input_stream: TextIO,
+    output_stream: TextIO,
+    *,
+    batch_size: int = 32,
+    model_name: str = DEFAULT_EXECUTABLE_UDF_MODEL,
+    method: str = "mask",
+    confidence_threshold: float | None = 0.7,
+    config: Any | None = None,
+    loader: Any | None = None,
+    **deidentify_kwargs: Any,
+) -> int:
+    """Redact a one-column TabSeparated stream.
+
+    Args:
+        input_stream: Text stream containing one escaped string per row.
+        output_stream: Text stream receiving one redacted string per row.
+        batch_size: Maximum number of rows passed to one batch call.
+        model_name: PII model passed to batch de-identification.
+        method: De-identification method.
+        confidence_threshold: Minimum confidence for PII detection.
+        config: Optional OpenMed configuration.
+        loader: Optional shared model loader.
+        **deidentify_kwargs: Extra keyword arguments forwarded to batch
+            de-identification.
+
+    Returns:
+        Number of rows emitted.
+    """
+
+    emitted = 0
+    for redacted_line in redact_tsv_lines(
+        input_stream,
+        batch_size=batch_size,
+        model_name=model_name,
+        method=method,
+        confidence_threshold=confidence_threshold,
+        config=config,
+        loader=loader,
+        **deidentify_kwargs,
+    ):
+        output_stream.write(redacted_line)
+        emitted += 1
+        if emitted % batch_size == 0:
+            output_stream.flush()
+    output_stream.flush()
+    return emitted
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    """Run the executable UDF stdin/stdout transform.
+
+    Args:
+        argv: Optional command-line arguments.
+        stdin: Optional input stream override.
+        stdout: Optional output stream override.
+        stderr: Optional error stream override.
+
+    Returns:
+        Zero on success and one when the transform fails.
+    """
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    input_stream = stdin if stdin is not None else sys.stdin
+    output_stream = stdout if stdout is not None else sys.stdout
+    error_stream = stderr if stderr is not None else sys.stderr
+
+    try:
+        redact_tsv_stream(
+            input_stream,
+            output_stream,
+            batch_size=args.batch_size,
+            model_name=args.model_name,
+            method=args.method,
+            confidence_threshold=args.confidence_threshold,
+            lang=args.lang,
+            policy=args.policy,
+            keep_year=args.keep_year,
+            use_safety_sweep=args.use_safety_sweep,
+        )
+    except Exception:
+        error_stream.write("executable UDF redaction failed\n")
+        return 1
+
+    return 0
+
+
+def _redact_batch(
+    texts: Sequence[str],
+    udf_config: ExecutableUDFConfig,
+    *,
+    config: Any | None,
+    loader: Any,
+) -> Iterator[str]:
+    nonempty_positions = [index for index, text in enumerate(texts) if text]
+    if not nonempty_positions:
+        yield from ("\n" for _ in texts)
+        return
+
+    batch_texts = [texts[index] for index in nonempty_positions]
+    kwargs = dict(udf_config.deidentify_kwargs)
+    kwargs.update(
+        {
+            "operation": "deidentify",
+            "batch_size": len(batch_texts),
+            "continue_on_error": False,
+            "loader": loader,
+            "method": udf_config.method,
+            "confidence_threshold": udf_config.confidence_threshold,
+        }
+    )
+
+    try:
+        result = process_batch(
+            batch_texts,
+            model_name=udf_config.model_name,
+            config=config,
+            **kwargs,
+        )
+    except Exception:
+        raise ExecutableUDFError("failed to redact an input batch") from None
+
+    items = _batch_items(result)
+    if len(items) != len(batch_texts):
+        raise ExecutableUDFError("batch result count did not match input row count")
+
+    redacted_values: list[str | None] = [None] * len(texts)
+    for index, item in zip(nonempty_positions, items):
+        redacted_values[index] = _redacted_text(item)
+
+    for redacted in redacted_values:
+        yield "\n" if redacted is None else _encode_tsv_value(redacted) + "\n"
+
+
+def _redacted_text(item: Any) -> str:
+    if isinstance(item, Mapping):
+        success = item.get("success", False)
+        result = item.get("result")
+    else:
+        success = getattr(item, "success", False)
+        result = getattr(item, "result", None)
+
+    if not success:
+        raise ExecutableUDFError("one or more input rows could not be redacted")
+
+    if isinstance(result, Mapping):
+        redacted = result.get("deidentified_text")
+    else:
+        redacted = getattr(result, "deidentified_text", None)
+    if not isinstance(redacted, str):
+        raise ExecutableUDFError("batch redaction returned an invalid result")
+    return redacted
+
+
+def _batch_items(result: Any) -> list[Any]:
+    if isinstance(result, Mapping):
+        items = result.get("items")
+    else:
+        items = getattr(result, "items", None)
+
+    if items is None:
+        return []
+    try:
+        return list(items)
+    except TypeError:
+        raise ExecutableUDFError("batch result contained invalid items") from None
+
+
+def _parse_tsv_row(raw_line: str, *, line_number: int) -> str:
+    row = raw_line.removesuffix("\n").removesuffix("\r")
+    if "\t" in row:
+        raise ExecutableUDFError(
+            f"input line {line_number} contains more than one TSV column"
+        )
+    return _decode_tsv_value(row)
+
+
+def _decode_tsv_value(value: str) -> str:
+    decoded: list[str] = []
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if character != "\\" or index + 1 == len(value):
+            decoded.append(character)
+            index += 1
+            continue
+
+        escaped = value[index + 1]
+        decoded.append(_TSV_DECODE_ESCAPES.get(escaped, f"\\{escaped}"))
+        index += 2
+    return "".join(decoded)
+
+
+def _encode_tsv_value(value: str) -> str:
+    return "".join(_TSV_ENCODE_ESCAPES.get(character, character) for character in value)
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Redact one ClickHouse TabSeparated string per stdin row.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=_positive_int,
+        default=32,
+        help="Number of rows buffered before batch redaction.",
+    )
+    parser.add_argument(
+        "--model-name",
+        default=DEFAULT_EXECUTABLE_UDF_MODEL,
+        help="PII model identifier passed to OpenMed batch de-identification.",
+    )
+    parser.add_argument(
+        "--method",
+        default="mask",
+        choices=("mask", "remove", "replace", "hash", "shift_dates"),
+        help="De-identification method.",
+    )
+    parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.7,
+        help="Minimum PII detection confidence.",
+    )
+    parser.add_argument(
+        "--lang",
+        default="en",
+        help="Language hint forwarded to de-identification.",
+    )
+    parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy profile forwarded to de-identification.",
+    )
+    parser.add_argument(
+        "--keep-year",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Keep or redact the year in detected dates.",
+    )
+    parser.add_argument(
+        "--use-safety-sweep",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable or disable deterministic structured-identifier detection.",
+    )
+    return parser
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/openmed/integrations/pandas_on_spark.py
+++ b/openmed/integrations/pandas_on_spark.py
@@ -1,0 +1,325 @@
+"""Pandas API on Spark accessors for distributed de-identification."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from threading import RLock
+from typing import Any
+
+try:
+    import pandas as pd
+    import pyspark.pandas as ps
+    from pyspark.pandas.extensions import (
+        register_dataframe_accessor,
+        register_series_accessor,
+    )
+except ImportError as exc:  # pragma: no cover - exercised by packaging users
+    raise ImportError(
+        "Pandas-on-Spark support requires the 'spark' extra. "
+        "Install with `pip install openmed[spark]`."
+    ) from exc
+
+Deidentifier = Callable[..., Any]
+
+DEFAULT_PANDAS_ON_SPARK_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+
+_CACHE_LOCK = RLock()
+_PROCESS_BATCH: Deidentifier | None = None
+_WORKER_LOADER: Any | None = None
+_WORKER_LOADER_CONFIG: Any | None = None
+_WORKER_LOADER_INITIALIZED = False
+
+
+@register_dataframe_accessor("deid")
+class OpenMedPandasOnSparkDataFrameAccessor:
+    """OpenMed helpers attached to ``pyspark.pandas.DataFrame.deid``."""
+
+    def __init__(self, pandas_obj: Any) -> None:
+        self._obj = pandas_obj
+
+    def deidentify(
+        self,
+        columns: Sequence[str] | str,
+        *,
+        method: str = "mask",
+        policy: str | None = None,
+        deidentifier: Deidentifier | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Return a distributed DataFrame with selected text columns redacted.
+
+        The signature mirrors the local Pandas accessor. Each selected column
+        is transformed through a pandas UDF, and every Arrow row group is sent
+        to :func:`openmed.processing.process_batch` as one batch.
+
+        Args:
+            columns: Free-text column names to redact.
+            method: De-identification method forwarded to ``process_batch``.
+            policy: Optional policy profile forwarded to ``process_batch``.
+            deidentifier: Optional batch callable used primarily by tests and
+                custom executor environments. It must accept a sequence of
+                strings and return the ``process_batch`` result shape.
+            **kwargs: Additional keyword arguments forwarded to
+                ``process_batch``. ``model_name`` may be supplied here.
+
+        Returns:
+            A new pandas-on-Spark DataFrame with selected columns redacted.
+        """
+
+        selected_columns = _validate_columns(self._obj, columns)
+        redacted = self._obj.copy()
+        process_batch_fn, process_kwargs = _resolve_process_batch(
+            deidentifier,
+            kwargs,
+        )
+
+        for column in selected_columns:
+            redacted[column] = _transform_series(
+                redacted[column],
+                method=method,
+                policy=policy,
+                process_batch_fn=process_batch_fn,
+                process_kwargs=process_kwargs,
+            )
+
+        return redacted
+
+
+@register_series_accessor("deid")
+class OpenMedPandasOnSparkSeriesAccessor:
+    """OpenMed helpers attached to ``pyspark.pandas.Series.deid``."""
+
+    def __init__(self, pandas_obj: Any) -> None:
+        self._obj = pandas_obj
+
+    def deidentify(
+        self,
+        *,
+        method: str = "mask",
+        policy: str | None = None,
+        deidentifier: Deidentifier | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Return this distributed text Series with identifiers redacted."""
+
+        process_batch_fn, process_kwargs = _resolve_process_batch(
+            deidentifier,
+            kwargs,
+        )
+        return _transform_series(
+            self._obj,
+            method=method,
+            policy=policy,
+            process_batch_fn=process_batch_fn,
+            process_kwargs=process_kwargs,
+        )
+
+
+def _transform_series(
+    series: Any,
+    *,
+    method: str,
+    policy: str | None,
+    process_batch_fn: Deidentifier | None,
+    process_kwargs: dict[str, Any],
+) -> Any:
+    if not pd.api.types.is_string_dtype(series.dtype):
+        raise TypeError("pandas-on-Spark de-identification requires a text column")
+
+    return series.pandas_on_spark.transform_batch(
+        _deidentify_series_batch,
+        method,
+        policy,
+        process_batch_fn,
+        process_kwargs,
+    )
+
+
+def _deidentify_series_batch(
+    batch: Any,
+    method: str,
+    policy: str | None,
+    process_batch_fn: Deidentifier | None,
+    process_kwargs: dict[str, Any],
+) -> ps.Series[str]:
+    """Redact one Arrow-backed pandas Series batch on a Spark worker."""
+
+    redacted = batch.copy(deep=True)
+    texts: list[str] = []
+    positions: list[int] = []
+    for position, value in enumerate(redacted.tolist()):
+        if _should_deidentify(value):
+            texts.append(value)
+            positions.append(position)
+
+    if not texts:
+        return redacted
+
+    replacements = _run_worker_batch(
+        texts,
+        method=method,
+        policy=policy,
+        process_batch_fn=process_batch_fn,
+        process_kwargs=process_kwargs,
+    )
+    for replacement, position in zip(replacements, positions):
+        redacted.iloc[position] = replacement
+
+    return redacted
+
+
+def _run_worker_batch(
+    texts: Sequence[str],
+    *,
+    method: str,
+    policy: str | None,
+    process_batch_fn: Deidentifier | None,
+    process_kwargs: dict[str, Any],
+) -> list[str]:
+    batcher = process_batch_fn if process_batch_fn is not None else _get_process_batch()
+    kwargs = dict(process_kwargs)
+    model_name = str(kwargs.pop("model_name", DEFAULT_PANDAS_ON_SPARK_MODEL)).strip()
+    if not model_name:
+        raise ValueError("model_name must be a non-empty string")
+
+    kwargs["operation"] = "deidentify"
+    kwargs["method"] = method
+    kwargs["model_name"] = model_name
+    kwargs.setdefault("batch_size", max(1, len(texts)))
+    if policy is not None:
+        kwargs["policy"] = policy
+
+    if process_batch_fn is None and kwargs.get("loader") is None:
+        loader = _get_worker_loader(kwargs.get("config"))
+        if loader is not None:
+            kwargs["loader"] = loader
+
+    batch_result = batcher(list(texts), **kwargs)
+    return _deidentified_texts(batch_result, expected=len(texts))
+
+
+def _resolve_process_batch(
+    deidentifier: Deidentifier | None,
+    kwargs: dict[str, Any],
+) -> tuple[Deidentifier | None, dict[str, Any]]:
+    process_kwargs = dict(kwargs)
+    process_batch_fn = process_kwargs.pop("process_batch_fn", None)
+    if deidentifier is not None and process_batch_fn is not None:
+        raise ValueError("pass only one of deidentifier or process_batch_fn")
+    if deidentifier is not None and not callable(deidentifier):
+        raise TypeError("deidentifier must be callable")
+    if process_batch_fn is not None and not callable(process_batch_fn):
+        raise TypeError("process_batch_fn must be callable")
+    return (
+        deidentifier if deidentifier is not None else process_batch_fn,
+        process_kwargs,
+    )
+
+
+def _get_process_batch() -> Deidentifier:
+    global _PROCESS_BATCH
+
+    with _CACHE_LOCK:
+        if _PROCESS_BATCH is None:
+            from openmed.processing import process_batch
+
+            _PROCESS_BATCH = process_batch
+        return _PROCESS_BATCH
+
+
+def _get_worker_loader(config: Any | None = None) -> Any | None:
+    global _WORKER_LOADER, _WORKER_LOADER_CONFIG, _WORKER_LOADER_INITIALIZED
+
+    with _CACHE_LOCK:
+        if _WORKER_LOADER_INITIALIZED and _WORKER_LOADER_CONFIG is config:
+            return _WORKER_LOADER
+
+        try:
+            from openmed.core import ModelLoader
+
+            _WORKER_LOADER = ModelLoader() if config is None else ModelLoader(config)
+        except ImportError:
+            _WORKER_LOADER = None
+        _WORKER_LOADER_CONFIG = config
+        _WORKER_LOADER_INITIALIZED = True
+        return _WORKER_LOADER
+
+
+def _validate_columns(
+    frame: Any,
+    columns: Sequence[str] | str,
+) -> tuple[str, ...]:
+    selected = _normalize_columns(columns)
+    missing = [column for column in selected if column not in frame.columns]
+    if missing:
+        raise KeyError(f"DataFrame is missing columns: {', '.join(missing)}")
+    return selected
+
+
+def _normalize_columns(columns: Sequence[str] | str) -> tuple[str, ...]:
+    if isinstance(columns, str):
+        normalized = (columns,)
+    else:
+        normalized = tuple(str(column) for column in columns)
+
+    if not normalized:
+        raise ValueError("columns must include at least one column name")
+    return normalized
+
+
+def _should_deidentify(value: Any) -> bool:
+    if not isinstance(value, str) or value == "":
+        return False
+    try:
+        return not bool(pd.isna(value))
+    except (TypeError, ValueError):
+        return True
+
+
+def _deidentified_texts(batch_result: Any, *, expected: int) -> list[str]:
+    items = getattr(batch_result, "items", batch_result)
+    if len(items) != expected:
+        raise ValueError(
+            f"process_batch returned {len(items)} results for {expected} inputs"
+        )
+    return [_deidentified_text(item) for item in items]
+
+
+def _deidentified_text(item: Any) -> str:
+    if hasattr(item, "success") and not item.success:
+        raise RuntimeError(
+            "pandas-on-Spark de-identification failed for one or more cells"
+        )
+
+    result = getattr(item, "result", item)
+    if isinstance(result, str):
+        return result
+
+    try:
+        return str(result.deidentified_text)
+    except AttributeError as exc:
+        raise TypeError(
+            "process_batch results must contain strings or deidentified_text"
+        ) from exc
+
+
+def clear_worker_pipeline_cache() -> None:
+    """Clear driver-local worker cache state used by deterministic tests."""
+
+    global _PROCESS_BATCH, _WORKER_LOADER
+    global _WORKER_LOADER_CONFIG, _WORKER_LOADER_INITIALIZED
+
+    with _CACHE_LOCK:
+        _PROCESS_BATCH = None
+        _WORKER_LOADER = None
+        _WORKER_LOADER_CONFIG = None
+        _WORKER_LOADER_INITIALIZED = False
+
+
+__all__ = [
+    "DEFAULT_PANDAS_ON_SPARK_MODEL",
+    "Deidentifier",
+    "OpenMedPandasOnSparkDataFrameAccessor",
+    "OpenMedPandasOnSparkSeriesAccessor",
+    "clear_worker_pipeline_cache",
+]

--- a/openmed/integrations/postgres_plpython.py
+++ b/openmed/integrations/postgres_plpython.py
@@ -1,0 +1,226 @@
+"""PostgreSQL PL/Python bodies for in-database de-identification.
+
+The accompanying ``sql/postgres_deidentify.sql`` migration exposes two SQL
+functions:
+
+* ``openmed_deidentify(text) -> text``
+* ``openmed_deidentify_batch(text[]) -> SETOF text``
+
+PostgreSQL passes PL/Python's per-session ``GD`` dictionary to the functions
+below.  The cached :class:`~openmed.core.models.ModelLoader` owns the warmed
+model pipeline, so repeated scalar calls and batch calls in the same database
+session do not reload it.  This module deliberately contains no logging calls:
+raw clinical text must never be written to PostgreSQL logs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_MODEL_NAME = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+DEFAULT_POLICY = "hipaa_safe_harbor"
+
+_SESSION_CACHE_KEY = "openmed.postgres_plpython.pipeline.v1"
+
+ProcessBatch = Callable[..., Any]
+LoaderFactory = Callable[[], Any]
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class _SessionState:
+    """Objects retained in PL/Python's per-session global dictionary."""
+
+    process_batch: ProcessBatch
+    pipeline_loader: Any
+
+
+def deidentify_text(
+    text: str | None,
+    session_globals: MutableMapping[str, Any],
+    *,
+    process_batch_fn: ProcessBatch | None = None,
+    loader_factory: LoaderFactory | None = None,
+) -> str | None:
+    """Return one de-identified PostgreSQL text value.
+
+    Args:
+        text: PostgreSQL ``text`` value. ``None`` is returned unchanged for
+            direct Python callers; the SQL function is also declared
+            ``STRICT`` so PostgreSQL normally handles SQL ``NULL`` itself.
+        session_globals: PL/Python's per-session ``GD`` dictionary.
+        process_batch_fn: Optional test seam replacing ``process_batch``.
+        loader_factory: Optional test seam replacing ``ModelLoader``.
+
+    Returns:
+        The de-identified text, or ``None`` for a null input.
+    """
+
+    if text is None or text == "":
+        return text
+
+    return deidentify_batch(
+        [text],
+        session_globals,
+        process_batch_fn=process_batch_fn,
+        loader_factory=loader_factory,
+    )[0]
+
+
+def deidentify_batch(
+    texts: Sequence[str | None] | None,
+    session_globals: MutableMapping[str, Any],
+    *,
+    process_batch_fn: ProcessBatch | None = None,
+    loader_factory: LoaderFactory | None = None,
+) -> list[str | None]:
+    """Return de-identified PostgreSQL rows in input order.
+
+    One ``process_batch`` call handles all non-empty values. SQL ``NULL`` and
+    empty-string array elements are passed through without model inference.
+    The loader cached in ``session_globals`` retains its warmed pipeline across
+    calls for the lifetime of the PostgreSQL session.
+
+    Args:
+        texts: PostgreSQL ``text[]`` values, including optional null elements.
+        session_globals: PL/Python's per-session ``GD`` dictionary.
+        process_batch_fn: Optional test seam replacing ``process_batch``.
+        loader_factory: Optional test seam replacing ``ModelLoader``.
+
+    Returns:
+        One output value for every input array element, in the same order.
+
+    Raises:
+        TypeError: If an array element is not text or null.
+        RuntimeError: If OpenMed cannot de-identify every non-empty value. The
+            message intentionally omits source text and underlying exceptions.
+    """
+
+    if texts is None:
+        return []
+
+    values = list(texts)
+    if any(value is not None and not isinstance(value, str) for value in values):
+        raise TypeError("PostgreSQL text[] values must be strings or NULL")
+
+    output = list(values)
+    positions = [
+        position
+        for position, value in enumerate(values)
+        if isinstance(value, str) and value != ""
+    ]
+    if not positions:
+        return output
+
+    try:
+        state = _get_session_state(
+            session_globals,
+            process_batch_fn=process_batch_fn,
+            loader_factory=loader_factory,
+        )
+        inputs = [values[position] for position in positions]
+        batch_result = state.process_batch(
+            inputs,
+            model_name=DEFAULT_MODEL_NAME,
+            operation="deidentify",
+            method="mask",
+            policy=DEFAULT_POLICY,
+            loader=state.pipeline_loader,
+            batch_size=max(1, len(inputs)),
+            continue_on_error=True,
+        )
+        redacted = _deidentified_texts(batch_result, expected=len(inputs))
+    except Exception:
+        raise RuntimeError("OpenMed de-identification failed") from None
+
+    for position, replacement in zip(positions, redacted):
+        output[position] = replacement
+    return output
+
+
+def _get_session_state(
+    session_globals: MutableMapping[str, Any],
+    *,
+    process_batch_fn: ProcessBatch | None,
+    loader_factory: LoaderFactory | None,
+) -> _SessionState:
+    cached = session_globals.get(_SESSION_CACHE_KEY)
+    if cached is not None:
+        if not isinstance(cached, _SessionState):
+            raise RuntimeError("OpenMed PL/Python session cache is invalid")
+        return cached
+
+    process_batch = process_batch_fn or _default_process_batch()
+    create_loader = loader_factory or _default_loader_factory
+    state = _SessionState(
+        process_batch=process_batch,
+        pipeline_loader=create_loader(),
+    )
+    session_globals[_SESSION_CACHE_KEY] = state
+    return state
+
+
+def _deidentified_texts(batch_result: Any, *, expected: int) -> list[str]:
+    if isinstance(batch_result, Mapping):
+        items = batch_result.get("items", _MISSING)
+    else:
+        items = getattr(batch_result, "items", batch_result)
+
+    if items is _MISSING or isinstance(items, (str, bytes)):
+        raise RuntimeError("OpenMed de-identification returned invalid results")
+
+    try:
+        items = list(items)
+    except (TypeError, ValueError):
+        raise RuntimeError(
+            "OpenMed de-identification returned invalid results"
+        ) from None
+
+    if len(items) != expected:
+        raise RuntimeError("OpenMed de-identification returned invalid results")
+
+    redacted: list[str] = []
+    for item in items:
+        success = _get_field(item, "success", default=_MISSING)
+        if success is not _MISSING and not success:
+            raise RuntimeError("OpenMed de-identification failed for a batch item")
+
+        result = _get_field(item, "result", default=item)
+        if isinstance(result, str):
+            redacted.append(result)
+            continue
+
+        replacement = _get_field(result, "deidentified_text", default=None)
+        if not isinstance(replacement, str):
+            raise RuntimeError("OpenMed de-identification returned invalid results")
+        redacted.append(replacement)
+
+    return redacted
+
+
+def _get_field(value: Any, name: str, *, default: Any) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _default_process_batch() -> ProcessBatch:
+    from openmed.processing import process_batch
+
+    return process_batch
+
+
+def _default_loader_factory() -> Any:
+    from openmed.core import ModelLoader
+
+    return ModelLoader()
+
+
+__all__ = [
+    "DEFAULT_MODEL_NAME",
+    "DEFAULT_POLICY",
+    "deidentify_batch",
+    "deidentify_text",
+]

--- a/openmed/integrations/ray_map_batches.py
+++ b/openmed/integrations/ray_map_batches.py
@@ -1,0 +1,405 @@
+"""Stateful Ray Data batch de-identification with shared model actors.
+
+The callable class in this module is intended for
+``ray.data.Dataset.map_batches``. Ray runs callable classes as actors, so each
+actor constructs one OpenMed batch pipeline and reuses its loaded model across
+all batches assigned to that worker.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Literal, Protocol, TypeAlias
+
+DEFAULT_RAY_PII_MODEL = "OpenMed/OpenMed-PII-SuperClinical-Small-44M-v1"
+
+BatchFormat: TypeAlias = Literal["pandas", "pyarrow"]
+ActorPoolConcurrency: TypeAlias = int | tuple[int, int] | tuple[int, int, int]
+
+
+class BatchPipeline(Protocol):
+    """Protocol implemented by actor-local batch processing pipelines."""
+
+    def process_texts(
+        self,
+        texts: Sequence[str],
+        ids: Sequence[str] | None = None,
+    ) -> Any:
+        """De-identify a batch of text values."""
+
+
+PipelineFactory: TypeAlias = Callable[..., BatchPipeline]
+
+
+class RayDeidentifyBatch:
+    """Callable Ray Data actor that de-identifies one column per batch.
+
+    Ray constructs this class once per actor. The constructor eagerly builds
+    and warms one OpenMed batch pipeline; subsequent ``__call__`` invocations
+    reuse the same model resources.
+
+    Args:
+        column: Name of the text column to de-identify.
+        policy_profile: Optional OpenMed policy profile passed as ``policy`` to
+            batch de-identification.
+        model_name: OpenMed model registry key or model identifier.
+        method: De-identification method, such as ``"mask"``.
+        process_batch_size: Maximum number of text values processed together
+            inside the actor pipeline.
+        process_batch_kwargs: Additional keyword arguments forwarded to the
+            actor-local OpenMed batch processor.
+        pipeline_factory: Optional factory used to construct the actor-local
+            pipeline. This is primarily useful for offline tests.
+    """
+
+    def __init__(
+        self,
+        column: str,
+        policy_profile: str | None = None,
+        *,
+        model_name: str = DEFAULT_RAY_PII_MODEL,
+        method: str = "mask",
+        process_batch_size: int = 512,
+        process_batch_kwargs: Mapping[str, Any] | None = None,
+        pipeline_factory: PipelineFactory | None = None,
+    ) -> None:
+        if not isinstance(column, str) or not column.strip():
+            raise ValueError("column must be a non-empty string")
+        if (
+            isinstance(process_batch_size, bool)
+            or not isinstance(process_batch_size, int)
+            or process_batch_size < 1
+        ):
+            raise ValueError("process_batch_size must be a positive integer")
+
+        kwargs = dict(process_batch_kwargs or {})
+        reserved = {
+            "batch_size",
+            "method",
+            "model_name",
+            "operation",
+            "policy",
+            "policy_profile",
+        }
+        conflicts = sorted(reserved.intersection(kwargs))
+        if conflicts:
+            joined = ", ".join(conflicts)
+            raise ValueError(
+                "process_batch_kwargs contains reserved argument(s): " + joined
+            )
+
+        self.column = column
+        self.policy_profile = policy_profile
+        self.model_name = model_name
+        self.method = method
+        factory = pipeline_factory or _create_openmed_batch_pipeline
+        self._pipeline = factory(
+            model_name=model_name,
+            method=method,
+            policy_profile=policy_profile,
+            process_batch_size=process_batch_size,
+            process_batch_kwargs=kwargs,
+        )
+
+    def __call__(self, batch: Any) -> Any:
+        """Return the batch with the configured text column de-identified."""
+
+        return self.process_batch(batch)
+
+    def process_batch(self, batch: Any) -> Any:
+        """De-identify one Arrow or pandas batch and preserve its shape."""
+
+        values = _target_values(batch, self.column)
+        positions: list[int] = []
+        texts: list[str] = []
+        for position, value in enumerate(values):
+            if _is_missing(value):
+                continue
+            if not isinstance(value, str):
+                raise TypeError(
+                    f"Ray batch column {self.column!r} must contain strings or nulls"
+                )
+            if value == "":
+                continue
+            positions.append(position)
+            texts.append(value)
+
+        redacted_values = list(values)
+        if texts:
+            ids = [f"ray_batch_{position}" for position in positions]
+            result = _process_pipeline_batch(self._pipeline, texts, ids)
+            redacted_texts = _deidentified_texts(result, expected=len(texts))
+            for position, redacted in zip(positions, redacted_texts):
+                redacted_values[position] = redacted
+
+        if len(redacted_values) != len(values):  # pragma: no cover - invariant
+            raise RuntimeError("Ray de-identification changed the batch row count")
+        return _replace_target_values(batch, self.column, redacted_values)
+
+
+RayMapBatchesDeidentifier = RayDeidentifyBatch
+
+
+def map_batches_deidentify(
+    dataset: Any,
+    *,
+    column: str,
+    policy_profile: str | None = None,
+    model_name: str = DEFAULT_RAY_PII_MODEL,
+    method: str = "mask",
+    batch_size: int | None = None,
+    batch_format: BatchFormat = "pyarrow",
+    concurrency: ActorPoolConcurrency = 1,
+    process_batch_kwargs: Mapping[str, Any] | None = None,
+    pipeline_factory: PipelineFactory | None = None,
+    **ray_remote_args: Any,
+) -> Any:
+    """Apply actor-backed batch de-identification to a Ray Dataset.
+
+    Args:
+        dataset: A ``ray.data.Dataset`` instance.
+        column: Name of the text column to de-identify.
+        policy_profile: Optional OpenMed policy profile.
+        model_name: OpenMed model registry key or model identifier.
+        method: De-identification method, such as ``"mask"``.
+        batch_size: Desired number of dataset rows in each Ray batch.
+        batch_format: Either ``"pandas"`` or ``"pyarrow"``.
+        concurrency: Fixed actor count, ``(min, max)`` autoscaling range, or
+            ``(min, max, initial)`` autoscaling configuration.
+        process_batch_kwargs: Extra OpenMed batch-processing arguments.
+        pipeline_factory: Optional actor-local pipeline factory, primarily for
+            offline tests.
+        **ray_remote_args: Resource requirements forwarded to
+            ``Dataset.map_batches``, such as ``num_cpus`` or ``num_gpus``.
+
+    Returns:
+        A lazy Ray Dataset with the same rows and non-target columns.
+    """
+
+    if batch_format not in {"pandas", "pyarrow"}:
+        raise ValueError("batch_format must be 'pandas' or 'pyarrow'")
+    if batch_size is not None and (
+        isinstance(batch_size, bool)
+        or not isinstance(batch_size, int)
+        or batch_size < 1
+    ):
+        raise ValueError("batch_size must be a positive integer or None")
+
+    try:
+        from ray.data import ActorPoolStrategy
+    except ImportError as exc:  # pragma: no cover - packaging users
+        raise ImportError(
+            "Ray Data support requires Ray. Install with `pip install 'ray[data]'`."
+        ) from exc
+
+    compute = _actor_pool_strategy(ActorPoolStrategy, concurrency)
+    constructor_kwargs = {
+        "column": column,
+        "policy_profile": policy_profile,
+        "model_name": model_name,
+        "method": method,
+        "process_batch_size": batch_size or 512,
+        "process_batch_kwargs": dict(process_batch_kwargs or {}),
+        "pipeline_factory": pipeline_factory,
+    }
+    return dataset.map_batches(
+        RayDeidentifyBatch,
+        batch_size=batch_size,
+        batch_format=batch_format,
+        compute=compute,
+        fn_constructor_kwargs=constructor_kwargs,
+        zero_copy_batch=True,
+        udf_modifying_row_count=False,
+        **ray_remote_args,
+    )
+
+
+def _create_openmed_batch_pipeline(
+    *,
+    model_name: str,
+    method: str,
+    policy_profile: str | None,
+    process_batch_size: int,
+    process_batch_kwargs: Mapping[str, Any],
+) -> BatchPipeline:
+    """Create and eagerly warm one actor-local OpenMed batch pipeline."""
+
+    from openmed.processing.batch import BatchProcessor
+
+    processor = BatchProcessor(
+        model_name=model_name,
+        operation="deidentify",
+        batch_size=process_batch_size,
+        method=method,
+        policy=policy_profile,
+        **dict(process_batch_kwargs),
+    )
+
+    privacy_pipeline = processor._get_privacy_filter_pipeline()
+    if privacy_pipeline is None:
+        loader = processor._get_shared_loader()
+        if loader is None:
+            raise ImportError(
+                "Ray de-identification requires model dependencies. "
+                "Install with `pip install 'openmed[hf]'`."
+            )
+
+        from openmed.core.pii import _resolve_effective_pii_model
+
+        effective_model = _resolve_effective_pii_model(
+            model_name,
+            str(processor.analyze_kwargs.get("lang", "en")),
+        )
+        loader.create_pipeline(
+            effective_model,
+            task="token-classification",
+            aggregation_strategy=processor.aggregation_strategy,
+            use_fast_tokenizer=True,
+        )
+
+    return processor
+
+
+def _actor_pool_strategy(
+    strategy_type: Callable[..., Any],
+    concurrency: ActorPoolConcurrency,
+) -> Any:
+    if isinstance(concurrency, bool):
+        raise ValueError("concurrency must use positive integer actor counts")
+    if isinstance(concurrency, int):
+        if concurrency < 1:
+            raise ValueError("concurrency must be at least 1")
+        return strategy_type(size=concurrency)
+    if not isinstance(concurrency, tuple) or len(concurrency) not in {2, 3}:
+        raise ValueError(
+            "concurrency must be an int, (min, max), or (min, max, initial)"
+        )
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) for value in concurrency
+    ):
+        raise ValueError("concurrency values must be integers")
+
+    minimum, maximum = concurrency[:2]
+    if minimum < 1 or maximum < minimum:
+        raise ValueError("concurrency requires 1 <= min <= max")
+    if len(concurrency) == 2:
+        return strategy_type(min_size=minimum, max_size=maximum)
+
+    initial = concurrency[2]
+    if initial < minimum or initial > maximum:
+        raise ValueError("initial concurrency must be between min and max")
+    return strategy_type(
+        min_size=minimum,
+        max_size=maximum,
+        initial_size=initial,
+    )
+
+
+def _target_values(batch: Any, column: str) -> list[Any]:
+    try:
+        import pandas as pd
+    except ImportError:  # pragma: no cover - Ray installs pandas
+        pd = None  # type: ignore[assignment]
+    if pd is not None and isinstance(batch, pd.DataFrame):
+        if column not in batch.columns:
+            raise KeyError(f"Ray batch is missing column {column!r}")
+        return batch[column].tolist()
+
+    try:
+        import pyarrow as pa
+    except ImportError:  # pragma: no cover - Ray installs PyArrow
+        pa = None  # type: ignore[assignment]
+    if pa is not None and isinstance(batch, pa.Table):
+        if column not in batch.column_names:
+            raise KeyError(f"Ray batch is missing column {column!r}")
+        return batch.column(column).to_pylist()
+
+    raise TypeError("RayDeidentifyBatch expects a pandas DataFrame or pyarrow Table")
+
+
+def _replace_target_values(batch: Any, column: str, values: Sequence[Any]) -> Any:
+    try:
+        import pandas as pd
+    except ImportError:  # pragma: no cover - Ray installs pandas
+        pd = None  # type: ignore[assignment]
+    if pd is not None and isinstance(batch, pd.DataFrame):
+        result = batch.copy(deep=True)
+        result[column] = list(values)
+        return result
+
+    try:
+        import pyarrow as pa
+    except ImportError:  # pragma: no cover - Ray installs PyArrow
+        pa = None  # type: ignore[assignment]
+    if pa is not None and isinstance(batch, pa.Table):
+        index = batch.schema.get_field_index(column)
+        field = batch.schema.field(index)
+        replacement = pa.array(values, type=field.type)
+        return batch.set_column(index, field, replacement)
+
+    raise TypeError("RayDeidentifyBatch expects a pandas DataFrame or pyarrow Table")
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    try:
+        import pandas as pd
+    except ImportError:  # pragma: no cover - Ray installs pandas
+        return False
+    try:
+        missing = pd.isna(value)
+    except (TypeError, ValueError):
+        return False
+    try:
+        return bool(missing)
+    except ValueError:
+        return False
+
+
+def _deidentified_texts(result: Any, *, expected: int) -> list[str]:
+    items = getattr(result, "items", result)
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes, bytearray)):
+        raise TypeError("OpenMed batch results must contain an item sequence")
+    if len(items) != expected:
+        raise ValueError(
+            f"OpenMed returned {len(items)} result(s) for {expected} input(s)"
+        )
+    return [_deidentified_text(item) for item in items]
+
+
+def _process_pipeline_batch(
+    pipeline: BatchPipeline,
+    texts: Sequence[str],
+    ids: Sequence[str],
+) -> Any:
+    process_batch = getattr(pipeline, "process_batch", None)
+    if callable(process_batch):
+        return process_batch(texts, ids=ids)
+    return pipeline.process_texts(texts, ids=ids)
+
+
+def _deidentified_text(item: Any) -> str:
+    if getattr(item, "error", None):
+        raise RuntimeError("Ray batch de-identification failed for one or more cells")
+    if hasattr(item, "success") and not item.success:
+        raise RuntimeError("Ray batch de-identification failed for one or more cells")
+
+    value = getattr(item, "result", item)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping) and "deidentified_text" in value:
+        return str(value["deidentified_text"])
+    if hasattr(value, "deidentified_text"):
+        return str(value.deidentified_text)
+    raise TypeError("OpenMed batch results must expose deidentified_text")
+
+
+__all__ = [
+    "ActorPoolConcurrency",
+    "BatchFormat",
+    "DEFAULT_RAY_PII_MODEL",
+    "RayDeidentifyBatch",
+    "RayMapBatchesDeidentifier",
+    "map_batches_deidentify",
+]

--- a/openmed/integrations/search_ingest_processor.py
+++ b/openmed/integrations/search_ingest_processor.py
@@ -1,0 +1,303 @@
+"""HTTP sidecar for redacting search-ingest document envelopes."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, status
+
+from openmed.core.pii_i18n import DEFAULT_PII_MODELS
+from openmed.processing.batch import process_batch
+
+DEFAULT_SEARCH_INGEST_MODEL = DEFAULT_PII_MODELS["en"]
+ProcessBatchCallable = Callable[..., Any]
+
+
+class SearchIngestProcessorError(RuntimeError):
+    """Raised when an ingest document cannot be redacted safely."""
+
+
+@dataclass(frozen=True)
+class _Target:
+    field_name: str
+    path: tuple[str, ...]
+    text: str
+
+
+def redact_ingest_document(
+    document: Mapping[str, Any],
+    *,
+    fields: Sequence[str],
+    policy: str | None = None,
+    process_batch_fn: ProcessBatchCallable = process_batch,
+) -> dict[str, Any]:
+    """Return a redacted copy of a search ingest-document envelope.
+
+    Field names are resolved relative to ``_source`` by default. Paths that
+    start with ``_source.`` or another envelope key are also accepted. Missing
+    paths, non-string values, and empty strings are preserved without invoking
+    the batch processor.
+
+    Args:
+        document: Elasticsearch/OpenSearch-style ingest document envelope.
+        fields: Top-level or dotted paths to string fields that should be
+            redacted.
+        policy: Optional OpenMed policy profile for this pipeline invocation.
+        process_batch_fn: Batch processor implementation, replaceable for
+            offline tests and embedded deployments.
+
+    Returns:
+        A deep copy of ``document`` with configured string fields redacted.
+
+    Raises:
+        TypeError: If ``document`` is not a mapping.
+        ValueError: If a configured field path or policy is invalid.
+        SearchIngestProcessorError: If batch redaction fails or returns an
+            invalid result. Error messages never include document text.
+    """
+
+    if not isinstance(document, Mapping):
+        raise TypeError("document must be a mapping")
+
+    normalized_fields = _normalize_fields(fields)
+    normalized_policy = _normalize_policy(policy)
+    output = copy.deepcopy(dict(document))
+    targets = _collect_targets(output, normalized_fields)
+    if not targets:
+        return output
+
+    kwargs: dict[str, Any] = {
+        "model_name": DEFAULT_SEARCH_INGEST_MODEL,
+        "ids": [f"ingest:{target.field_name}" for target in targets],
+        "operation": "deidentify",
+        "batch_size": len(targets),
+        "method": "mask",
+        "confidence_threshold": 0.7,
+        "continue_on_error": False,
+        "use_safety_sweep": True,
+    }
+    if normalized_policy is not None:
+        kwargs["policy"] = normalized_policy
+
+    try:
+        batch_result = process_batch_fn(
+            [target.text for target in targets],
+            **kwargs,
+        )
+        redacted_texts = _extract_redacted_texts(
+            batch_result,
+            expected=len(targets),
+        )
+    except Exception:
+        raise SearchIngestProcessorError(
+            "failed to redact configured ingest document fields"
+        ) from None
+
+    for target, redacted_text in zip(targets, redacted_texts):
+        _set_path(output, target.path, redacted_text)
+    return output
+
+
+def create_app(
+    *,
+    process_batch_fn: ProcessBatchCallable = process_batch,
+) -> FastAPI:
+    """Create the search-ingest redaction sidecar application.
+
+    Args:
+        process_batch_fn: Batch processor implementation used by ``/process``.
+
+    Returns:
+        A configured FastAPI application.
+    """
+
+    app = FastAPI(
+        title="OpenMed search ingest redaction processor",
+        version="1.0.0",
+    )
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/process")
+    def process_document(payload: dict[str, Any]) -> dict[str, Any]:
+        document = payload.get("document")
+        fields = payload.get("fields")
+        policy = payload.get("policy")
+
+        if not isinstance(document, Mapping):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="document must be an object",
+            )
+        if not isinstance(fields, list) or any(
+            not isinstance(field, str) for field in fields
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="fields must be an array of strings",
+            )
+        if policy is not None and not isinstance(policy, str):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="policy must be a string or null",
+            )
+
+        try:
+            return redact_ingest_document(
+                document,
+                fields=fields,
+                policy=policy,
+                process_batch_fn=process_batch_fn,
+            )
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(exc),
+            ) from None
+        except SearchIngestProcessorError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=str(exc),
+            ) from None
+
+    return app
+
+
+def _normalize_fields(fields: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(fields, (str, bytes)):
+        raise TypeError("fields must be a sequence of strings")
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for field in fields:
+        if not isinstance(field, str):
+            raise TypeError("fields must contain only strings")
+        field_name = field.strip()
+        if not field_name:
+            raise ValueError("field paths must not be empty")
+        if any(not part for part in field_name.split(".")):
+            raise ValueError("field paths must not contain empty segments")
+        if field_name not in seen:
+            seen.add(field_name)
+            normalized.append(field_name)
+    return tuple(normalized)
+
+
+def _normalize_policy(policy: str | None) -> str | None:
+    if policy is None:
+        return None
+    if not isinstance(policy, str):
+        raise TypeError("policy must be a string or null")
+    normalized = policy.strip()
+    if not normalized:
+        raise ValueError("policy must not be empty")
+    return normalized
+
+
+def _collect_targets(
+    document: Mapping[str, Any],
+    fields: Sequence[str],
+) -> list[_Target]:
+    targets: list[_Target] = []
+    seen_paths: set[tuple[str, ...]] = set()
+    for field_name in fields:
+        path = _resolve_path(document, field_name)
+        if path is None or path in seen_paths:
+            continue
+        value = _get_path(document, path)
+        if isinstance(value, str) and value:
+            targets.append(_Target(field_name=field_name, path=path, text=value))
+            seen_paths.add(path)
+    return targets
+
+
+def _resolve_path(
+    document: Mapping[str, Any],
+    field_name: str,
+) -> tuple[str, ...] | None:
+    parts = tuple(field_name.split("."))
+    source = document.get("_source")
+
+    if parts[0] != "_source" and isinstance(source, Mapping):
+        if field_name in source:
+            return ("_source", field_name)
+        source_path = ("_source", *parts)
+        if _path_exists(document, source_path):
+            return source_path
+
+    if field_name in document:
+        return (field_name,)
+    if _path_exists(document, parts):
+        return parts
+    return None
+
+
+def _path_exists(document: Mapping[str, Any], path: Sequence[str]) -> bool:
+    try:
+        _get_path(document, path)
+    except (KeyError, TypeError):
+        return False
+    return True
+
+
+def _get_path(document: Mapping[str, Any], path: Sequence[str]) -> Any:
+    current: Any = document
+    for part in path:
+        if not isinstance(current, Mapping) or part not in current:
+            raise KeyError(part)
+        current = current[part]
+    return current
+
+
+def _set_path(document: dict[str, Any], path: Sequence[str], value: str) -> None:
+    current = document
+    for part in path[:-1]:
+        nested = current[part]
+        if not isinstance(nested, dict):
+            raise SearchIngestProcessorError(
+                "configured ingest field path is not an object"
+            )
+        current = nested
+    current[path[-1]] = value
+
+
+def _extract_redacted_texts(batch_result: Any, *, expected: int) -> list[str]:
+    raw_items = getattr(batch_result, "items", batch_result)
+    try:
+        items = list(raw_items)
+    except TypeError as exc:
+        raise SearchIngestProcessorError(
+            "ingest redaction returned an invalid result"
+        ) from exc
+
+    if len(items) != expected:
+        raise SearchIngestProcessorError(
+            "ingest redaction returned an unexpected result count"
+        )
+
+    redacted_texts: list[str] = []
+    for item in items:
+        if hasattr(item, "success") and not item.success:
+            raise SearchIngestProcessorError(
+                "ingest redaction failed for one or more configured fields"
+            )
+        result = getattr(item, "result", item)
+        redacted_text = (
+            result
+            if isinstance(result, str)
+            else getattr(result, "deidentified_text", None)
+        )
+        if not isinstance(redacted_text, str):
+            raise SearchIngestProcessorError(
+                "ingest redaction returned an invalid field result"
+            )
+        redacted_texts.append(redacted_text)
+    return redacted_texts
+
+
+app = create_app()

--- a/openmed/integrations/sql/postgres_deidentify.sql
+++ b/openmed/integrations/sql/postgres_deidentify.sql
@@ -1,0 +1,39 @@
+-- Install OpenMed de-identification functions for PostgreSQL PL/Python.
+--
+-- Contract:
+--   openmed_deidentify(text) -> text
+--   openmed_deidentify_batch(text[]) -> SETOF text
+--
+-- Prerequisite: OpenMed must be installed in the Python environment used by
+-- PostgreSQL's plpython3u extension. Creating the extension normally requires
+-- a PostgreSQL superuser. Re-running this migration replaces both functions.
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS plpython3u;
+
+CREATE OR REPLACE FUNCTION openmed_deidentify(input_text text)
+RETURNS text
+LANGUAGE plpython3u
+STRICT
+VOLATILE
+PARALLEL UNSAFE
+AS $openmed$
+from openmed.integrations.postgres_plpython import deidentify_text
+
+return deidentify_text(input_text, GD)
+$openmed$;
+
+CREATE OR REPLACE FUNCTION openmed_deidentify_batch(input_texts text[])
+RETURNS SETOF text
+LANGUAGE plpython3u
+STRICT
+VOLATILE
+PARALLEL UNSAFE
+AS $openmed$
+from openmed.integrations.postgres_plpython import deidentify_batch
+
+return deidentify_batch(input_texts, GD)
+$openmed$;
+
+COMMIT;

--- a/openmed/integrations/stream_processor.py
+++ b/openmed/integrations/stream_processor.py
@@ -1,0 +1,333 @@
+"""Framework-neutral stream processor helpers for record de-identification.
+
+The lifecycle methods intentionally mirror common stateful stream runtimes:
+``open`` initializes one resident processing callable per map-function instance,
+``map`` handles a single record, and ``invoke`` writes one result to a sink.
+The helpers do not depend on a specific cluster runtime, so applications can
+adapt them to their stream processor without pulling that runtime into OpenMed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import Any, Protocol
+
+from openmed.core.policy import PolicyName, canonical_policy_name
+
+DEFAULT_STREAM_BATCH_SIZE = 32
+DEFAULT_STREAM_POLICY = "hipaa_safe_harbor"
+
+ProcessBatchCallable = Callable[..., Any]
+Record = Mapping[str, Any]
+
+
+class RecordWriter(Protocol):
+    """Object that accepts one de-identified record."""
+
+    def write(self, record: Record) -> Any:
+        """Write ``record`` to the downstream system."""
+
+
+class StreamDeidentifyMapFunction:
+    """De-identify one named field while preserving the rest of each record.
+
+    One instance is intended to live in one parallel stream subtask. The first
+    call to :meth:`open`, :meth:`map`, or :meth:`map_batch` resolves and retains
+    the batch processor for that instance. Records are copied before their
+    configured text field is replaced, keeping the transformation stateless and
+    a pure function of that field.
+    """
+
+    def __init__(
+        self,
+        text_field: str = "text",
+        *,
+        policy: str | PolicyName = DEFAULT_STREAM_POLICY,
+        method: str = "mask",
+        model_name: str = "disease_detection_superclinical",
+        batch_size: int = DEFAULT_STREAM_BATCH_SIZE,
+        process_batch_fn: ProcessBatchCallable | None = None,
+        **deidentify_kwargs: Any,
+    ) -> None:
+        """Create a record-level stream map function.
+
+        Args:
+            text_field: Record field containing free text to de-identify.
+            policy: OpenMed de-identification policy profile.
+            method: De-identification method forwarded to ``process_batch``.
+            model_name: Model registry key or artifact identifier.
+            batch_size: Maximum records passed to one ``process_batch`` call.
+            process_batch_fn: Optional test or runtime-specific replacement for
+                :func:`openmed.processing.process_batch`.
+            **deidentify_kwargs: Additional de-identification options forwarded
+                to ``process_batch``.
+        """
+
+        self.text_field = _non_empty_string(text_field, "text_field")
+        self.policy = canonical_policy_name(policy)
+        self.method = _non_empty_string(method, "method")
+        self.model_name = _non_empty_string(model_name, "model_name")
+        self.batch_size = _positive_int(batch_size, "batch_size")
+        if process_batch_fn is not None and not callable(process_batch_fn):
+            raise TypeError("process_batch_fn must be callable")
+
+        kwargs = dict(deidentify_kwargs)
+        for reserved in (
+            "batch_size",
+            "ids",
+            "method",
+            "model_name",
+            "operation",
+            "policy",
+            "texts",
+        ):
+            if reserved in kwargs:
+                raise ValueError(
+                    f"deidentify kwargs must not include reserved key {reserved!r}"
+                )
+
+        self.deidentify_kwargs = kwargs
+        self._configured_process_batch = process_batch_fn
+        self._process_batch: ProcessBatchCallable | None = None
+        self._is_open = False
+
+    @property
+    def is_open(self) -> bool:
+        """Whether this subtask instance has initialized its batch processor."""
+
+        return self._is_open
+
+    def open(self, runtime_context: Any | None = None) -> None:
+        """Initialize this subtask once and retain its batch processor.
+
+        Args:
+            runtime_context: Optional runtime-owned context. It is accepted for
+                compatibility with stream processors and is not inspected.
+        """
+
+        del runtime_context
+        if self._is_open:
+            return
+        if self._configured_process_batch is None:
+            from openmed.processing import process_batch
+
+            self._process_batch = process_batch
+        else:
+            self._process_batch = self._configured_process_batch
+        self._is_open = True
+
+    def map(self, record: Record) -> dict[str, Any]:
+        """Return one copied record with its configured field de-identified."""
+
+        return self.map_batch((record,))[0]
+
+    def map_batch(self, records: Iterable[Record]) -> list[dict[str, Any]]:
+        """De-identify records in bounded micro-batches.
+
+        Args:
+            records: Input record mappings. Missing target fields and non-string
+                target values fail closed; ``None`` and empty strings pass
+                through unchanged without invoking the model.
+
+        Returns:
+            Copied records in input order with only ``text_field`` replaced.
+        """
+
+        if not self._is_open:
+            self.open()
+
+        output: list[dict[str, Any]] = []
+        pending_texts: list[str] = []
+        pending_positions: list[int] = []
+
+        for record in records:
+            if not isinstance(record, Mapping):
+                raise TypeError("stream records must be mappings")
+            if self.text_field not in record:
+                raise KeyError(f"record is missing text field {self.text_field!r}")
+
+            copied = dict(record)
+            value = copied[self.text_field]
+            if value is not None and not isinstance(value, str):
+                raise TypeError(
+                    f"record field {self.text_field!r} must be a string or None"
+                )
+            output.append(copied)
+            if value:
+                pending_texts.append(value)
+                pending_positions.append(len(output) - 1)
+
+            if len(pending_texts) == self.batch_size:
+                self._apply_batch(output, pending_positions, pending_texts)
+                pending_texts = []
+                pending_positions = []
+
+        if pending_texts:
+            self._apply_batch(output, pending_positions, pending_texts)
+        return output
+
+    def _apply_batch(
+        self,
+        output: list[dict[str, Any]],
+        positions: Sequence[int],
+        texts: Sequence[str],
+    ) -> None:
+        process_batch_fn = self._process_batch
+        if process_batch_fn is None:  # pragma: no cover - defensive invariant
+            raise RuntimeError("stream map function is not open")
+
+        kwargs = {
+            "operation": "deidentify",
+            "model_name": self.model_name,
+            "batch_size": self.batch_size,
+            "continue_on_error": False,
+            "method": self.method,
+            "policy": self.policy,
+            **self.deidentify_kwargs,
+        }
+        batch_result = process_batch_fn(list(texts), **kwargs)
+        redacted = _deidentified_texts(batch_result, expected=len(texts))
+        for position, text in zip(positions, redacted):
+            output[position][self.text_field] = text
+
+
+class StreamSink:
+    """Thin sink adapter around a callable or object with ``write(record)``."""
+
+    def __init__(self, writer: Callable[[Record], Any] | RecordWriter) -> None:
+        """Create a sink for a downstream record writer.
+
+        Args:
+            writer: Callable receiving one record, or an object exposing
+                ``write(record)``. If the object exposes ``flush()``, it is
+                called when :meth:`flush` is invoked.
+        """
+
+        write_method = getattr(writer, "write", None)
+        if not callable(writer) and not callable(write_method):
+            raise TypeError("writer must be callable or expose write(record)")
+        self._writer = writer
+
+    def invoke(self, record: Record, context: Any | None = None) -> Any:
+        """Write one record using a stream-runtime-compatible sink shape."""
+
+        del context
+        write_method = getattr(self._writer, "write", None)
+        if callable(write_method):
+            return write_method(record)
+        return self._writer(record)  # type: ignore[operator]
+
+    def write_batch(self, records: Iterable[Record]) -> int:
+        """Write all records and return the number accepted by the sink."""
+
+        written = 0
+        for record in records:
+            self.invoke(record)
+            written += 1
+        return written
+
+    def flush(self) -> Any:
+        """Flush the wrapped writer when it provides a ``flush`` method."""
+
+        flush_method = getattr(self._writer, "flush", None)
+        if callable(flush_method):
+            return flush_method()
+        return None
+
+
+DeidentifyMapFunction = StreamDeidentifyMapFunction
+
+
+def run_stream_job(
+    source: Iterable[Record],
+    map_function: StreamDeidentifyMapFunction,
+    sink: StreamSink | Callable[[Record], Any] | RecordWriter,
+) -> int:
+    """Run an offline source -> map -> sink flow with bounded micro-batches.
+
+    This helper is suitable for local harnesses and examples. Cluster runtimes
+    can wire the same map and sink lifecycle methods into their native graph.
+
+    Args:
+        source: Iterable of input record mappings.
+        map_function: Configured record de-identification map function.
+        sink: A :class:`StreamSink`, callable, or object with ``write(record)``.
+
+    Returns:
+        Number of records written to the sink.
+    """
+
+    resolved_sink = sink if isinstance(sink, StreamSink) else StreamSink(sink)
+    if not map_function.is_open:
+        map_function.open()
+
+    written = 0
+    batch: list[Record] = []
+    for record in source:
+        batch.append(record)
+        if len(batch) == map_function.batch_size:
+            written += resolved_sink.write_batch(map_function.map_batch(batch))
+            batch = []
+    if batch:
+        written += resolved_sink.write_batch(map_function.map_batch(batch))
+    resolved_sink.flush()
+    return written
+
+
+def _deidentified_texts(batch_result: Any, *, expected: int) -> list[str]:
+    raw_items = getattr(batch_result, "items", batch_result)
+    try:
+        items = list(raw_items)
+    except TypeError as exc:
+        raise TypeError("process_batch must return an iterable of results") from exc
+    if len(items) != expected:
+        raise ValueError(
+            f"process_batch returned {len(items)} results for {expected} inputs"
+        )
+    return [_deidentified_text(item) for item in items]
+
+
+def _deidentified_text(item: Any) -> str:
+    if getattr(item, "success", True) is False:
+        error = getattr(item, "error", None) or "batch de-identification failed"
+        raise RuntimeError(str(error))
+
+    result = getattr(item, "result", item)
+    if isinstance(result, str):
+        return result
+    if isinstance(result, Mapping) and "deidentified_text" in result:
+        return str(result["deidentified_text"])
+    text = getattr(result, "deidentified_text", None)
+    if text is not None:
+        return str(text)
+    raise TypeError("process_batch results must expose deidentified_text")
+
+
+def _non_empty_string(value: str, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _positive_int(value: int, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        integer = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+    if integer < 1 or integer != value:
+        raise ValueError(f"{name} must be a positive integer")
+    return integer
+
+
+__all__ = [
+    "DEFAULT_STREAM_BATCH_SIZE",
+    "DEFAULT_STREAM_POLICY",
+    "DeidentifyMapFunction",
+    "ProcessBatchCallable",
+    "RecordWriter",
+    "StreamDeidentifyMapFunction",
+    "StreamSink",
+    "run_stream_job",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,6 +348,7 @@ yasbd = [
 
 [project.scripts]
 openmed = "openmed.cli:main"
+openmed-executable-udf = "openmed.integrations.executable_udf:main"
 openmed-mcp = "openmed.mcp.server:main"
 
 [tool.uv]

--- a/tests/unit/integrations/test_arrow_flight.py
+++ b/tests/unit/integrations/test_arrow_flight.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+flight = pytest.importorskip("pyarrow.flight")
+
+from openmed.integrations.arrow_flight import (  # noqa: E402
+    ARROW_FLIGHT_DESCRIPTOR_VERSION,
+    ArrowFlightDeidentificationServer,
+    make_deidentify_descriptor,
+)
+
+
+def test_do_exchange_redacts_each_record_batch_without_buffering_stream(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_names = ("Jane Doe", "John Roe", "Sam Poe")
+    calls: list[dict[str, Any]] = []
+
+    def fake_process_batch(texts, **kwargs):
+        calls.append({"texts": tuple(texts), **kwargs})
+        redacted_texts = []
+        for text in texts:
+            for name in raw_names:
+                text = text.replace(name, "[NAME]")
+            redacted_texts.append(text)
+        items = [
+            SimpleNamespace(
+                result=SimpleNamespace(deidentified_text=text),
+                error=None,
+            )
+            for text in redacted_texts
+        ]
+        return SimpleNamespace(items=items)
+
+    server = ArrowFlightDeidentificationServer(
+        ("127.0.0.1", 0),
+        batch_size=32,
+        process_batch_fn=fake_process_batch,
+    )
+    client = flight.connect(("127.0.0.1", server.port))
+    schema = pa.schema(
+        [
+            pa.field("record_id", pa.int64(), nullable=False),
+            pa.field("clinical_note", pa.string()),
+            pa.field("status", pa.string()),
+        ],
+        metadata={b"dataset": b"synthetic"},
+    )
+    first = pa.RecordBatch.from_pylist(
+        [
+            {
+                "record_id": 1,
+                "clinical_note": "Patient Jane Doe called today",
+                "status": "open",
+            },
+            {
+                "record_id": 2,
+                "clinical_note": "John Roe has a follow-up",
+                "status": "closed",
+            },
+        ],
+        schema=schema,
+    )
+    second = pa.RecordBatch.from_pylist(
+        [
+            {
+                "record_id": 3,
+                "clinical_note": "Sam Poe requested records",
+                "status": "open",
+            },
+            {
+                "record_id": 4,
+                "clinical_note": None,
+                "status": "pending",
+            },
+        ],
+        schema=schema,
+    )
+
+    caplog.set_level(logging.DEBUG)
+    try:
+        writer, reader = client.do_exchange(
+            make_deidentify_descriptor(
+                "clinical_note",
+                policy="hipaa_safe_harbor",
+            )
+        )
+        writer.begin(schema)
+
+        writer.write_batch(first)
+        first_response = reader.read_chunk().data
+        assert first_response.column("clinical_note").to_pylist() == [
+            "Patient [NAME] called today",
+            "[NAME] has a follow-up",
+        ]
+        assert len(calls) == 1
+
+        writer.write_batch(second)
+        second_response = reader.read_chunk().data
+        assert second_response.column("clinical_note").to_pylist() == [
+            "[NAME] requested records",
+            None,
+        ]
+        assert len(calls) == 2
+
+        writer.done_writing()
+        with pytest.raises(StopIteration):
+            reader.read_chunk()
+    finally:
+        client.close()
+        server.shutdown()
+
+    assert first_response.schema == schema
+    assert second_response.schema == schema
+    assert first_response.num_rows + second_response.num_rows == 4
+    assert first_response.column("record_id").to_pylist() == [1, 2]
+    assert second_response.column("record_id").to_pylist() == [3, 4]
+    assert first_response.column("status").to_pylist() == ["open", "closed"]
+    assert second_response.column("status").to_pylist() == ["open", "pending"]
+    assert [len(call["texts"]) for call in calls] == [2, 1]
+    assert all(call["operation"] == "deidentify" for call in calls)
+    assert all(call["policy"] == "hipaa_safe_harbor" for call in calls)
+    assert all(call["batch_size"] == 32 for call in calls)
+
+    log_output = "\n".join(record.getMessage() for record in caplog.records)
+    assert all(name not in log_output for name in raw_names)
+
+
+def test_descriptor_is_versioned_and_carries_policy() -> None:
+    descriptor = make_deidentify_descriptor(
+        "note",
+        policy="hipaa_safe_harbor",
+    )
+
+    assert descriptor.descriptor_type == flight.DescriptorType.CMD
+    assert descriptor.command == (
+        b'{"policy":"hipaa_safe_harbor","text_column":"note","version":1}'
+    )
+    assert ARROW_FLIGHT_DESCRIPTOR_VERSION == 1
+
+
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_server_rejects_non_positive_batch_size(batch_size: int) -> None:
+    with pytest.raises(ValueError, match="batch_size must be positive"):
+        ArrowFlightDeidentificationServer(batch_size=batch_size)
+
+
+def test_server_rejects_managed_process_batch_overrides() -> None:
+    with pytest.raises(ValueError, match="cannot override managed option.*policy"):
+        ArrowFlightDeidentificationServer(
+            process_batch_options={"policy": "not-from-descriptor"}
+        )

--- a/tests/unit/integrations/test_dataflow_processor.py
+++ b/tests/unit/integrations/test_dataflow_processor.py
@@ -1,0 +1,248 @@
+"""Offline tests for the Apache Beam/Dataflow batch processor."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+beam = pytest.importorskip("apache_beam", reason="requires Apache Beam")
+_pipeline_options = pytest.importorskip("apache_beam.options.pipeline_options")
+_test_pipeline = pytest.importorskip("apache_beam.testing.test_pipeline")
+_testing_util = pytest.importorskip("apache_beam.testing.util")
+_dataflow = pytest.importorskip("openmed.integrations.dataflow_processor")
+
+PipelineOptions = _pipeline_options.PipelineOptions
+BeamTestPipeline = _test_pipeline.TestPipeline
+assert_that = _testing_util.assert_that
+equal_to = _testing_util.equal_to
+DataflowBatchProcessor = _dataflow.DataflowBatchProcessor
+DataflowDeadLetter = _dataflow.DataflowDeadLetter
+
+
+def _redact(text: str) -> str:
+    return text.replace("Jane Roe", "[NAME]").replace("555-0101", "[PHONE]")
+
+
+class _ResidentProcessor:
+    batch_sizes: list[int] = []
+
+    def process_texts(self, texts: list[str]) -> Any:
+        type(self).batch_sizes.append(len(texts))
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    success=True,
+                    result=SimpleNamespace(deidentified_text=_redact(text)),
+                )
+                for text in texts
+            ]
+        )
+
+
+class _ProcessorFactory:
+    setup_calls = 0
+    options: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs: Any) -> _ResidentProcessor:
+        type(self).setup_calls += 1
+        type(self).options.append(dict(kwargs))
+        return _ResidentProcessor()
+
+
+@pytest.fixture(autouse=True)
+def _reset_probes() -> None:
+    _ProcessorFactory.setup_calls = 0
+    _ProcessorFactory.options = []
+    _ResidentProcessor.batch_sizes = []
+
+
+def _direct_runner_options() -> PipelineOptions:
+    return PipelineOptions(
+        [
+            "--runner=DirectRunner",
+            "--direct_num_workers=1",
+            "--direct_running_mode=in_memory",
+        ]
+    )
+
+
+def test_local_runner_redacts_in_batches_with_one_bundle_scoped_setup(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    records = [
+        {
+            "record_id": "synthetic-1",
+            "note": "Patient Jane Roe called 555-0101.",
+            "facility": "example-clinic",
+        },
+        {
+            "record_id": "synthetic-2",
+            "note": "Jane Roe requested a follow-up.",
+            "facility": "example-clinic",
+        },
+        {
+            "record_id": "synthetic-3",
+            "note": "No seeded identifiers.",
+            "facility": "example-clinic",
+        },
+    ]
+
+    with BeamTestPipeline(options=_direct_runner_options()) as pipeline:
+        outputs = (
+            pipeline
+            | "Create synthetic records" >> beam.Create(records)
+            | "Apply OpenMed processor"
+            >> DataflowBatchProcessor(
+                "note",
+                policy="hipaa_safe_harbor",
+                batch_size=2,
+                processor_factory=_ProcessorFactory(),
+                use_safety_sweep=True,
+            )
+        )
+        assert_that(
+            outputs.cleaned,
+            equal_to(
+                [
+                    {
+                        "record_id": "synthetic-1",
+                        "note": "Patient [NAME] called [PHONE].",
+                        "facility": "example-clinic",
+                    },
+                    {
+                        "record_id": "synthetic-2",
+                        "note": "[NAME] requested a follow-up.",
+                        "facility": "example-clinic",
+                    },
+                    {
+                        "record_id": "synthetic-3",
+                        "note": "No seeded identifiers.",
+                        "facility": "example-clinic",
+                    },
+                ]
+            ),
+            label="Assert cleaned records",
+        )
+        assert_that(
+            outputs.dead_letter,
+            equal_to([]),
+            label="Assert no dead letters",
+        )
+
+    assert _ProcessorFactory.setup_calls == 1
+    assert sorted(_ResidentProcessor.batch_sizes) == [1, 2]
+    assert _ProcessorFactory.options == [
+        {
+            "model_name": "disease_detection_superclinical",
+            "operation": "deidentify",
+            "batch_size": 2,
+            "continue_on_error": True,
+            "method": "mask",
+            "use_safety_sweep": True,
+            "policy": "hipaa_safe_harbor",
+        }
+    ]
+    assert "Jane Roe" not in caplog.text
+    assert "555-0101" not in caplog.text
+
+
+def test_none_and_unprocessable_elements_route_to_dead_letter() -> None:
+    records = [
+        None,
+        {"record_id": "missing-note"},
+        {"record_id": "null-note", "note": None},
+        {"record_id": "numeric-note", "note": 42},
+        {"record_id": "valid", "note": "Patient Jane Roe"},
+    ]
+
+    with BeamTestPipeline(options=_direct_runner_options()) as pipeline:
+        outputs = (
+            pipeline
+            | "Create mixed records" >> beam.Create(records)
+            | "Apply processor with dead letters"
+            >> DataflowBatchProcessor(
+                "note",
+                batch_size=8,
+                processor_factory=_ProcessorFactory(),
+            )
+        )
+        assert_that(
+            outputs.cleaned,
+            equal_to([{"record_id": "valid", "note": "Patient [NAME]"}]),
+            label="Assert one cleaned record",
+        )
+        assert_that(
+            outputs.dead_letter,
+            equal_to(
+                [
+                    DataflowDeadLetter(None, "invalid_element"),
+                    DataflowDeadLetter(
+                        {"record_id": "missing-note"}, "missing_text_field"
+                    ),
+                    DataflowDeadLetter(
+                        {"record_id": "null-note", "note": None}, "null_text"
+                    ),
+                    DataflowDeadLetter(
+                        {"record_id": "numeric-note", "note": 42},
+                        "invalid_text_type",
+                    ),
+                ]
+            ),
+            label="Assert dead-letter records",
+        )
+
+
+def test_batch_failure_is_phi_safe_and_does_not_fail_bundle(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_text = "Patient Jane Roe called 555-0101."
+
+    def fail_batch(texts: list[str], **kwargs: Any) -> None:
+        raise RuntimeError(f"failed to process {texts[0]}")
+
+    with BeamTestPipeline(options=_direct_runner_options()) as pipeline:
+        outputs = (
+            pipeline
+            | "Create failing record"
+            >> beam.Create([{"record_id": "synthetic-4", "note": raw_text}])
+            | "Apply failing processor"
+            >> DataflowBatchProcessor("note", process_batch_fn=fail_batch)
+        )
+        assert_that(
+            outputs.cleaned,
+            equal_to([]),
+            label="Assert failed record is not cleaned",
+        )
+        assert_that(
+            outputs.dead_letter,
+            equal_to(
+                [
+                    DataflowDeadLetter(
+                        {"record_id": "synthetic-4", "note": raw_text},
+                        "processing_error",
+                    )
+                ]
+            ),
+            label="Assert failure dead letter",
+        )
+
+    assert raw_text not in caplog.text
+    assert "Jane Roe" not in caplog.text
+    assert "555-0101" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "message"),
+    [
+        ({"text_field": ""}, ValueError, "text_field must be a non-empty string"),
+        ({"batch_size": 0}, ValueError, "batch_size must be a positive integer"),
+        ({"processor_factory": object()}, TypeError, "must be callable"),
+    ],
+)
+def test_constructor_rejects_invalid_options(
+    kwargs: dict[str, Any], error: type[Exception], message: str
+) -> None:
+    with pytest.raises(error, match=message):
+        DataflowBatchProcessor(**kwargs)

--- a/tests/unit/integrations/test_distributed_sql_udf.py
+++ b/tests/unit/integrations/test_distributed_sql_udf.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from openmed.integrations.distributed_sql_udf import (
+    OPENMED_DEIDENTIFY_DESCRIPTOR,
+    DistributedSQLDeidentifyUDF,
+    DistributedSQLUDFConfig,
+)
+from openmed.processing.batch import BatchItemResult, BatchResult
+
+
+def _synthetic_process_batch(calls: list[dict[str, Any]]):
+    def process_batch(texts: list[str], **kwargs: Any) -> BatchResult:
+        calls.append({"texts": list(texts), **kwargs})
+        replacements = {
+            "Jane Roe": "[PERSON]",
+            "john.roe@example.test": "[EMAIL]",
+            "555-0101": "[PHONE]",
+        }
+        items = []
+        for index, text in enumerate(texts):
+            redacted = text
+            for identifier, placeholder in replacements.items():
+                redacted = redacted.replace(identifier, placeholder)
+            items.append(
+                BatchItemResult(
+                    id=f"item_{index}",
+                    result=SimpleNamespace(deidentified_text=redacted),
+                )
+            )
+        return BatchResult(items=items)
+
+    return process_batch
+
+
+def test_udf_callable_redacts_synthetic_vector_in_row_windows() -> None:
+    calls: list[dict[str, Any]] = []
+    loader = object()
+    loader_count = 0
+
+    def loader_factory() -> object:
+        nonlocal loader_count
+        loader_count += 1
+        return loader
+
+    udf = DistributedSQLDeidentifyUDF(
+        config=DistributedSQLUDFConfig(batch_size=2),
+        process_batch_fn=_synthetic_process_batch(calls),
+        loader_factory=loader_factory,
+    )
+    rows = [
+        "Jane Roe has hypertension and takes metformin.",
+        "Email john.roe@example.test about the diabetes follow-up.",
+        "Call 555-0101 after the cardiology appointment.",
+    ]
+
+    assert loader_count == 0
+    output = udf(rows, "hipaa_safe_harbor")
+
+    assert output == [
+        "[PERSON] has hypertension and takes metformin.",
+        "Email [EMAIL] about the diabetes follow-up.",
+        "Call [PHONE] after the cardiology appointment.",
+    ]
+    assert [len(call["texts"]) for call in calls] == [2, 1]
+    assert all(call["operation"] == "deidentify" for call in calls)
+    assert all(call["policy"] == "hipaa_safe_harbor" for call in calls)
+    assert all(call["loader"] is loader for call in calls)
+    assert loader_count == 1
+
+
+def test_null_and_empty_inputs_bypass_loader_and_process_batch() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def unexpected_loader() -> object:
+        raise AssertionError("loader must remain lazy for null and empty rows")
+
+    udf = DistributedSQLDeidentifyUDF(
+        process_batch_fn=_synthetic_process_batch(calls),
+        loader_factory=unexpected_loader,
+    )
+
+    assert udf([None, ""], ["not_a_profile", "also_invalid"]) == [None, ""]
+    assert udf.deidentify(None, "not_a_profile") is None
+    assert udf.deidentify("", "not_a_profile") == ""
+    assert calls == []
+
+
+def test_loader_is_reused_across_worker_calls_and_profiles_are_grouped() -> None:
+    calls: list[dict[str, Any]] = []
+    loaders: list[object] = []
+
+    def loader_factory() -> object:
+        loader = object()
+        loaders.append(loader)
+        return loader
+
+    udf = DistributedSQLDeidentifyUDF(
+        process_batch_fn=_synthetic_process_batch(calls),
+        loader_factory=loader_factory,
+    )
+
+    first = udf(
+        ["Jane Roe has asthma.", "Call 555-0101 for hypertension."],
+        ["hipaa", "gdpr"],
+    )
+    second = udf(["Jane Roe has diabetes."], "safe_harbor")
+
+    assert first == ["[PERSON] has asthma.", "Call [PHONE] for hypertension."]
+    assert second == ["[PERSON] has diabetes."]
+    assert len(loaders) == 1
+    assert all(call["loader"] is loaders[0] for call in calls)
+    assert [call["policy"] for call in calls] == [
+        "hipaa_safe_harbor",
+        "gdpr_pseudonymization",
+        "hipaa_safe_harbor",
+    ]
+
+
+def test_profiles_must_align_with_text_rows() -> None:
+    udf = DistributedSQLDeidentifyUDF(
+        process_batch_fn=_synthetic_process_batch([]),
+        loader_factory=object,
+    )
+
+    with pytest.raises(ValueError, match="1 values for 2 text rows"):
+        udf(["one", "two"], ["hipaa_safe_harbor"])
+
+
+def test_registration_descriptor_maps_scalar_sql_to_vector_entrypoint() -> None:
+    assert OPENMED_DEIDENTIFY_DESCRIPTOR == {
+        "name": "openmed_deidentify",
+        "language": "python",
+        "entrypoint": ("openmed.integrations.distributed_sql_udf:deidentify_batch"),
+        "arguments": [
+            {"name": "text", "sql_type": "VARCHAR", "python_batch": "texts"},
+            {
+                "name": "profile",
+                "sql_type": "VARCHAR",
+                "python_batch": "profiles",
+            },
+        ],
+        "return_type": "VARCHAR",
+        "vectorized": True,
+        "null_handling": "called_on_null_input",
+        "default_batch_size": 64,
+    }

--- a/tests/unit/integrations/test_executable_udf.py
+++ b/tests/unit/integrations/test_executable_udf.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from openmed.integrations import executable_udf
+
+
+def _fake_redact(text: str) -> str:
+    return (
+        text.replace("Jane Roe", "[NAME]")
+        .replace("John Doe", "[NAME]")
+        .replace("555-0100", "[PHONE]")
+        .replace("jane.roe@example.org", "[EMAIL]")
+    )
+
+
+def _batch_result(texts: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                success=True,
+                result=SimpleNamespace(deidentified_text=_fake_redact(text)),
+            )
+            for text in texts
+        ]
+    )
+
+
+def test_stdin_stdout_adapter_redacts_every_row_in_order_and_batches(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+    shared_loader = object()
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        calls.append((list(texts), dict(kwargs)))
+        return _batch_result(list(texts))
+
+    monkeypatch.setattr(executable_udf, "process_batch", fake_process_batch)
+    input_rows = [
+        "Patient Jane Roe called 555-0100",
+        "No identifiers in this row",
+        "Escalate John Doe",
+        "",
+        "Email jane.roe@example.org",
+    ]
+    stdin = io.StringIO("\n".join(input_rows) + "\n")
+    stdout = io.StringIO()
+
+    emitted = executable_udf.redact_tsv_stream(
+        stdin,
+        stdout,
+        batch_size=2,
+        loader=shared_loader,
+        use_safety_sweep=False,
+    )
+
+    output_rows = stdout.getvalue().splitlines()
+    assert emitted == len(input_rows)
+    assert len(output_rows) == len(input_rows)
+    assert output_rows == [
+        "Patient [NAME] called [PHONE]",
+        "No identifiers in this row",
+        "Escalate [NAME]",
+        "",
+        "Email [EMAIL]",
+    ]
+    assert "Jane Roe" not in stdout.getvalue()
+    assert "John Doe" not in stdout.getvalue()
+    assert "555-0100" not in stdout.getvalue()
+    assert "jane.roe@example.org" not in stdout.getvalue()
+    assert [texts for texts, _ in calls] == [
+        input_rows[:2],
+        input_rows[2:3],
+        input_rows[4:],
+    ]
+    assert all(kwargs["operation"] == "deidentify" for _, kwargs in calls)
+    assert all(kwargs["continue_on_error"] is False for _, kwargs in calls)
+    assert all(kwargs["loader"] is shared_loader for _, kwargs in calls)
+    assert [kwargs["batch_size"] for _, kwargs in calls] == [2, 1, 1]
+    assert all(kwargs["use_safety_sweep"] is False for _, kwargs in calls)
+
+
+def test_tsv_escaping_round_trips_control_characters(monkeypatch) -> None:
+    received: list[str] = []
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        received.extend(texts)
+        return _batch_result(list(texts))
+
+    monkeypatch.setattr(executable_udf, "process_batch", fake_process_batch)
+    stdout = io.StringIO()
+
+    executable_udf.redact_tsv_stream(
+        io.StringIO("Jane Roe\\tcalled\\nagain\\\\soon\n"),
+        stdout,
+        loader=object(),
+    )
+
+    assert received == ["Jane Roe\tcalled\nagain\\soon"]
+    assert stdout.getvalue() == "[NAME]\\tcalled\\nagain\\\\soon\n"
+
+
+def test_tsv_escaping_preserves_unknown_backslash_sequences(monkeypatch) -> None:
+    received: list[str] = []
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        received.extend(texts)
+        return _batch_result(list(texts))
+
+    monkeypatch.setattr(executable_udf, "process_batch", fake_process_batch)
+    stdout = io.StringIO()
+
+    executable_udf.redact_tsv_stream(
+        io.StringIO(r"literal\q\N" + "\n"),
+        stdout,
+        loader=object(),
+    )
+
+    assert received == [r"literal\q\N"]
+    assert stdout.getvalue() == r"literal\\q\\N" + "\n"
+
+
+def test_blank_rows_preserve_cardinality_without_batch_calls(monkeypatch) -> None:
+    def fail_if_called(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("blank rows must not invoke batch redaction")
+
+    monkeypatch.setattr(executable_udf, "process_batch", fail_if_called)
+    stdout = io.StringIO()
+
+    emitted = executable_udf.redact_tsv_stream(
+        io.StringIO("\n\n"),
+        stdout,
+        loader=object(),
+    )
+
+    assert emitted == 2
+    assert stdout.getvalue() == "\n\n"
+
+
+def test_mapping_batch_results_are_redacted(monkeypatch) -> None:
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> dict[str, Any]:
+        return {
+            "items": [
+                {
+                    "success": True,
+                    "result": {"deidentified_text": _fake_redact(text)},
+                }
+                for text in texts
+            ]
+        }
+
+    monkeypatch.setattr(executable_udf, "process_batch", fake_process_batch)
+    stdout = io.StringIO()
+
+    executable_udf.redact_tsv_stream(
+        io.StringIO("Patient Jane Roe called\n"),
+        stdout,
+        loader=object(),
+    )
+
+    assert stdout.getvalue() == "Patient [NAME] called\n"
+
+
+def test_cli_failure_does_not_echo_or_log_raw_phi(monkeypatch, caplog) -> None:
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        raise RuntimeError(f"model failed on {texts[0]}")
+
+    monkeypatch.setattr(executable_udf, "process_batch", fake_process_batch)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    code = executable_udf.main(
+        ["--batch-size", "2"],
+        stdin=io.StringIO("Patient Jane Roe called\n"),
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert code == 1
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == "executable UDF redaction failed\n"
+    assert "Jane Roe" not in stderr.getvalue()
+    assert "Jane Roe" not in caplog.text
+
+
+def test_cardinality_mismatch_fails_closed(monkeypatch) -> None:
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(items=[])
+
+    monkeypatch.setattr(executable_udf, "process_batch", fake_process_batch)
+
+    try:
+        list(
+            executable_udf.redact_tsv_lines(
+                ["Jane Roe\n"],
+                loader=object(),
+            )
+        )
+    except executable_udf.ExecutableUDFError as exc:
+        assert "result count" in str(exc)
+        assert "Jane Roe" not in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("cardinality mismatch should fail closed")
+
+
+def test_console_script_points_to_executable_udf_entrypoint() -> None:
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+    assert (
+        'openmed-executable-udf = "openmed.integrations.executable_udf:main"'
+        in pyproject
+    )

--- a/tests/unit/integrations/test_pandas_on_spark.py
+++ b/tests/unit/integrations/test_pandas_on_spark.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+os.environ.setdefault("PYARROW_IGNORE_TIMEZONE", "1")
+
+
+def _spark_session(tmp_path: Path) -> Any:
+    pytest.importorskip("pyspark")
+    from pyspark.sql import SparkSession
+
+    try:
+        return (
+            SparkSession.builder.master("local[2]")
+            .appName("openmed-pandas-on-spark-unit")
+            .config("spark.ui.enabled", "false")
+            .config("spark.sql.shuffle.partitions", "2")
+            .config("spark.sql.execution.arrow.maxRecordsPerBatch", "10000")
+            .config("spark.sql.warehouse.dir", str(tmp_path / "warehouse"))
+            .getOrCreate()
+        )
+    except Exception as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"local Spark session is unavailable: {exc}")
+
+
+@pytest.fixture()
+def spark(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.setenv("PYSPARK_PYTHON", sys.executable)
+    monkeypatch.setenv("PYSPARK_DRIVER_PYTHON", sys.executable)
+    session = _spark_session(tmp_path)
+    try:
+        yield session
+    finally:
+        session.stop()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="local pandas-on-Spark cleanup is not stable on Windows",
+)
+def test_dataframe_accessor_redacts_synthetic_rows_in_partition_batches(
+    spark: Any,
+) -> None:
+    pd = pytest.importorskip("pandas")
+    ps = pytest.importorskip("pyspark.pandas")
+    import openmed.integrations.pandas_on_spark  # noqa: F401
+
+    batch_calls = spark.sparkContext.accumulator(0)
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> Any:
+        from types import SimpleNamespace
+
+        batch_calls.add(1)
+        assert kwargs["operation"] == "deidentify"
+        assert kwargs["method"] == "mask"
+        assert kwargs["policy"] == "hipaa_safe_harbor"
+        assert kwargs["lang"] == "en"
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    success=True,
+                    result=SimpleNamespace(
+                        deidentified_text=text.replace("Jane Roe", "[NAME]")
+                        .replace("John Doe", "[NAME]")
+                        .replace("555-0100", "[PHONE]")
+                        .replace("555-0199", "[PHONE]")
+                    ),
+                )
+                for text in texts
+            ]
+        )
+
+    source = pd.DataFrame(
+        {
+            "record_id": ["a", "b", "c", "d"],
+            "note": [
+                "Patient Jane Roe called 555-0100.",
+                "No identifiers here.",
+                "John Doe left voicemail at 555-0199.",
+                "Follow-up contains no seeded PHI.",
+            ],
+            "age": [42, 73, 55, 61],
+        },
+        index=pd.Index([10, 11, 20, 21], name="row_id"),
+    )
+    distributed = ps.from_pandas(source).spark.repartition(2)
+    partition_count = distributed.to_spark().rdd.getNumPartitions()
+
+    redacted = distributed.deid.deidentify(
+        columns="note",
+        policy="hipaa_safe_harbor",
+        deidentifier=fake_process_batch,
+        lang="en",
+    )
+    computed = redacted.to_pandas().sort_index()
+
+    assert computed.index.tolist() == source.index.tolist()
+    assert computed["record_id"].tolist() == source["record_id"].tolist()
+    assert computed["age"].tolist() == source["age"].tolist()
+    assert "Jane Roe" not in "\n".join(computed["note"])
+    assert "John Doe" not in "\n".join(computed["note"])
+    assert "555-0100" not in "\n".join(computed["note"])
+    assert "555-0199" not in "\n".join(computed["note"])
+    assert 0 < batch_calls.value <= partition_count
+    assert batch_calls.value < len(source)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="local pandas-on-Spark cleanup is not stable on Windows",
+)
+def test_series_accessor_returns_redacted_series(spark: Any) -> None:
+    pd = pytest.importorskip("pandas")
+    ps = pytest.importorskip("pyspark.pandas")
+    import openmed.integrations.pandas_on_spark  # noqa: F401
+
+    source = pd.Series(
+        [
+            "Patient Jane Roe called 555-0100.",
+            "John Doe left voicemail at 555-0199.",
+        ],
+        name="note",
+    )
+    distributed = ps.from_pandas(source)
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> Any:
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    success=True,
+                    result=SimpleNamespace(
+                        deidentified_text=text.replace("Jane Roe", "[NAME]")
+                        .replace("John Doe", "[NAME]")
+                        .replace("555-0100", "[PHONE]")
+                        .replace("555-0199", "[PHONE]")
+                    ),
+                )
+                for text in texts
+            ]
+        )
+
+    redacted = distributed.deid.deidentify(
+        process_batch_fn=fake_process_batch,
+    )
+
+    computed = redacted.to_pandas()
+    assert computed.name == source.name
+    assert "Jane Roe" not in "\n".join(computed)
+    assert "John Doe" not in "\n".join(computed)
+
+
+def test_dataframe_accessor_signature_matches_local_pandas_accessor() -> None:
+    pytest.importorskip("pyspark.pandas")
+    from openmed.integrations.pandas_on_spark import (
+        OpenMedPandasOnSparkDataFrameAccessor,
+    )
+    from openmed.interop.pandas_accessor import OpenMedDataFrameAccessor
+
+    assert inspect.signature(
+        OpenMedPandasOnSparkDataFrameAccessor.deidentify
+    ) == inspect.signature(OpenMedDataFrameAccessor.deidentify)
+
+
+def test_worker_loader_is_initialized_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("pyspark.pandas")
+    import openmed.core
+    from openmed.integrations import pandas_on_spark
+
+    loads = 0
+    sentinel = object()
+
+    def fake_loader() -> object:
+        nonlocal loads
+        loads += 1
+        return sentinel
+
+    pandas_on_spark.clear_worker_pipeline_cache()
+    monkeypatch.setattr(openmed.core, "ModelLoader", fake_loader)
+
+    assert pandas_on_spark._get_worker_loader() is sentinel
+    assert pandas_on_spark._get_worker_loader() is sentinel
+    assert loads == 1
+    pandas_on_spark.clear_worker_pipeline_cache()
+
+
+def test_worker_batch_reuses_loader_with_forwarded_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("pyspark.pandas")
+    import openmed.core
+    from openmed.integrations import pandas_on_spark
+
+    config = object()
+    sentinel = object()
+    loaded_configs: list[Any] = []
+    batch_kwargs: list[dict[str, Any]] = []
+
+    def fake_loader(loader_config: Any) -> object:
+        loaded_configs.append(loader_config)
+        return sentinel
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> list[str]:
+        batch_kwargs.append(kwargs)
+        return list(texts)
+
+    pandas_on_spark.clear_worker_pipeline_cache()
+    monkeypatch.setattr(openmed.core, "ModelLoader", fake_loader)
+    monkeypatch.setattr(
+        pandas_on_spark, "_get_process_batch", lambda: fake_process_batch
+    )
+
+    for _ in range(2):
+        assert pandas_on_spark._run_worker_batch(
+            ["synthetic text"],
+            method="mask",
+            policy="hipaa_safe_harbor",
+            process_batch_fn=None,
+            process_kwargs={"config": config},
+        ) == ["synthetic text"]
+
+    assert loaded_configs == [config]
+    assert all(kwargs["loader"] is sentinel for kwargs in batch_kwargs)
+    pandas_on_spark.clear_worker_pipeline_cache()
+
+
+def test_dataframe_accessor_rejects_missing_and_non_text_columns(spark: Any) -> None:
+    ps = pytest.importorskip("pyspark.pandas")
+    import openmed.integrations.pandas_on_spark  # noqa: F401
+
+    distributed = ps.DataFrame({"note": ["Patient Jane Roe"], "age": [42]})
+
+    with pytest.raises(KeyError, match="missing"):
+        distributed.deid.deidentify(columns="unknown")
+    with pytest.raises(TypeError, match="text column"):
+        distributed.deid.deidentify(columns="age")

--- a/tests/unit/integrations/test_postgres_plpython.py
+++ b/tests/unit/integrations/test_postgres_plpython.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import ast
+import re
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from openmed.integrations import postgres_plpython
+
+_DDL_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "openmed"
+    / "integrations"
+    / "sql"
+    / "postgres_deidentify.sql"
+)
+_CREATE_FUNCTION = re.compile(
+    r"CREATE\s+OR\s+REPLACE\s+FUNCTION\s+"
+    r"(?P<name>[a-z_][a-z0-9_]*)\s*\("
+    r"(?P<argument_name>[a-z_][a-z0-9_]*)\s+"
+    r"(?P<argument_type>text(?:\[\])?)\s*\)\s*"
+    r"RETURNS\s+(?P<return_type>SETOF\s+text|text)\b"
+    r"(?P<attributes>.*?)"
+    r"AS\s+(?P<tag>\$[a-z_][a-z0-9_]*\$)"
+    r"(?P<body>.*?)"
+    r"(?P=tag)\s*;",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+
+def _fake_batch_result(texts: list[str]) -> SimpleNamespace:
+    replacements = {
+        "Jane Roe": "[PERSON]",
+        "jane.roe@example.com": "[EMAIL]",
+        "555-0100": "[PHONE]",
+        "John Doe": "[PERSON]",
+        "555-0199": "[PHONE]",
+    }
+    items = []
+    for text in texts:
+        redacted = text
+        for source, replacement in replacements.items():
+            redacted = redacted.replace(source, replacement)
+        items.append(
+            SimpleNamespace(
+                success=True,
+                result=SimpleNamespace(deidentified_text=redacted),
+            )
+        )
+    return SimpleNamespace(items=items)
+
+
+def test_function_bodies_redact_synthetic_rows_and_reuse_session_pipeline():
+    session_globals: dict[str, Any] = {}
+    loader_creations = 0
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+    pipelines: list[object] = []
+
+    class FakeLoader:
+        def __init__(self) -> None:
+            self.pipeline: object | None = None
+
+        def create_pipeline(self) -> object:
+            if self.pipeline is None:
+                self.pipeline = object()
+                pipelines.append(self.pipeline)
+            return self.pipeline
+
+    loader = FakeLoader()
+
+    def loader_factory() -> Any:
+        nonlocal loader_creations
+        loader_creations += 1
+        return loader
+
+    def process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        calls.append((list(texts), kwargs))
+        kwargs["loader"].create_pipeline()
+        return _fake_batch_result(texts)
+
+    scalar = postgres_plpython.deidentify_text(
+        "Patient Jane Roe emailed jane.roe@example.com.",
+        session_globals,
+        process_batch_fn=process_batch,
+        loader_factory=loader_factory,
+    )
+    rows = postgres_plpython.deidentify_batch(
+        [
+            "John Doe called 555-0199.",
+            None,
+            "",
+            "Call Jane Roe at 555-0100.",
+        ],
+        session_globals,
+        process_batch_fn=process_batch,
+        loader_factory=loader_factory,
+    )
+
+    assert scalar == "Patient [PERSON] emailed [EMAIL]."
+    assert rows == [
+        "[PERSON] called [PHONE].",
+        None,
+        "",
+        "Call [PERSON] at [PHONE].",
+    ]
+    assert loader_creations == 1
+    assert len(pipelines) == 1
+    assert len(calls) == 2
+    assert calls[0][1]["loader"] is loader
+    assert calls[1][1]["loader"] is loader
+    assert calls[1][0] == [
+        "John Doe called 555-0199.",
+        "Call Jane Roe at 555-0100.",
+    ]
+    for _, kwargs in calls:
+        assert kwargs["operation"] == "deidentify"
+        assert kwargs["method"] == "mask"
+        assert kwargs["policy"] == "hipaa_safe_harbor"
+        assert kwargs["model_name"] == postgres_plpython.DEFAULT_MODEL_NAME
+
+
+def test_install_migration_parses_and_matches_documented_signatures():
+    ddl = _DDL_PATH.read_text(encoding="utf-8")
+    functions = {
+        match.group("name"): match.groupdict()
+        for match in _CREATE_FUNCTION.finditer(ddl)
+    }
+
+    assert re.search(r"\bBEGIN\s*;", ddl, flags=re.IGNORECASE)
+    assert re.search(
+        r"CREATE\s+EXTENSION\s+IF\s+NOT\s+EXISTS\s+plpython3u\s*;",
+        ddl,
+        flags=re.IGNORECASE,
+    )
+    assert re.search(r"\bCOMMIT\s*;", ddl, flags=re.IGNORECASE)
+    assert set(functions) == {"openmed_deidentify", "openmed_deidentify_batch"}
+    assert functions["openmed_deidentify"]["argument_type"].lower() == "text"
+    assert functions["openmed_deidentify"]["return_type"].lower() == "text"
+    assert functions["openmed_deidentify_batch"]["argument_type"].lower() == ("text[]")
+    assert functions["openmed_deidentify_batch"]["return_type"].lower() == (
+        "setof text"
+    )
+
+    argument_names = {
+        "openmed_deidentify": "input_text",
+        "openmed_deidentify_batch": "input_texts",
+    }
+    for name, function in functions.items():
+        attributes = function["attributes"].upper()
+        assert "LANGUAGE PLPYTHON3U" in attributes
+        assert "STRICT" in attributes
+        assert "VOLATILE" in attributes
+        assert "PARALLEL UNSAFE" in attributes
+        wrapped_body = "def _plpython_body(" + argument_names[name] + ", GD):\n"
+        wrapped_body += textwrap.indent(function["body"].strip(), "    ")
+        ast.parse(wrapped_body)
+
+
+def test_function_failures_and_sql_bodies_never_log_raw_text(caplog):
+    raw_text = "Patient Jane Roe has MRN 12345678"
+
+    def failing_process_batch(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        raise ValueError(raw_text)
+
+    with pytest.raises(RuntimeError, match="OpenMed de-identification failed") as exc:
+        postgres_plpython.deidentify_text(
+            raw_text,
+            {},
+            process_batch_fn=failing_process_batch,
+            loader_factory=object,
+        )
+
+    assert raw_text not in str(exc.value)
+    assert raw_text not in caplog.text
+
+    ddl = _DDL_PATH.read_text(encoding="utf-8")
+    bodies = [match.group("body") for match in _CREATE_FUNCTION.finditer(ddl)]
+    assert len(bodies) == 2
+    for body in bodies:
+        assert not re.search(
+            r"\bplpy\.(?:debug|log|info|notice|warning|error|fatal)\s*\(",
+            body,
+            flags=re.IGNORECASE,
+        )
+
+
+def test_mapping_results_and_initialization_failures_remain_phi_safe(caplog):
+    def mapping_process_batch(texts: list[str], **kwargs: Any) -> dict[str, Any]:
+        del kwargs, texts
+        return {
+            "items": [
+                {
+                    "success": True,
+                    "result": {"deidentified_text": "[REDACTED]"},
+                }
+            ]
+        }
+
+    assert (
+        postgres_plpython.deidentify_text(
+            "synthetic patient note",
+            {},
+            process_batch_fn=mapping_process_batch,
+            loader_factory=object,
+        )
+        == "[REDACTED]"
+    )
+
+    raw_text = "synthetic failure text"
+
+    def failing_loader() -> Any:
+        raise ValueError(raw_text)
+
+    with pytest.raises(RuntimeError, match="OpenMed de-identification failed") as exc:
+        postgres_plpython.deidentify_text(
+            raw_text,
+            {},
+            process_batch_fn=mapping_process_batch,
+            loader_factory=failing_loader,
+        )
+
+    assert raw_text not in str(exc.value)
+    assert raw_text not in caplog.text

--- a/tests/unit/integrations/test_ray_map_batches.py
+++ b/tests/unit/integrations/test_ray_map_batches.py
@@ -1,0 +1,198 @@
+"""Offline tests for actor-backed Ray Data batch de-identification."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from openmed.integrations.ray_map_batches import (
+    RayDeidentifyBatch,
+    map_batches_deidentify,
+)
+
+
+class _FakeBatchPipeline:
+    def __init__(self, stats: Any | None = None) -> None:
+        self._stats = stats
+
+    def process_batch(self, texts, ids=None):
+        if self._stats is not None:
+            import ray
+
+            ray.get(self._stats.record_batch.remote(len(texts)))
+        items = [
+            SimpleNamespace(
+                id=ids[index] if ids else f"item_{index}",
+                success=True,
+                result=SimpleNamespace(
+                    deidentified_text=text.replace("Jane Roe", "[PERSON]")
+                    .replace("John Doe", "[PERSON]")
+                    .replace("555-0100", "[PHONE]")
+                    .replace("555-0199", "[PHONE]")
+                ),
+            )
+            for index, text in enumerate(texts)
+        ]
+        return SimpleNamespace(items=items)
+
+
+@pytest.mark.parametrize("batch_format", ["pandas", "pyarrow"])
+def test_callable_preserves_batch_shape_and_non_target_columns(batch_format):
+    pd = pytest.importorskip("pandas", exc_type=ImportError)
+    frame = pd.DataFrame(
+        {
+            "record_id": ["a", "b", "c"],
+            "note": ["Jane Roe called 555-0100", None, "No identifiers"],
+            "score": [1, 2, 3],
+        }
+    )
+    batch = frame
+    if batch_format == "pyarrow":
+        pa = pytest.importorskip("pyarrow", exc_type=ImportError)
+        batch = pa.Table.from_pandas(frame, preserve_index=False)
+
+    actor = RayDeidentifyBatch(
+        column="note",
+        policy_profile="hipaa_safe_harbor",
+        pipeline_factory=lambda **_: _FakeBatchPipeline(),
+    )
+    output = actor.process_batch(batch)
+    output_frame = output if batch_format == "pandas" else output.to_pandas()
+
+    assert len(output_frame) == len(frame)
+    assert output_frame["record_id"].tolist() == frame["record_id"].tolist()
+    assert output_frame["score"].tolist() == frame["score"].tolist()
+    assert output_frame["note"].tolist()[0] == "[PERSON] called [PHONE]"
+    assert pd.isna(output_frame["note"].tolist()[1])
+    assert output_frame["note"].tolist()[2] == "No identifiers"
+
+
+def test_ray_dataset_uses_one_loaded_pipeline_per_actor():
+    ray = pytest.importorskip("ray", exc_type=ImportError)
+    pytest.importorskip("ray.data", exc_type=ImportError)
+
+    class PipelineStats:
+        def __init__(self) -> None:
+            self.loads: list[tuple[str, str | None]] = []
+            self.batch_sizes: list[int] = []
+
+        def record_load(self, model_name: str, policy_profile: str | None) -> None:
+            self.loads.append((model_name, policy_profile))
+
+        def record_batch(self, batch_size: int) -> None:
+            self.batch_sizes.append(batch_size)
+
+        def snapshot(self) -> dict[str, Any]:
+            return {
+                "loads": list(self.loads),
+                "batch_sizes": list(self.batch_sizes),
+            }
+
+    class FakeBatchPipeline:
+        def __init__(self, stats: Any) -> None:
+            self._stats = stats
+
+        def process_texts(self, texts, ids=None):
+            ray.get(self._stats.record_batch.remote(len(texts)))
+            items = [
+                SimpleNamespace(
+                    id=ids[index] if ids else f"item_{index}",
+                    success=True,
+                    result=SimpleNamespace(
+                        deidentified_text=text.replace("Jane Roe", "[PERSON]")
+                        .replace("John Doe", "[PERSON]")
+                        .replace("555-0100", "[PHONE]")
+                        .replace("555-0199", "[PHONE]")
+                    ),
+                )
+                for index, text in enumerate(texts)
+            ]
+            return SimpleNamespace(items=items)
+
+    class FakePipelineFactory:
+        def __init__(self, stats: Any) -> None:
+            self._stats = stats
+
+        def __call__(self, **kwargs):
+            ray.get(
+                self._stats.record_load.remote(
+                    kwargs["model_name"],
+                    kwargs["policy_profile"],
+                )
+            )
+            return FakeBatchPipeline(self._stats)
+
+    ray.shutdown()
+    try:
+        ray.init(local_mode=True, num_cpus=2, include_dashboard=False)
+    except RuntimeError as exc:
+        if "local_mode` is no longer supported" not in str(exc):
+            raise
+        ray.init(address="local", num_cpus=2, include_dashboard=False)
+    try:
+        stats_type = ray.remote(num_cpus=0)(PipelineStats)
+        stats = stats_type.remote()
+        records = [
+            {
+                "record_id": "a",
+                "note": "Jane Roe called 555-0100",
+                "score": 1,
+            },
+            {"record_id": "b", "note": "No identifiers", "score": 2},
+            {
+                "record_id": "c",
+                "note": "John Doe called 555-0199",
+                "score": 3,
+            },
+            {"record_id": "d", "note": "Follow-up", "score": 4},
+            {"record_id": "e", "note": "Discharge summary", "score": 5},
+        ]
+        dataset = ray.data.from_items(records, override_num_blocks=3)
+
+        redacted = map_batches_deidentify(
+            dataset,
+            column="note",
+            policy_profile="strict_no_leak",
+            model_name="fixture-pii-model",
+            batch_size=2,
+            batch_format="pandas",
+            concurrency=2,
+            pipeline_factory=FakePipelineFactory(stats),
+        ).materialize()
+        output = redacted.to_pandas()
+        snapshot = ray.get(stats.snapshot.remote())
+
+        assert len(output) == len(records)
+        assert output["record_id"].tolist() == [row["record_id"] for row in records]
+        assert output["score"].tolist() == [row["score"] for row in records]
+        assert "Jane Roe" not in "\n".join(output["note"])
+        assert "John Doe" not in "\n".join(output["note"])
+        assert snapshot["loads"] == [
+            ("fixture-pii-model", "strict_no_leak"),
+            ("fixture-pii-model", "strict_no_leak"),
+        ]
+        assert sum(snapshot["batch_sizes"]) == len(records)
+        assert max(snapshot["batch_sizes"]) <= 2
+    finally:
+        ray.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("concurrency", "message"),
+    [
+        (0, "at least 1"),
+        ((2, 1), "1 <= min <= max"),
+        ((1, 3, 4), "between min and max"),
+    ],
+)
+def test_invalid_actor_pool_concurrency_is_rejected(concurrency, message):
+    class Strategy:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    from openmed.integrations.ray_map_batches import _actor_pool_strategy
+
+    with pytest.raises(ValueError, match=message):
+        _actor_pool_strategy(Strategy, concurrency)

--- a/tests/unit/integrations/test_search_ingest_processor.py
+++ b/tests/unit/integrations/test_search_ingest_processor.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from openmed.integrations.search_ingest_processor import create_app
+
+
+def _fake_redact(text: str) -> str:
+    return (
+        text.replace("Jane Roe", "[NAME]")
+        .replace("555-0100", "[PHONE]")
+        .replace("jane.roe@example.test", "[EMAIL]")
+    )
+
+
+def _fake_result(texts: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                success=True,
+                result=SimpleNamespace(deidentified_text=_fake_redact(text)),
+            )
+            for text in texts
+        ]
+    )
+
+
+def test_http_processor_redacts_nested_fields_and_preserves_envelope(
+    caplog,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        calls.append({"texts": list(texts), "kwargs": dict(kwargs)})
+        return _fake_result(list(texts))
+
+    document = {
+        "_index": "synthetic-clinical-documents",
+        "_id": "synthetic-001",
+        "_routing": "tenant-a",
+        "_source": {
+            "note": "Patient Jane Roe called 555-0100.",
+            "patient": {
+                "summary": "Contact jane.roe@example.test for follow-up.",
+                "category": "synthetic",
+            },
+            "status": "open",
+        },
+        "_ingest": {"timestamp": "2026-07-19T00:00:00Z"},
+    }
+    original = deepcopy(document)
+    app = create_app(process_batch_fn=fake_process_batch)
+
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        response = client.post(
+            "/process",
+            json={
+                "document": document,
+                "fields": ["note", "patient.summary"],
+                "policy": "hipaa_safe_harbor",
+            },
+        )
+
+    assert response.status_code == 200
+    redacted = response.json()
+    assert set(redacted) == set(document)
+    assert redacted["_index"] == document["_index"]
+    assert redacted["_id"] == document["_id"]
+    assert redacted["_routing"] == document["_routing"]
+    assert redacted["_ingest"] == document["_ingest"]
+    assert redacted["_source"]["note"] == "Patient [NAME] called [PHONE]."
+    assert redacted["_source"]["patient"]["summary"] == "Contact [EMAIL] for follow-up."
+    assert redacted["_source"]["patient"]["category"] == "synthetic"
+    assert redacted["_source"]["status"] == "open"
+    assert document == original
+    assert calls[0]["texts"] == [
+        "Patient Jane Roe called 555-0100.",
+        "Contact jane.roe@example.test for follow-up.",
+    ]
+    assert calls[0]["kwargs"]["operation"] == "deidentify"
+    assert calls[0]["kwargs"]["policy"] == "hipaa_safe_harbor"
+    assert calls[0]["kwargs"]["continue_on_error"] is False
+    assert calls[0]["kwargs"]["use_safety_sweep"] is True
+    assert "Jane Roe" not in caplog.text
+    assert "555-0100" not in caplog.text
+    assert "jane.roe@example.test" not in caplog.text
+
+
+def test_unknown_and_non_string_field_paths_are_skipped_without_error() -> None:
+    calls: list[list[str]] = []
+
+    def fake_process_batch(texts: list[str], **kwargs: Any) -> SimpleNamespace:
+        calls.append(list(texts))
+        return _fake_result(list(texts))
+
+    document = {
+        "_index": "synthetic-clinical-documents",
+        "_source": {
+            "note": "Patient Jane Roe called.",
+            "metadata": {"attempt": 2},
+        },
+    }
+    app = create_app(process_batch_fn=fake_process_batch)
+
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        response = client.post(
+            "/process",
+            json={
+                "document": document,
+                "fields": ["missing.path", "metadata.attempt", "_source.note"],
+                "policy": "strict_no_leak",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "_index": "synthetic-clinical-documents",
+        "_source": {
+            "note": "Patient [NAME] called.",
+            "metadata": {"attempt": 2},
+        },
+    }
+    assert calls == [["Patient Jane Roe called."]]
+
+
+def test_batch_failures_return_phi_safe_error_and_do_not_log_document(
+    caplog,
+) -> None:
+    synthetic_text = "Patient Jane Roe called 555-0100."
+
+    def failing_process_batch(texts: list[str], **kwargs: Any) -> None:
+        raise RuntimeError(f"model failure while processing {texts[0]}")
+
+    app = create_app(process_batch_fn=failing_process_batch)
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        response = client.post(
+            "/process",
+            json={
+                "document": {"_source": {"note": synthetic_text}},
+                "fields": ["note"],
+                "policy": "hipaa_safe_harbor",
+            },
+        )
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": "failed to redact configured ingest document fields"
+    }
+    assert synthetic_text not in response.text
+    assert "Jane Roe" not in caplog.text
+    assert "555-0100" not in caplog.text
+
+
+def test_pipeline_definition_registers_processor_and_route() -> None:
+    root = Path(__file__).resolve().parents[3]
+    pipeline = json.loads(
+        (root / "examples/search-ingest/pipeline.json").read_text(encoding="utf-8")
+    )
+
+    processor = pipeline["processors"][0]
+    assert processor["id"] == "openmed-inline-redaction"
+    assert processor["type"] == "http"
+    assert processor["request"]["url"].endswith("/process")
+    assert processor["request"]["body"]["policy"] == "hipaa_safe_harbor"
+    assert pipeline["pipeline"]["processors"] == ["openmed-inline-redaction"]
+    assert pipeline["routes"][0]["pipeline"] == pipeline["pipeline"]["id"]

--- a/tests/unit/integrations/test_stream_processor.py
+++ b/tests/unit/integrations/test_stream_processor.py
@@ -1,0 +1,154 @@
+"""Offline tests for the framework-neutral stream processor helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from openmed.integrations.stream_processor import (
+    StreamDeidentifyMapFunction,
+    StreamSink,
+    run_stream_job,
+)
+
+
+def _redact(text: str) -> str:
+    return text.replace("Jane Roe", "[NAME]").replace("555-0101", "[PHONE]")
+
+
+class BatchProbe:
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def __call__(self, texts: list[str], **kwargs: Any) -> Any:
+        self.calls.append((list(texts), kwargs))
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    success=True,
+                    result=SimpleNamespace(deidentified_text=_redact(text)),
+                )
+                for text in texts
+            ]
+        )
+
+
+def test_map_batch_redacts_target_field_and_preserves_other_fields() -> None:
+    probe = BatchProbe()
+    mapper = StreamDeidentifyMapFunction(
+        "note",
+        policy="hipaa_safe_harbor",
+        batch_size=2,
+        process_batch_fn=probe,
+        use_safety_sweep=False,
+    )
+    records = [
+        {
+            "event_id": "evt-1",
+            "note": "Patient Jane Roe called 555-0101",
+            "encounter": {"id": "enc-7"},
+        },
+        {"event_id": "evt-2", "note": "No identifiers", "priority": 2},
+        {"event_id": "evt-3", "note": None, "priority": 1},
+    ]
+
+    output = mapper.map_batch(records)
+
+    assert output == [
+        {
+            "event_id": "evt-1",
+            "note": "Patient [NAME] called [PHONE]",
+            "encounter": {"id": "enc-7"},
+        },
+        {"event_id": "evt-2", "note": "No identifiers", "priority": 2},
+        {"event_id": "evt-3", "note": None, "priority": 1},
+    ]
+    assert records[0]["note"] == "Patient Jane Roe called 555-0101"
+    assert [texts for texts, _ in probe.calls] == [
+        ["Patient Jane Roe called 555-0101", "No identifiers"]
+    ]
+    kwargs = probe.calls[0][1]
+    assert kwargs == {
+        "operation": "deidentify",
+        "model_name": "disease_detection_superclinical",
+        "batch_size": 2,
+        "continue_on_error": False,
+        "method": "mask",
+        "policy": "hipaa_safe_harbor",
+        "use_safety_sweep": False,
+    }
+
+
+def test_out_of_order_duplicates_are_stateless_idempotent_and_keep_order() -> None:
+    probe = BatchProbe()
+    mapper = StreamDeidentifyMapFunction("note", batch_size=2, process_batch_fn=probe)
+    records = [
+        {"sequence": 9, "note": "Patient Jane Roe called"},
+        {"sequence": 2, "note": "Patient Jane Roe called"},
+        {"sequence": 7, "note": "Call 555-0101"},
+    ]
+
+    first = mapper.map_batch(records)
+    second = mapper.map_batch(first)
+
+    assert [record["sequence"] for record in first] == [9, 2, 7]
+    assert first[0]["note"] == first[1]["note"] == "Patient [NAME] called"
+    assert first[2]["note"] == "Call [PHONE]"
+    assert second == first
+    assert [len(texts) for texts, _ in probe.calls] == [2, 1, 2, 1]
+
+
+def test_offline_job_opens_once_per_subtask_and_writes_micro_batches() -> None:
+    probe = BatchProbe()
+
+    class OpenProbe(StreamDeidentifyMapFunction):
+        def __init__(self) -> None:
+            super().__init__("note", batch_size=2, process_batch_fn=probe)
+            self.open_calls = 0
+
+        def open(self, runtime_context: Any | None = None) -> None:
+            self.open_calls += 1
+            super().open(runtime_context)
+
+    mapper = OpenProbe()
+    written: list[dict[str, Any]] = []
+    source = [
+        {"sequence": 3, "note": "Patient Jane Roe"},
+        {"sequence": 1, "note": "Call 555-0101"},
+        {"sequence": 2, "note": "No identifiers"},
+    ]
+
+    count = run_stream_job(source, mapper, StreamSink(written.append))
+
+    assert count == 3
+    assert mapper.open_calls == 1
+    assert [record["sequence"] for record in written] == [3, 1, 2]
+    assert [len(texts) for texts, _ in probe.calls] == [2, 1]
+
+
+@pytest.mark.parametrize(
+    ("record", "error", "message"),
+    [
+        ({"other": "value"}, KeyError, "missing text field"),
+        ({"note": 42}, TypeError, "must be a string or None"),
+    ],
+)
+def test_map_rejects_invalid_records(
+    record: dict[str, Any], error: type[Exception], message: str
+) -> None:
+    mapper = StreamDeidentifyMapFunction("note", process_batch_fn=BatchProbe())
+
+    with pytest.raises(error, match=message):
+        mapper.map(record)
+
+
+def test_batch_result_count_must_match_input_count() -> None:
+    mapper = StreamDeidentifyMapFunction(
+        "note",
+        process_batch_fn=lambda texts, **kwargs: SimpleNamespace(items=[]),
+    )
+
+    with pytest.raises(ValueError, match="returned 0 results for 1 inputs"):
+        mapper.map({"note": "Patient Jane Roe"})


### PR DESCRIPTION
## Included pull requests

- #2156 — Add a Pandas-on-Spark accessor for distributed de-identification
- #2157 — Add a stream-processor map function and sink for record-level de-identification
- #2158 — Add an Arrow Flight de-identification service over record batches
- #2159 — feat: add Dataflow bundle processor
- #2160 — Add a Ray Data map-batches de-identification stage with shared model actors
- #2166 — Add a distributed SQL engine UDF plugin for in-query de-identification
- #2167 — Add PostgreSQL PL/Python de-identification functions
- #2168 — Add executable UDF column redaction adapter
- #2174 — Add a search-engine ingest processor for inline document redaction

## Issues resolved

Related to #838
Related to #843
Related to #844
Related to #847
Related to #848
Related to #840
Related to #841
Related to #854
Related to #846

## Maintainer integration changes

- Preserved both catalog entries where adapter documentation overlapped.
- Preserved the stream, Ray, and executable-UDF package exports across shared integration surfaces.
- Verified every source-PR merge against its rehearsed tree checkpoint.
- Validated final tree `0049ad377fdd5014845f8a88b0c490f36416d550`.

## Validation

- `python -m pytest <adapter focused suites> -q` — 37 passed, 8 skipped
- `ruff check openmed/integrations tests/unit/integrations` — passed
- `ruff format --check openmed/integrations tests/unit/integrations` — passed
- `mkdocs build --strict` — passed
