### PR TITLE
Refresh v2.3 wheel-size release budget

### DIFF
--- a/gates/release_budgets.json
+++ b/gates/release_budgets.json
@@ -16,9 +16,9 @@
     "package::openmed::wheel": {
       "key": "package::openmed::wheel",
       "metrics": {
-        "baseline_bytes": 4076360,
+        "baseline_bytes": 4618352,
         "headroom_percent": 10,
-        "maximum_bytes": 4483996
+        "maximum_bytes": 5080188
       }
     }
   },


### PR DESCRIPTION
# Pull Request

## Description
Refreshes the committed wheel-size baseline from the v2.2 release-candidate measurement to the exact final v2.3 Linux CI measurement. The existing 10% headroom policy is preserved unchanged.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test/release-gate repair

## Changes Made
- Set the wheel baseline to the final v2.3 Linux CI measurement: 4,618,352 bytes.
- Recalculate the maximum at the existing 10% headroom: 5,080,188 bytes.
- Leave package contents, dependencies, and enforcement logic unchanged.

## Testing
- [x] New and existing release unit tests pass locally
- [x] Real wheel-size gate passes against the final v2.3 wheel
- [x] Built-wheel license policy passes

Commands run:

- python -m pytest tests/unit/release -q — 183 passed
- python scripts/release/check_size_budget.py --skip-build --wheel-dir <final-v2.3-wheel> — passed at 4,618,569 / 5,080,188 bytes locally
- python scripts/release/check_license_policy.py --wheel <final-v2.3-wheel> — passed

## Documentation
- [x] No documentation change is needed for a release-budget baseline refresh
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I have performed a self-review
- [x] The committed maximum exactly matches ceil(baseline × 1.10)
- [x] The change generates no new warnings

## Dependencies
- [x] I have not added any new dependencies

## Related Issues
Closes #2966

## Screenshots/Examples
Not applicable; release-policy metadata only.