### PR TITLE
feat(agent): add opaque correlation identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added typed, 128-bit opaque correlation identifiers for agent runs and
+  actions, with strict kind-aware parsing, deterministic metadata-only JSON,
+  parent-action validation, and value-free failures (#2973).
 - Added an audited teacher-ensemble registry for weak labeling with
   manifest-resolved PII and Privacy Filter members, bounded weights and
   agreement thresholds, checksum-validator policies, and fail-closed runtime

--- a/docs/agent/event-correlation.md
+++ b/docs/agent/event-correlation.md
@@ -1,0 +1,50 @@
+# Agent Event Correlation
+
+`openmed.agent.correlation` provides opaque identifiers for correlating local
+agent runs and actions without embedding patient, user, workflow, or tool
+content.
+
+## Identifier Format
+
+- Run identifiers use `run_` followed by 32 lowercase hexadecimal characters.
+- Action identifiers use `act_` followed by 32 lowercase hexadecimal characters.
+- The hexadecimal token is exactly 16 bytes (128 bits).
+- Parsing is canonical: uppercase, shortened, extended, malformed, and
+  wrong-kind identifiers are rejected instead of normalized.
+
+Generate identifiers without supplying source content:
+
+```python
+from openmed.agent import ActionCorrelation, ActionId, RunId
+
+run_id = RunId.generate()
+parent_id = ActionId.generate()
+action_id = ActionId.generate()
+
+correlation = ActionCorrelation(
+    run_id=run_id,
+    action_id=action_id,
+    parent_action_id=parent_id,
+)
+
+payload = correlation.to_json()
+```
+
+`ActionCorrelation` requires a `RunId` for `run_id` and `ActionId` values for
+both action fields. An action cannot identify itself as its parent. Its compact
+JSON representation has deterministic key ordering and contains only the schema
+version and opaque identifiers.
+
+## Privacy Boundary
+
+Runtime generation uses `secrets.token_bytes`; the optional `token_source`
+argument exists only for deterministic offline tests. Do not derive an
+identifier by hashing or encoding prompts, clinical text, filenames, user IDs,
+tool arguments, model output, or other workflow content. Parsing is for
+previously generated opaque identifiers, not for turning business data into an
+identifier.
+
+Malformed values fail with a public field name and stable error code. Rejected
+values are not included in exception messages or object representations. The
+module does not persist events, implement distributed tracing, or encode patient
+or operator identity.

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -104,6 +104,7 @@ classification:
     - onboarding-china.md
     - onboarding-india.md
     - agent-usage.md
+    - agent/event-correlation.md
     - agent-skills/install.md
     - agent-skills/validation.md
     - agent-skills/setup.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - India Onboarding: onboarding-india.md
   - Core Guides:
       - Building with an Agent: agent-usage.md
+      - Agent Event Correlation: agent/event-correlation.md
       - Agent Skill Installation: agent-skills/install.md
       - Agent Skill Validation: agent-skills/validation.md
       - De-identification Policy Setup: agent-skills/setup.md

--- a/openmed/agent/__init__.py
+++ b/openmed/agent/__init__.py
@@ -2,4 +2,25 @@
 
 from __future__ import annotations
 
-__all__ = ["security"]
+from .correlation import (
+    ACTION_ID_PREFIX,
+    CORRELATION_SCHEMA_VERSION,
+    CORRELATION_TOKEN_BYTES,
+    RUN_ID_PREFIX,
+    ActionCorrelation,
+    ActionId,
+    CorrelationIdError,
+    RunId,
+)
+
+__all__ = [
+    "ACTION_ID_PREFIX",
+    "CORRELATION_SCHEMA_VERSION",
+    "CORRELATION_TOKEN_BYTES",
+    "RUN_ID_PREFIX",
+    "ActionCorrelation",
+    "ActionId",
+    "CorrelationIdError",
+    "RunId",
+    "security",
+]

--- a/openmed/agent/correlation.py
+++ b/openmed/agent/correlation.py
@@ -1,0 +1,342 @@
+"""Opaque correlation identifiers for local agent runs and actions.
+
+Identifiers contain only a fixed kind prefix and 128 random bits. They never
+derive from prompts, clinical text, filenames, tool arguments, or operator
+identity. Validation fails closed with field names and stable error codes
+instead of echoing rejected values.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, ClassVar, Final, TypeVar
+
+CORRELATION_SCHEMA_VERSION: Final = "openmed.agent.correlation.v1"
+CORRELATION_TOKEN_BYTES: Final = 16
+RUN_ID_PREFIX: Final = "run_"
+ACTION_ID_PREFIX: Final = "act_"
+
+_TOKEN_HEX_LENGTH: Final = CORRELATION_TOKEN_BYTES * 2
+_LOWER_HEX_RE = re.compile(rf"[0-9a-f]{{{_TOKEN_HEX_LENGTH}}}")
+_ALLOWED_FIELDS = frozenset(
+    {"schema_version", "run_id", "action_id", "parent_action_id"}
+)
+_ORDERED_FIELDS = (
+    "schema_version",
+    "run_id",
+    "action_id",
+    "parent_action_id",
+)
+_TOKEN_SOURCE_FAILED = object()
+
+_TokenSource = Callable[[int], bytes]
+_IdentifierT = TypeVar("_IdentifierT", bound="_OpaqueCorrelationId")
+
+
+class CorrelationIdError(ValueError):
+    """Raised when correlation metadata fails closed validation.
+
+    Args:
+        code: Stable machine-readable validation code.
+        field_name: Optional public field associated with the failure.
+    """
+
+    def __init__(self, code: str, field_name: str | None = None) -> None:
+        self.code = code
+        self.field_name = field_name
+        message = code if field_name is None else f"{field_name}: {code}"
+        super().__init__(message)
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _OpaqueCorrelationId:
+    """Shared immutable implementation for kind-specific opaque identifiers."""
+
+    value: str
+    _prefix: ClassVar[str] = ""
+    _field_name: ClassVar[str] = "identifier"
+
+    def __post_init__(self) -> None:
+        _validate_identifier(
+            self.value,
+            prefix=self._prefix,
+            field_name=self._field_name,
+        )
+
+    @classmethod
+    def generate(
+        cls: type[_IdentifierT],
+        *,
+        token_source: _TokenSource | None = None,
+    ) -> _IdentifierT:
+        """Generate an identifier from 128 random bits.
+
+        Args:
+            token_source: Optional byte source for deterministic tests. Runtime
+                callers should leave this unset to use :func:`secrets.token_bytes`.
+
+        Returns:
+            A canonical opaque identifier of the requested kind.
+
+        Raises:
+            CorrelationIdError: If an injected source fails or does not return
+                exactly 16 bytes.
+        """
+
+        return cls(
+            _generate_identifier(
+                cls._prefix,
+                field_name=cls._field_name,
+                token_source=token_source,
+            )
+        )
+
+    @classmethod
+    def parse(cls: type[_IdentifierT], value: Any) -> _IdentifierT:
+        """Parse a canonical identifier without normalizing its input."""
+
+        return cls(value)
+
+    def serialize(self) -> str:
+        """Return the canonical string representation."""
+
+        return self.value
+
+    def __str__(self) -> str:
+        """Return the canonical string representation."""
+
+        return self.value
+
+    def __repr__(self) -> str:
+        """Return a value-free representation for diagnostic output."""
+
+        return f"{type(self).__name__}(<opaque>)"
+
+
+class RunId(_OpaqueCorrelationId):
+    """Opaque identifier for one agent run.
+
+    Args:
+        value: Canonical ``run_`` identifier containing 32 lowercase hex
+            characters after the prefix.
+    """
+
+    __slots__ = ()
+    _prefix = RUN_ID_PREFIX
+    _field_name = "run_id"
+
+
+class ActionId(_OpaqueCorrelationId):
+    """Opaque identifier for one action within an agent run.
+
+    Args:
+        value: Canonical ``act_`` identifier containing 32 lowercase hex
+            characters after the prefix.
+    """
+
+    __slots__ = ()
+    _prefix = ACTION_ID_PREFIX
+    _field_name = "action_id"
+
+
+@dataclass(frozen=True, slots=True)
+class ActionCorrelation:
+    """Typed parent-child correlation metadata for one agent action.
+
+    Args:
+        run_id: Opaque identifier for the containing run.
+        action_id: Opaque identifier for this action.
+        parent_action_id: Optional identifier for another action that directly
+            owns this action.
+        schema_version: Stable serialization schema version.
+    """
+
+    run_id: RunId
+    action_id: ActionId
+    parent_action_id: ActionId | None = None
+    schema_version: str = CORRELATION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if type(self.run_id) is not RunId:
+            raise CorrelationIdError("wrong_identifier_kind", "run_id")
+        if type(self.action_id) is not ActionId:
+            raise CorrelationIdError("wrong_identifier_kind", "action_id")
+        if (
+            self.parent_action_id is not None
+            and type(self.parent_action_id) is not ActionId
+        ):
+            raise CorrelationIdError("wrong_identifier_kind", "parent_action_id")
+        if self.parent_action_id == self.action_id:
+            raise CorrelationIdError("self_parent", "parent_action_id")
+        if (
+            type(self.schema_version) is not str
+            or self.schema_version != CORRELATION_SCHEMA_VERSION
+        ):
+            raise CorrelationIdError("invalid_schema_version", "schema_version")
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ActionCorrelation":
+        """Build typed correlation metadata from a strict mapping.
+
+        Args:
+            data: Mapping containing run, action, and optional parent identifiers.
+
+        Returns:
+            Validated action correlation metadata.
+
+        Raises:
+            CorrelationIdError: If fields are missing, unknown, malformed, or
+                use the wrong identifier kind.
+        """
+
+        if not isinstance(data, Mapping) or isinstance(data, (str, bytes, bytearray)):
+            raise CorrelationIdError("not_a_mapping")
+
+        try:
+            fields = set(data)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException:
+            fields = None
+        if fields is None:
+            raise CorrelationIdError("not_a_mapping")
+        if fields - _ALLOWED_FIELDS:
+            raise CorrelationIdError("unknown_field")
+        if "run_id" not in fields or "action_id" not in fields:
+            raise CorrelationIdError("missing_field")
+
+        values = _read_mapping_values(data)
+        parent_value = values.get("parent_action_id")
+        return cls(
+            run_id=RunId.parse(values["run_id"]),
+            action_id=ActionId.parse(values["action_id"]),
+            parent_action_id=(
+                None if parent_value is None else _parse_parent_action_id(parent_value)
+            ),
+            schema_version=values.get(
+                "schema_version",
+                CORRELATION_SCHEMA_VERSION,
+            ),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str | bytes | bytearray) -> "ActionCorrelation":
+        """Build typed correlation metadata from a strict JSON object."""
+
+        try:
+            data = json.loads(payload, object_pairs_hook=_strict_json_object)
+        except (
+            json.JSONDecodeError,
+            CorrelationIdError,
+            TypeError,
+            UnicodeDecodeError,
+        ):
+            pass
+        else:
+            return cls.from_dict(data)
+        raise CorrelationIdError("malformed_json")
+
+    @property
+    def is_root_action(self) -> bool:
+        """Return whether this action has no parent action."""
+
+        return self.parent_action_id is None
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Return deterministic metadata-only correlation fields."""
+
+        values: dict[str, str | None] = {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id.serialize(),
+            "action_id": self.action_id.serialize(),
+            "parent_action_id": (
+                None
+                if self.parent_action_id is None
+                else self.parent_action_id.serialize()
+            ),
+        }
+        return {field_name: values[field_name] for field_name in _ORDERED_FIELDS}
+
+    def to_json(self) -> str:
+        """Return compact JSON with deterministic key ordering."""
+
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def _generate_identifier(
+    prefix: str,
+    *,
+    field_name: str,
+    token_source: _TokenSource | None,
+) -> str:
+    source = secrets.token_bytes if token_source is None else token_source
+    if not callable(source):
+        raise CorrelationIdError("invalid_token_source", field_name)
+
+    token: object
+    try:
+        token = source(CORRELATION_TOKEN_BYTES)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException:
+        token = _TOKEN_SOURCE_FAILED
+
+    if type(token) is not bytes or len(token) != CORRELATION_TOKEN_BYTES:
+        raise CorrelationIdError("invalid_token_source", field_name)
+    return f"{prefix}{token.hex()}"
+
+
+def _validate_identifier(value: Any, *, prefix: str, field_name: str) -> None:
+    if type(value) is not str:
+        raise CorrelationIdError("invalid_identifier", field_name)
+    token = value.removeprefix(prefix)
+    if not value.startswith(prefix) or _LOWER_HEX_RE.fullmatch(token) is None:
+        other_prefix = ACTION_ID_PREFIX if prefix == RUN_ID_PREFIX else RUN_ID_PREFIX
+        other_token = value.removeprefix(other_prefix)
+        if value.startswith(other_prefix) and _LOWER_HEX_RE.fullmatch(other_token):
+            raise CorrelationIdError("wrong_identifier_kind", field_name)
+        raise CorrelationIdError("invalid_identifier", field_name)
+
+
+def _parse_parent_action_id(value: Any) -> ActionId:
+    _validate_identifier(
+        value,
+        prefix=ACTION_ID_PREFIX,
+        field_name="parent_action_id",
+    )
+    return ActionId(value)
+
+
+def _read_mapping_values(data: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        return {field_name: data[field_name] for field_name in data}
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException:
+        pass
+    raise CorrelationIdError("unreadable_mapping")
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CorrelationIdError("duplicate_field")
+        result[key] = value
+    return result
+
+
+__all__ = [
+    "ACTION_ID_PREFIX",
+    "CORRELATION_SCHEMA_VERSION",
+    "CORRELATION_TOKEN_BYTES",
+    "RUN_ID_PREFIX",
+    "ActionCorrelation",
+    "ActionId",
+    "CorrelationIdError",
+    "RunId",
+]

--- a/tests/unit/agent/test_correlation.py
+++ b/tests/unit/agent/test_correlation.py
@@ -1,0 +1,274 @@
+"""Offline tests for opaque agent correlation identifiers."""
+
+from __future__ import annotations
+
+import json
+import re
+import traceback
+from typing import Any
+
+import pytest
+
+from openmed.agent.correlation import (
+    ACTION_ID_PREFIX,
+    CORRELATION_SCHEMA_VERSION,
+    CORRELATION_TOKEN_BYTES,
+    RUN_ID_PREFIX,
+    ActionCorrelation,
+    ActionId,
+    CorrelationIdError,
+    RunId,
+)
+
+RUN_TOKEN = bytes(range(CORRELATION_TOKEN_BYTES))
+ACTION_TOKEN = bytes(range(16, 16 + CORRELATION_TOKEN_BYTES))
+PARENT_TOKEN = bytes(range(32, 32 + CORRELATION_TOKEN_BYTES))
+
+
+def fixed_token(token: bytes):
+    """Return a deterministic token source that validates the requested width."""
+
+    def source(size: int) -> bytes:
+        assert size == CORRELATION_TOKEN_BYTES
+        return token
+
+    return source
+
+
+def test_generated_ids_use_fixed_prefixes_and_128_bit_tokens() -> None:
+    run_id = RunId.generate(token_source=fixed_token(RUN_TOKEN))
+    action_id = ActionId.generate(token_source=fixed_token(ACTION_TOKEN))
+
+    assert run_id.serialize() == f"{RUN_ID_PREFIX}{RUN_TOKEN.hex()}"
+    assert action_id.serialize() == f"{ACTION_ID_PREFIX}{ACTION_TOKEN.hex()}"
+    assert len(run_id.value.removeprefix(RUN_ID_PREFIX)) == 32
+    assert len(action_id.value.removeprefix(ACTION_ID_PREFIX)) == 32
+    assert RunId.parse(run_id.serialize()) == run_id
+    assert ActionId.parse(action_id.serialize()) == action_id
+    assert str(run_id) == run_id.value
+    assert str(action_id) == action_id.value
+
+
+def test_default_generation_produces_canonical_opaque_ids() -> None:
+    run_id = RunId.generate()
+    action_id = ActionId.generate()
+
+    assert re.fullmatch(r"run_[0-9a-f]{32}", run_id.value)
+    assert re.fullmatch(r"act_[0-9a-f]{32}", action_id.value)
+    assert "opaque" in repr(run_id)
+    assert "opaque" in repr(action_id)
+    assert run_id.value not in repr(run_id)
+    assert action_id.value not in repr(action_id)
+
+
+@pytest.mark.parametrize(
+    ("identifier_type", "value", "expected_code"),
+    [
+        (RunId, f"{RUN_ID_PREFIX}{'A' * 32}", "invalid_identifier"),
+        (RunId, f"{RUN_ID_PREFIX}{'0' * 31}", "invalid_identifier"),
+        (RunId, f"{RUN_ID_PREFIX}{'0' * 33}", "invalid_identifier"),
+        (RunId, f"{RUN_ID_PREFIX}{'g' * 32}", "invalid_identifier"),
+        (RunId, f"{ACTION_ID_PREFIX}{'0' * 32}", "wrong_identifier_kind"),
+        (ActionId, f"{RUN_ID_PREFIX}{'0' * 32}", "wrong_identifier_kind"),
+        (ActionId, True, "invalid_identifier"),
+        (ActionId, 1, "invalid_identifier"),
+    ],
+)
+def test_malformed_or_wrong_kind_ids_fail_closed(
+    identifier_type: type[RunId] | type[ActionId],
+    value: Any,
+    expected_code: str,
+) -> None:
+    with pytest.raises(CorrelationIdError) as caught:
+        identifier_type.parse(value)
+
+    assert caught.value.code == expected_code
+    assert repr(value) not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "token_source",
+    [
+        None,
+        fixed_token(b"short"),
+        fixed_token(b"x" * 17),
+        lambda _: "not-bytes",
+    ],
+)
+def test_invalid_injected_token_sources_fail_without_retaining_values(
+    token_source: Any,
+) -> None:
+    source = "not-callable" if token_source is None else token_source
+
+    with pytest.raises(CorrelationIdError) as caught:
+        RunId.generate(token_source=source)
+
+    assert caught.value.code == "invalid_token_source"
+    assert "not-bytes" not in str(caught.value)
+    assert "short" not in str(caught.value)
+
+
+def test_token_source_exception_is_replaced_with_value_free_error() -> None:
+    sentinel = "Patient Jane Roe /private/chart"
+
+    def failing_source(_: int) -> bytes:
+        raise RuntimeError(sentinel)
+
+    with pytest.raises(CorrelationIdError) as caught:
+        ActionId.generate(token_source=failing_source)
+
+    rendered = "".join(traceback.format_exception(caught.type, caught.value, caught.tb))
+    assert caught.value.code == "invalid_token_source"
+    assert sentinel not in rendered
+
+
+def test_parent_child_correlation_round_trips_deterministically() -> None:
+    correlation = ActionCorrelation(
+        run_id=RunId.generate(token_source=fixed_token(RUN_TOKEN)),
+        action_id=ActionId.generate(token_source=fixed_token(ACTION_TOKEN)),
+        parent_action_id=ActionId.generate(token_source=fixed_token(PARENT_TOKEN)),
+    )
+
+    assert correlation.is_root_action is False
+    assert list(correlation.to_dict()) == [
+        "schema_version",
+        "run_id",
+        "action_id",
+        "parent_action_id",
+    ]
+    assert ActionCorrelation.from_dict(correlation.to_dict()) == correlation
+    assert ActionCorrelation.from_json(correlation.to_json()) == correlation
+    assert correlation.to_json() == json.dumps(
+        correlation.to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def test_root_action_serializes_an_explicit_null_parent() -> None:
+    correlation = ActionCorrelation(
+        run_id=RunId.generate(token_source=fixed_token(RUN_TOKEN)),
+        action_id=ActionId.generate(token_source=fixed_token(ACTION_TOKEN)),
+    )
+
+    assert correlation.is_root_action is True
+    assert correlation.to_dict()["parent_action_id"] is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "run_id": f"{ACTION_ID_PREFIX}{ACTION_TOKEN.hex()}",
+            "action_id": f"{ACTION_ID_PREFIX}{RUN_TOKEN.hex()}",
+        },
+        {
+            "run_id": f"{RUN_ID_PREFIX}{RUN_TOKEN.hex()}",
+            "action_id": f"{RUN_ID_PREFIX}{ACTION_TOKEN.hex()}",
+        },
+        {
+            "run_id": f"{RUN_ID_PREFIX}{RUN_TOKEN.hex()}",
+            "action_id": f"{ACTION_ID_PREFIX}{ACTION_TOKEN.hex()}",
+            "parent_action_id": f"{RUN_ID_PREFIX}{PARENT_TOKEN.hex()}",
+        },
+    ],
+)
+def test_parent_child_fields_reject_wrong_identifier_kinds(
+    payload: dict[str, str],
+) -> None:
+    with pytest.raises(CorrelationIdError) as caught:
+        ActionCorrelation.from_dict(payload)
+
+    assert caught.value.code == "wrong_identifier_kind"
+    expected_field = next(
+        field_name
+        for field_name in ("run_id", "action_id", "parent_action_id")
+        if field_name in payload
+        and payload[field_name].startswith(
+            ACTION_ID_PREFIX if field_name == "run_id" else RUN_ID_PREFIX
+        )
+    )
+    assert caught.value.field_name == expected_field
+
+
+def test_action_cannot_parent_itself() -> None:
+    action_id = ActionId.generate(token_source=fixed_token(ACTION_TOKEN))
+
+    with pytest.raises(CorrelationIdError) as caught:
+        ActionCorrelation(
+            run_id=RunId.generate(token_source=fixed_token(RUN_TOKEN)),
+            action_id=action_id,
+            parent_action_id=action_id,
+        )
+
+    assert caught.value.code == "self_parent"
+    assert action_id.value not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"run_id": f"{RUN_ID_PREFIX}{RUN_TOKEN.hex()}"},
+        [RUN_ID_PREFIX, ACTION_ID_PREFIX],
+        "not-a-mapping",
+    ],
+)
+def test_missing_and_non_mapping_payloads_fail_closed(payload: Any) -> None:
+    with pytest.raises(CorrelationIdError):
+        ActionCorrelation.from_dict(payload)
+
+
+def test_unknown_fields_and_versions_fail_without_echoing_values() -> None:
+    sentinel = "Patient John Doe bearer-token"
+    payload = {
+        "schema_version": CORRELATION_SCHEMA_VERSION,
+        "run_id": f"{RUN_ID_PREFIX}{RUN_TOKEN.hex()}",
+        "action_id": f"{ACTION_ID_PREFIX}{ACTION_TOKEN.hex()}",
+        "prompt": sentinel,
+    }
+
+    with pytest.raises(CorrelationIdError) as caught:
+        ActionCorrelation.from_dict(payload)
+
+    assert caught.value.code == "unknown_field"
+    assert sentinel not in str(caught.value)
+
+    payload.pop("prompt")
+    payload["schema_version"] = sentinel
+    with pytest.raises(CorrelationIdError) as caught:
+        ActionCorrelation.from_dict(payload)
+    assert caught.value.code == "invalid_schema_version"
+    assert sentinel not in str(caught.value)
+
+
+@pytest.mark.parametrize("payload", ["{", b"\xff", 42])
+def test_malformed_json_fails_closed(payload: Any) -> None:
+    with pytest.raises(CorrelationIdError) as caught:
+        ActionCorrelation.from_json(payload)
+
+    assert caught.value.code == "malformed_json"
+
+
+def test_duplicate_json_fields_fail_closed() -> None:
+    run_id = f"{RUN_ID_PREFIX}{RUN_TOKEN.hex()}"
+    action_id = f"{ACTION_ID_PREFIX}{ACTION_TOKEN.hex()}"
+    payload = f'{{"run_id":"{run_id}","run_id":"{run_id}","action_id":"{action_id}"}}'
+
+    with pytest.raises(CorrelationIdError) as caught:
+        ActionCorrelation.from_json(payload)
+
+    assert caught.value.code == "malformed_json"
+
+
+def test_correlation_contract_is_exported_from_public_agent_api() -> None:
+    import openmed.agent as agent
+
+    assert agent.RunId is RunId
+    assert agent.ActionId is ActionId
+    assert agent.ActionCorrelation is ActionCorrelation
+    assert agent.CorrelationIdError is CorrelationIdError
+    assert agent.RUN_ID_PREFIX == RUN_ID_PREFIX
+    assert agent.ACTION_ID_PREFIX == ACTION_ID_PREFIX
+    assert agent.CORRELATION_TOKEN_BYTES == CORRELATION_TOKEN_BYTES
+    assert agent.CORRELATION_SCHEMA_VERSION == CORRELATION_SCHEMA_VERSION


### PR DESCRIPTION
## Description

Adds typed, metadata-only correlation identifiers for agent runs and actions. Identifiers use fixed kind prefixes plus 128 random bits, parse canonically, and fail without echoing rejected values. A typed action envelope validates run/action/parent kinds and serializes deterministically.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- Add `RunId`, `ActionId`, `ActionCorrelation`, and stable validation errors under `openmed.agent`.
- Use `secrets.token_bytes(16)` by default with an injectable token source for deterministic offline tests.
- Add strict kind-aware parsing, parent validation, deterministic JSON, value-free representations, docs, and publication metadata.

## Testing

- [x] Added tests covering generation, parsing, wrong-kind fields, parent relationships, deterministic serialization, malformed JSON, and value-free failures.
- [x] Focused new and existing unit tests pass locally: `70 passed`.
- [x] Model/input testing is not applicable; this is a stdlib-only metadata contract.

Commands run:

```text
python -m pytest tests/unit/agent/test_correlation.py tests/unit/agent/test_injection_guard.py tests/unit/test_public_api_docstrings.py tests/unit/release/test_changelog.py tests/unit/test_docs_publication.py tests/unit/test_docs_cookbook_links.py -q
uv run --frozen --extra dev mypy openmed/agent/correlation.py
uv run --frozen --extra dev mypy
uv run --frozen --extra dev pre-commit run --files <changed files>
ruff check .
ruff format --check .
uv run --frozen --extra dev --extra docs mkdocs build --strict
```

The full Ruff checks were also repeated in an LF-only worktree to avoid Windows checkout line-ending noise: all 1,791 Python files passed format checking.

## Documentation

- [x] Updated the documentation and MkDocs publication inventory.
- [x] Added Google-style docstrings to new public classes.
- [x] Updated `CHANGELOG.md`.

## Code Quality

- [x] Canonical Ruff lint/format checks pass.
- [x] Scoped pre-commit hooks pass, including Bandit and Gitleaks.
- [x] Performed a self-review for API scope, deterministic behavior, and value-free failures.
- [x] No new dependencies or runtime network calls were added.

## Dependencies

- [x] No new dependencies.

## Checklist

- [x] Read the contributing guidelines and repository agent guidance.
- [x] Commit is focused and has a clear imperative message.
- [x] No unrelated files or formatting churn are included.

## Related Issues

Closes #2973

## Screenshots/Examples

Not applicable; this change adds a Python metadata API and documentation only.