### PR TITLE
fix: refresh governed GitHub stars evidence

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -470,7 +470,7 @@ curl -X POST http://127.0.0.1:8080/pii/extract \
 
 </div>
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.de.md
+++ b/README.de.md
@@ -393,7 +393,7 @@ Wenn OpenMed für deine Forschung nützlich ist, zitiere es bitte:
 
 Wenn OpenMed dir nützlich ist, hilft ein Stern anderen, es zu entdecken.
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -393,7 +393,7 @@ Si OpenMed te resulta útil en tu investigación, cítalo:
 
 Si OpenMed te resulta útil, una estrella ayuda a que otros lo descubran.
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -472,7 +472,7 @@ OpenMed بر پایهٔ کارهای عالیِ متن‌باز ساخته شد�
 
 </div>
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -393,7 +393,7 @@ Si OpenMed vous est utile dans vos recherches, merci de le citer :
 
 Si OpenMed vous est utile, une étoile aide les autres à le découvrir.
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -731,7 +731,7 @@ OpenMed SDK का स्रोत [Apache-2.0 License](LICENSE) के अं�
 
 यदि OpenMed आपके लिए उपयोगी है, तो एक star दूसरों को इसे खोजने में मदद करता है।
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.it.md
+++ b/README.it.md
@@ -393,7 +393,7 @@ Se OpenMed ti è utile nella tua ricerca, ti preghiamo di citarlo:
 
 Se OpenMed ti è utile, una stella aiuta altri a scoprirlo.
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -393,7 +393,7 @@ OpenMed SDK のソースは [Apache-2.0 License](LICENSE) の下で公開され�
 
 OpenMed が役立つと感じたら、スターを付けると他の人が見つけやすくなります。
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ papers, posters, and derived documentation.
 
 If OpenMed is useful to you, a star helps others discover it.
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -393,7 +393,7 @@ Als OpenMed nuttig is in je onderzoek, citeer het dan:
 
 Als OpenMed nuttig voor je is, helpt een ster anderen om het te ontdekken.
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -393,7 +393,7 @@ Se o OpenMed for útil na sua pesquisa, por favor, cite:
 
 Se o OpenMed for útil para você, uma estrela ajuda outros a descobri-lo.
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.sw.md
+++ b/README.sw.md
@@ -588,7 +588,7 @@ OpenMed katika makala, mabango na nyaraka zinazotokana nayo.
 
 Ikiwa OpenMed inakufaa, nyota huwasaidia wengine kuipata.
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.te.md
+++ b/README.te.md
@@ -393,7 +393,7 @@ OpenMed SDK సోర్స్ [Apache-2.0 License](LICENSE) క్రింద 
 
 OpenMed మీకు ఉపయోగకరంగా ఉంటే, ఒక స్టార్ ఇతరులు దాన్ని కనుగొనడంలో సహాయపడుతుంది.
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -393,7 +393,7 @@ OpenMed araştırmanızda faydalı olduysa, lütfen atıfta bulunun:
 
 OpenMed sizin için faydalıysa, bir yıldız başkalarının onu keşfetmesine yardımcı olur.
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -711,7 +711,7 @@ OpenMed SDK 源代码基于 [Apache-2.0 License](LICENSE) 发布。第三方资�
 
 如果 OpenMed 对你有帮助，点个 star 能帮助更多人发现它。
 
-[4,700+ GitHub stars · 29 Jul 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
+[5,100+ GitHub stars · 30 Aug 2026 snapshot](https://github.com/maziyarpanahi/openmed/stargazers)
 
 ---
 

--- a/docs/brand/social/manifest.json
+++ b/docs/brand/social/manifest.json
@@ -5,7 +5,7 @@
   "source_hashes": {
     "docs/brand/social/_src/exports.json": "385c4ed79de723b47e8af696bd83cd8e06abdd8a6f07edb60ffb150545a59353",
     "docs/brand/social/_src/profile-copy.json": "04255d0564edcc50363d952bdc4c0cc4945ddaad24cccfddd52e57596c7409cf",
-    "docs/brand/system/claims.yml": "383552ce80af6ad698ac64e366ef7e00c98f3e02d405fb0489177f6a3860fde4",
+    "docs/brand/system/claims.yml": "116ac430937b5a54c02ca98a8e8257307a685eab9cb0a382d324fd7833343bad",
     "docs/brand/social/exports/README.md": "e28ac10689d4ae392509bad8a7102fba63d3895ab1c6d862ff2e13bb5d5178a0"
   },
   "approved_exports": {

--- a/docs/brand/system/claims.yml
+++ b/docs/brand/system/claims.yml
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-08-11",
+  "generated_at": "2026-08-30",
   "generation": {
     "command": "python scripts/brand/update_claims.py --write",
     "network": "forbidden",
@@ -24,15 +24,15 @@
     },
     "github_stars_snapshot": {
       "status": "verified",
-      "value": 4744,
-      "display": "4,700+ GitHub stars",
+      "value": 5181,
+      "display": "5,100+ GitHub stars",
       "definition": "Exact stargazers_count from the committed GitHub API evidence; public display is conservatively floored to the preceding 100-star quantum.",
       "source": "docs/brand/system/evidence/github-repository.json",
-      "as_of": "2026-07-29",
+      "as_of": "2026-08-30",
       "owner": "repository-owner",
-      "public_wording": "4,700+ GitHub stars",
-      "qualification": "Dated offline snapshot, not a live counter; the exact raw value was 4,744 when captured.",
-      "review_by": "2026-08-29",
+      "public_wording": "5,100+ GitHub stars",
+      "qualification": "Dated offline snapshot, not a live counter; the exact raw value was 5,181 when captured.",
+      "review_by": "2026-09-30",
       "follow_up_by": null
     },
     "repository_model_snapshot": {

--- a/docs/brand/system/evidence/github-repository.json
+++ b/docs/brand/system/evidence/github-repository.json
@@ -3,17 +3,17 @@
   "repository": "maziyarpanahi/openmed",
   "api_url": "https://api.github.com/repos/maziyarpanahi/openmed",
   "html_url": "https://github.com/maziyarpanahi/openmed",
-  "captured_at": "2026-07-29T09:12:38Z",
-  "repository_updated_at": "2026-07-29T08:26:53Z",
-  "stargazers_count": 4744,
+  "captured_at": "2026-08-30T09:11:06Z",
+  "repository_updated_at": "2026-08-30T05:51:53Z",
+  "stargazers_count": 5181,
   "display": {
     "method": "floor",
     "quantum": 100,
-    "value": 4700,
-    "label": "4,700+ GitHub stars"
+    "value": 5100,
+    "label": "5,100+ GitHub stars"
   },
   "owner": "repository-owner",
-  "review_by": "2026-08-29",
+  "review_by": "2026-09-30",
   "refresh": {
     "command": "python scripts/brand/update_claims.py --refresh-github-stars",
     "network": "explicit opt-in only",

--- a/docs/i18n/readme_section_hashes.json
+++ b/docs/i18n/readme_section_hashes.json
@@ -132,9 +132,9 @@
         },
         {
           "source_heading": "Star History",
-          "source_sha256": "99a6b34eeae29de71318567e0dd385b06c95120e8e372f982c89d7048997fa62",
+          "source_sha256": "215a52664bd987bf5e60e4a13f57fe609372f697e4707ad50979256b72fa4312",
           "translation_heading": "स्टार इतिहास",
-          "translation_sha256": "8d7805b9715bb7bdf4930ac6400f5ee884d890f46357a4a5b67c434314f61f44"
+          "translation_sha256": "9e2bbf09dc9d364f13d1569d451d5247b80876bf05c314e4114f91b10672f26c"
         }
       ]
     },
@@ -268,9 +268,9 @@
         },
         {
           "source_heading": "Star History",
-          "source_sha256": "99a6b34eeae29de71318567e0dd385b06c95120e8e372f982c89d7048997fa62",
+          "source_sha256": "215a52664bd987bf5e60e4a13f57fe609372f697e4707ad50979256b72fa4312",
           "translation_heading": "Historia ya nyota",
-          "translation_sha256": "852adb1dd98121fe76c0354c2805eb7068b97736242a50e43fb0704144bdf40c"
+          "translation_sha256": "e9fdd644482c31f6b858e9b8fb793316768ff7e0a6c13bc6f1dc8cd0c3dad569"
         }
       ]
     },
@@ -404,9 +404,9 @@
         },
         {
           "source_heading": "Star History",
-          "source_sha256": "99a6b34eeae29de71318567e0dd385b06c95120e8e372f982c89d7048997fa62",
+          "source_sha256": "215a52664bd987bf5e60e4a13f57fe609372f697e4707ad50979256b72fa4312",
           "translation_heading": "Star 历史",
-          "translation_sha256": "b9dc375f56387a63b30560bcc6bef51daae893126db83f154ba822f702518cb7"
+          "translation_sha256": "03819ab822f8f1aa23dc3043ad9dbb61ba9cfdfcd77b2a326efa52b0bd2e06fe"
         }
       ]
     }

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -251,11 +251,11 @@
                 <a
                     class="release-chip repository-stars"
                     href="https://github.com/maziyarpanahi/openmed/stargazers"
-                    aria-label="4,700+ GitHub stars"
+                    aria-label="5,100+ GitHub stars"
                     data-repository-stars
                 >
                     <span class="star-symbol" aria-hidden="true">★</span>
-                    <span data-star-count>4.7k</span>
+                    <span data-star-count>5.1k</span>
                 </a>
                 <!-- openmed-claim:github_stars:end -->
                 <a class="header-docs" href="docs/">Docs</a>
@@ -427,7 +427,7 @@
                 </div>
                 <div class="snapshot-note">
                     <span>Counted, not claimed · Hugging Face + PyPI · July 2026</span>
-                    <span data-community-stars>★ 4.7K GitHub stars · counted live</span>
+                    <span data-community-stars>★ 5.1K GitHub stars · counted live</span>
                 </div>
                 <!-- openmed-claim:repository_snapshot:end -->
             </div>

--- a/scripts/brand/update_claims.py
+++ b/scripts/brand/update_claims.py
@@ -623,7 +623,7 @@ def build_registry() -> dict[str, Any]:
 
     return {
         "schema_version": 2,
-        "generated_at": MODEL_MANIFEST_AS_OF,
+        "generated_at": max(MODEL_MANIFEST_AS_OF, github["captured_at"][:10]),
         "generation": {
             "command": "python scripts/brand/update_claims.py --write",
             "network": "forbidden",

--- a/scripts/brand/update_readme_brand.py
+++ b/scripts/brand/update_readme_brand.py
@@ -1561,8 +1561,17 @@ def transform(filename: str, text: str) -> str:
     )
     snapshot = _star_snapshot()
     if snapshot not in text:
+        governed_count = 0
         html_count = 0
         markdown_count = 0
+        text, governed_count = re.subn(
+            r"(?m)^\[[0-9,]+\+ GitHub stars · "
+            r"[0-9]{1,2} [A-Z][a-z]{2} [0-9]{4} snapshot\]"
+            r"\(https://github\.com/maziyarpanahi/openmed/stargazers\)$",
+            snapshot,
+            text,
+            count=1,
+        )
         text, html_count = re.subn(
             r'(?s)<a href="https://star-history\.com/[^"]*">\s*'
             r'<img src="https://api\.star-history\.com/[^"]*"[^>]*\s*/>\s*</a>',
@@ -1576,7 +1585,7 @@ def transform(filename: str, text: str) -> str:
             text,
             count=1,
         )
-        if html_count + markdown_count != 1:
+        if governed_count + html_count + markdown_count != 1:
             raise RuntimeError(f"{filename}: expected one remote star-history image")
     return text
 


### PR DESCRIPTION
## Description

Refresh the expired GitHub stars evidence from the canonical repository API, rebuild governed claim consumers, and make future refreshes advance the registry date and replace an existing governed README snapshot.

## Change type

- [x] Bug fix
- [x] Documentation
- [ ] New feature
- [ ] Breaking change

## Tests run

- python scripts/brand/validate_system.py
- python scripts/brand/update_claims.py --check
- python scripts/brand/update_readme_brand.py --check
- python scripts/brand/render_social_assets.py --check
- python scripts/i18n/check_readme_drift.py
- pytest tests/unit/test_brand_system.py -q
- pytest tests/unit/test_readme_i18n_drift.py tests/unit/test_readme_sw_drift.py -q
- pre-commit run on every changed path

## Documentation / changelog

The governed claims registry, evidence snapshot, localized README snapshots, social manifest, and website claim fragment are updated together.

## Dependency justification

No dependency changes.

## Linked issue

None. This repairs an expired repository-wide CI evidence gate.

## Screenshots / example output

Not applicable; generated claim consumers were reproduced and checked byte-exactly.