### PR TITLE
feat: enforce Android local-first inference guards

### DIFF
--- a/android/openmedkit/README.md
+++ b/android/openmedkit/README.md
@@ -30,6 +30,18 @@ code must not send protected health information to network services by default,
 must not require telemetry, and must not write raw PHI to logs, caches,
 temporary files, analytics events, or audit artifacts.
 
+The `analyzeText`, `extractPii`, and `deidentify` inference paths operate only on
+caller-supplied on-device model assets and do not open sockets or invoke HTTP.
+The optional model downloader is a separate, explicit pre-inference operation;
+it is never called by inference. The library manifest intentionally requests no
+`android.permission.INTERNET` permission.
+
+Internal inference diagnostics are disabled by default. Library code may emit
+diagnostics only through the typed `SafeLog` boundary, which accepts labels,
+Unicode offsets, and SHA-256 span hashes—not arbitrary messages or detected
+surface text. De-identification action records likewise retain provenance and
+replacement metadata without retaining the original identifier.
+
 This module is on-device only by design. It is not a medical device and does not
 provide diagnosis, treatment decisions, or emergency clinical guidance. Any
 future clinical workflow integration must keep human review and appropriate

--- a/android/openmedkit/build.gradle.kts
+++ b/android/openmedkit/build.gradle.kts
@@ -153,6 +153,10 @@ tasks.matching { it.name.startsWith("test") }.configureEach {
     dependsOn(verifyReleaseConsumerRules)
 }
 
+tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
+    systemProperty("openmedkit.moduleDirectory", projectDir.absolutePath)
+}
+
 val verifyReleasePublicationVersion by tasks.registering {
     group = "publishing"
     description = "Fails when the OpenMedKit publication version is a SNAPSHOT or malformed."

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/EntityPrediction.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/EntityPrediction.kt
@@ -1,6 +1,8 @@
 package com.openmed.openmedkit
 
 import com.openmed.openmedkit.segmentation.IcuTextSegmenter
+import com.openmed.openmedkit.util.phiSafeLabel
+import com.openmed.openmedkit.util.sha256Hex
 import java.math.BigDecimal
 import java.math.RoundingMode
 
@@ -57,8 +59,8 @@ data class EntityPrediction(
     }
 
     /**
-     * Human-readable description matching the Swift `EntityPrediction`
-     * format `[label] "text" (start:end) conf=0.00`.
+     * PHI-safe diagnostic description containing a label, offsets, confidence,
+     * and the SHA-256 digest of [text], but never the detected surface text.
      *
      * The confidence is rendered with two decimals using half-even
      * ("banker's") rounding on a period decimal separator, matching Swift's
@@ -76,6 +78,7 @@ data class EntityPrediction(
             } else {
                 confidence.toString()
             }
-        return "[$label] \"$text\" ($start:$end) conf=$conf"
+        return "[${phiSafeLabel(label)}] sha256=${sha256Hex(text)} " +
+            "($start:$end) conf=$conf"
     }
 }

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/OpenMedKit.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/OpenMedKit.kt
@@ -1,11 +1,20 @@
 package com.openmed.openmedkit
 
 import com.openmed.openmedkit.policy.PolicyProfiles
+import com.openmed.openmedkit.util.SafeLog
+import com.openmed.openmedkit.util.SafeLogOperation
+import com.openmed.openmedkit.util.toSafeLogSpan
 import java.io.Closeable
 import java.io.File
 
 /**
  * OpenMedKit public Kotlin facade for on-device clinical NLP.
+ *
+ * Inference uses caller-supplied local model assets and performs no library
+ * network access. Telemetry is disabled by default, and internal diagnostics
+ * contain labels, offsets, and hashes rather than raw span text. Results are
+ * assistive software output, not diagnosis, treatment advice, or a medical
+ * device decision.
  */
 class OpenMedKit(
     private val classifier: OnnxTokenClassifier,
@@ -36,9 +45,14 @@ class OpenMedKit(
             "confidenceThreshold must be between 0.0 and 1.0"
         }
         val predictions = classifier.predict(text)
-        return decoder.decode(predictions, text)
+        val entities = decoder.decode(predictions, text)
             .filter { it.confidence >= confidenceThreshold }
             .sortedByOffset()
+        SafeLog.record(
+            SafeLogOperation.ANALYZE_TEXT,
+            entities.map { it.toSafeLogSpan() },
+        )
+        return entities
     }
 
     /**
@@ -53,11 +67,16 @@ class OpenMedKit(
             analyzeText(text, confidenceThreshold),
             text,
         )
-        return if (useSmartMerging) {
+        val entities = if (useSmartMerging) {
             merger.merge(repaired, text)
         } else {
             repaired.sortedByOffset()
         }
+        SafeLog.record(
+            SafeLogOperation.EXTRACT_PII,
+            entities.map { it.toSafeLogSpan() },
+        )
+        return entities
     }
 
     /**
@@ -91,11 +110,16 @@ class OpenMedKit(
             deduplicateOverlappingEntities(chunkEntities),
             text,
         )
-        return if (useSmartMerging) {
+        val entities = if (useSmartMerging) {
             deduplicateOverlappingEntities(merger.merge(repaired, text))
         } else {
             deduplicateOverlappingEntities(repaired)
         }
+        SafeLog.record(
+            SafeLogOperation.EXTRACT_PII_CHUNKED,
+            entities.map { it.toSafeLogSpan() },
+        )
+        return entities
     }
 
     /**
@@ -128,7 +152,12 @@ class OpenMedKit(
     ): PolicyDeidentificationResult {
         val profile = PolicyProfiles.load(policy)
         val entities = extractPii(text, confidenceThreshold, useSmartMerging)
-        return deidentifyEngine.deidentify(text, entities, profile)
+        val result = deidentifyEngine.deidentify(text, entities, profile)
+        SafeLog.record(
+            SafeLogOperation.DEIDENTIFY,
+            entities.map { it.toSafeLogSpan() },
+        )
+        return result
     }
 
     override fun close() {
@@ -297,7 +326,12 @@ class OpenMed(
             null -> LocalPiiRecognizer.detect(text)
             else -> LocalPiiRecognizer.detect(text)
         }
-        return entities.filter { it.confidence >= confidenceThreshold }
+        val filtered = entities.filter { it.confidence >= confidenceThreshold }
+        SafeLog.record(
+            SafeLogOperation.ANALYZE_TEXT,
+            filtered.map { it.toSafeLogSpan() },
+        )
+        return filtered
     }
 
     /**
@@ -309,7 +343,12 @@ class OpenMed(
         useSmartMerging: Boolean = true,
     ): List<EntityPrediction> {
         val entities = analyzeText(text, confidenceThreshold)
-        return if (useSmartMerging) entities else entities
+        val extracted = if (useSmartMerging) entities else entities
+        SafeLog.record(
+            SafeLogOperation.EXTRACT_PII,
+            extracted.map { it.toSafeLogSpan() },
+        )
+        return extracted
     }
 
     /**

--- a/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/util/SafeLog.kt
+++ b/android/openmedkit/src/main/kotlin/com/openmed/openmedkit/util/SafeLog.kt
@@ -1,0 +1,92 @@
+package com.openmed.openmedkit.util
+
+import com.openmed.openmedkit.EntityPrediction
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicReference
+
+/** Inference operations that may emit PHI-safe diagnostic metadata. */
+internal enum class SafeLogOperation {
+    ANALYZE_TEXT,
+    EXTRACT_PII,
+    EXTRACT_PII_CHUNKED,
+    DEIDENTIFY,
+}
+
+/**
+ * A diagnostic span containing provenance only, never the detected surface text.
+ */
+internal data class SafeLogSpan(
+    val label: String,
+    val start: Int,
+    val end: Int,
+    val textSha256: String,
+) {
+    init {
+        require(label.matches(SAFE_LABEL_PATTERN)) { "label is not PHI-safe metadata" }
+        require(start >= 0) { "start must be non-negative" }
+        require(end >= start) { "end must not precede start" }
+        require(textSha256.matches(SHA256_PATTERN)) { "textSha256 must be lowercase SHA-256" }
+    }
+
+    private companion object {
+        val SAFE_LABEL_PATTERN = Regex("[A-Za-z0-9_.:-]{1,128}")
+        val SHA256_PATTERN = Regex("[0-9a-f]{64}")
+    }
+}
+
+/** A complete PHI-free diagnostic event. */
+internal data class SafeLogEvent(
+    val operation: SafeLogOperation,
+    val spans: List<SafeLogSpan>,
+)
+
+/** Sink seam kept internal so telemetry remains disabled by default. */
+internal fun interface SafeLogSink {
+    fun write(event: SafeLogEvent)
+}
+
+/**
+ * The only OpenMedKit inference logging boundary.
+ *
+ * [record] accepts typed PHI-free records rather than arbitrary messages or raw
+ * span text. The default sink is `null`, so the library emits no logs or
+ * telemetry unless an internal host integration explicitly installs a sink.
+ */
+internal object SafeLog {
+    private val sink = AtomicReference<SafeLogSink?>(null)
+
+    fun record(
+        operation: SafeLogOperation,
+        spans: List<SafeLogSpan>,
+    ) {
+        val activeSink = sink.get() ?: return
+        activeSink.write(SafeLogEvent(operation, spans.toList()))
+    }
+
+    /** Replace the sink for an isolated test and return the previous value. */
+    fun installSinkForTesting(replacement: SafeLogSink?): SafeLogSink? =
+        sink.getAndSet(replacement)
+}
+
+/** Convert an entity to label/offset/hash evidence before it reaches [SafeLog]. */
+internal fun EntityPrediction.toSafeLogSpan(): SafeLogSpan = SafeLogSpan(
+    label = phiSafeLabel(label),
+    start = start,
+    end = end,
+    textSha256 = sha256Hex(text),
+)
+
+internal fun phiSafeLabel(label: String): String {
+    val candidate = label.trim()
+    return if (candidate.matches(Regex("[A-Za-z0-9_.:-]{1,128}"))) {
+        candidate
+    } else {
+        "label_${sha256Hex(candidate).take(16)}"
+    }
+}
+
+internal fun sha256Hex(value: String): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray(StandardCharsets.UTF_8))
+        .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/EntityPredictionTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/EntityPredictionTest.kt
@@ -1,5 +1,6 @@
 package com.openmed.openmedkit
 
+import com.openmed.openmedkit.util.sha256Hex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -18,17 +19,24 @@ class EntityPredictionTest {
     }
 
     @Test
-    fun descriptionMatchesSwiftFormat() {
+    fun descriptionContainsHashInsteadOfRawSpanText() {
         val prediction = EntityPrediction("PERSON", "Alice", 0.98f, 0, 5)
 
-        assertEquals("[PERSON] \"Alice\" (0:5) conf=0.98", prediction.toString())
+        assertEquals(
+            "[PERSON] sha256=${sha256Hex("Alice")} (0:5) conf=0.98",
+            prediction.toString(),
+        )
+        assertTrue(!prediction.toString().contains("Alice"))
     }
 
     @Test
     fun descriptionRendersTwoDecimalConfidence() {
         val prediction = EntityPrediction("SSN", "123-45-6789", 0.5f, 10, 21)
 
-        assertEquals("[SSN] \"123-45-6789\" (10:21) conf=0.50", prediction.toString())
+        assertEquals(
+            "[SSN] sha256=${sha256Hex("123-45-6789")} (10:21) conf=0.50",
+            prediction.toString(),
+        )
     }
 
     @Test
@@ -36,11 +44,11 @@ class EntityPredictionTest {
         // Exactly-representable binary halves: Swift's C printf %.2f rounds
         // ties to even, so 0.125 -> 0.12 and 0.625 -> 0.62 (not 0.13 / 0.63).
         assertEquals(
-            "[X] \"x\" (0:1) conf=0.12",
+            "[X] sha256=${sha256Hex("x")} (0:1) conf=0.12",
             EntityPrediction("X", "x", 0.125f, 0, 1).toString(),
         )
         assertEquals(
-            "[X] \"x\" (0:1) conf=0.62",
+            "[X] sha256=${sha256Hex("x")} (0:1) conf=0.62",
             EntityPrediction("X", "x", 0.625f, 0, 1).toString(),
         )
     }
@@ -48,11 +56,11 @@ class EntityPredictionTest {
     @Test
     fun descriptionRendersBoundaryConfidences() {
         assertEquals(
-            "[X] \"x\" (0:1) conf=0.00",
+            "[X] sha256=${sha256Hex("x")} (0:1) conf=0.00",
             EntityPrediction("X", "x", 0.0f, 0, 1).toString(),
         )
         assertEquals(
-            "[X] \"x\" (0:1) conf=1.00",
+            "[X] sha256=${sha256Hex("x")} (0:1) conf=1.00",
             EntityPrediction("X", "x", 1.0f, 0, 1).toString(),
         )
     }

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/util/NoNetworkInferenceTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/util/NoNetworkInferenceTest.kt
@@ -1,0 +1,85 @@
+package com.openmed.openmedkit.util
+
+import com.openmed.openmedkit.OnnxTokenClassifier
+import com.openmed.openmedkit.OpenMedKit
+import com.openmed.openmedkit.TokenClassificationPrediction
+import java.io.File
+import java.security.Permission
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Suppress("DEPRECATION")
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class NoNetworkInferenceTest {
+    @Test
+    fun analyzeExtractAndDeidentifyOpenNoSockets() = runTest {
+        val source = "Patient Jane called 555-1212"
+        val networkAttempts = CopyOnWriteArrayList<String>()
+        val previousManager = System.getSecurityManager()
+        val denyNetwork = DenyNetworkSecurityManager(networkAttempts)
+        val kit = OpenMedKit(
+            classifier = StaticClassifier(
+                TokenClassificationPrediction("PERSON", "Jane", 0.99f, 8, 12),
+                TokenClassificationPrediction("PHONE", "555-1212", 0.99f, 20, 28),
+            ),
+        )
+
+        System.setSecurityManager(denyNetwork)
+        try {
+            assertTrue(kit.analyzeText(source).isNotEmpty())
+            assertTrue(kit.extractPii(source).isNotEmpty())
+            assertFalse(kit.deidentify(source).redactedText.contains("Jane"))
+        } finally {
+            kit.close()
+            System.setSecurityManager(previousManager)
+        }
+
+        assertTrue(networkAttempts.isEmpty(), "inference attempted network I/O")
+    }
+
+    @Test
+    fun libraryManifestDoesNotRequestInternetPermission() {
+        val manifest = File(
+            requireNotNull(System.getProperty("openmedkit.moduleDirectory")) {
+                "openmedkit.moduleDirectory test property is missing"
+            },
+            "src/main/AndroidManifest.xml",
+        )
+
+        assertTrue(manifest.isFile, "cannot locate OpenMedKit Android manifest")
+        assertFalse(manifest.readText().contains("android.permission.INTERNET"))
+    }
+
+    private class DenyNetworkSecurityManager(
+        private val attempts: MutableList<String>,
+    ) : SecurityManager() {
+        override fun checkPermission(permission: Permission?) = Unit
+
+        override fun checkPermission(permission: Permission?, context: Any?) = Unit
+
+        override fun checkConnect(host: String?, port: Int) {
+            attempts += "$host:$port"
+            throw AssertionError("network access is forbidden during inference")
+        }
+
+        override fun checkConnect(host: String?, port: Int, context: Any?) {
+            checkConnect(host, port)
+        }
+    }
+
+    private class StaticClassifier(
+        vararg predictions: TokenClassificationPrediction,
+    ) : OnnxTokenClassifier {
+        private val predictions = predictions.toList()
+
+        override suspend fun predict(text: String): List<TokenClassificationPrediction> =
+            predictions
+    }
+}

--- a/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/util/NoPhiLoggingTest.kt
+++ b/android/openmedkit/src/test/kotlin/com/openmed/openmedkit/util/NoPhiLoggingTest.kt
@@ -1,0 +1,126 @@
+package com.openmed.openmedkit.util
+
+import com.openmed.openmedkit.EntityPrediction
+import com.openmed.openmedkit.OnnxTokenClassifier
+import com.openmed.openmedkit.OpenMedKit
+import com.openmed.openmedkit.TokenClassificationPrediction
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class NoPhiLoggingTest {
+    @Test
+    fun inferenceDiagnosticsContainHashesAndOffsetsButNoPlaintextIdentifiers() = runTest {
+        val identifier = "Jane Patient"
+        val phone = "555-1212"
+        val source = "$identifier called $phone"
+        val captured = mutableListOf<SafeLogEvent>()
+        val previous = SafeLog.installSinkForTesting(captured::add)
+
+        val kit = OpenMedKit(
+            classifier = StaticClassifier(
+                prediction(source, identifier, "PERSON"),
+                prediction(source, phone, "PHONE"),
+            ),
+        )
+        try {
+            kit.analyzeText(source)
+            kit.extractPii(source)
+            val result = kit.deidentify(source)
+
+            assertFalse(result.redactedText.contains(identifier))
+            assertFalse(result.redactedText.contains(phone))
+            assertFalse(result.actions.toString().contains(identifier))
+            assertFalse(result.actions.toString().contains(phone))
+        } finally {
+            kit.close()
+            SafeLog.installSinkForTesting(previous)
+        }
+
+        val diagnostics = captured.joinToString("\n")
+        assertTrue(captured.isNotEmpty())
+        assertFalse(diagnostics.contains(identifier))
+        assertFalse(diagnostics.contains(phone))
+        assertTrue(diagnostics.contains(sha256Hex(identifier)))
+        assertTrue(diagnostics.contains(sha256Hex(phone)))
+        assertTrue(captured.flatMap { it.spans }.all { it.start >= 0 && it.end > it.start })
+    }
+
+    @Test
+    fun entityDescriptionCannotAccidentallyExposeItsSurfaceText() {
+        val identifier = "123-45-6789"
+        val prediction = EntityPrediction("SSN", identifier, 0.99f, 4, 15)
+
+        assertFalse(prediction.toString().contains(identifier))
+        assertTrue(prediction.toString().contains(sha256Hex(identifier)))
+    }
+
+    @Test
+    fun productionKotlinSourcesDoNotBypassSafeLog() {
+        val sourceRoot = locateMainKotlinSources()
+        val forbidden = Regex(
+            """android\.util\.Log|java\.util\.logging|Timber\.|""" +
+                """\bLog\.(v|d|i|w|e|wtf)\s*\(|""" +
+                """\bprintln\s*\(|\bprint\s*\(|System\.(out|err)""",
+        )
+        val violations = sourceRoot.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" && it.name != "SafeLog.kt" }
+            .flatMap { file ->
+                file.readLines().asSequence().mapIndexedNotNull { index, line ->
+                    if (forbidden.containsMatchIn(line)) {
+                        "${file.relativeTo(sourceRoot)}:${index + 1}"
+                    } else {
+                        null
+                    }
+                }
+            }
+            .toList()
+
+        assertEquals(
+            emptyList(),
+            violations,
+            "production logging must route through SafeLog",
+        )
+    }
+
+    private fun locateMainKotlinSources(): File = File(
+        requireNotNull(System.getProperty("openmedkit.moduleDirectory")) {
+            "openmedkit.moduleDirectory test property is missing"
+        },
+        "src/main/kotlin",
+    ).also {
+        check(it.isDirectory) { "cannot locate OpenMedKit Android Kotlin sources" }
+    }
+
+    private fun prediction(
+        source: String,
+        surface: String,
+        label: String,
+    ): TokenClassificationPrediction {
+        val start = source.indexOf(surface)
+        return TokenClassificationPrediction(
+            label = label,
+            text = surface,
+            confidence = 0.99f,
+            start = start,
+            end = start + surface.length,
+        )
+    }
+
+    private class StaticClassifier(
+        vararg predictions: TokenClassificationPrediction,
+    ) : OnnxTokenClassifier {
+        private val predictions = predictions.toList()
+
+        override suspend fun predict(text: String): List<TokenClassificationPrediction> =
+            predictions
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
Implements the Android/Kotlin local-first and no-PHI-logging contract. Inference diagnostics are typed and disabled by default, the real analyze/extract/deidentify paths are tested under a socket-denying rule, and the module documents its offline/on-device safety posture.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Add a no-op-by-default `SafeLog` boundary that accepts only labels, offsets, and SHA-256 hashes, and make entity descriptions PHI-safe.
- Route Android inference diagnostics through that boundary and add source, manifest, no-socket, and no-plaintext regression tests.
- Document offline inference, telemetry-off defaults, explicit downloader separation, on-device PHI, and the not-a-medical-device boundary.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands run with JDK 11 and Android SDK 33:
- `cd android && ./gradlew test` (188 tests across 44 suites, zero failures)
- `cd android && ./gradlew :openmedkit:lintDebug :openmedkit:assembleDebug`
- Focused guard and entity-description tests (12 passed)

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

The module README and public facade KDoc carry the runtime guarantees. No changelog entry is required for this scoped milestone issue.

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

The repository has no separate Kotlin formatter target; Android lint and assembly passed.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #570

## Screenshots/Examples
Not applicable.