### PR TITLE
Validate OMOP cohort exports and FHIR round-trip fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a bounded, manifest-driven deletion impact planner with deterministic
   counts-only reports, reverse-dependency analysis, ownership checks, and
   explicit plan-bound confirmation before injected local execution (#2529).
+- Added a deterministic, offline OMOP cohort export validator for key,
+  relationship, vocabulary, and NOTE/NOTE_NLP provenance invariants, with
+  aggregate counts and content-derived row fingerprints instead of source
+  values (#2402).
 - Added an offline manifest-coherence regenerator and CI drift gate for the
   runtime model registry, PII language defaults, governed README counts,
   registry model cards, and generated model and benchmark documentation (#77).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relationship, vocabulary, and NOTE/NOTE_NLP provenance invariants, with
   aggregate counts and content-derived row fingerprints instead of source
   values (#2402).
+- Added a bounded, deterministic FHIR R5 Bundle round-trip fidelity diff with
+  stable entry matching, explicit serializer-difference declarations, and
+  value-free reports containing structural paths, types, and SHA-256 digests
+  (#2401).
 - Added an offline manifest-coherence regenerator and CI drift gate for the
   runtime model registry, PII language defaults, governed README counts,
   registry model cards, and generated model and benchmark documentation (#77).

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -335,6 +335,7 @@ classification:
     - guides/fhir-omop-interoperability.md
     - interop/archive-safety.md
     - fhir-interop.md
+    - integrations/fhir-r5-fidelity.md
     - interop/fhir-bulk-data.md
     - interop/fhir-omop-matrix.md
     - fhir/reference-integrity.md

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -307,6 +307,7 @@ classification:
     - integrations/pandas-on-spark.md
     - integrations/ray-map-batches.md
     - integrations/sqlalchemy.md
+    - integrations/omop-cohort-check.md
     - duckdb-deidentification.md
     - integrations/distributed-sql-udf.md
     - integrations/warehouse-remote-function.md

--- a/docs/integrations/fhir-r5-fidelity.md
+++ b/docs/integrations/fhir-r5-fidelity.md
@@ -1,0 +1,50 @@
+# FHIR R5 round-trip fidelity
+
+`openmed.interop.fhir_r5_fidelity` compares a local FHIR R5 `Bundle` before
+and after a parser/exporter round trip. It is a deterministic exchange check,
+not a FHIR profile validator, terminology check, compliance certification, or
+clinical decision guarantee.
+
+The comparison is offline and dependency-free. JSON object member order and
+whitespace are ignored. Bundle entries are matched by `fullUrl`, then the
+resource `resourceType` and `id` pair, and finally by remaining position.
+Duplicate stable keys are paired deterministically, so a serializer that
+reorders entries does not create a false difference. Valid request and response
+entries without a `resource` are supported and compared as complete entries.
+
+```python
+from openmed.interop.fhir_r5_fidelity import diff_fhir_r5_bundles
+
+result = diff_fhir_r5_bundles(exported_bundle, reparsed_bundle)
+if not result.is_faithful:
+    print(result.to_markdown())
+```
+
+Reports contain structural paths, JSON types, resource types, and SHA-256
+digests of values and identifiers. They do not include raw IDs, references,
+code values, narrative, or other source values. Digests can still be
+correlatable metadata, so protect and retain `to_dict()`, `to_json()`, and
+`to_markdown()` outputs according to the source data policy.
+
+Known serializer-specific differences must be declared explicitly. Paths use
+dot notation with array indexes and support `[*]` for one segment or `**` for
+recursive matching:
+
+```python
+result = diff_fhir_r5_bundles(
+    before,
+    after,
+    allowed_paths=["entry[*].resource.meta.lastUpdated"],
+    unordered_paths=["entry[*].resource.meta.tag"],
+)
+```
+
+Only the named subtree is ignored; coded fields, resource references, and
+other fields remain part of the fidelity check. An empty `result.changes`
+means the two bundles are equivalent under the declarations supplied by the
+caller.
+
+JSON text and file inputs are limited to 16 MiB. Object keys must use FHIR JSON
+element-name syntax, resource metadata is validated before matching, and
+excessive nesting, node counts, cycles, and non-finite numbers are rejected.
+Failures use value-free errors and do not include rejected input or path text.

--- a/docs/integrations/omop-cohort-check.md
+++ b/docs/integrations/omop-cohort-check.md
@@ -1,0 +1,46 @@
+# OMOP Cohort Export Check
+
+OpenMed provides a local-only validator for the relationship, vocabulary, and
+provenance invariants used by its OMOP cohort exports. It accepts the
+`OmopCdmTables` returned by the loader or a mapping of table names to row
+iterables:
+
+```python
+from openmed.interop.omop import load_grounded_notes
+from openmed.interop.omop_cohort_check import validate_omop_cohort_export
+
+tables = load_grounded_notes(synthetic_notes)
+report = validate_omop_cohort_export(tables)
+
+if not report.is_valid:
+    print(report.to_dict())
+```
+
+The check is deterministic and makes no network call. It verifies primary-key
+uniqueness, person/visit/note relationships, concept references, vocabulary
+metadata for source-to-target mappings, and the OpenMed NOTE and NOTE_NLP
+provenance chain when those fields are present. Identifiers must be lossless,
+signed 64-bit integers or integer strings. Null, fractional, out-of-range, and
+duplicate primary keys are invalid; duplicate keys are not available as
+relationship targets. Provenance hashes must be lowercase, 64-character
+SHA-256 values.
+
+Reports contain table and column names, failure reasons, counts, and stable
+`sha256:` row fingerprints. They do not contain source identifiers, note text,
+or other row values. Invalid iterators, cyclic or excessively nested row
+values, and values that fail during fingerprinting produce bounded errors
+without copying the source value. Fingerprints can correlate identical rows
+and should be handled as diagnostic metadata rather than anonymous data. The
+validator is a structural quality check; it is not a compliance certification
+or a clinical decision guarantee.
+
+For a fail-closed boundary, use the assertion helper:
+
+```python
+from openmed.interop.omop_cohort_check import assert_valid_omop_cohort_export
+
+assert_valid_omop_cohort_export(tables)
+```
+
+The resulting `OmopCohortExportValidationError` includes the aggregate report
+and an exception message with only the number of failed row-level invariants.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -233,6 +233,7 @@ nav:
       - Pandas-on-Spark De-identification: integrations/pandas-on-spark.md
       - Ray Data Batch De-identification: integrations/ray-map-batches.md
       - SQLAlchemy Write-time Redaction: integrations/sqlalchemy.md
+      - OMOP Cohort Export Validation: integrations/omop-cohort-check.md
       - DuckDB De-identification UDFs: duckdb-deidentification.md
       - Distributed SQL De-identification UDF: integrations/distributed-sql-udf.md
       - Warehouse Remote-Function Handler: integrations/warehouse-remote-function.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -261,6 +261,7 @@ nav:
       - FHIR and OMOP Interoperability: guides/fhir-omop-interoperability.md
       - Archive Extraction Safety: interop/archive-safety.md
       - FHIR Interop Helpers: fhir-interop.md
+      - FHIR R5 Round-trip Fidelity: integrations/fhir-r5-fidelity.md
       - FHIR Bulk Data Privacy Gateway: interop/fhir-bulk-data.md
       - FHIR-to-OMOP Round-trip Conformance: interop/fhir-omop-matrix.md
       - FHIR Reference Integrity Reports: fhir/reference-integrity.md

--- a/openmed/interop/fhir_r5_fidelity.py
+++ b/openmed/interop/fhir_r5_fidelity.py
@@ -1,0 +1,1371 @@
+"""Deterministic, privacy-safe diffs for FHIR R5 Bundle round trips.
+
+The helper in this module compares already-exported JSON locally.  It does not
+validate a FHIR profile or contact a terminology server.  JSON object member
+ordering is naturally ignored, Bundle entries are matched by their stable
+``fullUrl`` or ``id`` when possible, and callers can explicitly allow known
+serialization differences by path.
+
+Reports contain paths, JSON types, resource metadata, and one-way SHA-256
+digests.  They intentionally never include source values because FHIR
+identifiers, narrative, coded displays, and references may contain sensitive
+data.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
+
+FHIRBundleInput: TypeAlias = Mapping[str, Any] | str | bytes | bytearray | Path
+PathSpec: TypeAlias = str | Sequence[str]
+
+_MISSING = object()
+_PATH_TOKEN_RE = re.compile(r"\*\*|\*|_?[a-z][A-Za-z0-9]{0,127}|\[(?:\*|[0-9]+)\]")
+_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_FHIR_ID_RE = re.compile(r"[A-Za-z0-9.-]{1,64}\Z")
+_FHIR_JSON_KEY_RE = re.compile(r"_?[a-z][A-Za-z0-9]{0,127}\Z")
+_FHIR_RESOURCE_TYPE_RE = re.compile(r"[A-Z][A-Za-z0-9]{0,63}\Z")
+_MAX_BUNDLE_BYTES = 16 * 1024 * 1024
+_MAX_JSON_DEPTH = 64
+_MAX_JSON_NODES = 1_000_000
+_MAX_PATH_PATTERNS = 1_024
+_MAX_PATH_TOKENS = 64
+_CHANGE_TYPES = frozenset(
+    {"added", "changed", "removed", "resource_type_changed", "type_changed"}
+)
+_JSON_TYPES = frozenset({"array", "boolean", "null", "number", "object", "string"})
+
+
+class FHIRR5FidelityError(ValueError):
+    """Raised when a supplied value is not a readable FHIR Bundle object."""
+
+
+@dataclass(frozen=True)
+class ResourceIdentifier:
+    """Privacy-safe metadata identifying a FHIR resource in a report.
+
+    ``id_hash`` and ``full_url_hash`` are SHA-256 digests prefixed with
+    ``sha256:``.  The raw FHIR ``id`` and ``fullUrl`` are never retained in the
+    result.
+    """
+
+    resource_type: str | None = None
+    id_hash: str | None = None
+    full_url_hash: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "resource_type",
+            _validated_resource_type(self.resource_type),
+        )
+        object.__setattr__(self, "id_hash", _validated_digest(self.id_hash, "id_hash"))
+        object.__setattr__(
+            self,
+            "full_url_hash",
+            _validated_digest(self.full_url_hash, "full_url_hash"),
+        )
+
+    @property
+    def resource_id_hash(self) -> str | None:
+        """Return the privacy-safe digest of the FHIR resource ``id``."""
+
+        return self.id_hash
+
+    @property
+    def resource_id(self) -> str | None:
+        """Return the resource id as a privacy-safe digest alias."""
+
+        return self.id_hash
+
+    @property
+    def identifier(self) -> str:
+        """Return a stable, PHI-safe display identifier."""
+
+        if self.resource_type and self.id_hash:
+            return f"{self.resource_type}/{self.id_hash}"
+        if self.resource_type and self.full_url_hash:
+            return f"{self.resource_type}@{self.full_url_hash}"
+        if self.resource_type:
+            return self.resource_type
+        if self.full_url_hash:
+            return f"resource@{self.full_url_hash}"
+        return "unknown"
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Return JSON-safe metadata without source values."""
+
+        return {
+            "resource_type": self.resource_type,
+            "id_hash": self.id_hash,
+            "full_url_hash": self.full_url_hash,
+            "identifier": self.identifier,
+        }
+
+
+@dataclass(frozen=True)
+class FHIRR5Difference:
+    """One privacy-safe difference between two FHIR Bundle values."""
+
+    path: str
+    change_type: str
+    before_type: str | None
+    after_type: str | None
+    before_hash: str | None
+    after_hash: str | None
+    before_resource: ResourceIdentifier = field(default_factory=ResourceIdentifier)
+    after_resource: ResourceIdentifier = field(default_factory=ResourceIdentifier)
+    before_resource_type: str | None = None
+    after_resource_type: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", _validated_report_path(self.path))
+        if self.change_type not in _CHANGE_TYPES:
+            raise ValueError("change_type is unsupported")
+        for name, value in (
+            ("before_type", self.before_type),
+            ("after_type", self.after_type),
+        ):
+            if value is not None and value not in _JSON_TYPES:
+                raise ValueError(f"{name} is unsupported")
+        object.__setattr__(
+            self,
+            "before_hash",
+            _validated_digest(self.before_hash, "before_hash"),
+        )
+        object.__setattr__(
+            self,
+            "after_hash",
+            _validated_digest(self.after_hash, "after_hash"),
+        )
+        if not isinstance(self.before_resource, ResourceIdentifier) or not isinstance(
+            self.after_resource, ResourceIdentifier
+        ):
+            raise TypeError("resource metadata must use ResourceIdentifier")
+        before_resource_type = _validated_resource_type(self.before_resource_type)
+        after_resource_type = _validated_resource_type(self.after_resource_type)
+        if before_resource_type not in {None, self.before_resource.resource_type}:
+            raise ValueError("before_resource_type conflicts with resource metadata")
+        if after_resource_type not in {None, self.after_resource.resource_type}:
+            raise ValueError("after_resource_type conflicts with resource metadata")
+        object.__setattr__(self, "before_resource_type", before_resource_type)
+        object.__setattr__(self, "after_resource_type", after_resource_type)
+
+    @property
+    def kind(self) -> str:
+        """Return ``change_type`` as a concise compatibility alias."""
+
+        return self.change_type
+
+    @property
+    def type_changed(self) -> bool:
+        """Return whether the JSON or FHIR resource type changed."""
+
+        return self.change_type in {"type_changed", "resource_type_changed"}
+
+    @property
+    def before_value_hash(self) -> str | None:
+        """Return the digest of the before value, if present."""
+
+        return self.before_hash
+
+    @property
+    def after_value_hash(self) -> str | None:
+        """Return the digest of the after value, if present."""
+
+        return self.after_hash
+
+    @property
+    def resource(self) -> ResourceIdentifier:
+        """Return the after resource metadata, or before metadata if removed."""
+
+        if self.after_resource != ResourceIdentifier():
+            return self.after_resource
+        return self.before_resource
+
+    @property
+    def resource_type(self) -> str | None:
+        """Return the best available resource type for this difference."""
+
+        return self.resource.resource_type
+
+    @property
+    def resource_id_hash(self) -> str | None:
+        """Return the best available privacy-safe resource-id digest."""
+
+        return self.resource.id_hash
+
+    @property
+    def resource_identifier(self) -> str:
+        """Return the best available privacy-safe resource identifier."""
+
+        return self.resource.identifier
+
+    @property
+    def json_path(self) -> str:
+        """Return the same path using a JSONPath-style ``$`` root."""
+
+        return f"$.{self.path}" if self.path else "$"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic report record without source values."""
+
+        resource = self.resource
+        return {
+            "path": self.path,
+            "json_path": self.json_path,
+            "change_type": self.change_type,
+            "kind": self.kind,
+            "before_type": self.before_type,
+            "after_type": self.after_type,
+            "before_hash": self.before_hash,
+            "after_hash": self.after_hash,
+            "before_value_hash": self.before_value_hash,
+            "after_value_hash": self.after_value_hash,
+            "resource_type": resource.resource_type,
+            "resource_id_hash": resource.id_hash,
+            "resource_id": resource.resource_id,
+            "resource_identifier": resource.identifier,
+            "before_resource_type": self.before_resource_type
+            or self.before_resource.resource_type,
+            "after_resource_type": self.after_resource_type
+            or self.after_resource.resource_type,
+            "before_resource": self.before_resource.to_dict(),
+            "after_resource": self.after_resource.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class FHIRR5FidelityDiff:
+    """Deterministic, PHI-safe comparison result for two FHIR R5 Bundles."""
+
+    changes: tuple[FHIRR5Difference, ...] = ()
+    ignored_paths: tuple[str, ...] = ()
+    unordered_paths: tuple[str, ...] = ()
+    before_digest: str = ""
+    after_digest: str = ""
+
+    def __post_init__(self) -> None:
+        try:
+            changes = tuple(self.changes)
+            ignored = tuple(
+                _format_path(pattern)
+                for pattern in _normalize_patterns(self.ignored_paths)
+            )
+            unordered = tuple(
+                _format_path(pattern)
+                for pattern in _normalize_patterns(self.unordered_paths)
+            )
+        except MemoryError:
+            raise
+        except Exception:
+            raise ValueError("FHIR R5 fidelity report metadata is invalid") from None
+        if not all(isinstance(change, FHIRR5Difference) for change in changes):
+            raise TypeError("changes must contain FHIRR5Difference instances")
+        object.__setattr__(
+            self, "changes", tuple(sorted(changes, key=_difference_sort_key))
+        )
+        object.__setattr__(self, "ignored_paths", ignored)
+        object.__setattr__(self, "unordered_paths", unordered)
+        object.__setattr__(
+            self,
+            "before_digest",
+            _validated_digest(self.before_digest, "before_digest", allow_empty=True),
+        )
+        object.__setattr__(
+            self,
+            "after_digest",
+            _validated_digest(self.after_digest, "after_digest", allow_empty=True),
+        )
+
+    @property
+    def equivalent(self) -> bool:
+        """Return whether no non-declared difference was found."""
+
+        return not self.changes
+
+    @property
+    def is_faithful(self) -> bool:
+        """Return whether the round trip preserved all compared fields."""
+
+        return self.equivalent
+
+    @property
+    def ok(self) -> bool:
+        """Return whether the comparison passed."""
+
+        return self.equivalent
+
+    @property
+    def has_changes(self) -> bool:
+        """Return whether any non-declared difference was found."""
+
+        return bool(self.changes)
+
+    @property
+    def differences(self) -> tuple[FHIRR5Difference, ...]:
+        """Return ``changes`` as a report-oriented compatibility alias."""
+
+        return self.changes
+
+    @property
+    def has_differences(self) -> bool:
+        """Return whether any non-declared difference was found."""
+
+        return self.has_changes
+
+    @property
+    def changed_paths(self) -> tuple[str, ...]:
+        """Return changed paths in deterministic report order."""
+
+        return tuple(change.path for change in self.changes)
+
+    @property
+    def type_changes(self) -> tuple[FHIRR5Difference, ...]:
+        """Return JSON and FHIR resource type changes only."""
+
+        return tuple(change for change in self.changes if change.type_changed)
+
+    @property
+    def summary(self) -> dict[str, int]:
+        """Return stable counts suitable for logs and dashboards."""
+
+        counts = {
+            "changes": len(self.changes),
+            "added": 0,
+            "removed": 0,
+            "changed": 0,
+            "type_changed": 0,
+            "resource_type_changed": 0,
+            "ignored_paths": len(self.ignored_paths),
+            "unordered_paths": len(self.unordered_paths),
+        }
+        for change in self.changes:
+            if change.change_type in counts:
+                counts[change.change_type] += 1
+        return counts
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable, privacy-safe diff report."""
+
+        return {
+            "equivalent": self.equivalent,
+            "summary": self.summary,
+            "before_digest": self.before_digest,
+            "after_digest": self.after_digest,
+            "ignored_paths": list(self.ignored_paths),
+            "unordered_paths": list(self.unordered_paths),
+            "changes": [change.to_dict() for change in self.changes],
+        }
+
+    def to_json(self, *, indent: int | None = None) -> str:
+        """Return deterministic JSON suitable for a local audit artifact."""
+
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=True,
+            indent=indent,
+            sort_keys=True,
+        )
+
+    def to_markdown(self) -> str:
+        """Return a compact Markdown report containing no source values."""
+
+        lines = [
+            "## FHIR R5 Round-Trip Fidelity",
+            "",
+            f"Equivalent: {'yes' if self.equivalent else 'no'}",
+            f"Changes: {len(self.changes)}",
+            "",
+        ]
+        if not self.changes:
+            lines.append("No non-declared differences.")
+            return "\n".join(lines)
+
+        lines.extend(
+            [
+                "| Path | Resource | Change | Before type | After type |",
+                "|---|---|---|---|---|",
+            ]
+        )
+        for change in self.changes:
+            lines.append(
+                "| "
+                f"{_markdown_cell(change.path)} | "
+                f"{_markdown_cell(change.resource_identifier)} | "
+                f"{_markdown_cell(change.change_type)} | "
+                f"{_markdown_cell(change.before_type)} | "
+                f"{_markdown_cell(change.after_type)} |"
+            )
+        return "\n".join(lines)
+
+
+def diff_fhir_r5_bundles(
+    before: FHIRBundleInput,
+    after: FHIRBundleInput,
+    *,
+    ignored_paths: Iterable[PathSpec] = (),
+    ignore_paths: Iterable[PathSpec] | None = None,
+    allowed_paths: Iterable[PathSpec] = (),
+    allowed_differences: Iterable[PathSpec] = (),
+    serialization_differences: Iterable[PathSpec] = (),
+    allowed_serialization_differences: Iterable[PathSpec] = (),
+    unordered_paths: Iterable[PathSpec] = (),
+) -> FHIRR5FidelityDiff:
+    """Compare two local FHIR R5 Bundle JSON values.
+
+    Object member order and JSON whitespace are ignored automatically.  Bundle
+    entries are matched by ``fullUrl`` first, then ``id``, and finally by
+    remaining position.  All other differences are compared recursively.
+
+    Args:
+        before: Bundle mapping, JSON text, or path to a local JSON file.
+        after: Bundle mapping, JSON text, or path to a local JSON file.
+        ignored_paths: Exact or wildcard paths whose complete subtrees are
+            intentionally excluded from the comparison.
+        ignore_paths: Alias for ``ignored_paths``.
+        allowed_paths: Additional alias for declared ignored paths.
+        allowed_differences: Alias for declared serialization-only paths.
+        serialization_differences: Paths for declared serialization-only
+            differences.
+        allowed_serialization_differences: Explicit alias for declared
+            serialization-only differences.
+        unordered_paths: Array paths where element order is declared
+            insignificant.  Use ``[*]`` for a single array-index wildcard in
+            an ignored path, for example ``entry[*].resource.meta.tag``.
+
+    Returns:
+        A deterministic diff whose records contain paths, type metadata, and
+        digests but never before/after source values.
+
+    Raises:
+        FHIRR5FidelityError: If either input is unreadable or is not a Bundle.
+    """
+
+    try:
+        return _diff_fhir_r5_bundles(
+            before,
+            after,
+            ignored_paths=ignored_paths,
+            ignore_paths=ignore_paths,
+            allowed_paths=allowed_paths,
+            allowed_differences=allowed_differences,
+            serialization_differences=serialization_differences,
+            allowed_serialization_differences=allowed_serialization_differences,
+            unordered_paths=unordered_paths,
+        )
+    except MemoryError:
+        raise
+    except Exception:
+        raise FHIRR5FidelityError(
+            "FHIR R5 bundles could not be compared safely"
+        ) from None
+
+
+def _diff_fhir_r5_bundles(
+    before: FHIRBundleInput,
+    after: FHIRBundleInput,
+    *,
+    ignored_paths: Iterable[PathSpec],
+    ignore_paths: Iterable[PathSpec] | None,
+    allowed_paths: Iterable[PathSpec],
+    allowed_differences: Iterable[PathSpec],
+    serialization_differences: Iterable[PathSpec],
+    allowed_serialization_differences: Iterable[PathSpec],
+    unordered_paths: Iterable[PathSpec],
+) -> FHIRR5FidelityDiff:
+    before_bundle = _load_bundle(before)
+    after_bundle = _load_bundle(after)
+    ignored = _normalize_patterns(
+        _combine_path_specs(
+            ignored_paths,
+            ignore_paths,
+            allowed_paths,
+            allowed_differences,
+            serialization_differences,
+            allowed_serialization_differences,
+        )
+    )
+    unordered = _normalize_patterns(_combine_path_specs(unordered_paths))
+
+    before_resource = _resource_identifier(before_bundle)
+    after_resource = _resource_identifier(after_bundle)
+    changes: list[FHIRR5Difference] = []
+
+    for key in sorted(set(before_bundle) | set(after_bundle)):
+        if key == "entry":
+            continue
+        _diff_value(
+            before_bundle.get(key, _MISSING),
+            after_bundle.get(key, _MISSING),
+            (key,),
+            before_resource,
+            after_resource,
+            ignored,
+            unordered,
+            changes,
+        )
+
+    _diff_bundle_entries(
+        _bundle_entries(before_bundle),
+        _bundle_entries(after_bundle),
+        ignored,
+        unordered,
+        changes,
+    )
+
+    changes.sort(key=_difference_sort_key)
+    return FHIRR5FidelityDiff(
+        changes=tuple(changes),
+        ignored_paths=tuple(_format_path(pattern) for pattern in ignored),
+        unordered_paths=tuple(_format_path(pattern) for pattern in unordered),
+        before_digest=_digest(before_bundle),
+        after_digest=_digest(after_bundle),
+    )
+
+
+def _load_bundle(value: FHIRBundleInput) -> dict[str, Any]:
+    payload: Any
+    if isinstance(value, Mapping):
+        payload = value
+    elif isinstance(value, (bytes, bytearray)):
+        payload = _parse_json_text(bytes(value))
+    elif isinstance(value, Path):
+        payload = _read_json_path(value)
+    elif isinstance(value, str):
+        stripped = value.lstrip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            payload = _parse_json_text(value)
+        else:
+            payload = _read_json_path(Path(value))
+    else:
+        payload = _call_to_dict(value)
+
+    try:
+        materialized = _materialize_json(payload)
+    except (TypeError, ValueError):
+        raise FHIRR5FidelityError(
+            "FHIR R5 bundle contains an unsupported JSON value"
+        ) from None
+    if not isinstance(materialized, dict):
+        raise FHIRR5FidelityError("FHIR R5 bundle must be a JSON object")
+    if materialized.get("resourceType") != "Bundle":
+        raise FHIRR5FidelityError("FHIR R5 bundle resourceType must be Bundle")
+    entries = materialized.get("entry", [])
+    if not isinstance(entries, list):
+        raise FHIRR5FidelityError("FHIR R5 bundle entry must be an array")
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise FHIRR5FidelityError("FHIR R5 bundle entries must be objects")
+        full_url = entry.get("fullUrl")
+        if full_url is not None and (
+            not isinstance(full_url, str) or len(full_url) > 8_192
+        ):
+            raise FHIRR5FidelityError("FHIR R5 bundle fullUrl is invalid")
+        resource = entry.get("resource", _MISSING)
+        if resource is not _MISSING and not isinstance(resource, dict):
+            raise FHIRR5FidelityError("FHIR R5 bundle entry resource must be an object")
+        if isinstance(resource, dict):
+            _validate_resource_metadata(resource)
+    return materialized
+
+
+def _validate_resource_metadata(resource: Mapping[str, Any]) -> None:
+    resource_type = resource.get("resourceType")
+    if not isinstance(resource_type, str) or not _FHIR_RESOURCE_TYPE_RE.fullmatch(
+        resource_type
+    ):
+        raise FHIRR5FidelityError("FHIR resourceType is invalid")
+    resource_id = resource.get("id", _MISSING)
+    if resource_id is not _MISSING and (
+        not isinstance(resource_id, str) or not _FHIR_ID_RE.fullmatch(resource_id)
+    ):
+        raise FHIRR5FidelityError("FHIR resource id is invalid")
+
+
+def _parse_json_text(value: str | bytes) -> Any:
+    if len(value) > _MAX_BUNDLE_BYTES:
+        raise FHIRR5FidelityError("FHIR R5 bundle JSON exceeds the size limit")
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+        raise FHIRR5FidelityError("FHIR R5 bundle JSON is invalid") from None
+
+
+def _read_json_path(path: Path) -> Any:
+    try:
+        if not path.is_file():
+            raise OSError
+        with path.open("rb") as handle:
+            payload = handle.read(_MAX_BUNDLE_BYTES + 1)
+        return _parse_json_text(payload)
+    except (OSError, FHIRR5FidelityError):
+        raise FHIRR5FidelityError("FHIR R5 bundle JSON could not be read") from None
+
+
+def _call_to_dict(value: Any) -> Any:
+    to_dict = getattr(value, "to_dict", None)
+    if not callable(to_dict):
+        raise FHIRR5FidelityError("FHIR R5 bundle must be JSON text or a mapping")
+    try:
+        return to_dict()
+    except Exception:
+        raise FHIRR5FidelityError("FHIR R5 bundle could not be converted") from None
+
+
+def _materialize_json(
+    value: Any,
+    *,
+    _active: set[int] | None = None,
+    _depth: int = 0,
+    _nodes: list[int] | None = None,
+) -> Any:
+    if _depth > _MAX_JSON_DEPTH:
+        raise ValueError("FHIR JSON nesting exceeds the supported depth")
+    nodes = [0] if _nodes is None else _nodes
+    nodes[0] += 1
+    if nodes[0] > _MAX_JSON_NODES:
+        raise ValueError("FHIR JSON exceeds the supported node count")
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in {float("inf"), float("-inf")}:
+            raise ValueError("non-finite number")
+        return value
+    if isinstance(value, (Mapping, list, tuple)):
+        active = set() if _active is None else _active
+        marker = id(value)
+        if marker in active:
+            raise ValueError("FHIR JSON contains a cyclic value")
+        active.add(marker)
+        try:
+            if isinstance(value, Mapping):
+                result: dict[str, Any] = {}
+                for key, item in value.items():
+                    if not isinstance(key, str) or not _FHIR_JSON_KEY_RE.fullmatch(key):
+                        raise TypeError("FHIR JSON object key is invalid")
+                    result[key] = _materialize_json(
+                        item,
+                        _active=active,
+                        _depth=_depth + 1,
+                        _nodes=nodes,
+                    )
+                return result
+            return [
+                _materialize_json(
+                    item,
+                    _active=active,
+                    _depth=_depth + 1,
+                    _nodes=nodes,
+                )
+                for item in value
+            ]
+        finally:
+            active.remove(marker)
+    raise TypeError("unsupported JSON value")
+
+
+@dataclass(frozen=True)
+class _BundleEntry:
+    index: int
+    value: Mapping[str, Any]
+    resource: Mapping[str, Any] | None
+
+
+def _bundle_entries(bundle: Mapping[str, Any]) -> tuple[_BundleEntry, ...]:
+    return tuple(
+        _BundleEntry(
+            index=index,
+            value=entry,
+            resource=(
+                entry.get("resource")
+                if isinstance(entry.get("resource"), Mapping)
+                else None
+            ),
+        )
+        for index, entry in enumerate(bundle.get("entry", []))
+    )
+
+
+def _diff_bundle_entries(
+    before_entries: Sequence[_BundleEntry],
+    after_entries: Sequence[_BundleEntry],
+    ignored: Sequence[tuple[str, ...]],
+    unordered: Sequence[tuple[str, ...]],
+    changes: list[FHIRR5Difference],
+) -> None:
+    pairs = _pair_entries(before_entries, after_entries)
+    for ordinal, (before_entry, after_entry) in enumerate(pairs):
+        entry_path = ("entry", f"[{ordinal}]")
+        if before_entry is None:
+            assert after_entry is not None
+            after_resource = _resource_identifier(
+                after_entry.resource,
+                full_url=after_entry.value.get("fullUrl"),
+            )
+            _diff_value(
+                _MISSING,
+                after_entry.value,
+                entry_path,
+                ResourceIdentifier(),
+                after_resource,
+                ignored,
+                unordered,
+                changes,
+            )
+            continue
+        if after_entry is None:
+            before_resource = _resource_identifier(
+                before_entry.resource,
+                full_url=before_entry.value.get("fullUrl"),
+            )
+            _diff_value(
+                before_entry.value,
+                _MISSING,
+                entry_path,
+                before_resource,
+                ResourceIdentifier(),
+                ignored,
+                unordered,
+                changes,
+            )
+            continue
+
+        before_resource = _resource_identifier(
+            before_entry.resource,
+            full_url=before_entry.value.get("fullUrl"),
+        )
+        after_resource = _resource_identifier(
+            after_entry.resource,
+            full_url=after_entry.value.get("fullUrl"),
+        )
+        for key in sorted(set(before_entry.value) | set(after_entry.value)):
+            if key == "resource":
+                continue
+            _diff_value(
+                before_entry.value.get(key, _MISSING),
+                after_entry.value.get(key, _MISSING),
+                (*entry_path, key),
+                before_resource,
+                after_resource,
+                ignored,
+                unordered,
+                changes,
+            )
+        if before_entry.resource is not None or after_entry.resource is not None:
+            _diff_value(
+                before_entry.resource
+                if before_entry.resource is not None
+                else _MISSING,
+                after_entry.resource if after_entry.resource is not None else _MISSING,
+                (*entry_path, "resource"),
+                before_resource,
+                after_resource,
+                ignored,
+                unordered,
+                changes,
+            )
+
+
+def _pair_entries(
+    before_entries: Sequence[_BundleEntry],
+    after_entries: Sequence[_BundleEntry],
+) -> list[tuple[_BundleEntry | None, _BundleEntry | None]]:
+    used_before: set[int] = set()
+    used_after: set[int] = set()
+    pairs: list[tuple[_BundleEntry | None, _BundleEntry | None]] = []
+
+    for field_name in ("fullUrl", "id"):
+        before_by_key = _entries_by_key(before_entries, used_before, field_name)
+        after_by_key = _entries_by_key(after_entries, used_after, field_name)
+        for key in sorted(
+            set(before_by_key) & set(after_by_key),
+            key=lambda item: _digest(item),
+        ):
+            for before_entry, after_entry in zip(
+                before_by_key[key], after_by_key[key], strict=False
+            ):
+                used_before.add(before_entry.index)
+                used_after.add(after_entry.index)
+                pairs.append((before_entry, after_entry))
+
+    remaining_before = [
+        entry for entry in before_entries if entry.index not in used_before
+    ]
+    remaining_after = [
+        entry for entry in after_entries if entry.index not in used_after
+    ]
+    for before_entry, after_entry in zip(
+        remaining_before, remaining_after, strict=False
+    ):
+        used_before.add(before_entry.index)
+        used_after.add(after_entry.index)
+        pairs.append((before_entry, after_entry))
+    pairs.extend(
+        (entry, None) for entry in before_entries if entry.index not in used_before
+    )
+    pairs.extend(
+        (None, entry) for entry in after_entries if entry.index not in used_after
+    )
+
+    return sorted(pairs, key=_entry_pair_sort_key)
+
+
+def _entries_by_key(
+    entries: Sequence[_BundleEntry],
+    used: set[int],
+    field_name: str,
+) -> dict[str, list[_BundleEntry]]:
+    result: dict[str, list[_BundleEntry]] = {}
+    for entry in entries:
+        if entry.index in used:
+            continue
+        key = _entry_key(entry, field_name)
+        if key is not None:
+            result.setdefault(key, []).append(entry)
+    for matches in result.values():
+        matches.sort(key=_entry_match_sort_key)
+    return result
+
+
+def _entry_key(entry: _BundleEntry, field_name: str) -> str | None:
+    if field_name == "fullUrl":
+        value = entry.value.get("fullUrl")
+        return value if isinstance(value, str) and value else None
+    if entry.resource is None:
+        return None
+    resource_id = entry.resource.get("id")
+    resource_type = entry.resource.get("resourceType")
+    if not isinstance(resource_id, str) or not isinstance(resource_type, str):
+        return None
+    return f"{resource_type}\x1f{resource_id}"
+
+
+def _entry_match_sort_key(entry: _BundleEntry) -> tuple[str, ...]:
+    resource = entry.resource or {}
+    meta = resource.get("meta")
+    version_id = meta.get("versionId") if isinstance(meta, Mapping) else None
+    return (
+        _digest(resource.get("resourceType")),
+        _digest(resource.get("id")),
+        _digest(version_id),
+        _digest(entry.value.get("fullUrl")),
+        _digest(entry.value),
+    )
+
+
+def _entry_pair_sort_key(
+    pair: tuple[_BundleEntry | None, _BundleEntry | None],
+) -> tuple[Any, ...]:
+    before_entry, after_entry = pair
+    entry = after_entry or before_entry
+    assert entry is not None
+    full_url = entry.value.get("fullUrl")
+    resource_id = entry.resource.get("id") if entry.resource is not None else None
+    resource_type = (
+        entry.resource.get("resourceType") if entry.resource is not None else None
+    )
+    stable_value = full_url if isinstance(full_url, str) else resource_id
+    if stable_value is None:
+        stable_value = _digest(entry.value)
+    return (
+        0 if isinstance(full_url, str) else 1 if isinstance(resource_id, str) else 2,
+        _digest(stable_value),
+        str(resource_type) if resource_type is not None else "",
+        entry.index,
+    )
+
+
+def _resource_identifier(
+    resource: Mapping[str, Any] | None,
+    *,
+    full_url: Any = None,
+) -> ResourceIdentifier:
+    if resource is None:
+        return ResourceIdentifier(
+            full_url_hash=_digest(full_url) if full_url is not None else None
+        )
+    resource_type = resource.get("resourceType")
+    return ResourceIdentifier(
+        resource_type=resource_type if isinstance(resource_type, str) else None,
+        id_hash=_digest(resource["id"]) if "id" in resource else None,
+        full_url_hash=_digest(full_url) if full_url is not None else None,
+    )
+
+
+def _diff_value(
+    before: Any,
+    after: Any,
+    path: tuple[str, ...],
+    before_resource: ResourceIdentifier,
+    after_resource: ResourceIdentifier,
+    ignored: Sequence[tuple[str, ...]],
+    unordered: Sequence[tuple[str, ...]],
+    changes: list[FHIRR5Difference],
+) -> None:
+    if _path_is_ignored(path, ignored):
+        return
+    if before is _MISSING or after is _MISSING:
+        if _has_descendant_pattern(path, ignored) or _has_descendant_pattern(
+            path, unordered
+        ):
+            present = after if before is _MISSING else before
+            if isinstance(present, Mapping):
+                for key in sorted(present):
+                    _diff_value(
+                        _MISSING if before is _MISSING else before.get(key, _MISSING),
+                        after.get(key, _MISSING)
+                        if isinstance(after, Mapping)
+                        else _MISSING,
+                        (*path, key),
+                        before_resource,
+                        after_resource,
+                        ignored,
+                        unordered,
+                        changes,
+                    )
+                return
+            if _is_array(present):
+                for index, item in enumerate(present):
+                    _diff_value(
+                        _MISSING if before is _MISSING else before[index],
+                        after[index] if _is_array(after) else _MISSING,
+                        (*path, f"[{index}]"),
+                        before_resource,
+                        after_resource,
+                        ignored,
+                        unordered,
+                        changes,
+                    )
+                return
+        _record_difference(
+            path,
+            before,
+            after,
+            before_resource,
+            after_resource,
+            changes,
+        )
+        return
+
+    if _path_matches(path, unordered) and _is_array(before) and _is_array(after):
+        if not _sequence_multiset_equal(before, after):
+            _record_difference(
+                path,
+                before,
+                after,
+                before_resource,
+                after_resource,
+                changes,
+            )
+        return
+
+    if isinstance(before, Mapping) and isinstance(after, Mapping):
+        for key in sorted(set(before) | set(after)):
+            _diff_value(
+                before.get(key, _MISSING),
+                after.get(key, _MISSING),
+                (*path, key),
+                before_resource,
+                after_resource,
+                ignored,
+                unordered,
+                changes,
+            )
+        return
+
+    if _is_array(before) and _is_array(after):
+        for index in range(max(len(before), len(after))):
+            before_item = before[index] if index < len(before) else _MISSING
+            after_item = after[index] if index < len(after) else _MISSING
+            child_before_resource = before_resource
+            child_after_resource = after_resource
+            if path and path[-1] == "contained":
+                if isinstance(before_item, Mapping):
+                    child_before_resource = _resource_identifier(before_item)
+                if isinstance(after_item, Mapping):
+                    child_after_resource = _resource_identifier(after_item)
+            _diff_value(
+                before_item,
+                after_item,
+                (*path, f"[{index}]"),
+                child_before_resource,
+                child_after_resource,
+                ignored,
+                unordered,
+                changes,
+            )
+        return
+
+    if _semantic_equal(before, after):
+        return
+    _record_difference(
+        path,
+        before,
+        after,
+        before_resource,
+        after_resource,
+        changes,
+    )
+
+
+def _record_difference(
+    path: tuple[str, ...],
+    before: Any,
+    after: Any,
+    before_resource: ResourceIdentifier,
+    after_resource: ResourceIdentifier,
+    changes: list[FHIRR5Difference],
+) -> None:
+    before_type = _json_type(before)
+    after_type = _json_type(after)
+    if before is _MISSING:
+        change_type = "added"
+    elif after is _MISSING:
+        change_type = "removed"
+    elif before_type != after_type:
+        change_type = "type_changed"
+    elif path[-1:] == ("resourceType",) and before != after:
+        change_type = "resource_type_changed"
+    else:
+        change_type = "changed"
+
+    changes.append(
+        FHIRR5Difference(
+            path=_format_path(path),
+            change_type=change_type,
+            before_type=before_type,
+            after_type=after_type,
+            before_hash=None if before is _MISSING else _digest(before),
+            after_hash=None if after is _MISSING else _digest(after),
+            before_resource=before_resource,
+            after_resource=after_resource,
+            before_resource_type=before_resource.resource_type,
+            after_resource_type=after_resource.resource_type,
+        )
+    )
+
+
+def _normalize_patterns(specs: Iterable[PathSpec]) -> tuple[tuple[str, ...], ...]:
+    if isinstance(specs, (str, Path)):
+        specs = (str(specs),)
+    patterns: set[tuple[str, ...]] = set()
+    for index, spec in enumerate(specs):
+        if index >= _MAX_PATH_PATTERNS:
+            raise ValueError("too many path specifications")
+        patterns.add(_normalize_path(spec))
+    return tuple(sorted(patterns, key=_format_path))
+
+
+def _combine_path_specs(
+    *groups: Iterable[PathSpec] | PathSpec | None,
+) -> tuple[PathSpec, ...]:
+    combined: list[PathSpec] = []
+    for group in groups:
+        if group is None:
+            continue
+        if isinstance(group, (str, Path)):
+            combined.append(str(group))
+        else:
+            for spec in group:
+                if len(combined) >= _MAX_PATH_PATTERNS:
+                    raise ValueError("too many path specifications")
+                combined.append(spec)
+    return tuple(combined)
+
+
+def _normalize_path(spec: PathSpec) -> tuple[str, ...]:
+    if isinstance(spec, (str, Path)):
+        text = str(spec).strip()
+        if text.startswith("/"):
+            tokens = tuple(
+                _normalize_path_token(part.replace("~1", "/").replace("~0", "~"))
+                for part in text.split("/")[1:]
+                if part
+            )
+        else:
+            if text.startswith("$."):
+                text = text[2:]
+            elif text.startswith("$"):
+                text = text[1:]
+            if text.startswith("Bundle."):
+                text = text[len("Bundle.") :]
+            matches = tuple(_PATH_TOKEN_RE.finditer(text))
+            tokens = tuple(_normalize_path_token(match.group(0)) for match in matches)
+            if _format_path(tokens) != text:
+                raise ValueError("path specification syntax is invalid")
+    else:
+        tokens = tuple(
+            _normalize_path_token(part) for part in spec if isinstance(part, str)
+        )
+        if len(tokens) != len(spec):
+            raise ValueError("path specification tokens must be strings")
+    if tokens and tokens[0].lower() == "bundle":
+        tokens = tokens[1:]
+    if not tokens or len(tokens) > _MAX_PATH_TOKENS:
+        raise ValueError("path specification must not be empty")
+    return tokens
+
+
+def _normalize_path_token(token: str) -> str:
+    token = token.strip()
+    if token == "Bundle":
+        return token
+    if token in {"*", "**", "[*]"}:
+        return token
+    if token.startswith("[") and token.endswith("]"):
+        inside = token[1:-1]
+        if not inside.isdigit():
+            raise ValueError("path array index is invalid")
+        return f"[{int(inside)}]"
+    if token.isdigit():
+        return f"[{token}]"
+    if not _FHIR_JSON_KEY_RE.fullmatch(token):
+        raise ValueError("path element name is invalid")
+    return token
+
+
+def _format_path(path: Sequence[str]) -> str:
+    result = ""
+    for token in path:
+        if token.startswith("["):
+            result += token
+        elif result:
+            result += f".{token}"
+        else:
+            result = token
+    return result
+
+
+def _path_is_ignored(
+    path: tuple[str, ...], patterns: Sequence[tuple[str, ...]]
+) -> bool:
+    return any(_pattern_covers_path(pattern, path) for pattern in patterns)
+
+
+def _path_matches(path: tuple[str, ...], patterns: Sequence[tuple[str, ...]]) -> bool:
+    return any(_pattern_matches_exact(pattern, path) for pattern in patterns)
+
+
+def _has_descendant_pattern(
+    path: tuple[str, ...], patterns: Sequence[tuple[str, ...]]
+) -> bool:
+    return any(_pattern_has_path_prefix(pattern, path) for pattern in patterns)
+
+
+def _pattern_has_path_prefix(pattern: Sequence[str], path: Sequence[str]) -> bool:
+    def match(pattern_index: int, path_index: int) -> bool:
+        if path_index == len(path):
+            return pattern_index < len(pattern)
+        if pattern_index == len(pattern):
+            return False
+        token = pattern[pattern_index]
+        if token == "**":
+            return match(pattern_index + 1, path_index) or match(
+                pattern_index, path_index + 1
+            )
+        if token not in {"*", "[*]"} and token != path[path_index]:
+            return False
+        return match(pattern_index + 1, path_index + 1)
+
+    return match(0, 0)
+
+
+def _pattern_covers_path(pattern: Sequence[str], path: Sequence[str]) -> bool:
+    def match(pattern_index: int, path_index: int) -> bool:
+        if pattern_index == len(pattern):
+            return True
+        token = pattern[pattern_index]
+        if token == "**":
+            return match(pattern_index + 1, path_index) or (
+                path_index < len(path) and match(pattern_index, path_index + 1)
+            )
+        if path_index == len(path):
+            return False
+        if token not in {"*", "[*]"} and token != path[path_index]:
+            return False
+        return match(pattern_index + 1, path_index + 1)
+
+    return match(0, 0)
+
+
+def _pattern_matches_exact(pattern: Sequence[str], path: Sequence[str]) -> bool:
+    def match(pattern_index: int, path_index: int) -> bool:
+        if pattern_index == len(pattern):
+            return path_index == len(path)
+        token = pattern[pattern_index]
+        if token == "**":
+            return match(pattern_index + 1, path_index) or (
+                path_index < len(path) and match(pattern_index, path_index + 1)
+            )
+        if path_index == len(path):
+            return False
+        if token not in {"*", "[*]"} and token != path[path_index]:
+            return False
+        return match(pattern_index + 1, path_index + 1)
+
+    return match(0, 0)
+
+
+def _is_array(value: Any) -> bool:
+    return isinstance(value, (list, tuple))
+
+
+def _sequence_multiset_equal(before: Sequence[Any], after: Sequence[Any]) -> bool:
+    return Counter(_semantic_key(value) for value in before) == Counter(
+        _semantic_key(value) for value in after
+    )
+
+
+def _semantic_key(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return (
+            "object",
+            tuple((key, _semantic_key(value[key])) for key in sorted(value)),
+        )
+    if _is_array(value):
+        return ("array", tuple(_semantic_key(item) for item in value))
+    return (_json_type(value), value)
+
+
+def _semantic_equal(before: Any, after: Any) -> bool:
+    if _json_type(before) != _json_type(after):
+        return False
+    if isinstance(before, Mapping) and isinstance(after, Mapping):
+        if set(before) != set(after):
+            return False
+        return all(_semantic_equal(before[key], after[key]) for key in before)
+    if _is_array(before) and _is_array(after):
+        return len(before) == len(after) and all(
+            _semantic_equal(left, right)
+            for left, right in zip(before, after, strict=False)
+        )
+    return before == after
+
+
+def _json_type(value: Any) -> str | None:
+    if value is _MISSING:
+        return None
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, Mapping):
+        return "object"
+    if _is_array(value):
+        return "array"
+    return "unsupported"
+
+
+def _validated_resource_type(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not _FHIR_RESOURCE_TYPE_RE.fullmatch(value):
+        raise ValueError("resource_type must be a safe FHIR type name")
+    return value
+
+
+def _validated_digest(
+    value: Any,
+    name: str,
+    *,
+    allow_empty: bool = False,
+) -> str | None:
+    if value is None:
+        return None
+    if allow_empty and value == "":
+        return ""
+    if not isinstance(value, str) or not _DIGEST_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a SHA-256 digest")
+    return value
+
+
+def _validated_report_path(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError("path must be a FHIR JSON path")
+    try:
+        tokens = _normalize_path(value)
+    except MemoryError:
+        raise
+    except Exception:
+        raise ValueError("path must be a FHIR JSON path") from None
+    if any(token in {"*", "**", "[*]"} for token in tokens):
+        raise ValueError("report paths cannot contain wildcards")
+    normalized = _format_path(tokens)
+    if normalized != value:
+        raise ValueError("path must use canonical FHIR JSON path syntax")
+    return normalized
+
+
+def _digest(value: Any) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise FHIRR5FidelityError(
+            "FHIR R5 bundle contains an unsupported value"
+        ) from None
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _difference_sort_key(change: FHIRR5Difference) -> tuple[Any, ...]:
+    return (
+        change.path,
+        change.change_type,
+        change.resource_identifier,
+        change.before_type or "",
+        change.after_type or "",
+        change.before_hash or "",
+        change.after_hash or "",
+    )
+
+
+def _markdown_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+compare_fhir_r5_bundles = diff_fhir_r5_bundles
+compare_bundles = diff_fhir_r5_bundles
+diff_bundles = diff_fhir_r5_bundles
+diff_fhir_r5 = diff_fhir_r5_bundles
+FhirR5Difference = FHIRR5Difference
+FhirR5FidelityDiff = FHIRR5FidelityDiff
+FHIRR5Diff = FHIRR5FidelityDiff
+FhirR5Diff = FHIRR5FidelityDiff
+
+
+__all__ = [
+    "FHIRBundleInput",
+    "FHIRR5Difference",
+    "FHIRR5Diff",
+    "FHIRR5FidelityDiff",
+    "FHIRR5FidelityError",
+    "FhirR5Difference",
+    "FhirR5Diff",
+    "FhirR5FidelityDiff",
+    "PathSpec",
+    "ResourceIdentifier",
+    "compare_bundles",
+    "compare_fhir_r5_bundles",
+    "diff_bundles",
+    "diff_fhir_r5",
+    "diff_fhir_r5_bundles",
+]

--- a/openmed/interop/omop_cohort_check.py
+++ b/openmed/interop/omop_cohort_check.py
@@ -1,0 +1,1030 @@
+"""Privacy-safe validation for OpenMed OMOP cohort exports.
+
+The checker operates on in-memory OMOP rows and intentionally has no network,
+database, or vocabulary-service dependency.  Validation output contains table
+and column names, aggregate counts, failure reasons, and deterministic row
+fingerprints only; it never copies source identifiers or note text into a
+report or exception.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from numbers import Integral
+from types import MappingProxyType
+from typing import Any, Final, TypeAlias
+
+from .omop.cdm_loader import OmopCdmTables
+
+TableRows: TypeAlias = Mapping[str, Iterable[Mapping[str, Any]]]
+
+_MISSING: Final = object()
+_INVALID: Final = object()
+_MAX_CANONICAL_DEPTH: Final = 64
+_MIN_BIGINT: Final = -(2**63)
+_MAX_BIGINT: Final = 2**63 - 1
+_FINGERPRINT_PATTERN: Final = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_SOURCE_HASH_PATTERN: Final = re.compile(r"[0-9a-f]{64}\Z")
+
+_TABLE_ORDER: Final[tuple[str, ...]] = (
+    "concept",
+    "person",
+    "visit_occurrence",
+    "note",
+    "note_nlp",
+    "condition_occurrence",
+    "drug_exposure",
+    "measurement",
+    "procedure_occurrence",
+    "observation",
+    "source_to_concept_map",
+)
+
+_PRIMARY_KEYS: Final[Mapping[str, str]] = {
+    "concept": "concept_id",
+    "person": "person_id",
+    "visit_occurrence": "visit_occurrence_id",
+    "note": "note_id",
+    "note_nlp": "note_nlp_id",
+    "condition_occurrence": "condition_occurrence_id",
+    "drug_exposure": "drug_exposure_id",
+    "measurement": "measurement_id",
+    "procedure_occurrence": "procedure_occurrence_id",
+    "observation": "observation_id",
+    "source_to_concept_map": "source_to_concept_map_id",
+}
+
+_DOMAIN_TABLES: Final[Mapping[str, str]] = {
+    "condition_occurrence": "condition_concept_id",
+    "drug_exposure": "drug_concept_id",
+    "measurement": "measurement_concept_id",
+    "procedure_occurrence": "procedure_concept_id",
+    "observation": "observation_concept_id",
+}
+
+_SOURCE_CONCEPT_COLUMNS: Final[Mapping[str, str]] = {
+    "condition_occurrence": "condition_source_concept_id",
+    "drug_exposure": "drug_source_concept_id",
+    "measurement": "measurement_source_concept_id",
+    "procedure_occurrence": "procedure_source_concept_id",
+    "observation": "observation_source_concept_id",
+}
+
+_CONCEPT_COLUMNS: Final[Mapping[str, tuple[str, ...]]] = {
+    "visit_occurrence": ("visit_concept_id", "visit_source_concept_id"),
+    "note": (
+        "note_type_concept_id",
+        "note_class_concept_id",
+        "encoding_concept_id",
+        "language_concept_id",
+    ),
+    "note_nlp": (
+        "section_concept_id",
+        "note_nlp_concept_id",
+        "note_nlp_source_concept_id",
+        "note_nlp_event_field_concept_id",
+    ),
+    "source_to_concept_map": ("source_concept_id", "target_concept_id"),
+}
+
+_ALLOWED_STANDARD_CONCEPTS: Final[frozenset[str]] = frozenset({"", "C", "N", "S"})
+_VIOLATION_REASONS: Final[frozenset[str]] = frozenset(
+    {
+        "ambiguous_event",
+        "conflicting_vocabulary_mapping",
+        "duplicate_primary_key",
+        "invalid_primary_key",
+        "invalid_provenance",
+        "invalid_reference",
+        "invalid_standard_concept",
+        "missing_primary_key",
+        "missing_provenance",
+        "missing_reference",
+        "nonstandard_concept_reference",
+        "nonstandard_target_concept",
+        "person_visit_mismatch",
+        "provenance_mismatch",
+        "unreachable_event",
+        "vocabulary_mismatch",
+    }
+)
+_VIOLATION_COLUMNS: Final[frozenset[str]] = frozenset(
+    {
+        *_PRIMARY_KEYS.values(),
+        *_DOMAIN_TABLES.values(),
+        *_SOURCE_CONCEPT_COLUMNS.values(),
+        *(column for columns in _CONCEPT_COLUMNS.values() for column in columns),
+        "note_id",
+        "note_nlp_event_id",
+        "note_nlp_id",
+        "person_id",
+        "source_code",
+        "source_note_hash",
+        "source_vocabulary_id",
+        "standard_concept",
+        "target_concept_id",
+        "target_vocabulary_id",
+        "visit_occurrence_id",
+    }
+)
+
+
+class _CohortInputError(ValueError):
+    """Internal marker for deliberately sanitized input errors."""
+
+
+@dataclass(frozen=True)
+class OmopCohortViolation:
+    """One grouped, PHI-free cohort validation failure."""
+
+    table: str
+    column: str | None
+    reason: str
+    count: int
+    row_fingerprints: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.table, str) or self.table not in _TABLE_ORDER:
+            raise ValueError("violation table is unsupported")
+        if self.column is not None and (
+            not isinstance(self.column, str) or self.column not in _VIOLATION_COLUMNS
+        ):
+            raise ValueError("violation column is unsupported")
+        if not isinstance(self.reason, str) or self.reason not in _VIOLATION_REASONS:
+            raise ValueError("violation reason is unsupported")
+        if (
+            isinstance(self.count, bool)
+            or not isinstance(self.count, int)
+            or self.count <= 0
+            or self.count > _MAX_BIGINT
+        ):
+            raise ValueError("violation count must be a positive bounded integer")
+        try:
+            fingerprints = tuple(sorted(set(self.row_fingerprints)))
+        except MemoryError:
+            raise
+        except Exception:
+            raise ValueError(
+                "row_fingerprints must contain SHA-256 fingerprints"
+            ) from None
+        if not fingerprints or any(
+            not isinstance(value, str) or not _FINGERPRINT_PATTERN.fullmatch(value)
+            for value in fingerprints
+        ):
+            raise ValueError("row_fingerprints must contain SHA-256 fingerprints")
+        if len(fingerprints) > self.count:
+            raise ValueError("row_fingerprints cannot exceed the violation count")
+        object.__setattr__(self, "row_fingerprints", fingerprints)
+
+    @property
+    def fingerprints(self) -> tuple[str, ...]:
+        """Return deterministic fingerprints for affected rows."""
+
+        return self.row_fingerprints
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible failure without source row values."""
+
+        result: dict[str, Any] = {
+            "table": self.table,
+            "reason": self.reason,
+            "count": self.count,
+            "row_fingerprints": list(self.row_fingerprints),
+        }
+        if self.column is not None:
+            result["column"] = self.column
+        return result
+
+
+@dataclass(frozen=True)
+class OmopCohortValidationReport:
+    """Aggregate diagnostics for one OMOP cohort export validation run."""
+
+    row_counts: Mapping[str, int]
+    violations: tuple[OmopCohortViolation, ...]
+
+    def __post_init__(self) -> None:
+        counts: dict[str, int] = {}
+        try:
+            items = tuple(self.row_counts.items())
+        except MemoryError:
+            raise
+        except Exception:
+            raise ValueError("row_counts must be a table count mapping") from None
+        for table, count in items:
+            if not isinstance(table, str) or table not in _TABLE_ORDER:
+                raise ValueError("row_counts contains an unsupported table")
+            if (
+                isinstance(count, bool)
+                or not isinstance(count, int)
+                or count < 0
+                or count > _MAX_BIGINT
+            ):
+                raise ValueError(
+                    "row_counts must contain bounded non-negative integers"
+                )
+            counts[table] = count
+        object.__setattr__(
+            self,
+            "row_counts",
+            MappingProxyType({name: counts.get(name, 0) for name in _TABLE_ORDER}),
+        )
+        try:
+            violations = tuple(self.violations)
+        except MemoryError:
+            raise
+        except Exception:
+            raise ValueError("violations must be an iterable of violations") from None
+        if not all(isinstance(item, OmopCohortViolation) for item in violations):
+            raise TypeError("violations must contain OmopCohortViolation instances")
+        object.__setattr__(self, "violations", violations)
+
+    @property
+    def violation_count(self) -> int:
+        """Return the number of failed row-level invariants."""
+
+        return sum(item.count for item in self.violations)
+
+    @property
+    def failure_count(self) -> int:
+        """Alias for :attr:`violation_count` used by cohort checks."""
+
+        return self.violation_count
+
+    @property
+    def failures(self) -> tuple[OmopCohortViolation, ...]:
+        """Return grouped failures under the issue's terminology."""
+
+        return self.violations
+
+    @property
+    def is_valid(self) -> bool:
+        """Return whether all checked invariants passed."""
+
+        return self.violation_count == 0
+
+    @property
+    def valid(self) -> bool:
+        """Return :attr:`is_valid` as a compact compatibility alias."""
+
+        return self.is_valid
+
+    @property
+    def by_table(self) -> Mapping[str, int]:
+        """Return deterministic failure counts grouped by table."""
+
+        counts: Counter[str] = Counter()
+        for item in self.violations:
+            counts[item.table] += item.count
+        return dict(sorted(counts.items()))
+
+    @property
+    def by_reason(self) -> Mapping[str, int]:
+        """Return deterministic failure counts grouped by reason."""
+
+        counts: Counter[str] = Counter()
+        for item in self.violations:
+            counts[item.reason] += item.count
+        return dict(sorted(counts.items()))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return counts, fingerprints, and no raw cohort values."""
+
+        return {
+            "count": self.violation_count,
+            "row_counts": dict(self.row_counts),
+            "by_table": dict(self.by_table),
+            "by_reason": dict(self.by_reason),
+            "violations": [item.to_dict() for item in self.violations],
+        }
+
+
+class OmopCohortExportValidationError(ValueError):
+    """Raised by the assertion helper with only aggregate diagnostics."""
+
+    def __init__(self, report: OmopCohortValidationReport) -> None:
+        if not isinstance(report, OmopCohortValidationReport):
+            raise TypeError("report must be an OmopCohortValidationReport")
+        self.report = report
+        super().__init__(
+            "OMOP cohort export validation failed with "
+            f"{report.violation_count} row-level failure(s)"
+        )
+
+
+class _FailureCollector:
+    """Collect grouped fingerprints while retaining exact failure counts."""
+
+    def __init__(self) -> None:
+        self._items: dict[tuple[str, str | None, str], Counter[str]] = defaultdict(
+            Counter
+        )
+
+    def add(
+        self,
+        table: str,
+        row: Mapping[str, Any],
+        reason: str,
+        column: str | None = None,
+    ) -> None:
+        fingerprint = omop_row_fingerprint(table, row)
+        self._items[(table, column, reason)][fingerprint] += 1
+
+    def report(self, row_counts: Mapping[str, int]) -> OmopCohortValidationReport:
+        table_order = {name: index for index, name in enumerate(_TABLE_ORDER)}
+        ordered = sorted(
+            self._items.items(),
+            key=lambda item: (
+                table_order.get(item[0][0], len(_TABLE_ORDER)),
+                item[0][1] or "",
+                item[0][2],
+            ),
+        )
+        violations = tuple(
+            OmopCohortViolation(
+                table=key[0],
+                column=key[1],
+                reason=key[2],
+                count=sum(fingerprints.values()),
+                row_fingerprints=tuple(sorted(fingerprints)),
+            )
+            for key, fingerprints in ordered
+        )
+        return OmopCohortValidationReport(
+            row_counts=dict(row_counts),
+            violations=violations,
+        )
+
+
+def omop_row_fingerprint(table: str, row: Mapping[str, Any]) -> str:
+    """Return a deterministic content fingerprint for one OMOP row.
+
+    The table name is included so identical rows in different tables do not
+    share a diagnostic fingerprint.  The input is serialized only to compute
+    the digest; it is never returned or embedded in an exception.
+    """
+
+    try:
+        if not isinstance(table, str) or table not in _TABLE_ORDER:
+            raise ValueError("OMOP row table is unsupported")
+        if not isinstance(row, Mapping):
+            raise TypeError("OMOP row must be a mapping")
+        payload = {
+            "schema": "openmed.omop.cohort-check.v1",
+            "table": table,
+            "row": _canonicalize(row),
+        }
+        encoded = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+    except MemoryError:
+        raise
+    except Exception:
+        raise ValueError("OMOP row cannot be fingerprinted safely") from None
+
+
+def validate_omop_cohort_export(
+    export: OmopCdmTables | TableRows | Mapping[str, Any],
+) -> OmopCohortValidationReport:
+    """Validate an in-memory OMOP cohort export without network access.
+
+    ``export`` may be an :class:`~openmed.interop.omop.OmopCdmTables` instance,
+    a mapping of OMOP table names to row iterables, or the mapping returned by
+    ``OmopCdmTables.to_dict()``.  Missing tables are treated as empty, while
+    rows in present tables are checked for key relationships, vocabulary
+    consistency, and OpenMed provenance links.
+
+    The returned report is deterministic for the same rows regardless of
+    input mapping order.  Invalid rows do not appear in the report; only their
+    aggregate counts and row fingerprints do.
+    """
+
+    try:
+        return _validate_omop_cohort_export(export)
+    except MemoryError:
+        raise
+    except _CohortInputError as exc:
+        raise ValueError(str(exc)) from None
+    except Exception:
+        raise ValueError("cohort export could not be validated safely") from None
+
+
+def _validate_omop_cohort_export(
+    export: OmopCdmTables | TableRows | Mapping[str, Any],
+) -> OmopCohortValidationReport:
+    tables = _normalise_tables(export)
+    row_counts = {name: len(tables[name]) for name in _TABLE_ORDER}
+    collector = _FailureCollector()
+    indexes = _build_primary_indexes(tables, collector)
+
+    _validate_relationships(tables, indexes, collector)
+    _validate_vocabulary(tables, indexes, collector)
+    _validate_provenance(tables, indexes, collector)
+
+    return collector.report(row_counts)
+
+
+def check_omop_cohort_export(
+    export: OmopCdmTables | TableRows | Mapping[str, Any],
+) -> OmopCohortValidationReport:
+    """Compatibility alias for :func:`validate_omop_cohort_export`."""
+
+    return validate_omop_cohort_export(export)
+
+
+def validate_cohort_export(
+    export: OmopCdmTables | TableRows | Mapping[str, Any],
+) -> OmopCohortValidationReport:
+    """Short alias for :func:`validate_omop_cohort_export`."""
+
+    return validate_omop_cohort_export(export)
+
+
+def assert_valid_omop_cohort_export(
+    export: OmopCdmTables | TableRows | Mapping[str, Any],
+) -> OmopCohortValidationReport:
+    """Validate an export and raise a PHI-free exception when it is invalid."""
+
+    report = validate_omop_cohort_export(export)
+    if not report.is_valid:
+        raise OmopCohortExportValidationError(report)
+    return report
+
+
+def _normalise_tables(
+    export: OmopCdmTables | TableRows | Mapping[str, Any],
+) -> dict[str, tuple[dict[str, Any], ...]]:
+    if isinstance(export, OmopCdmTables):
+        source: Mapping[str, Any] = export.tables
+    elif isinstance(export, Mapping):
+        nested = export.get("tables")
+        source = nested if isinstance(nested, Mapping) else export
+    else:
+        raise _CohortInputError("cohort export must be an OMOP table mapping")
+
+    normalised: dict[str, tuple[dict[str, Any], ...]] = {}
+    known_tables = set(_TABLE_ORDER)
+    for raw_name, raw_rows in source.items():
+        if not isinstance(raw_name, str):
+            raise _CohortInputError("cohort export table names must be strings")
+        name = raw_name.lower()
+        if name not in known_tables:
+            raise _CohortInputError("cohort export contains an unsupported table")
+        if raw_rows is None:
+            rows: Iterable[Any] = ()
+        elif isinstance(raw_rows, (str, bytes, bytearray)):
+            raise _CohortInputError("cohort export table rows must be mappings")
+        else:
+            try:
+                rows = iter(raw_rows)
+            except MemoryError:
+                raise
+            except Exception:
+                raise _CohortInputError(
+                    "cohort export table rows must be iterable"
+                ) from None
+
+        materialised: list[dict[str, Any]] = []
+        for row in rows:
+            if not isinstance(row, Mapping):
+                raise _CohortInputError("cohort export table rows must be mappings")
+            copied = dict(row)
+            if not all(isinstance(column, str) for column in copied):
+                raise _CohortInputError("cohort export column names must be strings")
+            materialised.append(copied)
+        if name in normalised:
+            raise _CohortInputError("cohort export contains duplicate table names")
+        normalised[name] = tuple(materialised)
+
+    return {name: normalised.get(name, ()) for name in _TABLE_ORDER}
+
+
+def _build_primary_indexes(
+    tables: Mapping[str, tuple[dict[str, Any], ...]],
+    collector: _FailureCollector,
+) -> dict[str, dict[int, Mapping[str, Any]]]:
+    indexes: dict[str, dict[int, Mapping[str, Any]]] = {
+        name: {} for name in _TABLE_ORDER
+    }
+    for table in _TABLE_ORDER:
+        primary_key = _PRIMARY_KEYS[table]
+        candidates: dict[int, list[Mapping[str, Any]]] = defaultdict(list)
+        for row in tables[table]:
+            value = _identifier(row.get(primary_key, _MISSING))
+            if value is _MISSING or value is None:
+                collector.add(table, row, "missing_primary_key", primary_key)
+            elif value is _INVALID or not isinstance(value, int):
+                collector.add(table, row, "invalid_primary_key", primary_key)
+            else:
+                candidates[value].append(row)
+        for value, rows in candidates.items():
+            if len(rows) == 1:
+                indexes[table][value] = rows[0]
+                continue
+            for duplicate_row in rows:
+                collector.add(
+                    table,
+                    duplicate_row,
+                    "duplicate_primary_key",
+                    primary_key,
+                )
+    return indexes
+
+
+def _validate_relationships(
+    tables: Mapping[str, tuple[dict[str, Any], ...]],
+    indexes: Mapping[str, Mapping[int, Mapping[str, Any]]],
+    collector: _FailureCollector,
+) -> None:
+    required_foreign_keys: Mapping[str, tuple[tuple[str, str], ...]] = {
+        "visit_occurrence": (("person_id", "person"),),
+        "note": (("person_id", "person"),),
+        "note_nlp": (("note_id", "note"),),
+        "condition_occurrence": (("person_id", "person"),),
+        "drug_exposure": (("person_id", "person"),),
+        "measurement": (("person_id", "person"),),
+        "procedure_occurrence": (("person_id", "person"),),
+        "observation": (("person_id", "person"),),
+    }
+
+    for table, references in required_foreign_keys.items():
+        for column, target in references:
+            _check_reference(
+                tables[table],
+                indexes[target],
+                table,
+                column,
+                collector,
+                required=True,
+            )
+
+    optional_foreign_keys: Mapping[str, tuple[tuple[str, str], ...]] = {
+        "visit_occurrence": (("visit_concept_id", "concept"),),
+        "note": (("visit_occurrence_id", "visit_occurrence"),),
+        "note_nlp": (),
+        "condition_occurrence": (
+            ("visit_occurrence_id", "visit_occurrence"),
+            ("note_id", "note"),
+            ("note_nlp_id", "note_nlp"),
+        ),
+        "drug_exposure": (
+            ("visit_occurrence_id", "visit_occurrence"),
+            ("note_id", "note"),
+            ("note_nlp_id", "note_nlp"),
+        ),
+        "measurement": (
+            ("visit_occurrence_id", "visit_occurrence"),
+            ("note_id", "note"),
+            ("note_nlp_id", "note_nlp"),
+        ),
+        "procedure_occurrence": (
+            ("visit_occurrence_id", "visit_occurrence"),
+            ("note_id", "note"),
+            ("note_nlp_id", "note_nlp"),
+        ),
+        "observation": (
+            ("visit_occurrence_id", "visit_occurrence"),
+            ("note_id", "note"),
+            ("note_nlp_id", "note_nlp"),
+        ),
+        "source_to_concept_map": (("note_nlp_id", "note_nlp"),),
+    }
+    for table, references in optional_foreign_keys.items():
+        for column, target in references:
+            if _field_enabled(tables[table], column):
+                _check_reference(
+                    tables[table],
+                    indexes[target],
+                    table,
+                    column,
+                    collector,
+                    required=True,
+                )
+
+    for table, columns in _CONCEPT_COLUMNS.items():
+        for column in columns:
+            if _field_enabled(tables[table], column):
+                _check_reference(
+                    tables[table],
+                    indexes["concept"],
+                    table,
+                    column,
+                    collector,
+                    required=True,
+                )
+    for table, column in _DOMAIN_TABLES.items():
+        _check_reference(
+            tables[table],
+            indexes["concept"],
+            table,
+            column,
+            collector,
+            required=True,
+        )
+
+    for table, source_column in _SOURCE_CONCEPT_COLUMNS.items():
+        _check_reference(
+            tables[table],
+            indexes["concept"],
+            table,
+            source_column,
+            collector,
+            required=True,
+        )
+
+    _validate_person_visit_consistency(tables, indexes, collector)
+
+
+def _validate_person_visit_consistency(
+    tables: Mapping[str, tuple[dict[str, Any], ...]],
+    indexes: Mapping[str, Mapping[int, Mapping[str, Any]]],
+    collector: _FailureCollector,
+) -> None:
+    for table in (
+        "note",
+        "condition_occurrence",
+        "drug_exposure",
+        "measurement",
+        "procedure_occurrence",
+        "observation",
+    ):
+        for row in tables[table]:
+            visit_id = _identifier(row.get("visit_occurrence_id", _MISSING))
+            person_id = _identifier(row.get("person_id", _MISSING))
+            if not isinstance(visit_id, int) or not isinstance(person_id, int):
+                continue
+            visit = indexes["visit_occurrence"].get(visit_id)
+            if visit is None:
+                continue
+            if _identifier(visit.get("person_id", _MISSING)) != person_id:
+                collector.add(
+                    table, row, "person_visit_mismatch", "visit_occurrence_id"
+                )
+
+
+def _validate_vocabulary(
+    tables: Mapping[str, tuple[dict[str, Any], ...]],
+    indexes: Mapping[str, Mapping[int, Mapping[str, Any]]],
+    collector: _FailureCollector,
+) -> None:
+    concept_rows = tables["concept"]
+    for row in concept_rows:
+        standard = row.get("standard_concept", _MISSING)
+        if (
+            standard is not _MISSING
+            and str(standard or "") not in _ALLOWED_STANDARD_CONCEPTS
+        ):
+            collector.add(
+                "concept", row, "invalid_standard_concept", "standard_concept"
+            )
+
+    for table, concept_column in _DOMAIN_TABLES.items():
+        for row in tables[table]:
+            concept_id = _identifier(row.get(concept_column, _MISSING))
+            if not isinstance(concept_id, int):
+                continue
+            concept = indexes["concept"].get(concept_id)
+            if concept is None:
+                continue
+            standard = concept.get("standard_concept", _MISSING)
+            if standard is not _MISSING and str(standard or "") not in {"", "S"}:
+                collector.add(
+                    table, row, "nonstandard_concept_reference", concept_column
+                )
+
+    for row in tables["source_to_concept_map"]:
+        source_id = _identifier(row.get("source_concept_id", _MISSING))
+        target_id = _identifier(row.get("target_concept_id", _MISSING))
+        source = (
+            indexes["concept"].get(source_id) if isinstance(source_id, int) else None
+        )
+        target = (
+            indexes["concept"].get(target_id) if isinstance(target_id, int) else None
+        )
+
+        source_vocabulary = _text_value(row.get("source_vocabulary_id", _MISSING))
+        if source is not None and source_vocabulary:
+            concept_vocabulary = _text_value(source.get("vocabulary_id", _MISSING))
+            if concept_vocabulary and source_vocabulary != concept_vocabulary:
+                collector.add(
+                    "source_to_concept_map",
+                    row,
+                    "vocabulary_mismatch",
+                    "source_vocabulary_id",
+                )
+
+        target_vocabulary = _text_value(row.get("target_vocabulary_id", _MISSING))
+        if target is not None and target_vocabulary:
+            concept_vocabulary = _text_value(target.get("vocabulary_id", _MISSING))
+            if concept_vocabulary and target_vocabulary != concept_vocabulary:
+                collector.add(
+                    "source_to_concept_map",
+                    row,
+                    "vocabulary_mismatch",
+                    "target_vocabulary_id",
+                )
+            standard = target.get("standard_concept", _MISSING)
+            if (
+                target_id != 0
+                and standard is not _MISSING
+                and str(standard or "") not in {"", "S"}
+            ):
+                collector.add(
+                    "source_to_concept_map",
+                    row,
+                    "nonstandard_target_concept",
+                    "target_concept_id",
+                )
+
+    mappings: dict[tuple[str, str], set[int]] = defaultdict(set)
+    for row in tables["source_to_concept_map"]:
+        source_code = _text_value(row.get("source_code", _MISSING))
+        source_vocabulary = _text_value(row.get("source_vocabulary_id", _MISSING))
+        target_id = _identifier(row.get("target_concept_id", _MISSING))
+        if source_code and source_vocabulary and isinstance(target_id, int):
+            mappings[(source_vocabulary, source_code)].add(target_id)
+    conflicting = {key for key, targets in mappings.items() if len(targets) > 1}
+    for row in tables["source_to_concept_map"]:
+        key = (
+            _text_value(row.get("source_vocabulary_id", _MISSING)),
+            _text_value(row.get("source_code", _MISSING)),
+        )
+        if key in conflicting:
+            collector.add(
+                "source_to_concept_map",
+                row,
+                "conflicting_vocabulary_mapping",
+                "source_code",
+            )
+
+
+def _validate_provenance(
+    tables: Mapping[str, tuple[dict[str, Any], ...]],
+    indexes: Mapping[str, Mapping[int, Mapping[str, Any]]],
+    collector: _FailureCollector,
+) -> None:
+    note_indexes = indexes["note"]
+    note_nlp_indexes = indexes["note_nlp"]
+    domain_tables = tuple(_DOMAIN_TABLES)
+
+    for row in tables["note"]:
+        if _field_enabled(tables["note"], "source_note_hash"):
+            source_hash = _text_value(row.get("source_note_hash", _MISSING))
+            if not _valid_source_hash(source_hash):
+                collector.add("note", row, "invalid_provenance", "source_note_hash")
+
+    for table in domain_tables:
+        fields_enabled = {
+            field
+            for field in ("note_id", "note_nlp_id", "source_note_hash")
+            if _field_enabled(tables[table], field)
+        }
+        for row in tables[table]:
+            note_id = _identifier(row.get("note_id", _MISSING))
+            note_nlp_id = _identifier(row.get("note_nlp_id", _MISSING))
+            source_hash = _text_value(row.get("source_note_hash", _MISSING))
+
+            for field in fields_enabled:
+                if field not in row or _is_empty(row.get(field)):
+                    collector.add(table, row, "missing_provenance", field)
+            if source_hash and not _valid_source_hash(source_hash):
+                collector.add(table, row, "invalid_provenance", "source_note_hash")
+
+            note = note_indexes.get(note_id) if isinstance(note_id, int) else None
+            note_nlp = (
+                note_nlp_indexes.get(note_nlp_id)
+                if isinstance(note_nlp_id, int)
+                else None
+            )
+            if note is not None and source_hash:
+                note_hash = _text_value(note.get("source_note_hash", _MISSING))
+                if note_hash and note_hash != source_hash:
+                    collector.add(table, row, "provenance_mismatch", "source_note_hash")
+            if note is not None and note_nlp is not None:
+                linked_note_id = _identifier(note_nlp.get("note_id", _MISSING))
+                if linked_note_id != note_id:
+                    collector.add(table, row, "provenance_mismatch", "note_nlp_id")
+
+            primary_id = _identifier(row.get(_PRIMARY_KEYS[table], _MISSING))
+            if note_nlp is not None and isinstance(primary_id, int):
+                event_id = _identifier(note_nlp.get("note_nlp_event_id", _MISSING))
+                if (
+                    event_id not in (_MISSING, _INVALID, None)
+                    and event_id != primary_id
+                ):
+                    collector.add(
+                        table,
+                        row,
+                        "provenance_mismatch",
+                        "note_nlp_event_id",
+                    )
+
+    event_rows: dict[int, list[tuple[str, Mapping[str, Any]]]] = defaultdict(list)
+    for table in domain_tables:
+        for row in tables[table]:
+            row_id = _identifier(row.get(_PRIMARY_KEYS[table], _MISSING))
+            if isinstance(row_id, int):
+                event_rows[row_id].append((table, row))
+
+    for row in tables["note_nlp"]:
+        event_id = _identifier(row.get("note_nlp_event_id", _MISSING))
+        if not isinstance(event_id, int):
+            continue
+        linked = event_rows.get(event_id, ())
+        if not linked:
+            collector.add("note_nlp", row, "unreachable_event", "note_nlp_event_id")
+            continue
+        note_nlp_id = _identifier(row.get("note_nlp_id", _MISSING))
+        matching_rows = [
+            domain_row
+            for _, domain_row in linked
+            if _identifier(domain_row.get("note_nlp_id", _MISSING)) == note_nlp_id
+        ]
+        if not matching_rows:
+            collector.add("note_nlp", row, "provenance_mismatch", "note_nlp_event_id")
+        elif len(matching_rows) > 1:
+            collector.add("note_nlp", row, "ambiguous_event", "note_nlp_event_id")
+
+    for row in tables["source_to_concept_map"]:
+        note_nlp_id = _identifier(row.get("note_nlp_id", _MISSING))
+        source_hash = _text_value(row.get("source_note_hash", _MISSING))
+        if source_hash and not _valid_source_hash(source_hash):
+            collector.add(
+                "source_to_concept_map",
+                row,
+                "invalid_provenance",
+                "source_note_hash",
+            )
+            continue
+        if not isinstance(note_nlp_id, int) or not source_hash:
+            continue
+        note_nlp = note_nlp_indexes.get(note_nlp_id)
+        if note_nlp is None:
+            continue
+        note_id = _identifier(note_nlp.get("note_id", _MISSING))
+        note = note_indexes.get(note_id) if isinstance(note_id, int) else None
+        note_hash = _text_value(note.get("source_note_hash", _MISSING)) if note else ""
+        if note_hash and note_hash != source_hash:
+            collector.add(
+                "source_to_concept_map",
+                row,
+                "provenance_mismatch",
+                "source_note_hash",
+            )
+
+
+def _check_reference(
+    rows: Iterable[Mapping[str, Any]],
+    target: Mapping[int, Mapping[str, Any]],
+    table: str,
+    column: str,
+    collector: _FailureCollector,
+    *,
+    required: bool,
+) -> None:
+    for row in rows:
+        value = _identifier(row.get(column, _MISSING))
+        if value is _MISSING:
+            if required:
+                collector.add(table, row, "missing_reference", column)
+        elif value is _INVALID:
+            collector.add(table, row, "invalid_reference", column)
+        elif value is None:
+            if required:
+                collector.add(table, row, "missing_reference", column)
+        elif value not in target:
+            collector.add(table, row, "missing_reference", column)
+
+
+def _field_enabled(rows: Iterable[Mapping[str, Any]], field: str) -> bool:
+    return any(field in row for row in rows)
+
+
+def _identifier(value: Any) -> int | object | None:
+    if value is _MISSING:
+        return _MISSING
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return _INVALID
+    if isinstance(value, Integral):
+        converted = int(value)
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            converted = int(stripped)
+        except ValueError:
+            return _INVALID
+    else:
+        return _INVALID
+    if converted < _MIN_BIGINT or converted > _MAX_BIGINT:
+        return _INVALID
+    return converted
+
+
+def _text_value(value: Any) -> str:
+    if value is _MISSING or value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip()
+
+
+def _valid_source_hash(value: str) -> bool:
+    return bool(_SOURCE_HASH_PATTERN.fullmatch(value))
+
+
+def _is_empty(value: Any) -> bool:
+    return (
+        value is _MISSING
+        or value is None
+        or (isinstance(value, str) and not value.strip())
+    )
+
+
+def _canonicalize(
+    value: Any,
+    *,
+    _active: set[int] | None = None,
+    _depth: int = 0,
+) -> Any:
+    if _depth > _MAX_CANONICAL_DEPTH:
+        raise ValueError("OMOP row nesting exceeds the supported depth")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return value
+        return {"type": "float", "value": str(value)}
+    if isinstance(value, (Mapping, list, tuple, set, frozenset)):
+        active = set() if _active is None else _active
+        marker = id(value)
+        if marker in active:
+            raise ValueError("OMOP row contains a cyclic value")
+        active.add(marker)
+        try:
+            if isinstance(value, Mapping):
+                items = [
+                    [
+                        _canonicalize(key, _active=active, _depth=_depth + 1),
+                        _canonicalize(item, _active=active, _depth=_depth + 1),
+                    ]
+                    for key, item in value.items()
+                ]
+                return {
+                    "type": "mapping",
+                    "items": sorted(items, key=_canonical_sort_key),
+                }
+            values = [
+                _canonicalize(item, _active=active, _depth=_depth + 1) for item in value
+            ]
+            if isinstance(value, (set, frozenset)):
+                values.sort(key=_canonical_sort_key)
+            return values
+        finally:
+            active.remove(marker)
+    return {
+        "type": f"{type(value).__module__}.{type(value).__qualname__}",
+        "value": str(value),
+    }
+
+
+def _canonical_sort_key(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+OmopCohortCheckReport = OmopCohortValidationReport
+OmopCohortExportReport = OmopCohortValidationReport
+
+__all__ = [
+    "OmopCohortCheckReport",
+    "OmopCohortExportReport",
+    "OmopCohortExportValidationError",
+    "OmopCohortValidationReport",
+    "OmopCohortViolation",
+    "TableRows",
+    "assert_valid_omop_cohort_export",
+    "check_omop_cohort_export",
+    "omop_row_fingerprint",
+    "validate_cohort_export",
+    "validate_omop_cohort_export",
+]

--- a/tests/browser/brand/budgets.json
+++ b/tests/browser/brand/budgets.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 2,
   "artifact": {
-    "maximum_files": 482,
-    "maximum_total_bytes": 42757931,
-    "maximum_unique_payload_bytes": 42420352,
+    "maximum_files": 484,
+    "maximum_total_bytes": 43039345,
+    "maximum_unique_payload_bytes": 42701766,
     "maximum_duplicate_payload_bytes": 458752,
     "maximum_source_map_files": 0
   },
@@ -33,8 +33,8 @@
   },
   "notes": [
     "Artifact limits are based on the exact staged v2.3 schema candidate plus the audited documentation, federated metrics, and manifest-backed catalog surfaces, including MkDocs search and multilingual tokenizer payloads, with bounded release headroom.",
-    "The audited candidate including the combined deletion guides on current master contains 482 files, 42647181 total bytes, 42309602 unique payload bytes, and 337579 duplicate payload bytes.",
-    "The 42420352-byte unique-payload ceiling and 42757931-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
+    "The audited candidate including the combined export-fidelity guides on current master contains 484 files, 42928595 total bytes, 42591016 unique payload bytes, and 337579 duplicate payload bytes.",
+    "The 42701766-byte unique-payload ceiling and 43039345-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
     "The generated 2266-row model registry remains directly accessible but is excluded from global search indexing so unrelated documentation routes do not absorb its search payload.",
     "Unique and duplicate byte limits hash file content so MkDocs duplication remains visible.",
     "No source maps ship; runtime JavaScript remains intact.",

--- a/tests/unit/interop/test_fhir_r5_fidelity.py
+++ b/tests/unit/interop/test_fhir_r5_fidelity.py
@@ -1,0 +1,351 @@
+"""Focused offline tests for the privacy-safe FHIR R5 fidelity diff."""
+
+from __future__ import annotations
+
+import copy
+import itertools
+import json
+from pathlib import Path
+
+import pytest
+
+from openmed.interop.fhir_r5_fidelity import (
+    FHIRR5Difference,
+    FHIRR5FidelityDiff,
+    FHIRR5FidelityError,
+    ResourceIdentifier,
+    diff_fhir_r5_bundles,
+)
+
+
+def _patient() -> dict:
+    return {
+        "resourceType": "Patient",
+        "id": "synthetic-patient-1",
+        "name": [{"text": "Synthetic Person"}],
+        "identifier": [{"system": "https://synthetic.example/id", "value": "S-1"}],
+    }
+
+
+def _observation() -> dict:
+    return {
+        "resourceType": "Observation",
+        "id": "synthetic-observation-1",
+        "status": "final",
+        "code": {
+            "coding": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "SYN-1234",
+                    "display": "Synthetic measurement",
+                }
+            ]
+        },
+        "subject": {"reference": "Patient/synthetic-patient-1"},
+        "valueQuantity": {"value": 7.2, "unit": "synthetic-unit"},
+    }
+
+
+def _bundle() -> dict:
+    return {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [
+            {
+                "fullUrl": "urn:uuid:synthetic-patient-1",
+                "resource": _patient(),
+            },
+            {
+                "fullUrl": "urn:uuid:synthetic-observation-1",
+                "resource": _observation(),
+            },
+        ],
+    }
+
+
+def test_round_trip_ignores_json_member_order_and_bundle_entry_order():
+    before = _bundle()
+    after = json.loads(json.dumps(before, sort_keys=True))
+    after["entry"].reverse()
+
+    result = diff_fhir_r5_bundles(before, after)
+
+    assert result.equivalent
+    assert result.changes == ()
+    assert result.before_digest.startswith("sha256:")
+    assert result.after_digest.startswith("sha256:")
+    assert result.to_json() == result.to_json()
+
+
+def test_diff_reports_paths_types_and_safe_resource_identifiers():
+    before = _bundle()
+    after = copy.deepcopy(before)
+    observation = after["entry"][1]["resource"]
+    observation["code"]["coding"][0]["code"] = "SYN-5678"
+    observation["valueQuantity"]["value"] = "7.2"
+    observation["subject"]["reference"] = "Patient/synthetic-patient-2"
+
+    result = diff_fhir_r5_bundles(before, after)
+    report_text = result.to_json() + result.to_markdown()
+
+    assert not result.equivalent
+    assert any(
+        path.endswith("resource.code.coding[0].code") for path in result.changed_paths
+    )
+    assert any(
+        path.endswith("resource.valueQuantity.value") for path in result.changed_paths
+    )
+    value_type_change = next(
+        change
+        for change in result.type_changes
+        if change.path.endswith("resource.valueQuantity.value")
+    )
+    assert value_type_change.change_type == "type_changed"
+    assert value_type_change.before_type == "number"
+    assert value_type_change.after_type == "string"
+    assert value_type_change.resource_type == "Observation"
+    assert value_type_change.resource_id_hash.startswith("sha256:")
+    assert "synthetic-patient-1" not in report_text
+    assert "synthetic-patient-2" not in report_text
+    assert "SYN-5678" not in report_text
+
+
+def test_declared_serialization_differences_are_ignored_by_path():
+    before = _bundle()
+    after = copy.deepcopy(before)
+    before["entry"][0]["resource"]["meta"] = {
+        "lastUpdated": "2099-01-01T00:00:00Z",
+        "tag": [
+            {"system": "https://synthetic.example/tag", "code": "a"},
+            {"system": "https://synthetic.example/tag", "code": "b"},
+        ],
+    }
+    after["entry"][0]["resource"]["meta"] = copy.deepcopy(
+        before["entry"][0]["resource"]["meta"]
+    )
+    after["entry"][0]["resource"]["meta"]["lastUpdated"] = "2099-02-01T00:00:00Z"
+    after["entry"][0]["resource"]["meta"]["tag"].reverse()
+
+    strict = diff_fhir_r5_bundles(before, after)
+    allowed = diff_fhir_r5_bundles(
+        before,
+        after,
+        allowed_paths=["entry[*].resource.meta.lastUpdated"],
+        unordered_paths=["entry[*].resource.meta.tag"],
+    )
+
+    assert not strict.equivalent
+    assert allowed.equivalent
+    assert allowed.ignored_paths == ("entry[*].resource.meta.lastUpdated",)
+    assert allowed.unordered_paths == ("entry[*].resource.meta.tag",)
+
+
+def test_resource_type_changes_are_reported_without_values():
+    before = _bundle()
+    after = copy.deepcopy(before)
+    after["entry"][0]["resource"]["resourceType"] = "Observation"
+
+    result = diff_fhir_r5_bundles(before, after)
+    type_change = next(
+        change
+        for change in result.changes
+        if change.path.endswith("resource.resourceType")
+    )
+
+    assert type_change.change_type == "resource_type_changed"
+    assert type_change.before_resource_type == "Patient"
+    assert type_change.after_resource_type == "Observation"
+    assert type_change.before_type == "string"
+    assert type_change.after_type == "string"
+
+
+def test_json_input_and_invalid_errors_are_local_and_phi_safe(tmp_path: Path):
+    bundle_path = tmp_path / "synthetic-bundle.json"
+    bundle_path.write_text(json.dumps(_bundle()), encoding="utf-8")
+
+    assert diff_fhir_r5_bundles(bundle_path, json.dumps(_bundle())).equivalent
+
+    secret = "Synthetic private narrative that must not appear"
+    with pytest.raises(FHIRR5FidelityError) as exc_info:
+        diff_fhir_r5_bundles(
+            f'{{"resourceType": "Bundle", "note": "{secret}',
+            _bundle(),
+        )
+
+    assert secret not in str(exc_info.value)
+
+
+def test_entry_ids_are_scoped_by_resource_type_when_reordered():
+    before = {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [
+            {"resource": {"resourceType": "Patient", "id": "shared-id"}},
+            {
+                "resource": {
+                    "resourceType": "Observation",
+                    "id": "shared-id",
+                    "status": "final",
+                }
+            },
+        ],
+    }
+    after = copy.deepcopy(before)
+    after["entry"].reverse()
+
+    assert diff_fhir_r5_bundles(before, after).equivalent
+
+
+def test_duplicate_full_urls_are_paired_deterministically():
+    before = {
+        "resourceType": "Bundle",
+        "type": "history",
+        "entry": [
+            {
+                "fullUrl": "urn:uuid:duplicate",
+                "resource": {
+                    "resourceType": "Observation",
+                    "id": "version-a",
+                    "status": "preliminary",
+                },
+            },
+            {
+                "fullUrl": "urn:uuid:duplicate",
+                "resource": {
+                    "resourceType": "Observation",
+                    "id": "version-b",
+                    "status": "final",
+                },
+            },
+        ],
+    }
+    after = copy.deepcopy(before)
+    after["entry"].reverse()
+
+    assert diff_fhir_r5_bundles(before, after).equivalent
+
+
+def test_resource_less_bundle_entries_are_compared():
+    before = {
+        "resourceType": "Bundle",
+        "type": "transaction",
+        "entry": [
+            {
+                "fullUrl": "urn:uuid:request-only",
+                "request": {"method": "GET", "url": "Patient/synthetic"},
+            }
+        ],
+    }
+    after = copy.deepcopy(before)
+
+    assert diff_fhir_r5_bundles(before, after).equivalent
+
+    after["entry"][0]["request"]["method"] = "HEAD"
+    result = diff_fhir_r5_bundles(before, after)
+
+    assert result.changed_paths == ("entry[0].request.method",)
+    assert "Patient/synthetic" not in result.to_json()
+
+
+def test_untrusted_keys_cycles_and_depth_fail_without_value_disclosure():
+    secret = "RAW-SYNTHETIC-PATIENT"
+    invalid_key = _bundle()
+    invalid_key[secret] = "value"
+
+    cyclic = _bundle()
+    cycle: list[object] = []
+    cycle.append(cycle)
+    cyclic["link"] = cycle
+
+    too_deep = _bundle()
+    nested: dict[str, object] = too_deep
+    for _ in range(70):
+        child: dict[str, object] = {}
+        nested["extension"] = child
+        nested = child
+
+    for invalid in (invalid_key, cyclic, too_deep):
+        with pytest.raises(FHIRR5FidelityError) as exc_info:
+            diff_fhir_r5_bundles(invalid, _bundle())
+        assert str(exc_info.value) == "FHIR R5 bundles could not be compared safely"
+        assert secret not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "entry[0].resource.RAW-SYNTHETIC-PATIENT",
+        "entry[0]RAW-SYNTHETIC-PATIENT.resource",
+        "/entry/0/resource/RAW-SYNTHETIC-PATIENT",
+    ],
+)
+def test_untrusted_path_declarations_fail_without_value_disclosure(path: str):
+    with pytest.raises(FHIRR5FidelityError) as exc_info:
+        diff_fhir_r5_bundles(_bundle(), _bundle(), ignored_paths=[path])
+
+    assert str(exc_info.value) == "FHIR R5 bundles could not be compared safely"
+    assert "RAW-SYNTHETIC-PATIENT" not in str(exc_info.value)
+
+
+def test_public_report_types_reject_untrusted_metadata():
+    secret = "RAW-SYNTHETIC-PATIENT"
+    constructors = (
+        lambda: ResourceIdentifier(resource_type=secret),
+        lambda: FHIRR5Difference(
+            path=f"entry[0].resource.{secret}",
+            change_type="changed",
+            before_type="string",
+            after_type="string",
+            before_hash=None,
+            after_hash=None,
+        ),
+        lambda: FHIRR5FidelityDiff(ignored_paths=(f"entry[0].{secret}",)),
+    )
+
+    for constructor in constructors:
+        with pytest.raises((TypeError, ValueError)) as exc_info:
+            constructor()
+        assert secret not in str(exc_info.value)
+
+
+def test_recursive_unordered_path_wildcard_matches_exact_array_path():
+    before = _bundle()
+    before["entry"][0]["resource"]["meta"] = {
+        "tag": [
+            {"system": "https://synthetic.example/tag", "code": "a"},
+            {"system": "https://synthetic.example/tag", "code": "b"},
+        ]
+    }
+    after = copy.deepcopy(before)
+    after["entry"][0]["resource"]["meta"]["tag"].reverse()
+
+    result = diff_fhir_r5_bundles(
+        before,
+        after,
+        unordered_paths=["entry.**.tag"],
+    )
+
+    assert result.equivalent
+    assert result.unordered_paths == ("entry.**.tag",)
+
+
+def test_unordered_comparison_preserves_json_numeric_equivalence():
+    before = _bundle()
+    before["total"] = [1, 2.0]
+    after = copy.deepcopy(before)
+    after["total"] = [2, 1.0]
+
+    assert diff_fhir_r5_bundles(
+        before,
+        after,
+        unordered_paths=["total"],
+    ).equivalent
+
+
+def test_path_declaration_iterables_are_bounded():
+    paths = itertools.repeat("entry[*].resource.meta.tag")
+
+    with pytest.raises(FHIRR5FidelityError) as exc_info:
+        diff_fhir_r5_bundles(_bundle(), _bundle(), unordered_paths=paths)
+
+    assert str(exc_info.value) == "FHIR R5 bundles could not be compared safely"

--- a/tests/unit/interop/test_omop_cohort_check.py
+++ b/tests/unit/interop/test_omop_cohort_check.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from openmed.interop.omop import OmopCdmTables, OmopLoadSummary, load_grounded_notes
+from openmed.interop.omop_cohort_check import (
+    OmopCohortExportValidationError,
+    OmopCohortValidationReport,
+    OmopCohortViolation,
+    assert_valid_omop_cohort_export,
+    check_omop_cohort_export,
+    omop_row_fingerprint,
+    validate_omop_cohort_export,
+)
+
+_SOURCE_NOTE_HASH = "a" * 64
+
+
+def _synthetic_export() -> dict[str, list[dict[str, object]]]:
+    return {
+        "concept": [
+            {
+                "concept_id": 0,
+                "vocabulary_id": "UNMAPPED",
+                "standard_concept": "",
+            },
+            {
+                "concept_id": 10,
+                "vocabulary_id": "SYNTHETIC",
+                "standard_concept": "S",
+            },
+            {
+                "concept_id": 20,
+                "vocabulary_id": "SYNTHETIC",
+                "standard_concept": "",
+            },
+        ],
+        "person": [{"person_id": 1, "person_source_value": "synthetic-person"}],
+        "visit_occurrence": [{"visit_occurrence_id": 2, "person_id": 1}],
+        "note": [
+            {
+                "note_id": 3,
+                "person_id": 1,
+                "visit_occurrence_id": 2,
+                "source_note_hash": _SOURCE_NOTE_HASH,
+                "note_text": "synthetic note corpus value",
+            }
+        ],
+        "note_nlp": [
+            {
+                "note_nlp_id": 4,
+                "note_id": 3,
+                "note_nlp_event_id": 5,
+            }
+        ],
+        "condition_occurrence": [
+            {
+                "condition_occurrence_id": 5,
+                "person_id": 1,
+                "condition_concept_id": 10,
+                "condition_source_concept_id": 20,
+                "visit_occurrence_id": 2,
+                "note_id": 3,
+                "note_nlp_id": 4,
+                "source_note_hash": _SOURCE_NOTE_HASH,
+            }
+        ],
+        "source_to_concept_map": [
+            {
+                "source_to_concept_map_id": 6,
+                "source_code": "SYN-CODE",
+                "source_concept_id": 20,
+                "source_vocabulary_id": "SYNTHETIC",
+                "target_concept_id": 10,
+                "target_vocabulary_id": "SYNTHETIC",
+                "note_nlp_id": 4,
+                "source_note_hash": _SOURCE_NOTE_HASH,
+            }
+        ],
+    }
+
+
+def test_validates_relationship_vocabulary_and_provenance_invariants() -> None:
+    export = _synthetic_export()
+
+    report = validate_omop_cohort_export(export)
+
+    assert report.is_valid
+    assert report.violation_count == 0
+    assert report.to_dict()["by_table"] == {}
+    assert report.to_dict()["by_reason"] == {}
+    assert report.to_dict()["row_counts"]["condition_occurrence"] == 1
+
+
+def test_reports_deterministic_counts_and_fingerprints_without_source_values() -> None:
+    export = _synthetic_export()
+    broken = copy.deepcopy(export)
+    broken["condition_occurrence"][0]["visit_occurrence_id"] = 999
+    broken["condition_occurrence"][0]["source_note_hash"] = "b" * 64
+    broken["source_to_concept_map"][0]["target_vocabulary_id"] = "OTHER"
+    broken["note_nlp"][0]["note_nlp_event_id"] = 999
+
+    report = validate_omop_cohort_export(broken)
+    repeated = validate_omop_cohort_export(copy.deepcopy(broken))
+    serialized = json.dumps(report.to_dict(), sort_keys=True)
+
+    assert report.is_valid is False
+    assert report.violation_count >= 4
+    assert report.to_dict() == repeated.to_dict()
+    assert "synthetic-note corpus value" not in serialized
+    assert "synthetic-person" not in serialized
+    assert all(
+        fingerprint.startswith("sha256:")
+        for violation in report.violations
+        for fingerprint in violation.row_fingerprints
+    )
+    assert (
+        "source_note_hash" in report.by_reason
+        or "provenance_mismatch" in report.by_reason
+    )
+
+
+def test_checker_accepts_loader_tables_and_aliases() -> None:
+    export = _synthetic_export()
+    tables = OmopCdmTables(
+        tables={name: tuple(rows) for name, rows in export.items()},
+        summary=OmopLoadSummary(
+            row_counts={name: len(rows) for name, rows in export.items()},
+            rejection_counts={},
+        ),
+    )
+
+    assert (
+        check_omop_cohort_export(tables).to_dict()
+        == validate_omop_cohort_export(tables.to_dict()).to_dict()
+    )
+    assert assert_valid_omop_cohort_export(tables).is_valid
+
+
+def test_checker_accepts_synthetic_loader_output() -> None:
+    note_text = "Synthetic finding."
+    start = note_text.index("finding")
+    tables = load_grounded_notes(
+        [
+            {
+                "document_id": "synthetic-document",
+                "person_id": "synthetic-person",
+                "visit_id": "synthetic-visit",
+                "note_text": note_text,
+                "entities": [
+                    {
+                        "text": "finding",
+                        "start": start,
+                        "end": start + len("finding"),
+                        "domain_id": "Condition",
+                        "concept_id": 10,
+                        "code": "SYN-1",
+                        "vocabulary_id": "SYNTHETIC",
+                        "concept_name": "Synthetic finding",
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert validate_omop_cohort_export(tables).is_valid
+
+
+def test_row_fingerprints_are_canonical_and_validation_errors_are_phi_free() -> None:
+    assert omop_row_fingerprint("person", {"b": 2, "a": 1}) == omop_row_fingerprint(
+        "person", {"a": 1, "b": 2}
+    )
+
+    broken = _synthetic_export()
+    broken["condition_occurrence"][0]["note_id"] = None
+    with pytest.raises(OmopCohortExportValidationError) as exc_info:
+        assert_valid_omop_cohort_export(broken)
+
+    assert "synthetic" not in str(exc_info.value)
+    assert exc_info.value.report.is_valid is False
+
+
+def test_missing_and_lossy_primary_keys_are_rejected() -> None:
+    export = {
+        "person": [
+            {"person_id": None},
+            {"person_id": 1.5},
+            {"person_id": 2**63},
+        ]
+    }
+
+    report = validate_omop_cohort_export(export)
+
+    assert report.by_reason == {
+        "invalid_primary_key": 2,
+        "missing_primary_key": 1,
+    }
+
+
+def test_duplicate_primary_keys_are_all_flagged_and_not_referenceable() -> None:
+    export = {
+        "person": [
+            {"person_id": 1, "person_source_value": "synthetic-first"},
+            {"person_id": 1, "person_source_value": "synthetic-second"},
+        ],
+        "visit_occurrence": [{"visit_occurrence_id": 2, "person_id": 1}],
+    }
+
+    report = validate_omop_cohort_export(export)
+
+    assert report.by_reason == {
+        "duplicate_primary_key": 2,
+        "missing_reference": 1,
+    }
+    assert "synthetic-first" not in json.dumps(report.to_dict())
+    assert "synthetic-second" not in json.dumps(report.to_dict())
+
+
+def test_hostile_and_cyclic_rows_fail_without_echoing_source_values() -> None:
+    sentinel = "RAW-SYNTHETIC-PATIENT"
+
+    class HostileValue:
+        def __str__(self) -> str:
+            raise ValueError(sentinel)
+
+    cyclic: dict[str, object] = {}
+    cyclic["nested"] = cyclic
+    nested: object = sentinel
+    for _ in range(65):
+        nested = [nested]
+
+    for row in ({"source_value": HostileValue()}, cyclic, {"nested": nested}):
+        with pytest.raises(ValueError) as exc_info:
+            validate_omop_cohort_export({"person": [row]})
+        assert sentinel not in str(exc_info.value)
+        assert len(str(exc_info.value)) < 100
+
+
+def test_hostile_row_iterators_fail_without_echoing_source_values() -> None:
+    sentinel = "RAW-SYNTHETIC-PATIENT"
+
+    class HostileRows:
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            raise ValueError(sentinel)
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_omop_cohort_export({"person": HostileRows()})
+
+    assert sentinel not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+
+
+def test_fingerprints_preserve_type_distinct_mapping_keys() -> None:
+    colliding_keys = {1: "first", "1": "second"}
+    string_key_only = {"1": "second"}
+
+    assert omop_row_fingerprint(
+        "person", {"nested": colliding_keys}
+    ) != omop_row_fingerprint("person", {"nested": string_key_only})
+
+
+def test_provenance_hashes_must_be_sha256_values() -> None:
+    export = _synthetic_export()
+    export["note"][0]["source_note_hash"] = "synthetic-not-a-hash"
+
+    report = validate_omop_cohort_export(export)
+
+    assert report.by_reason["invalid_provenance"] >= 1
+    assert "synthetic-not-a-hash" not in json.dumps(report.to_dict())
+
+
+def test_domain_rows_require_target_and_source_concept_references() -> None:
+    export = _synthetic_export()
+    del export["condition_occurrence"][0]["condition_concept_id"]
+    del export["condition_occurrence"][0]["condition_source_concept_id"]
+
+    report = validate_omop_cohort_export(export)
+
+    violations = {(item.column, item.reason): item.count for item in report.violations}
+    assert violations[("condition_concept_id", "missing_reference")] == 1
+    assert violations[("condition_source_concept_id", "missing_reference")] == 1
+
+
+def test_note_nlp_event_link_must_resolve_to_one_domain_row() -> None:
+    export = _synthetic_export()
+    export["drug_exposure"] = [
+        {
+            "drug_exposure_id": 5,
+            "person_id": 1,
+            "drug_concept_id": 10,
+            "drug_source_concept_id": 20,
+            "visit_occurrence_id": 2,
+            "note_id": 3,
+            "note_nlp_id": 4,
+            "source_note_hash": _SOURCE_NOTE_HASH,
+        }
+    ]
+
+    report = validate_omop_cohort_export(export)
+
+    assert report.by_reason["ambiguous_event"] == 1
+
+
+def test_public_report_types_reject_untrusted_diagnostic_labels() -> None:
+    fingerprint = "sha256:" + "0" * 64
+
+    with pytest.raises(ValueError, match="table is unsupported") as exc_info:
+        OmopCohortViolation(
+            table="raw-synthetic-patient",
+            column=None,
+            reason="missing_primary_key",
+            count=1,
+            row_fingerprints=(fingerprint,),
+        )
+    assert "raw-synthetic-patient" not in str(exc_info.value)
+
+    with pytest.raises(ValueError, match="unsupported table"):
+        OmopCohortValidationReport(
+            row_counts={"raw-synthetic-patient": 1},
+            violations=(),
+        )


### PR DESCRIPTION
## Description

Validate OMOP cohort exports and FHIR round-trip fidelity. These local APIs validate bounded inputs and produce value-free or counts-only evidence.

## Included pull requests

- #2484 — Add an OMOP cohort export validation check
- #2485 — feat: add FHIR R5 round-trip fidelity diff

## Issues resolved

Closes #2402
Closes #2401

## Maintainer integration changes

- Preserve the independently reviewed feature implementations and their public exports.
- Preserve every original PR through a guarded squash into this branch.
- Reconcile additive changelog, documentation, and public-export changes against current master.
- Measure the complete staged documentation artifact with existing bounded headroom.
- Verify the actual batch tree exactly matches the passing rehearsal.

## Validation

- `make format`, `make lint`, `make format-check` — passed.
- `PYTHONHASHSEED=0 uv run --with pytest-xdist python -m pytest tests/ -q -n 12 --dist worksteal` — 15,304 passed, 132 skipped.
- `make docs-build` — strict documentation, publication metadata, routes, and feed checks passed.
- Chromium staged-artifact checks — 2 passed, including hashes and byte budgets.
- High-severity Bandit gate — passed.
- The final exact head is revalidated before merge, including package build.

## Change type, documentation, and dependencies

Features, tests, documentation, and integration fixes. Guides, navigation, public API docstrings, and changelog are updated. No dependencies are added. Reports contain counts, categories, and fingerprints rather than source values.

Effective master rules require no hosted status checks. Complete local gates determine readiness while non-required hosted jobs remain queued; any reported hosted failure is reviewed before merging.
