### PR TITLE
feat(multimodal): add bounded WAV metadata reader

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -212,6 +212,7 @@ classification:
     - multimodal/asset-digests.md
     - multimodal/asset-manifests.md
     - multimodal/manifest-profiles.md
+    - multimodal/wav-preflight.md
     - multimodal/pdf-redaction-fidelity.md
     - multimodal/abstention-reasons.md
     - multimodal/email-ingestion.md

--- a/docs/multimodal/wav-preflight.md
+++ b/docs/multimodal/wav-preflight.md
@@ -1,0 +1,36 @@
+# WAV metadata preflight
+
+`openmed.multimodal.wav_metadata` reads privacy-safe metadata from PCM and
+IEEE-float RIFF/WAVE headers without importing an audio decoder.
+
+```python
+from openmed.multimodal.wav_metadata import read_wav_metadata
+
+with open("synthetic-audio.wav", "rb") as stream:
+    metadata = read_wav_metadata(stream)
+
+print(metadata.channels)
+print(metadata.sample_rate_hz)
+print(metadata.duration_seconds)
+```
+
+The result contains only the numeric format code, channel count, sample rate,
+bit depth, data-byte count, frame count, and duration. The parser stops at the
+`data` chunk header, so it neither reads nor returns sample bytes. It accepts
+uncompressed PCM (format code `1`) and IEEE float (format code `3`); compressed
+codecs and big-endian `RIFX` files fail closed.
+
+Parsing is limited to 64 KiB of header data by default. Set
+`max_header_bytes` to a smaller positive integer when a tighter bound is
+required. RIFF and chunk sizes, odd-byte padding, format consistency, and frame
+alignment are validated before metadata is returned.
+
+Binary streams are read from their current position. Seekable streams are
+restored on success or failure, non-seekable streams remain consumed through
+the `data` header, and caller-owned streams are never closed. Errors contain
+only stable categories and do not include paths, source bytes, or stream error
+details.
+
+This preflight does not decode samples, validate that the declared sample bytes
+are present, assess audio quality, resample content, or replace a full WAV
+decoder.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
       - Bounded Asset Digests: multimodal/asset-digests.md
       - Privacy-safe Asset Manifests: multimodal/asset-manifests.md
       - Multimodal Manifest Profiles: multimodal/manifest-profiles.md
+      - WAV Metadata Preflight: multimodal/wav-preflight.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md
       - Multimodal Abstention Reasons: multimodal/abstention-reasons.md
       - Email Ingestion and Redaction: multimodal/email-ingestion.md

--- a/openmed/multimodal/wav_metadata.py
+++ b/openmed/multimodal/wav_metadata.py
@@ -1,0 +1,259 @@
+"""Bounded, dependency-free WAV metadata parsing for multimodal preflight."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import BinaryIO, Callable, Final
+
+__all__ = [
+    "DEFAULT_MAX_WAV_HEADER_BYTES",
+    "WAVE_FORMAT_IEEE_FLOAT",
+    "WAVE_FORMAT_PCM",
+    "WavMetadata",
+    "WavMetadataError",
+    "read_wav_metadata",
+]
+
+DEFAULT_MAX_WAV_HEADER_BYTES: Final[int] = 64 * 1024
+WAVE_FORMAT_PCM: Final[int] = 0x0001
+WAVE_FORMAT_IEEE_FLOAT: Final[int] = 0x0003
+
+_READ_CHUNK_BYTES: Final[int] = 8192
+_UINT16_MAX: Final[int] = (1 << 16) - 1
+_UINT32_MAX: Final[int] = (1 << 32) - 1
+
+
+class WavMetadataError(ValueError):
+    """Value-free failure raised for malformed or unsupported WAV metadata."""
+
+    def __init__(self, category: str) -> None:
+        self.category = category
+        super().__init__(category)
+
+
+@dataclass(frozen=True, slots=True)
+class WavMetadata:
+    """Audio metadata read without decoding or retaining sample bytes."""
+
+    format_code: int
+    channels: int
+    sample_rate_hz: int
+    bit_depth: int
+    data_byte_count: int
+    frame_count: int
+    duration_seconds: float
+
+
+def read_wav_metadata(
+    source: bytes | BinaryIO,
+    *,
+    max_header_bytes: int = DEFAULT_MAX_WAV_HEADER_BYTES,
+) -> WavMetadata:
+    """Read PCM or IEEE-float metadata from a bounded RIFF/WAVE header.
+
+    Streams are read from their current position. Seekable streams are restored
+    before return or failure, and caller-owned streams are never closed.
+    Parsing stops at the ``data`` chunk header without reading audio samples.
+    """
+
+    if type(max_header_bytes) is not int or max_header_bytes <= 0:
+        raise ValueError("max_header_bytes must be a positive integer")
+
+    if isinstance(source, bytes):
+        return _parse_wav(_BoundedReader(source, max_header_bytes))
+
+    read = getattr(source, "read", None)
+    if not callable(read):
+        raise TypeError("source must be bytes or a binary stream")
+
+    initial_position = _stream_position(source)
+    try:
+        return _parse_wav(_BoundedReader(read, max_header_bytes))
+    finally:
+        if initial_position is not None:
+            _restore_position(source, initial_position)
+
+
+class _BoundedReader:
+    def __init__(
+        self,
+        source: bytes | Callable[[int], bytes],
+        limit: int,
+    ) -> None:
+        self._buffer = memoryview(source) if isinstance(source, bytes) else None
+        self._read = source if callable(source) else None
+        self._limit = limit
+        self.offset = 0
+
+    def read_exact(self, size: int) -> bytes:
+        self._check_limit(size)
+        if self._buffer is not None:
+            end = self.offset + size
+            if end > len(self._buffer):
+                raise WavMetadataError("wav_header_truncated")
+            chunk = bytes(self._buffer[self.offset : end])
+            self.offset = end
+            return chunk
+
+        chunks: list[bytes] = []
+        remaining = size
+        while remaining:
+            chunk = _read_stream_chunk(self._read, remaining)
+            if not chunk:
+                raise WavMetadataError("wav_header_truncated")
+            chunks.append(chunk)
+            self.offset += len(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def skip(self, size: int) -> None:
+        self._check_limit(size)
+        if self._buffer is not None:
+            end = self.offset + size
+            if end > len(self._buffer):
+                raise WavMetadataError("wav_header_truncated")
+            self.offset = end
+            return
+
+        remaining = size
+        while remaining:
+            request_bytes = min(remaining, _READ_CHUNK_BYTES)
+            chunk = _read_stream_chunk(self._read, request_bytes)
+            if not chunk:
+                raise WavMetadataError("wav_header_truncated")
+            self.offset += len(chunk)
+            remaining -= len(chunk)
+
+    def _check_limit(self, size: int) -> None:
+        if size > self._limit - self.offset:
+            raise WavMetadataError("wav_header_limit_exceeded")
+
+
+def _parse_wav(reader: _BoundedReader) -> WavMetadata:
+    riff_header = reader.read_exact(12)
+    if riff_header[:4] == b"RIFX":
+        raise WavMetadataError("wav_endianness_unsupported")
+    if riff_header[:4] != b"RIFF" or riff_header[8:12] != b"WAVE":
+        raise WavMetadataError("wav_signature_invalid")
+
+    riff_size = struct.unpack_from("<I", riff_header, 4)[0]
+    if riff_size < 4:
+        raise WavMetadataError("wav_riff_size_invalid")
+    riff_end = riff_size + 8
+
+    audio_format: tuple[int, int, int, int, int] | None = None
+    while reader.offset < riff_end:
+        if riff_end - reader.offset < 8:
+            raise WavMetadataError("wav_chunk_size_invalid")
+
+        chunk_header = reader.read_exact(8)
+        chunk_id = chunk_header[:4]
+        chunk_size = struct.unpack_from("<I", chunk_header, 4)[0]
+        padded_size = chunk_size + (chunk_size & 1)
+        if padded_size > riff_end - reader.offset:
+            raise WavMetadataError("wav_chunk_size_invalid")
+
+        if chunk_id == b"fmt ":
+            if audio_format is not None:
+                raise WavMetadataError("wav_fmt_chunk_duplicate")
+            if chunk_size < 16:
+                raise WavMetadataError("wav_fmt_chunk_invalid")
+            audio_format = _parse_format(reader.read_exact(16))
+            reader.skip(padded_size - 16)
+            continue
+
+        if chunk_id == b"data":
+            if audio_format is None:
+                raise WavMetadataError("wav_fmt_chunk_missing")
+            return _build_metadata(audio_format, chunk_size)
+
+        reader.skip(padded_size)
+
+    if audio_format is None:
+        raise WavMetadataError("wav_fmt_chunk_missing")
+    raise WavMetadataError("wav_data_chunk_missing")
+
+
+def _parse_format(payload: bytes) -> tuple[int, int, int, int, int]:
+    format_code, channels, sample_rate, byte_rate, block_align, bit_depth = (
+        struct.unpack("<HHIIHH", payload)
+    )
+    if format_code not in (WAVE_FORMAT_PCM, WAVE_FORMAT_IEEE_FLOAT):
+        raise WavMetadataError("wav_format_unsupported")
+    if channels == 0 or sample_rate == 0 or block_align == 0 or bit_depth == 0:
+        raise WavMetadataError("wav_format_values_invalid")
+    if format_code == WAVE_FORMAT_IEEE_FLOAT and bit_depth not in (32, 64):
+        raise WavMetadataError("wav_float_bit_depth_invalid")
+
+    bytes_per_sample = (bit_depth + 7) // 8
+    expected_block_align = channels * bytes_per_sample
+    expected_byte_rate = sample_rate * expected_block_align
+    if (
+        expected_block_align > _UINT16_MAX
+        or expected_byte_rate > _UINT32_MAX
+        or block_align != expected_block_align
+        or byte_rate != expected_byte_rate
+    ):
+        raise WavMetadataError("wav_format_consistency_invalid")
+    return format_code, channels, sample_rate, block_align, bit_depth
+
+
+def _build_metadata(
+    audio_format: tuple[int, int, int, int, int], data_byte_count: int
+) -> WavMetadata:
+    format_code, channels, sample_rate, block_align, bit_depth = audio_format
+    if data_byte_count % block_align:
+        raise WavMetadataError("wav_data_size_invalid")
+    frame_count = data_byte_count // block_align
+    return WavMetadata(
+        format_code=format_code,
+        channels=channels,
+        sample_rate_hz=sample_rate,
+        bit_depth=bit_depth,
+        data_byte_count=data_byte_count,
+        frame_count=frame_count,
+        duration_seconds=frame_count / sample_rate,
+    )
+
+
+def _read_stream_chunk(
+    read: Callable[[int], bytes] | None, request_bytes: int
+) -> bytes:
+    if read is None:
+        raise WavMetadataError("wav_stream_contract_error")
+    try:
+        chunk = read(request_bytes)
+    except Exception:
+        pass
+    else:
+        if isinstance(chunk, bytes) and len(chunk) <= request_bytes:
+            return chunk
+        raise WavMetadataError("wav_stream_contract_error")
+    raise WavMetadataError("wav_stream_read_error")
+
+
+def _stream_position(stream: BinaryIO) -> int | None:
+    seekable = getattr(stream, "seekable", None)
+    if not callable(seekable):
+        return None
+    try:
+        if not seekable():
+            return None
+        position = stream.tell()
+    except Exception:
+        pass
+    else:
+        if type(position) is int and position >= 0:
+            return position
+    raise WavMetadataError("wav_stream_position_error")
+
+
+def _restore_position(stream: BinaryIO, position: int) -> None:
+    try:
+        stream.seek(position)
+    except Exception:
+        pass
+    else:
+        return
+    raise WavMetadataError("wav_stream_restore_error")

--- a/tests/unit/multimodal/test_wav_metadata.py
+++ b/tests/unit/multimodal/test_wav_metadata.py
@@ -1,0 +1,255 @@
+"""Tests for bounded, privacy-safe WAV metadata parsing."""
+
+from __future__ import annotations
+
+import io
+import struct
+
+import pytest
+
+from openmed.multimodal.wav_metadata import (
+    DEFAULT_MAX_WAV_HEADER_BYTES,
+    WAVE_FORMAT_IEEE_FLOAT,
+    WAVE_FORMAT_PCM,
+    WavMetadataError,
+    read_wav_metadata,
+)
+
+
+def _chunk(chunk_id: bytes, payload: bytes) -> bytes:
+    padding = b"\x00" if len(payload) & 1 else b""
+    return chunk_id + struct.pack("<I", len(payload)) + payload + padding
+
+
+def _fmt(
+    *,
+    format_code: int = WAVE_FORMAT_PCM,
+    channels: int = 1,
+    sample_rate: int = 8000,
+    bit_depth: int = 16,
+    byte_rate: int | None = None,
+    block_align: int | None = None,
+) -> bytes:
+    sample_bytes = (bit_depth + 7) // 8
+    align = channels * sample_bytes if block_align is None else block_align
+    rate = sample_rate * align if byte_rate is None else byte_rate
+    return struct.pack(
+        "<HHIIHH", format_code, channels, sample_rate, rate, align, bit_depth
+    )
+
+
+def _wav(*chunks: bytes, riff_size: int | None = None) -> bytes:
+    body = b"WAVE" + b"".join(chunks)
+    declared_size = len(body) if riff_size is None else riff_size
+    return b"RIFF" + struct.pack("<I", declared_size) + body
+
+
+@pytest.mark.parametrize(
+    ("fmt", "samples", "expected"),
+    [
+        (
+            _fmt(channels=1, sample_rate=8000, bit_depth=16),
+            b"\x00" * 8,
+            (WAVE_FORMAT_PCM, 1, 8000, 16, 8, 4, 0.0005),
+        ),
+        (
+            _fmt(channels=2, sample_rate=44100, bit_depth=24),
+            b"\x00" * 12,
+            (WAVE_FORMAT_PCM, 2, 44100, 24, 12, 2, 2 / 44100),
+        ),
+        (
+            _fmt(
+                format_code=WAVE_FORMAT_IEEE_FLOAT,
+                channels=1,
+                sample_rate=48000,
+                bit_depth=32,
+            ),
+            b"\x00" * 8,
+            (WAVE_FORMAT_IEEE_FLOAT, 1, 48000, 32, 8, 2, 2 / 48000),
+        ),
+    ],
+)
+def test_reads_hand_checked_pcm_and_float_metadata(fmt, samples, expected):
+    result = read_wav_metadata(_wav(_chunk(b"fmt ", fmt), _chunk(b"data", samples)))
+
+    assert (
+        result.format_code,
+        result.channels,
+        result.sample_rate_hz,
+        result.bit_depth,
+        result.data_byte_count,
+        result.frame_count,
+        result.duration_seconds,
+    ) == expected
+
+
+def test_skips_extra_chunks_and_their_odd_byte_padding() -> None:
+    payload = _wav(
+        _chunk(b"JUNK", b"abc"),
+        _chunk(b"fmt ", _fmt()),
+        _chunk(b"LIST", b"12345"),
+        _chunk(b"data", b"\x00" * 4),
+    )
+
+    result = read_wav_metadata(payload)
+
+    assert result.frame_count == 2
+    assert result.data_byte_count == 4
+
+
+def test_empty_data_chunk_has_zero_frames_and_duration() -> None:
+    result = read_wav_metadata(_wav(_chunk(b"fmt ", _fmt()), _chunk(b"data", b"")))
+
+    assert result.data_byte_count == 0
+    assert result.frame_count == 0
+    assert result.duration_seconds == 0.0
+
+
+def test_parser_stops_at_data_header_without_reading_samples() -> None:
+    samples = b"do-not-read-these-audio-samples"
+    payload = _wav(_chunk(b"fmt ", _fmt(bit_depth=8)), _chunk(b"data", samples))
+    data_start = payload.index(b"data") + 8
+
+    class NonSeekableStream:
+        def __init__(self) -> None:
+            self.stream = io.BytesIO(payload)
+            self.closed = False
+
+        def seekable(self) -> bool:
+            return False
+
+        def read(self, size: int) -> bytes:
+            return self.stream.read(size)
+
+    stream = NonSeekableStream()
+    result = read_wav_metadata(stream)
+
+    assert result.data_byte_count == len(samples)
+    assert stream.stream.tell() == data_start
+    assert not stream.closed
+
+
+def test_seekable_stream_is_restored_and_never_closed() -> None:
+    wav = _wav(_chunk(b"fmt ", _fmt()), _chunk(b"data", b"\x00" * 4))
+    stream = io.BytesIO(b"prefix" + wav)
+    stream.seek(len(b"prefix"))
+
+    result = read_wav_metadata(stream)
+
+    assert result.frame_count == 2
+    assert stream.tell() == len(b"prefix")
+    assert not stream.closed
+
+
+@pytest.mark.parametrize(
+    ("payload", "category"),
+    [
+        (b"RIFX\x00\x00\x00\x04WAVE", "wav_endianness_unsupported"),
+        (b"not a wave!!", "wav_signature_invalid"),
+        (b"RIFF\x03\x00\x00\x00WAVE", "wav_riff_size_invalid"),
+        (
+            b"RIFF\xff\xff\xff\xffWAVEJUNK\xff\xff\xff\xff",
+            "wav_chunk_size_invalid",
+        ),
+        (_wav(_chunk(b"fmt ", b"\x00" * 15)), "wav_fmt_chunk_invalid"),
+        (_wav(_chunk(b"JUNK", b"abc")), "wav_fmt_chunk_missing"),
+        (_wav(_chunk(b"fmt ", _fmt())), "wav_data_chunk_missing"),
+        (
+            _wav(_chunk(b"data", b""), _chunk(b"fmt ", _fmt())),
+            "wav_fmt_chunk_missing",
+        ),
+        (
+            _wav(_chunk(b"fmt ", _fmt(format_code=6)), _chunk(b"data", b"")),
+            "wav_format_unsupported",
+        ),
+        (
+            _wav(
+                _chunk(
+                    b"fmt ",
+                    _fmt(format_code=WAVE_FORMAT_IEEE_FLOAT, bit_depth=16),
+                ),
+                _chunk(b"data", b""),
+            ),
+            "wav_float_bit_depth_invalid",
+        ),
+        (
+            _wav(
+                _chunk(b"fmt ", _fmt(block_align=3)),
+                _chunk(b"data", b""),
+            ),
+            "wav_format_consistency_invalid",
+        ),
+        (
+            _wav(
+                _chunk(b"fmt ", _fmt(byte_rate=1)),
+                _chunk(b"data", b""),
+            ),
+            "wav_format_consistency_invalid",
+        ),
+        (
+            _wav(_chunk(b"fmt ", _fmt()), _chunk(b"data", b"\x00")),
+            "wav_data_size_invalid",
+        ),
+    ],
+)
+def test_malformed_or_unsupported_headers_fail_closed(payload, category):
+    with pytest.raises(WavMetadataError) as raised:
+        read_wav_metadata(payload)
+
+    assert raised.value.category == category
+    assert str(raised.value) == category
+
+
+def test_truncated_header_fails_closed() -> None:
+    fmt_header = b"fmt " + struct.pack("<I", 16) + b"\x00" * 8
+    payload = _wav(fmt_header, riff_size=4 + 8 + 16)
+
+    with pytest.raises(WavMetadataError, match="wav_header_truncated"):
+        read_wav_metadata(payload)
+
+
+def test_configured_header_limit_is_enforced_before_an_oversized_read() -> None:
+    payload = _wav(
+        _chunk(b"JUNK", b"x" * 32),
+        _chunk(b"fmt ", _fmt()),
+        _chunk(b"data", b""),
+    )
+
+    with pytest.raises(WavMetadataError, match="wav_header_limit_exceeded"):
+        read_wav_metadata(payload, max_header_bytes=20)
+
+
+def test_stream_errors_are_value_free_and_do_not_close_the_stream() -> None:
+    sentinel = "/private/patient-name.wav?token=secret"
+
+    class BrokenStream:
+        closed = False
+
+        def seekable(self) -> bool:
+            return False
+
+        def read(self, size: int) -> bytes:
+            raise OSError(sentinel)
+
+    stream = BrokenStream()
+    with pytest.raises(WavMetadataError) as raised:
+        read_wav_metadata(stream)
+
+    assert str(raised.value) == "wav_stream_read_error"
+    assert sentinel not in str(raised.value)
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert not stream.closed
+
+
+@pytest.mark.parametrize("max_header_bytes", [0, -1, True, 1.5, None])
+def test_invalid_header_limits_are_rejected(max_header_bytes) -> None:
+    with pytest.raises(ValueError, match="max_header_bytes"):
+        read_wav_metadata(
+            b"RIFF\x04\x00\x00\x00WAVE",
+            max_header_bytes=max_header_bytes,
+        )
+
+
+def test_default_header_limit_is_bounded() -> None:
+    assert DEFAULT_MAX_WAV_HEADER_BYTES == 64 * 1024


### PR DESCRIPTION
WAV preflight now reads bounded metadata without touching samples, so malformed files fail closed before audio deps enter the chat. Closes #3004.