### PR TITLE
Fix cross-platform notebook freshness checks

### DIFF
--- a/tests/unit/test_notebook_gallery.py
+++ b/tests/unit/test_notebook_gallery.py
@@ -79,6 +79,8 @@ def _extract_cell_output_text(cell: nbformat.NotebookNode) -> str:
             text = out.get("text", "")
             if isinstance(text, list):
                 text = "".join(text)
+            if not _normalize_output_text(text):
+                continue
             text_parts.append(f"stream:{out.get('name', '')}:{text}")
         elif out_type in {"execute_result", "display_data"}:
             data = out.get("data", {})
@@ -116,6 +118,18 @@ def test_extract_cell_output_text_includes_every_mime_payload() -> None:
     assert 'application/json:{"value":3}' in canonical
     assert "text/html:<strong>three</strong>" in canonical
     assert "text/plain:three" in canonical
+
+
+def test_extract_cell_output_text_ignores_empty_stream_records() -> None:
+    """Kernel-specific empty stream records have no visible output semantics."""
+    cell = nbformat.v4.new_code_cell(
+        outputs=[
+            nbformat.v4.new_output("stream", name="stdout", text="ready\n"),
+            nbformat.v4.new_output("stream", name="stdout", text=""),
+            nbformat.v4.new_output("stream", name="stderr", text=" \n"),
+        ]
+    )
+    assert _extract_cell_output_text(cell) == "stream:stdout:ready"
 
 
 def _scan_for_leaks(text: str, filename: str) -> None:


### PR DESCRIPTION
# Pull Request

## Description
Makes notebook-gallery freshness checks portable across Jupyter kernels that
emit an additional empty stdout or stderr record. Empty stream records have no
visible output semantics; every non-empty stream and rich MIME payload remains
part of the exact freshness comparison.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Ignore stream output records whose normalized text is empty.
- Preserve exact comparison of all visible stdout, stderr, and rich MIME output.
- Add a regression covering empty stdout and whitespace-only stderr records.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different output variants

Exact validation:
- `PYTHONPATH=$PWD /Users/maziyar/Developer/openmed/.venv/bin/python -m pytest -p no:cacheprovider tests/unit/test_notebook_gallery.py -q` — 26 passed
- Ruff check passed for `tests/unit/test_notebook_gallery.py`
- Ruff format check passed for `tests/unit/test_notebook_gallery.py`
- `git diff --check`

## Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

No user-facing behavior or public API changes.

## Code Quality
- [ ] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Focused Ruff lint and format checks passed for the only changed file.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Related to #859.

This also unblocks the cross-platform CI runs observed on PRs #2901 and #2902.

## Screenshots/Examples
Not applicable; this is a test canonicalization fix.
