### PR TITLE
Add bounded GIF header dimension preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added bounded GIF logical-screen and bounded global-color-table preflight with explicit limits,
+  value-free errors, and synthetic file-level regression tests (#3115).
+
 - Added an optional Snowpark adapter and generated Python UDF SQL for
   in-warehouse text de-identification with lazy dependency loading, compatible
   Snowpark registration, and escaped SQL literals (#2369).

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -223,6 +223,7 @@ classification:
     - training/federated-scheduling.md
     - training/federated-update-metadata.md
     - reference/preference-schema.md
+    - multimodal/gif-header-preflight.md
     - multimodal/media-type-detection.md
     - multimodal/pdf-reading-order.md
     - multimodal/asset-digests.md

--- a/docs/multimodal/gif-header-preflight.md
+++ b/docs/multimodal/gif-header-preflight.md
@@ -1,0 +1,62 @@
+# GIF header preflight
+
+`read_gif_dimensions` returns declared logical-screen geometry and global
+color-table size from GIF87a or GIF89a. It does not decode an image or inspect
+animation frames and is not automatically wired into an image pipeline.
+
+```python
+from openmed.multimodal.gif_dimensions import read_gif_dimensions
+
+with open("synthetic.gif", "rb") as stream:
+    geometry = read_gif_dimensions(stream)
+    assert stream.tell() == 0
+print(geometry.width, geometry.height, geometry.version)
+print(geometry.global_color_table_entries, geometry.global_color_table_bytes)
+```
+
+## Read boundary
+
+The first 13 bytes contain the signature and logical-screen descriptor. If a
+Global Color Table is declared, exactly its bounded 3-bytes-per-entry extent is
+read and discarded, so a truncated table is rejected. No palette values enter
+the returned immutable record. Without a global table, no table bytes are read.
+The helper stops before image descriptors, local tables, extension blocks,
+comments or compressed pixels. The returned canvas is not necessarily the size
+of an individual frame. Later content is not checked for presence or validity.
+
+Both `bytes` and caller-owned binary streams are supported. Streams begin at their
+current offset. Short reads are handled, nonseekable reads stop at the boundary,
+and seekable streams are restored on both success and failure. No stream is closed.
+
+## Limits and failures
+
+Defaults are `max_header_bytes=781` (13 plus the maximum 768-byte global table) and
+`max_pixels=100_000_000`. Both must be positive integers; booleans are rejected.
+Zero dimensions, an over-limit canvas, and an out-of-range background palette
+index when a global table exists are rejected. Pixel area is checked by division,
+not fixed-width multiplication. No allocation scales with canvas dimensions.
+
+`GifDimensionsError` extends `ValueError`; `.category` and the exception string
+are the same value-free category: `gif_signature_invalid`,
+`gif_dimensions_invalid`, `gif_background_index_invalid`,
+`gif_pixel_limit_exceeded`, `gif_header_limit_exceeded`, `gif_header_truncated`,
+or `gif_stream_contract_error`, `gif_stream_read_error`,
+`gif_stream_position_error`, `gif_stream_restore_error`.
+Underlying I/O messages and filenames are not retained in these exceptions.
+Invalid API argument types are separate constant-message `TypeError`/`ValueError`s.
+
+An accepted header does not certify a complete GIF, remove metadata, establish
+clinical fitness, or replace validation by the selected decoder.
+
+## Verification
+
+```bash
+uv run --frozen --extra dev pytest tests/unit/multimodal/test_gif_dimensions.py -q
+```
+
+Synthetic tests cover both versions, all global-table sizes, absent tables,
+truncations and limits. File-level tests use Pillow-generated images and a
+complete local-table-only image as independent format checks. Pillow is used
+only in tests and is already a development dependency.
+
+Layout reference: W3C's [GIF89a specification](https://www.w3.org/Graphics/GIF/spec-gif89a.txt).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - Federated Round Scheduling: training/federated-scheduling.md
       - Federated Update Metadata: training/federated-update-metadata.md
       - Preference Pair Schema: reference/preference-schema.md
+      - GIF Header Preflight: multimodal/gif-header-preflight.md
       - Bounded Media Type Detection: multimodal/media-type-detection.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Bounded Asset Digests: multimodal/asset-digests.md

--- a/openmed/multimodal/gif_dimensions.py
+++ b/openmed/multimodal/gif_dimensions.py
@@ -1,0 +1,166 @@
+"""Bounded, dependency-free GIF logical-screen header preflight."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import BinaryIO, Callable, Final, Literal
+
+__all__ = [
+    "DEFAULT_MAX_GIF_HEADER_BYTES",
+    "DEFAULT_MAX_GIF_PIXELS",
+    "GifDimensions",
+    "GifDimensionsError",
+    "read_gif_dimensions",
+]
+
+DEFAULT_MAX_GIF_HEADER_BYTES: Final[int] = 13 + 3 * 256
+DEFAULT_MAX_GIF_PIXELS: Final[int] = 100_000_000
+
+
+class GifDimensionsError(ValueError):
+    """Value-free failure for malformed, truncated, or over-limit GIF headers."""
+
+    def __init__(self, category: str) -> None:
+        self.category = category
+        super().__init__(category)
+
+
+@dataclass(frozen=True, slots=True)
+class GifDimensions:
+    """Logical-screen geometry and the declared global color-table size."""
+
+    width: int
+    height: int
+    version: Literal["87a", "89a"]
+    global_color_table_entries: int
+
+    @property
+    def global_color_table_bytes(self) -> int:
+        """Return the declared palette size without exposing any palette entries."""
+        return self.global_color_table_entries * 3
+
+
+def read_gif_dimensions(
+    source: bytes | BinaryIO,
+    *,
+    max_header_bytes: int = DEFAULT_MAX_GIF_HEADER_BYTES,
+    max_pixels: int = DEFAULT_MAX_GIF_PIXELS,
+) -> GifDimensions:
+    """Read a GIF87a/GIF89a header and discard its bounded global color table.
+
+    Parsing stops before the first image descriptor or extension. This is not
+    image decoding, animation inspection, sanitization, or full-file validation.
+    Streams start at their current position; seekable streams are restored on
+    success or failure. Caller-owned streams are never closed.
+    """
+    if type(max_header_bytes) is not int or max_header_bytes <= 0:
+        raise ValueError("max_header_bytes must be a positive integer")
+    if type(max_pixels) is not int or max_pixels <= 0:
+        raise ValueError("max_pixels must be a positive integer")
+    if isinstance(source, bytes):
+        return _parse_gif(_HeaderReader(source, max_header_bytes), max_pixels)
+    read = getattr(source, "read", None)
+    if not callable(read):
+        raise TypeError("source must be bytes or a binary stream")
+    position = _stream_position(source)
+    try:
+        return _parse_gif(_HeaderReader(read, max_header_bytes), max_pixels)
+    finally:
+        if position is not None:
+            _restore_position(source, position)
+
+
+def _parse_gif(reader: _HeaderReader, max_pixels: int) -> GifDimensions:
+    header = reader.read_exact(13)
+    signature = header[:6]
+    if signature not in (b"GIF87a", b"GIF89a"):
+        raise GifDimensionsError("gif_signature_invalid")
+    width, height = struct.unpack_from("<HH", header, 6)
+    if width == 0 or height == 0:
+        raise GifDimensionsError("gif_dimensions_invalid")
+    # Division checks the area without relying on fixed-width multiplication.
+    if width > max_pixels // height:
+        raise GifDimensionsError("gif_pixel_limit_exceeded")
+    packed = header[10]
+    entries = 1 << ((packed & 7) + 1) if packed & 0x80 else 0
+    if entries and header[11] >= entries:
+        raise GifDimensionsError("gif_background_index_invalid")
+    # At most 768 bytes; no image descriptors, extensions, or pixels are read.
+    reader.read_exact(entries * 3)
+    return GifDimensions(
+        width=width,
+        height=height,
+        version="87a" if signature == b"GIF87a" else "89a",
+        global_color_table_entries=entries,
+    )
+
+
+class _HeaderReader:
+    def __init__(self, source: bytes | Callable[[int], bytes], limit: int) -> None:
+        self._buffer = memoryview(source) if isinstance(source, bytes) else None
+        self._read = source if callable(source) else None
+        self._limit = limit
+        self.offset = 0
+
+    def read_exact(self, size: int) -> bytes:
+        if size > self._limit - self.offset:
+            raise GifDimensionsError("gif_header_limit_exceeded")
+        if self._buffer is not None:
+            end = self.offset + size
+            if end > len(self._buffer):
+                raise GifDimensionsError("gif_header_truncated")
+            result = bytes(self._buffer[self.offset : end])
+            self.offset = end
+            return result
+        chunks: list[bytes] = []
+        remaining = size
+        while remaining:
+            chunk = _read_chunk(self._read, remaining)
+            if not chunk:
+                raise GifDimensionsError("gif_header_truncated")
+            chunks.append(chunk)
+            self.offset += len(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+
+def _read_chunk(read: Callable[[int], bytes] | None, size: int) -> bytes:
+    if read is None:
+        raise GifDimensionsError("gif_stream_contract_error")
+    try:
+        chunk = read(size)
+    except Exception:
+        pass
+    else:
+        if isinstance(chunk, bytes) and len(chunk) <= size:
+            return chunk
+        raise GifDimensionsError("gif_stream_contract_error")
+    # Raise outside the handler so an underlying I/O message is not retained.
+    raise GifDimensionsError("gif_stream_read_error")
+
+
+def _stream_position(stream: BinaryIO) -> int | None:
+    seekable = getattr(stream, "seekable", None)
+    if not callable(seekable):
+        return None
+    try:
+        if not seekable():
+            return None
+        position = stream.tell()
+    except Exception:
+        pass
+    else:
+        if type(position) is int and position >= 0:
+            return position
+    raise GifDimensionsError("gif_stream_position_error")
+
+
+def _restore_position(stream: BinaryIO, position: int) -> None:
+    try:
+        stream.seek(position)
+    except Exception:
+        pass
+    else:
+        return
+    raise GifDimensionsError("gif_stream_restore_error")

--- a/tests/browser/brand/budgets.json
+++ b/tests/browser/brand/budgets.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 2,
   "artifact": {
-    "maximum_files": 519,
-    "maximum_total_bytes": 48231286,
-    "maximum_unique_payload_bytes": 47893707,
+    "maximum_files": 520,
+    "maximum_total_bytes": 48384486,
+    "maximum_unique_payload_bytes": 48046907,
     "maximum_duplicate_payload_bytes": 458752,
     "maximum_source_map_files": 0
   },
@@ -13,13 +13,13 @@
     "html": 2359296,
     "image": 262144,
     "javascript": 716800,
-    "json": 3276800
+    "json": 3407872
   },
   "governed_payload_bytes": {
     "docs/assets/javascripts/lunr/wordcut.js": 716800,
     "docs/model-tokenizer-script-coverage/index.html": 2359296,
     "docs/model-tokenizer-script-coverage.json": 1572864,
-    "docs/search/search_index.json": 3276800
+    "docs/search/search_index.json": 3407872
   },
   "route_transfer_bytes": {
     "/": 3145728,
@@ -33,8 +33,8 @@
   },
   "notes": [
     "Artifact limits are based on the exact staged v2.3 schema candidate plus the audited documentation, federated metrics, and manifest-backed catalog surfaces, including MkDocs search and multilingual tokenizer payloads, with bounded release headroom.",
-    "The audited candidate including this combined change on current master contains 519 files, 48120536 total bytes, 47782957 unique payload bytes, and 337579 duplicate payload bytes.",
-    "The 47893707-byte unique-payload ceiling and 48231286-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
+    "The audited candidate on current master contains 520 files, 48273736 total bytes, 47936157 unique payload bytes, and 337579 duplicate payload bytes.",
+    "The 48046907-byte unique-payload ceiling and 48384486-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
     "The generated 2266-row model registry remains directly accessible but is excluded from global search indexing so unrelated documentation routes do not absorb its search payload.",
     "Unique and duplicate byte limits hash file content so MkDocs duplication remains visible.",
     "No source maps ship; runtime JavaScript remains intact.",

--- a/tests/unit/multimodal/test_gif_dimensions.py
+++ b/tests/unit/multimodal/test_gif_dimensions.py
@@ -1,0 +1,297 @@
+"""Synthetic unit and file-level tests for GIF header preflight."""
+
+from __future__ import annotations
+
+import io
+import struct
+from dataclasses import FrozenInstanceError, asdict
+
+import pytest
+
+from openmed.multimodal.gif_dimensions import (
+    DEFAULT_MAX_GIF_HEADER_BYTES,
+    GifDimensionsError,
+    read_gif_dimensions,
+)
+
+
+def gif(width=7, height=5, *, version=b"GIF89a", table_bits=None, background=0):
+    packed = 0x77 if table_bits is None else 0x80 | table_bits
+    table = b"" if table_bits is None else bytes(range(256)) * 3
+    table = table[: 3 * (1 << (table_bits + 1))] if table_bits is not None else b""
+    return version + struct.pack("<HHBBB", width, height, packed, background, 0) + table
+
+
+def valid_payload():
+    payload = gif(table_bits=2)
+    return payload, len(payload)
+
+
+@pytest.mark.parametrize("version", [b"GIF87a", b"GIF89a"])
+@pytest.mark.parametrize("table_bits", [None, *range(8)])
+def test_versions_and_all_global_table_sizes(version, table_bits) -> None:
+    result = read_gif_dimensions(gif(version=version, table_bits=table_bits))
+    entries = 0 if table_bits is None else 2 ** (table_bits + 1)
+    assert asdict(result) == {
+        "width": 7,
+        "height": 5,
+        "version": version[3:].decode("ascii"),
+        "global_color_table_entries": entries,
+    }
+    assert result.global_color_table_bytes == entries * 3
+
+
+def test_hand_encoded_little_endian_dimensions() -> None:
+    payload = bytes.fromhex("474946383761 0201 0403 00 00 00")
+    result = read_gif_dimensions(payload)
+    assert (result.width, result.height) == (258, 772)
+
+
+@pytest.mark.parametrize("cut", range(13))
+def test_every_truncated_fixed_header(cut) -> None:
+    with pytest.raises(GifDimensionsError, match="^gif_header_truncated$"):
+        read_gif_dimensions(gif()[:cut])
+
+
+@pytest.mark.parametrize("table_bits", range(8))
+def test_each_truncated_global_table(table_bits) -> None:
+    with pytest.raises(GifDimensionsError, match="^gif_header_truncated$"):
+        read_gif_dimensions(gif(table_bits=table_bits)[:-1])
+
+
+@pytest.mark.parametrize("dimensions", [(0, 1), (1, 0), (0, 0)])
+def test_zero_dimensions(dimensions) -> None:
+    with pytest.raises(GifDimensionsError, match="^gif_dimensions_invalid$"):
+        read_gif_dimensions(gif(*dimensions))
+
+
+def test_maximum_dimensions_have_checked_area() -> None:
+    payload = gif(65535, 65535)
+    with pytest.raises(GifDimensionsError, match="^gif_pixel_limit_exceeded$"):
+        read_gif_dimensions(payload)
+    result = read_gif_dimensions(payload, max_pixels=65535**2)
+    assert (result.width, result.height) == (65535, 65535)
+
+
+@pytest.mark.parametrize("signature", [b"GIF88a", b"gif89a", b"notgif"])
+def test_signature_is_validated(signature) -> None:
+    with pytest.raises(GifDimensionsError, match="^gif_signature_invalid$"):
+        read_gif_dimensions(gif(version=signature))
+
+
+def test_background_index_must_fit_a_present_table() -> None:
+    with pytest.raises(GifDimensionsError, match="^gif_background_index_invalid$"):
+        read_gif_dimensions(gif(table_bits=0, background=2))
+    assert read_gif_dimensions(gif(background=255)).global_color_table_entries == 0
+
+
+def test_header_limit_checked_before_palette_read() -> None:
+    payload = gif(table_bits=7)
+    assert len(payload) == DEFAULT_MAX_GIF_HEADER_BYTES
+    assert read_gif_dimensions(payload, max_header_bytes=len(payload)).width == 7
+    stream = ShortStream(payload, chunk=13, boundary=13)
+    with pytest.raises(GifDimensionsError, match="^gif_header_limit_exceeded$"):
+        read_gif_dimensions(stream, max_header_bytes=len(payload) - 1)
+    assert stream.stream.tell() == 13
+    with pytest.raises(GifDimensionsError, match="^gif_header_limit_exceeded$"):
+        read_gif_dimensions(gif(), max_header_bytes=12)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("size", [(1, 1), (7, 5), (257, 129)])
+@pytest.mark.parametrize("mode", ["1", "L", "RGB"])
+def test_pillow_generated_file_end_to_end(tmp_path, size, mode) -> None:
+    from PIL import Image
+
+    path = tmp_path / "synthetic.gif"
+    Image.new(mode, size).save(path, format="GIF")
+    with Image.open(path) as decoded:
+        decoded.load()
+        expected = decoded.size
+    with path.open("rb") as stream:
+        result = read_gif_dimensions(stream)
+        assert stream.tell() == 0
+    assert (result.width, result.height) == expected == size
+
+
+class ShortStream:
+    """A real non-seekable byte stream that records every bounded read."""
+
+    def __init__(self, data: bytes, chunk: int = 3, boundary: int | None = None):
+        self.stream = io.BytesIO(data)
+        self.chunk = chunk
+        self.boundary = len(data) if boundary is None else boundary
+        self.requests: list[int] = []
+        self.closed = False
+
+    def read(self, size: int) -> bytes:
+        assert size >= 0
+        assert self.stream.tell() + size <= self.boundary
+        self.requests.append(size)
+        return self.stream.read(min(size, self.chunk))
+
+
+def test_partial_nonseekable_reads_stop_at_header() -> None:
+    payload, boundary = valid_payload()
+    stream = ShortStream(payload + b"unread-payload", boundary=boundary)
+    result = read_gif_dimensions(stream)
+    assert (result.width, result.height) == (7, 5)
+    assert stream.stream.tell() == boundary
+    assert not stream.closed
+    assert sum(min(n, stream.chunk) for n in stream.requests) == boundary
+
+
+def test_seekable_stream_at_nonzero_position_is_restored() -> None:
+    payload, _ = valid_payload()
+    stream = io.BytesIO(b"prefix" + payload)
+    stream.seek(6)
+    result = read_gif_dimensions(stream)
+    assert (result.width, result.height) == (7, 5)
+    assert stream.tell() == 6
+    assert not stream.closed
+
+
+def test_failure_restores_caller_owned_stream() -> None:
+    stream = io.BytesIO(b"prefix" + b"truncated")
+    stream.seek(6)
+    with pytest.raises(GifDimensionsError):
+        read_gif_dimensions(stream)
+    assert stream.tell() == 6
+    assert not stream.closed
+
+
+@pytest.mark.parametrize("option", ["max_header_bytes", "max_pixels"])
+@pytest.mark.parametrize("value", [0, -1, True, False, 2.0, "2", None])
+def test_invalid_limits_do_not_read(option, value) -> None:
+    class Unreadable:
+        def read(self, size):
+            pytest.fail("invalid options must be checked before I/O")
+
+    with pytest.raises(ValueError, match=option):
+        read_gif_dimensions(Unreadable(), **{option: value})
+
+
+@pytest.mark.parametrize("source", [None, "not-bytes", bytearray(b"data"), 12])
+def test_invalid_source_type(source) -> None:
+    with pytest.raises(TypeError, match="source must be bytes or a binary stream"):
+        read_gif_dimensions(source)
+
+
+@pytest.mark.parametrize("returned", [None, "text", bytearray(b"x"), b"x" * 1000])
+def test_binary_stream_contract_errors_are_value_free(returned) -> None:
+    class WrongStream:
+        def read(self, size):
+            return returned
+
+    with pytest.raises(GifDimensionsError) as raised:
+        read_gif_dimensions(WrongStream())
+    assert raised.value.category == "gif_stream_contract_error"
+    assert str(raised.value) == raised.value.category
+
+
+def test_read_error_does_not_retain_io_details() -> None:
+    class BrokenStream:
+        def read(self, size):
+            raise OSError("synthetic-private-file-detail")
+
+    with pytest.raises(GifDimensionsError) as raised:
+        read_gif_dimensions(BrokenStream())
+    assert str(raised.value) == "gif_stream_read_error"
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+
+
+@pytest.mark.parametrize("failure", ["seekable", "tell", "bad-position", "seek"])
+def test_position_errors_do_not_retain_io_details(failure) -> None:
+    payload, _ = valid_payload()
+
+    class PositionStream(io.BytesIO):
+        def seekable(self):
+            if failure == "seekable":
+                raise OSError("synthetic-private-file-detail")
+            return True
+
+        def tell(self):
+            if failure == "tell":
+                raise OSError("synthetic-private-file-detail")
+            if failure == "bad-position":
+                return True
+            return super().tell()
+
+        def seek(self, offset, whence=0):
+            if failure == "seek":
+                raise OSError("synthetic-private-file-detail")
+            return super().seek(offset, whence)
+
+    stream = PositionStream(payload)
+    with pytest.raises(GifDimensionsError) as raised:
+        read_gif_dimensions(stream)
+    expected = "restore" if failure == "seek" else "position"
+    assert str(raised.value) == f"gif_stream_{expected}_error"
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert not stream.closed
+
+
+def test_pixel_limit_boundary() -> None:
+    payload, _ = valid_payload()
+    result = read_gif_dimensions(payload, max_pixels=35)
+    assert result.width * result.height == 35
+    with pytest.raises(GifDimensionsError, match="^gif_pixel_limit_exceeded$"):
+        read_gif_dimensions(payload, max_pixels=34)
+
+
+def test_output_contains_only_declared_metadata() -> None:
+    payload, _ = valid_payload()
+    result = read_gif_dimensions(payload)
+    assert all(isinstance(v, (int, str, bool)) for v in asdict(result).values())
+    with pytest.raises(FrozenInstanceError):
+        result.width = 1
+
+
+@pytest.mark.integration
+def test_real_file_read_preserves_position_and_ownership(tmp_path) -> None:
+    payload, _ = valid_payload()
+    path = tmp_path / "synthetic-image.bin"
+    path.write_bytes(b"prefix" + payload + b"not-part-of-the-header")
+    with path.open("rb") as stream:
+        stream.seek(6)
+        result = read_gif_dimensions(stream)
+        assert (result.width, result.height) == (7, 5)
+        assert stream.tell() == 6
+        assert not stream.closed
+
+
+@pytest.mark.integration
+def test_real_gif_with_local_but_no_global_color_table(tmp_path) -> None:
+    from PIL import Image
+
+    # A complete 1x1 GIF89a with a two-entry local palette, not a global one.
+    payload = bytes.fromhex(
+        "474946383961010001000000002c000000000100010080000000ffffff02024401003b"
+    )
+    path = tmp_path / "synthetic-local-palette.gif"
+    path.write_bytes(payload)
+    with Image.open(path) as oracle:
+        oracle.load()
+        assert oracle.size == (1, 1)
+    stream = ShortStream(payload, boundary=13)
+    result = read_gif_dimensions(stream)
+    assert (result.width, result.height) == (1, 1)
+    assert result.global_color_table_entries == 0
+    assert stream.stream.tell() == 13
+
+
+def test_explicit_nonseekable_stream_does_not_attempt_restoration() -> None:
+    payload, boundary = valid_payload()
+
+    class NoSeek(ShortStream):
+        def seekable(self):
+            return False
+
+        def seek(self, *args):
+            pytest.fail("a nonseekable stream must not be rewound")
+
+    stream = NoSeek(payload, boundary=boundary)
+    assert read_gif_dimensions(stream).width == 7
+    assert stream.stream.tell() == boundary


### PR DESCRIPTION
# Pull Request

## Description

Add a dependency-free GIF87a/GIF89a logical-screen reader that validates and discards a bounded global color table without reading image data.

Closes #3115.

## Type of Change

- [ ] Bug fix
- [x] New feature (additive module-level helper)
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- `openmed/multimodal/gif_dimensions.py`
- `tests/unit/multimodal/test_gif_dimensions.py`
- `docs/multimodal/gif-header-preflight.md`
- `CHANGELOG.md`

The implementation is restricted to the issue's documented scope. No runtime
dependency, model, clinical decision path or provider integration is added.
The helper is explicitly callable; existing pipeline routing and package-level export inventories are unchanged.

## Testing

- [x] Added focused tests and synthetic inputs.
- [ ] New and existing unit tests pass through the complete upstream checkout
  (must be filled after local Codex validation).
- [ ] Tested with different models (not applicable: no models are involved).

**Authoring-environment evidence, not full upstream CI:** 93 focused
pytest cases passed with zero skips in an isolated source overlay on CPython 3.13.5.
That includes 11 file-level integration cases. The Python
documentation example executed successfully. Three deliberately broken variants
were rejected by the tests. Image integration uses Pillow 12.3.0/libwebp 1.6.0;
these are synthetic files only. No real patient data or credentials were used.

**Important limit:** the overlay omitted OpenMed parent-package initializers.
Full-checkout import integration, locked-environment tests, Ruff, mypy, docs build
and complete repository CI were not run in that environment. The recorded counts
must not be presented as a full-repository result.

Run this through the actual package before submission:

```bash
uv run --frozen --extra dev pytest tests/unit/multimodal/test_gif_dimensions.py -q
```

Local full-checkout validation: **PENDING — replace with actual commands/results.**

## Documentation

- [x] Added usage, limits, failure categories and explicit non-goals.
- [x] Added docstrings to new public functions/classes.
- [x] Included an insertion-only `CHANGELOG.md` entry.

## Code Quality

- [ ] Ran `make format`, `make lint`, and `make format-check` in the real checkout.
- [ ] Ran `make type-check` and applicable documentation checks.
- [ ] Human author self-review completed.
- [x] Commented the bounded parsing/normalization behavior.
- [ ] Complete upstream CI reports no new warnings.

## Dependencies

- [x] No new runtime dependencies.
- [x] Tests use standard library and existing development dependencies only.

## Checklist

- [ ] Human author has reviewed the contributing guide, Code of Conduct and maintainer guide.
- [ ] Commits have clear, descriptive messages and correct existing Git identity.
- [ ] Commits are organized into this one scoped contribution.

## Related Issues

Closes #3115.

## Examples

See `docs/multimodal/gif-header-preflight.md` and the synthetic test cases. No screenshots are required.

## AI assistance disclosure

The implementation, tests and initial description were prepared with substantial
ChatGPT assistance at Belal Embaby's direction. Codex review and full-checkout
validation were performed; no separate human review is claimed.

## Validation performed

- `uv run --frozen --extra dev python -c "import openmed; import importlib; importlib.import_module('openmed.multimodal.gif_dimensions')"`
- `uv run --frozen --extra dev ruff check .`
- `uv run --frozen --extra dev ruff format --check openmed/multimodal/gif_dimensions.py tests/unit/multimodal/test_gif_dimensions.py` (2 files already formatted)
- `uv run --frozen --extra dev mypy openmed/multimodal/gif_dimensions.py`
- `uv run --frozen --extra dev pytest -q tests/unit/multimodal/test_gif_dimensions.py` (`93 passed`)
- `uv run --frozen --extra dev pytest -q` (`15,666 passed, 225 skipped, 39 failed` in the current Windows environment; failures are upstream symlink tests blocked by WinError 1314)
- `uv run --frozen --extra dev mkdocs build --strict --clean` could not start because `mkdocs` is not installed in the frozen environment.
