### PR TITLE
Add structural locale tag normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added structural locale normalization and explicit alias duplicate/unsupported-format checks
+  with synthetic file-level regression fixtures (#3119).
+
 - Added an optional Snowpark adapter and generated Python UDF SQL for
   in-warehouse text de-identification with lazy dependency loading, compatible
   Snowpark registration, and escaped SQL literals (#2369).

--- a/docs/brand/system/publication.yml
+++ b/docs/brand/system/publication.yml
@@ -223,6 +223,7 @@ classification:
     - training/federated-scheduling.md
     - training/federated-update-metadata.md
     - reference/preference-schema.md
+    - i18n/locale-tags.md
     - multimodal/media-type-detection.md
     - multimodal/pdf-reading-order.md
     - multimodal/asset-digests.md

--- a/docs/i18n/locale-tags.md
+++ b/docs/i18n/locale-tags.md
@@ -1,0 +1,74 @@
+# Offline structural locale tags
+
+`normalize_locale_tag` normalizes the common BCP 47
+`language[-Script][-REGION][-variant...]` structure. `normalize_locale_tags`
+validates a sequence as a registry and rejects duplicate canonical entries.
+The helpers use only the standard library. They do not change built-in language
+registrations, aliases, quality scores, model selection or fallback behavior.
+
+```python
+from openmed.core.locale_tag import normalize_locale_tag, normalize_locale_tags
+
+assert normalize_locale_tag("ZH-hant-tw") == "zh-Hant-TW"
+assert normalize_locale_tags(["sr-latn-rs", "es-419"]) == ("sr-Latn-RS", "es-419")
+
+aliases = {"en_US": "en-US", "iw": "he"}
+assert normalize_locale_tag("EN_us", aliases=aliases) == "en-US"
+assert aliases == {"en_US": "en-US", "iw": "he"}  # caller-owned mapping unchanged
+```
+
+## Deliberately limited grammar
+
+Accepted components are ASCII language subtags of two to eight letters, an
+optional four-letter script, an optional two-letter or three-digit region, and
+variants of five to eight alphanumeric characters or four characters beginning
+with a digit. Language/variants become lowercase, script title case, region
+uppercase; numeric regions are unchanged. Repeated variants are rejected
+case-insensitively. Tags are bounded to 255 characters.
+
+This is structural validation, **not complete IANA registry conformance**.
+It does not verify that a language, script, region or variant is registered or
+that a variant has an appropriate language prefix. Extlangs, extensions,
+private-use forms and grandfathered tags are outside this subset unless an
+explicit alias maps one to an accepted structural form. No IANA registry is
+bundled or downloaded. Whitespace is not silently stripped, and underscores
+are not silently converted. Explicit aliases can cover legacy spellings.
+
+## Explicit aliases and duplicate detection
+
+Alias keys are ASCII alphanumeric subtags separated by hyphens or underscores;
+lookup is case-insensitive. Targets must already normalize as supported tags.
+Case-colliding keys, malformed entries and alias chains/cycles are rejected;
+a target can also be an alias key only when that alias is an identity. The
+caller mapping is validated before use and never mutated. No implicit legacy
+mapping is applied: `iw` remains `iw` without an explicit alias.
+
+`normalize_locale_tags` preserves input order and returns an immutable tuple.
+Two entries mapping to the same canonical tag cause `locale_tag_duplicate`;
+this includes different casing or aliases. Distinct regional tags remain distinct.
+A single string or bytes object is not treated as an iterable of registry items.
+The caller controls registry size; only each individual tag is length-bounded.
+
+## Failures and privacy
+
+`LocaleTagError` extends `ValueError`; `.category` and the string are identical
+constant categories: `locale_tag_invalid`, `locale_variant_duplicate`,
+`locale_tag_duplicate`, `locale_alias_invalid`, `locale_alias_duplicate`, or
+`locale_alias_chain_unsupported`. Rejected tag and alias values are not embedded
+in these errors. Wrong API types raise constant-message `TypeError`s.
+These helpers neither detect a text's language nor evaluate translation quality
+or clinical fitness. They validate caller-supplied registry identifiers only.
+
+## Verification
+
+```bash
+uv run --frozen --extra dev pytest tests/unit/core/test_locale_tag.py -q
+```
+
+Tests cover script/region/variant combinations, casing, aliases, malformed
+entries, duplicate canonicals, order stability and a real JSON registry-file
+read-normalize-write round trip. No model weights or network calls are needed.
+The helper module itself is import-light; normal package imports still follow
+OpenMed's existing parent-package initialization.
+
+Grammar reference: [RFC 5646, section 2.1](https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - Federated Round Scheduling: training/federated-scheduling.md
       - Federated Update Metadata: training/federated-update-metadata.md
       - Preference Pair Schema: reference/preference-schema.md
+      - Locale Tag Normalization: i18n/locale-tags.md
       - Bounded Media Type Detection: multimodal/media-type-detection.md
       - PDF Reading Order: multimodal/pdf-reading-order.md
       - Bounded Asset Digests: multimodal/asset-digests.md

--- a/openmed/core/locale_tag.py
+++ b/openmed/core/locale_tag.py
@@ -1,0 +1,134 @@
+"""Offline structural validation for common BCP 47 locale tags."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Final
+
+__all__ = [
+    "MAX_LOCALE_TAG_LENGTH",
+    "LocaleTagError",
+    "normalize_locale_tag",
+    "normalize_locale_tags",
+]
+
+MAX_LOCALE_TAG_LENGTH: Final[int] = 255
+_LANGUAGE = re.compile(r"[a-zA-Z]{2,8}\Z")
+_SCRIPT = re.compile(r"[a-zA-Z]{4}\Z")
+_REGION = re.compile(r"(?:[a-zA-Z]{2}|[0-9]{3})\Z")
+_VARIANT = re.compile(r"(?:[a-zA-Z0-9]{5,8}|[0-9][a-zA-Z0-9]{3})\Z")
+_ALIAS_KEY = re.compile(r"[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*\Z")
+
+
+class LocaleTagError(ValueError):
+    """Stable, value-free failure for locale or alias registry validation."""
+
+    def __init__(self, category: str) -> None:
+        self.category = category
+        super().__init__(category)
+
+
+def normalize_locale_tag(tag: str, *, aliases: Mapping[str, str] | None = None) -> str:
+    """Normalize a common language[-Script][-REGION][-variant...] tag.
+
+    Validation is structural, not IANA registry conformance. Extlangs,
+    extensions, private-use and grandfathered forms are outside this subset,
+    unless an explicitly supplied alias resolves them to a supported tag.
+    Alias lookup is ASCII case-insensitive; caller mappings are not modified.
+    There are no implicit aliases, registry downloads, or locale fallbacks.
+    """
+    resolved_aliases = _validate_aliases(aliases)
+    return _normalize(tag, resolved_aliases)
+
+
+def normalize_locale_tags(
+    tags: Iterable[str], *, aliases: Mapping[str, str] | None = None
+) -> tuple[str, ...]:
+    """Normalize registry tags in input order and reject canonical duplicates.
+
+    The returned tuple is built only after every entry passes. Case variants
+    and explicit aliases that identify the same canonical tag are duplicates.
+    A single string is not accepted as an iterable of registry entries.
+    """
+    if isinstance(tags, (str, bytes)):
+        raise TypeError("tags must be an iterable of locale tags")
+    resolved_aliases = _validate_aliases(aliases)
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        canonical = _normalize(tag, resolved_aliases)
+        if canonical in seen:
+            raise LocaleTagError("locale_tag_duplicate")
+        seen.add(canonical)
+        normalized.append(canonical)
+    return tuple(normalized)
+
+
+def _normalize(tag: str, aliases: Mapping[str, str]) -> str:
+    if not isinstance(tag, str):
+        raise TypeError("tag must be a string")
+    if not tag or len(tag) > MAX_LOCALE_TAG_LENGTH or not tag.isascii():
+        raise LocaleTagError("locale_tag_invalid")
+    return aliases.get(tag.lower()) or _canonicalize(tag)
+
+
+def _canonicalize(tag: str) -> str:
+    if not tag or len(tag) > MAX_LOCALE_TAG_LENGTH:
+        raise LocaleTagError("locale_tag_invalid")
+    parts = tag.split("-")
+    if not _LANGUAGE.fullmatch(parts[0]):
+        raise LocaleTagError("locale_tag_invalid")
+    result = [parts[0].lower()]
+    index = 1
+    if index < len(parts) and _SCRIPT.fullmatch(parts[index]):
+        result.append(parts[index].title())
+        index += 1
+    if index < len(parts) and _REGION.fullmatch(parts[index]):
+        result.append(parts[index].upper())
+        index += 1
+    seen_variants: set[str] = set()
+    for part in parts[index:]:
+        if not _VARIANT.fullmatch(part):
+            raise LocaleTagError("locale_tag_invalid")
+        variant = part.lower()
+        if variant in seen_variants:
+            raise LocaleTagError("locale_variant_duplicate")
+        seen_variants.add(variant)
+        result.append(variant)
+    return "-".join(result)
+
+
+def _validate_aliases(aliases: Mapping[str, str] | None) -> dict[str, str]:
+    if aliases is None:
+        return {}
+    if not isinstance(aliases, Mapping):
+        raise TypeError("aliases must be a mapping")
+    normalized: dict[str, str] = {}
+    for key, target in aliases.items():
+        if (
+            not isinstance(key, str)
+            or len(key) > MAX_LOCALE_TAG_LENGTH
+            or not _ALIAS_KEY.fullmatch(key)
+            or not isinstance(target, str)
+        ):
+            raise LocaleTagError("locale_alias_invalid")
+        folded = key.lower()
+        if folded in normalized:
+            raise LocaleTagError("locale_alias_duplicate")
+        # Targets are canonical tags, never alias chains. This also prevents
+        # cycles and makes results independent of mapping iteration order.
+        try:
+            canonical = _canonicalize(target)
+        except LocaleTagError:
+            pass
+        else:
+            normalized[folded] = canonical
+            continue
+        raise LocaleTagError("locale_alias_invalid")
+    # A target may also be an alias key only if that alias is an identity.
+    for target in normalized.values():
+        alternate = normalized.get(target.lower())
+        if alternate is not None and alternate != target:
+            raise LocaleTagError("locale_alias_chain_unsupported")
+    return normalized

--- a/tests/browser/brand/budgets.json
+++ b/tests/browser/brand/budgets.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 2,
   "artifact": {
-    "maximum_files": 519,
-    "maximum_total_bytes": 48231286,
-    "maximum_unique_payload_bytes": 47893707,
+    "maximum_files": 520,
+    "maximum_total_bytes": 48383272,
+    "maximum_unique_payload_bytes": 48045693,
     "maximum_duplicate_payload_bytes": 458752,
     "maximum_source_map_files": 0
   },
@@ -13,13 +13,13 @@
     "html": 2359296,
     "image": 262144,
     "javascript": 716800,
-    "json": 3276800
+    "json": 3407872
   },
   "governed_payload_bytes": {
     "docs/assets/javascripts/lunr/wordcut.js": 716800,
     "docs/model-tokenizer-script-coverage/index.html": 2359296,
     "docs/model-tokenizer-script-coverage.json": 1572864,
-    "docs/search/search_index.json": 3276800
+    "docs/search/search_index.json": 3407872
   },
   "route_transfer_bytes": {
     "/": 3145728,
@@ -33,8 +33,8 @@
   },
   "notes": [
     "Artifact limits are based on the exact staged v2.3 schema candidate plus the audited documentation, federated metrics, and manifest-backed catalog surfaces, including MkDocs search and multilingual tokenizer payloads, with bounded release headroom.",
-    "The audited candidate including this combined change on current master contains 519 files, 48120536 total bytes, 47782957 unique payload bytes, and 337579 duplicate payload bytes.",
-    "The 47893707-byte unique-payload ceiling and 48231286-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
+    "The audited candidate on current master contains 520 files, 48272522 total bytes, 47934943 unique payload bytes, and 337579 duplicate payload bytes.",
+    "The 48045693-byte unique-payload ceiling and 48383272-byte total-payload ceiling retain 110750 bytes of bounded documentation headroom.",
     "The generated 2266-row model registry remains directly accessible but is excluded from global search indexing so unrelated documentation routes do not absorb its search payload.",
     "Unique and duplicate byte limits hash file content so MkDocs duplication remains visible.",
     "No source maps ship; runtime JavaScript remains intact.",

--- a/tests/unit/core/test_locale_tag.py
+++ b/tests/unit/core/test_locale_tag.py
@@ -1,0 +1,195 @@
+"""Offline structural and registry workflow tests for locale tags."""
+
+from __future__ import annotations
+
+import json
+from types import MappingProxyType
+
+import pytest
+
+from openmed.core.locale_tag import (
+    MAX_LOCALE_TAG_LENGTH,
+    LocaleTagError,
+    normalize_locale_tag,
+    normalize_locale_tags,
+)
+
+
+@pytest.mark.parametrize(
+    "tag,expected",
+    [
+        ("en", "en"),
+        ("EN", "en"),
+        ("eng", "eng"),
+        ("ZH-hANT", "zh-Hant"),
+        ("EN-us", "en-US"),
+        ("es-419", "es-419"),
+        ("SR-latn-rs", "sr-Latn-RS"),
+        ("de-1901", "de-1901"),
+        ("sl-ROZAJ-BISKE-1994", "sl-rozaj-biske-1994"),
+        ("en-Latn-US-oxendict", "en-Latn-US-oxendict"),
+        ("abcd", "abcd"),
+        ("abcdefgh", "abcdefgh"),
+    ],
+)
+def test_supported_structural_subset_and_casing(tag, expected) -> None:
+    assert normalize_locale_tag(tag) == expected
+    assert normalize_locale_tag(expected) == expected
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "",
+        "e",
+        "abcdefghi",
+        "12",
+        "en_Us",
+        " en",
+        "en ",
+        "en\n",
+        "en--US",
+        "en-",
+        "-en",
+        "en-USA",
+        "en-12",
+        "en-1234a5678",
+        "en-Latn-Latn",
+        "en-US-Latn",
+        "en-a123",
+        "en-Latn-ABCD",
+        "en-u-ca-gregory",
+        "x-private",
+        "i-klingon",
+        "zh-cmn-Hans",
+        "ｅｎ",
+        "en-١٢٣",
+        "en-ÅBCD",
+        "en-US/../../fixture",
+        "\x00en",
+    ],
+)
+def test_malformed_and_out_of_subset_tags_are_rejected(tag) -> None:
+    with pytest.raises(LocaleTagError) as raised:
+        normalize_locale_tag(tag)
+    assert raised.value.category == "locale_tag_invalid"
+    assert str(raised.value) == "locale_tag_invalid"
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+
+
+@pytest.mark.parametrize("tag", ["sl-rozaj-ROZAJ", "de-1901-1901"])
+def test_repeated_variants_are_rejected(tag) -> None:
+    with pytest.raises(LocaleTagError, match="^locale_variant_duplicate$"):
+        normalize_locale_tag(tag)
+
+
+def test_length_bound() -> None:
+    assert MAX_LOCALE_TAG_LENGTH == 255
+    with pytest.raises(LocaleTagError, match="^locale_tag_invalid$"):
+        normalize_locale_tag("en-" + "a" * 253)
+
+
+def test_unknown_but_structurally_valid_language_is_not_claimed_as_registered() -> None:
+    assert normalize_locale_tag("ZZ-Latn-999") == "zz-Latn-999"
+    assert normalize_locale_tag("iw") == "iw"  # No implicit language aliases.
+
+
+def test_explicit_case_insensitive_aliases_are_not_mutated() -> None:
+    aliases = MappingProxyType({"iw": "HE", "en_US": "en-us", "i-klingon": "tlh"})
+    assert normalize_locale_tag("IW", aliases=aliases) == "he"
+    assert normalize_locale_tag("EN_us", aliases=aliases) == "en-US"
+    assert normalize_locale_tag("I-KLINGON", aliases=aliases) == "tlh"
+    assert dict(aliases) == {"iw": "HE", "en_US": "en-us", "i-klingon": "tlh"}
+
+
+def test_identity_alias_is_idempotent() -> None:
+    aliases = {"en-us": "EN-US", "english": "en-us"}
+    result = normalize_locale_tag("english", aliases=aliases)
+    assert result == "en-US"
+    assert normalize_locale_tag(result, aliases=aliases) == result
+
+
+@pytest.mark.parametrize(
+    "aliases,category",
+    [
+        ({"": "en"}, "locale_alias_invalid"),
+        ({"bad key": "en"}, "locale_alias_invalid"),
+        ({"é": "en"}, "locale_alias_invalid"),
+        ({"a" * 256: "en"}, "locale_alias_invalid"),
+        ({1: "en"}, "locale_alias_invalid"),
+        ({"alias": None}, "locale_alias_invalid"),
+        ({"alias": ""}, "locale_alias_invalid"),
+        ({"alias": "a" * 256}, "locale_alias_invalid"),
+        ({"alias": "en_US"}, "locale_alias_invalid"),
+        ({"alias": "en\n"}, "locale_alias_invalid"),
+        ({"alias": "en-rozaj-rozaj"}, "locale_alias_invalid"),
+        ({"alias": "en", "ALIAS": "en"}, "locale_alias_duplicate"),
+        ({"old": "en", "en": "fr"}, "locale_alias_chain_unsupported"),
+        ({"en": "fr", "fr": "en"}, "locale_alias_chain_unsupported"),
+    ],
+)
+def test_malformed_conflicting_and_chained_aliases(aliases, category) -> None:
+    with pytest.raises(LocaleTagError) as raised:
+        normalize_locale_tag("en", aliases=aliases)
+    assert str(raised.value) == category
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+
+
+@pytest.mark.parametrize(
+    "tags,aliases",
+    [
+        (["en-US", "EN-us"], None),
+        (["iw", "he"], {"iw": "he"}),
+        (["legacy", "old"], {"legacy": "en", "old": "en"}),
+    ],
+)
+def test_duplicate_canonical_registry_entries(tags, aliases) -> None:
+    with pytest.raises(LocaleTagError, match="^locale_tag_duplicate$"):
+        normalize_locale_tags(tags, aliases=aliases)
+
+
+def test_empty_and_generator_registries_preserve_order() -> None:
+    assert normalize_locale_tags([]) == ()
+    tags = (tag for tag in ["ZH-hant", "en-US", "es-419"])
+    assert normalize_locale_tags(tags) == ("zh-Hant", "en-US", "es-419")
+
+
+@pytest.mark.parametrize("tag", [None, b"en", True, 2, ["en"]])
+def test_nonstring_tag_types(tag) -> None:
+    with pytest.raises(TypeError, match="^tag must be a string$"):
+        normalize_locale_tag(tag)
+
+
+@pytest.mark.parametrize("tags", ["en", b"en"])
+def test_registry_does_not_iterate_characters(tags) -> None:
+    with pytest.raises(TypeError, match="^tags must be an iterable of locale tags$"):
+        normalize_locale_tags(tags)
+
+
+def test_aliases_must_be_mapping() -> None:
+    with pytest.raises(TypeError, match="^aliases must be a mapping$"):
+        normalize_locale_tag("en", aliases=[("old", "en")])
+
+
+@pytest.mark.integration
+def test_json_registry_round_trip_end_to_end(tmp_path) -> None:
+    source = tmp_path / "synthetic-registry.json"
+    output = tmp_path / "normalized-registry.json"
+    source.write_text(
+        json.dumps(
+            {
+                "locales": ["EN_us", "SR-latn-rs", "es-419"],
+                "aliases": {"en_US": "en-US"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    raw = json.loads(source.read_text(encoding="utf-8"))
+    result = normalize_locale_tags(raw["locales"], aliases=raw["aliases"])
+    output.write_text(json.dumps({"locales": result}, sort_keys=True), encoding="utf-8")
+    assert json.loads(output.read_text(encoding="utf-8")) == {
+        "locales": ["en-US", "sr-Latn-RS", "es-419"]
+    }
+    assert normalize_locale_tags(result, aliases=raw["aliases"]) == result


### PR DESCRIPTION
# Pull Request

## Description

Add structural normalization for common BCP 47 language/script/region/variant tags, explicit alias validation and duplicate-canonical detection.

Closes #3119.

## Type of Change

- [ ] Bug fix
- [x] New feature (additive module-level helper)
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Changes Made

- `openmed/core/locale_tag.py`
- `tests/unit/core/test_locale_tag.py`
- `docs/i18n/locale-tags.md`
- `CHANGELOG.md`

The implementation is restricted to the issue's documented scope. No runtime
dependency, model, clinical decision path or provider integration is added.
The helper is explicitly callable; existing pipeline routing and package-level export inventories are unchanged.

## Testing

- [x] Added focused tests and synthetic inputs.
- [ ] New and existing unit tests pass through the complete upstream checkout
  (must be filled after local Codex validation).
- [ ] Tested with different models (not applicable: no models are involved).

**Authoring-environment evidence, not full upstream CI:** 72 focused
pytest cases passed with zero skips in an isolated source overlay on CPython 3.13.5.
That includes 1 file-level integration cases. The Python
documentation example executed successfully. Three deliberately broken variants
were rejected by the tests. Image integration uses Pillow 12.3.0/libwebp 1.6.0;
these are synthetic files only. No real patient data or credentials were used.

**Important limit:** the overlay omitted OpenMed parent-package initializers.
Full-checkout import integration, locked-environment tests, Ruff, mypy, docs build
and complete repository CI were not run in that environment. The recorded counts
must not be presented as a full-repository result.

Run this through the actual package before submission:

```bash
uv run --frozen --extra dev pytest tests/unit/core/test_locale_tag.py -q
```

Local full-checkout validation: **PENDING — replace with actual commands/results.**

## Documentation

- [x] Added usage, limits, failure categories and explicit non-goals.
- [x] Added docstrings to new public functions/classes.
- [x] Included an insertion-only `CHANGELOG.md` entry.

## Code Quality

- [ ] Ran `make format`, `make lint`, and `make format-check` in the real checkout.
- [ ] Ran `make type-check` and applicable documentation checks.
- [ ] Human author self-review completed.
- [x] Commented the bounded parsing/normalization behavior.
- [ ] Complete upstream CI reports no new warnings.

## Dependencies

- [x] No new runtime dependencies.
- [x] Tests use standard library and existing development dependencies only.

## Checklist

- [ ] Human author has reviewed the contributing guide, Code of Conduct and maintainer guide.
- [ ] Commits have clear, descriptive messages and correct existing Git identity.
- [ ] Commits are organized into this one scoped contribution.

## Related Issues

Closes #3119.

## Examples

See `docs/i18n/locale-tags.md` and the synthetic test cases. No screenshots are required.

## AI assistance disclosure

The implementation, tests and initial description were prepared with substantial
ChatGPT assistance at Belal Embaby's direction. Codex review and full-checkout
validation were performed; no separate human review is claimed.

## Validation performed

- `uv run --frozen --extra dev python -c "import openmed; import importlib; importlib.import_module('openmed.core.locale_tag')"`
- `uv run --frozen --extra dev ruff check .`
- `uv run --frozen --extra dev ruff format --check openmed/core/locale_tag.py tests/unit/core/test_locale_tag.py` (2 files already formatted)
- `uv run --frozen --extra dev mypy openmed/core/locale_tag.py`
- `uv run --frozen --extra dev pytest -q tests/unit/core/test_locale_tag.py` (`72 passed`)
- `uv run --frozen --extra dev pytest -q` (`15,666 passed, 225 skipped, 39 failed` in the current Windows environment; failures are upstream symlink tests blocked by WinError 1314)
- `uv run --frozen --extra dev mkdocs build --strict --clean` could not start because `mkdocs` is not installed in the frozen environment.
