### PR TITLE
Add service autoscaling metrics and HPA guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a Kubernetes HPA reference for aggregate queue-depth and in-flight
+  request metrics, with CPU fallback, deterministic load-to-replica guidance,
+  Prometheus Adapter wiring, and PHI-safe metric tests (#831).
 - Added a bounded zero-upload browser privacy playground with deterministic
   local rules, trusted same-origin adapter support, aggregate-only status,
   source-safe labels, and explicit network-boundary controls (#2373).

--- a/deploy/k8s/hpa.yaml
+++ b/deploy/k8s/hpa.yaml
@@ -1,0 +1,51 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: openmed-service
+  labels:
+    app.kubernetes.io/name: openmed-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: openmed-service
+  minReplicas: 2
+  maxReplicas: 10
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+  metrics:
+    - type: Pods
+      pods:
+        metric:
+          name: openmed_service_admission_queue_depth
+        target:
+          type: AverageValue
+          averageValue: "4"
+    - type: Pods
+      pods:
+        metric:
+          name: openmed_service_inflight_requests
+        target:
+          type: AverageValue
+          averageValue: "8"
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 65

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -134,6 +134,7 @@ classification:
     - serving/load-testing.md
     - serving/mtls.md
     - deploy/helm.md
+    - deploy/autoscaling.md
     - deploy/operator.md
     - deploy/openhim-mediator.md
     - deploy/africa-reference-deployment.md

--- a/docs/deploy/autoscaling.md
+++ b/docs/deploy/autoscaling.md
@@ -1,0 +1,119 @@
+# Kubernetes autoscaling
+
+OpenMed exposes aggregate queue and request gauges that a Kubernetes
+HorizontalPodAutoscaler (HPA) can use as backpressure signals. The reference
+manifest combines those custom metrics with CPU utilization, keeps two warm
+replicas, scales up quickly, and waits five minutes before scaling down.
+
+The signals contain counts and fixed queue labels only. They never contain
+request text, entities, model output, client identity, or other PHI.
+
+## Enable and scrape metrics
+
+Enable the pull-only metrics endpoint in the service deployment:
+
+```yaml
+env:
+  - name: OPENMED_SERVICE_METRICS_ENABLED
+    value: "true"
+```
+
+Configure Prometheus to scrape each OpenMed pod on `/metrics`. Confirm these
+series are present before applying the HPA:
+
+- `openmed_service_admission_queue_depth{queue="analyze"}` and
+  `openmed_service_admission_queue_depth{queue="pii_extract"}`
+- `openmed_service_inflight_requests`
+
+The queue gauge tracks admitted work that has not completed. The in-flight
+gauge tracks active HTTP requests. Both are useful earlier saturation signals
+than CPU alone when a model or accelerator becomes the bottleneck.
+
+## Wire prometheus-adapter
+
+The cluster needs a custom-metrics adapter such as `prometheus-adapter`. Add
+rules equivalent to the following to its configuration. Prometheus scrape
+discovery must attach `namespace` and `pod` labels to each series.
+
+```yaml
+rules:
+  custom:
+    - seriesQuery: 'openmed_service_admission_queue_depth{namespace!="",pod!=""}'
+      resources:
+        overrides:
+          namespace: {resource: namespace}
+          pod: {resource: pod}
+      name:
+        matches: '^openmed_service_admission_queue_depth$'
+        as: openmed_service_admission_queue_depth
+      metricsQuery: 'sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)'
+    - seriesQuery: 'openmed_service_inflight_requests{namespace!="",pod!=""}'
+      resources:
+        overrides:
+          namespace: {resource: namespace}
+          pod: {resource: pod}
+      name:
+        matches: '^openmed_service_inflight_requests$'
+        as: openmed_service_inflight_requests
+      metricsQuery: 'sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)'
+```
+
+Verify the custom metrics API before enabling automatic scaling:
+
+```bash
+kubectl get --raw \
+  '/apis/custom.metrics.k8s.io/v1beta1/namespaces/default/pods/*/openmed_service_admission_queue_depth'
+kubectl get --raw \
+  '/apis/custom.metrics.k8s.io/v1beta1/namespaces/default/pods/*/openmed_service_inflight_requests'
+```
+
+## Apply the reference HPA
+
+The checked-in manifest targets a Deployment named `openmed-service`. Change
+`spec.scaleTargetRef.name` when the deployed name differs, including when a
+Helm release prefixes the chart fullname.
+
+```bash
+kubectl apply -f deploy/k8s/hpa.yaml
+kubectl describe hpa openmed-service
+```
+
+The HPA uses these starting targets:
+
+| Signal | Per-pod target |
+| --- | ---: |
+| Admitted queue depth | 4 |
+| In-flight requests | 8 |
+| CPU utilization | 65% |
+
+Kubernetes calculates a desired replica count for each signal and selects the
+largest. CPU remains a general load signal when queueing is low, while either
+custom metric can request an earlier scale-up under backpressure. If the custom
+metrics API is unavailable, investigate the adapter; do not treat missing data
+as a zero queue.
+
+## Reproduce a threshold-to-replicas mapping
+
+For aggregate queue depth `Q` and in-flight requests `F`, the reference targets
+map load to `ceil(max(queue_depth / 4, in_flight / 8, 2))`, capped at 10
+replicas. The dependency-free helper mirrors this custom-metric calculation:
+
+```python
+from openmed.service.scaling_metrics import recommend_replicas
+
+decision = recommend_replicas(queue_depth=9, inflight_requests=8)
+assert decision.recommended_replicas == 3
+```
+
+| Queue depth | In flight | Queue replicas | In-flight replicas | Final replicas |
+| ---: | ---: | ---: | ---: | ---: |
+| 0 | 0 | 0 | 0 | 2 |
+| 8 | 8 | 2 | 1 | 2 |
+| 9 | 8 | 3 | 1 | 3 |
+| 4 | 33 | 1 | 5 | 5 |
+| 1000 | 1000 | 250 | 125 | 10 |
+
+Tune targets from synthetic load tests, keep resource requests accurate for
+the CPU metric, and use a disruption budget when maintaining more than one
+replica. Do not expose `/metrics` outside the cluster or add user-controlled
+label values.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
       - Service Load Testing & Latency SLOs: serving/load-testing.md
       - Mutual TLS Authentication: serving/mtls.md
       - Helm Deployment: deploy/helm.md
+      - Kubernetes Autoscaling: deploy/autoscaling.md
       - Kubernetes Model Operator: deploy/operator.md
       - OpenHIM De-identification Mediator: deploy/openhim-mediator.md
       - African Facility-to-HMIS Reference: deploy/africa-reference-deployment.md

--- a/openmed/service/scaling_metrics.py
+++ b/openmed/service/scaling_metrics.py
@@ -1,0 +1,119 @@
+"""Deterministic autoscaling guidance for aggregate service metrics.
+
+This module contains no cluster client and performs no network access. It
+turns the same queue-depth and in-flight gauges exported by
+``PrometheusMetricsRegistry`` into a reproducible replica recommendation that
+operators can use when choosing HorizontalPodAutoscaler targets.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from .metrics import ADMISSION_QUEUE_DEPTH_NAME, INFLIGHT_NAME
+
+QUEUE_DEPTH_METRIC = ADMISSION_QUEUE_DEPTH_NAME
+INFLIGHT_REQUESTS_METRIC = INFLIGHT_NAME
+
+
+@dataclass(frozen=True)
+class ScalingTargets:
+    """Per-pod metric targets and replica bounds for an OpenMed service."""
+
+    queue_depth_per_pod: int = 4
+    inflight_requests_per_pod: int = 8
+    min_replicas: int = 2
+    max_replicas: int = 10
+
+    def __post_init__(self) -> None:
+        """Reject ambiguous or unsafe scaling bounds."""
+
+        for name in (
+            "queue_depth_per_pod",
+            "inflight_requests_per_pod",
+            "min_replicas",
+            "max_replicas",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.min_replicas > self.max_replicas:
+            raise ValueError("min_replicas must not exceed max_replicas")
+
+
+@dataclass(frozen=True)
+class ScalingRecommendation:
+    """Replica counts implied by each aggregate load signal."""
+
+    queue_depth: int
+    inflight_requests: int
+    queue_replicas: int
+    inflight_replicas: int
+    recommended_replicas: int
+
+
+def recommend_replicas(
+    *,
+    queue_depth: int,
+    inflight_requests: int,
+    targets: ScalingTargets | None = None,
+) -> ScalingRecommendation:
+    """Map aggregate queue and in-flight load to a bounded replica count.
+
+    Kubernetes chooses the largest recommendation among configured HPA
+    metrics. This helper mirrors that behavior for a documented load shape,
+    then applies the configured minimum and maximum replica bounds.
+
+    Args:
+        queue_depth: Aggregate admitted queue depth across service pods.
+        inflight_requests: Aggregate active HTTP requests across service pods.
+        targets: Optional per-pod targets and replica bounds.
+
+    Returns:
+        A value-only recommendation containing both signal calculations.
+
+    Raises:
+        ValueError: If either observed count is not a non-negative integer.
+    """
+
+    observed_queue = _non_negative_integer(queue_depth, "queue_depth")
+    observed_inflight = _non_negative_integer(
+        inflight_requests,
+        "inflight_requests",
+    )
+    resolved = targets or ScalingTargets()
+    queue_replicas = math.ceil(observed_queue / resolved.queue_depth_per_pod)
+    inflight_replicas = math.ceil(
+        observed_inflight / resolved.inflight_requests_per_pod
+    )
+    recommended = min(
+        max(
+            resolved.min_replicas,
+            queue_replicas,
+            inflight_replicas,
+        ),
+        resolved.max_replicas,
+    )
+    return ScalingRecommendation(
+        queue_depth=observed_queue,
+        inflight_requests=observed_inflight,
+        queue_replicas=queue_replicas,
+        inflight_replicas=inflight_replicas,
+        recommended_replicas=recommended,
+    )
+
+
+def _non_negative_integer(value: int, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer")
+    return value
+
+
+__all__ = [
+    "INFLIGHT_REQUESTS_METRIC",
+    "QUEUE_DEPTH_METRIC",
+    "ScalingRecommendation",
+    "ScalingTargets",
+    "recommend_replicas",
+]

--- a/tests/unit/service/test_scaling_metrics.py
+++ b/tests/unit/service/test_scaling_metrics.py
@@ -1,0 +1,119 @@
+"""Tests for scaling metrics and the reference HPA."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from openmed.service.metrics import PrometheusMetricsRegistry
+from openmed.service.scaling_metrics import (
+    INFLIGHT_REQUESTS_METRIC,
+    QUEUE_DEPTH_METRIC,
+    ScalingTargets,
+    recommend_replicas,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+HPA_PATH = ROOT / "deploy" / "k8s" / "hpa.yaml"
+GUIDE_PATH = ROOT / "docs" / "deploy" / "autoscaling.md"
+
+
+def test_scaling_gauges_are_present_under_synthetic_load() -> None:
+    metrics = PrometheusMetricsRegistry()
+    metrics.request_started()
+    metrics.record_admission_queue_state(
+        queue="analyze",
+        depth=5,
+        shedding=False,
+    )
+
+    rendered = metrics.render()
+
+    assert f"# TYPE {QUEUE_DEPTH_METRIC} gauge" in rendered
+    assert f'{QUEUE_DEPTH_METRIC}{{queue="analyze"}} 5' in rendered
+    assert f"# TYPE {INFLIGHT_REQUESTS_METRIC} gauge" in rendered
+    assert f"{INFLIGHT_REQUESTS_METRIC} 1" in rendered
+
+
+def test_reference_hpa_targets_queue_inflight_and_cpu_metrics() -> None:
+    manifest = yaml.safe_load(HPA_PATH.read_text(encoding="utf-8"))
+
+    assert manifest["apiVersion"] == "autoscaling/v2"
+    assert manifest["kind"] == "HorizontalPodAutoscaler"
+    assert manifest["spec"]["scaleTargetRef"] == {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "name": "openmed-service",
+    }
+    assert manifest["spec"]["minReplicas"] == 2
+    assert manifest["spec"]["maxReplicas"] == 10
+
+    metrics = manifest["spec"]["metrics"]
+    pod_metrics = {
+        item["pods"]["metric"]["name"]: item["pods"]["target"]
+        for item in metrics
+        if item["type"] == "Pods"
+    }
+    assert pod_metrics == {
+        QUEUE_DEPTH_METRIC: {"type": "AverageValue", "averageValue": "4"},
+        INFLIGHT_REQUESTS_METRIC: {
+            "type": "AverageValue",
+            "averageValue": "8",
+        },
+    }
+    cpu = next(item for item in metrics if item["type"] == "Resource")
+    assert cpu["resource"]["name"] == "cpu"
+    assert cpu["resource"]["target"]["averageUtilization"] == 65
+
+
+@pytest.mark.parametrize(
+    ("queue_depth", "inflight_requests", "expected"),
+    [
+        (0, 0, 2),
+        (8, 8, 2),
+        (9, 8, 3),
+        (4, 33, 5),
+        (1000, 1000, 10),
+    ],
+)
+def test_load_shape_maps_thresholds_to_bounded_replicas(
+    queue_depth: int,
+    inflight_requests: int,
+    expected: int,
+) -> None:
+    result = recommend_replicas(
+        queue_depth=queue_depth,
+        inflight_requests=inflight_requests,
+    )
+
+    assert result.recommended_replicas == expected
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"queue_depth": -1, "inflight_requests": 0},
+        {"queue_depth": True, "inflight_requests": 0},
+        {"queue_depth": 0, "inflight_requests": -1},
+    ],
+)
+def test_load_shape_rejects_invalid_observations(kwargs) -> None:
+    with pytest.raises(ValueError, match="non-negative integer"):
+        recommend_replicas(**kwargs)
+
+
+def test_scaling_targets_reject_invalid_bounds() -> None:
+    with pytest.raises(ValueError, match="min_replicas"):
+        ScalingTargets(min_replicas=4, max_replicas=3)
+
+
+def test_autoscaling_guide_documents_reproducible_wiring() -> None:
+    guide = GUIDE_PATH.read_text(encoding="utf-8")
+
+    assert QUEUE_DEPTH_METRIC in guide
+    assert INFLIGHT_REQUESTS_METRIC in guide
+    assert "prometheus-adapter" in guide
+    assert "kubectl apply -f deploy/k8s/hpa.yaml" in guide
+    assert "ceil(max(queue_depth / 4, in_flight / 8, 2))" in guide


### PR DESCRIPTION
# Pull Request

## Description
Adds a Kubernetes HorizontalPodAutoscaler reference that scales OpenMed on its existing aggregate admission-queue and in-flight gauges, with CPU utilization as an additional signal. It also adds a dependency-free load-to-replica calculator and complete Prometheus Adapter wiring guidance.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [x] Test addition/improvement

## Changes Made
- Add an autoscaling/v2 HPA targeting queue depth, in-flight requests, and CPU with bounded scale behavior.
- Add deterministic per-signal replica recommendations using the same canonical metric names.
- Document scrape setup, custom-metrics adapter rules, verification commands, and a reproducible load-shape table.

## Testing
- [x] 12 focused autoscaling tests pass.
- [x] 89 service, backpressure, batching, and documentation tests pass.
- [x] Focused mypy validation passes.
- [x] Strict multilingual Pages staging passes.
- [x] Scoped pre-commit hooks and diff checks pass.

## Documentation
- [x] Updated the documentation.
- [x] Added public docstrings.
- [x] Updated CHANGELOG.md.

## Code Quality
- [x] Ran canonical scoped validation.
- [x] Performed a self-review.
- [x] No PHI-bearing labels or new warnings.

## Dependencies
- [x] No new dependencies.

## Related Issues
Closes #831

## Screenshots/Examples
Not applicable; the guide includes the full HPA workflow and threshold table.