### PR TITLE
Model valid federated round lifecycle transitions

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -201,6 +201,7 @@ classification:
     - document-adapter-provenance.md
     - reference/chat-schema.md
     - reference/training-schemas.md
+    - training/federated-round-lifecycle.md
     - reference/preference-schema.md
     - multimodal/pdf-reading-order.md
     - multimodal/pdf-redaction-fidelity.md

--- a/docs/training/federated-round-lifecycle.md
+++ b/docs/training/federated-round-lifecycle.md
@@ -1,0 +1,59 @@
+# Federated round lifecycle
+
+OpenMed models federated training coordination as an offline, metadata-only
+state machine. The lifecycle contains no participant identifiers, local
+metrics, model updates, or network behavior.
+
+## States and transitions
+
+| Current state | Allowed next states |
+| --- | --- |
+| `planned` | `preflight`, `aborted` |
+| `preflight` | `collecting`, `aborted` |
+| `collecting` | `aggregating`, `aborted` |
+| `aggregating` | `evaluating`, `aborted` |
+| `evaluating` | `held`, `promoted`, `aborted` |
+| `held` | `evaluating`, `aborted` |
+| `promoted` | None (terminal) |
+| `aborted` | None (terminal) |
+
+`held` represents a round waiting for review. It cannot move directly to
+`promoted`; review resumes through `evaluating`, where the external quality and
+privacy gates can make a new decision. This module validates the transition but
+does not decide whether a gate passes.
+
+## Usage
+
+```python
+from openmed.training.federated_round import (
+    FederatedRoundLifecycle,
+    FederatedRoundState,
+)
+
+round_lifecycle = FederatedRoundLifecycle()
+round_lifecycle = round_lifecycle.transition_to(FederatedRoundState.PREFLIGHT)
+round_lifecycle = round_lifecycle.transition_to(FederatedRoundState.COLLECTING)
+
+payload = round_lifecycle.to_json()
+restored = FederatedRoundLifecycle.from_json(payload)
+assert restored == round_lifecycle
+```
+
+Lifecycle objects are immutable. Invalid skips, backward transitions, and
+transitions from terminal states raise `FederatedRoundTransitionError` without
+changing the existing value.
+
+## Serialization contract
+
+The serialized payload contains exactly two fields:
+
+```json
+{
+  "schema_version": "openmed.training.federated_round.v1",
+  "state": "collecting"
+}
+```
+
+Deserialization rejects unknown fields, schema versions, and state values.
+Errors are categorical and do not echo the rejected value, so accidentally
+supplied participant metadata is not copied into routine diagnostics.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
       - Document Adapter Provenance: document-adapter-provenance.md
       - Chat Message Schema: reference/chat-schema.md
       - Training Schema Registry: reference/training-schemas.md
+      - Federated Round Lifecycle: training/federated-round-lifecycle.md
       - Preference Pair Schema: reference/preference-schema.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md

--- a/openmed/training/__init__.py
+++ b/openmed/training/__init__.py
@@ -63,6 +63,10 @@ __all__ = [
     "DIRECTID_RUN_MANIFEST_SCHEMA_VERSION",
     "DIRECTID_TRAINING_REPORT_SCHEMA_VERSION",
     "DIRECTID_TINY_HEAD_CONTRACT",
+    "FEDERATED_ROUND_SCHEMA_VERSION",
+    "FEDERATED_ROUND_STATES",
+    "FEDERATED_ROUND_TERMINAL_STATES",
+    "FEDERATED_ROUND_TRANSITIONS",
     "DirectIDArtifactEvaluator",
     "DirectIDArtifactExporter",
     "DirectIDArtifactMeasurement",
@@ -92,6 +96,10 @@ __all__ = [
     "DistillationReport",
     "DistillationTargets",
     "EntityTypeWeights",
+    "FederatedRoundLifecycle",
+    "FederatedRoundState",
+    "FederatedRoundStateError",
+    "FederatedRoundTransitionError",
     "HARD_NEGATIVE_CATEGORIES",
     "HardNegativeExample",
     "HardNegativeGenerator",
@@ -123,6 +131,7 @@ __all__ = [
     "WeakLabelDecision",
     "WeakLabelSpan",
     "arxiv_qbio_source",
+    "allowed_round_transitions",
     "assemble_dapt_corpus",
     "assert_manifest_has_no_raw_text",
     "build_distillation_report",
@@ -136,6 +145,7 @@ __all__ = [
     "count_hard_negatives",
     "compute_kd_loss",
     "compute_span_agreement_loss",
+    "can_transition_round",
     "decode_repaired_spans",
     "directid_dataset_manifest_hash",
     "directid_records_hash",
@@ -177,6 +187,7 @@ __all__ = [
     "validate_directid_dataset_manifest",
     "validate_directid_preset",
     "validate_directid_split_records",
+    "validate_round_transition",
     "weak_label_document",
     "write_clinical_privacy_checkpoint_manifest",
     "write_jsonl_records",
@@ -184,6 +195,21 @@ __all__ = [
 
 
 def __getattr__(name: str) -> Any:
+    if name in {
+        "FEDERATED_ROUND_SCHEMA_VERSION",
+        "FEDERATED_ROUND_STATES",
+        "FEDERATED_ROUND_TERMINAL_STATES",
+        "FEDERATED_ROUND_TRANSITIONS",
+        "FederatedRoundLifecycle",
+        "FederatedRoundState",
+        "FederatedRoundStateError",
+        "FederatedRoundTransitionError",
+        "allowed_round_transitions",
+        "can_transition_round",
+        "validate_round_transition",
+    }:
+        federated_round = import_module(".federated_round", __name__)
+        return getattr(federated_round, name)
     if name in {
         "CLINICAL_PRIVACY_CHECKPOINT_NAME",
         "CLINICAL_PRIVACY_CHECKPOINT_SCHEMA_VERSION",

--- a/openmed/training/federated_round.py
+++ b/openmed/training/federated_round.py
@@ -119,7 +119,10 @@ class FederatedRoundLifecycle:
 
     def __post_init__(self) -> None:
         _require_state(self.state)
-        if self.schema_version != FEDERATED_ROUND_SCHEMA_VERSION:
+        if (
+            type(self.schema_version) is not str
+            or self.schema_version != FEDERATED_ROUND_SCHEMA_VERSION
+        ):
             raise FederatedRoundStateError(
                 "unsupported federated round lifecycle schema"
             )
@@ -163,35 +166,40 @@ class FederatedRoundLifecycle:
     def from_dict(cls, payload: Mapping[str, Any]) -> FederatedRoundLifecycle:
         """Parse a strict lifecycle payload without retaining extra metadata."""
 
-        if not isinstance(payload, Mapping) or set(payload) != {
-            "schema_version",
-            "state",
-        }:
+        if not isinstance(payload, Mapping):
+            raise FederatedRoundStateError("invalid federated round lifecycle payload")
+        try:
+            keys = set(payload)
+        except Exception:
+            raise FederatedRoundStateError(
+                "invalid federated round lifecycle payload"
+            ) from None
+        if keys != {"schema_version", "state"}:
             raise FederatedRoundStateError("invalid federated round lifecycle payload")
         schema_version = payload["schema_version"]
         state_value = payload["state"]
         if (
-            not isinstance(schema_version, str)
+            type(schema_version) is not str
             or schema_version != FEDERATED_ROUND_SCHEMA_VERSION
         ):
             raise FederatedRoundStateError(
                 "unsupported federated round lifecycle schema"
             )
-        if not isinstance(state_value, str):
+        if type(state_value) is not str:
             raise FederatedRoundStateError("unknown federated round state")
         try:
             state = FederatedRoundState(state_value)
         except ValueError:
             raise FederatedRoundStateError("unknown federated round state") from None
-        return cls(state=state, schema_version=schema_version)
+        return cls(state=state, schema_version=FEDERATED_ROUND_SCHEMA_VERSION)
 
     @classmethod
     def from_json(cls, payload: str) -> FederatedRoundLifecycle:
         """Parse lifecycle JSON and replace parser details with a safe error."""
 
         try:
-            decoded = json.loads(payload)
-        except (json.JSONDecodeError, TypeError):
+            decoded = json.loads(payload, object_pairs_hook=_strict_json_object)
+        except (json.JSONDecodeError, FederatedRoundStateError, TypeError):
             raise FederatedRoundStateError(
                 "invalid federated round lifecycle JSON"
             ) from None
@@ -203,6 +211,17 @@ class FederatedRoundLifecycle:
 def _require_state(state: object) -> None:
     if not isinstance(state, FederatedRoundState):
         raise FederatedRoundStateError("unknown federated round state")
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Build one JSON object while rejecting ambiguous duplicate keys."""
+
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise FederatedRoundStateError("invalid federated round lifecycle JSON")
+        result[key] = value
+    return result
 
 
 __all__ = [

--- a/openmed/training/federated_round.py
+++ b/openmed/training/federated_round.py
@@ -1,0 +1,220 @@
+"""Deterministic lifecycle states for federated training rounds."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Final, Mapping
+
+FEDERATED_ROUND_SCHEMA_VERSION = "openmed.training.federated_round.v1"
+
+
+class FederatedRoundState(str, Enum):
+    """A privacy-safe lifecycle state shared by federated components."""
+
+    PLANNED = "planned"
+    PREFLIGHT = "preflight"
+    COLLECTING = "collecting"
+    AGGREGATING = "aggregating"
+    EVALUATING = "evaluating"
+    HELD = "held"
+    PROMOTED = "promoted"
+    ABORTED = "aborted"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+FEDERATED_ROUND_STATES: Final[tuple[FederatedRoundState, ...]] = tuple(
+    FederatedRoundState
+)
+FEDERATED_ROUND_TERMINAL_STATES: Final[frozenset[FederatedRoundState]] = frozenset(
+    {FederatedRoundState.PROMOTED, FederatedRoundState.ABORTED}
+)
+
+# A held round returns to evaluation after review; it cannot promote directly.
+FEDERATED_ROUND_TRANSITIONS: Final[
+    Mapping[FederatedRoundState, frozenset[FederatedRoundState]]
+] = MappingProxyType(
+    {
+        FederatedRoundState.PLANNED: frozenset(
+            {FederatedRoundState.PREFLIGHT, FederatedRoundState.ABORTED}
+        ),
+        FederatedRoundState.PREFLIGHT: frozenset(
+            {FederatedRoundState.COLLECTING, FederatedRoundState.ABORTED}
+        ),
+        FederatedRoundState.COLLECTING: frozenset(
+            {FederatedRoundState.AGGREGATING, FederatedRoundState.ABORTED}
+        ),
+        FederatedRoundState.AGGREGATING: frozenset(
+            {FederatedRoundState.EVALUATING, FederatedRoundState.ABORTED}
+        ),
+        FederatedRoundState.EVALUATING: frozenset(
+            {
+                FederatedRoundState.HELD,
+                FederatedRoundState.PROMOTED,
+                FederatedRoundState.ABORTED,
+            }
+        ),
+        FederatedRoundState.HELD: frozenset(
+            {FederatedRoundState.EVALUATING, FederatedRoundState.ABORTED}
+        ),
+        FederatedRoundState.PROMOTED: frozenset(),
+        FederatedRoundState.ABORTED: frozenset(),
+    }
+)
+
+
+class FederatedRoundStateError(ValueError):
+    """Raised when serialized lifecycle state is malformed or unsupported."""
+
+
+class FederatedRoundTransitionError(ValueError):
+    """Raised when a lifecycle transition is skipped, backward, or terminal."""
+
+
+def allowed_round_transitions(
+    state: FederatedRoundState,
+) -> tuple[FederatedRoundState, ...]:
+    """Return allowed targets in canonical lifecycle order."""
+
+    _require_state(state)
+    allowed = FEDERATED_ROUND_TRANSITIONS[state]
+    return tuple(
+        candidate for candidate in FEDERATED_ROUND_STATES if candidate in allowed
+    )
+
+
+def can_transition_round(
+    current: FederatedRoundState,
+    target: FederatedRoundState,
+) -> bool:
+    """Return whether one explicit state transition is allowed."""
+
+    _require_state(current)
+    _require_state(target)
+    return target in FEDERATED_ROUND_TRANSITIONS[current]
+
+
+def validate_round_transition(
+    current: FederatedRoundState,
+    target: FederatedRoundState,
+) -> None:
+    """Raise a typed error unless ``current -> target`` is allowed."""
+
+    if not can_transition_round(current, target):
+        raise FederatedRoundTransitionError(
+            f"invalid federated round transition: {current.value} -> {target.value}"
+        )
+
+
+@dataclass(frozen=True)
+class FederatedRoundLifecycle:
+    """Immutable, metadata-only state for one federated training round."""
+
+    state: FederatedRoundState = FederatedRoundState.PLANNED
+    schema_version: str = FEDERATED_ROUND_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _require_state(self.state)
+        if self.schema_version != FEDERATED_ROUND_SCHEMA_VERSION:
+            raise FederatedRoundStateError(
+                "unsupported federated round lifecycle schema"
+            )
+
+    @property
+    def is_terminal(self) -> bool:
+        """Return whether no further transitions are permitted."""
+
+        return self.state in FEDERATED_ROUND_TERMINAL_STATES
+
+    def allowed_transitions(self) -> tuple[FederatedRoundState, ...]:
+        """Return the legal next states in canonical order."""
+
+        return allowed_round_transitions(self.state)
+
+    def can_transition_to(self, target: FederatedRoundState) -> bool:
+        """Return whether ``target`` is a legal next state."""
+
+        return can_transition_round(self.state, target)
+
+    def transition_to(self, target: FederatedRoundState) -> FederatedRoundLifecycle:
+        """Validate and return a new lifecycle in ``target`` state."""
+
+        validate_round_transition(self.state, target)
+        return FederatedRoundLifecycle(state=target)
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the versioned metadata-only representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "state": self.state.value,
+        }
+
+    def to_json(self) -> str:
+        """Return deterministic JSON with stable field ordering."""
+
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n"
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> FederatedRoundLifecycle:
+        """Parse a strict lifecycle payload without retaining extra metadata."""
+
+        if not isinstance(payload, Mapping) or set(payload) != {
+            "schema_version",
+            "state",
+        }:
+            raise FederatedRoundStateError("invalid federated round lifecycle payload")
+        schema_version = payload["schema_version"]
+        state_value = payload["state"]
+        if (
+            not isinstance(schema_version, str)
+            or schema_version != FEDERATED_ROUND_SCHEMA_VERSION
+        ):
+            raise FederatedRoundStateError(
+                "unsupported federated round lifecycle schema"
+            )
+        if not isinstance(state_value, str):
+            raise FederatedRoundStateError("unknown federated round state")
+        try:
+            state = FederatedRoundState(state_value)
+        except ValueError:
+            raise FederatedRoundStateError("unknown federated round state") from None
+        return cls(state=state, schema_version=schema_version)
+
+    @classmethod
+    def from_json(cls, payload: str) -> FederatedRoundLifecycle:
+        """Parse lifecycle JSON and replace parser details with a safe error."""
+
+        try:
+            decoded = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
+            raise FederatedRoundStateError(
+                "invalid federated round lifecycle JSON"
+            ) from None
+        if not isinstance(decoded, Mapping):
+            raise FederatedRoundStateError("invalid federated round lifecycle payload")
+        return cls.from_dict(decoded)
+
+
+def _require_state(state: object) -> None:
+    if not isinstance(state, FederatedRoundState):
+        raise FederatedRoundStateError("unknown federated round state")
+
+
+__all__ = [
+    "FEDERATED_ROUND_SCHEMA_VERSION",
+    "FEDERATED_ROUND_STATES",
+    "FEDERATED_ROUND_TERMINAL_STATES",
+    "FEDERATED_ROUND_TRANSITIONS",
+    "FederatedRoundLifecycle",
+    "FederatedRoundState",
+    "FederatedRoundStateError",
+    "FederatedRoundTransitionError",
+    "allowed_round_transitions",
+    "can_transition_round",
+    "validate_round_transition",
+]

--- a/tests/unit/training/test_federated_round.py
+++ b/tests/unit/training/test_federated_round.py
@@ -156,6 +156,34 @@ def test_errors_and_serialization_do_not_expose_caller_metadata() -> None:
     assert sentinel not in serialized
 
 
+def test_duplicate_json_fields_are_rejected_instead_of_last_value_winning() -> None:
+    payload = (
+        '{"schema_version":"openmed.training.federated_round.v1",'
+        '"state":"planned","state":"promoted"}'
+    )
+
+    with pytest.raises(
+        FederatedRoundStateError,
+        match="invalid federated round lifecycle JSON",
+    ):
+        FederatedRoundLifecycle.from_json(payload)
+
+
+class SchemaVersionSubclass(str):
+    """A string subtype that must not be retained in immutable state."""
+
+
+def test_schema_version_subclasses_are_rejected_by_all_constructors() -> None:
+    schema = SchemaVersionSubclass(FEDERATED_ROUND_SCHEMA_VERSION)
+
+    with pytest.raises(FederatedRoundStateError):
+        FederatedRoundLifecycle(schema_version=schema)
+    with pytest.raises(FederatedRoundStateError):
+        FederatedRoundLifecycle.from_dict(
+            {"schema_version": schema, "state": "planned"}
+        )
+
+
 def test_plain_strings_cannot_bypass_typed_transition_validation() -> None:
     with pytest.raises(FederatedRoundStateError):
         can_transition_round("planned", S.PREFLIGHT)  # type: ignore[arg-type]

--- a/tests/unit/training/test_federated_round.py
+++ b/tests/unit/training/test_federated_round.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from openmed.training.federated_round import (
+    FEDERATED_ROUND_SCHEMA_VERSION,
+    FEDERATED_ROUND_STATES,
+    FEDERATED_ROUND_TERMINAL_STATES,
+    FEDERATED_ROUND_TRANSITIONS,
+    FederatedRoundLifecycle,
+    FederatedRoundState,
+    FederatedRoundStateError,
+    FederatedRoundTransitionError,
+    allowed_round_transitions,
+    can_transition_round,
+    validate_round_transition,
+)
+
+S = FederatedRoundState
+
+EXPECTED_TRANSITIONS = {
+    S.PLANNED: {S.PREFLIGHT, S.ABORTED},
+    S.PREFLIGHT: {S.COLLECTING, S.ABORTED},
+    S.COLLECTING: {S.AGGREGATING, S.ABORTED},
+    S.AGGREGATING: {S.EVALUATING, S.ABORTED},
+    S.EVALUATING: {S.HELD, S.PROMOTED, S.ABORTED},
+    S.HELD: {S.EVALUATING, S.ABORTED},
+    S.PROMOTED: set(),
+    S.ABORTED: set(),
+}
+
+
+@pytest.mark.parametrize("current", FEDERATED_ROUND_STATES)
+def test_transition_table_covers_every_state(current: FederatedRoundState) -> None:
+    expected = EXPECTED_TRANSITIONS[current]
+
+    assert set(FEDERATED_ROUND_TRANSITIONS[current]) == expected
+    assert set(allowed_round_transitions(current)) == expected
+    for target in FEDERATED_ROUND_STATES:
+        assert can_transition_round(current, target) is (target in expected)
+        if target in expected:
+            validate_round_transition(current, target)
+
+
+@pytest.mark.parametrize(
+    ("current", "target"),
+    [
+        (S.PLANNED, S.COLLECTING),
+        (S.COLLECTING, S.PREFLIGHT),
+        (S.EVALUATING, S.PREFLIGHT),
+        (S.PROMOTED, S.ABORTED),
+        (S.ABORTED, S.PLANNED),
+    ],
+)
+def test_skipped_backward_and_post_terminal_transitions_are_rejected(
+    current: FederatedRoundState,
+    target: FederatedRoundState,
+) -> None:
+    with pytest.raises(FederatedRoundTransitionError):
+        validate_round_transition(current, target)
+
+
+def test_held_round_must_return_through_evaluation_before_promotion() -> None:
+    held = FederatedRoundLifecycle(S.EVALUATING).transition_to(S.HELD)
+
+    with pytest.raises(FederatedRoundTransitionError):
+        held.transition_to(S.PROMOTED)
+
+    promoted = held.transition_to(S.EVALUATING).transition_to(S.PROMOTED)
+    assert promoted.state is S.PROMOTED
+    assert promoted.is_terminal is True
+
+
+@pytest.mark.parametrize("terminal", FEDERATED_ROUND_TERMINAL_STATES)
+def test_promoted_and_aborted_rounds_are_terminal(
+    terminal: FederatedRoundState,
+) -> None:
+    lifecycle = FederatedRoundLifecycle(terminal)
+
+    assert lifecycle.is_terminal is True
+    assert lifecycle.allowed_transitions() == ()
+    for target in FEDERATED_ROUND_STATES:
+        with pytest.raises(FederatedRoundTransitionError):
+            lifecycle.transition_to(target)
+
+
+def test_lifecycle_is_immutable_and_transitions_return_new_values() -> None:
+    planned = FederatedRoundLifecycle()
+    preflight = planned.transition_to(S.PREFLIGHT)
+
+    assert planned.state is S.PLANNED
+    assert preflight.state is S.PREFLIGHT
+    with pytest.raises(FrozenInstanceError):
+        planned.state = S.ABORTED  # type: ignore[misc]
+
+
+def test_serialization_is_versioned_deterministic_and_round_trips() -> None:
+    lifecycle = FederatedRoundLifecycle(S.EVALUATING)
+
+    assert lifecycle.to_dict() == {
+        "schema_version": FEDERATED_ROUND_SCHEMA_VERSION,
+        "state": "evaluating",
+    }
+    assert lifecycle.to_json() == (
+        "{\n"
+        f'  "schema_version": "{FEDERATED_ROUND_SCHEMA_VERSION}",\n'
+        '  "state": "evaluating"\n'
+        "}\n"
+    )
+    assert FederatedRoundLifecycle.from_dict(lifecycle.to_dict()) == lifecycle
+    assert FederatedRoundLifecycle.from_json(lifecycle.to_json()) == lifecycle
+    assert json.loads(lifecycle.to_json()) == lifecycle.to_dict()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"schema_version": FEDERATED_ROUND_SCHEMA_VERSION},
+        {
+            "schema_version": FEDERATED_ROUND_SCHEMA_VERSION,
+            "state": "planned",
+            "participant_id": "site-7",
+        },
+        {"schema_version": "v2", "state": "planned"},
+        {"schema_version": FEDERATED_ROUND_SCHEMA_VERSION, "state": "unknown"},
+        {"schema_version": FEDERATED_ROUND_SCHEMA_VERSION, "state": 1},
+    ],
+)
+def test_deserialization_fails_closed(payload: dict[str, object]) -> None:
+    with pytest.raises(FederatedRoundStateError):
+        FederatedRoundLifecycle.from_dict(payload)
+
+
+def test_errors_and_serialization_do_not_expose_caller_metadata() -> None:
+    sentinel = "Patient Jane Roe /srv/charts/123 local_recall=0.42"
+
+    with pytest.raises(FederatedRoundStateError) as error:
+        FederatedRoundLifecycle.from_dict(
+            {
+                "schema_version": FEDERATED_ROUND_SCHEMA_VERSION,
+                "state": sentinel,
+            }
+        )
+    assert sentinel not in str(error.value)
+
+    with pytest.raises(FederatedRoundStateError) as error:
+        FederatedRoundLifecycle.from_json(sentinel)
+    assert sentinel not in str(error.value)
+
+    serialized = FederatedRoundLifecycle().to_json()
+    assert set(json.loads(serialized)) == {"schema_version", "state"}
+    assert sentinel not in serialized
+
+
+def test_plain_strings_cannot_bypass_typed_transition_validation() -> None:
+    with pytest.raises(FederatedRoundStateError):
+        can_transition_round("planned", S.PREFLIGHT)  # type: ignore[arg-type]
+    with pytest.raises(FederatedRoundStateError):
+        FederatedRoundLifecycle("planned")  # type: ignore[arg-type]
+
+
+def test_lifecycle_is_available_through_lazy_training_exports() -> None:
+    import openmed.training as training
+
+    assert training.FederatedRoundLifecycle is FederatedRoundLifecycle
+    assert training.FederatedRoundState is FederatedRoundState
+    assert training.validate_round_transition is validate_round_transition
+    assert training.__all__.count("FederatedRoundLifecycle") == 1


### PR DESCRIPTION
Federated rounds now follow one locked-in lifecycle, so skipped gates and random state jumps get blocked. Closes #2958