### PR TITLE
feat: integrate v2.2 HL7 and X12 interoperability

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -205,6 +205,7 @@ classification:
     - prefect-integration.md
     - spacy-component.md
     - hl7v2-deidentification.md
+    - interop/x12-837-redaction.md
     - compliance.md
     - compliance/21-cfr-part-11-audit-trail.md
     - compliance/api-deprecation-policy.md

--- a/docs/hl7v2-deidentification.md
+++ b/docs/hl7v2-deidentification.md
@@ -70,3 +70,7 @@ redacted = redact_hl7v2(message_text, field_map=field_map)
 
 For offline tests, pass a `deidentifier` callable. The callable should return
 either a string or an object with `deidentified_text`.
+
+For downstream clinical NLP or review, use the [HL7 v2 narrative
+extractor](./interop/hl7v2-narrative-extraction.md) to render de-identified
+flat or sectioned text with final-text offsets back to segment fields.

--- a/docs/interop/hl7v2-narrative-extraction.md
+++ b/docs/interop/hl7v2-narrative-extraction.md
@@ -1,0 +1,121 @@
+# HL7 v2 Narrative Extraction
+
+OpenMed can turn common ADT, ORU, and ORM pipe messages into readable,
+de-identified text for clinical NLP or human review. The result includes exact
+character ranges that point back to the originating segment occurrence and
+field position.
+
+The extractor builds on the existing [HL7 v2 parser and structured
+redactor](../hl7v2-deidentification.md). It does not implement a second parser
+or attempt full HL7 conformance validation.
+
+## Quick Start
+
+```python
+from openmed.interop.hl7v2_narrative import extract_hl7v2_narrative
+
+result = extract_hl7v2_narrative("synthetic_oru.hl7")
+
+print(result.text)
+for span in result.spans_for("OBX", 5):
+    print(span.source.path, result.text_for(span))
+```
+
+`result.text` is the de-identified narrative. A source path such as
+`OBX[2]-5` means field 5 of the second OBX segment. `segment_index` on the
+source record is the zero-based position of that segment in the complete
+message.
+
+Provenance records contain only offsets, fixed labels, and HL7 coordinates.
+They do not retain the original field value.
+
+## Narrative Modes
+
+Flat mode is the default. It emits compact sentence-like text suitable for
+downstream NLP:
+
+```python
+flat = extract_hl7v2_narrative(message, mode="flat")
+```
+
+Sectioned mode emits stable Markdown headings and one field per line for
+review surfaces:
+
+```python
+sectioned = extract_hl7v2_narrative(message, mode="sectioned")
+print(sectioned.text)
+```
+
+Typical sections are `Message`, `Patient`, `Encounter`, `Orders`,
+`Observations`, and `Notes`. Empty sections are omitted. Both modes preserve
+message order within a section and return section-level offsets in
+`result.sections`.
+
+## Privacy Pipeline
+
+Narrative extraction has two local privacy layers:
+
+1. `openmed.interop.hl7v2.redact_hl7v2` handles configured structured fields,
+   including patient identifiers, names, dates, addresses, and phone numbers.
+2. The complete rendered narrative passes once through
+   `openmed.core.pii.deidentify` with `method="mask"` by default. This covers
+   free text and any other rendered value before it is returned.
+
+The extractor remaps field and section ranges after the second pass, so all
+offsets index the final de-identified text even when placeholders change its
+length.
+
+Use `deidentify_kwargs` to configure the final text pipeline. For deterministic
+offline tests, pass a callable that returns a string or an object or mapping
+with `deidentified_text`:
+
+```python
+result = extract_hl7v2_narrative(
+    message,
+    deidentify_kwargs={"policy": "hipaa_safe_harbor"},
+)
+```
+
+`date_shift_days`, `lang`, `locale`, `seed`, and an optional structured
+`field_map` are forwarded to the existing HL7 redaction layer. The default
+30-day shift is stable across runs; dates in the complete narrative still pass
+through the final privacy pipeline.
+
+## Provenance Lookup
+
+```python
+offset = result.text.index("7.1")
+for span in result.provenance_at(offset):
+    print(span.source.segment)          # OBX
+    print(span.source.field_position)   # 5
+    print(span.source.path)             # OBX[2]-5
+```
+
+`result.spans` and its explicit alias `result.field_mappings` are tuples of
+`HL7V2FieldSpan`. Each span provides:
+
+- `start` and `end`: offsets in the final narrative, with an exclusive end;
+- `section` and `label`: the fixed narrative context;
+- `source.segment`: the three-character segment name;
+- `source.segment_index`: the zero-based message position;
+- `source.segment_occurrence`: the one-based occurrence for that segment name;
+- `source.field_position`: the one-based HL7 field number.
+
+## Supported Rendering Scope
+
+The renderer covers the common context needed from ADT, ORU, and ORM flows:
+
+| Segment | Rendered fields |
+| --- | --- |
+| `MSH` | Message type and HL7 version |
+| `EVN` | Event type and recorded time |
+| `PID` | Patient ID, name, date of birth, and administrative sex |
+| `PV1` | Patient class, location, attending provider, admit/discharge time |
+| `ORC` | Order control and placer/filler order identifiers |
+| `OBR` | Requested test and observation time |
+| `OBX` | Observation, result, units, reference range, flags, status, time |
+| `NTE` | Note text |
+
+Unknown segments are ignored by the narrative renderer. They remain available
+to the underlying parser and can still be covered by a custom structured field
+map. Mapping the message into FHIR resources is outside this helper's scope.

--- a/docs/interop/x12-837-redaction.md
+++ b/docs/interop/x12-837-redaction.md
@@ -1,0 +1,67 @@
+# X12 837 Claim Redaction
+
+OpenMed can parse professional and institutional X12 837 claim text and redact
+structured subscriber, patient, and provider identifiers without changing the
+interchange envelope or segment layout. Processing is local and does not call
+external services.
+
+```python
+from openmed.interop.x12_837 import redact_x12_837
+
+result = redact_x12_837("synthetic-claim.837")
+redacted_edi = result.deidentified_text
+```
+
+The path must contain an 837 transaction framed by `ISA`/`IEA`, `GS`/`GE`, and
+`ST`/`SE`. The parser derives the element, repetition, component, and segment
+separators from the fixed-width ISA header. Re-serialization retains those
+separators, segment order, envelope/control values, and whitespace between
+segments.
+
+## Redacted loops
+
+The redactor uses the `NM101` entity identifier to recognize subscriber (`IL`),
+patient (`QC`), and common provider loops. Within those loops it replaces:
+
+- name components and identifiers in `NM1`;
+- additional names in `N2`;
+- street, city, state, and postal elements in `N3`/`N4`;
+- date of birth in `DMG`; and
+- loop-local identifiers in `REF`.
+
+Qualifiers such as `NM102`, `NM108`, `DMG01`, and `REF01` remain intact. Claim,
+service, hierarchy, and envelope segments are not modified. Composite and
+repetition separators inside a redacted element are preserved:
+
+```python
+result = redact_x12_837(message_text, replacement="MASKED")
+```
+
+Replacement tokens may not contain any separator declared by the interchange.
+
+## Raw-text provenance
+
+Every parsed element records a half-open character span into the original EDI
+text. Redaction results carry an element-level offset map between the raw input
+and serialized output:
+
+```python
+redaction = result.redactions[0]
+output_span = result.offset_map.source_to_output(*redaction.source_span)
+assert result.offset_map.output_to_source(*output_span) == redaction.source_span
+```
+
+This mapping is deliberately element-granular because replacements can change
+length. Each redaction record includes the source/output spans, segment and
+element coordinates, entity type, replacement, and a SHA-256 digest of the
+original value. It does not copy the raw PHI value into the audit record.
+
+## Scope and safety
+
+This adapter is a structural de-identification helper, not a full X12 validator.
+It does not implement companion-guide rules, claim adjudication, 835 remittance,
+or arbitrary transaction sets. Validate the resulting interchange with the
+receiver's normal X12 tooling before production exchange.
+
+All examples and tests use deliberately synthetic names, identifiers,
+addresses, dates, providers, and claim values; they contain no real claims.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - Prefect Batch De-identification: prefect-integration.md
       - spaCy Pipeline Component: spacy-component.md
       - HL7 v2 De-identification: hl7v2-deidentification.md
+      - HL7 v2 Narrative Extraction: interop/hl7v2-narrative-extraction.md
       - Compliance Posture: compliance.md
       - 21 CFR Part 11 Audit Trail: compliance/21-cfr-part-11-audit-trail.md
       - Public API Deprecation Policy: compliance/api-deprecation-policy.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ nav:
       - spaCy Pipeline Component: spacy-component.md
       - HL7 v2 De-identification: hl7v2-deidentification.md
       - HL7 v2 Narrative Extraction: interop/hl7v2-narrative-extraction.md
+      - X12 837 Claim Redaction: interop/x12-837-redaction.md
       - Compliance Posture: compliance.md
       - 21 CFR Part 11 Audit Trail: compliance/21-cfr-part-11-audit-trail.md
       - Public API Deprecation Policy: compliance/api-deprecation-policy.md

--- a/openmed/interop/hl7v2_narrative.py
+++ b/openmed/interop/hl7v2_narrative.py
@@ -1,0 +1,746 @@
+"""De-identified narrative extraction for common HL7 v2 messages.
+
+The extractor builds on :mod:`openmed.interop.hl7v2` rather than parsing pipe
+messages independently. Structured identifiers are redacted first, the
+rendered narrative is passed through the text de-identification pipeline, and
+the final visible value spans retain segment/field provenance.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any, Literal
+
+from openmed.interop.hl7v2 import (
+    FieldKey,
+    HL7Message,
+    HL7Segment,
+    HL7V2Encoding,
+    TextDeidentifier,
+    parse_hl7v2,
+    redact_hl7v2,
+)
+
+NarrativeMode = Literal["flat", "sectioned"]
+
+_SECTION_ORDER = (
+    "Message",
+    "Patient",
+    "Encounter",
+    "Orders",
+    "Observations",
+    "Notes",
+)
+
+_SEX_LABELS = {
+    "A": "Ambiguous",
+    "F": "Female",
+    "M": "Male",
+    "N": "Not applicable",
+    "O": "Other",
+    "U": "Unknown",
+}
+_PATIENT_CLASS_LABELS = {
+    "E": "Emergency",
+    "I": "Inpatient",
+    "O": "Outpatient",
+    "P": "Preadmit",
+    "R": "Recurring patient",
+}
+_RESULT_STATUS_LABELS = {
+    "C": "Corrected",
+    "F": "Final",
+    "I": "Specimen in lab",
+    "P": "Preliminary",
+    "R": "Entered, not verified",
+    "S": "Partial",
+    "X": "Cannot obtain",
+}
+
+
+@dataclass(frozen=True)
+class HL7V2FieldSource:
+    """One source field in an HL7 v2 message.
+
+    ``segment_index`` is zero-based in message order. ``segment_occurrence``
+    is one-based among segments with the same three-character name.
+    """
+
+    segment: str
+    segment_index: int
+    segment_occurrence: int
+    field_position: int
+
+    @property
+    def path(self) -> str:
+        """Return a compact, stable source path such as ``OBX[2]-5``."""
+
+        return f"{self.segment}[{self.segment_occurrence}]-{self.field_position}"
+
+
+@dataclass(frozen=True)
+class HL7V2FieldSpan:
+    """A final narrative character range mapped to one source field."""
+
+    start: int
+    end: int
+    source: HL7V2FieldSource
+    section: str
+    label: str
+
+    @property
+    def segment(self) -> str:
+        """Return the source segment name."""
+
+        return self.source.segment
+
+    @property
+    def field_position(self) -> int:
+        """Return the one-based source field position."""
+
+        return self.source.field_position
+
+
+@dataclass(frozen=True)
+class HL7V2NarrativeSection:
+    """One logical section and its range in the final narrative."""
+
+    name: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class HL7V2Narrative:
+    """De-identified narrative text plus source-field provenance."""
+
+    text: str
+    mode: NarrativeMode
+    message_type: str | None
+    spans: tuple[HL7V2FieldSpan, ...]
+    sections: tuple[HL7V2NarrativeSection, ...]
+
+    @property
+    def field_mappings(self) -> tuple[HL7V2FieldSpan, ...]:
+        """Return the field mappings (an explicit alias for ``spans``)."""
+
+        return self.spans
+
+    def provenance_at(self, offset: int) -> tuple[HL7V2FieldSpan, ...]:
+        """Return every source-field span covering a narrative offset."""
+
+        if offset < 0 or offset >= len(self.text):
+            return ()
+        return tuple(span for span in self.spans if span.start <= offset < span.end)
+
+    def spans_for(
+        self,
+        segment: str,
+        field_position: int,
+        *,
+        segment_occurrence: int | None = None,
+    ) -> tuple[HL7V2FieldSpan, ...]:
+        """Return narrative spans sourced from a segment/field coordinate."""
+
+        normalized_segment = segment.upper()
+        return tuple(
+            span
+            for span in self.spans
+            if span.source.segment == normalized_segment
+            and span.source.field_position == field_position
+            and (
+                segment_occurrence is None
+                or span.source.segment_occurrence == segment_occurrence
+            )
+        )
+
+    def text_for(self, span: HL7V2FieldSpan) -> str:
+        """Return the final narrative text covered by ``span``."""
+
+        return self.text[span.start : span.end]
+
+
+@dataclass(frozen=True)
+class _NarrativeItem:
+    section: str
+    label: str
+    value: str
+    source: HL7V2FieldSource
+
+
+@dataclass(frozen=True)
+class _RenderedNarrative:
+    text: str
+    spans: tuple[HL7V2FieldSpan, ...]
+    sections: tuple[HL7V2NarrativeSection, ...]
+
+
+def extract_hl7v2_narrative(
+    message_or_path: str | Path | HL7Message,
+    *,
+    mode: NarrativeMode = "flat",
+    field_map: Mapping[FieldKey | str, Any] | None = None,
+    deidentifier: TextDeidentifier | None = None,
+    deidentify_kwargs: Mapping[str, Any] | None = None,
+    date_shift_days: int = 30,
+    lang: str = "en",
+    locale: str | None = None,
+    seed: int | None = 0,
+) -> HL7V2Narrative:
+    """Render a safe narrative from a common ADT, ORU, or ORM message.
+
+    The existing HL7 v2 redactor first handles structured fields such as
+    patient identifiers and names. Its free-text hook is deliberately kept as
+    a no-op during that pass because the complete rendered narrative is then
+    sent through the supplied de-identification pipeline once. Final offsets
+    are projected after de-identification, so provenance always indexes the
+    returned text rather than the raw message or an intermediate narrative.
+
+    Args:
+        message_or_path: Pipe-delimited message text, UTF-8 path, or parsed
+            :class:`~openmed.interop.hl7v2.HL7Message`.
+        mode: ``"flat"`` for sentence-like text or ``"sectioned"`` for
+            Markdown-style sections.
+        field_map: Optional structured redaction rules forwarded to
+            :func:`~openmed.interop.hl7v2.redact_hl7v2`.
+        deidentifier: Optional narrative de-identifier. Defaults to
+            :func:`openmed.core.pii.deidentify`.
+        deidentify_kwargs: Extra keyword arguments for the narrative
+            de-identifier. The defaults are ``method="mask"`` and ``lang``.
+        date_shift_days: Stable structured date shift applied before narrative
+            rendering. The default is 30 days; the complete narrative also
+            passes through the privacy pipeline.
+        lang: Language forwarded to structured and narrative de-identification.
+        locale: Optional locale for deterministic structured surrogates.
+        seed: Seed for stable structured surrogates.
+
+    Returns:
+        A de-identified narrative with section ranges and field provenance.
+
+    Raises:
+        ValueError: If ``mode`` is unsupported.
+        TypeError: If the de-identifier does not return text in a supported
+            shape.
+    """
+
+    if mode not in {"flat", "sectioned"}:
+        raise ValueError("mode must be 'flat' or 'sectioned'")
+
+    message_input: str | Path
+    if isinstance(message_or_path, HL7Message):
+        message_input = message_or_path.serialize()
+    else:
+        message_input = message_or_path
+
+    structured_safe = redact_hl7v2(
+        message_input,
+        field_map=field_map,
+        deidentifier=_identity_deidentifier,
+        date_shift_days=date_shift_days,
+        lang=lang,
+        locale=locale,
+        seed=seed,
+    )
+    parsed = parse_hl7v2(structured_safe)
+    items = _collect_items(parsed)
+    rendered = _render_items(items, mode=mode)
+
+    deidentify = deidentifier or _load_deidentifier()
+    kwargs = {"method": "mask", "lang": lang, **dict(deidentify_kwargs or {})}
+    result = deidentify(rendered.text, **kwargs)
+    safe_text = _deidentified_text(result)
+
+    opcodes = SequenceMatcher(
+        None,
+        rendered.text,
+        safe_text,
+        autojunk=False,
+    ).get_opcodes()
+    spans = tuple(
+        _project_field_span(span, opcodes, len(safe_text)) for span in rendered.spans
+    )
+    spans = tuple(span for span in spans if span.end > span.start)
+    sections = tuple(
+        _project_section(section, opcodes, len(safe_text))
+        for section in rendered.sections
+    )
+
+    return HL7V2Narrative(
+        text=safe_text,
+        mode=mode,
+        message_type=_message_type(parsed),
+        spans=spans,
+        sections=sections,
+    )
+
+
+def _identity_deidentifier(text: str, **_: Any) -> str:
+    """Preserve HL7 free text until the complete narrative privacy pass."""
+
+    return text
+
+
+def _load_deidentifier() -> TextDeidentifier:
+    from openmed.core.pii import deidentify
+
+    return deidentify
+
+
+def _deidentified_text(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    if isinstance(result, Mapping) and "deidentified_text" in result:
+        return str(result["deidentified_text"])
+    if hasattr(result, "deidentified_text"):
+        return str(result.deidentified_text)
+    raise TypeError(
+        "narrative deidentifier must return a string, mapping, or object with "
+        "deidentified_text"
+    )
+
+
+def _collect_items(message: HL7Message) -> tuple[_NarrativeItem, ...]:
+    items: list[_NarrativeItem] = []
+    occurrences: defaultdict[str, int] = defaultdict(int)
+    observation_number = 0
+    order_number = 0
+    note_number = 0
+
+    for segment_index, segment in enumerate(message.segments):
+        occurrences[segment.name] += 1
+        occurrence = occurrences[segment.name]
+        source = _source_factory(segment, segment_index, occurrence)
+
+        if segment.name == "MSH":
+            _add(items, "Message", "Message type", segment, 9, source, _message_code)
+            _add(items, "Message", "HL7 version", segment, 12, source)
+        elif segment.name == "EVN":
+            _add(items, "Encounter", "Event type", segment, 1, source)
+            _add(items, "Encounter", "Event recorded", segment, 2, source, _date)
+        elif segment.name == "PID":
+            _add(items, "Patient", "Patient ID", segment, 3, source, _identifier)
+            _add(items, "Patient", "Patient name", segment, 5, source, _name)
+            _add(items, "Patient", "Date of birth", segment, 7, source, _date)
+            _add(items, "Patient", "Administrative sex", segment, 8, source, _sex)
+        elif segment.name == "PV1":
+            _add(
+                items,
+                "Encounter",
+                "Patient class",
+                segment,
+                2,
+                source,
+                _patient_class,
+            )
+            _add(items, "Encounter", "Location", segment, 3, source, _components)
+            _add(
+                items,
+                "Encounter",
+                "Attending provider",
+                segment,
+                7,
+                source,
+                _name,
+            )
+            _add(items, "Encounter", "Admitted", segment, 44, source, _date)
+            _add(items, "Encounter", "Discharged", segment, 45, source, _date)
+        elif segment.name == "ORC":
+            _add(items, "Orders", "Order control", segment, 1, source)
+            _add(items, "Orders", "Placer order ID", segment, 2, source, _identifier)
+            _add(items, "Orders", "Filler order ID", segment, 3, source, _identifier)
+        elif segment.name == "OBR":
+            order_number += 1
+            _add(
+                items,
+                "Orders",
+                f"Requested test {order_number}",
+                segment,
+                4,
+                source,
+                _coded,
+            )
+            _add(
+                items,
+                "Orders",
+                f"Observation requested {order_number}",
+                segment,
+                7,
+                source,
+                _date,
+            )
+        elif segment.name == "OBX":
+            observation_number += 1
+            _add(
+                items,
+                "Observations",
+                f"Observation {observation_number}",
+                segment,
+                3,
+                source,
+                _coded,
+            )
+            _add(
+                items,
+                "Observations",
+                f"Result {observation_number}",
+                segment,
+                5,
+                source,
+                _components,
+            )
+            _add(
+                items,
+                "Observations",
+                f"Units {observation_number}",
+                segment,
+                6,
+                source,
+                _coded,
+            )
+            _add(
+                items,
+                "Observations",
+                f"Reference range {observation_number}",
+                segment,
+                7,
+                source,
+            )
+            _add(
+                items,
+                "Observations",
+                f"Abnormal flags {observation_number}",
+                segment,
+                8,
+                source,
+                _components,
+            )
+            _add(
+                items,
+                "Observations",
+                f"Result status {observation_number}",
+                segment,
+                11,
+                source,
+                _result_status,
+            )
+            _add(
+                items,
+                "Observations",
+                f"Observed at {observation_number}",
+                segment,
+                14,
+                source,
+                _date,
+            )
+        elif segment.name == "NTE":
+            note_number += 1
+            _add(items, "Notes", f"Note {note_number}", segment, 3, source, _text)
+
+    return tuple(items)
+
+
+def _source_factory(
+    segment: HL7Segment,
+    segment_index: int,
+    segment_occurrence: int,
+) -> Callable[[int], HL7V2FieldSource]:
+    def build(field_position: int) -> HL7V2FieldSource:
+        return HL7V2FieldSource(
+            segment=segment.name,
+            segment_index=segment_index,
+            segment_occurrence=segment_occurrence,
+            field_position=field_position,
+        )
+
+    return build
+
+
+def _add(
+    items: list[_NarrativeItem],
+    section: str,
+    label: str,
+    segment: HL7Segment,
+    field_position: int,
+    source: Callable[[int], HL7V2FieldSource],
+    formatter: Callable[[str, HL7V2Encoding], str] | None = None,
+) -> None:
+    raw_value = segment.get_field(field_position)
+    if raw_value is None or not raw_value.strip():
+        return
+    value = (formatter or _text)(raw_value, segment.encoding).strip()
+    if not value:
+        return
+    items.append(
+        _NarrativeItem(
+            section=section,
+            label=label,
+            value=value,
+            source=source(field_position),
+        )
+    )
+
+
+def _render_items(
+    items: Sequence[_NarrativeItem],
+    *,
+    mode: NarrativeMode,
+) -> _RenderedNarrative:
+    by_section = {
+        section: [item for item in items if item.section == section]
+        for section in _SECTION_ORDER
+    }
+    parts: list[str] = []
+    spans: list[HL7V2FieldSpan] = []
+    sections: list[HL7V2NarrativeSection] = []
+    cursor = 0
+
+    def append(value: str) -> None:
+        nonlocal cursor
+        parts.append(value)
+        cursor += len(value)
+
+    emitted_sections = 0
+    for section in _SECTION_ORDER:
+        section_items = by_section[section]
+        if not section_items:
+            continue
+
+        if emitted_sections:
+            append("\n\n" if mode == "sectioned" else " ")
+        section_start = cursor
+        if mode == "sectioned":
+            append(f"## {section}\n")
+
+        for item_index, item in enumerate(section_items):
+            if item_index:
+                append("\n" if mode == "sectioned" else " ")
+            append(f"{item.label}: ")
+            value_start = cursor
+            append(item.value)
+            value_end = cursor
+            if mode == "flat" and item.value[-1:] not in ".!?":
+                append(".")
+            spans.append(
+                HL7V2FieldSpan(
+                    start=value_start,
+                    end=value_end,
+                    source=item.source,
+                    section=item.section,
+                    label=item.label,
+                )
+            )
+
+        sections.append(
+            HL7V2NarrativeSection(name=section, start=section_start, end=cursor)
+        )
+        emitted_sections += 1
+
+    return _RenderedNarrative(
+        text="".join(parts),
+        spans=tuple(spans),
+        sections=tuple(sections),
+    )
+
+
+def _message_type(message: HL7Message) -> str | None:
+    msh = next((segment for segment in message.segments if segment.name == "MSH"), None)
+    if msh is None:
+        return None
+    value = msh.get_field(9)
+    return value or None
+
+
+def _text(value: str, encoding: HL7V2Encoding) -> str:
+    return _decode_escapes(value, encoding).strip()
+
+
+def _components(value: str, encoding: HL7V2Encoding) -> str:
+    repetitions: list[str] = []
+    for repetition in value.split(encoding.repetition):
+        components = [
+            _decode_escapes(component, encoding).strip()
+            for component in repetition.split(encoding.component)
+            if component.strip()
+        ]
+        if components:
+            repetitions.append(" / ".join(components))
+    return "; ".join(repetitions)
+
+
+def _coded(value: str, encoding: HL7V2Encoding) -> str:
+    repetitions: list[str] = []
+    for repetition in value.split(encoding.repetition):
+        components = repetition.split(encoding.component)
+        code = _decode_escapes(components[0], encoding).strip() if components else ""
+        display = (
+            _decode_escapes(components[1], encoding).strip()
+            if len(components) > 1
+            else ""
+        )
+        if display and code and display != code:
+            repetitions.append(f"{display} ({code})")
+        elif display or code:
+            repetitions.append(display or code)
+    return "; ".join(repetitions)
+
+
+def _message_code(value: str, encoding: HL7V2Encoding) -> str:
+    components = [
+        _decode_escapes(component, encoding).strip()
+        for component in value.split(encoding.component)
+        if component.strip()
+    ]
+    return " ".join(components[:2])
+
+
+def _identifier(value: str, encoding: HL7V2Encoding) -> str:
+    first_repetition = value.split(encoding.repetition, 1)[0]
+    first_component = first_repetition.split(encoding.component, 1)[0]
+    return _decode_escapes(first_component, encoding).strip()
+
+
+def _name(value: str, encoding: HL7V2Encoding) -> str:
+    first_repetition = value.split(encoding.repetition, 1)[0]
+    components = [
+        _decode_escapes(component, encoding).strip()
+        for component in first_repetition.split(encoding.component)
+    ]
+    family = _component(components, 0)
+    given = _component(components, 1)
+    middle = _component(components, 2)
+    suffix = _component(components, 3)
+    prefix = _component(components, 4)
+    ordered = [prefix, given, middle, family, suffix]
+    return " ".join(part for part in ordered if part)
+
+
+def _component(components: Sequence[str], index: int) -> str:
+    return components[index] if index < len(components) else ""
+
+
+def _date(value: str, encoding: HL7V2Encoding) -> str:
+    raw = _identifier(value, encoding)
+    if len(raw) < 8 or not raw[:8].isdigit():
+        return raw
+    rendered = f"{raw[0:4]}-{raw[4:6]}-{raw[6:8]}"
+    time = raw[8:14]
+    if time:
+        rendered += f" {time[0:2]}"
+        if len(time) >= 4:
+            rendered += f":{time[2:4]}"
+        if len(time) >= 6:
+            rendered += f":{time[4:6]}"
+    return rendered
+
+
+def _sex(value: str, encoding: HL7V2Encoding) -> str:
+    code = _identifier(value, encoding).upper()
+    label = _SEX_LABELS.get(code)
+    return f"{label} ({code})" if label else code
+
+
+def _patient_class(value: str, encoding: HL7V2Encoding) -> str:
+    code = _identifier(value, encoding).upper()
+    label = _PATIENT_CLASS_LABELS.get(code)
+    return f"{label} ({code})" if label else code
+
+
+def _result_status(value: str, encoding: HL7V2Encoding) -> str:
+    code = _identifier(value, encoding).upper()
+    label = _RESULT_STATUS_LABELS.get(code)
+    return f"{label} ({code})" if label else code
+
+
+def _decode_escapes(value: str, encoding: HL7V2Encoding) -> str:
+    escape = encoding.escape
+    replacements = {
+        f"{escape}F{escape}": encoding.field,
+        f"{escape}S{escape}": encoding.component,
+        f"{escape}R{escape}": encoding.repetition,
+        f"{escape}T{escape}": encoding.subcomponent,
+        f"{escape}E{escape}": encoding.escape,
+        f"{escape}.br{escape}": "\n",
+    }
+    rendered = value
+    for encoded, decoded in replacements.items():
+        rendered = rendered.replace(encoded, decoded)
+    return rendered
+
+
+def _project_field_span(
+    span: HL7V2FieldSpan,
+    opcodes: Sequence[tuple[str, int, int, int, int]],
+    target_length: int,
+) -> HL7V2FieldSpan:
+    start, end = _project_range(span.start, span.end, opcodes, target_length)
+    return HL7V2FieldSpan(
+        start=start,
+        end=end,
+        source=span.source,
+        section=span.section,
+        label=span.label,
+    )
+
+
+def _project_section(
+    section: HL7V2NarrativeSection,
+    opcodes: Sequence[tuple[str, int, int, int, int]],
+    target_length: int,
+) -> HL7V2NarrativeSection:
+    start, end = _project_range(section.start, section.end, opcodes, target_length)
+    return HL7V2NarrativeSection(name=section.name, start=start, end=end)
+
+
+def _project_range(
+    start: int,
+    end: int,
+    opcodes: Sequence[tuple[str, int, int, int, int]],
+    target_length: int,
+) -> tuple[int, int]:
+    projected_start = _project_boundary(start, opcodes, prefer_end=False)
+    projected_end = _project_boundary(end, opcodes, prefer_end=True)
+    projected_start = max(0, min(projected_start, target_length))
+    projected_end = max(projected_start, min(projected_end, target_length))
+    return projected_start, projected_end
+
+
+def _project_boundary(
+    position: int,
+    opcodes: Sequence[tuple[str, int, int, int, int]],
+    *,
+    prefer_end: bool,
+) -> int:
+    for tag, source_start, source_end, target_start, target_end in opcodes:
+        if tag == "insert":
+            if position == source_start:
+                return target_end if prefer_end else target_start
+            continue
+        if not source_start <= position <= source_end:
+            continue
+        if tag == "equal":
+            return target_start + (position - source_start)
+        if position == source_start:
+            return target_start
+        if position == source_end:
+            return target_end
+        if tag == "delete":
+            return target_start
+        source_width = source_end - source_start
+        target_width = target_end - target_start
+        relative = (position - source_start) / source_width
+        return target_start + round(relative * target_width)
+    return opcodes[-1][4] if opcodes else position
+
+
+__all__ = [
+    "HL7V2FieldSource",
+    "HL7V2FieldSpan",
+    "HL7V2Narrative",
+    "HL7V2NarrativeSection",
+    "NarrativeMode",
+    "extract_hl7v2_narrative",
+]

--- a/openmed/interop/x12_837.py
+++ b/openmed/interop/x12_837.py
@@ -1,0 +1,645 @@
+"""Segment-aware X12 837 claim parsing and PHI redaction.
+
+The parser preserves the interchange delimiter set, segment order, and any
+whitespace between segments. It deliberately validates only the envelope
+needed to identify an 837 transaction; companion-guide and full X12
+conformance validation are outside this module's scope.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class X12Delimiters:
+    """Separators declared by the fixed-width ISA interchange header."""
+
+    element: str
+    repetition: str
+    component: str
+    segment: str
+
+
+@dataclass
+class X12Element:
+    """One X12 data element and its original raw-text character span."""
+
+    value: str
+    source_start: int
+    source_end: int
+
+    @property
+    def source_span(self) -> tuple[int, int]:
+        """Return the half-open source character span."""
+
+        return (self.source_start, self.source_end)
+
+
+@dataclass
+class X12Segment:
+    """A parsed X12 segment with one-based element access."""
+
+    tag: str
+    elements: list[X12Element]
+    leading: str
+    source_start: int
+    source_end: int
+
+    def get_element(self, position: int) -> X12Element | None:
+        """Return a one-based element, or ``None`` when it is absent."""
+
+        if position < 1:
+            raise ValueError("X12 element positions are one-based")
+        index = position - 1
+        if index >= len(self.elements):
+            return None
+        return self.elements[index]
+
+    def get_value(self, position: int) -> str | None:
+        """Return a one-based element value, or ``None`` when absent."""
+
+        element = self.get_element(position)
+        return element.value if element is not None else None
+
+    def set_value(self, position: int, value: str) -> None:
+        """Replace an existing one-based element value."""
+
+        element = self.get_element(position)
+        if element is None:
+            raise IndexError(f"{self.tag}{position:02d} is absent")
+        element.value = str(value)
+
+
+@dataclass(frozen=True)
+class X12OffsetEntry:
+    """Original and serialized character spans for one X12 element."""
+
+    segment_index: int
+    segment_tag: str
+    element_position: int
+    source_start: int
+    source_end: int
+    output_start: int
+    output_end: int
+
+    @property
+    def source_span(self) -> tuple[int, int]:
+        """Return the half-open span in the raw input."""
+
+        return (self.source_start, self.source_end)
+
+    @property
+    def output_span(self) -> tuple[int, int]:
+        """Return the half-open span in the serialized output."""
+
+        return (self.output_start, self.output_end)
+
+
+@dataclass(frozen=True)
+class X12OffsetMap:
+    """Bidirectional element-span projection between raw and output text.
+
+    Projection is exact at element granularity. That is the unit used by the
+    structured redactor and avoids inventing character-level correspondences
+    when a replacement has a different length from its source value.
+    """
+
+    entries: tuple[X12OffsetEntry, ...]
+
+    def for_element(
+        self,
+        segment_index: int,
+        element_position: int,
+    ) -> X12OffsetEntry:
+        """Return the mapping for a segment/element coordinate."""
+
+        matches = [
+            entry
+            for entry in self.entries
+            if entry.segment_index == segment_index
+            and entry.element_position == element_position
+        ]
+        if len(matches) != 1:
+            raise KeyError(
+                "no unique offset entry for "
+                f"segment {segment_index}, element {element_position}"
+            )
+        return matches[0]
+
+    def source_to_output(self, start: int, end: int) -> tuple[int, int]:
+        """Project an exact source element span to serialized output."""
+
+        entry = self._entry_for_span(start, end, source=True)
+        return entry.output_span
+
+    def output_to_source(self, start: int, end: int) -> tuple[int, int]:
+        """Project an exact output element span back to the raw input."""
+
+        entry = self._entry_for_span(start, end, source=False)
+        return entry.source_span
+
+    def _entry_for_span(
+        self,
+        start: int,
+        end: int,
+        *,
+        source: bool,
+    ) -> X12OffsetEntry:
+        if start < 0 or end < start:
+            raise ValueError("offset spans must satisfy 0 <= start <= end")
+
+        matches = [
+            entry
+            for entry in self.entries
+            if (entry.source_span if source else entry.output_span) == (start, end)
+        ]
+        if len(matches) != 1:
+            side = "source" if source else "output"
+            raise KeyError(f"no unique X12 element for {side} span {(start, end)}")
+        return matches[0]
+
+
+@dataclass
+class X12837Message:
+    """Parsed X12 837 message with lossless framing metadata."""
+
+    segments: list[X12Segment]
+    delimiters: X12Delimiters
+    suffix: str = ""
+
+    @classmethod
+    def parse(cls, message: str) -> "X12837Message":
+        """Parse an X12 837 interchange from raw text."""
+
+        delimiters = _delimiters_from_isa(message)
+        segments, suffix = _parse_segments(message, delimiters)
+        _validate_837_envelope(segments)
+        return cls(segments=segments, delimiters=delimiters, suffix=suffix)
+
+    def serialize(self) -> str:
+        """Serialize the message while preserving its original framing."""
+
+        rendered, _ = self.serialize_with_offset_map()
+        return rendered
+
+    def serialize_with_offset_map(self) -> tuple[str, X12OffsetMap]:
+        """Serialize and map every original element span into the output."""
+
+        chunks: list[str] = []
+        entries: list[X12OffsetEntry] = []
+        cursor = 0
+        element_separator = self.delimiters.element
+
+        for segment_index, segment in enumerate(self.segments):
+            chunks.append(segment.leading)
+            cursor += len(segment.leading)
+            chunks.append(segment.tag)
+            cursor += len(segment.tag)
+
+            for element_position, element in enumerate(segment.elements, start=1):
+                chunks.append(element_separator)
+                cursor += len(element_separator)
+                output_start = cursor
+                chunks.append(element.value)
+                cursor += len(element.value)
+                entries.append(
+                    X12OffsetEntry(
+                        segment_index=segment_index,
+                        segment_tag=segment.tag,
+                        element_position=element_position,
+                        source_start=element.source_start,
+                        source_end=element.source_end,
+                        output_start=output_start,
+                        output_end=cursor,
+                    )
+                )
+
+            chunks.append(self.delimiters.segment)
+            cursor += len(self.delimiters.segment)
+
+        chunks.append(self.suffix)
+        return "".join(chunks), X12OffsetMap(tuple(entries))
+
+    def segment_names(self) -> tuple[str, ...]:
+        """Return segment tags in message order."""
+
+        return tuple(segment.tag for segment in self.segments)
+
+
+@dataclass(frozen=True)
+class X12837Redaction:
+    """Audit-safe record for one redacted X12 element.
+
+    The original value is intentionally omitted. Its SHA-256 digest and raw
+    offsets provide provenance without copying PHI into audit artifacts.
+    """
+
+    segment_index: int
+    segment_tag: str
+    element_position: int
+    entity_code: str
+    label: str
+    source_start: int
+    source_end: int
+    output_start: int
+    output_end: int
+    original_sha256: str
+    replacement: str
+
+    @property
+    def source_span(self) -> tuple[int, int]:
+        """Return the half-open raw-input span."""
+
+        return (self.source_start, self.source_end)
+
+    @property
+    def output_span(self) -> tuple[int, int]:
+        """Return the half-open redacted-output span."""
+
+        return (self.output_start, self.output_end)
+
+
+@dataclass(frozen=True)
+class X12837RedactionResult:
+    """Redacted X12 text plus audit-safe provenance and offset projection."""
+
+    deidentified_text: str
+    redactions: tuple[X12837Redaction, ...]
+    offset_map: X12OffsetMap
+
+    @property
+    def redacted_text(self) -> str:
+        """Return an explicit alias for :attr:`deidentified_text`."""
+
+        return self.deidentified_text
+
+
+@dataclass(frozen=True)
+class _PendingRedaction:
+    segment_index: int
+    segment_tag: str
+    element_position: int
+    entity_code: str
+    label: str
+    source_start: int
+    source_end: int
+    original_sha256: str
+
+
+SUBSCRIBER_PATIENT_ENTITY_CODES = frozenset({"IL", "QC"})
+PROVIDER_ENTITY_CODES = frozenset(
+    {
+        "72",  # operating physician
+        "77",  # service location
+        "82",  # rendering provider
+        "85",  # billing provider
+        "87",  # pay-to provider
+        "DN",  # referring provider
+        "DQ",  # supervising provider
+        "FA",  # facility
+        "P3",  # primary care provider
+        "PE",  # payee
+    }
+)
+PHI_ENTITY_CODES = SUBSCRIBER_PATIENT_ENTITY_CODES | PROVIDER_ENTITY_CODES
+
+_NM1_REDACTIONS = {
+    3: "NAME",
+    4: "NAME",
+    5: "NAME",
+    6: "NAME",
+    7: "NAME",
+    9: "IDENTIFIER",
+}
+_CONTEXT_REDACTIONS = {
+    "N2": {1: "NAME", 2: "NAME"},
+    "N3": {1: "ADDRESS", 2: "ADDRESS"},
+    "N4": {1: "LOCATION", 2: "LOCATION", 3: "POSTAL_CODE"},
+    "DMG": {2: "DATE_OF_BIRTH"},
+    "REF": {2: "IDENTIFIER"},
+}
+_CONTEXT_PASSTHROUGH_SEGMENTS = frozenset({"PER", "PRV"})
+
+
+def parse_x12_837(message: str) -> X12837Message:
+    """Parse raw X12 837 text while preserving its separators and offsets."""
+
+    return X12837Message.parse(message)
+
+
+def redact_x12_837(
+    message_or_path: str | Path,
+    *,
+    replacement: str = "REDACTED",
+) -> X12837RedactionResult:
+    """Redact structured PHI elements from an X12 837 claim.
+
+    Patient, subscriber, and provider loops are identified from ``NM101``.
+    Names and identifiers in ``NM1``, address elements in ``N2``/``N3``/``N4``,
+    birth dates in ``DMG``, and loop-local identifiers in ``REF`` are replaced.
+    Envelope, control, qualifier, and claim/service segments are not modified.
+
+    Args:
+        message_or_path: Raw X12 837 text or a UTF-8 file path.
+        replacement: Token used for every non-empty PHI leaf. It must not
+            contain any separator declared by the interchange.
+
+    Returns:
+        Redacted text, structured redaction records, and a bidirectional
+        element-level offset map.
+    """
+
+    message_text = _read_message_or_path(message_or_path)
+    message = X12837Message.parse(message_text)
+    _validate_replacement(replacement, message.delimiters)
+
+    pending: list[_PendingRedaction] = []
+    active_entity_code: str | None = None
+
+    for segment_index, segment in enumerate(message.segments):
+        if segment.tag == "NM1":
+            entity_code = (segment.get_value(1) or "").upper()
+            active_entity_code = (
+                entity_code if entity_code in PHI_ENTITY_CODES else None
+            )
+            if active_entity_code is not None:
+                _redact_elements(
+                    segment,
+                    segment_index=segment_index,
+                    entity_code=active_entity_code,
+                    positions=_NM1_REDACTIONS,
+                    replacement=replacement,
+                    delimiters=message.delimiters,
+                    pending=pending,
+                )
+            continue
+
+        positions = _CONTEXT_REDACTIONS.get(segment.tag)
+        if active_entity_code is not None and positions is not None:
+            _redact_elements(
+                segment,
+                segment_index=segment_index,
+                entity_code=active_entity_code,
+                positions=positions,
+                replacement=replacement,
+                delimiters=message.delimiters,
+                pending=pending,
+            )
+            continue
+
+        if segment.tag not in _CONTEXT_PASSTHROUGH_SEGMENTS:
+            active_entity_code = None
+
+    deidentified_text, offset_map = message.serialize_with_offset_map()
+    redactions = tuple(
+        _finish_redaction(item, offset_map, deidentified_text) for item in pending
+    )
+    return X12837RedactionResult(
+        deidentified_text=deidentified_text,
+        redactions=redactions,
+        offset_map=offset_map,
+    )
+
+
+def _delimiters_from_isa(message: str) -> X12Delimiters:
+    if len(message) < 106 or not message.startswith("ISA"):
+        raise ValueError("X12 837 messages must start with a fixed-width ISA segment")
+
+    element = message[3]
+    repetition = message[82]
+    component = message[104]
+    segment = message[105]
+    delimiters = X12Delimiters(
+        element=element,
+        repetition=repetition,
+        component=component,
+        segment=segment,
+    )
+    values = (element, repetition, component, segment)
+    if any(len(value) != 1 or value.isspace() for value in values):
+        raise ValueError("X12 ISA separators must be non-whitespace characters")
+    if len(set(values)) != len(values):
+        raise ValueError("X12 ISA separators must be distinct")
+
+    isa_content = message[:105]
+    isa_parts = isa_content.split(element)
+    if len(isa_parts) != 17 or isa_parts[0] != "ISA":
+        raise ValueError("invalid fixed-width ISA segment")
+    if len(isa_parts[11]) != 1 or len(isa_parts[16]) != 1:
+        raise ValueError("ISA11 and ISA16 separators must be one character")
+    if isa_parts[11] != repetition or isa_parts[16] != component:
+        raise ValueError("ISA separator positions do not match ISA elements")
+    return delimiters
+
+
+def _parse_segments(
+    message: str,
+    delimiters: X12Delimiters,
+) -> tuple[list[X12Segment], str]:
+    segments: list[X12Segment] = []
+    cursor = 0
+    suffix = ""
+
+    while cursor < len(message):
+        leading_start = cursor
+        while cursor < len(message) and message[cursor].isspace():
+            cursor += 1
+        leading = message[leading_start:cursor]
+
+        terminator = message.find(delimiters.segment, cursor)
+        if terminator < 0:
+            suffix = message[leading_start:]
+            if suffix.strip():
+                raise ValueError("unterminated X12 segment")
+            break
+
+        segment_text = message[cursor:terminator]
+        if not segment_text:
+            raise ValueError("empty X12 segment")
+        parts = segment_text.split(delimiters.element)
+        tag = parts[0]
+        if not 2 <= len(tag) <= 3 or not tag.isalnum():
+            raise ValueError(f"invalid X12 segment tag {tag!r}")
+
+        elements: list[X12Element] = []
+        element_start = cursor + len(tag) + 1
+        for value in parts[1:]:
+            element_end = element_start + len(value)
+            elements.append(
+                X12Element(
+                    value=value,
+                    source_start=element_start,
+                    source_end=element_end,
+                )
+            )
+            element_start = element_end + 1
+
+        segments.append(
+            X12Segment(
+                tag=tag,
+                elements=elements,
+                leading=leading,
+                source_start=cursor,
+                source_end=terminator + 1,
+            )
+        )
+        cursor = terminator + 1
+
+    if not segments:
+        raise ValueError("empty X12 message")
+    return segments, suffix
+
+
+def _validate_837_envelope(segments: list[X12Segment]) -> None:
+    tags = [segment.tag for segment in segments]
+    if tags[0] != "ISA" or tags[-1] != "IEA":
+        raise ValueError("X12 interchange must be framed by ISA and IEA segments")
+
+    required = ("GS", "ST", "SE", "GE")
+    missing = [tag for tag in required if tag not in tags]
+    if missing:
+        raise ValueError(f"X12 837 envelope is missing: {', '.join(missing)}")
+
+    first_positions = [
+        tags.index(tag) for tag in ("ISA", "GS", "ST", "SE", "GE", "IEA")
+    ]
+    if first_positions != sorted(first_positions):
+        raise ValueError("X12 837 envelope segments are out of order")
+
+    transaction_segments = [segment for segment in segments if segment.tag == "ST"]
+    if any(segment.get_value(1) != "837" for segment in transaction_segments):
+        raise ValueError("only X12 837 transaction sets are supported")
+
+
+def _redact_elements(
+    segment: X12Segment,
+    *,
+    segment_index: int,
+    entity_code: str,
+    positions: dict[int, str],
+    replacement: str,
+    delimiters: X12Delimiters,
+    pending: list[_PendingRedaction],
+) -> None:
+    for position, label in positions.items():
+        element = segment.get_element(position)
+        if element is None or not element.value:
+            continue
+
+        original = element.value
+        redacted = _replace_leaf_values(original, replacement, delimiters)
+        if redacted == original:
+            continue
+
+        element.value = redacted
+        pending.append(
+            _PendingRedaction(
+                segment_index=segment_index,
+                segment_tag=segment.tag,
+                element_position=position,
+                entity_code=entity_code,
+                label=label,
+                source_start=element.source_start,
+                source_end=element.source_end,
+                original_sha256=hashlib.sha256(original.encode("utf-8")).hexdigest(),
+            )
+        )
+
+
+def _replace_leaf_values(
+    value: str,
+    replacement: str,
+    delimiters: X12Delimiters,
+) -> str:
+    leaf_separators = {delimiters.repetition, delimiters.component}
+    chunks: list[str] = []
+    leaf: list[str] = []
+
+    def flush() -> None:
+        raw_leaf = "".join(leaf)
+        chunks.append(replacement if raw_leaf else "")
+        leaf.clear()
+
+    for character in value:
+        if character in leaf_separators:
+            flush()
+            chunks.append(character)
+        else:
+            leaf.append(character)
+    flush()
+    return "".join(chunks)
+
+
+def _finish_redaction(
+    pending: _PendingRedaction,
+    offset_map: X12OffsetMap,
+    deidentified_text: str,
+) -> X12837Redaction:
+    entry = offset_map.for_element(
+        pending.segment_index,
+        pending.element_position,
+    )
+    return X12837Redaction(
+        segment_index=pending.segment_index,
+        segment_tag=pending.segment_tag,
+        element_position=pending.element_position,
+        entity_code=pending.entity_code,
+        label=pending.label,
+        source_start=pending.source_start,
+        source_end=pending.source_end,
+        output_start=entry.output_start,
+        output_end=entry.output_end,
+        original_sha256=pending.original_sha256,
+        replacement=deidentified_text[entry.output_start : entry.output_end],
+    )
+
+
+def _validate_replacement(replacement: str, delimiters: X12Delimiters) -> None:
+    if not isinstance(replacement, str):
+        raise TypeError("replacement must be a string")
+    separators = {
+        delimiters.element,
+        delimiters.repetition,
+        delimiters.component,
+        delimiters.segment,
+    }
+    if any(character in separators for character in replacement):
+        raise ValueError("replacement must not contain X12 separators")
+    if "\r" in replacement or "\n" in replacement:
+        raise ValueError("replacement must not contain line breaks")
+
+
+def _read_message_or_path(message_or_path: str | Path) -> str:
+    if isinstance(message_or_path, Path):
+        with message_or_path.open("r", encoding="utf-8", newline="") as handle:
+            return handle.read()
+
+    value = str(message_or_path)
+    try:
+        candidate = Path(value)
+        if candidate.is_file():
+            with candidate.open("r", encoding="utf-8", newline="") as handle:
+                return handle.read()
+    except OSError:
+        pass
+    return value
+
+
+__all__ = [
+    "PHI_ENTITY_CODES",
+    "PROVIDER_ENTITY_CODES",
+    "SUBSCRIBER_PATIENT_ENTITY_CODES",
+    "X12837Message",
+    "X12837Redaction",
+    "X12837RedactionResult",
+    "X12Delimiters",
+    "X12Element",
+    "X12OffsetEntry",
+    "X12OffsetMap",
+    "X12Segment",
+    "parse_x12_837",
+    "redact_x12_837",
+]

--- a/tests/unit/interop/test_hl7v2_narrative.py
+++ b/tests/unit/interop/test_hl7v2_narrative.py
@@ -1,0 +1,177 @@
+"""Tests for HL7 v2 de-identified narrative extraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from openmed.interop.hl7v2 import parse_hl7v2
+from openmed.interop.hl7v2_narrative import extract_hl7v2_narrative
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def fake_deidentifier(text: str, **kwargs):
+    """Deterministic offline stand-in for the complete narrative pass."""
+
+    assert kwargs["method"] == "mask"
+    assert kwargs["lang"] == "en"
+    redacted = (
+        text.replace("Jane Roe", "[PERSON]")
+        .replace("John Doe", "[PERSON]")
+        .replace("jane.roe@example.com", "[EMAIL]")
+        .replace("555-0199", "[PHONE]")
+        .replace("555-0101", "[PHONE]")
+        .replace("MRN67890", "[ID_NUM]")
+        .replace("MRN12345", "[ID_NUM]")
+    )
+    return SimpleNamespace(deidentified_text=redacted)
+
+
+def test_flat_oru_is_coherent_safe_and_maps_results_to_source_fields():
+    result = extract_hl7v2_narrative(
+        FIXTURES / "synthetic_phi_oru.hl7",
+        deidentifier=fake_deidentifier,
+    )
+
+    assert result.mode == "flat"
+    assert result.message_type == "ORU^R01"
+    assert result.text.startswith("Message type: ORU R01.")
+    assert "Observation 1: Clinical note (NOTE)." in result.text
+    assert (
+        "Result 1: Patient [PERSON] called from [PHONE] about [ID_NUM]." in result.text
+    )
+    assert (
+        "Observation 2: Glucose (GLU). Result 2: 7.1. Units 2: mmol/L." in result.text
+    )
+    assert "Note 1: Follow-up email [EMAIL] belongs to [PERSON]." in result.text
+    assert "Jane Roe" not in result.text
+    assert "jane.roe@example.com" not in result.text
+    assert "MRN67890" not in result.text
+
+    result_span = result.spans_for("OBX", 5, segment_occurrence=1)[0]
+    assert result_span.source.segment_index == 3
+    assert result_span.source.path == "OBX[1]-5"
+    assert result.text_for(result_span) == (
+        "Patient [PERSON] called from [PHONE] about [ID_NUM]."
+    )
+    assert ".." not in result.text
+
+    glucose_offset = result.text.index("7.1")
+    provenance = result.provenance_at(glucose_offset)
+    assert [(span.source.path, span.label) for span in provenance] == [
+        ("OBX[2]-5", "Result 2")
+    ]
+
+
+def test_sectioned_adt_has_stable_patient_and_encounter_sections():
+    first = extract_hl7v2_narrative(
+        FIXTURES / "synthetic_phi_adt.hl7",
+        mode="sectioned",
+        deidentifier=fake_deidentifier,
+    )
+    second = extract_hl7v2_narrative(
+        FIXTURES / "synthetic_phi_adt.hl7",
+        mode="sectioned",
+        deidentifier=fake_deidentifier,
+    )
+
+    assert first == second
+    assert first.text.startswith("## Message\n")
+    assert "\n\n## Patient\n" in first.text
+    assert "\n\n## Encounter\n" in first.text
+    assert "Administrative sex: Male (M)" in first.text
+    assert "Patient class: Inpatient (I)" in first.text
+    assert "DOE" not in first.text
+    assert "MRN12345" not in first.text
+    assert "1980-01-01" not in first.text
+    assert "Date of birth: 1980-01-31" in first.text
+
+    assert [section.name for section in first.sections] == [
+        "Message",
+        "Patient",
+        "Encounter",
+    ]
+    for section in first.sections:
+        assert first.text[section.start : section.end].startswith(f"## {section.name}")
+
+
+def test_deidentifier_receives_complete_narrative_once():
+    calls: list[str] = []
+
+    def deidentifier(text: str, **kwargs):
+        calls.append(text)
+        assert kwargs == {"method": "mask", "lang": "en"}
+        return text.replace("Jane Roe", "[PERSON]")
+
+    result = extract_hl7v2_narrative(
+        FIXTURES / "synthetic_phi_oru.hl7",
+        deidentifier=deidentifier,
+    )
+
+    assert len(calls) == 1
+    assert calls[0].startswith("Message type:")
+    assert "Patient Jane Roe called" in calls[0]
+    assert "Patient Jane Roe called" not in result.text
+
+
+def test_all_field_mappings_index_nonempty_final_text():
+    result = extract_hl7v2_narrative(
+        FIXTURES / "synthetic_phi_oru.hl7",
+        mode="sectioned",
+        deidentifier=fake_deidentifier,
+    )
+
+    assert result.field_mappings == result.spans
+    assert result.spans
+    for span in result.spans:
+        assert 0 <= span.start < span.end <= len(result.text)
+        assert result.text_for(span)
+        assert span.source.segment.isupper()
+        assert span.source.field_position > 0
+
+
+def test_parsed_message_and_mapping_result_are_supported():
+    message = parse_hl7v2(
+        (FIXTURES / "synthetic_phi_oru.hl7").read_text(encoding="utf-8")
+    )
+
+    result = extract_hl7v2_narrative(
+        message,
+        deidentifier=lambda text, **_: {"deidentified_text": text},
+    )
+
+    assert result.message_type == "ORU^R01"
+    assert result.spans_for("OBX", 3, segment_occurrence=2)
+
+
+def test_extractor_calls_public_hl7_parser(monkeypatch):
+    import openmed.interop.hl7v2_narrative as narrative_module
+
+    calls: list[str] = []
+    parser = narrative_module.parse_hl7v2
+
+    def tracking_parser(message: str):
+        calls.append(message)
+        return parser(message)
+
+    monkeypatch.setattr(narrative_module, "parse_hl7v2", tracking_parser)
+
+    narrative_module.extract_hl7v2_narrative(
+        FIXTURES / "synthetic_phi_adt.hl7",
+        deidentifier=lambda text, **_: text,
+    )
+
+    assert len(calls) == 1
+    assert calls[0].startswith("MSH")
+
+
+def test_invalid_mode_is_rejected_before_processing():
+    with pytest.raises(ValueError, match="flat.*sectioned"):
+        extract_hl7v2_narrative(
+            FIXTURES / "synthetic_phi_oru.hl7",
+            mode="html",  # type: ignore[arg-type]
+            deidentifier=fake_deidentifier,
+        )

--- a/tests/unit/interop/test_x12_837.py
+++ b/tests/unit/interop/test_x12_837.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openmed.interop.x12_837 import parse_x12_837, redact_x12_837
+
+# This fixture is entirely synthetic. Names, identifiers, addresses, dates,
+# providers, and claim values do not describe a real person or claim.
+SYNTHETIC_837 = "\n".join(
+    [
+        "ISA*00*          *00*          *ZZ*SYNTHSUBMIT001 *ZZ*SYNTHRECEIVE01 "
+        "*240101*1200*^*00501*000000001*1*T*:~",
+        "GS*HC*SYNTHSUBMIT*SYNTHRECV*20240101*1200*1*X*005010X222A1~",
+        "ST*837*0001*005010X222A1~",
+        "BHT*0019*00*SYNTHCLAIM*20240101*1200*CH~",
+        "NM1*41*2*SYNTHETIC SUBMITTER*****46*SUBMIT001~",
+        "NM1*40*2*SYNTHETIC RECEIVER*****46*RECV001~",
+        "HL*1**20*1~",
+        "NM1*85*2*SYNTHETIC CLINIC*****XX*1234567893~",
+        "N3*100 SYNTHETIC WAY~",
+        "N4*TESTVILLE*CA*90000~",
+        "REF*EI*999999999~",
+        "HL*2*1*22*1~",
+        "SBR*P*18*SYNTHGROUP******CI~",
+        "NM1*IL*1*SYNTHLAST*SYNTHFIRST*SYNTHMIDDLE***MI*SYNTHSUB123~",
+        "N3*200 SAMPLE STREET*APT 3~",
+        "N4*EXAMPLE CITY*CA*90210~",
+        "DMG*D8*19800101*F~",
+        "REF*SY*SYNTHSUB999~",
+        "HL*3*2*23*0~",
+        "PAT*19~",
+        "NM1*QC*1*SYNTHPATIENT*SYNTHGIVEN****MI*SYNTHPAT456~",
+        "N3*300 FIXTURE ROAD~",
+        "N4*DEMO TOWN*NY*10001~",
+        "DMG*D8*20100102*M~",
+        "REF*1W*SYNTHPAT999~",
+        "CLM*SYNTHCLAIM01*125***11:B:1*Y*A*Y*I~",
+        "NM1*82*1*SYNTHDOCTOR*SYNTHDOC****XX*1111111111~",
+        "REF*0B*SYNTHLICENSE~",
+        "LX*1~",
+        "SV1*HC:99213*125*UN*1***1~",
+        "DTP*472*D8*20240115~",
+        "SE*30*0001~",
+        "GE*1*1~",
+        "IEA*1*000000001~",
+        "",
+    ]
+)
+
+
+def _values(message, tag: str) -> list[tuple[str, ...]]:
+    return [
+        tuple(element.value for element in segment.elements)
+        for segment in message.segments
+        if segment.tag == tag
+    ]
+
+
+def test_synthetic_837_parses_and_reserializes_with_exact_framing():
+    parsed = parse_x12_837(SYNTHETIC_837)
+
+    assert parsed.serialize() == SYNTHETIC_837
+    assert parsed.delimiters.element == "*"
+    assert parsed.delimiters.repetition == "^"
+    assert parsed.delimiters.component == ":"
+    assert parsed.delimiters.segment == "~"
+    assert parsed.segment_names()[:4] == ("ISA", "GS", "ST", "BHT")
+    assert parsed.segment_names()[-3:] == ("SE", "GE", "IEA")
+    assert parsed.segments[1].leading == "\n"
+    assert parsed.suffix == "\n"
+
+
+def test_redacts_patient_subscriber_and_provider_elements_only():
+    original = parse_x12_837(SYNTHETIC_837)
+    result = redact_x12_837(SYNTHETIC_837)
+    redacted = parse_x12_837(result.deidentified_text)
+
+    for value in (
+        "SYNTHETIC CLINIC",
+        "1234567893",
+        "SYNTHLAST",
+        "SYNTHFIRST",
+        "SYNTHSUB123",
+        "200 SAMPLE STREET",
+        "EXAMPLE CITY",
+        "90210",
+        "19800101",
+        "SYNTHSUB999",
+        "SYNTHPATIENT",
+        "SYNTHGIVEN",
+        "SYNTHPAT456",
+        "300 FIXTURE ROAD",
+        "DEMO TOWN",
+        "10001",
+        "20100102",
+        "SYNTHPAT999",
+        "SYNTHDOCTOR",
+        "SYNTHLICENSE",
+    ):
+        assert value not in result.deidentified_text
+
+    assert "SYNTHETIC SUBMITTER" in result.deidentified_text
+    assert "SYNTHETIC RECEIVER" in result.deidentified_text
+    assert _values(original, "ISA") == _values(redacted, "ISA")
+    assert _values(original, "GS") == _values(redacted, "GS")
+    assert _values(original, "ST") == _values(redacted, "ST")
+    assert _values(original, "BHT") == _values(redacted, "BHT")
+    assert _values(original, "HL") == _values(redacted, "HL")
+    assert _values(original, "SBR") == _values(redacted, "SBR")
+    assert _values(original, "CLM") == _values(redacted, "CLM")
+    assert _values(original, "LX") == _values(redacted, "LX")
+    assert _values(original, "SV1") == _values(redacted, "SV1")
+    assert _values(original, "DTP") == _values(redacted, "DTP")
+    assert _values(original, "SE") == _values(redacted, "SE")
+    assert _values(original, "GE") == _values(redacted, "GE")
+    assert _values(original, "IEA") == _values(redacted, "IEA")
+
+    subscriber = next(
+        segment
+        for segment in redacted.segments
+        if segment.tag == "NM1" and segment.get_value(1) == "IL"
+    )
+    assert subscriber.get_value(2) == "1"
+    assert subscriber.get_value(3) == "REDACTED"
+    assert subscriber.get_value(8) == "MI"
+    assert subscriber.get_value(9) == "REDACTED"
+    assert result.deidentified_text.endswith("IEA*1*000000001~\n")
+
+
+def test_custom_isa_separators_and_segment_whitespace_round_trip():
+    source = (
+        SYNTHETIC_837.replace("SYNTHSUB999", "SYNTHSUB999:PART2^SYNTHALT999")
+        .replace("*", "|")
+        .replace("~", "?")
+        .replace("^", "!")
+    )
+
+    parsed = parse_x12_837(source)
+    result = redact_x12_837(source, replacement="MASKED")
+
+    assert parsed.delimiters.element == "|"
+    assert parsed.delimiters.repetition == "!"
+    assert parsed.delimiters.component == ":"
+    assert parsed.delimiters.segment == "?"
+    assert parsed.serialize() == source
+    assert "?\nGS|" in result.deidentified_text
+    assert "REF|SY|MASKED:MASKED!MASKED?" in result.deidentified_text
+    assert result.deidentified_text.endswith("IEA|1|000000001?\n")
+    assert parse_x12_837(result.deidentified_text).segment_names() == (
+        parsed.segment_names()
+    )
+
+
+def test_offset_map_round_trips_raw_audit_provenance():
+    result = redact_x12_837(SYNTHETIC_837)
+    redaction = next(
+        item
+        for item in result.redactions
+        if item.entity_code == "IL"
+        and item.segment_tag == "NM1"
+        and item.element_position == 9
+    )
+
+    assert SYNTHETIC_837[redaction.source_start : redaction.source_end] == (
+        "SYNTHSUB123"
+    )
+    assert (
+        result.deidentified_text[redaction.output_start : redaction.output_end]
+        == "REDACTED"
+    )
+    assert result.offset_map.source_to_output(*redaction.source_span) == (
+        redaction.output_span
+    )
+    assert result.offset_map.output_to_source(*redaction.output_span) == (
+        redaction.source_span
+    )
+    assert len(redaction.original_sha256) == 64
+    assert "SYNTHSUB123" not in repr(redaction)
+
+    st_control = result.offset_map.for_element(2, 2)
+    assert SYNTHETIC_837[st_control.source_start : st_control.source_end] == "0001"
+    assert (
+        result.deidentified_text[st_control.output_start : st_control.output_end]
+        == "0001"
+    )
+
+
+def test_redaction_preserves_composite_and_repetition_structure():
+    source = SYNTHETIC_837.replace("SYNTHSUB999", "SYNTHSUB999:PART2^SYNTHALT999")
+
+    result = redact_x12_837(source, replacement="MASKED")
+
+    assert "REF*SY*MASKED:MASKED^MASKED~" in result.deidentified_text
+    ref = next(
+        item
+        for item in result.redactions
+        if item.entity_code == "IL" and item.segment_tag == "REF"
+    )
+    assert ref.replacement == "MASKED:MASKED^MASKED"
+
+
+def test_reads_utf8_path_without_normalizing_intersegment_newlines(tmp_path: Path):
+    path = tmp_path / "synthetic-claim.837"
+    path.write_text(SYNTHETIC_837.replace("\n", "\r\n"), encoding="utf-8", newline="")
+
+    result = redact_x12_837(path)
+
+    assert "~\r\nGS" in result.deidentified_text
+    assert result.deidentified_text.endswith("IEA*1*000000001~\r\n")
+
+
+def test_rejects_non_837_and_separator_breaking_replacements():
+    with pytest.raises(ValueError, match="only X12 837"):
+        parse_x12_837(SYNTHETIC_837.replace("ST*837", "ST*835", 1))
+
+    with pytest.raises(ValueError, match="must not contain X12 separators"):
+        redact_x12_837(SYNTHETIC_837, replacement="NOT*SAFE")


### PR DESCRIPTION
## Included pull requests

- #2142 — Add HL7 v2 narrative extraction with provenance
- #2165 — Add X12 837 healthcare-claim PHI redaction

## Issues resolved

Related to #861
Related to #852

## Maintainer integration changes

- Preserved both HL7 narrative extraction and X12 redaction entries in the shared interoperability navigation.
- Verified both source-PR merges against their rehearsed tree checkpoints.
- Validated final tree `cd1126eedf284a52f327e0bccc87ffb497f8bdd2`.

## Validation

- `python -m pytest tests/unit/interop/test_hl7v2_narrative.py tests/unit/interop/test_x12_837.py -q` — 14 passed
- `ruff check openmed/interop <focused tests>` — passed
- `ruff format --check openmed/interop <focused tests>` — passed
- `mkdocs build --strict` — passed
