### PR TITLE
feat: add OMOP measurement and procedure exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added exact OMOP CDM v5.4 `measurement` and `procedure_occurrence` row
+  exporters with shared Athena concept resolution, deterministic unmapped
+  fallback, and preservation of numeric lab values, units, and ranges (#275).
 - Added dependency-free US Core 9.0.0 conformance checks for exported
   Condition, laboratory Observation, MedicationRequest, and
   AllergyIntolerance resources, including base-R4-first validation,

--- a/docs/clinical/concept-grounding.md
+++ b/docs/clinical/concept-grounding.md
@@ -161,6 +161,9 @@ resources. Vocabulary version provenance remains in the standard
 and source-to-concept rows. Supply an Athena resolver to populate standard
 `*_concept_id` values. An unmapped source remains `concept_id=0` with its source
 system, code, and text retained; OpenMed never invents an Athena concept ID.
+Pass `table="measurement"` or `table="procedure_occurrence"` to return exact
+CDM v5.4 row dictionaries for one table. Measurement rows retain caller-supplied
+numeric values, units, and reference ranges from grounded span metadata.
 `achilles_smoke_check()` provides a deterministic offline structural preflight.
 A full OHDSI ACHILLES run still requires a deployed CDM database.
 

--- a/openmed/clinical/exporters/__init__.py
+++ b/openmed/clinical/exporters/__init__.py
@@ -71,7 +71,9 @@ from .omop import (
     achilles_smoke_check,
     to_condition_occurrence,
     to_drug_exposure,
+    to_measurement,
     to_omop,
+    to_procedure_occurrence,
 )
 from .openehr import (
     DEFAULT_OPENEHR_BINDINGS,
@@ -152,9 +154,11 @@ __all__ = [
     "document_type_codeable_concept",
     "to_csv",
     "to_drug_exposure",
+    "to_measurement",
     "to_dataframe",
     "to_fhir",
     "to_omop",
+    "to_procedure_occurrence",
     "to_openehr_composition",
     "validate_openehr_composition",
     "validate_exchange",

--- a/openmed/clinical/exporters/omop/__init__.py
+++ b/openmed/clinical/exporters/omop/__init__.py
@@ -30,16 +30,25 @@ from .condition_occurrence import (
     to_condition_occurrence,
 )
 from .drug_exposure import DRUG_EXPOSURE_COLUMNS, to_drug_exposure
+from .measurement import MEASUREMENT_COLUMNS, to_measurement
+from .procedure_occurrence import (
+    PROCEDURE_OCCURRENCE_COLUMNS,
+    to_procedure_occurrence,
+)
 
 __all__ = [
     "CONDITION_OCCURRENCE_COLUMNS",
     "CORE_OMOP_TABLES",
     "ConceptResolver",
     "DRUG_EXPOSURE_COLUMNS",
+    "MEASUREMENT_COLUMNS",
+    "PROCEDURE_OCCURRENCE_COLUMNS",
     "achilles_smoke_check",
     "to_condition_occurrence",
     "to_drug_exposure",
+    "to_measurement",
     "to_omop",
+    "to_procedure_occurrence",
 ]
 
 CORE_OMOP_TABLES: tuple[str, ...] = (
@@ -80,9 +89,9 @@ def to_omop(
     With no ``table`` argument this preserves the existing local-first export:
     an :class:`~openmed.interop.omop.OmopCdmTables` containing the four core
     clinical tables plus supporting concept, person, visit, note, NOTE_NLP, and
-    source-to-concept rows. When ``table`` is ``condition_occurrence`` or
-    ``drug_exposure``, the function returns only that table's exact CDM v5.4
-    row dicts through the table-specific exporters.
+    source-to-concept rows. When ``table`` names one of ``CORE_OMOP_TABLES``,
+    the function returns only that table's exact CDM v5.4 row dicts through the
+    table-specific exporter.
 
     A caller-supplied resolver maps grounded source codes to Athena standard
     concept IDs. Missing mappings remain concept ID ``0`` while source text and
@@ -98,9 +107,10 @@ def to_omop(
         raise TypeError("to_omop expects GroundedSpan objects")
 
     if table is not None:
-        if table not in {"condition_occurrence", "drug_exposure"}:
+        if table not in CORE_OMOP_TABLES:
             raise ValueError(
-                "table must be 'condition_occurrence', 'drug_exposure', or None"
+                "table must be 'condition_occurrence', 'drug_exposure', "
+                "'measurement', 'procedure_occurrence', or None"
             )
         if table == "condition_occurrence":
             return to_condition_occurrence(
@@ -111,7 +121,25 @@ def to_omop(
                 document_id=document_id,
                 note_date=note_date,
             )
-        return to_drug_exposure(
+        if table == "drug_exposure":
+            return to_drug_exposure(
+                spans,
+                concept_resolver=active_resolver,
+                person_id=person_id,
+                visit_id=visit_id,
+                document_id=document_id,
+                note_date=note_date,
+            )
+        if table == "measurement":
+            return to_measurement(
+                spans,
+                concept_resolver=active_resolver,
+                person_id=person_id,
+                visit_id=visit_id,
+                document_id=document_id,
+                note_date=note_date,
+            )
+        return to_procedure_occurrence(
             spans,
             concept_resolver=active_resolver,
             person_id=person_id,

--- a/openmed/clinical/exporters/omop/measurement.py
+++ b/openmed/clinical/exporters/omop/measurement.py
@@ -1,0 +1,271 @@
+"""OMOP CDM v5.4 ``measurement`` export."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import date, datetime
+from math import isfinite
+from typing import Any
+
+from openmed.clinical.grounding.types import GroundedSpan
+
+from ._common import (
+    ConceptResolver,
+    concept_id,
+    context_value,
+    date_value,
+    domain_for_span,
+    foreign_key,
+    iter_spans,
+    resolve_concept,
+    source_value,
+    span_is_exportable,
+    table_row_id,
+)
+
+__all__ = [
+    "MEASUREMENT_COLUMNS",
+    "to_measurement",
+]
+
+MEASUREMENT_COLUMNS: tuple[str, ...] = (
+    "measurement_id",
+    "person_id",
+    "measurement_concept_id",
+    "measurement_date",
+    "measurement_datetime",
+    "measurement_time",
+    "measurement_type_concept_id",
+    "operator_concept_id",
+    "value_as_number",
+    "value_as_concept_id",
+    "unit_concept_id",
+    "range_low",
+    "range_high",
+    "provider_id",
+    "visit_occurrence_id",
+    "visit_detail_id",
+    "measurement_source_value",
+    "measurement_source_concept_id",
+    "unit_source_value",
+    "unit_source_concept_id",
+    "value_source_value",
+    "measurement_event_id",
+    "meas_event_field_concept_id",
+)
+
+
+def to_measurement(
+    grounded: GroundedSpan | Iterable[GroundedSpan],
+    *,
+    concept_resolver: ConceptResolver | Any | None = None,
+    resolver: ConceptResolver | Any | None = None,
+    person_id: int | str | None = None,
+    visit_occurrence_id: int | str | None = None,
+    visit_id: int | str | None = None,
+    document_id: str = "openmed-document",
+    note_date: str | date | datetime | None = None,
+    measurement_date: str | date | datetime | None = None,
+    measurement_type_concept_id: int | None = None,
+    value_as_number: int | float | str | None = None,
+    unit_concept_id: int | None = None,
+    unit_source_value: str | None = None,
+    range_low: int | float | str | None = None,
+    range_high: int | float | str | None = None,
+) -> tuple[dict[str, Any], ...]:
+    """Emit CDM v5.4 rows for grounded ``LAB_TEST`` spans.
+
+    The caller-supplied resolver is the same Athena-compatible resolver used
+    by the condition and drug exporters. An unresolved test keeps its source
+    value and emits ``measurement_concept_id=0``. Numeric results, units, and
+    reference ranges can be passed directly or supplied in span metadata.
+    """
+
+    if concept_resolver is not None and resolver is not None:
+        raise ValueError("provide only one of concept_resolver or resolver")
+    active_resolver = concept_resolver if concept_resolver is not None else resolver
+    rows: list[dict[str, Any]] = []
+    for index, span in enumerate(iter_spans(grounded)):
+        try:
+            domain = domain_for_span(span)
+        except ValueError:
+            continue
+        if domain != "Measurement" or not span_is_exportable(span):
+            continue
+
+        resolved = resolve_concept(span, active_resolver)
+        metadata_person = context_value(span, "person_id", "patient_id", "subject_id")
+        metadata_visit = context_value(
+            span,
+            "visit_occurrence_id",
+            "visit_id",
+            "encounter_id",
+        )
+        resolved_person_id = foreign_key(
+            person_id if person_id is not None else metadata_person,
+            namespace="person",
+        )
+        visit_input = (
+            visit_occurrence_id
+            if visit_occurrence_id is not None
+            else visit_id
+            if visit_id is not None
+            else metadata_visit
+        )
+        resolved_visit_id = foreign_key(visit_input, namespace="visit_occurrence")
+
+        explicit_row_id = context_value(span, "measurement_id")
+        row_id = foreign_key(explicit_row_id, namespace="measurement")
+        if row_id is None:
+            row_id = table_row_id(
+                "measurement",
+                span,
+                index=index,
+                document_id=document_id,
+                person_id=resolved_person_id,
+                visit_occurrence_id=resolved_visit_id,
+                concept_id=resolved.standard_concept_id,
+            )
+
+        measured_on = measurement_date
+        if measured_on is None:
+            measured_on = context_value(
+                span,
+                "measurement_date",
+                "result_date",
+                "specimen_date",
+                "date",
+                "note_date",
+            )
+        if measured_on is None:
+            measured_on = note_date
+
+        raw_value = value_as_number
+        if raw_value is None:
+            raw_value = context_value(
+                span,
+                "value_as_number",
+                "numeric_value",
+                "result_value",
+                "lab_value",
+                "value",
+            )
+        raw_range = context_value(span, "reference_range", "range")
+        resolved_range_low = range_low
+        if resolved_range_low is None:
+            resolved_range_low = context_value(span, "range_low", "reference_low")
+        resolved_range_high = range_high
+        if resolved_range_high is None:
+            resolved_range_high = context_value(span, "range_high", "reference_high")
+        if isinstance(raw_range, Mapping):
+            if resolved_range_low is None:
+                resolved_range_low = raw_range.get("low")
+            if resolved_range_high is None:
+                resolved_range_high = raw_range.get("high")
+
+        raw_unit = unit_source_value
+        if raw_unit is None:
+            raw_unit = context_value(
+                span,
+                "unit_source_value",
+                "unit",
+                "units",
+                "ucum_unit",
+            )
+        raw_unit_concept = unit_concept_id
+        if raw_unit_concept is None:
+            raw_unit_concept = context_value(span, "unit_concept_id")
+        unit_default = 0 if raw_unit is not None else None
+
+        type_id = concept_id(
+            measurement_type_concept_id
+            if measurement_type_concept_id is not None
+            else context_value(
+                span,
+                "measurement_type_concept_id",
+                "type_concept_id",
+            ),
+            name="measurement_type_concept_id",
+            default=0,
+        )
+        value_source = context_value(span, "value_source_value")
+        if value_source is None and raw_value is not None:
+            value_source = str(raw_value)
+
+        row = {
+            "measurement_id": row_id,
+            "person_id": resolved_person_id,
+            "measurement_concept_id": resolved.standard_concept_id,
+            "measurement_date": date_value(measured_on),
+            "measurement_datetime": date_value(
+                context_value(span, "measurement_datetime", "result_datetime")
+            ),
+            "measurement_time": _optional_string(
+                context_value(span, "measurement_time")
+            ),
+            "measurement_type_concept_id": type_id,
+            "operator_concept_id": concept_id(
+                context_value(span, "operator_concept_id"),
+                name="operator_concept_id",
+            ),
+            "value_as_number": _number_value(raw_value, name="value_as_number"),
+            "value_as_concept_id": concept_id(
+                context_value(span, "value_as_concept_id"),
+                name="value_as_concept_id",
+            ),
+            "unit_concept_id": concept_id(
+                raw_unit_concept,
+                name="unit_concept_id",
+                default=unit_default,
+            ),
+            "range_low": _number_value(resolved_range_low, name="range_low"),
+            "range_high": _number_value(resolved_range_high, name="range_high"),
+            "provider_id": foreign_key(
+                context_value(span, "provider_id"), namespace="provider"
+            ),
+            "visit_occurrence_id": resolved_visit_id,
+            "visit_detail_id": foreign_key(
+                context_value(span, "visit_detail_id"), namespace="visit_detail"
+            ),
+            "measurement_source_value": source_value(
+                span,
+                explicit=context_value(span, "measurement_source_value"),
+                fallback_code=resolved.source_code,
+            ),
+            "measurement_source_concept_id": resolved.source_concept_id,
+            "unit_source_value": _optional_string(raw_unit),
+            "unit_source_concept_id": concept_id(
+                context_value(span, "unit_source_concept_id"),
+                name="unit_source_concept_id",
+                default=unit_default,
+            ),
+            "value_source_value": _optional_string(value_source),
+            "measurement_event_id": foreign_key(
+                context_value(span, "measurement_event_id"),
+                namespace="measurement_event",
+            ),
+            "meas_event_field_concept_id": concept_id(
+                context_value(span, "meas_event_field_concept_id"),
+                name="meas_event_field_concept_id",
+            ),
+        }
+        rows.append({column: row[column] for column in MEASUREMENT_COLUMNS})
+    return tuple(rows)
+
+
+def _number_value(value: Any, *, name: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise TypeError(f"{name} must be a finite number or None")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite number or None") from exc
+    if not isfinite(result):
+        raise ValueError(f"{name} must be a finite number or None")
+    return result
+
+
+def _optional_string(value: Any) -> str | None:
+    return None if value is None else str(value)

--- a/openmed/clinical/exporters/omop/procedure_occurrence.py
+++ b/openmed/clinical/exporters/omop/procedure_occurrence.py
@@ -1,0 +1,178 @@
+"""OMOP CDM v5.4 ``procedure_occurrence`` export."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import date, datetime
+from typing import Any
+
+from openmed.clinical.grounding.types import GroundedSpan
+
+from ._common import (
+    ConceptResolver,
+    concept_id,
+    context_value,
+    date_value,
+    domain_for_span,
+    foreign_key,
+    iter_spans,
+    resolve_concept,
+    source_value,
+    span_is_exportable,
+    table_row_id,
+)
+
+__all__ = [
+    "PROCEDURE_OCCURRENCE_COLUMNS",
+    "to_procedure_occurrence",
+]
+
+PROCEDURE_OCCURRENCE_COLUMNS: tuple[str, ...] = (
+    "procedure_occurrence_id",
+    "person_id",
+    "procedure_concept_id",
+    "procedure_date",
+    "procedure_datetime",
+    "procedure_end_date",
+    "procedure_end_datetime",
+    "procedure_type_concept_id",
+    "modifier_concept_id",
+    "quantity",
+    "provider_id",
+    "visit_occurrence_id",
+    "visit_detail_id",
+    "procedure_source_value",
+    "procedure_source_concept_id",
+    "modifier_source_value",
+)
+
+
+def to_procedure_occurrence(
+    grounded: GroundedSpan | Iterable[GroundedSpan],
+    *,
+    concept_resolver: ConceptResolver | Any | None = None,
+    resolver: ConceptResolver | Any | None = None,
+    person_id: int | str | None = None,
+    visit_occurrence_id: int | str | None = None,
+    visit_id: int | str | None = None,
+    document_id: str = "openmed-document",
+    note_date: str | date | datetime | None = None,
+    procedure_date: str | date | datetime | None = None,
+    procedure_type_concept_id: int | None = None,
+) -> tuple[dict[str, Any], ...]:
+    """Emit CDM v5.4 rows for grounded ``PROCEDURE`` spans.
+
+    Standard and source concept IDs come from the shared Athena-compatible
+    resolver. Unmapped procedures use concept ID ``0`` while retaining the
+    original source value. Optional CDM attributes are read from span metadata.
+    """
+
+    if concept_resolver is not None and resolver is not None:
+        raise ValueError("provide only one of concept_resolver or resolver")
+    active_resolver = concept_resolver if concept_resolver is not None else resolver
+    rows: list[dict[str, Any]] = []
+    for index, span in enumerate(iter_spans(grounded)):
+        try:
+            domain = domain_for_span(span)
+        except ValueError:
+            continue
+        if domain != "Procedure" or not span_is_exportable(span):
+            continue
+
+        resolved = resolve_concept(span, active_resolver)
+        metadata_person = context_value(span, "person_id", "patient_id", "subject_id")
+        metadata_visit = context_value(
+            span,
+            "visit_occurrence_id",
+            "visit_id",
+            "encounter_id",
+        )
+        resolved_person_id = foreign_key(
+            person_id if person_id is not None else metadata_person,
+            namespace="person",
+        )
+        visit_input = (
+            visit_occurrence_id
+            if visit_occurrence_id is not None
+            else visit_id
+            if visit_id is not None
+            else metadata_visit
+        )
+        resolved_visit_id = foreign_key(visit_input, namespace="visit_occurrence")
+
+        explicit_row_id = context_value(span, "procedure_occurrence_id")
+        row_id = foreign_key(explicit_row_id, namespace="procedure_occurrence")
+        if row_id is None:
+            row_id = table_row_id(
+                "procedure_occurrence",
+                span,
+                index=index,
+                document_id=document_id,
+                person_id=resolved_person_id,
+                visit_occurrence_id=resolved_visit_id,
+                concept_id=resolved.standard_concept_id,
+            )
+
+        occurred_on = procedure_date
+        if occurred_on is None:
+            occurred_on = context_value(
+                span,
+                "procedure_date",
+                "start_date",
+                "date",
+                "note_date",
+            )
+        if occurred_on is None:
+            occurred_on = note_date
+
+        type_id = concept_id(
+            procedure_type_concept_id
+            if procedure_type_concept_id is not None
+            else context_value(
+                span,
+                "procedure_type_concept_id",
+                "type_concept_id",
+            ),
+            name="procedure_type_concept_id",
+            default=0,
+        )
+        modifier_source = context_value(span, "modifier_source_value")
+        row = {
+            "procedure_occurrence_id": row_id,
+            "person_id": resolved_person_id,
+            "procedure_concept_id": resolved.standard_concept_id,
+            "procedure_date": date_value(occurred_on),
+            "procedure_datetime": date_value(
+                context_value(span, "procedure_datetime", "start_datetime")
+            ),
+            "procedure_end_date": date_value(
+                context_value(span, "procedure_end_date", "end_date")
+            ),
+            "procedure_end_datetime": date_value(
+                context_value(span, "procedure_end_datetime", "end_datetime")
+            ),
+            "procedure_type_concept_id": type_id,
+            "modifier_concept_id": concept_id(
+                context_value(span, "modifier_concept_id"),
+                name="modifier_concept_id",
+            ),
+            "quantity": context_value(span, "quantity"),
+            "provider_id": foreign_key(
+                context_value(span, "provider_id"), namespace="provider"
+            ),
+            "visit_occurrence_id": resolved_visit_id,
+            "visit_detail_id": foreign_key(
+                context_value(span, "visit_detail_id"), namespace="visit_detail"
+            ),
+            "procedure_source_value": source_value(
+                span,
+                explicit=context_value(span, "procedure_source_value"),
+                fallback_code=resolved.source_code,
+            ),
+            "procedure_source_concept_id": resolved.source_concept_id,
+            "modifier_source_value": (
+                str(modifier_source) if modifier_source is not None else None
+            ),
+        }
+        rows.append({column: row[column] for column in PROCEDURE_OCCURRENCE_COLUMNS})
+    return tuple(rows)

--- a/tests/unit/clinical/test_omop_measurement_procedure.py
+++ b/tests/unit/clinical/test_omop_measurement_procedure.py
@@ -1,0 +1,206 @@
+"""Focused tests for measurement and procedure OMOP table exporters."""
+
+from __future__ import annotations
+
+from openmed.clinical.exporters import (
+    to_measurement,
+    to_omop,
+    to_procedure_occurrence,
+)
+from openmed.clinical.exporters.omop import (
+    MEASUREMENT_COLUMNS,
+    PROCEDURE_OCCURRENCE_COLUMNS,
+)
+from openmed.clinical.grounding import Candidate, GroundedSpan
+
+
+def test_omop_v54_column_sets_are_exact() -> None:
+    assert MEASUREMENT_COLUMNS == (
+        "measurement_id",
+        "person_id",
+        "measurement_concept_id",
+        "measurement_date",
+        "measurement_datetime",
+        "measurement_time",
+        "measurement_type_concept_id",
+        "operator_concept_id",
+        "value_as_number",
+        "value_as_concept_id",
+        "unit_concept_id",
+        "range_low",
+        "range_high",
+        "provider_id",
+        "visit_occurrence_id",
+        "visit_detail_id",
+        "measurement_source_value",
+        "measurement_source_concept_id",
+        "unit_source_value",
+        "unit_source_concept_id",
+        "value_source_value",
+        "measurement_event_id",
+        "meas_event_field_concept_id",
+    )
+    assert PROCEDURE_OCCURRENCE_COLUMNS == (
+        "procedure_occurrence_id",
+        "person_id",
+        "procedure_concept_id",
+        "procedure_date",
+        "procedure_datetime",
+        "procedure_end_date",
+        "procedure_end_datetime",
+        "procedure_type_concept_id",
+        "modifier_concept_id",
+        "quantity",
+        "provider_id",
+        "visit_occurrence_id",
+        "visit_detail_id",
+        "procedure_source_value",
+        "procedure_source_concept_id",
+        "modifier_source_value",
+    )
+
+
+def _span(
+    text: str,
+    label: str,
+    system: str,
+    code: str,
+    *,
+    metadata: dict[str, object] | None = None,
+) -> GroundedSpan:
+    return GroundedSpan(
+        text=text,
+        start=0,
+        end=len(text),
+        canonical_label=label,
+        candidates=(
+            Candidate(
+                system=system,
+                code=code,
+                display=text,
+                score=1.0,
+                source="synthetic",
+            ),
+        ),
+        metadata=metadata or {},
+    )
+
+
+def test_measurement_has_exact_cdm_columns_and_lab_values() -> None:
+    span = _span(
+        "Synthetic glucose",
+        "LAB_TEST",
+        "LOINC",
+        "SYNTH-GLUCOSE",
+        metadata={
+            "value_as_number": "7.4",
+            "unit": "mmol/L",
+            "unit_concept_id": 8753,
+            "unit_source_concept_id": 9448,
+            "reference_range": {"low": 3.9, "high": 7.8},
+            "measurement_type_concept_id": 32817,
+        },
+    )
+
+    rows = to_omop(
+        span,
+        table="measurement",
+        person_id=7,
+        visit_id=8,
+        note_date="2026-09-07",
+        concept_resolver={
+            ("LOINC", "SYNTH-GLUCOSE"): {
+                "target_concept_id": 3001,
+                "source_concept_id": 9001,
+            }
+        },
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert tuple(row) == MEASUREMENT_COLUMNS
+    assert row["measurement_concept_id"] == 3001
+    assert row["measurement_source_value"] == "Synthetic glucose"
+    assert row["measurement_source_concept_id"] == 9001
+    assert row["measurement_date"] == "2026-09-07"
+    assert row["value_as_number"] == 7.4
+    assert row["value_source_value"] == "7.4"
+    assert row["unit_concept_id"] == 8753
+    assert row["unit_source_value"] == "mmol/L"
+    assert row["unit_source_concept_id"] == 9448
+    assert row["range_low"] == 3.9
+    assert row["range_high"] == 7.8
+
+
+def test_unmapped_measurement_preserves_source_and_unmapped_unit() -> None:
+    row = to_measurement(
+        _span(
+            "Synthetic assay",
+            "LAB_TEST",
+            "LOINC",
+            "SYNTH-ASSAY",
+            metadata={"unit": "arbitrary-unit"},
+        )
+    )[0]
+
+    assert row["measurement_concept_id"] == 0
+    assert row["measurement_source_value"] == "Synthetic assay"
+    assert row["measurement_source_concept_id"] == 0
+    assert row["unit_concept_id"] == 0
+    assert row["unit_source_concept_id"] == 0
+    assert row["unit_source_value"] == "arbitrary-unit"
+
+
+def test_procedure_occurrence_has_exact_cdm_columns_and_mapping() -> None:
+    span = _span(
+        "Synthetic imaging procedure",
+        "PROCEDURE",
+        "SNOMED",
+        "SYNTH-PROCEDURE",
+        metadata={
+            "procedure_type_concept_id": 32817,
+            "procedure_end_date": "2026-09-08",
+            "quantity": 1,
+        },
+    )
+
+    rows = to_procedure_occurrence(
+        span,
+        person_id="synthetic-person",
+        visit_occurrence_id="synthetic-visit",
+        procedure_date="2026-09-07",
+        resolver={
+            ("SNOMED", "SYNTH-PROCEDURE"): {
+                "standard_concept_id": 4001,
+                "source_concept_id": 9002,
+            }
+        },
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert tuple(row) == PROCEDURE_OCCURRENCE_COLUMNS
+    assert row["procedure_concept_id"] == 4001
+    assert row["procedure_source_value"] == "Synthetic imaging procedure"
+    assert row["procedure_source_concept_id"] == 9002
+    assert row["procedure_date"] == "2026-09-07"
+    assert row["procedure_end_date"] == "2026-09-08"
+    assert row["quantity"] == 1
+    assert row["person_id"] > 0
+    assert row["visit_occurrence_id"] > 0
+
+
+def test_unmapped_procedure_routes_through_public_to_omop() -> None:
+    row = to_omop(
+        _span(
+            "Unmapped procedure",
+            "PROCEDURE",
+            "LOCAL",
+            "SYNTH-UNMAPPED",
+        ),
+        table="procedure_occurrence",
+    )[0]
+
+    assert row["procedure_concept_id"] == 0
+    assert row["procedure_source_value"] == "Unmapped procedure"
+    assert row["procedure_source_concept_id"] == 0


### PR DESCRIPTION
## Description
Adds table-specific OMOP CDM v5.4 exporters for grounded measurement and procedure spans. Both routes reuse the existing local Athena-compatible concept resolver and preserve source values when mappings are unavailable.

## Type of Change
- [x] New feature
- [x] Test addition/improvement
- [x] Documentation update

## Changes Made
- Added exact CDM v5.4 measurement rows, including numeric values, units, ranges, source concepts, and event linkage fields.
- Added exact CDM v5.4 procedure_occurrence rows, including end timestamps, modifiers, quantity, source concepts, and visit/provider links.
- Exposed both exporters through the public clinical API and table-specific to_omop routing.

## Testing
- [x] Focused OMOP exporter tests: 11 passed.
- [x] Clinical and interop regression suite: 2,487 passed, 21 skipped.
- [x] Full test suite: 14,724 passed, 132 skipped.
- [x] make format, make lint, make format-check, and make type-check.
- [x] make build and make docs-build.
- [x] Scoped pre-commit checks, including Bandit and secret detection.

## Documentation
- [x] Updated the clinical concept-grounding guide.
- [x] Updated CHANGELOG.md.
- [x] Added public API docstrings.

## Dependencies
- [x] No new dependencies.
- [x] No terminology or restricted vocabulary data is bundled.

## Related Issues
Closes #275

## Screenshots/Examples
Not applicable; this is a Python API and row-schema change.