### PR TITLE
feat(multimodal): add privacy-safe asset manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a dependency-free, versioned multimodal asset manifest with strict
+  media and digest validation, bounded metadata-only fields, deterministic
+  JSON serialization, and value-free rejection of paths, URLs, free text, and
+  unknown fields (#2954).
 - Added a deterministic Jupyter notebook cell redaction helper that preserves
   code sources and execution structure, applies explicit markdown and output
   policies, removes unredacted binary MIME data, and emits counts-only,

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -203,6 +203,7 @@ classification:
     - reference/training-schemas.md
     - reference/preference-schema.md
     - multimodal/pdf-reading-order.md
+    - multimodal/asset-manifests.md
     - multimodal/pdf-redaction-fidelity.md
     - multimodal/email-ingestion.md
     - multimodal/epub-extraction.md

--- a/docs/multimodal/asset-manifests.md
+++ b/docs/multimodal/asset-manifests.md
@@ -18,6 +18,11 @@ The validator rejects unknown fields, paths, URLs, and free-text fields such as
 descriptions or source metadata. Validation errors name the failed field or rule
 without echoing the supplied value.
 
+Integer sizes and counts use explicit 64-bit and 32-bit upper bounds,
+respectively. Duration is finite, positive, and capped at the same upper bound
+as other counts. Boolean values, scalar subclasses, duplicate JSON fields, and
+numeric values outside those bounds fail closed.
+
 ```python
 from openmed.multimodal.asset_manifest import AssetManifest
 

--- a/docs/multimodal/asset-manifests.md
+++ b/docs/multimodal/asset-manifests.md
@@ -1,0 +1,44 @@
+# Privacy-safe asset manifests
+
+`openmed.multimodal.asset_manifest` defines a small manifest for preflight
+steps that need to describe an input without reading or storing the input
+itself.
+
+The manifest is intentionally narrow. It records only:
+
+- `version`
+- `asset_id`
+- `media_type`
+- `sha256`
+- `byte_size`
+- optional bounded counts: `pages`, `width`, `height`, `frames`,
+  `duration_seconds`
+
+The validator rejects unknown fields, paths, URLs, and free-text fields such as
+descriptions or source metadata. Validation errors name the failed field or rule
+without echoing the supplied value.
+
+```python
+from openmed.multimodal.asset_manifest import AssetManifest
+
+manifest = AssetManifest.from_dict(
+    {
+        "asset_id": "dicom-001",
+        "media_type": "application/dicom",
+        "sha256": "a" * 64,
+        "byte_size": 4096,
+        "frames": 12,
+        "width": 512,
+        "height": 512,
+    }
+)
+
+payload = manifest.to_json()
+```
+
+`to_dict()` emits fields in a stable order and omits unset optional fields.
+`to_json()` emits compact JSON with sorted keys so callers can compare manifest
+payloads deterministically.
+
+The manifest does not read assets, perform OCR or inference, retain embedded
+metadata, or define model-specific tensor shapes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Training Schema Registry: reference/training-schemas.md
       - Preference Pair Schema: reference/preference-schema.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
+      - Privacy-safe Asset Manifests: multimodal/asset-manifests.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md
       - Email Ingestion and Redaction: multimodal/email-ingestion.md
       - EPUB Extraction: multimodal/epub-extraction.md

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -28,6 +28,7 @@ from . import documents_docx as _documents_docx
 from . import documents_html as _documents_html
 from . import documents_markdown as _documents_markdown
 from . import pptx as _pptx
+from .asset_manifest import MANIFEST_VERSION, AssetManifest, AssetManifestError
 from .base import (
     ExtractedDocument,
     SourceSpan,
@@ -252,6 +253,9 @@ __all__ = [
     "register_handler",
     "ensure_multimodal_available",
     "is_multimodal_available",
+    "AssetManifest",
+    "AssetManifestError",
+    "MANIFEST_VERSION",
     "MissingDependencyError",
     "UnsupportedDocumentError",
     "DocumentGraphError",

--- a/openmed/multimodal/asset_manifest.py
+++ b/openmed/multimodal/asset_manifest.py
@@ -1,0 +1,183 @@
+"""Privacy-safe asset manifests for multimodal preflight.
+
+The manifest records only bounded, non-identifying facts that downstream image,
+PDF, DICOM, and audio handlers can share before decoding an asset. It rejects
+paths, URLs, free-text payload fields, and unknown keys so callers do not
+accidentally persist PHI-bearing source metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+MANIFEST_VERSION = 1
+
+_ASSET_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_MEDIA_TYPE_RE = re.compile(r"^[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*$")
+_PATH_OR_URL_RE = re.compile(r"://|(^|[A-Za-z]):[\\/]|[\\/]|~")
+
+_ALLOWED_FIELDS = {
+    "version",
+    "asset_id",
+    "media_type",
+    "sha256",
+    "byte_size",
+    "pages",
+    "width",
+    "height",
+    "frames",
+    "duration_seconds",
+}
+
+_ORDERED_FIELDS = (
+    "version",
+    "asset_id",
+    "media_type",
+    "sha256",
+    "byte_size",
+    "pages",
+    "width",
+    "height",
+    "frames",
+    "duration_seconds",
+)
+
+_SUPPORTED_EXACT_MEDIA_TYPES = {
+    "application/dicom",
+    "application/pdf",
+    "application/dicom+json",
+}
+_SUPPORTED_MEDIA_PREFIXES = ("image/", "audio/")
+
+
+class AssetManifestError(ValueError):
+    """Raised when a privacy-safe asset manifest fails validation."""
+
+
+@dataclass(frozen=True)
+class AssetManifest:
+    """Versioned, privacy-safe description of a multimodal input asset."""
+
+    asset_id: str
+    media_type: str
+    sha256: str
+    byte_size: int
+    version: int = MANIFEST_VERSION
+    pages: int | None = None
+    width: int | None = None
+    height: int | None = None
+    frames: int | None = None
+    duration_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        _validate_version(self.version)
+        _validate_opaque_string("asset_id", self.asset_id, _ASSET_ID_RE)
+        _validate_media_type(self.media_type)
+        _validate_opaque_string("sha256", self.sha256, _SHA256_RE)
+        _validate_positive_int("byte_size", self.byte_size)
+        for field_name in ("pages", "width", "height", "frames"):
+            value = getattr(self, field_name)
+            if value is not None:
+                _validate_positive_int(field_name, value)
+        if self.duration_seconds is not None:
+            _validate_positive_number("duration_seconds", self.duration_seconds)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AssetManifest":
+        """Build and validate a manifest from a strict mapping."""
+        if not isinstance(data, Mapping):
+            raise AssetManifestError("manifest must be a mapping")
+
+        unknown = set(data) - _ALLOWED_FIELDS
+        if unknown:
+            raise AssetManifestError("manifest contains unknown fields")
+
+        missing = {"asset_id", "media_type", "sha256", "byte_size"} - set(data)
+        if missing:
+            raise AssetManifestError("manifest is missing required fields")
+
+        version = data.get("version", MANIFEST_VERSION)
+        return cls(
+            version=version,
+            asset_id=data["asset_id"],
+            media_type=data["media_type"],
+            sha256=data["sha256"],
+            byte_size=data["byte_size"],
+            pages=data.get("pages"),
+            width=data.get("width"),
+            height=data.get("height"),
+            frames=data.get("frames"),
+            duration_seconds=data.get("duration_seconds"),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str | bytes | bytearray) -> "AssetManifest":
+        """Build and validate a manifest from a JSON object."""
+        try:
+            data = json.loads(payload)
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
+            raise AssetManifestError("manifest JSON is malformed") from exc
+        return cls.from_dict(data)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic dictionary without unset optional fields."""
+        data: dict[str, Any] = {}
+        for field_name in _ORDERED_FIELDS:
+            value = getattr(self, field_name)
+            if value is not None:
+                data[field_name] = value
+        return data
+
+    def to_json(self) -> str:
+        """Return stable compact JSON with sorted keys."""
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def _validate_version(value: Any) -> None:
+    if value != MANIFEST_VERSION or isinstance(value, bool):
+        raise AssetManifestError("version must match the supported manifest version")
+
+
+def _validate_opaque_string(
+    field_name: str, value: Any, pattern: re.Pattern[str]
+) -> None:
+    if not isinstance(value, str):
+        raise AssetManifestError(f"{field_name} must be a string")
+    if _PATH_OR_URL_RE.search(value):
+        raise AssetManifestError(f"{field_name} must be an opaque value")
+    if pattern.fullmatch(value) is None:
+        raise AssetManifestError(f"{field_name} has an invalid format")
+
+
+def _validate_media_type(value: Any) -> None:
+    if not isinstance(value, str):
+        raise AssetManifestError("media_type must be a string")
+    media_type = value.lower()
+    if value != media_type:
+        raise AssetManifestError("media_type has an invalid format")
+    if _MEDIA_TYPE_RE.fullmatch(media_type) is None:
+        raise AssetManifestError("media_type has an invalid format")
+    if media_type in _SUPPORTED_EXACT_MEDIA_TYPES:
+        return
+    if media_type.startswith(_SUPPORTED_MEDIA_PREFIXES):
+        return
+    raise AssetManifestError("media_type is unsupported")
+
+
+def _validate_positive_int(field_name: str, value: Any) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise AssetManifestError(f"{field_name} must be a positive integer")
+    if value <= 0:
+        raise AssetManifestError(f"{field_name} must be a positive integer")
+
+
+def _validate_positive_number(field_name: str, value: Any) -> None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise AssetManifestError(f"{field_name} must be a positive finite number")
+    if not math.isfinite(value) or value <= 0:
+        raise AssetManifestError(f"{field_name} must be a positive finite number")

--- a/openmed/multimodal/asset_manifest.py
+++ b/openmed/multimodal/asset_manifest.py
@@ -15,6 +15,9 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 MANIFEST_VERSION = 1
+MAX_MANIFEST_BYTE_SIZE = (1 << 63) - 1
+MAX_MANIFEST_COUNT = (1 << 31) - 1
+MAX_MANIFEST_DURATION_SECONDS = float(MAX_MANIFEST_COUNT)
 
 _ASSET_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
@@ -59,7 +62,7 @@ class AssetManifestError(ValueError):
     """Raised when a privacy-safe asset manifest fails validation."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class AssetManifest:
     """Versioned, privacy-safe description of a multimodal input asset."""
 
@@ -79,49 +82,62 @@ class AssetManifest:
         _validate_opaque_string("asset_id", self.asset_id, _ASSET_ID_RE)
         _validate_media_type(self.media_type)
         _validate_opaque_string("sha256", self.sha256, _SHA256_RE)
-        _validate_positive_int("byte_size", self.byte_size)
+        _validate_positive_int(
+            "byte_size", self.byte_size, maximum=MAX_MANIFEST_BYTE_SIZE
+        )
         for field_name in ("pages", "width", "height", "frames"):
             value = getattr(self, field_name)
             if value is not None:
-                _validate_positive_int(field_name, value)
+                _validate_positive_int(field_name, value, maximum=MAX_MANIFEST_COUNT)
         if self.duration_seconds is not None:
-            _validate_positive_number("duration_seconds", self.duration_seconds)
+            _validate_positive_number(
+                "duration_seconds",
+                self.duration_seconds,
+                maximum=MAX_MANIFEST_DURATION_SECONDS,
+            )
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "AssetManifest":
         """Build and validate a manifest from a strict mapping."""
         if not isinstance(data, Mapping):
             raise AssetManifestError("manifest must be a mapping")
+        try:
+            fields = dict(data)
+            provided = set(fields)
+        except Exception:
+            raise AssetManifestError("manifest fields could not be read") from None
 
-        unknown = set(data) - _ALLOWED_FIELDS
+        unknown = provided - _ALLOWED_FIELDS
         if unknown:
             raise AssetManifestError("manifest contains unknown fields")
 
-        missing = {"asset_id", "media_type", "sha256", "byte_size"} - set(data)
+        missing = {"asset_id", "media_type", "sha256", "byte_size"} - provided
         if missing:
             raise AssetManifestError("manifest is missing required fields")
 
-        version = data.get("version", MANIFEST_VERSION)
+        version = fields.get("version", MANIFEST_VERSION)
         return cls(
             version=version,
-            asset_id=data["asset_id"],
-            media_type=data["media_type"],
-            sha256=data["sha256"],
-            byte_size=data["byte_size"],
-            pages=data.get("pages"),
-            width=data.get("width"),
-            height=data.get("height"),
-            frames=data.get("frames"),
-            duration_seconds=data.get("duration_seconds"),
+            asset_id=fields["asset_id"],
+            media_type=fields["media_type"],
+            sha256=fields["sha256"],
+            byte_size=fields["byte_size"],
+            pages=fields.get("pages"),
+            width=fields.get("width"),
+            height=fields.get("height"),
+            frames=fields.get("frames"),
+            duration_seconds=fields.get("duration_seconds"),
         )
 
     @classmethod
     def from_json(cls, payload: str | bytes | bytearray) -> "AssetManifest":
         """Build and validate a manifest from a JSON object."""
         try:
-            data = json.loads(payload)
-        except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
-            raise AssetManifestError("manifest JSON is malformed") from exc
+            data = json.loads(payload, object_pairs_hook=_strict_json_object)
+        except AssetManifestError:
+            raise
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError, ValueError):
+            raise AssetManifestError("manifest JSON is malformed") from None
         return cls.from_dict(data)
 
     def to_dict(self) -> dict[str, Any]:
@@ -139,7 +155,7 @@ class AssetManifest:
 
 
 def _validate_version(value: Any) -> None:
-    if value != MANIFEST_VERSION or isinstance(value, bool):
+    if type(value) is not int or value != MANIFEST_VERSION:
         raise AssetManifestError("version must match the supported manifest version")
 
 
@@ -169,15 +185,24 @@ def _validate_media_type(value: Any) -> None:
     raise AssetManifestError("media_type is unsupported")
 
 
-def _validate_positive_int(field_name: str, value: Any) -> None:
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise AssetManifestError(f"{field_name} must be a positive integer")
-    if value <= 0:
-        raise AssetManifestError(f"{field_name} must be a positive integer")
+def _validate_positive_int(field_name: str, value: Any, *, maximum: int) -> None:
+    if type(value) is not int or not 0 < value <= maximum:
+        raise AssetManifestError(f"{field_name} must be a bounded positive integer")
 
 
-def _validate_positive_number(field_name: str, value: Any) -> None:
-    if isinstance(value, bool) or not isinstance(value, int | float):
-        raise AssetManifestError(f"{field_name} must be a positive finite number")
-    if not math.isfinite(value) or value <= 0:
-        raise AssetManifestError(f"{field_name} must be a positive finite number")
+def _validate_positive_number(field_name: str, value: Any, *, maximum: float) -> None:
+    if type(value) not in (int, float):
+        raise AssetManifestError(
+            f"{field_name} must be a bounded positive finite number"
+        )
+    if not math.isfinite(value) or not 0 < value <= maximum:
+        raise AssetManifestError(
+            f"{field_name} must be a bounded positive finite number"
+        )
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    fields = dict(pairs)
+    if len(fields) != len(pairs):
+        raise AssetManifestError("manifest contains duplicate fields")
+    return fields

--- a/tests/unit/multimodal/test_asset_manifest.py
+++ b/tests/unit/multimodal/test_asset_manifest.py
@@ -6,7 +6,13 @@ import json
 
 import pytest
 
-from openmed.multimodal.asset_manifest import AssetManifest, AssetManifestError
+from openmed.multimodal.asset_manifest import (
+    MAX_MANIFEST_BYTE_SIZE,
+    MAX_MANIFEST_COUNT,
+    MAX_MANIFEST_DURATION_SECONDS,
+    AssetManifest,
+    AssetManifestError,
+)
 
 VALID_DIGEST = "a" * 64
 
@@ -88,7 +94,9 @@ def test_to_dict_uses_stable_order_and_omits_unset_fields():
         ("byte_size", -1),
         ("byte_size", 2.2),
         ("byte_size", True),
+        ("byte_size", MAX_MANIFEST_BYTE_SIZE + 1),
         ("pages", -1),
+        ("pages", MAX_MANIFEST_COUNT + 1),
         ("width", 0),
         ("height", -2),
         ("frames", 1.5),
@@ -96,7 +104,9 @@ def test_to_dict_uses_stable_order_and_omits_unset_fields():
         ("duration_seconds", -1.0),
         ("duration_seconds", float("inf")),
         ("duration_seconds", float("nan")),
+        ("duration_seconds", MAX_MANIFEST_DURATION_SECONDS + 1),
         ("version", 2),
+        ("version", 1.0),
         ("version", True),
         ("media_type", "text/plain"),
         ("media_type", "Image/PNG"),
@@ -180,6 +190,31 @@ def test_paths_urls_and_location_like_values_fail_without_echo(field, value):
 def test_malformed_json_fails_closed(payload):
     with pytest.raises(AssetManifestError):
         AssetManifest.from_json(payload)  # type: ignore[arg-type]
+
+
+def test_duplicate_json_fields_fail_closed_without_echoing_values() -> None:
+    payload = (
+        '{"asset_id":"asset-001","asset_id":"synthetic-secret",'
+        f'"media_type":"image/png","sha256":"{VALID_DIGEST}","byte_size":1}}'
+    )
+
+    with pytest.raises(AssetManifestError) as exc_info:
+        AssetManifest.from_json(payload)
+
+    assert "synthetic-secret" not in str(exc_info.value)
+
+
+def test_scalar_subclasses_do_not_bypass_strict_types() -> None:
+    class IntSubclass(int):
+        pass
+
+    with pytest.raises(AssetManifestError):
+        AssetManifest(
+            asset_id="asset-001",
+            media_type="image/png",
+            sha256=VALID_DIGEST,
+            byte_size=IntSubclass(1),
+        )
 
 
 def test_manifest_contract_is_available_from_public_multimodal_api():

--- a/tests/unit/multimodal/test_asset_manifest.py
+++ b/tests/unit/multimodal/test_asset_manifest.py
@@ -1,0 +1,190 @@
+"""Tests for privacy-safe multimodal asset manifests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.multimodal.asset_manifest import AssetManifest, AssetManifestError
+
+VALID_DIGEST = "a" * 64
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "asset_id": "img-001",
+            "media_type": "image/png",
+            "sha256": VALID_DIGEST,
+            "byte_size": 1024,
+            "width": 640,
+            "height": 480,
+        },
+        {
+            "asset_id": "pdf-001",
+            "media_type": "application/pdf",
+            "sha256": VALID_DIGEST,
+            "byte_size": 2048,
+            "pages": 4,
+        },
+        {
+            "asset_id": "dicom-001",
+            "media_type": "application/dicom",
+            "sha256": VALID_DIGEST,
+            "byte_size": 4096,
+            "frames": 12,
+            "width": 512,
+            "height": 512,
+        },
+        {
+            "asset_id": "audio-001",
+            "media_type": "audio/wav",
+            "sha256": VALID_DIGEST,
+            "byte_size": 8192,
+            "duration_seconds": 3.5,
+        },
+    ],
+)
+def test_valid_asset_examples_round_trip_with_stable_json(payload):
+    manifest = AssetManifest.from_dict(payload)
+
+    assert AssetManifest.from_json(manifest.to_json()) == manifest
+    assert json.loads(manifest.to_json()) == manifest.to_dict()
+    assert list(json.loads(manifest.to_json())) == sorted(manifest.to_dict())
+    assert manifest.to_json() == manifest.to_json()
+
+
+def test_to_dict_uses_stable_order_and_omits_unset_fields():
+    manifest = AssetManifest.from_dict(
+        {
+            "media_type": "application/pdf",
+            "byte_size": 20,
+            "sha256": VALID_DIGEST,
+            "asset_id": "asset-123",
+            "pages": 2,
+        }
+    )
+
+    assert list(manifest.to_dict()) == [
+        "version",
+        "asset_id",
+        "media_type",
+        "sha256",
+        "byte_size",
+        "pages",
+    ]
+    assert "width" not in manifest.to_dict()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("sha256", "A" * 64),
+        ("sha256", "abc"),
+        ("sha256", "g" * 64),
+        ("byte_size", 0),
+        ("byte_size", -1),
+        ("byte_size", 2.2),
+        ("byte_size", True),
+        ("pages", -1),
+        ("width", 0),
+        ("height", -2),
+        ("frames", 1.5),
+        ("duration_seconds", 0.0),
+        ("duration_seconds", -1.0),
+        ("duration_seconds", float("inf")),
+        ("duration_seconds", float("nan")),
+        ("version", 2),
+        ("version", True),
+        ("media_type", "text/plain"),
+        ("media_type", "Image/PNG"),
+    ],
+)
+def test_invalid_field_values_fail_closed(field, value):
+    payload = {
+        "version": 1,
+        "asset_id": "asset-001",
+        "media_type": "image/png",
+        "sha256": VALID_DIGEST,
+        "byte_size": 1024,
+    }
+    payload[field] = value
+
+    with pytest.raises(AssetManifestError):
+        AssetManifest.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"asset_id": "asset-001", "media_type": "image/png", "byte_size": 1},
+        {
+            "asset_id": "asset-001",
+            "media_type": "image/png",
+            "sha256": VALID_DIGEST,
+            "byte_size": 1,
+            "description": "Patient note",
+        },
+        "not-a-dict",
+    ],
+)
+def test_missing_unknown_and_non_mapping_payloads_fail_closed(payload):
+    with pytest.raises(AssetManifestError):
+        AssetManifest.from_dict(payload)  # type: ignore[arg-type]
+
+
+def test_unknown_free_text_field_fails_without_echo():
+    payload = {
+        "asset_id": "asset-001",
+        "media_type": "image/png",
+        "sha256": VALID_DIGEST,
+        "byte_size": 1,
+        "description": "synthetic sentinel chart text",
+    }
+
+    with pytest.raises(AssetManifestError) as exc_info:
+        AssetManifest.from_dict(payload)
+
+    assert payload["description"] not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("asset_id", "/tmp/patient.png"),
+        ("asset_id", "s3://bucket/patient.png"),
+        ("asset_id", "C:\\patient\\scan.dcm"),
+        ("media_type", "https://example.test/image/png"),
+        ("sha256", "/tmp/" + VALID_DIGEST),
+    ],
+)
+def test_paths_urls_and_location_like_values_fail_without_echo(field, value):
+    payload = {
+        "version": 1,
+        "asset_id": "asset-001",
+        "media_type": "image/png",
+        "sha256": VALID_DIGEST,
+        "byte_size": 1024,
+    }
+    payload[field] = value
+
+    with pytest.raises(AssetManifestError) as exc_info:
+        AssetManifest.from_dict(payload)
+
+    assert value not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("payload", ["{", b"\xff", 42])
+def test_malformed_json_fails_closed(payload):
+    with pytest.raises(AssetManifestError):
+        AssetManifest.from_json(payload)  # type: ignore[arg-type]
+
+
+def test_manifest_contract_is_available_from_public_multimodal_api():
+    import openmed.multimodal as multimodal
+
+    assert multimodal.AssetManifest is AssetManifest
+    assert multimodal.AssetManifestError is AssetManifestError
+    assert multimodal.MANIFEST_VERSION == 1


### PR DESCRIPTION
# Pull Request

## Description
Adds a standard-library-only, privacy-safe asset manifest for multimodal preflight metadata.

## Type of Change
- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made
- Add a versioned `AssetManifest` for opaque IDs, MIME types, SHA-256 digests, byte sizes, and optional page/dimension/frame/duration counts.
- Reject unknown fields, invalid bounds, paths, URLs, and free-text payload fields with value-free errors.
- Provide deterministic `to_dict()` and compact sorted `to_json()` serialization.
- Export the contract through `openmed.multimodal`, document it, and update the changelog.

## Testing
- [x] Added synthetic-only tests
- [x] Target unit tests pass: 37 passed
- [x] Covered image, PDF, DICOM, audio, malformed digests, invalid bounds, non-finite values, unknown fields, and no-echo failures
- [x] Targeted Ruff check and format check pass
- [x] Public import and PyCompile checks pass

## Documentation
- [x] Added documentation and docstrings
- [x] Updated the changelog
- [x] Full MkDocs build was not run; focused YAML/Markdown checks passed

## Dependencies
- [x] No new dependencies

## Related Issues
Closes #2954