### PR TITLE
test: make service concurrency checks deterministic

### DIFF
--- a/tests/unit/service/test_request_coalescing.py
+++ b/tests/unit/service/test_request_coalescing.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import threading
-import time
 from typing import Any
 
 import httpx
@@ -163,7 +162,9 @@ def test_high_priority_waiter_promotes_coalesced_bulk_batch(monkeypatch) -> None
     _enable_coalescing_env(monkeypatch)
     monkeypatch.setenv("OPENMED_SERVICE_BATCHING_ENABLED", "true")
     monkeypatch.setenv("OPENMED_SERVICE_BATCH_MAX_SIZE", "8")
-    monkeypatch.setenv("OPENMED_SERVICE_BATCH_MAX_WAIT_MS", "500")
+    # Keep the timer fallback beyond the liveness timeout so completion proves
+    # that the interactive waiter promoted and flushed the queued bulk job.
+    monkeypatch.setenv("OPENMED_SERVICE_BATCH_MAX_WAIT_MS", "60000")
     monkeypatch.setenv("OPENMED_SERVICE_BATCH_MAX_QUEUE_SIZE", "8")
     monkeypatch.setattr(service_runtime, "ModelLoader", FakeLoader)
     lock = threading.Lock()
@@ -178,8 +179,10 @@ def test_high_priority_waiter_promotes_coalesced_bulk_batch(monkeypatch) -> None
     monkeypatch.setattr(openmed, "analyze_text", fake_analyze)
     app = create_app()
 
-    async def scenario() -> tuple[list[httpx.Response], float]:
+    async def scenario() -> list[httpx.Response]:
         async with app.router.lifespan_context(app):
+            batcher = app.state.analyze_batcher
+            assert batcher is not None
             transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
             async with httpx.AsyncClient(
                 transport=transport,
@@ -192,8 +195,13 @@ def test_high_priority_waiter_promotes_coalesced_bulk_batch(monkeypatch) -> None
                         headers={"x-openmed-priority": "bulk"},
                     )
                 )
-                await asyncio.sleep(0.05)
-                start = time.perf_counter()
+                for _ in range(100):
+                    if (await batcher.queue_depths())["bulk"] == 1:
+                        break
+                    await asyncio.sleep(0)
+                else:
+                    raise AssertionError("bulk request never entered the batch queue")
+
                 second = asyncio.create_task(
                     client.post(
                         "/analyze",
@@ -201,15 +209,18 @@ def test_high_priority_waiter_promotes_coalesced_bulk_batch(monkeypatch) -> None
                         headers={"x-openmed-priority": "interactive"},
                     )
                 )
-                responses = list(await asyncio.gather(first, second))
-                return responses, time.perf_counter() - start
+                return list(
+                    await asyncio.wait_for(
+                        asyncio.gather(first, second),
+                        timeout=5.0,
+                    )
+                )
 
-    responses, joined_latency = asyncio.run(scenario())
+    responses = asyncio.run(scenario())
 
     assert [response.status_code for response in responses] == [200, 200]
     assert [response.json()["text"] for response in responses] == ["alpha", "alpha"]
     assert calls == 1
-    assert joined_latency < 0.3
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/service/test_streaming_deidentify_endpoint.py
+++ b/tests/unit/service/test_streaming_deidentify_endpoint.py
@@ -194,10 +194,14 @@ def test_blocking_core_iterator_does_not_block_event_loop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     worker_threads: list[int] = []
+    worker_started = threading.Event()
+    worker_release = threading.Event()
+    worker_released: list[bool] = []
 
     def slow_stream(*args: Any, **kwargs: Any):
         worker_threads.append(threading.get_ident())
-        time.sleep(0.3)
+        worker_started.set()
+        worker_released.append(worker_release.wait(timeout=10.0))
         yield StreamingDeidentificationEvent(redacted_text="safe output")
         yield StreamingDeidentificationEvent(
             redacted_text="",
@@ -208,7 +212,7 @@ def test_blocking_core_iterator_does_not_block_event_loop(
     monkeypatch.setattr("openmed.service.streaming.deidentify_stream", slow_stream)
     app = create_app()
 
-    async def scenario() -> tuple[httpx.Response, httpx.Response, float, int]:
+    async def scenario() -> tuple[httpx.Response, httpx.Response, int]:
         async with app.router.lifespan_context(app):
             loop_thread = threading.get_ident()
             transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
@@ -216,24 +220,35 @@ def test_blocking_core_iterator_does_not_block_event_loop(
                 transport=transport,
                 base_url=LOOPBACK_BASE_URL,
             ) as async_client:
-                started = time.perf_counter()
                 stream_task = asyncio.create_task(
                     async_client.post(
                         "/pii/deidentify/stream",
                         json={"text": "synthetic input", "chunk_size": 4},
                     )
                 )
-                await asyncio.sleep(0.02)
-                live = await async_client.get("/livez")
-                live_elapsed = time.perf_counter() - started
-                streamed = await stream_task
-                return streamed, live, live_elapsed, loop_thread
 
-    streamed, live, live_elapsed, loop_thread = asyncio.run(scenario())
+                async def wait_until_worker_starts() -> None:
+                    while not worker_started.is_set():
+                        await asyncio.sleep(0)
+
+                await asyncio.wait_for(wait_until_worker_starts(), timeout=10.0)
+                try:
+                    live = await asyncio.wait_for(
+                        async_client.get("/livez"), timeout=10.0
+                    )
+                finally:
+                    worker_release.set()
+                streamed = await asyncio.wait_for(
+                    stream_task,
+                    timeout=10.0,
+                )
+                return streamed, live, loop_thread
+
+    streamed, live, loop_thread = asyncio.run(scenario())
 
     assert streamed.status_code == 200
     assert live.status_code == 200
-    assert live_elapsed < 0.2
+    assert worker_released == [True]
     assert worker_threads and worker_threads[0] != loop_thread
 
 


### PR DESCRIPTION
## Description

Replaces two runner-speed-sensitive service tests with deterministic behavioral checks. The coalescing test now synchronizes on the real queue state, and the streaming test proves event-loop responsiveness by requiring a live request to release a deliberately blocked worker.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test addition/improvement

## Changes Made

- Remove the 300 ms promotion wall-clock assertion and synchronize on the actual bulk queue state.
- Hold the normal batch timer beyond its liveness timeout and prove that an interactive waiter promotes and flushes the queued job.
- Replace the 200 ms streaming wall-clock assertion with a deterministic thread-event ordering proof.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change on the exact Python version that failed in CI

Validation:
- Focused coalescing promotion test: 20 consecutive passes.
- Request-coalescing test file: 9 passed.
- Streaming endpoint test file on Python 3.10: 5 passed.
- Service unit suite on Python 3.10: 359 passed, 5 skipped.
- `make format-check`, `make lint`, and `make type-check`: passed.
- Scoped pre-commit: passed.

## Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

Not applicable; this changes only test synchronization contracts.

## Code Quality

- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where the synchronization contract needs explanation
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues

Release CI follow-up for runner-load failures in CI runs 32551315914 and 32559932811.

## Screenshots/Examples

Not applicable.
