### PR TITLE
Validate OpenMed configuration against its JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added fail-fast JSON Schema validation for `OpenMedConfig`, TOML files, and
+  custom profiles, with aggregated value-free diagnostics, an installed schema
+  path helper, and complete remote-backend field coverage (#2264).
 - Added a bounded zero-upload browser privacy playground with deterministic
   local rules, trusted same-origin adapter support, aggregate-only status,
   source-safe labels, and explicit network-boundary controls (#2373).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,40 @@ transliteration_aware_name_matching = false
 indic_name_similarity_threshold = 0.80
 ```
 
+### JSON Schema validation
+
+OpenMed publishes its Draft 2020-12 configuration schema inside the installed
+package. Editors and deployment tools can locate it without relying on the
+repository layout:
+
+```python
+from openmed.core.config import config_schema_path
+
+print(config_schema_path())
+```
+
+`OpenMedConfig.from_dict()`, `load_config_from_file()`, and custom profile
+loading validate keys and types against this schema. Unknown keys are rejected
+instead of being silently ignored, and all detected violations are reported in
+one `ConfigValidationError`. Diagnostics name schema fields but never echo
+their values, so credentials and other sensitive settings do not leak through
+validation errors.
+
+```python
+from openmed.core.config import ConfigValidationError, load_config_from_file
+
+try:
+    config = load_config_from_file("openmed.toml")
+except ConfigValidationError as error:
+    for violation in error.errors:
+        print(violation)  # Field names and constraints only; no values.
+```
+
+Instances constructed directly can be checked explicitly with
+`config.validate()`. The schema also declares `x-profile-keys`, the exact set
+accepted in custom profile TOML files. This keeps editor completion, runtime
+validation, and profile authoring on one source of truth.
+
 Runtime environment controls can select the config path, provide Hub
 credentials, or choose a device when the loaded config leaves it automatic:
 

--- a/openmed/core/__init__.py
+++ b/openmed/core/__init__.py
@@ -12,7 +12,9 @@ from .audit_chain import (
 from .budget import RequestBudget, coerce_budget
 from .config import (
     PROFILE_PRESETS,
+    ConfigValidationError,
     OpenMedConfig,
+    config_schema_path,
     delete_profile,
     get_profile,
     list_profiles,
@@ -176,6 +178,8 @@ __all__ = [
     "ModelSearchResult",
     "search_models",
     "OpenMedConfig",
+    "ConfigValidationError",
+    "config_schema_path",
     "CustomRecognizer",
     "AuditReport",
     "AuditSignature",

--- a/openmed/core/config.py
+++ b/openmed/core/config.py
@@ -1,10 +1,12 @@
 """Configuration management for OpenMed."""
 
+import json
 import math
 import os
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from .offline import (
     OFFLINE_ENV_VAR,
@@ -38,6 +40,184 @@ else:
 DEFAULT_CONFIG_DIR = _default_config_root / "openmed"
 DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_DIR / "config.toml"
 PROFILES_DIR = DEFAULT_CONFIG_DIR / "profiles"
+
+
+class ConfigValidationError(ValueError):
+    """Aggregate one or more schema violations without echoing config values."""
+
+    def __init__(self, errors: List[str]) -> None:
+        self.errors = tuple(errors)
+        super().__init__("Invalid OpenMed configuration: " + "; ".join(errors))
+
+
+def config_schema_path() -> Path:
+    """Return the installed Draft 2020-12 configuration schema path."""
+
+    return Path(__file__).with_name("config.schema.json")
+
+
+@lru_cache(maxsize=1)
+def _config_schema() -> Dict[str, Any]:
+    """Load the bundled configuration schema once per process."""
+
+    with config_schema_path().open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise RuntimeError("OpenMed configuration schema must be a JSON object")
+    return payload
+
+
+def _validate_config_mapping(
+    data: Mapping[str, Any],
+    *,
+    profile: bool = False,
+) -> None:
+    """Validate a mapping against the controlled bundled-schema subset."""
+
+    schema = _config_schema()
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        raise RuntimeError("OpenMed configuration schema has no properties object")
+
+    if profile:
+        declared_profile_keys = schema.get("x-profile-keys")
+        if not isinstance(declared_profile_keys, list) or not all(
+            isinstance(key, str) for key in declared_profile_keys
+        ):
+            raise RuntimeError(
+                "OpenMed configuration schema has no valid x-profile-keys list"
+            )
+        allowed_keys = set(declared_profile_keys)
+    else:
+        allowed_keys = set(properties)
+
+    errors: List[str] = []
+    for key in sorted(data, key=str):
+        if not isinstance(key, str) or key not in allowed_keys:
+            errors.append(f"{key}: unknown configuration key")
+            continue
+        property_schema = properties.get(key)
+        if not isinstance(property_schema, dict):
+            errors.append(f"{key}: schema definition is invalid")
+            continue
+        errors.extend(_property_validation_errors(key, data[key], property_schema))
+
+    if errors:
+        raise ConfigValidationError(errors)
+
+
+def _validate_config_keys(data: Mapping[str, Any]) -> None:
+    """Reject unknown full-config keys before dataclass construction."""
+
+    properties = _config_schema().get("properties")
+    if not isinstance(properties, dict):
+        raise RuntimeError("OpenMed configuration schema has no properties object")
+    errors = [
+        f"{key}: unknown configuration key"
+        for key in sorted(data, key=str)
+        if not isinstance(key, str) or key not in properties
+    ]
+    if errors:
+        raise ConfigValidationError(errors)
+
+
+def _property_validation_errors(
+    path: str,
+    value: Any,
+    schema: Mapping[str, Any],
+) -> List[str]:
+    errors: List[str] = []
+    declared_types = schema.get("type")
+    if isinstance(declared_types, str):
+        allowed_types = (declared_types,)
+    elif isinstance(declared_types, list) and all(
+        isinstance(item, str) for item in declared_types
+    ):
+        allowed_types = tuple(declared_types)
+    else:
+        return [f"{path}: schema type declaration is invalid"]
+
+    if not any(_matches_json_type(value, name) for name in allowed_types):
+        expected = " or ".join(allowed_types)
+        return [f"{path}: expected {expected}, got {_json_type_name(value)}"]
+
+    if value is None:
+        return errors
+
+    enum = schema.get("enum")
+    if isinstance(enum, list) and value not in enum:
+        errors.append(f"{path}: value is not in the allowed set")
+
+    if isinstance(value, str):
+        minimum_length = schema.get("minLength")
+        if isinstance(minimum_length, int) and len(value) < minimum_length:
+            errors.append(f"{path}: string is shorter than the minimum length")
+
+    if _matches_json_type(value, "number"):
+        numeric = float(value)
+        if not math.isfinite(numeric):
+            errors.append(f"{path}: number must be finite")
+        minimum = schema.get("minimum")
+        if isinstance(minimum, (int, float)) and numeric < float(minimum):
+            errors.append(f"{path}: number is below the minimum")
+        maximum = schema.get("maximum")
+        if isinstance(maximum, (int, float)) and numeric > float(maximum):
+            errors.append(f"{path}: number exceeds the maximum")
+        exclusive_minimum = schema.get("exclusiveMinimum")
+        if isinstance(exclusive_minimum, (int, float)) and numeric <= float(
+            exclusive_minimum
+        ):
+            errors.append(f"{path}: number must exceed the exclusive minimum")
+
+    if isinstance(value, list):
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(value):
+                errors.extend(
+                    _property_validation_errors(
+                        f"{path}[{index}]",
+                        item,
+                        item_schema,
+                    )
+                )
+    return errors
+
+
+def _matches_json_type(value: Any, type_name: str) -> bool:
+    if type_name == "null":
+        return value is None
+    if type_name == "boolean":
+        return isinstance(value, bool)
+    if type_name == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if type_name == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if type_name == "string":
+        return isinstance(value, str)
+    if type_name == "array":
+        return isinstance(value, list)
+    if type_name == "object":
+        return isinstance(value, Mapping)
+    return False
+
+
+def _json_type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, Mapping):
+        return "object"
+    return type(value).__name__
+
 
 # Built-in profile presets
 PROFILE_PRESETS: Dict[str, Dict[str, Any]] = {
@@ -346,50 +526,12 @@ class OpenMedConfig:
 
     @classmethod
     def from_dict(cls, config_dict: Dict[str, Any]) -> "OpenMedConfig":
-        """Create config from dictionary."""
-        # Filter out unknown keys
-        valid_keys = {
-            "default_org",
-            "cache_dir",
-            "device",
-            "hf_token",
-            "log_level",
-            "timeout",
-            "use_medical_tokenizer",
-            "medical_tokenizer_exceptions",
-            "chinese_segmentation_backend",
-            "chinese_user_dict_path",
-            "chinese_pkuseg_domain",
-            "clinical_protect_enabled",
-            "clinical_protect_terms",
-            "clinical_protect_use_builtin",
-            "backend",
-            "remote_inference_endpoint",
-            "remote_inference_protocol",
-            "remote_inference_model_name",
-            "remote_inference_model_version",
-            "remote_inference_tokenizer",
-            "remote_inference_timeout_seconds",
-            "remote_inference_verify_tls",
-            "batch_size",
-            "num_workers",
-            "lazy_model_loading",
-            "pii_model",
-            "pii_model_revision",
-            "onnx_variant",
-            "onnx_intra_op_num_threads",
-            "torch_attention_backend",
-            "load_in_4bit",
-            "bnb_4bit_use_double_quant",
-            "local_only",
-            "cjk_width_convention",
-            "chinese_target_script",
-            "transliteration_aware_name_matching",
-            "indic_name_similarity_threshold",
-            "profile",
-        }
-        filtered = {k: v for k, v in config_dict.items() if k in valid_keys}
-        return cls(**filtered)
+        """Create config from a schema-validated dictionary."""
+
+        _validate_config_keys(config_dict)
+        config = cls(**config_dict)
+        config.validate()
+        return config
 
     @classmethod
     def from_profile(cls, profile_name: str, **overrides: Any) -> "OpenMedConfig":
@@ -472,6 +614,15 @@ class OpenMedConfig:
             "indic_name_similarity_threshold": self.indic_name_similarity_threshold,
             "profile": self.profile,
         }
+
+    def validate(self) -> None:
+        """Validate this configuration against the bundled JSON Schema.
+
+        Raises:
+            ConfigValidationError: If one or more fields violate the schema.
+        """
+
+        _validate_config_mapping(self.to_dict())
 
     def with_profile(self, profile_name: str) -> "OpenMedConfig":
         """Return a new config with profile settings applied.
@@ -608,11 +759,10 @@ def load_config_from_file(path: Optional[Union[str, Path]] = None) -> OpenMedCon
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
     file_data = _load_toml(config_path)
+    _validate_config_mapping(file_data)
     merged = get_config().to_dict()
 
-    for key, value in file_data.items():
-        if key in merged:
-            merged[key] = value
+    merged.update(file_data)
 
     return OpenMedConfig.from_dict(merged)
 
@@ -621,6 +771,7 @@ def save_config_to_file(
     config: OpenMedConfig, path: Optional[Union[str, Path]] = None
 ) -> Path:
     """Persist configuration to a TOML file."""
+    config.validate()
     config_path = resolve_config_path(path)
     ensure_config_directory(config_path)
     toml_content = _dump_toml(config.to_dict())
@@ -668,7 +819,9 @@ def get_profile(profile_name: str) -> Dict[str, Any]:
 
     profile_path = PROFILES_DIR / f"{profile_name}.toml"
     if profile_path.exists():
-        return _load_toml(profile_path)
+        profile_data = _load_toml(profile_path)
+        _validate_config_mapping(profile_data, profile=True)
+        return profile_data
 
     raise ValueError(f"Unknown profile: {profile_name}")
 
@@ -683,6 +836,7 @@ def save_profile(profile_name: str, settings: Dict[str, Any]) -> Path:
     Returns:
         Path to the saved profile file.
     """
+    _validate_config_mapping(settings, profile=True)
     PROFILES_DIR.mkdir(parents=True, exist_ok=True)
     profile_path = PROFILES_DIR / f"{profile_name}.toml"
 

--- a/openmed/core/config.schema.json
+++ b/openmed/core/config.schema.json
@@ -69,8 +69,38 @@
     },
     "backend": {
       "description": "Inference backend; null selects automatic detection.",
-      "enum": [null, "hf", "mlx", "onnx"],
+      "enum": [null, "hf", "mlx", "onnx", "remote"],
       "type": ["string", "null"]
+    },
+    "remote_inference_endpoint": {
+      "description": "Optional KServe V2 or Triton inference endpoint.",
+      "type": ["string", "null"]
+    },
+    "remote_inference_protocol": {
+      "description": "Protocol used by the explicit remote inference backend.",
+      "enum": ["http", "grpc"],
+      "type": "string"
+    },
+    "remote_inference_model_name": {
+      "description": "Optional remote model repository name.",
+      "type": ["string", "null"]
+    },
+    "remote_inference_model_version": {
+      "description": "Optional remote model version.",
+      "type": ["string", "null"]
+    },
+    "remote_inference_tokenizer": {
+      "description": "Optional local tokenizer identifier for remote inference.",
+      "type": ["string", "null"]
+    },
+    "remote_inference_timeout_seconds": {
+      "description": "Positive timeout for explicit remote inference calls.",
+      "exclusiveMinimum": 0,
+      "type": "number"
+    },
+    "remote_inference_verify_tls": {
+      "description": "Whether explicit remote inference verifies TLS.",
+      "type": "boolean"
     },
     "batch_size": {
       "description": "Optional inference batch size.",
@@ -163,6 +193,13 @@
     "clinical_protect_terms",
     "clinical_protect_use_builtin",
     "backend",
+    "remote_inference_endpoint",
+    "remote_inference_protocol",
+    "remote_inference_model_name",
+    "remote_inference_model_version",
+    "remote_inference_tokenizer",
+    "remote_inference_timeout_seconds",
+    "remote_inference_verify_tls",
     "batch_size",
     "num_workers",
     "lazy_model_loading",

--- a/tests/unit/core/test_config_schema_validation.py
+++ b/tests/unit/core/test_config_schema_validation.py
@@ -1,0 +1,116 @@
+"""Tests for the bundled OpenMedConfig JSON Schema."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from openmed.core.config import (
+    ConfigValidationError,
+    OpenMedConfig,
+    config_schema_path,
+    load_config_from_file,
+)
+
+
+def _schema() -> dict[str, object]:
+    return json.loads(config_schema_path().read_text(encoding="utf-8"))
+
+
+def test_schema_is_valid_and_covers_every_config_field() -> None:
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+
+    field_names = {field.name for field in fields(OpenMedConfig)}
+    assert set(schema["properties"]) == field_names
+    assert set(schema["x-profile-keys"]) == field_names - {"profile"}
+
+
+def test_default_and_remote_configs_validate_against_published_schema() -> None:
+    schema = _schema()
+    validator = Draft202012Validator(schema)
+    default = OpenMedConfig()
+    remote = OpenMedConfig(
+        backend="remote",
+        remote_inference_endpoint="https://inference.example.invalid",
+        remote_inference_protocol="grpc",
+        remote_inference_model_name="synthetic-model",
+        remote_inference_model_version="1",
+        remote_inference_tokenizer="synthetic-tokenizer",
+    )
+
+    assert default.validate() is None
+    assert remote.validate() is None
+    assert list(validator.iter_errors(default.to_dict())) == []
+    assert list(validator.iter_errors(remote.to_dict())) == []
+
+
+def test_file_validation_aggregates_unknown_and_wrong_types_without_values(
+    tmp_path,
+) -> None:
+    private_value = "private-canary-value"
+    path = tmp_path / "config.toml"
+    path.write_text(
+        f'timeout = "slow"\nunknown_private_key = "{private_value}"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigValidationError) as exc_info:
+        load_config_from_file(path)
+
+    message = str(exc_info.value)
+    assert "timeout" in message
+    assert "expected integer" in message
+    assert "unknown_private_key" in message
+    assert private_value not in message
+    assert len(exc_info.value.errors) == 2
+
+
+def test_from_dict_rejects_unknown_keys_instead_of_filtering_them() -> None:
+    with pytest.raises(ConfigValidationError, match="typo_timeout"):
+        OpenMedConfig.from_dict({"typo_timeout": 30})
+
+
+@pytest.mark.parametrize(
+    ("contents", "bad_key"),
+    [
+        ('timeout = "slow"\n', "timeout"),
+        ("typo_timeout = 30\n", "typo_timeout"),
+    ],
+)
+def test_load_config_rejects_invalid_file_with_offending_key(
+    tmp_path,
+    contents: str,
+    bad_key: str,
+) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(ConfigValidationError, match=bad_key):
+        load_config_from_file(path)
+
+
+def test_schema_path_is_an_installed_json_resource() -> None:
+    path = config_schema_path()
+
+    assert path.name == "config.schema.json"
+    assert path.is_file()
+    assert _schema()["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+
+def test_list_items_and_numeric_bounds_are_validated() -> None:
+    config = OpenMedConfig()
+    config.medical_tokenizer_exceptions = ["safe", 7]  # type: ignore[list-item]
+    config.indic_name_similarity_threshold = 1.5
+    config.remote_inference_timeout_seconds = 0
+
+    with pytest.raises(ConfigValidationError) as exc_info:
+        config.validate()
+
+    message = str(exc_info.value)
+    assert "medical_tokenizer_exceptions[1]" in message
+    assert "indic_name_similarity_threshold" in message
+    assert "remote_inference_timeout_seconds" in message


### PR DESCRIPTION
# Pull Request

## Description
Makes the bundled Draft 2020-12 schema the fail-fast source of truth for OpenMed configuration keys, types, bounds, and custom profile fields. Unknown keys are no longer silently discarded, and validation diagnostics aggregate field names and constraints without echoing configuration values.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [x] Test addition/improvement

## Changes Made
- Add ConfigValidationError, OpenMedConfig.validate(), and config_schema_path().
- Validate TOML loads, dictionary construction, saved configs, and custom profiles while retaining established normalization behavior.
- Complete the schema for the explicit remote inference backend and enforce exact dataclass/schema field parity.
- Replace the old silent unknown-key filter with value-free aggregated errors.

## Testing
- [x] 176 configuration, profile, scaffold, remote-backend, documentation, and publication tests pass; 5 optional tests skip.
- [x] Focused mypy validation passes.
- [x] Scoped pre-commit hooks and diff checks pass.
- [x] Strict multilingual Pages staging passes.
- [x] Built wheel contains openmed/core/config.schema.json.

## Documentation
- [x] Updated configuration guidance.
- [x] Added public docstrings.
- [x] Updated CHANGELOG.md.

## Code Quality
- [x] Canonical scoped lint and formatting checks pass.
- [x] Self-review completed.
- [x] Validation errors never echo configuration values.

## Dependencies
- [x] No new runtime dependencies.

## Checklist
- [x] Branch contains current master d1927f857f79ba41b0bd435df5a1b1cbf569a83f.
- [x] Commits use the repository-owner identity and SSH signatures.
- [x] Schema is present in the built wheel.

## Related Issues
Closes #2264

## Screenshots/Examples
Not applicable; the updated configuration guide includes API examples.