### PR TITLE
feat: add federated preflight reporting

### DIFF
--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -214,6 +214,7 @@ classification:
     - reference/training-schemas.md
     - training/federated-round-lifecycle.md
     - training/federated-metrics.md
+    - training/federated-preflight.md
     - training/federated-round-status.md
     - training/federated-scheduling.md
     - training/federated-update-metadata.md

--- a/docs/training/federated-preflight.md
+++ b/docs/training/federated-preflight.md
@@ -1,0 +1,65 @@
+# Federated Preflight
+
+## Purpose
+
+The federated preflight report is the deterministic, fail-closed
+orchestration boundary used before federated round enrollment.
+
+It combines independently computed findings and produces one of:
+
+- `eligible`
+- `review-required`
+- `blocked`
+
+## Fail-closed behavior
+
+Mandatory checks are supplied by the caller.
+
+If a declared mandatory check has no finding, the preflight runner
+creates a `blocked` finding with:
+
+`MANDATORY_CHECK_MISSING`
+
+A blocked finding cannot be overridden by eligible or
+review-required findings.
+
+## Independent findings
+
+Each check produces its own finding.
+
+The report does not calculate an aggregate score and does not allow
+one successful check to compensate for a blocked safety check.
+
+## Existing validation contracts
+
+The preflight orchestration layer consumes existing contracts for:
+
+- federated scheduling
+- federated update metadata
+- federated metric envelopes
+- environment lock digest
+
+It does not reimplement capability-envelope or round-manifest
+validation owned by the dependencies tracked in #2821 and #2822.
+
+## Digest-only output
+
+Reports contain digest references rather than participant identities,
+local data, or training payloads.
+
+Digest references use the canonical form:
+
+`sha256:<64 lowercase hexadecimal characters>`
+
+## Scope
+
+This module only produces the preflight report.
+
+It does not:
+
+- enroll clients
+- open network connections
+- execute training
+- aggregate updates
+- promote models
+- provide compliance certification

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
       - Training Schema Registry: reference/training-schemas.md
       - Federated Round Lifecycle: training/federated-round-lifecycle.md
       - Federated Aggregate Metrics: training/federated-metrics.md
+      - Federated Preflight: training/federated-preflight.md
       - Federated Round Status: training/federated-round-status.md
       - Federated Round Scheduling: training/federated-scheduling.md
       - Federated Update Metadata: training/federated-update-metadata.md

--- a/openmed/training/__init__.py
+++ b/openmed/training/__init__.py
@@ -281,9 +281,7 @@ def __getattr__(name: str) -> Any:
         "check_federated_update_schema",
         "run_federated_preflight",
     }:
-        federated_preflight = import_module(
-            ".federated_preflight", __name__
-        )
+        federated_preflight = import_module(".federated_preflight", __name__)
         return getattr(federated_preflight, name)
     if name in {
         "DEFAULT_FEDERATED_MINIMUM_GROUP_SIZE",

--- a/openmed/training/__init__.py
+++ b/openmed/training/__init__.py
@@ -126,6 +126,15 @@ __all__ = [
     "FederatedUpdateMetadata",
     "FederatedUpdateMetadataError",
     "FederatedUpdatePolicy",
+    "FEDERATED_PREFLIGHT_SCHEMA_VERSION",
+    "FederatedPreflightFinding",
+    "FederatedPreflightReport",
+    "FederatedPreflightStatus",
+    "check_federated_environment",
+    "check_federated_schedule",
+    "check_federated_update_schema",
+    "check_federated_metric_schema",
+    "run_federated_preflight",
     "HARD_NEGATIVE_CATEGORIES",
     "HardNegativeExample",
     "HardNegativeGenerator",
@@ -261,6 +270,21 @@ def __getattr__(name: str) -> Any:
             ".federated_update_metadata", __name__
         )
         return getattr(federated_update_metadata, name)
+    if name in {
+        "FEDERATED_PREFLIGHT_SCHEMA_VERSION",
+        "FederatedPreflightFinding",
+        "FederatedPreflightReport",
+        "FederatedPreflightStatus",
+        "check_federated_environment",
+        "check_federated_metric_schema",
+        "check_federated_schedule",
+        "check_federated_update_schema",
+        "run_federated_preflight",
+    }:
+        federated_preflight = import_module(
+            ".federated_preflight", __name__
+        )
+        return getattr(federated_preflight, name)
     if name in {
         "DEFAULT_FEDERATED_MINIMUM_GROUP_SIZE",
         "FEDERATED_ROUND_STATUS_SCHEMA_VERSION",

--- a/openmed/training/federated_preflight.py
+++ b/openmed/training/federated_preflight.py
@@ -24,6 +24,7 @@ from .federated_update_metadata import (
 FEDERATED_PREFLIGHT_SCHEMA_VERSION = "openmed.training.federated_preflight.v1"
 _SHA256_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
 
+
 class FederatedPreflightStatus(str, Enum):
     """Overall status of a federated preflight report."""
 
@@ -31,11 +32,13 @@ class FederatedPreflightStatus(str, Enum):
     REVIEW_REQUIRED = "review-required"
     BLOCKED = "blocked"
 
+
 _STATUS_PRECEDENCE = {
     FederatedPreflightStatus.ELIGIBLE: 0,
     FederatedPreflightStatus.REVIEW_REQUIRED: 1,
     FederatedPreflightStatus.BLOCKED: 2,
 }
+
 
 @dataclass(frozen=True, slots=True)
 class FederatedPreflightFinding:
@@ -68,6 +71,7 @@ class FederatedPreflightFinding:
             "status": self.status.value,
         }
 
+
 @dataclass(frozen=True, slots=True)
 class FederatedPreflightReport:
     """Immutable, deterministic result of federated round preflight."""
@@ -94,9 +98,7 @@ class FederatedPreflightReport:
 
         expected_status = self._status_from_findings(self.findings)
         if self.status != expected_status:
-            raise ValueError(
-                "report status must be derived from finding statuses"
-            )
+            raise ValueError("report status must be derived from finding statuses")
         if len(set(self.digest_refs)) != len(self.digest_refs):
             raise ValueError("digest_refs must not contain duplicates")
 
@@ -145,8 +147,7 @@ class FederatedPreflightReport:
     def from_findings(
         cls,
         findings: (
-            tuple[FederatedPreflightFinding, ...]
-            | list[FederatedPreflightFinding]
+            tuple[FederatedPreflightFinding, ...] | list[FederatedPreflightFinding]
         ),
         *,
         digest_refs: tuple[str, ...] | list[str] = (),
@@ -171,12 +172,16 @@ class FederatedPreflightReport:
 
     def to_json(self) -> str:
         """Return deterministic canonical JSON."""
-        return json.dumps(
-            self.to_dict(),
-            ensure_ascii=False,
-            indent=2,
-            sort_keys=True,
-        ) + "\n"
+        return (
+            json.dumps(
+                self.to_dict(),
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+
 
 def check_federated_schedule(
     schedule: FederatedRoundSchedule,
@@ -211,11 +216,9 @@ def check_federated_schedule(
         reference=reference,
     )
 
+
 def run_federated_preflight(
-    findings: (
-        tuple[FederatedPreflightFinding, ...]
-        | list[FederatedPreflightFinding]
-    ),
+    findings: (tuple[FederatedPreflightFinding, ...] | list[FederatedPreflightFinding]),
     *,
     mandatory_checks: tuple[str, ...] | list[str] = (),
     digest_refs: tuple[str, ...] | list[str] = (),
@@ -233,9 +236,7 @@ def run_federated_preflight(
 
     for finding in normalized_findings:
         if not isinstance(finding, FederatedPreflightFinding):
-            raise TypeError(
-                "findings must contain FederatedPreflightFinding values"
-            )
+            raise TypeError("findings must contain FederatedPreflightFinding values")
 
     present_checks = {finding.check for finding in normalized_findings}
 
@@ -256,6 +257,7 @@ def run_federated_preflight(
         normalized_findings,
         digest_refs=digest_refs,
     )
+
 
 def check_federated_environment(
     declared_digest: str | None,
@@ -290,6 +292,7 @@ def check_federated_environment(
         reference=reference,
     )
 
+
 def check_federated_update_schema(
     payload: object,
     *,
@@ -314,6 +317,7 @@ def check_federated_update_schema(
         reason_code="UPDATE_SCHEMA_VALID",
         reference=reference,
     )
+
 
 def check_federated_metric_schema(
     payload: object,

--- a/openmed/training/federated_preflight.py
+++ b/openmed/training/federated_preflight.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from enum import Enum
 
 from openmed.core.repro_hash import compute_environment_lock_digest
+
 from .federated_metrics import (
     FederatedMetricEnvelope,
     FederatedMetricError,
@@ -19,7 +20,6 @@ from .federated_update_metadata import (
     FederatedUpdateMetadataError,
     FederatedUpdatePolicy,
 )
-
 
 FEDERATED_PREFLIGHT_SCHEMA_VERSION = "openmed.training.federated_preflight.v1"
 _SHA256_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")

--- a/openmed/training/federated_preflight.py
+++ b/openmed/training/federated_preflight.py
@@ -1,0 +1,340 @@
+"""Deterministic fail-closed preflight reporting for federated rounds."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from openmed.core.repro_hash import compute_environment_lock_digest
+from .federated_metrics import (
+    FederatedMetricEnvelope,
+    FederatedMetricError,
+)
+from .federated_schedule import FederatedRoundSchedule
+from .federated_update_metadata import (
+    FederatedUpdateMetadata,
+    FederatedUpdateMetadataError,
+    FederatedUpdatePolicy,
+)
+
+
+FEDERATED_PREFLIGHT_SCHEMA_VERSION = "openmed.training.federated_preflight.v1"
+_SHA256_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
+
+class FederatedPreflightStatus(str, Enum):
+    """Overall status of a federated preflight report."""
+
+    ELIGIBLE = "eligible"
+    REVIEW_REQUIRED = "review-required"
+    BLOCKED = "blocked"
+
+_STATUS_PRECEDENCE = {
+    FederatedPreflightStatus.ELIGIBLE: 0,
+    FederatedPreflightStatus.REVIEW_REQUIRED: 1,
+    FederatedPreflightStatus.BLOCKED: 2,
+}
+
+@dataclass(frozen=True, slots=True)
+class FederatedPreflightFinding:
+    """One independent finding produced by a federated preflight check."""
+
+    check: str
+    status: FederatedPreflightStatus
+    reason_code: str
+    reference: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.check:
+            raise ValueError("check must not be empty")
+
+        if not self.reason_code:
+            raise ValueError("reason_code must not be empty")
+
+        if not isinstance(self.status, FederatedPreflightStatus):
+            raise TypeError("status must be a FederatedPreflightStatus")
+
+        if self.reference == "":
+            raise ValueError("reference must be None or non-empty")
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Return the canonical dictionary representation."""
+        return {
+            "check": self.check,
+            "reason_code": self.reason_code,
+            "reference": self.reference,
+            "status": self.status.value,
+        }
+
+@dataclass(frozen=True, slots=True)
+class FederatedPreflightReport:
+    """Immutable, deterministic result of federated round preflight."""
+
+    status: FederatedPreflightStatus
+    findings: tuple[FederatedPreflightFinding, ...]
+    digest_refs: tuple[str, ...] = ()
+    schema_version: str = FEDERATED_PREFLIGHT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, FederatedPreflightStatus):
+            raise TypeError("status must be a FederatedPreflightStatus")
+
+        if self.schema_version != FEDERATED_PREFLIGHT_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported preflight schema version: {self.schema_version!r}"
+            )
+
+        for finding in self.findings:
+            if not isinstance(finding, FederatedPreflightFinding):
+                raise TypeError(
+                    "findings must contain FederatedPreflightFinding values"
+                )
+
+        expected_status = self._status_from_findings(self.findings)
+        if self.status != expected_status:
+            raise ValueError(
+                "report status must be derived from finding statuses"
+            )
+        if len(set(self.digest_refs)) != len(self.digest_refs):
+            raise ValueError("digest_refs must not contain duplicates")
+
+        for digest_ref in self.digest_refs:
+            if not isinstance(digest_ref, str):
+                raise TypeError("digest_refs must contain strings")
+            if _SHA256_DIGEST.fullmatch(digest_ref) is None:
+                raise ValueError("digest_refs must be sha256 digests")
+
+        object.__setattr__(
+            self,
+            "findings",
+            tuple(
+                sorted(
+                    self.findings,
+                    key=lambda finding: (
+                        finding.check,
+                        finding.reason_code,
+                        finding.status.value,
+                        finding.reference or "",
+                    ),
+                )
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "digest_refs",
+            tuple(sorted(self.digest_refs)),
+        )
+
+    @staticmethod
+    def _status_from_findings(
+        findings: tuple[FederatedPreflightFinding, ...],
+    ) -> FederatedPreflightStatus:
+        """Derive status using precedence, never aggregate scoring."""
+        if not findings:
+            return FederatedPreflightStatus.ELIGIBLE
+
+        return max(
+            (finding.status for finding in findings),
+            key=_STATUS_PRECEDENCE.__getitem__,
+        )
+
+    @classmethod
+    def from_findings(
+        cls,
+        findings: (
+            tuple[FederatedPreflightFinding, ...]
+            | list[FederatedPreflightFinding]
+        ),
+        *,
+        digest_refs: tuple[str, ...] | list[str] = (),
+    ) -> "FederatedPreflightReport":
+        """Build a report while deriving status from independent findings."""
+        normalized_findings = tuple(findings)
+
+        return cls(
+            status=cls._status_from_findings(normalized_findings),
+            findings=normalized_findings,
+            digest_refs=tuple(digest_refs),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the canonical dictionary representation."""
+        return {
+            "digest_refs": list(self.digest_refs),
+            "findings": [finding.to_dict() for finding in self.findings],
+            "schema_version": self.schema_version,
+            "status": self.status.value,
+        }
+
+    def to_json(self) -> str:
+        """Return deterministic canonical JSON."""
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        ) + "\n"
+
+def check_federated_schedule(
+    schedule: FederatedRoundSchedule,
+    *,
+    timestamp: datetime,
+    reference: str | None = None,
+) -> FederatedPreflightFinding:
+    """Check whether federated enrollment is currently allowed."""
+
+    phase = schedule.active_phase_at(timestamp)
+
+    if phase is None:
+        return FederatedPreflightFinding(
+            check="schedule",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="SCHEDULE_EXPIRED",
+            reference=reference,
+        )
+
+    if phase.value != "enrollment":
+        return FederatedPreflightFinding(
+            check="schedule",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="ENROLLMENT_WINDOW_CLOSED",
+            reference=reference,
+        )
+
+    return FederatedPreflightFinding(
+        check="schedule",
+        status=FederatedPreflightStatus.ELIGIBLE,
+        reason_code="SCHEDULE_VALID",
+        reference=reference,
+    )
+
+def run_federated_preflight(
+    findings: (
+        tuple[FederatedPreflightFinding, ...]
+        | list[FederatedPreflightFinding]
+    ),
+    *,
+    mandatory_checks: tuple[str, ...] | list[str] = (),
+    digest_refs: tuple[str, ...] | list[str] = (),
+) -> FederatedPreflightReport:
+    """Build a fail-closed report from independent preflight findings.
+
+    This function only orchestrates already-computed findings. It does not
+    implement capability, manifest, schedule, privacy, environment, or
+    update-schema validation.
+
+    Any mandatory check absent from ``findings`` produces a blocked finding.
+    """
+
+    normalized_findings = tuple(findings)
+
+    for finding in normalized_findings:
+        if not isinstance(finding, FederatedPreflightFinding):
+            raise TypeError(
+                "findings must contain FederatedPreflightFinding values"
+            )
+
+    present_checks = {finding.check for finding in normalized_findings}
+
+    for mandatory_check in mandatory_checks:
+        if not mandatory_check:
+            raise ValueError("mandatory check names must not be empty")
+
+        if mandatory_check not in present_checks:
+            normalized_findings += (
+                FederatedPreflightFinding(
+                    check=mandatory_check,
+                    status=FederatedPreflightStatus.BLOCKED,
+                    reason_code="MANDATORY_CHECK_MISSING",
+                ),
+            )
+
+    return FederatedPreflightReport.from_findings(
+        normalized_findings,
+        digest_refs=digest_refs,
+    )
+
+def check_federated_environment(
+    declared_digest: str | None,
+    *,
+    lock_path: str = "uv.lock",
+    reference: str | None = None,
+) -> FederatedPreflightFinding:
+    """Check that the declared environment lock matches the repository lock."""
+
+    if declared_digest is None or not declared_digest.strip():
+        return FederatedPreflightFinding(
+            check="environment",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="ENVIRONMENT_LOCK_MISSING",
+            reference=reference,
+        )
+
+    expected_digest = compute_environment_lock_digest(lock_path)
+
+    if declared_digest.strip() != expected_digest:
+        return FederatedPreflightFinding(
+            check="environment",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="ENVIRONMENT_LOCK_MISMATCH",
+            reference=reference,
+        )
+
+    return FederatedPreflightFinding(
+        check="environment",
+        status=FederatedPreflightStatus.ELIGIBLE,
+        reason_code="ENVIRONMENT_LOCK_VALID",
+        reference=reference,
+    )
+
+def check_federated_update_schema(
+    payload: object,
+    *,
+    policy: FederatedUpdatePolicy,
+    reference: str | None = None,
+) -> FederatedPreflightFinding:
+    """Validate update metadata using the existing coordinator policy."""
+
+    try:
+        FederatedUpdateMetadata.from_dict(payload, policy=policy)
+    except FederatedUpdateMetadataError:
+        return FederatedPreflightFinding(
+            check="update-schema",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="UPDATE_SCHEMA_INVALID",
+            reference=reference,
+        )
+
+    return FederatedPreflightFinding(
+        check="update-schema",
+        status=FederatedPreflightStatus.ELIGIBLE,
+        reason_code="UPDATE_SCHEMA_VALID",
+        reference=reference,
+    )
+
+def check_federated_metric_schema(
+    payload: object,
+    *,
+    reference: str | None = None,
+) -> FederatedPreflightFinding:
+    """Validate an aggregate metric envelope using its existing schema."""
+
+    try:
+        FederatedMetricEnvelope.from_dict(payload)
+    except FederatedMetricError:
+        return FederatedPreflightFinding(
+            check="metric-schema",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="METRIC_SCHEMA_INVALID",
+            reference=reference,
+        )
+
+    return FederatedPreflightFinding(
+        check="metric-schema",
+        status=FederatedPreflightStatus.ELIGIBLE,
+        reason_code="METRIC_SCHEMA_VALID",
+        reference=reference,
+    )

--- a/tests/unit/training/test_federated_preflight.py
+++ b/tests/unit/training/test_federated_preflight.py
@@ -1,0 +1,610 @@
+import pytest
+from datetime import datetime, timezone
+from openmed.core.repro_hash import compute_environment_lock_digest
+from openmed.training.federated_preflight import (
+    FEDERATED_PREFLIGHT_SCHEMA_VERSION,
+    FederatedPreflightFinding,
+    FederatedPreflightReport,
+    FederatedPreflightStatus,
+    check_federated_schedule,
+    check_federated_environment,
+    check_federated_metric_schema,
+    check_federated_update_schema,
+    run_federated_preflight,
+)
+from openmed.training.federated_update_metadata import (
+    FederatedParameterMetadata,
+    FederatedUpdateMetadata,
+    FederatedUpdatePolicy,
+    FEDERATED_UPDATE_METADATA_SCHEMA_VERSION,
+)
+from openmed.training import (
+    FederatedMetricKind,
+    FederatedPrivacyMechanism,
+    build_federated_metric_envelope,
+)
+from openmed.training.federated_schedule import FederatedRoundSchedule
+
+def test_empty_preflight_is_eligible() -> None:
+    report = FederatedPreflightReport.from_findings([])
+
+    assert report.status is FederatedPreflightStatus.ELIGIBLE
+    assert report.findings == ()
+    assert report.digest_refs == ()
+    assert report.schema_version == FEDERATED_PREFLIGHT_SCHEMA_VERSION
+
+
+def test_blocked_finding_dominates_review_and_eligible() -> None:
+    findings = [
+        FederatedPreflightFinding(
+            check="schedule",
+            status=FederatedPreflightStatus.REVIEW_REQUIRED,
+            reason_code="SCHEDULE_REVIEW",
+        ),
+        FederatedPreflightFinding(
+            check="privacy",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="PRIVACY_MECHANISM_MISSING",
+        ),
+        FederatedPreflightFinding(
+            check="manifest",
+            status=FederatedPreflightStatus.ELIGIBLE,
+            reason_code="MANIFEST_VALID",
+        ),
+    ]
+
+    report = FederatedPreflightReport.from_findings(findings)
+
+    assert report.status is FederatedPreflightStatus.BLOCKED
+    assert len(report.findings) == 3
+
+
+def test_review_required_dominates_eligible() -> None:
+    findings = [
+        FederatedPreflightFinding(
+            check="manifest",
+            status=FederatedPreflightStatus.ELIGIBLE,
+            reason_code="MANIFEST_VALID",
+        ),
+        FederatedPreflightFinding(
+            check="charter",
+            status=FederatedPreflightStatus.REVIEW_REQUIRED,
+            reason_code="CHARTER_REVIEW",
+        ),
+    ]
+
+    report = FederatedPreflightReport.from_findings(findings)
+
+    assert report.status is FederatedPreflightStatus.REVIEW_REQUIRED
+
+
+def test_findings_are_ordered_deterministically() -> None:
+    finding_a = FederatedPreflightFinding(
+        check="privacy",
+        status=FederatedPreflightStatus.BLOCKED,
+        reason_code="PRIVACY_MECHANISM_MISSING",
+    )
+    finding_b = FederatedPreflightFinding(
+        check="schedule",
+        status=FederatedPreflightStatus.REVIEW_REQUIRED,
+        reason_code="SCHEDULE_REVIEW",
+    )
+
+    report_one = FederatedPreflightReport.from_findings(
+        [finding_a, finding_b]
+    )
+    report_two = FederatedPreflightReport.from_findings(
+        [finding_b, finding_a]
+    )
+
+    assert report_one.findings == report_two.findings
+    assert report_one.to_json() == report_two.to_json()
+
+
+def test_json_output_is_byte_stable() -> None:
+    findings = [
+        FederatedPreflightFinding(
+            check="privacy",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="PRIVACY_MECHANISM_MISSING",
+            reference="sha256:privacy-contract",
+        ),
+        FederatedPreflightFinding(
+            check="schedule",
+            status=FederatedPreflightStatus.ELIGIBLE,
+            reason_code="SCHEDULE_VALID",
+            reference="sha256:schedule",
+        ),
+    ]
+
+    report = FederatedPreflightReport.from_findings(
+        findings,
+        digest_refs=[
+            "sha256:" + "f" * 64,
+            "sha256:" + "1" * 64,
+        ],
+    )
+
+    expected = report.to_json()
+
+    assert report.to_json() == expected
+    assert report.to_json().endswith("\n")
+    assert '"status": "blocked"' in expected
+    assert '"digest_refs": [' in expected
+
+
+def test_digest_references_are_deterministically_ordered() -> None:
+    digest_a = "sha256:" + "1" * 64
+    digest_m = "sha256:" + "8" * 64
+    digest_z = "sha256:" + "f" * 64
+
+    report = FederatedPreflightReport.from_findings(
+        [],
+        digest_refs=[
+            digest_z,
+            digest_a,
+            digest_m,
+        ],
+    )
+
+    assert report.digest_refs == (
+        digest_a,
+        digest_m,
+        digest_z,
+    )
+
+def test_report_rejects_invalid_digest_reference() -> None:
+    with pytest.raises(ValueError):
+        FederatedPreflightReport.from_findings(
+            (),
+            digest_refs=("not-a-digest",),
+        )
+
+
+def test_report_rejects_non_canonical_digest_reference() -> None:
+    digest = "sha256:" + "A" * 64
+
+    with pytest.raises(ValueError):
+        FederatedPreflightReport.from_findings(
+            (),
+            digest_refs=(digest,),
+        )
+
+
+def test_report_rejects_duplicate_digest_references() -> None:
+    digest = "sha256:" + "a" * 64
+
+    with pytest.raises(ValueError):
+        FederatedPreflightReport.from_findings(
+            (),
+            digest_refs=(digest, digest),
+        )
+
+
+def test_report_accepts_canonical_sha256_digest_reference() -> None:
+    digest = "sha256:" + "a" * 64
+
+    report = FederatedPreflightReport.from_findings(
+        (),
+        digest_refs=(digest,),
+    )
+
+    assert report.digest_refs == (digest,)
+
+def test_finding_rejects_empty_check() -> None:
+    try:
+        FederatedPreflightFinding(
+            check="",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="INVALID",
+        )
+    except ValueError as exc:
+        assert str(exc) == "check must not be empty"
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_finding_rejects_empty_reason_code() -> None:
+    try:
+        FederatedPreflightFinding(
+            check="privacy",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="",
+        )
+    except ValueError as exc:
+        assert str(exc) == "reason_code must not be empty"
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_report_rejects_status_that_does_not_match_findings() -> None:
+    finding = FederatedPreflightFinding(
+        check="privacy",
+        status=FederatedPreflightStatus.BLOCKED,
+        reason_code="PRIVACY_MECHANISM_MISSING",
+    )
+
+    try:
+        FederatedPreflightReport(
+            status=FederatedPreflightStatus.ELIGIBLE,
+            findings=(finding,),
+        )
+    except ValueError as exc:
+        assert str(exc) == "report status must be derived from finding statuses"
+    else:
+        raise AssertionError("expected ValueError")
+
+def test_preflight_runner_preserves_independent_check_results() -> None:
+    checks = [
+        FederatedPreflightFinding(
+            check="schedule",
+            status=FederatedPreflightStatus.ELIGIBLE,
+            reason_code="SCHEDULE_VALID",
+            reference="sha256:schedule",
+        ),
+        FederatedPreflightFinding(
+            check="privacy",
+            status=FederatedPreflightStatus.BLOCKED,
+            reason_code="PRIVACY_MECHANISM_MISSING",
+            reference="sha256:privacy",
+        ),
+    ]
+
+    report = run_federated_preflight(checks)
+
+    assert report.status is FederatedPreflightStatus.BLOCKED
+    assert len(report.findings) == 2
+    assert {
+        finding.check
+        for finding in report.findings
+    } == {"schedule", "privacy"}
+
+
+def test_missing_mandatory_check_fails_closed() -> None:
+    checks = [
+        FederatedPreflightFinding(
+            check="schedule",
+            status=FederatedPreflightStatus.ELIGIBLE,
+            reason_code="SCHEDULE_VALID",
+        ),
+    ]
+
+    report = run_federated_preflight(
+        checks,
+        mandatory_checks=[
+            "schedule",
+            "privacy",
+            "environment",
+        ],
+    )
+
+    assert report.status is FederatedPreflightStatus.BLOCKED
+
+    missing = [
+        finding
+        for finding in report.findings
+        if finding.reason_code == "MANDATORY_CHECK_MISSING"
+    ]
+
+    assert {finding.check for finding in missing} == {
+        "privacy",
+        "environment",
+    }
+
+
+def test_preflight_runner_is_deterministic_for_check_order() -> None:
+    check_a = FederatedPreflightFinding(
+        check="privacy",
+        status=FederatedPreflightStatus.BLOCKED,
+        reason_code="PRIVACY_MECHANISM_MISSING",
+    )
+    check_b = FederatedPreflightFinding(
+        check="schedule",
+        status=FederatedPreflightStatus.REVIEW_REQUIRED,
+        reason_code="SCHEDULE_REVIEW",
+    )
+
+    report_one = run_federated_preflight([check_a, check_b])
+    report_two = run_federated_preflight([check_b, check_a])
+
+    assert report_one.to_json() == report_two.to_json()
+
+
+def _schedule() -> FederatedRoundSchedule:
+    return FederatedRoundSchedule(
+        enrollment_starts_at=datetime(2026, 9, 9, 10, 0, tzinfo=timezone.utc),
+        update_submission_starts_at=datetime(
+            2026, 9, 9, 12, 0, tzinfo=timezone.utc
+        ),
+        aggregation_starts_at=datetime(
+            2026, 9, 9, 14, 0, tzinfo=timezone.utc
+        ),
+        evaluation_starts_at=datetime(
+            2026, 9, 9, 16, 0, tzinfo=timezone.utc
+        ),
+        finishes_at=datetime(2026, 9, 9, 18, 0, tzinfo=timezone.utc),
+    )
+
+
+def test_schedule_check_passes_during_enrollment() -> None:
+    finding = check_federated_schedule(
+        _schedule(),
+        timestamp=datetime(2026, 9, 9, 11, 0, tzinfo=timezone.utc),
+        reference="sha256:schedule",
+    )
+
+    assert finding.check == "schedule"
+    assert finding.status is FederatedPreflightStatus.ELIGIBLE
+    assert finding.reason_code == "SCHEDULE_VALID"
+    assert finding.reference == "sha256:schedule"
+
+
+def test_schedule_check_blocks_after_enrollment() -> None:
+    finding = check_federated_schedule(
+        _schedule(),
+        timestamp=datetime(2026, 9, 9, 13, 0, tzinfo=timezone.utc),
+    )
+
+    assert finding.status is FederatedPreflightStatus.BLOCKED
+    assert finding.reason_code == "ENROLLMENT_WINDOW_CLOSED"
+
+
+def test_schedule_check_blocks_after_round_finishes() -> None:
+    finding = check_federated_schedule(
+        _schedule(),
+        timestamp=datetime(2026, 9, 9, 19, 0, tzinfo=timezone.utc),
+    )
+
+    assert finding.status is FederatedPreflightStatus.BLOCKED
+    assert finding.reason_code == "SCHEDULE_EXPIRED"
+
+def test_environment_check_passes_for_matching_lock_digest(tmp_path) -> None:
+    lock = tmp_path / "uv.lock"
+    lock.write_text("environment-lock", encoding="utf-8")
+
+    expected = compute_environment_lock_digest(lock)
+
+    finding = check_federated_environment(
+        expected,
+        lock_path=str(lock),
+        reference=expected,
+    )
+
+    assert finding.check == "environment"
+    assert finding.status is FederatedPreflightStatus.ELIGIBLE
+    assert finding.reason_code == "ENVIRONMENT_LOCK_VALID"
+    assert finding.reference == expected
+
+def test_environment_check_blocks_missing_lock_digest(tmp_path) -> None:
+    lock = tmp_path / "uv.lock"
+    lock.write_text("environment-lock", encoding="utf-8")
+
+    finding = check_federated_environment(
+        None,
+        lock_path=str(lock),
+    )
+
+    assert finding.status is FederatedPreflightStatus.BLOCKED
+    assert finding.reason_code == "ENVIRONMENT_LOCK_MISSING"
+
+def test_environment_check_blocks_mismatched_lock_digest(tmp_path) -> None:
+    lock = tmp_path / "uv.lock"
+    lock.write_text("environment-lock", encoding="utf-8")
+
+    finding = check_federated_environment(
+        "sha256:" + "0" * 64,
+        lock_path=str(lock),
+    )
+
+    assert finding.status is FederatedPreflightStatus.BLOCKED
+    assert finding.reason_code == "ENVIRONMENT_LOCK_MISMATCH"
+
+def test_update_schema_passes_with_valid_metadata():
+    model_digest = "sha256:" + "a" * 64
+    update_digest = "sha256:" + "b" * 64
+
+    policy = FederatedUpdatePolicy(
+        model_digest=model_digest,
+        parameters=(
+            FederatedParameterMetadata(
+                "adapter.lora_A.weight",
+                (2, 3),
+                "float32",
+            ),
+            FederatedParameterMetadata(
+                "adapter.lora_B.weight",
+                (4, 2),
+                "float32",
+            ),
+        ),
+        max_total_elements=14,
+    )
+
+    payload = {
+        "schema_version": FEDERATED_UPDATE_METADATA_SCHEMA_VERSION,
+        "model_digest": model_digest,
+        "adapter_format": "dense",
+        "parameters": [
+            {
+                "name": "adapter.lora_A.weight",
+                "shape": [2, 3],
+                "dtype": "float32",
+            },
+            {
+                "name": "adapter.lora_B.weight",
+                "shape": [4, 2],
+                "dtype": "float32",
+            },
+        ],
+        "total_elements": 14,
+        "update_digest": update_digest,
+        "clipped": True,
+    }
+
+    finding = check_federated_update_schema(
+        payload,
+        policy=policy,
+        reference=update_digest,
+    )
+
+    assert finding.check == "update-schema"
+    assert finding.status is FederatedPreflightStatus.ELIGIBLE
+    assert finding.reason_code == "UPDATE_SCHEMA_VALID"
+    assert finding.reference == update_digest
+
+def test_update_schema_blocks_unsupported_schema():
+    model_digest = "sha256:" + "a" * 64
+
+    policy = FederatedUpdatePolicy(
+        model_digest=model_digest,
+        parameters=(
+            FederatedParameterMetadata(
+                "adapter.weight",
+                (2, 2),
+                "float32",
+            ),
+        ),
+    )
+
+    payload = {
+        "schema_version": "openmed.training.federated_update_metadata.v999",
+        "model_digest": model_digest,
+        "adapter_format": "dense",
+        "parameters": [
+            {
+                "name": "adapter.weight",
+                "shape": [2, 2],
+                "dtype": "float32",
+            }
+        ],
+        "total_elements": 4,
+        "update_digest": "sha256:" + "b" * 64,
+        "clipped": True,
+    }
+
+    finding = check_federated_update_schema(
+        payload,
+        policy=policy,
+    )
+
+    assert finding.status is FederatedPreflightStatus.BLOCKED
+    assert finding.reason_code == "UPDATE_SCHEMA_INVALID"
+
+def test_metric_schema_blocks_unsupported_schema() -> None:
+    envelope = build_federated_metric_envelope(
+        metric_id="documents_processed",
+        metric_kind=FederatedMetricKind.COUNT,
+        aggregate_value=18,
+        clipping_lower_bound=0,
+        clipping_upper_bound=100,
+        privacy_mechanism=FederatedPrivacyMechanism.THRESHOLD_ONLY,
+        privacy_mechanism_version="v1",
+        participant_count=12,
+    )
+
+    payload = envelope.to_dict()
+    payload["schema_version"] = "openmed.training.federated_metric.v999"
+
+    finding = check_federated_metric_schema(payload)
+
+    assert finding.status is FederatedPreflightStatus.BLOCKED
+    assert finding.reason_code == "METRIC_SCHEMA_INVALID"
+
+def test_update_schema_blocks_policy_mismatch():
+    model_digest = "sha256:" + "a" * 64
+
+    policy = FederatedUpdatePolicy(
+        model_digest=model_digest,
+        parameters=(
+            FederatedParameterMetadata(
+                "adapter.weight",
+                (2, 2),
+                "float32",
+            ),
+        ),
+    )
+
+    payload = {
+        "schema_version": FEDERATED_UPDATE_METADATA_SCHEMA_VERSION,
+        "model_digest": model_digest,
+        "adapter_format": "dense",
+        "parameters": [
+            {
+                "name": "adapter.other_weight",
+                "shape": [2, 2],
+                "dtype": "float32",
+            }
+        ],
+        "total_elements": 4,
+        "update_digest": "sha256:" + "b" * 64,
+        "clipped": True,
+    }
+
+    finding = check_federated_update_schema(
+        payload,
+        policy=policy,
+    )
+
+    assert finding.status is FederatedPreflightStatus.BLOCKED
+    assert finding.reason_code == "UPDATE_SCHEMA_INVALID"
+
+def test_update_schema_does_not_expose_invalid_payload():
+    model_digest = "sha256:" + "a" * 64
+    sentinel = "SYNTHETIC_PRIVATE_SENTINEL_3012"
+
+    policy = FederatedUpdatePolicy(
+        model_digest=model_digest,
+        parameters=(
+            FederatedParameterMetadata(
+                "adapter.weight",
+                (2, 2),
+                "float32",
+            ),
+        ),
+    )
+
+    payload = {
+        "schema_version": FEDERATED_UPDATE_METADATA_SCHEMA_VERSION,
+        "model_digest": sentinel,
+        "adapter_format": "dense",
+        "parameters": [
+            {
+                "name": "adapter.weight",
+                "shape": [2, 2],
+                "dtype": "float32",
+            }
+        ],
+        "total_elements": 4,
+        "update_digest": "sha256:" + "b" * 64,
+        "clipped": True,
+    }
+
+    finding = check_federated_update_schema(
+        payload,
+        policy=policy,
+        reference="sha256:" + "c" * 64,
+    )
+
+    assert finding.status is FederatedPreflightStatus.BLOCKED
+    assert sentinel not in str(finding.to_dict())
+
+def test_metric_schema_accepts_valid_envelope() -> None:
+    envelope = build_federated_metric_envelope(
+        metric_id="documents_processed",
+        metric_kind=FederatedMetricKind.COUNT,
+        aggregate_value=18,
+        clipping_lower_bound=0,
+        clipping_upper_bound=100,
+        privacy_mechanism=FederatedPrivacyMechanism.THRESHOLD_ONLY,
+        privacy_mechanism_version="v1",
+        participant_count=12,
+    )
+
+    finding = check_federated_metric_schema(
+        envelope.to_dict(),
+        reference="sha256:metric-fixture",
+    )
+
+    assert finding.status is FederatedPreflightStatus.ELIGIBLE
+    assert finding.reason_code == "METRIC_SCHEMA_VALID"
+    assert finding.reference == "sha256:metric-fixture"

--- a/tests/unit/training/test_federated_preflight.py
+++ b/tests/unit/training/test_federated_preflight.py
@@ -1,29 +1,30 @@
-import pytest
 from datetime import datetime, timezone
+import pytest
 from openmed.core.repro_hash import compute_environment_lock_digest
-from openmed.training.federated_preflight import (
-    FEDERATED_PREFLIGHT_SCHEMA_VERSION,
-    FederatedPreflightFinding,
-    FederatedPreflightReport,
-    FederatedPreflightStatus,
-    check_federated_schedule,
-    check_federated_environment,
-    check_federated_metric_schema,
-    check_federated_update_schema,
-    run_federated_preflight,
-)
-from openmed.training.federated_update_metadata import (
-    FederatedParameterMetadata,
-    FederatedUpdateMetadata,
-    FederatedUpdatePolicy,
-    FEDERATED_UPDATE_METADATA_SCHEMA_VERSION,
-)
 from openmed.training import (
     FederatedMetricKind,
     FederatedPrivacyMechanism,
     build_federated_metric_envelope,
 )
+from openmed.training.federated_preflight import (
+    FEDERATED_PREFLIGHT_SCHEMA_VERSION,
+    FederatedPreflightFinding,
+    FederatedPreflightReport,
+    FederatedPreflightStatus,
+    check_federated_environment,
+    check_federated_metric_schema,
+    check_federated_schedule,
+    check_federated_update_schema,
+    run_federated_preflight,
+)
 from openmed.training.federated_schedule import FederatedRoundSchedule
+from openmed.training.federated_update_metadata import (
+    FEDERATED_UPDATE_METADATA_SCHEMA_VERSION,
+    FederatedParameterMetadata,
+    FederatedUpdateMetadata,
+    FederatedUpdatePolicy,
+)
+
 
 def test_empty_preflight_is_eligible() -> None:
     report = FederatedPreflightReport.from_findings([])

--- a/tests/unit/training/test_federated_preflight.py
+++ b/tests/unit/training/test_federated_preflight.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
+
 import pytest
+
 from openmed.core.repro_hash import compute_environment_lock_digest
 from openmed.training import (
     FederatedMetricKind,

--- a/tests/unit/training/test_federated_preflight.py
+++ b/tests/unit/training/test_federated_preflight.py
@@ -93,12 +93,8 @@ def test_findings_are_ordered_deterministically() -> None:
         reason_code="SCHEDULE_REVIEW",
     )
 
-    report_one = FederatedPreflightReport.from_findings(
-        [finding_a, finding_b]
-    )
-    report_two = FederatedPreflightReport.from_findings(
-        [finding_b, finding_a]
-    )
+    report_one = FederatedPreflightReport.from_findings([finding_a, finding_b])
+    report_two = FederatedPreflightReport.from_findings([finding_b, finding_a])
 
     assert report_one.findings == report_two.findings
     assert report_one.to_json() == report_two.to_json()
@@ -156,6 +152,7 @@ def test_digest_references_are_deterministically_ordered() -> None:
         digest_z,
     )
 
+
 def test_report_rejects_invalid_digest_reference() -> None:
     with pytest.raises(ValueError):
         FederatedPreflightReport.from_findings(
@@ -193,6 +190,7 @@ def test_report_accepts_canonical_sha256_digest_reference() -> None:
     )
 
     assert report.digest_refs == (digest,)
+
 
 def test_finding_rejects_empty_check() -> None:
     try:
@@ -237,6 +235,7 @@ def test_report_rejects_status_that_does_not_match_findings() -> None:
     else:
         raise AssertionError("expected ValueError")
 
+
 def test_preflight_runner_preserves_independent_check_results() -> None:
     checks = [
         FederatedPreflightFinding(
@@ -257,10 +256,7 @@ def test_preflight_runner_preserves_independent_check_results() -> None:
 
     assert report.status is FederatedPreflightStatus.BLOCKED
     assert len(report.findings) == 2
-    assert {
-        finding.check
-        for finding in report.findings
-    } == {"schedule", "privacy"}
+    assert {finding.check for finding in report.findings} == {"schedule", "privacy"}
 
 
 def test_missing_mandatory_check_fails_closed() -> None:
@@ -316,15 +312,9 @@ def test_preflight_runner_is_deterministic_for_check_order() -> None:
 def _schedule() -> FederatedRoundSchedule:
     return FederatedRoundSchedule(
         enrollment_starts_at=datetime(2026, 9, 9, 10, 0, tzinfo=timezone.utc),
-        update_submission_starts_at=datetime(
-            2026, 9, 9, 12, 0, tzinfo=timezone.utc
-        ),
-        aggregation_starts_at=datetime(
-            2026, 9, 9, 14, 0, tzinfo=timezone.utc
-        ),
-        evaluation_starts_at=datetime(
-            2026, 9, 9, 16, 0, tzinfo=timezone.utc
-        ),
+        update_submission_starts_at=datetime(2026, 9, 9, 12, 0, tzinfo=timezone.utc),
+        aggregation_starts_at=datetime(2026, 9, 9, 14, 0, tzinfo=timezone.utc),
+        evaluation_starts_at=datetime(2026, 9, 9, 16, 0, tzinfo=timezone.utc),
         finishes_at=datetime(2026, 9, 9, 18, 0, tzinfo=timezone.utc),
     )
 
@@ -361,6 +351,7 @@ def test_schedule_check_blocks_after_round_finishes() -> None:
     assert finding.status is FederatedPreflightStatus.BLOCKED
     assert finding.reason_code == "SCHEDULE_EXPIRED"
 
+
 def test_environment_check_passes_for_matching_lock_digest(tmp_path) -> None:
     lock = tmp_path / "uv.lock"
     lock.write_text("environment-lock", encoding="utf-8")
@@ -378,6 +369,7 @@ def test_environment_check_passes_for_matching_lock_digest(tmp_path) -> None:
     assert finding.reason_code == "ENVIRONMENT_LOCK_VALID"
     assert finding.reference == expected
 
+
 def test_environment_check_blocks_missing_lock_digest(tmp_path) -> None:
     lock = tmp_path / "uv.lock"
     lock.write_text("environment-lock", encoding="utf-8")
@@ -390,6 +382,7 @@ def test_environment_check_blocks_missing_lock_digest(tmp_path) -> None:
     assert finding.status is FederatedPreflightStatus.BLOCKED
     assert finding.reason_code == "ENVIRONMENT_LOCK_MISSING"
 
+
 def test_environment_check_blocks_mismatched_lock_digest(tmp_path) -> None:
     lock = tmp_path / "uv.lock"
     lock.write_text("environment-lock", encoding="utf-8")
@@ -401,6 +394,7 @@ def test_environment_check_blocks_mismatched_lock_digest(tmp_path) -> None:
 
     assert finding.status is FederatedPreflightStatus.BLOCKED
     assert finding.reason_code == "ENVIRONMENT_LOCK_MISMATCH"
+
 
 def test_update_schema_passes_with_valid_metadata():
     model_digest = "sha256:" + "a" * 64
@@ -455,6 +449,7 @@ def test_update_schema_passes_with_valid_metadata():
     assert finding.reason_code == "UPDATE_SCHEMA_VALID"
     assert finding.reference == update_digest
 
+
 def test_update_schema_blocks_unsupported_schema():
     model_digest = "sha256:" + "a" * 64
 
@@ -493,6 +488,7 @@ def test_update_schema_blocks_unsupported_schema():
     assert finding.status is FederatedPreflightStatus.BLOCKED
     assert finding.reason_code == "UPDATE_SCHEMA_INVALID"
 
+
 def test_metric_schema_blocks_unsupported_schema() -> None:
     envelope = build_federated_metric_envelope(
         metric_id="documents_processed",
@@ -512,6 +508,7 @@ def test_metric_schema_blocks_unsupported_schema() -> None:
 
     assert finding.status is FederatedPreflightStatus.BLOCKED
     assert finding.reason_code == "METRIC_SCHEMA_INVALID"
+
 
 def test_update_schema_blocks_policy_mismatch():
     model_digest = "sha256:" + "a" * 64
@@ -550,6 +547,7 @@ def test_update_schema_blocks_policy_mismatch():
 
     assert finding.status is FederatedPreflightStatus.BLOCKED
     assert finding.reason_code == "UPDATE_SCHEMA_INVALID"
+
 
 def test_update_schema_does_not_expose_invalid_payload():
     model_digest = "sha256:" + "a" * 64
@@ -590,6 +588,7 @@ def test_update_schema_does_not_expose_invalid_payload():
 
     assert finding.status is FederatedPreflightStatus.BLOCKED
     assert sentinel not in str(finding.to_dict())
+
 
 def test_metric_schema_accepts_valid_envelope() -> None:
     envelope = build_federated_metric_envelope(


### PR DESCRIPTION
## Description

Implements the deterministic, fail-closed federated preflight reporting layer for #3012.

The preflight layer combines independently computed validation findings into a single immutable report with three possible outcomes: `eligible`, `review-required`, or `blocked`.

Blocked findings are non-compensable, and missing mandatory checks fail closed. Report output is deterministic and restricted to digest references without participant identities, local data, or training payloads.

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [x] Test addition/improvement

## Changes Made

* Added immutable federated preflight findings and reports with `eligible`, `review-required`, and `blocked` statuses.
* Added fail-closed orchestration for mandatory checks, with independent non-compensable findings.
* Added deterministic ordering and byte-stable JSON serialization for preflight reports.
* Added digest-only report references using canonical SHA-256 digests.
* Added adapters for the existing federated schedule, environment lock, update metadata, and metric envelope validation contracts.
* Added focused unit tests covering successful, blocked, missing-check, invalid-schema, environment, schedule, and deterministic-output cases.
* Added documentation describing the preflight contract and dependency boundaries.

## Testing

* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested this change with different models/inputs

Focused tests:

`uv run pytest tests/unit/training/test_federated_preflight.py -q`

Result: **28 passed**

Training test suite:

`uv run pytest tests/unit/training -q`

Result: **675 passed, 1 skipped**

## Documentation

* [x] I have updated the documentation accordingly
* [x] I have added docstrings to new functions/classes
* [ ] I have updated the CHANGELOG.md

## Code Quality

* [ ] I ran `make format`, `make lint`, and `make format-check`
* [ ] For Swift/OpenMedKit changes, I ran `make format-swift` and `make lint-swift`
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings

## Dependencies

* [x] I have not added any new dependencies
* [ ] OR I have added new dependencies and they are justified because: ____

## Checklist

* [x] I have read the [[contributing guide](https://github.com/maziyarpanahi/openmed/blob/master/CONTRIBUTING.md)](https://github.com/maziyarpanahi/openmed/blob/master/CONTRIBUTING.md), [[Code of Conduct](https://github.com/maziyarpanahi/openmed/blob/master/CODE_OF_CONDUCT.md)](https://github.com/maziyarpanahi/openmed/blob/master/CODE_OF_CONDUCT.md), and [[maintainer guide](https://github.com/maziyarpanahi/openmed/blob/master/MAINTAINERS.md)](https://github.com/maziyarpanahi/openmed/blob/master/MAINTAINERS.md)
* [x] My commits have clear, descriptive messages
* [x] I have squashed/organized my commits appropriately

## Related Issues

Closes #3012

Related to #2821
Related to #2822

## Dependency Boundaries

The capability-envelope and round-manifest validation interfaces from #2821 and #2822 are not currently exposed as stable contracts in the repository.

This PR intentionally does not reimplement those scopes. The preflight layer accepts independently computed findings so those dependency checks can be integrated once their stable interfaces are available.

The repository also does not currently expose a stable round-level federated privacy declaration contract, so this PR does not introduce a new privacy-policy implementation.

## Scope

This PR is limited to the preflight orchestration and reporting layer.

It does not:

* enroll clients
* open network connections
* execute training
* aggregate updates
* promote models
* provide compliance certification

## Screenshots/Examples

Not applicable. The output is a deterministic structured preflight report rather than a UI change.