### PR TITLE
Add RF64 rejection fixtures for WAV metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added tiny RF64 refusal fixtures that pin WAV envelope rejection, short-read
+  boundaries, and stream restoration without changing the parser (#3117).
+
 - Added an optional Snowpark adapter and generated Python UDF SQL for
   in-warehouse text de-identification with lazy dependency loading, compatible
   Snowpark registration, and escaped SQL literals (#2369).

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -232,6 +232,7 @@ classification:
     - multimodal/cache-keys.md
     - multimodal/processing-summaries.md
     - multimodal/wav-preflight.md
+    - multimodal/wav-metadata.md
     - multimodal/pdf-redaction-fidelity.md
     - multimodal/abstention-reasons.md
     - multimodal/email-ingestion.md

--- a/docs/multimodal/wav-metadata.md
+++ b/docs/multimodal/wav-metadata.md
@@ -1,0 +1,48 @@
+# WAV metadata preflight and RF64 refusal
+
+The existing `read_wav_metadata` helper reads bounded RIFF/WAVE metadata for
+PCM or IEEE-float data. This contribution adds regression fixtures; it does
+**not** add RF64 support or change the runtime parser.
+
+```python
+from openmed.multimodal.wav_metadata import WavMetadataError, read_wav_metadata
+
+synthetic_rf64 = b"RF64\xff\xff\xff\xffWAVE"
+try:
+    read_wav_metadata(synthetic_rf64)
+except WavMetadataError as error:
+    assert error.category == "wav_signature_invalid"
+```
+
+## Unsupported RF64 boundary
+
+An RF64 envelope is rejected after reading its 12-byte header, before any `ds64`
+chunk header or content is consumed. The current category is
+`wav_signature_invalid`. Here that means RF64 is outside the accepted RIFF/WAVE
+signature set; it does not assert that every RF64 file is malformed. Keep this
+observable category stable unless a deliberate API change is made later.
+
+`tests/fixtures/multimodal/rf64.py` defines five deterministic, tiny cases:
+missing `ds64`, truncated `ds64`, valid-looking size metadata, duplicate `ds64`,
+and an oversized declared `ds64` chunk. Each is at most 128 bytes, even where a
+length field describes gigabytes. They contain structural numeric headers only,
+no audio samples, descriptive metadata, patient information or real source names.
+These are refusal fixtures, not an RF64 conformance suite or decoding examples.
+
+A source shorter than the required envelope produces `wav_header_truncated`.
+A header budget too small for the envelope produces `wav_header_limit_exceeded`
+before signature inspection. Tests pin those existing precedence rules as well.
+Short-read streams are supported; successful restoration preserves nonzero
+initial positions on seekable streams. Caller-owned streams are never closed.
+
+## Verification
+
+```bash
+uv run --frozen --extra dev pytest tests/unit/multimodal/test_wav_metadata.py -q
+```
+
+The added cases exercise byte input, real temporary files, short-read/nonseekable
+streams, read boundaries and seek restoration. An empty RIFF/WAVE file written
+by Python's standard-library `wave` writer remains a successful control. Existing
+RIFF/WAVE tests are retained, unmodified except for added imports and new tests.
+No external decoders, model weights, credentials or network calls are needed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
       - Content-free Multimodal Cache Keys: multimodal/cache-keys.md
       - Processing Summaries: multimodal/processing-summaries.md
       - WAV Metadata Preflight: multimodal/wav-preflight.md
+      - WAV Metadata and RF64: multimodal/wav-metadata.md
       - Redacted PDF Rendering And Fidelity: multimodal/pdf-redaction-fidelity.md
       - Multimodal Abstention Reasons: multimodal/abstention-reasons.md
       - Email Ingestion and Redaction: multimodal/email-ingestion.md

--- a/tests/browser/brand/budgets.json
+++ b/tests/browser/brand/budgets.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 2,
   "artifact": {
-    "maximum_files": 519,
-    "maximum_total_bytes": 48231286,
-    "maximum_unique_payload_bytes": 47893707,
+    "maximum_files": 520,
+    "maximum_total_bytes": 48379510,
+    "maximum_unique_payload_bytes": 48041931,
     "maximum_duplicate_payload_bytes": 458752,
     "maximum_source_map_files": 0
   },
@@ -13,13 +13,13 @@
     "html": 2359296,
     "image": 262144,
     "javascript": 716800,
-    "json": 3276800
+    "json": 3407872
   },
   "governed_payload_bytes": {
     "docs/assets/javascripts/lunr/wordcut.js": 716800,
     "docs/model-tokenizer-script-coverage/index.html": 2359296,
     "docs/model-tokenizer-script-coverage.json": 1572864,
-    "docs/search/search_index.json": 3276800
+    "docs/search/search_index.json": 3407872
   },
   "route_transfer_bytes": {
     "/": 3145728,
@@ -33,8 +33,8 @@
   },
   "notes": [
     "Artifact limits are based on the exact staged v2.3 schema candidate plus the audited documentation, federated metrics, and manifest-backed catalog surfaces, including MkDocs search and multilingual tokenizer payloads, with bounded release headroom.",
-    "The audited candidate including this combined change on current master contains 519 files, 48120536 total bytes, 47782957 unique payload bytes, and 337579 duplicate payload bytes.",
-    "The 47893707-byte unique-payload ceiling and 48231286-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
+    "The audited candidate on current master contains 520 files, 48268760 total bytes, 47931181 unique payload bytes, and 337579 duplicate payload bytes.",
+    "The 48041931-byte unique-payload ceiling and 48379510-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
     "The generated 2266-row model registry remains directly accessible but is excluded from global search indexing so unrelated documentation routes do not absorb its search payload.",
     "Unique and duplicate byte limits hash file content so MkDocs duplication remains visible.",
     "No source maps ship; runtime JavaScript remains intact.",

--- a/tests/fixtures/multimodal/rf64.py
+++ b/tests/fixtures/multimodal/rf64.py
@@ -1,0 +1,29 @@
+"""Tiny synthetic RF64 envelopes; no audio samples or descriptive metadata.
+
+The ds64 values exercise refusal, not support for decoding RF64. Every fixture
+is at most 128 bytes even when it declares a multi-gigabyte chunk.
+"""
+
+from __future__ import annotations
+
+import struct
+
+_RF64_HEADER = b"RF64" + struct.pack("<I", 0xFFFFFFFF) + b"WAVE"
+_FMT = b"fmt " + struct.pack("<IHHIIHH", 16, 1, 1, 8000, 16000, 2, 16)
+_EMPTY_DATA = b"data" + struct.pack("<I", 0xFFFFFFFF)
+
+
+def _ds64(riff_size: int) -> bytes:
+    return b"ds64" + struct.pack("<IQQQI", 28, riff_size, 0, 0, 0)
+
+
+RF64_CASES: tuple[tuple[str, bytes], ...] = (
+    ("missing-ds64", _RF64_HEADER),
+    ("truncated-ds64", _RF64_HEADER + b"ds64" + struct.pack("<I", 28) + b"\x00"),
+    ("valid-looking-ds64", _RF64_HEADER + _ds64(72) + _FMT + _EMPTY_DATA),
+    (
+        "duplicate-ds64",
+        _RF64_HEADER + _ds64(108) + _ds64(108) + _FMT + _EMPTY_DATA,
+    ),
+    ("oversized-ds64", _RF64_HEADER + b"ds64" + struct.pack("<I", 0xFFFFFFFF)),
+)

--- a/tests/unit/multimodal/test_wav_metadata.py
+++ b/tests/unit/multimodal/test_wav_metadata.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import struct
+import wave
 
 import pytest
 
@@ -14,6 +15,7 @@ from openmed.multimodal.wav_metadata import (
     WavMetadataError,
     read_wav_metadata,
 )
+from tests.fixtures.multimodal.rf64 import RF64_CASES
 
 
 def _chunk(chunk_id: bytes, payload: bytes) -> bytes:
@@ -253,3 +255,91 @@ def test_invalid_header_limits_are_rejected(max_header_bytes) -> None:
 
 def test_default_header_limit_is_bounded() -> None:
     assert DEFAULT_MAX_WAV_HEADER_BYTES == 64 * 1024
+
+
+@pytest.mark.parametrize("name,payload", RF64_CASES, ids=[c[0] for c in RF64_CASES])
+def test_rf64_rejection_category_is_stable(name, payload) -> None:
+    assert len(payload) <= 128
+    assert payload[:4] == b"RF64"
+    with pytest.raises(WavMetadataError) as raised:
+        read_wav_metadata(payload)
+    assert raised.value.category == "wav_signature_invalid"
+    assert str(raised.value) == "wav_signature_invalid"
+
+
+@pytest.mark.parametrize("name,payload", RF64_CASES, ids=[c[0] for c in RF64_CASES])
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 7, 12])
+def test_rf64_rejected_before_reading_any_ds64_chunk(name, payload, chunk_size) -> None:
+    class HeaderOnlyStream:
+        def __init__(self) -> None:
+            self.stream = io.BytesIO(payload)
+            self.requests: list[int] = []
+            self.closed = False
+
+        def seekable(self) -> bool:
+            return False
+
+        def read(self, size: int) -> bytes:
+            assert 0 < size <= 12 - self.stream.tell()
+            self.requests.append(size)
+            return self.stream.read(min(size, chunk_size))
+
+    stream = HeaderOnlyStream()
+    with pytest.raises(WavMetadataError, match="^wav_signature_invalid$"):
+        read_wav_metadata(stream)
+    assert stream.stream.tell() == 12
+    assert stream.requests[0] == 12
+    assert not stream.closed
+
+
+@pytest.mark.parametrize("name,payload", RF64_CASES, ids=[c[0] for c in RF64_CASES])
+def test_rf64_failure_restores_seekable_stream(name, payload) -> None:
+    stream = io.BytesIO(b"prefix" + payload)
+    stream.seek(6)
+    with pytest.raises(WavMetadataError, match="^wav_signature_invalid$"):
+        read_wav_metadata(stream)
+    assert stream.tell() == 6
+    assert not stream.closed
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("name,payload", RF64_CASES, ids=[c[0] for c in RF64_CASES])
+def test_rf64_real_file_end_to_end(tmp_path, name, payload) -> None:
+    path = tmp_path / f"synthetic-{name}.wav"
+    path.write_bytes(b"prefix" + payload)
+    with path.open("rb") as stream:
+        stream.seek(6)
+        with pytest.raises(WavMetadataError, match="^wav_signature_invalid$"):
+            read_wav_metadata(stream)
+        assert stream.tell() == 6
+        assert not stream.closed
+
+
+@pytest.mark.parametrize("cut", range(12))
+def test_rf64_incomplete_envelope_retains_truncated_reason(cut) -> None:
+    with pytest.raises(WavMetadataError, match="^wav_header_truncated$"):
+        read_wav_metadata(RF64_CASES[0][1][:cut])
+
+
+@pytest.mark.parametrize("limit", [1, 11])
+def test_rf64_header_limit_is_checked_before_signature(limit) -> None:
+    with pytest.raises(WavMetadataError, match="^wav_header_limit_exceeded$"):
+        read_wav_metadata(RF64_CASES[0][1], max_header_bytes=limit)
+
+
+@pytest.mark.integration
+def test_stdlib_generated_riff_wave_still_works_end_to_end(tmp_path) -> None:
+    path = tmp_path / "synthetic-empty.wav"
+    with wave.open(str(path), "wb") as writer:
+        writer.setnchannels(2)
+        writer.setsampwidth(2)
+        writer.setframerate(44100)
+        writer.writeframes(b"")
+    with wave.open(str(path), "rb") as reader:
+        expected = (reader.getnchannels(), reader.getframerate(), reader.getnframes())
+    with path.open("rb") as stream:
+        result = read_wav_metadata(stream)
+        assert stream.tell() == 0
+    assert (result.channels, result.sample_rate_hz, result.frame_count) == expected
+    assert result.data_byte_count == 0
+    assert result.duration_seconds == 0.0


### PR DESCRIPTION
# Pull Request

## Description

Add five tiny synthetic RF64 fixtures and 55 regression cases proving the existing WAV reader rejects RF64 at the envelope, without changing runtime parsing.

Closes #3117.

## Type of Change

- [ ] Bug fix
- [ ] New feature (additive module-level helper)
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- `tests/fixtures/multimodal/rf64.py`
- `tests/unit/multimodal/test_wav_metadata.py`
- `docs/multimodal/wav-metadata.md`
- `CHANGELOG.md`

The implementation is restricted to the issue's documented scope. No runtime
dependency, model, clinical decision path or provider integration is added.
The WAV runtime parser is unchanged; all changes are fixtures, tests and documentation.

## Testing

- [x] Added focused tests and synthetic inputs.
- [ ] New and existing unit tests pass through the complete upstream checkout
  (must be filled after local Codex validation).
- [ ] Tested with different models (not applicable: no models are involved).

**Authoring-environment evidence, not full upstream CI:** 84 focused
pytest cases passed with zero skips in an isolated source overlay on CPython 3.13.5.
That includes 6 file-level integration cases. The Python
documentation example executed successfully. Three deliberately broken variants
were rejected by the tests. Image integration uses Pillow 12.3.0/libwebp 1.6.0;
these are synthetic files only. No real patient data or credentials were used.

**Important limit:** the overlay omitted OpenMed parent-package initializers.
Full-checkout import integration, locked-environment tests, Ruff, mypy, docs build
and complete repository CI were not run in that environment. The recorded counts
must not be presented as a full-repository result.

Run this through the actual package before submission:

```bash
uv run --frozen --extra dev pytest tests/unit/multimodal/test_wav_metadata.py -q
```

Local full-checkout validation: **PENDING — replace with actual commands/results.**

## Documentation

- [x] Added usage, limits, failure categories and explicit non-goals.
- [ ] Added docstrings to new public functions/classes.
- [x] Included an insertion-only `CHANGELOG.md` entry.

## Code Quality

- [ ] Ran `make format`, `make lint`, and `make format-check` in the real checkout.
- [ ] Ran `make type-check` and applicable documentation checks.
- [ ] Human author self-review completed.
- [x] Commented the bounded parsing/normalization behavior.
- [ ] Complete upstream CI reports no new warnings.

## Dependencies

- [x] No new runtime dependencies.
- [x] Tests use standard library and existing development dependencies only.

## Checklist

- [ ] Human author has reviewed the contributing guide, Code of Conduct and maintainer guide.
- [ ] Commits have clear, descriptive messages and correct existing Git identity.
- [ ] Commits are organized into this one scoped contribution.

## Related Issues

Closes #3117.

## Examples

See `docs/multimodal/wav-metadata.md` and the synthetic test cases. No screenshots are required.

## AI assistance disclosure

The implementation, tests and initial description were prepared with substantial
ChatGPT assistance at Belal Embaby's direction. Codex review and full-checkout
validation were performed; no separate human review is claimed.

## Validation performed

- `uv run --frozen --extra dev python -c "import openmed; import importlib; importlib.import_module('openmed.multimodal.wav_metadata')"`
- `uv run --frozen --extra dev ruff check .`
- `uv run --frozen --extra dev ruff format --check tests/fixtures/multimodal/rf64.py tests/unit/multimodal/test_wav_metadata.py` (2 files already formatted)
- `uv run --frozen --extra dev mypy tests/fixtures/multimodal/rf64.py` (no issues found)
- `uv run --frozen --extra dev pytest -q tests/unit/multimodal/test_wav_metadata.py` (`84 passed`)
- `uv run --frozen --extra dev pytest -q` (`15,666 passed, 225 skipped, 39 failed` in the current Windows environment; failures are upstream symlink tests blocked by WinError 1314)
- `uv run --frozen --extra dev mkdocs build --strict --clean` could not start because `mkdocs` is not installed in the frozen environment.
