### PR TITLE
feat(multimodal): add content-free cache keys

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -212,6 +212,7 @@ classification:
     - multimodal/asset-digests.md
     - multimodal/asset-manifests.md
     - multimodal/manifest-profiles.md
+    - multimodal/cache-keys.md
     - multimodal/pdf-redaction-fidelity.md
     - multimodal/abstention-reasons.md
     - multimodal/email-ingestion.md

--- a/docs/multimodal/cache-keys.md
+++ b/docs/multimodal/cache-keys.md
@@ -1,0 +1,62 @@
+# Content-free multimodal cache keys
+
+`build_multimodal_cache_key()` derives a stable local cache key from processing
+metadata without hashing source bytes itself or putting content in the key.
+Callers provide a previously computed asset SHA-256 digest, media type,
+provider version, model version, policy version, and any declared preprocessing
+options.
+
+```python
+from openmed.multimodal.cache_key import build_multimodal_cache_key
+from openmed.multimodal.digest import digest_asset
+
+asset = digest_asset(b"synthetic image bytes")
+key = build_multimodal_cache_key(
+    asset_digest=asset,
+    media_type="image/png",
+    provider_version="doctr-1.0",
+    model_version="vision-2.1",
+    policy_version="redact-v3",
+    preprocessing_options={
+        "color_mode": "rgb",
+        "resize_mode": "fit",
+        "target_width": 512,
+        "target_height": 512,
+    },
+)
+```
+
+The result has the form `openmed-multimodal-v1:<sha256>`. Mapping order does
+not affect it. Changing the asset digest, media type, provider version, model
+version, policy version, or a preprocessing option changes the key.
+
+## Preprocessing options
+
+Only the following options are accepted:
+
+| Option | Allowed values |
+| --- | --- |
+| `channel_mode` | `mono`, `native`, `stereo` |
+| `color_mode` | `grayscale`, `native`, `rgb`, `rgba` |
+| `orientation_mode` | `normalize`, `preserve` |
+| `resize_mode` | `fill`, `fit`, `none` |
+| `clip_duration_seconds` | finite number greater than 0 and at most 86,400 |
+| `frame_stride` | integer from 1 through 1,000,000 |
+| `render_dpi` | integer from 1 through 9,600 |
+| `sample_rate_hz` | integer from 1 through 768,000 |
+| `target_height` | integer from 1 through 65,536 |
+| `target_width` | integer from 1 through 65,536 |
+
+Unknown names, arbitrary categorical strings, booleans in numeric fields,
+nested values, non-finite numbers, and out-of-range numbers fail closed.
+
+## Privacy boundary
+
+Version fields accept only bounded metadata tokens. Paths, URLs, clinical text,
+credentials, prompts, raw bytes, and free-form option values are rejected
+without being echoed in errors. The returned key contains only a public schema
+prefix and a SHA-256 digest.
+
+The helper performs no file access, network access, media hashing, cache
+storage, eviction, or encryption. Callers remain responsible for computing the
+asset digest and declaring every preprocessing choice that affects their model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
       - Bounded Asset Digests: multimodal/asset-digests.md
       - Privacy-safe Asset Manifests: multimodal/asset-manifests.md
       - Multimodal Manifest Profiles: multimodal/manifest-profiles.md
+      - Content-free Multimodal Cache Keys: multimodal/cache-keys.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md
       - Multimodal Abstention Reasons: multimodal/abstention-reasons.md
       - Email Ingestion and Redaction: multimodal/email-ingestion.md

--- a/openmed/multimodal/cache_key.py
+++ b/openmed/multimodal/cache_key.py
@@ -1,0 +1,180 @@
+"""Content-free cache keys for deterministic multimodal processing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final, cast
+
+from .digest import AssetDigest
+
+__all__ = [
+    "CACHE_KEY_SCHEMA_VERSION",
+    "CATEGORICAL_PREPROCESSING_OPTIONS",
+    "NUMERIC_PREPROCESSING_OPTIONS",
+    "MultimodalCacheKeyError",
+    "build_multimodal_cache_key",
+]
+
+CACHE_KEY_SCHEMA_VERSION: Final = 1
+_CACHE_KEY_PREFIX: Final = "openmed-multimodal-v1"
+
+CATEGORICAL_PREPROCESSING_OPTIONS: Final[Mapping[str, frozenset[str]]] = (
+    MappingProxyType(
+        {
+            "channel_mode": frozenset({"mono", "native", "stereo"}),
+            "color_mode": frozenset({"grayscale", "native", "rgb", "rgba"}),
+            "orientation_mode": frozenset({"normalize", "preserve"}),
+            "resize_mode": frozenset({"fill", "fit", "none"}),
+        }
+    )
+)
+
+# Each numeric rule is ``(kind, minimum, maximum)``. Bounds keep canonical JSON
+# finite and prevent accidental use of unbounded measurements as option values.
+NUMERIC_PREPROCESSING_OPTIONS: Final[
+    Mapping[str, tuple[type[int] | type[float], float, float]]
+] = MappingProxyType(
+    {
+        "clip_duration_seconds": (float, 0.0, 86_400.0),
+        "frame_stride": (int, 1.0, 1_000_000.0),
+        "render_dpi": (int, 1.0, 9_600.0),
+        "sample_rate_hz": (int, 1.0, 768_000.0),
+        "target_height": (int, 1.0, 65_536.0),
+        "target_width": (int, 1.0, 65_536.0),
+    }
+)
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_MEDIA_TYPE_RE = re.compile(r"^[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*$")
+_VERSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$")
+_SUPPORTED_EXACT_MEDIA_TYPES = frozenset(
+    {"application/dicom", "application/dicom+json", "application/pdf"}
+)
+_SUPPORTED_MEDIA_PREFIXES = ("audio/", "image/")
+
+
+class MultimodalCacheKeyError(ValueError):
+    """Raised when cache-key metadata is unsafe or unsupported."""
+
+
+def build_multimodal_cache_key(
+    *,
+    asset_digest: str | AssetDigest,
+    media_type: str,
+    provider_version: str,
+    model_version: str,
+    policy_version: str,
+    preprocessing_options: Mapping[str, object] | None = None,
+) -> str:
+    """Return a versioned SHA-256 key from content-free processing metadata.
+
+    This function performs no I/O and never hashes source bytes, paths, text,
+    prompts, credentials, or arbitrary option values. Callers must compute the
+    asset digest separately and declare every preprocessing choice explicitly.
+    """
+
+    digest = _asset_sha256(asset_digest)
+    normalized_media_type = _media_type(media_type)
+    versions = {
+        "model_version": _version(model_version),
+        "policy_version": _version(policy_version),
+        "provider_version": _version(provider_version),
+    }
+    options = _preprocessing_options(preprocessing_options)
+    payload = {
+        "asset_sha256": digest,
+        "media_type": normalized_media_type,
+        "preprocessing_options": options,
+        "schema_version": CACHE_KEY_SCHEMA_VERSION,
+        **versions,
+    }
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return f"{_CACHE_KEY_PREFIX}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _asset_sha256(value: object) -> str:
+    if isinstance(value, AssetDigest):
+        return value.sha256
+    if type(value) is not str or _SHA256_RE.fullmatch(value) is None:
+        raise MultimodalCacheKeyError("asset digest is invalid")
+    return value
+
+
+def _media_type(value: object) -> str:
+    if type(value) is not str or _MEDIA_TYPE_RE.fullmatch(value) is None:
+        raise MultimodalCacheKeyError("media type is invalid")
+    if value in _SUPPORTED_EXACT_MEDIA_TYPES or value.startswith(
+        _SUPPORTED_MEDIA_PREFIXES
+    ):
+        return value
+    raise MultimodalCacheKeyError("media type is unsupported")
+
+
+def _version(value: object) -> str:
+    if type(value) is not str or _VERSION_RE.fullmatch(value) is None:
+        raise MultimodalCacheKeyError("processing version is invalid")
+    return value
+
+
+def _preprocessing_options(
+    value: Mapping[str, object] | None,
+) -> dict[str, int | float | str]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise MultimodalCacheKeyError("preprocessing options are invalid")
+    try:
+        options = dict(value)
+    except Exception:
+        raise MultimodalCacheKeyError("preprocessing options are invalid") from None
+
+    known = CATEGORICAL_PREPROCESSING_OPTIONS.keys() | (
+        NUMERIC_PREPROCESSING_OPTIONS.keys()
+    )
+    if any(type(name) is not str or name not in known for name in options):
+        raise MultimodalCacheKeyError("preprocessing option is unsupported")
+
+    normalized: dict[str, int | float | str] = {}
+    for name in sorted(options):
+        option = options[name]
+        categories = CATEGORICAL_PREPROCESSING_OPTIONS.get(name)
+        if categories is not None:
+            if type(option) is not str or option not in categories:
+                raise MultimodalCacheKeyError(
+                    "categorical preprocessing option is invalid"
+                )
+            normalized[name] = option
+            continue
+        normalized[name] = _numeric_option(
+            option,
+            NUMERIC_PREPROCESSING_OPTIONS[name],
+        )
+    return normalized
+
+
+def _numeric_option(
+    value: object,
+    rule: tuple[type[int] | type[float], float, float],
+) -> int | float:
+    kind, minimum, maximum = rule
+    if kind is int:
+        if type(value) is not int or not minimum <= value <= maximum:
+            raise MultimodalCacheKeyError("numeric preprocessing option is invalid")
+        return value
+    if type(value) not in (int, float):
+        raise MultimodalCacheKeyError("numeric preprocessing option is invalid")
+    normalized = float(cast(int | float, value))
+    if not math.isfinite(normalized) or not minimum < normalized <= maximum:
+        raise MultimodalCacheKeyError("numeric preprocessing option is invalid")
+    return normalized

--- a/tests/unit/multimodal/test_cache_key.py
+++ b/tests/unit/multimodal/test_cache_key.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator, Mapping
+
+import pytest
+
+from openmed.multimodal.cache_key import (
+    CACHE_KEY_SCHEMA_VERSION,
+    CATEGORICAL_PREPROCESSING_OPTIONS,
+    NUMERIC_PREPROCESSING_OPTIONS,
+    MultimodalCacheKeyError,
+    build_multimodal_cache_key,
+)
+from openmed.multimodal.digest import AssetDigest
+
+DIGEST = "a" * 64
+BASE = {
+    "asset_digest": DIGEST,
+    "media_type": "image/png",
+    "provider_version": "doctr-1.0",
+    "model_version": "vision-2.1",
+    "policy_version": "redact-v3",
+}
+
+
+def _key(**overrides: object) -> str:
+    inputs = dict(BASE)
+    inputs.update(overrides)
+    return build_multimodal_cache_key(**inputs)  # type: ignore[arg-type]
+
+
+def test_cache_key_is_versioned_content_free_sha256() -> None:
+    key = _key()
+
+    assert CACHE_KEY_SCHEMA_VERSION == 1
+    assert re.fullmatch(r"openmed-multimodal-v1:[0-9a-f]{64}", key)
+    for value in BASE.values():
+        assert value not in key
+
+
+def test_equivalent_option_mappings_produce_identical_keys() -> None:
+    first = _key(
+        preprocessing_options={
+            "resize_mode": "fit",
+            "target_width": 512,
+            "target_height": 256,
+            "clip_duration_seconds": 5,
+        }
+    )
+    second = _key(
+        preprocessing_options={
+            "clip_duration_seconds": 5.0,
+            "target_height": 256,
+            "target_width": 512,
+            "resize_mode": "fit",
+        }
+    )
+
+    assert first == second
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("asset_digest", "b" * 64),
+        ("media_type", "image/jpeg"),
+        ("provider_version", "doctr-1.1"),
+        ("model_version", "vision-2.2"),
+        ("policy_version", "redact-v4"),
+    ],
+)
+def test_every_declared_processing_version_changes_the_key(
+    field: str,
+    replacement: str,
+) -> None:
+    assert _key() != _key(**{field: replacement})
+
+
+def test_preprocessing_option_changes_invalidate_the_key() -> None:
+    baseline = _key(preprocessing_options={"resize_mode": "fit"})
+
+    assert baseline != _key(preprocessing_options={"resize_mode": "fill"})
+    assert baseline != _key(
+        preprocessing_options={"resize_mode": "fit", "target_width": 512}
+    )
+    assert _key() == _key(preprocessing_options={})
+
+
+def test_asset_digest_result_and_hex_string_are_equivalent() -> None:
+    digest = AssetDigest(sha256=DIGEST, byte_count=42)
+
+    assert _key(asset_digest=digest) == _key(asset_digest=DIGEST)
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("channel_mode", "mono"),
+        ("color_mode", "rgb"),
+        ("orientation_mode", "normalize"),
+        ("resize_mode", "none"),
+        ("clip_duration_seconds", 0.25),
+        ("frame_stride", 2),
+        ("render_dpi", 300),
+        ("sample_rate_hz", 16_000),
+        ("target_height", 512),
+        ("target_width", 512),
+    ],
+)
+def test_every_allowlisted_option_is_accepted(name: str, value: object) -> None:
+    assert re.fullmatch(
+        r"openmed-multimodal-v1:[0-9a-f]{64}",
+        _key(preprocessing_options={name: value}),
+    )
+
+
+def test_exported_option_allowlists_are_read_only() -> None:
+    with pytest.raises(TypeError):
+        CATEGORICAL_PREPROCESSING_OPTIONS["unsafe"] = frozenset({"value"})  # type: ignore[index]
+    with pytest.raises(TypeError):
+        NUMERIC_PREPROCESSING_OPTIONS["unsafe"] = (int, 0.0, 1.0)  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "asset_digest",
+    [
+        "A" * 64,
+        "a" * 63,
+        "g" * 64,
+        b"raw asset bytes",
+        "/srv/charts/patient.dcm",
+    ],
+)
+def test_invalid_digests_fail_without_echoing_values(asset_digest: object) -> None:
+    with pytest.raises(MultimodalCacheKeyError) as error:
+        _key(asset_digest=asset_digest)
+    assert str(asset_digest) not in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "media_type",
+    [
+        "Image/PNG",
+        "text/plain",
+        "image/png; patient=synthetic",
+        "https://internal.invalid/image/png",
+        "/srv/charts/patient.png",
+        b"image/png",
+    ],
+)
+def test_invalid_media_types_fail_without_echoing_values(media_type: object) -> None:
+    with pytest.raises(MultimodalCacheKeyError) as error:
+        _key(media_type=media_type)
+    assert str(media_type) not in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "unsafe",
+    [
+        "Patient Jane synthetic chart text",
+        "/srv/charts/patient-123",
+        "https://internal.invalid/model",
+        "Bearer synthetic-credential",
+        "prompt: extract diagnosis",
+        b"raw-version-bytes",
+        "",
+        "v" * 65,
+    ],
+)
+@pytest.mark.parametrize(
+    "field",
+    ["provider_version", "model_version", "policy_version"],
+)
+def test_unsafe_processing_versions_are_rejected_without_echo(
+    field: str,
+    unsafe: object,
+) -> None:
+    with pytest.raises(MultimodalCacheKeyError) as error:
+        _key(**{field: unsafe})
+    assert not isinstance(unsafe, str) or not unsafe or unsafe not in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"unknown_option": 1},
+        {"resize_mode": "Patient Jane chart text"},
+        {"resize_mode": "/srv/charts/patient.png"},
+        {"resize_mode": "https://internal.invalid/prompt"},
+        {"resize_mode": b"raw bytes"},
+        {"resize_mode": {"nested": "payload"}},
+        {"target_width": True},
+        {"target_width": 0},
+        {"target_width": 65_537},
+        {"target_width": 512.0},
+        {"clip_duration_seconds": float("nan")},
+        {"clip_duration_seconds": float("inf")},
+        {"clip_duration_seconds": 0},
+        {"clip_duration_seconds": 86_401},
+    ],
+)
+def test_unsafe_or_unbounded_options_fail_closed(
+    options: Mapping[str, object],
+) -> None:
+    sentinel = next(iter(options.values()))
+
+    with pytest.raises(MultimodalCacheKeyError) as error:
+        _key(preprocessing_options=options)
+    assert str(sentinel) not in str(error.value)
+
+
+def test_options_mapping_is_not_mutated() -> None:
+    options = {"resize_mode": "fit", "target_width": 512}
+    original = dict(options)
+
+    _key(preprocessing_options=options)
+
+    assert options == original
+
+
+def test_unreadable_option_mapping_does_not_leak_upstream_errors() -> None:
+    sentinel = "SYNTHETIC_PATIENT_VALUE_FROM_MAPPING"
+
+    class BrokenMapping(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise RuntimeError(sentinel)
+
+        def __iter__(self) -> Iterator[str]:
+            raise RuntimeError(sentinel)
+
+        def __len__(self) -> int:
+            return 1
+
+    with pytest.raises(MultimodalCacheKeyError) as error:
+        _key(preprocessing_options=BrokenMapping())
+    assert sentinel not in str(error.value)
+
+
+def test_helper_rejects_non_mapping_options() -> None:
+    sentinel = "SYNTHETIC_PATIENT_TEXT"
+
+    with pytest.raises(MultimodalCacheKeyError) as error:
+        _key(preprocessing_options=[sentinel])
+    assert sentinel not in str(error.value)


### PR DESCRIPTION
Multimodal cache keys now use strict content-free metadata, so PHI and messy config cannot cook the cache. Closes #3003.