### PR TITLE
feat(multimodal): add bounded streaming asset digests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added bounded streaming SHA-256 asset digests with caller-owned stream
+  position restoration and value-free limit and read failures (#2979).
 - Added a deterministic Jupyter notebook cell redaction helper that preserves
   code sources and execution structure, applies explicit markdown and output
   policies, removes unredacted binary MIME data, and emits counts-only,

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -203,6 +203,7 @@ classification:
     - reference/training-schemas.md
     - reference/preference-schema.md
     - multimodal/pdf-reading-order.md
+    - multimodal/asset-digests.md
     - multimodal/pdf-redaction-fidelity.md
     - multimodal/email-ingestion.md
     - multimodal/epub-extraction.md

--- a/docs/multimodal/asset-digests.md
+++ b/docs/multimodal/asset-digests.md
@@ -1,0 +1,29 @@
+# Bounded asset digests
+
+Use `digest_asset` to compute a SHA-256 digest without loading a PDF, image,
+DICOM object, audio file, or other binary asset into memory at once.
+
+```python
+from openmed.multimodal.digest import digest_asset
+
+with open("synthetic-scan.dcm", "rb") as stream:
+    result = digest_asset(stream, max_bytes=2 * 1024**3)
+
+print(result.sha256)
+print(result.byte_count)
+```
+
+Streams are read from their current position in chunks no larger than 1 MiB.
+Seekable streams are restored to that position on success or failure, and the
+helper never closes a caller-owned stream. Non-seekable streams are consumed.
+Passing `bytes` hashes the existing in-memory value directly.
+
+`max_bytes` is an optional hard limit. The helper reads at most one byte beyond
+the limit to detect overflow, then raises `DigestLimitExceededError`. Its error
+contains only the `digest_size_limit` category, `maximum_bytes`, and
+`bytes_read`; it never includes paths, filenames, or asset content. Other
+stream failures raise a value-free `DigestStreamError`.
+
+The result contains the lowercase 64-character SHA-256 hex digest and the exact
+number of bytes hashed. This helper does not open paths, validate media, scan
+for malware, sign content, or provide content-addressed storage.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Training Schema Registry: reference/training-schemas.md
       - Preference Pair Schema: reference/preference-schema.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
+      - Bounded Asset Digests: multimodal/asset-digests.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md
       - Email Ingestion and Redaction: multimodal/email-ingestion.md
       - EPUB Extraction: multimodal/epub-extraction.md

--- a/openmed/multimodal/digest.py
+++ b/openmed/multimodal/digest.py
@@ -1,0 +1,123 @@
+"""Bounded SHA-256 digests for in-memory and streamed multimodal assets."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import BinaryIO, Callable
+
+__all__ = [
+    "AssetDigest",
+    "DigestLimitExceededError",
+    "DigestStreamError",
+    "digest_asset",
+]
+
+_CHUNK_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class AssetDigest:
+    """SHA-256 hex digest and the number of bytes hashed."""
+
+    sha256: str
+    byte_count: int
+
+
+class DigestLimitExceededError(ValueError):
+    """Raised when an asset exceeds the configured byte limit."""
+
+    category = "digest_size_limit"
+
+    def __init__(self, *, maximum_bytes: int, bytes_read: int) -> None:
+        self.maximum_bytes = maximum_bytes
+        self.bytes_read = bytes_read
+        super().__init__(
+            f"{self.category}: maximum_bytes={maximum_bytes}, bytes_read={bytes_read}"
+        )
+
+
+class DigestStreamError(RuntimeError):
+    """Value-free error raised when a binary stream cannot be hashed safely."""
+
+
+def digest_asset(
+    source: bytes | BinaryIO,
+    *,
+    max_bytes: int | None = None,
+) -> AssetDigest:
+    """Return the SHA-256 hex digest and byte count for ``source``.
+
+    Binary streams are read from their current position in bounded chunks. A
+    seekable stream is restored to that position before this function returns
+    or raises, and caller-owned streams are never closed.
+    """
+
+    if max_bytes is not None and (type(max_bytes) is not int or max_bytes < 0):
+        raise ValueError("max_bytes must be a non-negative integer or None")
+
+    if isinstance(source, bytes):
+        byte_count = len(source)
+        _check_limit(byte_count, max_bytes)
+        return AssetDigest(hashlib.sha256(source).hexdigest(), byte_count)
+
+    read = getattr(source, "read", None)
+    if not callable(read):
+        raise TypeError("source must be bytes or a binary stream")
+
+    initial_position = _stream_position(source)
+    digest = hashlib.sha256()
+    byte_count = 0
+    try:
+        while True:
+            request_bytes = _CHUNK_BYTES
+            if max_bytes is not None:
+                request_bytes = min(request_bytes, max_bytes - byte_count + 1)
+            chunk = _read_chunk(read, request_bytes)
+            if not chunk:
+                break
+            byte_count += len(chunk)
+            _check_limit(byte_count, max_bytes)
+            digest.update(chunk)
+    finally:
+        if initial_position is not None:
+            _restore_position(source, initial_position)
+
+    return AssetDigest(digest.hexdigest(), byte_count)
+
+
+def _stream_position(stream: BinaryIO) -> int | None:
+    try:
+        return stream.tell() if stream.seekable() else None
+    except Exception:
+        return None
+
+
+def _read_chunk(read: Callable[[int], bytes], request_bytes: int) -> bytes:
+    try:
+        chunk = read(request_bytes)
+    except Exception:
+        pass
+    else:
+        if isinstance(chunk, bytes) and len(chunk) <= request_bytes:
+            return chunk
+        raise DigestStreamError("digest_stream_contract_error")
+    raise DigestStreamError("digest_stream_read_error")
+
+
+def _restore_position(stream: BinaryIO, position: int) -> None:
+    try:
+        stream.seek(position)
+    except Exception:
+        pass
+    else:
+        return
+    raise DigestStreamError("digest_stream_restore_error")
+
+
+def _check_limit(byte_count: int, max_bytes: int | None) -> None:
+    if max_bytes is not None and byte_count > max_bytes:
+        raise DigestLimitExceededError(
+            maximum_bytes=max_bytes,
+            bytes_read=byte_count,
+        )

--- a/openmed/multimodal/digest.py
+++ b/openmed/multimodal/digest.py
@@ -16,12 +16,22 @@ __all__ = [
 _CHUNK_BYTES = 1024 * 1024
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class AssetDigest:
     """SHA-256 hex digest and the number of bytes hashed."""
 
     sha256: str
     byte_count: int
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.sha256) is not str
+            or len(self.sha256) != 64
+            or any(character not in "0123456789abcdef" for character in self.sha256)
+        ):
+            raise ValueError("sha256 must be a lowercase hexadecimal digest")
+        if type(self.byte_count) is not int or self.byte_count < 0:
+            raise ValueError("byte_count must be a non-negative integer")
 
 
 class DigestLimitExceededError(ValueError):
@@ -87,10 +97,19 @@ def digest_asset(
 
 
 def _stream_position(stream: BinaryIO) -> int | None:
-    try:
-        return stream.tell() if stream.seekable() else None
-    except Exception:
+    seekable = getattr(stream, "seekable", None)
+    if not callable(seekable):
         return None
+    try:
+        if not seekable():
+            return None
+        position = stream.tell()
+    except Exception:
+        pass
+    else:
+        if type(position) is int and position >= 0:
+            return position
+    raise DigestStreamError("digest_stream_position_error")
 
 
 def _read_chunk(read: Callable[[int], bytes], request_bytes: int) -> bytes:

--- a/tests/unit/multimodal/test_digest.py
+++ b/tests/unit/multimodal/test_digest.py
@@ -6,6 +6,7 @@ import io
 import pytest
 
 from openmed.multimodal.digest import (
+    AssetDigest,
     DigestLimitExceededError,
     DigestStreamError,
     digest_asset,
@@ -88,6 +89,45 @@ def test_digest_stream_error_does_not_expose_underlying_details() -> None:
     assert str(raised.value) == "digest_stream_read_error"
     assert raised.value.__cause__ is None
     assert raised.value.__context__ is None
+
+
+def test_seekable_stream_position_failure_is_categorical_and_prevents_read() -> None:
+    class BrokenPositionStream(NonSeekableStream):
+        def seekable(self) -> bool:
+            return True
+
+        def tell(self) -> int:
+            raise OSError("/private/patient-name.dcm")
+
+    stream = BrokenPositionStream(b"secret bytes")
+
+    with pytest.raises(
+        DigestStreamError,
+        match="digest_stream_position_error",
+    ) as raised:
+        digest_asset(stream)
+
+    assert stream.read_sizes == []
+    assert "patient-name" not in str(raised.value)
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+
+
+@pytest.mark.parametrize(
+    ("sha256", "byte_count"),
+    [
+        ("A" * 64, 0),
+        ("a" * 63, 0),
+        ("a" * 64, -1),
+        ("a" * 64, True),
+    ],
+)
+def test_asset_digest_rejects_inconsistent_public_values(
+    sha256: str,
+    byte_count: object,
+) -> None:
+    with pytest.raises(ValueError):
+        AssetDigest(sha256=sha256, byte_count=byte_count)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("max_bytes", [-1, True, 1.5])

--- a/tests/unit/multimodal/test_digest.py
+++ b/tests/unit/multimodal/test_digest.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import hashlib
+import io
+
+import pytest
+
+from openmed.multimodal.digest import (
+    DigestLimitExceededError,
+    DigestStreamError,
+    digest_asset,
+)
+
+
+class NonSeekableStream:
+    def __init__(self, payload: bytes) -> None:
+        self._stream = io.BytesIO(payload)
+        self.closed = False
+        self.read_sizes: list[int] = []
+
+    def seekable(self) -> bool:
+        return False
+
+    def read(self, size: int) -> bytes:
+        self.read_sizes.append(size)
+        return self._stream.read(size)
+
+
+@pytest.mark.parametrize("payload", [b"", b"openmed"])
+def test_digest_bytes_matches_hashlib(payload: bytes) -> None:
+    result = digest_asset(payload)
+
+    assert result.sha256 == hashlib.sha256(payload).hexdigest()
+    assert result.byte_count == len(payload)
+
+
+def test_digest_seekable_stream_restores_position_without_closing() -> None:
+    payload = b"prefix-payload"
+    stream = io.BytesIO(payload)
+    stream.seek(len(b"prefix-"))
+
+    result = digest_asset(stream)
+
+    assert result.sha256 == hashlib.sha256(b"payload").hexdigest()
+    assert result.byte_count == len(b"payload")
+    assert stream.tell() == len(b"prefix-")
+    assert not stream.closed
+
+
+def test_digest_non_seekable_multichunk_stream_uses_bounded_reads() -> None:
+    payload = b"x" * (2 * 1024 * 1024 + 7)
+    stream = NonSeekableStream(payload)
+
+    result = digest_asset(stream)
+
+    assert result.sha256 == hashlib.sha256(payload).hexdigest()
+    assert result.byte_count == len(payload)
+    assert max(stream.read_sizes) == 1024 * 1024
+    assert len(stream.read_sizes) == 4
+    assert not stream.closed
+
+
+def test_digest_limit_reads_only_one_byte_past_limit_and_restores_position() -> None:
+    sensitive = b"patient-name-at-/private/scan.dcm"
+    stream = io.BytesIO(sensitive)
+    stream.seek(3)
+
+    with pytest.raises(DigestLimitExceededError) as raised:
+        digest_asset(stream, max_bytes=5)
+
+    assert raised.value.maximum_bytes == 5
+    assert raised.value.bytes_read == 6
+    assert str(raised.value) == ("digest_size_limit: maximum_bytes=5, bytes_read=6")
+    assert "patient" not in str(raised.value)
+    assert "scan.dcm" not in str(raised.value)
+    assert stream.tell() == 3
+    assert not stream.closed
+
+
+def test_digest_stream_error_does_not_expose_underlying_details() -> None:
+    class BrokenStream(NonSeekableStream):
+        def read(self, size: int) -> bytes:
+            raise OSError("/private/patient-name.dcm contains secret bytes")
+
+    with pytest.raises(DigestStreamError) as raised:
+        digest_asset(BrokenStream(b""))
+
+    assert str(raised.value) == "digest_stream_read_error"
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+
+
+@pytest.mark.parametrize("max_bytes", [-1, True, 1.5])
+def test_digest_rejects_invalid_limits(max_bytes: object) -> None:
+    with pytest.raises(ValueError, match="max_bytes"):
+        digest_asset(b"", max_bytes=max_bytes)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Add bounded SHA-256 hashing for bytes and binary streams.
- Process streams in fixed 1 MiB chunks.
- Return the digest and total byte count.
- Support an optional hard byte limit.
- Restore seekable streams without closing them.
- Prevent sensitive information from leaking through errors.
- Document the helper and its guarantees.

## Testing

- 9 focused tests passed.
- 289 multimodal tests passed, 21 skipped.
- Ruff lint and formatting checks passed.

Closes #2979
