### PR TITLE
Add bounded WebP header dimension preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added bounded VP8, VP8L, and VP8X WebP geometry preflight with explicit limits,
+  value-free errors, and synthetic file-level regression tests (#3116).
+
 - Added an optional Snowpark adapter and generated Python UDF SQL for
   in-warehouse text de-identification with lazy dependency loading, compatible
   Snowpark registration, and escaped SQL literals (#2369).

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -223,6 +223,7 @@ classification:
     - training/federated-scheduling.md
     - training/federated-update-metadata.md
     - reference/preference-schema.md
+    - multimodal/webp-header-preflight.md
     - multimodal/media-type-detection.md
     - multimodal/pdf-reading-order.md
     - multimodal/asset-digests.md

--- a/docs/multimodal/webp-header-preflight.md
+++ b/docs/multimodal/webp-header-preflight.md
@@ -1,0 +1,70 @@
+# WebP header preflight
+
+`read_webp_dimensions` reads declared geometry from a RIFF/WEBP envelope whose
+first chunk is VP8, VP8L or VP8X. The helper uses the standard library only and
+is not automatically registered as a decoder or pipeline validator.
+
+```python
+from openmed.multimodal.webp_dimensions import read_webp_dimensions
+
+with open("synthetic.webp", "rb") as stream:
+    geometry = read_webp_dimensions(stream, max_pixels=20_000_000)
+    assert stream.tell() == 0
+print(geometry.width, geometry.height, geometry.chunk_type)
+print(geometry.has_alpha, geometry.is_animated)
+```
+
+## Declared metadata, not decoded content
+
+VP8 reads the key-frame header's 14-bit width/height; scaling bits are masked.
+VP8L reads the lossless signature, 14-bit dimensions plus one, the alpha hint
+and the zero version field. VP8X reads 24-bit canvas dimensions plus one and
+alpha/animation flags while rejecting nonzero reserved bits.
+`has_alpha` reports a header declaration/hint, not inspection of actual pixels.
+For animated VP8X, geometry is the declared canvas, not an inspection of frames.
+
+The RIFF size must be even and at most `2**32 - 10`. The declared first chunk,
+including its odd-byte padding, must fit inside the RIFF envelope. VP8X's chunk
+size must be exactly ten. Canvas area cannot exceed `2**32 - 1` even when the
+caller supplies a larger pixel budget. Unknown first-chunk layouts are refused;
+the parser never scans through arbitrary metadata looking for another chunk.
+
+Only 25 bytes for VP8L or 30 for VP8/VP8X are read. Pixel payloads, later chunks,
+actual padding contents, trailing bytes and full-file length are not inspected.
+The caller must not treat a valid header as proof that payloads exist, animation
+is well formed, metadata is safe, or the file will decode. No pixel decoding,
+animation traversal, EXIF/XMP extraction, OCR or clinical interpretation occurs.
+
+## Ownership, limits and errors
+
+Sources are `bytes` or binary streams at their current offset. Short reads work;
+seekable streams are restored on success/failure; caller streams are never closed.
+Defaults are `max_header_bytes=30` and `max_pixels=100_000_000`; overrides must be
+positive integers excluding booleans. No allocation scales with a declared chunk
+size or canvas size.
+
+`WebpDimensionsError` extends `ValueError`, with identical value-free string and
+`.category`. Categories are `webp_signature_invalid`, `webp_riff_size_invalid`,
+`webp_chunk_size_invalid`, `webp_layout_unsupported`, `webp_vp8_header_invalid`,
+`webp_vp8_version_unsupported`, `webp_vp8l_header_invalid`,
+`webp_vp8l_version_unsupported`, `webp_vp8x_reserved_bits_invalid`,
+`webp_dimensions_invalid`, `webp_pixel_limit_exceeded`,
+`webp_header_limit_exceeded`, `webp_header_truncated`, and
+`webp_stream_contract_error`, `webp_stream_read_error`,
+`webp_stream_position_error`, `webp_stream_restore_error`.
+Invalid API argument types raise separate constant-message errors.
+
+## Verification
+
+```bash
+uv run --frozen --extra dev pytest tests/unit/multimodal/test_webp_dimensions.py -q
+```
+
+Pillow-generated lossy, lossless, alpha and animated files provide real-file
+oracles; handcrafted headers exercise malformed envelopes and exact read
+boundaries. Tests require Pillow with WebP support, already present in the
+project's development dependency. Runtime parsing never imports Pillow.
+
+References: [WebP RIFF container](https://developers.google.com/speed/webp/docs/riff_container),
+[lossless bitstream](https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification),
+and [VP8 frame header](https://www.rfc-editor.org/rfc/rfc6386.html#section-9.1).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - Federated Round Scheduling: training/federated-scheduling.md
       - Federated Update Metadata: training/federated-update-metadata.md
       - Preference Pair Schema: reference/preference-schema.md
+      - WebP Header Preflight: multimodal/webp-header-preflight.md
       - Bounded Media Type Detection: multimodal/media-type-detection.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Bounded Asset Digests: multimodal/asset-digests.md

--- a/openmed/multimodal/webp_dimensions.py
+++ b/openmed/multimodal/webp_dimensions.py
@@ -1,0 +1,207 @@
+"""Bounded, dependency-free WebP geometry preflight."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import BinaryIO, Callable, Final, Literal
+
+__all__ = [
+    "DEFAULT_MAX_WEBP_HEADER_BYTES",
+    "DEFAULT_MAX_WEBP_PIXELS",
+    "WebpDimensions",
+    "WebpDimensionsError",
+    "read_webp_dimensions",
+]
+
+DEFAULT_MAX_WEBP_HEADER_BYTES: Final[int] = 30
+DEFAULT_MAX_WEBP_PIXELS: Final[int] = 100_000_000
+_MAX_RIFF_SIZE: Final[int] = (1 << 32) - 10
+_MAX_CANVAS_PIXELS: Final[int] = (1 << 32) - 1
+
+
+class WebpDimensionsError(ValueError):
+    """Value-free failure for malformed, unsupported, or over-limit WebP headers."""
+
+    def __init__(self, category: str) -> None:
+        self.category = category
+        super().__init__(category)
+
+
+@dataclass(frozen=True, slots=True)
+class WebpDimensions:
+    """Declared canvas geometry and flags, not decoded-image validation."""
+
+    width: int
+    height: int
+    chunk_type: Literal["VP8", "VP8L", "VP8X"]
+    has_alpha: bool
+    is_animated: bool
+
+
+def read_webp_dimensions(
+    source: bytes | BinaryIO,
+    *,
+    max_header_bytes: int = DEFAULT_MAX_WEBP_HEADER_BYTES,
+    max_pixels: int = DEFAULT_MAX_WEBP_PIXELS,
+) -> WebpDimensions:
+    """Read geometry from the first VP8, VP8L, or VP8X chunk of a RIFF/WEBP file.
+
+    Reads at most 30 bytes. The declared first-chunk extent must fit the RIFF
+    envelope, but pixel payloads, padding, later chunks, and actual full-file
+    length are not read or validated. Unknown first-chunk layouts are refused.
+    For VP8X, the result is the declared canvas, including its animation flag;
+    it is not a promise that frames or metadata are valid or even present.
+    Seekable streams are restored on success/failure; streams are never closed.
+    """
+    if type(max_header_bytes) is not int or max_header_bytes <= 0:
+        raise ValueError("max_header_bytes must be a positive integer")
+    if type(max_pixels) is not int or max_pixels <= 0:
+        raise ValueError("max_pixels must be a positive integer")
+    if isinstance(source, bytes):
+        return _parse_webp(_HeaderReader(source, max_header_bytes), max_pixels)
+    read = getattr(source, "read", None)
+    if not callable(read):
+        raise TypeError("source must be bytes or a binary stream")
+    position = _stream_position(source)
+    try:
+        return _parse_webp(_HeaderReader(read, max_header_bytes), max_pixels)
+    finally:
+        if position is not None:
+            _restore_position(source, position)
+
+
+def _parse_webp(reader: _HeaderReader, max_pixels: int) -> WebpDimensions:
+    header = reader.read_exact(12)
+    if header[:4] != b"RIFF" or header[8:] != b"WEBP":
+        raise WebpDimensionsError("webp_signature_invalid")
+    riff_size = struct.unpack_from("<I", header, 4)[0]
+    if riff_size < 12 or riff_size > _MAX_RIFF_SIZE or riff_size & 1:
+        raise WebpDimensionsError("webp_riff_size_invalid")
+    chunk_header = reader.read_exact(8)
+    kind = chunk_header[:4]
+    chunk_size = struct.unpack_from("<I", chunk_header, 4)[0]
+    if chunk_size + (chunk_size & 1) > riff_size - 12:
+        raise WebpDimensionsError("webp_chunk_size_invalid")
+    if kind == b"VP8 ":
+        if chunk_size < 10:
+            raise WebpDimensionsError("webp_chunk_size_invalid")
+        payload = reader.read_exact(10)
+        if payload[0] & 1 or payload[3:6] != b"\x9d\x01\x2a":
+            raise WebpDimensionsError("webp_vp8_header_invalid")
+        if (payload[0] >> 1) & 7 > 3:
+            raise WebpDimensionsError("webp_vp8_version_unsupported")
+        raw_width, raw_height = struct.unpack_from("<HH", payload, 6)
+        result = WebpDimensions(
+            raw_width & 0x3FFF, raw_height & 0x3FFF, "VP8", False, False
+        )
+    elif kind == b"VP8L":
+        if chunk_size < 5:
+            raise WebpDimensionsError("webp_chunk_size_invalid")
+        payload = reader.read_exact(5)
+        if payload[0] != 0x2F:
+            raise WebpDimensionsError("webp_vp8l_header_invalid")
+        bits = struct.unpack_from("<I", payload, 1)[0]
+        if bits >> 29:
+            raise WebpDimensionsError("webp_vp8l_version_unsupported")
+        result = WebpDimensions(
+            (bits & 0x3FFF) + 1,
+            ((bits >> 14) & 0x3FFF) + 1,
+            "VP8L",
+            bool(bits & (1 << 28)),
+            False,
+        )
+    elif kind == b"VP8X":
+        if chunk_size != 10:
+            raise WebpDimensionsError("webp_chunk_size_invalid")
+        payload = reader.read_exact(10)
+        if payload[0] & 0xC1 or payload[1:4] != b"\x00\x00\x00":
+            raise WebpDimensionsError("webp_vp8x_reserved_bits_invalid")
+        result = WebpDimensions(
+            int.from_bytes(payload[4:7], "little") + 1,
+            int.from_bytes(payload[7:10], "little") + 1,
+            "VP8X",
+            bool(payload[0] & 0x10),
+            bool(payload[0] & 0x02),
+        )
+    else:
+        raise WebpDimensionsError("webp_layout_unsupported")
+    if (
+        result.width == 0
+        or result.height == 0
+        or result.width > _MAX_CANVAS_PIXELS // result.height
+    ):
+        raise WebpDimensionsError("webp_dimensions_invalid")
+    if result.width > max_pixels // result.height:
+        raise WebpDimensionsError("webp_pixel_limit_exceeded")
+    return result
+
+
+class _HeaderReader:
+    def __init__(self, source: bytes | Callable[[int], bytes], limit: int) -> None:
+        self._buffer = memoryview(source) if isinstance(source, bytes) else None
+        self._read = source if callable(source) else None
+        self._limit = limit
+        self.offset = 0
+
+    def read_exact(self, size: int) -> bytes:
+        if size > self._limit - self.offset:
+            raise WebpDimensionsError("webp_header_limit_exceeded")
+        if self._buffer is not None:
+            end = self.offset + size
+            if end > len(self._buffer):
+                raise WebpDimensionsError("webp_header_truncated")
+            result = bytes(self._buffer[self.offset : end])
+            self.offset = end
+            return result
+        chunks: list[bytes] = []
+        remaining = size
+        while remaining:
+            chunk = _read_chunk(self._read, remaining)
+            if not chunk:
+                raise WebpDimensionsError("webp_header_truncated")
+            chunks.append(chunk)
+            self.offset += len(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+
+def _read_chunk(read: Callable[[int], bytes] | None, size: int) -> bytes:
+    if read is None:
+        raise WebpDimensionsError("webp_stream_contract_error")
+    try:
+        chunk = read(size)
+    except Exception:
+        pass
+    else:
+        if isinstance(chunk, bytes) and len(chunk) <= size:
+            return chunk
+        raise WebpDimensionsError("webp_stream_contract_error")
+    # Raise outside the handler so an underlying I/O message is not retained.
+    raise WebpDimensionsError("webp_stream_read_error")
+
+
+def _stream_position(stream: BinaryIO) -> int | None:
+    seekable = getattr(stream, "seekable", None)
+    if not callable(seekable):
+        return None
+    try:
+        if not seekable():
+            return None
+        position = stream.tell()
+    except Exception:
+        pass
+    else:
+        if type(position) is int and position >= 0:
+            return position
+    raise WebpDimensionsError("webp_stream_position_error")
+
+
+def _restore_position(stream: BinaryIO, position: int) -> None:
+    try:
+        stream.seek(position)
+    except Exception:
+        pass
+    else:
+        return
+    raise WebpDimensionsError("webp_stream_restore_error")

--- a/tests/browser/brand/budgets.json
+++ b/tests/browser/brand/budgets.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 2,
   "artifact": {
-    "maximum_files": 519,
-    "maximum_total_bytes": 48231286,
-    "maximum_unique_payload_bytes": 47893707,
+    "maximum_files": 520,
+    "maximum_total_bytes": 48386816,
+    "maximum_unique_payload_bytes": 48049237,
     "maximum_duplicate_payload_bytes": 458752,
     "maximum_source_map_files": 0
   },
@@ -13,13 +13,13 @@
     "html": 2359296,
     "image": 262144,
     "javascript": 716800,
-    "json": 3276800
+    "json": 3407872
   },
   "governed_payload_bytes": {
     "docs/assets/javascripts/lunr/wordcut.js": 716800,
     "docs/model-tokenizer-script-coverage/index.html": 2359296,
     "docs/model-tokenizer-script-coverage.json": 1572864,
-    "docs/search/search_index.json": 3276800
+    "docs/search/search_index.json": 3407872
   },
   "route_transfer_bytes": {
     "/": 3145728,
@@ -33,8 +33,8 @@
   },
   "notes": [
     "Artifact limits are based on the exact staged v2.3 schema candidate plus the audited documentation, federated metrics, and manifest-backed catalog surfaces, including MkDocs search and multilingual tokenizer payloads, with bounded release headroom.",
-    "The audited candidate including this combined change on current master contains 519 files, 48120536 total bytes, 47782957 unique payload bytes, and 337579 duplicate payload bytes.",
-    "The 47893707-byte unique-payload ceiling and 48231286-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
+    "The audited candidate on current master contains 520 files, 48276066 total bytes, 47938487 unique payload bytes, and 337579 duplicate payload bytes.",
+    "The 48049237-byte unique-payload ceiling and 48386816-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
     "The generated 2266-row model registry remains directly accessible but is excluded from global search indexing so unrelated documentation routes do not absorb its search payload.",
     "Unique and duplicate byte limits hash file content so MkDocs duplication remains visible.",
     "No source maps ship; runtime JavaScript remains intact.",

--- a/tests/unit/multimodal/test_webp_dimensions.py
+++ b/tests/unit/multimodal/test_webp_dimensions.py
@@ -1,0 +1,362 @@
+"""Synthetic unit and codec-generated file tests for WebP header preflight."""
+
+from __future__ import annotations
+
+import io
+import struct
+from dataclasses import FrozenInstanceError, asdict
+
+import pytest
+
+from openmed.multimodal.webp_dimensions import WebpDimensionsError, read_webp_dimensions
+
+
+def webp(width=7, height=5, *, kind=b"VP8 ", flags=0):
+    if kind == b"VP8 ":
+        payload = b"\x10\x00\x00\x9d\x01\x2a" + struct.pack("<HH", width, height)
+    elif kind == b"VP8L":
+        bits = (width - 1) | ((height - 1) << 14) | ((flags & 1) << 28)
+        payload = b"\x2f" + struct.pack("<I", bits)
+    else:
+        payload = (
+            bytes([flags, 0, 0, 0])
+            + (width - 1).to_bytes(3, "little")
+            + (height - 1).to_bytes(3, "little")
+        )
+    chunk = kind + struct.pack("<I", len(payload)) + payload
+    if len(payload) & 1:
+        chunk += b"\x00"
+    return b"RIFF" + struct.pack("<I", 4 + len(chunk)) + b"WEBP" + chunk
+
+
+def valid_payload():
+    payload = webp()
+    return payload, 30
+
+
+def edit(payload: bytes, offset: int, fmt: str, value: int) -> bytes:
+    changed = bytearray(payload)
+    struct.pack_into(fmt, changed, offset, value)
+    return bytes(changed)
+
+
+@pytest.mark.parametrize("kind", [b"VP8 ", b"VP8L", b"VP8X"])
+@pytest.mark.parametrize("size", [(1, 1), (7, 5), (258, 772), (16383, 1)])
+def test_each_header_layout(kind, size) -> None:
+    result = read_webp_dimensions(webp(*size, kind=kind))
+    assert (result.width, result.height) == size
+    assert result.chunk_type == kind.decode("ascii").strip()
+    assert not result.is_animated
+    assert not result.has_alpha
+
+
+@pytest.mark.parametrize("flags", [0, 2, 4, 8, 16, 32, 62])
+def test_extended_flags_are_metadata_not_animation_traversal(flags) -> None:
+    payload = webp(kind=b"VP8X", flags=flags)
+    stream = ShortStream(payload + b"do-not-read-ANIM-EXIF-XMP", boundary=30)
+    result = read_webp_dimensions(stream)
+    assert result.is_animated is bool(flags & 2)
+    assert result.has_alpha is bool(flags & 16)
+    assert stream.stream.tell() == 30
+
+
+def test_lossless_alpha_flag() -> None:
+    assert read_webp_dimensions(webp(kind=b"VP8L", flags=1)).has_alpha
+
+
+def test_lossy_scaling_bits_do_not_change_canvas_size() -> None:
+    payload = webp(7 | 0xC000, 5 | 0x8000)
+    result = read_webp_dimensions(payload)
+    assert (result.width, result.height) == (7, 5)
+
+
+@pytest.mark.parametrize("kind,required", [(b"VP8 ", 30), (b"VP8L", 25), (b"VP8X", 30)])
+def test_truncation_and_exact_byte_budget(kind, required) -> None:
+    payload = webp(kind=kind)
+    for cut in range(required):
+        with pytest.raises(WebpDimensionsError, match="^webp_header_truncated$"):
+            read_webp_dimensions(payload[:cut])
+    result = read_webp_dimensions(payload[:required], max_header_bytes=required)
+    assert result.width == 7
+    with pytest.raises(WebpDimensionsError, match="^webp_header_limit_exceeded$"):
+        read_webp_dimensions(payload, max_header_bytes=required - 1)
+
+
+@pytest.mark.parametrize("size", [0, 3, 4, 11, 13, 0xFFFFFFFF, 0xFFFFFFF8])
+def test_invalid_riff_size(size) -> None:
+    with pytest.raises(WebpDimensionsError, match="^webp_riff_size_invalid$"):
+        read_webp_dimensions(edit(webp(), 4, "<I", size))
+
+
+@pytest.mark.parametrize("offset", [0, 8])
+def test_invalid_riff_or_webp_signature(offset) -> None:
+    with pytest.raises(WebpDimensionsError, match="^webp_signature_invalid$"):
+        read_webp_dimensions(edit(webp(), offset, "<I", 0))
+
+
+@pytest.mark.parametrize(
+    "kind,size",
+    [
+        (b"VP8 ", 0),
+        (b"VP8 ", 9),
+        (b"VP8L", 4),
+        (b"VP8X", 9),
+        (b"VP8X", 11),
+        (b"VP8 ", 0xFFFFFFFF),
+    ],
+)
+def test_declared_chunk_sizes(kind, size) -> None:
+    with pytest.raises(WebpDimensionsError, match="^webp_chunk_size_invalid$"):
+        read_webp_dimensions(edit(webp(kind=kind), 16, "<I", size))
+
+
+def test_odd_chunk_padding_must_fit_declared_riff_extent() -> None:
+    payload = edit(webp(), 16, "<I", 11)
+    with pytest.raises(WebpDimensionsError, match="^webp_chunk_size_invalid$"):
+        read_webp_dimensions(payload)
+
+
+def test_unknown_first_chunk_is_not_scanned() -> None:
+    payload = webp(kind=b"JUNK")
+    stream = ShortStream(payload, chunk=12, boundary=20)
+    with pytest.raises(WebpDimensionsError, match="^webp_layout_unsupported$"):
+        read_webp_dimensions(stream)
+    assert stream.stream.tell() == 20
+
+
+@pytest.mark.parametrize(
+    "offset,value,category",
+    [
+        (20, 17, "webp_vp8_header_invalid"),
+        (20, 24, "webp_vp8_version_unsupported"),
+        (23, 0, "webp_vp8_header_invalid"),
+        (26, 0, "webp_dimensions_invalid"),
+        (28, 0, "webp_dimensions_invalid"),
+    ],
+)
+def test_invalid_lossy_headers(offset, value, category) -> None:
+    with pytest.raises(WebpDimensionsError) as raised:
+        read_webp_dimensions(edit(webp(), offset, "<B", value))
+    assert str(raised.value) == category
+
+
+def test_invalid_lossless_signature_and_version() -> None:
+    with pytest.raises(WebpDimensionsError, match="^webp_vp8l_header_invalid$"):
+        read_webp_dimensions(edit(webp(kind=b"VP8L"), 20, "<B", 0))
+    with pytest.raises(WebpDimensionsError, match="^webp_vp8l_version_unsupported$"):
+        read_webp_dimensions(edit(webp(kind=b"VP8L"), 24, "<B", 0x20))
+
+
+@pytest.mark.parametrize(
+    "offset,value", [(20, 1), (20, 64), (20, 128), (21, 1), (22, 1), (23, 1)]
+)
+def test_extended_reserved_fields(offset, value) -> None:
+    with pytest.raises(WebpDimensionsError, match="^webp_vp8x_reserved_bits_invalid$"):
+        read_webp_dimensions(edit(webp(kind=b"VP8X"), offset, "<B", value))
+
+
+def test_extended_canvas_product_limit_cannot_be_disabled() -> None:
+    payload = webp(1 << 24, 1 << 24, kind=b"VP8X")
+    with pytest.raises(WebpDimensionsError, match="^webp_dimensions_invalid$"):
+        read_webp_dimensions(payload, max_pixels=1 << 63)
+    assert read_webp_dimensions(webp(1 << 24, 1, kind=b"VP8X")).width == 1 << 24
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("size", [(1, 1), (7, 5), (257, 129)])
+@pytest.mark.parametrize("lossless", [False, True])
+@pytest.mark.parametrize("mode", ["RGB", "RGBA"])
+def test_pillow_generated_file_end_to_end(tmp_path, size, lossless, mode) -> None:
+    from PIL import Image, features
+
+    assert features.check("webp"), "Pillow must include WebP for this integration test"
+    path = tmp_path / "synthetic.webp"
+    Image.new(mode, size).save(path, format="WEBP", lossless=lossless)
+    with Image.open(path) as decoded:
+        decoded.load()
+        expected = decoded.size
+    with path.open("rb") as stream:
+        result = read_webp_dimensions(stream)
+        assert stream.tell() == 0
+    assert (result.width, result.height) == expected == size
+
+
+@pytest.mark.integration
+def test_real_animated_webp_uses_canvas_not_frame_payloads(tmp_path) -> None:
+    from PIL import Image
+
+    path = tmp_path / "synthetic-animated.webp"
+    first = Image.new("RGB", (19, 13), (0, 0, 0))
+    second = Image.new("RGB", (19, 13), (255, 255, 255))
+    first.save(path, format="WEBP", save_all=True, append_images=[second], duration=10)
+    with Image.open(path) as decoded:
+        assert decoded.n_frames == 2
+    stream = ShortStream(path.read_bytes(), boundary=30)
+    result = read_webp_dimensions(stream)
+    assert (result.width, result.height) == (19, 13)
+    assert result.chunk_type == "VP8X"
+    assert result.is_animated
+    assert stream.stream.tell() == 30
+
+
+class ShortStream:
+    """A real non-seekable byte stream that records every bounded read."""
+
+    def __init__(self, data: bytes, chunk: int = 3, boundary: int | None = None):
+        self.stream = io.BytesIO(data)
+        self.chunk = chunk
+        self.boundary = len(data) if boundary is None else boundary
+        self.requests: list[int] = []
+        self.closed = False
+
+    def read(self, size: int) -> bytes:
+        assert size >= 0
+        assert self.stream.tell() + size <= self.boundary
+        self.requests.append(size)
+        return self.stream.read(min(size, self.chunk))
+
+
+def test_partial_nonseekable_reads_stop_at_header() -> None:
+    payload, boundary = valid_payload()
+    stream = ShortStream(payload + b"unread-payload", boundary=boundary)
+    result = read_webp_dimensions(stream)
+    assert (result.width, result.height) == (7, 5)
+    assert stream.stream.tell() == boundary
+    assert not stream.closed
+    assert sum(min(n, stream.chunk) for n in stream.requests) == boundary
+
+
+def test_seekable_stream_at_nonzero_position_is_restored() -> None:
+    payload, _ = valid_payload()
+    stream = io.BytesIO(b"prefix" + payload)
+    stream.seek(6)
+    result = read_webp_dimensions(stream)
+    assert (result.width, result.height) == (7, 5)
+    assert stream.tell() == 6
+    assert not stream.closed
+
+
+def test_failure_restores_caller_owned_stream() -> None:
+    stream = io.BytesIO(b"prefix" + b"truncated")
+    stream.seek(6)
+    with pytest.raises(WebpDimensionsError):
+        read_webp_dimensions(stream)
+    assert stream.tell() == 6
+    assert not stream.closed
+
+
+@pytest.mark.parametrize("option", ["max_header_bytes", "max_pixels"])
+@pytest.mark.parametrize("value", [0, -1, True, False, 2.0, "2", None])
+def test_invalid_limits_do_not_read(option, value) -> None:
+    class Unreadable:
+        def read(self, size):
+            pytest.fail("invalid options must be checked before I/O")
+
+    with pytest.raises(ValueError, match=option):
+        read_webp_dimensions(Unreadable(), **{option: value})
+
+
+@pytest.mark.parametrize("source", [None, "not-bytes", bytearray(b"data"), 12])
+def test_invalid_source_type(source) -> None:
+    with pytest.raises(TypeError, match="source must be bytes or a binary stream"):
+        read_webp_dimensions(source)
+
+
+@pytest.mark.parametrize("returned", [None, "text", bytearray(b"x"), b"x" * 1000])
+def test_binary_stream_contract_errors_are_value_free(returned) -> None:
+    class WrongStream:
+        def read(self, size):
+            return returned
+
+    with pytest.raises(WebpDimensionsError) as raised:
+        read_webp_dimensions(WrongStream())
+    assert raised.value.category == "webp_stream_contract_error"
+    assert str(raised.value) == raised.value.category
+
+
+def test_read_error_does_not_retain_io_details() -> None:
+    class BrokenStream:
+        def read(self, size):
+            raise OSError("synthetic-private-file-detail")
+
+    with pytest.raises(WebpDimensionsError) as raised:
+        read_webp_dimensions(BrokenStream())
+    assert str(raised.value) == "webp_stream_read_error"
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+
+
+@pytest.mark.parametrize("failure", ["seekable", "tell", "bad-position", "seek"])
+def test_position_errors_do_not_retain_io_details(failure) -> None:
+    payload, _ = valid_payload()
+
+    class PositionStream(io.BytesIO):
+        def seekable(self):
+            if failure == "seekable":
+                raise OSError("synthetic-private-file-detail")
+            return True
+
+        def tell(self):
+            if failure == "tell":
+                raise OSError("synthetic-private-file-detail")
+            if failure == "bad-position":
+                return True
+            return super().tell()
+
+        def seek(self, offset, whence=0):
+            if failure == "seek":
+                raise OSError("synthetic-private-file-detail")
+            return super().seek(offset, whence)
+
+    stream = PositionStream(payload)
+    with pytest.raises(WebpDimensionsError) as raised:
+        read_webp_dimensions(stream)
+    expected = "restore" if failure == "seek" else "position"
+    assert str(raised.value) == f"webp_stream_{expected}_error"
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert not stream.closed
+
+
+def test_pixel_limit_boundary() -> None:
+    payload, _ = valid_payload()
+    result = read_webp_dimensions(payload, max_pixels=35)
+    assert result.width * result.height == 35
+    with pytest.raises(WebpDimensionsError, match="^webp_pixel_limit_exceeded$"):
+        read_webp_dimensions(payload, max_pixels=34)
+
+
+def test_output_contains_only_declared_metadata() -> None:
+    payload, _ = valid_payload()
+    result = read_webp_dimensions(payload)
+    assert all(isinstance(v, (int, str, bool)) for v in asdict(result).values())
+    with pytest.raises(FrozenInstanceError):
+        result.width = 1
+
+
+@pytest.mark.integration
+def test_real_file_read_preserves_position_and_ownership(tmp_path) -> None:
+    payload, _ = valid_payload()
+    path = tmp_path / "synthetic-image.bin"
+    path.write_bytes(b"prefix" + payload + b"not-part-of-the-header")
+    with path.open("rb") as stream:
+        stream.seek(6)
+        result = read_webp_dimensions(stream)
+        assert (result.width, result.height) == (7, 5)
+        assert stream.tell() == 6
+        assert not stream.closed
+
+
+def test_explicit_nonseekable_stream_does_not_attempt_restoration() -> None:
+    payload, boundary = valid_payload()
+
+    class NoSeek(ShortStream):
+        def seekable(self):
+            return False
+
+        def seek(self, *args):
+            pytest.fail("a nonseekable stream must not be rewound")
+
+    stream = NoSeek(payload, boundary=boundary)
+    assert read_webp_dimensions(stream).width == 7
+    assert stream.stream.tell() == boundary


### PR DESCRIPTION
# Pull Request

## Description

Add a dependency-free first-chunk WebP geometry reader for VP8, VP8L and VP8X, with RIFF extent checks and declared alpha/animation flags.

Closes #3116.

## Type of Change

- [ ] Bug fix
- [x] New feature (additive module-level helper)
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- `openmed/multimodal/webp_dimensions.py`
- `tests/unit/multimodal/test_webp_dimensions.py`
- `docs/multimodal/webp-header-preflight.md`
- `CHANGELOG.md`

The implementation is restricted to the issue's documented scope. No runtime
dependency, model, clinical decision path or provider integration is added.
The helper is explicitly callable; existing pipeline routing and package-level export inventories are unchanged.

## Testing

- [x] Added focused tests and synthetic inputs.
- [ ] New and existing unit tests pass through the complete upstream checkout
  (must be filled after local Codex validation).
- [ ] Tested with different models (not applicable: no models are involved).

**Authoring-environment evidence, not full upstream CI:** 101 focused
pytest cases passed with zero skips in an isolated source overlay on CPython 3.13.5.
That includes 14 file-level integration cases. The Python
documentation example executed successfully. Three deliberately broken variants
were rejected by the tests. Image integration uses Pillow 12.3.0/libwebp 1.6.0;
these are synthetic files only. No real patient data or credentials were used.

**Important limit:** the overlay omitted OpenMed parent-package initializers.
Full-checkout import integration, locked-environment tests, Ruff, mypy, docs build
and complete repository CI were not run in that environment. The recorded counts
must not be presented as a full-repository result.

Run this through the actual package before submission:

```bash
uv run --frozen --extra dev pytest tests/unit/multimodal/test_webp_dimensions.py -q
```

Local full-checkout validation: **PENDING — replace with actual commands/results.**

## Documentation

- [x] Added usage, limits, failure categories and explicit non-goals.
- [x] Added docstrings to new public functions/classes.
- [x] Included an insertion-only `CHANGELOG.md` entry.

## Code Quality

- [ ] Ran `make format`, `make lint`, and `make format-check` in the real checkout.
- [ ] Ran `make type-check` and applicable documentation checks.
- [ ] Human author self-review completed.
- [x] Commented the bounded parsing/normalization behavior.
- [ ] Complete upstream CI reports no new warnings.

## Dependencies

- [x] No new runtime dependencies.
- [x] Tests use standard library and existing development dependencies only.

## Checklist

- [ ] Human author has reviewed the contributing guide, Code of Conduct and maintainer guide.
- [ ] Commits have clear, descriptive messages and correct existing Git identity.
- [ ] Commits are organized into this one scoped contribution.

## Related Issues

Closes #3116.

## Examples

See `docs/multimodal/webp-header-preflight.md` and the synthetic test cases. No screenshots are required.

## AI assistance disclosure

The implementation, tests and initial description were prepared with substantial
ChatGPT assistance at Belal Embaby's direction. Codex review and full-checkout
validation were performed; no separate human review is claimed.

## Validation performed

- `uv run --frozen --extra dev python -c "import openmed; import importlib; importlib.import_module('openmed.multimodal.webp_dimensions')"`
- `uv run --frozen --extra dev ruff check .`
- `uv run --frozen --extra dev ruff format --check openmed/multimodal/webp_dimensions.py tests/unit/multimodal/test_webp_dimensions.py` (2 files already formatted)
- `uv run --frozen --extra dev mypy openmed/multimodal/webp_dimensions.py`
- `uv run --frozen --extra dev pytest -q tests/unit/multimodal/test_webp_dimensions.py` (`101 passed`)
- `uv run --frozen --extra dev pytest -q` (`15,666 passed, 225 skipped, 39 failed` in the current Windows environment; failures are upstream symlink tests blocked by WinError 1314)
- `uv run --frozen --extra dev mkdocs build --strict --clean` could not start because `mkdocs` is not installed in the frozen environment.
