### PR TITLE
Complete RTF and fixed-width plaintext ingestion

### DIFF
--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -27,6 +27,7 @@ from . import dicom_sr as _dicom_sr
 from . import documents_docx as _documents_docx
 from . import documents_html as _documents_html
 from . import documents_markdown as _documents_markdown
+from . import documents_text as _documents_text
 from . import pptx as _pptx
 from .base import (
     ExtractedDocument,
@@ -119,6 +120,7 @@ from .documents_pdf_tables import (
     project_region_spans,
     project_structured_spans,
 )
+from .documents_text import extract_text, write_redacted_text
 from .email import EmailAttachmentReport, RedactedEmail, extract_email, redact_email
 from .epub import extract_epub
 from .exceptions import (
@@ -194,7 +196,7 @@ from .render_pdf import (
     render_redacted_pdf,
     write_redacted_pdf,
 )
-from .rtf import extract_rtf
+from .rtf import extract_rtf, write_redacted_rtf
 from .sms_messages import (
     DEFAULT_SMS_MODEL,
     SHORT_TEXT,
@@ -338,6 +340,9 @@ __all__ = [
     "extract_email",
     "redact_email",
     "extract_rtf",
+    "write_redacted_rtf",
+    "extract_text",
+    "write_redacted_text",
     "MetadataFinding",
     "ResidualMetadataReport",
     "MetadataScrubResult",

--- a/openmed/multimodal/_text_redaction.py
+++ b/openmed/multimodal/_text_redaction.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import inspect
 import os
 from collections.abc import Iterable, Mapping, Sequence
+from numbers import Integral
 from pathlib import Path
 from typing import Any
+
+from openmed.core.labels import is_recognized_label, normalize_label
 
 from .base import ExtractedDocument
 
@@ -45,7 +48,7 @@ def validate_replacements(
 ) -> tuple[TextReplacement, ...]:
     """Return sorted, de-duplicated, non-overlapping logical replacements."""
     unique = {
-        (int(start), int(end), str(replacement))
+        (_coerce_offset(start), _coerce_offset(end), str(replacement))
         for start, end, replacement in replacements
     }
     ordered = tuple(sorted(unique, key=lambda item: (item[0], item[1], item[2])))
@@ -179,13 +182,12 @@ def _coerce_entity(
         return (
             _coerce_offset(span[0]),
             _coerce_offset(span[1]),
-            default_replacement or _mask_for_label(label),
+            _replacement_for(default_replacement, label),
         )
     if isinstance(span, Mapping):
         start = span.get("start")
         end = span.get("end")
         label = span.get("label", span.get("entity_type", span.get("entity_group")))
-        replacement = span.get("replacement", span.get("redacted_text"))
     else:
         start = getattr(span, "start", None)
         end = getattr(span, "end", None)
@@ -194,23 +196,19 @@ def _coerce_entity(
             "label",
             getattr(span, "entity_type", getattr(span, "entity_group", None)),
         )
-        replacement = getattr(span, "replacement", getattr(span, "redacted_text", None))
     if start is None or end is None:
         return None
     return (
         _coerce_offset(start),
         _coerce_offset(end),
-        str(replacement)
-        if replacement is not None
-        else default_replacement or _mask_for_label(label),
+        _replacement_for(default_replacement, label),
     )
 
 
 def _coerce_offset(value: Any) -> int:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
+    if isinstance(value, bool) or not isinstance(value, Integral):
         raise ValueError("invalid detector entity offsets") from None
+    return int(value)
 
 
 def _looks_like_sequence_entity(value: Any) -> bool:
@@ -230,11 +228,17 @@ def _looks_like_sequence_entity(value: Any) -> bool:
 
 
 def _mask_for_label(label: Any) -> str:
-    safe = "".join(
-        character if character.isalnum() else "_"
-        for character in str(label or "PHI").upper()
-    ).strip("_")
-    return f"[{safe or 'PHI'}]"
+    if type(label) is not str or not is_recognized_label(label):
+        return "[PHI]"
+    return f"[{normalize_label(label)}]"
+
+
+def _replacement_for(default_replacement: Any, label: Any) -> str:
+    if default_replacement is None:
+        return _mask_for_label(label)
+    if type(default_replacement) is not str:
+        raise ValueError("policy replacement must be text")
+    return default_replacement
 
 
 __all__ = [

--- a/openmed/multimodal/_text_redaction.py
+++ b/openmed/multimodal/_text_redaction.py
@@ -1,0 +1,246 @@
+"""Shared detector and replacement helpers for text-backed ingesters."""
+
+from __future__ import annotations
+
+import inspect
+import os
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .base import ExtractedDocument
+
+TextReplacement = tuple[int, int, str]
+
+
+def detect_replacements(
+    document: ExtractedDocument,
+    models: Any,
+    lang: str | None,
+    policy: Any,
+) -> tuple[TextReplacement, ...]:
+    """Run a supplied detector and normalize its entities into replacements."""
+    detector = _resolve_detector(models)
+    if detector is None:
+        return ()
+    detected = _call_detector(detector, document.text, lang)
+    default_replacement = policy_value(policy, "replacement")
+    replacements = tuple(
+        replacement
+        for entity in _iter_entity_inputs(detected)
+        if (
+            replacement := _coerce_entity(
+                entity,
+                default_replacement=default_replacement,
+            )
+        )
+        is not None
+    )
+    return validate_replacements(document, replacements)
+
+
+def validate_replacements(
+    document: ExtractedDocument,
+    replacements: Iterable[TextReplacement],
+) -> tuple[TextReplacement, ...]:
+    """Return sorted, de-duplicated, non-overlapping logical replacements."""
+    unique = {
+        (int(start), int(end), str(replacement))
+        for start, end, replacement in replacements
+    }
+    ordered = tuple(sorted(unique, key=lambda item: (item[0], item[1], item[2])))
+    cursor = 0
+    for start, end, _ in ordered:
+        if start < 0 or end > len(document.text) or start >= end:
+            raise ValueError("replacement range is outside extracted document text")
+        if start < cursor:
+            raise ValueError("replacement ranges overlap")
+        cursor = end
+    return ordered
+
+
+def policy_value(policy: Any, *names: str) -> Any:
+    """Read the first configured policy field from a mapping or object."""
+    if policy is None:
+        return None
+    if isinstance(policy, Mapping):
+        for name in names:
+            if name in policy:
+                return policy[name]
+        return None
+    for name in names:
+        value = getattr(policy, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def validate_distinct_paths(source: Path, output: Path) -> None:
+    """Reject in-place writes and existing aliases of the source file."""
+    if source.resolve() == output.resolve():
+        raise ValueError("output path must differ from source path")
+    if output.exists() and os.path.samefile(source, output):
+        raise ValueError("output path must not alias source path")
+
+
+def _call_detector(detector: Any, text: str, lang: str | None) -> Any:
+    try:
+        signature = inspect.signature(detector)
+    except (TypeError, ValueError):
+        call_shape = "text_only"
+    else:
+        parameters = signature.parameters
+        lang_parameter = parameters.get("lang")
+        if lang_parameter is not None and lang_parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.VAR_POSITIONAL,
+        ):
+            signature.bind(text, lang)
+            call_shape = "positional_lang"
+        elif lang_parameter is not None and lang_parameter.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            signature.bind(text, lang=lang)
+            call_shape = "keyword_lang"
+        elif any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        ):
+            signature.bind(text, lang=lang)
+            call_shape = "keyword_lang"
+        else:
+            signature.bind(text)
+            call_shape = "text_only"
+    try:
+        if call_shape == "positional_lang":
+            return detector(text, lang)
+        if call_shape == "keyword_lang":
+            return detector(text, lang=lang)
+        return detector(text)
+    except Exception:
+        raise RuntimeError("text document detector failed") from None
+
+
+def _resolve_detector(models: Any) -> Any:
+    if models is None:
+        return None
+    if callable(models):
+        return models
+    if isinstance(models, Mapping):
+        for key in ("detector", "extract_pii", "analyze_text", "predict_entities"):
+            candidate = models.get(key)
+            if callable(candidate):
+                return candidate
+        return None
+    for name in (
+        "detect",
+        "extract_pii",
+        "analyze_text",
+        "predict_entities",
+        "predict",
+    ):
+        candidate = getattr(models, name, None)
+        if callable(candidate):
+            return candidate
+    return None
+
+
+def _iter_entity_inputs(spans: Any) -> tuple[Any, ...]:
+    if spans is None:
+        return ()
+    for name in ("entities", "pii_entities"):
+        entities = getattr(spans, name, None)
+        if entities is not None:
+            return tuple(entities)
+    if isinstance(spans, Mapping):
+        for key in ("entities", "pii_entities", "spans"):
+            entities = spans.get(key)
+            if entities is not None:
+                return tuple(entities)
+        if "start" in spans and "end" in spans:
+            return (spans,)
+    if _looks_like_sequence_entity(spans):
+        return (spans,)
+    if isinstance(spans, Iterable) and not isinstance(spans, (str, bytes, bytearray)):
+        return tuple(spans)
+    return (spans,)
+
+
+def _coerce_entity(
+    span: Any,
+    *,
+    default_replacement: str | None,
+) -> TextReplacement | None:
+    if isinstance(span, Sequence) and not isinstance(span, (str, bytes, bytearray)):
+        if len(span) < 2:
+            return None
+        label = str(span[2]) if len(span) >= 3 and span[2] is not None else None
+        return (
+            _coerce_offset(span[0]),
+            _coerce_offset(span[1]),
+            default_replacement or _mask_for_label(label),
+        )
+    if isinstance(span, Mapping):
+        start = span.get("start")
+        end = span.get("end")
+        label = span.get("label", span.get("entity_type", span.get("entity_group")))
+        replacement = span.get("replacement", span.get("redacted_text"))
+    else:
+        start = getattr(span, "start", None)
+        end = getattr(span, "end", None)
+        label = getattr(
+            span,
+            "label",
+            getattr(span, "entity_type", getattr(span, "entity_group", None)),
+        )
+        replacement = getattr(span, "replacement", getattr(span, "redacted_text", None))
+    if start is None or end is None:
+        return None
+    return (
+        _coerce_offset(start),
+        _coerce_offset(end),
+        str(replacement)
+        if replacement is not None
+        else default_replacement or _mask_for_label(label),
+    )
+
+
+def _coerce_offset(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise ValueError("invalid detector entity offsets") from None
+
+
+def _looks_like_sequence_entity(value: Any) -> bool:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return False
+    if len(value) < 2:
+        return False
+    return all(
+        not isinstance(candidate, Mapping)
+        and not all(hasattr(candidate, name) for name in ("start", "end"))
+        and not (
+            isinstance(candidate, Sequence)
+            and not isinstance(candidate, (str, bytes, bytearray))
+        )
+        for candidate in value[:2]
+    )
+
+
+def _mask_for_label(label: Any) -> str:
+    safe = "".join(
+        character if character.isalnum() else "_"
+        for character in str(label or "PHI").upper()
+    ).strip("_")
+    return f"[{safe or 'PHI'}]"
+
+
+__all__ = [
+    "TextReplacement",
+    "detect_replacements",
+    "policy_value",
+    "validate_distinct_paths",
+    "validate_replacements",
+]

--- a/openmed/multimodal/documents_text.py
+++ b/openmed/multimodal/documents_text.py
@@ -1,0 +1,162 @@
+"""Fixed-width plaintext extraction and layout-preserving write-back."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from ._text_redaction import (
+    TextReplacement,
+    detect_replacements,
+    policy_value,
+    validate_distinct_paths,
+    validate_replacements,
+)
+from .base import ExtractedDocument, SourceSpan, register_handler
+
+
+def extract_text(
+    path: str | Path,
+    *,
+    encoding: str = "utf-8",
+) -> ExtractedDocument:
+    """Read plaintext without newline normalization and record line geometry."""
+    source_path = Path(path)
+    with source_path.open("r", encoding=encoding, newline="") as handle:
+        text = handle.read()
+
+    spans: list[SourceSpan] = []
+    lines: list[dict[str, Any]] = []
+    cursor = 0
+    for line_index, raw_line in enumerate(text.splitlines(keepends=True)):
+        newline = _line_ending(raw_line)
+        content_end = cursor + len(raw_line) - len(newline)
+        end = cursor + len(raw_line)
+        lines.append(
+            {
+                "line": line_index,
+                "start": cursor,
+                "content_end": content_end,
+                "end": end,
+                "columns": content_end - cursor,
+                "newline": newline,
+            }
+        )
+        if cursor < end:
+            spans.append(
+                SourceSpan(
+                    start=cursor,
+                    end=end,
+                    metadata={
+                        "format": "text",
+                        "line": line_index,
+                        "source_start": cursor,
+                        "source_end": end,
+                        "content_end": content_end,
+                        "source_map_mode": "linear",
+                    },
+                )
+            )
+        cursor = end
+
+    return ExtractedDocument(
+        text=text,
+        spans=tuple(spans),
+        metadata={
+            "format": "text",
+            "source_path": str(source_path),
+            "encoding": encoding,
+            "line_count": len(lines),
+            "max_columns": max((line["columns"] for line in lines), default=0),
+            "lines": tuple(lines),
+        },
+    )
+
+
+def write_redacted_text(
+    source_path: str | Path,
+    output_path: str | Path,
+    replacements: Iterable[TextReplacement],
+    *,
+    encoding: str = "utf-8",
+    preserve_columns: bool = True,
+) -> Path:
+    """Write redacted plaintext while retaining fixed-width column positions.
+
+    When ``preserve_columns`` is true, replacement text is padded or truncated
+    to the original span width. Replacements cannot cross a line ending.
+    """
+    source = Path(source_path)
+    output = Path(output_path)
+    validate_distinct_paths(source, output)
+    document = extract_text(source, encoding=encoding)
+    logical = validate_replacements(document, replacements)
+
+    edits: list[TextReplacement] = []
+    for start, end, replacement in logical:
+        original = document.text[start:end]
+        if any(character in original for character in "\r\n"):
+            raise ValueError("plaintext replacement ranges cannot cross line endings")
+        if any(character in replacement for character in "\r\n"):
+            raise ValueError("plaintext replacements cannot contain line endings")
+        if preserve_columns:
+            width = end - start
+            replacement = replacement[:width].ljust(width)
+        edits.append((start, end, replacement))
+
+    redacted = document.text
+    for start, end, replacement in reversed(edits):
+        redacted = redacted[:start] + replacement + redacted[end:]
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding=encoding, newline="") as handle:
+        handle.write(redacted)
+    return output
+
+
+def _line_ending(line: str) -> str:
+    if line.endswith("\r\n"):
+        return "\r\n"
+    if line.endswith(("\r", "\n")):
+        return line[-1]
+    return ""
+
+
+def _text_handler(
+    path: str | Path,
+    *,
+    policy: Any = None,
+    models: Any = None,
+    lang: str | None = None,
+) -> ExtractedDocument:
+    encoding = str(policy_value(policy, "encoding") or "utf-8")
+    document = extract_text(path, encoding=encoding)
+    replacements = detect_replacements(document, models, lang, policy)
+    output_path = policy_value(
+        policy,
+        "output_path",
+        "redacted_path",
+        "destination_path",
+    )
+    metadata = dict(document.metadata)
+    metadata["detected_span_count"] = len(replacements)
+    if replacements and output_path is not None:
+        preserve_columns = policy_value(policy, "preserve_columns")
+        write_redacted_text(
+            path,
+            output_path,
+            replacements,
+            encoding=encoding,
+            preserve_columns=preserve_columns is not False,
+        )
+        metadata["redacted_text_path"] = str(output_path)
+    return ExtractedDocument(
+        text=document.text,
+        spans=document.spans,
+        metadata=metadata,
+    )
+
+
+register_handler(".txt", _text_handler, requires_multimodal=False)
+
+
+__all__ = ["extract_text", "write_redacted_text"]

--- a/openmed/multimodal/rtf.py
+++ b/openmed/multimodal/rtf.py
@@ -15,10 +15,18 @@ byte offset into the file on disk.
 from __future__ import annotations
 
 import codecs
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
+from ._text_redaction import (
+    TextReplacement,
+    detect_replacements,
+    policy_value,
+    validate_distinct_paths,
+    validate_replacements,
+)
 from .base import ExtractedDocument, SourceSpan, register_handler
 from .exceptions import UnsupportedDocumentError
 
@@ -213,6 +221,30 @@ def extract_rtf(path: str | Path) -> ExtractedDocument:
     source = source_path.read_bytes().decode(_SOURCE_ENCODING)
     _ensure_rtf_header(source)
     return _RtfExtractor(source).document(source_path)
+
+
+def write_redacted_rtf(
+    source_path: str | Path,
+    output_path: str | Path,
+    replacements: Iterable[TextReplacement],
+) -> Path:
+    """Project extracted-text replacements into a distinct valid RTF copy."""
+    source = Path(source_path)
+    output = Path(output_path)
+    validate_distinct_paths(source, output)
+    document = extract_rtf(source)
+    logical = validate_replacements(document, replacements)
+    edits = _project_replacements(document, logical)
+
+    source_text = source.read_bytes().decode(_SOURCE_ENCODING)
+    _validate_projected_replacements(edits)
+    redacted = source_text
+    for start, end, replacement in sorted(edits, reverse=True):
+        redacted = redacted[:start] + replacement + redacted[end:]
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(redacted.encode(_SOURCE_ENCODING))
+    return output
 
 
 def _ensure_rtf_header(source: str) -> None:
@@ -501,9 +533,87 @@ class _RtfExtractor:
                     "format": "rtf",
                     "source_start": source_start,
                     "source_end": source_end,
+                    "source_map_mode": (
+                        "linear" if len(text) == source_end - source_start else "atomic"
+                    ),
                 },
             )
         )
+
+
+def _project_replacements(
+    document: ExtractedDocument,
+    replacements: Sequence[TextReplacement],
+) -> tuple[TextReplacement, ...]:
+    projected: list[TextReplacement] = []
+    spans = tuple(document.spans)
+    span_index = 0
+    for start, end, replacement in replacements:
+        while span_index < len(spans) and spans[span_index].end <= start:
+            span_index += 1
+        covered = 0
+        cursor = span_index
+        replacement_inserted = False
+        while cursor < len(spans) and spans[cursor].start < end:
+            span = spans[cursor]
+            overlap_start = max(start, span.start)
+            overlap_end = min(end, span.end)
+            if overlap_start < overlap_end:
+                covered += overlap_end - overlap_start
+                source_start = int(span.metadata["source_start"])
+                source_end = int(span.metadata["source_end"])
+                if span.metadata.get("source_map_mode") == "linear":
+                    source_start += overlap_start - span.start
+                    source_end = source_start + (overlap_end - overlap_start)
+                    rendered = replacement if not replacement_inserted else ""
+                else:
+                    prefix = document.text[span.start : overlap_start]
+                    suffix = document.text[overlap_end : span.end]
+                    rendered = prefix
+                    if not replacement_inserted:
+                        rendered += replacement
+                    rendered += suffix
+                projected.append((source_start, source_end, _escape_rtf(rendered)))
+                replacement_inserted = True
+            cursor += 1
+        if covered != end - start:
+            raise ValueError("RTF replacement range contains structural text")
+    return tuple(projected)
+
+
+def _validate_projected_replacements(
+    edits: Sequence[tuple[int, int, str]],
+) -> None:
+    cursor = 0
+    for start, end, _ in sorted(edits):
+        if start < cursor:
+            raise ValueError("projected RTF replacement ranges overlap")
+        if start >= end:
+            raise ValueError("projected RTF replacement range is empty")
+        cursor = end
+
+
+def _escape_rtf(text: str) -> str:
+    escaped: list[str] = []
+    for character in text.replace("\r\n", "\n").replace("\r", "\n"):
+        if character in "\\{}":
+            escaped.append("\\" + character)
+        elif character == "\n":
+            escaped.append("\\line ")
+        elif character == "\t":
+            escaped.append("\\tab ")
+        elif " " <= character <= "~":
+            escaped.append(character)
+        else:
+            encoded = character.encode("utf-16-le")
+            for offset in range(0, len(encoded), 2):
+                unit = int.from_bytes(
+                    encoded[offset : offset + 2],
+                    "little",
+                )
+                signed = unit if unit < 0x8000 else unit - 0x10000
+                escaped.append(f"\\u{signed}?")
+    return "".join(escaped)
 
 
 def _strip_trailing_breaks(text: str, mapped_end: int) -> str:
@@ -554,10 +664,27 @@ def _rtf_handler(
     models: Any = None,
     lang: str | None = None,
 ) -> ExtractedDocument:
-    return extract_rtf(path)
+    document = extract_rtf(path)
+    replacements = detect_replacements(document, models, lang, policy)
+    output_path = policy_value(
+        policy,
+        "output_path",
+        "redacted_path",
+        "destination_path",
+    )
+    metadata = dict(document.metadata)
+    metadata["detected_span_count"] = len(replacements)
+    if replacements and output_path is not None:
+        write_redacted_rtf(path, output_path, replacements)
+        metadata["redacted_rtf_path"] = str(output_path)
+    return ExtractedDocument(
+        text=document.text,
+        spans=document.spans,
+        metadata=metadata,
+    )
 
 
 register_handler(".rtf", _rtf_handler, requires_multimodal=False)
 
 
-__all__ = ["extract_rtf"]
+__all__ = ["extract_rtf", "write_redacted_rtf"]

--- a/tests/unit/multimodal/test_documents_text.py
+++ b/tests/unit/multimodal/test_documents_text.py
@@ -1,0 +1,175 @@
+"""Tests for fixed-width plaintext extraction and write-back."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import openmed.multimodal as multimodal
+from openmed.multimodal import base
+from openmed.multimodal.documents_text import extract_text, write_redacted_text
+
+
+def _write_text(path: Path, text: str) -> Path:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write(text)
+    return path
+
+
+def test_extract_text_preserves_mixed_newlines_and_line_geometry(tmp_path: Path):
+    raw = "NAME        MRN\r\nJane Roe    A123\nJosé Li     B456\r"
+    source = _write_text(tmp_path / "report.txt", raw)
+
+    document = extract_text(source)
+
+    assert document.text == raw
+    assert document.metadata["format"] == "text"
+    assert document.metadata["encoding"] == "utf-8"
+    assert document.metadata["source_path"] == str(source)
+    assert document.metadata["lines"] == (
+        {
+            "line": 0,
+            "start": 0,
+            "content_end": 15,
+            "end": 17,
+            "columns": 15,
+            "newline": "\r\n",
+        },
+        {
+            "line": 1,
+            "start": 17,
+            "content_end": 33,
+            "end": 34,
+            "columns": 16,
+            "newline": "\n",
+        },
+        {
+            "line": 2,
+            "start": 34,
+            "content_end": 50,
+            "end": 51,
+            "columns": 16,
+            "newline": "\r",
+        },
+    )
+    jane = document.location_at(document.text.index("Jane"))
+    assert jane is not None
+    assert jane.metadata["line"] == 1
+    assert jane.metadata["source_map_mode"] == "linear"
+
+
+def test_write_redacted_text_preserves_fixed_width_columns(tmp_path: Path):
+    raw = "NAME        MRN\nJane Roe    A123\nFollow-up   stable\n"
+    source = _write_text(tmp_path / "report.txt", raw)
+    output = tmp_path / "redacted.txt"
+    start = raw.index("Jane Roe")
+    mrn_column = raw.splitlines()[1].index("A123")
+
+    result = write_redacted_text(
+        source,
+        output,
+        [(start, start + len("Jane Roe"), "[NAME]")],
+    )
+
+    redacted = output.read_text(encoding="utf-8")
+    assert result == output
+    assert redacted.splitlines()[1] == "[NAME]      A123"
+    assert redacted.splitlines()[1].index("A123") == mrn_column
+    assert len(redacted.splitlines()[1]) == len(raw.splitlines()[1])
+    assert redacted.splitlines()[2] == "Follow-up   stable"
+
+
+def test_write_redacted_text_truncates_long_masks_to_source_width(tmp_path: Path):
+    source = _write_text(tmp_path / "short.txt", "Li  123\n")
+    output = tmp_path / "redacted.txt"
+
+    write_redacted_text(source, output, [(0, 2, "[PERSON]")])
+
+    assert output.read_text(encoding="utf-8") == "[P  123\n"
+
+
+def test_text_handler_runs_detector_and_writes_redacted_copy(tmp_path: Path):
+    source = _write_text(tmp_path / "report.txt", "Patient     MRN\nJane Roe    A123\n")
+    output = tmp_path / "redacted.txt"
+    observed: list[tuple[str, str | None]] = []
+
+    def detector(text: str, *, lang: str | None = None):
+        observed.append((text, lang))
+        start = text.index("Jane Roe")
+        return {"entities": [{"start": start, "end": start + 8, "label": "NAME"}]}
+
+    document = multimodal.redact_document(
+        source,
+        models={"detector": detector},
+        lang="en",
+        policy={"output_path": output},
+    )
+
+    assert observed == [("Patient     MRN\nJane Roe    A123\n", "en")]
+    assert output.read_text(encoding="utf-8").splitlines()[1] == "[NAME]      A123"
+    assert document.metadata["detected_span_count"] == 1
+    assert document.metadata["redacted_text_path"] == str(output)
+    assert base._HANDLERS[".txt"][-1].requires_multimodal is False
+
+
+def test_text_handler_without_entities_does_not_create_output(tmp_path: Path):
+    source = _write_text(tmp_path / "report.txt", "No identifiers\n")
+    output = tmp_path / "unused.txt"
+
+    document = multimodal.redact_document(
+        source,
+        models=lambda text: [],
+        policy={"output_path": output},
+    )
+
+    assert document.metadata["detected_span_count"] == 0
+    assert not output.exists()
+
+
+def test_text_handler_accepts_object_entities_and_positional_only_lang(tmp_path: Path):
+    source = _write_text(tmp_path / "report.txt", "Jane Roe\n")
+    output = tmp_path / "redacted.txt"
+
+    class Entity:
+        start = 0
+        end = 8
+        entity_type = "PERSON"
+
+    def detector(text: str, lang: str | None = None, /):
+        assert text == "Jane Roe\n"
+        assert lang == "da"
+        return [Entity(), Entity()]
+
+    document = multimodal.redact_document(
+        source,
+        models=detector,
+        lang="da",
+        policy={"output_path": output},
+    )
+
+    assert document.metadata["detected_span_count"] == 1
+    assert output.read_text(encoding="utf-8") == "[PERSON]\n"
+
+
+def test_text_writer_rejects_line_crossings_and_source_aliases(tmp_path: Path):
+    source = _write_text(tmp_path / "report.txt", "Jane\nRoe\n")
+    output = tmp_path / "redacted.txt"
+
+    with pytest.raises(ValueError, match="cannot cross line endings"):
+        write_redacted_text(source, output, [(0, 8, "[NAME]")])
+    with pytest.raises(ValueError, match="must differ"):
+        write_redacted_text(source, source, [(0, 4, "mask")])
+    hardlink = tmp_path / "hardlink.txt"
+    os.link(source, hardlink)
+    with pytest.raises(ValueError, match="must not alias"):
+        write_redacted_text(source, hardlink, [(0, 4, "mask")])
+    assert source.read_text(encoding="utf-8") == "Jane\nRoe\n"
+
+
+def test_text_exports_are_public_and_unique():
+    assert multimodal.extract_text is extract_text
+    assert multimodal.write_redacted_text is write_redacted_text
+    assert multimodal.__all__.count("extract_text") == 1
+    assert multimodal.__all__.count("write_redacted_text") == 1

--- a/tests/unit/multimodal/test_documents_text.py
+++ b/tests/unit/multimodal/test_documents_text.py
@@ -108,7 +108,7 @@ def test_text_handler_runs_detector_and_writes_redacted_copy(tmp_path: Path):
     )
 
     assert observed == [("Patient     MRN\nJane Roe    A123\n", "en")]
-    assert output.read_text(encoding="utf-8").splitlines()[1] == "[NAME]      A123"
+    assert output.read_text(encoding="utf-8").splitlines()[1] == "[PERSON]    A123"
     assert document.metadata["detected_span_count"] == 1
     assert document.metadata["redacted_text_path"] == str(output)
     assert base._HANDLERS[".txt"][-1].requires_multimodal is False
@@ -151,6 +151,43 @@ def test_text_handler_accepts_object_entities_and_positional_only_lang(tmp_path:
 
     assert document.metadata["detected_span_count"] == 1
     assert output.read_text(encoding="utf-8") == "[PERSON]\n"
+
+
+def test_detector_cannot_supply_raw_replacement_or_untrusted_label(tmp_path: Path):
+    sentinel = "SYNTHETIC-RAW-PATIENT-VALUE"
+    source = _write_text(tmp_path / "report.txt", f"{sentinel}\n")
+    output = tmp_path / "redacted.txt"
+
+    def detector(text: str):
+        return [
+            {
+                "start": 0,
+                "end": len(sentinel),
+                "label": sentinel,
+                "replacement": sentinel,
+            }
+        ]
+
+    multimodal.redact_document(
+        source,
+        models=detector,
+        policy={"output_path": output},
+    )
+
+    rendered = output.read_text(encoding="utf-8")
+    assert sentinel not in rendered
+    assert rendered.rstrip() == "[PHI]"
+
+
+@pytest.mark.parametrize("offset", [True, 0.5])
+def test_detector_offsets_must_be_integral(tmp_path: Path, offset: object):
+    source = _write_text(tmp_path / "report.txt", "Jane Roe\n")
+
+    with pytest.raises(ValueError, match="invalid detector entity offsets"):
+        multimodal.redact_document(
+            source,
+            models=lambda text: [{"start": offset, "end": 8, "label": "NAME"}],
+        )
 
 
 def test_text_writer_rejects_line_crossings_and_source_aliases(tmp_path: Path):

--- a/tests/unit/multimodal/test_rtf_extract.py
+++ b/tests/unit/multimodal/test_rtf_extract.py
@@ -232,7 +232,7 @@ def test_rtf_handler_runs_detector_and_writes_redacted_copy(tmp_path: Path):
     )
 
     assert observed == [(EXPECTED_TEXT, "en")]
-    assert extract_rtf(output).text.startswith("Patient [NAME]")
+    assert extract_rtf(output).text.startswith("Patient [PERSON]")
     assert document.metadata["detected_span_count"] == 1
     assert document.metadata["redacted_rtf_path"] == str(output)
 

--- a/tests/unit/multimodal/test_rtf_extract.py
+++ b/tests/unit/multimodal/test_rtf_extract.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from openmed.multimodal import ExtractedDocument, extract_rtf, redact_document
+from openmed.multimodal import (
+    ExtractedDocument,
+    extract_rtf,
+    redact_document,
+    write_redacted_rtf,
+)
 from openmed.multimodal.exceptions import UnsupportedDocumentError
 
 DISCHARGE_NOTE = (
@@ -158,6 +163,102 @@ def test_redact_document_dispatches_rtf(tmp_path: Path):
 
     assert isinstance(doc, ExtractedDocument)
     assert "Patient Jane Roe" in doc.text
+
+
+def test_write_redacted_rtf_preserves_markup_and_escapes_replacement(tmp_path: Path):
+    source = _write_rtf(tmp_path / "source.rtf", DISCHARGE_NOTE)
+    output = tmp_path / "redacted.rtf"
+    document = extract_rtf(source)
+    start = document.text.index("Jane Roe")
+
+    result = write_redacted_rtf(
+        source,
+        output,
+        [(start, start + len("Jane Roe"), "A{B}\\C é")],
+    )
+
+    assert result == output
+    assert extract_rtf(output).text.startswith("Patient A{B}\\C é\nMRN\tA123")
+    raw = output.read_text(encoding="latin-1")
+    assert "{\\fonttbl" in raw
+    assert "A\\{B\\}\\\\C \\u233?" in raw
+    assert "Chart Clerk" in raw
+
+
+def test_write_redacted_rtf_projects_across_formatting_groups(tmp_path: Path):
+    source = _write_rtf(
+        tmp_path / "formatted.rtf",
+        "{\\rtf1\\ansi Patient Jane {\\b Roe} MRN A123}",
+    )
+    output = tmp_path / "redacted.rtf"
+    document = extract_rtf(source)
+    start = document.text.index("Jane Roe")
+
+    write_redacted_rtf(source, output, [(start, start + 8, "[NAME]")])
+
+    assert extract_rtf(output).text == "Patient [NAME] MRN A123"
+    assert "{\\b " in output.read_text(encoding="latin-1")
+
+
+def test_write_redacted_rtf_preserves_partial_atomic_hex_run(tmp_path: Path):
+    source = _write_rtf(
+        tmp_path / "encoded.rtf",
+        r"{\rtf1\ansi Patient \'4a\'61\'6e\'65 Roe}",
+    )
+    output = tmp_path / "redacted.rtf"
+    document = extract_rtf(source)
+    start = document.text.index("Jane")
+
+    write_redacted_rtf(source, output, [(start, start + 4, "[NAME]")])
+
+    assert extract_rtf(output).text == "Patient [NAME] Roe"
+
+
+def test_rtf_handler_runs_detector_and_writes_redacted_copy(tmp_path: Path):
+    source = _write_rtf(tmp_path / "source.rtf", DISCHARGE_NOTE)
+    output = tmp_path / "redacted.rtf"
+    observed: list[tuple[str, str | None]] = []
+
+    def detector(text: str, *, lang: str | None = None):
+        observed.append((text, lang))
+        start = text.index("Jane Roe")
+        return [(start, start + 8, "NAME")]
+
+    document = redact_document(
+        source,
+        models=detector,
+        lang="en",
+        policy={"output_path": output},
+    )
+
+    assert observed == [(EXPECTED_TEXT, "en")]
+    assert extract_rtf(output).text.startswith("Patient [NAME]")
+    assert document.metadata["detected_span_count"] == 1
+    assert document.metadata["redacted_rtf_path"] == str(output)
+
+
+def test_write_redacted_rtf_rejects_structural_ranges_and_source_alias(
+    tmp_path: Path,
+):
+    source = _write_rtf(tmp_path / "source.rtf", DISCHARGE_NOTE)
+    document = extract_rtf(source)
+    line_break = document.text.index("\n")
+
+    with pytest.raises(ValueError, match="structural text"):
+        write_redacted_rtf(
+            source,
+            tmp_path / "redacted.rtf",
+            [(line_break - 1, line_break + 1, "x")],
+        )
+    with pytest.raises(ValueError, match="must differ"):
+        write_redacted_rtf(source, source, [(0, 1, "x")])
+
+
+def test_rtf_write_helper_is_exported_once():
+    import openmed.multimodal as multimodal
+
+    assert multimodal.write_redacted_rtf is write_redacted_rtf
+    assert multimodal.__all__.count("write_redacted_rtf") == 1
 
 
 def test_rtf_without_header_raises(tmp_path: Path):


### PR DESCRIPTION
RTF and fixed-width text redaction now keeps the layout intact, so legacy files don't get cooked. Closes #290