### PR TITLE
feat(training): render privacy-safe federated round status

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -202,6 +202,7 @@ classification:
     - reference/chat-schema.md
     - reference/training-schemas.md
     - training/federated-round-lifecycle.md
+    - training/federated-round-status.md
     - reference/preference-schema.md
     - multimodal/pdf-reading-order.md
     - multimodal/pdf-redaction-fidelity.md

--- a/docs/training/federated-round-status.md
+++ b/docs/training/federated-round-status.md
@@ -1,0 +1,70 @@
+# Federated round status
+
+OpenMed can render a federated training round as a deterministic operator
+summary without publishing participant identities or local training data. The
+summary accepts aggregate counts and digest references only. It has no fields
+for client IDs, site names, patient counts, local losses, gradients, or
+per-client metrics.
+
+## Disclosure rules
+
+Participant and completed-participant counts are released only when each count
+is at least the configured `minimum_group_size`, which defaults to `5`. Smaller
+counts are replaced with a suppression marker in both JSON and Markdown. The
+minimum group size must be at least `2`.
+
+Quorum is calculated before suppression, so operators still see `met` or
+`not_met` when the exact participant count is hidden. The required quorum is
+not included in the rendered summary.
+
+Completion is reported as one of four coarse bands:
+
+| Band | Aggregate meaning |
+| --- | --- |
+| `not_started` | No participants have completed |
+| `under_half` | More than zero but fewer than half have completed |
+| `half_or_more` | At least half but fewer than all have completed |
+| `complete` | Every participant has completed |
+
+## Usage
+
+```python
+from openmed.training import (
+    FederatedRoundReasonCode,
+    FederatedRoundState,
+    build_federated_round_status,
+)
+
+status = build_federated_round_status(
+    state=FederatedRoundState.HELD,
+    participant_count=8,
+    completed_participant_count=8,
+    required_quorum=5,
+    minimum_group_size=5,
+    aggregate_digest_refs=("sha256:" + "a" * 64,),
+    reason_code=FederatedRoundReasonCode.QUALITY_REVIEW_REQUIRED,
+)
+
+json_artifact = status.to_json()
+markdown_artifact = status.to_markdown()
+```
+
+Digest references must be lowercase `sha256:` values. Duplicate references are
+rejected and valid references are sorted before rendering, so caller ordering
+cannot change the artifact. Held and aborted rounds require a reason from their
+respective stable reason-code sets; other lifecycle states reject reason codes.
+
+| Round state | Allowed reason codes |
+| --- | --- |
+| `held` | `privacy_review_required`, `quality_review_required`, `policy_review_required` |
+| `aborted` | `quorum_not_met`, `privacy_gate_failed`, `quality_gate_failed`, `policy_gate_failed`, `operator_cancelled`, `round_error` |
+
+## Privacy boundary
+
+The builder uses exact aggregate counts only to calculate quorum, completion,
+and disclosure. It immediately replaces sub-threshold counts with `null` in the
+immutable status object, so later renderers cannot recover the omitted number.
+
+Minimum-group suppression is an output control, not differential privacy or a
+privacy accountant. Transport, client attribution, local metrics, and privacy
+budget enforcement remain outside this module.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - Chat Message Schema: reference/chat-schema.md
       - Training Schema Registry: reference/training-schemas.md
       - Federated Round Lifecycle: training/federated-round-lifecycle.md
+      - Federated Round Status: training/federated-round-status.md
       - Preference Pair Schema: reference/preference-schema.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md

--- a/openmed/training/__init__.py
+++ b/openmed/training/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "CLINICAL_PRIVACY_TRAINING_SOURCE_IDS",
     "DAPT_CORPUS_MANIFEST_PATH",
     "DAPT_CORPUS_SCHEMA_VERSION",
+    "DEFAULT_FEDERATED_MINIMUM_GROUP_SIZE",
     "MAX_LORA_TRAINABLE_RATIO",
     "PRESET_BY_MODE",
     "QLORA_CONFIG_SCHEMA_VERSION",
@@ -64,6 +65,7 @@ __all__ = [
     "DIRECTID_TRAINING_REPORT_SCHEMA_VERSION",
     "DIRECTID_TINY_HEAD_CONTRACT",
     "FEDERATED_ROUND_SCHEMA_VERSION",
+    "FEDERATED_ROUND_STATUS_SCHEMA_VERSION",
     "FEDERATED_ROUND_STATES",
     "FEDERATED_ROUND_TERMINAL_STATES",
     "FEDERATED_ROUND_TRANSITIONS",
@@ -97,8 +99,13 @@ __all__ = [
     "DistillationTargets",
     "EntityTypeWeights",
     "FederatedRoundLifecycle",
+    "FederatedCompletionBand",
+    "FederatedQuorumStatus",
+    "FederatedRoundReasonCode",
     "FederatedRoundState",
     "FederatedRoundStateError",
+    "FederatedRoundStatus",
+    "FederatedRoundStatusError",
     "FederatedRoundTransitionError",
     "HARD_NEGATIVE_CATEGORIES",
     "HardNegativeExample",
@@ -138,6 +145,7 @@ __all__ = [
     "build_clinical_privacy_checkpoint_manifest",
     "build_clinical_family_release",
     "build_directid_dataset_evidence",
+    "build_federated_round_status",
     "config_hash",
     "clinical_family_recipe_hash",
     "clinical_model_family_spec",
@@ -195,6 +203,18 @@ __all__ = [
 
 
 def __getattr__(name: str) -> Any:
+    if name in {
+        "DEFAULT_FEDERATED_MINIMUM_GROUP_SIZE",
+        "FEDERATED_ROUND_STATUS_SCHEMA_VERSION",
+        "FederatedCompletionBand",
+        "FederatedQuorumStatus",
+        "FederatedRoundReasonCode",
+        "FederatedRoundStatus",
+        "FederatedRoundStatusError",
+        "build_federated_round_status",
+    }:
+        federated_status = import_module(".federated_status", __name__)
+        return getattr(federated_status, name)
     if name in {
         "FEDERATED_ROUND_SCHEMA_VERSION",
         "FEDERATED_ROUND_STATES",

--- a/openmed/training/federated_status.py
+++ b/openmed/training/federated_status.py
@@ -1,0 +1,338 @@
+"""Privacy-safe operator summaries for federated training rounds."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Final, Sequence
+
+from .federated_round import FederatedRoundState
+
+FEDERATED_ROUND_STATUS_SCHEMA_VERSION = "openmed.training.federated_status.v1"
+DEFAULT_FEDERATED_MINIMUM_GROUP_SIZE = 5
+
+_SHA256_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
+
+
+class FederatedQuorumStatus(str, Enum):
+    """Whether the aggregate participant count satisfies quorum."""
+
+    MET = "met"
+    NOT_MET = "not_met"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class FederatedCompletionBand(str, Enum):
+    """A coarse, non-percentage completion category."""
+
+    NOT_STARTED = "not_started"
+    UNDER_HALF = "under_half"
+    HALF_OR_MORE = "half_or_more"
+    COMPLETE = "complete"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class FederatedRoundReasonCode(str, Enum):
+    """Stable, categorical reasons for held and aborted rounds."""
+
+    PRIVACY_REVIEW_REQUIRED = "privacy_review_required"
+    QUALITY_REVIEW_REQUIRED = "quality_review_required"
+    POLICY_REVIEW_REQUIRED = "policy_review_required"
+    QUORUM_NOT_MET = "quorum_not_met"
+    PRIVACY_GATE_FAILED = "privacy_gate_failed"
+    QUALITY_GATE_FAILED = "quality_gate_failed"
+    POLICY_GATE_FAILED = "policy_gate_failed"
+    OPERATOR_CANCELLED = "operator_cancelled"
+    ROUND_ERROR = "round_error"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+_HOLD_REASON_CODES: Final[frozenset[FederatedRoundReasonCode]] = frozenset(
+    {
+        FederatedRoundReasonCode.PRIVACY_REVIEW_REQUIRED,
+        FederatedRoundReasonCode.QUALITY_REVIEW_REQUIRED,
+        FederatedRoundReasonCode.POLICY_REVIEW_REQUIRED,
+    }
+)
+_ABORT_REASON_CODES: Final[frozenset[FederatedRoundReasonCode]] = frozenset(
+    {
+        FederatedRoundReasonCode.QUORUM_NOT_MET,
+        FederatedRoundReasonCode.PRIVACY_GATE_FAILED,
+        FederatedRoundReasonCode.QUALITY_GATE_FAILED,
+        FederatedRoundReasonCode.POLICY_GATE_FAILED,
+        FederatedRoundReasonCode.OPERATOR_CANCELLED,
+        FederatedRoundReasonCode.ROUND_ERROR,
+    }
+)
+
+
+class FederatedRoundStatusError(ValueError):
+    """Raised when a round summary cannot be produced safely."""
+
+
+@dataclass(frozen=True)
+class FederatedRoundStatus:
+    """An immutable round summary that contains only publishable aggregates."""
+
+    state: FederatedRoundState
+    quorum_status: FederatedQuorumStatus
+    participant_count: int | None
+    completed_participant_count: int | None
+    minimum_group_size: int
+    completion_band: FederatedCompletionBand
+    aggregate_digest_refs: tuple[str, ...] = ()
+    reason_code: FederatedRoundReasonCode | None = None
+    schema_version: str = FEDERATED_ROUND_STATUS_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.state, FederatedRoundState):
+            raise FederatedRoundStatusError("invalid federated round state")
+        if not isinstance(self.quorum_status, FederatedQuorumStatus):
+            raise FederatedRoundStatusError("invalid quorum status")
+        _require_minimum_group_size(self.minimum_group_size)
+        _require_released_count(self.participant_count, self.minimum_group_size)
+        _require_released_count(
+            self.completed_participant_count, self.minimum_group_size
+        )
+        if (
+            self.participant_count is None
+            and self.completed_participant_count is not None
+        ):
+            raise FederatedRoundStatusError(
+                "completed participant count requires a released participant count"
+            )
+        if (
+            self.participant_count is not None
+            and self.completed_participant_count is not None
+            and self.completed_participant_count > self.participant_count
+        ):
+            raise FederatedRoundStatusError(
+                "completed participant count exceeds participant count"
+            )
+        if not isinstance(self.completion_band, FederatedCompletionBand):
+            raise FederatedRoundStatusError("invalid completion band")
+        if (
+            type(self.schema_version) is not str
+            or self.schema_version != FEDERATED_ROUND_STATUS_SCHEMA_VERSION
+        ):
+            raise FederatedRoundStatusError("unsupported federated round status schema")
+        _require_digest_refs(self.aggregate_digest_refs)
+        _require_reason_code(self.state, self.reason_code)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a privacy-safe deterministic mapping."""
+
+        return {
+            "aggregate_digest_refs": list(self.aggregate_digest_refs),
+            "completed_participant_count": self.completed_participant_count,
+            "completion_band": self.completion_band.value,
+            "minimum_group_size": self.minimum_group_size,
+            "participant_count": self.participant_count,
+            "quorum_status": self.quorum_status.value,
+            "reason_code": (
+                self.reason_code.value if self.reason_code is not None else None
+            ),
+            "schema_version": self.schema_version,
+            "state": self.state.value,
+        }
+
+    def to_json(self) -> str:
+        """Return byte-stable JSON with a trailing newline."""
+
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n"
+
+    def to_markdown(self) -> str:
+        """Return a byte-stable Markdown operator summary."""
+
+        reason = self.reason_code.value if self.reason_code is not None else "none"
+        lines = [
+            "# Federated round status",
+            "",
+            "| Field | Value |",
+            "| --- | --- |",
+            f"| Schema | `{self.schema_version}` |",
+            f"| State | `{self.state.value}` |",
+            f"| Quorum | `{self.quorum_status.value}` |",
+            (
+                "| Participants | "
+                f"`{_format_count(self.participant_count, self.minimum_group_size)}` |"
+            ),
+            (
+                "| Completed participants | "
+                f"`{_format_count(self.completed_participant_count, self.minimum_group_size)}` |"
+            ),
+            f"| Completion | `{self.completion_band.value}` |",
+            f"| Reason | `{reason}` |",
+            "",
+            "## Aggregate digests",
+            "",
+        ]
+        if self.aggregate_digest_refs:
+            lines.extend(f"- `{digest}`" for digest in self.aggregate_digest_refs)
+        else:
+            lines.append("None.")
+        return "\n".join(lines) + "\n"
+
+
+def build_federated_round_status(
+    *,
+    state: FederatedRoundState,
+    participant_count: int,
+    completed_participant_count: int,
+    required_quorum: int,
+    minimum_group_size: int = DEFAULT_FEDERATED_MINIMUM_GROUP_SIZE,
+    aggregate_digest_refs: Sequence[str] = (),
+    reason_code: FederatedRoundReasonCode | None = None,
+) -> FederatedRoundStatus:
+    """Build a summary while discarding exact sub-threshold counts."""
+
+    if not isinstance(state, FederatedRoundState):
+        raise FederatedRoundStatusError("invalid federated round state")
+    _require_non_negative_int(participant_count, "participant count")
+    _require_non_negative_int(
+        completed_participant_count, "completed participant count"
+    )
+    _require_positive_int(required_quorum, "required quorum")
+    _require_minimum_group_size(minimum_group_size)
+    if completed_participant_count > participant_count:
+        raise FederatedRoundStatusError(
+            "completed participant count exceeds participant count"
+        )
+    digest_refs = _normalize_digest_refs(aggregate_digest_refs)
+    _require_reason_code(state, reason_code)
+
+    return FederatedRoundStatus(
+        state=state,
+        quorum_status=(
+            FederatedQuorumStatus.MET
+            if participant_count >= required_quorum
+            else FederatedQuorumStatus.NOT_MET
+        ),
+        participant_count=_threshold_count(participant_count, minimum_group_size),
+        completed_participant_count=_threshold_count(
+            completed_participant_count, minimum_group_size
+        ),
+        minimum_group_size=minimum_group_size,
+        completion_band=_completion_band(
+            participant_count, completed_participant_count
+        ),
+        aggregate_digest_refs=digest_refs,
+        reason_code=reason_code,
+    )
+
+
+def _threshold_count(count: int, minimum_group_size: int) -> int | None:
+    return count if count >= minimum_group_size else None
+
+
+def _completion_band(
+    participant_count: int, completed_participant_count: int
+) -> FederatedCompletionBand:
+    if completed_participant_count == 0:
+        return FederatedCompletionBand.NOT_STARTED
+    if completed_participant_count == participant_count:
+        return FederatedCompletionBand.COMPLETE
+    if completed_participant_count * 2 < participant_count:
+        return FederatedCompletionBand.UNDER_HALF
+    return FederatedCompletionBand.HALF_OR_MORE
+
+
+def _normalize_digest_refs(value: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise FederatedRoundStatusError("invalid aggregate digest references")
+    normalized = tuple(value)
+    if any(
+        type(digest) is not str or _SHA256_DIGEST.fullmatch(digest) is None
+        for digest in normalized
+    ):
+        raise FederatedRoundStatusError("invalid aggregate digest references")
+    if len(set(normalized)) != len(normalized):
+        raise FederatedRoundStatusError("aggregate digest references are not canonical")
+    normalized = tuple(sorted(normalized))
+    _require_digest_refs(normalized)
+    return normalized
+
+
+def _require_digest_refs(value: object) -> None:
+    if type(value) is not tuple:
+        raise FederatedRoundStatusError("invalid aggregate digest references")
+    if any(
+        type(digest) is not str or _SHA256_DIGEST.fullmatch(digest) is None
+        for digest in value
+    ):
+        raise FederatedRoundStatusError("invalid aggregate digest references")
+    if tuple(sorted(value)) != value or len(set(value)) != len(value):
+        raise FederatedRoundStatusError("aggregate digest references are not canonical")
+
+
+def _require_reason_code(
+    state: FederatedRoundState, reason_code: FederatedRoundReasonCode | None
+) -> None:
+    if reason_code is not None and not isinstance(
+        reason_code, FederatedRoundReasonCode
+    ):
+        raise FederatedRoundStatusError("invalid federated round reason code")
+    if state is FederatedRoundState.HELD:
+        if reason_code not in _HOLD_REASON_CODES:
+            raise FederatedRoundStatusError("held round requires a hold reason code")
+        return
+    if state is FederatedRoundState.ABORTED:
+        if reason_code not in _ABORT_REASON_CODES:
+            raise FederatedRoundStatusError(
+                "aborted round requires an abort reason code"
+            )
+        return
+    if reason_code is not None:
+        raise FederatedRoundStatusError(
+            "reason code is only valid for held or aborted rounds"
+        )
+
+
+def _require_non_negative_int(value: object, field: str) -> None:
+    if type(value) is not int or value < 0:
+        raise FederatedRoundStatusError(f"{field} must be a non-negative integer")
+
+
+def _require_positive_int(value: object, field: str) -> None:
+    if type(value) is not int or value < 1:
+        raise FederatedRoundStatusError(f"{field} must be a positive integer")
+
+
+def _require_minimum_group_size(value: object) -> None:
+    if type(value) is not int or value < 2:
+        raise FederatedRoundStatusError(
+            "minimum group size must be an integer greater than one"
+        )
+
+
+def _require_released_count(value: object, minimum_group_size: int) -> None:
+    if value is None:
+        return
+    if type(value) is not int or value < minimum_group_size:
+        raise FederatedRoundStatusError("invalid released participant count")
+
+
+def _format_count(count: int | None, minimum_group_size: int) -> str:
+    if count is None:
+        return f"suppressed (<{minimum_group_size})"
+    return str(count)
+
+
+__all__ = [
+    "DEFAULT_FEDERATED_MINIMUM_GROUP_SIZE",
+    "FEDERATED_ROUND_STATUS_SCHEMA_VERSION",
+    "FederatedCompletionBand",
+    "FederatedQuorumStatus",
+    "FederatedRoundReasonCode",
+    "FederatedRoundStatus",
+    "FederatedRoundStatusError",
+    "build_federated_round_status",
+]

--- a/tests/unit/training/test_federated_status.py
+++ b/tests/unit/training/test_federated_status.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from openmed.training.federated_round import FederatedRoundState
+from openmed.training.federated_status import (
+    FEDERATED_ROUND_STATUS_SCHEMA_VERSION,
+    FederatedCompletionBand,
+    FederatedQuorumStatus,
+    FederatedRoundReasonCode,
+    FederatedRoundStatus,
+    FederatedRoundStatusError,
+    build_federated_round_status,
+)
+
+S = FederatedRoundState
+R = FederatedRoundReasonCode
+DIGEST_1 = "sha256:" + "1" * 64
+DIGEST_2 = "sha256:" + "2" * 64
+
+
+GOLDEN_SCENARIOS = {
+    "empty": {
+        "arguments": {
+            "state": S.PLANNED,
+            "participant_count": 0,
+            "completed_participant_count": 0,
+            "required_quorum": 3,
+        },
+        "payload": {
+            "aggregate_digest_refs": [],
+            "completed_participant_count": None,
+            "completion_band": "not_started",
+            "minimum_group_size": 5,
+            "participant_count": None,
+            "quorum_status": "not_met",
+            "reason_code": None,
+            "schema_version": FEDERATED_ROUND_STATUS_SCHEMA_VERSION,
+            "state": "planned",
+        },
+        "markdown": """# Federated round status
+
+| Field | Value |
+| --- | --- |
+| Schema | `openmed.training.federated_status.v1` |
+| State | `planned` |
+| Quorum | `not_met` |
+| Participants | `suppressed (<5)` |
+| Completed participants | `suppressed (<5)` |
+| Completion | `not_started` |
+| Reason | `none` |
+
+## Aggregate digests
+
+None.
+""",
+    },
+    "active": {
+        "arguments": {
+            "state": S.COLLECTING,
+            "participant_count": 8,
+            "completed_participant_count": 3,
+            "required_quorum": 5,
+            "aggregate_digest_refs": [DIGEST_2, DIGEST_1],
+        },
+        "payload": {
+            "aggregate_digest_refs": [DIGEST_1, DIGEST_2],
+            "completed_participant_count": None,
+            "completion_band": "under_half",
+            "minimum_group_size": 5,
+            "participant_count": 8,
+            "quorum_status": "met",
+            "reason_code": None,
+            "schema_version": FEDERATED_ROUND_STATUS_SCHEMA_VERSION,
+            "state": "collecting",
+        },
+        "markdown": f"""# Federated round status
+
+| Field | Value |
+| --- | --- |
+| Schema | `openmed.training.federated_status.v1` |
+| State | `collecting` |
+| Quorum | `met` |
+| Participants | `8` |
+| Completed participants | `suppressed (<5)` |
+| Completion | `under_half` |
+| Reason | `none` |
+
+## Aggregate digests
+
+- `{DIGEST_1}`
+- `{DIGEST_2}`
+""",
+    },
+    "held": {
+        "arguments": {
+            "state": S.HELD,
+            "participant_count": 8,
+            "completed_participant_count": 8,
+            "required_quorum": 5,
+            "aggregate_digest_refs": [DIGEST_1],
+            "reason_code": R.QUALITY_REVIEW_REQUIRED,
+        },
+        "payload": {
+            "aggregate_digest_refs": [DIGEST_1],
+            "completed_participant_count": 8,
+            "completion_band": "complete",
+            "minimum_group_size": 5,
+            "participant_count": 8,
+            "quorum_status": "met",
+            "reason_code": "quality_review_required",
+            "schema_version": FEDERATED_ROUND_STATUS_SCHEMA_VERSION,
+            "state": "held",
+        },
+        "markdown": f"""# Federated round status
+
+| Field | Value |
+| --- | --- |
+| Schema | `openmed.training.federated_status.v1` |
+| State | `held` |
+| Quorum | `met` |
+| Participants | `8` |
+| Completed participants | `8` |
+| Completion | `complete` |
+| Reason | `quality_review_required` |
+
+## Aggregate digests
+
+- `{DIGEST_1}`
+""",
+    },
+    "promoted": {
+        "arguments": {
+            "state": S.PROMOTED,
+            "participant_count": 8,
+            "completed_participant_count": 8,
+            "required_quorum": 5,
+            "aggregate_digest_refs": [DIGEST_2],
+        },
+        "payload": {
+            "aggregate_digest_refs": [DIGEST_2],
+            "completed_participant_count": 8,
+            "completion_band": "complete",
+            "minimum_group_size": 5,
+            "participant_count": 8,
+            "quorum_status": "met",
+            "reason_code": None,
+            "schema_version": FEDERATED_ROUND_STATUS_SCHEMA_VERSION,
+            "state": "promoted",
+        },
+        "markdown": f"""# Federated round status
+
+| Field | Value |
+| --- | --- |
+| Schema | `openmed.training.federated_status.v1` |
+| State | `promoted` |
+| Quorum | `met` |
+| Participants | `8` |
+| Completed participants | `8` |
+| Completion | `complete` |
+| Reason | `none` |
+
+## Aggregate digests
+
+- `{DIGEST_2}`
+""",
+    },
+    "aborted": {
+        "arguments": {
+            "state": S.ABORTED,
+            "participant_count": 3,
+            "completed_participant_count": 2,
+            "required_quorum": 5,
+            "reason_code": R.QUORUM_NOT_MET,
+        },
+        "payload": {
+            "aggregate_digest_refs": [],
+            "completed_participant_count": None,
+            "completion_band": "half_or_more",
+            "minimum_group_size": 5,
+            "participant_count": None,
+            "quorum_status": "not_met",
+            "reason_code": "quorum_not_met",
+            "schema_version": FEDERATED_ROUND_STATUS_SCHEMA_VERSION,
+            "state": "aborted",
+        },
+        "markdown": """# Federated round status
+
+| Field | Value |
+| --- | --- |
+| Schema | `openmed.training.federated_status.v1` |
+| State | `aborted` |
+| Quorum | `not_met` |
+| Participants | `suppressed (<5)` |
+| Completed participants | `suppressed (<5)` |
+| Completion | `half_or_more` |
+| Reason | `quorum_not_met` |
+
+## Aggregate digests
+
+None.
+""",
+    },
+}
+
+
+@pytest.mark.parametrize("scenario", GOLDEN_SCENARIOS)
+def test_round_summaries_have_stable_json_and_markdown_golden_outputs(
+    scenario: str,
+) -> None:
+    golden = GOLDEN_SCENARIOS[scenario]
+    summary = build_federated_round_status(**golden["arguments"])
+
+    assert summary.to_dict() == golden["payload"]
+    assert summary.to_json() == (
+        json.dumps(golden["payload"], indent=2, sort_keys=True) + "\n"
+    )
+    assert summary.to_markdown() == golden["markdown"]
+
+
+def test_sub_threshold_count_is_suppressed_while_quorum_remains_correct() -> None:
+    summary = build_federated_round_status(
+        state=S.PREFLIGHT,
+        participant_count=3,
+        completed_participant_count=0,
+        required_quorum=2,
+        minimum_group_size=5,
+    )
+
+    assert summary.quorum_status is FederatedQuorumStatus.MET
+    assert summary.participant_count is None
+    assert summary.to_dict()["participant_count"] is None
+    assert summary.to_dict()["minimum_group_size"] == 5
+    assert "`met`" in summary.to_markdown()
+    assert "`3`" not in summary.to_markdown()
+
+
+def test_builder_has_no_surface_for_participant_or_local_training_metadata() -> None:
+    forbidden = {
+        "client_id",
+        "client_ids",
+        "site_name",
+        "site_names",
+        "patient_count",
+        "local_loss",
+        "gradients",
+        "per_client_metrics",
+    }
+
+    assert forbidden.isdisjoint(
+        inspect.signature(build_federated_round_status).parameters
+    )
+    assert forbidden.isdisjoint(inspect.signature(FederatedRoundStatus).parameters)
+    with pytest.raises(TypeError) as error:
+        build_federated_round_status(
+            state=S.PLANNED,
+            participant_count=0,
+            completed_participant_count=0,
+            required_quorum=2,
+            **{"site_names": ["North Hospital"]},
+        )
+    assert "North Hospital" not in str(error.value)
+
+
+def test_suppressed_values_are_not_retained_by_the_returned_object() -> None:
+    summary = build_federated_round_status(
+        state=S.COLLECTING,
+        participant_count=4,
+        completed_participant_count=1,
+        required_quorum=2,
+        minimum_group_size=5,
+    )
+
+    assert summary.participant_count is None
+    assert summary.completed_participant_count is None
+    assert "participant_count=4" not in repr(summary)
+    assert "completed_participant_count=1" not in repr(summary)
+
+
+@pytest.mark.parametrize(
+    ("participants", "completed", "expected"),
+    [
+        (8, 0, FederatedCompletionBand.NOT_STARTED),
+        (8, 1, FederatedCompletionBand.UNDER_HALF),
+        (8, 3, FederatedCompletionBand.UNDER_HALF),
+        (8, 4, FederatedCompletionBand.HALF_OR_MORE),
+        (8, 7, FederatedCompletionBand.HALF_OR_MORE),
+        (8, 8, FederatedCompletionBand.COMPLETE),
+    ],
+)
+def test_completion_band_boundaries_are_stable(
+    participants: int,
+    completed: int,
+    expected: FederatedCompletionBand,
+) -> None:
+    summary = build_federated_round_status(
+        state=S.COLLECTING,
+        participant_count=participants,
+        completed_participant_count=completed,
+        required_quorum=2,
+    )
+
+    assert summary.completion_band is expected
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"participant_count": -1},
+        {"participant_count": True},
+        {"completed_participant_count": -1},
+        {"completed_participant_count": 4, "participant_count": 3},
+        {"required_quorum": 0},
+        {"required_quorum": True},
+        {"minimum_group_size": 1},
+        {"minimum_group_size": True},
+        {"state": "planned"},
+    ],
+)
+def test_invalid_aggregate_inputs_fail_closed(overrides: dict[str, object]) -> None:
+    arguments: dict[str, object] = {
+        "state": S.PLANNED,
+        "participant_count": 3,
+        "completed_participant_count": 1,
+        "required_quorum": 2,
+    }
+    arguments.update(overrides)
+
+    with pytest.raises(FederatedRoundStatusError):
+        build_federated_round_status(**arguments)
+
+
+@pytest.mark.parametrize(
+    ("state", "reason"),
+    [
+        (S.HELD, None),
+        (S.HELD, R.ROUND_ERROR),
+        (S.ABORTED, None),
+        (S.ABORTED, R.QUALITY_REVIEW_REQUIRED),
+        (S.COLLECTING, R.QUALITY_REVIEW_REQUIRED),
+    ],
+)
+def test_reason_codes_are_required_and_state_specific(
+    state: FederatedRoundState,
+    reason: FederatedRoundReasonCode | None,
+) -> None:
+    with pytest.raises(FederatedRoundStatusError):
+        build_federated_round_status(
+            state=state,
+            participant_count=8,
+            completed_participant_count=4,
+            required_quorum=5,
+            reason_code=reason,
+        )
+
+
+def test_digest_references_are_validated_sorted_and_unique() -> None:
+    summary = build_federated_round_status(
+        state=S.EVALUATING,
+        participant_count=8,
+        completed_participant_count=8,
+        required_quorum=5,
+        aggregate_digest_refs=[DIGEST_2, DIGEST_1],
+    )
+    assert summary.aggregate_digest_refs == (DIGEST_1, DIGEST_2)
+
+    for invalid in (["not-a-digest"], [DIGEST_1, DIGEST_1], "secret"):
+        with pytest.raises(FederatedRoundStatusError):
+            build_federated_round_status(
+                state=S.EVALUATING,
+                participant_count=8,
+                completed_participant_count=8,
+                required_quorum=5,
+                aggregate_digest_refs=invalid,
+            )
+
+
+def test_errors_do_not_echo_rejected_digest_values() -> None:
+    sentinel = "Patient Jane Roe /srv/site-a local_loss=0.42"
+
+    with pytest.raises(FederatedRoundStatusError) as error:
+        build_federated_round_status(
+            state=S.COLLECTING,
+            participant_count=8,
+            completed_participant_count=3,
+            required_quorum=5,
+            aggregate_digest_refs=[sentinel],
+        )
+    assert sentinel not in str(error.value)
+
+
+def test_status_is_immutable() -> None:
+    summary = build_federated_round_status(
+        state=S.PLANNED,
+        participant_count=0,
+        completed_participant_count=0,
+        required_quorum=2,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        summary.state = S.ABORTED  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(("participants", "completed"), [(None, 5), (5, 6)])
+def test_direct_status_construction_enforces_released_count_relationships(
+    participants: int | None, completed: int
+) -> None:
+    with pytest.raises(FederatedRoundStatusError):
+        FederatedRoundStatus(
+            state=S.COLLECTING,
+            quorum_status=FederatedQuorumStatus.MET,
+            participant_count=participants,
+            completed_participant_count=completed,
+            minimum_group_size=5,
+            completion_band=FederatedCompletionBand.HALF_OR_MORE,
+        )
+
+
+def test_status_api_is_available_through_lazy_training_exports() -> None:
+    import openmed.training as training
+
+    assert training.build_federated_round_status is build_federated_round_status
+    assert training.FederatedRoundReasonCode is FederatedRoundReasonCode
+    assert training.__all__.count("FederatedRoundStatus") == 1


### PR DESCRIPTION
Federated round updates now show the useful bits without leaking small-group data, so ops stays informed without the overshare. Closes #2959.