### PR TITLE
Add bounded BMP header dimension preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added bounded BMP CORE/INFO header geometry preflight with explicit limits,
+  value-free errors, and synthetic file-level regression tests (#3114).
+
 - Added an optional Snowpark adapter and generated Python UDF SQL for
   in-warehouse text de-identification with lazy dependency loading, compatible
   Snowpark registration, and escaped SQL literals (#2369).

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -223,6 +223,7 @@ classification:
     - training/federated-scheduling.md
     - training/federated-update-metadata.md
     - reference/preference-schema.md
+    - multimodal/bmp-header-preflight.md
     - multimodal/media-type-detection.md
     - multimodal/pdf-reading-order.md
     - multimodal/asset-digests.md

--- a/docs/multimodal/bmp-header-preflight.md
+++ b/docs/multimodal/bmp-header-preflight.md
@@ -1,0 +1,69 @@
+# BMP header preflight
+
+`read_bmp_dimensions` reads declared BMP geometry without decoding pixels.
+It is an explicit helper, not an automatically registered decoder or pipeline gate.
+
+```python
+from openmed.multimodal.bmp_dimensions import read_bmp_dimensions
+
+with open("synthetic.bmp", "rb") as stream:
+    geometry = read_bmp_dimensions(stream, max_pixels=20_000_000)
+    assert stream.tell() == 0
+print(geometry.width, geometry.height, geometry.bit_depth, geometry.top_down)
+```
+
+## Supported boundary
+
+The helper accepts `bytes` or a caller-owned binary stream at its current position.
+It supports the 12-byte Windows CORE DIB and the uncompressed 40-byte INFO DIB
+(`BI_RGB`). CORE depths are 1, 4, 8 and 24; INFO also supports 16 and 32.
+INFO negative height denotes top-down rows; the returned height is positive.
+The plane count must be one. Dimensions must be nonzero and width positive.
+Other DIB layouts and compression modes are explicitly unsupported, not guessed.
+
+Only 26 bytes (CORE) or 54 bytes (INFO) are read. Palette counts and the declared
+pixel offset/file extent are checked arithmetically, without reading the palette.
+Rows use four-byte alignment. INFO image size may be zero or the computed size.
+This does not prove that pixel payload bytes are present or decodable. Trailing
+content, color management, metadata, compression, OCR and sanitization are outside
+scope. An accepted header is not a clinical or security approval.
+
+## Limits and stream ownership
+
+The defaults are `max_header_bytes=54` and `max_pixels=100_000_000`. Both must be
+positive integers (not booleans). Lower limits can be supplied per call. The pixel
+limit is checked using division; declared file extents must fit their 32-bit fields.
+No allocation proportional to image dimensions or declared offsets is performed.
+
+Short reads are supported. A read never exceeds the remaining header budget.
+Seekable streams are restored after success and failure, including a nonzero
+starting offset. Nonseekable streams are consumed only through the required
+header. The caller retains ownership; the helper never closes a stream.
+
+## Failures
+
+`BmpDimensionsError` is a `ValueError` with a stable `.category`; its string is the
+same category. Input values, paths, resolutions and palette entries are not echoed.
+Categories include `bmp_signature_invalid`, `bmp_reserved_fields_invalid`,
+`bmp_dib_header_unsupported`, `bmp_compression_unsupported`, `bmp_planes_invalid`,
+`bmp_bit_depth_unsupported`, `bmp_dimensions_invalid`, `bmp_color_table_size_invalid`,
+`bmp_pixel_offset_invalid`, `bmp_file_size_invalid`, `bmp_image_size_invalid`,
+`bmp_pixel_limit_exceeded`, `bmp_header_limit_exceeded` and `bmp_header_truncated`.
+Stream failures use `bmp_stream_contract_error`, `bmp_stream_read_error`,
+`bmp_stream_position_error` or `bmp_stream_restore_error` without retaining an
+underlying I/O message. Unsupported formats should be handled explicitly by the
+caller rather than retried with larger limits. Invalid API argument types are
+reported separately as `TypeError`/`ValueError` with constant messages.
+
+## Verification
+
+```bash
+uv run --frozen --extra dev pytest tests/unit/multimodal/test_bmp_dimensions.py -q
+```
+
+Fixtures are synthetic. Tests compare complete files with Pillow, include CORE
+and top-down examples, exercise short/nonseekable streams and assert the precise
+read boundary. Pillow is an existing development dependency, not a runtime import.
+
+Layout references: Microsoft's [BITMAPCOREHEADER](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapcoreheader)
+and [BITMAPINFOHEADER](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - Federated Round Scheduling: training/federated-scheduling.md
       - Federated Update Metadata: training/federated-update-metadata.md
       - Preference Pair Schema: reference/preference-schema.md
+      - BMP Header Preflight: multimodal/bmp-header-preflight.md
       - Bounded Media Type Detection: multimodal/media-type-detection.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Bounded Asset Digests: multimodal/asset-digests.md

--- a/openmed/multimodal/bmp_dimensions.py
+++ b/openmed/multimodal/bmp_dimensions.py
@@ -1,0 +1,218 @@
+"""Bounded, dependency-free BMP CORE/INFO header preflight."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import BinaryIO, Callable, Final
+
+__all__ = [
+    "DEFAULT_MAX_BMP_HEADER_BYTES",
+    "DEFAULT_MAX_BMP_PIXELS",
+    "BmpDimensions",
+    "BmpDimensionsError",
+    "read_bmp_dimensions",
+]
+
+DEFAULT_MAX_BMP_HEADER_BYTES: Final[int] = 54
+DEFAULT_MAX_BMP_PIXELS: Final[int] = 100_000_000
+_UINT32_MAX: Final[int] = (1 << 32) - 1
+
+
+class BmpDimensionsError(ValueError):
+    """Value-free failure for malformed or unsupported BMP headers."""
+
+    def __init__(self, category: str) -> None:
+        self.category = category
+        super().__init__(category)
+
+
+@dataclass(frozen=True, slots=True)
+class BmpDimensions:
+    """BMP geometry without pixels, color tables, paths, or text metadata."""
+
+    width: int
+    height: int
+    planes: int
+    bit_depth: int
+    top_down: bool
+    dib_header_bytes: int
+
+
+def read_bmp_dimensions(
+    source: bytes | BinaryIO,
+    *,
+    max_header_bytes: int = DEFAULT_MAX_BMP_HEADER_BYTES,
+    max_pixels: int = DEFAULT_MAX_BMP_PIXELS,
+) -> BmpDimensions:
+    """Read Windows BMP CORE (12-byte) or uncompressed INFO (40-byte) geometry.
+
+    Other DIB layouts and compression modes are explicitly unsupported. Only
+    the file and DIB headers are read, never palette entries or pixels. Declared
+    offsets and pixel sizes are checked, but payload presence is not validated.
+    Seekable streams are restored to their original position on return/failure;
+    caller-owned streams are never closed.
+    """
+    if type(max_header_bytes) is not int or max_header_bytes <= 0:
+        raise ValueError("max_header_bytes must be a positive integer")
+    if type(max_pixels) is not int or max_pixels <= 0:
+        raise ValueError("max_pixels must be a positive integer")
+    if isinstance(source, bytes):
+        return _parse_bmp(_HeaderReader(source, max_header_bytes), max_pixels)
+    read = getattr(source, "read", None)
+    if not callable(read):
+        raise TypeError("source must be bytes or a binary stream")
+    position = _stream_position(source)
+    try:
+        return _parse_bmp(_HeaderReader(read, max_header_bytes), max_pixels)
+    finally:
+        if position is not None:
+            _restore_position(source, position)
+
+
+def _parse_bmp(reader: _HeaderReader, max_pixels: int) -> BmpDimensions:
+    file_header = reader.read_exact(14)
+    signature, file_size, reserved1, reserved2, pixel_offset = struct.unpack(
+        "<2sIHHI", file_header
+    )
+    if signature != b"BM":
+        raise BmpDimensionsError("bmp_signature_invalid")
+    if reserved1 or reserved2:
+        raise BmpDimensionsError("bmp_reserved_fields_invalid")
+    dib_size = struct.unpack("<I", reader.read_exact(4))[0]
+    width: int
+    signed_height: int
+    planes: int
+    bit_depth: int
+    compression: int
+    image_size: int
+    allowed_depths: tuple[int, ...]
+    if dib_size == 12:
+        dib_fields_12 = struct.unpack("<HHHH", reader.read_exact(8))
+        width = dib_fields_12[0]
+        signed_height = dib_fields_12[1]
+        planes = dib_fields_12[2]
+        bit_depth = dib_fields_12[3]
+        allowed_depths = (1, 4, 8, 24)
+        palette_entries = 1 << bit_depth if bit_depth in (1, 4, 8) else 0
+        palette_bytes = palette_entries * 3
+        image_size = 0
+    elif dib_size == 40:
+        dib_fields_40 = struct.unpack("<iiHHIIiiII", reader.read_exact(36))
+        width = dib_fields_40[0]
+        signed_height = dib_fields_40[1]
+        planes = dib_fields_40[2]
+        bit_depth = dib_fields_40[3]
+        compression = dib_fields_40[4]
+        image_size = dib_fields_40[5]
+        colors_used = dib_fields_40[8]
+        if compression != 0:
+            raise BmpDimensionsError("bmp_compression_unsupported")
+        allowed_depths = (1, 4, 8, 16, 24, 32)
+        palette_entries = colors_used
+        if bit_depth in (1, 4, 8):
+            if colors_used > 1 << bit_depth:
+                raise BmpDimensionsError("bmp_color_table_size_invalid")
+            palette_entries = colors_used or (1 << bit_depth)
+        palette_bytes = palette_entries * 4
+    else:
+        raise BmpDimensionsError("bmp_dib_header_unsupported")
+    if planes != 1:
+        raise BmpDimensionsError("bmp_planes_invalid")
+    if bit_depth not in allowed_depths:
+        raise BmpDimensionsError("bmp_bit_depth_unsupported")
+    if width <= 0 or signed_height == 0:
+        raise BmpDimensionsError("bmp_dimensions_invalid")
+    height = abs(signed_height)
+    if width > max_pixels // height:
+        raise BmpDimensionsError("bmp_pixel_limit_exceeded")
+    minimum_offset = 14 + dib_size + palette_bytes
+    if pixel_offset < minimum_offset:
+        raise BmpDimensionsError("bmp_pixel_offset_invalid")
+    row_bytes = ((width * bit_depth + 31) // 32) * 4
+    pixel_bytes = row_bytes * height
+    if (
+        pixel_bytes > _UINT32_MAX - pixel_offset
+        or file_size < pixel_offset + pixel_bytes
+    ):
+        raise BmpDimensionsError("bmp_file_size_invalid")
+    if image_size not in (0, pixel_bytes):
+        raise BmpDimensionsError("bmp_image_size_invalid")
+    return BmpDimensions(
+        width=width,
+        height=height,
+        planes=planes,
+        bit_depth=bit_depth,
+        top_down=signed_height < 0,
+        dib_header_bytes=dib_size,
+    )
+
+
+class _HeaderReader:
+    def __init__(self, source: bytes | Callable[[int], bytes], limit: int) -> None:
+        self._buffer = memoryview(source) if isinstance(source, bytes) else None
+        self._read = source if callable(source) else None
+        self._limit = limit
+        self.offset = 0
+
+    def read_exact(self, size: int) -> bytes:
+        if size > self._limit - self.offset:
+            raise BmpDimensionsError("bmp_header_limit_exceeded")
+        if self._buffer is not None:
+            end = self.offset + size
+            if end > len(self._buffer):
+                raise BmpDimensionsError("bmp_header_truncated")
+            result = bytes(self._buffer[self.offset : end])
+            self.offset = end
+            return result
+        chunks: list[bytes] = []
+        remaining = size
+        while remaining:
+            chunk = _read_chunk(self._read, remaining)
+            if not chunk:
+                raise BmpDimensionsError("bmp_header_truncated")
+            chunks.append(chunk)
+            self.offset += len(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+
+def _read_chunk(read: Callable[[int], bytes] | None, size: int) -> bytes:
+    if read is None:
+        raise BmpDimensionsError("bmp_stream_contract_error")
+    try:
+        chunk = read(size)
+    except Exception:
+        pass
+    else:
+        if isinstance(chunk, bytes) and len(chunk) <= size:
+            return chunk
+        raise BmpDimensionsError("bmp_stream_contract_error")
+    # Raise outside the handler so an underlying I/O message is not retained.
+    raise BmpDimensionsError("bmp_stream_read_error")
+
+
+def _stream_position(stream: BinaryIO) -> int | None:
+    seekable = getattr(stream, "seekable", None)
+    if not callable(seekable):
+        return None
+    try:
+        if not seekable():
+            return None
+        position = stream.tell()
+    except Exception:
+        pass
+    else:
+        if type(position) is int and position >= 0:
+            return position
+    raise BmpDimensionsError("bmp_stream_position_error")
+
+
+def _restore_position(stream: BinaryIO, position: int) -> None:
+    try:
+        stream.seek(position)
+    except Exception:
+        pass
+    else:
+        return
+    raise BmpDimensionsError("bmp_stream_restore_error")

--- a/tests/browser/brand/budgets.json
+++ b/tests/browser/brand/budgets.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 2,
   "artifact": {
-    "maximum_files": 519,
-    "maximum_total_bytes": 48231286,
-    "maximum_unique_payload_bytes": 47893707,
+    "maximum_files": 520,
+    "maximum_total_bytes": 48386135,
+    "maximum_unique_payload_bytes": 48048556,
     "maximum_duplicate_payload_bytes": 458752,
     "maximum_source_map_files": 0
   },
@@ -13,13 +13,13 @@
     "html": 2359296,
     "image": 262144,
     "javascript": 716800,
-    "json": 3276800
+    "json": 3407872
   },
   "governed_payload_bytes": {
     "docs/assets/javascripts/lunr/wordcut.js": 716800,
     "docs/model-tokenizer-script-coverage/index.html": 2359296,
     "docs/model-tokenizer-script-coverage.json": 1572864,
-    "docs/search/search_index.json": 3276800
+    "docs/search/search_index.json": 3407872
   },
   "route_transfer_bytes": {
     "/": 3145728,
@@ -33,8 +33,8 @@
   },
   "notes": [
     "Artifact limits are based on the exact staged v2.3 schema candidate plus the audited documentation, federated metrics, and manifest-backed catalog surfaces, including MkDocs search and multilingual tokenizer payloads, with bounded release headroom.",
-    "The audited candidate including this combined change on current master contains 519 files, 48120536 total bytes, 47782957 unique payload bytes, and 337579 duplicate payload bytes.",
-    "The 47893707-byte unique-payload ceiling and 48231286-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
+    "The audited candidate on current master contains 520 files, 48275385 total bytes, 47937806 unique payload bytes, and 337579 duplicate payload bytes.",
+    "The 48048556-byte unique-payload ceiling and 48386135-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
     "The generated 2266-row model registry remains directly accessible but is excluded from global search indexing so unrelated documentation routes do not absorb its search payload.",
     "Unique and duplicate byte limits hash file content so MkDocs duplication remains visible.",
     "No source maps ship; runtime JavaScript remains intact.",

--- a/tests/unit/multimodal/test_bmp_dimensions.py
+++ b/tests/unit/multimodal/test_bmp_dimensions.py
@@ -1,0 +1,343 @@
+"""Synthetic unit and file-level tests for BMP header preflight."""
+
+from __future__ import annotations
+
+import io
+import struct
+from dataclasses import FrozenInstanceError, asdict
+
+import pytest
+
+from openmed.multimodal.bmp_dimensions import BmpDimensionsError, read_bmp_dimensions
+
+
+def bmp(width=7, height=5, *, core=False, depth=24, planes=1, compression=0):
+    header_size = 12 if core else 40
+    palette_entries = 2**depth if depth in (1, 4, 8) else 0
+    offset = 14 + header_size + palette_entries * (3 if core else 4)
+    rows = ((abs(width) * depth + 31) // 32) * 4 * abs(height)
+    file_header = struct.pack("<2sIHHI", b"BM", offset + rows, 0, 0, offset)
+    if core:
+        return file_header + struct.pack("<IHHHH", 12, width, height, planes, depth)
+    return file_header + struct.pack(
+        "<IiiHHIIiiII", 40, width, height, planes, depth, compression, rows, 0, 0, 0, 0
+    )
+
+
+def valid_payload():
+    payload = bmp()
+    return payload, len(payload)
+
+
+def edit(payload: bytes, offset: int, fmt: str, value: int) -> bytes:
+    changed = bytearray(payload)
+    struct.pack_into(fmt, changed, offset, value)
+    return bytes(changed)
+
+
+@pytest.mark.parametrize("depth", [1, 4, 8, 24])
+def test_core_headers(depth) -> None:
+    result = read_bmp_dimensions(bmp(core=True, depth=depth))
+    assert asdict(result) == {
+        "width": 7,
+        "height": 5,
+        "planes": 1,
+        "bit_depth": depth,
+        "top_down": False,
+        "dib_header_bytes": 12,
+    }
+
+
+@pytest.mark.parametrize("height", [5, -5])
+@pytest.mark.parametrize("depth", [1, 4, 8, 16, 24, 32])
+def test_info_headers_and_top_down_rows(height, depth) -> None:
+    result = read_bmp_dimensions(bmp(height=height, depth=depth))
+    assert (result.width, result.height, result.bit_depth) == (7, 5, depth)
+    assert result.top_down is (height < 0)
+    assert result.planes == 1
+    assert result.dib_header_bytes == 40
+
+
+@pytest.mark.parametrize("core,boundary", [(True, 26), (False, 54)])
+def test_all_truncated_header_boundaries(core, boundary) -> None:
+    for cut in range(boundary):
+        with pytest.raises(BmpDimensionsError, match="^bmp_header_truncated$"):
+            read_bmp_dimensions(bmp(core=core)[:cut])
+    assert read_bmp_dimensions(bmp(core=core), max_header_bytes=boundary).width == 7
+    with pytest.raises(BmpDimensionsError, match="^bmp_header_limit_exceeded$"):
+        read_bmp_dimensions(bmp(core=core), max_header_bytes=boundary - 1)
+
+
+@pytest.mark.parametrize("header_size", [0, 11, 16, 52, 56, 64, 108, 124, 0xFFFFFFFF])
+def test_unsupported_dib_never_triggers_unbounded_reads(header_size) -> None:
+    payload = edit(bmp(), 14, "<I", header_size)
+    stream = ShortStream(payload, chunk=14, boundary=18)
+    with pytest.raises(BmpDimensionsError, match="^bmp_dib_header_unsupported$"):
+        read_bmp_dimensions(stream)
+    assert stream.stream.tell() == 18
+
+
+@pytest.mark.parametrize("planes", [0, 2, 65535])
+@pytest.mark.parametrize("core", [False, True])
+def test_plane_count_must_be_one(planes, core) -> None:
+    with pytest.raises(BmpDimensionsError, match="^bmp_planes_invalid$"):
+        read_bmp_dimensions(bmp(planes=planes, core=core))
+
+
+@pytest.mark.parametrize("depth", [0, 2, 3, 64, 65535])
+def test_invalid_bit_depths(depth) -> None:
+    payload = edit(bmp(), 28, "<H", depth)
+    with pytest.raises(BmpDimensionsError, match="^bmp_bit_depth_unsupported$"):
+        read_bmp_dimensions(payload)
+
+
+@pytest.mark.parametrize("compression", [1, 2, 3, 4, 5, 6, 0xFFFFFFFF])
+def test_compressed_layouts_are_explicitly_unsupported(compression) -> None:
+    with pytest.raises(BmpDimensionsError, match="^bmp_compression_unsupported$"):
+        read_bmp_dimensions(bmp(compression=compression))
+
+
+@pytest.mark.parametrize(
+    "offset,fmt,value,category",
+    [
+        (0, "<H", 0, "bmp_signature_invalid"),
+        (6, "<H", 1, "bmp_reserved_fields_invalid"),
+        (8, "<H", 1, "bmp_reserved_fields_invalid"),
+        (18, "<i", 0, "bmp_dimensions_invalid"),
+        (18, "<i", -1, "bmp_dimensions_invalid"),
+        (22, "<i", 0, "bmp_dimensions_invalid"),
+        (10, "<I", 53, "bmp_pixel_offset_invalid"),
+        (2, "<I", 53, "bmp_file_size_invalid"),
+        (34, "<I", 1, "bmp_image_size_invalid"),
+    ],
+)
+def test_malformed_fields_have_stable_categories(offset, fmt, value, category) -> None:
+    with pytest.raises(BmpDimensionsError) as raised:
+        read_bmp_dimensions(edit(bmp(), offset, fmt, value))
+    assert raised.value.category == category
+    assert str(raised.value) == category
+
+
+def test_zero_image_size_is_allowed_for_uncompressed_info() -> None:
+    assert read_bmp_dimensions(edit(bmp(), 34, "<I", 0)).width == 7
+
+
+def test_palette_count_and_offset_are_checked_without_reading_palette() -> None:
+    payload = bmp(depth=8)
+    assert read_bmp_dimensions(payload).bit_depth == 8
+    with pytest.raises(BmpDimensionsError, match="^bmp_color_table_size_invalid$"):
+        read_bmp_dimensions(edit(payload, 46, "<I", 257))
+    with pytest.raises(BmpDimensionsError, match="^bmp_pixel_offset_invalid$"):
+        read_bmp_dimensions(edit(payload, 10, "<I", 54))
+    reduced = edit(edit(payload, 46, "<I", 2), 10, "<I", 62)
+    assert read_bmp_dimensions(reduced).bit_depth == 8
+
+
+def test_uint32_pixel_extent_cannot_overflow() -> None:
+    payload = edit(edit(bmp(), 10, "<I", 0xFFFFFFFE), 2, "<I", 0xFFFFFFFF)
+    with pytest.raises(BmpDimensionsError, match="^bmp_file_size_invalid$"):
+        read_bmp_dimensions(payload)
+    payload = edit(edit(bmp(), 22, "<i", -(1 << 31)), 2, "<I", 0xFFFFFFFF)
+    with pytest.raises(BmpDimensionsError, match="^bmp_file_size_invalid$"):
+        read_bmp_dimensions(payload, max_pixels=1 << 63)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("size", [(1, 1), (7, 5), (257, 129)])
+@pytest.mark.parametrize("mode", ["1", "L", "RGB", "RGBA"])
+def test_pillow_generated_file_end_to_end(tmp_path, size, mode) -> None:
+    from PIL import Image
+
+    path = tmp_path / "synthetic.bmp"
+    Image.new(mode, size).save(path, format="BMP")
+    with Image.open(path) as decoded:
+        decoded.load()
+        expected = decoded.size
+    with path.open("rb") as stream:
+        result = read_bmp_dimensions(stream)
+        assert stream.tell() == 0
+    assert (result.width, result.height) == expected == size
+
+
+class ShortStream:
+    """A real non-seekable byte stream that records every bounded read."""
+
+    def __init__(self, data: bytes, chunk: int = 3, boundary: int | None = None):
+        self.stream = io.BytesIO(data)
+        self.chunk = chunk
+        self.boundary = len(data) if boundary is None else boundary
+        self.requests: list[int] = []
+        self.closed = False
+
+    def read(self, size: int) -> bytes:
+        assert size >= 0
+        assert self.stream.tell() + size <= self.boundary
+        self.requests.append(size)
+        return self.stream.read(min(size, self.chunk))
+
+
+def test_partial_nonseekable_reads_stop_at_header() -> None:
+    payload, boundary = valid_payload()
+    stream = ShortStream(payload + b"unread-payload", boundary=boundary)
+    result = read_bmp_dimensions(stream)
+    assert (result.width, result.height) == (7, 5)
+    assert stream.stream.tell() == boundary
+    assert not stream.closed
+    assert sum(min(n, stream.chunk) for n in stream.requests) == boundary
+
+
+def test_seekable_stream_at_nonzero_position_is_restored() -> None:
+    payload, _ = valid_payload()
+    stream = io.BytesIO(b"prefix" + payload)
+    stream.seek(6)
+    result = read_bmp_dimensions(stream)
+    assert (result.width, result.height) == (7, 5)
+    assert stream.tell() == 6
+    assert not stream.closed
+
+
+def test_failure_restores_caller_owned_stream() -> None:
+    stream = io.BytesIO(b"prefix" + b"truncated")
+    stream.seek(6)
+    with pytest.raises(BmpDimensionsError):
+        read_bmp_dimensions(stream)
+    assert stream.tell() == 6
+    assert not stream.closed
+
+
+@pytest.mark.parametrize("option", ["max_header_bytes", "max_pixels"])
+@pytest.mark.parametrize("value", [0, -1, True, False, 2.0, "2", None])
+def test_invalid_limits_do_not_read(option, value) -> None:
+    class Unreadable:
+        def read(self, size):
+            pytest.fail("invalid options must be checked before I/O")
+
+    with pytest.raises(ValueError, match=option):
+        read_bmp_dimensions(Unreadable(), **{option: value})
+
+
+@pytest.mark.parametrize("source", [None, "not-bytes", bytearray(b"data"), 12])
+def test_invalid_source_type(source) -> None:
+    with pytest.raises(TypeError, match="source must be bytes or a binary stream"):
+        read_bmp_dimensions(source)
+
+
+@pytest.mark.parametrize("returned", [None, "text", bytearray(b"x"), b"x" * 1000])
+def test_binary_stream_contract_errors_are_value_free(returned) -> None:
+    class WrongStream:
+        def read(self, size):
+            return returned
+
+    with pytest.raises(BmpDimensionsError) as raised:
+        read_bmp_dimensions(WrongStream())
+    assert raised.value.category == "bmp_stream_contract_error"
+    assert str(raised.value) == raised.value.category
+
+
+def test_read_error_does_not_retain_io_details() -> None:
+    class BrokenStream:
+        def read(self, size):
+            raise OSError("synthetic-private-file-detail")
+
+    with pytest.raises(BmpDimensionsError) as raised:
+        read_bmp_dimensions(BrokenStream())
+    assert str(raised.value) == "bmp_stream_read_error"
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+
+
+@pytest.mark.parametrize("failure", ["seekable", "tell", "bad-position", "seek"])
+def test_position_errors_do_not_retain_io_details(failure) -> None:
+    payload, _ = valid_payload()
+
+    class PositionStream(io.BytesIO):
+        def seekable(self):
+            if failure == "seekable":
+                raise OSError("synthetic-private-file-detail")
+            return True
+
+        def tell(self):
+            if failure == "tell":
+                raise OSError("synthetic-private-file-detail")
+            if failure == "bad-position":
+                return True
+            return super().tell()
+
+        def seek(self, offset, whence=0):
+            if failure == "seek":
+                raise OSError("synthetic-private-file-detail")
+            return super().seek(offset, whence)
+
+    stream = PositionStream(payload)
+    with pytest.raises(BmpDimensionsError) as raised:
+        read_bmp_dimensions(stream)
+    expected = "restore" if failure == "seek" else "position"
+    assert str(raised.value) == f"bmp_stream_{expected}_error"
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert not stream.closed
+
+
+def test_pixel_limit_boundary() -> None:
+    payload, _ = valid_payload()
+    result = read_bmp_dimensions(payload, max_pixels=35)
+    assert result.width * result.height == 35
+    with pytest.raises(BmpDimensionsError, match="^bmp_pixel_limit_exceeded$"):
+        read_bmp_dimensions(payload, max_pixels=34)
+
+
+def test_output_contains_only_declared_metadata() -> None:
+    payload, _ = valid_payload()
+    result = read_bmp_dimensions(payload)
+    assert all(isinstance(v, (int, str, bool)) for v in asdict(result).values())
+    with pytest.raises(FrozenInstanceError):
+        result.width = 1
+
+
+@pytest.mark.integration
+def test_real_file_read_preserves_position_and_ownership(tmp_path) -> None:
+    payload, _ = valid_payload()
+    path = tmp_path / "synthetic-image.bin"
+    path.write_bytes(b"prefix" + payload + b"not-part-of-the-header")
+    with path.open("rb") as stream:
+        stream.seek(6)
+        result = read_bmp_dimensions(stream)
+        assert (result.width, result.height) == (7, 5)
+        assert stream.tell() == 6
+        assert not stream.closed
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "core,depth,height",
+    [(True, 1, 5), (True, 8, 5), (True, 24, 5), (False, 24, -5)],
+)
+def test_core_and_top_down_files_against_pillow(tmp_path, core, depth, height) -> None:
+    from PIL import Image
+
+    header = bmp(core=core, depth=depth, height=height)
+    declared_size = struct.unpack_from("<I", header, 2)[0]
+    path = tmp_path / "synthetic-supported-layout.bmp"
+    path.write_bytes(header + bytes(declared_size - len(header)))
+    with Image.open(path) as oracle:
+        oracle.load()
+        expected = oracle.size
+    with path.open("rb") as stream:
+        result = read_bmp_dimensions(stream)
+    assert (result.width, result.height) == expected == (7, 5)
+    assert result.top_down is (height < 0)
+
+
+def test_explicit_nonseekable_stream_does_not_attempt_restoration() -> None:
+    payload, boundary = valid_payload()
+
+    class NoSeek(ShortStream):
+        def seekable(self):
+            return False
+
+        def seek(self, *args):
+            pytest.fail("a nonseekable stream must not be rewound")
+
+    stream = NoSeek(payload, boundary=boundary)
+    assert read_bmp_dimensions(stream).width == 7
+    assert stream.stream.tell() == boundary


### PR DESCRIPTION
# Pull Request

## Description

Add a dependency-free BMP CORE/INFO geometry reader with strict limits and synthetic unit and file-level integration tests.

Closes #3114.

## Type of Change

- [ ] Bug fix
- [x] New feature (additive module-level helper)
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- `openmed/multimodal/bmp_dimensions.py`
- `tests/unit/multimodal/test_bmp_dimensions.py`
- `docs/multimodal/bmp-header-preflight.md`
- `CHANGELOG.md`

The implementation is restricted to the issue's documented scope. No runtime
dependency, model, clinical decision path or provider integration is added.
The helper is explicitly callable; existing pipeline routing and package-level export inventories are unchanged.

## Testing

- [x] Added focused tests and synthetic inputs.
- [ ] New and existing unit tests pass through the complete upstream checkout
  (must be filled after local Codex validation).
- [ ] Tested with different models (not applicable: no models are involved).

**Authoring-environment evidence, not full upstream CI:** 107 focused
pytest cases passed with zero skips in an isolated source overlay on CPython 3.13.5.
That includes 17 file-level integration cases. The Python
documentation example executed successfully. Three deliberately broken variants
were rejected by the tests. Image integration uses Pillow 12.3.0/libwebp 1.6.0;
these are synthetic files only. No real patient data or credentials were used.

**Important limit:** the overlay omitted OpenMed parent-package initializers.
Full-checkout import integration, locked-environment tests, Ruff, mypy, docs build
and complete repository CI were not run in that environment. The recorded counts
must not be presented as a full-repository result.

Run this through the actual package before submission:

```bash
uv run --frozen --extra dev pytest tests/unit/multimodal/test_bmp_dimensions.py -q
```

Local full-checkout validation: **PENDING — replace with actual commands/results.**

## Documentation

- [x] Added usage, limits, failure categories and explicit non-goals.
- [x] Added docstrings to new public functions/classes.
- [x] Included an insertion-only `CHANGELOG.md` entry.

## Code Quality

- [ ] Ran `make format`, `make lint`, and `make format-check` in the real checkout.
- [ ] Ran `make type-check` and applicable documentation checks.
- [ ] Human author self-review completed.
- [x] Commented the bounded parsing/normalization behavior.
- [ ] Complete upstream CI reports no new warnings.

## Dependencies

- [x] No new runtime dependencies.
- [x] Tests use standard library and existing development dependencies only.

## Checklist

- [ ] Human author has reviewed the contributing guide, Code of Conduct and maintainer guide.
- [ ] Commits have clear, descriptive messages and correct existing Git identity.
- [ ] Commits are organized into this one scoped contribution.

## Related Issues

Closes #3114.

## Examples

See `docs/multimodal/bmp-header-preflight.md` and the synthetic test cases. No screenshots are required.

## AI assistance disclosure

The implementation, tests and initial description were prepared with substantial
ChatGPT assistance at Belal Embaby's direction. Codex review and full-checkout
validation were performed; no separate human review is claimed.

## Validation performed

- `uv run --frozen --extra dev python -c "import openmed; import importlib; importlib.import_module('openmed.multimodal.bmp_dimensions')"`
- `uv run --frozen --extra dev ruff check .`
- `uv run --frozen --extra dev ruff format --check openmed/multimodal/bmp_dimensions.py tests/unit/multimodal/test_bmp_dimensions.py` (2 files already formatted)
- `uv run --frozen --extra dev mypy openmed/multimodal/bmp_dimensions.py`
- `uv run --frozen --extra dev pytest -q tests/unit/multimodal/test_bmp_dimensions.py` (`107 passed`)
- `uv run --frozen --extra dev pytest -q` (`15,666 passed, 225 skipped, 39 failed` in the current Windows environment; failures are upstream symlink tests blocked by WinError 1314)
- `uv run --frozen --extra dev mkdocs build --strict --clean` could not start because `mkdocs` is not installed in the frozen environment.
