### PR TITLE
feat(multimodal): add privacy-safe asset batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added image, PDF, DICOM, and audio profiles that validate canonical manifest
   metadata into deterministic field-and-reason findings without opening or
   decoding an asset (#2978).
+- Added privacy-safe multimodal asset batches with opaque batch identifiers,
+  canonical asset ordering, duplicate identifier and digest detection, a
+  bounded asset count, derived byte, page, frame, and duration totals, and
+  sorted value-free findings for invalid, oversized, overflowing, or
+  inconsistent batches (#3002).
 - Added a closed, JSON-safe agent outcome vocabulary with success, abstention,
   reviewer-handoff, policy-denial, and failure classes, deterministic
   serialization, and value-free rejection of unknown codes or free-text

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -212,6 +212,7 @@ classification:
     - multimodal/asset-digests.md
     - multimodal/asset-manifests.md
     - multimodal/manifest-profiles.md
+    - multimodal/asset-batches.md
     - multimodal/pdf-redaction-fidelity.md
     - multimodal/abstention-reasons.md
     - multimodal/email-ingestion.md

--- a/docs/multimodal/asset-batches.md
+++ b/docs/multimodal/asset-batches.md
@@ -1,0 +1,103 @@
+# Privacy-safe asset batches
+
+`openmed.multimodal.asset_batch` groups several
+[asset manifests](asset-manifests.md) into one versioned batch so a clinical
+packet with mixed media can be ordered, de-duplicated, and summarized before
+any asset is opened.
+
+A batch records only:
+
+- `version`
+- `batch_id`, an opaque identifier with the same format as `asset_id`
+- `assets`, the ordered manifests
+- derived totals: `asset_count`, `total_bytes`, `total_pages`,
+  `total_frames`, `total_duration_seconds`
+
+The validator rejects unknown fields, paths, URLs, inline manifests that fail
+manifest validation, duplicate asset identifiers, repeated content digests,
+non-canonical ordering, batches above the hard cap of 10,000 assets, aggregate
+totals that overflow the manifest bounds, and declared totals that disagree
+with the manifests. Errors and findings name a reason code, a fixed schema
+field, or an asset position and never echo a supplied value.
+
+## Canonical order
+
+Assets are stored strictly ascending by `asset_id`. `AssetBatch.build()` sorts
+its input; `from_dict()`, `from_json()`, and direct construction reject any
+other order with `order_not_canonical`. Two batches that hold the same
+manifests therefore always serialize to the same bytes.
+
+```python
+from openmed.multimodal.asset_batch import AssetBatch, validate_asset_batch
+from openmed.multimodal.asset_manifest import AssetManifest
+
+pdf = AssetManifest.from_dict(
+    {
+        "asset_id": "pdf-001",
+        "media_type": "application/pdf",
+        "sha256": "a" * 64,
+        "byte_size": 2048,
+        "pages": 4,
+    }
+)
+audio = AssetManifest.from_dict(
+    {
+        "asset_id": "audio-001",
+        "media_type": "audio/wav",
+        "sha256": "b" * 64,
+        "byte_size": 8192,
+        "duration_seconds": 3.5,
+    }
+)
+
+batch = AssetBatch.build("packet-001", [pdf, audio])
+batch.total_pages  # 4
+batch.total_duration_seconds  # 3.5
+payload = batch.to_json()
+
+assert validate_asset_batch(batch) == []
+assert AssetBatch.from_json(payload) == batch
+```
+
+## Derived totals
+
+Totals are computed from the manifests rather than stored, so a Python batch
+can never hold inconsistent counts. `to_dict()` and `to_json()` always emit
+every total, including zero values for modalities that are absent. When a
+serialized payload declares totals they are optional but must match the
+derived values; `aggregate_invalid` reports a wrong type or a non-finite
+number and `aggregate_mismatch` reports a disagreement. Durations are summed
+with `math.fsum` and compared with a `1e-9` tolerance.
+
+## Findings
+
+`validate_asset_batch()` returns a sorted, de-duplicated list of
+`BatchFinding` records instead of raising, which lets preflight reports
+collect every problem in one pass. Each finding holds a `reason_code`, an
+optional `field_name` limited to the batch schema, and an optional zero-based
+asset `position`.
+
+| Reason code | Meaning |
+| --- | --- |
+| `invalid_batch` | The payload is not a readable mapping. |
+| `unknown_field` | The payload contains a key outside the schema. |
+| `missing_required` | `batch_id` or `assets` is absent. |
+| `invalid_version` | `version` is not the supported integer. |
+| `invalid_batch_id` | `batch_id` is not an opaque identifier. |
+| `invalid_assets` | `assets` is not a sequence of manifests. |
+| `invalid_asset` | The manifest at `position` failed manifest validation. |
+| `duplicate_asset_id` | The manifest at `position` repeats an earlier `asset_id`. |
+| `duplicate_sha256` | The manifest at `position` repeats an earlier digest. |
+| `order_not_canonical` | The manifest at `position` is out of ascending order. |
+| `batch_too_large` | The batch exceeds `max_assets` or the hard cap. |
+| `aggregate_overflow` | A derived total exceeds the manifest bound. |
+| `aggregate_invalid` | A declared total has the wrong type or is non-finite. |
+| `aggregate_mismatch` | A declared total disagrees with the manifests. |
+| `empty_batch` | The batch is empty and `allow_empty` is false. |
+
+`max_assets` and `allow_empty` are caller policy. Both `validate_asset_batch()`
+and the loaders accept them; `from_dict()` and `from_json()` raise
+`AssetBatchError` when any finding is present.
+
+The batch does not open assets, decide processing order from clinical
+semantics, run inference, or de-duplicate or delete source files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
       - Bounded Asset Digests: multimodal/asset-digests.md
       - Privacy-safe Asset Manifests: multimodal/asset-manifests.md
       - Multimodal Manifest Profiles: multimodal/manifest-profiles.md
+      - Privacy-safe Asset Batches: multimodal/asset-batches.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md
       - Multimodal Abstention Reasons: multimodal/abstention-reasons.md
       - Email Ingestion and Redaction: multimodal/email-ingestion.md

--- a/openmed/multimodal/__init__.py
+++ b/openmed/multimodal/__init__.py
@@ -36,6 +36,14 @@ from .abstention import (
     AbstentionStage,
     AbstentionValidationError,
 )
+from .asset_batch import (
+    BATCH_VERSION,
+    MAX_BATCH_ASSETS,
+    AssetBatch,
+    AssetBatchError,
+    BatchFinding,
+    validate_asset_batch,
+)
 from .asset_manifest import MANIFEST_VERSION, AssetManifest, AssetManifestError
 from .base import (
     ExtractedDocument,
@@ -294,6 +302,12 @@ __all__ = [
     "AssetManifest",
     "AssetManifestError",
     "MANIFEST_VERSION",
+    "AssetBatch",
+    "AssetBatchError",
+    "BATCH_VERSION",
+    "BatchFinding",
+    "MAX_BATCH_ASSETS",
+    "validate_asset_batch",
     "MAX_MEDIA_TYPE_PREFIX_BYTES",
     "MediaTypeStatus",
     "detect_media_type",

--- a/openmed/multimodal/asset_batch.py
+++ b/openmed/multimodal/asset_batch.py
@@ -1,0 +1,446 @@
+"""Privacy-safe multimodal asset batches for preflight.
+
+A batch groups an opaque batch identifier with an ordered tuple of
+:class:`~openmed.multimodal.asset_manifest.AssetManifest` records so clinical
+packets that contain several media assets can be ordered, de-duplicated, and
+summarized before any asset is opened. The batch carries only the bounded,
+non-identifying facts that the manifests already hold. It rejects duplicate
+asset identifiers, repeated content digests, non-canonical ordering, oversized
+batches, aggregate overflow, and declared totals that disagree with the
+manifests, and it never records paths, filenames, extracted text, or bytes.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Final
+
+from .asset_manifest import (
+    MAX_MANIFEST_BYTE_SIZE,
+    MAX_MANIFEST_COUNT,
+    MAX_MANIFEST_DURATION_SECONDS,
+    AssetManifest,
+    AssetManifestError,
+)
+
+__all__ = [
+    "BATCH_VERSION",
+    "MAX_BATCH_ASSETS",
+    "AssetBatch",
+    "AssetBatchError",
+    "BatchFinding",
+    "validate_asset_batch",
+]
+
+BATCH_VERSION: Final = 1
+MAX_BATCH_ASSETS: Final = 10_000
+
+_BATCH_ID_RE: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_PATH_OR_URL_RE: Final = re.compile(r"://|(^|[A-Za-z]):[\\/]|[\\/]|~")
+_DURATION_TOLERANCE: Final = 1e-9
+
+_COUNT_AGGREGATES: Final = ("asset_count", "total_bytes", "total_pages", "total_frames")
+_AGGREGATE_FIELDS: Final = (*_COUNT_AGGREGATES, "total_duration_seconds")
+_AGGREGATE_LIMITS: Final = {
+    "total_bytes": MAX_MANIFEST_BYTE_SIZE,
+    "total_pages": MAX_MANIFEST_COUNT,
+    "total_frames": MAX_MANIFEST_COUNT,
+    "total_duration_seconds": MAX_MANIFEST_DURATION_SECONDS,
+}
+_REQUIRED_FIELDS: Final = frozenset({"batch_id", "assets"})
+_ALLOWED_FIELDS: Final = frozenset(
+    {"version", "batch_id", "assets", *_AGGREGATE_FIELDS}
+)
+_ORDERED_FIELDS: Final = ("version", "batch_id", *_AGGREGATE_FIELDS, "assets")
+
+_REASON_CODES: Final = frozenset(
+    {
+        "aggregate_invalid",
+        "aggregate_mismatch",
+        "aggregate_overflow",
+        "batch_too_large",
+        "duplicate_asset_id",
+        "duplicate_sha256",
+        "empty_batch",
+        "invalid_asset",
+        "invalid_assets",
+        "invalid_batch",
+        "invalid_batch_id",
+        "invalid_version",
+        "missing_required",
+        "order_not_canonical",
+        "unknown_field",
+    }
+)
+
+
+class AssetBatchError(ValueError):
+    """Raised when a privacy-safe asset batch fails validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class BatchFinding:
+    """A deterministic, value-free finding from asset batch validation.
+
+    ``field_name`` is restricted to the fixed batch schema and ``position`` is
+    the zero-based index of the offending asset, so a finding can never carry
+    an unknown key, a path, or manifest content.
+    """
+
+    reason_code: str
+    field_name: str | None = None
+    position: int | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.reason_code) is not str or self.reason_code not in _REASON_CODES:
+            raise AssetBatchError("finding reason_code is unsupported")
+        if self.field_name is not None and (
+            type(self.field_name) is not str or self.field_name not in _ALLOWED_FIELDS
+        ):
+            raise AssetBatchError("finding field_name is unsupported")
+        if self.position is not None and (
+            type(self.position) is not int or self.position < 0
+        ):
+            raise AssetBatchError("finding position must be a non-negative integer")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the finding as a deterministic metadata-only dictionary."""
+        data: dict[str, Any] = {"reason_code": self.reason_code}
+        if self.field_name is not None:
+            data["field_name"] = self.field_name
+        if self.position is not None:
+            data["position"] = self.position
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class AssetBatch:
+    """Versioned, privacy-safe batch of multimodal asset manifests.
+
+    Assets are stored in canonical order, strictly ascending by ``asset_id``,
+    so equal batches always serialize identically. Aggregate totals are derived
+    from the manifests rather than stored, which keeps the Python object free
+    of inconsistent state; declared totals in serialized payloads are checked
+    against the derived values when a batch is loaded.
+    """
+
+    batch_id: str
+    assets: tuple[AssetManifest, ...]
+    version: int = BATCH_VERSION
+
+    def __post_init__(self) -> None:
+        findings = _structural_findings(self.version, self.batch_id, self.assets)
+        if findings:
+            raise AssetBatchError(_describe(findings))
+
+    @property
+    def asset_count(self) -> int:
+        """Number of assets in the batch."""
+        return len(self.assets)
+
+    @property
+    def total_bytes(self) -> int:
+        """Sum of manifest byte sizes."""
+        return _aggregates(self.assets)["total_bytes"]
+
+    @property
+    def total_pages(self) -> int:
+        """Sum of declared page counts across page-bearing assets."""
+        return _aggregates(self.assets)["total_pages"]
+
+    @property
+    def total_frames(self) -> int:
+        """Sum of declared frame counts across frame-bearing assets."""
+        return _aggregates(self.assets)["total_frames"]
+
+    @property
+    def total_duration_seconds(self) -> float:
+        """Sum of declared durations across duration-bearing assets."""
+        return _aggregates(self.assets)["total_duration_seconds"]
+
+    @classmethod
+    def build(cls, batch_id: str, manifests: Iterable[AssetManifest]) -> "AssetBatch":
+        """Build a canonically ordered batch from validated manifests."""
+        try:
+            items = tuple(manifests)
+        except Exception:
+            raise AssetBatchError("batch assets could not be read") from None
+        if any(not isinstance(item, AssetManifest) for item in items):
+            raise AssetBatchError("batch assets must be AssetManifest records")
+        ordered = tuple(sorted(items, key=lambda manifest: manifest.asset_id))
+        return cls(batch_id=batch_id, assets=ordered)
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Mapping[str, Any],
+        *,
+        max_assets: int = MAX_BATCH_ASSETS,
+        allow_empty: bool = False,
+    ) -> "AssetBatch":
+        """Build and validate a batch from a strict mapping.
+
+        Declared aggregate fields are optional in the input; when present they
+        must match the totals derived from the manifests.
+        """
+        _validate_policy(max_assets, allow_empty)
+        findings, assets = _validate_mapping(data)
+        if assets is not None:
+            findings.extend(_policy_findings(len(assets), max_assets, allow_empty))
+        if findings or assets is None:
+            raise AssetBatchError(_describe(findings))
+        fields = dict(data)
+        return cls(
+            version=fields.get("version", BATCH_VERSION),
+            batch_id=fields["batch_id"],
+            assets=assets,
+        )
+
+    @classmethod
+    def from_json(
+        cls,
+        payload: str | bytes | bytearray,
+        *,
+        max_assets: int = MAX_BATCH_ASSETS,
+        allow_empty: bool = False,
+    ) -> "AssetBatch":
+        """Build and validate a batch from a JSON object."""
+        try:
+            data = json.loads(payload, object_pairs_hook=_strict_json_object)
+        except AssetBatchError:
+            raise
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError, ValueError):
+            raise AssetBatchError("batch JSON is malformed") from None
+        return cls.from_dict(data, max_assets=max_assets, allow_empty=allow_empty)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic dictionary with derived aggregate totals."""
+        values: dict[str, Any] = {
+            "version": self.version,
+            "batch_id": self.batch_id,
+            "asset_count": self.asset_count,
+            **_aggregates(self.assets),
+            "assets": [manifest.to_dict() for manifest in self.assets],
+        }
+        return {field_name: values[field_name] for field_name in _ORDERED_FIELDS}
+
+    def to_json(self) -> str:
+        """Return stable compact JSON with sorted keys and canonical asset order."""
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def validate_asset_batch(
+    batch: Mapping[str, Any] | AssetBatch,
+    *,
+    max_assets: int = MAX_BATCH_ASSETS,
+    allow_empty: bool = False,
+) -> list[BatchFinding]:
+    """Validate a batch payload deterministically without opening any asset.
+
+    Structural findings cover unknown or missing fields, invalid identifiers,
+    invalid manifests, duplicate identifiers and digests, non-canonical order,
+    aggregate overflow, and declared totals that disagree with the manifests.
+    Policy findings cover empty batches and batches above ``max_assets``. The
+    result is sorted and de-duplicated so repeated runs are byte-stable.
+    """
+    _validate_policy(max_assets, allow_empty)
+    if isinstance(batch, AssetBatch):
+        findings: list[BatchFinding] = []
+        assets: tuple[AssetManifest, ...] | None = batch.assets
+    else:
+        findings, assets = _validate_mapping(batch)
+    if assets is not None:
+        findings.extend(_policy_findings(len(assets), max_assets, allow_empty))
+    return sorted(set(findings), key=_finding_sort_key)
+
+
+def _validate_policy(max_assets: Any, allow_empty: Any) -> None:
+    if type(max_assets) is not int or not 1 <= max_assets <= MAX_BATCH_ASSETS:
+        raise AssetBatchError("max_assets must be a positive integer within the limit")
+    if type(allow_empty) is not bool:
+        raise AssetBatchError("allow_empty must be a boolean")
+
+
+def _policy_findings(
+    count: int, max_assets: int, allow_empty: bool
+) -> list[BatchFinding]:
+    findings: list[BatchFinding] = []
+    if count == 0 and not allow_empty:
+        findings.append(BatchFinding("empty_batch", field_name="assets"))
+    if count > max_assets:
+        findings.append(BatchFinding("batch_too_large", field_name="assets"))
+    return findings
+
+
+def _validate_mapping(
+    data: Any,
+) -> tuple[list[BatchFinding], tuple[AssetManifest, ...] | None]:
+    if not isinstance(data, Mapping):
+        return [BatchFinding("invalid_batch")], None
+    try:
+        fields = dict(data)
+    except Exception:
+        return [BatchFinding("invalid_batch")], None
+
+    findings: list[BatchFinding] = []
+    if set(fields) - _ALLOWED_FIELDS:
+        findings.append(BatchFinding("unknown_field"))
+    for field_name in sorted(_REQUIRED_FIELDS - set(fields)):
+        findings.append(BatchFinding("missing_required", field_name=field_name))
+    if findings:
+        return findings, None
+
+    version = fields.get("version", BATCH_VERSION)
+    assets, asset_findings = _parse_assets(fields["assets"])
+    findings.extend(asset_findings)
+    if assets is None:
+        findings.extend(_scalar_findings(version, fields["batch_id"]))
+        return findings, None
+
+    findings.extend(_structural_findings(version, fields["batch_id"], assets))
+    findings.extend(_aggregate_findings(fields, assets))
+    return findings, assets
+
+
+def _parse_assets(
+    raw: Any,
+) -> tuple[tuple[AssetManifest, ...] | None, list[BatchFinding]]:
+    if isinstance(raw, (str, bytes, bytearray)) or not isinstance(raw, Sequence):
+        return None, [BatchFinding("invalid_assets", field_name="assets")]
+    manifests: list[AssetManifest] = []
+    findings: list[BatchFinding] = []
+    for position, item in enumerate(raw):
+        if isinstance(item, AssetManifest):
+            manifests.append(item)
+            continue
+        try:
+            manifests.append(AssetManifest.from_dict(item))
+        except AssetManifestError:
+            findings.append(BatchFinding("invalid_asset", position=position))
+    if findings:
+        return None, findings
+    return tuple(manifests), []
+
+
+def _scalar_findings(version: Any, batch_id: Any) -> list[BatchFinding]:
+    findings: list[BatchFinding] = []
+    if type(version) is not int or version != BATCH_VERSION:
+        findings.append(BatchFinding("invalid_version", field_name="version"))
+    if (
+        not isinstance(batch_id, str)
+        or _PATH_OR_URL_RE.search(batch_id)
+        or _BATCH_ID_RE.fullmatch(batch_id) is None
+    ):
+        findings.append(BatchFinding("invalid_batch_id", field_name="batch_id"))
+    return findings
+
+
+def _structural_findings(
+    version: Any, batch_id: Any, assets: Any
+) -> list[BatchFinding]:
+    findings = _scalar_findings(version, batch_id)
+    if type(assets) is not tuple:
+        findings.append(BatchFinding("invalid_assets", field_name="assets"))
+        return findings
+    invalid = [
+        BatchFinding("invalid_asset", position=position)
+        for position, item in enumerate(assets)
+        if not isinstance(item, AssetManifest)
+    ]
+    if invalid:
+        return findings + invalid
+    if len(assets) > MAX_BATCH_ASSETS:
+        findings.append(BatchFinding("batch_too_large", field_name="assets"))
+
+    seen_ids: set[str] = set()
+    seen_digests: set[str] = set()
+    for position, manifest in enumerate(assets):
+        if manifest.asset_id in seen_ids:
+            findings.append(BatchFinding("duplicate_asset_id", position=position))
+        if position > 0 and manifest.asset_id < assets[position - 1].asset_id:
+            findings.append(BatchFinding("order_not_canonical", position=position))
+        if manifest.sha256 in seen_digests:
+            findings.append(BatchFinding("duplicate_sha256", position=position))
+        seen_ids.add(manifest.asset_id)
+        seen_digests.add(manifest.sha256)
+
+    totals = _aggregates(assets)
+    for field_name, limit in _AGGREGATE_LIMITS.items():
+        if totals[field_name] > limit:
+            findings.append(BatchFinding("aggregate_overflow", field_name=field_name))
+    return findings
+
+
+def _aggregate_findings(
+    fields: Mapping[str, Any], assets: tuple[AssetManifest, ...]
+) -> list[BatchFinding]:
+    findings: list[BatchFinding] = []
+    computed: dict[str, int | float] = {
+        "asset_count": len(assets),
+        **_aggregates(assets),
+    }
+    for field_name in _AGGREGATE_FIELDS:
+        if field_name not in fields:
+            continue
+        declared = fields[field_name]
+        if field_name in _COUNT_AGGREGATES:
+            if type(declared) is not int:
+                findings.append(
+                    BatchFinding("aggregate_invalid", field_name=field_name)
+                )
+            elif declared != computed[field_name]:
+                findings.append(
+                    BatchFinding("aggregate_mismatch", field_name=field_name)
+                )
+            continue
+        if type(declared) not in (int, float) or not math.isfinite(declared):
+            findings.append(BatchFinding("aggregate_invalid", field_name=field_name))
+        elif not math.isclose(
+            declared,
+            computed[field_name],
+            rel_tol=_DURATION_TOLERANCE,
+            abs_tol=_DURATION_TOLERANCE,
+        ):
+            findings.append(BatchFinding("aggregate_mismatch", field_name=field_name))
+    return findings
+
+
+def _aggregates(assets: tuple[AssetManifest, ...]) -> dict[str, Any]:
+    return {
+        "total_bytes": sum(manifest.byte_size for manifest in assets),
+        "total_pages": sum(
+            manifest.pages for manifest in assets if manifest.pages is not None
+        ),
+        "total_frames": sum(
+            manifest.frames for manifest in assets if manifest.frames is not None
+        ),
+        "total_duration_seconds": math.fsum(
+            manifest.duration_seconds
+            for manifest in assets
+            if manifest.duration_seconds is not None
+        ),
+    }
+
+
+def _finding_sort_key(finding: BatchFinding) -> tuple[str, str, int]:
+    return (
+        finding.reason_code,
+        finding.field_name or "",
+        -1 if finding.position is None else finding.position,
+    )
+
+
+def _describe(findings: Sequence[BatchFinding]) -> str:
+    codes = sorted({finding.reason_code for finding in findings})
+    return "asset batch is invalid: " + ", ".join(codes)
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    fields = dict(pairs)
+    if len(fields) != len(pairs):
+        raise AssetBatchError("batch contains duplicate fields")
+    return fields

--- a/tests/unit/multimodal/test_asset_batch.py
+++ b/tests/unit/multimodal/test_asset_batch.py
@@ -1,0 +1,564 @@
+"""Tests for privacy-safe multimodal asset batches."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openmed.multimodal.asset_batch import (
+    BATCH_VERSION,
+    MAX_BATCH_ASSETS,
+    AssetBatch,
+    AssetBatchError,
+    BatchFinding,
+    validate_asset_batch,
+)
+from openmed.multimodal.asset_manifest import (
+    MAX_MANIFEST_BYTE_SIZE,
+    MAX_MANIFEST_COUNT,
+    MAX_MANIFEST_DURATION_SECONDS,
+    AssetManifest,
+)
+
+
+def _digest(seed: int) -> str:
+    return f"{seed:064x}"
+
+
+def _image(asset_id: str, seed: int, **fields: object) -> AssetManifest:
+    payload: dict[str, object] = {
+        "asset_id": asset_id,
+        "media_type": "image/png",
+        "sha256": _digest(seed),
+        "byte_size": 1024,
+        "width": 640,
+        "height": 480,
+    }
+    payload.update(fields)
+    return AssetManifest.from_dict(payload)
+
+
+IMAGE = _image("img-001", 1)
+PDF = AssetManifest.from_dict(
+    {
+        "asset_id": "pdf-001",
+        "media_type": "application/pdf",
+        "sha256": _digest(2),
+        "byte_size": 2048,
+        "pages": 4,
+    }
+)
+DICOM = AssetManifest.from_dict(
+    {
+        "asset_id": "dicom-001",
+        "media_type": "application/dicom",
+        "sha256": _digest(3),
+        "byte_size": 4096,
+        "frames": 12,
+        "width": 512,
+        "height": 512,
+    }
+)
+AUDIO = AssetManifest.from_dict(
+    {
+        "asset_id": "audio-001",
+        "media_type": "audio/wav",
+        "sha256": _digest(4),
+        "byte_size": 8192,
+        "duration_seconds": 3.5,
+    }
+)
+AUDIO_2 = AssetManifest.from_dict(
+    {
+        "asset_id": "audio-002",
+        "media_type": "audio/wav",
+        "sha256": _digest(5),
+        "byte_size": 16,
+        "duration_seconds": 2.25,
+    }
+)
+ORDERED_FIELDS = [
+    "version",
+    "batch_id",
+    "asset_count",
+    "total_bytes",
+    "total_pages",
+    "total_frames",
+    "total_duration_seconds",
+    "assets",
+]
+
+
+def test_mixed_modality_batch_round_trips_with_stable_json() -> None:
+    batch = AssetBatch.build("packet-001", [AUDIO, PDF, IMAGE, DICOM])
+
+    assert [manifest.asset_id for manifest in batch.assets] == [
+        "audio-001",
+        "dicom-001",
+        "img-001",
+        "pdf-001",
+    ]
+    assert batch.version == BATCH_VERSION
+    assert batch.asset_count == 4
+    assert batch.total_bytes == 1024 + 2048 + 4096 + 8192
+    assert batch.total_pages == 4
+    assert batch.total_frames == 12
+    assert batch.total_duration_seconds == 3.5
+    assert list(batch.to_dict()) == ORDERED_FIELDS
+    assert AssetBatch.from_json(batch.to_json()) == batch
+    assert AssetBatch.from_dict(batch.to_dict()) == batch
+    assert json.loads(batch.to_json()) == batch.to_dict()
+    assert batch.to_json() == batch.to_json()
+    assert validate_asset_batch(batch) == []
+    assert validate_asset_batch(batch.to_dict()) == []
+
+
+def test_single_asset_batch_round_trips() -> None:
+    batch = AssetBatch.build("packet-single", [PDF])
+
+    assert batch.to_dict() == {
+        "version": 1,
+        "batch_id": "packet-single",
+        "asset_count": 1,
+        "total_bytes": 2048,
+        "total_pages": 4,
+        "total_frames": 0,
+        "total_duration_seconds": 0.0,
+        "assets": [PDF.to_dict()],
+    }
+    assert AssetBatch.from_json(batch.to_json()) == batch
+    assert validate_asset_batch(batch.to_dict()) == []
+
+
+def test_empty_batch_is_only_accepted_when_allowed() -> None:
+    batch = AssetBatch.build("packet-empty", [])
+    expected = [BatchFinding("empty_batch", field_name="assets")]
+
+    assert batch.to_dict()["assets"] == []
+    assert batch.total_bytes == 0
+    assert batch.total_duration_seconds == 0.0
+    assert validate_asset_batch(batch) == expected
+    assert validate_asset_batch(batch.to_dict()) == expected
+    assert validate_asset_batch(batch, allow_empty=True) == []
+    assert AssetBatch.from_json(batch.to_json(), allow_empty=True) == batch
+
+    with pytest.raises(AssetBatchError, match="empty_batch"):
+        AssetBatch.from_json(batch.to_json())
+
+
+def test_duration_totals_use_exact_summation() -> None:
+    batch = AssetBatch.build("packet-audio", [AUDIO_2, AUDIO])
+
+    assert batch.total_duration_seconds == 5.75
+    assert json.loads(batch.to_json())["total_duration_seconds"] == 5.75
+    assert AssetBatch.from_json(batch.to_json()) == batch
+
+
+def test_build_orders_assets_canonically_and_rejects_other_orders() -> None:
+    batch = AssetBatch.build("packet-order", [PDF, IMAGE])
+    payload = batch.to_dict()
+    payload["assets"] = list(reversed(payload["assets"]))
+
+    assert [entry["asset_id"] for entry in batch.to_dict()["assets"]] == [
+        "img-001",
+        "pdf-001",
+    ]
+    assert validate_asset_batch(payload) == [
+        BatchFinding("order_not_canonical", position=1)
+    ]
+    with pytest.raises(AssetBatchError, match="order_not_canonical"):
+        AssetBatch(batch_id="packet-order", assets=(PDF, IMAGE))
+
+
+@pytest.mark.parametrize(
+    ("assets", "expected"),
+    [
+        (
+            (IMAGE, _image("img-001", 9)),
+            [BatchFinding("duplicate_asset_id", position=1)],
+        ),
+        (
+            (IMAGE, _image("img-002", 1)),
+            [BatchFinding("duplicate_sha256", position=1)],
+        ),
+        (
+            (IMAGE, IMAGE),
+            [
+                BatchFinding("duplicate_asset_id", position=1),
+                BatchFinding("duplicate_sha256", position=1),
+            ],
+        ),
+    ],
+)
+def test_duplicate_identifiers_and_digests_produce_stable_findings(
+    assets, expected
+) -> None:
+    payload = {
+        "batch_id": "packet-dup",
+        "assets": [manifest.to_dict() for manifest in assets],
+    }
+
+    assert validate_asset_batch(payload) == expected
+    with pytest.raises(AssetBatchError) as exc_info:
+        AssetBatch(batch_id="packet-dup", assets=assets)
+    for finding in expected:
+        assert finding.reason_code in str(exc_info.value)
+    with pytest.raises(AssetBatchError):
+        AssetBatch.build("packet-dup", assets)
+
+
+def test_batches_above_the_policy_limit_fail_closed() -> None:
+    batch = AssetBatch.build("packet-limit", [IMAGE, PDF])
+    expected = [BatchFinding("batch_too_large", field_name="assets")]
+
+    assert validate_asset_batch(batch, max_assets=2) == []
+    assert validate_asset_batch(batch, max_assets=1) == expected
+    assert validate_asset_batch(batch.to_dict(), max_assets=1) == expected
+    with pytest.raises(AssetBatchError, match="batch_too_large"):
+        AssetBatch.from_dict(batch.to_dict(), max_assets=1)
+
+
+def test_batches_above_the_hard_cap_fail_closed_with_one_finding() -> None:
+    assets = tuple(
+        AssetManifest(
+            asset_id=f"asset-{index:05d}",
+            media_type="image/png",
+            sha256=_digest(index + 1),
+            byte_size=1,
+        )
+        for index in range(MAX_BATCH_ASSETS + 1)
+    )
+    payload = {"batch_id": "packet-cap", "assets": [m.to_dict() for m in assets]}
+
+    with pytest.raises(AssetBatchError, match="batch_too_large"):
+        AssetBatch(batch_id="packet-cap", assets=assets)
+    assert validate_asset_batch(payload) == [
+        BatchFinding("batch_too_large", field_name="assets")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("field", "assets"),
+    [
+        (
+            "total_bytes",
+            (
+                _image("img-001", 1, byte_size=MAX_MANIFEST_BYTE_SIZE),
+                _image("img-002", 2, byte_size=MAX_MANIFEST_BYTE_SIZE),
+            ),
+        ),
+        (
+            "total_pages",
+            (
+                _image("pdf-001", 1, pages=MAX_MANIFEST_COUNT),
+                _image("pdf-002", 2, pages=MAX_MANIFEST_COUNT),
+            ),
+        ),
+        (
+            "total_frames",
+            (
+                _image("dicom-001", 1, frames=MAX_MANIFEST_COUNT),
+                _image("dicom-002", 2, frames=MAX_MANIFEST_COUNT),
+            ),
+        ),
+        (
+            "total_duration_seconds",
+            (
+                _image("audio-001", 1, duration_seconds=MAX_MANIFEST_DURATION_SECONDS),
+                _image("audio-002", 2, duration_seconds=MAX_MANIFEST_DURATION_SECONDS),
+            ),
+        ),
+    ],
+)
+def test_aggregate_overflow_fails_closed(field, assets) -> None:
+    payload = {
+        "batch_id": "packet-overflow",
+        "assets": [manifest.to_dict() for manifest in assets],
+    }
+
+    assert validate_asset_batch(payload) == [
+        BatchFinding("aggregate_overflow", field_name=field)
+    ]
+    with pytest.raises(AssetBatchError, match="aggregate_overflow"):
+        AssetBatch(batch_id="packet-overflow", assets=assets)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "reason_code"),
+    [
+        ("asset_count", 3, "aggregate_mismatch"),
+        ("total_bytes", 1, "aggregate_mismatch"),
+        ("total_pages", 0, "aggregate_mismatch"),
+        ("total_frames", 13, "aggregate_mismatch"),
+        ("total_duration_seconds", 3.6, "aggregate_mismatch"),
+        ("total_duration_seconds", -3.5, "aggregate_mismatch"),
+        ("asset_count", True, "aggregate_invalid"),
+        ("total_bytes", "15360", "aggregate_invalid"),
+        ("total_bytes", 15360.0, "aggregate_invalid"),
+        ("total_frames", None, "aggregate_invalid"),
+        ("total_duration_seconds", float("nan"), "aggregate_invalid"),
+        ("total_duration_seconds", float("inf"), "aggregate_invalid"),
+        ("total_duration_seconds", True, "aggregate_invalid"),
+        ("total_duration_seconds", "3.5", "aggregate_invalid"),
+    ],
+)
+def test_declared_aggregates_must_match_manifests(field, value, reason_code) -> None:
+    batch = AssetBatch.build("packet-agg", [AUDIO, PDF, IMAGE, DICOM])
+    payload = batch.to_dict()
+    payload[field] = value
+
+    assert validate_asset_batch(payload) == [
+        BatchFinding(reason_code, field_name=field)
+    ]
+    with pytest.raises(AssetBatchError, match=reason_code):
+        AssetBatch.from_dict(payload)
+
+
+def test_declared_aggregates_are_optional_and_accept_integer_durations() -> None:
+    batch = AssetBatch.build("packet-optional", [PDF, IMAGE])
+    payload = batch.to_dict()
+    for field in ORDERED_FIELDS[2:-1]:
+        payload.pop(field)
+
+    assert AssetBatch.from_dict(payload) == batch
+    assert AssetBatch.from_dict({**payload, "total_duration_seconds": 0}) == batch
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("not-a-dict", [BatchFinding("invalid_batch")]),
+        (
+            {},
+            [
+                BatchFinding("missing_required", field_name="assets"),
+                BatchFinding("missing_required", field_name="batch_id"),
+            ],
+        ),
+        (
+            {"batch_id": "packet-001"},
+            [BatchFinding("missing_required", field_name="assets")],
+        ),
+        (
+            {"batch_id": "packet-001", "assets": [], "patient_name": "x"},
+            [BatchFinding("unknown_field")],
+        ),
+        (
+            {"batch_id": "packet-001", "assets": [IMAGE.to_dict()], "version": 2},
+            [BatchFinding("invalid_version", field_name="version")],
+        ),
+        (
+            {"batch_id": "packet-001", "assets": [IMAGE.to_dict()], "version": True},
+            [BatchFinding("invalid_version", field_name="version")],
+        ),
+        (
+            {"batch_id": "packet-001", "assets": [IMAGE.to_dict()], "version": "1"},
+            [BatchFinding("invalid_version", field_name="version")],
+        ),
+        (
+            {"batch_id": "", "assets": [IMAGE.to_dict()]},
+            [BatchFinding("invalid_batch_id", field_name="batch_id")],
+        ),
+        (
+            {"batch_id": 42, "assets": [IMAGE.to_dict()]},
+            [BatchFinding("invalid_batch_id", field_name="batch_id")],
+        ),
+        (
+            {"batch_id": "a" * 129, "assets": [IMAGE.to_dict()]},
+            [BatchFinding("invalid_batch_id", field_name="batch_id")],
+        ),
+        (
+            {"batch_id": "/tmp/packet", "assets": [IMAGE.to_dict()]},
+            [BatchFinding("invalid_batch_id", field_name="batch_id")],
+        ),
+        (
+            {"batch_id": "s3://bucket/packet", "assets": [IMAGE.to_dict()]},
+            [BatchFinding("invalid_batch_id", field_name="batch_id")],
+        ),
+        (
+            {"batch_id": "packet-001", "assets": "img-001"},
+            [BatchFinding("invalid_assets", field_name="assets")],
+        ),
+        (
+            {"batch_id": "packet-001", "assets": IMAGE.to_dict()},
+            [BatchFinding("invalid_assets", field_name="assets")],
+        ),
+        (
+            {"batch_id": "packet-001", "assets": 5},
+            [BatchFinding("invalid_assets", field_name="assets")],
+        ),
+        (
+            {"batch_id": "packet-001", "assets": ["img-001"]},
+            [BatchFinding("invalid_asset", position=0)],
+        ),
+        (
+            {"batch_id": "packet-001", "assets": [IMAGE.to_dict(), 42]},
+            [BatchFinding("invalid_asset", position=1)],
+        ),
+        (
+            {
+                "batch_id": "packet-001",
+                "assets": [IMAGE.to_dict(), {**PDF.to_dict(), "description": "x"}],
+            },
+            [BatchFinding("invalid_asset", position=1)],
+        ),
+        (
+            {"batch_id": "/tmp/packet", "assets": [42], "version": 2},
+            [
+                BatchFinding("invalid_asset", position=0),
+                BatchFinding("invalid_batch_id", field_name="batch_id"),
+                BatchFinding("invalid_version", field_name="version"),
+            ],
+        ),
+    ],
+)
+def test_schema_failures_produce_stable_findings_and_fail_closed(
+    payload, expected
+) -> None:
+    assert validate_asset_batch(payload) == expected
+    with pytest.raises(AssetBatchError) as exc_info:
+        AssetBatch.from_dict(payload)
+    for finding in expected:
+        assert finding.reason_code in str(exc_info.value)
+
+
+def test_findings_are_sorted_and_deduplicated() -> None:
+    payload = {
+        "batch_id": "packet-mixed",
+        "assets": [_image("img-002", 1).to_dict(), IMAGE.to_dict()],
+    }
+
+    assert validate_asset_batch(payload, max_assets=1) == [
+        BatchFinding("batch_too_large", field_name="assets"),
+        BatchFinding("duplicate_sha256", position=1),
+        BatchFinding("order_not_canonical", position=1),
+    ]
+
+
+def test_sentinel_values_never_appear_in_findings_or_errors() -> None:
+    sentinels = (
+        "C:\\patients\\JANE-DOE-19700101",
+        "synthetic sentinel Jane Doe",
+        "synthetic sentinel chart text",
+        "patient_name",
+    )
+    payload = {
+        "batch_id": sentinels[0],
+        "assets": [
+            IMAGE.to_dict(),
+            {**PDF.to_dict(), "description": sentinels[2]},
+        ],
+        sentinels[3]: sentinels[1],
+    }
+
+    findings = validate_asset_batch(payload)
+    with pytest.raises(AssetBatchError) as exc_info:
+        AssetBatch.from_dict(payload)
+    rendered = json.dumps([finding.to_dict() for finding in findings])
+    assert findings
+    for sentinel in sentinels:
+        assert sentinel not in rendered
+        assert sentinel not in str(exc_info.value)
+
+    with pytest.raises(AssetBatchError) as direct_error:
+        AssetBatch(batch_id=sentinels[0], assets=(IMAGE,))
+    assert sentinels[0] not in str(direct_error.value)
+
+
+@pytest.mark.parametrize("payload", ["{", b"\xff", 42])
+def test_malformed_json_fails_closed(payload) -> None:
+    with pytest.raises(AssetBatchError):
+        AssetBatch.from_json(payload)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"batch_id":"packet-001","batch_id":"synthetic-secret","assets":[]}',
+        (
+            '{"batch_id":"packet-001","assets":[{"asset_id":"img-001",'
+            '"asset_id":"synthetic-secret","media_type":"image/png",'
+            f'"sha256":"{_digest(1)}","byte_size":1}}]}}'
+        ),
+    ],
+)
+def test_duplicate_json_fields_fail_closed_without_echoing_values(payload) -> None:
+    with pytest.raises(AssetBatchError) as exc_info:
+        AssetBatch.from_json(payload)
+
+    assert "synthetic-secret" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_assets": 0},
+        {"max_assets": True},
+        {"max_assets": MAX_BATCH_ASSETS + 1},
+        {"max_assets": "5"},
+        {"allow_empty": "yes"},
+        {"allow_empty": 1},
+    ],
+)
+def test_invalid_policy_arguments_fail_closed(kwargs) -> None:
+    batch = AssetBatch.build("packet-policy", [IMAGE])
+
+    with pytest.raises(AssetBatchError):
+        validate_asset_batch(batch, **kwargs)
+    with pytest.raises(AssetBatchError):
+        AssetBatch.from_dict(batch.to_dict(), **kwargs)
+
+
+@pytest.mark.parametrize("manifests", [42, [IMAGE, "pdf-001"], [IMAGE.to_dict()]])
+def test_build_rejects_non_manifest_inputs(manifests) -> None:
+    with pytest.raises(AssetBatchError):
+        AssetBatch.build("packet-build", manifests)
+
+
+@pytest.mark.parametrize(
+    "assets",
+    [[IMAGE], (IMAGE, "pdf-001"), (IMAGE, PDF.to_dict())],
+)
+def test_direct_construction_requires_a_tuple_of_manifests(assets) -> None:
+    with pytest.raises(AssetBatchError):
+        AssetBatch(batch_id="packet-direct", assets=assets)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"reason_code": "patient_leaked"},
+        {"reason_code": 1},
+        {"reason_code": "unknown_field", "field_name": "patient_name"},
+        {"reason_code": "invalid_asset", "position": -1},
+        {"reason_code": "invalid_asset", "position": True},
+        {"reason_code": "invalid_asset", "position": "0"},
+    ],
+)
+def test_findings_reject_unsupported_codes_fields_and_positions(kwargs) -> None:
+    with pytest.raises(AssetBatchError):
+        BatchFinding(**kwargs)
+
+
+def test_findings_serialize_without_unset_fields() -> None:
+    assert BatchFinding("invalid_batch").to_dict() == {"reason_code": "invalid_batch"}
+    assert BatchFinding("invalid_asset", position=2).to_dict() == {
+        "reason_code": "invalid_asset",
+        "position": 2,
+    }
+    assert BatchFinding("empty_batch", field_name="assets").to_dict() == {
+        "reason_code": "empty_batch",
+        "field_name": "assets",
+    }
+
+
+def test_batch_contract_is_available_from_public_multimodal_api() -> None:
+    import openmed.multimodal as multimodal
+
+    assert multimodal.AssetBatch is AssetBatch
+    assert multimodal.AssetBatchError is AssetBatchError
+    assert multimodal.BatchFinding is BatchFinding
+    assert multimodal.validate_asset_batch is validate_asset_batch
+    assert multimodal.BATCH_VERSION == 1
+    assert multimodal.MAX_BATCH_ASSETS == 10_000


### PR DESCRIPTION
## Description
Adds a privacy-safe multimodal asset batch contract so a clinical packet with several media assets can be ordered, de-duplicated, and summarized before any asset is opened. An `AssetBatch` pairs an opaque `batch_id` with a canonically ordered tuple of the existing `AssetManifest` records and derives byte, page, frame, and duration totals from the manifests. `validate_asset_batch()` returns sorted, de-duplicated `BatchFinding` records with stable reason codes so preflight reports can collect every problem in one pass.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- `openmed/multimodal/asset_batch.py`: frozen `AssetBatch` with `build()`, `from_dict()`, `from_json()`, `to_dict()`, and `to_json()`; canonical ascending `asset_id` order; hard cap of 10,000 assets; derived `asset_count`, `total_bytes`, `total_pages`, `total_frames`, and `total_duration_seconds`.
- `BatchFinding` and `validate_asset_batch()` with a closed reason-code vocabulary covering unknown or missing fields, invalid identifiers and manifests, duplicate asset IDs, repeated digests, non-canonical order, oversized batches, aggregate overflow, declared-total type errors and mismatches, and empty batches. `field_name` is restricted to the batch schema and `position` is the asset index, so findings never carry unknown keys, paths, or manifest content.
- Caller policy via `max_assets` and `allow_empty` on both the validator and the loaders; declared totals in payloads are optional but must match the derived values.
- Package exports in `openmed/multimodal/__init__.py`, docs page `docs/multimodal/asset-batches.md`, mkdocs nav and publication entries, and a CHANGELOG entry.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with different models/inputs

`tests/unit/multimodal/test_asset_batch.py` covers empty-when-allowed, single-asset, and mixed image/PDF/DICOM/audio round trips with byte-stable JSON; canonical ordering; duplicate IDs and digests; policy and hard-cap size limits; overflow for every summed total; declared-total mismatch and type failures; schema failures with field-only findings; sorted and de-duplicated findings; sentinel paths, names, chart text, and unknown keys never appearing in findings or errors; malformed and duplicate-key JSON; invalid policy arguments; and public API exposure.

```
.venv/bin/python -m pytest tests/unit/multimodal/test_asset_batch.py -q   # 75 passed
.venv/bin/python -m pytest tests/unit -q                                  # 14003 passed, 122 skipped, 1 failed
make format-check && make lint                                            # clean
mkdocs build --strict                                                     # clean
```

The one failure, `tests/unit/skills/test_agent_skill_validation.py::test_unresolvable_repository_root_returns_a_fixed_error`, also fails on a clean checkout of `master` in this environment and does not touch the multimodal package.

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the [contributing guide](https://github.com/maziyarpanahi/openmed/blob/master/CONTRIBUTING.md), [Code of Conduct](https://github.com/maziyarpanahi/openmed/blob/master/CODE_OF_CONDUCT.md), and [maintainer guide](https://github.com/maziyarpanahi/openmed/blob/master/MAINTAINERS.md)
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #3002

## Screenshots/Examples
```python
batch = AssetBatch.build("packet-001", [audio, pdf, image, dicom])
batch.to_dict()
# {"version": 1, "batch_id": "packet-001", "asset_count": 4,
#  "total_bytes": 15360, "total_pages": 4, "total_frames": 12,
#  "total_duration_seconds": 3.5, "assets": [...sorted by asset_id...]}

validate_asset_batch({"batch_id": "packet-001", "assets": [pdf_dict, image_dict]}, max_assets=1)
# [BatchFinding("batch_too_large", field_name="assets"),
#  BatchFinding("order_not_canonical", position=1)]
```
