### PR TITLE
feat(multimodal): integrate privacy-safe ingest contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   media and digest validation, bounded metadata-only fields, deterministic
   JSON serialization, and value-free rejection of paths, URLs, free text, and
   unknown fields (#2954).
+- Added bounded, dependency-free detection for PDF, PNG, JPEG, TIFF, DICOM,
+  and WAV prefixes, with stable match, mismatch, and unknown validation results
+  that do not log source bytes or trust filename extensions (#2955).
 
 - Added an audited teacher-ensemble registry for weak labeling with
   manifest-resolved PII and Privacy Filter members, bounded weights and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a dependency-free, versioned multimodal asset manifest with strict
+  media and digest validation, bounded metadata-only fields, deterministic
+  JSON serialization, and value-free rejection of paths, URLs, free text, and
+  unknown fields (#2954).
+
 - Added an audited teacher-ensemble registry for weak labeling with
   manifest-resolved PII and Privacy Filter members, bounded weights and
   agreement thresholds, checksum-validator policies, and fail-closed runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added bounded, dependency-free detection for PDF, PNG, JPEG, TIFF, DICOM,
   and WAV prefixes, with stable match, mismatch, and unknown validation results
   that do not log source bytes or trust filename extensions (#2955).
+- Added strict, deterministic multimodal abstention records with typed pipeline
+  stages, stable reason codes, metadata-only JSON, and value-free validation
+  failures (#2977).
 
 - Added an audited teacher-ensemble registry for weak labeling with
   manifest-resolved PII and Privacy Filter members, bounded weights and

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -203,6 +203,7 @@ classification:
     - reference/training-schemas.md
     - training/federated-round-lifecycle.md
     - reference/preference-schema.md
+    - multimodal/media-type-detection.md
     - multimodal/pdf-reading-order.md
     - multimodal/asset-manifests.md
     - multimodal/pdf-redaction-fidelity.md

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -204,6 +204,7 @@ classification:
     - training/federated-round-lifecycle.md
     - reference/preference-schema.md
     - multimodal/pdf-reading-order.md
+    - multimodal/asset-manifests.md
     - multimodal/pdf-redaction-fidelity.md
     - multimodal/email-ingestion.md
     - multimodal/epub-extraction.md

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -207,6 +207,7 @@ classification:
     - multimodal/pdf-reading-order.md
     - multimodal/asset-manifests.md
     - multimodal/pdf-redaction-fidelity.md
+    - multimodal/abstention-reasons.md
     - multimodal/email-ingestion.md
     - multimodal/epub-extraction.md
     - multimodal/xlsx-cell-redaction.md

--- a/docs/multimodal/abstention-reasons.md
+++ b/docs/multimodal/abstention-reasons.md
@@ -1,0 +1,55 @@
+# Multimodal Abstention Reasons
+
+Image, document, waveform, and audio pipelines should explain why processing
+stopped without copying source content into logs or audit artifacts. Use
+`AbstentionRecord` for that boundary. Its serialized form contains only a
+schema version, a pipeline stage, and a stable reason code.
+
+```python
+from openmed.multimodal.abstention import (
+    AbstentionReason,
+    AbstentionRecord,
+    AbstentionStage,
+)
+
+record = AbstentionRecord(
+    stage=AbstentionStage.INFERENCE,
+    reason=AbstentionReason.PHI_UNCERTAINTY,
+)
+print(record.to_json())
+```
+
+```json
+{"schema_version":1,"stage":"inference","reason":"phi_uncertainty"}
+```
+
+There is intentionally no message or context field. Do not add OCR text,
+transcripts, pixel data, DICOM values, paths, URLs, prompts, or provider error
+text beside this record. Keep operational detail in a separate private system
+whose retention and access policy is appropriate for PHI.
+
+## Stages and allowed reasons
+
+| Stage | Allowed reason codes |
+| --- | --- |
+| `preflight` | `unsupported_media`, `resource_limit`, `provider_unavailable` |
+| `decode` | `malformed_media`, `resource_limit`, `low_quality` |
+| `inference` | `resource_limit`, `low_quality`, `phi_uncertainty`, `speaker_uncertainty`, `temporal_instability`, `provider_unavailable` |
+| `post_process` | `resource_limit`, `low_quality`, `phi_uncertainty`, `speaker_uncertainty`, `temporal_instability` |
+
+Use the earliest stage that can make the decision. For example, reject an
+unsupported container during preflight and malformed bytes during decode.
+Low-quality output belongs to decode, inference, or post-processing depending
+on where the measurable quality gate runs.
+
+## Strict parsing
+
+`AbstentionRecord.from_json()` requires exactly these fields:
+
+- `schema_version`: currently `1`
+- `stage`: one documented stage
+- `reason`: one reason allowed for that stage
+
+Unknown fields, unknown values, malformed JSON, unsupported schema versions,
+and invalid stage-reason pairs fail closed. Validation errors name the failed
+part of the contract but never echo the submitted value.

--- a/docs/multimodal/asset-manifests.md
+++ b/docs/multimodal/asset-manifests.md
@@ -1,0 +1,49 @@
+# Privacy-safe asset manifests
+
+`openmed.multimodal.asset_manifest` defines a small manifest for preflight
+steps that need to describe an input without reading or storing the input
+itself.
+
+The manifest is intentionally narrow. It records only:
+
+- `version`
+- `asset_id`
+- `media_type`
+- `sha256`
+- `byte_size`
+- optional bounded counts: `pages`, `width`, `height`, `frames`,
+  `duration_seconds`
+
+The validator rejects unknown fields, paths, URLs, and free-text fields such as
+descriptions or source metadata. Validation errors name the failed field or rule
+without echoing the supplied value.
+
+Integer sizes and counts use explicit 64-bit and 32-bit upper bounds,
+respectively. Duration is finite, positive, and capped at the same upper bound
+as other counts. Boolean values, scalar subclasses, duplicate JSON fields, and
+numeric values outside those bounds fail closed.
+
+```python
+from openmed.multimodal.asset_manifest import AssetManifest
+
+manifest = AssetManifest.from_dict(
+    {
+        "asset_id": "dicom-001",
+        "media_type": "application/dicom",
+        "sha256": "a" * 64,
+        "byte_size": 4096,
+        "frames": 12,
+        "width": 512,
+        "height": 512,
+    }
+)
+
+payload = manifest.to_json()
+```
+
+`to_dict()` emits fields in a stable order and omits unset optional fields.
+`to_json()` emits compact JSON with sorted keys so callers can compare manifest
+payloads deterministically.
+
+The manifest does not read assets, perform OCR or inference, retain embedded
+metadata, or define model-specific tensor shapes.

--- a/docs/multimodal/media-type-detection.md
+++ b/docs/multimodal/media-type-detection.md
@@ -1,0 +1,35 @@
+# Bounded media-type detection
+
+`openmed.multimodal.media_type` provides a dependency-free preflight check for
+uploaded or in-memory clinical media. It inspects at most the first 132 bytes
+and does not use filenames, paths, or extensions.
+
+Supported signatures:
+
+- PDF
+- PNG and JPEG
+- little-endian and big-endian TIFF
+- DICOM Part 10 with the `DICM` marker at byte offset 128
+- WAV with `RIFF` and `WAVE` markers
+
+```python
+from openmed.multimodal.media_type import (
+    MediaTypeStatus,
+    detect_media_type,
+    validate_media_type,
+)
+
+prefix = b"%PDF-1.7\n"
+
+assert detect_media_type(prefix) == "application/pdf"
+assert validate_media_type(prefix, "application/pdf") is MediaTypeStatus.MATCH
+assert validate_media_type(prefix, "image/png") is MediaTypeStatus.MISMATCH
+```
+
+Truncated, ambiguous, and unsupported prefixes return `None` from
+`detect_media_type()` and `MediaTypeStatus.UNKNOWN` from `validate_media_type()`.
+Invalid declared types fail closed with a value-free error.
+
+This preflight check does not fully validate a file, scan for malware,
+decompress content, or replace format-specific parsers. Callers should pass
+only the bounded prefix and should not log source bytes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
       - Federated Round Lifecycle: training/federated-round-lifecycle.md
       - Preference Pair Schema: reference/preference-schema.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
+      - Privacy-safe Asset Manifests: multimodal/asset-manifests.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md
       - Email Ingestion and Redaction: multimodal/email-ingestion.md
       - EPUB Extraction: multimodal/epub-extraction.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Training Schema Registry: reference/training-schemas.md
       - Federated Round Lifecycle: training/federated-round-lifecycle.md
       - Preference Pair Schema: reference/preference-schema.md
+      - Bounded Media Type Detection: multimodal/media-type-detection.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Privacy-safe Asset Manifests: multimodal/asset-manifests.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Privacy-safe Asset Manifests: multimodal/asset-manifests.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md
+      - Multimodal Abstention Reasons: multimodal/abstention-reasons.md
       - Email Ingestion and Redaction: multimodal/email-ingestion.md
       - EPUB Extraction: multimodal/epub-extraction.md
       - XLSX Cell Redaction: multimodal/xlsx-cell-redaction.md

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -153,6 +153,12 @@ from .layout import (
     LayoutWordSpan,
     parse_layout,
 )
+from .media_type import (
+    MAX_MEDIA_TYPE_PREFIX_BYTES,
+    MediaTypeStatus,
+    detect_media_type,
+    validate_media_type,
+)
 from .metadata_scrub import (
     MetadataFinding,
     MetadataScrubError,
@@ -258,6 +264,10 @@ __all__ = [
     "AssetManifest",
     "AssetManifestError",
     "MANIFEST_VERSION",
+    "MAX_MEDIA_TYPE_PREFIX_BYTES",
+    "MediaTypeStatus",
+    "detect_media_type",
+    "validate_media_type",
     "MissingDependencyError",
     "UnsupportedDocumentError",
     "DocumentGraphError",

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -29,6 +29,7 @@ from . import documents_html as _documents_html
 from . import documents_markdown as _documents_markdown
 from . import documents_text as _documents_text
 from . import pptx as _pptx
+from .asset_manifest import MANIFEST_VERSION, AssetManifest, AssetManifestError
 from .base import (
     ExtractedDocument,
     SourceSpan,
@@ -254,6 +255,9 @@ __all__ = [
     "register_handler",
     "ensure_multimodal_available",
     "is_multimodal_available",
+    "AssetManifest",
+    "AssetManifestError",
+    "MANIFEST_VERSION",
     "MissingDependencyError",
     "UnsupportedDocumentError",
     "DocumentGraphError",

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -29,7 +29,6 @@ from . import documents_html as _documents_html
 from . import documents_markdown as _documents_markdown
 from . import documents_text as _documents_text
 from . import pptx as _pptx
-from .asset_manifest import MANIFEST_VERSION, AssetManifest, AssetManifestError
 from .abstention import (
     ABSTENTION_SCHEMA_VERSION,
     AbstentionReason,
@@ -37,6 +36,7 @@ from .abstention import (
     AbstentionStage,
     AbstentionValidationError,
 )
+from .asset_manifest import MANIFEST_VERSION, AssetManifest, AssetManifestError
 from .base import (
     ExtractedDocument,
     SourceSpan,

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -30,6 +30,13 @@ from . import documents_markdown as _documents_markdown
 from . import documents_text as _documents_text
 from . import pptx as _pptx
 from .asset_manifest import MANIFEST_VERSION, AssetManifest, AssetManifestError
+from .abstention import (
+    ABSTENTION_SCHEMA_VERSION,
+    AbstentionReason,
+    AbstentionRecord,
+    AbstentionStage,
+    AbstentionValidationError,
+)
 from .base import (
     ExtractedDocument,
     SourceSpan,
@@ -255,6 +262,11 @@ from .verify_pdf import (
 from .xlsx import XlsxCellRedaction, XlsxRedactionResult, redact_xlsx
 
 __all__ = [
+    "ABSTENTION_SCHEMA_VERSION",
+    "AbstentionReason",
+    "AbstentionRecord",
+    "AbstentionStage",
+    "AbstentionValidationError",
     "ExtractedDocument",
     "SourceSpan",
     "redact_document",

--- a/openmed/multimodal/abstention.py
+++ b/openmed/multimodal/abstention.py
@@ -1,0 +1,184 @@
+"""Stable, metadata-only abstention records for multimodal pipelines.
+
+The boundary in this module deliberately accepts only a stage and a reason
+code.  It has no free-text field, so callers cannot accidentally serialize OCR
+text, transcripts, DICOM values, file paths, URLs, or model prompts while
+explaining why processing stopped.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Final
+
+__all__ = [
+    "ABSTENTION_SCHEMA_VERSION",
+    "AbstentionReason",
+    "AbstentionRecord",
+    "AbstentionStage",
+    "AbstentionValidationError",
+]
+
+
+ABSTENTION_SCHEMA_VERSION: Final = 1
+
+
+class AbstentionValidationError(ValueError):
+    """Raised when an abstention record fails strict, PHI-safe validation."""
+
+
+class AbstentionStage(str, Enum):
+    """Pipeline stage at which multimodal processing stopped."""
+
+    PREFLIGHT = "preflight"
+    DECODE = "decode"
+    INFERENCE = "inference"
+    POST_PROCESS = "post_process"
+
+
+class AbstentionReason(str, Enum):
+    """Stable reason why a multimodal pipeline declined to continue."""
+
+    UNSUPPORTED_MEDIA = "unsupported_media"
+    MALFORMED_MEDIA = "malformed_media"
+    RESOURCE_LIMIT = "resource_limit"
+    LOW_QUALITY = "low_quality"
+    PHI_UNCERTAINTY = "phi_uncertainty"
+    SPEAKER_UNCERTAINTY = "speaker_uncertainty"
+    TEMPORAL_INSTABILITY = "temporal_instability"
+    PROVIDER_UNAVAILABLE = "provider_unavailable"
+
+
+_ALLOWED_REASONS: Final = {
+    AbstentionStage.PREFLIGHT: frozenset(
+        {
+            AbstentionReason.UNSUPPORTED_MEDIA,
+            AbstentionReason.RESOURCE_LIMIT,
+            AbstentionReason.PROVIDER_UNAVAILABLE,
+        }
+    ),
+    AbstentionStage.DECODE: frozenset(
+        {
+            AbstentionReason.MALFORMED_MEDIA,
+            AbstentionReason.RESOURCE_LIMIT,
+            AbstentionReason.LOW_QUALITY,
+        }
+    ),
+    AbstentionStage.INFERENCE: frozenset(
+        {
+            AbstentionReason.RESOURCE_LIMIT,
+            AbstentionReason.LOW_QUALITY,
+            AbstentionReason.PHI_UNCERTAINTY,
+            AbstentionReason.SPEAKER_UNCERTAINTY,
+            AbstentionReason.TEMPORAL_INSTABILITY,
+            AbstentionReason.PROVIDER_UNAVAILABLE,
+        }
+    ),
+    AbstentionStage.POST_PROCESS: frozenset(
+        {
+            AbstentionReason.RESOURCE_LIMIT,
+            AbstentionReason.LOW_QUALITY,
+            AbstentionReason.PHI_UNCERTAINTY,
+            AbstentionReason.SPEAKER_UNCERTAINTY,
+            AbstentionReason.TEMPORAL_INSTABILITY,
+        }
+    ),
+}
+
+_REQUIRED_FIELDS: Final = frozenset({"schema_version", "stage", "reason"})
+
+
+def _stage(value: object) -> AbstentionStage:
+    try:
+        return AbstentionStage(value)
+    except Exception:
+        raise AbstentionValidationError("stage is unsupported") from None
+
+
+def _reason(value: object) -> AbstentionReason:
+    try:
+        return AbstentionReason(value)
+    except Exception:
+        raise AbstentionValidationError("reason is unsupported") from None
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    fields = dict(pairs)
+    if len(fields) != len(pairs):
+        raise AbstentionValidationError("payload fields are invalid")
+    return fields
+
+
+@dataclass(frozen=True, slots=True)
+class AbstentionRecord:
+    """A deterministic explanation that contains no source-media content.
+
+    Args:
+        stage: Pipeline stage at which processing stopped.
+        reason: Stable reason code valid for that stage.
+        schema_version: Serialization contract version. Only version 1 is
+            currently accepted.
+    """
+
+    stage: AbstentionStage
+    reason: AbstentionReason
+    schema_version: int = ABSTENTION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        stage = _stage(self.stage)
+        reason = _reason(self.reason)
+        if type(self.schema_version) is not int or (
+            self.schema_version != ABSTENTION_SCHEMA_VERSION
+        ):
+            raise AbstentionValidationError("schema_version is unsupported")
+        if reason not in _ALLOWED_REASONS[stage]:
+            raise AbstentionValidationError("reason is not valid for stage")
+        object.__setattr__(self, "stage", stage)
+        object.__setattr__(self, "reason", reason)
+
+    def to_dict(self) -> dict[str, int | str]:
+        """Return the fixed-shape metadata-only representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "stage": self.stage.value,
+            "reason": self.reason.value,
+        }
+
+    def to_json(self) -> str:
+        """Serialize with deterministic key order and no insignificant space."""
+
+        return json.dumps(self.to_dict(), ensure_ascii=True, separators=(",", ":"))
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "AbstentionRecord":
+        """Parse a strict mapping without reflecting submitted values."""
+
+        if not isinstance(payload, Mapping):
+            raise AbstentionValidationError("payload must be an object")
+        try:
+            fields = dict(payload)
+        except Exception:
+            raise AbstentionValidationError("payload could not be read") from None
+        if frozenset(fields) != _REQUIRED_FIELDS:
+            raise AbstentionValidationError("payload fields are invalid")
+        return cls(
+            schema_version=fields["schema_version"],
+            stage=fields["stage"],
+            reason=fields["reason"],
+        )
+
+    @classmethod
+    def from_json(cls, payload: str | bytes | bytearray) -> "AbstentionRecord":
+        """Parse strict JSON without including rejected content in errors."""
+
+        try:
+            parsed = json.loads(payload, object_pairs_hook=_strict_object)
+        except AbstentionValidationError:
+            raise
+        except Exception:
+            raise AbstentionValidationError("payload is not valid JSON") from None
+        return cls.from_dict(parsed)

--- a/openmed/multimodal/asset_manifest.py
+++ b/openmed/multimodal/asset_manifest.py
@@ -1,0 +1,208 @@
+"""Privacy-safe asset manifests for multimodal preflight.
+
+The manifest records only bounded, non-identifying facts that downstream image,
+PDF, DICOM, and audio handlers can share before decoding an asset. It rejects
+paths, URLs, free-text payload fields, and unknown keys so callers do not
+accidentally persist PHI-bearing source metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+MANIFEST_VERSION = 1
+MAX_MANIFEST_BYTE_SIZE = (1 << 63) - 1
+MAX_MANIFEST_COUNT = (1 << 31) - 1
+MAX_MANIFEST_DURATION_SECONDS = float(MAX_MANIFEST_COUNT)
+
+_ASSET_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_MEDIA_TYPE_RE = re.compile(r"^[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*$")
+_PATH_OR_URL_RE = re.compile(r"://|(^|[A-Za-z]):[\\/]|[\\/]|~")
+
+_ALLOWED_FIELDS = {
+    "version",
+    "asset_id",
+    "media_type",
+    "sha256",
+    "byte_size",
+    "pages",
+    "width",
+    "height",
+    "frames",
+    "duration_seconds",
+}
+
+_ORDERED_FIELDS = (
+    "version",
+    "asset_id",
+    "media_type",
+    "sha256",
+    "byte_size",
+    "pages",
+    "width",
+    "height",
+    "frames",
+    "duration_seconds",
+)
+
+_SUPPORTED_EXACT_MEDIA_TYPES = {
+    "application/dicom",
+    "application/pdf",
+    "application/dicom+json",
+}
+_SUPPORTED_MEDIA_PREFIXES = ("image/", "audio/")
+
+
+class AssetManifestError(ValueError):
+    """Raised when a privacy-safe asset manifest fails validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class AssetManifest:
+    """Versioned, privacy-safe description of a multimodal input asset."""
+
+    asset_id: str
+    media_type: str
+    sha256: str
+    byte_size: int
+    version: int = MANIFEST_VERSION
+    pages: int | None = None
+    width: int | None = None
+    height: int | None = None
+    frames: int | None = None
+    duration_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        _validate_version(self.version)
+        _validate_opaque_string("asset_id", self.asset_id, _ASSET_ID_RE)
+        _validate_media_type(self.media_type)
+        _validate_opaque_string("sha256", self.sha256, _SHA256_RE)
+        _validate_positive_int(
+            "byte_size", self.byte_size, maximum=MAX_MANIFEST_BYTE_SIZE
+        )
+        for field_name in ("pages", "width", "height", "frames"):
+            value = getattr(self, field_name)
+            if value is not None:
+                _validate_positive_int(field_name, value, maximum=MAX_MANIFEST_COUNT)
+        if self.duration_seconds is not None:
+            _validate_positive_number(
+                "duration_seconds",
+                self.duration_seconds,
+                maximum=MAX_MANIFEST_DURATION_SECONDS,
+            )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AssetManifest":
+        """Build and validate a manifest from a strict mapping."""
+        if not isinstance(data, Mapping):
+            raise AssetManifestError("manifest must be a mapping")
+        try:
+            fields = dict(data)
+            provided = set(fields)
+        except Exception:
+            raise AssetManifestError("manifest fields could not be read") from None
+
+        unknown = provided - _ALLOWED_FIELDS
+        if unknown:
+            raise AssetManifestError("manifest contains unknown fields")
+
+        missing = {"asset_id", "media_type", "sha256", "byte_size"} - provided
+        if missing:
+            raise AssetManifestError("manifest is missing required fields")
+
+        version = fields.get("version", MANIFEST_VERSION)
+        return cls(
+            version=version,
+            asset_id=fields["asset_id"],
+            media_type=fields["media_type"],
+            sha256=fields["sha256"],
+            byte_size=fields["byte_size"],
+            pages=fields.get("pages"),
+            width=fields.get("width"),
+            height=fields.get("height"),
+            frames=fields.get("frames"),
+            duration_seconds=fields.get("duration_seconds"),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str | bytes | bytearray) -> "AssetManifest":
+        """Build and validate a manifest from a JSON object."""
+        try:
+            data = json.loads(payload, object_pairs_hook=_strict_json_object)
+        except AssetManifestError:
+            raise
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError, ValueError):
+            raise AssetManifestError("manifest JSON is malformed") from None
+        return cls.from_dict(data)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic dictionary without unset optional fields."""
+        data: dict[str, Any] = {}
+        for field_name in _ORDERED_FIELDS:
+            value = getattr(self, field_name)
+            if value is not None:
+                data[field_name] = value
+        return data
+
+    def to_json(self) -> str:
+        """Return stable compact JSON with sorted keys."""
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def _validate_version(value: Any) -> None:
+    if type(value) is not int or value != MANIFEST_VERSION:
+        raise AssetManifestError("version must match the supported manifest version")
+
+
+def _validate_opaque_string(
+    field_name: str, value: Any, pattern: re.Pattern[str]
+) -> None:
+    if not isinstance(value, str):
+        raise AssetManifestError(f"{field_name} must be a string")
+    if _PATH_OR_URL_RE.search(value):
+        raise AssetManifestError(f"{field_name} must be an opaque value")
+    if pattern.fullmatch(value) is None:
+        raise AssetManifestError(f"{field_name} has an invalid format")
+
+
+def _validate_media_type(value: Any) -> None:
+    if not isinstance(value, str):
+        raise AssetManifestError("media_type must be a string")
+    media_type = value.lower()
+    if value != media_type:
+        raise AssetManifestError("media_type has an invalid format")
+    if _MEDIA_TYPE_RE.fullmatch(media_type) is None:
+        raise AssetManifestError("media_type has an invalid format")
+    if media_type in _SUPPORTED_EXACT_MEDIA_TYPES:
+        return
+    if media_type.startswith(_SUPPORTED_MEDIA_PREFIXES):
+        return
+    raise AssetManifestError("media_type is unsupported")
+
+
+def _validate_positive_int(field_name: str, value: Any, *, maximum: int) -> None:
+    if type(value) is not int or not 0 < value <= maximum:
+        raise AssetManifestError(f"{field_name} must be a bounded positive integer")
+
+
+def _validate_positive_number(field_name: str, value: Any, *, maximum: float) -> None:
+    if type(value) not in (int, float):
+        raise AssetManifestError(
+            f"{field_name} must be a bounded positive finite number"
+        )
+    if not math.isfinite(value) or not 0 < value <= maximum:
+        raise AssetManifestError(
+            f"{field_name} must be a bounded positive finite number"
+        )
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    fields = dict(pairs)
+    if len(fields) != len(pairs):
+        raise AssetManifestError("manifest contains duplicate fields")
+    return fields

--- a/openmed/multimodal/media_type.py
+++ b/openmed/multimodal/media_type.py
@@ -1,0 +1,74 @@
+"""Bounded, dependency-free media-type detection for multimodal preflight."""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Final
+
+__all__ = [
+    "MAX_MEDIA_TYPE_PREFIX_BYTES",
+    "MediaTypeStatus",
+    "detect_media_type",
+    "validate_media_type",
+]
+
+MAX_MEDIA_TYPE_PREFIX_BYTES: Final[int] = 132
+
+_MEDIA_TYPE_RE: Final[re.Pattern[str]] = re.compile(
+    r"^[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*$"
+)
+
+
+class MediaTypeStatus(str, Enum):
+    """Categorical result of comparing detected and declared media types."""
+
+    MATCH = "match"
+    MISMATCH = "mismatch"
+    UNKNOWN = "unknown"
+
+
+def detect_media_type(prefix: bytes | bytearray | memoryview) -> str | None:
+    """Detect a supported media type from at most 132 leading bytes.
+
+    The detector returns ``None`` for truncated, ambiguous, and unsupported
+    inputs. It does not inspect filenames, decode content, or log input bytes.
+    """
+
+    if not isinstance(prefix, (bytes, bytearray, memoryview)):
+        raise TypeError("prefix must be bytes-like")
+
+    bounded = bytes(prefix[:MAX_MEDIA_TYPE_PREFIX_BYTES])
+    if bounded.startswith(b"%PDF-"):
+        return "application/pdf"
+    if bounded.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if bounded.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if bounded.startswith((b"II*\x00", b"MM\x00*")):
+        return "image/tiff"
+    if len(bounded) >= 132 and bounded[128:132] == b"DICM":
+        return "application/dicom"
+    if len(bounded) >= 12 and bounded.startswith(b"RIFF") and bounded[8:12] == b"WAVE":
+        return "audio/wav"
+    return None
+
+
+def validate_media_type(
+    prefix: bytes | bytearray | memoryview, declared_media_type: str
+) -> MediaTypeStatus:
+    """Compare detected and declared media types without exposing input bytes."""
+
+    if (
+        type(declared_media_type) is not str
+        or declared_media_type != declared_media_type.lower()
+        or _MEDIA_TYPE_RE.fullmatch(declared_media_type) is None
+    ):
+        raise ValueError("declared media type is unsupported")
+
+    detected = detect_media_type(prefix)
+    if detected is None:
+        return MediaTypeStatus.UNKNOWN
+    if detected == declared_media_type:
+        return MediaTypeStatus.MATCH
+    return MediaTypeStatus.MISMATCH

--- a/tests/unit/multimodal/test_abstention.py
+++ b/tests/unit/multimodal/test_abstention.py
@@ -1,0 +1,149 @@
+"""Tests for PHI-safe multimodal abstention records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.multimodal.abstention import (
+    AbstentionReason,
+    AbstentionRecord,
+    AbstentionStage,
+)
+
+VALID_RECORDS = (
+    (AbstentionStage.PREFLIGHT, AbstentionReason.UNSUPPORTED_MEDIA),
+    (AbstentionStage.PREFLIGHT, AbstentionReason.RESOURCE_LIMIT),
+    (AbstentionStage.PREFLIGHT, AbstentionReason.PROVIDER_UNAVAILABLE),
+    (AbstentionStage.DECODE, AbstentionReason.MALFORMED_MEDIA),
+    (AbstentionStage.DECODE, AbstentionReason.RESOURCE_LIMIT),
+    (AbstentionStage.DECODE, AbstentionReason.LOW_QUALITY),
+    (AbstentionStage.INFERENCE, AbstentionReason.RESOURCE_LIMIT),
+    (AbstentionStage.INFERENCE, AbstentionReason.LOW_QUALITY),
+    (AbstentionStage.INFERENCE, AbstentionReason.PHI_UNCERTAINTY),
+    (AbstentionStage.INFERENCE, AbstentionReason.SPEAKER_UNCERTAINTY),
+    (AbstentionStage.INFERENCE, AbstentionReason.TEMPORAL_INSTABILITY),
+    (AbstentionStage.INFERENCE, AbstentionReason.PROVIDER_UNAVAILABLE),
+    (AbstentionStage.POST_PROCESS, AbstentionReason.RESOURCE_LIMIT),
+    (AbstentionStage.POST_PROCESS, AbstentionReason.LOW_QUALITY),
+    (AbstentionStage.POST_PROCESS, AbstentionReason.PHI_UNCERTAINTY),
+    (AbstentionStage.POST_PROCESS, AbstentionReason.SPEAKER_UNCERTAINTY),
+    (AbstentionStage.POST_PROCESS, AbstentionReason.TEMPORAL_INSTABILITY),
+)
+
+INVALID_RECORDS = tuple(
+    (stage, reason)
+    for stage in AbstentionStage
+    for reason in AbstentionReason
+    if (stage, reason) not in VALID_RECORDS
+)
+
+
+def test_abstention_contract_is_available_from_public_multimodal_api() -> None:
+    from openmed.multimodal import (
+        ABSTENTION_SCHEMA_VERSION,
+        AbstentionValidationError,
+    )
+    from openmed.multimodal import (
+        AbstentionReason as PublicReason,
+    )
+    from openmed.multimodal import (
+        AbstentionRecord as PublicRecord,
+    )
+    from openmed.multimodal import (
+        AbstentionStage as PublicStage,
+    )
+
+    assert ABSTENTION_SCHEMA_VERSION == 1
+    assert PublicReason is AbstentionReason
+    assert PublicRecord is AbstentionRecord
+    assert PublicStage is AbstentionStage
+    assert issubclass(AbstentionValidationError, ValueError)
+
+
+@pytest.mark.parametrize(("stage", "reason"), VALID_RECORDS)
+def test_every_stage_and_reason_round_trips(
+    stage: AbstentionStage,
+    reason: AbstentionReason,
+) -> None:
+    record = AbstentionRecord(stage=stage, reason=reason)
+
+    assert AbstentionRecord.from_json(record.to_json()) == record
+
+
+def test_json_is_deterministic_and_metadata_only() -> None:
+    record = AbstentionRecord(
+        stage=AbstentionStage.PREFLIGHT,
+        reason=AbstentionReason.UNSUPPORTED_MEDIA,
+    )
+
+    assert record.to_json() == (
+        '{"schema_version":1,"stage":"preflight","reason":"unsupported_media"}'
+    )
+    assert set(json.loads(record.to_json())) == {
+        "schema_version",
+        "stage",
+        "reason",
+    }
+
+
+@pytest.mark.parametrize(
+    ("stage", "reason"),
+    INVALID_RECORDS,
+)
+def test_invalid_stage_reason_combinations_fail_closed(
+    stage: AbstentionStage,
+    reason: AbstentionReason,
+) -> None:
+    with pytest.raises(ValueError, match="reason is not valid for stage"):
+        AbstentionRecord(stage=stage, reason=reason)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {
+            "schema_version": 1,
+            "stage": "secret-stage-raw-ocr-text",
+            "reason": "unsupported_media",
+        },
+        {
+            "schema_version": 1,
+            "stage": "preflight",
+            "reason": "secret-reason-dicom-value",
+        },
+        {
+            "schema_version": 1,
+            "stage": "preflight",
+            "reason": "unsupported_media",
+            "transcript": "secret-transcript",
+        },
+    ),
+)
+def test_invalid_payloads_do_not_echo_submitted_content(payload: object) -> None:
+    submitted = json.dumps(payload)
+
+    with pytest.raises(ValueError) as exc_info:
+        AbstentionRecord.from_json(submitted)
+
+    assert "secret" not in str(exc_info.value)
+    assert "raw-ocr-text" not in str(exc_info.value)
+    assert "dicom-value" not in str(exc_info.value)
+    assert "secret-transcript" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        "not-json",
+        "[]",
+        '{"schema_version":1,"stage":"preflight","stage":"decode",'
+        '"reason":"unsupported_media"}',
+        '{"schema_version":2,"stage":"preflight","reason":"unsupported_media"}',
+        '{"schema_version":1,"stage":"preflight"}',
+    ),
+)
+def test_malformed_or_incomplete_payloads_fail_closed(payload: str) -> None:
+    with pytest.raises(ValueError):
+        AbstentionRecord.from_json(payload)

--- a/tests/unit/multimodal/test_asset_manifest.py
+++ b/tests/unit/multimodal/test_asset_manifest.py
@@ -1,0 +1,225 @@
+"""Tests for privacy-safe multimodal asset manifests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.multimodal.asset_manifest import (
+    MAX_MANIFEST_BYTE_SIZE,
+    MAX_MANIFEST_COUNT,
+    MAX_MANIFEST_DURATION_SECONDS,
+    AssetManifest,
+    AssetManifestError,
+)
+
+VALID_DIGEST = "a" * 64
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "asset_id": "img-001",
+            "media_type": "image/png",
+            "sha256": VALID_DIGEST,
+            "byte_size": 1024,
+            "width": 640,
+            "height": 480,
+        },
+        {
+            "asset_id": "pdf-001",
+            "media_type": "application/pdf",
+            "sha256": VALID_DIGEST,
+            "byte_size": 2048,
+            "pages": 4,
+        },
+        {
+            "asset_id": "dicom-001",
+            "media_type": "application/dicom",
+            "sha256": VALID_DIGEST,
+            "byte_size": 4096,
+            "frames": 12,
+            "width": 512,
+            "height": 512,
+        },
+        {
+            "asset_id": "audio-001",
+            "media_type": "audio/wav",
+            "sha256": VALID_DIGEST,
+            "byte_size": 8192,
+            "duration_seconds": 3.5,
+        },
+    ],
+)
+def test_valid_asset_examples_round_trip_with_stable_json(payload):
+    manifest = AssetManifest.from_dict(payload)
+
+    assert AssetManifest.from_json(manifest.to_json()) == manifest
+    assert json.loads(manifest.to_json()) == manifest.to_dict()
+    assert list(json.loads(manifest.to_json())) == sorted(manifest.to_dict())
+    assert manifest.to_json() == manifest.to_json()
+
+
+def test_to_dict_uses_stable_order_and_omits_unset_fields():
+    manifest = AssetManifest.from_dict(
+        {
+            "media_type": "application/pdf",
+            "byte_size": 20,
+            "sha256": VALID_DIGEST,
+            "asset_id": "asset-123",
+            "pages": 2,
+        }
+    )
+
+    assert list(manifest.to_dict()) == [
+        "version",
+        "asset_id",
+        "media_type",
+        "sha256",
+        "byte_size",
+        "pages",
+    ]
+    assert "width" not in manifest.to_dict()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("sha256", "A" * 64),
+        ("sha256", "abc"),
+        ("sha256", "g" * 64),
+        ("byte_size", 0),
+        ("byte_size", -1),
+        ("byte_size", 2.2),
+        ("byte_size", True),
+        ("byte_size", MAX_MANIFEST_BYTE_SIZE + 1),
+        ("pages", -1),
+        ("pages", MAX_MANIFEST_COUNT + 1),
+        ("width", 0),
+        ("height", -2),
+        ("frames", 1.5),
+        ("duration_seconds", 0.0),
+        ("duration_seconds", -1.0),
+        ("duration_seconds", float("inf")),
+        ("duration_seconds", float("nan")),
+        ("duration_seconds", MAX_MANIFEST_DURATION_SECONDS + 1),
+        ("version", 2),
+        ("version", 1.0),
+        ("version", True),
+        ("media_type", "text/plain"),
+        ("media_type", "Image/PNG"),
+    ],
+)
+def test_invalid_field_values_fail_closed(field, value):
+    payload = {
+        "version": 1,
+        "asset_id": "asset-001",
+        "media_type": "image/png",
+        "sha256": VALID_DIGEST,
+        "byte_size": 1024,
+    }
+    payload[field] = value
+
+    with pytest.raises(AssetManifestError):
+        AssetManifest.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"asset_id": "asset-001", "media_type": "image/png", "byte_size": 1},
+        {
+            "asset_id": "asset-001",
+            "media_type": "image/png",
+            "sha256": VALID_DIGEST,
+            "byte_size": 1,
+            "description": "Patient note",
+        },
+        "not-a-dict",
+    ],
+)
+def test_missing_unknown_and_non_mapping_payloads_fail_closed(payload):
+    with pytest.raises(AssetManifestError):
+        AssetManifest.from_dict(payload)  # type: ignore[arg-type]
+
+
+def test_unknown_free_text_field_fails_without_echo():
+    payload = {
+        "asset_id": "asset-001",
+        "media_type": "image/png",
+        "sha256": VALID_DIGEST,
+        "byte_size": 1,
+        "description": "synthetic sentinel chart text",
+    }
+
+    with pytest.raises(AssetManifestError) as exc_info:
+        AssetManifest.from_dict(payload)
+
+    assert payload["description"] not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("asset_id", "/tmp/patient.png"),
+        ("asset_id", "s3://bucket/patient.png"),
+        ("asset_id", "C:\\patient\\scan.dcm"),
+        ("media_type", "https://example.test/image/png"),
+        ("sha256", "/tmp/" + VALID_DIGEST),
+    ],
+)
+def test_paths_urls_and_location_like_values_fail_without_echo(field, value):
+    payload = {
+        "version": 1,
+        "asset_id": "asset-001",
+        "media_type": "image/png",
+        "sha256": VALID_DIGEST,
+        "byte_size": 1024,
+    }
+    payload[field] = value
+
+    with pytest.raises(AssetManifestError) as exc_info:
+        AssetManifest.from_dict(payload)
+
+    assert value not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("payload", ["{", b"\xff", 42])
+def test_malformed_json_fails_closed(payload):
+    with pytest.raises(AssetManifestError):
+        AssetManifest.from_json(payload)  # type: ignore[arg-type]
+
+
+def test_duplicate_json_fields_fail_closed_without_echoing_values() -> None:
+    payload = (
+        '{"asset_id":"asset-001","asset_id":"synthetic-secret",'
+        f'"media_type":"image/png","sha256":"{VALID_DIGEST}","byte_size":1}}'
+    )
+
+    with pytest.raises(AssetManifestError) as exc_info:
+        AssetManifest.from_json(payload)
+
+    assert "synthetic-secret" not in str(exc_info.value)
+
+
+def test_scalar_subclasses_do_not_bypass_strict_types() -> None:
+    class IntSubclass(int):
+        pass
+
+    with pytest.raises(AssetManifestError):
+        AssetManifest(
+            asset_id="asset-001",
+            media_type="image/png",
+            sha256=VALID_DIGEST,
+            byte_size=IntSubclass(1),
+        )
+
+
+def test_manifest_contract_is_available_from_public_multimodal_api():
+    import openmed.multimodal as multimodal
+
+    assert multimodal.AssetManifest is AssetManifest
+    assert multimodal.AssetManifestError is AssetManifestError
+    assert multimodal.MANIFEST_VERSION == 1

--- a/tests/unit/multimodal/test_media_type.py
+++ b/tests/unit/multimodal/test_media_type.py
@@ -1,0 +1,93 @@
+"""Tests for bounded multimodal media-type detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from openmed.multimodal.media_type import (
+    MAX_MEDIA_TYPE_PREFIX_BYTES,
+    MediaTypeStatus,
+    detect_media_type,
+    validate_media_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected"),
+    [
+        (b"%PDF-1.7\n", "application/pdf"),
+        (b"\x89PNG\r\n\x1a\n", "image/png"),
+        (b"\xff\xd8\xff\xe0", "image/jpeg"),
+        (b"II*\x00", "image/tiff"),
+        (b"MM\x00*", "image/tiff"),
+        (b"\x00" * 128 + b"DICM", "application/dicom"),
+        (b"RIFF\x10\x00\x00\x00WAVE", "audio/wav"),
+    ],
+)
+def test_detect_media_type_from_synthetic_prefix(prefix, expected):
+    assert detect_media_type(prefix) == expected
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        b"",
+        b"%PD",
+        b"\x89PNG",
+        b"\xff\xd8",
+        b"RIFF\x10\x00\x00\x00",
+        b"\x00" * 128 + b"DIC",
+        b"not-a-supported-format",
+    ],
+)
+def test_truncated_ambiguous_and_unsupported_prefixes_are_unknown(prefix):
+    assert detect_media_type(prefix) is None
+
+
+def test_detection_accepts_bytes_like_inputs_and_uses_a_bounded_prefix():
+    payload = memoryview(b"%PDF-1.7" + b"x" * (MAX_MEDIA_TYPE_PREFIX_BYTES + 500))
+
+    assert detect_media_type(payload) == "application/pdf"
+    assert MAX_MEDIA_TYPE_PREFIX_BYTES == 132
+
+
+def test_detection_never_recognizes_a_signature_beyond_the_prefix_bound() -> None:
+    payload = b"x" * MAX_MEDIA_TYPE_PREFIX_BYTES + b"%PDF-1.7"
+
+    assert detect_media_type(payload) is None
+
+
+@pytest.mark.parametrize(
+    ("prefix", "declared", "expected"),
+    [
+        (b"%PDF-1.7", "application/pdf", MediaTypeStatus.MATCH),
+        (b"%PDF-1.7", "image/png", MediaTypeStatus.MISMATCH),
+        (b"%PDF-1.7", "application/octet-stream", MediaTypeStatus.MISMATCH),
+        (b"unknown", "application/pdf", MediaTypeStatus.UNKNOWN),
+    ],
+)
+def test_validate_media_type_returns_stable_categories(prefix, declared, expected):
+    assert validate_media_type(prefix, declared) is expected
+
+
+@pytest.mark.parametrize("value", ["%PDF-1.7", 42, None])
+def test_detector_rejects_non_bytes_like_values(value):
+    with pytest.raises(TypeError, match="prefix must be bytes-like"):
+        detect_media_type(value)  # type: ignore[arg-type]
+
+
+def test_validator_rejects_invalid_declared_media_type_without_echoing_value():
+    declared = "https://patient.example/scan.dcm"
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_media_type(b"%PDF-1.7", declared)
+
+    assert declared not in str(exc_info.value)
+
+
+def test_media_type_contract_is_available_from_public_multimodal_api():
+    import openmed.multimodal as multimodal
+
+    assert multimodal.detect_media_type is detect_media_type
+    assert multimodal.validate_media_type is validate_media_type
+    assert multimodal.MediaTypeStatus is MediaTypeStatus


### PR DESCRIPTION
## Description

Integrates three related multimodal contributions from krudo-taco as one verified unit:

- #2968 — privacy-safe, versioned asset manifests
- #2971 — bounded media-type prefix detection
- #2986 — stable, metadata-only abstention reason records

Maintainer follow-up commits harden the public contracts, preserve value-free failures, update documentation, and normalize the combined exports. Every contributor commit remains in the original PR history before squash integration.

## Change type

- [x] Feature
- [x] Documentation
- [x] Tests

## Validation

- 13,927 passed, 116 skipped in the unrestricted combined-tree test suite
- Focused integration steps: 55 passed, then 80 passed, then 122 passed
- Aggregate multimodal validation: 431 passed, 18 skipped
- Strict MkDocs build passed
- Scoped pre-commit and public API docstring checks passed
- Nix, multi-architecture containers, ARM64 latency, security, lint, package build, SBOM, and platform matrices passed on the original exact PR heads
- Retargeted exact-head ARM64/AMD64 container smokes and ARM latency passed for #2971 and #2986
- Final tree matches the validated rehearsal tree: f0b7cd3fa79d296a7fb96d36d3187bab15c1fa5f

The Image SBOM workflow currently fails repository-wide because the unchanged Dockerfile pins netbase=6.5, which is no longer available from Debian forky. The same master SHA passed this workflow before the external package index drift; all PR-owned SBOM and container checks pass.

## Documentation and changelog

- Added dedicated documentation for asset manifests, media-type detection, and abstention reasons
- Updated MkDocs navigation, publication inventory, and CHANGELOG

## Dependencies

No new runtime dependency is added.

Closes #2954
Closes #2955
Closes #2977
