### PR TITLE
docs: forward-port finalized v2.2.0 release materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,36 +152,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   core privacy-pipeline stages, with lazy optional imports, no exporter by
   default, shared `Timer` measurements, synthetic leakage regression tests, and
   an `otel` installation extra.
-- Added a four-part, synthetic-only Jupyter notebook gallery for redaction,
-  batch processing, FHIR export, and multilingual evaluation, with offline
-  execution and committed-output freshness checks in CI.
-- Added first-class Cohere Compass vision-language inference for the five
-  OpenMed North Micro Vision MLX precision variants: a native Python runtime,
-  a shared OpenMedKit Swift/iOS runtime, local and Hub artifact loading,
-  native-resolution image processing, and deterministic text/image parity
-  tests across Python and Swift.
 - Added a minimal local-artifact `edge-sbc` ONNX Runtime profile, native ARM64
   Raspberry Pi and Jetson synthetic benchmark workflow, aggregate cold-start,
   token-throughput, install-size, and peak-RSS records, plus fail-closed
   footprint budgets and archived ARM64 proxy evidence.
 
-## [2.2.0] - 2026-08-13
+## [2.2.0] - 2026-08-21
 
 OpenMed 2.2 completes the trustworthy clinical-data-exchange milestone across
 terminology grounding, document intake, FHIR, OMOP, structured privacy, MCP,
-service security, and offline release evidence. The final audited
-`v2.1.0..v2.2.0` range contains 98 commits and 462 changed files, including 31
-merged feature-integration PRs, release-preparation PR #2699,
-release-evidence correction PR #2700, and the contributor commits preserved by
-the v2.2 batches.
+service security, local model runtimes, and offline release evidence. The final
+audited `v2.1.0..v2.2.0` range contains 111 commits and 571 changed files.
+GitHub generated notes associate 38 PRs with that range, including the
+contributor commits preserved by maintainer integration batches.
 
-The static public Python surface grows from 31,619 to 37,307 symbols with
-5,688 additions, zero removals or narrowed signatures, and zero new
+The static public Python surface grows from 31,619 to 37,735 symbols with
+6,116 additions, zero removals or narrowed signatures, and zero new
 deprecations. The REST surface grows additively from 17 to 19 paths and from
 15 to 17 component schemas through `POST /ground` and
-`POST /pii/deidentify/stream`. Swift package source is unchanged. Android
-keeps its public method signatures while making diagnostic descriptions and
-internal logging PHI-safe by default.
+`POST /pii/deidentify/stream`. Swift adds public Maple and Compass local-model
+runtimes without removing an existing package API. Android keeps its public
+method signatures while making diagnostic descriptions and internal logging
+PHI-safe by default.
 
 ### Added
 
@@ -192,6 +184,14 @@ internal logging PHI-safe by default.
   reproducible 4-bit/8-bit MLX planning and checksum-verified ONNX/ORT bundle
   tooling. Model weights remain external and every clinical or disclosure
   result requires human review.
+- Added first-class Cohere Compass vision-language inference for the five
+  OpenMed North Micro Vision MLX precision variants: a native Python runtime,
+  a shared OpenMedKit Swift/iOS runtime, local and Hub artifact loading,
+  native-resolution image processing, and deterministic text/image parity
+  tests across Python and Swift.
+- Added a four-part, synthetic-only Jupyter notebook gallery for redaction,
+  batch processing, FHIR export, and multilingual evaluation, with offline
+  execution and committed-output freshness checks in CI.
 - Added a local-first terminology workbench with checksum-pinned vocabulary
   snapshots, exact and ranked grounding, calibration, section context,
   caller-supplied Athena and crosswalk support, value-free provenance, and
@@ -242,11 +242,12 @@ internal logging PHI-safe by default.
   send it to diagnostics or telemetry.
 - Active Python, npm, Swift, Android/JitPack, Helm, container, website, and
   documentation coordinates now target `2.2.0` / `v2.2.0`.
-- Rebased the wheel-size gate to the reproducible 4,076,360-byte v2.2 wheel
-  after auditing 62,667 additions and 786 removals across 169 Python files.
-  The gate retains 10% headroom with a 4,483,996-byte maximum; the payload
-  contains source, synthetic metadata, and the committed model manifest rather
-  than an unexpected binary or restricted vocabulary asset.
+- The final candidate wheel is reproducibly 4,134,629 bytes and remains within
+  the committed 4,483,996-byte maximum. The gate retains its 4,076,360-byte
+  baseline and 10% headroom; the payload contains source, synthetic metadata,
+  and the committed model manifest rather than an unexpected binary or
+  restricted vocabulary asset.
+
 ### Fixed
 
 - Fixed production builds to emit Core Metadata 2.4 for compatibility with the
@@ -268,14 +269,13 @@ internal logging PHI-safe by default.
 
 ### Release integration ledger
 
-- GitHub-generated release-note PRs (33): #2228, #2230, #2237, #2239, #2241,
-  #2243, #2244, #2541, #2543, #2548, #2549, #2550, #2551, #2678, #2679,
-  #2680, #2681, #2682, #2685, #2686, #2687, #2688, #2689, #2690, #2691,
-  #2692, #2693, #2694, #2695, #2696, #2698, #2699, and #2700.
-- All 95 issues assigned to the `v2.2` milestone are closed. The final two
-  issues that had no contributor PR were implemented in #2696 and #2698.
+- GitHub-generated release-note PRs (38): #2228, #2230, #2237, #2239, #2241,
+  #2243, #2244, #2245, #2541, #2543, #2548, #2549, #2550, #2551, #2678,
+  #2679, #2680, #2681, #2682, #2685, #2686, #2687, #2688, #2689, #2690,
+  #2691, #2692, #2693, #2694, #2695, #2696, #2698, #2699, #2700, #2885,
+  #2886, #2887, and #2891.
 - The GitHub generated-note set is intentionally smaller than the complete
-  98-commit ancestry range because the maintainer batches preserve source
+  111-commit ancestry range because the maintainer batches preserve source
   contributor commits while presenting one reviewed integration PR per
   coherent subsystem.
 

--- a/docs/migration/2.1-to-2.2.md
+++ b/docs/migration/2.1-to-2.2.md
@@ -15,9 +15,9 @@ python scripts/release/api_surface_diff.py \
 
 ## Compatibility result
 
-The static Python API inventory grows from 31,619 to 37,307 symbols:
+The static Python API inventory grows from 31,619 to 37,735 symbols:
 
-- 5,688 public symbols are added.
+- 6,116 public symbols are added.
 - No public symbol is removed or renamed.
 - No existing callable signature is narrowed.
 - No existing symbol is newly marked with `@deprecated`.
@@ -26,11 +26,12 @@ The REST contract grows additively from 17 paths and 15 component schemas to
 19 paths and 17 component schemas. The new `POST /ground` and
 `POST /pii/deidentify/stream` operations do not replace an existing route.
 
-Swift package source is unchanged in this range. Android keeps its public
-method signatures, while the diagnostic representation of detected entities
-becomes PHI-safe by default. JavaScript, CLI, configuration, model-manifest,
-and evidence contracts require separate review because the Python AST
-comparison does not inspect them.
+Swift adds public Maple task/runtime types and Compass vision-language loading
+and generation without removing an existing OpenMedKit API. Android keeps its
+public method signatures, while the diagnostic representation of detected
+entities becomes PHI-safe by default. JavaScript, CLI, configuration,
+model-manifest, and evidence contracts require separate review because the
+Python AST comparison does not inspect them.
 
 ## Upgrade checklist
 
@@ -54,6 +55,10 @@ comparison does not inspect them.
 8. Treat structured release recommendations and clinical mappings as
    assistive evidence requiring qualified review; they must not automatically
    trigger diagnosis, treatment, billing, or data publication.
+9. If adopting Maple or Compass, pin and verify external model artifacts,
+   re-run task- and image-specific acceptance tests on the deployment device,
+   and keep model outputs inside the same human-review boundary as other
+   clinical extraction results.
 
 No before/after replacement snippet is required for a removed or deprecated
 Python symbol because the static comparison found neither category.
@@ -82,6 +87,18 @@ the prediction fields or span contract.
 Applications may still render the explicit `text` field locally when that is
 necessary for an approved user interface. Do not rely on `description` as a
 source-text transport and do not add `text` to diagnostic or telemetry paths.
+
+## Maple and Compass runtimes
+
+Python adds the `MapleClinicalAssistant` task API, MLX Maple export/runtime
+helpers, and the `openmed.mlx` Compass vision-language runtime. OpenMedKit adds
+`OpenMedMaple*` request, response, parsing, and MLX runtime types plus
+`OpenMedVisionLanguageModel` loading and generation.
+
+These are additive APIs, but their model artifacts remain external. The Swift
+package also pins MLX Swift LM to a reviewed revision for multimodal generation.
+Deployments that do not enable these runtimes do not gain an implicit network
+or model-download path.
 
 ## Clinical exchange and grounding
 

--- a/docs/release/v2.2.0.md
+++ b/docs/release/v2.2.0.md
@@ -2,10 +2,10 @@
 
 OpenMed `2.2.0` completes the trustworthy clinical-data-exchange milestone
 across terminology grounding, document intake, FHIR, OMOP, structured
-privacy, MCP, service security, Android local inference, and offline release
-evidence without removing a public Python symbol.
+privacy, MCP, service security, local model runtimes, Android local inference,
+and offline release evidence without removing a public Python symbol.
 
-Release date: 2026-08-13.
+Release date: 2026-08-21.
 
 ## Highlights
 
@@ -34,14 +34,23 @@ Release date: 2026-08-13.
 - **On-device safety:** Android network-denial guards, no INTERNET permission,
   opt-in typed aggregate logging, hashed entity descriptions, and explicit
   assistive-use documentation.
+- **Local model runtimes:** pinned Maple clinical task support and native
+  Compass vision-language inference across Python and OpenMedKit, with external
+  weights, checksum-bound artifacts, and human-review boundaries.
+- **Validated examples:** a four-part synthetic notebook gallery for redaction,
+  batch processing, FHIR export, and multilingual evaluation, with offline
+  execution and committed-output freshness checks.
 - **Release conformance:** hard-negative and multilingual traps, FHIR
   round-trip fixtures, timeline provenance, and a versioned synthetic v2.2
   matrix with pinned FHIR, OMOP, and evidence hashes.
 
 ## Compatibility
 
-The static public Python comparison grows from 31,619 to 37,307 symbols:
-5,688 additions, zero removals or narrowed signatures, and zero new
+The audited `v2.1.0..v2.2.0` range contains 111 commits and 571 changed files;
+GitHub generated notes associate 38 PRs with the complete ancestry range.
+
+The static public Python comparison grows from 31,619 to 37,735 symbols:
+6,116 additions, zero removals or narrowed signatures, and zero new
 deprecations. The REST surface grows additively from 17 to 19 paths and from
 15 to 17 component schemas with `POST /ground` and
 `POST /pii/deidentify/stream`.
@@ -51,11 +60,12 @@ snapshot-cache meaning. The new vocabulary type is available as
 `VocabularySnapshotManifest`. The public OMOP `ConceptResolver` type alias is
 also retained.
 
-Swift package source is unchanged in this release range. Android public method
-signatures are unchanged, but `EntityPrediction.description` now contains a
-SHA-256 digest instead of raw detected text. Applications that need a local UI
-preview must use the explicit `text` field and keep it out of logs, telemetry,
-crash reports, and remote diagnostics.
+Swift adds public Maple task/runtime types and Compass vision-language loading
+and generation without removing an existing OpenMedKit API. Android public
+method signatures are unchanged, but `EntityPrediction.description` now
+contains a SHA-256 digest instead of raw detected text. Applications that need
+a local UI preview must use the explicit `text` field and keep it out of logs,
+telemetry, crash reports, and remote diagnostics.
 
 See the [2.1-to-2.2 migration guide](../migration/2.1-to-2.2.md) for the
 cross-surface review and upgrade checklist.
@@ -71,6 +81,7 @@ automation should verify the required coordinate before deployment.
 ```bash
 pip install --upgrade "openmed==2.2.0"
 pip install --upgrade "openmed[hf,fhir]==2.2.0"
+pip install --upgrade "openmed[mlx]==2.2.0"
 ```
 
 ### Browser and Node.js
@@ -145,6 +156,8 @@ The exact release commit is required to pass:
 - locked dependencies, lint, formatting, and the complete Python test suite;
 - strict documentation, README translation drift, marketing staging, and
   regenerated OpenAPI checks;
+- offline execution and committed-output checks for the synthetic notebook
+  gallery;
 - wheel/sdist build, metadata, contents, Twine, SBOM, and provenance tests;
 - npm install, audit, tests, type checking, build, and tarball inspection;
 - Swift resolve/build/tests plus applicable hosted Apple platform jobs;


### PR DESCRIPTION
## Description

Forward-ports the finalized OpenMed v2.2.0 release materials from the audited
`release/openmed-220` head (`59d9cb0a`) onto current `master`.

This keeps the taggable v2.2.0 branch frozen instead of merging the 130
post-cut `master` commits into the release candidate. The release tag target
remains `release/openmed-220`; this PR only integrates its final documentation
back into `master`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Changes Made

- Finalize the v2.2.0 changelog date, audited range, API counts, wheel evidence,
  and release integration ledger.
- Move the shipped Compass and notebook-gallery entries out of `Unreleased`
  while preserving the post-cut entries already on `master`.
- Synchronize the v2.1-to-v2.2 migration guide and v2.2.0 release guide with
  the exact audited release-branch evidence.

## Testing

- [x] New and existing unit tests pass locally with my changes
- [x] Full strict documentation artifact builds locally
- [x] Exact merge simulation against current `master` is conflict-free

Commands and results:

- `uv run --extra dev --frozen pytest tests/unit/release/test_changelog.py tests/unit/test_publish_workflow_version.py -q` — 26 passed
- `make docs-build` — passed, including brand validation, strict MkDocs build,
  route crawl, LLM-feed checks, publication metadata, and locale policy
- `git merge-tree --write-tree --messages origin/master HEAD` — clean
- `git diff --check origin/master...HEAD` — clean

The frozen release candidate at `59d9cb0a` was separately validated with the
full Python suite: 12,185 passed and 117 skipped.

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md`
- [x] No public API docstrings are affected

## Code Quality

- [x] I have performed a self-review of the three-file documentation diff
- [x] My changes generate no new warnings
- [x] Python and Swift formatting gates are not applicable to this docs-only diff

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] The PR contains one focused commit

## Related Issues

None.

## Screenshots/Examples

Not applicable; this is a release-documentation update.
