### PR TITLE
Fix multi-stage container digest policy gate

### DIFF
--- a/tests/unit/deploy/test_container_multiarch.py
+++ b/tests/unit/deploy/test_container_multiarch.py
@@ -15,9 +15,14 @@ MKDOCS = ROOT / "mkdocs.yml"
 
 PINNED_PYTHON_BASE_RE = re.compile(
     r"^FROM(?: --platform=\$TARGETPLATFORM)? "
-    r"python:3\.11-slim@sha256:[0-9a-f]{64}$",
+    r"python:3\.11-slim@sha256:[0-9a-f]{64}(?: AS [A-Za-z0-9._-]+)?$",
     re.MULTILINE,
 )
+FROM_IMAGE_RE = re.compile(
+    r"^FROM(?: --platform=\S+)? (?P<image>\S+)(?: AS \S+)?$",
+    re.IGNORECASE | re.MULTILINE,
+)
+PINNED_IMAGE_RE = re.compile(r"^[^@\s]+@sha256:[0-9a-f]{64}$")
 
 
 def test_deployment_dockerfile_uses_digest_pinned_python_base():
@@ -28,8 +33,11 @@ def test_deployment_dockerfile_uses_digest_pinned_python_base():
 
 def test_root_dockerfile_keeps_compose_base_digest_pinned():
     content = ROOT_DOCKERFILE.read_text(encoding="utf-8")
+    stage_images = [match.group("image") for match in FROM_IMAGE_RE.finditer(content)]
 
     assert PINNED_PYTHON_BASE_RE.search(content)
+    assert stage_images
+    assert all(PINNED_IMAGE_RE.fullmatch(image) for image in stage_images)
 
 
 def test_multiarch_workflow_builds_manifest_and_smokes_each_platform():


### PR DESCRIPTION
# Pull Request

## Description
Updates the container digest policy test for the multi-stage service image introduced in #2947 while strengthening the gate to validate every root Dockerfile stage.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Accept a valid alias on the digest-pinned Python build stage.
- Parse all root Dockerfile stage images.
- Require every parsed stage image to carry a full SHA-256 digest.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

Commands run:

- `python -m pytest tests/unit/deploy/test_container_multiarch.py -q` — 7 passed
- `python -m pytest --last-failed -q` outside the restricted sandbox — 26 passed
- `ruff check tests/unit/deploy/test_container_multiarch.py`
- `ruff format --check tests/unit/deploy/test_container_multiarch.py`

## Documentation
- [x] No documentation change is needed for this test-only policy repair
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran the scoped canonical Ruff check and format-check
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] The regex names and assertions are self-explanatory
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #2964
Related to #2947

## Screenshots/Examples
Not applicable; test-only policy repair.
