### PR TITLE
feat: integrate v2.2 service security controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ text should follow `docs/migration/2.0-to-2.1.md`.
 - Added a read-only Strawberry GraphQL endpoint for selective analysis and
   de-identification fields, canonical entity discovery, policy details, safe
   aggregate risk facets, introspection, and deterministic SDL export (#828).
+- Added versioned HMAC-SHA256 request signing over method, path, timestamp,
+  nonce, and body digest, with client-side header helpers, bounded fail-closed
+  replay protection, and verifier-compatible signatures on async job webhooks
+  (#849).
 - Added a weekday-themed model release orchestrator that chains conversion,
   synthetic evaluation, signed release gates, model-card generation,
   publication, fresh-environment smoke checks, last-green rollback, quarantine

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -105,6 +105,7 @@ classification:
     - deploy/hardened-image.md
     - offline-install.md
     - serving/async-jobs.md
+    - serving/request-signing.md
     - serving/grpc.md
     - serving/graphql.md
     - serving/authentication.md

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -110,6 +110,7 @@ classification:
     - serving/graphql.md
     - serving/authentication.md
     - serving/load-testing.md
+    - serving/mtls.md
     - deploy/helm.md
     - deploy/openhim-mediator.md
     - deploy/africa-reference-deployment.md

--- a/docs/serving/async-jobs.md
+++ b/docs/serving/async-jobs.md
@@ -86,11 +86,15 @@ Webhook requests include:
 
 - `X-OpenMed-Event`: `job.done` or `job.failed`
 - `X-OpenMed-Timestamp`: Unix timestamp
+- `X-OpenMed-Nonce`: unique opaque request nonce
 - `X-OpenMed-Signature`: `sha256=<hmac>`
 
-The signature is computed over `<timestamp>.<canonical-json-body>` using the
-configured shared secret and HMAC-SHA256. Non-2xx responses and transport
-errors are retried with exponential backoff.
+The signature uses the shared
+[HMAC request-signing scheme](request-signing.md), covering `POST`, the exact
+callback path and query, timestamp, nonce, and SHA-256 digest of the canonical
+JSON body. Each delivery attempt is signed independently with a fresh nonce, so
+retries remain compatible with receiver-side replay protection. Non-2xx
+responses and transport errors are retried with exponential backoff.
 
 ## Local Store Configuration
 

--- a/docs/serving/authentication.md
+++ b/docs/serving/authentication.md
@@ -88,3 +88,9 @@ OPENMED_SERVICE_AUTH_FAILURE_RATE_LIMIT_KEY=peer
 
 The failure limiter only counts failed authentication attempts. Successful
 authenticated requests are not charged against it.
+
+## Mutual TLS
+
+For certificate-bearing workload identity, including deployments that require
+mTLS before JWT or API-key authorization, see
+[Mutual TLS Client Authentication](mtls.md).

--- a/docs/serving/mtls.md
+++ b/docs/serving/mtls.md
@@ -1,0 +1,124 @@
+# Mutual TLS Client Authentication
+
+Mutual TLS (mTLS) can require every REST caller to present a client
+certificate issued by a configured private CA. OpenMed validates the client
+chain again at the application boundary, exposes the verified certificate
+identity to handlers, and can map an exact subject or subject alternative name
+(SAN) to the principal and scopes used by route authorization.
+
+mTLS is disabled by default. Enable it without changing application code:
+
+```bash
+OPENMED_SERVICE_MTLS_ENABLED=true \
+OPENMED_SERVICE_MTLS_CA_BUNDLE=/etc/openmed/client-ca.pem \
+uvicorn openmed.service.app:app --host 127.0.0.1 --port 8080
+```
+
+`OPENMED_SERVICE_MTLS_CA_BUNDLE` must contain at least one trusted CA
+certificate. It must not contain a production private key. Online CRL and OCSP
+checking are not performed; certificate issuance and revocation infrastructure
+remain the deployer's responsibility.
+
+## Terminate TLS at the application
+
+For direct TLS, use an ASGI server that implements the ASGI TLS extension and
+places the leaf-first PEM client chain in
+`scope["extensions"]["tls"]["client_cert_chain"]`. Configure the server to
+require client certificates against the same CA bundle. For example, the
+corresponding Uvicorn transport flags are:
+
+```bash
+uvicorn openmed.service.app:app \
+  --host 0.0.0.0 \
+  --port 8443 \
+  --ssl-keyfile /etc/openmed/server-key.pem \
+  --ssl-certfile /etc/openmed/server-cert.pem \
+  --ssl-cert-reqs 2 \
+  --ssl-ca-certs /etc/openmed/client-ca.pem
+```
+
+The transport must both enforce the TLS handshake and expose the verified
+chain through the ASGI TLS extension. If the server does not expose that
+extension, OpenMed cannot recover the peer certificate from an HTTP request and
+returns `mtls_certificate_required`; use a compatible server or the trusted
+proxy pattern below.
+
+## Terminate TLS at a sidecar or ingress
+
+A sidecar or ingress may terminate mTLS and forward a URL-escaped PEM client
+chain in a dedicated header. Configure both the header name and the exact proxy
+addresses or CIDR networks allowed to supply it:
+
+```bash
+OPENMED_SERVICE_MTLS_ENABLED=true \
+OPENMED_SERVICE_MTLS_CA_BUNDLE=/etc/openmed/client-ca.pem \
+OPENMED_SERVICE_MTLS_CLIENT_CERT_HEADER=X-OpenMed-Client-Cert \
+OPENMED_SERVICE_MTLS_TRUSTED_PROXIES=127.0.0.1/32,10.42.0.0/16 \
+uvicorn openmed.service.app:app --host 127.0.0.1 --port 8080 --no-proxy-headers
+```
+
+The proxy must:
+
+1. remove the client-supplied `X-OpenMed-Client-Cert` header;
+2. require and verify a client certificate at its TLS listener;
+3. URL-escape the leaf-first PEM chain into the configured header; and
+4. connect to OpenMed only from an address in the trusted-proxy list.
+
+OpenMed rejects the header from any other peer and independently verifies the
+forwarded chain against `OPENMED_SERVICE_MTLS_CA_BUNDLE`. Do not configure a
+public or shared proxy network as trusted. The ASGI `scope["client"]` value must
+remain the transport peer address used for this check. Disable generic proxy
+header rewriting as shown above, or configure the server so untrusted
+`X-Forwarded-For` input cannot replace that peer address.
+
+## Map certificates to principals and scopes
+
+Verified certificate details are available to handlers as
+`request.state.mtls_identity`:
+
+- `subject`: the RFC 4514 distinguished name;
+- `sans`: typed values such as `uri:spiffe://openmed.test/clinic-api`,
+  `dns:clinic-api.internal`, or `ip:10.42.0.8`; and
+- `fingerprint_sha256`: the lowercase leaf-certificate fingerprint.
+
+Use exact subject or SAN values to assign a stable, non-PHI service principal
+and route scopes:
+
+```bash
+OPENMED_SERVICE_MTLS_PRINCIPALS='[
+  {
+    "identities": ["uri:spiffe://clinic.example/workload/openmed-client"],
+    "principal": "clinic-api",
+    "scopes": ["analyze:write", "pii:read", "pii:write", "models:read"]
+  }
+]'
+```
+
+The mapped `AuthPrincipal` is available as `request.state.auth_principal` and
+`request.scope["openmed.auth"]`. When no mapping matches, OpenMed uses
+`mtls:<sha256-fingerprint>` with no scopes. This authenticates the certificate
+without silently granting application permissions.
+
+## Combine mTLS with JWT or API keys
+
+mTLS protects the connection and supplies a workload identity. REST
+authentication remains independently configurable with
+`OPENMED_SERVICE_AUTH_ENABLED=true`. An explicit JWT or API key takes
+precedence for route authorization, while `request.state.mtls_identity`
+continues to identify the certificate-bearing workload. Without an explicit
+credential, the mapped mTLS principal is used, so only scopes granted by
+`OPENMED_SERVICE_MTLS_PRINCIPALS` can authorize scoped routes.
+
+To require JWT on normal application routes, leave the mTLS principal without
+route scopes and configure JWT keys and route scopes as described in
+[REST Service Authentication](authentication.md). The TLS certificate is still
+required before the JWT is evaluated.
+
+## Logging and PHI safety
+
+Client certificate PEM, subject, SANs, and fingerprint are never written to
+access logs. A successful mTLS request adds only the configured principal (or
+the fallback fingerprint-based service identifier) as `identity`, plus
+`credential_type=mtls`. Use machine and workload identities in certificates;
+do not put patient names, record identifiers, or other PHI in certificate
+subjects, SANs, or principal mappings.

--- a/docs/serving/request-signing.md
+++ b/docs/serving/request-signing.md
@@ -1,0 +1,130 @@
+# HMAC Request Signing
+
+OpenMed provides a shared HMAC-SHA256 scheme for callers that need request
+integrity and replay protection. It is available for inbound request
+verification and is also used by async job webhooks.
+
+This is an application-level integrity check. Keep using HTTPS, service
+authentication, and a secret manager; request signing does not replace them.
+
+## Signature Headers
+
+Every signed request carries exactly these headers:
+
+- `X-OpenMed-Timestamp`: Unix time in whole seconds
+- `X-OpenMed-Nonce`: a unique, opaque value for this request
+- `X-OpenMed-Signature`: `sha256=<64 lowercase hex characters>`
+
+The default freshness window is 300 seconds. Keep clocks synchronized and
+generate a new nonce for every new request.
+
+## Canonical String
+
+The version 1 canonical string is UTF-8 encoded with newline separators:
+
+```text
+OPENMED-HMAC-SHA256-V1
+<UPPERCASE HTTP METHOD>
+<EXACT PATH AND QUERY>
+<UNIX TIMESTAMP>
+<NONCE>
+sha256:<LOWERCASE SHA-256 OF THE EXACT BODY BYTES>
+```
+
+Use the origin-form request target, such as `/jobs?mode=async`. Do not include
+the scheme, host, or URL fragment, and do not decode or reorder query
+parameters. The body hash—not the body—is placed in the canonical string, so
+raw PHI is never copied into signing or replay-cache state.
+
+The signature is the lowercase hexadecimal HMAC-SHA256 digest of those bytes.
+Header names are matched case-insensitively, but their values and the request
+target must be preserved exactly.
+
+## Sign a Client Request
+
+Serialize the body once, sign those exact bytes, and send those same bytes:
+
+```python
+import json
+import os
+
+import httpx
+
+from openmed.service.signing import sign_request
+
+body = json.dumps(
+    {"document_hash": "sha256:...", "offsets": [[8, 20]]},
+    separators=(",", ":"),
+    sort_keys=True,
+).encode("utf-8")
+headers = sign_request(
+    "POST",
+    "/jobs",
+    body,
+    secret=os.environ["OPENMED_HMAC_SECRET"],
+)
+headers["Content-Type"] = "application/json"
+
+response = httpx.post(
+    "https://openmed.example.com/jobs",
+    content=body,
+    headers=headers,
+)
+response.raise_for_status()
+```
+
+`sign_request_headers` is an equivalent, explicitly named helper for clients.
+Both helpers generate a cryptographically random nonce unless one is supplied.
+
+## Verify a Request
+
+Create one cache per shared-secret verification domain and keep it for the life
+of the process:
+
+```python
+import os
+
+from openmed.service.signing import (
+    NonceCache,
+    SignatureVerificationError,
+    verify_request_signature,
+)
+
+nonce_cache = NonceCache(max_entries=10_000, window_seconds=300)
+
+
+def verify(method, path_and_query, body, headers):
+    try:
+        verify_request_signature(
+            method,
+            path_and_query,
+            body,
+            headers,
+            secret=os.environ["OPENMED_HMAC_SECRET"],
+            nonce_cache=nonce_cache,
+            max_skew_seconds=300,
+        )
+    except SignatureVerificationError:
+        return False
+    return True
+```
+
+Verification checks freshness and the HMAC before atomically consuming the
+nonce. A tampered method, path, timestamp, nonce, or body fails without
+occupying cache space. A successful request consumes its nonce, so calling the
+verifier again for that request correctly reports a replay.
+
+The cache removes nonces only after their acceptance windows pass. It never
+evicts an active nonce just to make room: if `max_entries` is reached, new
+requests fail closed with `NonceCacheFullError`. Increase the bound for the
+expected peak number of signed requests per window. The cache is local to one
+process; deployments that require cross-process replay protection need an
+external nonce store, which is outside this feature's scope.
+
+## Signed Webhooks
+
+Async job callbacks use this same canonical scheme with method `POST`, the
+callback URL's exact path and query, and the canonical JSON bytes sent on the
+wire. Receivers can pass the callback request directly to
+`verify_request_signature`. See [Async REST Jobs & Webhooks](async-jobs.md) for
+delivery and retry behavior.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
       - Hardened Service Image: deploy/hardened-image.md
       - Offline & Air-Gapped Installation: offline-install.md
       - Async REST Jobs & Webhooks: serving/async-jobs.md
+      - HMAC Request Signing: serving/request-signing.md
       - gRPC Service: serving/grpc.md
       - GraphQL Service: serving/graphql.md
       - REST Authentication: serving/authentication.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - GraphQL Service: serving/graphql.md
       - REST Authentication: serving/authentication.md
       - Service Load Testing & Latency SLOs: serving/load-testing.md
+      - Mutual TLS Authentication: serving/mtls.md
       - Helm Deployment: deploy/helm.md
       - OpenHIM De-identification Mediator: deploy/openhim-mediator.md
       - African Facility-to-HMIS Reference: deploy/africa-reference-deployment.md

--- a/openmed/service/app.py
+++ b/openmed/service/app.py
@@ -44,6 +44,7 @@ from .metrics import (
     PrometheusMetricsRegistry,
     metrics_enabled_from_env,
 )
+from .mtls import ServiceMTLS, parse_service_mtls_config
 from .openhim_mediator import (
     OPENHIM_HEARTBEAT_PATH,
     OPENHIM_MEDIA_TYPE,
@@ -619,6 +620,10 @@ def create_app() -> FastAPI:
         parse_service_auth_config(),
         error_response=_error_response,
     )
+    app.state.mtls = ServiceMTLS(
+        parse_service_mtls_config(),
+        error_response=_error_response,
+    )
     app.state.metrics = (
         PrometheusMetricsRegistry() if metrics_enabled_from_env() else None
     )
@@ -689,9 +694,16 @@ def create_app() -> FastAPI:
     @app.middleware("http")
     async def _auth_middleware(request: Request, call_next):
         auth = getattr(request.app.state, "auth", None)
-        if auth is None:
-            return await call_next(request)
-        return await auth.dispatch(request, call_next)
+        mtls = getattr(request.app.state, "mtls", None)
+
+        async def dispatch_auth(auth_request: Request) -> Response:
+            if auth is None:
+                return await call_next(auth_request)
+            return await auth.dispatch(auth_request, call_next)
+
+        if mtls is None:
+            return await dispatch_auth(request)
+        return await mtls.dispatch(request, dispatch_auth)
 
     @app.exception_handler(RequestValidationError)
     async def _request_validation_handler(

--- a/openmed/service/auth.py
+++ b/openmed/service/auth.py
@@ -445,6 +445,9 @@ class ServiceAuth:
 
         authorization = request.headers.get("authorization")
         if not authorization:
+            mtls_principal = request.scope.get("openmed.auth")
+            if isinstance(mtls_principal, AuthPrincipal):
+                return mtls_principal
             raise missing_credentials()
 
         scheme, _, value = authorization.strip().partition(" ")

--- a/openmed/service/logging.py
+++ b/openmed/service/logging.py
@@ -19,6 +19,8 @@ REQUEST_ID_HEADER = "X-Request-ID"
 SERVICE_LOG_LEVEL_ENV_VAR = "OPENMED_SERVICE_LOG_LEVEL"
 SERVICE_LOG_FORMAT_ENV_VAR = "OPENMED_SERVICE_LOG_FORMAT"
 _MODEL_NAME_SCOPE_KEY = "openmed.access_log_model_name"
+_IDENTITY_SCOPE_KEY = "openmed.access_log_identity"
+_CREDENTIAL_TYPE_SCOPE_KEY = "openmed.access_log_credential_type"
 
 _REQUEST_ID: ContextVar[Optional[str]] = ContextVar(
     "openmed_service_request_id",
@@ -73,6 +75,17 @@ def set_access_log_model_name(request: Any, model_name: Optional[str]) -> None:
         request.scope[_MODEL_NAME_SCOPE_KEY] = str(model_name)
 
 
+def set_access_log_identity(
+    request: Any,
+    *,
+    principal: str,
+    credential_type: str,
+) -> None:
+    """Attach a non-PHI caller identity to the current request access log."""
+    request.scope[_IDENTITY_SCOPE_KEY] = str(principal)
+    request.scope[_CREDENTIAL_TYPE_SCOPE_KEY] = str(credential_type)
+
+
 class CorrelationIdMiddleware:
     """Add request IDs and emit PHI-free structured access logs."""
 
@@ -118,6 +131,8 @@ class CorrelationIdMiddleware:
                         "status_code": status_code,
                         "duration_ms": round(duration_ms, 3),
                         "model_name": scope.get(_MODEL_NAME_SCOPE_KEY),
+                        "identity": scope.get(_IDENTITY_SCOPE_KEY),
+                        "credential_type": scope.get(_CREDENTIAL_TYPE_SCOPE_KEY),
                         "request_id": request_id,
                     },
                 )
@@ -165,7 +180,9 @@ def _format_access_log(payload: Mapping[str, Any], config: ServiceLogConfig) -> 
             f"{payload.get('status_code', 0)} "
             f"{payload.get('duration_ms', 0)}ms "
             f"request_id={payload.get('request_id', '')} "
-            f"model_name={payload.get('model_name') or '-'}"
+            f"model_name={payload.get('model_name') or '-'} "
+            f"identity={payload.get('identity') or '-'} "
+            f"credential_type={payload.get('credential_type') or '-'}"
         )
     return _json_dumps(payload)
 
@@ -213,5 +230,6 @@ __all__ = [
     "StructuredJsonLogFormatter",
     "current_request_id",
     "service_log_config_from_env",
+    "set_access_log_identity",
     "set_access_log_model_name",
 ]

--- a/openmed/service/mtls.py
+++ b/openmed/service/mtls.py
@@ -1,0 +1,510 @@
+"""Mutual-TLS client certificate authentication for the REST service."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import os
+import re
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import unquote_to_bytes
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.x509.verification import (
+    PolicyBuilder,
+    Store,
+    VerificationError,
+)
+from fastapi import Request
+from starlette.responses import Response
+
+from .auth import AuthPrincipal, parse_bool
+from .logging import set_access_log_identity
+
+SERVICE_MTLS_ENABLED_ENV_VAR = "OPENMED_SERVICE_MTLS_ENABLED"
+SERVICE_MTLS_CA_BUNDLE_ENV_VAR = "OPENMED_SERVICE_MTLS_CA_BUNDLE"
+SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR = "OPENMED_SERVICE_MTLS_CLIENT_CERT_HEADER"
+SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR = "OPENMED_SERVICE_MTLS_TRUSTED_PROXIES"
+SERVICE_MTLS_PRINCIPALS_ENV_VAR = "OPENMED_SERVICE_MTLS_PRINCIPALS"
+
+MAX_CLIENT_CERT_CHAIN_BYTES = 256 * 1024
+_HEADER_NAME_PATTERN = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+
+ErrorResponseFactory = Callable[..., Response]
+CallNext = Callable[[Request], Awaitable[Response]]
+IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+@dataclass(frozen=True)
+class MTLSPrincipalMapping:
+    """Map exact certificate identities to a route-authorization principal."""
+
+    identities: frozenset[str]
+    principal: str
+    scopes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class MTLSClientIdentity:
+    """Verified client certificate identity exposed to request handlers."""
+
+    subject: str
+    sans: tuple[str, ...]
+    fingerprint_sha256: str
+
+    @property
+    def identifiers(self) -> tuple[str, ...]:
+        """Return exact values eligible for configured principal mapping."""
+        return (self.subject, *self.sans)
+
+
+@dataclass(frozen=True)
+class ServiceMTLSConfig:
+    """Mutual-TLS settings for the REST service."""
+
+    enabled: bool = False
+    ca_bundle: Optional[Path] = None
+    client_cert_header: Optional[str] = None
+    trusted_proxies: tuple[IPNetwork, ...] = ()
+    principals: tuple[MTLSPrincipalMapping, ...] = ()
+
+
+class MTLSAuthenticationError(ValueError):
+    """mTLS authentication failure safe to expose through the API envelope."""
+
+    def __init__(self, *, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def parse_service_mtls_config() -> ServiceMTLSConfig:
+    """Read mTLS settings from the current process environment."""
+    enabled = parse_bool(
+        os.getenv(SERVICE_MTLS_ENABLED_ENV_VAR),
+        env_var=SERVICE_MTLS_ENABLED_ENV_VAR,
+        default=False,
+    )
+    if not enabled:
+        return ServiceMTLSConfig(enabled=False)
+
+    raw_ca_bundle = os.getenv(SERVICE_MTLS_CA_BUNDLE_ENV_VAR)
+    if raw_ca_bundle is None or not raw_ca_bundle.strip():
+        raise ValueError(
+            f"{SERVICE_MTLS_CA_BUNDLE_ENV_VAR} is required when mTLS is enabled"
+        )
+    ca_bundle = Path(raw_ca_bundle.strip())
+    if not ca_bundle.is_file():
+        raise ValueError(f"{SERVICE_MTLS_CA_BUNDLE_ENV_VAR} must name a readable file")
+
+    client_cert_header = _parse_client_cert_header(
+        os.getenv(SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR)
+    )
+    trusted_proxies = parse_trusted_proxies(
+        os.getenv(SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR)
+    )
+    if client_cert_header is not None and not trusted_proxies:
+        raise ValueError(
+            f"{SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR} is required when "
+            f"{SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR} is configured"
+        )
+
+    return ServiceMTLSConfig(
+        enabled=True,
+        ca_bundle=ca_bundle,
+        client_cert_header=client_cert_header,
+        trusted_proxies=trusted_proxies,
+        principals=parse_principal_mappings(os.getenv(SERVICE_MTLS_PRINCIPALS_ENV_VAR)),
+    )
+
+
+def parse_trusted_proxies(raw_value: Optional[str]) -> tuple[IPNetwork, ...]:
+    """Parse comma-separated trusted proxy addresses and CIDR networks."""
+    if raw_value is None or not raw_value.strip():
+        return ()
+
+    parsed: list[IPNetwork] = []
+    for item in raw_value.split(","):
+        value = item.strip()
+        if not value:
+            continue
+        try:
+            parsed.append(ipaddress.ip_network(value, strict=False))
+        except ValueError as exc:
+            raise ValueError(
+                f"{SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR} contains an invalid "
+                f"address or network"
+            ) from exc
+    return tuple(parsed)
+
+
+def parse_principal_mappings(
+    raw_value: Optional[str],
+) -> tuple[MTLSPrincipalMapping, ...]:
+    """Parse exact subject/SAN-to-principal mappings from JSON."""
+    if raw_value is None or not raw_value.strip():
+        return ()
+
+    try:
+        payload = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR} must be valid JSON"
+        ) from exc
+    if not isinstance(payload, list):
+        raise ValueError(f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR} must be a JSON list")
+
+    mappings: list[MTLSPrincipalMapping] = []
+    claimed_identities: set[str] = set()
+    for index, item in enumerate(payload):
+        if not isinstance(item, Mapping):
+            raise ValueError(
+                f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR}[{index}] must be a JSON object"
+            )
+        identities = _normalize_identities(
+            item.get("identities", item.get("identity")),
+            index=index,
+        )
+        duplicate = claimed_identities.intersection(identities)
+        if duplicate:
+            raise ValueError(
+                f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR} contains a duplicate identity"
+            )
+        claimed_identities.update(identities)
+
+        principal = str(item.get("principal") or "").strip()
+        if not principal:
+            raise ValueError(
+                f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR}[{index}] requires principal"
+            )
+        mappings.append(
+            MTLSPrincipalMapping(
+                identities=frozenset(identities),
+                principal=principal,
+                scopes=_normalize_scopes(item.get("scopes", item.get("scope"))),
+            )
+        )
+    return tuple(mappings)
+
+
+def verify_client_certificate_chain(
+    client_cert_chain: Sequence[str],
+    ca_bundle: str | Path,
+) -> MTLSClientIdentity:
+    """Verify a PEM client chain against a CA bundle and return its identity.
+
+    Args:
+        client_cert_chain: Leaf-first PEM client certificate chain.
+        ca_bundle: PEM bundle containing one or more trusted CA certificates.
+
+    Returns:
+        Subject, SAN values, and SHA-256 fingerprint from the verified leaf.
+
+    Raises:
+        ValueError: If the chain or CA bundle is invalid or untrusted.
+    """
+    ca_path = Path(ca_bundle)
+    try:
+        ca_certificates = x509.load_pem_x509_certificates(ca_path.read_bytes())
+    except (OSError, ValueError) as exc:
+        raise ValueError("mTLS CA bundle is invalid") from exc
+    if not ca_certificates:
+        raise ValueError("mTLS CA bundle does not contain a certificate")
+    return _verify_client_certificate_chain(client_cert_chain, Store(ca_certificates))
+
+
+class ServiceMTLS:
+    """Verify and attach an mTLS client principal to each HTTP request."""
+
+    def __init__(
+        self,
+        config: ServiceMTLSConfig,
+        *,
+        error_response: ErrorResponseFactory,
+    ) -> None:
+        self.config = config
+        self._error_response = error_response
+        self._store: Optional[Store] = None
+        if config.enabled:
+            if config.ca_bundle is None:
+                raise ValueError("mTLS CA bundle is required")
+            try:
+                ca_certificates = x509.load_pem_x509_certificates(
+                    config.ca_bundle.read_bytes()
+                )
+            except (OSError, ValueError) as exc:
+                raise ValueError("mTLS CA bundle is invalid") from exc
+            if not ca_certificates:
+                raise ValueError("mTLS CA bundle does not contain a certificate")
+            self._store = Store(ca_certificates)
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether mTLS authentication is active."""
+        return self.config.enabled
+
+    async def dispatch(self, request: Request, call_next: CallNext) -> Response:
+        """Require a trusted client certificate and attach its principal."""
+        if not self.enabled:
+            return await call_next(request)
+
+        try:
+            chain = self._certificate_chain(request)
+            if self._store is None:
+                raise invalid_client_certificate()
+            identity = _verify_client_certificate_chain(chain, self._store)
+        except MTLSAuthenticationError as exc:
+            return self._authentication_failure(exc)
+        except ValueError:
+            return self._authentication_failure(invalid_client_certificate())
+
+        principal = self._principal_for(identity)
+        request.state.mtls_identity = identity
+        request.state.auth_principal = principal
+        request.scope["openmed.mtls"] = identity
+        request.scope["openmed.auth"] = principal
+        set_access_log_identity(
+            request,
+            principal=principal.subject,
+            credential_type=principal.credential_type,
+        )
+        return await call_next(request)
+
+    def _certificate_chain(self, request: Request) -> tuple[str, ...]:
+        extensions = request.scope.get("extensions")
+        tls_extension: Any = None
+        if isinstance(extensions, Mapping):
+            tls_extension = extensions.get("tls")
+        if isinstance(tls_extension, Mapping):
+            if tls_extension.get("client_cert_error"):
+                raise invalid_client_certificate()
+            chain = tls_extension.get("client_cert_chain", ())
+            normalized = _normalize_pem_chain(chain)
+            if normalized:
+                return normalized
+
+        header_name = self.config.client_cert_header
+        if header_name is not None:
+            forwarded_certificate = request.headers.get(header_name)
+            if forwarded_certificate is not None:
+                if not _peer_is_trusted(request, self.config.trusted_proxies):
+                    raise invalid_client_certificate()
+                try:
+                    decoded = unquote_to_bytes(forwarded_certificate).decode("ascii")
+                except (UnicodeDecodeError, ValueError) as exc:
+                    raise invalid_client_certificate() from exc
+                return _normalize_pem_chain(decoded)
+
+        raise client_certificate_required()
+
+    def _principal_for(self, identity: MTLSClientIdentity) -> AuthPrincipal:
+        identifiers = set(identity.identifiers)
+        for mapping in self.config.principals:
+            if identifiers.intersection(mapping.identities):
+                principal = mapping.principal
+                scopes = mapping.scopes
+                break
+        else:
+            principal = f"mtls:{identity.fingerprint_sha256}"
+            scopes = ()
+
+        return AuthPrincipal(
+            subject=principal,
+            credential_type="mtls",
+            scopes=scopes,
+            claims={
+                "certificate_subject": identity.subject,
+                "certificate_sans": identity.sans,
+                "certificate_sha256": identity.fingerprint_sha256,
+            },
+        )
+
+    def _authentication_failure(self, exc: MTLSAuthenticationError) -> Response:
+        return self._error_response(
+            401,
+            exc.code,
+            exc.message,
+            details=None,
+        )
+
+
+def client_certificate_required() -> MTLSAuthenticationError:
+    """Return a missing-client-certificate error."""
+    return MTLSAuthenticationError(
+        code="mtls_certificate_required",
+        message="A verified client certificate is required",
+    )
+
+
+def invalid_client_certificate() -> MTLSAuthenticationError:
+    """Return a generic invalid-client-certificate error."""
+    return MTLSAuthenticationError(
+        code="mtls_certificate_invalid",
+        message="The client certificate is invalid or untrusted",
+    )
+
+
+def _verify_client_certificate_chain(
+    client_cert_chain: Sequence[str],
+    store: Store,
+) -> MTLSClientIdentity:
+    chain = _load_client_certificates(client_cert_chain)
+    try:
+        PolicyBuilder().store(store).build_client_verifier().verify(
+            chain[0], list(chain[1:])
+        )
+    except (VerificationError, x509.UnsupportedGeneralNameType) as exc:
+        raise ValueError("client certificate chain is untrusted") from exc
+
+    leaf = chain[0]
+    der = leaf.public_bytes(serialization.Encoding.DER)
+    return MTLSClientIdentity(
+        subject=leaf.subject.rfc4514_string(),
+        sans=_certificate_sans(leaf),
+        fingerprint_sha256=hashlib.sha256(der).hexdigest(),
+    )
+
+
+def _load_client_certificates(
+    client_cert_chain: Sequence[str],
+) -> tuple[x509.Certificate, ...]:
+    normalized = _normalize_pem_chain(client_cert_chain)
+    if not normalized:
+        raise ValueError("client certificate chain is empty")
+    certificates: list[x509.Certificate] = []
+    try:
+        for pem in normalized:
+            certificates.extend(x509.load_pem_x509_certificates(pem.encode("ascii")))
+    except (UnicodeEncodeError, ValueError) as exc:
+        raise ValueError("client certificate chain is invalid") from exc
+    if not certificates:
+        raise ValueError("client certificate chain is empty")
+    return tuple(certificates)
+
+
+def _normalize_pem_chain(raw_chain: Any) -> tuple[str, ...]:
+    if raw_chain is None:
+        return ()
+    if isinstance(raw_chain, str):
+        chain = (raw_chain,)
+    elif isinstance(raw_chain, Sequence) and not isinstance(
+        raw_chain, (bytes, bytearray)
+    ):
+        chain = tuple(str(item) for item in raw_chain)
+    else:
+        raise ValueError("client certificate chain is invalid")
+
+    total_bytes = 0
+    normalized: list[str] = []
+    for certificate in chain:
+        value = certificate.strip()
+        if not value:
+            continue
+        try:
+            total_bytes += len(value.encode("ascii"))
+        except UnicodeEncodeError as exc:
+            raise ValueError("client certificate chain is invalid") from exc
+        if total_bytes > MAX_CLIENT_CERT_CHAIN_BYTES:
+            raise ValueError("client certificate chain is too large")
+        normalized.append(value)
+    return tuple(normalized)
+
+
+def _certificate_sans(certificate: x509.Certificate) -> tuple[str, ...]:
+    try:
+        extension = certificate.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
+        ).value
+    except x509.ExtensionNotFound:
+        return ()
+
+    sans: list[str] = []
+    for name in extension:
+        if isinstance(name, x509.DNSName):
+            sans.append(f"dns:{name.value}")
+        elif isinstance(name, x509.UniformResourceIdentifier):
+            sans.append(f"uri:{name.value}")
+        elif isinstance(name, x509.IPAddress):
+            sans.append(f"ip:{name.value}")
+        elif isinstance(name, x509.RFC822Name):
+            sans.append(f"email:{name.value}")
+    return tuple(sans)
+
+
+def _parse_client_cert_header(raw_value: Optional[str]) -> Optional[str]:
+    if raw_value is None or not raw_value.strip():
+        return None
+    value = raw_value.strip()
+    if not _HEADER_NAME_PATTERN.fullmatch(value):
+        raise ValueError(
+            f"{SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR} must be a valid HTTP "
+            "header name"
+        )
+    return value
+
+
+def _peer_is_trusted(request: Request, networks: Sequence[IPNetwork]) -> bool:
+    if request.client is None:
+        return False
+    try:
+        peer = ipaddress.ip_address(request.client.host)
+    except ValueError:
+        return False
+    return any(peer in network for network in networks)
+
+
+def _normalize_identities(raw_value: Any, *, index: int) -> tuple[str, ...]:
+    if isinstance(raw_value, str):
+        values = (raw_value,)
+    elif isinstance(raw_value, Sequence) and not isinstance(
+        raw_value, (bytes, bytearray)
+    ):
+        values = tuple(str(item) for item in raw_value)
+    else:
+        raise ValueError(
+            f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR}[{index}] requires identity or identities"
+        )
+    normalized = tuple(value.strip() for value in values if value.strip())
+    if not normalized:
+        raise ValueError(
+            f"{SERVICE_MTLS_PRINCIPALS_ENV_VAR}[{index}] requires identity or identities"
+        )
+    return normalized
+
+
+def _normalize_scopes(raw_value: Any) -> tuple[str, ...]:
+    if raw_value is None:
+        return ()
+    if isinstance(raw_value, str):
+        values = raw_value.replace(",", " ").split()
+    elif isinstance(raw_value, Sequence) and not isinstance(
+        raw_value, (bytes, bytearray)
+    ):
+        values = [str(value).strip() for value in raw_value]
+    else:
+        raise ValueError("mTLS principal scopes must be a string or list")
+    return tuple(dict.fromkeys(value for value in values if value))
+
+
+__all__ = [
+    "MAX_CLIENT_CERT_CHAIN_BYTES",
+    "MTLSAuthenticationError",
+    "MTLSClientIdentity",
+    "MTLSPrincipalMapping",
+    "SERVICE_MTLS_CA_BUNDLE_ENV_VAR",
+    "SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR",
+    "SERVICE_MTLS_ENABLED_ENV_VAR",
+    "SERVICE_MTLS_PRINCIPALS_ENV_VAR",
+    "SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR",
+    "ServiceMTLS",
+    "ServiceMTLSConfig",
+    "parse_principal_mappings",
+    "parse_service_mtls_config",
+    "parse_trusted_proxies",
+    "verify_client_certificate_chain",
+]

--- a/openmed/service/signing.py
+++ b/openmed/service/signing.py
@@ -1,0 +1,399 @@
+"""HMAC-SHA256 request signing with bounded local replay protection."""
+
+from __future__ import annotations
+
+import hashlib
+import heapq
+import hmac
+import math
+import re
+import secrets
+import threading
+import time
+from collections.abc import Mapping
+from typing import Optional, Union
+
+SIGNATURE_HEADER = "X-OpenMed-Signature"
+TIMESTAMP_HEADER = "X-OpenMed-Timestamp"
+NONCE_HEADER = "X-OpenMed-Nonce"
+SIGNATURE_PREFIX = "sha256="
+DEFAULT_MAX_SKEW_SECONDS = 300
+DEFAULT_NONCE_CACHE_SIZE = 10_000
+
+_SIGNING_SCHEME = "OPENMED-HMAC-SHA256-V1"
+_HTTP_METHOD_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_NONCE_RE = re.compile(r"^[\x21-\x7e]{1,256}$")
+_SIGNATURE_RE = re.compile(r"^[0-9a-f]{64}$")
+
+Body = Union[bytes, bytearray, memoryview, str]
+Secret = Union[bytes, str]
+
+
+class SignatureVerificationError(ValueError):
+    """Base class for request-signature verification failures."""
+
+
+class InvalidSignatureError(SignatureVerificationError):
+    """Raised when signature headers or the HMAC digest are invalid."""
+
+
+class StaleTimestampError(SignatureVerificationError):
+    """Raised when a signed timestamp falls outside the accepted window."""
+
+
+class ReplayDetectedError(SignatureVerificationError):
+    """Raised when a nonce has already been accepted in the active window."""
+
+
+class NonceCacheFullError(SignatureVerificationError):
+    """Raised when replay protection cannot safely accept another nonce."""
+
+
+class NonceCache:
+    """Thread-safe, bounded in-memory cache for accepted request nonces.
+
+    Active entries are never evicted merely to make space because that would
+    allow their requests to be replayed. Expired entries are removed before a
+    nonce is claimed; when all entries are active, the cache fails closed.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_entries: int = DEFAULT_NONCE_CACHE_SIZE,
+        window_seconds: Union[int, float] = DEFAULT_MAX_SKEW_SECONDS,
+    ) -> None:
+        if (
+            isinstance(max_entries, bool)
+            or not isinstance(max_entries, int)
+            or max_entries < 1
+        ):
+            raise ValueError("max_entries must be at least 1")
+        self.max_entries = max_entries
+        self.window_seconds = _normalize_window(window_seconds)
+        self._entries: dict[str, float] = {}
+        self._expirations: list[tuple[float, int, str]] = []
+        self._sequence = 0
+        self._lock = threading.Lock()
+
+    def check_and_store(
+        self,
+        nonce: str,
+        *,
+        timestamp: Optional[Union[int, float]] = None,
+        now: Optional[Union[int, float]] = None,
+        window_seconds: Optional[Union[int, float]] = None,
+    ) -> bool:
+        """Atomically claim ``nonce`` and return whether it was newly stored.
+
+        The entry remains active until the signed timestamp's acceptance
+        window has passed. ``False`` means the nonce is already active or its
+        requested expiration is already past.
+        """
+        normalized_nonce = _normalize_nonce(nonce)
+        current_time = _normalize_clock_value(now, default=time.time())
+        signed_at = _normalize_clock_value(timestamp, default=current_time)
+        active_window = (
+            self.window_seconds
+            if window_seconds is None
+            else _normalize_window(window_seconds)
+        )
+        expires_at = signed_at + active_window
+
+        with self._lock:
+            self._purge_expired_locked(current_time)
+            if normalized_nonce in self._entries or expires_at < current_time:
+                return False
+            if len(self._entries) >= self.max_entries:
+                raise NonceCacheFullError(
+                    "Nonce cache is full with unexpired entries; request rejected"
+                )
+
+            self._sequence += 1
+            self._entries[normalized_nonce] = expires_at
+            heapq.heappush(
+                self._expirations,
+                (expires_at, self._sequence, normalized_nonce),
+            )
+            return True
+
+    def purge_expired(self, *, now: Optional[Union[int, float]] = None) -> int:
+        """Remove entries past their replay window and return the count."""
+        current_time = _normalize_clock_value(now, default=time.time())
+        with self._lock:
+            before = len(self._entries)
+            self._purge_expired_locked(current_time)
+            return before - len(self._entries)
+
+    def clear(self) -> None:
+        """Remove all cached nonces."""
+        with self._lock:
+            self._entries.clear()
+            self._expirations.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+    def _purge_expired_locked(self, now: float) -> None:
+        while self._expirations and self._expirations[0][0] < now:
+            expires_at, _, nonce = heapq.heappop(self._expirations)
+            if self._entries.get(nonce) == expires_at:
+                del self._entries[nonce]
+
+
+def canonical_signing_string(
+    method: str,
+    path: str,
+    timestamp: int,
+    nonce: str,
+    body: Body = b"",
+) -> bytes:
+    """Build the versioned request string covered by the HMAC.
+
+    Only the body's SHA-256 digest is included, so the canonical string never
+    contains raw request content or PHI.
+    """
+    normalized_method = _normalize_method(method)
+    normalized_path = _normalize_path(path)
+    normalized_timestamp = _normalize_timestamp(timestamp)
+    normalized_nonce = _normalize_nonce(nonce)
+    body_digest = hashlib.sha256(_body_bytes(body)).hexdigest()
+    return "\n".join(
+        (
+            _SIGNING_SCHEME,
+            normalized_method,
+            normalized_path,
+            str(normalized_timestamp),
+            normalized_nonce,
+            f"sha256:{body_digest}",
+        )
+    ).encode("utf-8")
+
+
+def sign_request(
+    method: str,
+    path: str,
+    body: Body = b"",
+    *,
+    secret: Secret,
+    timestamp: Optional[int] = None,
+    nonce: Optional[str] = None,
+) -> dict[str, str]:
+    """Return headers that sign the exact request method, target, and body."""
+    issued_at = _normalize_timestamp(
+        int(time.time()) if timestamp is None else timestamp
+    )
+    request_nonce = _normalize_nonce(
+        secrets.token_urlsafe(24) if nonce is None else nonce
+    )
+    digest = _signature_digest(
+        secret,
+        canonical_signing_string(method, path, issued_at, request_nonce, body),
+    )
+    return {
+        TIMESTAMP_HEADER: str(issued_at),
+        NONCE_HEADER: request_nonce,
+        SIGNATURE_HEADER: f"{SIGNATURE_PREFIX}{digest}",
+    }
+
+
+def sign_request_headers(
+    method: str,
+    path: str,
+    body: Body = b"",
+    *,
+    secret: Secret,
+    timestamp: Optional[int] = None,
+    nonce: Optional[str] = None,
+) -> dict[str, str]:
+    """Alias for :func:`sign_request` for client-side header construction."""
+    return sign_request(
+        method,
+        path,
+        body,
+        secret=secret,
+        timestamp=timestamp,
+        nonce=nonce,
+    )
+
+
+def verify_request_signature(
+    method: str,
+    path: str,
+    body: Body,
+    headers: Mapping[str, str],
+    *,
+    secret: Secret,
+    nonce_cache: NonceCache,
+    max_skew_seconds: Union[int, float] = DEFAULT_MAX_SKEW_SECONDS,
+    now: Optional[Union[int, float]] = None,
+) -> bool:
+    """Verify request integrity, freshness, and one-time nonce use.
+
+    Successful verification atomically consumes the nonce. Failures raise a
+    :class:`SignatureVerificationError` subclass and do not claim the nonce.
+    """
+    active_window = _normalize_window(max_skew_seconds)
+    current_time = _normalize_clock_value(now, default=time.time())
+    timestamp_value = _required_header(headers, TIMESTAMP_HEADER)
+    nonce = _required_header(headers, NONCE_HEADER)
+    signature_value = _required_header(headers, SIGNATURE_HEADER)
+
+    issued_at = _parse_timestamp_header(timestamp_value)
+    try:
+        normalized_nonce = _normalize_nonce(nonce)
+    except (TypeError, ValueError) as exc:
+        raise InvalidSignatureError("Invalid request signature headers") from exc
+
+    if abs(current_time - issued_at) > active_window:
+        raise StaleTimestampError("Signed timestamp is outside the accepted window")
+
+    if not signature_value.startswith(SIGNATURE_PREFIX):
+        raise InvalidSignatureError("Invalid request signature")
+    provided_digest = signature_value[len(SIGNATURE_PREFIX) :]
+    if not _SIGNATURE_RE.fullmatch(provided_digest):
+        raise InvalidSignatureError("Invalid request signature")
+
+    expected_digest = _signature_digest(
+        secret,
+        canonical_signing_string(
+            method,
+            path,
+            issued_at,
+            normalized_nonce,
+            body,
+        ),
+    )
+    if not hmac.compare_digest(provided_digest, expected_digest):
+        raise InvalidSignatureError("Invalid request signature")
+
+    if not nonce_cache.check_and_store(
+        normalized_nonce,
+        timestamp=issued_at,
+        now=current_time,
+        window_seconds=active_window,
+    ):
+        raise ReplayDetectedError("Request nonce has already been used")
+    return True
+
+
+def _required_header(headers: Mapping[str, str], target: str) -> str:
+    values = [
+        value
+        for name, value in headers.items()
+        if isinstance(name, str) and name.casefold() == target.casefold()
+    ]
+    if len(values) != 1 or not isinstance(values[0], str):
+        raise InvalidSignatureError("Missing or duplicate request signature header")
+    return values[0]
+
+
+def _parse_timestamp_header(value: str) -> int:
+    if not value.isascii() or not value.isdigit():
+        raise InvalidSignatureError("Invalid signed timestamp")
+    issued_at = int(value)
+    if value != str(issued_at):
+        raise InvalidSignatureError("Invalid signed timestamp")
+    return issued_at
+
+
+def _signature_digest(secret: Secret, signing_string: bytes) -> str:
+    return hmac.new(_secret_bytes(secret), signing_string, hashlib.sha256).hexdigest()
+
+
+def _secret_bytes(secret: Secret) -> bytes:
+    if isinstance(secret, str):
+        secret_bytes = secret.encode("utf-8")
+    elif isinstance(secret, bytes):
+        secret_bytes = secret
+    else:
+        raise TypeError("secret must be bytes or str")
+    if not secret_bytes:
+        raise ValueError("secret must not be blank")
+    return secret_bytes
+
+
+def _body_bytes(body: Body) -> bytes:
+    if isinstance(body, str):
+        return body.encode("utf-8")
+    if isinstance(body, bytes):
+        return body
+    if isinstance(body, (bytearray, memoryview)):
+        return bytes(body)
+    raise TypeError("body must be bytes-like or str")
+
+
+def _normalize_method(method: str) -> str:
+    if not isinstance(method, str) or not _HTTP_METHOD_RE.fullmatch(method):
+        raise ValueError("method must be a valid HTTP method token")
+    return method.upper()
+
+
+def _normalize_path(path: str) -> str:
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise ValueError("path must be an origin-form request target")
+    if "#" in path or any(not "!" <= character <= "~" for character in path):
+        raise ValueError(
+            "path must be a printable ASCII request target without a fragment"
+        )
+    return path
+
+
+def _normalize_timestamp(timestamp: int) -> int:
+    if isinstance(timestamp, bool) or not isinstance(timestamp, int):
+        raise TypeError("timestamp must be an integer Unix timestamp")
+    if timestamp < 0:
+        raise ValueError("timestamp must not be negative")
+    return timestamp
+
+
+def _normalize_nonce(nonce: str) -> str:
+    if not isinstance(nonce, str):
+        raise TypeError("nonce must be a string")
+    if not _NONCE_RE.fullmatch(nonce):
+        raise ValueError("nonce must contain 1-256 printable ASCII characters")
+    return nonce
+
+
+def _normalize_clock_value(
+    value: Optional[Union[int, float]], *, default: Union[int, float]
+) -> float:
+    normalized = default if value is None else value
+    if isinstance(normalized, bool) or not isinstance(normalized, (int, float)):
+        raise TypeError("clock values must be numeric")
+    clock_value = float(normalized)
+    if not math.isfinite(clock_value):
+        raise ValueError("clock values must be finite")
+    return clock_value
+
+
+def _normalize_window(value: Union[int, float]) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError("max_skew_seconds must be greater than 0")
+    return float(value)
+
+
+__all__ = [
+    "DEFAULT_MAX_SKEW_SECONDS",
+    "DEFAULT_NONCE_CACHE_SIZE",
+    "InvalidSignatureError",
+    "NONCE_HEADER",
+    "NonceCache",
+    "NonceCacheFullError",
+    "ReplayDetectedError",
+    "SIGNATURE_HEADER",
+    "SIGNATURE_PREFIX",
+    "SignatureVerificationError",
+    "StaleTimestampError",
+    "TIMESTAMP_HEADER",
+    "canonical_signing_string",
+    "sign_request",
+    "sign_request_headers",
+    "verify_request_signature",
+]

--- a/openmed/service/webhooks.py
+++ b/openmed/service/webhooks.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import json
 import time
 from dataclasses import dataclass
@@ -11,10 +9,14 @@ from typing import Any, Callable, Optional
 
 import httpx
 
-SIGNATURE_HEADER = "X-OpenMed-Signature"
-TIMESTAMP_HEADER = "X-OpenMed-Timestamp"
+from .signing import (
+    NONCE_HEADER,
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    sign_request,
+)
+
 EVENT_HEADER = "X-OpenMed-Event"
-SIGNATURE_PREFIX = "sha256="
 DEFAULT_WEBHOOK_TIMEOUT_SECONDS = 10.0
 
 
@@ -52,16 +54,26 @@ def sign_webhook_payload(
     payload: Any,
     *,
     secret: str,
+    path: str = "/",
     timestamp: Optional[int] = None,
-) -> tuple[bytes, str, str]:
-    """Return canonical body bytes, timestamp, and HMAC signature header value."""
-    if not secret:
-        raise ValueError("Webhook secret must not be blank")
+    nonce: Optional[str] = None,
+) -> tuple[bytes, str, str, str]:
+    """Return body bytes plus timestamp, nonce, and signature header values."""
     body = canonical_json_bytes(payload)
-    issued_at = str(int(time.time() if timestamp is None else timestamp))
-    signed = issued_at.encode("ascii") + b"." + body
-    digest = hmac.new(secret.encode("utf-8"), signed, hashlib.sha256).hexdigest()
-    return body, issued_at, f"{SIGNATURE_PREFIX}{digest}"
+    headers = sign_request(
+        "POST",
+        path,
+        body,
+        secret=secret,
+        timestamp=timestamp,
+        nonce=nonce,
+    )
+    return (
+        body,
+        headers[TIMESTAMP_HEADER],
+        headers[NONCE_HEADER],
+        headers[SIGNATURE_HEADER],
+    )
 
 
 def deliver_webhook(
@@ -75,18 +87,21 @@ def deliver_webhook(
     client: Optional[httpx.Client] = None,
     sleeper: Callable[[float], None] = time.sleep,
 ) -> WebhookDeliveryResult:
-    """POST a signed webhook payload, retrying non-2xx responses and I/O errors."""
+    """POST a signed webhook payload, retrying non-2xx responses and I/O errors.
+
+    Each HTTP delivery attempt receives its own timestamp and nonce so a
+    receiver can apply replay protection without rejecting a legitimate retry.
+    """
     if max_attempts < 1:
         raise ValueError("max_attempts must be at least 1")
     if backoff_seconds < 0:
         raise ValueError("backoff_seconds must be greater than or equal to 0")
 
-    body, timestamp, signature = sign_webhook_payload(payload, secret=secret)
-    headers = {
+    request_path = httpx.URL(url).raw_path.decode("ascii")
+    body = canonical_json_bytes(payload)
+    base_headers = {
         "Content-Type": "application/json",
         EVENT_HEADER: str(payload.get("event", "job.terminal")),
-        TIMESTAMP_HEADER: timestamp,
-        SIGNATURE_HEADER: signature,
     }
 
     owns_client = client is None
@@ -97,6 +112,13 @@ def deliver_webhook(
     try:
         for attempt in range(1, max_attempts + 1):
             attempts = attempt
+            signed_headers = sign_request(
+                "POST",
+                request_path,
+                body,
+                secret=secret,
+            )
+            headers = {**base_headers, **signed_headers}
             try:
                 response = active_client.post(url, content=body, headers=headers)
                 last_status_code = response.status_code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,7 @@ hf = [
 ]
 
 service = [
+  "cryptography>=50,<51",
   "fastapi>=0.110",
   "grpcio>=1.64",
   "httpx>=0.27",

--- a/tests/fixtures/mtls/README.md
+++ b/tests/fixtures/mtls/README.md
@@ -1,0 +1,17 @@
+# Synthetic mTLS test material
+
+`tests/unit/service/test_mtls_auth.py` creates a synthetic root CA, a trusted
+client certificate, and a client certificate signed by a different CA in the
+pytest temporary directory. It uses short-lived RSA keys and certificates with
+synthetic workload-only names:
+
+- subject: `CN=synthetic-clinic-client,O=OpenMed Test`
+- URI SAN: `spiffe://openmed.test/clinic-api`
+- DNS SAN: `clinic-api.test`
+- extended key usage: TLS client authentication
+
+The generated client chain exercises successful authentication, principal and
+scope mapping, handler-visible subject/SAN fields, and rejection of an
+untrusted issuer. The material is regenerated for each test session. No private
+keys, production certificates, patient identifiers, or other PHI are committed
+to the repository.

--- a/tests/unit/service/test_hmac_signing_replay.py
+++ b/tests/unit/service/test_hmac_signing_replay.py
@@ -1,0 +1,192 @@
+"""Tests for HMAC request signing and local replay protection."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from openmed.service.signing import (
+    NONCE_HEADER,
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    InvalidSignatureError,
+    NonceCache,
+    NonceCacheFullError,
+    ReplayDetectedError,
+    StaleTimestampError,
+    canonical_signing_string,
+    sign_request,
+    verify_request_signature,
+)
+from openmed.service.webhooks import deliver_webhook
+
+
+def test_signed_request_verifies_and_rejects_tampering_and_replay() -> None:
+    body = b'{"document_hash":"sha256:abc","offsets":[[4,12]]}'
+    headers = sign_request(
+        "POST",
+        "/jobs?mode=async",
+        body,
+        secret="shared-secret",
+        timestamp=1_800_000_000,
+        nonce="synthetic-request-1",
+    )
+    cache = NonceCache(max_entries=10, window_seconds=300)
+
+    with pytest.raises(InvalidSignatureError):
+        verify_request_signature(
+            "POST",
+            "/jobs?mode=async",
+            body + b" ",
+            headers,
+            secret="shared-secret",
+            nonce_cache=cache,
+            now=1_800_000_000,
+        )
+
+    assert verify_request_signature(
+        "POST",
+        "/jobs?mode=async",
+        body,
+        headers,
+        secret="shared-secret",
+        nonce_cache=cache,
+        now=1_800_000_000,
+    )
+
+    with pytest.raises(ReplayDetectedError):
+        verify_request_signature(
+            "POST",
+            "/jobs?mode=async",
+            body,
+            headers,
+            secret="shared-secret",
+            nonce_cache=cache,
+            now=1_800_000_001,
+        )
+
+
+def test_stale_timestamp_is_rejected_without_consuming_nonce() -> None:
+    headers = sign_request(
+        "GET",
+        "/jobs/abc",
+        secret="shared-secret",
+        timestamp=1_800_000_000,
+        nonce="stale-request",
+    )
+    cache = NonceCache(window_seconds=30)
+
+    with pytest.raises(StaleTimestampError):
+        verify_request_signature(
+            "GET",
+            "/jobs/abc",
+            b"",
+            headers,
+            secret="shared-secret",
+            nonce_cache=cache,
+            max_skew_seconds=30,
+            now=1_800_000_031,
+        )
+
+    assert len(cache) == 0
+
+
+def test_canonical_string_contains_body_hash_not_raw_body() -> None:
+    body = b"Patient Maria Garcia"
+
+    canonical = canonical_signing_string(
+        "post",
+        "/pii/deidentify",
+        1_800_000_000,
+        "privacy-safe-nonce",
+        body,
+    )
+
+    assert b"Patient" not in canonical
+    assert b"Maria" not in canonical
+    assert canonical.startswith(b"OPENMED-HMAC-SHA256-V1\nPOST\n")
+    assert canonical.endswith(
+        b"sha256:96d954518f3d24df5c23dfe61bb203c80c41561ab480a0b198d3125320deed1e"
+    )
+
+
+def test_nonce_cache_is_bounded_and_evicts_only_past_window() -> None:
+    cache = NonceCache(max_entries=2, window_seconds=10)
+
+    assert cache.check_and_store("nonce-a", timestamp=100, now=100)
+    assert cache.check_and_store("nonce-b", timestamp=101, now=101)
+    with pytest.raises(NonceCacheFullError):
+        cache.check_and_store("nonce-c", timestamp=102, now=102)
+    assert len(cache) == 2
+
+    assert cache.purge_expired(now=111) == 1
+    assert len(cache) == 1
+    assert cache.check_and_store("nonce-c", timestamp=111, now=111)
+    assert len(cache) == 2
+
+
+def test_outbound_webhook_carries_a_verifiable_signature() -> None:
+    cache = NonceCache()
+    verified = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal verified
+        verified = verify_request_signature(
+            request.method,
+            request.url.raw_path.decode("ascii"),
+            request.content,
+            request.headers,
+            secret="webhook-secret",
+            nonce_cache=cache,
+            now=int(request.headers[TIMESTAMP_HEADER]),
+        )
+        assert request.headers[NONCE_HEADER]
+        assert request.headers[SIGNATURE_HEADER].startswith("sha256=")
+        return httpx.Response(204)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    result = deliver_webhook(
+        "https://callbacks.example.test/openmed/jobs?source=openmed",
+        {"event": "job.done", "job_id": "abc", "status": "done"},
+        secret="webhook-secret",
+        client=client,
+    )
+
+    assert result.success is True
+    assert verified is True
+
+
+def test_client_signer_returns_only_the_three_signature_headers() -> None:
+    headers = sign_request(
+        "POST",
+        "/jobs",
+        json.dumps({"document_hash": "sha256:abc"}).encode(),
+        secret=b"shared-secret",
+        timestamp=1_800_000_000,
+        nonce="client-nonce",
+    )
+
+    assert headers == {
+        TIMESTAMP_HEADER: "1800000000",
+        NONCE_HEADER: "client-nonce",
+        SIGNATURE_HEADER: headers[SIGNATURE_HEADER],
+    }
+    assert headers[SIGNATURE_HEADER].startswith("sha256=")
+
+
+def test_explicit_empty_nonce_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        sign_request(
+            "POST",
+            "/jobs",
+            secret="shared-secret",
+            timestamp=1_800_000_000,
+            nonce="",
+        )
+
+
+def test_nonce_cache_rejects_non_finite_window() -> None:
+    with pytest.raises(ValueError):
+        NonceCache(window_seconds=float("nan"))

--- a/tests/unit/service/test_mtls_auth.py
+++ b/tests/unit/service/test_mtls_auth.py
@@ -1,0 +1,553 @@
+"""Unit tests for mutual-TLS client certificate authentication."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import quote
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+from fastapi import Request
+from fastapi.testclient import TestClient
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from openmed.service.app import create_app
+from openmed.service.auth import hash_api_key
+from openmed.service.logging import ACCESS_LOGGER_NAME
+from openmed.service.mtls import (
+    SERVICE_MTLS_CA_BUNDLE_ENV_VAR,
+    SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR,
+    SERVICE_MTLS_ENABLED_ENV_VAR,
+    SERVICE_MTLS_PRINCIPALS_ENV_VAR,
+    SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR,
+    parse_service_mtls_config,
+    verify_client_certificate_chain,
+)
+
+LOOPBACK_BASE_URL = "https://127.0.0.1"
+SYNTHETIC_URI_SAN = "uri:spiffe://openmed.test/clinic-api"
+SYNTHETIC_DNS_SAN = "dns:clinic-api.test"
+_SERVICE_ENV_VARS = (
+    SERVICE_MTLS_ENABLED_ENV_VAR,
+    SERVICE_MTLS_CA_BUNDLE_ENV_VAR,
+    SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR,
+    SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR,
+    SERVICE_MTLS_PRINCIPALS_ENV_VAR,
+    "OPENMED_SERVICE_AUTH_ENABLED",
+    "OPENMED_SERVICE_AUTH_DENY_BY_DEFAULT",
+    "OPENMED_SERVICE_AUTH_API_KEYS",
+    "OPENMED_SERVICE_AUTH_JWKS",
+    "OPENMED_SERVICE_AUTH_JWKS_FILE",
+    "OPENMED_SERVICE_AUTH_ROUTE_SCOPES",
+    "OPENMED_SERVICE_PRELOAD_MODELS",
+    "OPENMED_SERVICE_LOG_FORMAT",
+    "OPENMED_SERVICE_LOG_LEVEL",
+)
+
+
+@dataclass(frozen=True)
+class SyntheticMTLSMaterial:
+    """Short-lived synthetic certificates used by the mTLS tests."""
+
+    ca_bundle: Path
+    client_pem: str
+    untrusted_client_pem: str
+    subject: str
+
+
+class TLSClientScopeMiddleware:
+    """Add synthetic ASGI TLS extension data to HTTP request scopes."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        client_cert_chain: Sequence[str] = (),
+        client_cert_error: Optional[str] = None,
+        client: Optional[tuple[str, int]] = None,
+    ) -> None:
+        self.app = app
+        self.client_cert_chain = tuple(client_cert_chain)
+        self.client_cert_error = client_cert_error
+        self.client = client
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        request_scope = dict(scope)
+        extensions = dict(request_scope.get("extensions", {}))
+        extensions["tls"] = {
+            "server_cert": None,
+            "client_cert_chain": self.client_cert_chain,
+            "client_cert_name": None,
+            "client_cert_error": self.client_cert_error,
+        }
+        request_scope["extensions"] = extensions
+        if self.client is not None:
+            request_scope["client"] = self.client
+        await self.app(request_scope, receive, send)
+
+
+class PeerScopeMiddleware:
+    """Override the HTTP peer address for trusted-proxy tests."""
+
+    def __init__(self, app: ASGIApp, client: tuple[str, int]) -> None:
+        self.app = app
+        self.client = client
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            scope = dict(scope)
+            scope["client"] = self.client
+        await self.app(scope, receive, send)
+
+
+@pytest.fixture(autouse=True)
+def clean_service_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENMED_PROFILE", "test")
+    for env_var in _SERVICE_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+@pytest.fixture(scope="module")
+def synthetic_mtls_material(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> SyntheticMTLSMaterial:
+    fixture_dir = tmp_path_factory.mktemp("openmed-mtls")
+    now = datetime.now(timezone.utc)
+
+    ca_key, ca_certificate = _build_ca("OpenMed Synthetic Test CA", now=now)
+    client_certificate = _build_client_certificate(
+        ca_key,
+        ca_certificate,
+        common_name="synthetic-clinic-client",
+        now=now,
+    )
+    untrusted_ca_key, untrusted_ca = _build_ca("Untrusted Synthetic CA", now=now)
+    untrusted_client = _build_client_certificate(
+        untrusted_ca_key,
+        untrusted_ca,
+        common_name="untrusted-synthetic-client",
+        now=now,
+    )
+
+    ca_bundle = fixture_dir / "ca.pem"
+    ca_bundle.write_bytes(ca_certificate.public_bytes(serialization.Encoding.PEM))
+    return SyntheticMTLSMaterial(
+        ca_bundle=ca_bundle,
+        client_pem=client_certificate.public_bytes(serialization.Encoding.PEM).decode(
+            "ascii"
+        ),
+        untrusted_client_pem=untrusted_client.public_bytes(
+            serialization.Encoding.PEM
+        ).decode("ascii"),
+        subject=client_certificate.subject.rfc4514_string(),
+    )
+
+
+def test_mtls_defaults_to_disabled() -> None:
+    config = parse_service_mtls_config()
+
+    assert config.enabled is False
+    assert config.ca_bundle is None
+
+
+def test_enabling_mtls_requires_a_ca_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(SERVICE_MTLS_ENABLED_ENV_VAR, "true")
+
+    with pytest.raises(ValueError, match=SERVICE_MTLS_CA_BUNDLE_ENV_VAR):
+        parse_service_mtls_config()
+
+
+def test_valid_synthetic_client_certificate_verifies_and_exposes_identity(
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    identity = verify_client_certificate_chain(
+        [synthetic_mtls_material.client_pem],
+        synthetic_mtls_material.ca_bundle,
+    )
+
+    assert identity.subject == synthetic_mtls_material.subject
+    assert identity.sans == (SYNTHETIC_URI_SAN, SYNTHETIC_DNS_SAN)
+    assert len(identity.fingerprint_sha256) == 64
+
+
+def test_untrusted_synthetic_client_certificate_is_rejected(
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    with pytest.raises(ValueError, match="untrusted"):
+        verify_client_certificate_chain(
+            [synthetic_mtls_material.untrusted_client_pem],
+            synthetic_mtls_material.ca_bundle,
+        )
+
+
+def test_mtls_toggle_requires_certificate_without_code_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    disabled_app = create_app()
+    with TestClient(
+        disabled_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        disabled_response = client.get("/health")
+
+    _enable_mtls(monkeypatch, synthetic_mtls_material)
+    enabled_app = create_app()
+    with TestClient(
+        enabled_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        enabled_response = client.get("/health")
+
+    assert disabled_response.status_code == 200
+    _assert_error(enabled_response, 401, "mtls_certificate_required")
+
+
+def test_valid_request_maps_san_to_route_authorization_principal(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    _enable_mtls(
+        monkeypatch,
+        synthetic_mtls_material,
+        scopes=["identity:read"],
+    )
+    monkeypatch.setenv("OPENMED_SERVICE_AUTH_ENABLED", "true")
+    monkeypatch.setenv(
+        "OPENMED_SERVICE_AUTH_ROUTE_SCOPES",
+        json.dumps({"GET /whoami": ["identity:read"]}),
+    )
+    app = create_app()
+
+    @app.get("/whoami")
+    async def whoami(request: Request) -> dict[str, Any]:
+        principal = request.state.auth_principal
+        identity = request.state.mtls_identity
+        return {
+            "principal": principal.subject,
+            "credential_type": principal.credential_type,
+            "scopes": list(principal.scopes),
+            "subject": identity.subject,
+            "sans": list(identity.sans),
+        }
+
+    asgi_app = TLSClientScopeMiddleware(
+        app,
+        client_cert_chain=[synthetic_mtls_material.client_pem],
+    )
+    with TestClient(
+        asgi_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/whoami")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "principal": "synthetic-clinic-api",
+        "credential_type": "mtls",
+        "scopes": ["identity:read"],
+        "subject": synthetic_mtls_material.subject,
+        "sans": [SYNTHETIC_URI_SAN, SYNTHETIC_DNS_SAN],
+    }
+
+
+def test_untrusted_request_returns_generic_authentication_error(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    _enable_mtls(monkeypatch, synthetic_mtls_material)
+    app = TLSClientScopeMiddleware(
+        create_app(),
+        client_cert_chain=[synthetic_mtls_material.untrusted_client_pem],
+    )
+
+    with TestClient(
+        app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/health")
+
+    payload = _assert_error(response, 401, "mtls_certificate_invalid")
+    rendered = json.dumps(payload)
+    assert "Untrusted Synthetic CA" not in rendered
+    assert synthetic_mtls_material.untrusted_client_pem not in rendered
+
+
+def test_forwarded_certificate_requires_a_trusted_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    _enable_mtls(monkeypatch, synthetic_mtls_material)
+    monkeypatch.setenv(
+        SERVICE_MTLS_CLIENT_CERT_HEADER_ENV_VAR,
+        "X-OpenMed-Client-Cert",
+    )
+    monkeypatch.setenv(SERVICE_MTLS_TRUSTED_PROXIES_ENV_VAR, "127.0.0.1/32")
+    header_value = quote(synthetic_mtls_material.client_pem, safe="")
+
+    trusted_app = PeerScopeMiddleware(create_app(), ("127.0.0.1", 54321))
+    with TestClient(
+        trusted_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        trusted = client.get(
+            "/health",
+            headers={"X-OpenMed-Client-Cert": header_value},
+        )
+
+    untrusted_app = PeerScopeMiddleware(create_app(), ("203.0.113.9", 54321))
+    with TestClient(
+        untrusted_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        untrusted = client.get(
+            "/health",
+            headers={"X-OpenMed-Client-Cert": header_value},
+        )
+
+    assert trusted.status_code == 200
+    _assert_error(untrusted, 401, "mtls_certificate_invalid")
+
+
+def test_explicit_api_key_can_authorize_inside_mtls_connection(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+) -> None:
+    _enable_mtls(monkeypatch, synthetic_mtls_material)
+    monkeypatch.setenv("OPENMED_SERVICE_AUTH_ENABLED", "true")
+    monkeypatch.setenv(
+        "OPENMED_SERVICE_AUTH_API_KEYS",
+        json.dumps(
+            [
+                {
+                    "id": "synthetic-key",
+                    "key_hash": hash_api_key("synthetic-secret"),
+                    "principal": "jwt-layer-principal",
+                    "scopes": ["identity:read"],
+                }
+            ]
+        ),
+    )
+    monkeypatch.setenv(
+        "OPENMED_SERVICE_AUTH_ROUTE_SCOPES",
+        json.dumps({"GET /whoami": ["identity:read"]}),
+    )
+    app = create_app()
+
+    @app.get("/whoami")
+    async def whoami(request: Request) -> dict[str, Any]:
+        return {
+            "principal": request.state.auth_principal.subject,
+            "credential_type": request.state.auth_principal.credential_type,
+            "mtls_subject": request.state.mtls_identity.subject,
+        }
+
+    asgi_app = TLSClientScopeMiddleware(
+        app,
+        client_cert_chain=[synthetic_mtls_material.client_pem],
+    )
+    with TestClient(
+        asgi_app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get(
+            "/whoami",
+            headers={"X-API-Key": "synthetic-secret"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "principal": "jwt-layer-principal",
+        "credential_type": "api_key",
+        "mtls_subject": synthetic_mtls_material.subject,
+    }
+
+
+def test_access_log_contains_only_stable_mtls_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_mtls_material: SyntheticMTLSMaterial,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _enable_mtls(monkeypatch, synthetic_mtls_material)
+    caplog.set_level(logging.INFO, logger=ACCESS_LOGGER_NAME)
+    app = TLSClientScopeMiddleware(
+        create_app(),
+        client_cert_chain=[synthetic_mtls_material.client_pem],
+    )
+
+    with TestClient(
+        app,
+        base_url=LOOPBACK_BASE_URL,
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    records = [record for record in caplog.records if record.name == ACCESS_LOGGER_NAME]
+    assert len(records) == 1
+    rendered = records[0].getMessage()
+    payload = json.loads(rendered)
+    assert payload["identity"] == "synthetic-clinic-api"
+    assert payload["credential_type"] == "mtls"
+    assert synthetic_mtls_material.subject not in rendered
+    assert SYNTHETIC_URI_SAN not in rendered
+    assert SYNTHETIC_DNS_SAN not in rendered
+    assert synthetic_mtls_material.client_pem not in rendered
+
+
+def _enable_mtls(
+    monkeypatch: pytest.MonkeyPatch,
+    material: SyntheticMTLSMaterial,
+    *,
+    scopes: Optional[list[str]] = None,
+) -> None:
+    monkeypatch.setenv(SERVICE_MTLS_ENABLED_ENV_VAR, "true")
+    monkeypatch.setenv(SERVICE_MTLS_CA_BUNDLE_ENV_VAR, str(material.ca_bundle))
+    monkeypatch.setenv(
+        SERVICE_MTLS_PRINCIPALS_ENV_VAR,
+        json.dumps(
+            [
+                {
+                    "identities": [SYNTHETIC_URI_SAN],
+                    "principal": "synthetic-clinic-api",
+                    "scopes": scopes or [],
+                }
+            ]
+        ),
+    )
+
+
+def _assert_error(response: Any, status_code: int, code: str) -> dict[str, Any]:
+    assert response.status_code == status_code
+    payload = response.json()
+    assert payload["error"]["code"] == code
+    assert "message" in payload["error"]
+    assert "details" in payload["error"]
+    return payload
+
+
+def _build_ca(
+    common_name: str,
+    *,
+    now: datetime,
+) -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "OpenMed Test"),
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ]
+    )
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(days=1))
+        .not_valid_after(now + timedelta(days=30))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return key, certificate
+
+
+def _build_client_certificate(
+    ca_key: rsa.RSAPrivateKey,
+    ca_certificate: x509.Certificate,
+    *,
+    common_name: str,
+    now: datetime,
+) -> x509.Certificate:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "OpenMed Test"),
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ]
+    )
+    return (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca_certificate.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(hours=1))
+        .not_valid_after(now + timedelta(days=7))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=True,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.UniformResourceIdentifier("spiffe://openmed.test/clinic-api"),
+                    x509.DNSName("clinic-api.test"),
+                ]
+            ),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(
+                ca_certificate.public_key()
+            ),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )

--- a/tests/unit/service/test_webhooks.py
+++ b/tests/unit/service/test_webhooks.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-import hmac
 import json
 
 import httpx
 
+from openmed.service.signing import (
+    NONCE_HEADER,
+    NonceCache,
+    sign_request,
+    verify_request_signature,
+)
 from openmed.service.webhooks import (
     SIGNATURE_HEADER,
     TIMESTAMP_HEADER,
@@ -19,32 +24,50 @@ from openmed.service.webhooks import (
 def test_sign_webhook_payload_uses_canonical_json_and_timestamp() -> None:
     payload = {"status": "done", "job_id": "abc", "label_histogram": {"NAME": 1}}
 
-    body, timestamp, signature = sign_webhook_payload(
+    body, timestamp, nonce, signature = sign_webhook_payload(
         payload,
         secret="secret",
+        path="/openmed?source=jobs",
         timestamp=1_800_000_000,
+        nonce="webhook-nonce",
     )
 
     assert body == canonical_json_bytes(payload)
     assert timestamp == "1800000000"
-    expected = hmac.digest(
-        b"secret",
-        b"1800000000." + body,
-        "sha256",
-    ).hex()
-    assert signature == f"sha256={expected}"
+    assert nonce == "webhook-nonce"
+    expected = sign_request(
+        "POST",
+        "/openmed?source=jobs",
+        body,
+        secret="secret",
+        timestamp=1_800_000_000,
+        nonce="webhook-nonce",
+    )
+    assert signature == expected[SIGNATURE_HEADER]
 
 
 def test_deliver_webhook_retries_with_backoff_until_success() -> None:
     attempts = 0
     delays: list[float] = []
+    seen_nonces: list[str] = []
     seen_request: httpx.Request | None = None
+    nonce_cache = NonceCache()
 
     def handler(request: httpx.Request) -> httpx.Response:
         nonlocal attempts
         nonlocal seen_request
         attempts += 1
         seen_request = request
+        seen_nonces.append(request.headers[NONCE_HEADER])
+        assert verify_request_signature(
+            request.method,
+            request.url.raw_path.decode("ascii"),
+            request.content,
+            request.headers,
+            secret="secret",
+            nonce_cache=nonce_cache,
+            now=int(request.headers[TIMESTAMP_HEADER]),
+        )
         if attempts == 1:
             return httpx.Response(503)
         return httpx.Response(204)
@@ -67,6 +90,8 @@ def test_deliver_webhook_retries_with_backoff_until_success() -> None:
     assert seen_request is not None
     assert seen_request.headers[SIGNATURE_HEADER].startswith("sha256=")
     assert seen_request.headers[TIMESTAMP_HEADER]
+    assert seen_request.headers[NONCE_HEADER]
+    assert len(seen_nonces) == len(set(seen_nonces))
 
 
 def test_deliver_webhook_reports_failure_after_attempts() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -6328,6 +6328,7 @@ scrubadub = [
     { name = "scrubadub" },
 ]
 service = [
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "grpcio" },
     { name = "httpx" },
@@ -6377,6 +6378,7 @@ requires-dist = [
     { name = "coremltools", marker = "extra == 'coreml'", specifier = ">=8.0" },
     { name = "cryptography", marker = "extra == 'dev'", specifier = ">=50,<51" },
     { name = "cryptography", marker = "extra == 'integrity'", specifier = ">=50,<51" },
+    { name = "cryptography", marker = "extra == 'service'", specifier = ">=50,<51" },
     { name = "dagster", marker = "extra == 'dagster'", specifier = ">=1.8,<2" },
     { name = "dask", extras = ["dataframe"], marker = "extra == 'dask'", specifier = ">=2024.8" },
     { name = "dask", extras = ["dataframe"], marker = "extra == 'dev'", specifier = ">=2024.8" },


### PR DESCRIPTION
## Included pull requests

- #2193 — Add HMAC request signing with replay protection to the service
- #2195 — Add mutual-TLS client-certificate authentication to the service

## Issues resolved

Related to #849
Related to #832

## Maintainer integration changes

- Preserved all existing service documentation entries while adding request-signing and mTLS guides.
- Verified both source-PR merges against their rehearsed tree checkpoints.
- Validated final tree `f7df0461c81938644b78c4e67c9e1aaee9c3d87a`.

## Validation

- `python -m pytest <HMAC, webhook, mTLS, and auth focused suites> -q` — 29 passed
- `ruff check <changed Python surfaces>` — passed
- `ruff format --check <changed Python surfaces>` — passed
- `mkdocs build --strict` — passed
