### PR TITLE
feat(clinical): add deterministic citation ordering

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -172,6 +172,7 @@ classification:
     - clinical/terminology-provenance.md
     - clinical/consent-cache.md
     - clinical/timeline-provenance.md
+    - clinical/citation-ordering.md
     - clinical/chinese-terminology-grounding.md
     - chinese-segmentation-operations.md
     - clinical/multilingual-relations.md

--- a/docs/clinical/citation-ordering.md
+++ b/docs/clinical/citation-ordering.md
@@ -1,0 +1,59 @@
+# Deterministic citation ordering
+
+`order_citations()` gives guarded clinical outputs a canonical evidence order
+without retaining source text. Citation rows contain only opaque document,
+section, and evidence identifiers; half-open source offsets; and a primary
+evidence marker.
+
+```python
+from openmed.clinical.citation_ordering import Citation, CitationOrdering
+
+artifact = CitationOrdering(
+    (
+        Citation(
+            document_id="doc-02",
+            section="assessment",
+            source_start=24,
+            source_end=31,
+            evidence_id="evidence-02",
+        ),
+        Citation(
+            document_id="doc-01",
+            section="history",
+            source_start=4,
+            source_end=13,
+            evidence_id="evidence-01",
+            primary=True,
+        ),
+    )
+)
+
+payload = artifact.to_json()
+```
+
+## Ordering contract
+
+Citations are sorted lexicographically by:
+
+1. `document_id`
+2. `section`
+3. `source_start`
+4. `source_end`
+5. `evidence_id`
+
+The primary marker does not change this order. It identifies the primary row
+after ordering. A citation collection represents one guarded claim, so two
+distinct primary citations are rejected. Duplicate coordinates are also
+rejected when their primary markers disagree.
+
+## Privacy boundary
+
+Identifiers must be opaque metadata tokens and source offsets must satisfy
+`0 <= source_start < source_end`. Prompts, tool arguments, clinical outputs,
+evidence text, bearer values, and filesystem paths are not fields in the
+artifact schema. Validation errors are fixed categories and never echo rejected
+values.
+
+The implementation is deterministic, uses only the Python standard library,
+and performs no network calls. It orders evidence metadata for review; it does
+not evaluate clinical claims or choose primary evidence.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
       - Terminology Snapshot Provenance: clinical/terminology-provenance.md
       - Consent Cache Invalidation: clinical/consent-cache.md
       - Clinical Timeline Provenance: clinical/timeline-provenance.md
+      - Deterministic Citation Ordering: clinical/citation-ordering.md
       - Chinese Terminology Grounding: clinical/chinese-terminology-grounding.md
       - Chinese Segmentation Operations: chinese-segmentation-operations.md
       - Multilingual Clinical Relations: clinical/multilingual-relations.md

--- a/openmed/clinical/citation_ordering.py
+++ b/openmed/clinical/citation_ordering.py
@@ -1,0 +1,162 @@
+"""Deterministic, metadata-only ordering for guarded-output citations."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Final, Iterable
+
+CITATION_ORDERING_SCHEMA_VERSION: Final[int] = 1
+
+_METADATA_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+
+
+class CitationOrderingError(ValueError):
+    """Raised when citation metadata cannot be ordered safely."""
+
+
+@dataclass(frozen=True)
+class Citation:
+    """Value-free evidence coordinates for one guarded clinical claim."""
+
+    document_id: str
+    section: str
+    source_start: int
+    source_end: int
+    evidence_id: str
+    primary: bool = False
+
+    def __post_init__(self) -> None:
+        _validate_metadata_id(self.document_id)
+        _validate_metadata_id(self.section)
+        _validate_metadata_id(self.evidence_id)
+        if (
+            type(self.source_start) is not int
+            or type(self.source_end) is not int
+            or self.source_start < 0
+            or self.source_end <= self.source_start
+        ):
+            raise CitationOrderingError("invalid citation source offset")
+        if type(self.primary) is not bool:
+            raise CitationOrderingError("invalid citation primary marker")
+
+    @property
+    def source_offset(self) -> tuple[int, int]:
+        """Return the half-open ``[start, end)`` source offset."""
+
+        return self.source_start, self.source_end
+
+    @property
+    def is_primary(self) -> bool:
+        """Return whether this citation is explicitly primary evidence."""
+
+        return self.primary
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the closed metadata-only citation representation."""
+
+        return {
+            "document_id": self.document_id,
+            "section": self.section,
+            "source_offset": {
+                "start": self.source_start,
+                "end": self.source_end,
+            },
+            "evidence_id": self.evidence_id,
+            "primary": self.primary,
+        }
+
+
+def order_citations(citations: Iterable[Citation]) -> tuple[Citation, ...]:
+    """Validate and return citations in their canonical metadata order.
+
+    The input represents citations for one guarded claim, so at most one row
+    may carry the primary-evidence marker. Exact duplicate coordinates may be
+    retained, but they cannot disagree about whether that evidence is primary.
+    """
+
+    if isinstance(citations, (str, bytes, bytearray)):
+        raise CitationOrderingError("invalid citation collection")
+    try:
+        records = tuple(citations)
+    except Exception:
+        raise CitationOrderingError("invalid citation collection") from None
+    if any(not isinstance(citation, Citation) for citation in records):
+        raise CitationOrderingError("invalid citation collection")
+
+    markers_by_key: dict[tuple[str, str, int, int, str], bool] = {}
+    primary_keys: set[tuple[str, str, int, int, str]] = set()
+    for citation in records:
+        key = _citation_key(citation)
+        existing_marker = markers_by_key.get(key)
+        if existing_marker is not None and existing_marker is not citation.primary:
+            raise CitationOrderingError("conflicting citation primary markers")
+        markers_by_key[key] = citation.primary
+        if citation.primary:
+            primary_keys.add(key)
+
+    if len(primary_keys) > 1:
+        raise CitationOrderingError("conflicting citation primary markers")
+    return tuple(sorted(records, key=_citation_key))
+
+
+@dataclass(frozen=True)
+class CitationOrdering:
+    """Versioned deterministic artifact for one claim's ordered citations."""
+
+    citations: tuple[Citation, ...]
+    schema_version: int = CITATION_ORDERING_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.schema_version) is not int
+            or self.schema_version != CITATION_ORDERING_SCHEMA_VERSION
+        ):
+            raise CitationOrderingError("unsupported citation ordering schema")
+        object.__setattr__(self, "citations", order_citations(self.citations))
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-ready artifact with no source or evidence text."""
+
+        return {
+            "schema_version": self.schema_version,
+            "citations": [citation.to_dict() for citation in self.citations],
+        }
+
+    def to_json(self) -> str:
+        """Return byte-stable JSON for audit and regression artifacts."""
+
+        return (
+            json.dumps(
+                self.to_dict(),
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            + "\n"
+        )
+
+
+def _citation_key(citation: Citation) -> tuple[str, str, int, int, str]:
+    return (
+        citation.document_id,
+        citation.section,
+        citation.source_start,
+        citation.source_end,
+        citation.evidence_id,
+    )
+
+
+def _validate_metadata_id(value: object) -> None:
+    if type(value) is not str or _METADATA_ID_RE.fullmatch(value) is None:
+        raise CitationOrderingError("invalid citation metadata identifier")
+
+
+__all__ = [
+    "CITATION_ORDERING_SCHEMA_VERSION",
+    "Citation",
+    "CitationOrdering",
+    "CitationOrderingError",
+    "order_citations",
+]

--- a/tests/unit/clinical/test_citation_ordering.py
+++ b/tests/unit/clinical/test_citation_ordering.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from openmed.clinical.citation_ordering import (
+    CITATION_ORDERING_SCHEMA_VERSION,
+    Citation,
+    CitationOrdering,
+    CitationOrderingError,
+    order_citations,
+)
+
+
+def _citation(
+    evidence_id: str,
+    *,
+    document_id: str = "doc-01",
+    section: str = "assessment",
+    start: int = 10,
+    end: int = 20,
+    primary: bool = False,
+) -> Citation:
+    return Citation(
+        document_id=document_id,
+        section=section,
+        source_start=start,
+        source_end=end,
+        evidence_id=evidence_id,
+        primary=primary,
+    )
+
+
+def test_ordering_uses_every_declared_key_in_sequence() -> None:
+    citations = [
+        _citation("evidence-b"),
+        _citation("evidence-a"),
+        _citation("evidence-c", end=19),
+        _citation("evidence-d", start=5, end=9),
+        _citation("evidence-e", section="history"),
+        _citation("evidence-f", document_id="doc-00", section="z-section"),
+    ]
+
+    ordered = order_citations(reversed(citations))
+
+    assert [citation.evidence_id for citation in ordered] == [
+        "evidence-f",
+        "evidence-d",
+        "evidence-c",
+        "evidence-a",
+        "evidence-b",
+        "evidence-e",
+    ]
+
+
+def test_empty_and_generator_inputs_are_supported() -> None:
+    assert order_citations(()) == ()
+
+    citations = (_citation(f"evidence-{index}") for index in (3, 1, 2))
+    assert [citation.evidence_id for citation in order_citations(citations)] == [
+        "evidence-1",
+        "evidence-2",
+        "evidence-3",
+    ]
+
+
+def test_primary_marker_is_preserved_without_overriding_metadata_order() -> None:
+    primary = _citation("evidence-z", primary=True)
+    secondary = _citation("evidence-a")
+
+    ordered = order_citations([primary, secondary])
+
+    assert ordered == (secondary, primary)
+    assert ordered[0].is_primary is False
+    assert ordered[1].is_primary is True
+
+
+def test_multiple_primary_citations_are_rejected_without_echoing_ids() -> None:
+    sentinel = "SENSITIVE_SENTINEL"
+
+    with pytest.raises(
+        CitationOrderingError,
+        match="conflicting citation primary markers",
+    ) as error:
+        order_citations(
+            [
+                _citation("evidence-a", document_id=sentinel, primary=True),
+                _citation("evidence-b", primary=True),
+            ]
+        )
+    assert sentinel not in str(error.value)
+
+
+def test_duplicate_key_cannot_disagree_about_primary_marker() -> None:
+    with pytest.raises(
+        CitationOrderingError,
+        match="conflicting citation primary markers",
+    ):
+        order_citations(
+            [
+                _citation("evidence-a"),
+                _citation("evidence-a", primary=True),
+            ]
+        )
+
+
+def test_exact_secondary_duplicates_remain_stably_ordered() -> None:
+    citation = _citation("evidence-a")
+
+    assert order_citations([citation, citation]) == (citation, citation)
+
+
+def test_artifact_is_versioned_byte_stable_and_input_order_independent() -> None:
+    first = CitationOrdering(
+        (
+            _citation("evidence-b", start=21, end=30),
+            _citation("evidence-a", primary=True),
+        )
+    )
+    second = CitationOrdering(tuple(reversed(first.citations)))
+
+    assert first == second
+    assert first.to_json() == second.to_json()
+    assert first.to_json() == (
+        '{"citations":[{"document_id":"doc-01","evidence_id":"evidence-a",'
+        '"primary":true,"section":"assessment","source_offset":'
+        '{"end":20,"start":10}},{"document_id":"doc-01",'
+        '"evidence_id":"evidence-b","primary":false,"section":"assessment",'
+        '"source_offset":{"end":30,"start":21}}],"schema_version":1}\n'
+    )
+    assert json.loads(first.to_json()) == first.to_dict()
+
+
+def test_empty_artifact_has_a_stable_shape() -> None:
+    artifact = CitationOrdering(())
+
+    assert artifact.to_dict() == {
+        "schema_version": CITATION_ORDERING_SCHEMA_VERSION,
+        "citations": [],
+    }
+    assert artifact.to_json() == '{"citations":[],"schema_version":1}\n'
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"document_id": ""},
+        {"document_id": "/srv/charts/123"},
+        {"section": "assessment and plan"},
+        {"evidence_id": "https://internal.invalid/evidence"},
+        {"source_start": -1},
+        {"source_start": True},
+        {"source_end": 10},
+        {"source_end": 9},
+        {"primary": 1},
+    ],
+)
+def test_invalid_metadata_fails_without_echoing_values(
+    kwargs: dict[str, object],
+) -> None:
+    values: dict[str, object] = {
+        "document_id": "doc-01",
+        "section": "assessment",
+        "source_start": 10,
+        "source_end": 20,
+        "evidence_id": "evidence-01",
+        "primary": False,
+    }
+    values.update(kwargs)
+
+    with pytest.raises(CitationOrderingError) as error:
+        Citation(**values)  # type: ignore[arg-type]
+    assert all(
+        not isinstance(value, str) or not value or value not in str(error.value)
+        for value in kwargs.values()
+    )
+
+
+def test_artifact_schema_cannot_carry_sensitive_values() -> None:
+    citation = _citation("evidence-a")
+    payload = CitationOrdering((citation,)).to_dict()
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert set(payload) == {"schema_version", "citations"}
+    assert set(payload["citations"][0]) == {
+        "document_id",
+        "section",
+        "source_offset",
+        "evidence_id",
+        "primary",
+    }
+    for forbidden in (
+        "prompt",
+        "argument",
+        "output",
+        "evidence_text",
+        "bearer",
+        "path",
+    ):
+        assert forbidden not in serialized
+
+
+def test_invalid_collections_and_schema_versions_fail_closed() -> None:
+    with pytest.raises(CitationOrderingError, match="invalid citation collection"):
+        order_citations("not-a-collection")  # type: ignore[arg-type]
+    with pytest.raises(CitationOrderingError, match="invalid citation collection"):
+        order_citations([object()])  # type: ignore[list-item]
+    with pytest.raises(
+        CitationOrderingError,
+        match="unsupported citation ordering schema",
+    ):
+        CitationOrdering((), schema_version=2)
+
+
+def test_iterable_failures_do_not_echo_upstream_content() -> None:
+    sentinel = "SYNTHETIC_PATIENT_TEXT_FROM_GENERATOR"
+
+    def broken_citations():
+        raise RuntimeError(sentinel)
+        yield _citation("unreachable")
+
+    with pytest.raises(
+        CitationOrderingError,
+        match="invalid citation collection",
+    ) as error:
+        order_citations(broken_citations())
+    assert sentinel not in str(error.value)
+
+
+def test_citations_and_artifacts_are_immutable() -> None:
+    citation = _citation("evidence-a")
+    artifact = CitationOrdering((citation,))
+
+    with pytest.raises(FrozenInstanceError):
+        citation.primary = True  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        artifact.citations = ()  # type: ignore[misc]


### PR DESCRIPTION
Citations now sort deterministically and reject conflicting primaries, so audit diffs stop getting cooked. Closes #2743.