### PR TITLE
feat: validate federated update metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to OpenMed will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added a versioned federated update metadata envelope with coordinator-owned
+  parameter expectations, bounded exact shape arithmetic, deterministic JSON,
+  clipping declarations, and value-free rejection of unknown or identifying
+  fields (#3010).
+
 ## [2.3.0] - 2026-09-04
 
 OpenMed 2.3 expands the stable v2 contract across privacy-safe agent and trace

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -211,6 +211,7 @@ classification:
     - training/federated-round-lifecycle.md
     - training/federated-round-status.md
     - training/federated-scheduling.md
+    - training/federated-update-metadata.md
     - reference/preference-schema.md
     - multimodal/media-type-detection.md
     - multimodal/pdf-reading-order.md

--- a/docs/training/federated-update-metadata.md
+++ b/docs/training/federated-update-metadata.md
@@ -1,0 +1,115 @@
+# Federated update metadata
+
+Validate the declared structure of a dense adapter update before aggregation
+without opening tensors, computing gradients, or accepting client identity.
+The envelope accepts only model and update SHA-256 references, an adapter
+format, parameter names, shapes, dtypes, an exact total element count, a clipping
+declaration, and the schema version.
+
+## Coordinator policy
+
+The coordinator supplies `FederatedUpdatePolicy` independently of the update.
+Its parameter specifications are the complete allowlist of names, shapes, and
+dtypes expected for the selected model. Do not construct this policy from
+incoming update metadata: doing so would let a submitter authorize its own
+parameters. This module does not infer model structure or read a model file.
+
+```python
+from openmed.training import (
+    FEDERATED_UPDATE_METADATA_SCHEMA_VERSION,
+    FederatedParameterMetadata,
+    FederatedUpdateMetadata,
+    FederatedUpdatePolicy,
+)
+
+# Synthetic digest references and adapter shapes for this example only.
+model_digest = "sha256:" + "a" * 64
+policy = FederatedUpdatePolicy(
+    model_digest=model_digest,
+    parameters=(
+        FederatedParameterMetadata("adapter.lora_A.weight", (2, 3), "float32"),
+        FederatedParameterMetadata("adapter.lora_B.weight", (4, 2), "float32"),
+    ),
+    require_clipped=True,
+    max_total_elements=14,
+)
+
+payload = {
+    "schema_version": FEDERATED_UPDATE_METADATA_SCHEMA_VERSION,
+    "model_digest": model_digest,
+    "adapter_format": "dense",
+    "parameters": [
+        {"name": "adapter.lora_B.weight", "shape": [4, 2], "dtype": "float32"},
+        {"name": "adapter.lora_A.weight", "shape": [2, 3], "dtype": "float32"},
+    ],
+    "total_elements": 14,  # (4 * 2) + (2 * 3)
+    "update_digest": "sha256:" + "b" * 64,
+    "clipped": True,
+}
+
+metadata = FederatedUpdateMetadata.from_dict(payload, policy=policy)
+canonical_json = metadata.to_json()
+assert FederatedUpdateMetadata.from_json(canonical_json, policy=policy) == metadata
+```
+
+Use `from_json()` at a JSON boundary so duplicate object keys are rejected
+before they can be silently overwritten by a generic JSON decoder. `from_dict()`
+accepts built-in dictionaries and lists containing JSON-style values. Direct
+construction also requires a policy and enforces the same metadata invariants.
+
+## Version and validation rules
+
+The schema identifier is `openmed.training.federated_update_metadata.v1`.
+Every envelope and parameter field shown above is required. Unknown fields
+are rejected; there is no extensions or free-text field.
+
+| Field or limit | Contract |
+| --- | --- |
+| `adapter_format` | Exactly `dense`; no sparse, packed, or container-specific formats |
+| Model digest | `sha256:` followed by 64 lowercase hexadecimal digits; must match policy |
+| Update digest | Same digest syntax; a declared content reference only |
+| Parameter names | Unique dotted ASCII identifiers, at most 256 characters; numeric path components such as `layers.0.weight` are allowed |
+| Parameter set | Exactly the coordinator's set, including each expected shape and dtype |
+| Parameter count | Between 1 and 1,024 |
+| Shape | Between 1 and 8 positive integer dimensions, each at most `2**31 - 1` |
+| Dtype | `float16`, `bfloat16`, `float32`, or `float64`, matching that parameter's policy |
+| Element arithmetic | Checked integer products and sum; at most `2**63 - 1` |
+| Total elements | Must equal the sum of shape products and respect the policy budget, default 100,000,000 |
+| `clipped` | Strict boolean; must be `true` unless trusted policy permits an unclipped declaration |
+| JSON size | At most 1 MiB of UTF-8 text, including whitespace |
+
+Booleans, strings, floating-point numbers, NaN, and infinity are not integer
+dimensions or counts. Scalars (zero-rank shapes), zero-sized dimensions, unknown
+parameters, missing parameters, duplicate parameters, unsupported versions, and
+overflows fail closed. Reordering dimensions is a shape mismatch even when the
+product remains the same.
+
+## Deterministic output and privacy boundary
+
+Validated metadata is immutable. Parameter records are sorted by name;
+`to_json()` sorts object keys and emits indented JSON with a trailing newline.
+Changing the input parameter or key order does not change the canonical bytes.
+`to_dict()` returns fresh dictionaries and shape lists, so later caller mutations
+cannot change the validated envelope.
+
+Tensor arrays, gradients, examples, client IDs, site names, paths, endpoints,
+and local metrics are rejected as unknown fields at every record level.
+Parameter-name syntax excludes paths, URLs, whitespace, and arbitrary free
+text. Known fields also reject invalid types instead of coercing them. Failures
+raise `FederatedUpdateMetadataError` with fixed messages that omit submitted
+keys and values; JSON parser excerpts are suppressed. The module performs no
+logging, filesystem access, network calls, tensor allocation, or training.
+
+The accepted metadata is still a declaration. Valid digest syntax and a matching
+model reference do not verify tensor bytes, signatures, provenance, or the
+truth of a clipping claim. This schema does not certify that digests or
+coordinator-approved names are non-identifying. Those meanings depend on the
+trusted caller's policy and handling. Do not log arbitrary rejected payloads.
+
+Round manifest verification, actual tensor allowlisting, and numerical clipping
+remain separate work in issues [#2822](https://github.com/maziyarpanahi/openmed/issues/2822),
+[#2824](https://github.com/maziyarpanahi/openmed/issues/2824), and
+[#2825](https://github.com/maziyarpanahi/openmed/issues/2825). This module has no
+imports from those pending implementations. See also
+[federated round lifecycle](federated-round-lifecycle.md) and
+[federated round status](federated-round-status.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
       - Federated Round Lifecycle: training/federated-round-lifecycle.md
       - Federated Round Status: training/federated-round-status.md
       - Federated Round Scheduling: training/federated-scheduling.md
+      - Federated Update Metadata: training/federated-update-metadata.md
       - Preference Pair Schema: reference/preference-schema.md
       - Bounded Media Type Detection: multimodal/media-type-detection.md
       - PDF Reading Order: multimodal/pdf-reading-order.md

--- a/openmed/training/__init__.py
+++ b/openmed/training/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "DEFAULT_FEDERATED_MINIMUM_GROUP_SIZE",
     "FEDERATED_SCHEDULE_PHASES",
     "FEDERATED_SCHEDULE_SCHEMA_VERSION",
+    "FEDERATED_UPDATE_METADATA_SCHEMA_VERSION",
     "MAX_FEDERATED_PHASE_DURATION_SECONDS",
     "MAX_LORA_TRAINABLE_RATIO",
     "PRESET_BY_MODE",
@@ -113,6 +114,10 @@ __all__ = [
     "FederatedRoundStatus",
     "FederatedRoundStatusError",
     "FederatedRoundTransitionError",
+    "FederatedParameterMetadata",
+    "FederatedUpdateMetadata",
+    "FederatedUpdateMetadataError",
+    "FederatedUpdatePolicy",
     "HARD_NEGATIVE_CATEGORIES",
     "HardNegativeExample",
     "HardNegativeGenerator",
@@ -223,6 +228,17 @@ __all__ = [
 
 
 def __getattr__(name: str) -> Any:
+    if name in {
+        "FEDERATED_UPDATE_METADATA_SCHEMA_VERSION",
+        "FederatedParameterMetadata",
+        "FederatedUpdateMetadata",
+        "FederatedUpdateMetadataError",
+        "FederatedUpdatePolicy",
+    }:
+        federated_update_metadata = import_module(
+            ".federated_update_metadata", __name__
+        )
+        return getattr(federated_update_metadata, name)
     if name in {
         "DEFAULT_FEDERATED_MINIMUM_GROUP_SIZE",
         "FEDERATED_ROUND_STATUS_SCHEMA_VERSION",

--- a/openmed/training/federated_update_metadata.py
+++ b/openmed/training/federated_update_metadata.py
@@ -1,0 +1,354 @@
+"""Content-free validation of declared dense adapter update metadata.
+
+The caller supplies trusted expected metadata separately from the update. This
+module never reads tensors or verifies their contents, lineage, or clipping.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import InitVar, dataclass
+from typing import Any, Final
+
+FEDERATED_UPDATE_METADATA_SCHEMA_VERSION = (
+    "openmed.training.federated_update_metadata.v1"
+)
+
+_MAX_ELEMENTS: Final = (1 << 63) - 1
+_MAX_DIMENSION: Final = (1 << 31) - 1
+_MAX_PARAMETERS: Final = 1024
+_MAX_RANK: Final = 8
+_MAX_JSON_BYTES: Final = 1024 * 1024
+_DTYPES: Final = frozenset({"float16", "bfloat16", "float32", "float64"})
+_DIGEST: Final = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_NAME: Final = re.compile(
+    r"[A-Za-z_][A-Za-z0-9_]*(?:\.(?:[A-Za-z_][A-Za-z0-9_]*|[0-9]+))*\Z"
+)
+_PARAMETER_FIELDS: Final = frozenset({"name", "shape", "dtype"})
+_UPDATE_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "model_digest",
+        "adapter_format",
+        "parameters",
+        "total_elements",
+        "update_digest",
+        "clipped",
+    }
+)
+
+
+class FederatedUpdateMetadataError(ValueError):
+    """Raised for invalid metadata without including submitted values."""
+
+
+@dataclass(frozen=True, slots=True)
+class FederatedParameterMetadata:
+    """A bounded parameter name, shape, and floating-point dtype.
+
+    Args:
+        name: Dotted ASCII parameter name from the coordinator's allowlist.
+        shape: One to eight positive integer dimensions; scalar and empty
+            tensors are not supported by this dense adapter format.
+        dtype: One of float16, bfloat16, float32, or float64.
+    """
+
+    name: str
+    shape: tuple[int, ...]
+    dtype: str
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.name) is not str
+            or not 1 <= len(self.name) <= 256
+            or _NAME.fullmatch(self.name) is None
+        ):
+            raise FederatedUpdateMetadataError("invalid parameter name")
+        _shape_elements(self.shape)
+        if type(self.dtype) is not str or self.dtype not in _DTYPES:
+            raise FederatedUpdateMetadataError("unsupported parameter dtype")
+
+    @property
+    def element_count(self) -> int:
+        """Return the exact checked product of the declared dimensions."""
+        return _shape_elements(self.shape)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a fresh mapping containing only parameter metadata."""
+        return {"name": self.name, "shape": list(self.shape), "dtype": self.dtype}
+
+
+@dataclass(frozen=True, slots=True)
+class FederatedUpdatePolicy:
+    """Trusted coordinator expectations supplied independently of an update.
+
+    Args:
+        model_digest: Expected lowercase SHA-256 reference for the base model.
+        parameters: Complete allowlist of expected parameter names, shapes,
+            and dtypes. Every entry must be present in a dense update.
+        adapter_format: Supported representation, currently only ``dense``.
+        require_clipped: Reject an update that does not declare clipping.
+        max_total_elements: Positive declared element budget, at most 2**63 - 1.
+    """
+
+    model_digest: str
+    parameters: tuple[FederatedParameterMetadata, ...]
+    adapter_format: str = "dense"
+    require_clipped: bool = True
+    max_total_elements: int = 100_000_000
+
+    def __post_init__(self) -> None:
+        _require_digest(self.model_digest)
+        _require_format(self.adapter_format)
+        if type(self.require_clipped) is not bool:
+            raise FederatedUpdateMetadataError("invalid clipping policy")
+        _require_count(self.max_total_elements)
+        ordered = _ordered_parameters(self.parameters)
+        _total_elements(ordered, self.max_total_elements)
+        object.__setattr__(self, "parameters", ordered)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class FederatedUpdateMetadata:
+    """An immutable envelope checked against a caller-owned policy.
+
+    Args:
+        model_digest: Declared base-model SHA-256 reference.
+        adapter_format: Declared representation, currently only ``dense``.
+        parameters: Complete declared parameter metadata.
+        total_elements: Claimed sum of the products of parameter dimensions.
+        update_digest: Declared update SHA-256 reference; not a content check.
+        clipped: Whether the submitter declares the update has been clipped.
+        policy: Trusted coordinator policy, required even for construction.
+            It is used for validation and is not stored or serialized.
+        schema_version: Exact supported metadata schema identifier.
+    """
+
+    model_digest: str
+    adapter_format: str
+    parameters: tuple[FederatedParameterMetadata, ...]
+    total_elements: int
+    update_digest: str
+    clipped: bool
+    policy: InitVar[FederatedUpdatePolicy]
+    schema_version: str = FEDERATED_UPDATE_METADATA_SCHEMA_VERSION
+
+    def __post_init__(self, policy: FederatedUpdatePolicy) -> None:
+        if type(policy) is not FederatedUpdatePolicy:
+            raise FederatedUpdateMetadataError("invalid update policy")
+        if (
+            type(self.schema_version) is not str
+            or self.schema_version != FEDERATED_UPDATE_METADATA_SCHEMA_VERSION
+        ):
+            raise FederatedUpdateMetadataError("unsupported update metadata schema")
+        _require_digest(self.model_digest)
+        _require_digest(self.update_digest)
+        _require_format(self.adapter_format)
+        if self.model_digest != policy.model_digest:
+            raise FederatedUpdateMetadataError("model digest does not match policy")
+        if self.adapter_format != policy.adapter_format:
+            raise FederatedUpdateMetadataError("adapter format does not match policy")
+        if type(self.clipped) is not bool:
+            raise FederatedUpdateMetadataError("invalid clipping status")
+        if policy.require_clipped and not self.clipped:
+            raise FederatedUpdateMetadataError("update must declare clipping")
+        _require_count(self.total_elements)
+        ordered = _ordered_parameters(self.parameters)
+        total = _total_elements(ordered, policy.max_total_elements)
+        if self.total_elements != total:
+            raise FederatedUpdateMetadataError(
+                "total element count does not match shapes"
+            )
+        if ordered != policy.parameters:
+            raise FederatedUpdateMetadataError("parameters do not match policy")
+        object.__setattr__(self, "parameters", ordered)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a fresh versioned mapping with parameters ordered by name."""
+        return {
+            "schema_version": self.schema_version,
+            "model_digest": self.model_digest,
+            "adapter_format": self.adapter_format,
+            "parameters": [parameter.to_dict() for parameter in self.parameters],
+            "total_elements": self.total_elements,
+            "update_digest": self.update_digest,
+            "clipped": self.clipped,
+        }
+
+    def to_json(self) -> str:
+        """Return byte-stable JSON with sorted keys and a trailing newline."""
+        return (
+            json.dumps(self.to_dict(), indent=2, sort_keys=True, allow_nan=False) + "\n"
+        )
+
+    @classmethod
+    def from_dict(
+        cls, payload: object, *, policy: FederatedUpdatePolicy
+    ) -> FederatedUpdateMetadata:
+        """Validate a JSON-style dictionary against separate trusted metadata.
+
+        Args:
+            payload: Built-in dictionary with exactly the envelope fields.
+                Parameter records must be dictionaries with name, shape, and
+                dtype only. Shapes must be JSON-style lists of integers.
+            policy: Coordinator expectations; never obtain this from payload.
+
+        Returns:
+            Validated immutable metadata in canonical parameter order.
+
+        Raises:
+            FederatedUpdateMetadataError: If the schema or policy is violated.
+        """
+        payload = _require_fields(payload, _UPDATE_FIELDS)
+        parameters = payload["parameters"]
+        if type(parameters) is not list or not 1 <= len(parameters) <= _MAX_PARAMETERS:
+            raise FederatedUpdateMetadataError("invalid parameter collection")
+        parsed = []
+        for parameter in parameters:
+            parameter = _require_fields(parameter, _PARAMETER_FIELDS)
+            shape = parameter["shape"]
+            if type(shape) is not list or not 1 <= len(shape) <= _MAX_RANK:
+                raise FederatedUpdateMetadataError("invalid parameter shape")
+            parsed.append(
+                FederatedParameterMetadata(
+                    name=parameter["name"], shape=tuple(shape), dtype=parameter["dtype"]
+                )
+            )
+        return cls(
+            model_digest=payload["model_digest"],
+            adapter_format=payload["adapter_format"],
+            parameters=tuple(parsed),
+            total_elements=payload["total_elements"],
+            update_digest=payload["update_digest"],
+            clipped=payload["clipped"],
+            schema_version=payload["schema_version"],
+            policy=policy,
+        )
+
+    @classmethod
+    def from_json(
+        cls, payload: str, *, policy: FederatedUpdatePolicy
+    ) -> FederatedUpdateMetadata:
+        """Parse bounded JSON, rejecting duplicate keys and non-integer numbers.
+
+        Args:
+            payload: UTF-8 encodable JSON text, at most one MiB.
+            policy: Independently supplied coordinator expectations.
+
+        Returns:
+            Validated immutable update metadata.
+
+        Raises:
+            FederatedUpdateMetadataError: On invalid JSON, limits, or policy.
+                Errors never include submitted keys, values, or parser excerpts.
+        """
+        if type(payload) is not str or len(payload) > _MAX_JSON_BYTES:
+            raise FederatedUpdateMetadataError("invalid update metadata JSON")
+        try:
+            if len(payload.encode("utf-8")) > _MAX_JSON_BYTES:
+                raise FederatedUpdateMetadataError("invalid update metadata JSON")
+            decoded = json.loads(
+                payload,
+                object_pairs_hook=_strict_object,
+                parse_int=_parse_integer,
+                parse_float=_reject_number,
+                parse_constant=_reject_number,
+            )
+        except (ValueError, RecursionError):
+            raise FederatedUpdateMetadataError("invalid update metadata JSON") from None
+        return cls.from_dict(decoded, policy=policy)
+
+
+def _require_fields(payload: object, expected: frozenset[str]) -> dict[str, Any]:
+    if (
+        type(payload) is not dict
+        or len(payload) != len(expected)
+        or any(type(key) is not str for key in payload)
+        or payload.keys() != expected
+    ):
+        raise FederatedUpdateMetadataError("invalid metadata fields")
+    return payload
+
+
+def _require_digest(value: object) -> None:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        raise FederatedUpdateMetadataError("invalid SHA-256 digest reference")
+
+
+def _require_format(value: object) -> None:
+    if type(value) is not str or value != "dense":
+        raise FederatedUpdateMetadataError("unsupported adapter format")
+
+
+def _require_count(value: object) -> None:
+    if type(value) is not int or not 1 <= value <= _MAX_ELEMENTS:
+        raise FederatedUpdateMetadataError("invalid element count")
+
+
+def _shape_elements(shape: object) -> int:
+    if type(shape) is not tuple or not 1 <= len(shape) <= _MAX_RANK:
+        raise FederatedUpdateMetadataError("invalid parameter shape")
+    product = 1
+    for dimension in shape:
+        if type(dimension) is not int or not 1 <= dimension <= _MAX_DIMENSION:
+            raise FederatedUpdateMetadataError("invalid shape dimension")
+        if product > _MAX_ELEMENTS // dimension:
+            raise FederatedUpdateMetadataError("shape element count exceeds limit")
+        product *= dimension
+    return product
+
+
+def _ordered_parameters(
+    value: object,
+) -> tuple[FederatedParameterMetadata, ...]:
+    if type(value) is not tuple or not 1 <= len(value) <= _MAX_PARAMETERS:
+        raise FederatedUpdateMetadataError("invalid parameter collection")
+    if any(type(parameter) is not FederatedParameterMetadata for parameter in value):
+        raise FederatedUpdateMetadataError("invalid parameter metadata")
+    if len({parameter.name for parameter in value}) != len(value):
+        raise FederatedUpdateMetadataError("duplicate parameter names")
+    return tuple(sorted(value, key=lambda parameter: parameter.name))
+
+
+def _total_elements(
+    parameters: tuple[FederatedParameterMetadata, ...], limit: int
+) -> int:
+    total = 0
+    for parameter in parameters:
+        count = parameter.element_count
+        if count > limit - total:
+            raise FederatedUpdateMetadataError("total element count exceeds limit")
+        total += count
+    return total
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise FederatedUpdateMetadataError("duplicate metadata fields")
+        result[key] = value
+    return result
+
+
+def _parse_integer(value: str) -> int:
+    if len(value.lstrip("-")) > 19:
+        raise FederatedUpdateMetadataError("invalid metadata integer")
+    parsed = int(value)
+    if not -_MAX_ELEMENTS <= parsed <= _MAX_ELEMENTS:
+        raise FederatedUpdateMetadataError("invalid metadata integer")
+    return parsed
+
+
+def _reject_number(value: str) -> None:
+    raise FederatedUpdateMetadataError("non-integer metadata number")
+
+
+__all__ = [
+    "FEDERATED_UPDATE_METADATA_SCHEMA_VERSION",
+    "FederatedParameterMetadata",
+    "FederatedUpdateMetadata",
+    "FederatedUpdateMetadataError",
+    "FederatedUpdatePolicy",
+]

--- a/tests/browser/brand/budgets.json
+++ b/tests/browser/brand/budgets.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "artifact": {
-    "maximum_files": 458,
+    "maximum_files": 459,
     "maximum_total_bytes": 39059456,
     "maximum_unique_payload_bytes": 38535168,
     "maximum_duplicate_payload_bytes": 458752,

--- a/tests/browser/brand/budgets.json
+++ b/tests/browser/brand/budgets.json
@@ -3,7 +3,7 @@
   "artifact": {
     "maximum_files": 459,
     "maximum_total_bytes": 39059456,
-    "maximum_unique_payload_bytes": 38535168,
+    "maximum_unique_payload_bytes": 38687316,
     "maximum_duplicate_payload_bytes": 458752,
     "maximum_source_map_files": 0
   },

--- a/tests/unit/training/test_federated_update_metadata.py
+++ b/tests/unit/training/test_federated_update_metadata.py
@@ -1,0 +1,509 @@
+"""Synthetic, offline contracts for federated update metadata validation."""
+
+from __future__ import annotations
+
+import json
+import traceback
+from dataclasses import FrozenInstanceError, replace
+from itertools import permutations
+
+import pytest
+
+from openmed.training import federated_update_metadata as metadata_module
+from openmed.training.federated_update_metadata import (
+    FEDERATED_UPDATE_METADATA_SCHEMA_VERSION,
+    FederatedParameterMetadata,
+    FederatedUpdateMetadata,
+    FederatedUpdateMetadataError,
+    FederatedUpdatePolicy,
+)
+
+MODEL = "sha256:" + "a" * 64
+UPDATE = "sha256:" + "b" * 64
+
+
+@pytest.fixture
+def policy():
+    return FederatedUpdatePolicy(
+        model_digest=MODEL,
+        parameters=(
+            FederatedParameterMetadata("adapter.lora_A.weight", (2, 3), "float32"),
+            FederatedParameterMetadata("adapter.lora_B.weight", (4, 2), "float32"),
+        ),
+        max_total_elements=14,
+    )
+
+
+@pytest.fixture
+def payload():
+    return {
+        "schema_version": FEDERATED_UPDATE_METADATA_SCHEMA_VERSION,
+        "model_digest": MODEL,
+        "adapter_format": "dense",
+        "parameters": [
+            {"name": "adapter.lora_A.weight", "shape": [2, 3], "dtype": "float32"},
+            {"name": "adapter.lora_B.weight", "shape": [4, 2], "dtype": "float32"},
+        ],
+        "total_elements": 14,
+        "update_digest": UPDATE,
+        "clipped": True,
+    }
+
+
+def test_dense_metadata_round_trips_with_canonical_order(payload, policy):
+    reference = FederatedUpdateMetadata.from_dict(payload, policy=policy)
+    assert reference.total_elements == 14
+    assert [p.element_count for p in reference.parameters] == [6, 8]
+    assert reference.to_dict() == payload
+    for order in permutations(payload["parameters"]):
+        changed = dict(reversed(list(payload.items())))
+        changed["parameters"] = [dict(reversed(list(p.items()))) for p in order]
+        parsed = FederatedUpdateMetadata.from_json(json.dumps(changed), policy=policy)
+        assert parsed == reference
+        assert parsed.to_json() == reference.to_json()
+        assert (
+            FederatedUpdateMetadata.from_json(parsed.to_json(), policy=policy) == parsed
+        )
+    assert reference.to_json().endswith("\n")
+
+
+def test_input_and_serialized_copies_cannot_change_validated_metadata(payload, policy):
+    result = FederatedUpdateMetadata.from_dict(payload, policy=policy)
+    canonical = result.to_json()
+    payload["parameters"][0]["shape"][0] = 99
+    exported = result.to_dict()
+    exported["parameters"][1]["name"] = "forbidden"
+    assert result.to_json() == canonical
+    with pytest.raises(FrozenInstanceError):
+        result.total_elements = 1
+    with pytest.raises(FrozenInstanceError):
+        result.parameters[0].shape = (1,)
+    assert not hasattr(result, "policy")
+
+
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16", "float32", "float64"])
+def test_supported_dtypes_require_matching_policy(payload, dtype):
+    for p in payload["parameters"]:
+        p["dtype"] = dtype
+    policy = FederatedUpdatePolicy(
+        MODEL,
+        tuple(
+            FederatedParameterMetadata(p["name"], tuple(p["shape"]), dtype)
+            for p in payload["parameters"]
+        ),
+    )
+    assert (
+        FederatedUpdateMetadata.from_dict(payload, policy=policy).total_elements == 14
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype", ["int8", "uint8", "bool", "complex64", "fp32", "FLOAT32", "", None, [], 32]
+)
+def test_unsupported_dtypes_are_rejected(payload, policy, dtype):
+    payload["parameters"][0]["dtype"] = dtype
+    with pytest.raises(FederatedUpdateMetadataError, match="dtype"):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+
+
+@pytest.mark.parametrize(
+    "change", ["unknown", "missing", "duplicate", "shape", "dtype"]
+)
+def test_parameter_contract_is_authoritative(payload, policy, change):
+    if change == "unknown":
+        payload["parameters"][0]["name"] = "base_model.weight"
+    elif change == "missing":
+        payload["parameters"].pop()
+        payload["total_elements"] = 6
+    elif change == "duplicate":
+        payload["parameters"][1]["name"] = payload["parameters"][0]["name"]
+    elif change == "shape":
+        # Same element count is insufficient: dimension order must match too.
+        payload["parameters"][0]["shape"] = [3, 2]
+    else:
+        payload["parameters"][0]["dtype"] = "float16"
+    with pytest.raises(FederatedUpdateMetadataError):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [],
+        [0],
+        [-1],
+        [True, 6],
+        [2.0, 3],
+        ["2", 3],
+        [[2], 3],
+        [None],
+        [1] * 9,
+        [1 << 31],
+        "2,3",
+        {"0": 2},
+        (2, 3),
+        None,
+    ],
+)
+def test_shapes_fail_closed(payload, policy, shape):
+    payload["parameters"][0]["shape"] = shape
+    with pytest.raises(FederatedUpdateMetadataError):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+
+
+@pytest.mark.parametrize("total", [13, 15, 0, -1, True, 14.0, "14", None, 1 << 63])
+def test_total_elements_are_exact_integers(payload, policy, total):
+    payload["total_elements"] = total
+    with pytest.raises(FederatedUpdateMetadataError):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+
+
+def test_shape_multiplication_overflow_is_rejected_before_materialization():
+    with pytest.raises(FederatedUpdateMetadataError, match="shape element count"):
+        FederatedParameterMetadata("adapter.weight", ((1 << 31) - 1,) * 3, "float32")
+
+
+def test_sum_overflow_and_policy_budget_are_checked_without_tensors(payload, policy):
+    # Each product fits int64, but the three-parameter sum does not.
+    large = tuple(
+        FederatedParameterMetadata(
+            f"adapter.{i}.weight", ((1 << 31) - 1,) * 2, "float32"
+        )
+        for i in range(3)
+    )
+    with pytest.raises(FederatedUpdateMetadataError, match="total element count"):
+        FederatedUpdatePolicy(MODEL, large, max_total_elements=(1 << 63) - 1)
+    payload["parameters"][0]["shape"] = [3, 3]
+    payload["total_elements"] = 17
+    with pytest.raises(
+        FederatedUpdateMetadataError, match="total element count exceeds"
+    ):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+    with pytest.raises(
+        FederatedUpdateMetadataError, match="total element count exceeds"
+    ):
+        replace(policy, max_total_elements=13)
+
+
+def test_large_valid_counts_remain_exact_beyond_float_precision():
+    parameter = FederatedParameterMetadata(
+        "adapter.weight", ((1 << 27) - 1, (1 << 27) - 1), "float64"
+    )
+    total = ((1 << 27) - 1) ** 2
+    policy = FederatedUpdatePolicy(MODEL, (parameter,), max_total_elements=total)
+    result = FederatedUpdateMetadata(
+        model_digest=MODEL,
+        adapter_format="dense",
+        parameters=(parameter,),
+        total_elements=total,
+        update_digest=UPDATE,
+        clipped=True,
+        policy=policy,
+    )
+    assert total > (1 << 53)
+    assert (
+        FederatedUpdateMetadata.from_json(
+            result.to_json(), policy=policy
+        ).total_elements
+        == total
+    )
+    with pytest.raises(FederatedUpdateMetadataError, match="does not match shapes"):
+        replace(result, total_elements=total - 1, policy=policy)
+
+
+@pytest.mark.parametrize("field", ["model_digest", "update_digest"])
+@pytest.mark.parametrize(
+    "digest",
+    [
+        "a" * 64,
+        "sha256:" + "A" * 64,
+        "sha256:" + "a" * 63,
+        "sha256:" + "a" * 65,
+        "sha256:" + "g" * 64,
+        MODEL + "\n",
+        " " + MODEL,
+        "sha512:" + "a" * 64,
+        "https://example.invalid/model",
+        "",
+        None,
+        [0],
+    ],
+)
+def test_malformed_digests_are_rejected(payload, policy, field, digest):
+    payload[field] = digest
+    with pytest.raises(FederatedUpdateMetadataError, match="digest"):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+
+
+def test_well_formed_model_digest_must_match_coordinator_policy(payload, policy):
+    payload["model_digest"] = UPDATE
+    with pytest.raises(
+        FederatedUpdateMetadataError, match="model digest does not match"
+    ):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+
+
+def test_clipping_is_required_by_default_and_policy_controls_exception(payload, policy):
+    payload["clipped"] = False
+    with pytest.raises(FederatedUpdateMetadataError, match="declare clipping"):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+    optional = replace(policy, require_clipped=False)
+    result = FederatedUpdateMetadata.from_dict(payload, policy=optional)
+    assert result.clipped is False
+    assert result.to_dict()["clipped"] is False
+
+
+@pytest.mark.parametrize("clipped", [1, 0, "true", "false", None, [], {}])
+def test_clipping_status_is_a_strict_boolean(payload, policy, clipped):
+    payload["clipped"] = clipped
+    with pytest.raises(FederatedUpdateMetadataError, match="clipping status"):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("adapter_format", "sparse"),
+        ("adapter_format", "safetensors"),
+        ("adapter_format", None),
+        ("schema_version", "v2"),
+        ("schema_version", 1),
+        ("schema_version", FEDERATED_UPDATE_METADATA_SCHEMA_VERSION + "\n"),
+    ],
+)
+def test_unknown_formats_and_versions_are_rejected(payload, policy, field, value):
+    payload[field] = value
+    with pytest.raises(FederatedUpdateMetadataError):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("tensors", [[1, 2]]),
+        ("values", [1, 2]),
+        ("gradients", [0.1]),
+        ("examples", ["synthetic private marker"]),
+        ("client_id", "synthetic_client"),
+        ("site_name", "synthetic_site"),
+        ("path", "/synthetic/private"),
+        ("endpoint", "https://example.invalid"),
+        ("local_metrics", {"loss": 1}),
+        ("allowed_parameters", []),
+        ("require_clipped", False),
+        ("policy", {}),
+        ("notes", "synthetic private marker"),
+    ],
+)
+@pytest.mark.parametrize("nested", [False, True])
+def test_forbidden_fields_are_rejected_at_every_record_level(
+    payload, policy, field, value, nested
+):
+    target = payload["parameters"][0] if nested else payload
+    target[field] = value
+    for candidate in (payload, json.dumps(payload)):
+        parse = (
+            FederatedUpdateMetadata.from_json
+            if isinstance(candidate, str)
+            else FederatedUpdateMetadata.from_dict
+        )
+        with pytest.raises(FederatedUpdateMetadataError):
+            parse(candidate, policy=policy)
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_every_schema_field_is_required(payload, policy, nested):
+    original = payload["parameters"][0] if nested else payload
+    for field in original:
+        candidate = json.loads(json.dumps(payload))
+        target = candidate["parameters"][0] if nested else candidate
+        del target[field]
+        with pytest.raises(
+            FederatedUpdateMetadataError, match="invalid metadata fields"
+        ):
+            FederatedUpdateMetadata.from_dict(candidate, policy=policy)
+
+
+@pytest.mark.parametrize("location", ["top", "parameter"])
+def test_duplicate_json_keys_are_rejected_even_when_values_agree(
+    payload, policy, location
+):
+    encoded = json.dumps(payload)
+    if location == "top":
+        encoded = encoded.replace('"clipped": true', '"clipped": true, "clipped": true')
+    else:
+        encoded = encoded.replace(
+            '"dtype": "float32"', '"dtype": "float32", "dtype": "float32"', 1
+        )
+    with pytest.raises(FederatedUpdateMetadataError, match="JSON"):
+        FederatedUpdateMetadata.from_json(encoded, policy=policy)
+
+
+@pytest.mark.parametrize(
+    "number", ["NaN", "Infinity", "-Infinity", "14.0", "14e0", "1" * 1000, str(1 << 63)]
+)
+def test_json_rejects_non_integer_and_oversized_number_tokens(payload, policy, number):
+    encoded = json.dumps(payload).replace(
+        '"total_elements": 14', f'"total_elements": {number}'
+    )
+    with pytest.raises(FederatedUpdateMetadataError, match="JSON"):
+        FederatedUpdateMetadata.from_json(encoded, policy=policy)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "{",
+        "null",
+        "[]",
+        "true",
+        "\ud800",
+        b"{}",
+        None,
+        pytest.param(" " * (1024 * 1024 + 1), id="oversized-json"),
+        "[" * 2000 + "]" * 2000,
+    ],
+)
+def test_invalid_or_unbounded_json_fails_with_safe_errors(policy, raw):
+    with pytest.raises(FederatedUpdateMetadataError):
+        FederatedUpdateMetadata.from_json(raw, policy=policy)
+
+
+def test_json_limit_counts_utf8_bytes(policy):
+    encoded = '{"notes":"' + "\u2603" * 350000 + '"}'
+    assert len(encoded) < 1024 * 1024 < len(encoded.encode("utf-8"))
+    with pytest.raises(FederatedUpdateMetadataError, match="JSON"):
+        FederatedUpdateMetadata.from_json(encoded, policy=policy)
+
+
+@pytest.mark.parametrize("parameters", [[], {}, "private", [1, 2], [None], [True]])
+def test_parameter_collection_must_contain_metadata_records(
+    payload, policy, parameters
+):
+    payload["parameters"] = parameters
+    with pytest.raises(FederatedUpdateMetadataError):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "/tmp/private",
+        "C:\\private",
+        "https://example.invalid",
+        "client@example.invalid",
+        "site name",
+        "adapter.weight\n",
+        "",
+        "a" * 257,
+        None,
+    ],
+)
+def test_parameter_names_cannot_contain_paths_or_free_text(name):
+    with pytest.raises(FederatedUpdateMetadataError, match="parameter name"):
+        FederatedParameterMetadata(name, (1,), "float32")
+
+
+def test_parameter_count_limit_is_enforced(payload, policy):
+    parameters = tuple(
+        FederatedParameterMetadata(f"adapter.{i}.weight", (1,), "float16")
+        for i in range(1024)
+    )
+    limit_policy = FederatedUpdatePolicy(MODEL, parameters)
+    result = FederatedUpdateMetadata(
+        model_digest=MODEL,
+        adapter_format="dense",
+        parameters=parameters,
+        total_elements=1024,
+        update_digest=UPDATE,
+        clipped=True,
+        policy=limit_policy,
+    )
+    assert (
+        FederatedUpdateMetadata.from_json(result.to_json(), policy=limit_policy)
+        == result
+    )
+    with pytest.raises(FederatedUpdateMetadataError, match="parameter collection"):
+        replace(
+            limit_policy,
+            parameters=parameters
+            + (FederatedParameterMetadata("extra", (1,), "float16"),),
+        )
+    payload["parameters"] = [payload["parameters"][0]] * 1025
+    with pytest.raises(FederatedUpdateMetadataError, match="parameter collection"):
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("max_total_elements", True),
+        ("max_total_elements", 0),
+        ("max_total_elements", 1 << 63),
+        ("max_total_elements", 14.0),
+        ("require_clipped", 1),
+        ("model_digest", "invalid"),
+        ("adapter_format", "sparse"),
+        ("parameters", ()),
+        ("parameters", []),
+        ("parameters", ({"name": "anything"},)),
+    ],
+)
+def test_policy_direct_construction_validates_all_fields(policy, field, value):
+    with pytest.raises(FederatedUpdateMetadataError):
+        replace(policy, **{field: value})
+    with pytest.raises(FederatedUpdateMetadataError):
+        replace(policy, parameters=(policy.parameters[0], policy.parameters[0]))
+
+
+def test_direct_construction_cannot_bypass_policy_checks(payload, policy):
+    valid = FederatedUpdateMetadata.from_dict(payload, policy=policy)
+    for changes in (
+        {"total_elements": 99},
+        {"clipped": False},
+        {"model_digest": UPDATE},
+        {"schema_version": "bad"},
+        {"parameters": policy.parameters[:1], "total_elements": 6},
+    ):
+        with pytest.raises(FederatedUpdateMetadataError):
+            replace(valid, policy=policy, **changes)
+    with pytest.raises(FederatedUpdateMetadataError, match="policy"):
+        FederatedUpdateMetadata.from_dict(payload, policy=None)
+    with pytest.raises(TypeError):
+        FederatedUpdateMetadata(
+            model_digest=MODEL,
+            adapter_format="dense",
+            parameters=policy.parameters,
+            total_elements=14,
+            update_digest=UPDATE,
+            clipped=True,
+        )
+
+
+def test_errors_never_echo_rejected_identifiers_values_or_parser_excerpts(
+    payload, policy, caplog, capsys
+):
+    marker = "SYNTHETIC_PRIVATE_SENTINEL_3010"
+    for raw in (
+        '{"' + marker + '":',
+        '{"values":["' + marker + '"]}',
+        json.dumps({**payload, "model_digest": marker}),
+    ):
+        with pytest.raises(FederatedUpdateMetadataError) as exc:
+            FederatedUpdateMetadata.from_json(raw, policy=policy)
+        assert marker not in str(exc.value)
+        assert marker not in "".join(
+            traceback.format_exception_only(type(exc.value), exc.value)
+        )
+        assert exc.value.__cause__ is None
+    assert caplog.text == ""
+    assert capsys.readouterr() == ("", "")
+
+
+def test_lazy_training_exports_resolve():
+    import openmed.training as training
+
+    for name in metadata_module.__all__:
+        assert name in training.__all__
+        assert getattr(training, name) is getattr(metadata_module, name)


### PR DESCRIPTION
## Description

Coordinators need to reject malformed or unexpected adapter metadata before aggregation without accepting tensor values or client identifiers. This PR adds an immutable, versioned envelope for dense adapter metadata, validated against independently supplied coordinator expectations.

The policy specifies the expected model digest, complete parameter set, shapes, dtypes, element budget, and clipping requirement. Digest references and clipping status remain declarations; this module does not inspect tensor bytes or verify that clipping occurred.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made

- Added parameter metadata, a coordinator policy, and a versioned update envelope with lazy exports from `openmed.training`.
- Enforced exact shape products and totals, bounded integer arithmetic, parameter uniqueness and allowlists, dtype matching, digest syntax, and required clipping declarations.
- Added strict JSON parsing with duplicate-key rejection, a 1 MiB input limit, canonical output, and fixed validation errors that omit submitted values.
- Rejected extra fields, including tensor arrays, gradients, examples, client IDs, site names, paths, endpoints, and local metrics.
- Added 163 metadata test cases, a documented example, documentation registration, and an Unreleased changelog entry. Oversized-input tests use a short pytest ID for Windows compatibility.

## Testing

- [x] Added tests covering valid and invalid metadata, deterministic round trips, arithmetic limits, policy enforcement, and rejection of identifying fields.
- [x] Affected suites pass: Windows/Python 3.13 reports **311 passed, 2 skipped**; Linux/Python 3.12 reports **313 passed**.
- [ ] The complete test suite passes locally; remaining environment limitations are documented below.

Full-suite results:

| Environment | Passed | Skipped | Failed |
| --- | ---: | ---: | ---: |
| Windows / Python 3.13 | 14,594 | 202 | 30 |
| Linux / Python 3.12 | 14,681 | 136 | 9 |

The Windows failures comprise 28 symlink permission/linking failures, one failing Windows Bash launcher, and one NumPy type-stub compatibility error in the existing scoped mypy check. All 30 exact failing cases passed when rerun on Linux.

The Linux failures comprise seven notebook/JavaScript cases with socket or IPC permission errors and two reference-demo cases requiring a missing SOCKS proxy dependency. These failures do not occur in the new metadata suite. Neither full-suite run is claimed as fully passing.

## Documentation

- [x] Added `docs/training/federated-update-metadata.md` with the schema, coordinator policy, limits, examples, and privacy boundary.
- [x] Registered the page in MkDocs navigation and the publication manifest.
- [x] Added public API docstrings and updated `CHANGELOG.md`.
- [x] The strict MkDocs build passed.

## Code Quality

- [x] Canonical Ruff lint and format checks passed.
- [x] All pre-commit hooks and `git diff --check` passed.
- [x] The new module and existing scoped public modules passed mypy on Linux/Python 3.12.
- [x] Reviewed the change against the issue's acceptance criteria and scope.

## Dependencies

- [x] No new dependencies; the metadata module uses only the Python standard library.

## Checklist

- [x] The branch contains one focused commit with a descriptive message.
- [x] The change is limited to seven implementation, test, documentation, and registration files.

## Related Issues

Closes #3010

Related to #2822, #2824, and #2825. Following the maintainer's guidance, round manifest verification, actual tensor allowlisting, and numerical clipping remain separate scopes. This module performs no training, aggregation, tensor loading, or model-structure inference.

## Screenshots/Examples

The documentation includes a synthetic two-parameter example with shapes `[2, 3]` and `[4, 2]`, an exact total of 14 elements, and a deterministic JSON round trip.