### PR TITLE
feat(release): dispatch retraining recipe proposals

### DIFF
--- a/.github/workflows/retrain-trigger.yml
+++ b/.github/workflows/retrain-trigger.yml
@@ -1,0 +1,110 @@
+name: Retrain recipe trigger
+
+on:
+  schedule:
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+    inputs:
+      input_path:
+        description: Committed aggregate-only retrain trigger input.
+        required: false
+        default: gates/retrain_trigger_inputs.json
+
+concurrency:
+  group: retrain-recipe-trigger
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  propose-recipes:
+    runs-on: ubuntu-latest
+    env:
+      TRIGGER_INPUT: ${{ inputs.input_path || 'gates/retrain_trigger_inputs.json' }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          version: "0.11.28"
+
+      - name: Install the offline scorer
+        run: uv sync --frozen
+
+      - name: Score aggregate signals and prepare recipe proposals
+        env:
+          TRIGGER_ARTIFACT_DIR: ${{ runner.temp }}/retrain-trigger
+        run: |
+          mkdir -p "$TRIGGER_ARTIFACT_DIR"
+          uv run --frozen python scripts/release/retrain_queue.py \
+            --input "$TRIGGER_INPUT" \
+            --queue-output "$TRIGGER_ARTIFACT_DIR/retrain_queue.jsonl" \
+            --evidence-output "$TRIGGER_ARTIFACT_DIR/decision_evidence.json" \
+            --summary-output "$TRIGGER_ARTIFACT_DIR/dispatch_summary.json" \
+            --recipes-dir recipes
+
+      - name: Read fail-closed dispatch summary
+        id: dispatch
+        env:
+          TRIGGER_ARTIFACT_DIR: ${{ runner.temp }}/retrain-trigger
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["TRIGGER_ARTIFACT_DIR"])
+          summary = json.loads((root / "dispatch_summary.json").read_text())
+          required = {"queue_count", "changed_recipe_count", "evidence_hash"}
+          if not required.issubset(summary):
+              raise SystemExit("dispatch summary is incomplete")
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as out:
+              out.write(f"queue_count={int(summary['queue_count'])}\n")
+              out.write(
+                  f"changed_recipe_count={int(summary['changed_recipe_count'])}\n"
+              )
+              out.write(f"evidence_hash={summary['evidence_hash']}\n")
+          PY
+
+      - name: Upload aggregate trigger evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: retrain-trigger-evidence
+          if-no-files-found: error
+          path: ${{ runner.temp }}/retrain-trigger
+
+      - name: Open recipe configuration PR
+        if: >-
+          steps.dispatch.outputs.queue_count != '0' &&
+          steps.dispatch.outputs.changed_recipe_count != '0'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: feature/retrain-recipe-proposals
+          base: master
+          commit-message: Update retraining recipe proposals
+          title: Update retraining recipe proposals
+          body: |
+            Updates aggregate-only retraining recipe configuration.
+
+            Trigger evidence: `${{ steps.dispatch.outputs.evidence_hash }}`
+
+            This workflow does not train, convert, or publish model artifacts.
+            Every resulting candidate must still pass the downstream model
+            release gates before promotion.
+          labels: |
+            roadmap-v2
+            feature
+            P1
+          add-paths: |
+            recipes/*.yaml
+          delete-branch: true

--- a/gates/retrain_trigger_inputs.json
+++ b/gates/retrain_trigger_inputs.json
@@ -1,0 +1,4 @@
+{
+  "candidates": [],
+  "schema_version": "openmed.retrain_trigger.inputs.v1"
+}

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -64,3 +64,22 @@ not accept environment-variable overrides.
 5. Run both checks above and include the resulting measurements in the review.
 
 Do not raise a budget merely to make an unexplained regression pass.
+
+## Retraining recipe proposals
+
+`retrain_queue.py` consumes the committed aggregate-only input contract at
+`gates/retrain_trigger_inputs.json`. It writes the complete decision evidence
+and queued JSONL records separately, then updates `recipes/<family>.yaml` only
+for families whose weighted score reaches the configured threshold:
+
+```bash
+python scripts/release/retrain_queue.py \
+  --queue-output artifacts/retrain-trigger/retrain_queue.jsonl \
+  --evidence-output artifacts/retrain-trigger/decision_evidence.json \
+  --summary-output artifacts/retrain-trigger/dispatch_summary.json
+```
+
+The scheduled workflow uploads queue and decision evidence as workflow
+artifacts. It opens a configuration-only pull request when a recipe actually
+changes. The workflow never trains, converts, or publishes model artifacts;
+the normal downstream release gates remain mandatory before promotion.

--- a/scripts/release/retrain_queue.py
+++ b/scripts/release/retrain_queue.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Score aggregate retraining signals and prepare recipe-only proposals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from openmed.core.audit import stable_hash
+from openmed.eval.drift_monitor import assert_no_raw_text
+from openmed.eval.retrain_trigger import (
+    RETRAIN_QUEUE_SCHEMA_VERSION,
+    RetrainDecision,
+    RetrainTriggerPolicy,
+    RetrainTriggerResult,
+    load_retrain_trigger_inputs,
+    score_retrain_candidates,
+    write_retrain_trigger_artifacts,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INPUT_PATH = ROOT / "gates" / "retrain_trigger_inputs.json"
+DEFAULT_ARTIFACT_DIR = ROOT / "artifacts" / "retrain-trigger"
+DEFAULT_RECIPES_DIR = ROOT / "recipes"
+RETRAIN_RECIPE_SCHEMA_VERSION = "openmed.retrain_recipe.v1"
+RETRAIN_DISPATCH_SUMMARY_SCHEMA_VERSION = "openmed.retrain_dispatch_summary.v1"
+
+
+@dataclass(frozen=True)
+class RetrainDispatchSummary:
+    """Stable summary consumed by the scheduled workflow."""
+
+    queue_count: int
+    evidence_hash: str
+    changed_families: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the deterministic JSON-ready summary."""
+
+        payload: dict[str, Any] = {
+            "changed_families": list(self.changed_families),
+            "changed_recipe_count": len(self.changed_families),
+            "evidence_hash": self.evidence_hash,
+            "queue_count": self.queue_count,
+            "schema_version": RETRAIN_DISPATCH_SUMMARY_SCHEMA_VERSION,
+        }
+        payload["summary_hash"] = stable_hash(payload)
+        assert_no_raw_text(payload, where="retrain dispatch summary")
+        return payload
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Serialize the summary with stable ordering."""
+
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=indent,
+            sort_keys=True,
+        )
+
+
+def update_recipe_configs(
+    result: RetrainTriggerResult,
+    *,
+    recipes_dir: str | Path,
+) -> tuple[str, ...]:
+    """Update only recipe files for queued families and return changed families."""
+
+    grouped: dict[str, list[RetrainDecision]] = {}
+    for decision in result.queued:
+        grouped.setdefault(decision.candidate.family, []).append(decision)
+    if not grouped:
+        return ()
+
+    evidence_hash = str(result.to_evidence_dict()["artifact_hash"])
+    root = Path(recipes_dir)
+    pending: list[tuple[str, Path, str]] = []
+    for family, decisions in sorted(grouped.items()):
+        path = root / f"{family}.yaml"
+        existing = _load_recipe(path)
+        proposal = dict(existing)
+        proposal["retraining_trigger"] = _trigger_recipe_section(
+            decisions,
+            evidence_hash=evidence_hash,
+        )
+        rendered = yaml.safe_dump(
+            proposal,
+            allow_unicode=False,
+            default_flow_style=False,
+            sort_keys=True,
+            width=88,
+        )
+        if path.is_file() and path.read_text(encoding="utf-8") == rendered:
+            continue
+        pending.append((family, path, rendered))
+
+    if pending:
+        root.mkdir(parents=True, exist_ok=True)
+    for _, path, rendered in pending:
+        path.write_text(rendered, encoding="utf-8")
+    return tuple(family for family, _, _ in pending)
+
+
+def run_retrain_dispatch(
+    *,
+    input_path: str | Path,
+    queue_path: str | Path,
+    evidence_path: str | Path,
+    summary_path: str | Path,
+    recipes_dir: str | Path,
+    policy: RetrainTriggerPolicy | None = None,
+) -> RetrainDispatchSummary:
+    """Run offline scoring, write evidence, and prepare deterministic recipes."""
+
+    candidates = load_retrain_trigger_inputs(input_path)
+    result = score_retrain_candidates(candidates, policy=policy)
+    write_retrain_trigger_artifacts(
+        result,
+        queue_path=queue_path,
+        evidence_path=evidence_path,
+    )
+    changed_families = update_recipe_configs(result, recipes_dir=recipes_dir)
+    evidence_hash = str(result.to_evidence_dict()["artifact_hash"])
+    summary = RetrainDispatchSummary(
+        queue_count=len(result.queued),
+        evidence_hash=evidence_hash,
+        changed_families=changed_families,
+    )
+    output = Path(summary_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(summary.to_json() + "\n", encoding="utf-8")
+    return summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the offline retrain-dispatch argument parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT_PATH)
+    parser.add_argument(
+        "--queue-output",
+        type=Path,
+        default=DEFAULT_ARTIFACT_DIR / "retrain_queue.jsonl",
+    )
+    parser.add_argument(
+        "--evidence-output",
+        type=Path,
+        default=DEFAULT_ARTIFACT_DIR / "decision_evidence.json",
+    )
+    parser.add_argument(
+        "--summary-output",
+        type=Path,
+        default=DEFAULT_ARTIFACT_DIR / "dispatch_summary.json",
+    )
+    parser.add_argument("--recipes-dir", type=Path, default=DEFAULT_RECIPES_DIR)
+    parser.add_argument("--threshold", type=float, default=1.0)
+    parser.add_argument("--drift-weight", type=float, default=1.0)
+    parser.add_argument("--gate-failure-weight", type=float, default=1.0)
+    parser.add_argument("--staleness-weight", type=float, default=1.0)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the aggregate-only retrain recipe dispatcher."""
+
+    args = build_parser().parse_args(argv)
+    try:
+        summary = run_retrain_dispatch(
+            input_path=args.input,
+            queue_path=args.queue_output,
+            evidence_path=args.evidence_output,
+            summary_path=args.summary_output,
+            recipes_dir=args.recipes_dir,
+            policy=RetrainTriggerPolicy(
+                threshold=args.threshold,
+                drift_weight=args.drift_weight,
+                gate_failure_weight=args.gate_failure_weight,
+                staleness_weight=args.staleness_weight,
+            ),
+        )
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"Retrain dispatch failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(summary.to_json())
+    return 0
+
+
+def _load_recipe(path: Path) -> Mapping[str, Any]:
+    if not path.is_file():
+        return {}
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if payload is None:
+        return {}
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"recipe must contain a YAML object: {path.name}")
+    if any(not isinstance(key, str) for key in payload):
+        raise ValueError(f"recipe keys must be strings: {path.name}")
+    return payload
+
+
+def _trigger_recipe_section(
+    decisions: Sequence[RetrainDecision],
+    *,
+    evidence_hash: str,
+) -> dict[str, Any]:
+    candidates = [_recipe_candidate(decision) for decision in decisions]
+    section: dict[str, Any] = {
+        "candidates": candidates,
+        "downstream_release_gates": {
+            "required": True,
+            "workflow": "release-gates.yml",
+        },
+        "evidence_hash": evidence_hash,
+        "queue_schema_version": RETRAIN_QUEUE_SCHEMA_VERSION,
+        "schema_version": RETRAIN_RECIPE_SCHEMA_VERSION,
+    }
+    section["proposal_hash"] = stable_hash(section)
+    assert_no_raw_text(section, where="retrain recipe proposal")
+    return section
+
+
+def _recipe_candidate(decision: RetrainDecision) -> dict[str, Any]:
+    queue_row = decision.to_queue_dict()
+    return {
+        "decision_hash": queue_row["decision_hash"],
+        "dominant_label": queue_row["dominant_label"],
+        "dominant_signal": queue_row["dominant_signal"],
+        "failed_gates": queue_row["failed_gates"],
+        "recipe_slices": queue_row["recipe_slices"],
+        "score": queue_row["score"],
+        "source_hashes": queue_row["source_hashes"],
+        "threshold": queue_row["threshold"],
+        "tier": queue_row["tier"],
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/release/test_retrain_trigger_workflow.py
+++ b/tests/unit/release/test_retrain_trigger_workflow.py
@@ -1,0 +1,285 @@
+"""Tests for the aggregate retrain queue and recipe-only workflow."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from openmed.eval.retrain_trigger import (
+    RETRAIN_TRIGGER_INPUT_SCHEMA_VERSION,
+    RetrainCandidateSignals,
+    RetrainRecipeSlice,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "release" / "retrain_queue.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "retrain-trigger.yml"
+INPUTS = ROOT / "gates" / "retrain_trigger_inputs.json"
+HASH_A = "sha256:" + "a" * 64
+HASH_B = "sha256:" + "b" * 64
+
+spec = importlib.util.spec_from_file_location("scripts.release.retrain_queue", SCRIPT)
+assert spec is not None and spec.loader is not None
+retrain_queue = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = retrain_queue
+spec.loader.exec_module(retrain_queue)
+
+
+def _write_inputs(path: Path, candidates: list[RetrainCandidateSignals]) -> None:
+    payload = {
+        "candidates": [candidate.to_dict() for candidate in candidates],
+        "schema_version": RETRAIN_TRIGGER_INPUT_SCHEMA_VERSION,
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _run(
+    root: Path,
+    candidates: list[RetrainCandidateSignals],
+) -> tuple[Any, Path, Path, Path, Path]:
+    root.mkdir(parents=True)
+    input_path = root / "input.json"
+    queue_path = root / "artifacts" / "retrain_queue.jsonl"
+    evidence_path = root / "artifacts" / "decision_evidence.json"
+    summary_path = root / "artifacts" / "dispatch_summary.json"
+    recipes_dir = root / "recipes"
+    _write_inputs(input_path, candidates)
+    summary = retrain_queue.run_retrain_dispatch(
+        input_path=input_path,
+        queue_path=queue_path,
+        evidence_path=evidence_path,
+        summary_path=summary_path,
+        recipes_dir=recipes_dir,
+    )
+    return summary, queue_path, evidence_path, summary_path, recipes_dir
+
+
+def _queued_candidate(*, family: str = "pii") -> RetrainCandidateSignals:
+    return RetrainCandidateSignals(
+        family=family,
+        tier="tiny",
+        gate_failure_ratio=1.25,
+        dominant_label="SSN",
+        failed_gates=("G3",),
+        source_hashes={"gate": HASH_A},
+        recipe_slices=(
+            RetrainRecipeSlice(
+                rank=1,
+                label="SSN",
+                language="en",
+                candidate_count=3,
+                priority_score=4.5,
+                evidence_hash=HASH_B,
+                fixture_hashes=(HASH_A,),
+            ),
+        ),
+    )
+
+
+def test_empty_queue_writes_evidence_without_recipe_change(tmp_path: Path) -> None:
+    summary, queue_path, evidence_path, summary_path, recipes_dir = _run(
+        tmp_path / "empty",
+        [RetrainCandidateSignals(family="pii", tier="tiny")],
+    )
+
+    assert summary.queue_count == 0
+    assert summary.changed_families == ()
+    assert queue_path.read_bytes() == b""
+    assert json.loads(evidence_path.read_text())["queue_count"] == 0
+    assert json.loads(summary_path.read_text())["changed_recipe_count"] == 0
+    assert not recipes_dir.exists()
+
+
+def test_queued_family_changes_only_its_recipe_config(tmp_path: Path) -> None:
+    root = tmp_path / "queued"
+    recipes_dir = root / "recipes"
+    recipes_dir.mkdir(parents=True)
+    pii_path = recipes_dir / "pii.yaml"
+    other_path = recipes_dir / "structured.yaml"
+    pii_path.write_text("optimizer:\n  learning_rate: 0.0001\n")
+    other_path.write_text("owner: structured\n")
+    other_before = other_path.read_bytes()
+    input_path = root / "input.json"
+    _write_inputs(
+        input_path,
+        [
+            RetrainCandidateSignals(family="structured", tier="tiny"),
+            _queued_candidate(),
+        ],
+    )
+
+    summary = retrain_queue.run_retrain_dispatch(
+        input_path=input_path,
+        queue_path=root / "artifacts" / "queue.jsonl",
+        evidence_path=root / "artifacts" / "evidence.json",
+        summary_path=root / "artifacts" / "summary.json",
+        recipes_dir=recipes_dir,
+    )
+
+    assert summary.queue_count == 1
+    assert summary.changed_families == ("pii",)
+    assert other_path.read_bytes() == other_before
+    recipe = yaml.safe_load(pii_path.read_text())
+    assert recipe["optimizer"] == {"learning_rate": 0.0001}
+    trigger = recipe["retraining_trigger"]
+    assert trigger["evidence_hash"] == summary.evidence_hash
+    assert trigger["downstream_release_gates"] == {
+        "required": True,
+        "workflow": "release-gates.yml",
+    }
+    candidate = trigger["candidates"][0]
+    assert candidate["dominant_signal"] == "gate-failure"
+    assert candidate["failed_gates"] == ["G3"]
+    assert candidate["recipe_slices"][0]["priority_score"] == 4.5
+    assert candidate["source_hashes"] == {"gate": HASH_A}
+    assert trigger["proposal_hash"].startswith("sha256:")
+
+
+def test_reversed_inputs_produce_byte_identical_outputs(tmp_path: Path) -> None:
+    pii = _queued_candidate()
+    clinical = _queued_candidate(family="clinical")
+    first = _run(tmp_path / "first", [pii, clinical])
+    second = _run(tmp_path / "second", [clinical, pii])
+
+    _, first_queue, first_evidence, _, first_recipes = first
+    _, second_queue, second_evidence, _, second_recipes = second
+    assert first_queue.read_bytes() == second_queue.read_bytes()
+    assert first_evidence.read_bytes() == second_evidence.read_bytes()
+    assert (first_recipes / "pii.yaml").read_bytes() == (
+        second_recipes / "pii.yaml"
+    ).read_bytes()
+    assert (first_recipes / "clinical.yaml").read_bytes() == (
+        second_recipes / "clinical.yaml"
+    ).read_bytes()
+
+
+def test_identical_recipe_is_not_reported_as_changed(tmp_path: Path) -> None:
+    root = tmp_path / "repeat"
+    first = _run(root, [_queued_candidate()])
+    recipe_path = first[-1] / "pii.yaml"
+    before = recipe_path.read_bytes()
+
+    summary = retrain_queue.run_retrain_dispatch(
+        input_path=root / "input.json",
+        queue_path=root / "artifacts" / "retrain_queue.jsonl",
+        evidence_path=root / "artifacts" / "decision_evidence.json",
+        summary_path=root / "artifacts" / "dispatch_summary.json",
+        recipes_dir=root / "recipes",
+    )
+
+    assert summary.queue_count == 1
+    assert summary.changed_families == ()
+    assert recipe_path.read_bytes() == before
+
+
+def test_cli_rejects_raw_text_without_writing_a_recipe(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    root = tmp_path / "unsafe"
+    root.mkdir()
+    input_path = root / "input.json"
+    payload = {
+        "schema_version": RETRAIN_TRIGGER_INPUT_SCHEMA_VERSION,
+        "candidates": [
+            {
+                **RetrainCandidateSignals(family="pii", tier="tiny").to_dict(),
+                "raw_text": "Synthetic patient context",
+            }
+        ],
+    }
+    input_path.write_text(json.dumps(payload))
+
+    status = retrain_queue.main(
+        [
+            "--input",
+            str(input_path),
+            "--queue-output",
+            str(root / "queue.jsonl"),
+            "--evidence-output",
+            str(root / "evidence.json"),
+            "--summary-output",
+            str(root / "summary.json"),
+            "--recipes-dir",
+            str(root / "recipes"),
+        ]
+    )
+
+    assert status == 2
+    assert "raw-text" in capsys.readouterr().err
+    assert not (root / "recipes").exists()
+
+
+def test_committed_input_is_a_noop_aggregate_contract(tmp_path: Path) -> None:
+    payload = json.loads(INPUTS.read_text())
+    assert payload == {
+        "candidates": [],
+        "schema_version": RETRAIN_TRIGGER_INPUT_SCHEMA_VERSION,
+    }
+
+    summary = retrain_queue.run_retrain_dispatch(
+        input_path=INPUTS,
+        queue_path=tmp_path / "queue.jsonl",
+        evidence_path=tmp_path / "evidence.json",
+        summary_path=tmp_path / "summary.json",
+        recipes_dir=tmp_path / "recipes",
+    )
+    assert summary.queue_count == 0
+    assert not (tmp_path / "recipes").exists()
+
+
+def test_workflow_is_scheduled_and_recipe_only() -> None:
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    workflow = yaml.load(workflow_text, Loader=yaml.BaseLoader)
+
+    assert set(workflow["on"]) == {"schedule", "workflow_dispatch"}
+    assert workflow["permissions"] == {
+        "contents": "write",
+        "pull-requests": "write",
+    }
+    steps = workflow["jobs"]["propose-recipes"]["steps"]
+    action_refs = {
+        step["uses"] for step in steps if isinstance(step, dict) and "uses" in step
+    }
+    assert action_refs == {
+        "actions/checkout@v7",
+        "actions/setup-python@v7",
+        "actions/upload-artifact@v7",
+        "astral-sh/setup-uv@v8.3.2",
+        "peter-evans/create-pull-request@v8",
+    }
+    create_pr = next(
+        step
+        for step in steps
+        if step.get("uses") == "peter-evans/create-pull-request@v8"
+    )
+    assert create_pr["if"] == (
+        "steps.dispatch.outputs.queue_count != '0' && "
+        "steps.dispatch.outputs.changed_recipe_count != '0'"
+    )
+    assert create_pr["with"]["add-paths"].strip() == "recipes/*.yaml"
+    assert "downstream model\nrelease gates" in create_pr["with"]["body"]
+
+
+def test_workflow_cannot_train_convert_or_publish_models() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    forbidden = (
+        "HF_WRITE_TOKEN",
+        "secrets.",
+        "openmed.core.hf_publish",
+        "openmed.mlx.convert",
+        "openmed.coreml.convert",
+        "openmed.onnx.convert",
+        "scripts/release/dispatch_batch.py",
+        "scripts/release/orchestrate.py",
+        "recipes/queue.yaml",
+    )
+
+    assert [marker for marker in forbidden if marker in workflow] == []
+    assert "scripts/release/retrain_queue.py" in workflow
+    assert "Every resulting candidate must still pass" in workflow


### PR DESCRIPTION
## Description
Adds the offline retraining queue dispatcher and scheduled recipe-proposal workflow for aggregate trigger signals. The workflow opens a PR only when the queue changes a recipe, carries PHI-free evidence into the affected family configuration, and cannot train, convert, or publish model artifacts.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition/improvement

## Changes Made
- Add deterministic offline queue scoring and family-scoped recipe updates.
- Add scheduled/manual recipe proposal workflow with aggregate evidence artifacts.
- Add offline no-op, determinism, isolation, PHI-safety, and workflow-boundary tests.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with different inputs

`PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/ -q` (14,805 passed, 176 skipped)

Focused tests: 25 passed. Dispatcher coverage: 94%. `actionlint`, action-reference policy, Ruff format/lint, mypy, pre-commit, Bandit, pip-audit, and package build all passed.

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md

## Code Quality
- [x] I ran `make format`, `make lint`, and `make format-check`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Dependencies
- [x] I have not added any new dependencies

## Checklist
- [x] I have read the contributing, conduct, and maintainer guides
- [x] My commits have clear, descriptive messages
- [x] I have squashed/organized my commits appropriately

## Related Issues
Closes #3064
Related to #1273
Depends on #3063

## Screenshots/Examples
Not applicable; this is an offline release automation workflow.