### PR TITLE
feat(clinical): add value-free evidence tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added deterministic clinical evidence tables with source offsets, controlled
+  assertion and review metadata, optional protected-value hashes, and
+  value-free JSON and Markdown rendering (#2567).
 - Added a deterministic Jupyter notebook cell redaction helper that preserves
   code sources and execution structure, applies explicit markdown and output
   policies, removes unredacted binary MIME data, and emits counts-only,

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -172,6 +172,7 @@ classification:
     - clinical/terminology-provenance.md
     - clinical/consent-cache.md
     - clinical/timeline-provenance.md
+    - clinical/evidence-tables.md
     - clinical/chinese-terminology-grounding.md
     - chinese-segmentation-operations.md
     - clinical/multilingual-relations.md

--- a/docs/clinical/evidence-tables.md
+++ b/docs/clinical/evidence-tables.md
@@ -1,0 +1,82 @@
+# Clinical Evidence Tables
+
+Clinical evidence tables provide a compact, deterministic review view without
+exporting note text or extracted values. Each row contains only half-open source
+offsets, a controlled assertion state, confidence, a review flag, and an
+optional SHA-256 digest.
+
+The table is a review aid. It is not a clinical decision, compliance
+certification, or guarantee that an extraction is correct.
+
+## Build typed records
+
+```python
+from openmed.clinical.evidence_table import (
+    AssertionStatus,
+    EvidenceRecord,
+    EvidenceTable,
+)
+
+records = [
+    EvidenceRecord.from_extraction(
+        source_start=12,
+        source_end=29,
+        assertion_status=AssertionStatus.AFFIRMED,
+        confidence=0.94,
+        review_required=False,
+    ),
+    EvidenceRecord.from_extraction(
+        source_start=44,
+        source_end=58,
+        assertion_status=AssertionStatus.UNCERTAIN,
+        confidence=0.61,
+        review_required=True,
+    ),
+]
+
+table = EvidenceTable.from_records(records)
+print(table.to_json())
+print(table.to_markdown())
+```
+
+Records are sorted by source offsets and safe metadata before rendering. JSON
+includes deterministic assertion and review counts plus the ordered records.
+Markdown uses the same ordering and represents absent value hashes as
+`omitted`.
+
+## Protected values are omitted by default
+
+`protected_value` is accepted only by `EvidenceRecord.from_extraction()` and is
+never stored on the returned object. Without an explicit opt-in, it is omitted:
+
+```python
+record = EvidenceRecord.from_extraction(
+    source_start=12,
+    source_end=29,
+    assertion_status=AssertionStatus.AFFIRMED,
+    confidence=0.94,
+    review_required=False,
+    protected_value="synthetic finding",
+)
+
+assert record.value_hash is None
+```
+
+Set `include_value_hash=True` when a stable comparison token is needed. The
+record then stores only `sha256:<hex>` and discards the raw input after hashing.
+SHA-256 does not make a low-entropy value anonymous; do not publish hashes when
+dictionary attacks are plausible. Prefer omission unless the review workflow
+has a documented need for correlation.
+
+## Validation contract
+
+- Offsets must be non-negative and form a non-empty half-open span.
+- Assertion status must be one of `affirmed`, `negated`, `uncertain`,
+  `historical`, `hypothetical`, or `unknown`.
+- Confidence must be finite and between `0` and `1`.
+- `review_required` must be a boolean.
+- A supplied hash must match `sha256:` followed by 64 lowercase hex digits.
+
+Validation errors identify the invalid field without including the submitted
+value. The module uses only the Python standard library and performs no network
+calls.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
       - Terminology Snapshot Provenance: clinical/terminology-provenance.md
       - Consent Cache Invalidation: clinical/consent-cache.md
       - Clinical Timeline Provenance: clinical/timeline-provenance.md
+      - Clinical Evidence Tables: clinical/evidence-tables.md
       - Chinese Terminology Grounding: clinical/chinese-terminology-grounding.md
       - Chinese Segmentation Operations: chinese-segmentation-operations.md
       - Multilingual Clinical Relations: clinical/multilingual-relations.md

--- a/openmed/clinical/evidence_table.py
+++ b/openmed/clinical/evidence_table.py
@@ -17,7 +17,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Final, Iterable
 
-__all__ = ["AssertionStatus", "EvidenceRecord", "EvidenceTable"]
+__all__ = [
+    "EVIDENCE_TABLE_DISCLAIMER",
+    "EVIDENCE_TABLE_SCHEMA_VERSION",
+    "AssertionStatus",
+    "EvidenceRecord",
+    "EvidenceTable",
+]
 
 
 EVIDENCE_TABLE_SCHEMA_VERSION: Final = 1
@@ -189,6 +195,7 @@ class EvidenceTable:
             allow_nan=False,
             ensure_ascii=True,
             separators=(",", ":"),
+            sort_keys=True,
         )
 
     def to_markdown(self) -> str:

--- a/openmed/clinical/evidence_table.py
+++ b/openmed/clinical/evidence_table.py
@@ -1,0 +1,289 @@
+"""Deterministic, value-free clinical evidence tables for review.
+
+This module retains only source offsets, controlled assertion states,
+confidence, review flags, and optional SHA-256 digests. Raw extracted values
+never enter an :class:`EvidenceRecord`, so JSON, Markdown, representations, and
+validation errors cannot disclose them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Final, Iterable
+
+__all__ = ["AssertionStatus", "EvidenceRecord", "EvidenceTable"]
+
+
+EVIDENCE_TABLE_SCHEMA_VERSION: Final = 1
+EVIDENCE_TABLE_DISCLAIMER: Final = (
+    "Clinical evidence tables are value-free review aids, not clinical "
+    "decisions or compliance certifications."
+)
+
+_VALUE_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class AssertionStatus(str, Enum):
+    """Controlled assertion states retained in evidence tables."""
+
+    AFFIRMED = "affirmed"
+    NEGATED = "negated"
+    UNCERTAIN = "uncertain"
+    HISTORICAL = "historical"
+    HYPOTHETICAL = "hypothetical"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRecord:
+    """Value-free metadata for one extracted clinical finding.
+
+    Use :meth:`from_extraction` when a protected source value is available.
+    The value is omitted by default; opt-in hashing computes a digest before
+    the immutable record is constructed, so the raw value is never stored.
+    """
+
+    source_start: int
+    source_end: int
+    assertion_status: AssertionStatus
+    confidence: float
+    review_required: bool
+    value_hash: str | None = None
+
+    def __post_init__(self) -> None:
+        start, end = _source_offsets(self.source_start, self.source_end)
+        object.__setattr__(self, "source_start", start)
+        object.__setattr__(self, "source_end", end)
+        object.__setattr__(
+            self,
+            "assertion_status",
+            _assertion_status(self.assertion_status),
+        )
+        object.__setattr__(self, "confidence", _confidence(self.confidence))
+        if type(self.review_required) is not bool:
+            raise TypeError("review_required must be a boolean")
+        if self.value_hash is not None:
+            object.__setattr__(self, "value_hash", _value_hash(self.value_hash))
+
+    @classmethod
+    def from_extraction(
+        cls,
+        *,
+        source_start: object,
+        source_end: object,
+        assertion_status: object,
+        confidence: object,
+        review_required: object,
+        protected_value: str | bytes | None = None,
+        include_value_hash: bool = False,
+    ) -> "EvidenceRecord":
+        """Build a record while hashing or omitting a protected value.
+
+        Args:
+            source_start: Inclusive character offset in the source document.
+            source_end: Exclusive character offset in the source document.
+            assertion_status: One controlled :class:`AssertionStatus` value.
+            confidence: Finite probability in the closed interval ``[0, 1]``.
+            review_required: Whether a reviewer must inspect this finding.
+            protected_value: Optional raw extracted value. It is never stored.
+            include_value_hash: Hash ``protected_value`` when ``True``;
+                otherwise omit it.
+        """
+
+        if type(include_value_hash) is not bool:
+            raise TypeError("include_value_hash must be a boolean")
+        value_hash = None
+        if include_value_hash:
+            if protected_value is None:
+                raise ValueError("protected value is required for hashing")
+            value_hash = _hash_protected_value(protected_value)
+        start, end = _source_offsets(source_start, source_end)
+        status = _assertion_status(assertion_status)
+        normalized_confidence = _confidence(confidence)
+        if not isinstance(review_required, bool):
+            raise TypeError("review_required must be a boolean")
+        return cls(
+            source_start=start,
+            source_end=end,
+            assertion_status=status,
+            confidence=normalized_confidence,
+            review_required=review_required,
+            value_hash=value_hash,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic mapping containing no raw clinical value."""
+
+        payload: dict[str, Any] = {
+            "source_offsets": {
+                "start": self.source_start,
+                "end": self.source_end,
+            },
+            "assertion_status": self.assertion_status.value,
+            "confidence": self.confidence,
+            "review_required": self.review_required,
+        }
+        if self.value_hash is not None:
+            payload["value_hash"] = self.value_hash
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceTable:
+    """Deterministically sorted evidence records with JSON and Markdown views."""
+
+    records: tuple[EvidenceRecord, ...]
+    schema_version: int = EVIDENCE_TABLE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if type(self.schema_version) is not int or (
+            self.schema_version != EVIDENCE_TABLE_SCHEMA_VERSION
+        ):
+            raise ValueError("unsupported evidence table schema version")
+        records = tuple(self.records)
+        if any(type(record) is not EvidenceRecord for record in records):
+            raise TypeError("records must contain EvidenceRecord values")
+        object.__setattr__(self, "records", tuple(sorted(records, key=_record_key)))
+
+    @classmethod
+    def from_records(cls, records: Iterable[EvidenceRecord]) -> "EvidenceTable":
+        """Build a table from any finite iterable of typed records."""
+
+        return cls(records=tuple(records))
+
+    @property
+    def review_required_count(self) -> int:
+        """Return the number of records flagged for review."""
+
+        return sum(record.review_required for record in self.records)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the deterministic counts-and-offsets representation."""
+
+        counts = Counter(record.assertion_status for record in self.records)
+        assertion_counts = {
+            status.value: counts[status]
+            for status in AssertionStatus
+            if counts[status] > 0
+        }
+        return {
+            "schema_version": self.schema_version,
+            "record_count": len(self.records),
+            "review_required_count": self.review_required_count,
+            "assertion_counts": assertion_counts,
+            "records": [record.to_dict() for record in self.records],
+            "disclaimer": EVIDENCE_TABLE_DISCLAIMER,
+        }
+
+    def to_json(self) -> str:
+        """Serialize the table as compact deterministic JSON."""
+
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+        )
+
+    def to_markdown(self) -> str:
+        """Render a compact table containing offsets and safe metadata only."""
+
+        lines = [
+            "# Clinical Evidence Table",
+            "",
+            EVIDENCE_TABLE_DISCLAIMER,
+            "",
+            f"Records: {len(self.records)}",
+            f"Review required: {self.review_required_count}",
+            "",
+            "| # | Start | End | Assertion | Confidence | Review required | Value hash |",
+            "| ---: | ---: | ---: | --- | ---: | --- | --- |",
+        ]
+        for index, record in enumerate(self.records, start=1):
+            lines.append(
+                "| "
+                f"{index} | {record.source_start} | {record.source_end} | "
+                f"{record.assertion_status.value} | {record.confidence:.6f} | "
+                f"{'yes' if record.review_required else 'no'} | "
+                f"{record.value_hash or 'omitted'} |"
+            )
+        return "\n".join(lines) + "\n"
+
+
+def _source_offsets(start: object, end: object) -> tuple[int, int]:
+    if (
+        isinstance(start, bool)
+        or not isinstance(start, int)
+        or isinstance(end, bool)
+        or not isinstance(end, int)
+    ):
+        raise TypeError("source offsets must be integers")
+    try:
+        normalized_start = int(start)
+        normalized_end = int(end)
+    except Exception:
+        raise TypeError("source offsets must be integers") from None
+    if normalized_start < 0 or normalized_end <= normalized_start:
+        raise ValueError("source offsets must form a non-empty half-open span")
+    return normalized_start, normalized_end
+
+
+def _assertion_status(value: object) -> AssertionStatus:
+    try:
+        return AssertionStatus(value)
+    except Exception:
+        raise ValueError("assertion_status is unsupported") from None
+
+
+def _confidence(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError("confidence must be a real number")
+    try:
+        normalized = float(value)
+    except Exception:
+        raise TypeError("confidence must be a real number") from None
+    if not math.isfinite(normalized) or not 0.0 <= normalized <= 1.0:
+        raise ValueError("confidence must be in the closed interval [0, 1]")
+    return normalized
+
+
+def _hash_protected_value(value: str | bytes) -> str:
+    try:
+        if isinstance(value, str):
+            data = str(value).encode("utf-8")
+        elif isinstance(value, bytes):
+            data = bytes(value)
+        else:
+            raise TypeError
+    except Exception:
+        raise TypeError("protected value must be text or bytes") from None
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def _value_hash(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("value_hash is invalid")
+    try:
+        normalized = str(value)
+    except Exception:
+        raise ValueError("value_hash is invalid") from None
+    if _VALUE_HASH_RE.fullmatch(normalized) is None:
+        raise ValueError("value_hash is invalid")
+    return normalized
+
+
+def _record_key(record: EvidenceRecord) -> tuple[Any, ...]:
+    return (
+        record.source_start,
+        record.source_end,
+        record.assertion_status.value,
+        record.confidence,
+        record.review_required,
+        record.value_hash or "",
+    )

--- a/tests/unit/clinical/test_evidence_table.py
+++ b/tests/unit/clinical/test_evidence_table.py
@@ -10,6 +10,8 @@ import traceback
 import pytest
 
 from openmed.clinical.evidence_table import (
+    EVIDENCE_TABLE_DISCLAIMER,
+    EVIDENCE_TABLE_SCHEMA_VERSION,
     AssertionStatus,
     EvidenceRecord,
     EvidenceTable,
@@ -117,6 +119,16 @@ def test_json_is_compact_and_deterministic() -> None:
     assert table.to_json() == table.to_json()
     assert '": ' not in table.to_json()
     assert ', "' not in table.to_json()
+
+
+def test_json_uses_canonical_key_order_and_public_schema_constants() -> None:
+    table = EvidenceTable(records=(record(3, 7),))
+
+    assert EVIDENCE_TABLE_SCHEMA_VERSION == 1
+    assert "value-free review aids" in EVIDENCE_TABLE_DISCLAIMER
+    assert table.to_json().startswith(
+        '{"assertion_counts":{"affirmed":1},"disclaimer":'
+    )
 
 
 def test_markdown_contains_offsets_and_review_flags_without_values() -> None:

--- a/tests/unit/clinical/test_evidence_table.py
+++ b/tests/unit/clinical/test_evidence_table.py
@@ -1,0 +1,359 @@
+"""Tests for value-free clinical evidence table rendering."""
+
+from __future__ import annotations
+
+import json
+import math
+import socket
+import traceback
+
+import pytest
+
+from openmed.clinical.evidence_table import (
+    AssertionStatus,
+    EvidenceRecord,
+    EvidenceTable,
+)
+
+RAW_MARKER = "raw-phi-marker"
+
+
+class LeakyInt(int):
+    def __repr__(self) -> str:
+        return RAW_MARKER
+
+    def __format__(self, format_spec: str) -> str:
+        return RAW_MARKER
+
+
+class LeakyFloat(float):
+    def __float__(self) -> float:
+        raise RuntimeError(RAW_MARKER)
+
+
+class LeakyStr(str):
+    def __repr__(self) -> str:
+        return RAW_MARKER
+
+    def __format__(self, format_spec: str) -> str:
+        return RAW_MARKER
+
+    def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
+        raise RuntimeError(RAW_MARKER)
+
+
+class ExplodingStr(str):
+    def __str__(self) -> str:
+        raise RuntimeError(RAW_MARKER)
+
+    def __hash__(self) -> int:
+        raise RuntimeError(RAW_MARKER)
+
+
+def record(
+    start: int,
+    end: int,
+    assertion: AssertionStatus = AssertionStatus.AFFIRMED,
+    confidence: float = 0.9,
+    review_required: bool = False,
+) -> EvidenceRecord:
+    return EvidenceRecord.from_extraction(
+        source_start=start,
+        source_end=end,
+        assertion_status=assertion,
+        confidence=confidence,
+        review_required=review_required,
+    )
+
+
+def test_table_sorts_records_and_counts_review_state() -> None:
+    table = EvidenceTable(
+        records=(
+            record(20, 30, AssertionStatus.NEGATED, 0.8, True),
+            record(4, 9, AssertionStatus.AFFIRMED, 0.95),
+            record(20, 25, AssertionStatus.UNCERTAIN, 0.6, True),
+        )
+    )
+
+    payload = table.to_dict()
+
+    assert [item["source_offsets"] for item in payload["records"]] == [
+        {"start": 4, "end": 9},
+        {"start": 20, "end": 25},
+        {"start": 20, "end": 30},
+    ]
+    assert payload["record_count"] == 3
+    assert payload["review_required_count"] == 2
+    assert payload["assertion_counts"] == {
+        "affirmed": 1,
+        "negated": 1,
+        "uncertain": 1,
+    }
+
+
+def test_json_is_compact_and_deterministic() -> None:
+    table = EvidenceTable(records=(record(3, 7),))
+
+    expected = {
+        "schema_version": 1,
+        "record_count": 1,
+        "review_required_count": 0,
+        "assertion_counts": {"affirmed": 1},
+        "records": [
+            {
+                "source_offsets": {"start": 3, "end": 7},
+                "assertion_status": "affirmed",
+                "confidence": 0.9,
+                "review_required": False,
+            }
+        ],
+        "disclaimer": (
+            "Clinical evidence tables are value-free review aids, not clinical "
+            "decisions or compliance certifications."
+        ),
+    }
+
+    assert json.loads(table.to_json()) == expected
+    assert table.to_json() == table.to_json()
+    assert '": ' not in table.to_json()
+    assert ', "' not in table.to_json()
+
+
+def test_markdown_contains_offsets_and_review_flags_without_values() -> None:
+    table = EvidenceTable(
+        records=(
+            record(1, 5, review_required=True),
+            record(8, 13, AssertionStatus.HISTORICAL, 0.75),
+        )
+    )
+
+    markdown = table.to_markdown()
+
+    assert "| 1 | 1 | 5 | affirmed | 0.900000 | yes | omitted |" in markdown
+    assert "| 2 | 8 | 13 | historical | 0.750000 | no | omitted |" in markdown
+    assert "Records: 2" in markdown
+    assert "Review required: 1" in markdown
+
+
+def test_protected_value_hashing_is_opt_in_and_never_stores_raw_value() -> None:
+    protected_value = "synthetic-sensitive-finding"
+
+    omitted = EvidenceRecord.from_extraction(
+        source_start=1,
+        source_end=5,
+        assertion_status=AssertionStatus.AFFIRMED,
+        confidence=0.9,
+        review_required=False,
+        protected_value=protected_value,
+    )
+    hashed = EvidenceRecord.from_extraction(
+        source_start=1,
+        source_end=5,
+        assertion_status=AssertionStatus.AFFIRMED,
+        confidence=0.9,
+        review_required=False,
+        protected_value=protected_value,
+        include_value_hash=True,
+    )
+
+    assert omitted.value_hash is None
+    assert hashed.value_hash is not None
+    assert hashed.value_hash.startswith("sha256:")
+    rendered = EvidenceTable(records=(omitted, hashed)).to_json()
+    assert protected_value not in rendered
+    assert protected_value not in repr(omitted)
+    assert protected_value not in repr(hashed)
+
+
+def test_hashing_requires_a_protected_value_without_echoing_other_fields() -> None:
+    with pytest.raises(ValueError, match="protected value is required"):
+        EvidenceRecord.from_extraction(
+            source_start=1,
+            source_end=5,
+            assertion_status=AssertionStatus.AFFIRMED,
+            confidence=0.9,
+            review_required=False,
+            include_value_hash=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    ((-1, 2), (2, 2), (4, 3), (True, 2), (1, False)),
+)
+def test_invalid_offsets_fail_closed(start: object, end: object) -> None:
+    with pytest.raises((TypeError, ValueError), match="source offsets"):
+        EvidenceRecord.from_extraction(
+            source_start=start,
+            source_end=end,
+            assertion_status=AssertionStatus.AFFIRMED,
+            confidence=0.9,
+            review_required=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "confidence",
+    (-0.01, 1.01, math.nan, math.inf, True, "secret-confidence"),
+)
+def test_invalid_confidence_fails_without_echoing_value(confidence: object) -> None:
+    with pytest.raises((TypeError, ValueError)) as exc_info:
+        EvidenceRecord.from_extraction(
+            source_start=1,
+            source_end=5,
+            assertion_status=AssertionStatus.AFFIRMED,
+            confidence=confidence,
+            review_required=False,
+        )
+
+    assert "secret-confidence" not in str(exc_info.value)
+
+
+def test_unknown_assertion_fails_without_echoing_value() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        EvidenceRecord.from_extraction(
+            source_start=1,
+            source_end=5,
+            assertion_status="secret-assertion",
+            confidence=0.9,
+            review_required=False,
+        )
+
+    assert "secret-assertion" not in str(exc_info.value)
+
+
+def test_review_required_must_be_boolean() -> None:
+    with pytest.raises(TypeError, match="review_required must be a boolean"):
+        EvidenceRecord.from_extraction(
+            source_start=1,
+            source_end=5,
+            assertion_status=AssertionStatus.AFFIRMED,
+            confidence=0.9,
+            review_required=1,
+        )
+
+
+def test_direct_value_hash_must_have_the_stable_digest_shape() -> None:
+    with pytest.raises(ValueError, match="value_hash is invalid"):
+        EvidenceRecord(
+            source_start=1,
+            source_end=5,
+            assertion_status=AssertionStatus.AFFIRMED,
+            confidence=0.9,
+            review_required=False,
+            value_hash="synthetic-sensitive-finding",
+        )
+
+
+def test_scalar_subclasses_are_normalized_before_storage_and_rendering() -> None:
+    record = EvidenceRecord(
+        source_start=LeakyInt(1),
+        source_end=LeakyInt(5),
+        assertion_status=AssertionStatus.AFFIRMED,
+        confidence=0.9,
+        review_required=False,
+        value_hash=LeakyStr(f"sha256:{'a' * 64}"),
+    )
+    table = EvidenceTable(records=(record,))
+
+    assert type(record.source_start) is int
+    assert type(record.source_end) is int
+    assert type(record.value_hash) is str
+    assert RAW_MARKER not in repr(record)
+    assert RAW_MARKER not in table.to_json()
+    assert RAW_MARKER not in table.to_markdown()
+
+
+def test_hashing_bypasses_a_string_subclass_encode_override() -> None:
+    record = EvidenceRecord.from_extraction(
+        source_start=1,
+        source_end=5,
+        assertion_status=AssertionStatus.AFFIRMED,
+        confidence=0.9,
+        review_required=False,
+        protected_value=LeakyStr("synthetic-sensitive-finding"),
+        include_value_hash=True,
+    )
+
+    assert record.value_hash is not None
+    assert RAW_MARKER not in repr(record)
+
+
+def test_scalar_normalization_errors_do_not_reflect_subclass_content() -> None:
+    with pytest.raises(TypeError) as exc_info:
+        EvidenceRecord.from_extraction(
+            source_start=1,
+            source_end=5,
+            assertion_status=AssertionStatus.AFFIRMED,
+            confidence=LeakyFloat(0.9),
+            review_required=False,
+        )
+
+    assert RAW_MARKER not in str(exc_info.value)
+
+
+def test_hashing_error_traceback_does_not_reflect_subclass_content() -> None:
+    with pytest.raises(TypeError) as exc_info:
+        EvidenceRecord.from_extraction(
+            source_start=1,
+            source_end=5,
+            assertion_status=AssertionStatus.AFFIRMED,
+            confidence=0.9,
+            review_required=False,
+            protected_value=ExplodingStr("synthetic-sensitive-finding"),
+            include_value_hash=True,
+        )
+
+    rendered_traceback = "".join(
+        traceback.format_exception(
+            exc_info.type,
+            exc_info.value,
+            exc_info.tb,
+        )
+    )
+    assert RAW_MARKER not in rendered_traceback
+
+
+def test_assertion_error_traceback_does_not_reflect_subclass_content() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        EvidenceRecord.from_extraction(
+            source_start=1,
+            source_end=5,
+            assertion_status=ExplodingStr("synthetic-sensitive-assertion"),
+            confidence=0.9,
+            review_required=False,
+        )
+
+    rendered_traceback = "".join(
+        traceback.format_exception(
+            exc_info.type,
+            exc_info.value,
+            exc_info.tb,
+        )
+    )
+    assert RAW_MARKER not in rendered_traceback
+
+
+def test_empty_table_has_stable_zero_counts() -> None:
+    assert EvidenceTable(records=()).to_dict() == {
+        "schema_version": 1,
+        "record_count": 0,
+        "review_required_count": 0,
+        "assertion_counts": {},
+        "records": [],
+        "disclaimer": (
+            "Clinical evidence tables are value-free review aids, not clinical "
+            "decisions or compliance certifications."
+        ),
+    }
+
+
+def test_rendering_performs_no_network_calls(monkeypatch) -> None:
+    def fail_network(*args, **kwargs):
+        raise AssertionError("network access is forbidden")
+
+    monkeypatch.setattr(socket, "create_connection", fail_network)
+
+    table = EvidenceTable(records=(record(1, 5),))
+    table.to_json()
+    table.to_markdown()


### PR DESCRIPTION
## Description

Add deterministic clinical evidence tables for comparing extracted findings
without exporting note text or raw protected values.

Records retain only source offsets, a controlled assertion state, confidence,
a review flag, and an optional SHA-256 digest. JSON and Markdown use the same
canonical ordering and aggregate counts.

Closes #2567.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add typed `EvidenceRecord` and `EvidenceTable` interfaces.
- Omit protected values by default and support explicit SHA-256 hashing.
- Render deterministic JSON and Markdown with assertion and review counts.
- Normalize scalar subclasses before storage and rendering.
- Suppress unsafe validation exception context so raw values cannot leak through tracebacks.
- Document the interface, privacy boundary, and low-entropy hash limitation.

## Testing

- [x] I have added tests that prove the feature works
- [x] New and relevant existing unit tests pass locally
- [ ] I have tested this change with different models/inputs — not applicable

Commands:

- `uv run --frozen --extra dev python -m pytest tests/unit/clinical/test_evidence_table.py -q` — 26 passed
- `uv run --frozen --extra dev python -m pytest tests/unit/clinical -q` — 1,748 passed, 4 skipped
- Publication-contract tests — passed
- `make lint` — passed
- `make type-check` — passed
- `make format-check` — passed
- `mkdocs build --strict` — passed

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality

- [x] I ran the repository lint, type-check, and format-check gates
- [x] I performed a self-review
- [x] The focused diff received an independent privacy review
- [x] My changes generate no new warnings

## Dependencies

- [x] I have not added any new dependencies

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit has a clear, descriptive message
- [x] The change is focused on one issue

## Related Issues

Closes #2567

## Screenshots/Examples

```json
{
  "source_offsets": {"start": 12, "end": 29},
  "assertion_status": "affirmed",
  "confidence": 0.94,
  "review_required": false
}
```