### PR TITLE
feat(agent): add monotonic timing metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added deterministic monotonic timing metadata records for agent runs and
+  actions with exact integer durations and value-free validation failures
+  (#2974).
 - Added a deterministic Jupyter notebook cell redaction helper that preserves
   code sources and execution structure, applies explicit markdown and output
   policies, removes unredacted binary MIME data, and emits counts-only,

--- a/docs/agent/timing-metadata.md
+++ b/docs/agent/timing-metadata.md
@@ -1,0 +1,33 @@
+# Agent Timing Metadata
+
+Agent run timing metadata is caller-supplied and monotonic. The timing records
+accept integer nanosecond boundaries, compute exact integer durations, and never
+read a wall clock.
+
+Use `RunTiming` for the overall run and `ActionTiming` for individual steps:
+
+```python
+from openmed.agent.timing import ActionTiming, AgentRunTiming, RunTiming
+
+timing = AgentRunTiming(
+    run=RunTiming(start_ns=0, end_ns=250, correlation_id="run-01"),
+    actions=(
+        ActionTiming(action_id="retrieve", start_ns=10, end_ns=80),
+        ActionTiming(action_id="redact", start_ns=80, end_ns=120),
+    ),
+    allow_action_overlaps=False,
+)
+
+payload = timing.to_dict()
+```
+
+The serialized payload contains only relative nanosecond boundaries, exact
+durations, action identifiers, parent action identifiers when present, and
+optional opaque correlation identifiers. It does not include wall-clock
+timestamps, event payloads, local paths, or PHI.
+
+Validation fails closed for negative, reversed, boolean, non-integer, and
+over-maximum boundaries. When `allow_action_overlaps=False`, adjacent sequential
+actions are allowed but overlapping action intervals are rejected. Nested actions
+must reference an existing parent action and stay inside the parent interval.
+Error messages name only fields, not submitted values.

--- a/docs/agent/timing-metadata.md
+++ b/docs/agent/timing-metadata.md
@@ -21,10 +21,15 @@ timing = AgentRunTiming(
 payload = timing.to_dict()
 ```
 
-The serialized payload contains only relative nanosecond boundaries, exact
+`to_json()` emits deterministic compact JSON. The serialized payload contains
+only relative nanosecond boundaries, exact
 durations, action identifiers, parent action identifiers when present, and
 optional opaque correlation identifiers. It does not include wall-clock
 timestamps, event payloads, local paths, or PHI.
+
+Identifiers are bounded to 128 characters and a conservative opaque alphabet.
+Paths, URLs, slashes, backslashes, and free text are rejected without echoing
+the submitted value. Parent links must form an acyclic graph.
 
 Validation fails closed for negative, reversed, boolean, non-integer, and
 over-maximum boundaries. When `allow_action_overlaps=False`, adjacent sequential

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -104,6 +104,7 @@ classification:
     - onboarding-china.md
     - onboarding-india.md
     - agent-usage.md
+    - agent/timing-metadata.md
     - agent-skills/install.md
     - agent-skills/validation.md
     - agent-skills/setup.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - India Onboarding: onboarding-india.md
   - Core Guides:
       - Building with an Agent: agent-usage.md
+      - Agent Timing Metadata: agent/timing-metadata.md
       - Agent Skill Installation: agent-skills/install.md
       - Agent Skill Validation: agent-skills/validation.md
       - De-identification Policy Setup: agent-skills/setup.md

--- a/openmed/agent/__init__.py
+++ b/openmed/agent/__init__.py
@@ -2,4 +2,12 @@
 
 from __future__ import annotations
 
-__all__ = ["security"]
+from .timing import ActionTiming, AgentRunTiming, RunTiming, TimingValidationError
+
+__all__ = [
+    "ActionTiming",
+    "AgentRunTiming",
+    "RunTiming",
+    "TimingValidationError",
+    "security",
+]

--- a/openmed/agent/timing.py
+++ b/openmed/agent/timing.py
@@ -1,0 +1,204 @@
+"""Deterministic monotonic timing records for agent runs."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class TimingValidationError(ValueError):
+    """Raised when timing metadata fails closed validation."""
+
+
+def _validate_ns(value: Any, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TimingValidationError(f"{field_name} must be an integer")
+    if value < 0:
+        raise TimingValidationError(f"{field_name} must be non-negative")
+    return value
+
+
+def _validate_correlation_id(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TimingValidationError(f"{field_name} must be a string")
+    return value
+
+
+@dataclass(frozen=True)
+class RunTiming:
+    """Immutable monotonic nanosecond boundaries for one agent run."""
+
+    start_ns: int
+    end_ns: int
+    max_duration_ns: int | None = None
+    correlation_id: str | None = None
+
+    def __post_init__(self) -> None:
+        _validate_interval(
+            self.start_ns,
+            self.end_ns,
+            "run",
+            max_duration_ns=self.max_duration_ns,
+        )
+        _validate_correlation_id(self.correlation_id, "run.correlation_id")
+
+    @property
+    def duration_ns(self) -> int:
+        """Return the exact integer duration."""
+
+        return self.end_ns - self.start_ns
+
+    def to_dict(self) -> dict[str, int | str]:
+        """Return a JSON-safe relative timing record."""
+
+        payload: dict[str, int | str] = {
+            "start_ns": self.start_ns,
+            "end_ns": self.end_ns,
+            "duration_ns": self.duration_ns,
+        }
+        if self.correlation_id is not None:
+            payload["correlation_id"] = self.correlation_id
+        return payload
+
+
+@dataclass(frozen=True)
+class ActionTiming:
+    """Immutable monotonic nanosecond boundaries for one agent action."""
+
+    action_id: str
+    start_ns: int
+    end_ns: int
+    parent_action_id: str | None = None
+    max_duration_ns: int | None = None
+    correlation_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.action_id, str) or not self.action_id:
+            raise TimingValidationError("action_id must be a non-empty string")
+        _validate_correlation_id(self.parent_action_id, "parent_action_id")
+        _validate_correlation_id(self.correlation_id, "action.correlation_id")
+        _validate_interval(
+            self.start_ns,
+            self.end_ns,
+            "action",
+            max_duration_ns=self.max_duration_ns,
+        )
+
+    @property
+    def duration_ns(self) -> int:
+        """Return the exact integer duration."""
+
+        return self.end_ns - self.start_ns
+
+    def to_dict(self) -> dict[str, int | str]:
+        """Return a JSON-safe relative timing record."""
+
+        payload: dict[str, int | str] = {
+            "action_id": self.action_id,
+            "start_ns": self.start_ns,
+            "end_ns": self.end_ns,
+            "duration_ns": self.duration_ns,
+        }
+        if self.parent_action_id is not None:
+            payload["parent_action_id"] = self.parent_action_id
+        if self.correlation_id is not None:
+            payload["correlation_id"] = self.correlation_id
+        return payload
+
+
+@dataclass(frozen=True)
+class AgentRunTiming:
+    """Validated monotonic timing metadata for an agent run and its actions."""
+
+    run: RunTiming
+    actions: Sequence[ActionTiming] = field(default_factory=tuple)
+    allow_action_overlaps: bool = True
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.run, RunTiming):
+            raise TimingValidationError("run must be a RunTiming record")
+        if not isinstance(self.allow_action_overlaps, bool):
+            raise TimingValidationError("allow_action_overlaps must be a boolean")
+        actions = tuple(self.actions)
+        for action in actions:
+            if not isinstance(action, ActionTiming):
+                raise TimingValidationError("actions must contain ActionTiming records")
+        _validate_actions(actions, self.run, self.allow_action_overlaps)
+        object.__setattr__(self, "actions", actions)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-safe run record without wall-clock or event payloads."""
+
+        return {
+            "run": self.run.to_dict(),
+            "actions": [action.to_dict() for action in self.actions],
+        }
+
+
+def _validate_interval(
+    start_ns: Any,
+    end_ns: Any,
+    prefix: str,
+    *,
+    max_duration_ns: Any,
+) -> None:
+    start = _validate_ns(start_ns, f"{prefix}.start_ns")
+    end = _validate_ns(end_ns, f"{prefix}.end_ns")
+    if end < start:
+        raise TimingValidationError(f"{prefix}.end_ns must be greater than start_ns")
+    if max_duration_ns is not None:
+        maximum = _validate_ns(max_duration_ns, f"{prefix}.max_duration_ns")
+        if end - start > maximum:
+            raise TimingValidationError(
+                f"{prefix}.duration_ns must not exceed max_duration_ns"
+            )
+
+
+def _validate_actions(
+    actions: tuple[ActionTiming, ...],
+    run: RunTiming,
+    allow_action_overlaps: bool,
+) -> None:
+    by_id: dict[str, ActionTiming] = {}
+    for action in actions:
+        if action.action_id in by_id:
+            raise TimingValidationError("action_id must be unique")
+        by_id[action.action_id] = action
+        if action.start_ns < run.start_ns:
+            raise TimingValidationError("action.start_ns must be within run")
+        if action.end_ns > run.end_ns:
+            raise TimingValidationError("action.end_ns must be within run")
+
+    for action in actions:
+        if action.parent_action_id is None:
+            continue
+        parent = by_id.get(action.parent_action_id)
+        if parent is None:
+            raise TimingValidationError(
+                "parent_action_id must reference an existing action_id"
+            )
+        if parent.action_id == action.action_id:
+            raise TimingValidationError("parent_action_id must not reference action_id")
+        if action.start_ns < parent.start_ns or action.end_ns > parent.end_ns:
+            raise TimingValidationError(
+                "action interval must be within parent_action_id"
+            )
+
+    if not allow_action_overlaps:
+        ordered = sorted(actions, key=lambda item: (item.start_ns, item.end_ns))
+        for previous, current in zip(ordered, ordered[1:]):
+            if current.start_ns < previous.end_ns:
+                raise TimingValidationError(
+                    "actions must not overlap when allow_action_overlaps is false"
+                )
+
+
+__all__ = [
+    "ActionTiming",
+    "AgentRunTiming",
+    "RunTiming",
+    "TimingValidationError",
+]

--- a/openmed/agent/timing.py
+++ b/openmed/agent/timing.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import json
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_PATH_OR_URL_RE = re.compile(r"://|(^|[A-Za-z]):[\\/]|[\\/]|~")
 
 
 class TimingValidationError(ValueError):
@@ -12,22 +17,28 @@ class TimingValidationError(ValueError):
 
 
 def _validate_ns(value: Any, field_name: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int):
+    if type(value) is not int:
         raise TimingValidationError(f"{field_name} must be an integer")
     if value < 0:
         raise TimingValidationError(f"{field_name} must be non-negative")
     return value
 
 
-def _validate_correlation_id(value: Any, field_name: str) -> str | None:
+def _validate_identifier(value: Any, field_name: str, *, optional: bool) -> str | None:
     if value is None:
-        return None
-    if not isinstance(value, str):
-        raise TimingValidationError(f"{field_name} must be a string")
+        if optional:
+            return None
+        raise TimingValidationError(f"{field_name} must be a safe opaque identifier")
+    if (
+        type(value) is not str
+        or _IDENTIFIER_RE.fullmatch(value) is None
+        or _PATH_OR_URL_RE.search(value) is not None
+    ):
+        raise TimingValidationError(f"{field_name} must be a safe opaque identifier")
     return value
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RunTiming:
     """Immutable monotonic nanosecond boundaries for one agent run."""
 
@@ -43,7 +54,7 @@ class RunTiming:
             "run",
             max_duration_ns=self.max_duration_ns,
         )
-        _validate_correlation_id(self.correlation_id, "run.correlation_id")
+        _validate_identifier(self.correlation_id, "run.correlation_id", optional=True)
 
     @property
     def duration_ns(self) -> int:
@@ -64,7 +75,7 @@ class RunTiming:
         return payload
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ActionTiming:
     """Immutable monotonic nanosecond boundaries for one agent action."""
 
@@ -76,10 +87,11 @@ class ActionTiming:
     correlation_id: str | None = None
 
     def __post_init__(self) -> None:
-        if not isinstance(self.action_id, str) or not self.action_id:
-            raise TimingValidationError("action_id must be a non-empty string")
-        _validate_correlation_id(self.parent_action_id, "parent_action_id")
-        _validate_correlation_id(self.correlation_id, "action.correlation_id")
+        _validate_identifier(self.action_id, "action_id", optional=False)
+        _validate_identifier(self.parent_action_id, "parent_action_id", optional=True)
+        _validate_identifier(
+            self.correlation_id, "action.correlation_id", optional=True
+        )
         _validate_interval(
             self.start_ns,
             self.end_ns,
@@ -109,7 +121,7 @@ class ActionTiming:
         return payload
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class AgentRunTiming:
     """Validated monotonic timing metadata for an agent run and its actions."""
 
@@ -120,9 +132,12 @@ class AgentRunTiming:
     def __post_init__(self) -> None:
         if not isinstance(self.run, RunTiming):
             raise TimingValidationError("run must be a RunTiming record")
-        if not isinstance(self.allow_action_overlaps, bool):
+        if type(self.allow_action_overlaps) is not bool:
             raise TimingValidationError("allow_action_overlaps must be a boolean")
-        actions = tuple(self.actions)
+        try:
+            actions = tuple(self.actions)
+        except Exception:
+            raise TimingValidationError("actions could not be read") from None
         for action in actions:
             if not isinstance(action, ActionTiming):
                 raise TimingValidationError("actions must contain ActionTiming records")
@@ -136,6 +151,11 @@ class AgentRunTiming:
             "run": self.run.to_dict(),
             "actions": [action.to_dict() for action in self.actions],
         }
+
+    def to_json(self) -> str:
+        """Return deterministic compact JSON containing only timing metadata."""
+
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
 
 
 def _validate_interval(
@@ -186,6 +206,21 @@ def _validate_actions(
             raise TimingValidationError(
                 "action interval must be within parent_action_id"
             )
+
+        ancestors = {action.action_id}
+        current = parent
+        while current.parent_action_id is not None:
+            if current.action_id in ancestors:
+                raise TimingValidationError("parent_action_id graph must be acyclic")
+            ancestors.add(current.action_id)
+            next_parent = by_id.get(current.parent_action_id)
+            if next_parent is None:
+                raise TimingValidationError(
+                    "parent_action_id must reference an existing action_id"
+                )
+            current = next_parent
+        if current.action_id in ancestors:
+            raise TimingValidationError("parent_action_id graph must be acyclic")
 
     if not allow_action_overlaps:
         ordered = sorted(actions, key=lambda item: (item.start_ns, item.end_ns))

--- a/tests/unit/agent/test_timing.py
+++ b/tests/unit/agent/test_timing.py
@@ -142,24 +142,75 @@ def test_parent_and_run_bounds_fail_without_echoing_identifiers() -> None:
 
 
 def test_serialization_stays_relative_and_payload_free() -> None:
-    serialized = json.dumps(
-        AgentRunTiming(
-            run=RunTiming(start_ns=0, end_ns=1, correlation_id="opaque-run"),
-            actions=(
-                ActionTiming(
-                    action_id="scan",
-                    start_ns=0,
-                    end_ns=1,
-                    correlation_id="opaque-action",
-                ),
+    timing = AgentRunTiming(
+        run=RunTiming(start_ns=0, end_ns=1, correlation_id="opaque-run"),
+        actions=(
+            ActionTiming(
+                action_id="scan",
+                start_ns=0,
+                end_ns=1,
+                correlation_id="opaque-action",
             ),
-        ).to_dict(),
-        sort_keys=True,
+        ),
     )
+    serialized = timing.to_json()
 
+    assert serialized == json.dumps(
+        timing.to_dict(), sort_keys=True, separators=(",", ":")
+    )
     assert "opaque-run" in serialized
     assert "opaque-action" in serialized
     assert "wall" not in serialized
     assert "timestamp" not in serialized
     assert "payload" not in serialized
     assert "event" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("constructor", "kwargs"),
+    (
+        (RunTiming, {"start_ns": 0, "end_ns": 1, "correlation_id": "/phi/run"}),
+        (
+            ActionTiming,
+            {"action_id": "https://phi.example/action", "start_ns": 0, "end_ns": 1},
+        ),
+        (
+            ActionTiming,
+            {
+                "action_id": "safe",
+                "start_ns": 0,
+                "end_ns": 1,
+                "correlation_id": "x" * 129,
+            },
+        ),
+    ),
+)
+def test_identifiers_reject_paths_urls_and_unbounded_text_without_echo(
+    constructor, kwargs
+) -> None:
+    with pytest.raises(TimingValidationError) as caught:
+        constructor(**kwargs)
+
+    message = str(caught.value)
+    assert "/phi/run" not in message
+    assert "phi.example" not in message
+    assert "x" * 129 not in message
+
+
+def test_parent_action_graph_rejects_cycles() -> None:
+    with pytest.raises(TimingValidationError, match="acyclic"):
+        AgentRunTiming(
+            run=RunTiming(start_ns=0, end_ns=10),
+            actions=(
+                ActionTiming("first", 0, 10, parent_action_id="second"),
+                ActionTiming("second", 0, 10, parent_action_id="first"),
+            ),
+        )
+
+
+def test_timing_contract_is_available_from_public_agent_api() -> None:
+    import openmed.agent as agent
+
+    assert agent.RunTiming is RunTiming
+    assert agent.ActionTiming is ActionTiming
+    assert agent.AgentRunTiming is AgentRunTiming

--- a/tests/unit/agent/test_timing.py
+++ b/tests/unit/agent/test_timing.py
@@ -1,0 +1,165 @@
+"""Offline tests for monotonic agent timing metadata."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.agent.timing import (
+    ActionTiming,
+    AgentRunTiming,
+    RunTiming,
+    TimingValidationError,
+)
+
+
+def test_run_timing_accepts_zero_duration_and_exact_maximum() -> None:
+    zero = RunTiming(start_ns=8, end_ns=8, max_duration_ns=0)
+    bounded = RunTiming(start_ns=10, end_ns=25, max_duration_ns=15)
+
+    assert zero.duration_ns == 0
+    assert bounded.duration_ns == 15
+    assert bounded.to_dict() == {
+        "start_ns": 10,
+        "end_ns": 25,
+        "duration_ns": 15,
+    }
+
+
+def test_agent_timing_accepts_nested_and_sequential_actions() -> None:
+    timing = AgentRunTiming(
+        run=RunTiming(start_ns=10, end_ns=40, correlation_id="run-opaque"),
+        actions=(
+            ActionTiming(action_id="extract", start_ns=12, end_ns=30),
+            ActionTiming(
+                action_id="tool",
+                parent_action_id="extract",
+                start_ns=15,
+                end_ns=20,
+                correlation_id="action-opaque",
+            ),
+            ActionTiming(action_id="classify", start_ns=30, end_ns=35),
+        ),
+    )
+
+    assert timing.actions[0].duration_ns == 18
+    assert timing.actions[1].duration_ns == 5
+    assert timing.actions[2].duration_ns == 5
+    assert timing.to_dict() == {
+        "run": {
+            "start_ns": 10,
+            "end_ns": 40,
+            "duration_ns": 30,
+            "correlation_id": "run-opaque",
+        },
+        "actions": [
+            {
+                "action_id": "extract",
+                "start_ns": 12,
+                "end_ns": 30,
+                "duration_ns": 18,
+            },
+            {
+                "action_id": "tool",
+                "parent_action_id": "extract",
+                "start_ns": 15,
+                "end_ns": 20,
+                "duration_ns": 5,
+                "correlation_id": "action-opaque",
+            },
+            {
+                "action_id": "classify",
+                "start_ns": 30,
+                "end_ns": 35,
+                "duration_ns": 5,
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "kwargs, field, hidden_value",
+    [
+        ({"start_ns": -1, "end_ns": 2}, "run.start_ns", "-1"),
+        ({"start_ns": 5, "end_ns": 4}, "run.end_ns", "5"),
+        ({"start_ns": True, "end_ns": 2}, "run.start_ns", "True"),
+        ({"start_ns": 1.25, "end_ns": 2}, "run.start_ns", "1.25"),
+        ({"start_ns": 0, "end_ns": 3, "max_duration_ns": 2}, "run.duration_ns", "3"),
+    ],
+)
+def test_invalid_run_boundaries_fail_with_field_only_errors(
+    kwargs: dict[str, object],
+    field: str,
+    hidden_value: str,
+) -> None:
+    with pytest.raises(TimingValidationError) as caught:
+        RunTiming(**kwargs)  # type: ignore[arg-type]
+
+    message = str(caught.value)
+    assert field in message
+    assert hidden_value not in message
+
+
+def test_overlapping_actions_fail_when_disallowed_without_echoing_values() -> None:
+    with pytest.raises(TimingValidationError) as caught:
+        AgentRunTiming(
+            run=RunTiming(start_ns=0, end_ns=30),
+            actions=(
+                ActionTiming(action_id="first", start_ns=5, end_ns=15),
+                ActionTiming(action_id="second", start_ns=14, end_ns=20),
+            ),
+            allow_action_overlaps=False,
+        )
+
+    message = str(caught.value)
+    assert "actions" in message
+    assert "first" not in message
+    assert "second" not in message
+    assert "14" not in message
+
+
+def test_parent_and_run_bounds_fail_without_echoing_identifiers() -> None:
+    with pytest.raises(TimingValidationError) as caught:
+        AgentRunTiming(
+            run=RunTiming(start_ns=10, end_ns=40),
+            actions=(
+                ActionTiming(action_id="outer", start_ns=12, end_ns=20),
+                ActionTiming(
+                    action_id="inner",
+                    parent_action_id="outer",
+                    start_ns=15,
+                    end_ns=21,
+                ),
+            ),
+        )
+
+    message = str(caught.value)
+    assert "parent_action_id" in message
+    assert "outer" not in message
+    assert "inner" not in message
+    assert "21" not in message
+
+
+def test_serialization_stays_relative_and_payload_free() -> None:
+    serialized = json.dumps(
+        AgentRunTiming(
+            run=RunTiming(start_ns=0, end_ns=1, correlation_id="opaque-run"),
+            actions=(
+                ActionTiming(
+                    action_id="scan",
+                    start_ns=0,
+                    end_ns=1,
+                    correlation_id="opaque-action",
+                ),
+            ),
+        ).to_dict(),
+        sort_keys=True,
+    )
+
+    assert "opaque-run" in serialized
+    assert "opaque-action" in serialized
+    assert "wall" not in serialized
+    assert "timestamp" not in serialized
+    assert "payload" not in serialized
+    assert "event" not in serialized


### PR DESCRIPTION
# Pull Request

## Description
Adds deterministic monotonic timing records for agent runs and action spans using caller-supplied integer nanosecond boundaries.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Add immutable `RunTiming`, `ActionTiming`, and `AgentRunTiming` records.
- Validate non-negative integers, ordering, maximum duration bounds, parent nesting, and disallowed action overlaps.
- Serialize relative timings, exact durations, action identifiers, and optional opaque correlation identifiers only.

## Testing
- [x] Added timing boundary, nesting, overlap, safe-error, and serialization tests.
- [x] Target unit tests pass: 10 passed.
- [ ] I have tested this change with different models/inputs.

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the contributing guidelines
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #2974

## Screenshots/Examples
Not applicable.
