### PR TITLE
fix: refresh container security baseline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim@sha256:e031123e3d85762b141ad1cbc56452ba69c6e722ebf2f042cc0dc86c47c0d8b3
+FROM python:3.11-slim@sha256:9c900dea9e8fb7e16277c179b555cc72d29a352dbc33cff48ad5a0412fd5bfc7
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -6,6 +6,20 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     OPENMED_SERVICE_KEEP_ALIVE=10m
 
 WORKDIR /app
+
+# Keep the immutable base's OS security fixes explicit and reproducible.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        "bsdutils=1:2.41.5-0+deb13u1" \
+        "libblkid1=2.41.5-0+deb13u1" \
+        "liblastlog2-2=2.41.5-0+deb13u1" \
+        "libmount1=2.41.5-0+deb13u1" \
+        "libsmartcols1=2.41.5-0+deb13u1" \
+        "libuuid1=2.41.5-0+deb13u1" \
+        "login=1:4.16.0-2+really2.41.5-0+deb13u1" \
+        "mount=2.41.5-0+deb13u1" \
+        "util-linux=2.41.5-0+deb13u1" \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY . /app
 

--- a/deploy/security/cve-allowlist.yaml
+++ b/deploy/security/cve-allowlist.yaml
@@ -3,44 +3,27 @@ policy:
   # CI can override this with VULN_SCAN_SEVERITY_THRESHOLD.
   default_threshold: HIGH
 allowlist:
+  # OpenSSL advisory: https://openssl-library.org/news/secadv/20260813.txt
+  - id: CVE-2026-14456
+    package: libssl3t64
+    expires: 2026-09-18
+    reason: >-
+      OpenSSL QUIC-server-only DoS; this HTTP image has no QUIC listener and
+      Debian trixie has no fixed package yet.
+  - id: CVE-2026-14456
+    package: openssl
+    expires: 2026-09-18
+    reason: >-
+      OpenSSL QUIC-server-only DoS; this HTTP image has no QUIC listener and
+      Debian trixie has no fixed package yet.
+  - id: CVE-2026-14456
+    package: openssl-provider-legacy
+    expires: 2026-09-18
+    reason: >-
+      OpenSSL QUIC-server-only DoS; this HTTP image has no QUIC listener and
+      Debian trixie has no fixed package yet.
   # Re-reviewed 2026-08-04 against the current Trivy image report. These
   # package-specific Debian findings still have no available fixed version.
-  - id: CVE-2026-53615
-    package: bsdutils
-    expires: 2026-09-03
-    reason: Debian util-linux finding; no fixed version is available yet.
-  - id: CVE-2026-53615
-    package: libblkid1
-    expires: 2026-09-03
-    reason: Debian util-linux finding; no fixed version is available yet.
-  - id: CVE-2026-53615
-    package: liblastlog2-2
-    expires: 2026-09-03
-    reason: Debian util-linux finding; no fixed version is available yet.
-  - id: CVE-2026-53615
-    package: libmount1
-    expires: 2026-09-03
-    reason: Debian util-linux finding; no fixed version is available yet.
-  - id: CVE-2026-53615
-    package: libsmartcols1
-    expires: 2026-09-03
-    reason: Debian util-linux finding; no fixed version is available yet.
-  - id: CVE-2026-53615
-    package: libuuid1
-    expires: 2026-09-03
-    reason: Debian util-linux finding; no fixed version is available yet.
-  - id: CVE-2026-53615
-    package: login
-    expires: 2026-09-03
-    reason: Debian util-linux finding; no fixed version is available yet.
-  - id: CVE-2026-53615
-    package: mount
-    expires: 2026-09-03
-    reason: Debian util-linux finding; no fixed version is available yet.
-  - id: CVE-2026-53615
-    package: util-linux
-    expires: 2026-09-03
-    reason: Debian util-linux finding; no fixed version is available yet.
   - id: CVE-2026-41992
     package: gzip
     expires: 2026-09-03


### PR DESCRIPTION
# Pull Request

## Description
Refresh the pinned service-container baseline after the current `master` vulnerability scan began failing on newly published Debian and OpenSSL findings. This keeps the unrelated YASBD change in #2675 scoped to its original four files.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Changes Made
- Refresh the immutable `python:3.11-slim` digest to the current multi-architecture image.
- Install the exact Debian `util-linux` security versions that fix CVE-2026-53615 and remove the now-stale waivers.
- Add package-specific waivers through 2026-09-18 for CVE-2026-14456, which the [OpenSSL advisory](https://openssl-library.org/news/secadv/20260813.txt) limits to QUIC server listeners; this Uvicorn image exposes HTTP only, and Debian trixie has no fixed OpenSSL package yet.

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Additional validation:
- `pytest tests/unit/security/test_vulnerability_scan_gate.py -q` — 6 passed.
- `pre-commit run --files Dockerfile deploy/security/cve-allowlist.yaml` — passed.
- `docker build --pull -t openmed:security-baseline-20260819 .` — passed.
- Current Trivy 0.74.0 image scan plus the repository gate — 123 findings scanned, 17 active package-specific waivers, zero blocking findings.
- The built image reports all nine affected `util-linux` binaries at `2.41.5-0+deb13u1` (with the Debian epoch where applicable).

## Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

No user-facing documentation changes are required for this container-baseline repair.

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Related to #2675

## Screenshots/Examples
Not applicable; the validation output is summarized above.
