### PR TITLE
feat: add v2.2 conformance release gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: V2.2 conformance
+
+on:
+  push:
+    branches: [main, master, develop]
+  pull_request:
+    branches: [main, master, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  v22-conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev --python 3.11
+
+      - name: Run the focused V2.2 conformance gate
+        run: .venv/bin/python -m pytest tests/integration/test_v22_exchange_conformance.py tests/unit/release/test_v22_coverage_matrix.py -q

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -85,6 +85,7 @@ classification:
   navigated:
     - index.md
     - feature-map.md
+    - release/v2.2-standards-matrix.md
     - release/v2.1.0.md
     - release/v2.0.0.md
     - release/v1.6-v1.7-feature-coverage.md

--- a/docs/release/v2.2-standards-matrix.md
+++ b/docs/release/v2.2-standards-matrix.md
@@ -1,0 +1,44 @@
+<!-- Generated from tests/fixtures/v22/coverage_matrix.json. -->
+# OpenMed v2.2 tested standards matrix
+
+This release gate is an offline, synthetic integration proof. It records
+only the subsets exercised by the focused suite and is not certification
+by HL7, OHDSI, the EU, or any national authority.
+
+Matrix schema: `openmed.v22.coverage-matrix.v1`
+Matrix version: `1`
+Release: `2.2`
+
+## Focused command
+
+```shell
+.venv/bin/python -m pytest tests/integration/test_v22_exchange_conformance.py tests/unit/release/test_v22_coverage_matrix.py -q
+```
+
+The command is intentionally small. GitHub Actions runs the repository-wide
+suite separately.
+
+## Declared coverage
+
+| ID | Standard or profile | Version | Tested subset | Known gaps | Fixtures and SHA-256 | Source modules | Test nodes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| form-deidentification-grounding | OpenMed clinical form review and ICD-10-CM grounding contract | form review v1; ICD-10-CM synthetic snapshot v22-synthetic-2026-08 | Synthetic OCR key/value fields with graph offsets and hash provenance<br>Direct-identifier redaction before review serialization<br>Exact local grounding of one Condition span to E11.9 | No OCR engine, remote terminology service, ambiguous coding, or real clinical document is exercised | `tests/fixtures/v22/expected_reference_hashes.json`<br>`sha256:34de044adc534ade16b725476f4bd8ba501d0c9ad7da56790232f726215681fd`<br>`tests/fixtures/v22/grounding_vocabulary.jsonl`<br>`sha256:9f3d2d3c7c23c9c9879389f43f0b0b45616ad65e51535de1779ba8d841bc5490`<br>`tests/fixtures/v22/reference_form.json`<br>`sha256:bdb8db8d2d37d02087026469caeaa2f26f4abd8661b8de426cdfb2b619a40bb8` | `openmed.structured.forms`<br>`openmed.clinical.grounding.api`<br>`openmed.eval.v22_conformance` | `tests/integration/test_v22_exchange_conformance.py::test_reference_exchange_flow_is_deterministic_offline_and_phi_free` |
+| fhir-r4-ips | HL7 FHIR R4 core and International Patient Summary | FHIR 4.0.1; IPS 2.0.1 | Document Bundle containing Composition, pseudonymous Patient, and grounded Condition<br>Local profile validation and internal reference-integrity checks | No external validator, terminology expansion, signature, narrative, or full IPS section set is exercised | `tests/fixtures/v22/expected_reference_hashes.json`<br>`sha256:34de044adc534ade16b725476f4bd8ba501d0c9ad7da56790232f726215681fd`<br>`tests/fixtures/v22/reference_form.json`<br>`sha256:bdb8db8d2d37d02087026469caeaa2f26f4abd8661b8de426cdfb2b619a40bb8` | `openmed.clinical.exporters.fhir.exchange`<br>`openmed.clinical.exporters.fhir.grounded`<br>`openmed.interop.fhir.reference_integrity`<br>`openmed.eval.v22_conformance` | `tests/integration/test_v22_exchange_conformance.py::test_reference_exchange_flow_is_deterministic_offline_and_phi_free` |
+| fhir-r4-to-omop-5-4 | OpenMed FHIR R4 to OMOP CDM bridge | FHIR 4.0.1 input; OMOP CDM 5.4 output | Pseudonymous Patient and one ICD-10-CM Condition<br>Caller-supplied synthetic vocabulary mapping, constraint validation, counts, hashes, and path-only information loss | FHIR Composition is excluded because it is outside the bridge's declared resource set<br>No database writer, cohort query, vocabulary service, or reverse round trip is exercised | `tests/fixtures/v22/expected_reference_hashes.json`<br>`sha256:34de044adc534ade16b725476f4bd8ba501d0c9ad7da56790232f726215681fd`<br>`tests/fixtures/v22/omop_vocabulary.json`<br>`sha256:28911fa9de2f5b58b8d8d87e8548c983d6c795ccad803d2bbfcb4678aa60fc37` | `openmed.interop.fhir_omop`<br>`openmed.interop.omop.cdm_loader`<br>`openmed.eval.v22_conformance` | `tests/integration/test_v22_exchange_conformance.py::test_reference_exchange_flow_is_deterministic_offline_and_phi_free` |
+| fhir-r5-adapter-negative | OpenMed explicit FHIR cross-release adapter | FHIR R5 5.0.0 to FHIR R4 4.0.1 | Path-specific rejection of a non-representable Observation field | This fixture does not claim general R5-to-R4 conversion or validate every supported resource | `tests/fixtures/v22/fhir_r5_negative.json`<br>`sha256:b3cde1c0f152788417d2bace6f5e26eb8ea6caaea9722d261c7a58075ffd0613` | `openmed.interop.fhir.versions`<br>`openmed.eval.v22_conformance` | `tests/integration/test_v22_exchange_conformance.py::test_negative_conformance_fixtures_fail_at_safe_boundaries` |
+| fhir-bulk-resume-negative | FHIR Bulk Data local checkpoint compatibility boundary | OpenMed checkpoint manifest v1 | Digest-only page token, policy, endpoint scope, and aggregate progress<br>Positive same-context resume and fail-closed endpoint-scope mismatch | No Bulk Data server, export kickoff, polling, file download, or complete protocol conformance is exercised | `tests/fixtures/v22/bulk_resume_negative.json`<br>`sha256:b88a29f2e574706edbe371b9ae95416e5fb7301d8a3f383cae56e20918d940ca` | `openmed.interop.fhir.bulk_checkpoint`<br>`openmed.eval.v22_conformance` | `tests/integration/test_v22_exchange_conformance.py::test_negative_conformance_fixtures_fail_at_safe_boundaries` |
+| structured-privacy-negative | NIST SP 800-188-oriented OpenMed structured privacy lab | structured privacy artifact schema v1 | One unique synthetic record rejected by a zero-tolerance membership-inference threshold<br>Aggregate, value-free privacy evidence serialization | The bounded self-test is not a universal re-identification bound, qualified-expert determination, or anonymity certification | `tests/fixtures/v22/structured_privacy_negative.json`<br>`sha256:cda409fee76e21e86a4dcadade0170fff112b1b8a705772fd8fb5e800984b048` | `openmed.structured.privacy_lab`<br>`openmed.eval.v22_conformance` | `tests/integration/test_v22_exchange_conformance.py::test_negative_conformance_fixtures_fail_at_safe_boundaries` |
+| mcp-authorization-negative | OpenMed MCP authorization conformance contract | openmed.mcp.authorization_conformance.v1 | Local mocked OAuth-style authorization flow rejects an unapproved state-changing tool call<br>Public result contains only case id and failure category | No live identity provider, HTTP transport, token endpoint, Dynamic Client Registration, or MCP certification is exercised | `tests/fixtures/v22/mcp_authorization_negative.json`<br>`sha256:19890c8eb2825d3c16e2e9a4eed66674596ec92f6db3406eb2f73b5c218fdefd` | `openmed.mcp.authorization_conformance`<br>`openmed.eval.v22_conformance` | `tests/integration/test_v22_exchange_conformance.py::test_negative_conformance_fixtures_fail_at_safe_boundaries` |
+
+## Leakage and evidence boundary
+
+The reference test requires zero exact occurrences of every synthetic
+direct identifier across review JSON, grounding audit output, serialized
+FHIR, the redacted OMOP report, captured errors and logs, generated evidence,
+and temporary artifact paths. Fixture data is synthetic and committed; no
+real-patient or DUA data is used.
+
+FHIR Composition is deliberately excluded from the FHIR-to-OMOP input because
+the bridge declares only Patient, Encounter, Condition, Observation, Procedure,
+MedicationStatement, and MedicationRequest. Every other limitation is stated
+in the table rather than inferred as support.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Overview:
       - Welcome: index.md
       - Feature Map: feature-map.md
+      - OpenMed 2.2 Tested Standards Matrix: release/v2.2-standards-matrix.md
       - OpenMed 2.1.0 Release Notes: release/v2.1.0.md
       - OpenMed 2.0.0 Release Notes: release/v2.0.0.md
       - v1.6-v1.7 Feature Coverage: release/v1.6-v1.7-feature-coverage.md

--- a/openmed/eval/v22_conformance.py
+++ b/openmed/eval/v22_conformance.py
@@ -1,0 +1,875 @@
+"""Offline V2.2 exchange conformance and release-evidence helpers.
+
+The reference flow is intentionally synthetic and narrow. It proves that the
+declared OpenMed form, grounding, FHIR R4/IPS, and FHIR-to-OMOP subsets compose
+without a network connection. It does not claim standards certification.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from openmed.clinical.exporters.fhir.exchange import build_ips_patient_summary
+from openmed.clinical.exporters.fhir.grounded import to_fhir
+from openmed.clinical.grounding import VocabLoader, VocabSource, ground
+from openmed.interop.fhir.bulk_checkpoint import (
+    BulkCheckpointCompatibilityError,
+    create_checkpoint,
+    validate_resume,
+)
+from openmed.interop.fhir.reference_integrity import reference_integrity_report
+from openmed.interop.fhir.versions import (
+    FHIRVersion,
+    UnsupportedFHIRFieldError,
+    convert_resource,
+)
+from openmed.interop.fhir_omop import (
+    FHIR_RESOURCE_TYPES as FHIR_OMOP_RESOURCE_TYPES,
+)
+from openmed.interop.fhir_omop import load_fhir_bundle
+from openmed.interop.omop import validate_omop_tables
+from openmed.mcp.authorization_conformance import (
+    ConformanceManifest,
+    run_conformance,
+)
+from openmed.structured.forms import extract_form_fields
+from openmed.structured.privacy_lab import (
+    StructuredPrivacyPolicy,
+    run_structured_privacy_lab,
+)
+
+V22_COVERAGE_SCHEMA_VERSION: Final = "openmed.v22.coverage-matrix.v1"
+V22_EVIDENCE_SCHEMA_VERSION: Final = "openmed.v22.conformance-evidence.v1"
+V22_FOCUSED_TEST_COMMAND: Final = (
+    ".venv/bin/python -m pytest "
+    "tests/integration/test_v22_exchange_conformance.py "
+    "tests/unit/release/test_v22_coverage_matrix.py -q"
+)
+
+_DIGEST_RE: Final = re.compile(r"^sha256:[0-9a-f]{64}$")
+_MATRIX_REQUIRED_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "matrix_version",
+        "release",
+        "synthetic_only",
+        "test_command",
+        "entries",
+    }
+)
+_ENTRY_REQUIRED_FIELDS: Final = frozenset(
+    {
+        "id",
+        "standard_profile",
+        "version",
+        "supported_subset",
+        "known_gaps",
+        "fixture_sha256",
+        "test_nodes",
+        "source_modules",
+    }
+)
+
+
+class V22ConformanceError(ValueError):
+    """Raised when the focused V2.2 proof fails closed."""
+
+
+class V22CoverageMatrixError(V22ConformanceError):
+    """Raised when the versioned V2.2 coverage matrix drifts."""
+
+
+@dataclass(frozen=True)
+class V22ReferenceResult:
+    """PHI-free artifacts and hashes from the synthetic reference flow."""
+
+    review_artifact: Mapping[str, Any]
+    grounding_audit: Mapping[str, Any]
+    fhir_bundle: Mapping[str, Any]
+    omop_report: Mapping[str, Any]
+    evidence: Mapping[str, Any]
+    artifact_paths: Mapping[str, Path]
+    fhir_sha256: str
+    omop_sha256: str
+    evidence_sha256: str
+
+    @property
+    def hashes(self) -> dict[str, str]:
+        """Return the three release-pinned deterministic hashes."""
+
+        return {
+            "fhir_sha256": self.fhir_sha256,
+            "omop_sha256": self.omop_sha256,
+            "evidence_sha256": self.evidence_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class V22NegativeBoundaryResult:
+    """One sanitized expected-failure result from a focused fixture."""
+
+    case_id: str
+    category: str
+    boundary: str
+    safe_error: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a deterministic public result without fixture values."""
+
+        return {
+            "case_id": self.case_id,
+            "status": "expected_failure",
+            "category": self.category,
+            "boundary": self.boundary,
+            "safe_error": self.safe_error,
+            "error_sha256": _sha256_text(self.safe_error),
+        }
+
+
+def canonical_json(value: Any) -> str:
+    """Serialize a JSON-compatible value deterministically."""
+
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def sha256_json(value: Any) -> str:
+    """Return a prefixed SHA-256 digest of canonical JSON."""
+
+    return _sha256_text(canonical_json(value))
+
+
+def critical_leakage_counts(
+    direct_identifiers: Sequence[str],
+    surfaces: Mapping[str, Any],
+) -> dict[str, int]:
+    """Count exact, case-insensitive identifier occurrences by surface."""
+
+    identifiers = tuple(
+        identifier.casefold()
+        for identifier in direct_identifiers
+        if isinstance(identifier, str) and identifier
+    )
+    counts: dict[str, int] = {}
+    for name, value in surfaces.items():
+        text = _surface_text(value).casefold()
+        counts[str(name)] = sum(text.count(identifier) for identifier in identifiers)
+    return dict(sorted(counts.items()))
+
+
+def assert_zero_critical_leakage(
+    direct_identifiers: Sequence[str],
+    surfaces: Mapping[str, Any],
+) -> dict[str, int]:
+    """Return per-surface zero counts or fail without echoing an identifier."""
+
+    counts = critical_leakage_counts(direct_identifiers, surfaces)
+    leaking = sorted(name for name, count in counts.items() if count)
+    if leaking:
+        raise V22ConformanceError(
+            "critical identifier leakage detected in surfaces: " + ", ".join(leaking)
+        )
+    return counts
+
+
+def run_v22_reference_flow(
+    fixture_root: str | Path,
+    work_dir: str | Path,
+) -> V22ReferenceResult:
+    """Run the offline synthetic form-to-FHIR-to-OMOP reference flow.
+
+    Only redacted review data, grounding hashes/codes, pseudonymous FHIR, OMOP
+    rows with redacted note text, and counts/hashes are written to ``work_dir``.
+    """
+
+    fixtures = Path(fixture_root)
+    output_dir = Path(work_dir)
+    form_fixture = _read_json(fixtures / "reference_form.json")
+    direct_identifiers = _string_sequence(
+        form_fixture.get("synthetic_direct_identifiers"),
+        "synthetic_direct_identifiers",
+    )
+
+    form_result = extract_form_fields(
+        form_fixture["source"],
+        schema=form_fixture["schema"],
+    )
+    fields = {field.link_id: field for field in form_result.fields}
+    missing_fields = sorted(
+        {"patient_name", "record_id", "contact_phone", "condition", "a1c_value"}
+        - fields.keys()
+    )
+    if missing_fields:
+        raise V22ConformanceError(
+            "reference form is missing declared fields: " + ", ".join(missing_fields)
+        )
+    review_artifact = form_result.to_dict()
+
+    vocabulary_path = fixtures / "grounding_vocabulary.jsonl"
+    vocabulary_digest = _sha256_bytes(vocabulary_path.read_bytes())
+    loader = VocabLoader(
+        cache_dir=output_dir / "vocabulary-cache",
+        local_only=True,
+        registry={
+            "icd10cm": VocabSource(
+                system="icd10cm",
+                path=vocabulary_path,
+                sha256=vocabulary_digest.removeprefix("sha256:"),
+                version="v22-synthetic-2026-08",
+                license_note="Synthetic test vocabulary; not a distributable code set.",
+            )
+        },
+    )
+    condition = fields["condition"]
+    grounded = ground(
+        [
+            {
+                "text": condition.value,
+                "start": condition.start,
+                "end": condition.end,
+                "label": "condition",
+                "assertion": {
+                    "temporality": "recent",
+                    "certainty": "certain",
+                    "negation": "affirmed",
+                    "experiencer": "patient",
+                },
+            }
+        ],
+        systems=("icd10cm",),
+        loader=loader,
+        offline=True,
+    )
+    if len(grounded) != 1 or grounded[0].codes != {"icd10cm": "E11.9"}:
+        raise V22ConformanceError(
+            "reference condition did not ground to the pinned code"
+        )
+    grounding_audit = grounded[0].to_audit_dict()
+
+    patient_seed = canonical_json(sorted(direct_identifiers))
+    patient_id = f"patient-{hashlib.sha256(patient_seed.encode()).hexdigest()[:24]}"
+    document_id = f"v22-{sha256_json(review_artifact)[7:23]}"
+    patient = {"resourceType": "Patient", "id": patient_id}
+    subject_reference = f"Patient/{patient_id}"
+    condition_resource = to_fhir(
+        grounded[0],
+        resource="Condition",
+        subject_reference=subject_reference,
+        document_id=document_id,
+    )
+    if not isinstance(condition_resource, Mapping):
+        raise V22ConformanceError("reference FHIR Condition export was empty")
+    fhir_bundle = build_ips_patient_summary(
+        [condition_resource],
+        patient=patient,
+        document_id=document_id,
+        author_reference=subject_reference,
+        validate_output=True,
+    )
+    integrity = reference_integrity_report(fhir_bundle, fhir_version="R4")
+    if not integrity.valid:
+        raise V22ConformanceError("reference FHIR Bundle has unresolved references")
+
+    omop_resources = [
+        entry["resource"]
+        for entry in fhir_bundle.get("entry", ())
+        if isinstance(entry, Mapping)
+        and isinstance(entry.get("resource"), Mapping)
+        and entry["resource"].get("resourceType") in FHIR_OMOP_RESOURCE_TYPES
+    ]
+    omop_vocabulary = _read_json(fixtures / "omop_vocabulary.json")
+    loaded = load_fhir_bundle(
+        omop_resources,
+        vocabulary=omop_vocabulary,
+        vocabulary_snapshot="v22-synthetic-2026-08",
+        source_system="OpenMed V2.2 synthetic FHIR",
+        source_version="FHIR R4 4.0.1",
+    )
+    violations = validate_omop_tables(loaded.omop)
+    if violations:
+        raise V22ConformanceError("reference OMOP output violates CDM constraints")
+    omop_report = loaded.to_dict()
+
+    review_sha256 = sha256_json(review_artifact)
+    grounding_sha256 = sha256_json(grounding_audit)
+    fhir_sha256 = sha256_json(fhir_bundle)
+    omop_sha256 = sha256_json(omop_report)
+    evidence: dict[str, Any] = {
+        "schema_version": V22_EVIDENCE_SCHEMA_VERSION,
+        "release": "2.2",
+        "synthetic": True,
+        "offline": True,
+        "reference_flow": [
+            "form_intake_and_deidentification",
+            "local_icd10cm_grounding",
+            "fhir_r4_ips_patient_summary",
+            "fhir_r4_to_omop_cdm_5_4",
+        ],
+        "artifact_hashes": {
+            "form_review_sha256": review_sha256,
+            "grounding_audit_sha256": grounding_sha256,
+            "fhir_sha256": fhir_sha256,
+            "omop_sha256": omop_sha256,
+        },
+        "grounding": {
+            "code": grounding_audit["code"],
+            "system_uri": grounding_audit["system_uri"],
+            "start": grounding_audit["start"],
+            "end": grounding_audit["end"],
+            "vocabulary_sha256": vocabulary_digest,
+        },
+        "fhir": {
+            "core_version": "4.0.1",
+            "ips_profile_version": "2.0.1",
+            "resource_counts": _fhir_resource_counts(fhir_bundle),
+            "reference_integrity": integrity.to_dict(),
+        },
+        "omop": {
+            "cdm_version": "5.4",
+            "summary": loaded.summary.to_dict(),
+        },
+        "critical_leakage": {
+            "maximum_allowed": 0,
+            "observed": 0,
+            "surfaces": [
+                "form review",
+                "grounding audit",
+                "FHIR serialization",
+                "OMOP report",
+                "evidence artifact",
+                "temporary paths",
+            ],
+        },
+        "qualification": (
+            "Tested synthetic subsets only; no HL7, OHDSI, regulatory, or "
+            "national-authority certification is claimed."
+        ),
+    }
+    evidence_sha256 = sha256_json(evidence)
+
+    artifact_paths = {
+        "form_review": output_dir / "form-review.json",
+        "grounding_audit": output_dir / "grounding-audit.json",
+        "fhir": output_dir / "fhir-r4-patient-summary.json",
+        "omop": output_dir / "omop-cdm-5.4-report.json",
+        "evidence": output_dir / "v2.2-conformance-evidence.json",
+    }
+    assert_zero_critical_leakage(
+        direct_identifiers,
+        {
+            "form_review": review_artifact,
+            "grounding_audit": grounding_audit,
+            "fhir": fhir_bundle,
+            "omop": omop_report,
+            "evidence": evidence,
+            "temporary_paths": [str(path) for path in artifact_paths.values()],
+        },
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for name, payload in (
+        ("form_review", review_artifact),
+        ("grounding_audit", grounding_audit),
+        ("fhir", fhir_bundle),
+        ("omop", omop_report),
+        ("evidence", evidence),
+    ):
+        _write_json(artifact_paths[name], payload)
+
+    return V22ReferenceResult(
+        review_artifact=review_artifact,
+        grounding_audit=grounding_audit,
+        fhir_bundle=fhir_bundle,
+        omop_report=omop_report,
+        evidence=evidence,
+        artifact_paths=artifact_paths,
+        fhir_sha256=fhir_sha256,
+        omop_sha256=omop_sha256,
+        evidence_sha256=evidence_sha256,
+    )
+
+
+def run_v22_negative_checks(
+    fixture_root: str | Path,
+) -> tuple[V22NegativeBoundaryResult, ...]:
+    """Run four independent offline expected-failure fixtures."""
+
+    fixtures = Path(fixture_root)
+    return (
+        _run_fhir_r5_negative(fixtures / "fhir_r5_negative.json"),
+        _run_bulk_resume_negative(fixtures / "bulk_resume_negative.json"),
+        _run_structured_privacy_negative(fixtures / "structured_privacy_negative.json"),
+        _run_mcp_authorization_negative(fixtures / "mcp_authorization_negative.json"),
+    )
+
+
+def load_coverage_matrix(path: str | Path) -> dict[str, Any]:
+    """Load the versioned JSON coverage matrix and reject duplicate keys."""
+
+    try:
+        payload = json.loads(
+            Path(path).read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except (OSError, ValueError, TypeError) as exc:
+        raise V22CoverageMatrixError("coverage matrix is not valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise V22CoverageMatrixError("coverage matrix must be an object")
+    return payload
+
+
+def validate_coverage_matrix(
+    repo_root: str | Path,
+    matrix: Mapping[str, Any] | str | Path,
+) -> dict[str, Any]:
+    """Validate versions, fixture hashes, test nodes, and source modules."""
+
+    root = Path(repo_root).resolve()
+    payload = (
+        load_coverage_matrix(matrix)
+        if isinstance(matrix, (str, Path))
+        else dict(matrix)
+    )
+    missing = sorted(_MATRIX_REQUIRED_FIELDS - payload.keys())
+    if missing:
+        raise V22CoverageMatrixError(
+            "coverage matrix is missing fields: " + ", ".join(missing)
+        )
+    if payload["schema_version"] != V22_COVERAGE_SCHEMA_VERSION:
+        raise V22CoverageMatrixError("coverage matrix schema_version is unsupported")
+    if payload["matrix_version"] != 1 or payload["release"] != "2.2":
+        raise V22CoverageMatrixError("coverage matrix release version is invalid")
+    if payload["synthetic_only"] is not True:
+        raise V22CoverageMatrixError("coverage matrix must declare synthetic_only")
+    if payload["test_command"] != V22_FOCUSED_TEST_COMMAND:
+        raise V22CoverageMatrixError("coverage matrix test command drifted")
+    entries = payload["entries"]
+    if not isinstance(entries, list) or not entries:
+        raise V22CoverageMatrixError("coverage matrix entries must be a non-empty list")
+
+    seen_ids: set[str] = set()
+    for index, entry_value in enumerate(entries):
+        if not isinstance(entry_value, Mapping):
+            raise V22CoverageMatrixError(f"coverage entry {index} must be an object")
+        entry = dict(entry_value)
+        missing_entry = sorted(_ENTRY_REQUIRED_FIELDS - entry.keys())
+        if missing_entry:
+            raise V22CoverageMatrixError(
+                f"coverage entry {index} is missing fields: " + ", ".join(missing_entry)
+            )
+        entry_id = _required_text(entry["id"], f"entries[{index}].id")
+        if entry_id in seen_ids:
+            raise V22CoverageMatrixError("coverage entry ids must be unique")
+        seen_ids.add(entry_id)
+        _required_text(entry["standard_profile"], f"entries[{index}].standard_profile")
+        _required_text(entry["version"], f"entries[{index}].version")
+        _nonempty_text_list(
+            entry["supported_subset"], f"entries[{index}].supported_subset"
+        )
+        _nonempty_text_list(entry["known_gaps"], f"entries[{index}].known_gaps")
+        _validate_fixture_hashes(root, entry["fixture_sha256"], index)
+        _validate_test_nodes(root, entry["test_nodes"], index)
+        _validate_source_modules(root, entry["source_modules"], index)
+    return payload
+
+
+def render_coverage_matrix_markdown(matrix: Mapping[str, Any]) -> str:
+    """Render the complete, deterministic V2.2 standards coverage document."""
+
+    entries = matrix.get("entries", ())
+    lines = [
+        "<!-- Generated from tests/fixtures/v22/coverage_matrix.json. -->",
+        "# OpenMed v2.2 tested standards matrix",
+        "",
+        "This release gate is an offline, synthetic integration proof. It records",
+        "only the subsets exercised by the focused suite and is not certification",
+        "by HL7, OHDSI, the EU, or any national authority.",
+        "",
+        f"Matrix schema: `{matrix.get('schema_version', '')}`",
+        f"Matrix version: `{matrix.get('matrix_version', '')}`",
+        f"Release: `{matrix.get('release', '')}`",
+        "",
+        "## Focused command",
+        "",
+        "```shell",
+        str(matrix.get("test_command", "")),
+        "```",
+        "",
+        "The command is intentionally small. GitHub Actions runs the repository-wide",
+        "suite separately.",
+        "",
+        "## Declared coverage",
+        "",
+        "| ID | Standard or profile | Version | Tested subset | Known gaps | Fixtures and SHA-256 | Source modules | Test nodes |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for entry_value in entries if isinstance(entries, Sequence) else ():
+        entry = dict(entry_value)
+        fixtures = entry.get("fixture_sha256", {})
+        fixture_cell = "<br>".join(
+            f"`{_markdown(path)}`<br>`{_markdown(digest)}`"
+            for path, digest in sorted(dict(fixtures).items())
+        )
+        lines.append(
+            "| "
+            + " | ".join(
+                (
+                    _markdown(entry.get("id", "")),
+                    _markdown(entry.get("standard_profile", "")),
+                    _markdown(entry.get("version", "")),
+                    "<br>".join(
+                        _markdown(item) for item in entry.get("supported_subset", ())
+                    ),
+                    "<br>".join(
+                        _markdown(item) for item in entry.get("known_gaps", ())
+                    ),
+                    fixture_cell,
+                    "<br>".join(
+                        f"`{_markdown(item)}`"
+                        for item in entry.get("source_modules", ())
+                    ),
+                    "<br>".join(
+                        f"`{_markdown(item)}`" for item in entry.get("test_nodes", ())
+                    ),
+                )
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Leakage and evidence boundary",
+            "",
+            "The reference test requires zero exact occurrences of every synthetic",
+            "direct identifier across review JSON, grounding audit output, serialized",
+            "FHIR, the redacted OMOP report, captured errors and logs, generated evidence,",
+            "and temporary artifact paths. Fixture data is synthetic and committed; no",
+            "real-patient or DUA data is used.",
+            "",
+            "FHIR Composition is deliberately excluded from the FHIR-to-OMOP input because",
+            "the bridge declares only Patient, Encounter, Condition, Observation, Procedure,",
+            "MedicationStatement, and MedicationRequest. Every other limitation is stated",
+            "in the table rather than inferred as support.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _run_fhir_r5_negative(path: Path) -> V22NegativeBoundaryResult:
+    fixture = _read_json(path)
+    sensitive = _string_sequence(fixture["sensitive_values"], "sensitive_values")
+    try:
+        convert_resource(fixture["resource"], FHIRVersion.R5, FHIRVersion.R4)
+    except UnsupportedFHIRFieldError as exc:
+        if exc.path != "Observation.unsupportedCrossVersionField":
+            raise V22ConformanceError(
+                "FHIR R5 fixture failed at the wrong path"
+            ) from exc
+        safe_error = str(exc)
+    else:
+        raise V22ConformanceError("FHIR R5 negative fixture unexpectedly converted")
+    result = V22NegativeBoundaryResult(
+        case_id="fhir-r5-unsupported-field",
+        category="unsupported_cross_version_field",
+        boundary="Observation.unsupportedCrossVersionField",
+        safe_error=safe_error,
+    )
+    assert_zero_critical_leakage(
+        sensitive, {"error": safe_error, "result": result.to_dict()}
+    )
+    return result
+
+
+def _run_bulk_resume_negative(path: Path) -> V22NegativeBoundaryResult:
+    fixture = _read_json(path)
+    sensitive = _string_sequence(fixture["sensitive_values"], "sensitive_values")
+    checkpoint_context = dict(fixture["checkpoint_context"])
+    progress = dict(fixture["progress"])
+    checkpoint = create_checkpoint(
+        fixture["resource_type"],
+        **checkpoint_context,
+        **progress,
+    )
+    validate_resume(
+        checkpoint,
+        resource_type=fixture["resource_type"],
+        **checkpoint_context,
+    )
+    try:
+        validate_resume(
+            checkpoint,
+            resource_type=fixture["resource_type"],
+            **dict(fixture["resume_context"]),
+        )
+    except BulkCheckpointCompatibilityError as exc:
+        safe_error = str(exc)
+        if "endpoint scope" not in safe_error:
+            raise V22ConformanceError(
+                "Bulk Data resume fixture failed at the wrong boundary"
+            ) from exc
+    else:
+        raise V22ConformanceError("Bulk Data resume fixture unexpectedly matched")
+    result = V22NegativeBoundaryResult(
+        case_id="bulk-data-resume-scope-mismatch",
+        category="incompatible_checkpoint",
+        boundary="endpoint_scope",
+        safe_error=safe_error,
+    )
+    assert_zero_critical_leakage(
+        sensitive,
+        {
+            "checkpoint": checkpoint.to_dict(),
+            "error": safe_error,
+            "result": result.to_dict(),
+        },
+    )
+    return result
+
+
+def _run_structured_privacy_negative(path: Path) -> V22NegativeBoundaryResult:
+    fixture = _read_json(path)
+    sensitive = _string_sequence(fixture["sensitive_values"], "sensitive_values")
+    rows = fixture["records"]
+    result_payload = run_structured_privacy_lab(
+        rows,
+        StructuredPrivacyPolicy(**fixture["policy"]),
+        population_assumptions=fixture["population_assumptions"],
+        membership_candidates=rows,
+    )
+    if result_payload.meets_policy:
+        raise V22ConformanceError(
+            "structured privacy negative fixture unexpectedly met policy"
+        )
+    safe_error = "structured privacy policy rejected at membership inference boundary"
+    result = V22NegativeBoundaryResult(
+        case_id="structured-privacy-membership-threshold",
+        category="membership_inference_threshold",
+        boundary="structured_privacy_policy",
+        safe_error=safe_error,
+    )
+    assert_zero_critical_leakage(
+        sensitive,
+        {
+            "privacy_report": result_payload.to_dict(),
+            "error": safe_error,
+            "result": result.to_dict(),
+        },
+    )
+    return result
+
+
+def _run_mcp_authorization_negative(path: Path) -> V22NegativeBoundaryResult:
+    fixture = _read_json(path)
+    sensitive = _string_sequence(fixture["sensitive_values"], "sensitive_values")
+    manifest_payload = {
+        key: fixture[key]
+        for key in (
+            "schema_version",
+            "synthetic",
+            "protected_resource",
+            "authorization_server",
+            "policy",
+            "cases",
+        )
+    }
+    manifest = ConformanceManifest.from_mapping(manifest_payload)
+    case_id = "negative-unapproved-state-change"
+    report = run_conformance(manifest, covered_case_ids=(case_id,))
+    if not report.ok or len(report.results) != 1:
+        raise V22ConformanceError("MCP authorization negative fixture did not conform")
+    case = report.results[0]
+    if (
+        case.failure_category != "unapproved_state_change"
+        or case.failure_boundary != "state_change_policy"
+    ):
+        raise V22ConformanceError(
+            "MCP authorization fixture failed at the wrong boundary"
+        )
+    safe_error = "unapproved_state_change at state_change_policy"
+    result = V22NegativeBoundaryResult(
+        case_id=case_id,
+        category="unapproved_state_change",
+        boundary="state_change_policy",
+        safe_error=safe_error,
+    )
+    assert_zero_critical_leakage(
+        sensitive,
+        {
+            "mcp_report": report.to_dict(),
+            "error": safe_error,
+            "result": result.to_dict(),
+        },
+    )
+    return result
+
+
+def _validate_fixture_hashes(root: Path, value: Any, index: int) -> None:
+    if not isinstance(value, Mapping) or not value:
+        raise V22CoverageMatrixError(
+            f"entries[{index}].fixture_sha256 must be a non-empty object"
+        )
+    for relative, expected in value.items():
+        if not isinstance(relative, str) or not isinstance(expected, str):
+            raise V22CoverageMatrixError("fixture paths and hashes must be strings")
+        if _DIGEST_RE.fullmatch(expected) is None:
+            raise V22CoverageMatrixError(f"fixture hash is invalid: {relative}")
+        path = _resolve_inside(root, relative, "fixture")
+        if not path.is_file():
+            raise V22CoverageMatrixError(f"declared fixture is missing: {relative}")
+        if _sha256_bytes(path.read_bytes()) != expected:
+            raise V22CoverageMatrixError(f"declared fixture hash drifted: {relative}")
+
+
+def _validate_test_nodes(root: Path, value: Any, index: int) -> None:
+    nodes = _nonempty_text_list(value, f"entries[{index}].test_nodes")
+    for node in nodes:
+        relative, *selectors = node.split("::")
+        path = _resolve_inside(root, relative, "test")
+        if not path.is_file():
+            raise V22CoverageMatrixError(f"declared test is missing: {node}")
+        if selectors:
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (OSError, SyntaxError) as exc:
+                raise V22CoverageMatrixError(
+                    f"declared test cannot be parsed: {node}"
+                ) from exc
+            names = {
+                item.name
+                for item in ast.walk(tree)
+                if isinstance(
+                    item, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+                )
+            }
+            if selectors[-1] not in names:
+                raise V22CoverageMatrixError(f"declared test node is missing: {node}")
+
+
+def _validate_source_modules(root: Path, value: Any, index: int) -> None:
+    modules = _nonempty_text_list(value, f"entries[{index}].source_modules")
+    for module in modules:
+        base = root.joinpath(*module.split("."))
+        candidates = (base.with_suffix(".py"), base / "__init__.py")
+        if not any(candidate.is_file() for candidate in candidates):
+            raise V22CoverageMatrixError(f"declared source module is missing: {module}")
+
+
+def _resolve_inside(root: Path, relative: str, kind: str) -> Path:
+    if not relative or Path(relative).is_absolute():
+        raise V22CoverageMatrixError(
+            f"declared {kind} path must be repository-relative"
+        )
+    resolved = (root / relative).resolve()
+    if not resolved.is_relative_to(root):
+        raise V22CoverageMatrixError(f"declared {kind} path escapes the repository")
+    return resolved
+
+
+def _fhir_resource_counts(bundle: Mapping[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for entry in bundle.get("entry", ()):
+        if not isinstance(entry, Mapping) or not isinstance(
+            entry.get("resource"), Mapping
+        ):
+            continue
+        resource_type = str(entry["resource"].get("resourceType", ""))
+        counts[resource_type] = counts.get(resource_type, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError) as exc:
+        raise V22ConformanceError(f"invalid V2.2 fixture: {path.name}") from exc
+    if not isinstance(payload, dict):
+        raise V22ConformanceError(f"V2.2 fixture must be an object: {path.name}")
+    return payload
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(canonical_json(value) + "\n", encoding="utf-8")
+
+
+def _sha256_text(value: str) -> str:
+    return _sha256_bytes(value.encode("utf-8"))
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def _surface_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, Path):
+        return str(value)
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def _string_sequence(value: Any, name: str) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise V22ConformanceError(f"{name} must be a sequence")
+    result = tuple(item for item in value if isinstance(item, str) and item)
+    if len(result) != len(value) or not result:
+        raise V22ConformanceError(f"{name} must contain non-empty strings")
+    return result
+
+
+def _required_text(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise V22CoverageMatrixError(f"{name} must be non-empty text")
+    return value
+
+
+def _nonempty_text_list(value: Any, name: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise V22CoverageMatrixError(f"{name} must be a non-empty list")
+    result = tuple(_required_text(item, name) for item in value)
+    return result
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON object key")
+        result[key] = value
+    return result
+
+
+def _markdown(value: Any) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ").strip()
+
+
+__all__ = [
+    "V22_COVERAGE_SCHEMA_VERSION",
+    "V22_EVIDENCE_SCHEMA_VERSION",
+    "V22_FOCUSED_TEST_COMMAND",
+    "V22ConformanceError",
+    "V22CoverageMatrixError",
+    "V22NegativeBoundaryResult",
+    "V22ReferenceResult",
+    "assert_zero_critical_leakage",
+    "canonical_json",
+    "critical_leakage_counts",
+    "load_coverage_matrix",
+    "render_coverage_matrix_markdown",
+    "run_v22_negative_checks",
+    "run_v22_reference_flow",
+    "sha256_json",
+    "validate_coverage_matrix",
+]

--- a/tests/fixtures/v22/bulk_resume_negative.json
+++ b/tests/fixtures/v22/bulk_resume_negative.json
@@ -1,0 +1,28 @@
+{
+  "resource_type": "Observation",
+  "checkpoint_context": {
+    "page_token": "SYNTH-PAGE-TOKEN-2200",
+    "policy": {
+      "name": "v22-synthetic-export",
+      "revision": 1
+    },
+    "endpoint_scope": "https://bulk.synthetic.invalid/group/SYNTH-GROUP-2200"
+  },
+  "resume_context": {
+    "page_token": "SYNTH-PAGE-TOKEN-2200",
+    "policy": {
+      "name": "v22-synthetic-export",
+      "revision": 1
+    },
+    "endpoint_scope": "https://bulk.synthetic.invalid/group/SYNTH-GROUP-OTHER"
+  },
+  "progress": {
+    "pages_processed": 2,
+    "resources_processed": 7
+  },
+  "sensitive_values": [
+    "SYNTH-PAGE-TOKEN-2200",
+    "SYNTH-GROUP-2200",
+    "SYNTH-GROUP-OTHER"
+  ]
+}

--- a/tests/fixtures/v22/coverage_matrix.json
+++ b/tests/fixtures/v22/coverage_matrix.json
@@ -1,0 +1,172 @@
+{
+  "schema_version": "openmed.v22.coverage-matrix.v1",
+  "matrix_version": 1,
+  "release": "2.2",
+  "synthetic_only": true,
+  "test_command": ".venv/bin/python -m pytest tests/integration/test_v22_exchange_conformance.py tests/unit/release/test_v22_coverage_matrix.py -q",
+  "entries": [
+    {
+      "id": "form-deidentification-grounding",
+      "standard_profile": "OpenMed clinical form review and ICD-10-CM grounding contract",
+      "version": "form review v1; ICD-10-CM synthetic snapshot v22-synthetic-2026-08",
+      "supported_subset": [
+        "Synthetic OCR key/value fields with graph offsets and hash provenance",
+        "Direct-identifier redaction before review serialization",
+        "Exact local grounding of one Condition span to E11.9"
+      ],
+      "known_gaps": [
+        "No OCR engine, remote terminology service, ambiguous coding, or real clinical document is exercised"
+      ],
+      "fixture_sha256": {
+        "tests/fixtures/v22/reference_form.json": "sha256:bdb8db8d2d37d02087026469caeaa2f26f4abd8661b8de426cdfb2b619a40bb8",
+        "tests/fixtures/v22/grounding_vocabulary.jsonl": "sha256:9f3d2d3c7c23c9c9879389f43f0b0b45616ad65e51535de1779ba8d841bc5490",
+        "tests/fixtures/v22/expected_reference_hashes.json": "sha256:34de044adc534ade16b725476f4bd8ba501d0c9ad7da56790232f726215681fd"
+      },
+      "test_nodes": [
+        "tests/integration/test_v22_exchange_conformance.py::test_reference_exchange_flow_is_deterministic_offline_and_phi_free"
+      ],
+      "source_modules": [
+        "openmed.structured.forms",
+        "openmed.clinical.grounding.api",
+        "openmed.eval.v22_conformance"
+      ]
+    },
+    {
+      "id": "fhir-r4-ips",
+      "standard_profile": "HL7 FHIR R4 core and International Patient Summary",
+      "version": "FHIR 4.0.1; IPS 2.0.1",
+      "supported_subset": [
+        "Document Bundle containing Composition, pseudonymous Patient, and grounded Condition",
+        "Local profile validation and internal reference-integrity checks"
+      ],
+      "known_gaps": [
+        "No external validator, terminology expansion, signature, narrative, or full IPS section set is exercised"
+      ],
+      "fixture_sha256": {
+        "tests/fixtures/v22/reference_form.json": "sha256:bdb8db8d2d37d02087026469caeaa2f26f4abd8661b8de426cdfb2b619a40bb8",
+        "tests/fixtures/v22/expected_reference_hashes.json": "sha256:34de044adc534ade16b725476f4bd8ba501d0c9ad7da56790232f726215681fd"
+      },
+      "test_nodes": [
+        "tests/integration/test_v22_exchange_conformance.py::test_reference_exchange_flow_is_deterministic_offline_and_phi_free"
+      ],
+      "source_modules": [
+        "openmed.clinical.exporters.fhir.exchange",
+        "openmed.clinical.exporters.fhir.grounded",
+        "openmed.interop.fhir.reference_integrity",
+        "openmed.eval.v22_conformance"
+      ]
+    },
+    {
+      "id": "fhir-r4-to-omop-5-4",
+      "standard_profile": "OpenMed FHIR R4 to OMOP CDM bridge",
+      "version": "FHIR 4.0.1 input; OMOP CDM 5.4 output",
+      "supported_subset": [
+        "Pseudonymous Patient and one ICD-10-CM Condition",
+        "Caller-supplied synthetic vocabulary mapping, constraint validation, counts, hashes, and path-only information loss"
+      ],
+      "known_gaps": [
+        "FHIR Composition is excluded because it is outside the bridge's declared resource set",
+        "No database writer, cohort query, vocabulary service, or reverse round trip is exercised"
+      ],
+      "fixture_sha256": {
+        "tests/fixtures/v22/omop_vocabulary.json": "sha256:28911fa9de2f5b58b8d8d87e8548c983d6c795ccad803d2bbfcb4678aa60fc37",
+        "tests/fixtures/v22/expected_reference_hashes.json": "sha256:34de044adc534ade16b725476f4bd8ba501d0c9ad7da56790232f726215681fd"
+      },
+      "test_nodes": [
+        "tests/integration/test_v22_exchange_conformance.py::test_reference_exchange_flow_is_deterministic_offline_and_phi_free"
+      ],
+      "source_modules": [
+        "openmed.interop.fhir_omop",
+        "openmed.interop.omop.cdm_loader",
+        "openmed.eval.v22_conformance"
+      ]
+    },
+    {
+      "id": "fhir-r5-adapter-negative",
+      "standard_profile": "OpenMed explicit FHIR cross-release adapter",
+      "version": "FHIR R5 5.0.0 to FHIR R4 4.0.1",
+      "supported_subset": [
+        "Path-specific rejection of a non-representable Observation field"
+      ],
+      "known_gaps": [
+        "This fixture does not claim general R5-to-R4 conversion or validate every supported resource"
+      ],
+      "fixture_sha256": {
+        "tests/fixtures/v22/fhir_r5_negative.json": "sha256:b3cde1c0f152788417d2bace6f5e26eb8ea6caaea9722d261c7a58075ffd0613"
+      },
+      "test_nodes": [
+        "tests/integration/test_v22_exchange_conformance.py::test_negative_conformance_fixtures_fail_at_safe_boundaries"
+      ],
+      "source_modules": [
+        "openmed.interop.fhir.versions",
+        "openmed.eval.v22_conformance"
+      ]
+    },
+    {
+      "id": "fhir-bulk-resume-negative",
+      "standard_profile": "FHIR Bulk Data local checkpoint compatibility boundary",
+      "version": "OpenMed checkpoint manifest v1",
+      "supported_subset": [
+        "Digest-only page token, policy, endpoint scope, and aggregate progress",
+        "Positive same-context resume and fail-closed endpoint-scope mismatch"
+      ],
+      "known_gaps": [
+        "No Bulk Data server, export kickoff, polling, file download, or complete protocol conformance is exercised"
+      ],
+      "fixture_sha256": {
+        "tests/fixtures/v22/bulk_resume_negative.json": "sha256:b88a29f2e574706edbe371b9ae95416e5fb7301d8a3f383cae56e20918d940ca"
+      },
+      "test_nodes": [
+        "tests/integration/test_v22_exchange_conformance.py::test_negative_conformance_fixtures_fail_at_safe_boundaries"
+      ],
+      "source_modules": [
+        "openmed.interop.fhir.bulk_checkpoint",
+        "openmed.eval.v22_conformance"
+      ]
+    },
+    {
+      "id": "structured-privacy-negative",
+      "standard_profile": "NIST SP 800-188-oriented OpenMed structured privacy lab",
+      "version": "structured privacy artifact schema v1",
+      "supported_subset": [
+        "One unique synthetic record rejected by a zero-tolerance membership-inference threshold",
+        "Aggregate, value-free privacy evidence serialization"
+      ],
+      "known_gaps": [
+        "The bounded self-test is not a universal re-identification bound, qualified-expert determination, or anonymity certification"
+      ],
+      "fixture_sha256": {
+        "tests/fixtures/v22/structured_privacy_negative.json": "sha256:cda409fee76e21e86a4dcadade0170fff112b1b8a705772fd8fb5e800984b048"
+      },
+      "test_nodes": [
+        "tests/integration/test_v22_exchange_conformance.py::test_negative_conformance_fixtures_fail_at_safe_boundaries"
+      ],
+      "source_modules": [
+        "openmed.structured.privacy_lab",
+        "openmed.eval.v22_conformance"
+      ]
+    },
+    {
+      "id": "mcp-authorization-negative",
+      "standard_profile": "OpenMed MCP authorization conformance contract",
+      "version": "openmed.mcp.authorization_conformance.v1",
+      "supported_subset": [
+        "Local mocked OAuth-style authorization flow rejects an unapproved state-changing tool call",
+        "Public result contains only case id and failure category"
+      ],
+      "known_gaps": [
+        "No live identity provider, HTTP transport, token endpoint, Dynamic Client Registration, or MCP certification is exercised"
+      ],
+      "fixture_sha256": {
+        "tests/fixtures/v22/mcp_authorization_negative.json": "sha256:19890c8eb2825d3c16e2e9a4eed66674596ec92f6db3406eb2f73b5c218fdefd"
+      },
+      "test_nodes": [
+        "tests/integration/test_v22_exchange_conformance.py::test_negative_conformance_fixtures_fail_at_safe_boundaries"
+      ],
+      "source_modules": [
+        "openmed.mcp.authorization_conformance",
+        "openmed.eval.v22_conformance"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/v22/expected_reference_hashes.json
+++ b/tests/fixtures/v22/expected_reference_hashes.json
@@ -1,0 +1,5 @@
+{
+  "evidence_sha256": "sha256:ade795b4786f85f05faa78c72a7db70a1a4cff16fc26f2705a1b90afd74fdf62",
+  "fhir_sha256": "sha256:f34d7706affa057a543e37234a22dcbdf1cdef7a8111e5668c2058aad80ac425",
+  "omop_sha256": "sha256:ddee897ef09ea71dc60af56476cd875c46778dc68ecbfab87fc50da4c3d26a3e"
+}

--- a/tests/fixtures/v22/fhir_r5_negative.json
+++ b/tests/fixtures/v22/fhir_r5_negative.json
@@ -1,0 +1,16 @@
+{
+  "resource": {
+    "resourceType": "Observation",
+    "id": "v22-r5-observation",
+    "status": "final",
+    "code": {
+      "text": "Synthetic observation"
+    },
+    "unsupportedCrossVersionField": {
+      "value": "SYNTH-R5-SECRET-2200"
+    }
+  },
+  "sensitive_values": [
+    "SYNTH-R5-SECRET-2200"
+  ]
+}

--- a/tests/fixtures/v22/grounding_vocabulary.jsonl
+++ b/tests/fixtures/v22/grounding_vocabulary.jsonl
@@ -1,0 +1,1 @@
+{"aliases":["type 2 diabetes","type ii diabetes mellitus","t2dm"],"canonical_term":"Type 2 diabetes mellitus without complications","concept_id":"E11.9","system":"icd10cm"}

--- a/tests/fixtures/v22/mcp_authorization_negative.json
+++ b/tests/fixtures/v22/mcp_authorization_negative.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "openmed.mcp.authorization_conformance.v1",
+  "synthetic": true,
+  "protected_resource": {
+    "resource": "https://mcp.synthetic.invalid",
+    "authorization_servers": [
+      "https://auth.synthetic.invalid"
+    ],
+    "scopes_supported": [
+      "mcp.tools.state_change"
+    ],
+    "bearer_methods_supported": [
+      "header"
+    ]
+  },
+  "authorization_server": {
+    "issuer": "https://auth.synthetic.invalid",
+    "authorization_endpoint": "https://auth.synthetic.invalid/authorize",
+    "token_endpoint": "https://auth.synthetic.invalid/token",
+    "code_challenge_methods_supported": [
+      "S256"
+    ],
+    "registered_redirect_uris": [
+      "http://127.0.0.1:8765/callback"
+    ]
+  },
+  "policy": {
+    "max_tool_payload_bytes": 1024
+  },
+  "cases": [
+    {
+      "id": "negative-unapproved-state-change",
+      "kind": "negative",
+      "behavior": "reject a state-changing tool call without explicit approval",
+      "failure_boundary": "state_change_policy",
+      "expected_failure": "unapproved_state_change",
+      "authorization_request": {
+        "resource": "https://mcp.synthetic.invalid",
+        "scopes": [
+          "mcp.tools.state_change"
+        ],
+        "redirect_uri": "http://127.0.0.1:8765/callback",
+        "pkce": {
+          "method": "S256",
+          "verifier_ref": "SYNTH-MCP-VERIFIER-2200",
+          "challenge_ref": "SYNTH-MCP-VERIFIER-2200"
+        },
+        "client_key_ref": "SYNTH-MCP-CLIENT-KEY-2200"
+      },
+      "token_claims": {
+        "audience": "https://mcp.synthetic.invalid",
+        "issuer": "https://auth.synthetic.invalid",
+        "resource": "https://mcp.synthetic.invalid",
+        "scopes": [
+          "mcp.tools.state_change"
+        ],
+        "confirmation_key_ref": "SYNTH-MCP-CLIENT-KEY-2200"
+      },
+      "tool_call": {
+        "name": "openmed_update_task",
+        "required_scope": "mcp.tools.state_change",
+        "payload_bytes": 128,
+        "state_change": true,
+        "approval": false
+      },
+      "transport": {
+        "forward_authorization": false
+      }
+    }
+  ],
+  "sensitive_values": [
+    "SYNTH-MCP-VERIFIER-2200",
+    "SYNTH-MCP-CLIENT-KEY-2200"
+  ]
+}

--- a/tests/fixtures/v22/omop_vocabulary.json
+++ b/tests/fixtures/v22/omop_vocabulary.json
@@ -1,0 +1,12 @@
+{
+  "http://hl7.org/fhir/sid/icd-10-cm|E11.9": {
+    "concept_id": 201826,
+    "source_concept_id": 9002200,
+    "source_concept_name": "Synthetic ICD-10-CM source condition",
+    "source_vocabulary_id": "ICD10CM",
+    "target_vocabulary_id": "SNOMED",
+    "target_concept_name": "Diabetes mellitus",
+    "standard_concept": "S",
+    "target_concept_code": "73211009"
+  }
+}

--- a/tests/fixtures/v22/reference_form.json
+++ b/tests/fixtures/v22/reference_form.json
@@ -1,0 +1,69 @@
+{
+  "schema": [
+    {
+      "linkId": "patient_name",
+      "text": "Patient name",
+      "type": "string"
+    },
+    {
+      "linkId": "record_id",
+      "text": "Record ID",
+      "type": "string"
+    },
+    {
+      "linkId": "contact_phone",
+      "text": "Contact phone",
+      "type": "string"
+    },
+    {
+      "linkId": "condition",
+      "text": "Condition",
+      "type": "string"
+    },
+    {
+      "linkId": "a1c_value",
+      "text": "A1c value",
+      "type": "decimal"
+    }
+  ],
+  "source": {
+    "format": "synthetic-ocr",
+    "pages": [
+      {
+        "page": 0,
+        "blocks": [
+          {
+            "text": "Patient name: Cedar Example",
+            "page": 0,
+            "bbox": [40, 20, 360, 40]
+          },
+          {
+            "text": "Record ID: SYN-V22-2200",
+            "page": 0,
+            "bbox": [40, 50, 360, 70]
+          },
+          {
+            "text": "Contact phone: +1-555-010-2200",
+            "page": 0,
+            "bbox": [40, 80, 360, 100]
+          },
+          {
+            "text": "Condition: type 2 diabetes",
+            "page": 0,
+            "bbox": [40, 110, 360, 130]
+          },
+          {
+            "text": "A1c value: 7.2",
+            "page": 0,
+            "bbox": [40, 140, 360, 160]
+          }
+        ]
+      }
+    ]
+  },
+  "synthetic_direct_identifiers": [
+    "Cedar Example",
+    "SYN-V22-2200",
+    "+1-555-010-2200"
+  ]
+}

--- a/tests/fixtures/v22/structured_privacy_negative.json
+++ b/tests/fixtures/v22/structured_privacy_negative.json
@@ -1,0 +1,34 @@
+{
+  "records": [
+    {
+      "synthetic_record_id": "SYNTH-PRIVATE-ROW-2200",
+      "age": 47,
+      "postal_prefix": "SYN-99",
+      "sensitive_outcome": "synthetic-rare-outcome"
+    }
+  ],
+  "policy": {
+    "quasi_identifiers": [
+      "age",
+      "postal_prefix"
+    ],
+    "sensitive_attributes": [
+      "sensitive_outcome"
+    ],
+    "direct_identifiers": [
+      "synthetic_record_id"
+    ],
+    "target_k": 1,
+    "target_l": 1,
+    "target_t": 1.0,
+    "membership_max_inference_rate": 0.0
+  },
+  "population_assumptions": {
+    "scope": "synthetic-v22-fixture"
+  },
+  "sensitive_values": [
+    "SYNTH-PRIVATE-ROW-2200",
+    "SYN-99",
+    "synthetic-rare-outcome"
+  ]
+}

--- a/tests/integration/test_v22_exchange_conformance.py
+++ b/tests/integration/test_v22_exchange_conformance.py
@@ -1,0 +1,163 @@
+"""Focused offline integration proof for the OpenMed V2.2 exchange surface."""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+
+import pytest
+
+from openmed.eval.v22_conformance import (
+    assert_zero_critical_leakage,
+    canonical_json,
+    run_v22_negative_checks,
+    run_v22_reference_flow,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "tests" / "fixtures" / "v22"
+
+
+def _deny_network(*args: object, **kwargs: object) -> None:
+    del args, kwargs
+    raise AssertionError("V2.2 conformance fixtures must not open network sockets")
+
+
+def _block_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(socket, "create_connection", _deny_network)
+    monkeypatch.setattr(socket.socket, "connect", _deny_network)
+
+
+@pytest.mark.integration
+def test_reference_exchange_flow_is_deterministic_offline_and_phi_free(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _block_network(monkeypatch)
+    expected = json.loads(
+        (FIXTURES / "expected_reference_hashes.json").read_text(encoding="utf-8")
+    )
+    form_fixture = json.loads(
+        (FIXTURES / "reference_form.json").read_text(encoding="utf-8")
+    )
+    direct_identifiers = form_fixture["synthetic_direct_identifiers"]
+
+    first = run_v22_reference_flow(FIXTURES, tmp_path / "first")
+    second = run_v22_reference_flow(FIXTURES, tmp_path / "second")
+
+    assert first.hashes == second.hashes == expected
+    assert first.grounding_audit["code"] == "E11.9"
+    assert first.grounding_audit["system_uri"] == ("http://hl7.org/fhir/sid/icd-10-cm")
+    assert first.grounding_audit["end"] - first.grounding_audit["start"] == len(
+        "type 2 diabetes"
+    )
+    assert first.evidence["fhir"]["reference_integrity"]["valid"] is True
+    assert first.evidence["fhir"]["resource_counts"] == {
+        "Composition": 1,
+        "Condition": 1,
+        "Patient": 1,
+    }
+    assert first.evidence["omop"]["summary"]["resource_counts"] == {
+        "Condition": 1,
+        "Patient": 1,
+    }
+    assert first.evidence["omop"]["summary"]["mapped_codes"] == 1
+    assert first.evidence["critical_leakage"] == {
+        "maximum_allowed": 0,
+        "observed": 0,
+        "surfaces": [
+            "form review",
+            "grounding audit",
+            "FHIR serialization",
+            "OMOP report",
+            "evidence artifact",
+            "temporary paths",
+        ],
+    }
+
+    condition = next(
+        entry["resource"]
+        for entry in first.fhir_bundle["entry"]
+        if entry["resource"]["resourceType"] == "Condition"
+    )
+    patient_entry = next(
+        entry
+        for entry in first.fhir_bundle["entry"]
+        if entry["resource"]["resourceType"] == "Patient"
+    )
+    assert condition["code"]["coding"][0]["code"] == "E11.9"
+    assert condition["subject"]["reference"] == patient_entry["fullUrl"]
+
+    generated_contents = {
+        name: path.read_text(encoding="utf-8")
+        for name, path in first.artifact_paths.items()
+    }
+    for name, path in first.artifact_paths.items():
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert path.read_text(encoding="utf-8") == canonical_json(payload) + "\n"
+        assert name in generated_contents
+    leakage_counts = assert_zero_critical_leakage(
+        direct_identifiers,
+        {
+            "review": first.review_artifact,
+            "grounding": first.grounding_audit,
+            "fhir": first.fhir_bundle,
+            "omop": first.omop_report,
+            "evidence": first.evidence,
+            "files": generated_contents,
+            "temporary_paths": [str(path) for path in first.artifact_paths.values()],
+            "logs": caplog.text,
+        },
+    )
+    assert set(leakage_counts.values()) == {0}
+
+
+@pytest.mark.integration
+def test_negative_conformance_fixtures_fail_at_safe_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _block_network(monkeypatch)
+    results = run_v22_negative_checks(FIXTURES)
+    rendered = [result.to_dict() for result in results]
+
+    assert {
+        result["case_id"]: (result["category"], result["boundary"])
+        for result in rendered
+    } == {
+        "fhir-r5-unsupported-field": (
+            "unsupported_cross_version_field",
+            "Observation.unsupportedCrossVersionField",
+        ),
+        "bulk-data-resume-scope-mismatch": (
+            "incompatible_checkpoint",
+            "endpoint_scope",
+        ),
+        "structured-privacy-membership-threshold": (
+            "membership_inference_threshold",
+            "structured_privacy_policy",
+        ),
+        "negative-unapproved-state-change": (
+            "unapproved_state_change",
+            "state_change_policy",
+        ),
+    }
+    assert all(result["status"] == "expected_failure" for result in rendered)
+    assert all(result["error_sha256"].startswith("sha256:") for result in rendered)
+
+    sensitive_values: list[str] = []
+    for name in (
+        "fhir_r5_negative.json",
+        "bulk_resume_negative.json",
+        "structured_privacy_negative.json",
+        "mcp_authorization_negative.json",
+    ):
+        fixture = json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+        sensitive_values.extend(fixture["sensitive_values"])
+    counts = assert_zero_critical_leakage(
+        sensitive_values,
+        {"safe_results": rendered, "logs": caplog.text},
+    )
+    assert set(counts.values()) == {0}

--- a/tests/unit/release/test_v22_coverage_matrix.py
+++ b/tests/unit/release/test_v22_coverage_matrix.py
@@ -1,0 +1,90 @@
+"""Release-contract tests for the generated V2.2 standards matrix."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from openmed.eval.v22_conformance import (
+    V22_FOCUSED_TEST_COMMAND,
+    V22CoverageMatrixError,
+    load_coverage_matrix,
+    render_coverage_matrix_markdown,
+    validate_coverage_matrix,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "v22"
+MATRIX_PATH = FIXTURE_DIR / "coverage_matrix.json"
+DOC_PATH = ROOT / "docs" / "release" / "v2.2-standards-matrix.md"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "tests.yml"
+
+
+def test_coverage_matrix_validates_declared_artifacts() -> None:
+    matrix = validate_coverage_matrix(ROOT, MATRIX_PATH)
+    declared_fixtures = {
+        path for entry in matrix["entries"] for path in entry["fixture_sha256"]
+    }
+    committed_fixtures = {
+        path.relative_to(ROOT).as_posix()
+        for path in FIXTURE_DIR.iterdir()
+        if path.is_file() and path.name != MATRIX_PATH.name
+    }
+
+    assert matrix["test_command"] == V22_FOCUSED_TEST_COMMAND
+    assert declared_fixtures == committed_fixtures
+    assert all(entry["supported_subset"] for entry in matrix["entries"])
+    assert all(entry["known_gaps"] for entry in matrix["entries"])
+
+
+def test_coverage_matrix_rejects_missing_contract_parts() -> None:
+    original = load_coverage_matrix(MATRIX_PATH)
+
+    missing_version = copy.deepcopy(original)
+    missing_version["entries"][0]["version"] = ""
+    with pytest.raises(V22CoverageMatrixError, match="version"):
+        validate_coverage_matrix(ROOT, missing_version)
+
+    missing_fixture = copy.deepcopy(original)
+    fixtures = missing_fixture["entries"][0]["fixture_sha256"]
+    digest = next(iter(fixtures.values()))
+    missing_fixture["entries"][0]["fixture_sha256"] = {
+        "tests/fixtures/v22/not-present.json": digest
+    }
+    with pytest.raises(V22CoverageMatrixError, match="fixture is missing"):
+        validate_coverage_matrix(ROOT, missing_fixture)
+
+    missing_test = copy.deepcopy(original)
+    missing_test["entries"][0]["test_nodes"] = [
+        "tests/integration/test_v22_exchange_conformance.py::not_a_test"
+    ]
+    with pytest.raises(V22CoverageMatrixError, match="test node is missing"):
+        validate_coverage_matrix(ROOT, missing_test)
+
+    missing_module = copy.deepcopy(original)
+    missing_module["entries"][0]["source_modules"] = ["openmed.eval.not_a_real_module"]
+    with pytest.raises(V22CoverageMatrixError, match="source module is missing"):
+        validate_coverage_matrix(ROOT, missing_module)
+
+
+def test_standards_document_is_generated_from_matrix() -> None:
+    matrix = validate_coverage_matrix(ROOT, MATRIX_PATH)
+    expected = render_coverage_matrix_markdown(matrix)
+    actual = DOC_PATH.read_text(encoding="utf-8")
+
+    assert actual == expected
+    assert "not certification" in actual
+    assert "tested subset" in actual.casefold()
+    assert "known gaps" in actual.casefold()
+    assert V22_FOCUSED_TEST_COMMAND in actual
+
+
+def test_hosted_workflow_runs_focused_command() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "v22-conformance:" in workflow
+    assert "uv sync --frozen --extra dev --python 3.11" in workflow
+    assert V22_FOCUSED_TEST_COMMAND in workflow
+    assert ".venv/bin/python -m pytest tests/ -q" not in workflow


### PR DESCRIPTION
# Pull Request

## Description
Adds the final v2.2 release-evidence gate: a deterministic, offline synthetic form-to-grounding-to-FHIR-to-OMOP flow plus focused negative fixtures and an explicit tested-standards matrix.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Add a local synthetic reference flow with pinned FHIR R4, OMOP CDM 5.4, and evidence hashes, plus a zero-critical-leakage gate.
- Add independent FHIR R5 adapter, Bulk Data resume, structured privacy, and MCP authorization negative fixtures.
- Add a validated coverage matrix, generated standards document, and dedicated hosted CI job for the focused v2.2 command.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Commands and results:
- `.venv/bin/python -m pytest tests/integration/test_v22_exchange_conformance.py tests/unit/release/test_v22_coverage_matrix.py -q` — 6 passed
- `.venv/bin/python -m pytest tests/ -q` — 12,092 passed, 105 skipped
- `make docs-build` — strict documentation and publication validation passed
- `pre-commit run --files ...` — all scoped hooks passed
- `uv lock --check` — passed

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

The generated v2.2 tested-standards matrix is published in the documentation navigation. No release notes or version bump are part of this gate.

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

No Swift files are changed.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #1968

## Screenshots/Examples
No UI change. The focused gate emits PHI-free JSON artifacts with pinned FHIR, OMOP, and evidence SHA-256 digests.
