### PR TITLE
feat(training): validate federated round scheduling windows

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -202,6 +202,7 @@ classification:
     - reference/chat-schema.md
     - reference/training-schemas.md
     - training/federated-round-lifecycle.md
+    - training/federated-scheduling.md
     - reference/preference-schema.md
     - multimodal/pdf-reading-order.md
     - multimodal/pdf-redaction-fidelity.md

--- a/docs/training/federated-scheduling.md
+++ b/docs/training/federated-scheduling.md
@@ -1,0 +1,62 @@
+# Federated round scheduling
+
+OpenMed represents a federated round schedule as five strictly ordered UTC
+boundaries. The boundaries define contiguous enrollment, update-submission,
+aggregation, and evaluation windows without selecting a lifecycle state or
+reading the system clock.
+
+## Window semantics
+
+Each phase is a half-open interval: its start is included and the next boundary
+is excluded. At an exact boundary, the new phase is active. At `finishes_at`,
+no phase remains active.
+
+| Phase | Window |
+| --- | --- |
+| `enrollment` | `enrollment_starts_at` to `update_submission_starts_at` |
+| `update_submission` | `update_submission_starts_at` to `aggregation_starts_at` |
+| `aggregation` | `aggregation_starts_at` to `evaluation_starts_at` |
+| `evaluation` | `evaluation_starts_at` to `finishes_at` |
+
+`active_phase_at(timestamp)` returns the phase containing the supplied UTC
+timestamp. `next_phase_at(timestamp)` returns the first phase with a future
+start boundary. Before the schedule starts, enrollment is next; during
+evaluation and after finish, there is no next phase.
+
+## Usage
+
+```python
+from datetime import datetime, timedelta, timezone
+
+from openmed.training import FederatedRoundSchedule
+
+start = datetime(2026, 9, 1, tzinfo=timezone.utc)
+schedule = FederatedRoundSchedule(
+    enrollment_starts_at=start,
+    update_submission_starts_at=start + timedelta(hours=12),
+    aggregation_starts_at=start + timedelta(hours=24),
+    evaluation_starts_at=start + timedelta(hours=30),
+    finishes_at=start + timedelta(hours=36),
+    max_enrollment_duration_seconds=12 * 60 * 60,
+)
+
+active = schedule.active_phase_at(start)
+payload = schedule.to_json()
+restored = FederatedRoundSchedule.from_json(payload)
+assert restored == schedule
+```
+
+All timestamps must be timezone-aware with a zero UTC offset. Serialization
+uses canonical `Z` timestamps and preserves microseconds when present. Naive or
+non-UTC timestamps and equal or reversed boundaries are rejected.
+
+## Duration limits
+
+Each phase can have an optional positive integer maximum duration in seconds.
+The configured maximum is inclusive, and each phase also has a hard upper bound
+of 365 days. These limits reject accidental year-scale windows while allowing a
+caller to apply a tighter scheduling policy.
+
+The schema contains only boundaries, duration limits, phase names, and its
+version. It has no fields for site or client identities, patient counts, local
+metrics, network endpoints, notifications, or retry policy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - Chat Message Schema: reference/chat-schema.md
       - Training Schema Registry: reference/training-schemas.md
       - Federated Round Lifecycle: training/federated-round-lifecycle.md
+      - Federated Round Scheduling: training/federated-scheduling.md
       - Preference Pair Schema: reference/preference-schema.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md

--- a/openmed/training/__init__.py
+++ b/openmed/training/__init__.py
@@ -18,6 +18,9 @@ __all__ = [
     "CLINICAL_PRIVACY_TRAINING_SOURCE_IDS",
     "DAPT_CORPUS_MANIFEST_PATH",
     "DAPT_CORPUS_SCHEMA_VERSION",
+    "FEDERATED_SCHEDULE_PHASES",
+    "FEDERATED_SCHEDULE_SCHEMA_VERSION",
+    "MAX_FEDERATED_PHASE_DURATION_SECONDS",
     "MAX_LORA_TRAINABLE_RATIO",
     "PRESET_BY_MODE",
     "QLORA_CONFIG_SCHEMA_VERSION",
@@ -97,6 +100,9 @@ __all__ = [
     "DistillationTargets",
     "EntityTypeWeights",
     "FederatedRoundLifecycle",
+    "FederatedRoundSchedule",
+    "FederatedScheduleError",
+    "FederatedSchedulePhase",
     "FederatedRoundState",
     "FederatedRoundStateError",
     "FederatedRoundTransitionError",
@@ -209,6 +215,16 @@ __all__ = [
 
 
 def __getattr__(name: str) -> Any:
+    if name in {
+        "FEDERATED_SCHEDULE_PHASES",
+        "FEDERATED_SCHEDULE_SCHEMA_VERSION",
+        "MAX_FEDERATED_PHASE_DURATION_SECONDS",
+        "FederatedRoundSchedule",
+        "FederatedScheduleError",
+        "FederatedSchedulePhase",
+    }:
+        federated_schedule = import_module(".federated_schedule", __name__)
+        return getattr(federated_schedule, name)
     if name in {
         "FEDERATED_ROUND_SCHEMA_VERSION",
         "FEDERATED_ROUND_STATES",

--- a/openmed/training/federated_schedule.py
+++ b/openmed/training/federated_schedule.py
@@ -1,0 +1,316 @@
+"""Deterministic UTC scheduling windows for federated training rounds."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any, Final, Mapping
+
+FEDERATED_SCHEDULE_SCHEMA_VERSION = "openmed.training.federated_schedule.v1"
+MAX_FEDERATED_PHASE_DURATION_SECONDS = 365 * 24 * 60 * 60
+
+
+class FederatedSchedulePhase(str, Enum):
+    """A bounded participation phase in chronological order."""
+
+    ENROLLMENT = "enrollment"
+    UPDATE_SUBMISSION = "update_submission"
+    AGGREGATION = "aggregation"
+    EVALUATION = "evaluation"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+FEDERATED_SCHEDULE_PHASES: Final[tuple[FederatedSchedulePhase, ...]] = tuple(
+    FederatedSchedulePhase
+)
+
+
+class FederatedScheduleError(ValueError):
+    """Raised when a federated schedule is malformed or unsupported."""
+
+
+@dataclass(frozen=True)
+class FederatedRoundSchedule:
+    """Immutable phase boundaries with no participant or network metadata."""
+
+    enrollment_starts_at: datetime
+    update_submission_starts_at: datetime
+    aggregation_starts_at: datetime
+    evaluation_starts_at: datetime
+    finishes_at: datetime
+    max_enrollment_duration_seconds: int | None = None
+    max_update_submission_duration_seconds: int | None = None
+    max_aggregation_duration_seconds: int | None = None
+    max_evaluation_duration_seconds: int | None = None
+    schema_version: str = FEDERATED_SCHEDULE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.schema_version) is not str
+            or self.schema_version != FEDERATED_SCHEDULE_SCHEMA_VERSION
+        ):
+            raise FederatedScheduleError("unsupported federated schedule schema")
+
+        boundary_names = (
+            "enrollment_starts_at",
+            "update_submission_starts_at",
+            "aggregation_starts_at",
+            "evaluation_starts_at",
+            "finishes_at",
+        )
+        for name in boundary_names:
+            object.__setattr__(self, name, _require_utc(getattr(self, name), name))
+
+        for previous_name, current_name in zip(boundary_names, boundary_names[1:]):
+            if getattr(self, current_name) <= getattr(self, previous_name):
+                raise FederatedScheduleError(
+                    f"{current_name} must be later than {previous_name}"
+                )
+
+        boundaries = self._boundaries()
+        duration_limits = self._duration_limits()
+        for (phase, start, end), limit in zip(boundaries, duration_limits):
+            field = _maximum_field(phase)
+            _require_optional_duration(limit, field)
+            duration = end - start
+            if duration > timedelta(seconds=MAX_FEDERATED_PHASE_DURATION_SECONDS):
+                raise FederatedScheduleError(
+                    f"{_end_field(phase)} exceeds the supported phase duration"
+                )
+            if limit is not None and duration > timedelta(seconds=limit):
+                raise FederatedScheduleError(f"{_end_field(phase)} exceeds {field}")
+
+    def active_phase_at(self, timestamp: datetime) -> FederatedSchedulePhase | None:
+        """Return the active half-open phase at a caller-supplied UTC timestamp."""
+
+        moment = _require_utc(timestamp, "timestamp")
+        for phase, start, end in self._boundaries():
+            if start <= moment < end:
+                return phase
+        return None
+
+    def next_phase_at(self, timestamp: datetime) -> FederatedSchedulePhase | None:
+        """Return the next phase that has not started at the supplied timestamp."""
+
+        moment = _require_utc(timestamp, "timestamp")
+        for phase, start, _ in self._boundaries():
+            if moment < start:
+                return phase
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the versioned metadata-only schedule representation."""
+
+        return {
+            "boundaries": {
+                "aggregation_starts_at": _format_utc(self.aggregation_starts_at),
+                "enrollment_starts_at": _format_utc(self.enrollment_starts_at),
+                "evaluation_starts_at": _format_utc(self.evaluation_starts_at),
+                "finishes_at": _format_utc(self.finishes_at),
+                "update_submission_starts_at": _format_utc(
+                    self.update_submission_starts_at
+                ),
+            },
+            "maximum_duration_seconds": {
+                "aggregation": self.max_aggregation_duration_seconds,
+                "enrollment": self.max_enrollment_duration_seconds,
+                "evaluation": self.max_evaluation_duration_seconds,
+                "update_submission": self.max_update_submission_duration_seconds,
+            },
+            "schema_version": self.schema_version,
+        }
+
+    def to_json(self) -> str:
+        """Return byte-stable JSON with canonical UTC timestamps."""
+
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n"
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> FederatedRoundSchedule:
+        """Parse a strict schedule payload without retaining unknown metadata."""
+
+        if not isinstance(payload, Mapping):
+            raise FederatedScheduleError("invalid federated schedule payload")
+        if _keys(payload) != {
+            "boundaries",
+            "maximum_duration_seconds",
+            "schema_version",
+        }:
+            raise FederatedScheduleError("invalid federated schedule payload")
+        if (
+            type(payload["schema_version"]) is not str
+            or payload["schema_version"] != FEDERATED_SCHEDULE_SCHEMA_VERSION
+        ):
+            raise FederatedScheduleError("unsupported federated schedule schema")
+
+        boundaries = payload["boundaries"]
+        maximums = payload["maximum_duration_seconds"]
+        if not isinstance(boundaries, Mapping) or _keys(boundaries) != {
+            "aggregation_starts_at",
+            "enrollment_starts_at",
+            "evaluation_starts_at",
+            "finishes_at",
+            "update_submission_starts_at",
+        }:
+            raise FederatedScheduleError("invalid federated schedule boundaries")
+        if not isinstance(maximums, Mapping) or _keys(maximums) != {
+            "aggregation",
+            "enrollment",
+            "evaluation",
+            "update_submission",
+        }:
+            raise FederatedScheduleError("invalid federated schedule durations")
+
+        return cls(
+            enrollment_starts_at=_parse_utc(
+                boundaries["enrollment_starts_at"], "enrollment_starts_at"
+            ),
+            update_submission_starts_at=_parse_utc(
+                boundaries["update_submission_starts_at"],
+                "update_submission_starts_at",
+            ),
+            aggregation_starts_at=_parse_utc(
+                boundaries["aggregation_starts_at"], "aggregation_starts_at"
+            ),
+            evaluation_starts_at=_parse_utc(
+                boundaries["evaluation_starts_at"], "evaluation_starts_at"
+            ),
+            finishes_at=_parse_utc(boundaries["finishes_at"], "finishes_at"),
+            max_enrollment_duration_seconds=maximums["enrollment"],
+            max_update_submission_duration_seconds=maximums["update_submission"],
+            max_aggregation_duration_seconds=maximums["aggregation"],
+            max_evaluation_duration_seconds=maximums["evaluation"],
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> FederatedRoundSchedule:
+        """Parse schedule JSON while replacing parser details with a safe error."""
+
+        if type(payload) is not str:
+            raise FederatedScheduleError("invalid federated schedule JSON")
+        try:
+            decoded = json.loads(payload, object_pairs_hook=_strict_json_object)
+        except (json.JSONDecodeError, FederatedScheduleError, TypeError):
+            raise FederatedScheduleError("invalid federated schedule JSON") from None
+        if not isinstance(decoded, Mapping):
+            raise FederatedScheduleError("invalid federated schedule payload")
+        return cls.from_dict(decoded)
+
+    def _boundaries(
+        self,
+    ) -> tuple[tuple[FederatedSchedulePhase, datetime, datetime], ...]:
+        return (
+            (
+                FederatedSchedulePhase.ENROLLMENT,
+                self.enrollment_starts_at,
+                self.update_submission_starts_at,
+            ),
+            (
+                FederatedSchedulePhase.UPDATE_SUBMISSION,
+                self.update_submission_starts_at,
+                self.aggregation_starts_at,
+            ),
+            (
+                FederatedSchedulePhase.AGGREGATION,
+                self.aggregation_starts_at,
+                self.evaluation_starts_at,
+            ),
+            (
+                FederatedSchedulePhase.EVALUATION,
+                self.evaluation_starts_at,
+                self.finishes_at,
+            ),
+        )
+
+    def _duration_limits(self) -> tuple[int | None, ...]:
+        return (
+            self.max_enrollment_duration_seconds,
+            self.max_update_submission_duration_seconds,
+            self.max_aggregation_duration_seconds,
+            self.max_evaluation_duration_seconds,
+        )
+
+
+def _require_utc(value: object, field: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise FederatedScheduleError(f"{field} must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise FederatedScheduleError(f"{field} must be timezone-aware")
+    if value.utcoffset() != timedelta(0):
+        raise FederatedScheduleError(f"{field} must use UTC")
+    return value.astimezone(timezone.utc)
+
+
+def _require_optional_duration(value: object, field: str) -> None:
+    if value is None:
+        return
+    if (
+        type(value) is not int
+        or value < 1
+        or value > MAX_FEDERATED_PHASE_DURATION_SECONDS
+    ):
+        raise FederatedScheduleError(f"{field} must be a supported positive integer")
+
+
+def _format_utc(value: datetime) -> str:
+    canonical = _require_utc(value, "timestamp")
+    timespec = "microseconds" if canonical.microsecond else "seconds"
+    return canonical.isoformat(timespec=timespec).replace("+00:00", "Z")
+
+
+def _parse_utc(value: object, field: str) -> datetime:
+    if type(value) is not str or not value.endswith("Z"):
+        raise FederatedScheduleError(f"{field} must be a canonical UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError:
+        raise FederatedScheduleError(
+            f"{field} must be a canonical UTC timestamp"
+        ) from None
+    if _format_utc(parsed) != value:
+        raise FederatedScheduleError(f"{field} must be a canonical UTC timestamp")
+    return parsed
+
+
+def _keys(value: Mapping[Any, Any]) -> set[Any]:
+    try:
+        return set(value)
+    except Exception:
+        raise FederatedScheduleError("invalid federated schedule payload") from None
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise FederatedScheduleError("invalid federated schedule JSON")
+        result[key] = value
+    return result
+
+
+def _end_field(phase: FederatedSchedulePhase) -> str:
+    if phase is FederatedSchedulePhase.ENROLLMENT:
+        return "update_submission_starts_at"
+    if phase is FederatedSchedulePhase.UPDATE_SUBMISSION:
+        return "aggregation_starts_at"
+    if phase is FederatedSchedulePhase.AGGREGATION:
+        return "evaluation_starts_at"
+    return "finishes_at"
+
+
+def _maximum_field(phase: FederatedSchedulePhase) -> str:
+    return f"max_{phase.value}_duration_seconds"
+
+
+__all__ = [
+    "FEDERATED_SCHEDULE_PHASES",
+    "FEDERATED_SCHEDULE_SCHEMA_VERSION",
+    "MAX_FEDERATED_PHASE_DURATION_SECONDS",
+    "FederatedRoundSchedule",
+    "FederatedScheduleError",
+    "FederatedSchedulePhase",
+]

--- a/tests/unit/training/test_federated_schedule.py
+++ b/tests/unit/training/test_federated_schedule.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import FrozenInstanceError, fields
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from openmed.training.federated_schedule import (
+    FEDERATED_SCHEDULE_PHASES,
+    FEDERATED_SCHEDULE_SCHEMA_VERSION,
+    MAX_FEDERATED_PHASE_DURATION_SECONDS,
+    FederatedRoundSchedule,
+    FederatedScheduleError,
+    FederatedSchedulePhase,
+)
+
+P = FederatedSchedulePhase
+START = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+def _schedule(**overrides: object) -> FederatedRoundSchedule:
+    values: dict[str, object] = {
+        "enrollment_starts_at": START,
+        "update_submission_starts_at": START + timedelta(hours=1),
+        "aggregation_starts_at": START + timedelta(hours=2),
+        "evaluation_starts_at": START + timedelta(hours=3),
+        "finishes_at": START + timedelta(hours=4),
+    }
+    values.update(overrides)
+    return FederatedRoundSchedule(**values)
+
+
+def test_schedule_serialization_is_deterministic_and_round_trips() -> None:
+    schedule = _schedule(
+        max_enrollment_duration_seconds=3600,
+        max_update_submission_duration_seconds=3600,
+        max_aggregation_duration_seconds=3600,
+        max_evaluation_duration_seconds=3600,
+    )
+    expected = {
+        "boundaries": {
+            "aggregation_starts_at": "2026-09-01T02:00:00Z",
+            "enrollment_starts_at": "2026-09-01T00:00:00Z",
+            "evaluation_starts_at": "2026-09-01T03:00:00Z",
+            "finishes_at": "2026-09-01T04:00:00Z",
+            "update_submission_starts_at": "2026-09-01T01:00:00Z",
+        },
+        "maximum_duration_seconds": {
+            "aggregation": 3600,
+            "enrollment": 3600,
+            "evaluation": 3600,
+            "update_submission": 3600,
+        },
+        "schema_version": FEDERATED_SCHEDULE_SCHEMA_VERSION,
+    }
+
+    assert schedule.to_dict() == expected
+    assert schedule.to_json() == json.dumps(expected, indent=2, sort_keys=True) + "\n"
+    assert FederatedRoundSchedule.from_dict(expected) == schedule
+    assert FederatedRoundSchedule.from_json(schedule.to_json()) == schedule
+
+
+@pytest.mark.parametrize(
+    ("timestamp", "active", "next_phase"),
+    [
+        (START - timedelta(microseconds=1), None, P.ENROLLMENT),
+        (START, P.ENROLLMENT, P.UPDATE_SUBMISSION),
+        (START + timedelta(minutes=30), P.ENROLLMENT, P.UPDATE_SUBMISSION),
+        (START + timedelta(hours=1), P.UPDATE_SUBMISSION, P.AGGREGATION),
+        (START + timedelta(hours=1, minutes=30), P.UPDATE_SUBMISSION, P.AGGREGATION),
+        (START + timedelta(hours=2), P.AGGREGATION, P.EVALUATION),
+        (START + timedelta(hours=2, minutes=30), P.AGGREGATION, P.EVALUATION),
+        (START + timedelta(hours=3), P.EVALUATION, None),
+        (START + timedelta(hours=3, minutes=30), P.EVALUATION, None),
+        (START + timedelta(hours=4), None, None),
+        (START + timedelta(days=1), None, None),
+    ],
+)
+def test_active_and_next_phase_resolution_uses_half_open_boundaries(
+    timestamp: datetime,
+    active: FederatedSchedulePhase | None,
+    next_phase: FederatedSchedulePhase | None,
+) -> None:
+    schedule = _schedule()
+
+    assert schedule.active_phase_at(timestamp) is active
+    assert schedule.next_phase_at(timestamp) is next_phase
+
+
+def test_microseconds_are_preserved_in_canonical_serialization() -> None:
+    schedule = _schedule(
+        finishes_at=START + timedelta(hours=4, microseconds=1),
+    )
+
+    assert schedule.to_dict()["boundaries"]["finishes_at"] == (
+        "2026-09-01T04:00:00.000001Z"
+    )
+    assert FederatedRoundSchedule.from_json(schedule.to_json()) == schedule
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "enrollment_starts_at",
+        "update_submission_starts_at",
+        "aggregation_starts_at",
+        "evaluation_starts_at",
+        "finishes_at",
+    ],
+)
+def test_naive_boundaries_fail_with_field_only_errors(field: str) -> None:
+    value = getattr(_schedule(), field).replace(tzinfo=None)
+
+    with pytest.raises(FederatedScheduleError) as error:
+        _schedule(**{field: value})
+    assert str(error.value) == f"{field} must be timezone-aware"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "enrollment_starts_at",
+        "update_submission_starts_at",
+        "aggregation_starts_at",
+        "evaluation_starts_at",
+        "finishes_at",
+    ],
+)
+def test_non_utc_boundaries_fail_with_field_only_errors(field: str) -> None:
+    value = getattr(_schedule(), field).astimezone(timezone(timedelta(hours=1)))
+
+    with pytest.raises(FederatedScheduleError) as error:
+        _schedule(**{field: value})
+    assert str(error.value) == f"{field} must use UTC"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "enrollment_starts_at",
+        "update_submission_starts_at",
+        "aggregation_starts_at",
+        "evaluation_starts_at",
+        "finishes_at",
+    ],
+)
+def test_boolean_boundaries_are_rejected(field: str) -> None:
+    with pytest.raises(FederatedScheduleError) as error:
+        _schedule(**{field: True})
+    assert str(error.value) == f"{field} must be a datetime"
+
+
+@pytest.mark.parametrize(
+    ("field", "previous_field"),
+    [
+        ("update_submission_starts_at", "enrollment_starts_at"),
+        ("aggregation_starts_at", "update_submission_starts_at"),
+        ("evaluation_starts_at", "aggregation_starts_at"),
+        ("finishes_at", "evaluation_starts_at"),
+    ],
+)
+@pytest.mark.parametrize("offset", [timedelta(0), timedelta(microseconds=-1)])
+def test_equal_and_reversed_boundaries_are_rejected(
+    field: str, previous_field: str, offset: timedelta
+) -> None:
+    schedule = _schedule()
+    invalid = getattr(schedule, previous_field) + offset
+
+    with pytest.raises(FederatedScheduleError) as error:
+        _schedule(**{field: invalid})
+    assert str(error.value) == f"{field} must be later than {previous_field}"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "max_enrollment_duration_seconds",
+        "max_update_submission_duration_seconds",
+        "max_aggregation_duration_seconds",
+        "max_evaluation_duration_seconds",
+    ],
+)
+@pytest.mark.parametrize("value", [True, False, 0, -1, 1.5, "3600"])
+def test_invalid_maximum_durations_fail_with_field_only_errors(
+    field: str, value: object
+) -> None:
+    with pytest.raises(FederatedScheduleError) as error:
+        _schedule(**{field: value})
+    assert str(error.value) == f"{field} must be a supported positive integer"
+
+
+@pytest.mark.parametrize(
+    ("maximum_field", "end_field"),
+    [
+        (
+            "max_enrollment_duration_seconds",
+            "update_submission_starts_at",
+        ),
+        (
+            "max_update_submission_duration_seconds",
+            "aggregation_starts_at",
+        ),
+        (
+            "max_aggregation_duration_seconds",
+            "evaluation_starts_at",
+        ),
+        (
+            "max_evaluation_duration_seconds",
+            "finishes_at",
+        ),
+    ],
+)
+def test_exact_maximum_duration_is_allowed_and_one_second_over_is_rejected(
+    maximum_field: str, end_field: str
+) -> None:
+    assert _schedule(**{maximum_field: 3600})
+
+    with pytest.raises(FederatedScheduleError) as error:
+        _schedule(**{maximum_field: 3599})
+    assert str(error.value) == f"{end_field} exceeds {maximum_field}"
+
+
+def test_unsupported_configured_and_actual_durations_are_rejected() -> None:
+    with pytest.raises(FederatedScheduleError):
+        _schedule(
+            max_enrollment_duration_seconds=(MAX_FEDERATED_PHASE_DURATION_SECONDS + 1)
+        )
+
+    too_late = START + timedelta(seconds=MAX_FEDERATED_PHASE_DURATION_SECONDS + 1)
+    with pytest.raises(
+        FederatedScheduleError,
+        match="update_submission_starts_at exceeds the supported phase duration",
+    ):
+        _schedule(
+            update_submission_starts_at=too_late,
+            aggregation_starts_at=too_late + timedelta(hours=1),
+            evaluation_starts_at=too_late + timedelta(hours=2),
+            finishes_at=too_late + timedelta(hours=3),
+        )
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        START.replace(tzinfo=None),
+        START.astimezone(timezone(timedelta(hours=-4))),
+        True,
+    ],
+)
+def test_phase_resolution_rejects_non_utc_or_non_datetime_inputs(
+    timestamp: object,
+) -> None:
+    schedule = _schedule()
+
+    with pytest.raises(FederatedScheduleError):
+        schedule.active_phase_at(timestamp)
+    with pytest.raises(FederatedScheduleError):
+        schedule.next_phase_at(timestamp)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"schema_version": FEDERATED_SCHEDULE_SCHEMA_VERSION},
+        {
+            "schema_version": FEDERATED_SCHEDULE_SCHEMA_VERSION,
+            "boundaries": {},
+            "maximum_duration_seconds": {},
+        },
+        {
+            **_schedule().to_dict(),
+            "site_name": "north-hospital",
+        },
+    ],
+)
+def test_deserialization_rejects_incomplete_and_unknown_fields(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(FederatedScheduleError):
+        FederatedRoundSchedule.from_dict(payload)
+
+
+def test_noncanonical_timestamps_and_duplicate_json_fields_are_rejected() -> None:
+    payload = _schedule().to_dict()
+    payload["boundaries"]["enrollment_starts_at"] = "2026-09-01T00:00:00+00:00"
+    with pytest.raises(FederatedScheduleError):
+        FederatedRoundSchedule.from_dict(payload)
+
+    duplicate = (
+        _schedule()
+        .to_json()
+        .replace(
+            '"schema_version": "openmed.training.federated_schedule.v1"',
+            '"schema_version": "openmed.training.federated_schedule.v1",\n'
+            '  "schema_version": "openmed.training.federated_schedule.v1"',
+        )
+    )
+    with pytest.raises(FederatedScheduleError, match="invalid federated schedule JSON"):
+        FederatedRoundSchedule.from_json(duplicate)
+
+
+def test_errors_and_schema_never_retain_caller_metadata() -> None:
+    sentinel = "Patient Jane Roe /srv/site-a local_loss=0.42"
+    payload = _schedule().to_dict()
+    payload["boundaries"]["enrollment_starts_at"] = sentinel
+
+    with pytest.raises(FederatedScheduleError) as error:
+        FederatedRoundSchedule.from_dict(payload)
+    assert sentinel not in str(error.value)
+
+    forbidden = {
+        "client_id",
+        "site_name",
+        "patient_count",
+        "local_metric",
+        "network_endpoint",
+        "url",
+    }
+    assert forbidden.isdisjoint(inspect.signature(FederatedRoundSchedule).parameters)
+    assert forbidden.isdisjoint(field.name for field in fields(FederatedRoundSchedule))
+    serialized = _schedule().to_json()
+    assert all(name not in serialized for name in forbidden)
+
+
+def test_schedule_is_immutable_and_phase_order_is_stable() -> None:
+    schedule = _schedule()
+
+    assert FEDERATED_SCHEDULE_PHASES == (
+        P.ENROLLMENT,
+        P.UPDATE_SUBMISSION,
+        P.AGGREGATION,
+        P.EVALUATION,
+    )
+    with pytest.raises(FrozenInstanceError):
+        schedule.finishes_at = START  # type: ignore[misc]
+
+
+def test_schedule_api_is_available_through_lazy_training_exports() -> None:
+    import openmed.training as training
+
+    assert training.FederatedRoundSchedule is FederatedRoundSchedule
+    assert training.FederatedSchedulePhase is FederatedSchedulePhase
+    assert training.__all__.count("FederatedRoundSchedule") == 1


### PR DESCRIPTION
Federated rounds now get strict UTC phase windows, so scheduling stays deterministic instead of getting cooked by messy deadlines. Closes #2981.