### PR TITLE
feat(multimodal): detect media types from bounded prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added bounded, dependency-free detection for PDF, PNG, JPEG, TIFF, DICOM,
+  and WAV prefixes, with stable match, mismatch, and unknown validation results
+  that do not log source bytes or trust filename extensions (#2955).
 - Added a deterministic Jupyter notebook cell redaction helper that preserves
   code sources and execution structure, applies explicit markdown and output
   policies, removes unredacted binary MIME data, and emits counts-only,

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -202,6 +202,7 @@ classification:
     - reference/chat-schema.md
     - reference/training-schemas.md
     - reference/preference-schema.md
+    - multimodal/media-type-detection.md
     - multimodal/pdf-reading-order.md
     - multimodal/pdf-redaction-fidelity.md
     - multimodal/email-ingestion.md

--- a/docs/multimodal/media-type-detection.md
+++ b/docs/multimodal/media-type-detection.md
@@ -1,0 +1,35 @@
+# Bounded media-type detection
+
+`openmed.multimodal.media_type` provides a dependency-free preflight check for
+uploaded or in-memory clinical media. It inspects at most the first 132 bytes
+and does not use filenames, paths, or extensions.
+
+Supported signatures:
+
+- PDF
+- PNG and JPEG
+- little-endian and big-endian TIFF
+- DICOM Part 10 with the `DICM` marker at byte offset 128
+- WAV with `RIFF` and `WAVE` markers
+
+```python
+from openmed.multimodal.media_type import (
+    MediaTypeStatus,
+    detect_media_type,
+    validate_media_type,
+)
+
+prefix = b"%PDF-1.7\n"
+
+assert detect_media_type(prefix) == "application/pdf"
+assert validate_media_type(prefix, "application/pdf") is MediaTypeStatus.MATCH
+assert validate_media_type(prefix, "image/png") is MediaTypeStatus.MISMATCH
+```
+
+Truncated, ambiguous, and unsupported prefixes return `None` from
+`detect_media_type()` and `MediaTypeStatus.UNKNOWN` from `validate_media_type()`.
+Invalid declared types fail closed with a value-free error.
+
+This preflight check does not fully validate a file, scan for malware,
+decompress content, or replace format-specific parsers. Callers should pass
+only the bounded prefix and should not log source bytes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - Chat Message Schema: reference/chat-schema.md
       - Training Schema Registry: reference/training-schemas.md
       - Preference Pair Schema: reference/preference-schema.md
+      - Bounded Media Type Detection: multimodal/media-type-detection.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md
       - Email Ingestion and Redaction: multimodal/email-ingestion.md

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -28,6 +28,12 @@ from . import documents_docx as _documents_docx
 from . import documents_html as _documents_html
 from . import documents_markdown as _documents_markdown
 from . import pptx as _pptx
+from .media_type import (
+    MAX_MEDIA_TYPE_PREFIX_BYTES,
+    MediaTypeStatus,
+    detect_media_type,
+    validate_media_type,
+)
 from .base import (
     ExtractedDocument,
     SourceSpan,
@@ -252,6 +258,10 @@ __all__ = [
     "register_handler",
     "ensure_multimodal_available",
     "is_multimodal_available",
+    "MAX_MEDIA_TYPE_PREFIX_BYTES",
+    "MediaTypeStatus",
+    "detect_media_type",
+    "validate_media_type",
     "MissingDependencyError",
     "UnsupportedDocumentError",
     "DocumentGraphError",

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -28,12 +28,6 @@ from . import documents_docx as _documents_docx
 from . import documents_html as _documents_html
 from . import documents_markdown as _documents_markdown
 from . import pptx as _pptx
-from .media_type import (
-    MAX_MEDIA_TYPE_PREFIX_BYTES,
-    MediaTypeStatus,
-    detect_media_type,
-    validate_media_type,
-)
 from .base import (
     ExtractedDocument,
     SourceSpan,
@@ -155,6 +149,12 @@ from .layout import (
     LayoutSpan,
     LayoutWordSpan,
     parse_layout,
+)
+from .media_type import (
+    MAX_MEDIA_TYPE_PREFIX_BYTES,
+    MediaTypeStatus,
+    detect_media_type,
+    validate_media_type,
 )
 from .metadata_scrub import (
     MetadataFinding,

--- a/openmed/multimodal/media_type.py
+++ b/openmed/multimodal/media_type.py
@@ -6,6 +6,13 @@ import re
 from enum import Enum
 from typing import Final
 
+__all__ = [
+    "MAX_MEDIA_TYPE_PREFIX_BYTES",
+    "MediaTypeStatus",
+    "detect_media_type",
+    "validate_media_type",
+]
+
 MAX_MEDIA_TYPE_PREFIX_BYTES: Final[int] = 132
 
 _MEDIA_TYPE_RE: Final[re.Pattern[str]] = re.compile(

--- a/openmed/multimodal/media_type.py
+++ b/openmed/multimodal/media_type.py
@@ -1,0 +1,67 @@
+"""Bounded, dependency-free media-type detection for multimodal preflight."""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Final
+
+MAX_MEDIA_TYPE_PREFIX_BYTES: Final[int] = 132
+
+_MEDIA_TYPE_RE: Final[re.Pattern[str]] = re.compile(
+    r"^[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*$"
+)
+
+
+class MediaTypeStatus(str, Enum):
+    """Categorical result of comparing detected and declared media types."""
+
+    MATCH = "match"
+    MISMATCH = "mismatch"
+    UNKNOWN = "unknown"
+
+
+def detect_media_type(prefix: bytes | bytearray | memoryview) -> str | None:
+    """Detect a supported media type from at most 132 leading bytes.
+
+    The detector returns ``None`` for truncated, ambiguous, and unsupported
+    inputs. It does not inspect filenames, decode content, or log input bytes.
+    """
+
+    if not isinstance(prefix, (bytes, bytearray, memoryview)):
+        raise TypeError("prefix must be bytes-like")
+
+    bounded = bytes(prefix[:MAX_MEDIA_TYPE_PREFIX_BYTES])
+    if bounded.startswith(b"%PDF-"):
+        return "application/pdf"
+    if bounded.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if bounded.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if bounded.startswith((b"II*\x00", b"MM\x00*")):
+        return "image/tiff"
+    if len(bounded) >= 132 and bounded[128:132] == b"DICM":
+        return "application/dicom"
+    if len(bounded) >= 12 and bounded.startswith(b"RIFF") and bounded[8:12] == b"WAVE":
+        return "audio/wav"
+    return None
+
+
+def validate_media_type(
+    prefix: bytes | bytearray | memoryview, declared_media_type: str
+) -> MediaTypeStatus:
+    """Compare detected and declared media types without exposing input bytes."""
+
+    if (
+        type(declared_media_type) is not str
+        or declared_media_type != declared_media_type.lower()
+        or _MEDIA_TYPE_RE.fullmatch(declared_media_type) is None
+    ):
+        raise ValueError("declared media type is unsupported")
+
+    detected = detect_media_type(prefix)
+    if detected is None:
+        return MediaTypeStatus.UNKNOWN
+    if detected == declared_media_type:
+        return MediaTypeStatus.MATCH
+    return MediaTypeStatus.MISMATCH

--- a/tests/unit/multimodal/test_media_type.py
+++ b/tests/unit/multimodal/test_media_type.py
@@ -51,6 +51,12 @@ def test_detection_accepts_bytes_like_inputs_and_uses_a_bounded_prefix():
     assert MAX_MEDIA_TYPE_PREFIX_BYTES == 132
 
 
+def test_detection_never_recognizes_a_signature_beyond_the_prefix_bound() -> None:
+    payload = b"x" * MAX_MEDIA_TYPE_PREFIX_BYTES + b"%PDF-1.7"
+
+    assert detect_media_type(payload) is None
+
+
 @pytest.mark.parametrize(
     ("prefix", "declared", "expected"),
     [

--- a/tests/unit/multimodal/test_media_type.py
+++ b/tests/unit/multimodal/test_media_type.py
@@ -1,0 +1,87 @@
+"""Tests for bounded multimodal media-type detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.multimodal.media_type import (
+    MAX_MEDIA_TYPE_PREFIX_BYTES,
+    MediaTypeStatus,
+    detect_media_type,
+    validate_media_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected"),
+    [
+        (b"%PDF-1.7\n", "application/pdf"),
+        (b"\x89PNG\r\n\x1a\n", "image/png"),
+        (b"\xff\xd8\xff\xe0", "image/jpeg"),
+        (b"II*\x00", "image/tiff"),
+        (b"MM\x00*", "image/tiff"),
+        (b"\x00" * 128 + b"DICM", "application/dicom"),
+        (b"RIFF\x10\x00\x00\x00WAVE", "audio/wav"),
+    ],
+)
+def test_detect_media_type_from_synthetic_prefix(prefix, expected):
+    assert detect_media_type(prefix) == expected
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        b"",
+        b"%PD",
+        b"\x89PNG",
+        b"\xff\xd8",
+        b"RIFF\x10\x00\x00\x00",
+        b"\x00" * 128 + b"DIC",
+        b"not-a-supported-format",
+    ],
+)
+def test_truncated_ambiguous_and_unsupported_prefixes_are_unknown(prefix):
+    assert detect_media_type(prefix) is None
+
+
+def test_detection_accepts_bytes_like_inputs_and_uses_a_bounded_prefix():
+    payload = memoryview(b"%PDF-1.7" + b"x" * (MAX_MEDIA_TYPE_PREFIX_BYTES + 500))
+
+    assert detect_media_type(payload) == "application/pdf"
+    assert MAX_MEDIA_TYPE_PREFIX_BYTES == 132
+
+
+@pytest.mark.parametrize(
+    ("prefix", "declared", "expected"),
+    [
+        (b"%PDF-1.7", "application/pdf", MediaTypeStatus.MATCH),
+        (b"%PDF-1.7", "image/png", MediaTypeStatus.MISMATCH),
+        (b"%PDF-1.7", "application/octet-stream", MediaTypeStatus.MISMATCH),
+        (b"unknown", "application/pdf", MediaTypeStatus.UNKNOWN),
+    ],
+)
+def test_validate_media_type_returns_stable_categories(prefix, declared, expected):
+    assert validate_media_type(prefix, declared) is expected
+
+
+@pytest.mark.parametrize("value", ["%PDF-1.7", 42, None])
+def test_detector_rejects_non_bytes_like_values(value):
+    with pytest.raises(TypeError, match="prefix must be bytes-like"):
+        detect_media_type(value)  # type: ignore[arg-type]
+
+
+def test_validator_rejects_invalid_declared_media_type_without_echoing_value():
+    declared = "https://patient.example/scan.dcm"
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_media_type(b"%PDF-1.7", declared)
+
+    assert declared not in str(exc_info.value)
+
+
+def test_media_type_contract_is_available_from_public_multimodal_api():
+    import openmed.multimodal as multimodal
+
+    assert multimodal.detect_media_type is detect_media_type
+    assert multimodal.validate_media_type is validate_media_type
+    assert multimodal.MediaTypeStatus is MediaTypeStatus


### PR DESCRIPTION
# Pull Request

## Description
Adds dependency-free, bounded media-type detection for multimodal preflight.

## Type of Change
- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made
- Detect PDF, PNG, JPEG, little- and big-endian TIFF, DICOM Part 10, and WAV from at most 132 bytes.
- Return stable match, mismatch, and unknown validation results without trusting extensions or logging bytes.
- Export the contract through `openmed.multimodal`, document it, and update the changelog.

## Testing
- [x] Added synthetic-only tests
- [x] Target unit tests pass: 24 passed

## Documentation
- [x] Added documentation and docstrings
- [x] Updated CHANGELOG.md

## Dependencies
- [x] No new dependencies

## Related Issues
Closes #2955