### PR TITLE
feat(multimodal): add stable abstention reason codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added strict, deterministic multimodal abstention records with typed pipeline
+  stages, stable reason codes, metadata-only JSON, and value-free validation
+  failures (#2977).
 - Added a deterministic Jupyter notebook cell redaction helper that preserves
   code sources and execution structure, applies explicit markdown and output
   policies, removes unredacted binary MIME data, and emits counts-only,

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -204,6 +204,7 @@ classification:
     - reference/preference-schema.md
     - multimodal/pdf-reading-order.md
     - multimodal/pdf-redaction-fidelity.md
+    - multimodal/abstention-reasons.md
     - multimodal/email-ingestion.md
     - multimodal/epub-extraction.md
     - multimodal/xlsx-cell-redaction.md

--- a/docs/multimodal/abstention-reasons.md
+++ b/docs/multimodal/abstention-reasons.md
@@ -1,0 +1,55 @@
+# Multimodal Abstention Reasons
+
+Image, document, waveform, and audio pipelines should explain why processing
+stopped without copying source content into logs or audit artifacts. Use
+`AbstentionRecord` for that boundary. Its serialized form contains only a
+schema version, a pipeline stage, and a stable reason code.
+
+```python
+from openmed.multimodal.abstention import (
+    AbstentionReason,
+    AbstentionRecord,
+    AbstentionStage,
+)
+
+record = AbstentionRecord(
+    stage=AbstentionStage.INFERENCE,
+    reason=AbstentionReason.PHI_UNCERTAINTY,
+)
+print(record.to_json())
+```
+
+```json
+{"schema_version":1,"stage":"inference","reason":"phi_uncertainty"}
+```
+
+There is intentionally no message or context field. Do not add OCR text,
+transcripts, pixel data, DICOM values, paths, URLs, prompts, or provider error
+text beside this record. Keep operational detail in a separate private system
+whose retention and access policy is appropriate for PHI.
+
+## Stages and allowed reasons
+
+| Stage | Allowed reason codes |
+| --- | --- |
+| `preflight` | `unsupported_media`, `resource_limit`, `provider_unavailable` |
+| `decode` | `malformed_media`, `resource_limit`, `low_quality` |
+| `inference` | `resource_limit`, `low_quality`, `phi_uncertainty`, `speaker_uncertainty`, `temporal_instability`, `provider_unavailable` |
+| `post_process` | `resource_limit`, `low_quality`, `phi_uncertainty`, `speaker_uncertainty`, `temporal_instability` |
+
+Use the earliest stage that can make the decision. For example, reject an
+unsupported container during preflight and malformed bytes during decode.
+Low-quality output belongs to decode, inference, or post-processing depending
+on where the measurable quality gate runs.
+
+## Strict parsing
+
+`AbstentionRecord.from_json()` requires exactly these fields:
+
+- `schema_version`: currently `1`
+- `stage`: one documented stage
+- `reason`: one reason allowed for that stage
+
+Unknown fields, unknown values, malformed JSON, unsupported schema versions,
+and invalid stage-reason pairs fail closed. Validation errors name the failed
+part of the contract but never echo the submitted value.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
       - Preference Pair Schema: reference/preference-schema.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md
+      - Multimodal Abstention Reasons: multimodal/abstention-reasons.md
       - Email Ingestion and Redaction: multimodal/email-ingestion.md
       - EPUB Extraction: multimodal/epub-extraction.md
       - XLSX Cell Redaction: multimodal/xlsx-cell-redaction.md

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -28,6 +28,13 @@ from . import documents_docx as _documents_docx
 from . import documents_html as _documents_html
 from . import documents_markdown as _documents_markdown
 from . import pptx as _pptx
+from .abstention import (
+    ABSTENTION_SCHEMA_VERSION,
+    AbstentionReason,
+    AbstentionRecord,
+    AbstentionStage,
+    AbstentionValidationError,
+)
 from .base import (
     ExtractedDocument,
     SourceSpan,
@@ -246,6 +253,11 @@ from .verify_pdf import (
 from .xlsx import XlsxCellRedaction, XlsxRedactionResult, redact_xlsx
 
 __all__ = [
+    "ABSTENTION_SCHEMA_VERSION",
+    "AbstentionReason",
+    "AbstentionRecord",
+    "AbstentionStage",
+    "AbstentionValidationError",
     "ExtractedDocument",
     "SourceSpan",
     "redact_document",

--- a/openmed/multimodal/abstention.py
+++ b/openmed/multimodal/abstention.py
@@ -1,0 +1,184 @@
+"""Stable, metadata-only abstention records for multimodal pipelines.
+
+The boundary in this module deliberately accepts only a stage and a reason
+code.  It has no free-text field, so callers cannot accidentally serialize OCR
+text, transcripts, DICOM values, file paths, URLs, or model prompts while
+explaining why processing stopped.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Final
+
+__all__ = [
+    "ABSTENTION_SCHEMA_VERSION",
+    "AbstentionReason",
+    "AbstentionRecord",
+    "AbstentionStage",
+    "AbstentionValidationError",
+]
+
+
+ABSTENTION_SCHEMA_VERSION: Final = 1
+
+
+class AbstentionValidationError(ValueError):
+    """Raised when an abstention record fails strict, PHI-safe validation."""
+
+
+class AbstentionStage(str, Enum):
+    """Pipeline stage at which multimodal processing stopped."""
+
+    PREFLIGHT = "preflight"
+    DECODE = "decode"
+    INFERENCE = "inference"
+    POST_PROCESS = "post_process"
+
+
+class AbstentionReason(str, Enum):
+    """Stable reason why a multimodal pipeline declined to continue."""
+
+    UNSUPPORTED_MEDIA = "unsupported_media"
+    MALFORMED_MEDIA = "malformed_media"
+    RESOURCE_LIMIT = "resource_limit"
+    LOW_QUALITY = "low_quality"
+    PHI_UNCERTAINTY = "phi_uncertainty"
+    SPEAKER_UNCERTAINTY = "speaker_uncertainty"
+    TEMPORAL_INSTABILITY = "temporal_instability"
+    PROVIDER_UNAVAILABLE = "provider_unavailable"
+
+
+_ALLOWED_REASONS: Final = {
+    AbstentionStage.PREFLIGHT: frozenset(
+        {
+            AbstentionReason.UNSUPPORTED_MEDIA,
+            AbstentionReason.RESOURCE_LIMIT,
+            AbstentionReason.PROVIDER_UNAVAILABLE,
+        }
+    ),
+    AbstentionStage.DECODE: frozenset(
+        {
+            AbstentionReason.MALFORMED_MEDIA,
+            AbstentionReason.RESOURCE_LIMIT,
+            AbstentionReason.LOW_QUALITY,
+        }
+    ),
+    AbstentionStage.INFERENCE: frozenset(
+        {
+            AbstentionReason.RESOURCE_LIMIT,
+            AbstentionReason.LOW_QUALITY,
+            AbstentionReason.PHI_UNCERTAINTY,
+            AbstentionReason.SPEAKER_UNCERTAINTY,
+            AbstentionReason.TEMPORAL_INSTABILITY,
+            AbstentionReason.PROVIDER_UNAVAILABLE,
+        }
+    ),
+    AbstentionStage.POST_PROCESS: frozenset(
+        {
+            AbstentionReason.RESOURCE_LIMIT,
+            AbstentionReason.LOW_QUALITY,
+            AbstentionReason.PHI_UNCERTAINTY,
+            AbstentionReason.SPEAKER_UNCERTAINTY,
+            AbstentionReason.TEMPORAL_INSTABILITY,
+        }
+    ),
+}
+
+_REQUIRED_FIELDS: Final = frozenset({"schema_version", "stage", "reason"})
+
+
+def _stage(value: object) -> AbstentionStage:
+    try:
+        return AbstentionStage(value)
+    except Exception:
+        raise AbstentionValidationError("stage is unsupported") from None
+
+
+def _reason(value: object) -> AbstentionReason:
+    try:
+        return AbstentionReason(value)
+    except Exception:
+        raise AbstentionValidationError("reason is unsupported") from None
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    fields = dict(pairs)
+    if len(fields) != len(pairs):
+        raise AbstentionValidationError("payload fields are invalid")
+    return fields
+
+
+@dataclass(frozen=True, slots=True)
+class AbstentionRecord:
+    """A deterministic explanation that contains no source-media content.
+
+    Args:
+        stage: Pipeline stage at which processing stopped.
+        reason: Stable reason code valid for that stage.
+        schema_version: Serialization contract version. Only version 1 is
+            currently accepted.
+    """
+
+    stage: AbstentionStage
+    reason: AbstentionReason
+    schema_version: int = ABSTENTION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        stage = _stage(self.stage)
+        reason = _reason(self.reason)
+        if type(self.schema_version) is not int or (
+            self.schema_version != ABSTENTION_SCHEMA_VERSION
+        ):
+            raise AbstentionValidationError("schema_version is unsupported")
+        if reason not in _ALLOWED_REASONS[stage]:
+            raise AbstentionValidationError("reason is not valid for stage")
+        object.__setattr__(self, "stage", stage)
+        object.__setattr__(self, "reason", reason)
+
+    def to_dict(self) -> dict[str, int | str]:
+        """Return the fixed-shape metadata-only representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "stage": self.stage.value,
+            "reason": self.reason.value,
+        }
+
+    def to_json(self) -> str:
+        """Serialize with deterministic key order and no insignificant space."""
+
+        return json.dumps(self.to_dict(), ensure_ascii=True, separators=(",", ":"))
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "AbstentionRecord":
+        """Parse a strict mapping without reflecting submitted values."""
+
+        if not isinstance(payload, Mapping):
+            raise AbstentionValidationError("payload must be an object")
+        try:
+            fields = dict(payload)
+        except Exception:
+            raise AbstentionValidationError("payload could not be read") from None
+        if frozenset(fields) != _REQUIRED_FIELDS:
+            raise AbstentionValidationError("payload fields are invalid")
+        return cls(
+            schema_version=fields["schema_version"],
+            stage=fields["stage"],
+            reason=fields["reason"],
+        )
+
+    @classmethod
+    def from_json(cls, payload: str | bytes | bytearray) -> "AbstentionRecord":
+        """Parse strict JSON without including rejected content in errors."""
+
+        try:
+            parsed = json.loads(payload, object_pairs_hook=_strict_object)
+        except AbstentionValidationError:
+            raise
+        except Exception:
+            raise AbstentionValidationError("payload is not valid JSON") from None
+        return cls.from_dict(parsed)

--- a/tests/unit/multimodal/test_abstention.py
+++ b/tests/unit/multimodal/test_abstention.py
@@ -1,0 +1,127 @@
+"""Tests for PHI-safe multimodal abstention records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.multimodal.abstention import (
+    AbstentionReason,
+    AbstentionRecord,
+    AbstentionStage,
+)
+
+VALID_RECORDS = (
+    (AbstentionStage.PREFLIGHT, AbstentionReason.UNSUPPORTED_MEDIA),
+    (AbstentionStage.PREFLIGHT, AbstentionReason.RESOURCE_LIMIT),
+    (AbstentionStage.PREFLIGHT, AbstentionReason.PROVIDER_UNAVAILABLE),
+    (AbstentionStage.DECODE, AbstentionReason.MALFORMED_MEDIA),
+    (AbstentionStage.DECODE, AbstentionReason.RESOURCE_LIMIT),
+    (AbstentionStage.DECODE, AbstentionReason.LOW_QUALITY),
+    (AbstentionStage.INFERENCE, AbstentionReason.RESOURCE_LIMIT),
+    (AbstentionStage.INFERENCE, AbstentionReason.LOW_QUALITY),
+    (AbstentionStage.INFERENCE, AbstentionReason.PHI_UNCERTAINTY),
+    (AbstentionStage.INFERENCE, AbstentionReason.SPEAKER_UNCERTAINTY),
+    (AbstentionStage.INFERENCE, AbstentionReason.TEMPORAL_INSTABILITY),
+    (AbstentionStage.INFERENCE, AbstentionReason.PROVIDER_UNAVAILABLE),
+    (AbstentionStage.POST_PROCESS, AbstentionReason.RESOURCE_LIMIT),
+    (AbstentionStage.POST_PROCESS, AbstentionReason.LOW_QUALITY),
+    (AbstentionStage.POST_PROCESS, AbstentionReason.PHI_UNCERTAINTY),
+    (AbstentionStage.POST_PROCESS, AbstentionReason.SPEAKER_UNCERTAINTY),
+    (AbstentionStage.POST_PROCESS, AbstentionReason.TEMPORAL_INSTABILITY),
+)
+
+INVALID_RECORDS = tuple(
+    (stage, reason)
+    for stage in AbstentionStage
+    for reason in AbstentionReason
+    if (stage, reason) not in VALID_RECORDS
+)
+
+
+@pytest.mark.parametrize(("stage", "reason"), VALID_RECORDS)
+def test_every_stage_and_reason_round_trips(
+    stage: AbstentionStage,
+    reason: AbstentionReason,
+) -> None:
+    record = AbstentionRecord(stage=stage, reason=reason)
+
+    assert AbstentionRecord.from_json(record.to_json()) == record
+
+
+def test_json_is_deterministic_and_metadata_only() -> None:
+    record = AbstentionRecord(
+        stage=AbstentionStage.PREFLIGHT,
+        reason=AbstentionReason.UNSUPPORTED_MEDIA,
+    )
+
+    assert record.to_json() == (
+        '{"schema_version":1,"stage":"preflight","reason":"unsupported_media"}'
+    )
+    assert set(json.loads(record.to_json())) == {
+        "schema_version",
+        "stage",
+        "reason",
+    }
+
+
+@pytest.mark.parametrize(
+    ("stage", "reason"),
+    INVALID_RECORDS,
+)
+def test_invalid_stage_reason_combinations_fail_closed(
+    stage: AbstentionStage,
+    reason: AbstentionReason,
+) -> None:
+    with pytest.raises(ValueError, match="reason is not valid for stage"):
+        AbstentionRecord(stage=stage, reason=reason)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {
+            "schema_version": 1,
+            "stage": "secret-stage-raw-ocr-text",
+            "reason": "unsupported_media",
+        },
+        {
+            "schema_version": 1,
+            "stage": "preflight",
+            "reason": "secret-reason-dicom-value",
+        },
+        {
+            "schema_version": 1,
+            "stage": "preflight",
+            "reason": "unsupported_media",
+            "transcript": "secret-transcript",
+        },
+    ),
+)
+def test_invalid_payloads_do_not_echo_submitted_content(payload: object) -> None:
+    submitted = json.dumps(payload)
+
+    with pytest.raises(ValueError) as exc_info:
+        AbstentionRecord.from_json(submitted)
+
+    assert "secret" not in str(exc_info.value)
+    assert "raw-ocr-text" not in str(exc_info.value)
+    assert "dicom-value" not in str(exc_info.value)
+    assert "secret-transcript" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        "not-json",
+        "[]",
+        '{"schema_version":1,"stage":"preflight","stage":"decode",'
+        '"reason":"unsupported_media"}',
+        '{"schema_version":2,"stage":"preflight","reason":"unsupported_media"}',
+        '{"schema_version":1,"stage":"preflight"}',
+    ),
+)
+def test_malformed_or_incomplete_payloads_fail_closed(payload: str) -> None:
+    with pytest.raises(ValueError):
+        AbstentionRecord.from_json(payload)

--- a/tests/unit/multimodal/test_abstention.py
+++ b/tests/unit/multimodal/test_abstention.py
@@ -40,6 +40,28 @@ INVALID_RECORDS = tuple(
 )
 
 
+def test_abstention_contract_is_available_from_public_multimodal_api() -> None:
+    from openmed.multimodal import (
+        ABSTENTION_SCHEMA_VERSION,
+        AbstentionValidationError,
+    )
+    from openmed.multimodal import (
+        AbstentionReason as PublicReason,
+    )
+    from openmed.multimodal import (
+        AbstentionRecord as PublicRecord,
+    )
+    from openmed.multimodal import (
+        AbstentionStage as PublicStage,
+    )
+
+    assert ABSTENTION_SCHEMA_VERSION == 1
+    assert PublicReason is AbstentionReason
+    assert PublicRecord is AbstentionRecord
+    assert PublicStage is AbstentionStage
+    assert issubclass(AbstentionValidationError, ValueError)
+
+
 @pytest.mark.parametrize(("stage", "reason"), VALID_RECORDS)
 def test_every_stage_and_reason_round_trips(
     stage: AbstentionStage,


### PR DESCRIPTION
## Description

Add strict, metadata-only abstention records for image, document, waveform,
and audio pipelines. The record contains only a schema version, pipeline stage,
and stable reason code, so it cannot carry source media or free-text PHI.

Closes #2977.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add four typed pipeline stages and eight stable abstention reason codes.
- Validate all 17 supported stage-reason combinations and reject the other 15.
- Add deterministic, strict JSON parsing with duplicate-key and unknown-field rejection.
- Ensure validation failures never reflect submitted OCR, transcript, DICOM, path, URL, or prompt content.
- Document the schema and register the page in the navigation and publication contract.

## Testing

- [x] I have added tests that prove the feature works
- [x] New and relevant existing unit tests pass locally
- [ ] I have tested this change with different models/inputs — not applicable

Commands:

- `uv run --frozen --extra dev python -m pytest tests/unit/multimodal/test_abstention.py -q` — 41 passed
- Documentation publication checks — passed
- `make lint` — passed
- `make type-check` — passed
- `make format-check` — passed
- `mkdocs build --strict` — passed

A full repository run completed with 13,674 passed and 135 skipped. The remaining
self-referential-symlink failure reproduces unchanged on `origin/master`.

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran the repository lint, type-check, and format-check gates
- [x] I performed a self-review
- [x] The focused diff received an independent code review
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] The change is focused on one issue

## Related Issues

Closes #2977

## Screenshots/Examples

```json
{"schema_version":1,"stage":"inference","reason":"phi_uncertainty"}
```