### PR TITLE
feat: add US Core conformance checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added dependency-free US Core 9.0.0 conformance checks for exported
+  Condition, laboratory Observation, MedicationRequest, and
+  AllergyIntolerance resources, including base-R4-first validation,
+  must-support warnings, required-binding errors, canonical profile resolution,
+  and compact CC0 constraint metadata (#2366).
 - Added a versioned federated update metadata envelope with coordinator-owned
   parameter expectations, bounded exact shape arithmetic, deterministic JSON,
   clipping declarations, and value-free rejection of unknown or identifying

--- a/docs/fhir-interop.md
+++ b/docs/fhir-interop.md
@@ -191,12 +191,54 @@ Results also expose `.issues`, so `from_validation_result(result)` can render a
 standard R4 `OperationOutcome`.
 
 The bundled subset covers the resources OpenMed emits: `Condition`,
-`Observation`, `MedicationStatement`, `Procedure`, `DiagnosticReport`,
-`AllergyIntolerance`, `Immunization`, and `Encounter`. A different resource type
-produces a `not-supported` warning rather than a false conformance claim. The
-constraint table contains only OpenMed's compact derivation of CC0-licensed base
-R4 structure and fixed code-system metadata; it does not include clinical
-terminology content, proprietary profiles, or implementation-guide packages.
+`Observation`, `MedicationRequest`, `MedicationStatement`, `Procedure`,
+`DiagnosticReport`, `AllergyIntolerance`, `Immunization`, and `Encounter`. A
+different resource type produces a `not-supported` warning rather than a false
+conformance claim. The constraint table contains only OpenMed's compact
+derivation of CC0-licensed base R4 structure and fixed code-system metadata; it
+does not include clinical terminology content, proprietary profiles, or
+implementation-guide packages.
+
+## US Core STU9 Conformance
+
+Use `check_us_core()` for the bundled US Core 9.0.0 subset covering exported
+`Condition`, laboratory `Observation`, `MedicationRequest`, and
+`AllergyIntolerance` resources. It always runs base R4 validation first, reports
+missing must-support elements as warnings, and reports required cardinality or
+locally enumerable binding violations as errors:
+
+```python
+from openmed.clinical.exporters.fhir import check_us_core
+
+result = check_us_core(
+    {
+        "resourceType": "Condition",
+        "category": [
+            {
+                "coding": [
+                    {
+                        "system": (
+                            "http://terminology.hl7.org/CodeSystem/condition-category"
+                        ),
+                        "code": "problem-list-item",
+                    }
+                ]
+            }
+        ],
+        "code": {"text": "synthetic condition"},
+        "subject": {"reference": "Patient/synthetic"},
+    }
+)
+assert result.is_valid
+```
+
+Pass a supported canonical URL or StructureDefinition id as `profile` to select
+the encounter-diagnosis `Condition` profile or override the resource default.
+The checker resolves supported `meta.profile` declarations as well. Its compact
+constraint table is OpenMed-authored from the
+[US Core STU9 definitions](https://hl7.org/fhir/us/core/STU9/) and does not
+bundle clinical terminology expansions. Use the full HL7 validator or the
+receiving server for complete invariants and terminology validation.
 
 This base validator is intentionally distinct from `check_bundle()`. The latter
 loads caller-supplied `StructureDefinition` and `ValueSet` resources to check

--- a/docs/guides/fhir-omop-interoperability.md
+++ b/docs/guides/fhir-omop-interoperability.md
@@ -82,22 +82,29 @@ packages, or call remote terminology servers.
 
 ## Check US Core locally
 
-Download the US Core package through your normal FHIR package workflow and
-keep it outside the repository. Add the appropriate US Core canonical URL to
-each exported resource's `meta.profile`, populate every required US Core field,
-then run the same checker:
+For OpenMed's four supported export profiles, use the bundled US Core 9.0.0
+subset directly. It runs base R4 validation first and requires no package
+download:
 
 ```python
-from openmed.clinical.exporters.fhir import check_bundle
+from openmed.clinical.exporters.fhir import check_us_core
 
-us_core_outcome = check_bundle(
-    bundle,
-    "/opt/fhir/packages/hl7.fhir.us.core",
-)
+results = [check_us_core(entry["resource"]) for entry in bundle["entry"]]
+errors = [finding for result in results for finding in result.errors]
 ```
 
-Use the US Core version required by the receiving system. A base-R4-valid
-resource is not automatically US Core conformant. See
+The compact checker covers US Core Condition problems/health concerns and
+encounter diagnoses, laboratory Observation, MedicationRequest, and
+AllergyIntolerance. Missing must-support fields produce warnings; required
+cardinality and bundled administrative binding violations produce errors. It
+does not bundle or claim validation of external clinical terminology value
+sets.
+
+For another US Core version or profile, download the implementation-guide
+package through your normal FHIR package workflow, keep it outside the
+repository, declare its canonical URL in `meta.profile`, and use
+`check_bundle()`. A base-R4-valid resource is not automatically US Core
+conformant. See
 [WHO SMART Guidelines Profile Checks](../fhir-smart-guidelines.md) for package
 layout, supported constraints, post-de-identification comparison, and safe
 `OperationOutcome` handling.

--- a/openmed/clinical/exporters/fhir/__init__.py
+++ b/openmed/clinical/exporters/fhir/__init__.py
@@ -62,6 +62,7 @@ from .privacy import (
 from .profile_check import check_bundle
 from .provenance import to_audit_event, to_provenance
 from .references import deterministic_fullurl
+from .uscore import US_CORE_VERSION, ConformanceResult, check_us_core
 from .validate import (
     BASE_R4_RESOURCE_TYPES,
     ValidationFinding,
@@ -123,4 +124,7 @@ __all__ = [
     "ValidationResult",
     "validate_bundle",
     "validate_resource",
+    "ConformanceResult",
+    "US_CORE_VERSION",
+    "check_us_core",
 ]

--- a/openmed/clinical/exporters/fhir/definitions/r4_base.json
+++ b/openmed/clinical/exporters/fhir/definitions/r4_base.json
@@ -85,6 +85,42 @@
         {"path": "component.referenceRange", "min": 0, "max": "*", "types": ["BackboneElement"]}
       ]
     },
+    "MedicationRequest": {
+      "elements": [
+        {"path": "identifier", "min": 0, "max": "*", "types": ["Identifier"]},
+        {"path": "status", "min": 1, "max": 1, "types": ["code"], "binding": "medication-request-status"},
+        {"path": "statusReason", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "intent", "min": 1, "max": 1, "types": ["code"], "binding": "medication-request-intent"},
+        {"path": "category", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "priority", "min": 0, "max": 1, "types": ["code"], "binding": "request-priority"},
+        {"path": "doNotPerform", "min": 0, "max": 1, "types": ["boolean"]},
+        {"path": "reported[x]", "min": 0, "max": 1, "types": ["boolean", "Reference"]},
+        {"path": "medication[x]", "min": 1, "max": 1, "types": ["CodeableConcept", "Reference"]},
+        {"path": "subject", "min": 1, "max": 1, "types": ["Reference"]},
+        {"path": "encounter", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "supportingInformation", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "authoredOn", "min": 0, "max": 1, "types": ["dateTime"]},
+        {"path": "requester", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "performer", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "performerType", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "recorder", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "reasonCode", "min": 0, "max": "*", "types": ["CodeableConcept"]},
+        {"path": "reasonReference", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "instantiatesCanonical", "min": 0, "max": "*", "types": ["canonical"]},
+        {"path": "instantiatesUri", "min": 0, "max": "*", "types": ["uri"]},
+        {"path": "basedOn", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "groupIdentifier", "min": 0, "max": 1, "types": ["Identifier"]},
+        {"path": "courseOfTherapyType", "min": 0, "max": 1, "types": ["CodeableConcept"]},
+        {"path": "insurance", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "note", "min": 0, "max": "*", "types": ["Annotation"]},
+        {"path": "dosageInstruction", "min": 0, "max": "*", "types": ["Dosage"]},
+        {"path": "dispenseRequest", "min": 0, "max": 1, "types": ["BackboneElement"]},
+        {"path": "substitution", "min": 0, "max": 1, "types": ["BackboneElement"]},
+        {"path": "priorPrescription", "min": 0, "max": 1, "types": ["Reference"]},
+        {"path": "detectedIssue", "min": 0, "max": "*", "types": ["Reference"]},
+        {"path": "eventHistory", "min": 0, "max": "*", "types": ["Reference"]}
+      ]
+    },
     "MedicationStatement": {
       "elements": [
         {"path": "identifier", "min": 0, "max": "*", "types": ["Identifier"]},
@@ -252,6 +288,15 @@
     "observation-status": {
       "system": "http://hl7.org/fhir/observation-status",
       "codes": ["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"]
+    },
+    "medication-request-status": {
+      "codes": ["active", "on-hold", "cancelled", "completed", "entered-in-error", "stopped", "draft", "unknown"]
+    },
+    "medication-request-intent": {
+      "codes": ["proposal", "plan", "order", "original-order", "reflex-order", "filler-order", "instance-order", "option"]
+    },
+    "request-priority": {
+      "codes": ["routine", "urgent", "asap", "stat"]
     },
     "medication-statement-status": {
       "codes": ["active", "completed", "entered-in-error", "intended", "stopped", "on-hold", "unknown", "not-taken"]

--- a/openmed/clinical/exporters/fhir/definitions/us_core_constraints.json
+++ b/openmed/clinical/exporters/fhir/definitions/us_core_constraints.json
@@ -1,0 +1,399 @@
+{
+  "schemaVersion": 1,
+  "fhirVersion": "4.0.1",
+  "usCoreVersion": "9.0.0",
+  "license": "CC0-1.0",
+  "source": "https://hl7.org/fhir/us/core/STU9/",
+  "description": "OpenMed-authored compact constraints for selected US Core STU9 profiles; no clinical terminology expansions or implementation-guide content.",
+  "defaults": {
+    "AllergyIntolerance": "us-core-allergyintolerance",
+    "Condition": "us-core-condition-problems-health-concerns",
+    "MedicationRequest": "us-core-medicationrequest",
+    "Observation": "us-core-observation-lab"
+  },
+  "bindings": {
+    "allergy-code": {
+      "external": true,
+      "strength": "extensible",
+      "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1267.43"
+    },
+    "allergy-manifestation": {
+      "external": true,
+      "strength": "extensible",
+      "url": "http://hl7.org/fhir/ValueSet/clinical-findings"
+    },
+    "condition-code": {
+      "external": true,
+      "strength": "extensible",
+      "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code"
+    },
+    "condition-encounter-category": {
+      "systems": {
+        "http://terminology.hl7.org/CodeSystem/condition-category": [
+          "encounter-diagnosis"
+        ]
+      }
+    },
+    "condition-problem-category": {
+      "systems": {
+        "http://hl7.org/fhir/us/core/CodeSystem/condition-category": [
+          "health-concern"
+        ],
+        "http://terminology.hl7.org/CodeSystem/condition-category": [
+          "problem-list-item"
+        ]
+      }
+    },
+    "medication-request-category": {
+      "systems": {
+        "http://terminology.hl7.org/CodeSystem/medicationrequest-category": [
+          "community",
+          "discharge",
+          "inpatient",
+          "outpatient"
+        ]
+      }
+    },
+    "medication-request-medication": {
+      "external": true,
+      "strength": "extensible",
+      "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4"
+    },
+    "medication-request-route": {
+      "external": true,
+      "strength": "extensible",
+      "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1267.22"
+    },
+    "observation-interpretation": {
+      "external": true,
+      "strength": "extensible",
+      "url": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+    },
+    "observation-laboratory-code": {
+      "external": true,
+      "strength": "extensible",
+      "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-laboratory-test-codes"
+    },
+    "observation-laboratory-category": {
+      "systems": {
+        "http://terminology.hl7.org/CodeSystem/observation-category": [
+          "laboratory"
+        ]
+      }
+    },
+    "reaction-severity": {
+      "systems": {
+        "http://hl7.org/fhir/reaction-event-severity": [
+          "mild",
+          "moderate",
+          "severe"
+        ]
+      }
+    }
+  },
+  "profiles": [
+    {
+      "id": "us-core-condition-problems-health-concerns",
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns",
+      "resourceType": "Condition",
+      "elements": [
+        {
+          "path": "meta",
+          "mustSupport": true
+        },
+        {
+          "path": "meta.lastUpdated",
+          "mustSupport": true
+        },
+        {
+          "path": "extension",
+          "location": "extension[assertedDate]",
+          "mustSupport": true,
+          "selector": {
+            "url": "http://hl7.org/fhir/StructureDefinition/condition-assertedDate"
+          }
+        },
+        {
+          "path": "clinicalStatus",
+          "mustSupport": true
+        },
+        {
+          "path": "verificationStatus",
+          "mustSupport": true
+        },
+        {
+          "path": "category",
+          "location": "category[us-core]",
+          "min": 1,
+          "mustSupport": true,
+          "selector": {
+            "binding": "condition-problem-category"
+          }
+        },
+        {
+          "path": "code",
+          "min": 1,
+          "mustSupport": true,
+          "externalBinding": "condition-code"
+        },
+        {
+          "path": "subject",
+          "min": 1,
+          "mustSupport": true
+        },
+        {
+          "path": "onset[x]",
+          "mustSupport": true
+        },
+        {
+          "path": "abatement[x]",
+          "mustSupport": true
+        },
+        {
+          "path": "recordedDate",
+          "mustSupport": true
+        }
+      ]
+    },
+    {
+      "id": "us-core-condition-encounter-diagnosis",
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis",
+      "resourceType": "Condition",
+      "elements": [
+        {
+          "path": "category",
+          "location": "category[us-core]",
+          "min": 1,
+          "max": 1,
+          "mustSupport": true,
+          "selector": {
+            "binding": "condition-encounter-category"
+          }
+        },
+        {
+          "path": "code",
+          "min": 1,
+          "mustSupport": true,
+          "externalBinding": "condition-code"
+        },
+        {
+          "path": "subject",
+          "min": 1,
+          "mustSupport": true
+        },
+        {
+          "path": "encounter",
+          "mustSupport": true
+        },
+        {
+          "path": "recordedDate",
+          "mustSupport": true
+        }
+      ]
+    },
+    {
+      "id": "us-core-observation-lab",
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
+      "resourceType": "Observation",
+      "elements": [
+        {
+          "path": "meta",
+          "mustSupport": true
+        },
+        {
+          "path": "meta.lastUpdated",
+          "mustSupport": true
+        },
+        {
+          "path": "status",
+          "min": 1,
+          "mustSupport": true
+        },
+        {
+          "path": "category",
+          "location": "category[us-core]",
+          "min": 1,
+          "max": 1,
+          "mustSupport": true,
+          "selector": {
+            "binding": "observation-laboratory-category"
+          }
+        },
+        {
+          "path": "code",
+          "min": 1,
+          "mustSupport": true,
+          "externalBinding": "observation-laboratory-code"
+        },
+        {
+          "path": "subject",
+          "min": 1,
+          "mustSupport": true
+        },
+        {
+          "path": "encounter",
+          "mustSupport": true
+        },
+        {
+          "path": "effective[x]",
+          "mustSupport": true
+        },
+        {
+          "path": "performer",
+          "mustSupport": true
+        },
+        {
+          "path": "interpretation",
+          "mustSupport": true,
+          "externalBinding": "observation-interpretation"
+        },
+        {
+          "path": "specimen",
+          "mustSupport": true
+        },
+        {
+          "path": "referenceRange",
+          "mustSupport": true
+        }
+      ],
+      "mustSupportAnyOf": [
+        {
+          "paths": [
+            "value[x]",
+            "dataAbsentReason"
+          ],
+          "location": "value[x]|dataAbsentReason"
+        }
+      ]
+    },
+    {
+      "id": "us-core-medicationrequest",
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest",
+      "resourceType": "MedicationRequest",
+      "elements": [
+        {
+          "path": "status",
+          "min": 1,
+          "mustSupport": true
+        },
+        {
+          "path": "intent",
+          "min": 1,
+          "mustSupport": true
+        },
+        {
+          "path": "category",
+          "location": "category[us-core]",
+          "mustSupport": true,
+          "selector": {
+            "binding": "medication-request-category"
+          }
+        },
+        {
+          "path": "reported[x]",
+          "mustSupport": true
+        },
+        {
+          "path": "medication[x]",
+          "min": 1,
+          "mustSupport": true,
+          "externalBinding": "medication-request-medication"
+        },
+        {
+          "path": "subject",
+          "min": 1,
+          "mustSupport": true
+        },
+        {
+          "path": "encounter",
+          "mustSupport": true
+        },
+        {
+          "path": "authoredOn",
+          "mustSupport": true
+        },
+        {
+          "path": "requester",
+          "mustSupport": true
+        },
+        {
+          "path": "dosageInstruction",
+          "mustSupport": true
+        },
+        {
+          "path": "dosageInstruction.text",
+          "mustSupport": true
+        },
+        {
+          "path": "dosageInstruction.timing",
+          "mustSupport": true
+        },
+        {
+          "path": "dosageInstruction.route",
+          "mustSupport": true,
+          "externalBinding": "medication-request-route"
+        },
+        {
+          "path": "dosageInstruction.doseAndRate",
+          "mustSupport": true
+        },
+        {
+          "path": "dosageInstruction.doseAndRate.dose[x]",
+          "mustSupport": true
+        },
+        {
+          "path": "dispenseRequest",
+          "mustSupport": true
+        },
+        {
+          "path": "dispenseRequest.numberOfRepeatsAllowed",
+          "mustSupport": true
+        },
+        {
+          "path": "dispenseRequest.quantity",
+          "mustSupport": true
+        }
+      ]
+    },
+    {
+      "id": "us-core-allergyintolerance",
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance",
+      "resourceType": "AllergyIntolerance",
+      "elements": [
+        {
+          "path": "clinicalStatus",
+          "mustSupport": true
+        },
+        {
+          "path": "verificationStatus",
+          "mustSupport": true
+        },
+        {
+          "path": "code",
+          "min": 1,
+          "mustSupport": true,
+          "externalBinding": "allergy-code"
+        },
+        {
+          "path": "patient",
+          "min": 1,
+          "mustSupport": true
+        },
+        {
+          "path": "reaction",
+          "mustSupport": true
+        },
+        {
+          "path": "reaction.manifestation",
+          "min": 1,
+          "mustSupport": true,
+          "externalBinding": "allergy-manifestation"
+        },
+        {
+          "path": "reaction.severity",
+          "binding": "reaction-severity"
+        }
+      ]
+    }
+  ]
+}

--- a/openmed/clinical/exporters/fhir/uscore.py
+++ b/openmed/clinical/exporters/fhir/uscore.py
@@ -1,0 +1,368 @@
+"""Offline US Core STU9 checks for selected OpenMed FHIR R4 exports.
+
+The checker intentionally implements a compact, OpenMed-authored subset of US
+Core 9.0.0. It validates the four resource profiles used by OpenMed exports,
+runs the bundled base-R4 validator first, and never downloads implementation
+guide or terminology content. Findings contain only fixed messages and element
+paths so clinical values are not copied into logs or audit artifacts.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+from ._validation_primitives import _extract_codes, _occurrence_groups
+from .validate import ValidationFinding, validate_resource
+
+__all__ = ["ConformanceResult", "US_CORE_VERSION", "check_us_core"]
+
+US_CORE_VERSION = "9.0.0"
+
+
+@dataclass(frozen=True)
+class ConformanceResult:
+    """Immutable findings from base R4 and US Core profile checks.
+
+    Attributes:
+        profile: Resolved US Core canonical URL, when a profile was selected.
+        resource_type: FHIR resource type reported by the input, when valid.
+        errors: Findings that prevent a conformance claim.
+        warnings: Advisory findings, including absent must-support elements.
+    """
+
+    profile: str | None
+    resource_type: str | None
+    errors: tuple[ValidationFinding, ...] = ()
+    warnings: tuple[ValidationFinding, ...] = ()
+
+    @property
+    def findings(self) -> tuple[ValidationFinding, ...]:
+        """Return every finding, with errors before warnings."""
+
+        return self.errors + self.warnings
+
+    @property
+    def issues(self) -> tuple[ValidationFinding, ...]:
+        """Return findings for the shared OperationOutcome adapter."""
+
+        return self.findings
+
+    @property
+    def is_valid(self) -> bool:
+        """Return ``True`` when neither validation layer found an error."""
+
+        return not self.errors
+
+    @property
+    def valid(self) -> bool:
+        """Alias for :attr:`is_valid`."""
+
+        return self.is_valid
+
+
+def check_us_core(
+    resource: Mapping[str, Any],
+    profile: str | None = None,
+) -> ConformanceResult:
+    """Check one resource against base R4 and a bundled US Core profile subset.
+
+    Supported profiles cover Condition problems/health concerns, Condition
+    encounter diagnoses, laboratory Observation, MedicationRequest, and
+    AllergyIntolerance. A profile can be supplied as its canonical URL, a
+    versioned canonical (``url|9.0.0``), or its StructureDefinition id. When it
+    is omitted, a supported canonical in ``meta.profile`` takes precedence,
+    followed by the resource type's default profile.
+
+    Args:
+        resource: FHIR R4 resource mapping. Malformed resources are returned as
+            structured findings rather than raising.
+        profile: Optional US Core profile canonical URL or id.
+
+    Returns:
+        A :class:`ConformanceResult` containing sanitized base and profile
+        findings. No network access is performed.
+    """
+
+    base_result = validate_resource(resource)
+    resource_type = _resource_type(resource)
+    selected, selection_finding = _select_profile(resource, resource_type, profile)
+
+    findings = list(base_result.findings)
+    if selection_finding is not None:
+        findings.append(selection_finding)
+    elif selected is not None:
+        findings.extend(_check_profile(resource, selected))
+
+    unique = _deduplicate(findings)
+    return ConformanceResult(
+        profile=selected["url"] if selected is not None else None,
+        resource_type=resource_type,
+        errors=tuple(item for item in unique if item.severity == "error"),
+        warnings=tuple(item for item in unique if item.severity == "warning"),
+    )
+
+
+def _resource_type(resource: Any) -> str | None:
+    if not isinstance(resource, Mapping):
+        return None
+    resource_type = resource.get("resourceType")
+    return resource_type if isinstance(resource_type, str) and resource_type else None
+
+
+def _select_profile(
+    resource: Any,
+    resource_type: str | None,
+    requested: str | None,
+) -> tuple[Mapping[str, Any] | None, ValidationFinding | None]:
+    if resource_type is None:
+        return None, None
+
+    candidate = (
+        requested
+        or _declared_profile(resource)
+        or _definitions()["defaults"].get(resource_type)
+    )
+    root = resource_type
+    if candidate is None:
+        return None, _warning(
+            f"{root}.resourceType",
+            "Resource type has no bundled US Core profile subset.",
+            "not-supported",
+        )
+
+    canonical, version = _split_version(candidate)
+    if version is not None and version != US_CORE_VERSION:
+        return None, _error(
+            f"{root}.meta.profile",
+            "US Core profile version is not supported by the bundled subset.",
+            "not-supported",
+        )
+
+    selected = _profile_aliases().get(_normalise_canonical(canonical))
+    if selected is None:
+        return None, _error(
+            f"{root}.meta.profile",
+            "US Core profile is not supported by the bundled subset.",
+            "not-supported",
+        )
+    if selected["resourceType"] != resource_type:
+        return None, _error(
+            f"{root}.meta.profile",
+            "US Core profile does not match the resource type.",
+            "value",
+        )
+    return selected, None
+
+
+def _declared_profile(resource: Any) -> str | None:
+    if not isinstance(resource, Mapping):
+        return None
+    meta = resource.get("meta")
+    if not isinstance(meta, Mapping):
+        return None
+    declared = meta.get("profile")
+    if not isinstance(declared, Sequence) or isinstance(declared, (str, bytes)):
+        return None
+    for item in declared:
+        if not isinstance(item, str):
+            continue
+        canonical, _ = _split_version(item)
+        if _normalise_canonical(canonical) in _profile_aliases():
+            return item
+    return None
+
+
+def _split_version(candidate: str) -> tuple[str, str | None]:
+    canonical, separator, version = candidate.strip().partition("|")
+    return canonical.rstrip("/"), version if separator else None
+
+
+def _normalise_canonical(candidate: str) -> str:
+    normalised = candidate.strip().rstrip("/")
+    for prefix in ("https://hl7.org/", "https://www.hl7.org/", "http://www.hl7.org/"):
+        if normalised.startswith(prefix):
+            return "http://hl7.org/" + normalised[len(prefix) :]
+    return normalised
+
+
+@lru_cache(maxsize=1)
+def _profile_aliases() -> Mapping[str, Mapping[str, Any]]:
+    aliases: dict[str, Mapping[str, Any]] = {}
+    for profile in _definitions()["profiles"]:
+        aliases[_normalise_canonical(profile["url"])] = profile
+        aliases[profile["id"]] = profile
+        aliases[f"StructureDefinition/{profile['id']}"] = profile
+    return aliases
+
+
+def _check_profile(
+    resource: Mapping[str, Any],
+    profile: Mapping[str, Any],
+) -> list[ValidationFinding]:
+    root = profile["resourceType"]
+    findings: list[ValidationFinding] = []
+    for element in profile["elements"]:
+        findings.extend(_check_element(resource, root, element))
+    for group in profile.get("mustSupportAnyOf", ()):
+        findings.extend(_check_must_support_group(resource, root, group))
+    return findings
+
+
+def _check_element(
+    resource: Mapping[str, Any],
+    root: str,
+    element: Mapping[str, Any],
+) -> list[ValidationFinding]:
+    path = element["path"]
+    groups = _occurrence_groups(resource, path.split("."), root)
+    location = f"{root}.{element.get('location', path.replace('[x]', ''))}"
+    findings: list[ValidationFinding] = []
+
+    # A nested must-support child is only actionable when its parent exists.
+    if not groups:
+        return findings
+
+    for group in groups:
+        occurrences = tuple(group.occurrences)
+        selector = element.get("selector")
+        if selector is not None:
+            matching = tuple(
+                occurrence
+                for occurrence in occurrences
+                if _matches_selector(occurrence.value, selector)
+            )
+        else:
+            matching = occurrences
+
+        minimum = int(element.get("min", 0))
+        maximum_value = element.get("max", "*")
+        maximum = None if maximum_value == "*" else int(maximum_value)
+
+        if len(matching) < minimum:
+            code = (
+                "code-invalid" if occurrences and selector is not None else "required"
+            )
+            message = (
+                "Element does not satisfy the required US Core binding."
+                if code == "code-invalid"
+                else "Required US Core profile element is missing or empty."
+            )
+            findings.append(_error(location, message, code))
+        if maximum is not None and len(matching) > maximum:
+            findings.append(
+                _error(
+                    location,
+                    "Maximum US Core profile element cardinality is exceeded.",
+                    "structure",
+                )
+            )
+
+        binding_name = element.get("binding")
+        if binding_name is not None and selector is None:
+            binding = _definitions()["bindings"][binding_name]
+            for occurrence in occurrences:
+                if not _matches_binding(occurrence.value, binding):
+                    findings.append(
+                        _error(
+                            occurrence.expression,
+                            "Element does not satisfy the required US Core binding.",
+                            "code-invalid",
+                        )
+                    )
+
+        if (
+            element.get("mustSupport")
+            and not matching
+            and not any(
+                item.severity == "error" and item.location == location
+                for item in findings
+            )
+        ):
+            findings.append(
+                _warning(
+                    location,
+                    "US Core must-support element is absent.",
+                    "incomplete",
+                )
+            )
+    return findings
+
+
+def _check_must_support_group(
+    resource: Mapping[str, Any],
+    root: str,
+    group: Mapping[str, Any],
+) -> list[ValidationFinding]:
+    for path in group["paths"]:
+        groups = _occurrence_groups(resource, path.split("."), root)
+        if any(item.occurrences for item in groups):
+            return []
+    return [
+        _warning(
+            f"{root}.{group['location']}",
+            "US Core must-support choice is absent.",
+            "incomplete",
+        )
+    ]
+
+
+def _matches_selector(value: Any, selector: Mapping[str, Any]) -> bool:
+    expected_url = selector.get("url")
+    if expected_url is not None:
+        return isinstance(value, Mapping) and value.get("url") == expected_url
+    binding_name = selector.get("binding")
+    if binding_name is not None:
+        return _matches_binding(value, _definitions()["bindings"][binding_name])
+    return False
+
+
+def _matches_binding(value: Any, binding: Mapping[str, Any]) -> bool:
+    systems = binding["systems"]
+    for system, code in _extract_codes(value):
+        if not system and isinstance(value, str):
+            return any(code in allowed for allowed in systems.values())
+        allowed = systems.get(system)
+        if allowed is not None and code in allowed:
+            return True
+    return False
+
+
+def _deduplicate(findings: Sequence[ValidationFinding]) -> list[ValidationFinding]:
+    unique: list[ValidationFinding] = []
+    seen: set[tuple[str, str, str]] = set()
+    for finding in findings:
+        key = (finding.severity, finding.code, finding.location)
+        if key not in seen:
+            unique.append(finding)
+            seen.add(key)
+    return unique
+
+
+def _error(location: str, message: str, code: str) -> ValidationFinding:
+    return ValidationFinding("error", location, message, code)
+
+
+def _warning(location: str, message: str, code: str) -> ValidationFinding:
+    return ValidationFinding("warning", location, message, code)
+
+
+@lru_cache(maxsize=1)
+def _definitions() -> Mapping[str, Any]:
+    definition_path = (
+        resources.files(__package__)
+        .joinpath("definitions")
+        .joinpath("us_core_constraints.json")
+    )
+    payload = json.loads(definition_path.read_text(encoding="utf-8"))
+    if (
+        payload.get("schemaVersion") != 1
+        or payload.get("fhirVersion") != "4.0.1"
+        or payload.get("usCoreVersion") != US_CORE_VERSION
+    ):
+        raise RuntimeError("bundled US Core constraint table is incompatible")
+    return payload

--- a/openmed/clinical/exporters/fhir/validate.py
+++ b/openmed/clinical/exporters/fhir/validate.py
@@ -41,6 +41,7 @@ BASE_R4_RESOURCE_TYPES = frozenset(
         "DiagnosticReport",
         "Encounter",
         "Immunization",
+        "MedicationRequest",
         "MedicationStatement",
         "Observation",
         "Procedure",
@@ -112,10 +113,11 @@ class ValidationResult:
 def validate_resource(resource: Mapping[str, Any]) -> ValidationResult:
     """Validate one resource against OpenMed's bundled FHIR R4 base subset.
 
-    Supported resource types are Condition, Observation, MedicationStatement,
-    Procedure, DiagnosticReport, AllergyIntolerance, Immunization, and
-    Encounter. Other resource types produce a warning because no claim of base
-    conformance can be made for a type outside the bundled subset.
+    Supported resource types are Condition, Observation, MedicationRequest,
+    MedicationStatement, Procedure, DiagnosticReport, AllergyIntolerance,
+    Immunization, and Encounter. Other resource types produce a warning because
+    no claim of base conformance can be made for a type outside the bundled
+    subset.
 
     Args:
         resource: Resource-like input. Non-mappings and malformed mappings are

--- a/tests/unit/clinical/test_fhir_uscore.py
+++ b/tests/unit/clinical/test_fhir_uscore.py
@@ -1,0 +1,308 @@
+"""Tests for the dependency-free US Core STU9 conformance subset."""
+
+from __future__ import annotations
+
+import json
+import socket
+from importlib import resources
+from typing import Any
+
+from openmed.clinical.exporters.fhir import (
+    US_CORE_VERSION,
+    ConformanceResult,
+    check_us_core,
+    from_validation_result,
+)
+
+CONDITION_PROFILE = (
+    "http://hl7.org/fhir/us/core/StructureDefinition/"
+    "us-core-condition-problems-health-concerns"
+)
+
+
+def _coding(system: str, code: str) -> dict[str, Any]:
+    return {"coding": [{"system": system, "code": code}]}
+
+
+def _condition(**updates: Any) -> dict[str, Any]:
+    resource: dict[str, Any] = {
+        "resourceType": "Condition",
+        "meta": {"lastUpdated": "2026-09-07T08:00:00Z"},
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/condition-assertedDate",
+                "valueDateTime": "2026-09-01",
+            }
+        ],
+        "clinicalStatus": _coding(
+            "http://terminology.hl7.org/CodeSystem/condition-clinical", "active"
+        ),
+        "verificationStatus": _coding(
+            "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+            "confirmed",
+        ),
+        "category": [
+            _coding(
+                "http://terminology.hl7.org/CodeSystem/condition-category",
+                "problem-list-item",
+            )
+        ],
+        "code": {"text": "synthetic condition"},
+        "subject": {"reference": "Patient/synthetic"},
+        "onsetDateTime": "2026-08-01",
+        "abatementDateTime": "2026-08-02",
+        "recordedDate": "2026-08-03",
+    }
+    resource.update(updates)
+    return resource
+
+
+def _observation(**updates: Any) -> dict[str, Any]:
+    resource: dict[str, Any] = {
+        "resourceType": "Observation",
+        "meta": {"lastUpdated": "2026-09-07T08:00:00Z"},
+        "status": "final",
+        "category": [
+            _coding(
+                "http://terminology.hl7.org/CodeSystem/observation-category",
+                "laboratory",
+            )
+        ],
+        "code": {"text": "synthetic laboratory test"},
+        "subject": {"reference": "Patient/synthetic"},
+        "encounter": {"reference": "Encounter/synthetic"},
+        "effectiveDateTime": "2026-09-01",
+        "performer": [{"reference": "Practitioner/synthetic"}],
+        "valueQuantity": {"value": 7.2, "unit": "synthetic"},
+        "interpretation": [{"text": "synthetic interpretation"}],
+        "specimen": {"reference": "Specimen/synthetic"},
+        "referenceRange": [{"text": "synthetic range"}],
+    }
+    resource.update(updates)
+    return resource
+
+
+def _medication_request(**updates: Any) -> dict[str, Any]:
+    resource: dict[str, Any] = {
+        "resourceType": "MedicationRequest",
+        "status": "active",
+        "intent": "order",
+        "category": [
+            _coding(
+                "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "outpatient",
+            )
+        ],
+        "reportedBoolean": False,
+        "medicationCodeableConcept": {"text": "synthetic medication"},
+        "subject": {"reference": "Patient/synthetic"},
+        "encounter": {"reference": "Encounter/synthetic"},
+        "authoredOn": "2026-09-01",
+        "requester": {"reference": "Practitioner/synthetic"},
+        "dosageInstruction": [
+            {
+                "text": "synthetic dosage",
+                "timing": {"code": {"text": "synthetic schedule"}},
+                "route": {"text": "synthetic route"},
+                "doseAndRate": [{"doseQuantity": {"value": 1}}],
+            }
+        ],
+        "dispenseRequest": {
+            "numberOfRepeatsAllowed": 1,
+            "quantity": {"value": 30},
+        },
+    }
+    resource.update(updates)
+    return resource
+
+
+def _allergy(**updates: Any) -> dict[str, Any]:
+    resource: dict[str, Any] = {
+        "resourceType": "AllergyIntolerance",
+        "clinicalStatus": _coding(
+            "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+            "active",
+        ),
+        "verificationStatus": _coding(
+            "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+            "confirmed",
+        ),
+        "code": {"text": "synthetic allergy"},
+        "patient": {"reference": "Patient/synthetic"},
+        "reaction": [
+            {
+                "manifestation": [{"text": "synthetic manifestation"}],
+                "severity": "mild",
+            }
+        ],
+    }
+    resource.update(updates)
+    return resource
+
+
+def test_absent_must_support_element_is_a_sanitized_warning() -> None:
+    resource = _condition()
+    resource.pop("clinicalStatus")
+
+    result = check_us_core(resource)
+
+    assert isinstance(result, ConformanceResult)
+    assert result.is_valid
+    assert any(
+        item.code == "incomplete" and item.location == "Condition.clinicalStatus"
+        for item in result.warnings
+    )
+    assert all("synthetic" not in item.message for item in result.findings)
+
+
+def test_required_category_binding_violation_is_an_error() -> None:
+    result = check_us_core(
+        _condition(
+            category=[
+                _coding(
+                    "http://terminology.hl7.org/CodeSystem/condition-category",
+                    "encounter-diagnosis",
+                )
+            ]
+        )
+    )
+
+    assert ("code-invalid", "Condition.category[us-core]") in {
+        (item.code, item.location) for item in result.errors
+    }
+
+
+def test_fully_populated_condition_is_clean() -> None:
+    result = check_us_core(_condition())
+
+    assert result.profile == CONDITION_PROFILE
+    assert result.resource_type == "Condition"
+    assert result.findings == ()
+
+
+def test_supported_profiles_are_clean_and_run_base_r4_first() -> None:
+    resources_to_check = [
+        _observation(),
+        _medication_request(),
+        _allergy(),
+    ]
+
+    for resource in resources_to_check:
+        result = check_us_core(resource)
+        assert result.findings == (), (resource["resourceType"], result.findings)
+
+    invalid_medication = _medication_request(status="synthetic-invalid")
+    result = check_us_core(invalid_medication)
+    assert ("code-invalid", "MedicationRequest.status") in {
+        (item.code, item.location) for item in result.errors
+    }
+
+
+def test_observation_value_or_absent_reason_satisfies_must_support_choice() -> None:
+    observation = _observation()
+    observation.pop("valueQuantity")
+    observation["dataAbsentReason"] = {"text": "synthetic reason"}
+
+    result = check_us_core(observation)
+
+    assert not any(
+        "value[x]|dataAbsentReason" in item.location for item in result.warnings
+    )
+
+
+def test_allergy_reaction_requires_manifestation_and_valid_severity() -> None:
+    result = check_us_core(_allergy(reaction=[{"severity": "synthetic-invalid"}]))
+
+    assert ("required", "AllergyIntolerance.reaction.manifestation") in {
+        (item.code, item.location) for item in result.errors
+    }
+    assert ("code-invalid", "AllergyIntolerance.reaction[0].severity") in {
+        (item.code, item.location) for item in result.errors
+    }
+
+
+def test_profile_resolution_accepts_meta_id_https_and_version() -> None:
+    encounter_profile = (
+        "https://hl7.org/fhir/us/core/StructureDefinition/"
+        f"us-core-condition-encounter-diagnosis|{US_CORE_VERSION}"
+    )
+    resource = _condition(
+        meta={"profile": [encounter_profile]},
+        category=[
+            _coding(
+                "http://terminology.hl7.org/CodeSystem/condition-category",
+                "encounter-diagnosis",
+            )
+        ],
+        encounter={"reference": "Encounter/synthetic"},
+    )
+
+    result = check_us_core(resource)
+
+    assert result.profile and result.profile.endswith(
+        "us-core-condition-encounter-diagnosis"
+    )
+    assert result.is_valid
+    assert check_us_core(_allergy(), "us-core-allergyintolerance").is_valid
+
+
+def test_unknown_version_and_resource_mismatch_are_structured_errors() -> None:
+    wrong_version = check_us_core(_condition(), f"{CONDITION_PROFILE}|8.0.1")
+    wrong_resource = check_us_core(
+        _observation(), "us-core-condition-problems-health-concerns"
+    )
+
+    assert [(item.code, item.location) for item in wrong_version.errors] == [
+        ("not-supported", "Condition.meta.profile")
+    ]
+    assert [(item.code, item.location) for item in wrong_resource.errors] == [
+        ("value", "Observation.meta.profile")
+    ]
+
+
+def test_base_and_profile_required_findings_are_deduplicated() -> None:
+    resource = _condition()
+    resource.pop("subject")
+
+    result = check_us_core(resource)
+
+    assert [item.location for item in result.errors].count("Condition.subject") == 1
+
+
+def test_result_adapts_to_operation_outcome() -> None:
+    resource = _condition()
+    resource.pop("clinicalStatus")
+
+    outcome = from_validation_result(check_us_core(resource))
+
+    assert any(
+        issue["severity"] == "warning"
+        and issue["code"] == "incomplete"
+        and issue["expression"] == ["Condition.clinicalStatus"]
+        for issue in outcome["issue"]
+    )
+
+
+def test_check_is_offline_and_constraints_are_permissive(monkeypatch: Any) -> None:
+    def fail_network(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("US Core checker attempted network access")
+
+    monkeypatch.setattr(socket, "socket", fail_network)
+    assert check_us_core(_condition()).is_valid
+
+    path = resources.files("openmed.clinical.exporters.fhir").joinpath(
+        "definitions", "us_core_constraints.json"
+    )
+    definitions = json.loads(path.read_text(encoding="utf-8"))
+    assert definitions["license"] == "CC0-1.0"
+    assert definitions["usCoreVersion"] == US_CORE_VERSION
+    assert definitions["bindings"]["condition-code"] == {
+        "external": True,
+        "strength": "extensible",
+        "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code",
+    }
+    serialized = json.dumps(definitions).casefold()
+    assert not any(
+        restricted in serialized
+        for restricted in ("cpt", "mimic", "snomed", "umls", "n2c2", "i2b2")
+    )

--- a/tests/unit/clinical/test_fhir_validate.py
+++ b/tests/unit/clinical/test_fhir_validate.py
@@ -199,6 +199,13 @@ def test_all_bundled_resource_types_have_a_clean_minimal_resource() -> None:
         _condition(),
         _observation(),
         {
+            "resourceType": "MedicationRequest",
+            "status": "active",
+            "intent": "order",
+            "medicationCodeableConcept": {"text": "synthetic medication"},
+            "subject": {"reference": "Patient/synthetic"},
+        },
+        {
             "resourceType": "MedicationStatement",
             "status": "active",
             "medicationCodeableConcept": {"text": "synthetic medication"},


### PR DESCRIPTION
## Description
Adds an offline US Core 9.0.0 conformance layer for exported Condition, laboratory Observation, MedicationRequest, and AllergyIntolerance resources. The checker runs base R4 validation first and uses compact CC0 constraint metadata without bundling clinical terminology expansions.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made
- Add `check_us_core()`, `ConformanceResult`, canonical profile resolution, and sanitized must-support/binding/cardinality findings.
- Bundle an OpenMed-authored US Core STU9 constraint subset and minimal base R4 MedicationRequest structure.
- Add focused coverage, interoperability guidance, and a changelog entry.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different models/inputs

`14,675 passed, 176 skipped` with `.venv/bin/python -m pytest tests/ -q`.

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Also passed `make type-check`, `make build`, `make docs-build`, and scoped pre-commit including Bandit and secret scanning. Both distribution artifacts contain the new module and constraint table.

## Dependencies
- [x] I have not added any new dependencies
- [ ] OR I have added new dependencies and they are justified because: ____

## Checklist
- [x] I have read the [contributing guide](https://github.com/maziyarpanahi/openmed/blob/master/CONTRIBUTING.md), [Code of Conduct](https://github.com/maziyarpanahi/openmed/blob/master/CODE_OF_CONDUCT.md), and [maintainer guide](https://github.com/maziyarpanahi/openmed/blob/master/MAINTAINERS.md)
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #2366

## Screenshots/Examples
Not applicable; this is a Python API and bundled-data change.