### PR TITLE
Add async public API wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added lazy async wrappers for PII extraction, de-identification, text
+  analysis, and batch processing that offload the established synchronous APIs
+  without importing asyncio or creating an event loop during base package
+  import (#2338).
 - Added a bounded zero-upload browser privacy playground with deterministic
   local rules, trusted same-origin adapter support, aggregate-only status,
   source-safe labels, and explicit network-boundary controls (#2373).

--- a/docs/async-api.md
+++ b/docs/async-api.md
@@ -1,0 +1,69 @@
+# Async Python API
+
+OpenMed provides first-class coroutine wrappers for its blocking Python
+helpers. They run the existing synchronous implementation in asyncio's worker
+thread pool, so an application event loop remains responsive while model
+inference or batch processing is in progress.
+
+```python
+import openmed
+
+result = await openmed.adeidentify(
+    "Synthetic patient Casey Example called 555-0100.",
+    method="mask",
+)
+print(result.deidentified_text)
+```
+
+The lazy top-level exports are:
+
+| Async helper | Synchronous implementation |
+| --- | --- |
+| `openmed.aextract_pii(...)` | `openmed.extract_pii(...)` |
+| `openmed.adeidentify(...)` | `openmed.deidentify(...)` |
+| `openmed.aanalyze_text(...)` | `openmed.analyze_text(...)` |
+| `openmed.abatch(...)` | `openmed.process_batch(...)` |
+
+Each wrapper accepts the same arguments and returns the same result type as its
+synchronous implementation. Exceptions also propagate unchanged. Importing
+`openmed` alone does not import `asyncio` or create an event loop; the async
+module is loaded only when one of these helpers is first accessed.
+
+## FastAPI example
+
+The wrappers are suitable for an async route when inference remains local and
+the caller wants to avoid blocking the server event loop:
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+import openmed
+
+app = FastAPI()
+
+
+class RedactionRequest(BaseModel):
+    text: str
+
+
+@app.post("/redact")
+async def redact(request: RedactionRequest) -> dict[str, str]:
+    result = await openmed.adeidentify(
+        request.text,
+        method="mask",
+        use_safety_sweep=True,
+    )
+    return {"text": result.deidentified_text}
+```
+
+Do not log request text, model outputs, or exceptions containing source values.
+Reuse a warmed loader when traffic is sustained, and apply application-level
+concurrency limits so requests do not create unbounded worker pressure.
+
+## Cancellation and shutdown
+
+Cancelling the awaiting task stops waiting for the result, but Python cannot
+forcibly stop a synchronous function that is already running in a worker
+thread. Use OpenMed request budgets for bounded work and allow the process to
+finish in-flight worker calls during graceful shutdown.

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -110,6 +110,7 @@ classification:
     - reference/trace-jsonl.md
     - reference/trace-tool-calls.md
     - analyze-text.md
+    - async-api.md
     - rest-service.md
     - service/self-hosted-redaction.md
     - mcp-clients.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
       - JSONL Trace Content Walker: reference/trace-jsonl.md
       - Structure-aware Tool-call Redaction: reference/trace-tool-calls.md
       - Analyze Text Helper: analyze-text.md
+      - Async Python API: async-api.md
       - REST Service (MVP): rest-service.md
       - Self-hosted Redaction Service: service/self-hosted-redaction.md
       - MCP Client Connections: mcp-clients.md

--- a/openmed/__init__.py
+++ b/openmed/__init__.py
@@ -34,6 +34,10 @@ if TYPE_CHECKING:
     from .processing.sentences import SentenceSpan
 
 _LAZY_IMPORTS = {
+    "aanalyze_text": ".aio",
+    "abatch": ".aio",
+    "adeidentify": ".aio",
+    "aextract_pii": ".aio",
     "ModelLoader": ".core",
     "OpenMedConfig": ".core",
     "ModelCachePolicy": ".core",

--- a/openmed/aio.py
+++ b/openmed/aio.py
@@ -1,0 +1,114 @@
+"""Asynchronous wrappers for OpenMed's synchronous public helpers.
+
+The wrappers in this module keep inference behavior in the established
+synchronous implementations and move the blocking call to a worker thread.
+Importing :mod:`openmed` does not import this module or :mod:`asyncio`; the
+top-level async helpers are resolved lazily on first access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
+
+from . import analyze_text as _analyze_text
+from .core.pii import deidentify as _deidentify
+from .core.pii import extract_pii as _extract_pii
+from .processing import process_batch as _process_batch
+
+if TYPE_CHECKING:
+    from .core.audit import AuditReport
+    from .core.pii import DeidentificationResult
+    from .core.results import AnalyzeResult
+    from .processing import BatchResult
+    from .processing.outputs import PredictionResult
+
+_ResultT = TypeVar("_ResultT")
+
+
+async def _run_in_thread(
+    function: Callable[..., _ResultT],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> _ResultT:
+    """Run ``function`` in asyncio's worker pool with context propagation."""
+
+    return await asyncio.to_thread(function, *args, **kwargs)
+
+
+async def aextract_pii(*args: Any, **kwargs: Any) -> "PredictionResult":
+    """Asynchronously call :func:`openmed.extract_pii` in a worker thread.
+
+    Args:
+        *args: Positional arguments accepted by :func:`openmed.extract_pii`.
+        **kwargs: Keyword arguments accepted by :func:`openmed.extract_pii`.
+
+    Returns:
+        The same prediction result returned by :func:`openmed.extract_pii`.
+    """
+
+    return await _run_in_thread(_extract_pii, *args, **kwargs)
+
+
+async def adeidentify(
+    *args: Any,
+    **kwargs: Any,
+) -> "DeidentificationResult | AuditReport":
+    """Asynchronously call :func:`openmed.deidentify` in a worker thread.
+
+    Args:
+        *args: Positional arguments accepted by :func:`openmed.deidentify`.
+        **kwargs: Keyword arguments accepted by :func:`openmed.deidentify`.
+
+    Returns:
+        The same de-identification or audit result returned by
+        :func:`openmed.deidentify`.
+    """
+
+    return await _run_in_thread(_deidentify, *args, **kwargs)
+
+
+async def aanalyze_text(
+    *args: Any,
+    **kwargs: Any,
+) -> "AnalyzeResult | str | list[dict[str, Any]]":
+    """Asynchronously call :func:`openmed.analyze_text` in a worker thread.
+
+    Args:
+        *args: Positional arguments accepted by :func:`openmed.analyze_text`.
+        **kwargs: Keyword arguments accepted by :func:`openmed.analyze_text`.
+
+    Returns:
+        The same structured or rendered result returned by
+        :func:`openmed.analyze_text`.
+    """
+
+    return await _run_in_thread(_analyze_text, *args, **kwargs)
+
+
+async def abatch(*args: Any, **kwargs: Any) -> "BatchResult":
+    """Asynchronously call :func:`openmed.process_batch` in a worker thread.
+
+    Args:
+        *args: Positional arguments accepted by :func:`openmed.process_batch`.
+        **kwargs: Keyword arguments accepted by :func:`openmed.process_batch`.
+
+    Returns:
+        The same batch result returned by :func:`openmed.process_batch`.
+    """
+
+    return await _run_in_thread(_process_batch, *args, **kwargs)
+
+
+# ``inspect.signature`` follows ``__wrapped__`` while the async helpers retain
+# their distinct names and coroutine identity. This keeps runtime signature
+# discovery aligned with the synchronous public API without duplicating its
+# long, evolving parameter lists.
+setattr(aextract_pii, "__wrapped__", _extract_pii)
+setattr(adeidentify, "__wrapped__", _deidentify)
+setattr(aanalyze_text, "__wrapped__", _analyze_text)
+setattr(abatch, "__wrapped__", _process_batch)
+
+
+__all__ = ["aanalyze_text", "abatch", "adeidentify", "aextract_pii"]

--- a/tests/unit/test_async_api.py
+++ b/tests/unit/test_async_api.py
@@ -1,0 +1,108 @@
+"""Tests for the lazy asynchronous public API."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import openmed
+import openmed.aio as aio
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    ("async_helper", "sync_helper"),
+    [
+        (aio.aextract_pii, aio._extract_pii),
+        (aio.adeidentify, aio._deidentify),
+        (aio.aanalyze_text, aio._analyze_text),
+        (aio.abatch, aio._process_batch),
+    ],
+)
+def test_async_helpers_preserve_sync_signatures(async_helper, sync_helper) -> None:
+    assert inspect.iscoroutinefunction(async_helper)
+    assert inspect.signature(async_helper) == inspect.signature(sync_helper)
+
+
+@pytest.mark.parametrize(
+    ("async_name", "sync_name"),
+    [
+        ("aextract_pii", "_extract_pii"),
+        ("adeidentify", "_deidentify"),
+        ("aanalyze_text", "_analyze_text"),
+        ("abatch", "_process_batch"),
+    ],
+)
+def test_async_helpers_offload_and_return_sync_result(
+    monkeypatch: pytest.MonkeyPatch,
+    async_name: str,
+    sync_name: str,
+) -> None:
+    caller_thread = threading.get_ident()
+    observed: dict[str, Any] = {}
+    expected = object()
+
+    def fake_sync(*args: Any, **kwargs: Any) -> object:
+        observed.update(
+            args=args,
+            kwargs=kwargs,
+            worker_thread=threading.get_ident(),
+        )
+        return expected
+
+    monkeypatch.setattr(aio, sync_name, fake_sync)
+    result = asyncio.run(getattr(aio, async_name)("synthetic", marker=7))
+
+    assert result is expected
+    assert observed == {
+        "args": ("synthetic",),
+        "kwargs": {"marker": 7},
+        "worker_thread": observed["worker_thread"],
+    }
+    assert observed["worker_thread"] != caller_thread
+
+
+def test_async_helper_errors_propagate(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(*args: Any, **kwargs: Any) -> None:
+        raise ValueError("synthetic failure")
+
+    monkeypatch.setattr(aio, "_extract_pii", fail)
+
+    with pytest.raises(ValueError, match="synthetic failure"):
+        asyncio.run(aio.aextract_pii("synthetic"))
+
+
+def test_top_level_async_helpers_are_lazy_exports() -> None:
+    for name in ("aextract_pii", "adeidentify", "aanalyze_text", "abatch"):
+        helper = getattr(openmed, name)
+        assert helper is getattr(aio, name)
+        assert inspect.iscoroutinefunction(helper)
+
+
+def test_import_openmed_does_not_import_asyncio() -> None:
+    check = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "assert 'asyncio' not in sys.modules; "
+                "import openmed; "
+                "assert 'asyncio' not in sys.modules"
+            ),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert check.returncode == 0, check.stderr


### PR DESCRIPTION
# Pull Request

## Description
Adds lazy asynchronous wrappers for the synchronous PII extraction, de-identification, analysis, and batch APIs. Calls are offloaded with asyncio.to_thread so async applications can keep their event loop responsive without duplicating inference logic.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [x] Test addition/improvement

## Changes Made
- Add aextract_pii, adeidentify, aanalyze_text, and abatch with runtime signature parity.
- Export the helpers lazily without importing asyncio during base package import.
- Document FastAPI usage, cancellation behavior, privacy-safe logging, and bounded concurrency.

## Testing
- [x] Added tests that prove the feature works.
- [x] 98 focused API, core, and documentation tests pass.
- [x] Focused mypy validation passes for openmed/aio.py.
- [x] Strict multilingual Pages staging passes.
- [x] Scoped pre-commit hooks pass.

## Documentation
- [x] Updated the documentation.
- [x] Added docstrings to new functions.
- [x] Updated CHANGELOG.md.

## Code Quality
- [x] Ran the canonical scoped pre-commit hooks.
- [x] Performed a self-review.
- [x] No new warnings or dependencies.

## Dependencies
- [x] No new dependencies.

## Related Issues
Closes #2338

## Screenshots/Examples
Not applicable; the documentation includes a FastAPI example.