### PR TITLE
feat: add FHIR R4 structural validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ the [2.2-to-2.3 migration guide](docs/migration/2.2-to-2.3.md).
 
 ### Added
 
+- Added dependency-free base FHIR R4 structural validation for eight exported
+  clinical resource types, including deterministic structured findings,
+  cardinality and primitive datatype checks, fixed required bindings, Bundle
+  aggregation, and a compact CC0-derived constraint table (#2364).
 - Added typed, 128-bit opaque correlation identifiers for agent runs and
   actions, with strict kind-aware parsing, deterministic metadata-only JSON,
   parent-action validation, and value-free failures (#2973).

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -35,7 +35,7 @@ For the model families available by clinical specialty, use the
 
 | Area | What it covers | Where to look |
 | --- | --- | --- |
-| FHIR helpers | Deterministic R4 Bundles, stable `urn:uuid` references, `OperationOutcome`, `Provenance`, `AuditEvent`, CodeableConcept builders/checkers, SMART-on-FHIR bulk ingestion, and coding provenance. | `openmed/clinical/exporters/fhir/`, `openmed/clinical/exporters/codeable_concept.py`, `openmed/clinical/exporters/codeable_concept_check.py`, `openmed/service/smart_backend.py`, [FHIR Interop Helpers](./fhir-interop.md) |
+| FHIR helpers | Deterministic R4 Bundles, bundled base-R4 structural validation, local IG profile checks, stable `urn:uuid` references, `OperationOutcome`, `Provenance`, `AuditEvent`, CodeableConcept builders/checkers, SMART-on-FHIR bulk ingestion, and coding provenance. | `openmed/clinical/exporters/fhir/`, `openmed/clinical/exporters/codeable_concept.py`, `openmed/clinical/exporters/codeable_concept_check.py`, `openmed/service/smart_backend.py`, [FHIR Interop Helpers](./fhir-interop.md) |
 | OMOP and CDM loading | Deterministic note-to-CDM extraction and OMOP CDM loader foundations. | `openmed/interop/cdm_etl.py`, `openmed/interop/omop/cdm_loader.py` |
 | FHIR operations and bulk export | `$de-identify` resource/Bundle wrappers and FHIR Bulk NDJSON de-identification summaries. | `openmed/interop/fhir_operations.py`, `openmed/interop/fhir_bulk.py`, `examples/v17_multimodal_browser_interop.py` |
 | HL7 v2 and CDA/C-CDA | HL7 v2 segment/field redaction, CDA/C-CDA XML de-identification, and multimodal XML dispatch. | `openmed/interop/hl7v2.py`, `openmed/interop/cda.py`, [HL7 v2 De-identification](./hl7v2-deidentification.md) |

--- a/docs/fhir-interop.md
+++ b/docs/fhir-interop.md
@@ -147,3 +147,59 @@ missing resources and does not validate external FHIR profiles.
 For an opt-in, offline check of profiles declared in `meta.profile`, including
 post-de-identification comparison, see
 [WHO SMART Guidelines Profile Checks](./fhir-smart-guidelines.md).
+
+## Base R4 Structural Validation
+
+Use `validate_resource()` or `validate_bundle()` before handing an OpenMed
+export to a FHIR server. Both functions run entirely offline against a bundled,
+minimal table of base FHIR R4 (4.0.1) cardinalities, datatypes, and small fixed
+required bindings:
+
+```python
+from openmed.clinical.exporters.fhir import validate_bundle, validate_resource
+
+resource_result = validate_resource(
+    {
+        "resourceType": "Observation",
+        "status": "final",
+        "code": {"text": "synthetic measurement"},
+    }
+)
+assert resource_result.is_valid
+
+bundle_result = validate_bundle(
+    {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [
+            {
+                "resource": {
+                    "resourceType": "Observation",
+                    "code": {"text": "synthetic measurement"},
+                }
+            }
+        ],
+    }
+)
+assert bundle_result.errors[0].location == "Bundle.entry[0].resource.status"
+```
+
+`ValidationResult.errors` and `.warnings` contain immutable
+`ValidationFinding` objects with `severity`, `location`, `message`, and a FHIR
+issue `code`. Messages describe structure only and never quote resource values.
+Results also expose `.issues`, so `from_validation_result(result)` can render a
+standard R4 `OperationOutcome`.
+
+The bundled subset covers the resources OpenMed emits: `Condition`,
+`Observation`, `MedicationStatement`, `Procedure`, `DiagnosticReport`,
+`AllergyIntolerance`, `Immunization`, and `Encounter`. A different resource type
+produces a `not-supported` warning rather than a false conformance claim. The
+constraint table contains only OpenMed's compact derivation of CC0-licensed base
+R4 structure and fixed code-system metadata; it does not include clinical
+terminology content, proprietary profiles, or implementation-guide packages.
+
+This base validator is intentionally distinct from `check_bundle()`. The latter
+loads caller-supplied `StructureDefinition` and `ValueSet` resources to check
+declared implementation-guide profiles. Neither checker contacts a terminology
+server or replaces the complete HL7 validator for invariants, extensions, and
+full profile conformance.

--- a/openmed/clinical/exporters/fhir/__init__.py
+++ b/openmed/clinical/exporters/fhir/__init__.py
@@ -62,6 +62,13 @@ from .privacy import (
 from .profile_check import check_bundle
 from .provenance import to_audit_event, to_provenance
 from .references import deterministic_fullurl
+from .validate import (
+    BASE_R4_RESOURCE_TYPES,
+    ValidationFinding,
+    ValidationResult,
+    validate_bundle,
+    validate_resource,
+)
 
 __all__ = [
     "CONDITION_CLINICAL_SYSTEM",
@@ -111,4 +118,9 @@ __all__ = [
     "import_bundle",
     "import_fhir",
     "validate_exchange",
+    "BASE_R4_RESOURCE_TYPES",
+    "ValidationFinding",
+    "ValidationResult",
+    "validate_bundle",
+    "validate_resource",
 ]

--- a/openmed/clinical/exporters/fhir/_validation_primitives.py
+++ b/openmed/clinical/exporters/fhir/_validation_primitives.py
@@ -1,0 +1,136 @@
+"""Shared, dependency-free traversal primitives for FHIR validation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class _Occurrence:
+    value: Any
+    expression: str
+    key: str | None = None
+    repeated: bool = False
+
+
+@dataclass(frozen=True)
+class _OccurrenceGroup:
+    expression: str
+    occurrences: tuple[_Occurrence, ...]
+
+
+def _occurrence_groups(
+    node: Any,
+    segments: Sequence[str],
+    root_expression: str,
+) -> list[_OccurrenceGroup]:
+    """Resolve element paths while retaining per-parent cardinality groups."""
+
+    if not segments:
+        occurrence = (
+            (_Occurrence(node, root_expression),) if _is_present(node) else tuple()
+        )
+        return [_OccurrenceGroup(root_expression, occurrence)]
+
+    parents = [_Occurrence(node, root_expression)]
+    for segment in segments[:-1]:
+        next_parents: list[_Occurrence] = []
+        for parent in parents:
+            next_parents.extend(_children(parent, segment))
+        parents = next_parents
+        if not parents:
+            return []
+
+    final_segment = segments[-1]
+    groups: list[_OccurrenceGroup] = []
+    for parent in parents:
+        children = tuple(_children(parent, final_segment))
+        groups.append(
+            _OccurrenceGroup(
+                expression=_child_expression(parent.expression, final_segment),
+                occurrences=children,
+            )
+        )
+    return groups
+
+
+def _children(parent: _Occurrence, segment: str) -> list[_Occurrence]:
+    if not isinstance(parent.value, Mapping):
+        return []
+    children: list[_Occurrence] = []
+    for key in _matching_keys(parent.value, segment):
+        value = parent.value[key]
+        expression = f"{parent.expression}.{key}"
+        if isinstance(value, list):
+            children.extend(
+                _Occurrence(
+                    item,
+                    f"{expression}[{index}]",
+                    key=key,
+                    repeated=True,
+                )
+                for index, item in enumerate(value)
+                if _is_present(item)
+            )
+        elif _is_present(value):
+            children.append(_Occurrence(value, expression, key=key))
+    return children
+
+
+def _matching_keys(node: Mapping[str, Any], segment: str) -> list[str]:
+    if segment.endswith("[x]"):
+        prefix = segment[:-3]
+        return sorted(
+            key
+            for key in node
+            if isinstance(key, str)
+            and key.startswith(prefix)
+            and len(key) > len(prefix)
+            and key[len(prefix)].isupper()
+        )
+    return [segment] if segment in node else []
+
+
+def _child_expression(parent_expression: str, segment: str) -> str:
+    if segment.endswith("[x]"):
+        segment = segment[:-3]
+    return f"{parent_expression}.{segment}"
+
+
+def _path_expression(root_expression: str, segments: Sequence[str]) -> str:
+    expression = root_expression
+    for segment in segments:
+        expression = _child_expression(expression, segment)
+    return expression
+
+
+def _is_present(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (Mapping, Sequence)) and not isinstance(value, (str, bytes)):
+        return bool(value)
+    return True
+
+
+def _extract_codes(value: Any) -> list[tuple[str, str]]:
+    """Extract ``(system, code)`` pairs from code/Coding/CodeableConcept values."""
+
+    if isinstance(value, str):
+        return [("", value)]
+    if not isinstance(value, Mapping):
+        return []
+    code = value.get("code")
+    if isinstance(code, str):
+        system = value.get("system")
+        return [((system if isinstance(system, str) else ""), code)]
+    coding = value.get("coding")
+    if isinstance(coding, list):
+        codes: list[tuple[str, str]] = []
+        for item in coding:
+            codes.extend(_extract_codes(item))
+        return codes
+    return []

--- a/openmed/clinical/exporters/fhir/definitions/r4_base.json
+++ b/openmed/clinical/exporters/fhir/definitions/r4_base.json
@@ -1,0 +1,281 @@
+{
+  "schemaVersion": 1,
+  "fhirVersion": "4.0.1",
+  "license": "CC0-1.0",
+  "source": "https://hl7.org/fhir/R4/",
+  "description": "OpenMed-authored minimal base R4 constraint table; no terminology expansion or implementation-guide content.",
+  "bundleTypes": [
+    "batch",
+    "batch-response",
+    "collection",
+    "document",
+    "history",
+    "message",
+    "searchset",
+    "transaction",
+    "transaction-response"
+  ],
+  "commonElements": [
+    {"path": "id", "min": 0, "max": 1, "types": ["id"]},
+    {"path": "meta", "min": 0, "max": 1, "types": ["Meta"]},
+    {"path": "implicitRules", "min": 0, "max": 1, "types": ["uri"]},
+    {"path": "language", "min": 0, "max": 1, "types": ["code"]},
+    {"path": "text", "min": 0, "max": 1, "types": ["Narrative"]},
+    {"path": "contained", "min": 0, "max": "*", "types": ["Resource"]},
+    {"path": "extension", "min": 0, "max": "*", "types": ["Extension"]},
+    {"path": "modifierExtension", "min": 0, "max": "*", "types": ["Extension"]}
+  ],
+  "resources": {
+    "Condition": {
+      "elements": [
+        {"path": "identifier", "min": 0, "max": "*", "types": ["Identifier"]},
+        {"path": "clinicalStatus", "min": 0, "max": 1, "types": ["CodeableConcept"], "binding": "condition-clinical"},
+        {"path": "verificationStatus", "min": 0, "max": 1, "types": ["CodeableConcept"], "binding": "condition-verification"},
+        {"path": "category", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "severity", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "code", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "bodySite", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "subject", "min": 1, "max": 1, "types": ["Reference"]},
+        {"path": "encounter", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "onset[x]", "min": 0, "max": 1, "types": ["dateTime", "Age", "Period", "Range", "string"]},
+        {"path": "abatement[x]", "min": 0, "max": 1, "types": ["dateTime", "Age", "Period", "Range", "string"]},
+        {"path": "recordedDate", "min": 0, "max": 1, "types": ["dateTime"]},
+        {"path": "recorder", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "asserter", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "stage", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "evidence", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "note", "min": 0, "max": "*", "types": ["Annotation"]}
+      ]
+    },
+    "Observation": {
+      "elements": [
+        {"path": "identifier", "min": 0, "max": "*", "types": ["Identifier"]},
+        {"path": "basedOn", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "partOf", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "status", "min": 1, "max": 1, "types": ["code"], "binding": "observation-status"},
+        {"path": "category", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "code", "min": 1, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "subject", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "focus", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "encounter", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "effective[x]", "min": 0, "max": 1, "types": ["dateTime", "Period", "Timing", "instant"]},
+        {"path": "issued", "min": 0, "max": 1, "types": ["instant"]},
+        {"path": "performer", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "value[x]", "min": 0, "max": 1, "types": ["Quantity", "CodeableConcept", "string", "boolean", "integer", "Range", "Ratio", "SampledData", "time", "dateTime", "Period"]},
+        {"path": "valueQuantity.value", "min": 0, "max": 1, "types": ["decimal"]},
+        {"path": "valueQuantity.comparator", "min": 0, "max": 1, "types": ["code"]},
+        {"path": "valueQuantity.unit", "min": 0, "max": 1, "types": ["string"]},
+        {"path": "valueQuantity.system", "min": 0, "max": 1, "types": ["uri"]},
+        {"path": "valueQuantity.code", "min": 0, "max": 1, "types": ["code"]},
+        {"path": "dataAbsentReason", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "interpretation", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "note", "min": 0, "max": "*", "types": ["Annotation"]},
+        {"path": "bodySite", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "method", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "specimen", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "device", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "referenceRange", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "hasMember", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "derivedFrom", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "component", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "component.code", "min": 1, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "component.value[x]", "min": 0, "max": 1, "types": ["Quantity", "CodeableConcept", "string", "boolean", "integer", "Range", "Ratio", "SampledData", "time", "dateTime", "Period"]},
+        {"path": "component.dataAbsentReason", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "component.interpretation", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "component.referenceRange", "min": 0, "max": "*", "types": ["BackboneElement"]}
+      ]
+    },
+    "MedicationStatement": {
+      "elements": [
+        {"path": "identifier", "min": 0, "max": "*", "types": ["Identifier"]},
+        {"path": "basedOn", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "partOf", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "status", "min": 1, "max": 1, "types": ["code"], "binding": "medication-statement-status"},
+        {"path": "statusReason", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "category", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "medication[x]", "min": 1, "max": 1, "types": ["CodeableConcept", "Reference"]},
+        {"path": "subject", "min": 1, "max": 1, "types": ["Reference"]},
+        {"path": "context", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "effective[x]", "min": 0, "max": 1, "types": ["dateTime", "Period"]},
+        {"path": "dateAsserted", "min": 0, "max": 1, "types": ["dateTime"]},
+        {"path": "informationSource", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "derivedFrom", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "reasonCode", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "reasonReference", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "note", "min": 0, "max": "*", "types": ["Annotation"]},
+        {"path": "dosage", "min": 0, "max": "*", "types": ["Dosage"]}
+      ]
+    },
+    "Procedure": {
+      "elements": [
+        {"path": "identifier", "min": 0, "max": "*", "types": ["Identifier"]},
+        {"path": "instantiatesCanonical", "min": 0, "max": "*", "types": ["canonical"]},
+        {"path": "instantiatesUri", "min": 0, "max": "*", "types": ["uri"]},
+        {"path": "basedOn", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "partOf", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "status", "min": 1, "max": 1, "types": ["code"], "binding": "event-status"},
+        {"path": "statusReason", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "category", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "code", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "subject", "min": 1, "max": 1, "types": ["Reference"]},
+        {"path": "encounter", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "performed[x]", "min": 0, "max": 1, "types": ["dateTime", "Period", "string", "Age", "Range"]},
+        {"path": "recorder", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "asserter", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "performer", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "location", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "reasonCode", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "reasonReference", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "bodySite", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "outcome", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "report", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "complication", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "complicationDetail", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "followUp", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "note", "min": 0, "max": "*", "types": ["Annotation"]},
+        {"path": "focalDevice", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "usedReference", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "usedCode", "min": 0, "max": "*", "types": ["CodeableConcept"]}
+      ]
+    },
+    "DiagnosticReport": {
+      "elements": [
+        {"path": "identifier", "min": 0, "max": "*", "types": ["Identifier"]},
+        {"path": "basedOn", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "status", "min": 1, "max": 1, "types": ["code"], "binding": "diagnostic-report-status"},
+        {"path": "category", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "code", "min": 1, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "subject", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "encounter", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "effective[x]", "min": 0, "max": 1, "types": ["dateTime", "Period"]},
+        {"path": "issued", "min": 0, "max": 1, "types": ["instant"]},
+        {"path": "performer", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "resultsInterpreter", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "specimen", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "result", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "imagingStudy", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "media", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "conclusion", "min": 0, "max": 1, "types": ["string"]},
+        {"path": "conclusionCode", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "presentedForm", "min": 0, "max": "*", "types": ["Attachment"]}
+      ]
+    },
+    "AllergyIntolerance": {
+      "elements": [
+        {"path": "identifier", "min": 0, "max": "*", "types": ["Identifier"]},
+        {"path": "clinicalStatus", "min": 0, "max": 1, "types": ["CodeableConcept"], "binding": "allergy-clinical"},
+        {"path": "verificationStatus", "min": 0, "max": 1, "types": ["CodeableConcept"], "binding": "allergy-verification"},
+        {"path": "type", "min": 0, "max": 1, "types": ["code"], "binding": "allergy-type"},
+        {"path": "category", "min": 0, "max": "*", "types": ["code"], "binding": "allergy-category"},
+        {"path": "criticality", "min": 0, "max": 1, "types": ["code"], "binding": "allergy-criticality"},
+        {"path": "code", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "patient", "min": 1, "max": 1, "types": ["Reference"]},
+        {"path": "encounter", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "onset[x]", "min": 0, "max": 1, "types": ["dateTime", "Age", "Period", "Range", "string"]},
+        {"path": "recordedDate", "min": 0, "max": 1, "types": ["dateTime"]},
+        {"path": "recorder", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "asserter", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "lastOccurrence", "min": 0, "max": 1, "types": ["dateTime"]},
+        {"path": "note", "min": 0, "max": "*", "types": ["Annotation"]},
+        {"path": "reaction", "min": 0, "max": "*", "types": ["BackboneElement"]}
+      ]
+    },
+    "Immunization": {
+      "elements": [
+        {"path": "identifier", "min": 0, "max": "*", "types": ["Identifier"]},
+        {"path": "status", "min": 1, "max": 1, "types": ["code"], "binding": "immunization-status"},
+        {"path": "statusReason", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "vaccineCode", "min": 1, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "patient", "min": 1, "max": 1, "types": ["Reference"]},
+        {"path": "encounter", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "occurrence[x]", "min": 1, "max": 1, "types": ["dateTime", "string"]},
+        {"path": "recorded", "min": 0, "max": 1, "types": ["dateTime"]},
+        {"path": "primarySource", "min": 0, "max": 1, "types": ["boolean"]},
+        {"path": "reportOrigin", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "location", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "manufacturer", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "lotNumber", "min": 0, "max": 1, "types": ["string"]},
+        {"path": "expirationDate", "min": 0, "max": 1, "types": ["date"]},
+        {"path": "site", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "route", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "doseQuantity", "min": 0, "max": 1, "types": ["Quantity"]},
+        {"path": "performer", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "note", "min": 0, "max": "*", "types": ["Annotation"]},
+        {"path": "reasonCode", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "reasonReference", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "isSubpotent", "min": 0, "max": 1, "types": ["boolean"]},
+        {"path": "subpotentReason", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "education", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "programEligibility", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "fundingSource", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "reaction", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "protocolApplied", "min": 0, "max": "*", "types": ["BackboneElement"]}
+      ]
+    },
+    "Encounter": {
+      "elements": [
+        {"path": "identifier", "min": 0, "max": "*", "types": ["Identifier"]},
+        {"path": "status", "min": 1, "max": 1, "types": ["code"], "binding": "encounter-status"},
+        {"path": "statusHistory", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "class", "min": 1, "max": 1, "types": ["Coding"]},
+        {"path": "classHistory", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "type", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "serviceType", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "priority", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "subject", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "episodeOfCare", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "basedOn", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "participant", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "appointment", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "period", "min": 0, "max": 1, "types": ["Period"]},
+        {"path": "length", "min": 0, "max": 1, "types": ["Duration"]},
+        {"path": "reasonCode", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "reasonReference", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "diagnosis", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "account", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "hospitalization", "min": 0, "max": 1, "types": ["BackboneElement"]},
+        {"path": "location", "min": 0, "max": "*", "types": ["BackboneElement"]},
+        {"path": "serviceProvider", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "partOf", "min": 0, "max": 1, "types": ["Reference"]}
+      ]
+    }
+  },
+  "valueSets": {
+    "condition-clinical": {
+      "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+      "codes": ["active", "recurrence", "relapse", "inactive", "remission", "resolved"]
+    },
+    "condition-verification": {
+      "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+      "codes": ["unconfirmed", "provisional", "differential", "confirmed", "refuted", "entered-in-error"]
+    },
+    "observation-status": {
+      "system": "http://hl7.org/fhir/observation-status",
+      "codes": ["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"]
+    },
+    "medication-statement-status": {
+      "codes": ["active", "completed", "entered-in-error", "intended", "stopped", "on-hold", "unknown", "not-taken"]
+    },
+    "event-status": {
+      "codes": ["preparation", "in-progress", "not-done", "on-hold", "stopped", "completed", "entered-in-error", "unknown"]
+    },
+    "diagnostic-report-status": {
+      "codes": ["registered", "partial", "preliminary", "final", "amended", "corrected", "appended", "cancelled", "entered-in-error", "unknown"]
+    },
+    "allergy-clinical": {
+      "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+      "codes": ["active", "inactive", "resolved"]
+    },
+    "allergy-verification": {
+      "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+      "codes": ["unconfirmed", "confirmed", "refuted", "entered-in-error"]
+    },
+    "allergy-type": {"codes": ["allergy", "intolerance"]},
+    "allergy-category": {"codes": ["food", "medication", "environment", "biologic"]},
+    "allergy-criticality": {"codes": ["low", "high", "unable-to-assess"]},
+    "immunization-status": {"codes": ["completed", "entered-in-error", "not-done"]},
+    "encounter-status": {
+      "codes": ["planned", "arrived", "triaged", "in-progress", "onleave", "finished", "cancelled", "entered-in-error", "unknown"]
+    }
+  }
+}

--- a/openmed/clinical/exporters/fhir/profile_check.py
+++ b/openmed/clinical/exporters/fhir/profile_check.py
@@ -23,6 +23,14 @@ from os import PathLike
 from pathlib import Path
 from typing import Any
 
+from ._validation_primitives import (
+    _extract_codes,
+    _is_present,
+    _Occurrence,
+    _occurrence_groups,
+    _OccurrenceGroup,
+    _path_expression,
+)
 from .operation_outcome import OperationOutcomeIssue, to_operation_outcome
 
 __all__ = ["check_bundle"]
@@ -56,18 +64,6 @@ class _Package:
     profiles: Mapping[str, Mapping[str, Any]]
     value_sets: Mapping[str, _ValueSet]
     findings: tuple[_Finding, ...]
-
-
-@dataclass(frozen=True)
-class _Occurrence:
-    value: Any
-    expression: str
-
-
-@dataclass(frozen=True)
-class _OccurrenceGroup:
-    expression: str
-    occurrences: tuple[_Occurrence, ...]
 
 
 def check_bundle(
@@ -812,24 +808,6 @@ def _value_in_value_set(value: Any, codes: frozenset[tuple[str, str]]) -> bool:
     return False
 
 
-def _extract_codes(value: Any) -> list[tuple[str, str]]:
-    if isinstance(value, str):
-        return [("", value)]
-    if not isinstance(value, Mapping):
-        return []
-    code = value.get("code")
-    if isinstance(code, str):
-        system = value.get("system")
-        return [((system if isinstance(system, str) else ""), code)]
-    coding = value.get("coding")
-    if isinstance(coding, list):
-        codes: list[tuple[str, str]] = []
-        for item in coding:
-            codes.extend(_extract_codes(item))
-        return codes
-    return []
-
-
 def _check_slice(
     resource: Mapping[str, Any],
     resource_type: str,
@@ -1127,90 +1105,3 @@ def _unsupported_constraint_findings(
                         )
                     )
     return findings
-
-
-def _occurrence_groups(
-    node: Any,
-    segments: Sequence[str],
-    root_expression: str,
-) -> list[_OccurrenceGroup]:
-    if not segments:
-        occurrence = (
-            (_Occurrence(node, root_expression),) if _is_present(node) else tuple()
-        )
-        return [_OccurrenceGroup(root_expression, occurrence)]
-
-    parents = [_Occurrence(node, root_expression)]
-    for segment in segments[:-1]:
-        next_parents: list[_Occurrence] = []
-        for parent in parents:
-            next_parents.extend(_children(parent, segment))
-        parents = next_parents
-        if not parents:
-            return []
-
-    final_segment = segments[-1]
-    groups: list[_OccurrenceGroup] = []
-    for parent in parents:
-        children = tuple(_children(parent, final_segment))
-        groups.append(
-            _OccurrenceGroup(
-                expression=_child_expression(parent.expression, final_segment),
-                occurrences=children,
-            )
-        )
-    return groups
-
-
-def _children(parent: _Occurrence, segment: str) -> list[_Occurrence]:
-    if not isinstance(parent.value, Mapping):
-        return []
-    children: list[_Occurrence] = []
-    for key in _matching_keys(parent.value, segment):
-        value = parent.value[key]
-        expression = f"{parent.expression}.{key}"
-        if isinstance(value, list):
-            children.extend(
-                _Occurrence(item, f"{expression}[{index}]")
-                for index, item in enumerate(value)
-                if _is_present(item)
-            )
-        elif _is_present(value):
-            children.append(_Occurrence(value, expression))
-    return children
-
-
-def _matching_keys(node: Mapping[str, Any], segment: str) -> list[str]:
-    if segment.endswith("[x]"):
-        prefix = segment[:-3]
-        return sorted(
-            key
-            for key in node
-            if key.startswith(prefix)
-            and len(key) > len(prefix)
-            and key[len(prefix)].isupper()
-        )
-    return [segment] if segment in node else []
-
-
-def _child_expression(parent_expression: str, segment: str) -> str:
-    if segment.endswith("[x]"):
-        segment = segment[:-3]
-    return f"{parent_expression}.{segment}"
-
-
-def _path_expression(root_expression: str, segments: Sequence[str]) -> str:
-    expression = root_expression
-    for segment in segments:
-        expression = _child_expression(expression, segment)
-    return expression
-
-
-def _is_present(value: Any) -> bool:
-    if value is None:
-        return False
-    if isinstance(value, str):
-        return bool(value.strip())
-    if isinstance(value, (Mapping, Sequence)) and not isinstance(value, (str, bytes)):
-        return bool(value)
-    return True

--- a/openmed/clinical/exporters/fhir/validate.py
+++ b/openmed/clinical/exporters/fhir/validate.py
@@ -1,0 +1,542 @@
+"""Dependency-free structural validation for OpenMed's FHIR R4 exports.
+
+This validator checks the small base-R4 subset bundled with OpenMed. It is
+deliberately separate from :mod:`profile_check`, which evaluates profiles from
+a caller-supplied implementation-guide package. Both validators share only
+generic traversal and coding primitives.
+
+The public functions never raise because a resource is malformed. Findings use
+FHIRPath-style locations and fixed, value-free messages so validation reports
+do not echo clinical content or identifiers.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+from ._validation_primitives import _extract_codes, _Occurrence, _occurrence_groups
+
+__all__ = [
+    "BASE_R4_RESOURCE_TYPES",
+    "ValidationFinding",
+    "ValidationResult",
+    "validate_bundle",
+    "validate_resource",
+]
+
+BASE_R4_RESOURCE_TYPES = frozenset(
+    {
+        "AllergyIntolerance",
+        "Condition",
+        "DiagnosticReport",
+        "Encounter",
+        "Immunization",
+        "MedicationStatement",
+        "Observation",
+        "Procedure",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ValidationFinding:
+    """One sanitized base-R4 validation finding.
+
+    Attributes:
+        severity: Either ``"error"`` or ``"warning"``.
+        location: FHIRPath-style location of the malformed element.
+        message: Value-free explanation safe to include in audit output.
+        code: FHIR R4 ``issue-type`` code for OperationOutcome adaptation.
+    """
+
+    severity: str
+    location: str
+    message: str
+    code: str = "invalid"
+
+    @property
+    def expression(self) -> str:
+        """Return the location under the OperationOutcome-compatible name."""
+
+        return self.location
+
+    @property
+    def diagnostics(self) -> str:
+        """Return the message under the OperationOutcome-compatible name."""
+
+        return self.message
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Immutable errors and warnings produced by base-R4 validation."""
+
+    errors: tuple[ValidationFinding, ...] = ()
+    warnings: tuple[ValidationFinding, ...] = ()
+
+    @property
+    def findings(self) -> tuple[ValidationFinding, ...]:
+        """Return every finding, with errors before warnings."""
+
+        return self.errors + self.warnings
+
+    @property
+    def issues(self) -> tuple[ValidationFinding, ...]:
+        """Return findings for the shared OperationOutcome adapter."""
+
+        return self.findings
+
+    @property
+    def is_valid(self) -> bool:
+        """Return ``True`` when validation found no errors."""
+
+        return not self.errors
+
+    @property
+    def valid(self) -> bool:
+        """Alias for :attr:`is_valid` used by other validation results."""
+
+        return self.is_valid
+
+
+def validate_resource(resource: Mapping[str, Any]) -> ValidationResult:
+    """Validate one resource against OpenMed's bundled FHIR R4 base subset.
+
+    Supported resource types are Condition, Observation, MedicationStatement,
+    Procedure, DiagnosticReport, AllergyIntolerance, Immunization, and
+    Encounter. Other resource types produce a warning because no claim of base
+    conformance can be made for a type outside the bundled subset.
+
+    Args:
+        resource: Resource-like input. Non-mappings and malformed mappings are
+            surfaced as structured errors rather than raised exceptions.
+
+    Returns:
+        An immutable :class:`ValidationResult`. Messages never contain values
+        read from ``resource``.
+    """
+
+    try:
+        findings = _validate_resource_at(resource, root=None)
+    except Exception:
+        findings = [
+            _error(
+                "Resource",
+                "Resource structure could not be inspected.",
+                code="structure",
+            )
+        ]
+    return _to_result(findings)
+
+
+def validate_bundle(bundle: Mapping[str, Any]) -> ValidationResult:
+    """Validate every resource contained in an exported FHIR R4 Bundle.
+
+    The Bundle container is checked for its required type and entry shape. Each
+    ``entry.resource`` is then checked independently and its findings retain a
+    Bundle-qualified FHIRPath-style location.
+
+    Args:
+        bundle: Bundle-like input. Malformed input is always returned as
+            findings and is never raised to the caller.
+
+    Returns:
+        Aggregated errors and warnings in deterministic entry order.
+    """
+
+    try:
+        findings = _validate_bundle(bundle)
+    except Exception:
+        findings = [
+            _error(
+                "Bundle",
+                "Bundle structure could not be inspected.",
+                code="structure",
+            )
+        ]
+    return _to_result(findings)
+
+
+def _validate_bundle(bundle: Any) -> list[ValidationFinding]:
+    if not isinstance(bundle, Mapping):
+        return [_error("Bundle", "Bundle must be a JSON object.", code="structure")]
+
+    findings: list[ValidationFinding] = []
+    if bundle.get("resourceType") != "Bundle":
+        findings.append(
+            _error(
+                "Bundle.resourceType",
+                "resourceType must identify a FHIR Bundle.",
+                code="value",
+            )
+        )
+
+    bundle_type = bundle.get("type")
+    if bundle_type is None or bundle_type == "":
+        findings.append(
+            _error("Bundle.type", "Required element is missing or empty.", "required")
+        )
+    elif not _matches_primitive(bundle_type, "code"):
+        findings.append(
+            _error("Bundle.type", "Element has an invalid FHIR R4 datatype.")
+        )
+    elif bundle_type not in _definitions()["bundleTypes"]:
+        findings.append(
+            _error(
+                "Bundle.type",
+                "Code is outside the required base R4 binding.",
+                "code-invalid",
+            )
+        )
+
+    entries = bundle.get("entry")
+    if entries is None:
+        return findings
+    if not isinstance(entries, Sequence) or isinstance(entries, (str, bytes)):
+        findings.append(
+            _error("Bundle.entry", "Bundle.entry must be an array.", "structure")
+        )
+        return findings
+
+    for index, entry in enumerate(entries):
+        root = f"Bundle.entry[{index}].resource"
+        if not isinstance(entry, Mapping) or not isinstance(
+            entry.get("resource"), Mapping
+        ):
+            findings.append(
+                _error(
+                    root,
+                    "Bundle entry does not contain a FHIR resource.",
+                    "required",
+                )
+            )
+            continue
+        findings.extend(_validate_resource_at(entry["resource"], root=root))
+    return findings
+
+
+def _validate_resource_at(
+    resource: Any,
+    *,
+    root: str | None,
+) -> list[ValidationFinding]:
+    fallback_root = root or "Resource"
+    if not isinstance(resource, Mapping):
+        return [
+            _error(
+                fallback_root,
+                "FHIR resource must be a JSON object.",
+                code="structure",
+            )
+        ]
+
+    resource_type = resource.get("resourceType")
+    if not isinstance(resource_type, str) or not resource_type:
+        return [
+            _error(
+                f"{fallback_root}.resourceType",
+                "Required resourceType is missing or invalid.",
+                code="required",
+            )
+        ]
+
+    location_root = root or resource_type
+    definition = _definitions()["resources"].get(resource_type)
+    if definition is None:
+        return [
+            _warning(
+                f"{location_root}.resourceType",
+                "Resource type is outside the bundled base R4 validation subset.",
+                code="not-supported",
+            )
+        ]
+
+    elements = (*_definitions()["commonElements"], *definition["elements"])
+    findings: list[ValidationFinding] = []
+    for element in elements:
+        findings.extend(_validate_element(resource, location_root, element))
+    return findings
+
+
+def _validate_element(
+    resource: Mapping[str, Any],
+    root: str,
+    element: Mapping[str, Any],
+) -> list[ValidationFinding]:
+    path = element["path"]
+    segments = tuple(path.split("."))
+    groups = _occurrence_groups(resource, segments, root)
+    minimum = element.get("min", 0)
+    raw_maximum = element.get("max", "*")
+    maximum = None if raw_maximum == "*" else int(raw_maximum)
+    repeating = maximum is None or maximum > 1
+    findings: list[ValidationFinding] = []
+
+    for group in groups:
+        count = len(group.occurrences)
+        if count < minimum:
+            findings.append(
+                _error(
+                    group.expression,
+                    "Required element is missing or empty.",
+                    "required",
+                )
+            )
+        if maximum is not None and count > maximum:
+            findings.append(
+                _error(
+                    group.expression,
+                    "Maximum element cardinality is exceeded.",
+                    "structure",
+                )
+            )
+
+        if group.occurrences:
+            represented_as_array = any(item.repeated for item in group.occurrences)
+            if repeating and not represented_as_array:
+                findings.append(
+                    _error(
+                        group.expression,
+                        "Repeating element must use a JSON array.",
+                        "structure",
+                    )
+                )
+            elif not repeating and represented_as_array:
+                findings.append(
+                    _error(
+                        group.expression,
+                        "Single-valued element must not use a JSON array.",
+                        "structure",
+                    )
+                )
+
+        for occurrence in group.occurrences:
+            if not _occurrence_matches_types(occurrence, path, element["types"]):
+                findings.append(
+                    _error(
+                        occurrence.expression,
+                        "Element has an invalid FHIR R4 datatype.",
+                    )
+                )
+                continue
+            binding_name = element.get("binding")
+            if binding_name is not None and not _matches_binding(
+                occurrence.value,
+                _definitions()["valueSets"][binding_name],
+            ):
+                findings.append(
+                    _error(
+                        occurrence.expression,
+                        "Code is outside the required base R4 binding.",
+                        "code-invalid",
+                    )
+                )
+    return findings
+
+
+def _occurrence_matches_types(
+    occurrence: _Occurrence,
+    path: str,
+    allowed_types: Sequence[str],
+) -> bool:
+    if path.endswith("[x]"):
+        prefix = path.rsplit(".", 1)[-1][:-3]
+        key = occurrence.key or ""
+        if not key.startswith(prefix) or len(key) <= len(prefix):
+            return False
+        suffix = key[len(prefix) :]
+        selected_type = suffix[0].lower() + suffix[1:]
+        matching_type = next(
+            (
+                allowed
+                for allowed in allowed_types
+                if allowed.casefold() == selected_type.casefold()
+            ),
+            None,
+        )
+        return matching_type is not None and _matches_type(
+            occurrence.value, matching_type
+        )
+    return any(_matches_type(occurrence.value, item) for item in allowed_types)
+
+
+def _matches_type(value: Any, fhir_type: str) -> bool:
+    if fhir_type in _COMPLEX_TYPES:
+        return isinstance(value, Mapping)
+    return _matches_primitive(value, fhir_type)
+
+
+def _matches_primitive(value: Any, fhir_type: str) -> bool:
+    if fhir_type == "boolean":
+        return type(value) is bool
+    if fhir_type == "integer":
+        return type(value) is int and -(2**31) <= value < 2**31
+    if fhir_type == "unsignedInt":
+        return type(value) is int and 0 <= value < 2**31
+    if fhir_type == "positiveInt":
+        return type(value) is int and 0 < value < 2**31
+    if fhir_type == "decimal":
+        return type(value) in (int, float) and math.isfinite(value)
+    if not isinstance(value, str) or not value:
+        return False
+    if fhir_type in {"string", "markdown", "xhtml"}:
+        return bool(value)
+    if fhir_type == "code":
+        return _CODE_RE.fullmatch(value) is not None
+    if fhir_type == "id":
+        return _ID_RE.fullmatch(value) is not None
+    if fhir_type == "date":
+        return _valid_date(value)
+    if fhir_type == "dateTime":
+        return _valid_datetime(value, require_time=False)
+    if fhir_type == "instant":
+        return _valid_datetime(value, require_time=True)
+    if fhir_type == "time":
+        return _TIME_RE.fullmatch(value) is not None
+    if fhir_type in {"uri", "url", "canonical"}:
+        return not any(character.isspace() for character in value)
+    if fhir_type == "oid":
+        return _OID_RE.fullmatch(value) is not None
+    if fhir_type == "uuid":
+        return _UUID_RE.fullmatch(value) is not None
+    if fhir_type == "base64Binary":
+        try:
+            base64.b64decode(value, validate=True)
+        except (binascii.Error, ValueError):
+            return False
+        return True
+    return False
+
+
+def _valid_date(value: str) -> bool:
+    match = _DATE_RE.fullmatch(value)
+    if match is None:
+        return False
+    month = match.group("month")
+    day = match.group("day")
+    if month is None:
+        return True
+    if day is None:
+        return True
+    try:
+        date(int(match.group("year")), int(month), int(day))
+    except ValueError:
+        return False
+    return True
+
+
+def _valid_datetime(value: str, *, require_time: bool) -> bool:
+    if "T" not in value:
+        return not require_time and _valid_date(value)
+    if _DATETIME_RE.fullmatch(value) is None:
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None
+
+
+def _matches_binding(value: Any, value_set: Mapping[str, Any]) -> bool:
+    allowed_codes = frozenset(value_set["codes"])
+    expected_system = value_set.get("system", "")
+    primitive = isinstance(value, str)
+    for system, code in _extract_codes(value):
+        if code not in allowed_codes:
+            continue
+        if primitive or not expected_system or system == expected_system:
+            return True
+    return False
+
+
+def _to_result(findings: Sequence[ValidationFinding]) -> ValidationResult:
+    return ValidationResult(
+        errors=tuple(item for item in findings if item.severity == "error"),
+        warnings=tuple(item for item in findings if item.severity == "warning"),
+    )
+
+
+def _error(
+    location: str,
+    message: str,
+    code: str = "invalid",
+) -> ValidationFinding:
+    return ValidationFinding("error", location, message, code)
+
+
+def _warning(
+    location: str,
+    message: str,
+    code: str = "invalid",
+) -> ValidationFinding:
+    return ValidationFinding("warning", location, message, code)
+
+
+@lru_cache(maxsize=1)
+def _definitions() -> Mapping[str, Any]:
+    definition_path = resources.files(__package__).joinpath(
+        "definitions", "r4_base.json"
+    )
+    payload = json.loads(definition_path.read_text(encoding="utf-8"))
+    if payload.get("schemaVersion") != 1 or payload.get("fhirVersion") != "4.0.1":
+        raise RuntimeError("bundled FHIR R4 constraint table is incompatible")
+    return payload
+
+
+_COMPLEX_TYPES = frozenset(
+    {
+        "Address",
+        "Age",
+        "Annotation",
+        "Attachment",
+        "BackboneElement",
+        "CodeableConcept",
+        "Coding",
+        "ContactPoint",
+        "Dosage",
+        "Duration",
+        "Extension",
+        "HumanName",
+        "Identifier",
+        "Meta",
+        "Narrative",
+        "Period",
+        "Quantity",
+        "Range",
+        "Ratio",
+        "Reference",
+        "Resource",
+        "SampledData",
+        "Signature",
+        "Timing",
+    }
+)
+
+_CODE_RE = re.compile(r"[^\s]+(?: [^\s]+)*")
+_ID_RE = re.compile(r"[A-Za-z0-9\-.]{1,64}")
+_DATE_RE = re.compile(
+    r"(?P<year>[1-9]\d{3})(?:-(?P<month>0[1-9]|1[0-2])"
+    r"(?:-(?P<day>0[1-9]|[12]\d|3[01]))?)?"
+)
+_DATETIME_RE = re.compile(
+    r"[1-9]\d{3}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])"
+    r"T(?:[01]\d|2[0-3]):[0-5]\d:(?:[0-5]\d|60)(?:\.\d+)?"
+    r"(?:Z|[+-](?:(?:0\d|1[0-3]):[0-5]\d|14:00))"
+)
+_TIME_RE = re.compile(r"(?:[01]\d|2[0-3]):[0-5]\d:(?:[0-5]\d|60)(?:\.\d+)?")
+_OID_RE = re.compile(r"urn:oid:[0-2](?:\.(?:0|[1-9]\d*))+", re.IGNORECASE)
+_UUID_RE = re.compile(
+    r"urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-"
+    r"[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)

--- a/openmed/interop/fhir/validation.py
+++ b/openmed/interop/fhir/validation.py
@@ -307,15 +307,33 @@ def _validate_resource(
             reason = "resource contains a field outside the supported FHIR subset"
         issues.append(_issue("error", "not-supported", path_value, reason))
 
+    if version == FHIRVersion.R4:
+        _append_base_r4_issues(resource, resource_type, path, issues)
+
     required_by_resource: dict[str, tuple[str, ...]] = {
         "Composition": ("status", "type", "date", "author", "title"),
-        "Condition": ("code", "subject"),
-        "Observation": ("status", "code"),
-        "MedicationStatement": ("status", "subject"),
-        "AllergyIntolerance": ("code", "patient"),
-        "Procedure": ("status", "subject"),
         "DocumentReference": ("status", "content"),
     }
+    if version == FHIRVersion.R4:
+        # These are exchange-workbench expectations beyond base R4's 0..1
+        # cardinality. The shared base validator owns all other overlapping
+        # R4 required fields, datatypes, cardinalities, and fixed bindings.
+        required_by_resource.update(
+            {
+                "AllergyIntolerance": ("code",),
+                "Condition": ("code",),
+            }
+        )
+    else:
+        required_by_resource.update(
+            {
+                "AllergyIntolerance": ("code", "patient"),
+                "Condition": ("code", "subject"),
+                "MedicationStatement": ("status", "subject"),
+                "Observation": ("status", "code"),
+                "Procedure": ("status", "subject"),
+            }
+        )
     for field in required_by_resource.get(resource_type, ()):
         if field not in resource or resource[field] in (None, [], ""):
             issues.append(
@@ -327,11 +345,8 @@ def _validate_resource(
                 )
             )
 
-    if resource_type == "MedicationStatement":
-        if version == FHIRVersion.R4:
-            medication_fields = {"medicationCodeableConcept", "medicationReference"}
-        else:
-            medication_fields = {"medication"}
+    if resource_type == "MedicationStatement" and version != FHIRVersion.R4:
+        medication_fields = {"medication"}
         if not medication_fields & set(resource):
             issues.append(
                 _issue(
@@ -353,6 +368,41 @@ def _validate_resource(
                     "Patient has no name or birthDate for summary use",
                 )
             )
+
+
+def _append_base_r4_issues(
+    resource: Mapping[str, Any],
+    resource_type: str,
+    path: str,
+    issues: list[_ValidationIssue],
+) -> None:
+    """Append canonical base-R4 findings to the exchange result."""
+
+    from openmed.clinical.exporters.fhir.validate import (
+        BASE_R4_RESOURCE_TYPES,
+    )
+    from openmed.clinical.exporters.fhir.validate import (
+        validate_resource as validate_base_resource,
+    )
+
+    if resource_type not in BASE_R4_RESOURCE_TYPES:
+        return
+    result = validate_base_resource(resource)
+    for finding in result.findings:
+        finding_path = finding.location
+        if path:
+            if finding_path == resource_type:
+                finding_path = path
+            elif finding_path.startswith(f"{resource_type}."):
+                finding_path = f"{path}.{finding_path[len(resource_type) + 1 :]}"
+        issues.append(
+            _issue(
+                finding.severity,
+                finding.code,
+                finding_path,
+                finding.message,
+            )
+        )
 
 
 def _validate_profile_release(

--- a/tests/unit/clinical/test_fhir_validate.py
+++ b/tests/unit/clinical/test_fhir_validate.py
@@ -1,0 +1,329 @@
+"""Tests for dependency-free FHIR R4 base structural validation."""
+
+from __future__ import annotations
+
+import json
+import socket
+from importlib import resources
+from typing import Any
+
+from openmed.clinical.exporters.fhir import (
+    BASE_R4_RESOURCE_TYPES,
+    ValidationFinding,
+    ValidationResult,
+    from_validation_result,
+    validate_bundle,
+    validate_resource,
+)
+from openmed.interop.fhir import validation_result as interop_validation_result
+
+
+def _observation(**updates: Any) -> dict[str, Any]:
+    resource: dict[str, Any] = {
+        "resourceType": "Observation",
+        "id": "synthetic-observation",
+        "status": "final",
+        "code": {"text": "synthetic measurement"},
+        "subject": {"reference": "Patient/synthetic"},
+        "valueQuantity": {
+            "value": 7.2,
+            "unit": "mmol/L",
+            "system": "http://unitsofmeasure.org",
+            "code": "mmol/L",
+        },
+    }
+    resource.update(updates)
+    return resource
+
+
+def _condition(**updates: Any) -> dict[str, Any]:
+    resource: dict[str, Any] = {
+        "resourceType": "Condition",
+        "verificationStatus": {
+            "coding": [
+                {
+                    "system": (
+                        "http://terminology.hl7.org/CodeSystem/condition-ver-status"
+                    ),
+                    "code": "confirmed",
+                }
+            ]
+        },
+        "code": {"text": "synthetic condition"},
+        "subject": {"reference": "Patient/synthetic"},
+    }
+    resource.update(updates)
+    return resource
+
+
+def test_well_formed_observation_validates_cleanly() -> None:
+    result = validate_resource(_observation())
+
+    assert isinstance(result, ValidationResult)
+    assert result.is_valid
+    assert result.errors == ()
+    assert result.warnings == ()
+    assert result.findings == ()
+
+
+def test_observation_missing_status_has_required_element_error() -> None:
+    observation = _observation()
+    observation.pop("status")
+
+    result = validate_resource(observation)
+
+    assert not result.is_valid
+    assert result.errors == (
+        ValidationFinding(
+            severity="error",
+            location="Observation.status",
+            message="Required element is missing or empty.",
+            code="required",
+        ),
+    )
+
+
+def test_condition_outside_required_verification_binding_is_flagged() -> None:
+    result = validate_resource(
+        _condition(
+            verificationStatus={
+                "coding": [
+                    {
+                        "system": (
+                            "http://terminology.hl7.org/CodeSystem/condition-ver-status"
+                        ),
+                        "code": "synthetic-invalid-status",
+                    }
+                ]
+            }
+        )
+    )
+
+    assert [(item.code, item.location) for item in result.errors] == [
+        ("code-invalid", "Condition.verificationStatus")
+    ]
+    assert "synthetic-invalid-status" not in result.errors[0].message
+
+
+def test_required_binding_requires_the_fixed_code_system() -> None:
+    result = validate_resource(
+        _condition(
+            verificationStatus={
+                "coding": [
+                    {"system": "https://openmed.example/wrong", "code": "confirmed"}
+                ]
+            }
+        )
+    )
+
+    assert [item.code for item in result.errors] == ["code-invalid"]
+
+
+def test_cardinality_and_primitive_datatype_violations_are_structured() -> None:
+    result = validate_resource(
+        _observation(
+            status=["final", "amended"],
+            valueBoolean="true",
+            valueQuantity=None,
+        )
+    )
+
+    assert ("structure", "Observation.status") in {
+        (item.code, item.location) for item in result.errors
+    }
+    assert ("invalid", "Observation.valueBoolean") in {
+        (item.code, item.location) for item in result.errors
+    }
+
+
+def test_choice_elements_enforce_one_selected_value_and_selected_type() -> None:
+    result = validate_resource(
+        _observation(valueQuantity=None, valueString="synthetic", valueBoolean=True)
+    )
+
+    assert any(
+        item.code == "structure"
+        and item.location == "Observation.value"
+        and "cardinality" in item.message
+        for item in result.errors
+    )
+
+    wrong_choice = validate_resource(_observation(valueQuantity="not-a-quantity"))
+    assert ("invalid", "Observation.valueQuantity") in {
+        (item.code, item.location) for item in wrong_choice.errors
+    }
+
+
+def test_repeating_elements_require_json_arrays() -> None:
+    result = validate_resource(_observation(performer={"reference": "Practitioner/x"}))
+
+    assert ("structure", "Observation.performer") in {
+        (item.code, item.location) for item in result.errors
+    }
+
+
+def test_bundle_validates_every_entry_and_qualifies_locations() -> None:
+    missing_status = _observation()
+    missing_status.pop("status")
+    invalid_condition = _condition(
+        verificationStatus={
+            "coding": [
+                {
+                    "system": (
+                        "http://terminology.hl7.org/CodeSystem/condition-ver-status"
+                    ),
+                    "code": "synthetic-invalid-status",
+                }
+            ]
+        }
+    )
+    bundle = {
+        "resourceType": "Bundle",
+        "type": "transaction",
+        "entry": [
+            {"resource": missing_status},
+            {"resource": invalid_condition},
+        ],
+    }
+
+    result = validate_bundle(bundle)
+
+    assert [(item.code, item.location) for item in result.errors] == [
+        ("required", "Bundle.entry[0].resource.status"),
+        ("code-invalid", "Bundle.entry[1].resource.verificationStatus"),
+    ]
+
+
+def test_all_bundled_resource_types_have_a_clean_minimal_resource() -> None:
+    resources = [
+        _condition(),
+        _observation(),
+        {
+            "resourceType": "MedicationStatement",
+            "status": "active",
+            "medicationCodeableConcept": {"text": "synthetic medication"},
+            "subject": {"reference": "Patient/synthetic"},
+        },
+        {
+            "resourceType": "Procedure",
+            "status": "completed",
+            "subject": {"reference": "Patient/synthetic"},
+        },
+        {
+            "resourceType": "DiagnosticReport",
+            "status": "final",
+            "code": {"text": "synthetic report"},
+        },
+        {
+            "resourceType": "AllergyIntolerance",
+            "patient": {"reference": "Patient/synthetic"},
+        },
+        {
+            "resourceType": "Immunization",
+            "status": "completed",
+            "vaccineCode": {"text": "synthetic vaccine"},
+            "patient": {"reference": "Patient/synthetic"},
+            "occurrenceDateTime": "2026-01-02T03:04:05Z",
+        },
+        {
+            "resourceType": "Encounter",
+            "status": "finished",
+            "class": {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                "code": "AMB",
+            },
+        },
+    ]
+
+    result = validate_bundle(
+        {
+            "resourceType": "Bundle",
+            "type": "collection",
+            "entry": [{"resource": resource} for resource in resources],
+        }
+    )
+
+    assert result.is_valid
+    assert result.findings == ()
+
+
+def test_unsupported_and_malformed_resources_never_raise() -> None:
+    unsupported = validate_resource({"resourceType": "Patient"})
+    malformed_values = [None, [], "resource", {}, {"resourceType": 7}]
+
+    assert unsupported.is_valid
+    assert unsupported.warnings[0].code == "not-supported"
+    for malformed in malformed_values:
+        result = validate_resource(malformed)  # type: ignore[arg-type]
+        assert result.errors
+
+    malformed_bundle = validate_bundle(  # type: ignore[arg-type]
+        {
+            "resourceType": "Bundle",
+            "type": "transaction",
+            "entry": [{}, {"resource": []}],
+        }
+    )
+    assert len(malformed_bundle.errors) == 2
+
+
+def test_validation_does_not_open_network_connections(monkeypatch: Any) -> None:
+    def fail_network(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("base R4 validator attempted network access")
+
+    monkeypatch.setattr(socket, "socket", fail_network)
+
+    assert validate_resource(_observation()).is_valid
+
+
+def test_result_adapts_to_operation_outcome() -> None:
+    observation = _observation()
+    observation.pop("status")
+
+    outcome = from_validation_result(validate_resource(observation))
+
+    assert outcome["issue"] == [
+        {
+            "severity": "error",
+            "code": "required",
+            "diagnostics": "Required element is missing or empty.",
+            "expression": ["Observation.status"],
+        }
+    ]
+
+
+def test_versioned_interop_validator_reuses_base_r4_findings() -> None:
+    observation = _observation()
+    observation.pop("status")
+
+    result = interop_validation_result(observation, "R4")
+
+    required_status = [
+        issue
+        for issue in result.as_dict()["issues"]
+        if issue["code"] == "required" and issue["path"] == "Observation.status"
+    ]
+    assert required_status == [
+        {
+            "severity": "error",
+            "code": "required",
+            "path": "Observation.status",
+            "diagnostics": "Required element is missing or empty.",
+        }
+    ]
+
+
+def test_bundled_constraints_are_the_scoped_permissive_r4_subset() -> None:
+    path = resources.files("openmed.clinical.exporters.fhir").joinpath(
+        "definitions", "r4_base.json"
+    )
+    definitions = json.loads(path.read_text(encoding="utf-8"))
+
+    assert definitions["license"] == "CC0-1.0"
+    assert definitions["fhirVersion"] == "4.0.1"
+    assert set(definitions["resources"]) == BASE_R4_RESOURCE_TYPES
+    serialized = json.dumps(definitions).casefold()
+    assert not any(
+        restricted in serialized
+        for restricted in ("cpt", "mimic", "snomed", "umls", "n2c2", "i2b2")
+    )


### PR DESCRIPTION
# Description
Implements canonical task OM-303 with a dependency-free base FHIR R4 structural validator for exported clinical resources. The validator returns immutable, value-free structured findings and validates every Bundle entry without network access.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [x] Test addition/improvement

## Changes Made
- Added `validate_resource` and `validate_bundle` with required-element, cardinality, JSON representation, primitive datatype, choice datatype, and fixed required-binding checks.
- Bundled a compact CC0-derived R4 4.0.1 constraint table for Condition, Observation, MedicationStatement, Procedure, DiagnosticReport, AllergyIntolerance, Immunization, and Encounter; no clinical terminology expansion or restricted profile data is included.
- Shared generic path and coding traversal with the caller-supplied IG profile checker, and routed the existing version-aware R4 exchange validator through the canonical base validator.
- Added synthetic offline regression coverage, public exports, interoperability documentation, feature-map coverage, and changelog material.

## Testing
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different inputs

Validation evidence:
- `.venv/bin/python -m pytest tests/ -q` — 14,626 passed, 94 skipped
- focused FHIR and interoperability suite — 109 passed
- `make format` — passed
- `make lint` — passed
- `make format-check` — passed
- `make type-check` — passed
- `make build` — wheel and sdist built; bundled constraints verified in both artifacts
- `make docs-build` — passed strict docs, brand, route, asset, and publication checks
- scoped pre-commit hooks — passed, including Bandit and secret detection

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift` (not applicable; no Swift changes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: not applicable

Declared dependency OM-107 is present on current master through the merged Condition and Observation exporter implementation. No dependency scope is absorbed here.

## Checklist
- [x] I have read the contributing guide, Code of Conduct, maintainer guide, and repository instructions
- [x] My commits have clear, descriptive messages
- [x] I have organized the change as one focused commit

## Related Issues
Closes #2364

## Screenshots/Examples
Not applicable; this is a Python API and bundled-data change with executable examples in the FHIR interoperability documentation.