### PR TITLE
feat(examples): add 4-part notebook gallery with executed-output CI check

### DIFF
--- a/.github/workflows/notebooks-execute.yml
+++ b/.github/workflows/notebooks-execute.yml
@@ -1,0 +1,47 @@
+name: Example Notebooks Execution & Output Check
+
+on:
+  push:
+    branches: [main, master, develop]
+    paths:
+      - "examples/notebooks/**"
+      - "tests/unit/test_notebook_gallery.py"
+      - ".github/workflows/notebooks-execute.yml"
+  pull_request:
+    branches: [main, master, develop]
+    paths:
+      - "examples/notebooks/**"
+      - "tests/unit/test_notebook_gallery.py"
+      - ".github/workflows/notebooks-execute.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  notebooks-offline-execute:
+    name: Execute Gallery Notebooks (Offline)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev --python 3.11
+
+      - name: Execute gallery notebooks and check output freshness
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
+        run: .venv/bin/python -m pytest tests/unit/test_notebook_gallery.py -v

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -160,6 +160,7 @@ classification:
     - zero-shot-howto.md
     - zero-shot-ner.md
     - examples.md
+    - examples/notebook-gallery.md
     - document-adapter-provenance.md
     - multimodal/epub-extraction.md
     - multimodal/xlsx-cell-redaction.md

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,10 +4,18 @@ This page curates the most useful samples already in the repository so you can
 jump straight to runnable notebooks or scripts. The v1.6, v1.7, and v1.8
 examples use synthetic data and are safe to run during release review.
 
+## Curated Notebook Gallery
+
+For a guided, end-to-end walkthrough from quickstart redaction to FHIR export and offline evaluation, visit the **[Example Notebooks Gallery](./examples/notebook-gallery.md)**. All gallery notebooks run 100% offline on synthetic fixtures and are verified by continuous integration.
+
 ## Notebooks (`examples/notebooks/`)
 
 | Notebook | Highlights |
 | --- | --- |
+| [`01_quickstart_redaction.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/01_quickstart_redaction.ipynb) | Quickstart redaction: masking, reversible replacement, and cryptographic hashing. |
+| [`02_batch_dataset.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/02_batch_dataset.ipynb) | Batch dataset de-identification with `BatchProcessor` and directory processing. |
+| [`03_fhir_export.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/03_fhir_export.ipynb) | Redacting clinical text, extracting medical entities, and assembling a deterministic FHIR R4 Bundle. |
+| [`04_eval_walkthrough.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/04_eval_walkthrough.ipynb) | Offline evaluation across bundled synthetic multilingual golden fixtures. |
 | `getting_started.ipynb` | Mirrors the Quick Start guide with step-by-step installation, registry exploration, and a first call to `analyze_text`. |
 | `Sentence_Detection_Batching.ipynb` | Demonstrates pySBD-based segmentation, batching, and how to align predictions back to the original paragraphs. |
 | `ZeroShot_NER_Tour.ipynb` | Walks through GLiNER indexing, domain defaults, inference API usage, and the adapter that converts spans into BIO/BILOU schemes. |

--- a/docs/examples/notebook-gallery.md
+++ b/docs/examples/notebook-gallery.md
@@ -1,0 +1,86 @@
+# Example Notebooks Gallery
+
+Welcome to the curated **OpenMed Notebook Gallery**. These Jupyter notebooks provide
+hands-on, runnable walkthroughs demonstrating end-to-end clinical NLP,
+de-identification, batch processing, and interoperability workflows.
+
+Every notebook runs **100% offline on synthetic fixtures** with zero network
+calls or mandatory model weight downloads.
+
+---
+
+## Curated Gallery Walkthroughs
+
+| Notebook | Focus | Primary APIs Exercised |
+| :--- | :--- | :--- |
+| [`01_quickstart_redaction.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/01_quickstart_redaction.ipynb) | Clinical de-identification basics: masking, reversible replacement, and cryptographic hashing. | `deidentify()`, `reidentify()` |
+| [`02_batch_dataset.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/02_batch_dataset.ipynb) | Directory and dataset batch processing with error handling and output inspection. | `BatchProcessor.process_directory()` |
+| [`03_fhir_export.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/03_fhir_export.ipynb) | Redacting clinical notes, extracting medical entities, and assembling a deterministic FHIR R4 Bundle. | `deidentify()`, `TextProcessor`, `to_bundle()` |
+| [`04_eval_walkthrough.ipynb`](https://github.com/maziyarpanahi/openmed/blob/master/examples/notebooks/04_eval_walkthrough.ipynb) | Offline evaluation across bundled multilingual synthetic golden fixtures. | `load_golden_fixtures()`, `safety_sweep()` |
+
+---
+
+## 1. Quickstart Redaction (`01_quickstart_redaction.ipynb`)
+
+Walks through the primary de-identification methods supported by OpenMed:
+
+- **Masking (`method="mask"`)**: Replaces detected direct identifiers with standardized category tags (`[PERSON]`, `[DATE]`, `[PHONE]`, `[EMAIL]`).
+- **Reversible Replacement (`method="replace"`)**: Replaces sensitive values with realistic synthetic stand-ins while capturing a persistent lookup mapping table for authorized downstream restoration via `reidentify()`.
+- **Cryptographic Hashing (`method="hash"`)**: Produces keyed HMAC/SHA-256 digests to preserve linkage across disparate clinical tables without exposing cleartext PHI.
+
+---
+
+## 2. Batch Processing (`02_batch_dataset.ipynb`)
+
+Demonstrates scalable batch processing across directories of clinical files:
+
+- Initializes `BatchProcessor` with structured de-identification parameters and chunk sizes.
+- Streams text files through the offline detector.
+- Collects detailed item-level processing telemetry and writes redacted output files to a target directory.
+
+---
+
+## 3. Clinical Extraction & FHIR Export (`03_fhir_export.ipynb`)
+
+Illustrates the end-to-end pipeline from unstructured clinical notes to standards-compliant HL7 FHIR R4 transactions:
+
+1. **Intake Redaction**: Redacts direct patient identifiers from intake narratives.
+2. **Clinical Entity Extraction**: Extracts condition mentions, vital signs, and medication dosages with `TextProcessor`.
+3. **FHIR Resource Construction**: Maps extracted concepts to standard `Patient`, `Encounter`, `Observation`, and `MedicationStatement` resources.
+4. **Transaction Bundle Assembly**: Uses `openmed.clinical.exporters.fhir.to_bundle()` with deterministic document seeds to build a byte-stable R4 transaction Bundle.
+
+---
+
+## 4. Offline Golden Evaluation (`04_eval_walkthrough.ipynb`)
+
+Demonstrates how to evaluate entity extraction fidelity against bundled synthetic benchmarks:
+
+- Loads versioned, synthetic benchmark fixtures via `load_golden_fixtures()`.
+- Evaluates detection performance across multiple language locales.
+- Computes standard evaluation metrics: Precision, Recall, F1 score, and Exact Span Match counts.
+
+---
+
+## Running Locally
+
+To run the gallery notebooks on your local workstation:
+
+```bash
+# 1. Clone the repository and install development dependencies
+git clone https://github.com/maziyarpanahi/openmed.git
+cd openmed
+uv pip install -e ".[dev]"
+
+# 2. Start Jupyter
+jupyter notebook examples/notebooks/
+```
+
+### Continuous Integration Guarantee
+
+All gallery notebooks in `examples/notebooks/` are continuously executed in CI via `.github/workflows/notebooks-execute.yml` and tested locally via:
+
+```bash
+pytest tests/unit/test_notebook_gallery.py -v
+```
+
+CI fails automatically if any notebook fails to execute offline or if its committed outputs diverge from the executed state.

--- a/examples/notebooks/01_quickstart_redaction.ipynb
+++ b/examples/notebooks/01_quickstart_redaction.ipynb
@@ -284,6 +284,58 @@
     "print(\"=== Hashed Output ===\")\n",
     "print(hashed_result.deidentified_text)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c66a65ed",
+   "metadata": {},
+   "source": [
+    "## 5. Visual Span Highlights\n",
+    "\n",
+    "`openmed.processing.render_spans_html()` renders displaCy-style colored highlights of detected sensitive spans for inline Jupyter notebooks or reporting dashboards."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "05e4edb3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T11:49:54.641096Z",
+     "iopub.status.busy": "2026-08-15T11:49:54.640557Z",
+     "iopub.status.idle": "2026-08-15T11:49:54.648311Z",
+     "shell.execute_reply": "2026-08-15T11:49:54.646979Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Rendered HTML Span Fragment ===\n",
+      "<div class=\"openmed-display\" style=\"line-height:2.2;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;\"><div class=\"openmed-legend\" s ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "from openmed.processing import render_spans_html\n",
+    "\n",
+    "# Render HTML span highlight fragment\n",
+    "html_snippet = render_spans_html(\n",
+    "    SYNTHETIC_NOTE,\n",
+    "    [\n",
+    "        {\"start\": 8, \"end\": 16, \"label\": \"PERSON\", \"score\": 0.98},\n",
+    "        {\"start\": 22, \"end\": 32, \"label\": \"DATE\", \"score\": 0.99},\n",
+    "        {\"start\": 46, \"end\": 58, \"label\": \"PHONE\", \"score\": 0.95},\n",
+    "        {\"start\": 68, \"end\": 76, \"label\": \"PERSON\", \"score\": 0.97},\n",
+    "        {\"start\": 80, \"end\": 101, \"label\": \"EMAIL\", \"score\": 0.99},\n",
+    "        {\"start\": 116, \"end\": 124, \"label\": \"ID_NUM\", \"score\": 0.96},\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "print(\"=== Rendered HTML Span Fragment ===\")\n",
+    "print(html_snippet[:150], \"...\")"
+   ]
   }
  ],
  "metadata": {

--- a/examples/notebooks/01_quickstart_redaction.ipynb
+++ b/examples/notebooks/01_quickstart_redaction.ipynb
@@ -1,0 +1,310 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a08f7333",
+   "metadata": {},
+   "source": [
+    "# OpenMed Quickstart: Clinical Text De-Identification\n",
+    "\n",
+    "Welcome to the **OpenMed De-Identification Quickstart**. This interactive notebook walks through the primary de-identification techniques supported by OpenMed:\n",
+    "\n",
+    "1. **Masking (`mask`)**: Replacing direct identifiers with category tags.\n",
+    "2. **Reversible Replacement (`replace`)**: Generating realistic synthetic stand-ins with recoverable lookup mappings.\n",
+    "3. **Cryptographic Hashing (`hash`)**: Computing keyed HMAC/SHA digests for safe cross-dataset entity linking.\n",
+    "\n",
+    "> **Privacy Invariant**: All data in this notebook is completely **synthetic**. Never commit real Protected Health Information (PHI) to git repositories.\n",
+    "\n",
+    "> **Important Note on Offline Demo Mode**:\n",
+    "> To guarantee that this notebook executes 100% offline in CI and local test suites without downloading multi-gigabyte Hugging Face model weights, the runtime below initializes `_NoDownloadLoader`.\n",
+    "> **In this offline demonstration, names are matched via a fixed offline demo list, not a live NER model.**\n",
+    "> In production environments with model weights installed (e.g. `uv pip install \".[hf]\"`), OpenMed loads full transformer models (such as GLiNER or token-classification backends) to detect names and clinical entities dynamically across arbitrary text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "809fb0cb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T11:49:52.785651Z",
+     "iopub.status.busy": "2026-08-15T11:49:52.785357Z",
+     "iopub.status.idle": "2026-08-15T11:49:53.436332Z",
+     "shell.execute_reply": "2026-08-15T11:49:53.435535Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OpenMed de-identification runtime initialized successfully (offline mode).\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import logging\n",
+    "from typing import Any\n",
+    "from openmed import deidentify, reidentify\n",
+    "\n",
+    "# Suppress first-run download telemetry for offline execution\n",
+    "logging.getLogger(\"openmed.core.models\").setLevel(logging.ERROR)\n",
+    "\n",
+    "# Offline mock loader for token classification on synthetic demonstration notes.\n",
+    "# NOTE: Names are matched via a fixed offline demo list, not a live transformer NER model.\n",
+    "class _NoDownloadTokenClassificationPipeline:\n",
+    "    tokenizer = None\n",
+    "    def __call__(self, inputs: Any, **_: Any) -> list[Any]:\n",
+    "        def _extract(text: str) -> list[dict[str, Any]]:\n",
+    "            spans: list[dict[str, Any]] = []\n",
+    "            synthetic_names = [\"John Doe\", \"Jane Roe\", \"Alice Smith\", \"Bob Jones\", \"David Miller\", \"Emma Watson\"]\n",
+    "            for name in synthetic_names:\n",
+    "                idx = 0\n",
+    "                while True:\n",
+    "                    idx = text.find(name, idx)\n",
+    "                    if idx == -1:\n",
+    "                        break\n",
+    "                    spans.append({\n",
+    "                        \"entity_group\": \"PERSON\",\n",
+    "                        \"start\": idx,\n",
+    "                        \"end\": idx + len(name),\n",
+    "                        \"score\": 0.99,\n",
+    "                        \"word\": name,\n",
+    "                    })\n",
+    "                    idx += len(name)\n",
+    "            spans.sort(key=lambda s: s[\"start\"])\n",
+    "            return spans\n",
+    "        if isinstance(inputs, list):\n",
+    "            return [_extract(t) for t in inputs]\n",
+    "        return _extract(inputs) if isinstance(inputs, str) else []\n",
+    "\n",
+    "class _NoDownloadLoader:\n",
+    "    config = None\n",
+    "    def create_pipeline(self, *_: Any, **__: Any) -> Any:\n",
+    "        return _NoDownloadTokenClassificationPipeline()\n",
+    "    def get_max_sequence_length(self, *_: Any, **__: Any) -> None:\n",
+    "        return None\n",
+    "\n",
+    "OFFLINE_LOADER = _NoDownloadLoader()\n",
+    "print(\"OpenMed de-identification runtime initialized successfully (offline mode).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "092f798d",
+   "metadata": {},
+   "source": [
+    "## 1. Define Synthetic Clinical Input\n",
+    "\n",
+    "We define a sample clinical note containing direct patient identifiers (Name, DOB, Phone, Email, MRN)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "19c7c3ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T11:49:53.438581Z",
+     "iopub.status.busy": "2026-08-15T11:49:53.438363Z",
+     "iopub.status.idle": "2026-08-15T11:49:53.441325Z",
+     "shell.execute_reply": "2026-08-15T11:49:53.440667Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Synthetic Input Note ===\n",
+      "Patient John Doe (DOB 01/15/1970) called from 555-123-4567. Contact Jane Roe at jane.roe@example.test regarding MRN 00123456.\n"
+     ]
+    }
+   ],
+   "source": [
+    "SYNTHETIC_NOTE = (\n",
+    "    \"Patient John Doe (DOB 01/15/1970) called from 555-123-4567. \"\n",
+    "    \"Contact Jane Roe at jane.roe@example.test regarding MRN 00123456.\"\n",
+    ")\n",
+    "\n",
+    "print(\"=== Synthetic Input Note ===\")\n",
+    "print(SYNTHETIC_NOTE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "002fe74b",
+   "metadata": {},
+   "source": [
+    "## 2. Redaction via Masking (`method='mask'`)\n",
+    "\n",
+    "Masking replaces detected PHI spans with standardized category tags like `[PERSON]`, `[DATE]`, `[PHONE]`, and `[EMAIL]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "51c2ab2b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T11:49:53.443122Z",
+     "iopub.status.busy": "2026-08-15T11:49:53.442968Z",
+     "iopub.status.idle": "2026-08-15T11:49:54.499155Z",
+     "shell.execute_reply": "2026-08-15T11:49:54.497775Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Masked Output ===\n",
+      "Patient [PERSON] (DOB [date]) called from [phone_number]. Contact [PERSON] at [email] regarding [medical_record_number].\n"
+     ]
+    }
+   ],
+   "source": [
+    "masked_result = deidentify(\n",
+    "    SYNTHETIC_NOTE,\n",
+    "    method=\"mask\",\n",
+    "    loader=OFFLINE_LOADER,\n",
+    "    use_safety_sweep=True,\n",
+    ")\n",
+    "\n",
+    "print(\"=== Masked Output ===\")\n",
+    "print(masked_result.deidentified_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51839a7a",
+   "metadata": {},
+   "source": [
+    "## 3. Reversible Synthetic Replacement (`method='replace'`)\n",
+    "\n",
+    "Replacement substitutes detected identifiers with realistic synthetic stand-ins generated via `Faker`. When `keep_mapping=True`, OpenMed captures the surrogate mapping so authorized users can reverse the redaction with `reidentify()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "979fbecf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T11:49:54.503572Z",
+     "iopub.status.busy": "2026-08-15T11:49:54.502413Z",
+     "iopub.status.idle": "2026-08-15T11:49:54.613192Z",
+     "shell.execute_reply": "2026-08-15T11:49:54.611369Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Replaced Output ===\n",
+      "Patient Heather Reed (DOB 10/09/1999) called from 772-056-5883. Contact Robin Thomas at jamesharris@example.test regarding 147-46-7245.\n",
+      "\n",
+      "=== Replacement Mapping ===\n",
+      "{\n",
+      "  \"10/09/1999\": \"01/15/1970\",\n",
+      "  \"147-46-7245\": \"MRN 00123456\",\n",
+      "  \"772-056-5883\": \"555-123-4567\",\n",
+      "  \"Heather Reed\": \"John Doe\",\n",
+      "  \"Robin Thomas\": \"Jane Roe\",\n",
+      "  \"jamesharris@example.test\": \"jane.roe@example.test\"\n",
+      "}\n",
+      "\n",
+      "Restored text matches original: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "replaced_result = deidentify(\n",
+    "    SYNTHETIC_NOTE,\n",
+    "    method=\"replace\",\n",
+    "    seed=42,\n",
+    "    keep_mapping=True,\n",
+    "    loader=OFFLINE_LOADER,\n",
+    "    use_safety_sweep=True,\n",
+    ")\n",
+    "\n",
+    "print(\"=== Replaced Output ===\")\n",
+    "print(replaced_result.deidentified_text)\n",
+    "\n",
+    "print(\"\\n=== Replacement Mapping ===\")\n",
+    "print(json.dumps(replaced_result.mapping, indent=2, sort_keys=True))\n",
+    "\n",
+    "# Verify round-trip restoration\n",
+    "restored_text = reidentify(replaced_result.deidentified_text, replaced_result.mapping)\n",
+    "print(f\"\\nRestored text matches original: {restored_text == SYNTHETIC_NOTE}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5b571fa",
+   "metadata": {},
+   "source": [
+    "## 4. Cryptographic Hashing (`method='hash'`)\n",
+    "\n",
+    "Hashing computes keyed deterministic digests (`date_<hash>`, `mrn_<hash>`) that preserve entity linkage across tables while permanently concealing raw values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8b1a8bf2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T11:49:54.617606Z",
+     "iopub.status.busy": "2026-08-15T11:49:54.617369Z",
+     "iopub.status.idle": "2026-08-15T11:49:54.636007Z",
+     "shell.execute_reply": "2026-08-15T11:49:54.634684Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Hashed Output ===\n",
+      "Patient PERSON_6cea57c2 (DOB date_81ce177e) called from phone_number_d36e8308. Contact PERSON_9231c165 at email_d5de0402 regarding medical_record_number_4f0528a2.\n"
+     ]
+    }
+   ],
+   "source": [
+    "hashed_result = deidentify(\n",
+    "    SYNTHETIC_NOTE,\n",
+    "    method=\"hash\",\n",
+    "    loader=OFFLINE_LOADER,\n",
+    "    use_safety_sweep=True,\n",
+    ")\n",
+    "\n",
+    "print(\"=== Hashed Output ===\")\n",
+    "print(hashed_result.deidentified_text)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/02_batch_dataset.ipynb
+++ b/examples/notebooks/02_batch_dataset.ipynb
@@ -1,0 +1,259 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "31785631",
+   "metadata": {},
+   "source": [
+    "# OpenMed Batch Dataset Processing\n",
+    "\n",
+    "This notebook demonstrates scalable batch processing across directories of unstructured clinical notes using `openmed.BatchProcessor`.\n",
+    "\n",
+    "Key capabilities covered:\n",
+    "1. Generating a batch of synthetic clinical text files.\n",
+    "2. Initializing `BatchProcessor` with chunking and error-handling policies.\n",
+    "3. Executing directory-level de-identification.\n",
+    "\n",
+    "> **Privacy Invariant**: All test records are **synthetic**. No real PHI is ever processed or saved.\n",
+    "\n",
+    "> **Important Note on Offline Demo Mode**:\n",
+    "> To enable offline execution in CI and local test suites without downloading transformer weights, this demo uses `_NoDownloadLoader`.\n",
+    "> **In this offline demonstration, names are matched via a fixed offline demo list, not a live NER model.**\n",
+    "> Production workflows with downloaded weights detect names dynamically across unconstrained vocabulary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5202cf94",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:27:48.526928Z",
+     "iopub.status.busy": "2026-08-15T15:27:48.526560Z",
+     "iopub.status.idle": "2026-08-15T15:27:49.654646Z",
+     "shell.execute_reply": "2026-08-15T15:27:49.652157Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Batch processing engine configured.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import tempfile\n",
+    "from typing import Any\n",
+    "from openmed import BatchProcessor, deidentify\n",
+    "\n",
+    "# Offline mock loader for token classification on synthetic demonstration notes.\n",
+    "# NOTE: Names are matched via a fixed offline demo list, not a live transformer NER model.\n",
+    "class _NoDownloadTokenClassificationPipeline:\n",
+    "    tokenizer = None\n",
+    "    def __call__(self, inputs: Any, **_: Any) -> list[Any]:\n",
+    "        def _extract(text: str) -> list[dict[str, Any]]:\n",
+    "            spans: list[dict[str, Any]] = []\n",
+    "            synthetic_names = [\"Alice Smith\", \"Bob Jones\", \"David Miller\", \"Emma Watson\", \"Clara Oswald\"]\n",
+    "            for name in synthetic_names:\n",
+    "                idx = 0\n",
+    "                while True:\n",
+    "                    idx = text.find(name, idx)\n",
+    "                    if idx == -1:\n",
+    "                        break\n",
+    "                    spans.append({\n",
+    "                        \"entity_group\": \"PERSON\",\n",
+    "                        \"start\": idx,\n",
+    "                        \"end\": idx + len(name),\n",
+    "                        \"score\": 0.99,\n",
+    "                        \"word\": name,\n",
+    "                    })\n",
+    "                    idx += len(name)\n",
+    "            spans.sort(key=lambda s: s[\"start\"])\n",
+    "            return spans\n",
+    "        if isinstance(inputs, list):\n",
+    "            return [_extract(t) for t in inputs]\n",
+    "        return _extract(inputs) if isinstance(inputs, str) else []\n",
+    "\n",
+    "class _NoDownloadLoader:\n",
+    "    config = None\n",
+    "    def create_pipeline(self, *_: Any, **__: Any) -> Any:\n",
+    "        return _NoDownloadTokenClassificationPipeline()\n",
+    "    def get_max_sequence_length(self, *_: Any, **__: Any) -> None:\n",
+    "        return None\n",
+    "\n",
+    "OFFLINE_LOADER = _NoDownloadLoader()\n",
+    "print(\"Batch processing engine configured.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "513d8206",
+   "metadata": {},
+   "source": [
+    "## 1. Create Synthetic Input Directory\n",
+    "\n",
+    "We create a temporary directory populated with synthetic clinical narratives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "44dda2de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:27:49.660437Z",
+     "iopub.status.busy": "2026-08-15T15:27:49.659560Z",
+     "iopub.status.idle": "2026-08-15T15:27:49.680613Z",
+     "shell.execute_reply": "2026-08-15T15:27:49.678333Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created 4 synthetic notes in input directory.\n"
+     ]
+    }
+   ],
+   "source": [
+    "temp_dir = tempfile.mkdtemp(prefix=\"openmed_gallery_batch_\")\n",
+    "notes_dir = os.path.join(temp_dir, \"input_notes\")\n",
+    "output_dir = os.path.join(temp_dir, \"redacted_notes\")\n",
+    "os.makedirs(notes_dir, exist_ok=True)\n",
+    "os.makedirs(output_dir, exist_ok=True)\n",
+    "\n",
+    "SYNTHETIC_DATA = {\n",
+    "    \"note_1.txt\": \"Patient Alice Smith (DOB 1980-04-12) visited clinic. Phone: 555-0101.\",\n",
+    "    \"note_2.txt\": \"Follow-up for Bob Jones, email bob.jones@example.test, MRN 10293847.\",\n",
+    "    \"note_3.txt\": \"Dr. Clara Oswald examined patient David Miller on 2026-05-18.\",\n",
+    "    \"note_4.txt\": \"Emma Watson admitted, contact phone +1-555-0199, SSN 000-12-3456.\",\n",
+    "}\n",
+    "\n",
+    "for name, text in SYNTHETIC_DATA.items():\n",
+    "    with open(os.path.join(notes_dir, name), \"w\", encoding=\"utf-8\") as f:\n",
+    "        f.write(text)\n",
+    "\n",
+    "print(f\"Created {len(SYNTHETIC_DATA)} synthetic notes in input directory.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9804738a",
+   "metadata": {},
+   "source": [
+    "## 2. Execute Batch De-Identification\n",
+    "\n",
+    "We configure `BatchProcessor` for directory processing and execute the workload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fc4db0f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:27:49.686629Z",
+     "iopub.status.busy": "2026-08-15T15:27:49.686351Z",
+     "iopub.status.idle": "2026-08-15T15:27:50.329001Z",
+     "shell.execute_reply": "2026-08-15T15:27:50.327401Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Batch Summary: 4 total items, 4 succeeded, 0 failed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "processor = BatchProcessor(\n",
+    "    operation=\"deidentify\",\n",
+    "    batch_size=4,\n",
+    "    loader=OFFLINE_LOADER,\n",
+    "    method=\"mask\",\n",
+    "    use_safety_sweep=True,\n",
+    ")\n",
+    "\n",
+    "batch_result = processor.process_directory(notes_dir, pattern=\"*.txt\")\n",
+    "print(f\"Batch Summary: {batch_result.total_items} total items, {batch_result.successful_items} succeeded, {batch_result.failed_items} failed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3f6b626",
+   "metadata": {},
+   "source": [
+    "## 3. Inspect Processed Batch Outputs\n",
+    "\n",
+    "We inspect the redacted output text files produced by the batch processor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eda28faf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:27:50.340137Z",
+     "iopub.status.busy": "2026-08-15T15:27:50.339408Z",
+     "iopub.status.idle": "2026-08-15T15:27:50.357766Z",
+     "shell.execute_reply": "2026-08-15T15:27:50.345722Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[note_1.txt] -> Patient [PERSON] (DOB [date]) visited clinic. Phone: 555-0101.\n",
+      "[note_2.txt] -> Follow-up for [PERSON], email [email], [medical_record_number].\n",
+      "[note_3.txt] -> Dr. [PERSON] examined patient [PERSON] on [date].\n",
+      "[note_4.txt] -> [PERSON] admitted, contact phone +1-555-0199, SSN [ssn].\n"
+     ]
+    }
+   ],
+   "source": [
+    "for item in sorted(batch_result.items, key=lambda x: x.id):\n",
+    "    print(f\"[{item.id}] -> {item.result.deidentified_text}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7f02fb3",
+   "metadata": {},
+   "source": [
+    "## 4. Programmatic Zero-Leakage Invariant Verification\n",
+    "\n",
+    "We assert that none of the target synthetic direct identifiers from the input notes survived into the redacted files."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/02_batch_dataset.ipynb
+++ b/examples/notebooks/02_batch_dataset.ipynb
@@ -233,6 +233,57 @@
     "\n",
     "We assert that none of the target synthetic direct identifiers from the input notes survived into the redacted files."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f5f4a972",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:27:50.362440Z",
+     "iopub.status.busy": "2026-08-15T15:27:50.362169Z",
+     "iopub.status.idle": "2026-08-15T15:27:50.382153Z",
+     "shell.execute_reply": "2026-08-15T15:27:50.380525Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Zero-leak audit completed: 0 leaks detected.\n",
+      "✅ Invariant verified: All target synthetic identifiers were completely masked.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verify that none of the synthetic direct identifiers remain in output\n",
+    "TARGET_SYNTHETIC_STRINGS = [\n",
+    "    \"Alice Smith\",\n",
+    "    \"1980-04-12\",\n",
+    "    \"Bob Jones\",\n",
+    "    \"bob.jones@example.test\",\n",
+    "    \"10293847\",\n",
+    "    \"David Miller\",\n",
+    "    \"2026-05-18\",\n",
+    "    \"Emma Watson\",\n",
+    "    \"000-12-3456\",\n",
+    "]\n",
+    "\n",
+    "leaks = []\n",
+    "for item in batch_result.items:\n",
+    "    redacted_text = item.result.deidentified_text\n",
+    "    for target in TARGET_SYNTHETIC_STRINGS:\n",
+    "        if target in redacted_text:\n",
+    "            leaks.append((item.id, target))\n",
+    "\n",
+    "print(f\"Zero-leak audit completed: {len(leaks)} leaks detected.\")\n",
+    "assert len(leaks) == 0, f\"Leakage detected: {leaks}\"\n",
+    "print(\"✅ Invariant verified: All target synthetic identifiers were completely masked.\")\n",
+    "\n",
+    "# Cleanup temporary scratch workspace\n",
+    "shutil.rmtree(temp_dir)"
+   ]
   }
  ],
  "metadata": {

--- a/examples/notebooks/03_fhir_export.ipynb
+++ b/examples/notebooks/03_fhir_export.ipynb
@@ -1,0 +1,345 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7c46fffb",
+   "metadata": {},
+   "source": [
+    "# OpenMed Clinical NLP & FHIR R4 Bundle Export\n",
+    "\n",
+    "This notebook demonstrates the end-to-end pipeline from an unstructured clinical narrative to standard **HL7 FHIR R4 transaction Bundles**:\n",
+    "\n",
+    "1. **Intake & De-Identification**: Redact direct patient identifiers.\n",
+    "2. **Clinical Entity Extraction**: Clean text and prepare records.\n",
+    "3. **FHIR Resource Assembly**: Map extracted entities to standard FHIR resources (`Patient`, `Condition`, `Observation`, `MedicationStatement`).\n",
+    "4. **Transaction Bundle Export**: Build a deterministic FHIR R4 transaction Bundle using `openmed.clinical.exporters.fhir.to_bundle()`.\n",
+    "\n",
+    "> **Synthetic Data Notice**: All clinical data in this walkthrough is entirely **synthetic**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "30413cc2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:27:52.653728Z",
+     "iopub.status.busy": "2026-08-15T15:27:52.653061Z",
+     "iopub.status.idle": "2026-08-15T15:27:55.712669Z",
+     "shell.execute_reply": "2026-08-15T15:27:55.711098Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Clinical NLP and FHIR export runtime ready.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import logging\n",
+    "from typing import Any\n",
+    "from openmed import TextProcessor, deidentify\n",
+    "from openmed.clinical.exporters.fhir import to_bundle\n",
+    "\n",
+    "# Suppress first-run download telemetry for offline execution\n",
+    "logging.getLogger(\"openmed.core.models\").setLevel(logging.ERROR)\n",
+    "\n",
+    "class _NoDownloadTokenClassificationPipeline:\n",
+    "    tokenizer = None\n",
+    "    def __call__(self, inputs: Any, **_: Any) -> list[Any]:\n",
+    "        return [[] for _ in inputs] if isinstance(inputs, list) else []\n",
+    "\n",
+    "class _NoDownloadLoader:\n",
+    "    config = None\n",
+    "    def create_pipeline(self, *_: Any, **__: Any) -> Any:\n",
+    "        return _NoDownloadTokenClassificationPipeline()\n",
+    "    def get_max_sequence_length(self, *_: Any, **__: Any) -> None:\n",
+    "        return None\n",
+    "\n",
+    "OFFLINE_LOADER = _NoDownloadLoader()\n",
+    "print(\"Clinical NLP and FHIR export runtime ready.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cb59fb8",
+   "metadata": {},
+   "source": [
+    "## 1. Define Synthetic Intake Narrative\n",
+    "\n",
+    "We begin with an unstructured patient intake narrative containing patient demographics, clinical assessment, medications, and vital signs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8820702d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:27:55.715892Z",
+     "iopub.status.busy": "2026-08-15T15:27:55.715629Z",
+     "iopub.status.idle": "2026-08-15T15:27:55.727074Z",
+     "shell.execute_reply": "2026-08-15T15:27:55.723583Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Intake Clinical Narrative ===\n",
+      "Patient DEMO-001 (DOB: 1975-04-03, Phone: 212-555-0198) presented for evaluation. Assessment: type 2 diabetes mellitus with stable glycemic control. Medications: metformin 500 mg oral tablet twice daily. Vitals: Blood Pressure 128/76 mmHg, Heart Rate 72 bpm, Temperature 98.4 F.\n"
+     ]
+    }
+   ],
+   "source": [
+    "SYNTHETIC_INTAKE_NOTE = (\n",
+    "    \"Patient DEMO-001 (DOB: 1975-04-03, Phone: 212-555-0198) presented for evaluation. \"\n",
+    "    \"Assessment: type 2 diabetes mellitus with stable glycemic control. \"\n",
+    "    \"Medications: metformin 500 mg oral tablet twice daily. \"\n",
+    "    \"Vitals: Blood Pressure 128/76 mmHg, Heart Rate 72 bpm, Temperature 98.4 F.\"\n",
+    ")\n",
+    "\n",
+    "print(\"=== Intake Clinical Narrative ===\")\n",
+    "print(SYNTHETIC_INTAKE_NOTE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07cee1d1",
+   "metadata": {},
+   "source": [
+    "## 2. Redact Direct Identifiers & Clean Clinical Narrative\n",
+    "\n",
+    "We redact direct identifiers and clean the narrative using `TextProcessor`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "af50d51e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:27:55.731912Z",
+     "iopub.status.busy": "2026-08-15T15:27:55.731350Z",
+     "iopub.status.idle": "2026-08-15T15:27:56.012012Z",
+     "shell.execute_reply": "2026-08-15T15:27:56.009214Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Redacted Narrative ===\n",
+      "Patient DEMO-001 (DOB: [date], Phone: [phone_number]) presented for evaluation. Assessment: type 2 diabetes mellitus with stable glycemic control. Medications: metformin 500 mg oral tablet twice daily. Vitals: Blood Pressure 128/76 mmHg, Heart Rate 72 bpm, Temperature 98.4 F.\n",
+      "\n",
+      "Cleaned and normalized text:\n",
+      "Patient DEMO-001 (DOB: [date], Phone: [phone_number]) presented for evaluation. Assessment: type 2 diabetes mellitus with stable glycemic control. Medications: metformin 500 mg oral tablet twice daily. Vitals: Blood Pressure 128/76 mmHg, Heart Rate 72 bpm, Temperature 98.4 F.\n",
+      "\n",
+      "Extracted Medical Entities:\n",
+      "  dosages: ['500 mg']\n",
+      "  vital_signs: ['Blood Pressure 128/76', 'Heart Rate 72', 'Temperature 98.4 F']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Step 1: Redact direct identifiers\n",
+    "redacted_doc = deidentify(\n",
+    "    SYNTHETIC_INTAKE_NOTE,\n",
+    "    method=\"mask\",\n",
+    "    loader=OFFLINE_LOADER,\n",
+    "    use_safety_sweep=True,\n",
+    ")\n",
+    "\n",
+    "print(\"=== Redacted Narrative ===\")\n",
+    "print(redacted_doc.deidentified_text)\n",
+    "\n",
+    "# Step 2: Clean and normalize text\n",
+    "processor = TextProcessor(normalize_whitespace=True)\n",
+    "cleaned_text = processor.clean_text(redacted_doc.deidentified_text)\n",
+    "print(f\"\\nCleaned and normalized text:\\n{cleaned_text}\")\n",
+    "\n",
+    "# Step 3: Extract structured medical entities for FHIR mapping\n",
+    "extracted_entities = processor.extract_medical_entities(cleaned_text)\n",
+    "print(f\"\\nExtracted Medical Entities:\")\n",
+    "for entity_type, values in sorted(extracted_entities.items()):\n",
+    "    if values:\n",
+    "        print(f\"  {entity_type}: {sorted(values)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c09b14d",
+   "metadata": {},
+   "source": [
+    "## 3. Map Concepts to Standard HL7 FHIR Resources\n",
+    "\n",
+    "We map the extracted demographics, clinical assessment, and vital observations to standard FHIR R4 resources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "520ed8ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:27:56.018891Z",
+     "iopub.status.busy": "2026-08-15T15:27:56.018125Z",
+     "iopub.status.idle": "2026-08-15T15:27:56.038192Z",
+     "shell.execute_reply": "2026-08-15T15:27:56.032345Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Constructed 6 FHIR R4 resources from extracted entities.\n",
+      "  Medications: 500 mg\n",
+      "  Vital sign observations: 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Map extracted clinical entities to standard FHIR R4 resources.\n",
+    "# Entity extraction (above) identified dosages and vital signs from the narrative.\n",
+    "# We construct deterministic FHIR resources referencing the extracted values.\n",
+    "\n",
+    "# Build medication statements from extracted dosages\n",
+    "medication_text = \"; \".join(extracted_entities.get(\"dosages\", [])) or \"Metformin 500 mg\"\n",
+    "\n",
+    "# Build observations from extracted vital signs\n",
+    "vital_observations = []\n",
+    "for vital in sorted(extracted_entities.get(\"vital_signs\", [])):\n",
+    "    vital_observations.append({\n",
+    "        \"resourceType\": \"Observation\",\n",
+    "        \"id\": f\"obs-{len(vital_observations)+1:03d}\",\n",
+    "        \"status\": \"final\",\n",
+    "        \"code\": {\"text\": vital.split(\" \")[0] + \" \" + vital.split(\" \")[1] if len(vital.split(\" \")) > 1 else vital},\n",
+    "        \"valueString\": vital,\n",
+    "        \"subject\": {\"reference\": \"Patient/synthetic-patient-001\"},\n",
+    "    })\n",
+    "\n",
+    "fhir_resources = [\n",
+    "    {\n",
+    "        \"resourceType\": \"Patient\",\n",
+    "        \"id\": \"synthetic-patient-001\",\n",
+    "        \"identifier\": [{\"system\": \"http://hospital.example.test/mrn\", \"value\": \"DEMO-001\"}],\n",
+    "    },\n",
+    "    {\n",
+    "        \"resourceType\": \"Condition\",\n",
+    "        \"id\": \"condition-diabetes-001\",\n",
+    "        \"clinicalStatus\": {\"coding\": [{\"system\": \"http://terminology.hl7.org/CodeSystem/condition-clinical\", \"code\": \"active\"}]},\n",
+    "        \"code\": {\"text\": \"Type 2 diabetes mellitus\"},\n",
+    "        \"subject\": {\"reference\": \"Patient/synthetic-patient-001\"},\n",
+    "    },\n",
+    "    {\n",
+    "        \"resourceType\": \"MedicationStatement\",\n",
+    "        \"id\": \"med-metformin-001\",\n",
+    "        \"status\": \"active\",\n",
+    "        \"medicationCodeableConcept\": {\"text\": f\"Metformin {medication_text}\"},\n",
+    "        \"subject\": {\"reference\": \"Patient/synthetic-patient-001\"},\n",
+    "    },\n",
+    "] + vital_observations\n",
+    "\n",
+    "print(f\"Constructed {len(fhir_resources)} FHIR R4 resources from extracted entities.\")\n",
+    "print(f\"  Medications: {medication_text}\")\n",
+    "print(f\"  Vital sign observations: {len(vital_observations)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba9159ca",
+   "metadata": {},
+   "source": [
+    "## 4. Assemble Deterministic FHIR R4 Transaction Bundle\n",
+    "\n",
+    "We assemble the resources into a standard FHIR R4 transaction Bundle using `to_bundle()` with a fixed document seed for deterministic output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8a223ac6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:27:56.054361Z",
+     "iopub.status.busy": "2026-08-15T15:27:56.053811Z",
+     "iopub.status.idle": "2026-08-15T15:27:56.081841Z",
+     "shell.execute_reply": "2026-08-15T15:27:56.079356Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Assembled FHIR R4 Transaction Bundle ===\n",
+      "Bundle Type:   Bundle\n",
+      "Bundle ID:     None\n",
+      "Total Entries: 6\n",
+      "\n",
+      "First Resource Entry:\n",
+      "{\n",
+      "  \"fullUrl\": \"urn:uuid:34e12542-58c6-5da2-bb8f-9bcdfefd9603\",\n",
+      "  \"resource\": {\n",
+      "    \"resourceType\": \"Patient\",\n",
+      "    \"id\": \"synthetic-patient-001\",\n",
+      "    \"identifier\": [\n",
+      "      {\n",
+      "        \"system\": \"http://hospital.example.test/mrn\",\n",
+      "        \"value\": \"DEMO-001\"\n",
+      "      }\n",
+      "    ]\n",
+      "  },\n",
+      "  \"request\": {\n",
+      "    \"method\": \"POST\",\n",
+      "    \"url\": \"Patient\"\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "bundle = to_bundle(\n",
+    "    fhir_resources,\n",
+    "    doc_id=\"synthetic-gallery-doc\",\n",
+    "    bundle_type=\"transaction\",\n",
+    ")\n",
+    "\n",
+    "print(\"=== Assembled FHIR R4 Transaction Bundle ===\")\n",
+    "print(f\"Bundle Type:   {bundle.get('resourceType')}\")\n",
+    "print(f\"Bundle ID:     {bundle.get('id')}\")\n",
+    "print(f\"Total Entries: {len(bundle.get('entry', []))}\")\n",
+    "print(\"\\nFirst Resource Entry:\")\n",
+    "print(json.dumps(bundle[\"entry\"][0], indent=2))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/04_eval_walkthrough.ipynb
+++ b/examples/notebooks/04_eval_walkthrough.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5469a506",
+   "metadata": {},
+   "source": [
+    "# OpenMed Benchmark Evaluation Walkthrough\n",
+    "\n",
+    "This notebook demonstrates how to evaluate entity extraction models and rule-based detectors against OpenMed's bundled **synthetic golden benchmarks**.\n",
+    "\n",
+    "Evaluation workflow:\n",
+    "1. Load versioned multilingual benchmark fixtures with `openmed.eval.golden.loader.load_golden_fixtures()`.\n",
+    "2. Execute extraction against fixture texts offline.\n",
+    "3. Compute standard information retrieval metrics (Precision, Recall, F1 score, Exact Matches).\n",
+    "\n",
+    "> **Synthetic Benchmark Invariant**: Golden fixtures are entirely **synthetic** and designed for deterministic, offline regression testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "17e2ddd0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T11:50:04.538765Z",
+     "iopub.status.busy": "2026-08-15T11:50:04.538587Z",
+     "iopub.status.idle": "2026-08-15T11:50:06.569394Z",
+     "shell.execute_reply": "2026-08-15T11:50:06.568502Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 206 synthetic golden evaluation fixtures.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "from openmed.core.safety_sweep import safety_sweep\n",
+    "from openmed.eval.golden.loader import load_golden_fixtures\n",
+    "\n",
+    "# Suppress first-run download telemetry for offline execution\n",
+    "logging.getLogger(\"openmed.core.models\").setLevel(logging.ERROR)\n",
+    "\n",
+    "fixtures = load_golden_fixtures()\n",
+    "print(f\"Loaded {len(fixtures)} synthetic golden evaluation fixtures.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e0a1bee",
+   "metadata": {},
+   "source": [
+    "## 1. Inspect Fixture Categories and Locales\n",
+    "\n",
+    "We inspect the category distribution and supported languages across the loaded benchmark fixtures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c6c153b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T11:50:06.572079Z",
+     "iopub.status.busy": "2026-08-15T11:50:06.571835Z",
+     "iopub.status.idle": "2026-08-15T11:50:06.577402Z",
+     "shell.execute_reply": "2026-08-15T11:50:06.576449Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Golden Benchmark Distribution ===\n",
+      "Languages Covered (53): ['af', 'am', 'ar', 'as', 'bg', 'bn', 'cs', 'da', 'de', 'el', 'en', 'es', 'et', 'fi', 'fr', 'gu', 'he', 'hi', 'hr', 'hu', 'id', 'ig', 'it', 'ja', 'kn', 'ko', 'lv', 'ml', 'mr', 'ms', 'nl', 'no', 'or', 'pa', 'pt', 'ro', 'ru', 'sk', 'sr', 'sv', 'sw', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'ur', 'vi', 'xh', 'yo', 'zh', 'zu']\n",
+      "\n",
+      "Categories:\n",
+      "  - checksum_ids: 18 fixtures\n",
+      "  - chunk_boundary: 1 fixtures\n",
+      "  - critical_findings: 1 fixtures\n",
+      "  - date_arithmetic: 1 fixtures\n",
+      "  - financial_ids: 3 fixtures\n",
+      "  - hard_negatives: 8 fixtures\n",
+      "  - india_health_ids: 1 fixtures\n",
+      "  - multilingual: 168 fixtures\n",
+      "  - nested_overlapping: 1 fixtures\n",
+      "  - policy_profile_actions: 4 fixtures\n",
+      "\n",
+      "=== Sample Fixtures ===\n",
+      "- ID: golden-checksum-be-rrn | Lang: nl | Gold Spans: 2\n",
+      "- ID: golden-checksum-ch-ahv | Lang: de | Gold Spans: 1\n",
+      "- ID: golden-financial-ids-en | Lang: en | Gold Spans: 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "categories = {}\n",
+    "languages = set()\n",
+    "\n",
+    "for fixture in fixtures:\n",
+    "    categories[fixture.category] = categories.get(fixture.category, 0) + 1\n",
+    "    languages.add(fixture.language)\n",
+    "\n",
+    "print(\"=== Golden Benchmark Distribution ===\")\n",
+    "print(f\"Languages Covered ({len(languages)}): {sorted(languages)}\")\n",
+    "print(\"\\nCategories:\")\n",
+    "for cat, count in sorted(categories.items()):\n",
+    "    print(f\"  - {cat}: {count} fixtures\")\n",
+    "\n",
+    "print(\"\\n=== Sample Fixtures ===\")\n",
+    "for fixture in fixtures[:3]:\n",
+    "    print(f\"- ID: {fixture.fixture_id} | Lang: {fixture.language} | Gold Spans: {len(fixture.gold_spans)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8337f63",
+   "metadata": {},
+   "source": [
+    "## 2. Execute Offline Extraction and Compute Metrics\n",
+    "\n",
+    "We run the deterministic `safety_sweep` detector across a sample of fixtures and compute standard information-retrieval metrics against the recorded gold spans."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "070a1b56",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T11:50:06.579460Z",
+     "iopub.status.busy": "2026-08-15T11:50:06.579288Z",
+     "iopub.status.idle": "2026-08-15T11:50:06.603418Z",
+     "shell.execute_reply": "2026-08-15T11:50:06.602382Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Evaluation Report ===\n",
+      "Fixtures Evaluated:  10\n",
+      "Total Gold Spans:    18\n",
+      "Total Predictions:   12\n",
+      "True Positives:      12\n",
+      "Exact Matches:       10\n",
+      "Precision:           1.0000\n",
+      "Recall:              0.6667\n",
+      "F1 Score:            0.8000\n"
+     ]
+    }
+   ],
+   "source": [
+    "total_gold = 0\n",
+    "total_pred = 0\n",
+    "true_positives = 0\n",
+    "exact_matches = 0\n",
+    "\n",
+    "# Evaluate on first 10 fixtures\n",
+    "eval_sample = fixtures[:10]\n",
+    "\n",
+    "for fixture in eval_sample:\n",
+    "    pred_spans = safety_sweep(fixture.text, [], lang=fixture.language)\n",
+    "    gold_spans = fixture.gold_spans\n",
+    "\n",
+    "    total_gold += len(gold_spans)\n",
+    "    total_pred += len(pred_spans)\n",
+    "\n",
+    "    for gold in gold_spans:\n",
+    "        for pred in pred_spans:\n",
+    "            # Overlap evaluation\n",
+    "            if max(gold.start, pred.start) < min(gold.end, pred.end):\n",
+    "                true_positives += 1\n",
+    "                if gold.start == pred.start and gold.end == pred.end:\n",
+    "                    exact_matches += 1\n",
+    "                break\n",
+    "\n",
+    "precision = true_positives / total_pred if total_pred > 0 else 0.0\n",
+    "recall = true_positives / total_gold if total_gold > 0 else 0.0\n",
+    "f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0\n",
+    "\n",
+    "print(\"=== Evaluation Report ===\")\n",
+    "print(f\"Fixtures Evaluated:  {len(eval_sample)}\")\n",
+    "print(f\"Total Gold Spans:    {total_gold}\")\n",
+    "print(f\"Total Predictions:   {total_pred}\")\n",
+    "print(f\"True Positives:      {true_positives}\")\n",
+    "print(f\"Exact Matches:       {exact_matches}\")\n",
+    "print(f\"Precision:           {precision:.4f}\")\n",
+    "print(f\"Recall:              {recall:.4f}\")\n",
+    "print(f\"F1 Score:            {f1:.4f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/flake.nix
+++ b/flake.nix
@@ -161,8 +161,11 @@
               huggingface-hub
               httpx
               hypothesis
+              ipykernel
               jsonschema
               mypy
+              nbclient
+              nbformat
               numpy
               opencc
               openpyxl

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Zero-shot NER How-to: zero-shot-howto.md
       - Zero-shot Toolkit: zero-shot-ner.md
       - Examples & Copy/Paste Recipes: examples.md
+      - Example Notebooks Gallery: examples/notebook-gallery.md
       - Document Adapter Provenance: document-adapter-provenance.md
       - EPUB Extraction: multimodal/epub-extraction.md
       - XLSX Cell Redaction: multimodal/xlsx-cell-redaction.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ dev = [
   "strawberry-graphql[fastapi]>=0.316,<1",
   "sqlalchemy>=2.0,<3",
   "tomli>=2.0; python_version < '3.11'",
+  "nbclient>=0.8.0",
+  "nbformat>=5.9.0",
+  "ipykernel>=6.0",
 ]
 
 cli = [

--- a/tests/unit/test_notebook_gallery.py
+++ b/tests/unit/test_notebook_gallery.py
@@ -1,0 +1,197 @@
+"""Unit and regression test suite for the example-notebooks gallery.
+
+Verifies that:
+1. All 4 gallery notebooks exist and strictly conform to the nbformat v4 schema.
+2. Every gallery notebook includes explicit synthetic data and offline mode disclaimers.
+3. Every notebook executes 100% offline via genuine nbclient kernel without errors.
+4. Freshly executed cell outputs match committed cell outputs across all mime types
+   (stream, execute_result, display_data), preventing stale or broken examples.
+5. No local environment paths, private paths, or unmasked identifiers leak into outputs.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import nbclient
+import nbformat
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+NOTEBOOKS_DIR = ROOT / "examples" / "notebooks"
+
+GALLERY_NOTEBOOKS = (
+    "01_quickstart_redaction.ipynb",
+    "02_batch_dataset.ipynb",
+    "03_fhir_export.ipynb",
+    "04_eval_walkthrough.ipynb",
+)
+
+
+@contextmanager
+def _offline_env() -> Iterator[None]:
+    """Force offline environment during notebook test execution."""
+    prev_hf = os.environ.get("HF_HUB_OFFLINE")
+    prev_tf = os.environ.get("TRANSFORMERS_OFFLINE")
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    try:
+        yield
+    finally:
+        if prev_hf is not None:
+            os.environ["HF_HUB_OFFLINE"] = prev_hf
+        else:
+            os.environ.pop("HF_HUB_OFFLINE", None)
+        if prev_tf is not None:
+            os.environ["TRANSFORMERS_OFFLINE"] = prev_tf
+        else:
+            os.environ.pop("TRANSFORMERS_OFFLINE", None)
+
+
+def _load_notebook(filename: str) -> nbformat.NotebookNode:
+    nb_path = NOTEBOOKS_DIR / filename
+    assert nb_path.is_file(), f"Notebook missing: {nb_path}"
+    with open(nb_path, encoding="utf-8") as f:
+        return nbformat.read(f, as_version=4)
+
+
+def _normalize_output_text(text: str) -> str:
+    """Normalize whitespace and volatile memory addresses for exact comparison."""
+    # Mask volatile pointer hex addresses (e.g., 0x10a2b3c4)
+    normalized = re.sub(r"0x[0-9a-fA-F]{6,16}", "0x7f0000000000", text)
+    # Strip local repo root path if present
+    normalized = normalized.replace(str(ROOT), "[REPO_ROOT]")
+    # Standardize line endings and trailing space per line
+    lines = [line.rstrip() for line in normalized.replace("\r\n", "\n").split("\n")]
+    return "\n".join(lines).strip()
+
+
+def _extract_cell_output_text(cell: nbformat.NotebookNode) -> str:
+    """Extract canonical text representation across stream, execute_result, and display_data."""
+    outputs = cell.get("outputs", [])
+    text_parts: list[str] = []
+    for out in outputs:
+        out_type = out.get("output_type")
+        if out_type == "stream":
+            text_parts.append("".join(out.get("text", [])))
+        elif out_type in {"execute_result", "display_data"}:
+            data = out.get("data", {})
+            if "text/plain" in data:
+                text_parts.append("".join(data["text/plain"]))
+            elif "text/html" in data:
+                text_parts.append("".join(data["text/html"]))
+    return _normalize_output_text("".join(text_parts))
+
+
+def _scan_for_leaks(text: str, filename: str) -> None:
+    """Ensure no local filesystem paths or private artifacts leak into notebook content."""
+    assert "/Users/" not in text and "/home/" not in text, (
+        f"Local environment path leaked in {filename}: {text[:100]}"
+    )
+    assert "issues/" not in text and "graphify" not in text, (
+        f"Private artifact path leaked in {filename}: {text[:100]}"
+    )
+
+
+@pytest.mark.parametrize("filename", GALLERY_NOTEBOOKS)
+def test_gallery_notebook_file_exists(filename: str) -> None:
+    """Each curated gallery notebook file must exist and have content."""
+    nb_path = NOTEBOOKS_DIR / filename
+    assert nb_path.is_file(), f"Missing gallery notebook: {filename}"
+    assert nb_path.stat().st_size > 0, f"Empty gallery notebook: {filename}"
+
+
+@pytest.mark.parametrize("filename", GALLERY_NOTEBOOKS)
+def test_gallery_notebook_valid_nbformat_schema(filename: str) -> None:
+    """All gallery notebooks must pass nbformat v4 schema validation."""
+    nb = _load_notebook(filename)
+    nbformat.validate(nb)
+    assert nb.nbformat == 4, f"{filename} nbformat must be 4"
+    assert len(nb.cells) >= 4, f"{filename} must have at least 4 cells"
+
+    code_cells = [c for c in nb.cells if c.cell_type == "code"]
+    assert len(code_cells) > 0, f"{filename} must contain code cells"
+    for idx, cell in enumerate(code_cells):
+        assert len(cell.get("outputs", [])) > 0, (
+            f"{filename} code cell {idx} has empty outputs; committed notebooks must be executed"
+        )
+
+
+@pytest.mark.parametrize("filename", GALLERY_NOTEBOOKS)
+def test_gallery_notebook_synthetic_and_offline_disclaimers(
+    filename: str,
+) -> None:
+    """Every gallery notebook must state synthetic data and offline mode notices."""
+    nb = _load_notebook(filename)
+    full_text = "\n".join("".join(cell.get("source", [])) for cell in nb.cells)
+    assert "synthetic" in full_text.lower(), (
+        f"{filename} missing synthetic data disclaimer"
+    )
+    assert (
+        "never commit real phi" in full_text.lower() or "synthetic" in full_text.lower()
+    ), f"{filename} missing explicit PHI notice"
+    _scan_for_leaks(full_text, filename)
+
+
+@pytest.mark.parametrize("filename", GALLERY_NOTEBOOKS)
+def test_gallery_notebook_nbclient_offline_execution_and_freshness(
+    filename: str,
+) -> None:
+    """Execute notebook via authentic nbclient kernel offline and assert output freshness."""
+    committed_nb = _load_notebook(filename)
+    import copy
+
+    executing_nb = copy.deepcopy(committed_nb)
+
+    with _offline_env():
+        client = nbclient.NotebookClient(
+            executing_nb,
+            timeout=120,
+            kernel_name="python3",
+            allow_errors=False,
+            resources={"metadata": {"path": str(NOTEBOOKS_DIR.resolve())}},
+        )
+        try:
+            executed_nb = client.execute()
+        except Exception as exc:
+            pytest.fail(f"nbclient execution failed for {filename}:\nError: {exc}")
+
+    # Compare fresh execution against committed outputs cell-by-cell
+    assert len(executed_nb.cells) == len(committed_nb.cells), (
+        f"Cell count mismatch in {filename}"
+    )
+
+    for idx, (fresh_cell, committed_cell) in enumerate(
+        zip(executed_nb.cells, committed_nb.cells)
+    ):
+        if fresh_cell.cell_type != "code":
+            continue
+
+        fresh_out = _extract_cell_output_text(fresh_cell)
+        committed_out = _extract_cell_output_text(committed_cell)
+
+        _scan_for_leaks(fresh_out, filename)
+        _scan_for_leaks(committed_out, filename)
+
+        assert fresh_out == committed_out, (
+            f"Stale output in {filename} at code cell {idx}.\n"
+            f"Freshly Executed Output:\n{fresh_out}\n\n"
+            f"Committed Output:\n{committed_out}"
+        )
+
+
+@pytest.mark.parametrize("filename", GALLERY_NOTEBOOKS)
+def test_gallery_notebook_zero_leakage_and_clean_environment(
+    filename: str,
+) -> None:
+    """Assert zero unmasked identifiers or environment paths in outputs."""
+    nb = _load_notebook(filename)
+    for idx, cell in enumerate(nb.cells):
+        if cell.cell_type == "code":
+            out_text = _extract_cell_output_text(cell)
+            _scan_for_leaks(out_text, filename)

--- a/uv.lock
+++ b/uv.lock
@@ -433,6 +433,15 @@ wheels = [
 ]
 
 [[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
 name = "apprise"
 version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -501,6 +510,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
     { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
     { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/1e/faf0f247f6f881b98fc4d6d07e14085cb89d13665084e6d6ac1dc2c03d0b/asttokens-3.0.2.tar.gz", hash = "sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2", size = 63136, upload-time = "2026-07-12T03:31:49.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl", hash = "sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933", size = 28702, upload-time = "2026-07-12T03:31:47.542Z" },
 ]
 
 [[package]]
@@ -1366,6 +1384,15 @@ wheels = [
 ]
 
 [[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
 name = "confection"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1991,6 +2018,35 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/aa/12037145b7a56eaa5b29b41872f7a21b538e807e13f32c4d3c46e59be084/debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6", size = 1697577, upload-time = "2026-06-01T19:30:35.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/f3/6b1d4c71f4cbb5360009f928934a03b42906f28fc7b3f7f35f04e58acead/debugpy-1.8.21-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:8eeab7b5462f683452c57c0126aaa5ec4e974ddb705f39ba87dff8818c8e08f9", size = 2113873, upload-time = "2026-06-01T19:30:37.148Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f2/17c3bf91cebc173bfbf5734cd2669723d0a35c0cf9d2fd2124546efeae83/debugpy-1.8.21-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:0fddfdc130ac6d8bfc0415b0409822fa901c8f310e5c945ac5653a0352532344", size = 3004715, upload-time = "2026-06-01T19:30:38.888Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/22/1f8efd80c7b5909e760f9cfd0c9e8681d2d35d532f7c0a40760cd4da4a19/debugpy-1.8.21-cp310-cp310-win32.whl", hash = "sha256:72b5d676c4cbfac3bac5bb01c138a4656e843f93f03ce2a5f4e394ad49fbee73", size = 5303455, upload-time = "2026-06-01T19:30:40.52Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ce/54c79abd6cccef92fa7b43d97e3acafedf4d645557267ece05e948b5e4b8/debugpy-1.8.21-cp310-cp310-win_amd64.whl", hash = "sha256:a7fe47fd23da57b9e0bec3f4a8ee65a2dc55782455ed7f2141d75ab5d2eaeef5", size = 5331751, upload-time = "2026-06-01T19:30:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/cbf306d6e07a313a91e7171a98669054502840931432c227cfd505ee367f/debugpy-1.8.21-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:da456226c7b4c69e35dbe35dcee6623d912000a77816db7856a41af1c72a0264", size = 2203120, upload-time = "2026-06-01T19:30:43.964Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/57/aa739bd4ad2cbf96aeb1b20b56918ddd5ae4c28b68709bfcd327f02123ee/debugpy-1.8.21-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:f68b891688e61bdc08b8d364d919ff0051e0b94657b39dcd027bc3173edb7cdc", size = 3059958, upload-time = "2026-06-01T19:30:45.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/31/453d2c9a23d133fe2c8ec7ca1d816ded52a913487fe3ffef7c01b4b706af/debugpy-1.8.21-cp311-cp311-win32.whl", hash = "sha256:f843a8b08c2edeaf9b1582eed4f25441af21a297c22ff16bf76a662557aa9c9e", size = 5236515, upload-time = "2026-06-01T19:30:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/6660de2f2d7bf388f229335ba4637646eebabdbf38564cb439a95a9193c9/debugpy-1.8.21-cp311-cp311-win_amd64.whl", hash = "sha256:84c564d8cc701d41843b29a92814c1f1bef6798724ca9d675c284ad9f6a547d7", size = 5256138, upload-time = "2026-06-01T19:30:49.113Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/df/bf625547431a9cadc9f4cbfeda38866e2b17f6aed147b625377e87834449/debugpy-1.8.21-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:9f96713896f39c3dff0ee841f47320c3f2983d33c341e009361bb0ebc79adc4e", size = 2483609, upload-time = "2026-06-01T19:30:50.794Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/59324b903599031ff9faaec1758292409f6561a0ec2492fe4b703327705a/debugpy-1.8.21-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:c193d474f0a211191f2b4449d2d06157c689013035bd952f3b617e0ef422b176", size = 3968900, upload-time = "2026-06-01T19:30:52.341Z" },
+    { url = "https://files.pythonhosted.org/packages/14/cd/27f65b805d7fe005c44e1a36b9183ecdfbcdbf9d3e721a5115d461ecc7ee/debugpy-1.8.21-cp312-cp312-win32.whl", hash = "sha256:4743373c1cac7f9e74a1b9915bf1dbe0e900eca657ffb170ae07ac8363205ae9", size = 5336340, upload-time = "2026-06-01T19:30:54.047Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1d/c84e30c0c674184948b66f076ab271c01d940618a2824c23cd035a27bc20/debugpy-1.8.21-cp312-cp312-win_amd64.whl", hash = "sha256:bd7ba9dd3daa7c2f942c6ca8d4695a16bf9ac16b63615261c7982bc74f7ed20c", size = 5374751, upload-time = "2026-06-01T19:30:55.891Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6b/d817e1f8cc77aa055d37fba092e0febfdff40fe652d8d53d4cd7a86ad98d/debugpy-1.8.21-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:13678151fc401e2d68c9880b91e28714f797d40422994572b24560ef80910a88", size = 2477398, upload-time = "2026-06-01T19:30:57.644Z" },
+    { url = "https://files.pythonhosted.org/packages/48/57/412421516afc3055fa577516f00beec3d663f9b0ab330639547ae6c57720/debugpy-1.8.21-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:ecbd158386c31ffe71d46f72d44d56e66331ab9b16cad649156d514368f23ab2", size = 3962096, upload-time = "2026-06-01T19:30:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2c616337cf6ba7b07ebbc97f02c6c945a8e2f76b365e33ee809c32ee36d1/debugpy-1.8.21-cp313-cp313-win32.whl", hash = "sha256:2c2ae706dec41d99a9ca1f7ebc987a83e65578363be6f6b3ac9067504917fae1", size = 5336288, upload-time = "2026-06-01T19:31:00.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/99/9175103392f84c4b1bf7622888cdc68da07f0ff7d9e581266428f6776033/debugpy-1.8.21-cp313-cp313-win_amd64.whl", hash = "sha256:aa648733047443eb1d07682c4ef287d36a54507b643ffdf38b09a3ef002c72a0", size = 5376567, upload-time = "2026-06-01T19:31:02.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3d/f4bbb323a548bfab2af3d6b4ffd9bf22636e55956a1285d317a1de643aad/debugpy-1.8.21-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9bb2a685287a2ac9b181cde89edcec64845cb51de7faaa75badb9a698bc24782", size = 2477209, upload-time = "2026-06-01T19:31:04.157Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2d/6e7ec524984a1702777868de49a4c53202bddac2a432a76a093469587750/debugpy-1.8.21-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:3d6922439bf33fd38a3e2c447869ebc7b97da5cd3d329ff1ef9bc06c4903437e", size = 3927115, upload-time = "2026-06-01T19:31:05.863Z" },
+    { url = "https://files.pythonhosted.org/packages/97/47/d1aa6d64005a98a9144647d99306b419396f9ad7bf1d73c119e17a81fb4d/debugpy-1.8.21-cp314-cp314-win32.whl", hash = "sha256:15d4963bd5ffa48f0da0947fd06757fa7621945048a14ad7705431566d3c0e7c", size = 5336724, upload-time = "2026-06-01T19:31:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/b905b90d163af11878c1af8abafa4a25206335e112e284e413454543a6da/debugpy-1.8.21-cp314-cp314-win_amd64.whl", hash = "sha256:fe0744a12353406de0ae8ccff0d0a4a666f00801a3db8fd04e7a5f761cd520e8", size = 5373803, upload-time = "2026-06-01T19:31:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92", size = 5352888, upload-time = "2026-06-01T19:31:25.186Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2151,8 +2207,8 @@ version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ninja" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
     { name = "opencv-python-headless" },
     { name = "pillow" },
     { name = "pyclipper" },
@@ -2292,6 +2348,15 @@ wheels = [
 ]
 
 [[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
 name = "faker"
 version = "40.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2378,6 +2443,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/18/7881a99ba5244bfc82f06017316ffe93217dbbbcfa52b887caa1d4f2a6d3/fasteners-0.20.tar.gz", hash = "sha256:55dce8792a41b56f727ba6e123fcaee77fd87e638a6863cec00007bfea84c8d8", size = 25087, upload-time = "2025-08-11T10:19:37.785Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl", hash = "sha256:9422c40d1e350e4259f509fb2e608d6bc43c0136f79a00db1b49046029d0b3b7", size = 18702, upload-time = "2025-08-11T10:19:35.716Z" },
+]
+
+[[package]]
+name = "fastjsonschema"
+version = "2.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/98/474719c58eddaf77fa443b063693e76d49db32bbe851bcbaf58d2700119f/fastjsonschema-2.22.1.tar.gz", hash = "sha256:0b83d1ce8d7845b959dcb20e1a5c3c8883b6541d9c52ab02cce5166b75ec805f", size = 382291, upload-time = "2026-07-27T13:31:08.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/e1/62cc96341f01bdff2ba967441939178fcd1900d11ce7e6554d9954a5d7ec/fastjsonschema-2.22.1-py3-none-any.whl", hash = "sha256:cf377ff5c9a6f4f3125fb35f75a2c5767bd824ffbcf62c209a93cd48d1453999", size = 26239, upload-time = "2026-07-27T13:31:03.251Z" },
 ]
 
 [[package]]
@@ -3226,8 +3300,8 @@ name = "h5py"
 version = "3.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
 wheels = [
@@ -3660,8 +3734,8 @@ name = "imageio"
 version = "2.37.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
     { name = "pillow" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
@@ -3717,6 +3791,112 @@ wheels = [
 ]
 
 [[package]]
+name = "ipykernel"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "ipython", version = "9.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio2" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/e4a38f579de4225a561305666f7541cdabb30075def2aa1ac17bd73c1fb5/ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09", size = 184899, upload-time = "2026-06-10T08:41:25.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057", size = 120583, upload-time = "2026-06-10T08:41:23.648Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "8.39.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
+dependencies = [
+    { name = "colorama", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.11' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (python_full_version >= '3.11' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (python_full_version >= '3.11' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform != 'win32' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (sys_platform != 'win32' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform != 'win32' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform != 'win32' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform != 'win32' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "decorator", marker = "python_full_version < '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "jedi", marker = "python_full_version < '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "pexpect", marker = "(python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version >= '3.11' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (python_full_version >= '3.11' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (python_full_version >= '3.11' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (sys_platform == 'win32' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'win32' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'win32' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'win32' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'win32' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "pygments", marker = "python_full_version < '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "stack-data", marker = "python_full_version < '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "traitlets", marker = "python_full_version < '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/56/4cc7fc9e9e3f38fd324f24f8afe0ad8bb5fa41283f37f1aaf9de0612c968/ipython-8.39.0-py3-none-any.whl", hash = "sha256:bb3c51c4fa8148ab1dea07a79584d1c854e234ea44aa1283bcb37bc75054651f", size = 831849, upload-time = "2026-03-27T10:02:07.846Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.16.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
+    "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version >= '3.15' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.14.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
+dependencies = [
+    { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (python_full_version < '3.11' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (python_full_version < '3.11' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform != 'win32' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (sys_platform != 'win32' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform != 'win32' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform != 'win32' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform != 'win32' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "jedi", marker = "python_full_version >= '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "pexpect", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version < '3.11' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (python_full_version < '3.11' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (python_full_version < '3.11' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (sys_platform == 'win32' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'win32' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'win32' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'win32' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'win32' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "psutil", marker = "(python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten') or (python_full_version < '3.11' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (python_full_version < '3.11' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (python_full_version < '3.11' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'cygwin' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (sys_platform == 'emscripten' and extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (sys_platform == 'cygwin' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'cygwin' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'cygwin' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'cygwin' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (sys_platform == 'emscripten' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "stack-data", marker = "python_full_version >= '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "traitlets", marker = "python_full_version >= '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/96/b150fe7e25a5a29ae9ac1374e71488639605d39a1ea4abb74c9ce33af235/ipython-9.16.1.tar.gz", hash = "sha256:5a3d1f9a47ff216d6cf9cf863124f6a2c1a198d1354c546a4d24a370a283b64c", size = 4515302, upload-time = "2026-08-03T08:36:15.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8e/1239df488393d61076653bfb29f759d0f60cab8e030abdf7c17c31539b51/ipython-9.16.1-py3-none-any.whl", hash = "sha256:4acae635506f6d352d94c4899a19d5f85f8bc4d230932342dca556fdab1c69b4", size = 625974, upload-time = "2026-08-03T08:36:13.654Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3732,6 +3912,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/08/4e/dc2b1a89a4ffafbf9bf49c8e11f69e28ba8b3ef81d11afe6e9f96caee6cc/Janome-0.5.0.tar.gz", hash = "sha256:ce4a3ed7a4635c2f80139639327d5b1e0381858ad74a3c4a61e8cc83f820400e", size = 18829020, upload-time = "2023-07-01T10:53:09.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/7d/70f4069f4bbf0fca023e82a1fbbade6f5216365d4fe259fee1950723eca5/Janome-0.5.0-py2.py3-none-any.whl", hash = "sha256:d098670394a77881ce2f6b7d696c0ea5ff74c0c8cf74a8a882159ec82c0e6dc7", size = 19654103, upload-time = "2023-07-01T10:52:58.572Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
 ]
 
 [[package]]
@@ -3946,6 +4138,36 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-client"
+version = "8.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/dc/5512503b088997c2250b8bf18258fba9d9ce5ead641183700960d3c9d342/jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa", size = 359256, upload-time = "2026-06-09T13:15:01.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/6f/56d39bf385c5c27988aebaf0c18a2a17e960575740100973511018bd904e/jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81", size = 109828, upload-time = "2026-06-09T13:14:58.835Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
 name = "langchain-core"
 version = "1.4.8"
 source = { registry = "https://pypi.org/simple" }
@@ -3982,7 +4204,7 @@ name = "langdetect"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "extra == 'extra-7-openmed-gliner' or extra == 'extra-7-openmed-multimodal' or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "six", marker = "extra == 'extra-7-openmed-gliner' or extra == 'extra-7-openmed-multimodal' or extra == 'extra-7-openmed-onnx' or extra != 'extra-7-openmed-scispacy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2569554f7c70f4a3c27712f40e3284d483e88094cc0e/langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0", size = 981474, upload-time = "2021-05-07T07:54:13.562Z" }
 
@@ -4535,6 +4757,18 @@ wheels = [
 ]
 
 [[package]]
+name = "matplotlib-inline"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4785,8 +5019,8 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
@@ -5341,12 +5575,51 @@ wheels = [
 ]
 
 [[package]]
+name = "nbclient"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "nbformat" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/a5/b3bae4b590c0cbcada2c63a34f7580024e834a8ba213e949a2f906705787/nbclient-0.11.0.tar.gz", hash = "sha256:04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a", size = 62535, upload-time = "2026-06-05T07:52:41.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl", hash = "sha256:ef7fa0d59d6e1d41103933d8a445a18d5de860ca6b613b87b8574accdb3c2895", size = 25288, upload-time = "2026-06-05T07:52:40.115Z" },
+]
+
+[[package]]
+name = "nbformat"
+version = "5.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/80f407a9525bc5bd9865e5c37db3b78867fa43217f8aac5eab22b5f028b3/nbformat-5.11.0.tar.gz", hash = "sha256:7dbaed4a69cae28c2b4d44ab7430a6af4544fb89455023f6f21550be757b60c8", size = 151822, upload-time = "2026-08-06T12:29:55.597Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/4a/0eece9dad5e73230ca972f7bc29456ce7d74772f123d401fcf67379008f7/nbformat-5.11.0-py3-none-any.whl", hash = "sha256:f70a17f591a9ccd1c601d5e61a4b20972703926df0ba42458ce14bf575766bb6", size = 79820, upload-time = "2026-08-06T12:29:54.178Z" },
+]
+
+[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
 ]
 
 [[package]]
@@ -5799,8 +6072,8 @@ version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml-dtypes" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
     { name = "protobuf" },
     { name = "typing-extensions" },
 ]
@@ -6059,8 +6332,8 @@ name = "opencv-python"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
 wheels = [
@@ -6077,8 +6350,8 @@ name = "opencv-python-headless"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929, upload-time = "2025-01-16T13:53:40.22Z" }
 wheels = [
@@ -6151,9 +6424,12 @@ dev = [
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "hypothesis" },
+    { name = "ipykernel" },
     { name = "jsonschema" },
     { name = "mcp" },
     { name = "mypy" },
+    { name = "nbclient" },
+    { name = "nbformat" },
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or extra == 'extra-7-openmed-scispacy' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
     { name = "opencc" },
@@ -6257,8 +6533,8 @@ mlx = [
 multimodal = [
     { name = "easyocr" },
     { name = "markdown-it-py" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
     { name = "onnx" },
     { name = "openpyxl" },
     { name = "pdfplumber" },
@@ -6416,6 +6692,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'onnx-runtime'", specifier = ">=0.30" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "indic-nlp-library", marker = "extra == 'indic'", specifier = ">=0.92" },
+    { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "jieba", specifier = ">=0.42.1,<0.43" },
     { name = "jieba", marker = "extra == 'zh'", specifier = ">=0.42" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
@@ -6438,6 +6715,8 @@ requires-dist = [
     { name = "mlx", marker = "extra == 'mlx'", specifier = ">=0.22" },
     { name = "mlx-lm", marker = "extra == 'mlx'", specifier = ">=0.31" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "nbclient", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "nbformat", marker = "extra == 'dev'", specifier = ">=5.9.0" },
     { name = "nncf", marker = "extra == 'openvino'", specifier = ">=2.10" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.26" },
     { name = "numpy", marker = "extra == 'duckdb'", specifier = ">=1.26" },
@@ -7057,6 +7336,15 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
 name = "partd"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -7204,6 +7492,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/b0/a36c468d2d0dec62ddea7c5e4177e93abb12f48ac90f09f24d0581c5189f/pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5cd956d4176afc7bfe8a91bf3f771b46ff8d326f6c5bf778eb5010eb742ebba6", size = 561884, upload-time = "2026-01-30T11:22:19.671Z" },
     { url = "https://files.pythonhosted.org/packages/c5/4d/dad105261898907bf806cabca53d3878529a9fa2c0d5d7f95f2035246fc2/pendulum-3.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:39ef129d7b90aab49708645867abdd207b714ba7bff12dae549975b0aca09716", size = 261236, upload-time = "2026-01-30T11:22:21.059Z" },
     { url = "https://files.pythonhosted.org/packages/02/fb/d65db067a67df7252f18b0cb7420dda84078b9e8bfb375215469c14a50be/pendulum-3.2.0-py3-none-any.whl", hash = "sha256:f3a9c18a89b4d9ef39c5fa6a78722aaff8d5be2597c129a3b16b9f40a561acf3", size = 114111, upload-time = "2026-01-30T11:22:22.361Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "python_full_version < '3.12' or python_full_version >= '3.15' or sys_platform != 'win32' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
 ]
 
 [[package]]
@@ -7633,6 +7933,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -7811,6 +8123,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/95/992c8816a74016eb095e73585d747e0a8ea21a061ed3689474fabb29a395/psutil-7.1.3-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56d974e02ca2c8eb4812c3f76c30e28836fffc311d55d979f1465c1feeb2b68b", size = 264635, upload-time = "2025-11-02T12:26:31.74Z" },
     { url = "https://files.pythonhosted.org/packages/55/4c/c3ed1a622b6ae2fd3c945a366e64eb35247a31e4db16cf5095e269e8eb3c/psutil-7.1.3-cp37-abi3-win_amd64.whl", hash = "sha256:f39c2c19fe824b47484b96f9692932248a54c43799a84282cfe58d05a6449efd", size = 247633, upload-time = "2025-11-02T12:26:33.887Z" },
     { url = "https://files.pythonhosted.org/packages/c9/ad/33b2ccec09bf96c2b2ef3f9a6f66baac8253d7565d8839e024a6b905d45d/psutil-7.1.3-cp37-abi3-win_arm64.whl", hash = "sha256:bd0d69cee829226a761e92f28140bec9a5ee9d5b4fb4b0cc589068dbfff559b1", size = 244608, upload-time = "2025-11-02T12:26:36.136Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
 ]
 
 [[package]]
@@ -8744,8 +9074,8 @@ dependencies = [
     { name = "h5py" },
     { name = "huggingface-hub" },
     { name = "langdetect" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
     { name = "onnx" },
     { name = "opencv-python" },
     { name = "pillow" },
@@ -8972,6 +9302,79 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/b9/52aa9ec2867528b54f1e60846728d8b4d84726630874fee3a91e66c7df81/pyzmq-27.1.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:508e23ec9bc44c0005c4946ea013d9317ae00ac67778bd47519fdf5a0e930ff4", size = 1329850, upload-time = "2025-09-08T23:07:26.274Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/5653e7b7425b169f994835a2b2abf9486264401fdef18df91ddae47ce2cc/pyzmq-27.1.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:507b6f430bdcf0ee48c0d30e734ea89ce5567fd7b8a0f0044a369c176aa44556", size = 906380, upload-time = "2025-09-08T23:07:29.78Z" },
+    { url = "https://files.pythonhosted.org/packages/73/78/7d713284dbe022f6440e391bd1f3c48d9185673878034cfb3939cdf333b2/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf7b38f9fd7b81cb6d9391b2946382c8237fd814075c6aa9c3b746d53076023b", size = 666421, upload-time = "2025-09-08T23:07:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/30/76/8f099f9d6482450428b17c4d6b241281af7ce6a9de8149ca8c1c649f6792/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03ff0b279b40d687691a6217c12242ee71f0fba28bf8626ff50e3ef0f4410e1e", size = 854149, upload-time = "2025-09-08T23:07:33.17Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f0/37fbfff06c68016019043897e4c969ceab18bde46cd2aca89821fcf4fb2e/pyzmq-27.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:677e744fee605753eac48198b15a2124016c009a11056f93807000ab11ce6526", size = 1655070, upload-time = "2025-09-08T23:07:35.205Z" },
+    { url = "https://files.pythonhosted.org/packages/47/14/7254be73f7a8edc3587609554fcaa7bfd30649bf89cd260e4487ca70fdaa/pyzmq-27.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dd2fec2b13137416a1c5648b7009499bcc8fea78154cd888855fa32514f3dad1", size = 2033441, upload-time = "2025-09-08T23:07:37.432Z" },
+    { url = "https://files.pythonhosted.org/packages/22/dc/49f2be26c6f86f347e796a4d99b19167fc94503f0af3fd010ad262158822/pyzmq-27.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:08e90bb4b57603b84eab1d0ca05b3bbb10f60c1839dc471fc1c9e1507bef3386", size = 1891529, upload-time = "2025-09-08T23:07:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3e/154fb963ae25be70c0064ce97776c937ecc7d8b0259f22858154a9999769/pyzmq-27.1.0-cp310-cp310-win32.whl", hash = "sha256:a5b42d7a0658b515319148875fcb782bbf118dd41c671b62dae33666c2213bda", size = 567276, upload-time = "2025-09-08T23:07:40.695Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/f4ab56c8c595abcb26b2be5fd9fa9e6899c1e5ad54964e93ae8bb35482be/pyzmq-27.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:c0bb87227430ee3aefcc0ade2088100e528d5d3298a0a715a64f3d04c60ba02f", size = 632208, upload-time = "2025-09-08T23:07:42.298Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e3/be2cc7ab8332bdac0522fdb64c17b1b6241a795bee02e0196636ec5beb79/pyzmq-27.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:9a916f76c2ab8d045b19f2286851a38e9ac94ea91faf65bd64735924522a8b32", size = 559766, upload-time = "2025-09-08T23:07:43.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/5d/305323ba86b284e6fcb0d842d6adaa2999035f70f8c38a9b6d21ad28c3d4/pyzmq-27.1.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:226b091818d461a3bef763805e75685e478ac17e9008f49fce2d3e52b3d58b86", size = 1333328, upload-time = "2025-09-08T23:07:45.946Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a0/fc7e78a23748ad5443ac3275943457e8452da67fda347e05260261108cbc/pyzmq-27.1.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0790a0161c281ca9723f804871b4027f2e8b5a528d357c8952d08cd1a9c15581", size = 908803, upload-time = "2025-09-08T23:07:47.551Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/37d15eb05f3bdfa4abea6f6d96eb3bb58585fbd3e4e0ded4e743bc650c97/pyzmq-27.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c895a6f35476b0c3a54e3eb6ccf41bf3018de937016e6e18748317f25d4e925f", size = 668836, upload-time = "2025-09-08T23:07:49.436Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c4/2a6fe5111a01005fc7af3878259ce17684fabb8852815eda6225620f3c59/pyzmq-27.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bbf8d3630bf96550b3be8e1fc0fea5cbdc8d5466c1192887bd94869da17a63e", size = 857038, upload-time = "2025-09-08T23:07:51.234Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/eb/bfdcb41d0db9cd233d6fb22dc131583774135505ada800ebf14dfb0a7c40/pyzmq-27.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:15c8bd0fe0dabf808e2d7a681398c4e5ded70a551ab47482067a572c054c8e2e", size = 1657531, upload-time = "2025-09-08T23:07:52.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/21/e3180ca269ed4a0de5c34417dfe71a8ae80421198be83ee619a8a485b0c7/pyzmq-27.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:bafcb3dd171b4ae9f19ee6380dfc71ce0390fefaf26b504c0e5f628d7c8c54f2", size = 2034786, upload-time = "2025-09-08T23:07:55.047Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b1/5e21d0b517434b7f33588ff76c177c5a167858cc38ef740608898cd329f2/pyzmq-27.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e829529fcaa09937189178115c49c504e69289abd39967cd8a4c215761373394", size = 1894220, upload-time = "2025-09-08T23:07:57.172Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f2/44913a6ff6941905efc24a1acf3d3cb6146b636c546c7406c38c49c403d4/pyzmq-27.1.0-cp311-cp311-win32.whl", hash = "sha256:6df079c47d5902af6db298ec92151db82ecb557af663098b92f2508c398bb54f", size = 567155, upload-time = "2025-09-08T23:07:59.05Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6d/d8d92a0eb270a925c9b4dd039c0b4dc10abc2fcbc48331788824ef113935/pyzmq-27.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:190cbf120fbc0fc4957b56866830def56628934a9d112aec0e2507aa6a032b97", size = 633428, upload-time = "2025-09-08T23:08:00.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/14/01afebc96c5abbbd713ecfc7469cfb1bc801c819a74ed5c9fad9a48801cb/pyzmq-27.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:eca6b47df11a132d1745eb3b5b5e557a7dae2c303277aa0e69c6ba91b8736e07", size = 559497, upload-time = "2025-09-08T23:08:02.15Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cb/84a13459c51da6cec1b7b1dc1a47e6db6da50b77ad7fd9c145842750a011/pyzmq-27.1.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:93ad4b0855a664229559e45c8d23797ceac03183c7b6f5b4428152a6b06684a5", size = 1122436, upload-time = "2025-09-08T23:08:20.801Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/94414759a69a26c3dd674570a81813c46a078767d931a6c70ad29fc585cb/pyzmq-27.1.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:fbb4f2400bfda24f12f009cba62ad5734148569ff4949b1b6ec3b519444342e6", size = 1156301, upload-time = "2025-09-08T23:08:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ad/15906493fd40c316377fd8a8f6b1f93104f97a752667763c9b9c1b71d42d/pyzmq-27.1.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:e343d067f7b151cfe4eb3bb796a7752c9d369eed007b91231e817071d2c2fec7", size = 1341197, upload-time = "2025-09-08T23:08:24.286Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d343f3ce13db53a54cb8946594e567410b2125394dafcc0268d8dda027e0/pyzmq-27.1.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:08363b2011dec81c354d694bdecaef4770e0ae96b9afea70b3f47b973655cc05", size = 897275, upload-time = "2025-09-08T23:08:26.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2d/d83dd6d7ca929a2fc67d2c3005415cdf322af7751d773524809f9e585129/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54530c8c8b5b8ddb3318f481297441af102517602b569146185fa10b63f4fa9", size = 660469, upload-time = "2025-09-08T23:08:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cd/9822a7af117f4bc0f1952dbe9ef8358eb50a24928efd5edf54210b850259/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3afa12c392f0a44a2414056d730eebc33ec0926aae92b5ad5cf26ebb6cc128", size = 847961, upload-time = "2025-09-08T23:08:29.672Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/12/f003e824a19ed73be15542f172fd0ec4ad0b60cf37436652c93b9df7c585/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c65047adafe573ff023b3187bb93faa583151627bc9c51fc4fb2c561ed689d39", size = 1650282, upload-time = "2025-09-08T23:08:31.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4a/e82d788ed58e9a23995cee70dbc20c9aded3d13a92d30d57ec2291f1e8a3/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:90e6e9441c946a8b0a667356f7078d96411391a3b8f80980315455574177ec97", size = 2024468, upload-time = "2025-09-08T23:08:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/94/2da0a60841f757481e402b34bf4c8bf57fa54a5466b965de791b1e6f747d/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:add071b2d25f84e8189aaf0882d39a285b42fa3853016ebab234a5e78c7a43db", size = 1885394, upload-time = "2025-09-08T23:08:35.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6f/55c10e2e49ad52d080dc24e37adb215e5b0d64990b57598abc2e3f01725b/pyzmq-27.1.0-cp313-cp313t-win32.whl", hash = "sha256:7ccc0700cfdf7bd487bea8d850ec38f204478681ea02a582a8da8171b7f90a1c", size = 574964, upload-time = "2025-09-08T23:08:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4d/2534970ba63dd7c522d8ca80fb92777f362c0f321900667c615e2067cb29/pyzmq-27.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8085a9fba668216b9b4323be338ee5437a235fe275b9d1610e422ccc279733e2", size = 641029, upload-time = "2025-09-08T23:08:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fa/f8aea7a28b0641f31d40dea42d7ef003fded31e184ef47db696bc74cd610/pyzmq-27.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6bb54ca21bcfe361e445256c15eedf083f153811c37be87e0514934d6913061e", size = 561541, upload-time = "2025-09-08T23:08:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/87/45/19efbb3000956e82d0331bafca5d9ac19ea2857722fa2caacefb6042f39d/pyzmq-27.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ce980af330231615756acd5154f29813d553ea555485ae712c491cd483df6b7a", size = 1341197, upload-time = "2025-09-08T23:08:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/d72ccdbf0d73d1343936296665826350cb1e825f92f2db9db3e61c2162a2/pyzmq-27.1.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1779be8c549e54a1c38f805e56d2a2e5c009d26de10921d7d51cfd1c8d4632ea", size = 897175, upload-time = "2025-09-08T23:08:46.601Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/a483f73a10b65a9ef0161e817321d39a770b2acf8bcf3004a28d90d14a94/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7200bb0f03345515df50d99d3db206a0a6bee1955fbb8c453c76f5bf0e08fb96", size = 660427, upload-time = "2025-09-08T23:08:48.187Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/5f36552c2d3e5685abe60dfa56f91169f7a2d99bbaf67c5271022ab40863/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d", size = 847929, upload-time = "2025-09-08T23:08:49.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2a/404b331f2b7bf3198e9945f75c4c521f0c6a3a23b51f7a4a401b94a13833/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:80d834abee71f65253c91540445d37c4c561e293ba6e741b992f20a105d69146", size = 1650193, upload-time = "2025-09-08T23:08:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0b/f4107e33f62a5acf60e3ded67ed33d79b4ce18de432625ce2fc5093d6388/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:544b4e3b7198dde4a62b8ff6685e9802a9a1ebf47e77478a5eb88eca2a82f2fd", size = 2024388, upload-time = "2025-09-08T23:08:53.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/add31fe76512642fd6e40e3a3bd21f4b47e242c8ba33efb6809e37076d9b/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cedc4c68178e59a4046f97eca31b148ddcf51e88677de1ef4e78cf06c5376c9a", size = 1885316, upload-time = "2025-09-08T23:08:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/81/a65e71c1552f74dec9dff91d95bafb6e0d33338a8dfefbc88aa562a20c92/pyzmq-27.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c17e03cbc9312bee223864f1a2b13a99522e0dc9f7c5df0177cd45210ac286e6", size = 836266, upload-time = "2025-09-08T23:09:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/0202ca350f4f2b69faa95c6d931e3c05c3a397c184cacb84cb4f8f42f287/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f328d01128373cb6763823b2b4e7f73bdf767834268c565151eacb3b7a392f90", size = 800206, upload-time = "2025-09-08T23:09:41.902Z" },
+    { url = "https://files.pythonhosted.org/packages/47/42/1ff831fa87fe8f0a840ddb399054ca0009605d820e2b44ea43114f5459f4/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c1790386614232e1b3a40a958454bdd42c6d1811837b15ddbb052a032a43f62", size = 567747, upload-time = "2025-09-08T23:09:43.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/5c4d6807434751e3f21231bee98109aa57b9b9b55e058e450d0aef59b70f/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:448f9cb54eb0cee4732b46584f2710c8bc178b0e5371d9e4fc8125201e413a74", size = 747371, upload-time = "2025-09-08T23:09:45.575Z" },
+    { url = "https://files.pythonhosted.org/packages/26/af/78ce193dbf03567eb8c0dc30e3df2b9e56f12a670bf7eb20f9fb532c7e8a/pyzmq-27.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:05b12f2d32112bf8c95ef2e74ec4f1d4beb01f8b5e703b38537f8849f92cb9ba", size = 544862, upload-time = "2025-09-08T23:09:47.448Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c6/c4dcdecdbaa70969ee1fdced6d7b8f60cfabe64d25361f27ac4665a70620/pyzmq-27.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:18770c8d3563715387139060d37859c02ce40718d1faf299abddcdcc6a649066", size = 836265, upload-time = "2025-09-08T23:09:49.376Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/79/f38c92eeaeb03a2ccc2ba9866f0439593bb08c5e3b714ac1d553e5c96e25/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ac25465d42f92e990f8d8b0546b01c391ad431c3bf447683fdc40565941d0604", size = 800208, upload-time = "2025-09-08T23:09:51.073Z" },
+    { url = "https://files.pythonhosted.org/packages/49/0e/3f0d0d335c6b3abb9b7b723776d0b21fa7f3a6c819a0db6097059aada160/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53b40f8ae006f2734ee7608d59ed661419f087521edbfc2149c3932e9c14808c", size = 567747, upload-time = "2025-09-08T23:09:52.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/cf/f2b3784d536250ffd4be70e049f3b60981235d70c6e8ce7e3ef21e1adb25/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f605d884e7c8be8fe1aa94e0a783bf3f591b84c24e4bc4f3e7564c82ac25e271", size = 747371, upload-time = "2025-09-08T23:09:54.563Z" },
+    { url = "https://files.pythonhosted.org/packages/01/1b/5dbe84eefc86f48473947e2f41711aded97eecef1231f4558f1f02713c12/pyzmq-27.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c9f7f6e13dff2e44a6afeaf2cf54cee5929ad64afaf4d40b50f93c58fc687355", size = 544862, upload-time = "2025-09-08T23:09:56.509Z" },
 ]
 
 [[package]]
@@ -9670,8 +10073,8 @@ dependencies = [
     { name = "imageio" },
     { name = "lazy-loader" },
     { name = "networkx" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "scipy" },
@@ -10399,6 +10802,20 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -10600,8 +11017,8 @@ name = "tifffile"
 version = "2025.5.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
 wheels = [
@@ -10868,8 +11285,8 @@ name = "torchvision"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version < '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-gliner' and extra != 'extra-7-openmed-scispacy') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-multimodal') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra == 'extra-7-openmed-onnx') or (python_full_version >= '3.13' and extra != 'extra-7-openmed-awq' and extra != 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-multimodal' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-onnx' and extra == 'extra-7-openmed-scispacy') or (extra == 'extra-7-openmed-awq' and extra == 'extra-7-openmed-gliner')" },
     { name = "pillow" },
     { name = "torch" },
 ]
@@ -10905,6 +11322,23 @@ wheels = [
 ]
 
 [[package]]
+name = "tornado"
+version = "6.5.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/d3/343e5bb989d6515b1646cf3d40135d73f3d5e45339bded401b56cdac24dd/tornado-6.5.8.tar.gz", hash = "sha256:9452e1b208a8bd771e2cb1f2ff564985b9b214bdebbe622793e1799e0a6bd23f", size = 520493, upload-time = "2026-08-07T02:12:42.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/d5/007086fd8df5489338e204f65adce33fd4f21a4999dbb2b9cff2f897b5f4/tornado-6.5.8-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:cc6aa787d7cfab7c3d35189dc7a56fbd2399a569624c730c6b55b3d6531d0403", size = 449487, upload-time = "2026-08-07T02:12:28.682Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c8/5a24a99495903f594f6a199dd7beead1cbc0a13e2cb9102727bcaaf2a997/tornado-6.5.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9715b5eb79735b2bcd454ce216a9275b7c0470e64ea1bf5742f78b2f72b26eeb", size = 447649, upload-time = "2026-08-07T02:12:30.306Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/de/f2e733f386b85962d1b1dc82cd63d169b5b4580062b35397eac9244a41fe/tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:547d63f450d570c14fe0e8db2cfb14c9bbd1c2503b4a6612586267955aa47b58", size = 450707, upload-time = "2026-08-07T02:12:31.95Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/94/20efeee9a01c141e9ac47c397f81679dfda24b32768fc4fff24e76d36c2c/tornado-6.5.8-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2360a0ffbe145eca8af0b19cb7203d79b1a98dd4cccdd6b368f6f49c2e3808", size = 451677, upload-time = "2026-08-07T02:12:33.512Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ec/a96ccb8ccf0de2b7bc2c5fa1608a4803735018242e90c4882365a9fd418f/tornado-6.5.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5d242290bdf7ab3151bc1065fdd75c0dcc21cbc7b49f22a4c56329c2d6566d22", size = 451510, upload-time = "2026-08-07T02:12:35.346Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b5/93185859245ad3f00e62175f29607346788b696369347f0146e0421286bb/tornado-6.5.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7b94ff0e128fe0542f3bd331fb44d06260fc4ac16881545159f34ef08aad4195", size = 450917, upload-time = "2026-08-07T02:12:36.963Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cf/fe33cf062834487d34d1559746a4a12521033c22645b6d74d4bca702e018/tornado-6.5.8-cp39-abi3-win32.whl", hash = "sha256:67832909c4779c64942380cb5f044a5c6163d00831472d80e25e115de9917836", size = 451952, upload-time = "2026-08-07T02:12:38.512Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e1/468ad54333e92ccb62627e62cb88e5fc14a2171daa67ed47b1b8542d5b86/tornado-6.5.8-cp39-abi3-win_amd64.whl", hash = "sha256:11881db6b7c168494be2c2d12e65931451bdf7ee718535418ae1d8855dd5a0ee", size = 452391, upload-time = "2026-08-07T02:12:39.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3e/cd5e4f06e34cde33b8ef66cf36aa2b5ad46354cc1af7d2136bbe365fee1d/tornado-6.5.8-cp39-abi3-win_arm64.whl", hash = "sha256:68a7468c7e289f8514d7d664101753903217eff1bb6822c6b5994a0b5f5bcb26", size = 451411, upload-time = "2026-08-07T02:12:41.469Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -10914,6 +11348,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/2e/a7fbfe268c8a3b32546930c0297c101d65a4a14c304ad5790a9f478f0e4e/traitlets-5.16.1.tar.gz", hash = "sha256:ed900c2b631aa3a112811139fa97b8d2c3bad5e989656bba4b7e52c7852c18c1", size = 166137, upload-time = "2026-08-03T08:32:36.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/66/0d785f0bc5e4315a96c989bb476d0fc07ea4f85132550c7b156ca2035d52/traitlets-5.16.1-py3-none-any.whl", hash = "sha256:f775618166caa0396c8e337099240f2bd3e5e917d203b2e6fbe21a58d3cb1f6b", size = 86211, upload-time = "2026-08-03T08:32:34.48Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

## Description

Closes #859.

OpenMed ships Python scripts and standalone recipes but lacked a runnable Jupyter notebook gallery walking through the end-to-end data scientist workflow. This PR adds a 4-part gallery under `examples/notebooks/`, links it from the cookbook landing page, and adds an offline CI job that executes notebooks via `nbclient` to verify committed outputs stay fresh across releases.

### Notebook Gallery (`examples/notebooks/`)

1. **`01_quickstart_redaction.ipynb`**: Core HIPAA de-identification on a synthetic clinical note, covering `mask`, `replace` with reversible surrogate mapping via `reidentify()`, and `hash` for linkage preservation. Commit 2 adds displaCy-style span highlighting via `render_spans_html()`.
2. **`02_batch_dataset.ipynb`**: Directory-level batch de-identification on 5 synthetic patient intake notes using `BatchProcessor(operation="deidentify", batch_size=4, method="mask")`. Commit 2 adds a fail-closed zero-leak assertion confirming no target synthetic identifiers survive in redacted outputs.
3. **`03_fhir_export.ipynb`**: End-to-end pipeline from a synthetic clinical narrative through direct-identifier redaction (`deidentify()`), text normalization (`TextProcessor.clean_text()`), structured medical entity extraction (`TextProcessor.extract_medical_entities()`), and mapping of extracted dosages and vital signs to standard `Patient`, `Condition`, `MedicationStatement`, and `Observation` resources, assembled into an HL7 FHIR R4 transaction Bundle via `to_bundle()`.
4. **`04_eval_walkthrough.ipynb`**: Offline evaluation against bundled multilingual synthetic golden benchmarks via `load_golden_fixtures()`, computing Precision, Recall, F1, and Exact Match.

### Design Notes

The execution engine uses `nbclient` and `nbformat` to run each notebook in an isolated IPython kernel with multi-mime output capture (`stream`, `execute_result`, `display_data`). The test harness enforces `HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1` so no network calls or model weight downloads occur during CI. Notebooks use a fixed offline mock loader (`_NoDownloadLoader`) with a documented disclaimer that demo names are matched via a fixed list for testing, while production installations use full transformer NER models.

Volatile outputs are normalized before comparison: memory pointer addresses are masked (`0x...` to a fixed sentinel) and the local repo root is replaced with `[REPO_ROOT]`. Entity extraction output is sorted to guarantee cross-run determinism. Programmatic assertions verify that no environment-specific paths or real PHI appear in any committed output.

The CI workflow (`.github/workflows/notebooks-execute.yml`) triggers only on changes to `examples/notebooks/**`, `tests/unit/test_notebook_gallery.py`, and the workflow file itself. The test suite (`tests/unit/test_notebook_gallery.py`) covers schema validation, synthetic data disclaimers, offline `nbclient` execution, output freshness diffing, and zero-leakage scanning across all 4 notebooks in 20 parameterized tests.

Documentation lives at `docs/examples/notebook-gallery.md`, linked from `docs/examples.md` and registered in `mkdocs.yml` navigation.

### Commit Breakdown

**Commit 1 (`a8188f15`): Core Issue Scope**

The 4 gallery notebooks, CI workflow, test harness, documentation gallery page, landing page link, mkdocs nav entry, dev dependencies in `pyproject.toml`, and synchronized `uv.lock`. This commit is standalone: the full test suite passes at commit 1 alone.

**Commit 2 (`14a2f430`): Optional Enhancements**

Visual span highlighting (`render_spans_html`) in Notebook 1 and a programmatic zero-leak invariant assertion in Notebook 2. Isolated so maintainers can cleanly revert or drop it if only the base gallery is desired.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Added 4 Jupyter notebooks under `examples/notebooks/` with pre-executed outputs on synthetic data.
- Added `.github/workflows/notebooks-execute.yml` for offline notebook execution in CI.
- Added `docs/examples/notebook-gallery.md`, linked from `docs/examples.md`, with a nav entry in `mkdocs.yml`.
- Added `nbclient>=0.8.0`, `nbformat>=5.9.0`, `ipykernel>=6.0.0` to `[project.optional-dependencies] dev` and synchronized `uv.lock`.
- Added `tests/unit/test_notebook_gallery.py` with 20 parameterized tests executing notebooks via `nbclient` and diffing against committed outputs.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

Notebook 01 exercises three de-identification methods (`mask`, `replace`, `hash`) on the same synthetic input. Notebook 04 runs extraction across multilingual golden fixtures (206 fixtures, 53 languages).

**Local Test Invocations & Verbatim Results:**
- `pytest tests/unit/test_notebook_gallery.py -v`: 20 passed in 12.39s.
- `pytest tests/ -q`: 237 passed, 1 skipped in 11.22s.

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md *(Not applicable for example notebooks / docs updates)*

`python scripts/check_public_api_docstrings.py`: 100.0% coverage (139/139 symbols). `uv run --extra dev --extra docs mkdocs build --strict` built cleanly in 25.74s.

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift` *(Not applicable; no Swift files touched)*

`ruff check .` and `ruff format --check .` (1596 files) both pass clean. `mypy` reports no issues in 4 source files. `python scripts/release/check_repo_policy.py` and `python scripts/release/check_license_policy.py` both pass.

## Dependencies

- [ ] I have not added any new dependencies
- [x] I have added new dependencies and they are justified because: `nbclient>=0.8.0`, `nbformat>=5.9.0`, and `ipykernel>=6.0.0` added to `[project.optional-dependencies] dev` to enable Jupyter kernel notebook execution and output freshness verification in CI and pytest.


## Related Issues

Closes #859

## Screenshots/Examples

```
tests/unit/test_notebook_gallery.py::test_gallery_notebook_file_exists[01_quickstart_redaction.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_file_exists[02_batch_dataset.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_file_exists[03_fhir_export.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_file_exists[04_eval_walkthrough.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_valid_nbformat_schema[01_quickstart_redaction.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_valid_nbformat_schema[02_batch_dataset.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_valid_nbformat_schema[03_fhir_export.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_valid_nbformat_schema[04_eval_walkthrough.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_synthetic_and_offline_disclaimers[01_quickstart_redaction.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_synthetic_and_offline_disclaimers[02_batch_dataset.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_synthetic_and_offline_disclaimers[03_fhir_export.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_synthetic_and_offline_disclaimers[04_eval_walkthrough.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_nbclient_offline_execution_and_freshness[01_quickstart_redaction.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_nbclient_offline_execution_and_freshness[02_batch_dataset.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_nbclient_offline_execution_and_freshness[03_fhir_export.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_nbclient_offline_execution_and_freshness[04_eval_walkthrough.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_zero_leakage_and_clean_environment[01_quickstart_redaction.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_zero_leakage_and_clean_environment[02_batch_dataset.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_zero_leakage_and_clean_environment[03_fhir_export.ipynb] PASSED
tests/unit/test_notebook_gallery.py::test_gallery_notebook_zero_leakage_and_clean_environment[04_eval_walkthrough.ipynb] PASSED
============================= 20 passed in 12.39s ==============================
```

