### PR TITLE
feat(agent): add stable outcome reason codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a closed, JSON-safe agent outcome vocabulary with success, abstention,
+  reviewer-handoff, policy-denial, and failure classes, deterministic
+  serialization, and value-free rejection of unknown codes or free-text
+  reasons (#2950).
 - Added a deterministic Jupyter notebook cell redaction helper that preserves
   code sources and execution structure, applies explicit markdown and output
   policies, removes unredacted binary MIME data, and emits counts-only,

--- a/docs/agent/outcome-reasons.md
+++ b/docs/agent/outcome-reasons.md
@@ -1,0 +1,37 @@
+# Agent outcome reason codes
+
+`openmed.agent.outcomes` gives agent workflows a small, closed vocabulary for
+what happened. The payload is metadata only: a class, a reason code, and a
+schema version. It does not store prompts, tool arguments, tool outputs,
+evidence text, paths, or credentials.
+
+The public API distinguishes:
+
+- `success` with `completed`
+- `abstained` with `insufficient_evidence`, `out_of_scope`, or `low_confidence`
+- `review_required` with `conflicting_evidence`, `safety_review`, or `human_gate`
+- `policy_denied` with `consent_required`, `purpose_mismatch`, or `phi_policy`
+- `failed` with `tool_error`, `timeout`, or `invalid_input`
+
+Unknown classes, unknown reason codes, class/reason mismatches, extra fields,
+and free-text reasons fail closed. Exception messages name the field or a
+stable error code and do not echo the submitted value.
+
+```python
+from openmed.agent import WorkflowOutcome
+
+outcome = WorkflowOutcome.from_dict(
+    {
+        "outcome_class": "abstained",
+        "reason_code": "insufficient_evidence",
+    }
+)
+
+payload = outcome.to_json()
+```
+
+`to_dict()` emits fields in a stable order. `to_json()` emits compact JSON
+with sorted keys so identical inputs serialize byte-for-byte identically.
+
+This module does not execute tools, persist run logs, or decide clinical
+actions.

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -104,6 +104,7 @@ classification:
     - onboarding-china.md
     - onboarding-india.md
     - agent-usage.md
+    - agent/outcome-reasons.md
     - agent-skills/install.md
     - agent-skills/validation.md
     - agent-skills/setup.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - India Onboarding: onboarding-india.md
   - Core Guides:
       - Building with an Agent: agent-usage.md
+      - Agent Outcome Reason Codes: agent/outcome-reasons.md
       - Agent Skill Installation: agent-skills/install.md
       - Agent Skill Validation: agent-skills/validation.md
       - De-identification Policy Setup: agent-skills/setup.md

--- a/openmed/agent/__init__.py
+++ b/openmed/agent/__init__.py
@@ -2,4 +2,19 @@
 
 from __future__ import annotations
 
-__all__ = ["security"]
+from .outcomes import (
+    OUTCOME_SCHEMA_VERSION,
+    OutcomeClass,
+    OutcomeError,
+    WorkflowOutcome,
+    allowed_reason_codes,
+)
+
+__all__ = [
+    "OUTCOME_SCHEMA_VERSION",
+    "OutcomeClass",
+    "OutcomeError",
+    "WorkflowOutcome",
+    "allowed_reason_codes",
+    "security",
+]

--- a/openmed/agent/outcomes.py
+++ b/openmed/agent/outcomes.py
@@ -1,0 +1,168 @@
+"""Stable outcome classes and reason codes for agent workflows.
+
+The vocabulary is closed. Callers can record success, abstention, reviewer
+handoff, policy denial, or execution failure without attaching free-text
+status strings. Unknown identifiers fail closed, and exception messages name
+fields or stable error codes rather than submitted values.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+OUTCOME_SCHEMA_VERSION = "openmed.agent.outcome.v1"
+
+_ALLOWED_FIELDS = frozenset({"schema_version", "outcome_class", "reason_code"})
+_ORDERED_FIELDS = ("schema_version", "outcome_class", "reason_code")
+
+_REASON_CODES: dict[str, frozenset[str]] = {
+    "success": frozenset({"completed"}),
+    "abstained": frozenset(
+        {"insufficient_evidence", "out_of_scope", "low_confidence"}
+    ),
+    "review_required": frozenset(
+        {"conflicting_evidence", "safety_review", "human_gate"}
+    ),
+    "policy_denied": frozenset(
+        {"consent_required", "purpose_mismatch", "phi_policy"}
+    ),
+    "failed": frozenset({"tool_error", "timeout", "invalid_input"}),
+}
+
+
+class OutcomeClass(str, Enum):
+    """Closed set of workflow outcomes.
+
+    Values:
+        SUCCESS: The workflow finished the requested work.
+        ABSTAINED: The workflow stopped without producing a clinical answer.
+        REVIEW_REQUIRED: A reviewer must inspect the run before use.
+        POLICY_DENIED: A policy or consent check blocked execution.
+        FAILED: Execution failed for a non-policy reason.
+    """
+
+    SUCCESS = "success"
+    ABSTAINED = "abstained"
+    REVIEW_REQUIRED = "review_required"
+    POLICY_DENIED = "policy_denied"
+    FAILED = "failed"
+
+
+class OutcomeError(ValueError):
+    """Raised when an outcome payload fails closed validation."""
+
+    def __init__(self, code: str, field_name: str | None = None) -> None:
+        self.code = code
+        self.field_name = field_name
+        if field_name is None:
+            message = code
+        else:
+            message = f"{field_name}: {code}"
+        super().__init__(message)
+
+
+def allowed_reason_codes(outcome_class: OutcomeClass | str) -> frozenset[str]:
+    """Return the closed reason-code set for an outcome class."""
+    key = (
+        outcome_class.value
+        if isinstance(outcome_class, OutcomeClass)
+        else outcome_class
+    )
+    try:
+        return _REASON_CODES[key]
+    except KeyError as exc:
+        raise OutcomeError("unknown_class", "outcome_class") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowOutcome:
+    """JSON-safe workflow outcome with a class and a closed reason code."""
+
+    outcome_class: OutcomeClass
+    reason_code: str
+    schema_version: str = OUTCOME_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _validate_schema_version(self.schema_version)
+        if not isinstance(self.outcome_class, OutcomeClass):
+            raise OutcomeError("unknown_class", "outcome_class")
+        _validate_reason_code(self.outcome_class, self.reason_code)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "WorkflowOutcome":
+        """Build and validate an outcome from a strict mapping."""
+        if not isinstance(data, Mapping) or isinstance(data, (str, bytes, bytearray)):
+            raise OutcomeError("not_a_mapping")
+
+        unknown = set(data) - _ALLOWED_FIELDS
+        if unknown:
+            raise OutcomeError("unknown_field")
+
+        if "outcome_class" not in data or "reason_code" not in data:
+            raise OutcomeError("missing_field")
+
+        outcome_class = _parse_outcome_class(data["outcome_class"])
+        schema_version = data.get("schema_version", OUTCOME_SCHEMA_VERSION)
+        return cls(
+            outcome_class=outcome_class,
+            reason_code=data["reason_code"],
+            schema_version=schema_version,
+        )
+
+    @classmethod
+    def from_json(cls, payload: str | bytes | bytearray) -> "WorkflowOutcome":
+        """Build and validate an outcome from a JSON object."""
+        try:
+            data = json.loads(payload)
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
+            raise OutcomeError("malformed_json") from exc
+        return cls.from_dict(data)
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a deterministic dictionary in field order."""
+        values = {
+            "schema_version": self.schema_version,
+            "outcome_class": self.outcome_class.value,
+            "reason_code": self.reason_code,
+        }
+        return {key: values[key] for key in _ORDERED_FIELDS}
+
+    def to_json(self) -> str:
+        """Return compact JSON with sorted keys for byte-identical payloads."""
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def _parse_outcome_class(value: Any) -> OutcomeClass:
+    if isinstance(value, OutcomeClass):
+        return value
+    if not isinstance(value, str) or isinstance(value, bool):
+        raise OutcomeError("unknown_class", "outcome_class")
+    try:
+        return OutcomeClass(value)
+    except ValueError as exc:
+        raise OutcomeError("unknown_class", "outcome_class") from exc
+
+
+def _validate_schema_version(value: Any) -> None:
+    if value != OUTCOME_SCHEMA_VERSION or isinstance(value, bool):
+        raise OutcomeError("invalid_schema_version", "schema_version")
+
+
+def _validate_reason_code(outcome_class: OutcomeClass, value: Any) -> None:
+    if not isinstance(value, str) or isinstance(value, bool):
+        raise OutcomeError("unknown_reason", "reason_code")
+    allowed = _REASON_CODES[outcome_class.value]
+    if value not in allowed:
+        raise OutcomeError("unknown_reason", "reason_code")
+
+
+__all__ = [
+    "OUTCOME_SCHEMA_VERSION",
+    "OutcomeClass",
+    "OutcomeError",
+    "WorkflowOutcome",
+    "allowed_reason_codes",
+]

--- a/openmed/agent/outcomes.py
+++ b/openmed/agent/outcomes.py
@@ -20,15 +20,11 @@ _ORDERED_FIELDS = ("schema_version", "outcome_class", "reason_code")
 
 _REASON_CODES: dict[str, frozenset[str]] = {
     "success": frozenset({"completed"}),
-    "abstained": frozenset(
-        {"insufficient_evidence", "out_of_scope", "low_confidence"}
-    ),
+    "abstained": frozenset({"insufficient_evidence", "out_of_scope", "low_confidence"}),
     "review_required": frozenset(
         {"conflicting_evidence", "safety_review", "human_gate"}
     ),
-    "policy_denied": frozenset(
-        {"consent_required", "purpose_mismatch", "phi_policy"}
-    ),
+    "policy_denied": frozenset({"consent_required", "purpose_mismatch", "phi_policy"}),
     "failed": frozenset({"tool_error", "timeout", "invalid_input"}),
 }
 
@@ -66,15 +62,17 @@ class OutcomeError(ValueError):
 
 def allowed_reason_codes(outcome_class: OutcomeClass | str) -> frozenset[str]:
     """Return the closed reason-code set for an outcome class."""
-    key = (
-        outcome_class.value
-        if isinstance(outcome_class, OutcomeClass)
-        else outcome_class
-    )
+    if isinstance(outcome_class, OutcomeClass):
+        key = outcome_class.value
+    elif type(outcome_class) is str:
+        key = outcome_class
+    else:
+        raise OutcomeError("unknown_class", "outcome_class")
     try:
         return _REASON_CODES[key]
-    except KeyError as exc:
-        raise OutcomeError("unknown_class", "outcome_class") from exc
+    except KeyError:
+        pass
+    raise OutcomeError("unknown_class", "outcome_class")
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,7 +95,13 @@ class WorkflowOutcome:
         if not isinstance(data, Mapping) or isinstance(data, (str, bytes, bytearray)):
             raise OutcomeError("not_a_mapping")
 
-        unknown = set(data) - _ALLOWED_FIELDS
+        unknown: set[Any] | None = None
+        try:
+            unknown = set(data) - _ALLOWED_FIELDS
+        except Exception:
+            pass
+        if unknown is None:
+            raise OutcomeError("not_a_mapping")
         if unknown:
             raise OutcomeError("unknown_field")
 
@@ -116,10 +120,12 @@ class WorkflowOutcome:
     def from_json(cls, payload: str | bytes | bytearray) -> "WorkflowOutcome":
         """Build and validate an outcome from a JSON object."""
         try:
-            data = json.loads(payload)
-        except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
-            raise OutcomeError("malformed_json") from exc
-        return cls.from_dict(data)
+            data = json.loads(payload, object_pairs_hook=_strict_json_object)
+        except (json.JSONDecodeError, OutcomeError, TypeError, UnicodeDecodeError):
+            pass
+        else:
+            return cls.from_dict(data)
+        raise OutcomeError("malformed_json")
 
     def to_dict(self) -> dict[str, str]:
         """Return a deterministic dictionary in field order."""
@@ -138,25 +144,35 @@ class WorkflowOutcome:
 def _parse_outcome_class(value: Any) -> OutcomeClass:
     if isinstance(value, OutcomeClass):
         return value
-    if not isinstance(value, str) or isinstance(value, bool):
+    if type(value) is not str:
         raise OutcomeError("unknown_class", "outcome_class")
     try:
         return OutcomeClass(value)
-    except ValueError as exc:
-        raise OutcomeError("unknown_class", "outcome_class") from exc
+    except ValueError:
+        pass
+    raise OutcomeError("unknown_class", "outcome_class")
 
 
 def _validate_schema_version(value: Any) -> None:
-    if value != OUTCOME_SCHEMA_VERSION or isinstance(value, bool):
+    if type(value) is not str or value != OUTCOME_SCHEMA_VERSION:
         raise OutcomeError("invalid_schema_version", "schema_version")
 
 
 def _validate_reason_code(outcome_class: OutcomeClass, value: Any) -> None:
-    if not isinstance(value, str) or isinstance(value, bool):
+    if type(value) is not str:
         raise OutcomeError("unknown_reason", "reason_code")
     allowed = _REASON_CODES[outcome_class.value]
     if value not in allowed:
         raise OutcomeError("unknown_reason", "reason_code")
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise OutcomeError("duplicate_field")
+        result[key] = value
+    return result
 
 
 __all__ = [

--- a/tests/unit/agent/test_outcomes.py
+++ b/tests/unit/agent/test_outcomes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import traceback
 
 import pytest
 
@@ -152,6 +153,48 @@ def test_malformed_json_fails_closed(payload):
     with pytest.raises(OutcomeError) as exc_info:
         WorkflowOutcome.from_json(payload)  # type: ignore[arg-type]
     assert exc_info.value.code == "malformed_json"
+
+
+def test_duplicate_json_fields_fail_closed_instead_of_last_value_winning():
+    payload = (
+        '{"outcome_class":"success","outcome_class":"failed","reason_code":"completed"}'
+    )
+
+    with pytest.raises(OutcomeError) as exc_info:
+        WorkflowOutcome.from_json(payload)
+
+    assert exc_info.value.code == "malformed_json"
+
+
+def test_rejected_values_are_absent_from_full_exception_chain():
+    sentinel = "Patient Jane Roe /private/chart bearer-token"
+
+    with pytest.raises(OutcomeError) as exc_info:
+        WorkflowOutcome.from_json(sentinel)
+
+    rendered = "".join(
+        traceback.format_exception(exc_info.type, exc_info.value, exc_info.tb)
+    )
+    assert sentinel not in rendered
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+
+
+class StringSubclass(str):
+    """A string subtype that must not be retained in immutable outcomes."""
+
+
+@pytest.mark.parametrize("field", ["schema_version", "reason_code"])
+def test_string_subclasses_are_rejected_by_direct_constructor(field: str):
+    values = {
+        "outcome_class": OutcomeClass.SUCCESS,
+        "reason_code": "completed",
+        "schema_version": OUTCOME_SCHEMA_VERSION,
+    }
+    values[field] = StringSubclass(values[field])
+
+    with pytest.raises(OutcomeError):
+        WorkflowOutcome(**values)  # type: ignore[arg-type]
 
 
 def test_allowed_reason_codes_are_closed_per_class():

--- a/tests/unit/agent/test_outcomes.py
+++ b/tests/unit/agent/test_outcomes.py
@@ -1,0 +1,173 @@
+"""Tests for stable agent workflow outcome codes."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.agent.outcomes import (
+    OUTCOME_SCHEMA_VERSION,
+    OutcomeClass,
+    OutcomeError,
+    WorkflowOutcome,
+    allowed_reason_codes,
+)
+
+VALID_EXAMPLES = (
+    {"outcome_class": "success", "reason_code": "completed"},
+    {"outcome_class": "abstained", "reason_code": "insufficient_evidence"},
+    {"outcome_class": "abstained", "reason_code": "out_of_scope"},
+    {"outcome_class": "abstained", "reason_code": "low_confidence"},
+    {"outcome_class": "review_required", "reason_code": "conflicting_evidence"},
+    {"outcome_class": "review_required", "reason_code": "safety_review"},
+    {"outcome_class": "review_required", "reason_code": "human_gate"},
+    {"outcome_class": "policy_denied", "reason_code": "consent_required"},
+    {"outcome_class": "policy_denied", "reason_code": "purpose_mismatch"},
+    {"outcome_class": "policy_denied", "reason_code": "phi_policy"},
+    {"outcome_class": "failed", "reason_code": "tool_error"},
+    {"outcome_class": "failed", "reason_code": "timeout"},
+    {"outcome_class": "failed", "reason_code": "invalid_input"},
+)
+
+
+@pytest.mark.parametrize("payload", VALID_EXAMPLES)
+def test_valid_outcomes_round_trip_with_stable_json(payload):
+    outcome = WorkflowOutcome.from_dict(payload)
+
+    assert WorkflowOutcome.from_json(outcome.to_json()) == outcome
+    assert json.loads(outcome.to_json()) == outcome.to_dict()
+    assert list(json.loads(outcome.to_json())) == sorted(outcome.to_dict())
+    assert outcome.to_json() == outcome.to_json()
+    assert outcome.to_json() == json.dumps(
+        {
+            "outcome_class": payload["outcome_class"],
+            "reason_code": payload["reason_code"],
+            "schema_version": OUTCOME_SCHEMA_VERSION,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def test_to_dict_uses_stable_field_order():
+    outcome = WorkflowOutcome.from_dict(
+        {"reason_code": "completed", "outcome_class": "success"}
+    )
+
+    assert list(outcome.to_dict()) == [
+        "schema_version",
+        "outcome_class",
+        "reason_code",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("outcome_class", "reason_code"),
+    [
+        ("success", "insufficient_evidence"),
+        ("abstained", "completed"),
+        ("review_required", "phi_policy"),
+        ("policy_denied", "timeout"),
+        ("failed", "human_gate"),
+        ("success", "looks_good"),
+        ("abstained", "Patient chart is incomplete"),
+        ("not-a-real-class", "completed"),
+    ],
+)
+def test_unknown_or_mismatched_codes_fail_without_echo(outcome_class, reason_code):
+    payload = {"outcome_class": outcome_class, "reason_code": reason_code}
+
+    with pytest.raises(OutcomeError) as exc_info:
+        WorkflowOutcome.from_dict(payload)
+
+    message = str(exc_info.value)
+    known_classes = {
+        "success",
+        "abstained",
+        "review_required",
+        "policy_denied",
+        "failed",
+    }
+    if outcome_class not in known_classes:
+        assert outcome_class not in message
+    assert reason_code not in message
+    assert exc_info.value.code in {"unknown_class", "unknown_reason"}
+
+
+def test_free_text_reason_field_fails_without_echo():
+    sentinel = "Patient John Doe has AKI; bearer tok_live_sentinel"
+    payload = {
+        "outcome_class": "failed",
+        "reason_code": "tool_error",
+        "message": sentinel,
+    }
+
+    with pytest.raises(OutcomeError) as exc_info:
+        WorkflowOutcome.from_dict(payload)
+
+    assert sentinel not in str(exc_info.value)
+    assert exc_info.value.code == "unknown_field"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"outcome_class": "success"},
+        {"reason_code": "completed"},
+        "not-a-dict",
+        ["success", "completed"],
+    ],
+)
+def test_missing_and_non_mapping_payloads_fail_closed(payload):
+    with pytest.raises(OutcomeError):
+        WorkflowOutcome.from_dict(payload)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("outcome_class", True),
+        ("outcome_class", 1),
+        ("reason_code", True),
+        ("reason_code", 0),
+        ("schema_version", "openmed.agent.outcome.v0"),
+        ("schema_version", True),
+    ],
+)
+def test_invalid_field_types_fail_closed(field, value):
+    payload = {
+        "schema_version": OUTCOME_SCHEMA_VERSION,
+        "outcome_class": "success",
+        "reason_code": "completed",
+    }
+    payload[field] = value
+
+    with pytest.raises(OutcomeError):
+        WorkflowOutcome.from_dict(payload)
+
+
+@pytest.mark.parametrize("payload", ["{", b"\xff", 42])
+def test_malformed_json_fails_closed(payload):
+    with pytest.raises(OutcomeError) as exc_info:
+        WorkflowOutcome.from_json(payload)  # type: ignore[arg-type]
+    assert exc_info.value.code == "malformed_json"
+
+
+def test_allowed_reason_codes_are_closed_per_class():
+    assert "completed" in allowed_reason_codes(OutcomeClass.SUCCESS)
+    assert "insufficient_evidence" in allowed_reason_codes("abstained")
+    with pytest.raises(OutcomeError) as exc_info:
+        allowed_reason_codes("not-a-real-class")
+    assert exc_info.value.code == "unknown_class"
+    assert "not-a-real-class" not in str(exc_info.value)
+
+
+def test_outcome_contract_is_available_from_public_agent_api():
+    import openmed.agent as agent
+
+    assert agent.WorkflowOutcome is WorkflowOutcome
+    assert agent.OutcomeClass is OutcomeClass
+    assert agent.OutcomeError is OutcomeError
+    assert agent.OUTCOME_SCHEMA_VERSION == OUTCOME_SCHEMA_VERSION
+    assert agent.allowed_reason_codes is allowed_reason_codes


### PR DESCRIPTION
# Pull Request

## Description
Adds a closed, JSON-safe vocabulary for agent workflow outcomes: success, abstention, reviewer handoff, policy denial, and execution failure.

## Type of Change
- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made
- Add typed outcome classes and a closed reason-code set in `openmed.agent.outcomes`.
- Reject unknown classes, unknown reasons, extra fields, and free-text reasons without echoing submitted values.
- Serialize identical inputs to the same compact JSON payload.
- Re-export the contract from `openmed.agent`, document it, and update the changelog.

## Testing
- [x] Added tests that prove unknown codes, extra fields, and sentinel text fail closed
- [x] Target unit tests pass: 38 passed
- [x] Public `openmed.agent` imports checked in those tests

## Documentation
- [x] Added documentation and docstrings
- [x] Updated CHANGELOG.md
- [x] Added a MkDocs nav entry

## Dependencies
- [x] No new dependencies

## Related Issues
Closes #2950